### PR TITLE
fixed launch bounds for gamma_cuda_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -133,7 +133,7 @@ void gamma_cuda_kernel(
         ret_val = (min_value > sample) ? min_value : sample;
       };
   at::cuda::CUDA_tensor_apply2<scalar_t, scalar_t, decltype(functor),
-                               /*max_threads_per_block=*/512,
+                               /*max_threads_per_block=*/256,
                                /*min_blocks_per_sm==*/2>(ret, alpha, functor);
 }
 


### PR DESCRIPTION
Changed launch bounds for gamma_cuda_kernel from 512 to 256.

Timing data (using Nvidia Titan-V):
![GammaTimingData](https://user-images.githubusercontent.com/22803332/122821464-bc873300-d291-11eb-9be6-2fb690f0d5c7.PNG)

