### PR TITLE
task 1: annotate (and tensor type)

### DIFF
--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 from torch.fx import symbolic_trace
-from torch.fx.tensor_type import Tensor_Type, Dyn
+from torch.fx.tensor_type import TensorType, Dyn, is_consistent
 from torch.fx.annotate import annotate
 
 
@@ -14,30 +14,41 @@ class AnnotationsTest(unittest.TestCase):
         where n is the corresoinding node in the resulting graph.
         """
         class M(torch.nn.Module):
-            def forward(self, x: Tensor_Type((1, 2, 3, Dyn)), y: Dyn):
+            def forward(self, x: TensorType((1, 2, 3, Dyn)), y: Dyn):
                 return torch.add(x, y)
 
         module = M()
-        symbolic_traced : torch.fx.GraphModule = symbolic_trace(module)
+        symbolic_traced: torch.fx.GraphModule = symbolic_trace(module)
+
+        expected_ph_types = [TensorType((1, 2, 3, Dyn)), Dyn]
+        expected_iter = iter(expected_ph_types)
 
         for n in symbolic_traced.graph.nodes:
-            if n.name == 'x':
-                assert n.type == Tensor_Type((1, 2, 3, Dyn))
-            if n.name == 'y':
-                assert n.type == Dyn
+            if n.op == 'placeholder':
+                assert n.type == next(expected_iter)
 
     def test_annotate(self):
         class M(torch.nn.Module):
 
             def forward(self, x):
-                y = annotate(x, Tensor_Type((1, 2, 3, Dyn)))
+                y = annotate(x, TensorType((1, 2, 3, Dyn)))
                 return torch.add(x, y)
 
         module = M()
         symbolic_traced : torch.fx.GraphModule = symbolic_trace(module)
         for n in symbolic_traced.graph.nodes:
-            if n.name == 'x':
-                assert n.type == Tensor_Type((1, 2, 3, Dyn))
+            if n.op == 'placeholder':
+                assert n.type == TensorType((1, 2, 3, Dyn))
+
+    def test_consistency(self):
+        """
+        Test the consistency relation.
+        """
+        self.assertTrue(is_consistent(TensorType((1, 2, 3)), TensorType((1, Dyn, 3))))
+        self.assertTrue(is_consistent(int, Dyn))
+        self.assertTrue(is_consistent(int, int))
+        self.assertFalse(is_consistent(TensorType((1, 2, 3)), TensorType((1, 2, 3, 5))))
+        self.assertFalse(is_consistent(TensorType((1, 2, 3)), int))
 
 
 if __name__ == '__main__':

--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -1,0 +1,44 @@
+import unittest
+import torch
+from torch.fx import symbolic_trace
+from torch.fx.tensor_type import Tensor_Type, Dyn
+from torch.fx.annotate import annotate
+
+
+class AnnotationsTest(unittest.TestCase):
+
+    def test_annotations(self):
+        """
+        Test type annotations in the forward function.
+        The annoation should appear in the n.graph
+        where n is the corresoinding node in the resulting graph.
+        """
+        class M(torch.nn.Module):
+            def forward(self, x: Tensor_Type((1, 2, 3, Dyn)), y: Dyn):
+                return torch.add(x, y)
+
+        module = M()
+        symbolic_traced : torch.fx.GraphModule = symbolic_trace(module)
+
+        for n in symbolic_traced.graph.nodes:
+            if n.name == 'x':
+                assert n.type == Tensor_Type((1, 2, 3, Dyn))
+            if n.name == 'y':
+                assert n.type == Dyn
+
+    def test_annotate(self):
+        class M(torch.nn.Module):
+
+            def forward(self, x):
+                y = annotate(x, Tensor_Type((1, 2, 3, Dyn)))
+                return torch.add(x, y)
+
+        module = M()
+        symbolic_traced : torch.fx.GraphModule = symbolic_trace(module)
+        for n in symbolic_traced.graph.nodes:
+            if n.name == 'x':
+                assert n.type == Tensor_Type((1, 2, 3, Dyn))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -35,6 +35,7 @@ from torch.fx.proxy import TraceError
 from fx.test_subgraph_rewriter import TestSubgraphRewriter  # noqa: F401
 from fx.test_dce_pass import TestDCE  # noqa: F401
 from fx.test_fx_const_fold import TestConstFold  # noqa: F401
+from fx.test_gradual_type import AnnotationsTest, TypeCheckerTest # noqa: F401
 
 from typing import Any, Callable, Dict, NamedTuple, List, Optional, Tuple, Union
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, IS_WINDOWS, IS_SANDCASTLE, IS_MACOS

--- a/torch/fx/annotate.py
+++ b/torch/fx/annotate.py
@@ -10,3 +10,5 @@ def annotate(val, type):
         else:
             val.node.type = type
         return val
+    else:
+        return val

--- a/torch/fx/annotate.py
+++ b/torch/fx/annotate.py
@@ -1,0 +1,12 @@
+import torch
+
+
+def annotate(val, type):
+    # val could be either a regular value (not tracing)
+    # or fx.Proxy (tracing)
+    if isinstance(val, torch.fx.Proxy):
+        if val.node.type:
+            raise RuntimeError("type already exists")
+        else:
+            val.node.type = type
+        return val

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -1,4 +1,4 @@
-class Tensor_Type:
+class TensorType:
     """
     Tensor_Type defines a type for tensors, which consists of a list of dimensions.
 
@@ -9,7 +9,7 @@ class Tensor_Type:
     """
 
     def __init__(self, dim):
-        self.__origin__ = Tensor_Type
+        self.__origin__ = TensorType
         self.__args__ = dim
 
     def __repr__(self):
@@ -24,22 +24,24 @@ class Tensor_Type:
     @staticmethod
     def __class_getitem__(*args):
         assert isinstance(args[0], tuple)
-        return Tensor_Type(args[0])
+        return TensorType(args[0])
 
-class Dyn_Type:
+
+class _DynType:
     """
-    Dyn_Type defines a type which stands for the absence of type information.
+    _DynType defines a type which stands for the absence of type information.
     """
     def __init__(self):
-        self.__name__ = 'Dyn_Type'
+        self.__name__ = '_DynType'
 
     def __eq__(self, other):
         return isinstance(other, self.__class__)
 
-Dyn = Dyn_Type()
+
+Dyn = _DynType()
 
 
-def consistency(t1, t2):
+def is_consistent(t1, t2):
     """
     A binary relation denoted by ~ that determines if t1 is consistent with t2.
     The relation is reflexive, semmetric but not transitive.
@@ -54,9 +56,9 @@ def consistency(t1, t2):
     if t1 == t2:
         return True
 
-    if isinstance(t1, Dyn_Type) or isinstance(t2, Dyn_Type):
+    if isinstance(t1, _DynType) or isinstance(t2, _DynType):
         return True
 
-    if isinstance(t1, Tensor_Type) and isinstance(t2, Tensor_Type):
+    if isinstance(t1, TensorType) and isinstance(t2, TensorType):
         return len(t1.__args__) == len(t2.__args__) and \
-               all([consistency(elem1, elem2) for elem1, elem2 in zip(t1.__args__, t2.__args__)])
+               all([is_consistent(elem1, elem2) for elem1, elem2 in zip(t1.__args__, t2.__args__)])

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -1,0 +1,62 @@
+class Tensor_Type:
+    """
+    Tensor_Type defines a type for tensors, which consists of a list of dimensions.
+
+    Example:
+        class M(torch.nn.Module):
+            def forward(self, x:Tensor_Type((1,2,3, Dyn)), y:Tensor_Type((1,2,3, Dyn))):
+                return torch.add(x, y)
+    """
+
+    def __init__(self, dim):
+        self.__origin__ = Tensor_Type
+        self.__args__ = dim
+
+    def __repr__(self):
+        return f'Tensor_Type[{self.__args__}]'
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return list(self.__args__) == list(other.__args__)
+        else:
+            return False
+
+    @staticmethod
+    def __class_getitem__(*args):
+        assert isinstance(args[0], tuple)
+        return Tensor_Type(args[0])
+
+class Dyn_Type:
+    """
+    Dyn_Type defines a type which stands for the absence of type information.
+    """
+    def __init__(self):
+        self.__name__ = 'Dyn_Type'
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__)
+
+Dyn = Dyn_Type()
+
+
+def consistency(t1, t2):
+    """
+    A binary relation denoted by ~ that determines if t1 is consistent with t2.
+    The relation is reflexive, semmetric but not transitive.
+    returns True if t1 and t2 are consistent and False otherwise.
+
+    Example:
+        Dyn ~ Tensor_Type((1,2,3))
+        int ~ Dyn
+        int ~ int
+        Tensor_Type((1,Dyn,3)) ~ Tensor_Type((1,2,3))
+    """
+    if t1 == t2:
+        return True
+
+    if isinstance(t1, Dyn_Type) or isinstance(t2, Dyn_Type):
+        return True
+
+    if isinstance(t1, Tensor_Type) and isinstance(t2, Tensor_Type):
+        return len(t1.__args__) == len(t2.__args__) and \
+               all([consistency(elem1, elem2) for elem1, elem2 in zip(t1.__args__, t2.__args__)])


### PR DESCRIPTION
Task 1 
- Define `torch.fx.annotate` to add manual type annotations to intermediate statements
- Add tensor types and the dynamic type
- Add tests