### PR TITLE
Weighted decay with frequency (count-based)

### DIFF
--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -1,5 +1,3 @@
-
-
 import functools
 
 import caffe2.python.hypothesis_test_util as hu
@@ -193,16 +191,15 @@ class TestAdagrad(serial.SerializedTestCase):
     @settings(suppress_health_check=[HealthCheck.filter_too_much], deadline=10000)
     @given(
         inputs=hu.tensors(n=3),
-        lr=st.floats(
-            min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
-        ),
-        epsilon=st.floats(
-            min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
-        ),
+        lr=st.sampled_from([0.01, 0.99]),
+        epsilon=st.sampled_from([0.01, 0.99]),
         weight_decay=st.sampled_from([0.0, 0.1]),
+        counter_halflife=st.sampled_from([-1, 5]),
         **hu.gcs
     )
-    def test_row_wise_sparse_adagrad(self, inputs, lr, epsilon, weight_decay, gc, dc):
+    def test_row_wise_sparse_adagrad(
+        self, inputs, lr, epsilon, weight_decay, counter_halflife, gc, dc
+    ):
         adagrad_sparse_test_helper(
             self,
             inputs,
@@ -214,6 +211,7 @@ class TestAdagrad(serial.SerializedTestCase):
             dc,
             row_wise=True,
             weight_decay=weight_decay,
+            counter_halflife=counter_halflife,
         )
 
     @given(

--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -958,6 +958,8 @@ class AdagradOptimizer(Optimizer):
                     ), "weight decay is not implemented for {} yet".format(op)
                     input_args += [mask_blob, mask_changed_blob]
                 else:
+                    if self.counter_halflife > 0:
+                        input_args += [update_counter]
                     op = "RowWiseSparseAdagrad"
             else:
                 if self.use_mask is True:
@@ -974,13 +976,22 @@ class AdagradOptimizer(Optimizer):
                 input_args += [lr_iteration, last_mask_updated_iter]
                 output_args += [mask_blob, last_mask_updated_iter]
 
-            if weight_decay > 0:
+            if weight_decay > 0 and self.counter_halflife == -1:
                 net.__getattr__(op)(
                     input_args,
                     output_args,
                     epsilon=self.epsilon,
                     weight_decay=weight_decay,
                     engine=self.engine,
+                )
+            elif weight_decay > 0 and self.counter_halflife != -1:
+                net.__getattr__(op)(
+                    input_args,
+                    output_args,
+                    epsilon=self.epsilon,
+                    weight_decay=weight_decay,
+                    engine=self.engine,
+                    counter_halflife=self.counter_halflife,
                 )
             else:
                 net.__getattr__(op)(

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -371,10 +371,13 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
       : Operator<Context>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
         weight_decay_(
-            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+            this->template GetSingleArgument<float>("weight_decay", 0.f)),
+        counter_halflife_(
+            this->template GetSingleArgument<int64_t>("counter_halflife", -1)) {
     VLOG(1) << "gradient optimization operator in use: "
             << "RowWiseSparseAdagradOp"
-            << " weight_decay_=" << weight_decay_;
+            << " weight_decay_=" << weight_decay_
+            << " counter_halflife=" << counter_halflife_;
   }
 
   bool RunOnDevice() override {
@@ -397,6 +400,9 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
 
     const auto* indices = Input(INDICES).template data<SIndex>();
     const auto* gradIn = Input(GRAD).template data<float>();
+    const auto* count = counter_halflife_ == -1
+        ? nullptr
+        : Input(COUNTER).template data<double>();
 
     auto n = Input(INDICES).numel();
     if (n == 0) {
@@ -459,8 +465,8 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
           epsilon_,
           lr[0],
           weight_decay_,
-          /*counter=*/nullptr,
-          /*counter_halflife=*/0);
+          (counter_halflife_ > 0) ? count : nullptr,
+          counter_halflife_);
     } else {
       num_rows_processed = kernel_i64_(
           n,
@@ -472,8 +478,8 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
           epsilon_,
           lr[0],
           weight_decay_,
-          /*counter=*/nullptr,
-          /*counter_halflife=*/0);
+          (counter_halflife_ > 0) ? count : nullptr,
+          counter_halflife_);
     }
 
     if (num_rows_processed < n) {
@@ -500,8 +506,11 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
 
     for (auto i = 0; i < n; ++i) {
       auto idx = indices[i];
+      float freq = (count[idx] > 0 && counter_halflife_ > 0)
+          ? counter_halflife_ / count[idx]
+          : 1.0;
       if (block_size == 1) {
-        float gi = std::fma(weight_decay_, param[idx], gradIn[i]);
+        float gi = std::fma(weight_decay_ * freq, param[idx], gradIn[i]);
         float hi = moment[idx] = moment[idx] + gi * gi;
         param[idx] = param[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
@@ -534,13 +543,13 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
         float* h = moment + idx;
         float hs = 0.;
         for (auto j = 0; j < block_size; ++j) {
-          float gj = std::fma(weight_decay_, w[j], g[j]);
+          float gj = std::fma(weight_decay_ * freq, w[j], g[j]);
           hs += gj * gj;
         }
         float hi = h[0] = h[0] + hs / block_size;
         float step = lr[0] / (std::sqrt(hi) + epsilon_);
         for (auto j = 0; j < block_size; ++j) {
-          float gj = std::fma(weight_decay_, w[j], g[j]);
+          float gj = std::fma(weight_decay_ * freq, w[j], g[j]);
           w[j] = w[j] + gj * step;
         }
       }
@@ -552,13 +561,14 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
  protected:
   float epsilon_;
   const float weight_decay_;
+  const int64_t counter_halflife_;
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
   fbgemm::SparseAdaGradSignature<std::int32_t>::Type kernel_i32_;
   fbgemm::SparseAdaGradSignature<std::int64_t>::Type kernel_i64_;
   std::int64_t last_block_size_{-1};
 #endif
 
-  INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR);
+  INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR, COUNTER);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1);
 };
 } // namespace caffe2


### PR DESCRIPTION
Summary: Instead of setting weight_decay w uniformly for all ids, for each row i in the sparse embedding table, the actual weight_decay `w_i` becomes `w*freq_i` where `freq_i = halflife/counter_i \in [\log(2), halflife]`. Counter is from `rowwise_counter` with definition `counter_i = 1 + \exp(-iter_{\delta}*\rho)*counter_i`.

Test Plan:
buck test //caffe2/caffe2/python/operator_test:adagrad_test -- test_row_wise_sparse_adagrad

buck test caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_weight_decay

Reviewed By: 0x10cxR1

Differential Revision: D25581030

