### PR TITLE
Update Makefile to support local clang-tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ cmakelint:
 		--step 'Run cmakelint'
 
 clang_tidy:
-	echo "clang-tidy local lint is not yet implemented"
-	exit 1
+	@$(PYTHON) tools/actions_local_runner.py \
+	    --job 'clang-tidy'
 
 toc:
 	@$(PYTHON) tools/actions_local_runner.py \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60430 Update Makefile to support local clang-tidy**
* #60429 Add full local check for clang-tidy using docker image
* #60428 Split clang-tidy job into smaller steps

