### PR TITLE
[BE] Fix Convolution.cpp build warnings

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -76,8 +76,7 @@ std::ostream& operator<<(std::ostream & out, const ConvParams& params) {
 
 auto ConvParams::is_strided() const -> bool {
   bool is_strided = false;
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  for (int s : stride) {
+  for (auto s : stride) {
     is_strided |= (s != 1);
   }
   return is_strided;
@@ -85,8 +84,7 @@ auto ConvParams::is_strided() const -> bool {
 
 auto ConvParams::is_dilated() const -> bool {
   bool is_dilated = false;
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  for (int d : dilation) {
+  for (auto d : dilation) {
     is_dilated |= (d != 1);
   }
   return is_dilated;
@@ -94,8 +92,7 @@ auto ConvParams::is_dilated() const -> bool {
 
 auto ConvParams::is_padded() const -> bool {
   bool is_padded = false;
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  for (int p : padding) {
+  for (auto p : padding) {
     is_padded |= (p != 0);
   }
   return is_padded;
@@ -103,8 +100,7 @@ auto ConvParams::is_padded() const -> bool {
 
 auto ConvParams::is_output_padding_neg() const -> bool {
   bool is_non_neg = false;
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  for (int p : output_padding) {
+  for (auto p : output_padding) {
     is_non_neg |= (p < 0);
   }
   return is_non_neg;
@@ -112,7 +108,7 @@ auto ConvParams::is_output_padding_neg() const -> bool {
 
 auto ConvParams::is_output_padding_big() const -> bool {
   bool is_big = false;
-  for (size_t i = 0; i < output_padding.size(); i++) {
+  for (auto i: c10::irange(output_padding.size())) {
     is_big |= (output_padding[i] >= stride[i]);
   }
   return is_big;
@@ -120,8 +116,7 @@ auto ConvParams::is_output_padding_big() const -> bool {
 
 auto ConvParams::is_padding_neg() const -> bool {
   bool is_non_neg = false;
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  for (int p : padding) {
+  for (auto p : padding) {
     is_non_neg |= (p < 0);
   }
   return is_non_neg;
@@ -129,8 +124,7 @@ auto ConvParams::is_padding_neg() const -> bool {
 
 auto ConvParams::is_stride_nonpos() const -> bool {
   bool is_nonpos = false;
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  for (int s : stride) {
+  for (auto s : stride) {
     is_nonpos |= (s <= 0);
   }
   return is_nonpos;
@@ -611,8 +605,8 @@ static Tensor convolution_same(
     IntArrayRef stride, IntArrayRef dilation, int64_t groups) {
 
   auto k = weight.dim();
-  auto dim = k - 2;
-  TORCH_CHECK(dim > 0, "weight should have at least three dimensions");
+  TORCH_CHECK(k > 2, "weight should have at least three dimensions");
+  auto dim = static_cast<size_t>(k - 2);
   auto weight_sizes = weight.sizes();
   auto input_sizes = input.sizes();
   TORCH_CHECK(k == input.dim(),
@@ -620,21 +614,18 @@ static Tensor convolution_same(
               k, "-dimensional weight", weight_sizes, ", but got ",
               input.dim(), "-dimensional input of size ",
               input.sizes(), " instead");
-  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-  TORCH_CHECK(stride.size() == dim || stride.size() == 1,
+  TORCH_CHECK(stride.size() == dim || stride.size() == 1U,
               "stride cannot broadcast to ", dim, " dimensions");
-  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-  TORCH_CHECK(dilation.size() == dim || dilation.size() == 1,
+  TORCH_CHECK(dilation.size() == dim || dilation.size() == 1U,
               "dilation cannot broadcast to ", dim, " dimensions");
-  // NOLINTNEXTLINE(modernize-loop-convert,clang-diagnostic-sign-compare)
-  for (int64_t i = 0; i < stride.size(); ++i) {
+  for (auto i: c10::irange(stride.size())) {
     TORCH_CHECK(stride[i] == 1, "padding='same' is not supported for strided convolutions");
   }
 
   // Calculate the correct padding
   DimVector padding_l, padding_r;
   bool symmetric_padding = true;
-  for (int64_t i = 0; i < dim; ++i) {
+  for (auto i: c10::irange(dim)) {
     auto s = stride.size() == 1 ? stride[0] : stride[i];
     auto d = dilation.size() == 1 ? dilation[0] : dilation[i];
     auto pad = pooling_same_mode_padding_lr(
@@ -656,7 +647,7 @@ static Tensor convolution_same(
   TORCH_WARN_ONCE("Using padding='same' with even kernel lengths and odd dilation may"
                   " require a zero-padded copy of the input be created");
   SmallVector<int64_t, kDimVectorStaticSize * 2> pad_nd(static_cast<size_t>(2 * dim));
-  for (int i = 0; i < dim; ++i) {
+  for (auto i: c10::irange(dim)) {
     // Apply padding by the difference, leaving only a symmetric padding
     auto delta_pad = padding_r[i] - padding_l[i];
     auto pad_idx = 2 * (dim - 1 - i);  // F.pad goes from last dim to first


### PR DESCRIPTION
Use `c10::irange` and `auto` to get rid of narrowing cast and signed-unsigned compilation warnings
