### PR TITLE
Use `accscalar_t` for CUDA add/sub with Tensor and Scalar

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
@@ -36,7 +36,7 @@ void add_kernel_cuda(TensorIteratorBase& iter, const Scalar& alpha_scalar) {
   if (!isIntegralType(iter.common_dtype(), /* includeBool */ true) && (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
     // if common dtype is half the scalar constant can overflow in half precision, and yet the result can
     // still be representable in the half dtype. Cast scalar to acc_type to have better accuracy.
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
       using accscalar_t = at::acc_type<scalar_t, true>;
       int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
       auto b = iter.scalar_value<accscalar_t>(scalar_arg);

--- a/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
@@ -3,6 +3,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/BinaryOps.h>
+#include <c10/cuda/CUDAGuard.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -19,12 +20,38 @@ struct AddFunctor {
     accscalar_t alpha;
 };
 
+template<typename scalar_t, typename accscalar_t>
+struct AddScalarFunctor {
+  AddScalarFunctor(accscalar_t alpha, accscalar_t b): alpha(alpha), b(b) {}
+  __device__ __forceinline__ scalar_t operator() (const scalar_t a) const {
+
+    return static_cast<scalar_t>(static_cast<accscalar_t>(a) + alpha * b);
+  }
+  private:
+    accscalar_t alpha;
+    accscalar_t b;
+};
+
 void add_kernel_cuda(TensorIteratorBase& iter, const Scalar& alpha_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
-    using accscalar_t = at::acc_type<scalar_t, true>;
-    AddFunctor<scalar_t, accscalar_t> f(alpha_scalar.to<accscalar_t>());
-    gpu_kernel_with_scalars(iter, f);
-  });
+  if (!isIntegralType(iter.common_dtype(), /* includeBool */ true) && (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
+    // if common dtype is half the scalar constant can overflow in half precision, and yet the result can
+    // still be representable in the half dtype. Cast scalar to acc_type to have better accuracy.
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
+      auto b = iter.scalar_value<accscalar_t>(scalar_arg);
+      iter.remove_operand(scalar_arg);
+      const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
+      AddScalarFunctor<scalar_t, decltype(b)> f(alpha_scalar.to<accscalar_t>(), b);
+      gpu_kernel(iter, f);
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      AddFunctor<scalar_t, accscalar_t> f(alpha_scalar.to<accscalar_t>());
+      gpu_kernel_with_scalars(iter, f);
+    });
+  }
 }
 
 static void sub_kernel_cuda(TensorIteratorBase& iter, const Scalar& alpha_scalar) {

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2356,11 +2356,16 @@ class TestBinaryUfuncs(TestCase):
                                lambda: torch.add(m1, m1, out=m2))
 
     @onlyCUDA
-    def test_add_half_tensor_with_alpha(self, device):
+    def test_addsub_half_tensor(self, device):
         x = torch.tensor([60000.0], dtype=torch.half, device=device)
-        y = torch.tensor([-60000.0], dtype=torch.half, device=device)
-        actual = torch.add(x, y, alpha=2)
-        self.assertTrue(not (actual.isnan() or actual.isinf()))
+        for op, y, alpha in (
+            (torch.add, torch.tensor([-60000.0], dtype=torch.half, device=device), 2),
+            (torch.sub, torch.tensor([60000.0], dtype=torch.half, device=device), 2),
+            (torch.add, -70000.0, 1),
+            (torch.sub, 70000.0, 1),
+        ):
+            actual = op(x, y, alpha=alpha)
+            self.assertTrue(not (actual.isnan() or actual.isinf()))
 
     def test_sub_typing(self, device):
         m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=device)


### PR DESCRIPTION
Follow up of #60227, related to #59907 & #58833 

With this pull request, `torch.add` & `torch.sub` use `acc_type` for `Scalar` if either of two arguments is `Scalar`.
This mimics the behavior of [`torch.mul`](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu#L18), `torch._foreach_(add|sub).Scalar` and `torch._foreach_(add|sub).ScalarList`.

---

**reference**
- torch.mul CUDA kernel: https://github.com/pytorch/pytorch/blob/b0c9762e2d1dfcde549344628ad6be063378ef6a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu#L17-L25
- `torch._foreach_(add|sub).Scalar`: cast scalar https://github.com/pytorch/pytorch/blob/b0c9762e2d1dfcde549344628ad6be063378ef6a/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu#L27
- `torch._foreach_(add|sub).ScalarList`: `BinaryOpScalarListFunctor` https://github.com/pytorch/pytorch/blob/b0c9762e2d1dfcde549344628ad6be063378ef6a/aten/src/ATen/native/cuda/ForeachFunctors.cuh#L180-L182 and multi_tensor_apply handles `scalar_t` and computes `opmath_t` (almost equivalent `accscalar_t`)  https://github.com/pytorch/pytorch/blob/b0c9762e2d1dfcde549344628ad6be063378ef6a/aten/src/ATen/native/cuda/MultiTensorApply.cuh#L60-L68. BinaryOpScalarListFunctor 
is used https://github.com/pytorch/pytorch/blob/b0c9762e2d1dfcde549344628ad6be063378ef6a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu#L24

cc @ngimel @ptrblck @mcarilli 