### PR TITLE
changed launch bounds, unrolled for loop for grid sampler 2d fwd and bwd

### DIFF
--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -25,12 +25,12 @@ namespace at { namespace cuda { namespace detail {
 constexpr int CUDA_NUM_THREADS = 1024;
 
 // CUDA: number of blocks for threads.
-inline int GET_BLOCKS(const int64_t N) {
+inline int GET_BLOCKS(const int64_t N, const int64_t max_threads_per_block=CUDA_NUM_THREADS) {
   TORCH_INTERNAL_ASSERT(N > 0, "CUDA kernel launch blocks must be positive, but got N=", N);
   constexpr int64_t max_int = std::numeric_limits<int>::max();
 
   // Round up division for positive number that cannot cause integer overflow
-  auto block_num = (N - 1) / CUDA_NUM_THREADS + 1;
+  auto block_num = (N - 1) / max_threads_per_block + 1;
   TORCH_INTERNAL_ASSERT(block_num <= max_int, "Can't schedule too many blocks on CUDA device");
 
   return static_cast<int>(block_num);

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -17,7 +17,7 @@ using at::native::detail::GridSamplerPadding;
 
 namespace {
   template <typename scalar_t, typename index_t>
-  C10_LAUNCH_BOUNDS_1(1024)
+  C10_LAUNCH_BOUNDS_1(256)
   __global__ void grid_sampler_2d_kernel(
       const index_t nthreads,
       TensorInfo<scalar_t, index_t> input,
@@ -122,6 +122,7 @@ namespace {
         for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
           scalar_t coefficients[4];
 
+          #pragma unroll 4
           for (index_t i = 0; i < 4; ++i) {
             coefficients[i] = cubic_interp1d(
               get_value_bounded<scalar_t>(inp_ptr_NC, ix_nw - 1, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
@@ -297,7 +298,7 @@ namespace {
 // including batch * channel offset (NC_offset).
 
   template <typename scalar_t, typename index_t>
-  C10_LAUNCH_BOUNDS_1(1024)
+  C10_LAUNCH_BOUNDS_1(256)
   __global__ void grid_sampler_2d_backward_kernel(
       const index_t nthreads,
       TensorInfo<scalar_t, index_t> grad_output,
@@ -457,8 +458,10 @@ namespace {
 
         for (index_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, NC_offset += gInp_sC, inp_ptr_NC+= inp_sC) {
           scalar_t gOut = *gOut_ptr_NCHW;
-
+          
+          #pragma unroll 4
           for (index_t i = 0; i < 4; ++i) {
+            #pragma unroll 4
             for (index_t j = 0; j < 4; ++j) {
 
               // set input gradient. See Note [Passing pointer and offset to fastAtomicAdd].
@@ -721,7 +724,7 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(output)) {
         grid_sampler_2d_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
             getTensorInfo<scalar_t, int>(input),
             getTensorInfo<scalar_t, int>(grid),
@@ -732,7 +735,7 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_2d_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             count,
             getTensorInfo<scalar_t, int64_t>(input),
             getTensorInfo<scalar_t, int64_t>(grid),
@@ -807,7 +810,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(grad_output)) {
         grid_sampler_2d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
             getTensorInfo<scalar_t, int>(grad_output),
             getTensorInfo<scalar_t, int>(input),
@@ -821,7 +824,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_2d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             count,
             getTensorInfo<scalar_t, int64_t>(grad_output),
             getTensorInfo<scalar_t, int64_t>(input),


### PR DESCRIPTION
Changed launch bounds for grid sampler 2d fwd and bwd from 1024 to 256, added loop unrolling to fix register spilling into local memory. 

Timing Data: (using Nvidia Titan-V)
Interpolation mode 2, padding 0, align corners False

![GridSampler2dTimingData](https://user-images.githubusercontent.com/22803332/122830305-01fd2d80-d29d-11eb-9cd3-7da533a03f33.PNG)
