### PR TITLE
correct filename issue for test_cpp_extensions_aot

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -436,6 +436,8 @@ def calculate_job_times(reports: List["Report"]) -> Dict[str, float]:
                 new_avg = (curr_avg * curr_count + test_file['total_seconds']) / new_count
                 jobs_to_times[name] = (new_avg, new_count)
 
+    # This is no longer needed after https://github.com/pytorch/pytorch/pull/60604,
+    # TODO remove this once viable/strict move pass the merged commit.
     # if there's 'test_cpp_extensions_aot' entry in jobs_to_times, add 'test_cpp_extensions_aot_ninja'
     # and 'test_cpp_extensions_aot_no_ninja' duplicate entries to ease future computation since
     # test_cpp_extensions_aot_no_ninja and test_cpp_extensions_aot_ninja are Python test jobs that
@@ -602,7 +604,7 @@ def test_cuda_primary_ctx(test_module, test_directory, options):
     return run_test(test_module, test_directory, options, extra_unittest_args=['--subprocess'])
 
 
-def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
+def _test_cpp_extensions_aot(test_directory, options, use_ninja):
     if use_ninja:
         try:
             cpp_extension.verify_ninja_availability()
@@ -654,13 +656,11 @@ def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
 
 
 def test_cpp_extensions_aot_ninja(test_module, test_directory, options):
-    return _test_cpp_extensions_aot('test_cpp_extensions_aot', test_directory,
-                                    options, use_ninja=True)
+    return _test_cpp_extensions_aot(test_directory, options, use_ninja=True)
 
 
 def test_cpp_extensions_aot_no_ninja(test_module, test_directory, options):
-    return _test_cpp_extensions_aot('test_cpp_extensions_aot',
-                                    test_directory, options, use_ninja=False)
+    return _test_cpp_extensions_aot(test_directory, options, use_ninja=False)
 
 
 def test_distributed(test_module, test_directory, options):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -632,6 +632,9 @@ def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
 
     # "install" the test modules and run tests
     python_path = os.environ.get('PYTHONPATH', '')
+    from shutil import copyfile
+    test_module = 'test_cpp_extensions_aot' + ('_ninja' if use_ninja else '_no_ninja')
+    copyfile(test_directory + '/test_cpp_extensions_aot.py', test_directory + '/' + test_module + '.py')
     try:
         cpp_extensions = os.path.join(test_directory, 'cpp_extensions')
         install_directory = ''
@@ -646,6 +649,8 @@ def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
         return run_test(test_module, test_directory, options)
     finally:
         os.environ['PYTHONPATH'] = python_path
+        if os.path.exists(test_directory + '/' + test_module + '.py'):
+            os.remove(test_directory + '/' + test_module + '.py')
 
 
 def test_cpp_extensions_aot_ninja(test_module, test_directory, options):


### PR DESCRIPTION
Using file copy to make actual ninja vs. no_ninja suffixed python test files.
This is to trick xmlrunner to report test cases in the correct folder.

Test Plan
- CI reports correctly into the corresponding folders
- If download the test statistics, calculate shards now doesn't need custom logic to handle `test_cpp_extensions_aot`

CI result shown it is working properly:
https://github.com/pytorch/pytorch/pull/60604/checks?check_run_id=2900038654 vs
https://github.com/pytorch/pytorch/pull/60604/checks?check_run_id=2900038673

Both `test_cpp_extensions_aot_[ninja|no_ninja]` now reported correctly in their corresponding folders. Where as previously they all reported into the same folder without suffix