### PR TITLE
DOC Describes parameters/buffers registered as None in load_state_dict

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1375,6 +1375,11 @@ class Module:
             ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
                 * **missing_keys** is a list of str containing the missing keys
                 * **unexpected_keys** is a list of str containing the unexpected keys
+
+        Note:
+            If a parameter or buffer is registered as ``None`` and its corresponding key
+            exists :attr:`state_dict`, :meth:`load_state_dict` will raise a
+            ``RuntimeError``.
         """
         missing_keys: List[str] = []
         unexpected_keys: List[str] = []

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1378,7 +1378,7 @@ class Module:
 
         Note:
             If a parameter or buffer is registered as ``None`` and its corresponding key
-            exists :attr:`state_dict`, :meth:`load_state_dict` will raise a
+            exists in :attr:`state_dict`, :meth:`load_state_dict` will raise a
             ``RuntimeError``.
         """
         missing_keys: List[str] = []


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/8104