### PR TITLE
ensure xml report path are relative to CI prefix

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -260,7 +260,7 @@ def chunk_list(lst, nchunks):
 def sanitize_test_filename(filename):
     # in py39 inspect.getfile returns absolute path, converting it to relative path if needed
     if filename.startswith(CI_TEST_PREFIX):
-        filename = filename[len(CI_TEST_PREFIX)+1:]
+        filename = filename[len(CI_TEST_PREFIX) + 1:]
     strip_py = re.sub(r'.py$', '', filename)
     return re.sub('/', r'.', strip_py)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -258,7 +258,7 @@ def chunk_list(lst, nchunks):
 
 # sanitize filename e.g., distributed/pipeline/sync/skip/test_api.py -> distributed.pipeline.sync.skip.test_api
 def sanitize_test_filename(filename):
-    # in py39 inspect.getfile returns absolute path, converting it to relative path if needed
+    # inspect.getfile returns absolute path in some CI jobs, converting it to relative path if needed
     if filename.startswith(CI_TEST_PREFIX):
         filename = filename[len(CI_TEST_PREFIX) + 1:]
     strip_py = re.sub(r'.py$', '', filename)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -189,6 +189,9 @@ if not expecttest.ACCEPT:
 UNITTEST_ARGS = [sys.argv[0]] + remaining
 torch.manual_seed(SEED)
 
+# CI Prefix path used only on CI environment
+CI_TEST_PREFIX = str(pathlib.Path(os.getcwd()))
+
 def wait_for_process(p):
     try:
         return p.wait()
@@ -255,6 +258,9 @@ def chunk_list(lst, nchunks):
 
 # sanitize filename e.g., distributed/pipeline/sync/skip/test_api.py -> distributed.pipeline.sync.skip.test_api
 def sanitize_test_filename(filename):
+    # in py39 inspect.getfile returns absolute path, converting it to relative path if needed
+    if filename.startswith(CI_TEST_PREFIX):
+        filename = filename[len(CI_TEST_PREFIX)+1:]
     strip_py = re.sub(r'.py$', '', filename)
     return re.sub('/', r'.', strip_py)
 


### PR DESCRIPTION
Root cause of this is for some reason: `inspect.getfile` returns absolute path instead of relative path to `os.getcwd` in newer python version. we sanitize this by removing the CI_PREFIX if applies

See:
https://app.circleci.com/pipelines/github/pytorch/pytorch/339568/workflows/43cac71c-759e-471f-83c2-d59c152dcd8a/jobs/14278585 vs. https://app.circleci.com/pipelines/github/pytorch/pytorch/339568/workflows/43cac71c-759e-471f-83c2-d59c152dcd8a/jobs/14278285

Test Plan:
CI


Plot twist: 

windows tests are actually launched via
```
pushd test
python run_test.py
```
while linux/macos tests are
```
python test/run_test.py
```
This might cause problem when using `os.getcwd()` we will see from PR CI results.