### PR TITLE
Fix incorrect doc about the dtype for `torch.randint` described in issue #56347

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7619,7 +7619,8 @@ Args:
 Keyword args:
     {generator}
     {out}
-    {dtype}
+    dtype (`torch.dtype`, optional) - the desired data type of returned tensor. Default: if ``None``,
+        this function returns a tensor with dtype ``torch.int64``.
     {layout}
     {device}
     {requires_grad}


### PR DESCRIPTION
Summary: Fix incorrect documentation about the dtype for `torch.randint` described in issue #56347

Test Plan: Review documentation to make sure formatting is right

Differential Revision: D29321181

