### PR TITLE
Improve error message for non-differentiable inputs

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -573,14 +573,14 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
         for arg in tensor_args:
             if arg in args_with_derivatives:
                 continue
-            name = arg.name
-            if info and name in info.non_differentiable_arg_names:
+            arg_name = arg.name
+            if info and arg_name in info.non_differentiable_arg_names:
                 continue
-            if name == 'output':
+            if arg_name == 'output':
                 # Double-backwards definitions sometimes take in 'input' and
                 # 'output', but only define the derivative for input.
                 continue
-            body.append(f'check_no_requires_grad({name}, "{name}");')
+            body.append(f'check_no_requires_grad({arg_name}, "{arg_name}", "{name}");')
         return body
 
     def save_variables(

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -292,32 +292,27 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
   return tensors;
 }
 
-inline void check_no_requires_grad(const Tensor& tensor, const char* name) {
-  auto& var = static_cast<const Variable&>(tensor);
-  if (var.defined() && var.requires_grad()) {
-    std::string msg = "the derivative for '";
-    msg += name;
-    msg += "' is not implemented";
-    TORCH_CHECK(false, msg);
-  }
+inline void check_no_requires_grad(const Tensor& tensor, const char* name, const char* fn_name="") {
+  TORCH_CHECK(!(tensor.defined() && tensor.requires_grad()), "The function '", fn_name, "' is not differentiable "
+              "with respect to argument '", name, "'. This input cannot have requires_grad True.");
 }
 
-inline void check_no_requires_grad(const c10::optional<Tensor>& tensor, const char* name) {
+inline void check_no_requires_grad(const c10::optional<Tensor>& tensor, const char* name, const char* fn_name="") {
   if (tensor.has_value()) {
-    check_no_requires_grad(*tensor, name);
+    check_no_requires_grad(*tensor, name, fn_name);
   }
 }
 
-inline void check_no_requires_grad(TensorList tensors, const char* name) {
+inline void check_no_requires_grad(TensorList tensors, const char* name, const char* fn_name="") {
   for (auto& tensor : tensors) {
-    check_no_requires_grad(tensor, name);
+    check_no_requires_grad(tensor, name, fn_name);
   }
 }
 
-inline void check_no_requires_grad(const c10::List<c10::optional<Tensor>>& tensors, const char* name) {
+inline void check_no_requires_grad(const c10::List<c10::optional<Tensor>>& tensors, const char* name, const char* fn_name="") {
   for (c10::optional<Tensor> tensor : tensors) {
     if (tensor.has_value()) {
-      check_no_requires_grad(*tensor, name);
+      check_no_requires_grad(*tensor, name, fn_name);
     }
   }
 }


### PR DESCRIPTION
Improve the error message when inputs should not requires_grad=True.

For example, we now get
```
RuntimeError: The function 'binary_cross_entropy' is not differentiable with respect to argument 'weight'. This input cannot have requires_grad True. 
```