### PR TITLE
[1/n]support double for Caffe2 ScatterWeightedSum

### DIFF
--- a/caffe2/operators/utility_ops.cc
+++ b/caffe2/operators/utility_ops.cc
@@ -58,7 +58,7 @@ REGISTER_CPU_OPERATOR(WeightedSumGradient, WeightedSumGradientOp<CPUContext>);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_CPU_OPERATOR(
     ScatterWeightedSum,
-    ScatterWeightedSumOp<float, CPUContext>);
+    ScatterWeightedSumOp<CPUContext>);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_CPU_OPERATOR(ScatterAssign, ScatterAssignOp<CPUContext>);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/caffe2/operators/utility_ops.cu
+++ b/caffe2/operators/utility_ops.cu
@@ -188,13 +188,16 @@ __global__ void AxpySliceKernel2(
 }
 
 template <>
-bool ScatterWeightedSumOp<float, CUDAContext>::RunOnDevice() {
-  return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(this, Input(2));
+bool ScatterWeightedSumOp<CUDAContext>::RunOnDevice() {
+  const auto& x0 = Input(0);
+  const auto x0Type = TypeMetaToDataType(x0.dtype());
+  CAFFE_ENFORCE_EQ(x0Type, TensorProto_DataType_FLOAT, "Only float type is allowed for X0 on GPU.");
+  return ScatterWeightedSumOp<CUDAContext>::template DoRun<float>();
 }
 
 template <>
-template <typename Index>
-bool ScatterWeightedSumOp<float, CUDAContext>::DoRunWithType() {
+template <typename T, typename Index>
+bool ScatterWeightedSumOp<CUDAContext>::DoRunWithType() {
   CAFFE_ENFORCE_EQ(InputSize() % 2, 1);
   auto& X0 = Input(0);
   auto& weight0 = Input(1);
@@ -279,7 +282,7 @@ bool ScatterWeightedSumOp<float, CUDAContext>::DoRunWithType() {
 
 REGISTER_CUDA_OPERATOR(
     ScatterWeightedSum,
-    ScatterWeightedSumOp<float, CUDAContext>);
+    ScatterWeightedSumOp<CUDAContext>);
 
 namespace {
 

--- a/caffe2/utils/math/elementwise.cc
+++ b/caffe2/utils/math/elementwise.cc
@@ -370,6 +370,7 @@ CAFFE2_SPECIALIZED_SCALE(float, double)
         ConstEigenVectorArrayMap<TData>(X, N) * static_cast<TData>(*alpha); \
   }
 CAFFE2_SPECIALIZED_AXPY(float, float)
+CAFFE2_SPECIALIZED_AXPY(float, double)
 #undef CAFFE2_SPECIALIZED_AXPY
 
 #else // CAFFE2_USE_EIGEN_FOR_BLAS
@@ -494,6 +495,7 @@ DELEGATE_SCALE(float, double, cblas_dscal)
     BLASFunc(N, static_cast<TData>(*alpha), X, 1, Y, 1); \
   }
 DELEGATE_AXPY(float, float, cblas_saxpy)
+DELEGATE_AXPY(float, double, cblas_daxpy)
 #undef DELEGATE_AXPY
 
 #endif // CAFFE2_USE_EIGEN_FOR_BLAS


### PR DESCRIPTION
Summary: Add float64 data type support for ScatterWeightedSum for cases that 10^7 precision is not sufficient.

Test Plan: buck test caffe2/caffe2/python/operator_test:sparse_ops_test -- testScatterWeightedSum

Differential Revision: D29190324

