### PR TITLE
Allow Docker build on macOS

### DIFF
--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -320,7 +320,7 @@ if [ -n "${JENKINS:-}" ]; then
   JENKINS_GID=$(id -g jenkins)
 fi
 
-tmp_tag="tmp-$(cat /dev/urandom | tr -dc 'a-z' | head -c 32)"
+tmp_tag=$(basename "$(mktemp -u)" | tr '[:upper:]' '[:lower:]')
 
 # Build image
 # TODO: build-arg THRIFT is not turned on for any image, remove it once we confirm


### PR DESCRIPTION
This PR allows developers using macOS to build Docker images locally. The `basename $(mktemp -u)` part was suggested by @seemethere; I modified it slightly to appease ShellCheck and because [Docker doesn't allow uppercase characters in tags](https://stackoverflow.com/a/54291205).

**Test plan:**

On a Mac:
```
cd .circleci/docker
./build.sh pytorch-linux-xenial-py3.6-gcc5.4
```