### PR TITLE
Port `isposinf` & `isneginf` kernel to structured kernels

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -844,6 +844,14 @@ void TensorIteratorBase::build_unary_op(const Tensor& out, const Tensor& a) {
       .check_all_same_dtype(true));
 }
 
+void TensorIteratorBase::build_unary_comparison_op(const Tensor& out, const Tensor& a) {
+  build(TensorIteratorConfig()
+      .set_check_mem_overlap(true)
+      .add_owned_output(out)
+      .add_owned_input(a)
+      .check_all_same_dtype(false));
+}
+
 TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a, const Tensor& b) {
   TensorIterator iter;
   iter.build_binary_op(out, a, b);
@@ -902,6 +910,12 @@ TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a) {
 TensorIterator TensorIterator::unary_float_op(Tensor& out, const Tensor& a) {
   TensorIterator iter;
   iter.build_unary_float_op(out, a);
+  return iter;
+}
+
+TensorIterator TensorIterator::unary_comparison_op(const Tensor& out, const Tensor& a) {
+  TensorIterator iter;
+  iter.build_unary_comparison_op(out, a);
   return iter;
 }
 

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -844,7 +844,9 @@ void TensorIteratorBase::build_unary_op(const Tensor& out, const Tensor& a) {
       .check_all_same_dtype(true));
 }
 
-void TensorIteratorBase::build_unary_boolean_op(const Tensor& out, const Tensor& a) {
+// Helper to construct a unary op that forcibly promotes output to boolean.
+// Only be used when the output tensor must have boolean type.
+void TensorIteratorBase::build_unary_force_boolean_op(const Tensor& out, const Tensor& a) {
   build(TensorIteratorConfig()
       .set_check_mem_overlap(true)
       .check_all_same_dtype(false)
@@ -914,9 +916,9 @@ TensorIterator TensorIterator::unary_float_op(Tensor& out, const Tensor& a) {
   return iter;
 }
 
-TensorIterator TensorIterator::unary_boolean_op(const Tensor& out, const Tensor& a) {
+TensorIterator TensorIterator::unary_force_boolean_op(const Tensor& out, const Tensor& a) {
   TensorIterator iter;
-  iter.build_unary_boolean_op(out, a);
+  iter.build_unary_force_boolean_op(out, a);
   return iter;
 }
 

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -844,12 +844,13 @@ void TensorIteratorBase::build_unary_op(const Tensor& out, const Tensor& a) {
       .check_all_same_dtype(true));
 }
 
-void TensorIteratorBase::build_unary_comparison_op(const Tensor& out, const Tensor& a) {
+void TensorIteratorBase::build_unary_boolean_op(const Tensor& out, const Tensor& a) {
   build(TensorIteratorConfig()
       .set_check_mem_overlap(true)
+      .check_all_same_dtype(false)
+      .declare_static_dtype_and_device(at::kBool, a.device())
       .add_owned_output(out)
-      .add_owned_input(a)
-      .check_all_same_dtype(false));
+      .add_owned_input(a));
 }
 
 TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a, const Tensor& b) {
@@ -913,9 +914,9 @@ TensorIterator TensorIterator::unary_float_op(Tensor& out, const Tensor& a) {
   return iter;
 }
 
-TensorIterator TensorIterator::unary_comparison_op(const Tensor& out, const Tensor& a) {
+TensorIterator TensorIterator::unary_boolean_op(const Tensor& out, const Tensor& a) {
   TensorIterator iter;
-  iter.build_unary_comparison_op(out, a);
+  iter.build_unary_boolean_op(out, a);
   return iter;
 }
 

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -350,6 +350,7 @@ public:
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_binary_op)
   void build_unary_float_op(const Tensor& out, const Tensor& a);
   void build_unary_op(const Tensor& out, const Tensor& a);
+  void build_unary_comparison_op(const Tensor& out, const Tensor& a);
 
 #undef TORCH_DISALLOW_TEMPORARIES
 protected:
@@ -482,6 +483,7 @@ struct TORCH_API TensorIterator final : public TensorIteratorBase {
   static TensorIterator unary_op(Tensor& out, const Tensor& a);
   static TensorIterator unary_float_op(Tensor& out, const Tensor& a);
   static TensorIterator nullary_op(Tensor& out);
+  static TensorIterator unary_comparison_op(const Tensor& out, const Tensor& a);
   static TensorIterator borrowing_nullary_op(const Tensor& out);
   static TensorIterator borrowing_nullary_op(Tensor&& out) = delete;
   static TensorIterator reduce_op(Tensor& out, const Tensor& a);

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -350,7 +350,7 @@ public:
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_binary_op)
   void build_unary_float_op(const Tensor& out, const Tensor& a);
   void build_unary_op(const Tensor& out, const Tensor& a);
-  void build_unary_comparison_op(const Tensor& out, const Tensor& a);
+  void build_unary_boolean_op(const Tensor& out, const Tensor& a);
 
 #undef TORCH_DISALLOW_TEMPORARIES
 protected:
@@ -483,7 +483,7 @@ struct TORCH_API TensorIterator final : public TensorIteratorBase {
   static TensorIterator unary_op(Tensor& out, const Tensor& a);
   static TensorIterator unary_float_op(Tensor& out, const Tensor& a);
   static TensorIterator nullary_op(Tensor& out);
-  static TensorIterator unary_comparison_op(const Tensor& out, const Tensor& a);
+  static TensorIterator unary_boolean_op(const Tensor& out, const Tensor& a);
   static TensorIterator borrowing_nullary_op(const Tensor& out);
   static TensorIterator borrowing_nullary_op(Tensor&& out) = delete;
   static TensorIterator reduce_op(Tensor& out, const Tensor& a);

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -350,7 +350,7 @@ public:
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_binary_op)
   void build_unary_float_op(const Tensor& out, const Tensor& a);
   void build_unary_op(const Tensor& out, const Tensor& a);
-  void build_unary_boolean_op(const Tensor& out, const Tensor& a);
+  void build_unary_force_boolean_op(const Tensor& out, const Tensor& a);
 
 #undef TORCH_DISALLOW_TEMPORARIES
 protected:
@@ -483,7 +483,7 @@ struct TORCH_API TensorIterator final : public TensorIteratorBase {
   static TensorIterator unary_op(Tensor& out, const Tensor& a);
   static TensorIterator unary_float_op(Tensor& out, const Tensor& a);
   static TensorIterator nullary_op(Tensor& out);
-  static TensorIterator unary_boolean_op(const Tensor& out, const Tensor& a);
+  static TensorIterator unary_force_boolean_op(const Tensor& out, const Tensor& a);
   static TensorIterator borrowing_nullary_op(const Tensor& out);
   static TensorIterator borrowing_nullary_op(Tensor&& out) = delete;
   static TensorIterator reduce_op(Tensor& out, const Tensor& a);

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -46,6 +46,20 @@ TORCH_META_FUNC2(isin, Scalar_Tensor) (
   set_output({0}, TensorOptions(test_elements.device()).dtype(ScalarType::Bool));
 }
 
+TORCH_META_FUNC(isposinf) (const Tensor& self) {
+  TORCH_CHECK(!self.is_complex(), "isposinf does not support complex inputs.");
+  TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
+              "isposinf does not support non-boolean outputs.");
+  set_output(self.sizes(), TensorOptions(self.device()).dtype(ScalarType::Bool));
+}
+
+TORCH_META_FUNC(isneginf) (const Tensor& self) {
+  TORCH_CHECK(!self.is_complex(), "isneginf does not support complex inputs.");
+  TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
+              "isneginf does not support non-boolean outputs.");
+  set_output(self.sizes(), TensorOptions(self.device()).dtype(ScalarType::Bool));
+}
+
 } // namespace meta
 
 namespace native {
@@ -157,54 +171,6 @@ Tensor isinf(const Tensor &self) {
   return AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, self.scalar_type(), "isinf", [&]() {
     return self.abs() == std::numeric_limits<scalar_t>::infinity();
   });
-}
-
-Tensor isposinf(const Tensor &self) {
-  Tensor result = at::empty_like(self, at::kBool, at::MemoryFormat::Preserve);
-  at::isposinf_out(result, self);
-  return result;
-}
-
-Tensor& isposinf_out(const Tensor& self, Tensor& result) {
-  TORCH_CHECK(!self.is_complex(), "isposinf does not support complex inputs.");
-  TORCH_CHECK(result.scalar_type() == at::kBool, "isposinf does not support non-boolean outputs.");
-  result.resize_(self.sizes());
-
-  if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    result.fill_(false);
-  } else {
-    auto iter = TensorIteratorConfig()
-      .check_all_same_dtype(false)
-      .add_output(result)
-      .add_input(self)
-      .build();
-    isposinf_stub(iter.device_type(), iter);
-  }
-  return result;
-}
-
-Tensor isneginf(const Tensor &self) {
-  Tensor result = at::empty_like(self, at::kBool, at::MemoryFormat::Preserve);
-  at::isneginf_out(result, self);
-  return result;
-}
-
-Tensor& isneginf_out(const Tensor& self, Tensor& result) {
-  TORCH_CHECK(!self.is_complex(), "isneginf does not support complex inputs.");
-  TORCH_CHECK(result.scalar_type() == at::kBool, "isneginf does not support non-boolean outputs.");
-  result.resize_(self.sizes());
-
-  if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    result.fill_(false);
-  } else {
-    auto iter = TensorIteratorConfig()
-      .check_all_same_dtype(false)
-      .add_output(result)
-      .add_input(self)
-      .build();
-    isneginf_stub(iter.device_type(), iter);
-  }
-  return result;
 }
 
 Tensor isfinite(const Tensor& self) {
@@ -785,6 +751,22 @@ TORCH_IMPL_FUNC(isin_Scalar_Tensor_out) (
   // redispatch
   at::isin_out(const_cast<Tensor&>(out), wrapped_scalar_tensor(elements, test_elements.device()),
     test_elements, assume_unique, invert);
+}
+
+TORCH_IMPL_FUNC(isposinf_out) (const Tensor& self, const Tensor& result) {
+  if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
+    result.fill_(false);
+  } else {
+    isposinf_stub(self.device().type(), self, result);
+  }
+}
+
+TORCH_IMPL_FUNC(isneginf_out) (const Tensor& self, const Tensor& result) {
+  if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
+    result.fill_(false);
+  } else {
+    isneginf_stub(self.device().type(), self, result);
+  }
 }
 
 } // namespace native

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -50,14 +50,14 @@ TORCH_META_FUNC(isposinf) (const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "isposinf does not support complex inputs.");
   TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
               "isposinf does not support non-boolean outputs.");
-  set_output(self.sizes(), TensorOptions(self.device()).dtype(ScalarType::Bool));
+  build_unary_boolean_op(maybe_get_output(), self);
 }
 
 TORCH_META_FUNC(isneginf) (const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "isneginf does not support complex inputs.");
   TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
               "isneginf does not support non-boolean outputs.");
-  set_output(self.sizes(), TensorOptions(self.device()).dtype(ScalarType::Bool));
+  build_unary_boolean_op(maybe_get_output(), self);
 }
 
 } // namespace meta
@@ -757,7 +757,7 @@ TORCH_IMPL_FUNC(isposinf_out) (const Tensor& self, const Tensor& result) {
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
     result.fill_(false);
   } else {
-    isposinf_stub(self.device().type(), self, result);
+    isposinf_stub(device_type(), *this);
   }
 }
 
@@ -765,7 +765,7 @@ TORCH_IMPL_FUNC(isneginf_out) (const Tensor& self, const Tensor& result) {
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
     result.fill_(false);
   } else {
-    isneginf_stub(self.device().type(), self, result);
+    isneginf_stub(device_type(), *this);
   }
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -50,14 +50,14 @@ TORCH_META_FUNC(isposinf) (const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "isposinf does not support complex inputs.");
   TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
               "isposinf does not support non-boolean outputs.");
-  build_unary_boolean_op(maybe_get_output(), self);
+  build_unary_force_boolean_op(maybe_get_output(), self);
 }
 
 TORCH_META_FUNC(isneginf) (const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "isneginf does not support complex inputs.");
   TORCH_CHECK(maybe_get_output().defined() ? maybe_get_output().dtype() == at::kBool : true,
               "isneginf does not support non-boolean outputs.");
-  build_unary_boolean_op(maybe_get_output(), self);
+  build_unary_force_boolean_op(maybe_get_output(), self);
 }
 
 } // namespace meta

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -17,7 +17,7 @@ DECLARE_DISPATCH(reduce_minmax_fn, _aminmax_stub);
 using where_fn = void (*)(TensorIterator &, ScalarType);
 DECLARE_DISPATCH(where_fn, where_kernel);
 
-using is_infinity_op_fn = void (*)(const Tensor&, const Tensor&);
+using is_infinity_op_fn = void (*)(TensorIteratorBase &);
 DECLARE_DISPATCH(is_infinity_op_fn, isposinf_stub);
 DECLARE_DISPATCH(is_infinity_op_fn, isneginf_stub);
 

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -17,7 +17,7 @@ DECLARE_DISPATCH(reduce_minmax_fn, _aminmax_stub);
 using where_fn = void (*)(TensorIterator &, ScalarType);
 DECLARE_DISPATCH(where_fn, where_kernel);
 
-using is_infinity_op_fn = void (*)(TensorIterator &);
+using is_infinity_op_fn = void (*)(const Tensor&, const Tensor&);
 DECLARE_DISPATCH(is_infinity_op_fn, isposinf_stub);
 DECLARE_DISPATCH(is_infinity_op_fn, isneginf_stub);
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -219,13 +219,15 @@ static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
   });
 }
 
-static void isposinf_kernel_impl(TensorIterator& iter) {
+static void isposinf_kernel_impl(const Tensor& self, const Tensor& result) {
+  auto iter = TensorIterator::unary_comparison_op(result, self);
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isposinf_cpu", [&]() {
     cpu_kernel(iter, [](scalar_t a) -> bool { return a == std::numeric_limits<scalar_t>::infinity(); });
   });
 }
 
-static void isneginf_kernel_impl(TensorIterator& iter) {
+static void isneginf_kernel_impl(const Tensor& self, const Tensor& result) {
+  auto iter = TensorIterator::unary_comparison_op(result, self);
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isneginf_cpu", [&]() {
     cpu_kernel(iter, [](scalar_t a) -> bool { return a == -std::numeric_limits<scalar_t>::infinity(); });
   });

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -219,15 +219,13 @@ static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
   });
 }
 
-static void isposinf_kernel_impl(const Tensor& self, const Tensor& result) {
-  auto iter = TensorIterator::unary_comparison_op(result, self);
+static void isposinf_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isposinf_cpu", [&]() {
     cpu_kernel(iter, [](scalar_t a) -> bool { return a == std::numeric_limits<scalar_t>::infinity(); });
   });
 }
 
-static void isneginf_kernel_impl(const Tensor& self, const Tensor& result) {
-  auto iter = TensorIterator::unary_comparison_op(result, self);
+static void isneginf_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isneginf_cpu", [&]() {
     cpu_kernel(iter, [](scalar_t a) -> bool { return a == -std::numeric_limits<scalar_t>::infinity(); });
   });

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -29,7 +29,8 @@ void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
   });
 }
 
-void isposinf_kernel_impl(TensorIterator &iter) {
+void isposinf_kernel_impl(const Tensor& self, const Tensor& result) {
+  auto iter = TensorIterator::unary_comparison_op(result, self);
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isposinf_cuda", [&]() {
     gpu_kernel(
       iter,
@@ -38,7 +39,8 @@ void isposinf_kernel_impl(TensorIterator &iter) {
   });
 }
 
-void isneginf_kernel_impl(TensorIterator &iter) {
+void isneginf_kernel_impl(const Tensor& self, const Tensor& result) {
+  auto iter = TensorIterator::unary_comparison_op(result, self);
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isneginf_cuda", [&]() {
     gpu_kernel(
       iter,

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -29,8 +29,7 @@ void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
   });
 }
 
-void isposinf_kernel_impl(const Tensor& self, const Tensor& result) {
-  auto iter = TensorIterator::unary_comparison_op(result, self);
+void isposinf_kernel_impl(TensorIteratorBase &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isposinf_cuda", [&]() {
     gpu_kernel(
       iter,
@@ -39,8 +38,7 @@ void isposinf_kernel_impl(const Tensor& self, const Tensor& result) {
   });
 }
 
-void isneginf_kernel_impl(const Tensor& self, const Tensor& result) {
-  auto iter = TensorIterator::unary_comparison_op(result, self);
+void isneginf_kernel_impl(TensorIteratorBase &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.input_dtype(), "isneginf_cuda", [&]() {
     gpu_kernel(
       iter,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9535,6 +9535,7 @@
 
 - func: isposinf.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
+  structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: isposinf_out
 
@@ -9544,6 +9545,7 @@
 
 - func: isneginf.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   structured: True
+  structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: isneginf_out
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9531,15 +9531,19 @@
 
 - func: isposinf(Tensor self) -> Tensor
   variants: function, method
+  structured_delegate: isposinf.out
 
 - func: isposinf.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
     CPU, CUDA: isposinf_out
 
 - func: isneginf(Tensor self) -> Tensor
   variants: function, method
+  structured_delegate: isneginf.out
 
 - func: isneginf.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
     CPU, CUDA: isneginf_out
 


### PR DESCRIPTION
Porting `torch.isposinf` & `torch.isneginf` to structured kernel
Related #55070