### PR TITLE
cmake: Use BUILD_INTERFACE with TORCH_SRC_DIR

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1187,7 +1187,7 @@ endif()
 # jit/unpickler.cpp need to be compiled only when USE_DISTRIBUTED is set
 if(USE_DISTRIBUTED)
   # Needed to support the inclusion of c10d/Foo.hpp headers.
-  target_include_directories(torch_cpu PUBLIC ${TORCH_SRC_DIR}/lib)
+  target_include_directories(torch_cpu PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>)
   target_compile_definitions(torch_cpu PUBLIC USE_DISTRIBUTED)
   if(USE_GLOO AND USE_C10D_GLOO)
     target_compile_definitions(torch_cpu PUBLIC USE_C10D_GLOO)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1187,7 +1187,7 @@ endif()
 # jit/unpickler.cpp need to be compiled only when USE_DISTRIBUTED is set
 if(USE_DISTRIBUTED)
   # Needed to support the inclusion of c10d/Foo.hpp headers.
-  target_include_directories(torch_cpu PUBLIC $<BUILD_INTERFACE:${TORCH_SRC_DIR}/lib)
+  target_include_directories(torch_cpu PUBLIC $<BUILD_INTERFACE:${TORCH_SRC_DIR}/lib>)
   target_compile_definitions(torch_cpu PUBLIC USE_DISTRIBUTED)
   if(USE_GLOO AND USE_C10D_GLOO)
     target_compile_definitions(torch_cpu PUBLIC USE_C10D_GLOO)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1187,7 +1187,7 @@ endif()
 # jit/unpickler.cpp need to be compiled only when USE_DISTRIBUTED is set
 if(USE_DISTRIBUTED)
   # Needed to support the inclusion of c10d/Foo.hpp headers.
-  target_include_directories(torch_cpu PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>)
+  target_include_directories(torch_cpu PUBLIC $<BUILD_INTERFACE:${TORCH_SRC_DIR}/lib)
   target_compile_definitions(torch_cpu PUBLIC USE_DISTRIBUTED)
   if(USE_GLOO AND USE_C10D_GLOO)
     target_compile_definitions(torch_cpu PUBLIC USE_C10D_GLOO)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60403 cmake: Use BUILD_INTERFACE with TORCH_SRC_DIR**

TORCH_SRC_DIR has the potential to be hardcoded if used by itself so
prefer to use along with BUILD_INTERFACE so that the actual path is not
hardcoded

See https://cmake.org/cmake/help/latest/command/target_include_directories.html

Fixes errors initially introduced in https://github.com/pytorch/pytorch/pull/59563

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29276503](https://our.internmc.facebook.com/intern/diff/D29276503)