### PR TITLE
Annotate  NoneType as Optional[type]

### DIFF
--- a/test/jit/test_pdt.py
+++ b/test/jit/test_pdt.py
@@ -3,7 +3,7 @@ import sys
 import torch
 from torch.testing._internal.jit_utils import JitTestCase, make_global
 from torch.jit._monkeytype_config import _IS_MONKEYTYPE_INSTALLED
-from typing import List, Dict, Tuple, Any, NamedTuple  # noqa: F401
+from typing import List, Dict, Tuple, Any, Optional, NamedTuple  # noqa: F401
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -436,3 +436,36 @@ class TestPDT(JitTestCase):
         pdt_model = FXModel()
         scripted_fn = torch.jit._script_pdt(pdt_model, example_inputs={pdt_model: [([10, 20, ], ), ], })
         self.assertEqual(scripted_fn([20]), pdt_model([20]))
+
+    def test_nonetype_as_optional_of_tensor(self):
+        def test_none(a) -> Any:
+            if a is None:
+                return 0
+            else:
+                return a + torch.ones(1)
+
+        make_global(test_none)
+
+        scripted_fn = torch.jit._script_pdt(test_none, example_inputs=[(None, )])
+        self.assertEqual(scripted_fn(torch.ones(1), ), test_none(torch.ones(1), ))
+
+        class TestForwardWithNoneType(torch.nn.Module):
+            def forward(self, a):
+                count = 0
+                for i, val in enumerate(a):
+                    if val is None:
+                        count += 1
+                return count
+
+        make_global(TestForwardWithNoneType)
+        pdt_model = TestForwardWithNoneType()
+
+        # Test List[NoneType] as input
+        scripted_model = torch.jit._script_pdt(pdt_model, example_inputs=[([None, ], )])
+        self.assertEqual(scripted_model([torch.ones(1), torch.ones(1), None]),
+                         pdt_model([torch.ones(1), torch.ones(1), None]))
+
+        # Test Tuple[NoneType] as input
+        scripted_model = torch.jit._script_pdt(pdt_model, example_inputs=[((None, ), )])
+        self.assertEqual(scripted_model((torch.ones(1), torch.ones(1), None)),
+                         pdt_model((torch.ones(1), torch.ones(1), None)))

--- a/test/jit/test_pdt.py
+++ b/test/jit/test_pdt.py
@@ -3,7 +3,11 @@ import sys
 import torch
 from torch.testing._internal.jit_utils import JitTestCase, make_global
 from torch.jit._monkeytype_config import _IS_MONKEYTYPE_INSTALLED
+<<<<<<< HEAD
 from typing import List, Dict, Tuple, Any, Optional, NamedTuple  # noqa: F401
+=======
+from typing import List, Dict, Tuple, Any, Optional  # noqa: F401
+>>>>>>> f43ddae364 (Annotate  NoneType as Optional[torch.Tensor])
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -469,3 +473,16 @@ class TestPDT(JitTestCase):
         scripted_model = torch.jit._script_pdt(pdt_model, example_inputs=[((None, ), )])
         self.assertEqual(scripted_model((torch.ones(1), torch.ones(1), None)),
                          pdt_model((torch.ones(1), torch.ones(1), None)))
+        def test_none_for_list(a) -> List:
+            for i, val in enumerate(a):
+                if val is None:
+                    a[i] = torch.ones(1)
+                else:
+                    a[i] += torch.ones(1)
+            return a
+
+        make_global(test_none_for_list)
+
+        scripted_fn = torch.jit._script_pdt(test_none_for_list, example_inputs=[([None, ], )])
+        self.assertEqual(scripted_fn([torch.ones(1), torch.ones(1), None]),
+                         test_none_for_list([torch.ones(1), torch.ones(1), None]))

--- a/test/jit/test_pdt.py
+++ b/test/jit/test_pdt.py
@@ -3,7 +3,7 @@ import sys
 import torch
 from torch.testing._internal.jit_utils import JitTestCase, make_global
 from torch.jit._monkeytype_config import _IS_MONKEYTYPE_INSTALLED
-from typing import List, Dict, Tuple, Any  # noqa: F401
+from typing import List, Dict, Tuple, Any, Optional  # noqa: F401
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -422,3 +422,36 @@ class TestPDT(JitTestCase):
         pdt_model = TestNNParameter()
         scripted_fn = torch.jit._script_pdt(pdt_model, example_inputs={pdt_model: [(10, ), ], })
         self.assertEqual(scripted_fn(20), pdt_model(20))
+
+    def test_nonetype_as_optional_of_tensor(self):
+        def test_none(a) -> Any:
+            if a is None:
+                return 0
+            else:
+                return a + torch.ones(1)
+
+        make_global(test_none)
+
+        scripted_fn = torch.jit._script_pdt(test_none, example_inputs=[(None, )])
+        self.assertEqual(scripted_fn(torch.ones(1), ), test_none(torch.ones(1), ))
+
+        class TestForwardWithNoneType(torch.nn.Module):
+            def forward(self, a):
+                count = 0
+                for i, val in enumerate(a):
+                    if val is None:
+                        count += 1
+                return count
+
+        make_global(TestForwardWithNoneType)
+        pdt_model = TestForwardWithNoneType()
+
+        # Test List[NoneType] as input
+        scripted_model = torch.jit._script_pdt(pdt_model, example_inputs=[([None, ], )])
+        self.assertEqual(scripted_model([torch.ones(1), torch.ones(1), None]),
+                         pdt_model([torch.ones(1), torch.ones(1), None]))
+
+        # Test Tuple[NoneType] as input
+        scripted_model = torch.jit._script_pdt(pdt_model, example_inputs=[((None, ), )])
+        self.assertEqual(scripted_model((torch.ones(1), torch.ones(1), None)),
+                         pdt_model((torch.ones(1), torch.ones(1), None)))

--- a/torch/jit/_monkeytype_config.py
+++ b/torch/jit/_monkeytype_config.py
@@ -87,6 +87,10 @@ if _IS_MONKEYTYPE_INSTALLED:
                 if len(types) > 1:
                     all_args[arg] = {'Any'}
                 else:
+                    if 'NoneType' in _all_type:
+                        # Handle all Nonetype as Optional[torch.Tensor]
+                        # TODO: Handle Optional for other data types
+                        _all_type = _all_type.replace('NoneType', 'Optional[torch.Tensor]')
                     all_args[arg] = {_all_type[:-1]}
             return all_args
 

--- a/torch/jit/_monkeytype_config.py
+++ b/torch/jit/_monkeytype_config.py
@@ -85,6 +85,10 @@ if _IS_MONKEYTYPE_INSTALLED:
                 if len(types) > 1:
                     all_args[arg] = {'Any'}
                 else:
+                    if 'NoneType' in _all_type:
+                        # Handle all Nonetype as Optional[torch.Tensor]
+                        # TODO: Handle Optional for other data types
+                        _all_type = _all_type.replace('NoneType', 'Optional[torch.Tensor]')
                     all_args[arg] = {_all_type[:-1]}
             return all_args
 


### PR DESCRIPTION
Summary:
------------
Infer NoneType as Optional[torch.Tensor] for monkeytype type inference

Test:
------
python test/test_jit.py -k TestPDT.test_nonetype_as_optional_of_type
