### PR TITLE
add quantized_resize and dequantize for some cuda backends

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1790,7 +1790,7 @@
   dispatch:
     CPU, Meta: resize_
     CUDA: resize_cuda_
-    QuantizedCPU: quantized_resize_cpu_
+    QuantizedCPU, QuantizedCUDA: quantized_resize_cpu_
 
 - func: empty_quantized(int[] size, Tensor qtensor) -> Tensor
   variants: function
@@ -5158,6 +5158,7 @@
   variants: function, method
   dispatch:
     CPU: dequantize_cpu
+    CUDA: dequantize_quantized_cpu
     QuantizedCPU, QuantizedCUDA: dequantize_quantized_cpu
 
 - func: dequantize.tensors(Tensor[] tensors) -> Tensor[]


### PR DESCRIPTION
Summary:
adding entries into native_functions.yaml to enable these functions
since the code is common between cuda and cpu

Test Plan: tested with a full model, unit tests on the way

Differential Revision: D29312809

