### PR TITLE
Allow freezing to work when in eval mode

### DIFF
--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -486,7 +486,7 @@ Module freeze(
     c10::optional<std::vector<std::string>> preserved_attrs,
     bool optimize_numerics) {
   TORCH_CHECK(
-      module.is_training(),
+      !module.is_training(),
       "Freezing is currently only implemented for modules in eval mode. Please call .eval() before freezing");
 
   Module out_mod = freeze_module(


### PR DESCRIPTION
Currently, the code throws an error telling you to put the Module in to eval mode, even though it already is in this mode.

Fixes #{issue number}
