### PR TITLE
[ONNX] Update instance_norm implementation and support training

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3321,6 +3321,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.BatchNorm3d(3, affine=False)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9) # Because ConstantOfShape op is not supported for opset < 9
     def test_instancenorm1d_runningstats(self):
         x = torch.randn(10, 5, 128)
         model = torch.nn.InstanceNorm1d(5, affine=True, track_running_stats=True)
@@ -3337,6 +3338,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm1d(5, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9) # Because ConstantOfShape op is not supported for opset < 9
     def test_instancenorm2d_runningstats(self):
         x = torch.randn(10, 3, 128, 128)
         model = torch.nn.InstanceNorm2d(3, affine=True, track_running_stats=True)
@@ -3353,6 +3355,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm2d(3, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9) # Because ConstantOfShape op is not supported for opset < 9
     def test_instancenorm3d_runningstats(self):
         x = torch.randn(10, 3, 128, 128, 128)
         model = torch.nn.InstanceNorm3d(3, affine=True, track_running_stats=True)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7779,7 +7779,7 @@ class TestONNXRuntime(unittest.TestCase):
                 insnorm = self.insnorm(x)
                 return insnorm
 
-        x = torch.randn(3, 3, 1, 2)
+        x = torch.randn(10, 3, 128, 128)
         model_export = MyModule()
 
         model_export.train()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3321,7 +3321,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.BatchNorm3d(3, affine=False)
         self.run_test(model, x)
 
-    @skipIfUnsupportedMinOpsetVersion(9) # Because ConstantOfShape op is not supported for opset < 9
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because ConstantOfShape op is not supported for opset < 9
     def test_instancenorm1d_runningstats(self):
         x = torch.randn(10, 5, 128)
         model = torch.nn.InstanceNorm1d(5, affine=True, track_running_stats=True)
@@ -3338,7 +3338,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm1d(5, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
-    @skipIfUnsupportedMinOpsetVersion(9) # Because ConstantOfShape op is not supported for opset < 9
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because ConstantOfShape op is not supported for opset < 9
     def test_instancenorm2d_runningstats(self):
         x = torch.randn(10, 3, 128, 128)
         model = torch.nn.InstanceNorm2d(3, affine=True, track_running_stats=True)
@@ -3355,7 +3355,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm2d(3, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
-    @skipIfUnsupportedMinOpsetVersion(9) # Because ConstantOfShape op is not supported for opset < 9
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because ConstantOfShape op is not supported for opset < 9
     def test_instancenorm3d_runningstats(self):
         x = torch.randn(10, 3, 128, 128, 128)
         model = torch.nn.InstanceNorm3d(3, affine=True, track_running_stats=True)
@@ -7792,7 +7792,6 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(10, 3, 128, 128)
         model_export = MyModule()
-
         self.run_test(model_export, (x,), training=torch.onnx.TrainingMode.TRAINING, rtol=1e-3, atol=1e-5)
         model_export.train()
         self.run_test(model_export, (x, ), training=torch.onnx.TrainingMode.PRESERVE, rtol=1e-3, atol=1e-5)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1410,8 +1410,8 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
     else:
         input_size = sym_help._get_tensor_sizes(input)
         # If input shape is [N, C, H, W], reshape to [1, N * C, H, W] and call batch_norm.
-        # For more information :
-        # https://github.com/pytorch/pytorch/blob/9baf75c86edc7f6cd1c04bf9f42d18bc0d05f504/aten/src/ATen/native/Normalization.cpp#L532
+        # For more information instance_norm():
+        # https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Normalization.cpp#L542
         input_size_reshape = input_size.copy()
         n = input_size[0]
         c = input_size[1]

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1389,6 +1389,7 @@ def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
 
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled):
+    sym_help.check_training_mode(use_input_stats, "instance_norm")
     channel_size = sym_help._get_tensor_dim_size(input, 1)
     if weight is None or sym_help._is_none(weight):
         if channel_size is None:
@@ -1408,7 +1409,9 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
         return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
     else:
         input_size = sym_help._get_tensor_sizes(input)
-        # if input shape is [N, C, H, W], reshape to [1, N * C, H, W] and call batch_norm
+        # If input shape is [N, C, H, W], reshape to [1, N * C, H, W] and call batch_norm.
+        # For more information :
+        # https://github.com/pytorch/pytorch/blob/9baf75c86edc7f6cd1c04bf9f42d18bc0d05f504/aten/src/ATen/native/Normalization.cpp#L532
         input_size_reshape = input_size.copy()
         n = input_size[0]
         c = input_size[1]

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1389,27 +1389,39 @@ def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
 
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled):
+    channel_size = sym_help._get_tensor_dim_size(input, 1)
+    if weight is None or sym_help._is_none(weight):
+        if channel_size is None:
+            raise RuntimeError("Unsupported: ONNX export of instance_norm for unknown "
+                               "channel size.")
+        weight_value = torch.tensor([1.] * channel_size).type(
+            "torch." + input.type().scalarType() + "Tensor")
+        weight = g.op("Constant", value_t=weight_value)
+    if bias is None or sym_help._is_none(bias):
+        if channel_size is None:
+            raise RuntimeError("Unsupported: ONNX export of instance_norm for unknown "
+                               "channel size.")
+        bias_value = torch.tensor([0.] * channel_size).type(
+            "torch." + input.type().scalarType() + "Tensor")
+        bias = g.op("Constant", value_t=bias_value)
     if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
-        channel_size = sym_help._get_tensor_dim_size(input, 1)
-        if weight is None or sym_help._is_none(weight):
-            if channel_size is None:
-                raise RuntimeError("Unsupported: ONNX export of instance_norm for unknown "
-                                   "channel size.")
-            weight_value = torch.tensor([1.] * channel_size).type(
-                "torch." + input.type().scalarType() + "Tensor")
-            weight = g.op("Constant", value_t=weight_value)
-        if bias is None or sym_help._is_none(bias):
-            if channel_size is None:
-                raise RuntimeError("Unsupported: ONNX export of instance_norm for unknown "
-                                   "channel size.")
-            bias_value = torch.tensor([0.] * channel_size).type(
-                "torch." + input.type().scalarType() + "Tensor")
-            bias = g.op("Constant", value_t=bias_value)
         return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
     else:
-        # Now if track_running_stats is set to True it would get the same result with batchnorm. The PyTorch internal
-        # implementation of instance_norm may have a problem with running_mean and running_var repeat, will open a github issue.
-        return batch_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled)
+        input_size = sym_help._get_tensor_sizes(input)
+        # if input shape is [N, C, H, W], reshape to [1, N * C, H, W] and call batch_norm
+        input_size_reshape = input_size.copy()
+        n = input_size[0]
+        c = input_size[1]
+        input_size_reshape[0] = 1
+        input_size_reshape[1] = n * c
+        weight_ = repeat(g, weight, g.op("Constant", value_t=torch.tensor([n], dtype=torch.int64)))
+        bias_ = repeat(g, bias, g.op("Constant", value_t=torch.tensor([n], dtype=torch.int64)))
+        running_mean_ = repeat(g, running_mean, g.op("Constant", value_t=torch.tensor([n], dtype=torch.int64)))
+        running_var_ = repeat(g, running_var, g.op("Constant", value_t=torch.tensor([n], dtype=torch.int64)))
+        input_reshaped = g.op('Reshape', input, g.op('Constant', value_t=torch.LongTensor(input_size_reshape)))
+        out = batch_norm(g, input_reshaped, weight_, bias_, running_mean_, running_var_, use_input_stats,
+                         momentum, eps, cudnn_enabled)
+        return view(g, out, g.op("Constant", value_t=torch.tensor(input_size)))
 
 
 @parse_args("v", "i", "i", "i")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1414,6 +1414,9 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
         # https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Normalization.cpp#L542
         input_size_reshape = input_size.copy()
         n = input_size[0]
+        if n is None:
+            raise RuntimeError("Unsupported: ONNX export of instance_norm training for unknown "
+                               "batch size.")
         c = input_size[1]
         input_size_reshape[0] = 1
         input_size_reshape[1] = n * c


### PR DESCRIPTION
* Update the instance_norm track_running_stats=True implementation and support the training mode
* Reference: https://github.com/pytorch/pytorch/blob/9baf75c86edc7f6cd1c04bf9f42d18bc0d05f504/aten/src/ATen/native/Normalization.cpp#L532
* Fix https://github.com/pytorch/pytorch/issues/53887