### PR TITLE
Remove _broadcast_object() for broadcast_object_list()

### DIFF
--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -54,46 +54,6 @@ def _is_trainable(param: torch.Tensor) -> bool:
     return param.requires_grad
 
 
-def _broadcast_object(
-    obj: Any, src_rank: int,
-    group: object = dist.group.WORLD,
-    device: torch.device = torch.device("cpu")
-) -> Any:
-    r"""
-    Broadcasts an object to the given group, sending the object if called from
-    the source rank and receiving the object otherwise.
-
-    Arguments:
-        obj: object to broadcast; only used if called on the source rank.
-        src_rank (int): source rank.
-        group (``ProcessGroup``, optional): group used for the broadcast
-            (default: ``dist.group.WORLD``).
-        device (``torch.device``, optional): device to send from or receive
-            to (default: ``torch.device("cpu")``).
-
-    Returns:
-        The broadcasted object.
-    """
-    if dist.get_rank() == src_rank:
-        # Send the object
-        buffer = io.BytesIO()
-        torch.save(obj, buffer)
-        data = bytearray(buffer.getbuffer())
-        length_tensor = torch.LongTensor([len(data)]).to(device)
-        data_send_tensor = torch.ByteTensor(data).to(device)
-        dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
-        dist.broadcast(data_send_tensor, src=src_rank, group=group, async_op=False)
-    else:
-        # Receive the object
-        length_tensor = torch.LongTensor([0]).to(device)
-        dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
-        data_recv_tensor = torch.empty([int(length_tensor.item())], dtype=torch.uint8, device=device)
-        dist.broadcast(data_recv_tensor, src=src_rank, group=group, async_op=False)
-        buffer = io.BytesIO(data_recv_tensor.cpu().numpy())
-        obj = torch.load(buffer, map_location=device)
-    return obj
-
-
 def _get_global_rank(group: Any, rank: int) -> int:
     r"""
     Returns the global rank for the given group and rank.
@@ -214,6 +174,11 @@ class ZeroRedundancyOptimizer(Optimizer):
         # is the target in `consolidate_state_dict()`
         self._all_state_dicts: List[Dict[str, Any]] = []
 
+        # Set the current device if using NCCL backend
+        if dist.get_backend(self.group) == dist.Backend.NCCL and \
+            self._default_device.type == "cuda":
+            torch.cuda.set_device(self._default_device)
+
         self.initialized = True
 
     def _clear_cache(self) -> None:
@@ -280,8 +245,6 @@ class ZeroRedundancyOptimizer(Optimizer):
         self._sync_param_groups(self.param_groups, self.optim.param_groups)
 
         # Pull the sharded state from all ranks and store them in rank order
-        empty_messenger = torch.tensor([0], dtype=torch.uint8, device=self._default_device)
-
         # NOTE: We wastefully use `broadcast()` (e.g. instead of `gather()`)
         # due to compatibility issues with NCCL backend; a possible follow-up
         # is to move all sharded state management to RPC RRef
@@ -298,33 +261,20 @@ class ZeroRedundancyOptimizer(Optimizer):
                     )
                 else:
                     # Receive the optimizer state from the source rank
-                    local_state_dict = _broadcast_object(
-                        empty_messenger,
-                        src_rank=global_rank,
-                        group=self.group,
-                        device=self._default_device,
-                    )
+                    local_state_dict_list = [None]
+                    dist.broadcast_object_list(local_state_dict_list, src=global_rank, group=self.group, device=self._default_device)
+                    local_state_dict = local_state_dict_list[0]
                     self._all_state_dicts.append(
                         _recursive_copy_to_device(local_state_dict, non_blocking=True, device=torch.device("cpu"))
                     )
             else:
                 if rank == self.rank:
                     # Send the optimizer state to the target rank
-                    _ = _broadcast_object(
-                        self.optim.state_dict(),
-                        src_rank=self.global_rank,
-                        group=self.group,
-                        device=self._default_device,
-                    )
+                    dist.broadcast_object_list([self.optim.state_dict()], src=self.global_rank, group=self.group)
                 elif rank != to:
                     # Discard the received object; `broadcast()` is used for
                     # compatibility reasons
-                    _ = _broadcast_object(
-                        empty_messenger,
-                        src_rank=global_rank,
-                        group=self.group,
-                        device=self._default_device,
-                    )
+                    dist.broadcast_object_list([None], src=global_rank, group=self.group, device=self._default_device)
 
     def _partition_parameters(self) -> List[List[Dict]]:
         r"""

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -176,7 +176,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
         # Set the current device if using NCCL backend
         if dist.get_backend(self.group) == dist.Backend.NCCL and \
-            self._default_device.type == "cuda":
+                self._default_device.type == "cuda":
             torch.cuda.set_device(self._default_device)
 
         self.initialized = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60574 Remove _broadcast_object() for broadcast_object_list()**
* #60573 Use torch.save()/load() to specify device

Addresses #60062.

**Overview:**
`broadcast_object_list()` relies on `_object_to_tensor()` and `_tensor_to_object()` for transforming each object to a tensor to be communicated. Currently, those two functions use `Pickler.dump()` and `Unpickler.load()`, whose semantics appear to match those of `torch.save()` and `torch.load()`. However, `torch.load()` provides an additional argument `map_location`, which allows the user to specify where to load tensors contained in the loaded object.

The issue with the existing implementation is evidenced when using NCCL backend and broadcasting tensors on GPU. The root cause lies in the default behavior of `torch.load()` (and `Unpickler.load()`) -- **tensors are loaded to device where they were saved**. Suppose we have two processes each with a designated GPU: rank 0 with `cuda:0` and rank 1 with `cuda:1`. If rank 0 broadcasts an object with a tensor to rank 1, when rank 1 loads the tensor via `_tensor_to_object()`, it loads the tensor back to `cuda:0`. This results in a problematic slowdown in hardware organizations where the data transfer from rank 1 to `cuda:0` is much slower than from rank 1 to `cuda:1`. Moreover, regardless of performance effects, I posit that the semantics are non-intuitive -- I would expect the received tensor is on the receiver's GPU, not the sender's.

The change introduced in the first commit of this PR is simply a starting point and can definitely be amended as seen fit. The [test for `broadcast_object_list()`](https://github.com/pytorch/pytorch/blob/da030c59e78dd343c03780a98cd3c2a4d2e3da9c/torch/testing/_internal/distributed/distributed_test.py#L5684) expects the existing behavior of loading tensors to the sender's device. Hence, to preserve backward compatibility, I introduced a `device=None` argument to `broadcast_object_list()`, which can be used to specify the destination for loaded tensors. I do not believe that any of the other collective communication functions using `_tensor_to_object()` (e.g. `all_gather_object()`, `scatter_object_list()`, etc.) are affected since they [do not support GPU](https://pytorch.org/docs/stable/distributed.html). 

The second commit in the PR retires `_broadcast_object()` in ZeRO in favor for `broadcast_object_list()`. 

**Test Plan:**
See [the ci-all tests](https://github.com/pytorch/pytorch/pull/60580).

The ZeRO tests pass (checked on the AI AWS cluster):
```
srun -p $DEV_QUEUE --cpus-per-task=16 -t 5:00:00 --gpus-per-node=4 python test/distributed/optim/test_zero_redundancy_optimizer.py
```