### PR TITLE
Reland D29190420: [nnc][tests] Tests and benchmarks for computeSum

### DIFF
--- a/benchmarks/cpp/tensorexpr/bench_reduce.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_reduce.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 #include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/csrc/jit/tensorexpr/operators/operators.h>
 #include <torch/torch.h>
 
 #include <immintrin.h>
@@ -19,9 +20,11 @@ class Reduce1D : public benchmark::Fixture {
     M = state.range(0);
     A = torch::randn({M});
     B = torch::zeros({});
+    ref = torch::sum(A, {0});
   }
 
   void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(B, ref, std::sqrt(A.numel()) * 1e-7));
     state.counters["BYTES"] = benchmark::Counter(uint64_t(state.iterations()) * M * sizeof(float),
                                                  benchmark::Counter::kIsRate);
   }
@@ -29,6 +32,7 @@ class Reduce1D : public benchmark::Fixture {
   int M;
   at::Tensor A;
   at::Tensor B;
+  at::Tensor ref;
 };
 
 }  // namespace
@@ -379,3 +383,232 @@ BENCHMARK_DEFINE_F(Reduce1D, TeRfactorV1)(benchmark::State& state) {
 }
 
 BENCHMARK_REGISTER_F(Reduce1D, TeRfactorV1)->Args({1 << 24});
+
+BENCHMARK_DEFINE_F(Reduce1D, Op)(benchmark::State& state) {
+  te::KernelScope ks;
+  const int M = A.numel();
+  const int kChunkSize = 8;
+
+  te::Placeholder a("A", te::kFloat, {M});
+  te::Tensor* b = te::computeSum({a.handle(), te::IntList({0}), false}, at::kFloat);
+  te::LoopNest nest({b});
+
+  auto loops = nest.getLoopStmtsFor(b);
+  te::For *mi, *mo;
+  te::Buf *rf;
+  nest.splitWithMask(loops[0], kChunkSize, &mi);
+  loops = nest.reorder({loops[0], mi}, {1, 0});
+  nest.rfactor(nest.getLoopBodyFor(b), loops[0], &rf);
+  nest.reorderAxis(loops[0], loops[1]);
+  for (auto const& loop : nest.getAllInnermostLoopsWritingToBuf(rf)) {
+    nest.vectorize(loop);
+  }
+
+  nest.prepareForCodegen();
+  nest.simplify();
+  te::LLVMCodeGen cg(nest.root_stmt(), {a, b});
+
+  for (auto _ : state) {
+    cg.call({A.data_ptr<float>(), B.data_ptr<float>()});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce1D, Op)->Args({1 << 24});
+
+class Reduce2DCol : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    at::set_num_threads(1);
+    torch::manual_seed(0x12345678);
+    M = state.range(0);
+    N = state.range(1);
+    A = torch::randn({M, N});
+    ref = torch::sum(A, {0});
+    B = torch::zeros_like(ref);
+  }
+
+  void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(B, ref, std::sqrt(A.numel()) * 1e-5));
+    state.counters["BYTES"] = benchmark::Counter(uint64_t(state.iterations()) * (A.nbytes() + B.nbytes()),
+                                                 benchmark::Counter::kIsRate);
+  }
+
+  int M;
+  int N;
+  at::Tensor A;
+  at::Tensor B;
+  at::Tensor ref;
+};
+
+BENCHMARK_DEFINE_F(Reduce2DCol, Torch)(benchmark::State& state) {
+  for (auto _ : state) {
+    B = torch::sum(A, {0});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DCol, Torch)
+->Args({1 << 3, 1 << 21})
+->Args({1 << 6, 1 << 18})
+->Args({1 << 12, 1 << 12});
+
+BENCHMARK_DEFINE_F(Reduce2DCol, OpSchedule)(benchmark::State& state) {
+  te::KernelScope ks;
+  constexpr int kCacheSize = 1 << 12;
+  te::Placeholder a("A", te::kFloat, {M, N});
+  te::Tensor* b = te::computeSum({a.handle(), te::IntList({0}), false}, at::kFloat);
+  te::LoopNest nest({b});
+
+  auto sch = state.range(2);
+  if (sch == 0) {
+  } else if (sch == 1) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[0], loops[1]);
+  } else if (sch == 2) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.splitWithTail(loops[0], kCacheSize);
+    loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[1], loops[2]);
+  } else if (sch == 3) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.splitWithTail(loops[1], 8);
+    loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[0], loops[1]);
+  }
+
+  nest.prepareForCodegen();
+  nest.simplify();
+  te::LLVMCodeGen cg(nest.root_stmt(), {a, b});
+  for (auto _ : state) {
+    cg.call({A.data_ptr<float>(), B.data_ptr<float>()});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DCol, OpSchedule)->Apply(//CustomArgs);
+    [](benchmark::internal::Benchmark* b) {
+      for (auto sch : {0, 1, 2, 3}) {
+        for (auto rows : {3, 6, 12}) {
+          auto cols = 24 - rows;
+          b->Args({1 << rows, 1 << cols, sch});
+        }
+      }
+    });
+
+class Reduce2DRow : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    at::set_num_threads(1);
+    torch::manual_seed(0x12345678);
+    M = state.range(0);
+    N = state.range(1);
+    A = torch::randn({M, N});
+    ref = torch::sum(A, {1});
+    B = torch::zeros_like(ref);
+  }
+
+  void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(B, ref, std::sqrt(A.numel()) * 1e-4));
+    state.counters["BYTES"] = benchmark::Counter(uint64_t(state.iterations()) * (A.nbytes() + B.nbytes()),
+                                                 benchmark::Counter::kIsRate);
+  }
+
+  int M;
+  int N;
+  at::Tensor A;
+  at::Tensor B;
+  at::Tensor ref;
+};
+
+BENCHMARK_DEFINE_F(Reduce2DRow, Torch)(benchmark::State& state) {
+  for (auto _ : state) {
+    B = torch::sum(A, {1});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DRow, Torch)
+->Args({1 << 3, 1 << 21})
+->Args({1 << 6, 1 << 18})
+->Args({1 << 12, 1 << 12})
+->Args({1 << 18, 1 << 6});
+
+BENCHMARK_DEFINE_F(Reduce2DRow, Hand)(benchmark::State& state) {
+  auto a = A.data_ptr<float>();
+  auto b = B.data_ptr<float>();
+  constexpr int Mb = 4;
+  constexpr int Nb = 4;
+  auto fn = [&] {
+    for (int m_outer = 0; m_outer < M; m_outer += Mb) {
+      float bregs[Mb][Nb] = {0.0f};
+      for (int n_outer = 0; n_outer < N; n_outer += Nb) {
+        for (int m_inner = 0; m_inner < Mb; m_inner++) {
+          for (int n_inner = 0; n_inner < Nb; n_inner++) {
+            bregs[m_inner][n_inner] += a[(m_outer + m_inner) * N + n_outer + n_inner];
+          }
+        }
+      }
+      for (int m_inner = 0; m_inner < Mb; m_inner++) {
+        b[m_outer + m_inner] = 0.f;
+        for (int n_inner = 0; n_inner < Nb; n_inner++) {
+          b[m_outer + m_inner] += bregs[m_inner][n_inner];
+        }
+      }
+    }
+  };
+  for (auto _ : state) {
+    fn();
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DRow, Hand)
+->Args({1 << 18, 1 << 6});
+
+BENCHMARK_DEFINE_F(Reduce2DRow, OpSchedule)(benchmark::State& state) {
+  te::KernelScope ks;
+  constexpr int kChunkSize = 8;
+  te::Placeholder a("A", te::kFloat, {M, N});
+  te::Tensor* b = te::computeSum({a.handle(), te::IntList({1}), false}, at::kFloat);
+  te::LoopNest nest({b});
+
+  auto sch = state.range(2);
+  if (sch == 1) {
+    auto loops = nest.getLoopStmtsFor(b);
+    te::For *mi, *mo;
+    te::Buf *rf;
+    nest.splitWithMask(loops[1], kChunkSize, &mi);
+    loops = nest.reorder({loops[1], mi}, {1, 0});
+    TORCH_CHECK(nest.rfactor(nest.getLoopBodyFor(b), loops[0], &rf));
+    nest.reorderAxis(loops[0], loops[1]);
+    for (auto const& loop : nest.getAllInnermostLoopsWritingToBuf(rf)) {
+      nest.vectorize(loop);
+    }
+  } else if (sch == 2) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.splitWithMask(loops[1], 8);
+    nest.splitWithMask(loops[0], 4);
+    loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[1], loops[2]);
+  } else if (sch == 3) {
+    auto loops = nest.getLoopStmtsFor(b);
+    te::For *mi, *mo;
+    te::Buf *rf;
+    nest.splitWithMask(loops[1], kChunkSize, &mi);
+    loops = nest.reorder({loops[1], mi}, {1, 0});
+    TORCH_CHECK(nest.rfactor(nest.getLoopBodyFor(b), loops[0], &rf));
+    nest.reorderAxis(loops[0], loops[1]);
+    te::LoopNest::compressBuffer(rf, nest.root_stmt());
+    for (auto const& loop : nest.getAllInnermostLoopsWritingToBuf(rf)) {
+      nest.vectorize(loop);
+    }
+  }
+
+  nest.prepareForCodegen();
+  nest.simplify();
+  te::LLVMCodeGen cg(nest.root_stmt(), {a, b});
+
+  for (auto _ : state) {
+    cg.call({A.data_ptr<float>(), B.data_ptr<float>()});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DRow, OpSchedule)->Apply(//CustomArgs);
+    [](benchmark::internal::Benchmark* b) {
+      for (auto sch : {0, 1, 2, 3}) {
+        for (auto rows : {3, 6, 12, 18}) {
+          auto cols = 24 - rows;
+          b->Args({1 << rows, 1 << cols, sch});
+        }
+      }
+    });

--- a/test/cpp/tensorexpr/test_ops.cpp
+++ b/test/cpp/tensorexpr/test_ops.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include <torch/csrc/jit/tensorexpr/eval.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/operators/operators.h>
+#include <torch/torch.h>
+
+using namespace torch::jit::tensorexpr;
+
+using Tensors = std::vector<Tensor*>;
+using Args = std::vector<CodeGen::BufferArg>;
+std::unique_ptr<SimpleIREvaluator> compile(
+    const Args& inputs,
+    const Tensors& outputs) {
+  LoopNest nest({outputs});
+  nest.prepareForCodegen();
+  nest.simplify();
+  auto join = inputs;
+  join.insert(join.end(), outputs.begin(), outputs.end());
+  return std::make_unique<SimpleIREvaluator>(nest.root_stmt(), join);
+}
+
+TEST(Ops, Sum) {
+  KernelScope ks;
+
+  std::vector<IntList> testDims = {{0}, {1}, {0, 1}};
+  for (auto const& dims : testDims) {
+    constexpr int M = 8;
+    constexpr int N = 16;
+
+    Placeholder a("a", kFloat, {M, N});
+    Tensor* b = computeSum({a.handle(), dims, false}, c10::kFloat);
+    auto cg = compile({a}, {b});
+
+    auto at = at::arange(M * N, at::kFloat).view({M, N});
+    auto ref = at::sum(at, dims);
+    auto bt = at::empty_like(ref);
+
+    cg->call({at.data_ptr<float>(), bt.data_ptr<float>()});
+
+    ASSERT_TRUE(at::allclose(bt, ref));
+  }
+}


### PR DESCRIPTION
Summary:
Original commit changeset: ed655497a981

Whatever gcc version OSS Bazel uses wasn't happy move-constructing the
SimpleIREvaluator, so use a unique_ptr instead.

Test Plan:
CI.  Hope that the gcc version used by OSS Bazel build is
happier with this (it should be), since actually testing it locally is
an intractable pain.

Differential Revision: D29333116

