### PR TITLE
fixed launch bounds for grid sampler 3d

### DIFF
--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -25,12 +25,12 @@ namespace at { namespace cuda { namespace detail {
 constexpr int CUDA_NUM_THREADS = 1024;
 
 // CUDA: number of blocks for threads.
-inline int GET_BLOCKS(const int64_t N) {
+inline int GET_BLOCKS(const int64_t N, const int64_t max_threads_per_block=CUDA_NUM_THREADS) {
   TORCH_INTERNAL_ASSERT(N > 0, "CUDA kernel launch blocks must be positive, but got N=", N);
   constexpr int64_t max_int = std::numeric_limits<int>::max();
 
   // Round up division for positive number that cannot cause integer overflow
-  auto block_num = (N - 1) / CUDA_NUM_THREADS + 1;
+  auto block_num = (N - 1) / max_threads_per_block + 1;
   TORCH_INTERNAL_ASSERT(block_num <= max_int, "Can't schedule too many blocks on CUDA device");
 
   return static_cast<int>(block_num);

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -143,7 +143,7 @@ namespace {
   }
 
   template <typename scalar_t, typename index_t>
-  C10_LAUNCH_BOUNDS_1(1024)
+  C10_LAUNCH_BOUNDS_1(512)
   __global__ void grid_sampler_3d_kernel(
       const index_t nthreads,
       TensorInfo<scalar_t, index_t> input,
@@ -476,7 +476,7 @@ namespace {
   }
 
   template <typename scalar_t, typename index_t>
-  C10_LAUNCH_BOUNDS_1(1024)
+  C10_LAUNCH_BOUNDS_1(256)
   __global__ void grid_sampler_3d_backward_kernel(
       const index_t nthreads,
       TensorInfo<scalar_t, index_t> grad_output,
@@ -741,7 +741,7 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(output)) {
         grid_sampler_3d_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
             getTensorInfo<scalar_t, int>(input),
             getTensorInfo<scalar_t, int>(grid),
@@ -752,7 +752,7 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_3d_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
             count,
             getTensorInfo<scalar_t, int64_t>(input),
             getTensorInfo<scalar_t, int64_t>(grid),
@@ -836,7 +836,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(grad_output)) {
         grid_sampler_3d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
             getTensorInfo<scalar_t, int>(grad_output),
             getTensorInfo<scalar_t, int>(input),
@@ -849,7 +849,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_3d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             count,
             getTensorInfo<scalar_t, int64_t>(grad_output),
             getTensorInfo<scalar_t, int64_t>(input),


### PR DESCRIPTION
Changed launch bounds for grid_sampler_3d from 1024 to 512 and grid_sampler_3d_backward from 1024 to 256.

Timing data (using Nvidia Titan-V):
![GridSampler3dTimingData](https://user-images.githubusercontent.com/22803332/122813457-d3c12300-d287-11eb-99c1-6572f539660f.PNG)

