### PR TITLE
use explicitly non-returning GPU atomics

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -200,7 +200,7 @@ namespace {
         for(ih = 0; ih < kH; ++ih) {
           for(iw = 0; iw < kW; ++iw) {
             // atomic add since different threads could update same variable
-            gpuAtomicAdd(&(ptr_gradInput[iw]), grad_delta);
+            gpuAtomicAddNoReturn(&(ptr_gradInput[iw]), grad_delta);
           }
           ptr_gradInput += isizeW; // next input line
         }

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -291,7 +291,7 @@ __global__ void atomicadaptiveaveragegradinput(
       for (it = 0; it < kT; ++it) {
         for (ih = 0; ih < kH; ++ih) {
           for (iw = 0; iw < kW; ++iw) {
-            gpuAtomicAdd(&(ptr_gradInput[ih*isizeW + iw]), grad_delta);
+            gpuAtomicAddNoReturn(&(ptr_gradInput[ih*isizeW + iw]), grad_delta);
           }
         }
         ptr_gradInput += isizeH*isizeW; // next input frame

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -185,7 +185,7 @@ __global__ void atomicadaptivemaxgradinput(
       int argmax = (*ptr_ind);
 
       // atomic add since different threads could update same variable
-      gpuAtomicAdd(&(gradInput[argmax]), z);
+      gpuAtomicAddNoReturn(&(gradInput[argmax]), z);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -262,7 +262,7 @@ __global__ void atomicadaptivemaxgradinput(
       int64_t *ptr_ind = indices_dt + oh*osizeW + ow;
       T grad_delta = *ptr_gradOutput;
       int64_t argmax = (*ptr_ind);
-      gpuAtomicAdd(&(gradInput_d[argmax]), grad_delta);
+      gpuAtomicAddNoReturn(&(gradInput_d[argmax]), grad_delta);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -253,7 +253,7 @@ __global__ void avg_pool3d_cuda_update_grad_input_atomic(
       {
         for (int iCol = wstart; iCol < wend; ++iCol)
         {
-          gpuAtomicAdd(&gradInput[slice][iFrame][iRow][iCol], val);
+          gpuAtomicAddNoReturn(&gradInput[slice][iFrame][iRow][iCol], val);
         }
       }
     }

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -142,7 +142,7 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
   {
     int maxIndex = indices[slice][oFrame][oRow][oColumn];
     if (maxIndex != -1) {
-      gpuAtomicAdd(&gradInputData[slice * itime * iheight * iwidth + maxIndex],
+      gpuAtomicAddNoReturn(&gradInputData[slice * itime * iheight * iwidth + maxIndex],
                 gradOutput[slice][oFrame][oRow][oColumn]);
     }
   }

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -252,7 +252,7 @@ __global__ void EmbeddingBag_accGradParametersKernel_max(
       index_t word_idx = max_indices[bag * stride + featureDim];
       if (word_idx >= 0 && word_idx != padding_idx) {
         // If bag is empty, we have max_indices[idx] set to -1 in forward.
-        gpuAtomicAdd(&(gradWeight[word_idx * stride + featureDim]),
+        gpuAtomicAddNoReturn(&(gradWeight[word_idx * stride + featureDim]),
                 gradOutput[bag * stride + featureDim]);
       }
     }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -114,7 +114,7 @@ __global__ void fractional_max_pool2d_backward_out_cuda_frame(
     int inputH = index / gradInput.size(3);
     assert(inputH < gradInput.size(2));
 
-    gpuAtomicAdd(
+    gpuAtomicAddNoReturn(
       &gradInput[batch][plane][inputH][inputW],
       gradOutput[batch][plane][outputH][outputW]
     );

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -134,7 +134,7 @@ __global__ void fractional_max_pool3d_backward_out_frame(
       gradInput.size(4));
     assert(inputT < gradInput.size(2));
 
-    gpuAtomicAdd(
+    gpuAtomicAddNoReturn(
       &gradInput[batch][plane][inputT][inputH][inputW],
       gradOutput[batch][plane][outputT][outputH][outputW]
       );

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -369,7 +369,7 @@ __global__ void indexAddSmallIndex(cuda::detail::TensorInfo<T, IndexType> dst,
           cuda::detail::IndexToOffset<T, IndexType, SrcDim>::get(linearIndex, src);
       srcOffset += srcIndex * src.strides[srcAddDim];
 
-      gpuAtomicAdd(&dst.data[dstOffset], src.data[srcOffset] * alpha);
+      gpuAtomicAddNoReturn(&dst.data[dstOffset], src.data[srcOffset] * alpha);
     }
   }
 }
@@ -419,7 +419,7 @@ __global__ void indexAddLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
       cuda::detail::IndexToOffset<T, IndexType, SrcDim>::get(elementInSlice, src);
     srcOffset += srcIndex * src.strides[srcAddDim];
 
-    gpuAtomicAdd(&dst.data[dstOffset], src.data[srcOffset] * alpha);
+    gpuAtomicAddNoReturn(&dst.data[dstOffset], src.data[srcOffset] * alpha);
   }
 }
 

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -18,7 +18,7 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
 #if (                         \
     (CUDA_VERSION < 10000) || \
     (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
-  gpuAtomicAdd(
+  gpuAtomicAddNoReturn(
       reinterpret_cast<at::Half*>(tensor) + index,
       static_cast<at::Half>(value));
 #else
@@ -30,16 +30,16 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
     __half2 value2;
     value2.x = value;
     value2.y = __int2half_rz(0);
-    atomicAdd(reinterpret_cast<__half2*>(target_addr), value2);
+    atomicAddNoReturn(reinterpret_cast<__half2*>(target_addr), value2);
 
   } else if (!low_byte && index > 0) {
     __half2 value2;
     value2.x = __int2half_rz(0);
     value2.y = value;
-    atomicAdd(reinterpret_cast<__half2*>(target_addr - 1), value2);
+    atomicAddNoReturn(reinterpret_cast<__half2*>(target_addr - 1), value2);
 
   } else {
-    atomicAdd(
+    atomicAddNoReturn(
         reinterpret_cast<__half*>(tensor) + index, static_cast<__half>(value));
   }
 #endif
@@ -55,7 +55,7 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
     index_t index,
     const index_t numel,
     scalar_t value) {
-  gpuAtomicAdd(tensor + index, value);
+  gpuAtomicAddNoReturn(tensor + index, value);
 }
 
 template <class scalar_t, class index_t>
@@ -68,7 +68,7 @@ __device__ __forceinline__ void fastAtomicAdd(
   if (fast_atomics) {
     fastSpecializedAtomicAdd(tensor, index, numel, value);
   } else {
-    gpuAtomicAdd(tensor + index, value);
+    gpuAtomicAddNoReturn(tensor + index, value);
   }
 }
 

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -30,16 +30,16 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
     __half2 value2;
     value2.x = value;
     value2.y = __int2half_rz(0);
-    atomicAddNoReturn(reinterpret_cast<__half2*>(target_addr), value2);
+    atomicAdd(reinterpret_cast<__half2*>(target_addr), value2);
 
   } else if (!low_byte && index > 0) {
     __half2 value2;
     value2.x = __int2half_rz(0);
     value2.y = value;
-    atomicAddNoReturn(reinterpret_cast<__half2*>(target_addr - 1), value2);
+    atomicAdd(reinterpret_cast<__half2*>(target_addr - 1), value2);
 
   } else {
-    atomicAddNoReturn(
+    atomicAdd(
         reinterpret_cast<__half*>(tensor) + index, static_cast<__half>(value));
   }
 #endif

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -455,7 +455,7 @@ ctc_loss_backward_collect_nonblank_gpu_kernel(scalar_t* __restrict__ gradient_da
 
   for (int64_t t = 0; t < input_length; t++) {
     scalar_t lp = log_probs_data[lp_batch_offset + t * lp_input_stride + lp_char_stride * target];
-    gpuAtomicAdd(&gradient_data[gr_batch_offset + t * gr_input_stride + gr_char_stride * target],
+    gpuAtomicAddNoReturn(&gradient_data[gr_batch_offset + t * gr_input_stride + gr_char_stride * target],
               -std::exp(log_alpha_data[la_batch_offset + la_input_stride * t + la_target_stride * (s*2+1)]
                         + log_beta_data[lb_batch_offset + lb_input_stride * t + lb_target_stride * (s*2+1)]
                         + nll - lp) * gr);

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -101,7 +101,7 @@ __global__ void reflection_pad1d_backward_out_kernel(
 
   if (output_x < output_w) {
     auto index_pair = get_index_mapping1d(input_w, output_w, output_x, pad_l);
-    gpuAtomicAdd(
+    gpuAtomicAddNoReturn(
       &grad_input[index_pair.first], grad_output[index_pair.second]);
   }
 }
@@ -142,7 +142,7 @@ __global__ void reflection_pad2d_backward_out_kernel(
       pad_l, pad_t,
       output_xy, y_shift, z_shift, nplane);
 
-    gpuAtomicAdd(&grad_input[index_pair.first], grad_output[index_pair.second]);
+    gpuAtomicAddNoReturn(&grad_input[index_pair.first], grad_output[index_pair.second]);
   }
 }
 template <typename scalar_t, typename F>
@@ -249,7 +249,7 @@ __global__ void reflection_pad3d_backward_out_kernel(
           int64_t input_x) {
         auto value_to_add = grad_output[batch][plane][output_z][output_y][output_x];
         auto target = &grad_input[batch][plane][input_z][input_y][input_x];
-        gpuAtomicAdd(target, value_to_add);
+        gpuAtomicAddNoReturn(target, value_to_add);
       });
 }
 

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -69,7 +69,7 @@ __global__ void replication_pad_backward_kernel(
   int inputPointX = imin(imax(padL, outputPointX), gradInput.size(2) + padL - 1) - oStartX + iStartX;
 
   scalar_t valueToCopy = gradOutput[batch][plane][outputPointX];
-  gpuAtomicAdd(&gradInput[batch][plane][inputPointX], valueToCopy);
+  gpuAtomicAddNoReturn(&gradInput[batch][plane][inputPointX], valueToCopy);
 }
 
 template <typename scalar_t>
@@ -123,7 +123,7 @@ __global__ void replication_pad_backward_kernel(
   int inputPointY = imin(imax(padT, outputPointY), gradInput.size(2) + padT - 1) - oStartY + iStartY;
 
   scalar_t valueToCopy = gradOutput[batch][plane][outputPointY][outputPointX];
-  gpuAtomicAdd(&gradInput[batch][plane][inputPointY][inputPointX], valueToCopy);
+  gpuAtomicAddNoReturn(&gradInput[batch][plane][inputPointY][inputPointX], valueToCopy);
 }
 
 template <typename scalar_t>
@@ -197,7 +197,7 @@ __global__ void replication_pad_backward_kernel(
 
   scalar_t valueToCopy =
     gradOutput[batch][plane][outputPointZ][outputPointY][outputPointX];
-  gpuAtomicAdd(&gradInput[batch][plane][inputPointZ][inputPointY][inputPointX],
+  gpuAtomicAddNoReturn(&gradInput[batch][plane][inputPointZ][inputPointY][inputPointX],
       valueToCopy);
 }
 

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -29,7 +29,7 @@ class ReduceAdd {
 public:
   template <typename scalar_t>
   constexpr C10_DEVICE void operator() (scalar_t * self_data, const scalar_t * src_data) const {
-    gpuAtomicAdd(self_data, *src_data);
+    gpuAtomicAddNoReturn(self_data, *src_data);
   }
 };
 static ReduceAdd reduce_add;

--- a/aten/src/ATen/native/cuda/Sorting.cu
+++ b/aten/src/ATen/native/cuda/Sorting.cu
@@ -136,7 +136,7 @@ __global__ void gatherMedian(
   }
   __syncthreads();
   if (nan_count > 0) {
-    atomicAddNoReturn(&num_nan, nan_count);
+    gpuAtomicAddNoReturn(&num_nan, nan_count);
   }
   __syncthreads();
 

--- a/aten/src/ATen/native/cuda/Sorting.cu
+++ b/aten/src/ATen/native/cuda/Sorting.cu
@@ -136,7 +136,7 @@ __global__ void gatherMedian(
   }
   __syncthreads();
   if (nan_count > 0) {
-    atomicAdd(&num_nan, nan_count);
+    atomicAddNoReturn(&num_nan, nan_count);
   }
   __syncthreads();
 

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -219,7 +219,7 @@ __device__ void countRadixUsingMask(
   if (getLaneId() == 0) {
 #pragma unroll
     for (uint32_t i = 0; i < RadixSize; ++i) {
-      gpuAtomicAdd(&smem[i], counts[i]);
+      gpuAtomicAddNoReturn(&smem[i], counts[i]);
     }
   }
 

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -73,7 +73,7 @@ __global__ void kernelHistogram1D(
       if (bVal >= minvalue && bVal <= maxvalue) {
         // Use value at `b` as an offset of `smem`
         const IndexType bin = getBin<input_t, IndexType>(bVal, minvalue, maxvalue, nbins);
-        gpuAtomicAdd(&smem[bin], getOp(linearIndex));
+        gpuAtomicAddNoReturn(&smem[bin], getOp(linearIndex));
       }
     }
     __syncthreads();
@@ -83,7 +83,7 @@ __global__ void kernelHistogram1D(
     for (IndexType i = threadIdx.x; i < a.sizes[0]; i += blockDim.x) {
       const IndexType aOffset =
           detail::IndexToOffset<output_t, IndexType, ADims>::get(i, a);
-      gpuAtomicAdd(&a.data[aOffset], smem[i]);
+      gpuAtomicAddNoReturn(&a.data[aOffset], smem[i]);
     }
 
   } else if (MemoryType == CUDAHistogramMemoryType::MULTI_BLOCK) {
@@ -102,7 +102,7 @@ __global__ void kernelHistogram1D(
         const IndexType pIdx = p.strides[0] * blockIdx.x + bin;
         const IndexType pOffset =
             detail::IndexToOffset<output_t, IndexType, PDims>::get(pIdx, p);
-        gpuAtomicAdd(&p.data[pOffset], getOp(linearIndex));
+        gpuAtomicAddNoReturn(&p.data[pOffset], getOp(linearIndex));
       }
     }
     __syncthreads();
@@ -115,7 +115,7 @@ __global__ void kernelHistogram1D(
     for (IndexType i = threadIdx.x; i < a.sizes[0]; i += blockDim.x) {
       const IndexType aOffset =
           detail::IndexToOffset<output_t, IndexType, ADims>::get(i, a);
-      gpuAtomicAdd(&a.data[aOffset], p.data[pOffset + i]);
+      gpuAtomicAddNoReturn(&a.data[aOffset], p.data[pOffset + i]);
     }
 
   } else {
@@ -132,7 +132,7 @@ __global__ void kernelHistogram1D(
         const IndexType bin = getBin<input_t, IndexType>(bVal, minvalue, maxvalue, nbins);
         const IndexType aOffset =
             detail::IndexToOffset<output_t, IndexType, ADims>::get(bin, a);
-        gpuAtomicAdd(&a.data[aOffset], getOp(linearIndex));
+        gpuAtomicAddNoReturn(&a.data[aOffset], getOp(linearIndex));
       }
     }
   }

--- a/aten/src/ATen/native/cuda/UpSample.cuh
+++ b/aten/src/ATen/native/cuda/UpSample.cuh
@@ -171,7 +171,7 @@ __device__ __forceinline__ static void upsample_increment_value_bounded(
   /* TODO: result here is truncated to scalar_t,
      check: https://github.com/pytorch/pytorch/pull/19630#discussion_r281426912
    */
-  gpuAtomicAdd(
+  gpuAtomicAddNoReturn(
       &data[batch][channel][access_y][access_x], static_cast<scalar_t>(value));
 }
 

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -100,8 +100,8 @@ __global__ void upsample_linear1d_out_frame_backward(
     for (int n = 0; n < batchsize; n++) {
       for (int c = 0; c < channels; ++c) {
         const scalar_t d2val = odata[n][c][w2];
-        gpuAtomicAdd(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
-        gpuAtomicAdd(
+        gpuAtomicAddNoReturn(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
+        gpuAtomicAddNoReturn(
             &idata[n][c][w1 + w1p], static_cast<scalar_t>(w1lambda * d2val));
       }
     }

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -299,25 +299,12 @@ static inline __device__ void gpuAtomicAddNoReturn(bool *address, bool val) { gp
 static inline __device__ void gpuAtomicAddNoReturn(at::Half *address, at::Half val) { gpuAtomicAdd(address, val); }
 static inline __device__ void gpuAtomicAddNoReturn(at::BFloat16 *address, at::BFloat16 val) { gpuAtomicAdd(address, val); }
 static inline __device__ void gpuAtomicAddNoReturn(double *address, double val) { gpuAtomicAdd(address, val); }
-template<typename T>
-static inline __device__ void atomicAddNoReturn(c10::complex<T> *address, c10::complex<T> val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(uint8_t *address, uint8_t val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(int8_t *address, int8_t val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(int16_t *address, int16_t val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(int32_t *address, int32_t val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(int64_t *address, int64_t val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(bool *address, bool val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(at::Half *address, at::Half val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(at::BFloat16 *address, at::BFloat16 val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(double *address, double val) { gpuAtomicAdd(address, val); }
 
 /* Special case fp32 atomic. */
 #if defined(__HIP_PLATFORM_HCC__) && defined(__gfx908__)
 static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
-static inline __device__ void atomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
 #else
 static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }
-static inline __device__ void atomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }
 #endif
 
 // Atomic multiplication implementation.

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -281,6 +281,45 @@ static inline __device__ void atomicAdd(bool *address, bool val) {
   gpuAtomicAdd(address, val);
 }
 
+/* Note [explicitly non-returning atomics]
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * AMD's MI100 (gfx908) provides an optimized fp32 atomicAdd, exposed via atomicAddNoRet().
+ * Due to compiler limitations, callers must opt-in to guarantee the optimized instruction.
+ * This non-returning atomicAddNoRet cannot be used to implement the returning atomicAdd,
+ * therefore we need a new API 'gpuAtomicAddNoReturn'.
+ */
+template<typename T>
+static inline __device__ void gpuAtomicAddNoReturn(c10::complex<T> *address, c10::complex<T> val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(uint8_t *address, uint8_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(int8_t *address, int8_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(int16_t *address, int16_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(int32_t *address, int32_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(int64_t *address, int64_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(bool *address, bool val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(at::Half *address, at::Half val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(at::BFloat16 *address, at::BFloat16 val) { gpuAtomicAdd(address, val); }
+static inline __device__ void gpuAtomicAddNoReturn(double *address, double val) { gpuAtomicAdd(address, val); }
+template<typename T>
+static inline __device__ void atomicAddNoReturn(c10::complex<T> *address, c10::complex<T> val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(uint8_t *address, uint8_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(int8_t *address, int8_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(int16_t *address, int16_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(int32_t *address, int32_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(int64_t *address, int64_t val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(bool *address, bool val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(at::Half *address, at::Half val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(at::BFloat16 *address, at::BFloat16 val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(double *address, double val) { gpuAtomicAdd(address, val); }
+
+/* Special case fp32 atomic. */
+#if defined(__HIP_PLATFORM_HCC__) && defined(__gfx908__)
+static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
+static inline __device__ void atomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
+#else
+static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }
+static inline __device__ void atomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }
+#endif
+
 // Atomic multiplication implementation.
 
 inline __device__ at::Half gpuAtomicMul(at::Half * address, at::Half val) {

--- a/caffe2/operators/accuracy_op.cu
+++ b/caffe2/operators/accuracy_op.cu
@@ -1,5 +1,6 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/accuracy_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 #include <cub/block/block_reduce.cuh>
@@ -34,7 +35,7 @@ __global__ void AccuracyKernel(
     __syncthreads();
   }
   if (threadIdx.x == 0) {
-    atomicAdd(accuracy, static_cast<float>(correct));
+    gpu_atomic_add(accuracy, static_cast<float>(correct));
   }
 }
 

--- a/caffe2/operators/batch_gather_ops.cu
+++ b/caffe2/operators/batch_gather_ops.cu
@@ -4,6 +4,7 @@
 #include "caffe2/operators/batch_gather_ops.h"
 // Shared batch kernel
 #include "caffe2/operators/gather_op.cuh"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 namespace caffe2 {
 
@@ -47,7 +48,7 @@ __global__ void BatchGatherGradientKernel(
     const float* src_offset =
         grad_data + i * gathered_batch_size + j * block_size;
     float* dst_offset = out + i * data_batch_size + idx * block_size;
-    atomicAdd(dst_offset + k, src_offset[k]);
+    gpu_atomic_add(dst_offset + k, src_offset[k]);
   }
 }
 

--- a/caffe2/operators/channelwise_conv3d_op_cudnn.cu
+++ b/caffe2/operators/channelwise_conv3d_op_cudnn.cu
@@ -4,6 +4,7 @@
 #include "caffe2/operators/conv_op.h"
 #include "caffe2/operators/conv_op_cache_cudnn.h"
 #include "caffe2/operators/conv_pool_op_base.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 // Adopted from caffe2 depthwise conv at
 // pytorch/caffe2/caffe2/operators/depthwise_3x3_conv_op_cudnn.cu
@@ -220,7 +221,7 @@ __global__ void DepthwiseConv3dBackpropFilterGPUKernelNCHW(
             T* addr = filter_backprop +
                 (in_d * filter_rows * filter_cols * filter_length) +
                 (f_l * filter_rows * filter_cols) + (f_c + filter_cols * f_r);
-            atomicAdd(addr, partial_sum);
+            gpu_atomic_add(addr, partial_sum);
           }
         }
       }
@@ -251,7 +252,7 @@ __global__ void DepthwiseConv3dBackpropFilterGPUKernelNCHW(
               T* addr = filter_backprop +
                   (in_d * filter_rows * filter_cols * filter_length) +
                   (f_l * filter_rows * filter_cols) + (f_c + filter_cols * f_r);
-              atomicAdd(addr, partial_sum);
+              gpu_atomic_add(addr, partial_sum);
             }
           }
         }

--- a/caffe2/operators/deform_conv_op.cu
+++ b/caffe2/operators/deform_conv_op.cu
@@ -64,6 +64,7 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/deform_conv_op.h"
 #include "caffe2/operators/deform_conv_op_impl.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 namespace caffe2 {
 
@@ -407,7 +408,7 @@ __global__ void deformable_col2im_gpu_kernel(
               cur_w + dx,
               height,
               width);
-          atomicAdd(grad_im + cur_bottom_grad_pos, weight * cur_top_grad);
+          gpu_atomic_add(grad_im + cur_bottom_grad_pos, weight * cur_top_grad);
         }
       }
     }

--- a/caffe2/operators/depthwise_3x3_conv_op_cudnn.cu
+++ b/caffe2/operators/depthwise_3x3_conv_op_cudnn.cu
@@ -4,6 +4,7 @@
 #include "caffe2/operators/conv_op.h"
 #include "caffe2/operators/conv_op_cache_cudnn.h"
 #include "caffe2/operators/conv_pool_op_base.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 namespace caffe2 {
 
@@ -176,7 +177,7 @@ __global__ void DepthwiseConv2dBackpropFilterGPUKernelNCHW(
 #endif
           T* addr = filter_backprop + (in_d * filter_rows * filter_cols) +
               (f_c + filter_cols * f_r);
-          atomicAdd(addr, partial_sum);
+          gpu_atomic_add(addr, partial_sum);
         }
       }
     } else {
@@ -199,7 +200,7 @@ __global__ void DepthwiseConv2dBackpropFilterGPUKernelNCHW(
 #endif
             T* addr = filter_backprop + (in_d * filter_rows * filter_cols) +
                 (f_c + filter_cols * f_r);
-            atomicAdd(addr, partial_sum);
+            gpu_atomic_add(addr, partial_sum);
           }
         }
       }

--- a/caffe2/operators/multi_class_accuracy_op.cu
+++ b/caffe2/operators/multi_class_accuracy_op.cu
@@ -1,5 +1,6 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/multi_class_accuracy_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
@@ -18,9 +19,9 @@ __global__ void MultiClassAccuracyKernel(const int N, const int D, const float* 
     }
     int labelid = labeldata[i];
     if (maxid == labelid) {
-      atomicAdd(accuracies + labelid, static_cast<float>(1));
+      gpu_atomic_add(accuracies + labelid, static_cast<float>(1));
     }
-    atomicAdd(amounts + labelid, static_cast<int>(1));
+    gpu_atomic_add(amounts + labelid, static_cast<int>(1));
   }
 }
 __global__ void MultiClassAccuracyDivideKernel(

--- a/caffe2/operators/pad_op_gpu.cu
+++ b/caffe2/operators/pad_op_gpu.cu
@@ -2,6 +2,7 @@
 
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/pad_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 namespace caffe2 {
 
@@ -161,7 +162,7 @@ __global__ void PadImageGradientReflectNCHW(
     w = max(w, -w);
     h = min(h, 2 * height - h - 2);
     w = min(w, 2 * width - w - 2);
-    atomicAdd(&bottom_diff[(nc * height + h) * width + w], top_diff[index]);
+    gpu_atomic_add(&bottom_diff[(nc * height + h) * width + w], top_diff[index]);
   }
 }
 
@@ -178,7 +179,7 @@ __global__ void PadImageGradientEdgeNCHW(
     nc /= padded_height;
     const int h = min(height - 1, max(ph - pad_t, 0));
     const int w = min(width - 1, max(pw - pad_l, 0));
-    atomicAdd(&bottom_diff[(nc * height + h) * width + w], top_diff[index]);
+    gpu_atomic_add(&bottom_diff[(nc * height + h) * width + w], top_diff[index]);
   }
 }
 
@@ -219,7 +220,7 @@ __global__ void PadImageGradientReflectNHWC(
     w = max(w, -w);
     h = min(h, 2 * height - h - 2);
     w = min(w, 2 * width - w - 2);
-    atomicAdd(
+    gpu_atomic_add(
         &bottom_diff[((n * height + h) * width + w) * channels + c],
         top_diff[index]);
   }
@@ -240,7 +241,7 @@ __global__ void PadImageGradientEdgeNHWC(
     n /= padded_height;
     const int h = min(height - 1, max(ph - pad_t, 0));
     const int w = min(width - 1, max(pw - pad_l, 0));
-    atomicAdd(
+    gpu_atomic_add(
         &bottom_diff[((n * height + h) * width + w) * channels + c],
         top_diff[index]);
   }

--- a/caffe2/operators/resize_3d_op.cu
+++ b/caffe2/operators/resize_3d_op.cu
@@ -1,5 +1,6 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/resize_3d_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
@@ -74,9 +75,9 @@ __global__ void NearestNeighbor3DGradientKernel(
         (((n * num_channels + c) * output_frames + out_f) * output_height +
           out_y) * output_width + out_x;
 #if __CUDA_ARCH__ >= 350
-    atomicAdd(dX + out_index, __ldg(dY + index));
+    gpu_atomic_add(dX + out_index, __ldg(dY + index));
 #else
-    atomicAdd(dX + out_index, *(dY + index));
+    gpu_atomic_add(dX + out_index, *(dY + index));
 #endif
   }
 }

--- a/caffe2/operators/resize_op.cu
+++ b/caffe2/operators/resize_op.cu
@@ -1,5 +1,6 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/resize_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
@@ -60,9 +61,9 @@ __global__ void NearestNeighborGradientKernel(
     const int out_index =
         ((n * num_channels + c) * output_height + out_y) * output_width + out_x;
 #if __CUDA_ARCH__ >= 350
-    atomicAdd(dX + out_index, __ldg(dY + index));
+    gpu_atomic_add(dX + out_index, __ldg(dY + index));
 #else
-    atomicAdd(dX + out_index, *(dY + index));
+    gpu_atomic_add(dX + out_index, *(dY + index));
 #endif
   }
 }

--- a/caffe2/operators/roi_align_gradient_op.cu
+++ b/caffe2/operators/roi_align_gradient_op.cu
@@ -3,19 +3,12 @@
 #include <stdio.h>
 #include <cfloat>
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
 
 namespace {
-
-template <typename T>
-inline __device__ T gpu_atomic_add(const T val, T* address);
-
-template <>
-inline __device__ float gpu_atomic_add(const float val, float* address) {
-  return atomicAdd(address, val);
-}
 
 template <typename T>
 __device__ void bilinear_interpolate_gradient(
@@ -174,13 +167,13 @@ __global__ void RoIAlignBackwardFeature(
 
         if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
           gpu_atomic_add(
-              static_cast<T>(g1), offset_bottom_diff + y_low * width + x_low);
+              offset_bottom_diff + y_low * width + x_low, static_cast<T>(g1));
           gpu_atomic_add(
-              static_cast<T>(g2), offset_bottom_diff + y_low * width + x_high);
+              offset_bottom_diff + y_low * width + x_high, static_cast<T>(g2));
           gpu_atomic_add(
-              static_cast<T>(g3), offset_bottom_diff + y_high * width + x_low);
+              offset_bottom_diff + y_high * width + x_low, static_cast<T>(g3));
           gpu_atomic_add(
-              static_cast<T>(g4), offset_bottom_diff + y_high * width + x_high);
+              offset_bottom_diff + y_high * width + x_high, static_cast<T>(g4));
         } // if
       } // ix
     } // iy

--- a/caffe2/operators/roi_align_rotated_gradient_op.cu
+++ b/caffe2/operators/roi_align_rotated_gradient_op.cu
@@ -8,19 +8,12 @@
 #include <stdio.h>
 #include <cfloat>
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
 
 namespace {
-
-template <typename T>
-inline __device__ T gpu_atomic_add(const T val, T* address);
-
-template <>
-inline __device__ float gpu_atomic_add(const float val, float* address) {
-  return atomicAdd(address, val);
-}
 
 template <typename T>
 __device__ void bilinear_interpolate_gradient(
@@ -182,13 +175,13 @@ __global__ void RoIAlignRotatedBackward(
 
         if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
           gpu_atomic_add(
-              static_cast<T>(g1), offset_bottom_diff + y_low * width + x_low);
+              offset_bottom_diff + y_low * width + x_low, static_cast<T>(g1));
           gpu_atomic_add(
-              static_cast<T>(g2), offset_bottom_diff + y_low * width + x_high);
+              offset_bottom_diff + y_low * width + x_high, static_cast<T>(g2));
           gpu_atomic_add(
-              static_cast<T>(g3), offset_bottom_diff + y_high * width + x_low);
+              offset_bottom_diff + y_high * width + x_low, static_cast<T>(g3));
           gpu_atomic_add(
-              static_cast<T>(g4), offset_bottom_diff + y_high * width + x_high);
+              offset_bottom_diff + y_high * width + x_high, static_cast<T>(g4));
         } // if
       } // ix
     } // iy

--- a/caffe2/operators/roi_pool_op.cu
+++ b/caffe2/operators/roi_pool_op.cu
@@ -2,18 +2,11 @@
 
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/roi_pool_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 namespace caffe2 {
 
 namespace {
-
-template <typename T>
-inline __device__ T gpu_atomic_add(const T val, T* address);
-
-template <>
-inline __device__ float gpu_atomic_add(const float val, float* address) {
-  return atomicAdd(address, val);
-}
 
 template <typename T>
 __global__ void ROIPoolForward(
@@ -114,8 +107,8 @@ __global__ void ROIPoolBackward(
     int argmax = offset_argmax_data[ph * pooled_width + pw];
     if (argmax != -1) {
       gpu_atomic_add(
-          static_cast<T>(offset_top_diff[ph * pooled_width + pw]),
-          offset_bottom_diff + argmax);
+          offset_bottom_diff + argmax,
+          static_cast<T>(offset_top_diff[ph * pooled_width + pw]));
     }
   }
 }

--- a/caffe2/operators/sparse_to_dense_op.cu
+++ b/caffe2/operators/sparse_to_dense_op.cu
@@ -2,6 +2,7 @@
 
 #include "caffe2/core/common_gpu.h"
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 namespace caffe2 {
 
@@ -11,7 +12,7 @@ namespace caffe2 {
     CUDA_1D_KERNEL_LOOP(i, N) {
       int idx = indices[i / block_nitems];
       int dst_idx = block_nitems * idx + i % block_nitems;
-      atomicAdd(&dst[dst_idx], vals[i]);
+      gpu_atomic_add(&dst[dst_idx], vals[i]);
     }
   }
 

--- a/caffe2/operators/top_k_radix_selection.cuh
+++ b/caffe2/operators/top_k_radix_selection.cuh
@@ -4,6 +4,7 @@
 #include "caffe2/core/common_gpu.h"
 #include "caffe2/utils/GpuDefs.cuh"
 #include "caffe2/utils/GpuScanUtils.cuh"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 #include <cuda_runtime.h>
 
@@ -181,7 +182,7 @@ __device__ void countRadixUsingMask(CountType counts[RadixSize],
   if (getLaneId() == 0) {
 #pragma unroll
     for (unsigned int i = 0; i < RadixSize; ++i) {
-      atomicAdd(&smem[i], counts[i]);
+      gpu_atomic_add(&smem[i], counts[i]);
     }
   }
 

--- a/caffe2/operators/upsample_op.cu
+++ b/caffe2/operators/upsample_op.cu
@@ -2,6 +2,7 @@
 
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/upsample_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
@@ -126,16 +127,16 @@ __global__ void UpsampleBilinearGradientKernel(
     const float dYi = dY[index];
 #endif
 
-    atomicAdd(
+    gpu_atomic_add(
         &dX[idx(n, num_channels, c, output_height, output_width, h1, w1)],
         h0lambda * w0lambda * dYi);
-    atomicAdd(
+    gpu_atomic_add(
         &dX[idx(n, num_channels, c, output_height, output_width, h1, w1 + w1p)],
         h0lambda * w1lambda * dYi);
-    atomicAdd(
+    gpu_atomic_add(
         &dX[idx(n, num_channels, c, output_height, output_width, h1 + h1p, w1)],
         h1lambda * w0lambda * dYi);
-    atomicAdd(
+    gpu_atomic_add(
         &dX[idx(
             n,
             num_channels,

--- a/caffe2/operators/utility_ops.cu
+++ b/caffe2/operators/utility_ops.cu
@@ -8,6 +8,7 @@
 
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/flatten_op.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/math.h"
 
 namespace caffe2 {
@@ -157,7 +158,7 @@ __global__ void AxpySliceKernel(
       float a = *alpha[b];
       const float* x_offset = X[b] + (i * slice_size);
       for (int j = threadIdx.x; j < slice_size; j += blockDim.x) {
-        atomicAdd(&y_offset[j], a * x_offset[j]);
+        gpu_atomic_add(&y_offset[j], a * x_offset[j]);
       }
     }
   }
@@ -182,7 +183,7 @@ __global__ void AxpySliceKernel2(
     T_INDEX idx = Indices[i];
     float* y_offset = Y + (idx * slice_size);
     for (int j = threadIdx.x; j < slice_size; j += blockDim.x) {
-      atomicAdd(&y_offset[j], alpha[0] * X[(i * slice_size) + j]);
+      gpu_atomic_add(&y_offset[j], alpha[0] * X[(i * slice_size) + j]);
     }
   }
 }

--- a/caffe2/sgd/adagrad_fused_op_gpu.cuh
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cuh
@@ -126,7 +126,7 @@ static inline __device__ void gpuAtomicAdd(c10::Half* address, c10::Half val) {
     old = atomicCAS(address_as_ui, assumed, old);
   } while (assumed != old);
 #else
-  gpu_atomic_add(reinterpret_cast<__half*>(address), val);
+  atomicAdd(reinterpret_cast<__half*>(address), val);
 #endif
 }
 

--- a/caffe2/sgd/adagrad_fused_op_gpu.cuh
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cuh
@@ -8,6 +8,7 @@
 #include "caffe2/core/common_gpu.h"
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 
 #ifdef __HIP_PLATFORM_HCC__
 #define SEGREDUCE_MINBLOCKS 8
@@ -103,7 +104,7 @@ randFactor<at::Half, float, NEAREST>::convertTypeFromTargetToParam(
 }
 
 static inline __device__ void gpuAtomicAdd(float* address, float val) {
-  atomicAdd(address, val);
+  gpu_atomic_add(address, val);
 }
 
 static inline __device__ void gpuAtomicAdd(c10::Half* address, c10::Half val) {
@@ -125,7 +126,7 @@ static inline __device__ void gpuAtomicAdd(c10::Half* address, c10::Half val) {
     old = atomicCAS(address_as_ui, assumed, old);
   } while (assumed != old);
 #else
-  atomicAdd(reinterpret_cast<__half*>(address), val);
+  gpu_atomic_add(reinterpret_cast<__half*>(address), val);
 #endif
 }
 

--- a/caffe2/utils/GpuAtomics.cuh
+++ b/caffe2/utils/GpuAtomics.cuh
@@ -1,0 +1,28 @@
+#ifndef CAFFE2_UTILS_GPU_ATOMICS_H_
+#define CAFFE2_UTILS_GPU_ATOMICS_H_
+
+#include <cuda_runtime.h>
+
+namespace caffe2 {
+
+namespace {
+
+template <typename T>
+inline __device__ void gpu_atomic_add(T* address, const T val) {
+  atomicAdd(address, val);
+}
+
+template <>
+inline __device__ void gpu_atomic_add(float* address, const float val) {
+#if defined(__HIP_PLATFORM_HCC__) && defined(__gfx908__)
+  atomicAddNoRet(address, val);
+#else
+  atomicAdd(address, val);
+#endif
+}
+
+} // namespace
+
+} // namespace caffe2
+
+#endif  // CAFFE2_UTILS_GPU_ATOMICS_H_

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -14,6 +14,7 @@
 #include <thrust/functional.h>
 
 #include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/GpuAtomics.cuh"
 #include "caffe2/utils/conversions.h"
 
 #include "caffe2/utils/fixed_divisor.h"
@@ -2217,13 +2218,13 @@ __global__ void Im2ColNdNCHWCUDAKernel(
       if (!kCol2Im) {
         Y_data[col_index] = is_padding ? 0 : __ldg(X_data + img_index);
       } else if (!is_padding) {
-        atomicAdd(Y_data + img_index, __ldg(X_data + col_index));
+        gpu_atomic_add(Y_data + img_index, __ldg(X_data + col_index));
       }
 #else
       if (!kCol2Im) {
         Y_data[col_index] = is_padding ? 0 : X_data[img_index];
       } else if (!is_padding) {
-        atomicAdd(Y_data + img_index, X_data[col_index]);
+        gpu_atomic_add(Y_data + img_index, X_data[col_index]);
       }
 #endif
     }

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -8062,6 +8062,7 @@ CAFFE2_SPECIFIC_MAPPINGS = collections.OrderedDict(
         ("/THCCachingAllocator_gpu", ("/hip/THCCachingAllocator_gpu", API_CAFFE2)),
         ("/top_k_heap_selection", ("/hip/top_k_heap_selection", API_CAFFE2)),
         ("/top_k_radix_selection", ("/hip/top_k_radix_selection", API_CAFFE2)),
+        ("/GpuAtomics", ("/hip/GpuAtomics", API_CAFFE2)),
         ("/GpuDefs", ("/hip/GpuDefs", API_CAFFE2)),
         ("/GpuScanUtils", ("/hip/GpuScanUtils", API_CAFFE2)),
         ("/GpuBitonicSort", ("/hip/GpuBitonicSort", API_CAFFE2)),


### PR DESCRIPTION
Enables an important performance optimization for ROCm, in light of the discussion in #41028.

CC @jithunnair-amd @sunway513