### PR TITLE
fixed launch bounds for gru cell fwd and bwd

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -387,9 +387,9 @@ __host__ __device__ __forceinline__ T ATenCeilDiv(T a, T b) {
 }
 
 template <int step = 1>
-inline bool getApplyGrid(uint64_t totalElements, dim3& grid, int64_t curDevice) {
+inline bool getApplyGrid(uint64_t totalElements, dim3& grid, int64_t curDevice, int max_threads_per_block=AT_APPLY_THREADS_PER_BLOCK) {
   if (curDevice == -1) return false;
-  uint64_t numel_per_thread = static_cast<uint64_t>(AT_APPLY_THREADS_PER_BLOCK) * static_cast<uint64_t>(step);
+  uint64_t numel_per_thread = static_cast<uint64_t>(max_threads_per_block) * static_cast<uint64_t>(step);
   uint64_t numBlocks = ATenCeilDiv(totalElements, numel_per_thread);
   uint64_t maxGridX = at::cuda::getDeviceProperties(curDevice)->maxGridSize[0];
   if (numBlocks > maxGridX)
@@ -406,8 +406,8 @@ constexpr int getApplyBlockSize() {
   return AT_APPLY_THREADS_PER_BLOCK;
 }
 
-inline dim3 getApplyBlock() {
-  return dim3(AT_APPLY_THREADS_PER_BLOCK);
+inline dim3 getApplyBlock(int max_threads_per_block=AT_APPLY_THREADS_PER_BLOCK) {
+  return dim3(max_threads_per_block);
 }
 
 template <typename scalar1, typename scalar2, int step, typename Op,


### PR DESCRIPTION
Changed launch bounds for gru cell fwd and bwd from (512, 4) to (256, 4). Similarly to lstm_cell, the user facing op (torch.gru_cell) is bottlenecked performance wise by dgemm calls, so while fixing the launch bound improves the gru_cell_forward and gru_cell_backward kernels specifically, the overall runtime of the entire user facing op is still pretty much the same.

Timing Data (using Nvidia Titan-V):

Entire op (torch.gru_cell): 
![GruTimingData](https://user-images.githubusercontent.com/22803332/125684510-21fcc748-c3c4-4bc8-8393-4ce96f4f6e72.PNG)

gru_cell_forward and gru_cell_backward kernels: 
![GruTimingDataNew](https://user-images.githubusercontent.com/22803332/125684556-39f1e057-f619-4ef9-bcc4-1e8679ed677e.PNG)

