### PR TITLE
[quant][fx][fix] QAT with object_type in qconfig

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1001,6 +1001,47 @@ class TestQuantizeFx(QuantizationTestCase):
         ]
         self.checkGraphModuleNodes(m, expected_node_list=node_list)
 
+    def test_qconfig_qat_module_type(self):
+        class Linear(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.ones(5, 5)
+                self.b = torch.zeros(5)
+
+            def forward(self, x):
+                return torch.nn.functional.linear(x, self.w, self.b)
+
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mods1 = torch.nn.Sequential(
+                    torch.nn.Linear(5, 5),
+                )
+            def forward(self, x):
+                x = self.mods1(x)
+                return x
+
+        model = M().train()
+
+        qconfig_dict = {
+                    "": None,
+                    "object_type": [
+                        (torch.nn.Linear, default_qat_qconfig),
+                    ],
+                }
+        m = prepare_qat_fx(model, qconfig_dict)
+        m(torch.rand(5, 5))
+        m = convert_fx(m)
+        m(torch.rand(5, 5))
+        # first conv is quantized, second conv is not quantized
+        node_list = [
+            ns.call_function(torch.quantize_per_tensor),
+            ns.call_module(nnq.Linear),
+            ns.call_method("dequantize"),
+        ]
+        self.checkGraphModuleNodes(m, expected_node_list=node_list)
+
     def test_qconfig_function(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1018,6 +1018,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 self.mods1 = torch.nn.Sequential(
                     torch.nn.Linear(5, 5),
                 )
+
             def forward(self, x):
                 x = self.mods1(x)
                 return x
@@ -1025,11 +1026,11 @@ class TestQuantizeFx(QuantizationTestCase):
         model = M().train()
 
         qconfig_dict = {
-                    "": None,
-                    "object_type": [
-                        (torch.nn.Linear, default_qat_qconfig),
-                    ],
-                }
+            "": None,
+            "object_type": [
+                (torch.nn.Linear, default_qat_qconfig),
+            ],
+        }
         m = prepare_qat_fx(model, qconfig_dict)
         m(torch.rand(5, 5))
         m = convert_fx(m)

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1034,7 +1034,6 @@ class TestQuantizeFx(QuantizationTestCase):
         m(torch.rand(5, 5))
         m = convert_fx(m)
         m(torch.rand(5, 5))
-        # first conv is quantized, second conv is not quantized
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
             ns.call_module(nnq.Linear),

--- a/torch/quantization/fx/prepare.py
+++ b/torch/quantization/fx/prepare.py
@@ -143,7 +143,6 @@ def get_standalone_module_configs(
     sm_prepare_config_dict = {} if config[1] is None else config[1]
     return sm_qconfig_dict, sm_prepare_config_dict
 
-
 def qat_swap_modules(
         root: torch.nn.Module,
         additional_qat_module_mapping: Dict[Callable, Callable]) -> None:

--- a/torch/quantization/fx/prepare.py
+++ b/torch/quantization/fx/prepare.py
@@ -143,6 +143,7 @@ def get_standalone_module_configs(
     sm_prepare_config_dict = {} if config[1] is None else config[1]
     return sm_qconfig_dict, sm_prepare_config_dict
 
+
 def qat_swap_modules(
         root: torch.nn.Module,
         additional_qat_module_mapping: Dict[Callable, Callable]) -> None:
@@ -1028,10 +1029,6 @@ def prepare(
     flattened_qconfig_dict = get_flattened_qconfig_dict(qconfig_dict)
     # TODO: support regex as well
     propagate_qconfig_(model, flattened_qconfig_dict)
-    if model.training:
-        additional_qat_module_mapping = prepare_custom_config_dict.get(
-            "additional_qat_module_mapping", {})
-        qat_swap_modules(model, additional_qat_module_mapping)
 
     # mapping from fully qualified module name to module instance
     # for example,
@@ -1041,6 +1038,11 @@ def prepare(
     #   'linear.weight_fake_quant': PerChannelMinMaxObserver(...),
     # }
     modules = dict(model.named_modules())
+
+    if model.training:
+        additional_qat_module_mapping = prepare_custom_config_dict.get(
+            "additional_qat_module_mapping", {})
+        qat_swap_modules(model, additional_qat_module_mapping)
 
     # fill qconfig_map, a map from node name to qconfig, used in find_matches
     equalization_qconfig_map = generate_qconfig_map(model, modules, model.graph, equalization_qconfig_dict, node_name_to_scope)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60555 [quant][fx][fix] QAT with object_type in qconfig**
* #60386 [quant] avoid resize calls in observer/fake_quant

Summary:
When we do QAT, we swap the FP32 modules with the corresponding quantized modules counterpart by calling `qat_swap_modules` in prepare.
However when we try to look up using the swapped module type in qconfig_dict, we cannot find a match anymore since the qconfig dict contains the original
module type.

In this PR we update the qconfig_dict to include the modules swapped for QATT

Test Plan:
python test/test_quantization.py TestQuantizeFx.test_qconfig_qat_module_type

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29337036](https://our.internmc.facebook.com/intern/diff/D29337036)