### PR TITLE
[nnc] Merge inconsistent profiling information

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -313,7 +313,12 @@ void removeProfileNodesAndSpecializeTypes(Block* b) {
       if (profiled_type == TensorType::get()) {
         continue;
       }
-      it->input()->setType(it->ty(attr::profiled_type));
+      // If we encounter non-identical profiled types for the same value, merge
+      // them.  This situation can happen if, e.g., loop unrolling duplicates
+      // profiled types in a loop body in a manner that isn't logically
+      // consistent (see TestTEFuser.test_unrolled_cat).
+      it->input()->setType(
+          it->input()->type()->expect<TensorType>()->merge(*profiled_type));
       it.destroyCurrent();
 
     } else {

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -317,8 +317,12 @@ void removeProfileNodesAndSpecializeTypes(Block* b) {
       // them.  This situation can happen if, e.g., loop unrolling duplicates
       // profiled types in a loop body in a manner that isn't logically
       // consistent (see TestTEFuser.test_unrolled_cat).
-      it->input()->setType(
-          it->input()->type()->expect<TensorType>()->merge(*profiled_type));
+      auto input_type = it->input()->type()->expect<TensorType>();
+      if (input_type == TensorType::get()) {
+        it->input()->setType(profiled_type);
+      } else {
+        it->input()->setType(input_type->merge(*profiled_type));
+      }
       it.destroyCurrent();
 
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60510 [nnc] Merge inconsistent profiling information**

We encountered a situation where loop unrolling caused us to duplicate
profiled tensor types in a manner that wasn't logically consistent (see the
attached test case).  When applying this profiling information, we need to
merge the profiled types so that we use a conservative (unspecialized) type.

Differential Revision: [D29322487](https://our.internmc.facebook.com/intern/diff/D29322487/)