### PR TITLE
[sharded_tensor] add new init_from_local_shards API

### DIFF
--- a/test/distributed/_sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_sharding_spec/test_sharding_spec.py
@@ -6,6 +6,7 @@ from torch.distributed._sharding_spec import (
     EnumerableShardingSpec,
     ShardMetadata,
 )
+from torch.distributed._sharding_spec._internals import check_tensor
 
 class TestShardingSpec(TestCase):
 
@@ -73,7 +74,7 @@ class TestShardingSpec(TestCase):
                 placement="cuda:1",
             )
         ])
-        spec.check_tensor(torch.rand(10, 5).size())
+        check_tensor(spec.shards, torch.rand(10, 5).size())
 
         # test row and column sharding
         spec = EnumerableShardingSpec([
@@ -98,7 +99,7 @@ class TestShardingSpec(TestCase):
                 placement="cuda:3",
             ),
         ])
-        spec.check_tensor(torch.rand(6, 6).size())
+        check_tensor(spec.shards, torch.rand(6, 6).size())
 
         # test uneven shard sizes.
         spec = EnumerableShardingSpec([
@@ -123,7 +124,7 @@ class TestShardingSpec(TestCase):
                 placement="cuda:3",
             ),
         ])
-        spec.check_tensor(torch.rand(6, 6).size())
+        check_tensor(spec.shards, torch.rand(6, 6).size())
 
         # test invalid sharding
         with self.assertRaisesRegex(ValueError, 'not a valid device'):
@@ -183,7 +184,7 @@ class TestShardingSpec(TestCase):
         ])
 
         with self.assertRaisesRegex(ValueError, 'Rank of tensor is.*but shards rank'):
-            spec.check_tensor(torch.rand(10, 10, 10).size())
+            check_tensor(spec.shards, torch.rand(10, 10, 10).size())
 
         spec = EnumerableShardingSpec([
             ShardMetadata(
@@ -199,7 +200,7 @@ class TestShardingSpec(TestCase):
         ])
 
         with self.assertRaisesRegex(ValueError, 'exceeds tensor dim'):
-            spec.check_tensor(torch.rand(10, 3).size())
+            check_tensor(spec.shards, torch.rand(10, 3).size())
 
         spec = EnumerableShardingSpec([
             ShardMetadata(
@@ -215,4 +216,4 @@ class TestShardingSpec(TestCase):
         ])
 
         with self.assertRaisesRegex(ValueError, 'does not match tensor volume'):
-            spec.check_tensor(torch.rand(10, 10).size())
+            check_tensor(spec.shards, torch.rand(10, 10).size())

--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -1,8 +1,8 @@
+from typing import List
+
 import torch
 from torch.distributed._sharding_spec import ShardingSpec
-from .api import (
-    ShardedTensor,
-)
+from .api import ShardedTensor, Shard, ShardedTensorMetadata
 
 def empty(
         sharding_spec: ShardingSpec,
@@ -17,7 +17,7 @@ def empty(
     Creates an empty :class:`ShardedTensor`. Needs to be called on all ranks in an SPMD fashion.
 
     Args:
-        sharding_spec (:class:`torch.distributed._sharding_spec.ShardingSpec): The specification
+        sharding_spec (:class:`torch.distributed._sharding_spec.ShardingSpec`): The specification
             describing how to shard the Tensor.
         size (int...): a sequence of integers defining the shape of the output
             tensor. Can be a variable number of arguments or a collection like a list or tuple.
@@ -47,4 +47,34 @@ def empty(
         requires_grad=requires_grad,
         pin_memory=pin_memory,
         memory_format=memory_format,
+        process_group=process_group)
+
+
+def init_from_local_shards(
+        local_shards: List[Shard],
+        sharded_tensor_metadata: ShardedTensorMetadata,
+        process_group=None):
+    """
+    Creates an :class:`ShardedTensor` from local shards and the global metadata.
+    Needs to be called on all ranks in an SPMD fashion.
+
+    Args:
+        local_shards (List[:class `torch.distributed._sharded_tensor.Shard`]): A list
+            of shards that represent the local shards on this rank.
+        sharded_tensor_metadata (:class:`torch.distributed._sharded_tensor.ShardedTensorMetadata`)
+            The ShardedTensorMetadata that created manually, represents the global metadata
+            of the ShardedTensor, must comply with `local_shards` defined in each rank.
+            Note that `sharded_tensor_metadata` must be valid and should also contain
+            local shards metadata.
+
+    Keyword args:
+        process_group (ProcessGroup, optional): The process group to work on. If None,
+            the default process group will be used.
+
+    Returns:
+        A :class:`ShardedTensor` object handle on this rank
+    """
+    return ShardedTensor._init_from_local_shards(
+        local_shards,
+        sharded_tensor_metadata,
         process_group=process_group)

--- a/torch/distributed/_sharding_spec/_internals.py
+++ b/torch/distributed/_sharding_spec/_internals.py
@@ -1,5 +1,10 @@
+from typing import List, Union
+from dataclasses import dataclass
+
 import torch
 from torch.distributed.utils import _parse_remote_device
+
+Device = Union[torch.device, int, str]
 
 def is_valid_device(device):
     """
@@ -20,3 +25,129 @@ def is_valid_device(device):
         pass
 
     return False
+
+
+@dataclass
+class ShardMetadata(object):
+    """
+    Represents a shard of the overall Tensor including its
+    offsets, lengths and device placement.
+
+    Args:
+        shard_offsets(List[int]): Offsets in the orignal tensor indicating
+            the start offsets for this shard. Should have the same rank as
+            the original tensor.
+        shard_lengths(List[int]): Lengths indicating the length of each
+            dimension for this shard. Should have the same rank as the
+            original tensor.
+        placement(Device):
+            Specifies the placement of this shard.
+
+            The placement can be a local device or a remote device specified by one
+            of the following remote formats:
+
+                1. "rank:<rank>/<device>" (ex: "rank:0/cuda:0").
+                2. "<worker_name>/<device>" (ex: "trainer0/cuda:0").
+    """
+
+    __slots__ = ['shard_offsets', 'shard_lengths', 'placement']
+
+    shard_offsets: List[int]
+    shard_lengths: List[int]
+    placement: Device
+
+    def __post_init__(self):
+        if not is_valid_device(self.placement):
+            raise ValueError(f'{self.placement} is not a valid device')
+
+        if len(self.shard_offsets) != len(self.shard_lengths):
+            raise ValueError(
+                f'shard_offsets and shard_lengths should have '
+                f'the same number of elements, found {len(self.shard_offsets)} '
+                f'and {self.shard_lengths} respectively')
+
+        for i in range(len(self.shard_offsets)):
+            if self.shard_offsets[i] < 0:
+                raise ValueError('shard_offsets should be >=0')
+            if self.shard_lengths[i] <= 0:
+                raise ValueError('shard_lengths should be > 0')
+
+
+
+def _check_shard_metadata_pair_overlap(shard1: ShardMetadata, shard2: ShardMetadata):
+    """
+    Checks if two shards overlap.
+    """
+
+    # For each dim of each shard, check if one shard resides on the other
+    # end of second shard with respect to that dim. As an example for a 2D
+    # shard, we would check if one shard is above or on the left of the
+    # other shard.
+    ndims = len(shard1.shard_offsets)
+    for i in range(ndims):
+        if shard1.shard_offsets[i] >= shard2.shard_offsets[i] + shard2.shard_lengths[i]:
+            return False
+        if shard2.shard_offsets[i] >= shard1.shard_offsets[i] + shard1.shard_lengths[i]:
+            return False
+
+    return True
+
+def validate_non_overlapping_shards_metadata(shards: List[ShardMetadata]):
+    """
+    Ensures none of the shards overlap with each other.
+
+    Args:
+        shards(List[ShardMetadata]): List of :class:`ShardMetadata` objects representing
+            each shard.
+    Raises:
+        ``ValueError`` if there's overlap in any two shards.
+    """
+    # TODO: evaluate optimizing this if needed.
+    for i in range(len(shards)):
+        for j in range(i + 1, len(shards)):
+            if _check_shard_metadata_pair_overlap(shards[i], shards[j]):
+                raise ValueError(f'Shards {shards[i]} and {shards[j]} overlap')
+
+
+def check_tensor(shards_metadata, tensor_dims) -> None:
+    """
+    Checks if the shards_metadata is compatible with the provided tensor dims.
+
+    Args:
+        shards_metadata(List[ShardMetadata]): List of :class:`ShardMetadata`
+            objects representing each shard of the tensor.
+        tensor_dims(Sequence of int): Dimensions of tensor to verify
+    Raises:
+        ``ValueError`` if not compatible.
+    """
+
+    # If the tensor's volume matches the total volume of all shards and
+    # all shard boundaries are within tensor dims, we have a compatible
+    # sharding spec for this tensor. Note that we have already verified
+    # we don't have overlapping shards.
+    tensor_rank = len(tensor_dims)
+    shards_rank = len(shards_metadata[0].shard_offsets)
+    if tensor_rank != shards_rank:
+        raise ValueError(f'Rank of tensor is {tensor_rank}, but shards rank is {shards_rank}')
+
+    total_shard_volume = 0
+    for shard in shards_metadata:
+        shard_volume = 1
+        for i, shard_length in enumerate(shard.shard_lengths):
+            shard_volume *= shard_length
+            if shard.shard_offsets[i] + shard.shard_lengths[i] > tensor_dims[i]:
+                raise ValueError(
+                    f'Shard offset {shard.shard_offsets[i]} and length '
+                    f'{shard.shard_lengths[i]} exceeds tensor dim: {tensor_dims[i]} for shard {shard}')
+        total_shard_volume += shard_volume
+
+    tensor_volume = 1
+    for size in tensor_dims:
+        tensor_volume *= size
+
+    if total_shard_volume != tensor_volume:
+        # TODO: Can we improve this error message to point out the gaps?
+        raise ValueError(
+            f'Total volume of shards: {total_shard_volume} '
+            f'does not match tensor volume: {tensor_volume}, in other words '
+            f'all the individual shards do not cover the entire tensor')

--- a/torch/distributed/_sharding_spec/api.py
+++ b/torch/distributed/_sharding_spec/api.py
@@ -1,11 +1,13 @@
 from abc import ABC
 from dataclasses import dataclass
-import torch
 from typing import List, Union
 
-from ._internals import is_valid_device
-
-Device = Union[torch.device, int, str]
+from ._internals import (
+    Device,
+    ShardMetadata,
+    is_valid_device,
+    validate_non_overlapping_shards_metadata
+)
 
 class PlacementSpec(ABC):
     """
@@ -100,52 +102,6 @@ class ChunkShardingSpec(ShardingSpec):
 
 
 @dataclass
-class ShardMetadata(object):
-    """
-    Represents a shard of the overall Tensor including its
-    offsets, lengths and device placement.
-
-    Args:
-        shard_offsets(List[int]): Offsets in the orignal tensor indicating
-            the start offsets for this shard. Should have the same rank as
-            the original tensor.
-        shard_lengths(List[int]): Lengths indicating the length of each
-            dimension for this shard. Should have the same rank as the
-            original tensor.
-        placement(Device):
-            Specifies the placement of this shard.
-
-            The placement can be a local device or a remote device specified by one
-            of the following remote formats:
-
-                1. "rank:<rank>/<device>" (ex: "rank:0/cuda:0").
-                2. "<worker_name>/<device>" (ex: "trainer0/cuda:0").
-    """
-
-    __slots__ = ['shard_offsets', 'shard_lengths', 'placement']
-
-    shard_offsets: List[int]
-    shard_lengths: List[int]
-    placement: Device
-
-    def __post_init__(self):
-        if not is_valid_device(self.placement):
-            raise ValueError(f'{self.placement} is not a valid device')
-
-        if len(self.shard_offsets) != len(self.shard_lengths):
-            raise ValueError(
-                f'shard_offsets and shard_lengths should have '
-                f'the same number of elements, found {len(self.shard_offsets)} '
-                f'and {self.shard_lengths} respectively')
-
-        for i in range(len(self.shard_offsets)):
-            if self.shard_offsets[i] < 0:
-                raise ValueError('shard_offsets should be >=0')
-            if self.shard_lengths[i] <= 0:
-                raise ValueError('shard_lengths should be > 0')
-
-
-@dataclass
 class EnumerableShardingSpec(ShardingSpec):
     """
     This is a type of PlacementSpec that allows users to specify a generic
@@ -169,75 +125,4 @@ class EnumerableShardingSpec(ShardingSpec):
                 raise ValueError(f'Found inconsistent ranks for shards: {rank} and {len(shard.shard_offsets)}')
             rank = len(shard.shard_offsets)
 
-        self._validate_non_overlapping(self.shards)
-
-    @staticmethod
-    def _validate_non_overlapping(shards: List[ShardMetadata]):
-        """
-        Ensures none of the shards overlap with each other.
-        """
-        # TODO: evaluate optimizing this if needed.
-        for i in range(len(shards)):
-            for j in range(i + 1, len(shards)):
-                if EnumerableShardingSpec._check_shard_pair_overlap(shards[i], shards[j]):
-                    raise ValueError(f'Shards {shards[i]} and {shards[j]} overlap')
-
-    @staticmethod
-    def _check_shard_pair_overlap(shard1: ShardMetadata, shard2: ShardMetadata):
-        """
-        Checks if two shards overlap.
-        """
-
-        # For each dim of each shard, check if one shard resides on the other
-        # end of second shard with respect to that dim. As an example for a 2D
-        # shard, we would check if one shard is above or on the left of the
-        # other shard.
-        ndims = len(shard1.shard_offsets)
-        for i in range(ndims):
-            if shard1.shard_offsets[i] >= shard2.shard_offsets[i] + shard2.shard_lengths[i]:
-                return False
-            if shard2.shard_offsets[i] >= shard1.shard_offsets[i] + shard1.shard_lengths[i]:
-                return False
-
-        return True
-
-    def check_tensor(self, tensor_dims) -> None:
-        """
-        Checks if the sharding spec is compatible with the provided tensor dims.
-
-        Args:
-            tensor_dims(Sequence of int): Dimensions of tensor to verify
-        Raises:
-            ``ValueError`` if not compatible.
-        """
-
-        # If the tensor's volume matches the total volume of all shards and
-        # all shard boundaries are within tensor dims, we have a compatible
-        # sharding spec for this tensor. Note that we have already verified
-        # we don't have overlapping shards.
-        tensor_rank = len(tensor_dims)
-        shards_rank = len(self.shards[0].shard_offsets)
-        if tensor_rank != shards_rank:
-            raise ValueError(f'Rank of tensor is {tensor_rank}, but shards rank is {shards_rank}')
-
-        total_shard_volume = 0
-        for shard in self.shards:
-            shard_volume = 1
-            for i, shard_length in enumerate(shard.shard_lengths):
-                shard_volume *= shard_length
-                if shard.shard_offsets[i] + shard.shard_lengths[i] > tensor_dims[i]:
-                    raise ValueError(
-                        f'Shard offset {shard.shard_offsets[i]} and length '
-                        f'{shard.shard_lengths[i]} exceeds tensor dim: {tensor_dims[i]} for shard {shard}')
-            total_shard_volume += shard_volume
-
-        tensor_volume = 1
-        for size in tensor_dims:
-            tensor_volume *= size
-
-        if total_shard_volume != tensor_volume:
-            # TODO: Can we improve this error message to point out the gaps?
-            raise ValueError(
-                f'Total volume of shards: {total_shard_volume}'
-                f'does not match tensor volume: {tensor_volume}, in other words'
-                f' all the individual shards do not cover the entire tensor')
+        validate_non_overlapping_shards_metadata(self.shards)


### PR DESCRIPTION
Summary: This added `init_from_local_shards` API to construc t a ShardedTensor from local_shards and global metadata list.

Test Plan: 
test_init_from_local_shards
test_init_from_local_shards_invalid_sharding

Differential Revision: D29276777

