### PR TITLE
[PyTorch][NASProfiler] Add moduleHierarchy Python API to print out hierarchical information about a Node

### DIFF
--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -4,7 +4,29 @@
 
 namespace torch {
 namespace jit {
+// util functions
+namespace utils {
 
+std::string get_module_info(const ModuleInstanceInfo& module_instance_info) {
+  std::string module_info;
+  const auto& class_type = module_instance_info.class_type();
+  std::string instance_name = module_instance_info.instance_name();
+  std::string type_name;
+  if (class_type) {
+    type_name += class_type->name()->qualifiedName();
+    type_name = type_name.substr(type_name.find_last_of('.') + 1);
+  }
+  if (type_name.empty()) {
+    type_name = "UNKNOWN_TYPE";
+  }
+  if (instance_name.empty()) {
+    instance_name = "UNKNOWN_INSTANCE";
+  }
+  module_info.append(instance_name).append("(").append(type_name).append(")");
+  return module_info;
+}
+
+} // namespace utils
 ScopePtr Scope::intrusive_from_this() {
   c10::raw::intrusive_ptr::incref(this); // we are creating a new pointer
                                          // from a raw `this` pointer

--- a/torch/csrc/jit/ir/scope.h
+++ b/torch/csrc/jit/ir/scope.h
@@ -9,6 +9,11 @@
 
 namespace torch {
 namespace jit {
+struct ModuleInstanceInfo;
+namespace utils {
+TORCH_API std::string get_module_info(
+    const ModuleInstanceInfo& module_instance_info);
+} // namespace utils
 
 // Scope is a node of a trie that represents the tree of nested scopes.
 // Individual scopes are pushed and popped from Graph, which holds a

--- a/torch/csrc/jit/mobile/debug_info.cpp
+++ b/torch/csrc/jit/mobile/debug_info.cpp
@@ -35,24 +35,18 @@ std::pair<std::vector<StackEntry>, std::string> getStackTraceWithModuleHierarchy
       const auto& opt_module_instance_info = callstack_ptr->module_instance();
       if (opt_module_instance_info.has_value()) {
         const auto& module_instance_info = opt_module_instance_info.value();
+        // Sometimes (e.g., in lowered backends) we augment instance name with
+        // type name instead of losing type name. In those cases instance_name
+        // includes both instance name and type name. See
+        // callstack_debug_info_serialization.cpp
         if (module_instance_info.class_type()) {
-          const auto& class_type = module_instance_info.class_type();
-          const auto& instance_name = module_instance_info.instance_name();
-          auto type_name = class_type->name()->qualifiedName();
-          type_name = type_name.substr(type_name.find_last_of('.') + 1);
-          module_info.append(".")
-              .append(instance_name)
-              .append("(")
-              .append(type_name)
-              .append(")");
-        } else if (!module_instance_info.instance_name().empty()) {
-          module_info += "." + module_instance_info.instance_name();
+          module_info.append(".").append(
+              utils::get_module_info(module_instance_info));
         } else {
-          const auto& instance_name = module_instance_info.instance_name();
-          module_info += "." + instance_name + "(UNKNOWN_TYPE)";
+          module_info.append(".").append(module_instance_info.instance_name());
         }
       } else {
-        module_info += ".(UNKNOWN_INSTANCE(UNKNOWN_TYPE)";
+        module_info += ".UNKNOWN_INSTANCE(UNKNOWN_TYPE)";
       }
       // Now add source range info to stack
       // When we serialize function names, those can be added here.

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -570,6 +570,30 @@ void initPythonIRBindings(PyObject* module_) {
           py::arg("recurse") = true)
       .def("input", [](Node& n) { return n.input(); })
       .def("output", [](Node& n) { return n.output(); })
+      .def(
+          "getModuleHierarchy",
+          [](Node& n) {
+            if (!n.callstack().has_value()) {
+              return std::string();
+            }
+            InlinedCallStackPtr callstack_ptr = n.callstack().value();
+            std::string module_info;
+            for (auto& entry : callstack_ptr->vec()) {
+              const auto& opt_module_info =
+                  std::get<kModuleInstanceInfo>(entry);
+              if (opt_module_info.has_value()) {
+                const auto& module_instance_info = opt_module_info.value();
+                if (!module_info.empty()) {
+                  module_info.append(".");
+                }
+                module_info.append(
+                    utils::get_module_info(module_instance_info));
+              } else {
+                module_info += ".UNKNOWN_INSTANCE(UNKNOWN_TYPE)";
+              }
+            }
+            return module_info;
+          })
       .NS(addInput)
       .NS(replaceInput)
       .NS(replaceInputWith)

--- a/torch/csrc/jit/python/python_ir.h
+++ b/torch/csrc/jit/python/python_ir.h
@@ -6,6 +6,8 @@
 namespace torch {
 namespace jit {
 
+constexpr size_t kModuleInstanceInfo = 2;
+
 void initPythonIRBindings(PyObject* module);
 
 // execute a Python function, used for Ops we can't optimize but that we want to


### PR DESCRIPTION
Summary: Currently inlining module graph will drop module hierarchy info on Python side. Here we retrieve the module hierarchy from cpp side and expose it to a new Python API on Node called `moduleHierarchy()`.

Test Plan:
Usage:
```
torch._C._jit_pass_inline(module.graph)
torch._C._jit_pass_propagate_shapes_on_graph(module.graph)
node = module.graph.findNode("quantized::conv2d_relu")
'top(' + module.original_name + ').' + node.moduleHierarchy() + '.' + node.kind()
```
Output:
```
'top(QuantWrapper).module(FBNetHR).0(Sequential).xif0_0(ConvBNRelu).conv(ConvReLU2d).quantized::conv2d_relu'
```

Differential Revision: D29252169

