### PR TITLE
fixed launch bounds for lstm_cell fwd and bwd

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -387,9 +387,9 @@ __host__ __device__ __forceinline__ T ATenCeilDiv(T a, T b) {
 }
 
 template <int step = 1>
-inline bool getApplyGrid(uint64_t totalElements, dim3& grid, int64_t curDevice) {
+inline bool getApplyGrid(uint64_t totalElements, dim3& grid, int64_t curDevice, int max_threads_per_block=AT_APPLY_THREADS_PER_BLOCK) {
   if (curDevice == -1) return false;
-  uint64_t numel_per_thread = static_cast<uint64_t>(AT_APPLY_THREADS_PER_BLOCK) * static_cast<uint64_t>(step);
+  uint64_t numel_per_thread = static_cast<uint64_t>(max_threads_per_block) * static_cast<uint64_t>(step);
   uint64_t numBlocks = ATenCeilDiv(totalElements, numel_per_thread);
   uint64_t maxGridX = at::cuda::getDeviceProperties(curDevice)->maxGridSize[0];
   if (numBlocks > maxGridX)
@@ -406,8 +406,8 @@ constexpr int getApplyBlockSize() {
   return AT_APPLY_THREADS_PER_BLOCK;
 }
 
-inline dim3 getApplyBlock() {
-  return dim3(AT_APPLY_THREADS_PER_BLOCK);
+inline dim3 getApplyBlock(int max_threads_per_block=AT_APPLY_THREADS_PER_BLOCK) {
+  return dim3(max_threads_per_block);
 }
 
 template <typename scalar1, typename scalar2, int step, typename Op,


### PR DESCRIPTION
Changed launch bounds for lstm_cell forward from (512, 4) to (128, 4), lstm_cell backward from (512, 4) to (256, 4) to fix register spilling into local memory. Using Nsight Compute profiler, noticed up to x2 performance increase in lstm_cell fwd and bwd kernels, but the user-facing operation torch.lstm_cell is still bottlenecked by a bunch of volta_dgemm calls. 

Timing data: (using Nvidia Titan-V):

User facing torch.lstm_cell: 
![LstmTimingData](https://user-images.githubusercontent.com/22803332/125675772-18fb240a-cd0d-4305-8f97-6c4ca0d05965.PNG)

lstm_cell fwd and bwd: 
![LstmTimingDataNew](https://user-images.githubusercontent.com/22803332/125673989-7bb9fc78-7c35-4adf-9c7e-0cd7f4fe3709.PNG)

