### PR TITLE
[NormalizeArgs] Retain node.meta

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1018,6 +1018,36 @@ class {test_classname}(torch.nn.Module):
                     if submod_class == nn_class:
                         self.assertEqual(len(node.args), 0)
 
+    def test_normalize_args_preserve_meta(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, a):
+                return torch.add(a, 3)
+
+        m = MyModule()
+        traced = symbolic_trace(m)
+
+        for node in traced.graph.nodes:
+            if node.op == "call_function" and node.target == torch.add:
+                node.meta["my_key"] = 7
+                break
+        else:
+            self.fail("Didn't find call_function torch.add")
+
+        input = torch.randn(2, 3)
+        ShapeProp(traced).propagate(input)
+        traced = NormalizeArgs(traced).transform()
+
+        for node in traced.graph.nodes:
+            if node.op == "call_function" and node.target == torch.add:
+                self.assertTrue("my_key" in node.meta)
+                self.assertEqual(node.meta["my_key"], 7)
+                break
+        else:
+            self.fail("Didn't find call_function torch.add")
+
     @skipIfNoTorchVision
     def test_annotate_returns_with_schema(self):
         m = resnet18()

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -58,6 +58,7 @@ class NormalizeArgs(Transformer):
             out = super().run_node(n)
         if n.op != "output":
             self.node_map[out] = n
+            out.node.meta = n.meta
         return out
 
     def call_function(


### PR DESCRIPTION
Summary: After normalizing args, still retain each node's `meta`

Test Plan: Added unit test.

Differential Revision: D29293179

