### PR TITLE
[torch/distributed.elastic] Fix utils.distributed_test.test_create_store_timeout_on_server to be dual-stack ip compatible

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -16,7 +16,7 @@ from torch.distributed.elastic.utils.distributed import (
     get_free_port,
     get_socket_with_port,
 )
-from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, IS_MACOS
+from torch.testing._internal.common_utils import IS_MACOS, IS_WINDOWS, run_tests
 
 
 def _create_c10d_store_mp(is_server, server_addr, port, world_size):
@@ -101,18 +101,22 @@ class DistributedUtilTest(unittest.TestCase):
             )
 
     def test_port_already_in_use_on_server(self):
-        sock = get_socket_with_port()
-        with closing(sock):
-            # try to create a store on the same port without releasing the socket
-            # should raise a IOError
-            port = sock.getsockname()[1]
-            with self.assertRaises(IOError):
-                create_c10d_store(
-                    is_server=True,
-                    server_addr=socket.gethostname(),
-                    server_port=port,
-                    timeout=1,
-                )
+        # try to create the TCPStore server twice on the same port
+        # the second should fail due to a port conflict
+        # first store binds onto a free port
+        # try creating the second store on the port that the first store binded to
+        server_addr = socket.gethostname()
+        pick_free_port = 0
+        store1 = create_c10d_store(
+            is_server=True,
+            server_addr=server_addr,
+            server_port=pick_free_port,
+            timeout=1,
+        )
+        with self.assertRaises(IOError):
+            create_c10d_store(
+                is_server=True, server_addr=server_addr, server_port=store1.port
+            )
 
     def test_port_already_in_use_on_worker(self):
         sock = get_socket_with_port()


### PR DESCRIPTION
Summary:
Fixes 1/2 flaky tests as described in: https://github.com/pytorch/pytorch/issues/60260

`test_create_store_timeout_on_server` tests whether trying to create a `c10d::TCPStore` server on an already taken port actually fails with an `IOError`. Prior to this change the `utils.get_socket_with_port()` util method was used to synthetically reserve a port, then try creating the `TCPStore` on that port to validate the `IOError`. The issue with this is that on a dual stack ip setup, `get_socket_with_port()` (since it uses `socket.AF_UNSPEC`) reserves an ipv6 port, while `TCPStore` will try binding to an ipv4 port, so an `IOError` is not observed.

Changing the logic of the test to create two `TCPStore` servers. The first chooses a free port (by passing `server_port=0`) while the second tries to create a `TCPStore` server on the port that the first store is already running on. This would induce an `IOError` on the second store's constructor.

NOTE: this change does not solve another broader issue with `TCPStore` where the server and workers can listen and connect on ipv4 vs ipv6 when they are running on dual-stak ip hosts without ipv4 DNS entry and/or a `/etc/gai.conf` specifying the preferred bind ordering. See: https://github.com/pytorch/pytorch/pull/49124

Test Plan:
```
buck test //caffe2/test/distributed/elastic/utils:distributed_test
```

Differential Revision: D29334947

