### PR TITLE
Dedup test_cpp_extenions_aot class names

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -631,7 +631,7 @@ def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
             return return_code
 
     # "install" the test modules and run tests
-    python_path = os.environ.get('PYTHONPATH', '')
+    shell_env = os.environ.copy()
     try:
         cpp_extensions = os.path.join(test_directory, 'cpp_extensions')
         install_directory = ''
@@ -642,10 +642,11 @@ def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
                     install_directory = os.path.join(root, directory)
 
         assert install_directory, 'install_directory must not be empty'
-        os.environ['PYTHONPATH'] = os.pathsep.join([install_directory, python_path])
+        os.environ['PYTHONPATH'] = os.pathsep.join([install_directory, shell_env.get('PYTHONPATH', '')])
+        os.environ['USE_NINJA'] = str(1 if use_ninja else 0)
         return run_test(test_module, test_directory, options)
     finally:
-        os.environ['PYTHONPATH'] = python_path
+        os.environ = shell_env
 
 
 def test_cpp_extensions_aot_ninja(test_module, test_directory, options):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -646,7 +646,8 @@ def _test_cpp_extensions_aot(test_module, test_directory, options, use_ninja):
         os.environ['USE_NINJA'] = str(1 if use_ninja else 0)
         return run_test(test_module, test_directory, options)
     finally:
-        os.environ = shell_env
+        os.environ.clear()
+        os.environ.update(shell_env)
 
 
 def test_cpp_extensions_aot_ninja(test_module, test_directory, options):

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -207,4 +207,12 @@ class TestTorchLibrary(common.TestCase):
 
 
 if __name__ == "__main__":
+    if os.getenv("USE_NINJA") == "1":
+        import sys
+        module = sys.modules[__name__]
+        test_classes = [getattr(module, name) for name in dir(module) if name.startswith('Test')]
+        for cls in test_classes:
+            cls.__qualname__ += "Ninja"
+            cls.__name__ += "Ninja"
+
     common.run_tests()


### PR DESCRIPTION
Modify test_cpp_extenions_aot to append Ninja suffix to test class names if invoked with USE_NINJA environment variable
Modify run_test.py to pass the variable

