### PR TITLE
Increase tolerance for some distributed tests to 5e-5

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -376,7 +376,7 @@ class AbstractDistributedDataParallelTest(object):
                 len(list(model.parameters())), len(list(ddp_model.parameters()))
             )
             for i, j in zip(model.parameters(), ddp_model.parameters()):
-                self.assertEqual(i, j)
+                self.assertEqual(i, j, rtol=1.3e-06, atol=5e-5)
 
             # Shuffle the input so that DDP input is different
             torch.manual_seed(1337 + iteration)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1134,7 +1134,7 @@ class DistributedDataParallelTest(test_c10d_common.AbstractDistributedDataParall
                 )
                 for i, j in zip(model.parameters(), ddp_model.parameters()):
                     # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-                    self.assertEqualIgnoreType(i.grad, j.grad)
+                    self.assertEqualIgnoreType(i.grad, j.grad, rtol=1.3e-06, atol=5e-5)
 
             # Shuffle the input so that DDP input is different
             torch.manual_seed(1337 + iteration)
@@ -1777,7 +1777,7 @@ class DistributedDataParallelTest(test_c10d_common.AbstractDistributedDataParall
             for i, j in zip(model.parameters(), ddp_model.parameters()):
                 self.assertTrue(i.grad is not None)
                 self.assertTrue(j.grad is not None)
-                self.assertEqual(i.grad, j.grad)
+                self.assertEqual(i.grad, j.grad, rtol=1.3e-06, atol=5e-5)
 
     # DDP works as expect when layer is checkpointed only once
     @requires_nccl()


### PR DESCRIPTION
On A100 GPUs 10 tests fail due to slightly higher deviations.
This fixes those.

Note that rtol is still the default and atol was increased by a factor of 5 (from 1e-5)

The failing tests were:

- test_accumulate_gradients_module
- test_accumulate_gradients_module_with_grad_is_view
- test_ddp_checkpointing_once
- test_ddp_checkpointing_twice
- test_ddp_checkpointing_unused_params
- test_ddp_checkpointing_weight_sharing
- test_nccl_backend_1gpu_module_device_ids_integer_list
- test_nccl_backend_1gpu_module_device_ids_torch_device_list
- test_nccl_backend_single_device_module_device_ids_None
- test_nccl_backend_single_device_module_empty_device_id