### PR TITLE
Add pyproject.toml

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-include_trailing_comma=True
-multi_line_output=3
-skip=third_party
-skip_gitignore=True
-use_parentheses=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.isort]
+include_trailing_comma = true
+multi_line_output = 3
+skip = [
+    "third_party",
+]
+skip_gitignore = true
+use_parentheses = true


### PR DESCRIPTION
This makes PyTorch conform to [PEP 517](https://www.python.org/dev/peps/pep-0517/) and [PEP 518](https://www.python.org/dev/peps/pep-0518/) by explicitly stating that we use [`setuptools`](https://setuptools.readthedocs.io/). It also follows up on https://github.com/pytorch/pytorch/pull/60119#pullrequestreview-685791812 by moving our [`isort`](https://pycqa.github.io/isort/) config into the new `pyproject.toml` file. I didn't move any of our other tool configs into `pyproject.toml` in this PR because:

- `.flake8` is assumed to exist in its current format for `tools/actions_local_runner.py` to work
- `mypy.ini` is not our only `mypy` config
- `pytest.ini` has detailed comments on `addopts` which [would have to be removed](https://github.com/toml-lang/toml/issues/340#issuecomment-122164501) in TOML because that setting is [a string, not an array](https://docs.pytest.org/en/6.2.x/customize.html#pyproject-toml)