### PR TITLE
Expose onnx_shape_inference option in torch.onnx.export

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -34,7 +34,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
            operator_export_type=None, opset_version=None, _retain_param_name=True,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_external_data_format=False):
+           enable_onnx_checker=True, use_external_data_format=False,
+           onnx_shape_inference=True):
     r"""
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported;
@@ -266,6 +267,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             location "f". If False, then the model is stored in regular format, i.e. model and
             parameters are all in one file. This argument is ignored for all export types other
             than ONNX.
+        onnx_shape_inference (bool, default True): If True the onnx shape inference will be run
+            as part of the export, to export shaped model.
     """
 
     from torch.onnx import utils
@@ -274,7 +277,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                         operator_export_type, opset_version, _retain_param_name,
                         do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, enable_onnx_checker, use_external_data_format)
+                        custom_opsets, enable_onnx_checker, use_external_data_format,
+                        onnx_shape_inference)
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -75,7 +75,8 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            operator_export_type=None, opset_version=None, _retain_param_name=True,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_external_data_format=False):
+           enable_onnx_checker=True, use_external_data_format=False,
+           onnx_shape_inference=True):
     if aten:
         assert operator_export_type is None
         operator_export_type = OperatorExportTypes.ONNX_ATEN
@@ -90,7 +91,8 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             example_outputs=example_outputs, strip_doc_string=strip_doc_string,
             dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets, enable_onnx_checker=enable_onnx_checker,
-            use_external_data_format=use_external_data_format)
+            use_external_data_format=use_external_data_format,
+            onnx_shape_inference=onnx_shape_inference)
 
 
 def _is_constant_tensor_list(node):


### PR DESCRIPTION
Some model export fails when it's `True` so I need this for a workaround