### PR TITLE
Enable rcb lookup for typing during FX tracing for Profile-Directed-Typing

### DIFF
--- a/test/jit/test_pdt.py
+++ b/test/jit/test_pdt.py
@@ -3,7 +3,7 @@ import sys
 import torch
 from torch.testing._internal.jit_utils import JitTestCase, make_global
 from torch.jit._monkeytype_config import _IS_MONKEYTYPE_INSTALLED
-from typing import List, Dict, Tuple, Any  # noqa: F401
+from typing import List, Dict, Tuple, Any, NamedTuple  # noqa: F401
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -422,3 +422,17 @@ class TestPDT(JitTestCase):
         pdt_model = TestNNParameter()
         scripted_fn = torch.jit._script_pdt(pdt_model, example_inputs={pdt_model: [(10, ), ], })
         self.assertEqual(scripted_fn(20), pdt_model(20))
+
+    def test_fx_tracing_with_optional_tensor(self):
+        class FXModelOutput(NamedTuple):
+            result: List[int]
+
+        class FXModel(torch.nn.Module):
+            def forward(self, a) -> FXModelOutput:
+                result = FXModelOutput(result=a)
+                return result
+
+        make_global(FXModel, FXModelOutput)
+        pdt_model = FXModel()
+        scripted_fn = torch.jit._script_pdt(pdt_model, example_inputs={pdt_model: [([10, 20, ], ), ], })
+        self.assertEqual(scripted_fn([20]), pdt_model([20]))

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -15,6 +15,7 @@ from textwrap import dedent
 import torch
 import sys
 import builtins
+import typing
 import io
 import pickle
 import functools
@@ -222,6 +223,8 @@ def createResolutionCallbackFromClosure(fn):
         def __getattr__(self, key):
             if key in closure:
                 return closure[key]
+            elif hasattr(typing, key):
+                return getattr(typing, key)
             elif hasattr(builtins, key):
                 return getattr(builtins, key)
             return None


### PR DESCRIPTION
Summary:
-----------

For FX traced models, types from typing modules are not available during the lookup for the function to be traced. Because of which the resolving the type results to a None type object. By enabling lookup for `typing` module in `_jit_internal.py`, we can mitigate this issue with FX_Tracing and scripting. 

Test:
--------
with-proxy python test/test_jit.py -k TestPDT.test_fx_tracing_with_typing