### PR TITLE
Add back smoke tests for windows shard 1 for CircleCI

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -1,11 +1,21 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
+set GFLAGS_EXE="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe"
+if exist %GFLAGS_EXE% (
+    echo Some smoke tests
+    %GFLAGS_EXE% /i python.exe +sls
+    python %SCRIPT_HELPERS_DIR%\run_python_nn_smoketests.py
+    if ERRORLEVEL 1 exit /b 1
+
+    %GFLAGS_EXE% /i python.exe -sls
+    if ERRORLEVEL 1 exit /b 1
+)
+
 echo Copying over test times file
 copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"
 
-pushd test
-
 echo Run nn tests
+pushd test
 
 if "%RUN_SMOKE_TESTS_ONLY%"=="1" (
     :: Download specified test cases to run


### PR DESCRIPTION
The reason I removed the smoke tests here were because we didn't have gflags on our GHA runners and we wanted to get sharding done sooner rather than later.

However, we shouldn't remove these tests for windows as they are important for debugging linker issues with torch. Thus, this is step 1 in adding the tests back. 

Next step:
- add gflags to base ami
- remove the exist check

Test plan: 
CI shouldn't break