### PR TITLE
[torch][segment_reduce] Add support for sum and min reductions

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.h
+++ b/aten/src/ATen/native/SegmentReduce.h
@@ -7,7 +7,7 @@
 namespace at {
 namespace native {
 
-enum SegmentReductionType { MAX, MEAN };
+enum SegmentReductionType { MAX, MEAN, MIN, SUM };
 
 using segment_reduce_fn = Tensor (*)(
     SegmentReductionType,


### PR DESCRIPTION
Summary:
This concludes the support for all reductions types initially planned (min, max, mean, sum).

Next Steps:
- Cleanups
       -  update default values when length is 0 and initial not given
       - templatize the code to avoid branching with every item.( and other known improvements)
- more unit tests, verification
- benchmarking

Test Plan: updated unit tests.

Differential Revision: D29268218

