### PR TITLE
Mkl sets num threads locally

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -48,7 +48,7 @@ void set_num_threads(int nthreads) {
   omp_set_num_threads(nthreads);
 #endif
 #ifdef TH_BLAS_MKL
-  mkl_set_num_threads(nthreads);
+  mkl_set_num_threads_local(nthreads);
 
   // because PyTorch uses OpenMP outside of MKL invocations
   // as well, we want this flag to be false, so that


### PR DESCRIPTION
Fixes #60469

In `ParallelOpenMP.cpp`
https://github.com/pytorch/pytorch/blob/cac9ae1506feabfc87d37a208b3d39ed46c59483/aten/src/ATen/ParallelOpenMP.cpp#L44-L65

Instead of `omp_set_num_threads` which changes the number of threads locally, `mkl_set_num_threads` changes the number of threads globally. I think changing the number of threads should only be done locally after a fork.