### PR TITLE
[nnc] Add LoopNest::getLoopAt to retrieve a specified inner For-stmt

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -662,6 +662,58 @@ TEST(LoopNest, ExprSplitWithMaskRepeatedNoMask) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+TEST(LoopNest, getLoopAt) {
+  KernelScope kernel_scope;
+
+  // Input IR:
+  //  for (int i = 0; i < 100; i++) {
+  //    for (int j = 0; j < 100; j++) {
+  //      A[i, j] = sin(i * j);
+  //      for (int k1 = 0; k1 < 200; k1++) {
+  //        B[i, j, k1] = (A[i, j]) / (k1 + 1);
+  //      }
+  //      for (int k2 = 0; k2 < 300; k2++) {
+  //        C[i, j, k2] = (A[i, j]) * (k2 + 1);
+  //      }
+  //    }
+  //  }
+  Buf* A = new Buf("A", {new IntImm(100), new IntImm(100)}, kInt);
+  Buf* B = new Buf("B", {new IntImm(100), new IntImm(100), new IntImm(200)}, kInt);
+  Buf* C = new Buf("C", {new IntImm(100), new IntImm(100), new IntImm(300)}, kInt);
+  BufHandle a_buf(A);
+  BufHandle b_buf(B);
+  BufHandle c_buf(C);
+  VarHandle i("i", kInt);
+  VarHandle j("j", kInt);
+  VarHandle k1("k1", kInt);
+  VarHandle k2("k2", kInt);
+  auto store1 = Store::make(a_buf, {i, j}, sin(i * j));
+  auto store2 = Store::make(
+      b_buf,
+      {i, j, k1},
+      Div::make(Load::make(a_buf, {i, j}), (k1+1)));
+  auto store3 = Store::make(
+      c_buf,
+      {i, j, k2},
+      Mul::make(Load::make(a_buf, {i, j}), (k2+1)));
+  auto for_k2 = For::make(k2, 0, 300, Block::make({store3}));
+  auto for_k1 = For::make(k1, 0, 200, Block::make({store2}));
+  auto for_j = For::make(j, 0, 100, Block::make({store1, for_k1, for_k2}));
+  auto for_i = For::make(i, 0, 100, for_j);
+  LoopNest l(Block::make({for_i}), {B, C});
+  auto ret_k2 = l.getLoopAt(for_i, {0, 2});
+
+  std::ostringstream oss;
+  oss << *ret_k2;
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int k2
+# CHECK-NEXT: C[i, j, k2] =
+      )IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoopNest, TileSimple) {
   KernelScope kernel_scope;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -678,8 +678,10 @@ TEST(LoopNest, getLoopAt) {
   //    }
   //  }
   Buf* A = new Buf("A", {new IntImm(100), new IntImm(100)}, kInt);
-  Buf* B = new Buf("B", {new IntImm(100), new IntImm(100), new IntImm(200)}, kInt);
-  Buf* C = new Buf("C", {new IntImm(100), new IntImm(100), new IntImm(300)}, kInt);
+  Buf* B =
+      new Buf("B", {new IntImm(100), new IntImm(100), new IntImm(200)}, kInt);
+  Buf* C =
+      new Buf("C", {new IntImm(100), new IntImm(100), new IntImm(300)}, kInt);
   BufHandle a_buf(A);
   BufHandle b_buf(B);
   BufHandle c_buf(C);
@@ -689,19 +691,16 @@ TEST(LoopNest, getLoopAt) {
   VarHandle k2("k2", kInt);
   auto store1 = Store::make(a_buf, {i, j}, sin(i * j));
   auto store2 = Store::make(
-      b_buf,
-      {i, j, k1},
-      Div::make(Load::make(a_buf, {i, j}), (k1+1)));
+      b_buf, {i, j, k1}, Div::make(Load::make(a_buf, {i, j}), (k1 + 1)));
   auto store3 = Store::make(
-      c_buf,
-      {i, j, k2},
-      Mul::make(Load::make(a_buf, {i, j}), (k2+1)));
+      c_buf, {i, j, k2}, Mul::make(Load::make(a_buf, {i, j}), (k2 + 1)));
   auto for_k2 = For::make(k2, 0, 300, Block::make({store3}));
   auto for_k1 = For::make(k1, 0, 200, Block::make({store2}));
   auto for_j = For::make(j, 0, 100, Block::make({store1, for_k1, for_k2}));
   auto for_i = For::make(i, 0, 100, for_j);
   LoopNest l(Block::make({for_i}), {B, C});
   auto ret_k2 = l.getLoopAt(for_i, {0, 2});
+  TORCH_CHECK(ret_k2 == for_k2);
 
   std::ostringstream oss;
   oss << *ret_k2;

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1926,6 +1926,30 @@ std::vector<For*> LoopNest::reorder(
   return result;
 }
 
+For* LoopNest::getLoopAt(For* root, const std::vector<int>& indices) const {
+  if (indices.empty()) {
+    return root;
+  }
+  if (root == nullptr) {
+    throw malformed_input("root loop is null");
+  }
+
+  For* curr = root;
+  for (auto i : indices) {
+    if (i < 0 || curr->body()->nstmts() <= i) {
+      return nullptr;
+    }
+    std::list<Stmt*>::iterator stmtp = curr->body()->begin();
+    std::advance(stmtp, i);
+    curr = dynamic_cast<For*>(*stmtp);
+    if (curr == nullptr) {
+      return nullptr;
+    }
+  }
+
+  return curr;
+}
+
 For* LoopNest::tile(For* x, For* y, int x_factor, int y_factor) {
   auto parent = dynamic_cast<Block*>(x->get_parent());
   if (parent == nullptr) {

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -50,6 +50,26 @@ class TORCH_API LoopNest {
   Stmt* getLoopBodyFor(Tensor*) const;
   Stmt* getLoopBodyFor(const Buf*) const;
 
+  // Returns the For stmt indexed by 'indices' in the 'root' For stmt.
+  //'indices' indicates the path to the returned loop from 'root' in AST, e.g.,
+  //
+  // root: for(int i...){
+  // j_loop: for (int j...){
+  // k1_loop:  for (int k1...){
+  //            A[i, j, k1] = ....
+  //          }
+  //          B[i, j] = ...
+  // k2_loop:  for (int k2...){
+  //            A[i, j, k2] = ...
+  //          }
+  //        }
+  //      }
+  //
+  // the path from 'root' to 'j_loop' is [0]
+  // the path from 'root' to 'k1_loop' is [0, 0]
+  // the path from 'root' to 'k2_loop' is [0, 2]
+  For* getLoopAt(For* root, const std::vector<int>& indices) const;
+
   // Returns the For stmt that is immediately enclosing the given stmt.
   static For* getParentLoop(const Stmt* st);
 

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -334,9 +334,9 @@ void initTensorExprBindings(PyObject* module) {
       .def_static(
           "make",
           [](const BufHandle& buf,
-             std::vector<ExprHandle>& indicies,
+             std::vector<ExprHandle>& indices,
              const ExprHandle& value) {
-            return Store::make(buf, indicies, value);
+            return Store::make(buf, indices, value);
           },
           py::return_value_policy::reference);
 
@@ -441,6 +441,12 @@ void initTensorExprBindings(PyObject* module) {
           "get_writes_for",
           [](const LoopNest& self, const BufHandle& b) {
             return self.getAllWritesToBuf(b.node());
+          },
+          py::return_value_policy::reference)
+      .def(
+          "get_loop_at",
+          [](const LoopNest& self, For* root, const std::vector<int>& indices) {
+            return self.getLoopAt(root, indices);
           },
           py::return_value_policy::reference)
       .def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60601 [nnc] Add LoopNest::unsafe_fuseLoops to let users apply fusion on stmts that may violate our correctness checks
* **#60569 [nnc] Add LoopNest::getLoopAt to retrieve a specified inner For-stmt**
* #57758 [NNC] Add tile transformation in loopnest (fixed #52785)

Differential Revision: [D29337767](https://our.internmc.facebook.com/intern/diff/D29337767)