### PR TITLE
Accumulate 16-bit float sums in 32-bit accumulators

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -16,11 +16,15 @@ namespace {
 
 #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 
+static inline void cvtbf16_fp32(const __m128i& a, __m256& o) {
+  o = _mm256_castsi256_ps(_mm256_slli_epi32(_mm256_cvtepu16_epi32(a), 16));
+}
+
 static inline void cvtbf16_fp32(const __m256i& a, __m256& o1, __m256& o2) {
   __m128i lo = _mm256_extractf128_si256(a, 0);
   __m128i hi = _mm256_extractf128_si256(a, 1);
-  o1 = _mm256_castsi256_ps(_mm256_slli_epi32(_mm256_cvtepu16_epi32(lo), 16));
-  o2 = _mm256_castsi256_ps(_mm256_slli_epi32(_mm256_cvtepu16_epi32(hi), 16));
+  cvtbf16_fp32(lo, o1);
+  cvtbf16_fp32(hi, o2);
 }
 static inline __m256i cvtfp32_bf16(const __m256& a, const __m256& b) {
   __m256i lo = _mm256_castps_si256(a);

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -348,7 +348,6 @@ void vectorized_outer_sum(
   using StorePolicy = CastStoreAccumulate<scalar_t, acc_t>;
 
   constexpr int64_t vec_stride = vacc_t::size() * sizeof(scalar_t);
-  const int64_t vec_size = size0 / vacc_t::size();
   constexpr int64_t nrows = 4;
 
   // Input is contiguous over the second (non-reduced) dimension

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -1,18 +1,18 @@
-#include <ATen/native/ReduceOps.h>
-
-#include <algorithm>
-
+#include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/native/ReduceOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Reduce.h>
 #include <ATen/native/cpu/utils.h>
+
+#include <algorithm>
 
 namespace at {
 namespace native {
 namespace {
 
 template <typename scalar_t>
-struct LoadImpl {
+struct LoadPolicy {
   static scalar_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
     auto *ptr = reinterpret_cast<const scalar_t*>(data + index * stride);
     return *ptr;
@@ -20,31 +20,144 @@ struct LoadImpl {
 };
 
 template <typename scalar_t>
-struct LoadImpl<Vectorized<scalar_t>> {
+struct LoadPolicy<Vectorized<scalar_t>> {
   static Vectorized<scalar_t> load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
     auto *ptr = data + index * stride;
     return Vectorized<scalar_t>::loadu(ptr);
   }
 };
 
-template <typename T>
-T load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
-  return LoadImpl<T>::load(data, stride, index);
-}
+template <typename scalar_t, typename acc_t>
+struct CastLoadPolicy {
+  static acc_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    const auto val = LoadPolicy<scalar_t>::load(data, stride, index);
+    return acc_t(val);
+  }
+};
 
 template <typename scalar_t>
-void accumulate_result(char * C10_RESTRICT data, int64_t stride, int64_t index, scalar_t value) {
-  auto *const ptr = reinterpret_cast<scalar_t*>(data + index * stride);
-  *ptr += value;
+struct CastLoadPolicy<scalar_t, scalar_t>:
+    LoadPolicy<scalar_t> {
+};
+
+// For inner sum, load full vec_t then sum partials down to vacc_t size
+template <typename vec_t, typename vacc_t>
+struct InnerSumCastLoadPolicy {
+  using scalar_t = typename vec_t::value_type;
+  using acc_t = typename vacc_t::value_type;
+
+  static vacc_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    const auto val = LoadPolicy<vec_t>::load(data, stride, index);
+    alignas(64) scalar_t values[vec_t::size()];
+    val.store(values);
+
+    constexpr int vstride = vec_t::size() / vacc_t::size();
+    alignas(64) acc_t acc[vacc_t::size()];
+    for (int i = 0; i < vacc_t::size(); ++i) {
+      acc[i] = values[i * vstride];
+    }
+    for (int k = 1; k < vstride; ++k) {
+      for (int i = 0; i < vacc_t::size(); ++i) {
+        acc[i] += values[i * vstride + k];
+      }
+    }
+
+    return vacc_t::loadu(acc);
+  }
+};
+
+template <typename scalar_t>
+struct InnerSumCastLoadPolicy<scalar_t, scalar_t>:
+    LoadPolicy<scalar_t> {
+};
+
+#if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
+template <>
+struct InnerSumCastLoadPolicy<Vectorized<c10::BFloat16>, Vectorized<float>> {
+  using vec_t = Vectorized<c10::BFloat16>;
+  using vacc_t = Vectorized<float>;
+
+  static vacc_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    auto ptr = reinterpret_cast<const __m256i*>(data + stride * index);
+    __m256i values = _mm256_loadu_si256(ptr);
+    __m256 first, second;
+    cvtbf16_fp32(values, first, second);
+    return _mm256_add_ps(first, second);
+  }
+};
+#endif
+
+// For outer sum, load a partial vec_t of size vacc_t then cast to vacc_t
+template <typename vec_t, typename vacc_t>
+struct OuterSumCastLoadPolicy {
+  using scalar_t = typename vec_t::value_type;
+  using acc_t = typename vacc_t::value_type;
+
+  static vacc_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    const auto val = vec_t::loadu(data + stride * index, vacc_t::size());
+    alignas(64) scalar_t values[vec_t::size()];
+    val.store(values);
+
+    alignas(64) acc_t acc[vacc_t::size()];
+    for (int i = 0; i < vacc_t::size(); ++i) {
+      acc[i] = values[i];
+    }
+
+    return vacc_t::loadu(acc);
+  }
+};
+
+#if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
+template <>
+struct OuterSumCastLoadPolicy<Vectorized<c10::BFloat16>, Vectorized<float>> {
+  using vec_t = Vectorized<c10::BFloat16>;
+  using vacc_t = Vectorized<float>;
+
+  static vacc_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    auto ptr = reinterpret_cast<const __m128i*>(data + stride * index);
+    __m128i bf_vals = _mm_loadu_si128(ptr);
+    __m256 f_vals;
+    cvtbf16_fp32(bf_vals, f_vals);
+    return f_vals;
+  }
+};
+#endif
+
+template <typename scalar_t>
+struct OuterSumCastLoadPolicy<scalar_t, scalar_t>:
+    LoadPolicy<scalar_t> {
+};
+
+template <typename scalar_t, typename acc_t>
+struct CastStoreAccumulate {
+  static void store(char * C10_RESTRICT data, int64_t stride, int64_t index, acc_t value) {
+    auto * ptr = reinterpret_cast<scalar_t*>(data + index * stride);
+    *ptr += value;
+  }
+};
+
+template <typename StorePolicy, typename scalar_t>
+static void store(char * C10_RESTRICT data, int64_t stride, int64_t index, scalar_t value) {
+  StorePolicy::store(data, stride, index, value);
 }
 
-template <typename scalar_t, size_t numel>
-void accumulate_result(char * C10_RESTRICT data, int64_t stride, int64_t index,
-    const std::array<scalar_t, numel> &values) {
-  auto *const base_ptr = data + stride * index;
-  for (const auto k : c10::irange(numel)) {
-    accumulate_result(base_ptr, stride, k, values[k]);
+template <typename StorePolicy, typename scalar_t, size_t numel>
+static void store(char * C10_RESTRICT data, int64_t stride, int64_t index,
+                  const std::array<scalar_t, numel> &values) {
+  auto *base_ptr = data + stride * index;
+  for (size_t k = 0; k < numel; ++k) {
+    auto val = values[k];
+    StorePolicy::store(base_ptr, stride, k, val);
   }
+}
+
+template <typename StorePolicy, typename scalar_t>
+static void store(char * C10_RESTRICT data, int64_t stride, int64_t index,
+                  const Vectorized<scalar_t> &values) {
+  using vec_t = Vectorized<scalar_t>;
+  alignas(64) std::array<scalar_t, vec_t::size()> array_values;
+  values.store(array_values.data());
+  store<StorePolicy>(data, stride, index, array_values);
 }
 
 /** Simultaneously sum over n rows at once
@@ -80,7 +193,7 @@ A simplified recursive implementation would look like this:
     return sum;
   }
 */
-template <typename scalar_t, int64_t nrows>
+template <typename scalar_t, int64_t nrows, typename LoadPolicy>
 std::array<scalar_t, nrows> multi_row_sum(
     const char * C10_RESTRICT in_data,
     const int64_t row_stride,
@@ -105,7 +218,7 @@ std::array<scalar_t, nrows> multi_row_sum(
       # pragma unroll
       #endif
       for (int64_t k = 0; k < nrows; ++k) {
-        acc[0][k] += load<scalar_t>(sum_base, col_stride, k);
+        acc[0][k] += LoadPolicy::load(sum_base, col_stride, k);
       }
     }
 
@@ -131,7 +244,7 @@ std::array<scalar_t, nrows> multi_row_sum(
     # pragma unroll
     #endif
     for (int64_t k = 0; k < nrows; ++k) {
-      acc[0][k] += load<scalar_t>(sum_base, col_stride, k);
+      acc[0][k] += LoadPolicy::load(sum_base, col_stride, k);
     }
   }
 
@@ -152,18 +265,18 @@ std::array<scalar_t, nrows> multi_row_sum(
   return ret;
 }
 
-template <typename scalar_t>
+template <typename scalar_t, typename LoadPolicy>
 scalar_t row_sum(const char * C10_RESTRICT in_data,
                  const int64_t in_stride, const int64_t size) {
   constexpr int64_t ilp_factor = 4;
 
   // Interpret row as a (-1, ilp_factor) shaped array to find partial sums
   const int64_t size_ilp = size / ilp_factor;
-  auto partial_sums = multi_row_sum<scalar_t, ilp_factor>(
+  auto partial_sums = multi_row_sum<scalar_t, ilp_factor, LoadPolicy>(
       in_data, in_stride * ilp_factor, in_stride, size_ilp);
 
   for (int64_t i = size_ilp * ilp_factor; i < size; ++i) {
-    partial_sums[0] += load<scalar_t>(in_data, in_stride, i);
+    partial_sums[0] += LoadPolicy::load(in_data, in_stride, i);
   }
 
   for (int64_t k = 1; k < ilp_factor; ++k) {
@@ -179,26 +292,30 @@ void vectorized_inner_sum(
     char * C10_RESTRICT data[2], int64_t outer_stride, int64_t out_stride,
     int64_t size0, int64_t size1) {
   using vec_t = Vectorized<scalar_t>;
+  using acc_t = at::acc_type<scalar_t, true>;
+  using vacc_t = Vectorized<acc_t>;
+  using VecLoadPolicy = InnerSumCastLoadPolicy<vec_t, vacc_t>;
+  using ScalarLoadPolicy = CastLoadPolicy<scalar_t, acc_t>;
+  using StorePolicy = CastStoreAccumulate<scalar_t, acc_t>;
   constexpr int64_t vec_stride = vec_t::size() * sizeof(scalar_t);
   const int64_t vec_size = size0 / vec_t::size();
 
   // Input is contiguous over the first (reduced) dimension
   for (int64_t j = 0; j < size1; ++j) {
     const auto *row_in = data[1] + j * outer_stride;
-    auto vec_acc = row_sum<vec_t>(row_in, vec_stride, vec_size);
+    auto vec_acc = row_sum<vacc_t, VecLoadPolicy>(row_in, vec_stride, vec_size);
 
-    scalar_t final_acc = 0;
+    acc_t final_acc = 0;
     for (int64_t k = vec_size * vec_t::size(); k < size0; ++k) {
-      final_acc += load<scalar_t>(row_in, sizeof(scalar_t), k);
+      final_acc += ScalarLoadPolicy::load(row_in, sizeof(scalar_t), k);
     }
 
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    scalar_t partials[vec_t::size()];
-    vec_acc.store(partials);
-    for (int64_t k = 0; k < vec_t::size(); ++k) {
+    alignas(64) std::array<acc_t, vacc_t::size()> partials;
+    vec_acc.store(partials.data());
+    for (size_t k = 0; k < partials.size(); ++k) {
       final_acc += partials[k];
     }
-    accumulate_result(data[0], out_stride, j, final_acc);
+    store<StorePolicy>(data[0], out_stride, j, final_acc);
   }
 }
 
@@ -207,10 +324,14 @@ void scalar_inner_sum(
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char * C10_RESTRICT data[2], int64_t in_strides[2], int64_t out_stride,
     int64_t size0, int64_t size1) {
+  using acc_t = at::acc_type<scalar_t, true>;
+  using LoadPolicy = CastLoadPolicy<scalar_t, acc_t>;
+  using StorePolicy = CastStoreAccumulate<scalar_t, acc_t>;
+
   for (int64_t j = 0; j < size1; ++j) {
     const auto *row_in = data[1] + j * in_strides[1];
-    scalar_t ans = row_sum<scalar_t>(row_in, in_strides[0], size0);
-    accumulate_result(data[0], out_stride, j, ans);
+    auto ans = row_sum<acc_t, LoadPolicy>(row_in, in_strides[0], size0);
+    store<StorePolicy>(data[0], out_stride, j, ans);
   }
 }
 
@@ -220,39 +341,42 @@ void vectorized_outer_sum(
     char * C10_RESTRICT data[2], int64_t inner_stride, int64_t out_stride,
     int64_t size0, int64_t size1) {
   using vec_t = Vectorized<scalar_t>;
+  using acc_t = at::acc_type<scalar_t, true>;
+  using vacc_t = Vectorized<acc_t>;
+  using VecLoadPolicy = OuterSumCastLoadPolicy<vec_t, vacc_t>;
+  using ScalarLoadPolicy = CastLoadPolicy<scalar_t, acc_t>;
+  using StorePolicy = CastStoreAccumulate<scalar_t, acc_t>;
+
+  constexpr int64_t vec_stride = vacc_t::size() * sizeof(scalar_t);
+  const int64_t vec_size = size0 / vacc_t::size();
   constexpr int64_t nrows = 4;
-  constexpr int64_t vec_stride = vec_t::size() * sizeof(scalar_t);
 
   // Input is contiguous over the second (non-reduced) dimension
   int64_t j = 0;
-  for (; j + nrows * vec_t::size() <= size1; j += nrows * vec_t::size()) {
+  for (; j + nrows * vacc_t::size() <= size1; j += nrows * vacc_t::size()) {
     const auto *row_in = data[1] + j * sizeof(scalar_t);
-    auto sums = multi_row_sum<vec_t, nrows>(row_in, inner_stride, vec_stride, size0);
+    auto sums = multi_row_sum<vacc_t, nrows, VecLoadPolicy>(
+        row_in, inner_stride, vec_stride, size0);
 
     for (int64_t i = 0; i < nrows; ++i) {
-      const int64_t base_idx = j + i * vec_t::size();
-
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-      std::array<scalar_t, vec_t::size()> ans;
-      sums[i].store(ans.data());
-      accumulate_result(data[0], out_stride, base_idx, ans);
+      const int64_t base_idx = j + i * vacc_t::size();
+      store<StorePolicy>(data[0], out_stride, base_idx, sums[i]);
     }
   }
 
-  for (; j + vec_t::size() <= size1; j += vec_t::size()) {
+  for (; j + vacc_t::size() <= size1; j += vacc_t::size()) {
     const auto *row_in = data[1] + j * sizeof(scalar_t);
-    const vec_t sums = row_sum<vec_t>(row_in, inner_stride, size0);
+    const vacc_t sums = row_sum<vacc_t, VecLoadPolicy>(
+        row_in, inner_stride, size0);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-    std::array<scalar_t, vec_t::size()> ans;
-    sums.store(ans.data());
-    accumulate_result(data[0], out_stride, j, ans);
+    store<StorePolicy>(data[0], out_stride, j, sums);
   }
 
   for (; j < size1; ++j) {
     const auto *row_in = data[1] + j * sizeof(scalar_t);
-    scalar_t ans = row_sum<scalar_t>(row_in, inner_stride, size0);
-    accumulate_result(data[0], out_stride, j, ans);
+    auto ans = row_sum<acc_t, ScalarLoadPolicy>(row_in, inner_stride, size0);
+    store<StorePolicy>(data[0], out_stride, j, ans);
   }
 }
 
@@ -261,20 +385,24 @@ void scalar_outer_sum(
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char * C10_RESTRICT data[2], int64_t in_strides[2], int64_t out_stride,
     int64_t size0, int64_t size1) {
+  using acc_t = at::acc_type<scalar_t, true>;
+  using LoadPolicy = CastLoadPolicy<scalar_t, acc_t>;
+  using StorePolicy = CastStoreAccumulate<scalar_t, acc_t>;
 
   constexpr int64_t nrows = 4;
   int64_t j = 0;
   for (; j + (nrows - 1) < size1; j += nrows) {
     const auto *row_in = data[1] + j * in_strides[1];
-    auto sums = multi_row_sum<scalar_t, nrows>(
+    auto sums = multi_row_sum<acc_t, nrows, LoadPolicy>(
         row_in, in_strides[0], in_strides[1], size0);
-    accumulate_result(data[0], out_stride, j, sums);
+    store<StorePolicy>(data[0], out_stride, j, sums);
   }
 
   for (; j < size1; ++j) {
     const auto *row_in = data[1] + j * in_strides[1];
-    scalar_t ans = row_sum<scalar_t>(row_in, in_strides[0], size0);
-    accumulate_result(data[0], out_stride, j, ans);
+    auto ans = row_sum<acc_t, LoadPolicy>(
+        row_in, in_strides[0], size0);
+    store<StorePolicy>(data[0], out_stride, j, ans);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60389 WIP: Accumulate float sums in double accumulators
* **#60387 Accumulate 16-bit float sums in 32-bit accumulators**

Fixes gh-59489

Using 32-bit accumulators is a win-win: improved precision and improved
performance since the half precision types needed to be converted back and forth
to 32-bit float to do the arithmetic anyway.

Note that on multi-threaded or dis-contiguous sums, there can be partial sums
stored in the output so they are necessarily trucated to 16-bit. Fixing this
would require a rework of TensorIterator reductions.

Differential Revision: [D29447187](https://our.internmc.facebook.com/intern/diff/D29447187)