### PR TITLE
Run dist_autograd backward RPCs on appropriate CUDA streams.

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -354,7 +354,10 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
 }
 
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
-    processBackwardAutogradReq(RpcCommandBase& rpc) const {
+    processBackwardAutogradReq(
+        RpcCommandBase& rpc,
+        std::vector<c10::Stream> streams) const {
+  c10::MultiStreamGuard guard(streams);
   auto& gradientsCall = static_cast<PropagateGradientsReq&>(rpc);
   const auto& autogradMetadata = gradientsCall.getAutogradMetadata();
 
@@ -527,7 +530,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::processRpc(
       return processForwardAutogradReq(rpc, std::move(streams));
     }
     case MessageType::BACKWARD_AUTOGRAD_REQ: {
-      return processBackwardAutogradReq(rpc);
+      return processBackwardAutogradReq(rpc, std::move(streams));
     };
     case MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ: {
       return processCleanupAutogradContextReq(rpc);

--- a/torch/csrc/distributed/rpc/request_callback_no_python.h
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.h
@@ -66,7 +66,8 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       std::vector<c10::Stream> streams) const;
 
   c10::intrusive_ptr<JitFuture> processBackwardAutogradReq(
-      RpcCommandBase& rpc) const;
+      RpcCommandBase& rpc,
+      std::vector<c10::Stream> streams) const;
 
   c10::intrusive_ptr<JitFuture> processCleanupAutogradContextReq(
       RpcCommandBase& rpc) const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60606 Run dist_autograd backward RPCs on appropriate CUDA streams.**

TensorPipe receives tensors over the wire on custom streams and these
streams are passed to some RPC callbacks but not to `BACKWARD_AUTOGRAD_REQ`. As a
result, `BACKWARD_AUTOGRAD_REQ` ran on the default stream while still using
tensors from the custom stream. This resulted in downstream autograd operations
running on the incorrect stream.

To fix this, I've passed the streams to `BACKWARD_AUTOGRAD_REQ` as well and
added an appropriate guard.

#Closes: https://github.com/pytorch/pytorch/issues/59793

Differential Revision: [D29347244](https://our.internmc.facebook.com/intern/diff/D29347244/)