### PR TITLE
Add proper implementations for select, slice and squeeze

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
@@ -842,16 +842,10 @@ at::Tensor repeat(const at::Tensor& self, at::IntArrayRef repeats) {
       bridge::GetLtcTensor(self), Helpers::I64List(repeats)));
 }
 
-// TODO(asuhan): Fix the select and copy_ combination below and rely on the core
-// implementation of select_backward instead, removing this one.
-at::Tensor select_backward(const at::Tensor& grad, at::IntArrayRef input_sizes,
-                           int64_t dim, int64_t index) {
+at::Tensor select(const at::Tensor& self, int64_t dim, int64_t index) {
   LTC_FN_COUNTER("xla::");
-  at::Tensor eager_grad =
-      grad.to(lazy_tensors::NNCComputationClient::HardwareDeviceType());
-  auto eager_grad_input = at::zeros(input_sizes, eager_grad.options());
-  eager_grad_input.select(dim, index).copy_(grad);
-  return bridge::CreateLtcTensor(eager_grad_input, bridge::GetLtcDevice(grad));
+  return bridge::AtenFromLtcTensor(
+      LazyTensor::select(bridge::GetLtcTensor(self), dim, index));
 }
 
 at::Tensor stack(at::TensorList tensors, int64_t dim) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
@@ -77,11 +77,7 @@ at::Tensor subtensor(const at::Tensor& tensor, int dim, int groups, int g) {
     return at::Tensor();
   }
   int64_t n = tensor.sizes()[dim] / groups;
-  at::Tensor eager_tensor =
-      tensor.to(lazy_tensors::NNCComputationClient::HardwareDeviceType());
-  return bridge::CreateLtcTensor(
-      eager_tensor.narrow(dim, n * g, n).contiguous(),
-      bridge::GetLtcDevice(tensor));
+  return tensor.narrow(dim, n * g, n).contiguous();
 }
 
 }  // namespace
@@ -846,6 +842,16 @@ at::Tensor select(const at::Tensor& self, int64_t dim, int64_t index) {
   LTC_FN_COUNTER("xla::");
   return bridge::AtenFromLtcTensor(
       LazyTensor::select(bridge::GetLtcTensor(self), dim, index));
+}
+
+at::Tensor slice(const at::Tensor& self, int64_t dim,
+                 c10::optional<int64_t> start, c10::optional<int64_t> end,
+                 int64_t step) {
+  int64_t start_val = start.has_value() ? start.value() : 0;
+  int64_t end_val = end.has_value() ? end.value() : INT64_MAX;
+  LTC_FN_COUNTER("xla::");
+  return bridge::AtenFromLtcTensor(LazyTensor::slice(
+      bridge::GetLtcTensor(self), dim, start_val, end_val, step));
 }
 
 at::Tensor stack(at::TensorList tensors, int64_t dim) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
@@ -860,39 +860,29 @@ at::Tensor stack(at::TensorList tensors, int64_t dim) {
       LazyTensor::stack(bridge::GetLtcTensors(tensors), dim));
 }
 
+at::Tensor squeeze(const at::Tensor& self) {
+  LTC_FN_COUNTER("xla::");
+  return bridge::AtenFromLtcTensor(
+      LazyTensor::squeeze(bridge::GetLtcTensor(self)));
+}
+
+at::Tensor squeeze(const at::Tensor& self, int64_t dim) {
+  LTC_FN_COUNTER("xla::");
+  return bridge::AtenFromLtcTensor(
+      LazyTensor::squeeze(bridge::GetLtcTensor(self), dim));
+}
+
 at::Tensor& squeeze_(at::Tensor& self) {
-  LTC_FN_TRACK(3);
-  LTC_COUNTER("aten::squeeze_", 1);
-  LTC_VLOG(3) << "XLA squeeze_ :"
-              << " self=" << self.toString();
-  std::vector<at::Tensor> xlatens_tensors = {self};
-  auto xlatens = bridge::LtcCreateTensorList(xlatens_tensors);
-  xlatens[0].squeeze_();
-  std::vector<size_t> xlatens_update_indices = {0};
-  if (bridge::IsInteropView(self)) {
-    bridge::LtcUpdateTensorsMeta(xlatens_tensors, xlatens,
-                                 xlatens_update_indices);
-  } else {
-    bridge::LtcUpdateTensors(xlatens_tensors, xlatens, xlatens_update_indices);
-  }
+  LTC_FN_COUNTER("xla::");
+  LazyTensor self_tensor = bridge::GetLtcTensor(self);
+  LazyTensor::squeeze_(self_tensor);
   return self;
 }
 
 at::Tensor& squeeze_(at::Tensor& self, int64_t dim) {
-  LTC_FN_TRACK(3);
-  LTC_COUNTER("aten::squeeze_", 1);
-  LTC_VLOG(3) << "XLA squeeze_ :"
-              << " self=" << self.toString();
-  std::vector<at::Tensor> xlatens_tensors = {self};
-  auto xlatens = bridge::LtcCreateTensorList(xlatens_tensors);
-  xlatens[0].squeeze_(dim);
-  std::vector<size_t> xlatens_update_indices = {0};
-  if (bridge::IsInteropView(self)) {
-    bridge::LtcUpdateTensorsMeta(xlatens_tensors, xlatens,
-                                 xlatens_update_indices);
-  } else {
-    bridge::LtcUpdateTensors(xlatens_tensors, xlatens, xlatens_update_indices);
-  }
+  LTC_FN_COUNTER("xla::");
+  LazyTensor self_tensor = bridge::GetLtcTensor(self);
+  LazyTensor::squeeze_(self_tensor, dim);
   return self;
 }
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -38,6 +38,7 @@ supported:
   - permute
   - repeat
   - select.int
+  - slice.Tensor
   - _softmax
   - _softmax_backward_data
   - squeeze_

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -37,7 +37,7 @@ supported:
   - max_pool3d_with_indices_backward
   - permute
   - repeat
-  - select_backward
+  - select.int
   - _softmax
   - _softmax_backward_data
   - squeeze_

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -41,6 +41,8 @@ supported:
   - slice.Tensor
   - _softmax
   - _softmax_backward_data
+  - squeeze
+  - squeeze.dim
   - squeeze_
   - squeeze_.dim
   - stack


### PR DESCRIPTION
Lowering `ltc_{generic_slice, update_slice}` is straightforward using `aten::slice` and in-place copy. Also, add true lowerings for squeeze operations, we have the underlying infrastructure now.