### PR TITLE
[caffe2/utils] Add explicit rule to avoid package boundary violation

### DIFF
--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -7,6 +7,13 @@
 #include <fstream>
 #include <unordered_set>
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#else // defined(_WIN32)
+#include <Windows.h>
+#include <fileapi.h>
+#endif // defined(_WIN32)
+
 #include <google/protobuf/io/coded_stream.h>
 
 #ifndef CAFFE2_USE_LITE_PROTO
@@ -16,7 +23,7 @@
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #endif // !CAFFE2_USE_LITE_PROTO
 
-#include "caffe2/core/logging.h"
+#include <c10/util/Logging.h>
 
 using ::google::protobuf::MessageLite;
 
@@ -409,12 +416,12 @@ INSTANTIATE_GET_SINGLE_ARGUMENT(NetDef, n, false)
 #define INSTANTIATE_GET_REPEATED_ARGUMENT(                             \
     T, fieldname, enforce_lossless_conversion)                         \
   template <>                                                          \
-  C10_EXPORT vector<T> ArgumentHelper::GetRepeatedArgument<T>(         \
+  C10_EXPORT std::vector<T> ArgumentHelper::GetRepeatedArgument<T>(         \
       const string& name, const std::vector<T>& default_value) const { \
     if (arg_map_.count(name) == 0) {                                   \
       return default_value;                                            \
     }                                                                  \
-    vector<T> values;                                                  \
+    std::vector<T> values;                                                  \
     for (const auto& v : arg_map_.at(name).fieldname()) {              \
       if (enforce_lossless_conversion) {                               \
         auto supportsConversion =                                      \
@@ -489,7 +496,7 @@ C10_EXPORT Argument MakeArgument(const string& name, const MessageLite& value) {
 #define CAFFE2_MAKE_REPEATED_ARGUMENT(T, fieldname) \
   template <>                                       \
   C10_EXPORT Argument MakeArgument(                 \
-      const string& name, const vector<T>& value) { \
+      const string& name, const std::vector<T>& value) { \
     Argument arg;                                   \
     arg.set_name(name);                             \
     for (const auto& v : value) {                   \

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -7,7 +7,8 @@
 #include <google/protobuf/message.h>
 #endif  // !CAFFE2_USE_LITE_PROTO
 
-#include "caffe2/core/logging.h"
+#include <c10/util/Logging.h>
+
 #include "caffe2/utils/proto_wrap.h"
 #include "caffe2/proto/caffe2_pb.h"
 
@@ -221,7 +222,7 @@ class C10_EXPORT ArgumentHelper {
   }
 
   template <typename Def, typename T>
-  static vector<T> GetRepeatedArgument(
+  static std::vector<T> GetRepeatedArgument(
       const Def& def,
       const string& name,
       const std::vector<T>& default_value = std::vector<T>()) {
@@ -234,7 +235,7 @@ class C10_EXPORT ArgumentHelper {
   }
 
   template <typename Def, typename MessageType>
-  static vector<MessageType> GetRepeatedMessageArgument(
+  static std::vector<MessageType> GetRepeatedMessageArgument(
       const Def& def,
       const string& name) {
     return ArgumentHelper(def).GetRepeatedMessageArgument<MessageType>(name);
@@ -261,7 +262,7 @@ class C10_EXPORT ArgumentHelper {
   template <typename T>
   bool HasSingleArgumentOfType(const string& name) const;
   template <typename T>
-  vector<T> GetRepeatedArgument(
+  std::vector<T> GetRepeatedArgument(
       const string& name,
       const std::vector<T>& default_value = std::vector<T>()) const;
 
@@ -280,9 +281,9 @@ class C10_EXPORT ArgumentHelper {
   }
 
   template <typename MessageType>
-  vector<MessageType> GetRepeatedMessageArgument(const string& name) const {
+  std::vector<MessageType> GetRepeatedMessageArgument(const string& name) const {
     CAFFE_ENFORCE(arg_map_.count(name), "Cannot find parameter named ", name);
-    vector<MessageType> messages(arg_map_.at(name).strings_size());
+    std::vector<MessageType> messages(arg_map_.at(name).strings_size());
     for (int i = 0; i < messages.size(); ++i) {
       CAFFE_ENFORCE(
           messages[i].ParseFromString(arg_map_.at(name).strings(i)),
@@ -292,7 +293,7 @@ class C10_EXPORT ArgumentHelper {
   }
 
  private:
-  CaffeMap<string, Argument> arg_map_;
+  std::map<string, Argument> arg_map_;
 };
 
 // **** Arguments Utils *****

--- a/caffe2/utils/proto_wrap.cc
+++ b/caffe2/utils/proto_wrap.cc
@@ -1,5 +1,4 @@
 #include "caffe2/utils/proto_wrap.h"
-#include "caffe2/core/common.h"
 
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/generated_message_util.h>

--- a/caffe2/utils/proto_wrap.h
+++ b/caffe2/utils/proto_wrap.h
@@ -1,7 +1,7 @@
 #ifndef CAFFE2_UTILS_PROTO_WRAP_H_
 #define CAFFE2_UTILS_PROTO_WRAP_H_
 
-#include "caffe2/core/common.h"
+#include <c10/util/Logging.h>
 
 namespace caffe2 {
 

--- a/caffe2/utils/simple_queue.h
+++ b/caffe2/utils/simple_queue.h
@@ -5,7 +5,7 @@
 #include <mutex>  // NOLINT
 #include <queue>
 
-#include "caffe2/core/logging.h"
+#include <c10/util/Logging.h>
 
 namespace caffe2 {
 


### PR DESCRIPTION
Summary:
Add a rule to wrap proto_utils.h and depend on that, rather than
relying on a glob which violates package boundaries.

Differential Revision: D29273453

