### PR TITLE
optimize non lastdim softmax bf16

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -206,7 +206,7 @@ Tensor softmax_backward_cpu(
   if (grad.ndimension() > 0 && dim == grad.ndimension() - 1) {
     softmax_backward_lastdim_kernel(kCPU, grad_input, grad, output);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(grad.scalar_type(), "softmax_backward", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::BFloat16, grad.scalar_type(), "softmax_backward", [&] {
       host_softmax_backward<scalar_t, false>(grad_input, grad, output, dim);
     });
   }

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -207,6 +207,113 @@ struct vec_host_softmax_lastdim {
   }
 };
 
+inline void _vec_softmax(
+    BFloat16* input_data_base,
+    BFloat16* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using Vec = vec::Vectorized<float>;
+  using Vec_bf16 = vec::Vectorized<BFloat16>;
+  int64_t dim_stride = inner_size;
+  int64_t outer_stride = dim_size * dim_stride;
+  int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
+  int vectorized_step = Vec_bf16().size(); // Currently, we only support BFloat16 in this special implementation
+  parallel_for(
+      0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
+        int64_t idx = begin;
+        std::unique_ptr<float[]> temp_vec_input(new float[dim_size*vectorized_step*2]());
+        std::unique_ptr<float[]> temp_vec_output(new float[dim_size*vectorized_step*2]());
+        float* temp_vec_input_data = temp_vec_input.get();
+        float* temp_vec_output_data = temp_vec_output.get();
+        while (idx < end) {
+          int64_t outer_idx = idx / inner_size;
+          int64_t inner_idx = idx % inner_size;
+          if (((inner_idx + vectorized_step) <= inner_size) && ((idx + vectorized_step) <= end)) {
+            // Vectorization
+            BFloat16* input_data =
+                input_data_base + outer_idx * outer_stride + inner_idx;
+            BFloat16* output_data =
+                output_data_base + outer_idx * outer_stride + inner_idx;
+            // Step 1: Get max Score
+            Vec_bf16 max_m256_bf16 = Vec_bf16::loadu(input_data);
+            std::tuple<vec::Vectorized<float>, vec::Vectorized<float>> convert_result = convert_bfloat16_float(max_m256_bf16);
+            Vec max_m256_o1 = std::get<0>(convert_result);
+            Vec max_m256_o2 = std::get<1>(convert_result);
+            std::get<0>(convert_result).store(temp_vec_input_data);
+            std::get<1>(convert_result).store(temp_vec_input_data + vectorized_step);
+            for (int64_t d = 1; d < dim_size; d++) {
+              Vec_bf16 input_m256_bf16 = Vec_bf16::loadu(input_data + d * dim_stride);
+              convert_result = convert_bfloat16_float(input_m256_bf16);
+              max_m256_o1 = vec::maximum(max_m256_o1, std::get<0>(convert_result));
+              max_m256_o2 = vec::maximum(max_m256_o2, std::get<1>(convert_result));
+              std::get<0>(convert_result).store(temp_vec_input_data + d*vectorized_step*2);
+              std::get<1>(convert_result).store(temp_vec_input_data + d*vectorized_step*2 + vectorized_step);
+            }
+            // Step2: Calculate sum
+            Vec sum_m256_o1 = Vec(0.0);
+            Vec sum_m256_o2 = Vec(0.0);
+            for (int64_t d = 0; d < dim_size; d++) {
+              Vec output_m256_o1 = Vec::loadu(temp_vec_input_data + d*vectorized_step*2);
+              Vec output_m256_o2 = Vec::loadu(temp_vec_input_data + d*vectorized_step*2 + vectorized_step);
+              output_m256_o1 = output_m256_o1.exp();
+              output_m256_o2 = output_m256_o2.exp();
+
+              output_m256_o1.store(temp_vec_output_data + d*vectorized_step*2);
+              output_m256_o2.store(temp_vec_output_data + d*vectorized_step*2 + vectorized_step);
+
+              sum_m256_o1 = sum_m256_o1 + output_m256_o1;
+              sum_m256_o2 = sum_m256_o2 + output_m256_o2;
+            }
+            // Step3: Unify
+            for (int64_t d = 0; d < dim_size; d++) {
+              Vec output_m256_o1 = Vec::loadu(temp_vec_output_data + d*vectorized_step*2);
+              Vec output_m256_o2 = Vec::loadu(temp_vec_output_data + d*vectorized_step*2 + vectorized_step);
+              output_m256_o1 = output_m256_o1/sum_m256_o1;
+              output_m256_o2 = output_m256_o2/sum_m256_o2;
+              Vec_bf16 output_m256_bf16 = convert_float_bfloat16(output_m256_o1, output_m256_o2);
+              output_m256_bf16.store(output_data + d * dim_stride);
+            }
+            idx += vectorized_step;
+          } else {
+            // Tail case(Scalar): it is exactly same logic as host_softmax
+            // inside aten/src/ATen/native/SoftMax.cpp. There are 2 kind of
+            // cases which will fall through this part:
+            // Case 1: For the idx at the end of total chunk for each thread, there are not enough numbers for parallization.
+            // Case 2: For the idx at the end of each inner_size inside thread, there are not enough numbers for parallization.
+            int64_t tail_number = ((idx+vectorized_step) > end) ? /*Case1*/ (end - idx) : /*Case2*/ (inner_size - inner_idx);
+            for (int64_t i=0; i < tail_number; i++) {
+              outer_idx = (idx + i) / inner_size;
+              inner_idx = (idx + i) % inner_size;
+              BFloat16* input_data =
+                  input_data_base + outer_idx * outer_stride + inner_idx;
+              BFloat16* output_data =
+                  output_data_base + outer_idx * outer_stride + inner_idx;
+              // Step1: Get max score
+              float max_input = float(input_data[0]);
+              for (int64_t d = 1; d < dim_size; d++) {
+                max_input = std::max(max_input, float(input_data[d * dim_stride]));
+              }
+              // Step2: Calculate the Sum
+              float sum_data = 0.0;
+              float temp_output_data = 0.0;
+              for (int64_t d = 0; d < dim_size; d++) {
+                temp_output_data = std::exp(input_data[d * dim_stride] - max_input);
+                sum_data += temp_output_data;
+                output_data[d * dim_stride] = c10::BFloat16(temp_output_data);
+              }
+              // Step3: Unify
+              for (int64_t d = 0; d < dim_size; d++) {
+                output_data[d * dim_stride] =
+                    c10::BFloat16(float(output_data[d * dim_stride])/sum_data);
+              }
+            }
+            idx += tail_number;
+          }
+        }
+      });
+}
+
 template <typename scalar_t>
 inline void _vec_softmax(
     scalar_t* input_data_base,
@@ -218,16 +325,7 @@ inline void _vec_softmax(
   int64_t dim_stride = inner_size;
   int64_t outer_stride = dim_size * dim_stride;
   int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
-  int vectorized_step = Vec().size(); // Currently, we only support scalar_t with double or float32
-#ifdef CPU_CAPABILITY_AVX512
-  TORCH_INTERNAL_ASSERT(
-    (vectorized_step == 16) || (vectorized_step == 8),
-    "vectorized_step must be 16 with dtype float or 8 with dtype double");
-#else
-  TORCH_INTERNAL_ASSERT(
-    (vectorized_step == 8) || (vectorized_step == 4),
-    "vectorized_step must be 8 with dtype float or 4 with dtype double");
-#endif
+  int vectorized_step = Vec().size();
   parallel_for(
       0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
         int64_t idx = begin;
@@ -242,20 +340,20 @@ inline void _vec_softmax(
                 output_data_base + outer_idx * outer_stride + inner_idx;
             // Step 1: Get max Score
             Vec max_m256 = Vec::loadu(input_data);
-            for (int64_t d = 1; d < dim_size; d += 1) {
+            for (int64_t d = 1; d < dim_size; d++) {
               Vec input_m256 = Vec::loadu(input_data + d * dim_stride);
               max_m256 = vec::maximum(max_m256, input_m256);
             }
             // Step2: Calculate sum
             Vec sum_m256 = Vec(0.0);
-            for (int64_t d = 0; d < dim_size; d += 1) {
+            for (int64_t d = 0; d < dim_size; d++) {
               Vec output_m256 =
                   (Vec::loadu(input_data + d * dim_stride) - max_m256).exp();
               output_m256.store(output_data + d * dim_stride);
               sum_m256 = sum_m256 + output_m256;
             }
             // Step3: Unify
-            for (int64_t d = 0; d < dim_size; d += 1) {
+            for (int64_t d = 0; d < dim_size; d++) {
               Vec output_m256 =
                   Vec::loadu(output_data + d * dim_stride) / sum_m256;
               output_m256.store(output_data + d * dim_stride);
@@ -277,18 +375,18 @@ inline void _vec_softmax(
                   output_data_base + outer_idx * outer_stride + inner_idx;
               // Step1: Get max score
               scalar_t max_input = input_data[0];
-              for (int64_t d = 1; d < dim_size; d += 1) {
+              for (int64_t d = 1; d < dim_size; d++) {
                 max_input = std::max(max_input, input_data[d * dim_stride]);
               }
               // Step2: Calculate the Sum
               scalar_t sum_data = 0;
-              for (int64_t d = 0; d < dim_size; d += 1) {
+              for (int64_t d = 0; d < dim_size; d++) {
                 output_data[d * dim_stride] =
                     std::exp(input_data[d * dim_stride] - max_input);
                 sum_data += output_data[d * dim_stride];
               }
               // Step3: Unify
-              for (int64_t d = 0; d < dim_size; d += 1) {
+              for (int64_t d = 0; d < dim_size; d++) {
                 output_data[d * dim_stride] =
                     output_data[d * dim_stride]/sum_data;
               }
@@ -350,9 +448,9 @@ static void softmax_lastdim_kernel_impl(
 }
 
 static void softmax_kernel_impl(Tensor& result, const Tensor& self, int64_t dim) {
-  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "softmax_kernel_impl", [&] {
-    vec_softmax<scalar_t, false>::apply(result, self, dim);
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::BFloat16, self.scalar_type(),
+    "softmax_kernel_impl",
+    [&] { vec_softmax<scalar_t, false>::apply(result, self, dim); });
 }
 
 static void log_softmax_lastdim_kernel_impl(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16401,9 +16401,10 @@ class TestNNDeviceType(NNTestCase):
         self._test_bfloat16_ops(torch.nn.AdaptiveAvgPool2d((3, 5)), device, inp_dims=(8, 4, 16, 16), prec=0.05)
         self._test_bfloat16_ops(torch.nn.AdaptiveAvgPool3d((3, 5, 7)), device, inp_dims=(8, 4, 16, 16, 16), prec=0.05)
 
-    @onlyCUDA
+    @onlyOnCPUAndCUDA
     def test_softmax_bfloat16(self, device):
-        self._test_bfloat16_ops(torch.nn.Softmax(dim=1), device, inp_dims=(16, 32), prec=1e-2)
+        for dim in [0, 1, 2, 3]:
+            self._test_bfloat16_ops(torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=1e-2)
 
     @onlyCUDA
     @skipCUDAIfRocm


### PR DESCRIPTION
Here is the PR to enable the softmax calculation with data type of `bfloat16` when not along the last dim.
* Use bf16 specialization for forward calculation to reduce the bf16/fp32 cast in vec template.
* Release the bf16 limitation for backward calculation.
