### PR TITLE
Make pytorch clang-tidy clean

### DIFF
--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -32,6 +32,7 @@ struct CudaIPCGlobalEntities {
   std::shared_ptr<CudaIPCRefCountersFile> next_available_ref_counters_file_;
   CudaIPCSentDataLimbo CudaIPCSentDataLimbo_;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   CudaIPCGlobalEntities() : ref_counters_files_() {}
   ~CudaIPCGlobalEntities() {
     CudaIPCSentDataLimbo_.collect();
@@ -55,6 +56,7 @@ struct CudaIPCGlobalEntities {
   }
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 CudaIPCGlobalEntities cuda_ipc_global_entities;
 
 CudaIPCSentDataLimbo::~CudaIPCSentDataLimbo() {
@@ -107,6 +109,7 @@ void CudaIPCSentDataLimbo::add(std::unique_ptr<CudaIPCSentData> shared_block) {
 }
 
 void CudaIPCSentDataDelete(void* ptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::unique_ptr<CudaIPCSentData> sent_data(
       static_cast<CudaIPCSentData*>(ptr));
   if (sent_data->counter_value() > 0) {
@@ -252,6 +255,7 @@ bool CudaIPCCollect() {
 
 namespace c10 {
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_FREE_MEMORY_CALLBACK("cuda_ipc_collect", CudaIPCCollectCallback);
 }
 } // namespace c10

--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -202,6 +202,7 @@ TransformerEncoderImpl::TransformerEncoderImpl(
 
 void TransformerEncoderImpl::reset() {
   layers = this->register_module("layers", ModuleList());
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   for (const auto i : c10::irange(options.num_layers())) {
     layers->push_back(options.encoder_layer()->clone());
   }
@@ -264,6 +265,7 @@ TransformerDecoderImpl::TransformerDecoderImpl(
 void TransformerDecoderImpl::reset() {
 
   layers = this->register_module("layers", ModuleList());
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   for (const auto i : c10::irange(options.num_layers())) {
     layers->push_back(options.decoder_layer()->clone());
   }

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -157,8 +157,8 @@ struct TORCH_API VariableInfo {
 // backward function for Function<T>. Calls to CppNode::apply are forward to
 // T::backward().
 template <class T>
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct CppNode : public Node {
-
   variable_list apply(variable_list&& inputs) override;
   AutogradContext ctx_;
   std::vector<bool> is_variable_input_;
@@ -176,6 +176,7 @@ struct ExtractVariables : IterArgs<ExtractVariables> {
   variable_list& list_;
   ExtractVariables(std::vector<bool>& is_var, variable_list& list) : is_var_(is_var), list_(list) {}
   void operator()(const c10::optional<at::Tensor>& x) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (x.has_value() && x.value().defined()) {
       is_var_.push_back(true);
       list_.emplace_back(x.value());
@@ -201,10 +202,14 @@ inline void extract_vars(std::vector<bool> &is_var, variable_list& list, Args&&.
 template <typename T>
 typename std::enable_if<std::is_same<T, variable_list>::value, T>::type to_output_type(
   std::vector<c10::optional<Variable>>& output_list) {
-    variable_list result;
-    std::transform(output_list.begin(), output_list.end(), std::back_inserter(result),
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  variable_list result;
+  std::transform(
+      output_list.begin(),
+      output_list.end(),
+      std::back_inserter(result),
       [](const c10::optional<Variable>& var) { return *var; });
-    return result;
+  return result;
 }
 
 template <typename T>
@@ -218,6 +223,7 @@ inline std::vector<c10::optional<Variable>> to_optional(Variable& output) {
 }
 
 inline std::vector<c10::optional<Variable>> to_optional(variable_list& output) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<c10::optional<Variable>> result;
   std::transform(output.begin(), output.end(), std::back_inserter(result),
     [](const Variable& var) { return var; });
@@ -228,6 +234,7 @@ template<class T>
 template<typename X, typename... Args>
 auto Function<T>::apply(Args&&... args) -> std::enable_if_t<std::is_same<X,T>::value, forward_t<X,Args...>> {
   std::shared_ptr<CppNode<T>> node(new CppNode<T>(), deleteNode);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   variable_list input_vars;
 
   const size_t num_inputs = sizeof...(Args);
@@ -236,6 +243,7 @@ auto Function<T>::apply(Args&&... args) -> std::enable_if_t<std::is_same<X,T>::v
   // TODO Add tracing here
   extract_vars(node->is_variable_input_, input_vars, args...);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool is_executable =  GradMode::is_enabled() && any_variable_requires_grad(input_vars);
   auto next_edges = (is_executable ? collect_next_edges(input_vars) : edge_list());
   node->set_ctx_grad_fn(node);
@@ -248,6 +256,7 @@ auto Function<T>::apply(Args&&... args) -> std::enable_if_t<std::is_same<X,T>::v
   }
 
   using forward_return_t = forward_t<X, Args...>;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   forward_return_t outputs;
   {
     AutoGradMode grad_mode(false);
@@ -285,7 +294,9 @@ template<class T>
 variable_list CppNode<T>::apply(variable_list&& inputs) {
   at::OptionalDeviceGuard _device_guard;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int num_inputs = inputs.size();
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   variable_list backward_inputs;
   backward_inputs.reserve(num_inputs);
   for (const auto i : c10::irange(num_inputs)) {
@@ -304,6 +315,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
 
   auto outputs = T::backward(&ctx_, backward_inputs);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int num_forward_inputs = is_variable_input_.size();
   auto num_outputs = outputs.size();
   // Returning too many results is ok, but only as long as they're all undefined.
@@ -329,6 +341,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
     throw std::runtime_error(msg);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   variable_list results;
   results.reserve(num_outputs);
   for (const auto i : c10::irange(num_outputs)) {

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -62,11 +62,13 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   std::unordered_map<Node*, InputBuffer> not_ready_;
   std::unordered_map<Node*, int> dependencies_;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct ExecInfo {
     struct Capture {
       Capture(const Capture&) = delete;
       Capture(Capture&&) = default;
 
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
       Capture(int input_idx, int output_idx)
           : input_idx_(input_idx), output_idx_(output_idx) {}
       int input_idx_; // within Node inputs
@@ -169,6 +171,7 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   // mutex_ as the two are protecting different data structures.
   std::mutex final_callbacks_lock_;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   GraphTask(
       bool keep_graph,
       bool grad_mode,
@@ -397,6 +400,7 @@ struct TORCH_API Engine {
     // allocated inside Engine::execute and lives for the duration of execute
     std::queue<std::weak_ptr<GraphTask>> graphtasks_queue_;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     ThreadPoolShared() : num_workers_(0) {}
  };
 

--- a/torch/csrc/autograd/forward_grad.cpp
+++ b/torch/csrc/autograd/forward_grad.cpp
@@ -17,7 +17,7 @@ namespace {
 
     // Temporary flag to disable forward mode
     // TODO(alband) remove these when perf issues are solved
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // NOLINTNEXTLINE(clang-diagnostic-unused-variable,cppcoreguidelines-avoid-non-const-global-variables)
     static bool is_forward_grad_enabled = false;
 }
 

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -84,17 +84,18 @@ struct ForwardGrad;
 #define EXPECTED_MAX_LEVEL 2
 
 struct TORCH_API ForwardADLevel {
-    ForwardADLevel(uint64_t idx): idx_(idx) {}
-    ~ForwardADLevel();
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  ForwardADLevel(uint64_t idx) : idx_(idx) {}
+  ~ForwardADLevel();
 
-    static uint64_t get_next_idx();
-    static void release_idx(uint64_t idx);
-    static std::shared_ptr<ForwardADLevel> get_by_idx(uint64_t idx);
-    static std::shared_ptr<ForwardADLevel> try_get_by_idx(uint64_t idx);
+  static uint64_t get_next_idx();
+  static void release_idx(uint64_t idx);
+  static std::shared_ptr<ForwardADLevel> get_by_idx(uint64_t idx);
+  static std::shared_ptr<ForwardADLevel> try_get_by_idx(uint64_t idx);
 
-    void erase(const std::shared_ptr<ForwardGrad>& grad) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        grads_.erase(grad);
+  void erase(const std::shared_ptr<ForwardGrad>& grad) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    grads_.erase(grad);
     }
 
     void insert(const std::shared_ptr<ForwardGrad>& grad) {
@@ -110,37 +111,38 @@ private:
 };
 
 struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
+  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
+  ForwardGrad() {}
 
-    // NOLINTNEXTLINE(modernize-use-equals-default)
-    ForwardGrad() {}
+  // This function must only be called when AutogradMeta or SavedVariable is
+  // being destructed as it ensures that:
+  //   - The only (potential) other references to this ForwardGrad are the
+  //     different level it is registered to
+  //   - No other thread will try to call `set_value` or `value` ever from now
+  //   on
+  //   - Any of the ForwardADLevel that this ForwardGrad is registered with
+  //   might
+  //     call `reset` at any point during this function
+  void clear() {
+    c10::SmallVector<uint64_t, EXPECTED_MAX_LEVEL> levels_idx;
 
-    // This function must only be called when AutogradMeta or SavedVariable is being
-    // destructed as it ensures that:
-    //   - The only (potential) other references to this ForwardGrad are the
-    //     different level it is registered to
-    //   - No other thread will try to call `set_value` or `value` ever from now on
-    //   - Any of the ForwardADLevel that this ForwardGrad is registered with might
-    //     call `reset` at any point during this function
-    void clear() {
-        c10::SmallVector<uint64_t, EXPECTED_MAX_LEVEL> levels_idx;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      for (auto& c : content_) {
+        levels_idx.push_back(c.first);
+      }
+    }
 
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            for (auto& c: content_) {
-                levels_idx.push_back(c.first);
-            }
-        }
-
-        for (auto l_idx: levels_idx) {
-            // Use "try" version here as another thread might have deleted this
-            // level before we got here
-            // This is an owning reference as we want to keep the level alive
-            // until we successfully unregister ourselves
-            auto level = ForwardADLevel::try_get_by_idx(l_idx);
-            if (level) {
-                level->erase(shared_from_this());
-            }
-        }
+    for (auto l_idx : levels_idx) {
+      // Use "try" version here as another thread might have deleted this
+      // level before we got here
+      // This is an owning reference as we want to keep the level alive
+      // until we successfully unregister ourselves
+      auto level = ForwardADLevel::try_get_by_idx(l_idx);
+      if (level) {
+        level->erase(shared_from_this());
+      }
+    }
     }
 
     void set_value(const at::Tensor& value, uint64_t level) {

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -99,6 +99,7 @@ class NodeGuard {
 struct TORCH_API Node : std::enable_shared_from_this<Node> {
  public:
   /// Construct a new `Node` with the given `next_edges`
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Node(
       uint64_t sequence_nr,
       edge_list&& next_edges = edge_list())
@@ -124,6 +125,7 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
     thread_id_ = at::RecordFunction::currentThreadId();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Node(edge_list&& next_edges = edge_list())
     : Node(/*sequence_nr=*/at::sequence_number::get_and_increment(),
     std::move(next_edges)) {}
@@ -182,12 +184,14 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
     const at::TensorOptions& options
   , at::IntArrayRef shape
   , at::Device device) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint32_t input_nr = input_metadata_.size();
     input_metadata_.emplace_back(options, shape, device);
     return input_nr;
   }
 
   uint32_t add_input_metadata(const at::Tensor& t) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint32_t input_nr = input_metadata_.size();
     input_metadata_.emplace_back(t);
     return input_nr;
@@ -195,6 +199,7 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
 
   /// Adds a placeholder for an input that will not be used.
   uint32_t add_input_metadata(undefined_input u) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint32_t input_nr = input_metadata_.size();
     input_metadata_.emplace_back();
     return input_nr;
@@ -546,10 +551,12 @@ struct TraceableFunction : public Node {
 
 namespace detail {
 // Implementation of `collect_next_edges` (see below).
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
   edge_list next_edges;
   using IterArgs<MakeNextFunctionList>::operator();
   void operator()(const Variable& variable) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (variable.defined()) {
       next_edges.push_back(impl::gradient_edge(variable));
     } else {
@@ -557,6 +564,7 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
     }
   }
   void operator()(const c10::optional<Variable>& variable) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (variable.has_value() && variable->defined()) {
       next_edges.push_back(impl::gradient_edge(*variable));
     } else {

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -41,8 +41,9 @@ struct TORCH_API NotImplemented : public Error {
 struct TORCH_API DelayedError : public Node {
   DelayedError(std::string msg, int num_inputs)
     : msg(std::move(msg)) {
-      for(const auto i : c10::irange(num_inputs))
-        add_input_metadata(Node::undefined_input());
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
+    for (const auto i : c10::irange(num_inputs))
+      add_input_metadata(Node::undefined_input());
     }
 
   variable_list apply(variable_list&& inputs) override;
@@ -69,6 +70,7 @@ struct TORCH_API UndefinedGradBackward : public Node {
 };
 
 struct TORCH_API GraphRoot : public Node {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   GraphRoot(edge_list functions, variable_list inputs)
       : Node(std::move(functions)),
       outputs(std::move(inputs)) {

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -16,6 +16,7 @@
 
 namespace torch {
 namespace autograd {
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 Scatter::Scatter(
     std::vector<at::Device> devices,
     // NOLINTNEXTLINE(modernize-pass-by-value)
@@ -51,6 +52,7 @@ variable_list Scatter::apply(variable_list&& inputs) {
       // NOLINTNEXTLINE(performance-move-const-arg)
       std::move(input), device_indices, chunk_sizes_, dim_, streams_);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<Variable> variables;
   variables.reserve(tensors.size());
   for (auto& tensor : tensors) {
@@ -99,7 +101,9 @@ variable_list Gather::apply(variable_list&& inputs) {
   std::shared_ptr<Node> grad_fn;
   // compute this before moving variables from `inputs`
   if (compute_requires_grad(inputs)) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<at::Device> source_devices;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<int64_t> input_sizes;
     for (auto& input : inputs) {
       source_devices.push_back(input.device());
@@ -114,6 +118,7 @@ variable_list Gather::apply(variable_list&& inputs) {
     grad_fn->set_next_edges(collect_next_edges(inputs));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Tensor> tensors;
   tensors.reserve(inputs.size());
   for (auto& variable : inputs) {

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -98,6 +98,7 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
       AT_ASSERT(res[i].defined());
       if (i == 0) {
         grad_slice.copy_(res[i]);
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)
         grad_inputs[i] = std::move(result); // NOLINT(bugprone-use-after-move)
       } else {
         grad_inputs[i] = std::move(res[i]);

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -17,10 +17,12 @@
 namespace torch { namespace autograd {
 
 struct InputBuffer {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit InputBuffer(size_t size)
     : buffer(size) {}
   InputBuffer(const InputBuffer& other) = delete;
   InputBuffer(InputBuffer&& other) = default;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit InputBuffer(variable_list&& inputs): buffer(std::move(inputs)) {};
   InputBuffer& operator=(InputBuffer&& other) = default;
 

--- a/torch/csrc/autograd/profiler_cuda.cpp
+++ b/torch/csrc/autograd/profiler_cuda.cpp
@@ -61,10 +61,12 @@ struct CUDAMethods : public CUDAStubs {
   }
 
   void nvtxMarkA(const char* name) const override {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     ::nvtxMark(name);
   }
 
   void nvtxRangePushA(const char* name) const override {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     ::nvtxRangePushA(name);
   }
 
@@ -97,6 +99,7 @@ struct RegisterCUDAMethods {
     registerCUDAMethods(&methods);
   }
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterCUDAMethods reg;
 
 } // namespaces

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -357,6 +357,7 @@ struct TORCH_API LegacyEvent {
 // a std::vector resize from taking a large amount of time inside
 // a profiling  event
 struct RangeEventList {
+  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   RangeEventList() {
     events_.reserve(kReservedCapacity);
   }
@@ -369,6 +370,7 @@ struct RangeEventList {
 
   std::vector<LegacyEvent> consolidate() {
     std::lock_guard<std::mutex> lock(mutex_);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<LegacyEvent> result;
     result.insert(
         result.begin(),
@@ -500,6 +502,7 @@ struct TORCH_API TLSProfilerGuard {
     enableProfilerLegacy(cfg);
   }
   ~TLSProfilerGuard() {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     thread_event_lists event_lists = disableProfilerLegacy(profilerDisableOptions_);
     if (cb_) {
       try {
@@ -525,6 +528,7 @@ TORCH_API std::vector<std::string> callstackStr(const std::vector<FileLineFunc>&
 TORCH_API std::vector<std::vector<int64_t>> inputSizes(const at::RecordFunction& fn);
 
 struct TORCH_API ProfilerThreadLocalState : public c10::MemoryReportingInfoBase {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit ProfilerThreadLocalState(const ProfilerConfig& config)
       : config_(config), remoteProfiledEvents_{c10::nullopt} {}
   ~ProfilerThreadLocalState() override = default;

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -22,6 +22,7 @@ namespace torch { namespace autograd {
 // A Function which is implemented by a Python object (i.e., a THPFunction).
 // Calls to 'apply' are forwarded to the Python method implementation.
 struct PyNode : public Node {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   PyNode(THPObjectPtr obj) : obj(obj.release()) {}
 
   variable_list apply(variable_list&& inputs) override;
@@ -74,6 +75,7 @@ inline bool ensure_tuple(THPObjectPtr& obj) {
 
 }} // namespace torch::autograd
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THPFunction {
     PyObject_HEAD
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -103,6 +103,7 @@ class PyInterpreterHolder {
  private:
   c10::impl::PyInterpreter* impl_;
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyInterpreterHolder self_interpreter;
 
 } // anonymous namespace
@@ -754,7 +755,9 @@ struct ConcretePythonGILHooks : public c10::impl::PythonGILHooks {
 // An alternative way to reduce the risk of python_gil_hooks going prematurely
 // dead would be to leak it at destruction time.  I didn't do that because
 // it's annoying to write the Registerer class for this case.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 ConcretePythonGILHooks python_gil_hooks;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static c10::impl::PythonGILHooksRegisterer python_gil_hooks_registerer(&python_gil_hooks);
 #endif
 
@@ -1136,7 +1139,9 @@ PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject *kwargs
 }
 
 static void clear_slots(PyTypeObject* type, PyObject* self) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   Py_ssize_t i, n;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   PyMemberDef* mp;
 
   n = Py_SIZE(type);
@@ -1145,7 +1150,9 @@ static void clear_slots(PyTypeObject* type, PyObject* self) {
     if (mp->type == T_OBJECT_EX && !(mp->flags & READONLY)) {
       char* addr = (char*)self + mp->offset;
       PyObject* obj = *(PyObject**)addr;
+      // NOLINTNEXTLINE(modernize-use-nullptr)
       if (obj != NULL) {
+        // NOLINTNEXTLINE(modernize-use-nullptr)
         *(PyObject**)addr = NULL;
         Py_DECREF(obj);
       }
@@ -1230,10 +1237,13 @@ void THPVariable_subclass_dealloc(PyObject* self) {
   // All Python defined classes have __dict__
   if (C10_LIKELY(type->tp_dictoffset)) {
     PyObject** dictptr = _PyObject_GetDictPtr(self);
+    // NOLINTNEXTLINE(modernize-use-nullptr)
     if (dictptr != NULL) {
       PyObject* dict = *dictptr;
+      // NOLINTNEXTLINE(modernize-use-nullptr)
       if (dict != NULL) {
         Py_DECREF(dict);
+        // NOLINTNEXTLINE(modernize-use-nullptr)
         *dictptr = NULL;
       }
     }
@@ -1298,7 +1308,9 @@ static int traverse_slots(
     PyObject* self,
     visitproc visit,
     void* arg) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   Py_ssize_t i, n;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   PyMemberDef* mp;
 
   n = Py_SIZE(type);
@@ -1307,6 +1319,7 @@ static int traverse_slots(
     if (mp->type == T_OBJECT_EX) {
       char* addr = (char*)self + mp->offset;
       PyObject* obj = *(PyObject**)addr;
+      // NOLINTNEXTLINE(modernize-use-nullptr)
       if (obj != NULL) {
         int err = visit(obj, arg);
         if (err)

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -256,6 +256,7 @@ struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
 
   void set_fw_grad(const Variable& new_grad, const Variable& self, uint64_t level, bool is_inplace_op) override;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   AutogradMeta(at::TensorImpl* self_impl = nullptr, bool requires_grad = false, Edge gradient_edge = Edge() ) {
     grad_fn_ = std::move(gradient_edge.function);
     requires_grad_ = false;
@@ -641,6 +642,7 @@ inline Variable make_variable_differentiable_view(
       shared_view_info, creation_meta));
       return data;
     } else {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       c10::intrusive_ptr<at::TensorImpl> data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
         /*version_counter=*/0,
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
@@ -689,6 +691,7 @@ inline Variable make_variable(
     if (data.getIntrusivePtr().use_count() == 1 && data.getIntrusivePtr()->unique_version()) {
       auto data_impl = data.unsafeReleaseIntrusivePtr();
       data_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (requires_grad) {
         data_impl->set_autograd_meta(std::make_unique<AutogradMeta>(data_impl.get(), requires_grad));
       } else {
@@ -699,6 +702,7 @@ inline Variable make_variable(
       auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
         /*version_counter=*/0,
         /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (requires_grad) {
         data_impl_copy->set_autograd_meta(std::make_unique<AutogradMeta>(
           data_impl_copy.get(), requires_grad));

--- a/torch/csrc/copy_utils.h
+++ b/torch/csrc/copy_utils.h
@@ -5,6 +5,7 @@
 #include <torch/csrc/Types.h>
 
 typedef std::function<void(PyObject*, PyObject*, bool)> THPCopyFunction;
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THPCopyInfo {
   PyTypeObject* srcType;  // Python type of src tensor/storage
   THPCopyFunction copy;   // copy function

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -12,6 +12,7 @@
 #include <structmember.h>
 #include <cuda_runtime_api.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyObject *THCPEventClass = nullptr;
 
 static PyObject * THCPEvent_pynew(
@@ -34,7 +35,9 @@ static PyObject * THCPEvent_pynew(
     return nullptr;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   THCPEvent* self = (THCPEvent *)ptr.get();
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   unsigned int flags =
     (blocking ? cudaEventBlockingSync : cudaEventDefault) |
     (enable_timing ? cudaEventDefault : cudaEventDisableTiming) |
@@ -70,8 +73,10 @@ static PyObject * THCPEvent_from_ipc_handle(
   if (!ptr) {
     return nullptr;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   THCPEvent* self = (THCPEvent *)ptr.get();
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cudaIpcEventHandle_t handle;
   std::memcpy(&handle, handle_string.c_str(), handle_string.size());
   new (&self->cuda_event) at::cuda::CUDAEvent(device.index(), &handle);
@@ -151,6 +156,7 @@ static PyObject * THCPEvent_synchronize(PyObject *_self, PyObject *noargs) {
 static PyObject * THCPEvent_ipc_handle(PyObject *_self, PyObject *noargs) {
   HANDLE_TH_ERRORS
   auto self = (THCPEvent*)_self;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cudaIpcEventHandle_t handle;
   self->cuda_event.ipc_handle(&handle);
   return PyBytes_FromStringAndSize((const char *)&handle, sizeof(handle));
@@ -180,6 +186,7 @@ static PyMethodDef THCPEvent_methods[] = {
   {nullptr}
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject THCPEventType = {
   PyVarObject_HEAD_INIT(nullptr, 0)
   "torch._C._CudaEventBase",             /* tp_name */

--- a/torch/csrc/cuda/Event.h
+++ b/torch/csrc/cuda/Event.h
@@ -5,10 +5,12 @@
 #include <torch/csrc/python_headers.h>
 #include <THC/THC.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THCPEvent {
   PyObject_HEAD
   at::cuda::CUDAEvent cuda_event;
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyObject *THCPEventClass;
 
 void THCPEvent_init(PyObject *module);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -32,7 +32,9 @@
 
 using namespace torch;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 THCState *state = nullptr;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool in_bad_fork = false;  // True for children forked after cuda init
 
 #ifndef WIN32
@@ -206,7 +208,9 @@ PyObject * THCPModule_cudaCachingAllocator_raw_alloc(PyObject *_unused, PyObject
     return nullptr;
   }
   ssize_t size = PyLong_AsSsize_t(size_o);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cudaStream_t stream = static_cast<cudaStream_t>(PyLong_AsVoidPtr(stream_o));
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   void* mem = c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(size, stream);
   return PyLong_FromVoidPtr(mem);
   END_HANDLE_TH_ERRORS
@@ -245,11 +249,13 @@ PyObject * THCPModule_cudaSleep(PyObject *_unused, PyObject *cycles)
   END_HANDLE_TH_ERRORS
 }
 
-// We need to ensure that as long as a thread will NEVER loose the GIL as long as
-// it holds the CUDA mutex. Otherwise another thread might be scheduled and try to
-// e.g. allocate a new tensor which will cause a deadlock. It's enough to have a
-// single global, because it can be only set once (cudaMutex is not recursive)
-// by the thread that owns the mutex (obviously there can be only one such thread).
+// We need to ensure that as long as a thread will NEVER loose the GIL as long
+// as it holds the CUDA mutex. Otherwise another thread might be scheduled and
+// try to e.g. allocate a new tensor which will cause a deadlock. It's enough to
+// have a single global, because it can be only set once (cudaMutex is not
+// recursive) by the thread that owns the mutex (obviously there can be only one
+// such thread).
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static PyGILState_STATE cudaMutexGILState;
 
 PyObject * THCPModule_cudaLockMutex(PyObject *module, PyObject *noargs)
@@ -535,6 +541,7 @@ static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
 PyObject * THCPModule_getCurrentBlasHandle_wrap(PyObject *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
   return PyLong_FromVoidPtr(handle);
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/cuda/Module.h
+++ b/torch/csrc/cuda/Module.h
@@ -1,6 +1,7 @@
 #ifndef THCP_CUDA_MODULE_INC
 #define THCP_CUDA_MODULE_INC
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern THCState *state;
 
 void THCPModule_setDevice(int idx);

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -10,6 +10,7 @@
 #include <structmember.h>
 #include <cuda_runtime_api.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyObject *THCPStreamClass = nullptr;
 
 static PyObject * THCPStream_pynew(
@@ -48,6 +49,7 @@ static PyObject * THCPStream_pynew(
       at::cuda::getStreamFromPool(
         /* isHighPriority */ priority < 0 ? true : false);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   THCPStream* self = (THCPStream *)ptr.get();
   self->cdata = stream.pack();
   new (&self->cuda_stream) at::cuda::CUDAStream(stream);
@@ -139,6 +141,7 @@ static PyMethodDef THCPStream_methods[] = {
   {nullptr}
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject THCPStreamType = {
   PyVarObject_HEAD_INIT(nullptr, 0)
   "torch._C._CudaStreamBase",            /* tp_name */

--- a/torch/csrc/cuda/Stream.h
+++ b/torch/csrc/cuda/Stream.h
@@ -10,6 +10,7 @@
 struct THCPStream : THPStream{
   at::cuda::CUDAStream cuda_stream;
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyObject *THCPStreamClass;
 
 void THCPStream_init(PyObject *module);

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -95,6 +95,7 @@ std::vector<Tensor>& broadcast_out(
 }
 
 std::vector<Tensor> broadcast(const Tensor& tensor, IntArrayRef devices) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<Tensor> diff_device_dst_tensors;
   diff_device_dst_tensors.reserve(devices.size());
   for (auto device : devices) {
@@ -108,10 +109,12 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntArrayRef devices) {
     }
   }
   _broadcast_out_impl(tensor, diff_device_dst_tensors);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<Tensor> dst_tensors;
   dst_tensors.reserve(devices.size());
   auto it = diff_device_dst_tensors.begin();
   for (auto device : devices) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (device != tensor.get_device()) {
       dst_tensors.push_back(*it++);
     } else {
@@ -169,6 +172,7 @@ tensor_list2d broadcast_coalesced(
   buffer_size = std::min(torch::cuda::nccl::get_max_count(), buffer_size);
 #endif
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   tensor_list2d outputs(devices.size());
   outputs[0] = tensors.vec();
   for (auto& o : outputs)
@@ -235,6 +239,7 @@ std::vector<at::Tensor>& scatter_out(
       "Expected at least one output tensor to scatter to");
   dim = at::maybe_wrap_dim(dim, tensor);
   int64_t total_size = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int64_t> chunk_sizes;
   chunk_sizes.reserve(out_tensors.size());
   for(const auto i : c10::irange(out_tensors.size())) {
@@ -324,6 +329,7 @@ std::vector<at::Tensor> scatter(
         chunk_sizes->size());
   }
   dim = at::maybe_wrap_dim(dim, tensor);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Tensor> chunks = chunk_sizes
       ? tensor.split_with_sizes(/*split_sizes=*/*chunk_sizes, /*dim=*/dim)
       : tensor.chunk(/*chunks=*/devices.size(), /*dim=*/dim);
@@ -369,6 +375,7 @@ static inline at::Tensor& _gather_out_impl(
     at::TensorList tensors,
     at::Tensor& out_tensor,
     int64_t dim) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int64_t> chunk_sizes;
   chunk_sizes.reserve(tensors.size());
   for (auto& tensor : tensors) {
@@ -391,6 +398,7 @@ at::Tensor& gather_out(
   auto& first = tensors.front();
   const auto first_size = first.sizes();
   dim = at::maybe_wrap_dim(dim, first);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int64_t> expected_size(first_size.begin(), first_size.end());
   for(const auto i : c10::irange(tensors.size())) {
     const auto& tensor = tensors[i];
@@ -445,6 +453,7 @@ at::Tensor gather(
   auto& first = tensors.front();
   const auto first_size = first.sizes();
   dim = at::maybe_wrap_dim(dim, first);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int64_t> expected_size(first_size.begin(), first_size.end());
   auto memory_format = first.suggest_memory_format();
   for(const auto i : c10::irange(tensors.size())) {

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -12,8 +12,10 @@
 // to simply copy the contents of this symbol to disk and dlopen it to create an
 // instance of python.
 extern "C" __attribute__((
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     __weak__)) char _binary_libtorch_deployinterpreter_so_start[];
 extern "C"
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     __attribute__((__weak__)) char _binary_libtorch_deployinterpreter_so_end[];
 #ifdef FBCODE_CAFFE2
 // in fbcode, we build the interpreter version with cuda bindings explicitly and
@@ -59,6 +61,7 @@ InterpreterSession ReplicatedObj::acquire_session(
   TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 InterpreterSession::~InterpreterSession() {
   if (manager_ && notify_idx_ >= 0) {
     manager_->resources_.free(notify_idx_);
@@ -80,6 +83,7 @@ void ReplicatedObjImpl::unload(const Interpreter* on_this_interpreter) {
   TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 ReplicatedObjImpl::~ReplicatedObjImpl() {
   unload(nullptr);
 }

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -26,6 +26,7 @@ struct TORCH_API InterpreterSession {
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   Obj self; // when retreived from a PythonMovable this will be set.
   InterpreterSession(InterpreterSession&&) noexcept = default;
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~InterpreterSession();
   Obj global(const char* module, const char* name) {
     TORCH_DEPLOY_TRY
@@ -186,6 +187,7 @@ struct TORCH_API ReplicatedObjImpl {
       PickledObject data,
       InterpreterManager* manager)
       : object_id_(object_id), data_(data), manager_(manager) {}
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~ReplicatedObjImpl();
   void unload(const Interpreter* on_this_interpreter);
   int64_t object_id_;

--- a/torch/csrc/deploy/example/benchmark.cpp
+++ b/torch/csrc/deploy/example/benchmark.cpp
@@ -19,6 +19,7 @@
 
 typedef void (*function_type)(const char*);
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool cuda = false;
 
 constexpr auto latency_p = {
@@ -63,6 +64,7 @@ struct RunPython {
     }
     return I.create_movable(obj);
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   RunPython(
       torch::deploy::Package& package,
       std::vector<at::IValue> eg,
@@ -71,6 +73,7 @@ struct RunPython {
   void operator()(int i) {
     auto I = obj_.acquire_session();
     if (cuda) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       std::vector<at::IValue> eg2 = {i};
       eg2.insert(eg2.end(), eg_.begin(), eg_.end());
       I.self(eg2);
@@ -93,6 +96,7 @@ struct RunPython {
 
 static torch::IValue to_device(const torch::IValue& v, torch::Device to);
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::vector<torch::IValue> to_device_vec(
     at::ArrayRef<torch::IValue> vs,
     torch::Device to) {
@@ -176,6 +180,7 @@ struct Benchmark {
         should_run_(true),
         items_completed_(0),
         reached_min_items_completed_(0) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (strategy == "one_python") {
       manager.debugLimitInterpreters(1);
     } else if (strategy == "multi_python") {
@@ -186,8 +191,10 @@ struct Benchmark {
   Report run() {
     pthread_barrier_init(&first_run_, nullptr, n_threads_ + 1);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     torch::deploy::Package package = manager_.load_package(file_to_run_);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<at::IValue> eg;
     {
       auto I = package.acquire_session();
@@ -199,6 +206,7 @@ struct Benchmark {
                ->elements();
     }
 
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (strategy_ == "jit") {
       run_one_work_item = RunJIT(file_to_run_, std::move(eg));
     } else {
@@ -206,6 +214,7 @@ struct Benchmark {
           RunPython(package, std::move(eg), manager_.all_instances().data());
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<std::vector<double>> latencies(n_threads_);
 
     for (const auto i : c10::irange(n_threads_)) {
@@ -245,6 +254,7 @@ struct Benchmark {
       thread.join();
     }
     auto end = std::chrono::steady_clock::now();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     double total_seconds = std::chrono::duration<double>(end - begin).count();
     Report report;
     report.benchmark = file_to_run_;
@@ -261,6 +271,7 @@ struct Benchmark {
   void reportLatencies(
       std::vector<double>& results,
       const std::vector<std::vector<double>>& latencies) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<double> flat_latencies;
     for (const auto& elem : latencies) {
       flat_latencies.insert(flat_latencies.end(), elem.begin(), elem.end());
@@ -290,6 +301,7 @@ struct Benchmark {
 int main(int argc, char* argv[]) {
   int max_thread = atoi(argv[1]);
   cuda = std::string(argv[2]) == "cuda";
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   bool jit_enable = std::string(argv[3]) == "jit";
   Report::report_header(std::cout);
   torch::deploy::InterpreterManager manager(max_thread);

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -108,9 +108,12 @@ FOREACH_LIBRARY(DECLARE_LIBRARY_INIT)
 #undef DECLARE_LIBRARY_INIT
 
 extern "C" PyObject* initModule(void);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern "C" struct _frozen _PyImport_FrozenModules[];
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern "C" struct _frozen _PyImport_FrozenModules_torch[];
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const char* startup = R"RAW(
 import sys
 import importlib.abc
@@ -271,6 +274,7 @@ struct InitLockAcquire {
     // thread grabs the GIL to do non-initialization tasks, then it might start
     // initializing (GIL -> init_lock). To avoid this, release the GIL before
     // trying to get the init_lock and then reacquire it afterward.
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     PyThreadState* _save;
     _save = PyEval_SaveThread();
     init_lock.lock();

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -37,7 +37,9 @@ void compare_torchpy_jit(const char* model_filename, const char* jit_filename) {
   ASSERT_TRUE(ref_output.allclose(output, 1e-03, 1e-05));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const char* simple = "torch/csrc/deploy/example/generated/simple";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const char* simple_jit = "torch/csrc/deploy/example/generated/simple_jit";
 
 const char* path(const char* envname, const char* path) {
@@ -45,6 +47,7 @@ const char* path(const char* envname, const char* path) {
   return e ? e : path;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, LoadLibrary) {
   torch::deploy::InterpreterManager m(1);
   torch::deploy::Package p = m.load_package(
@@ -53,16 +56,19 @@ TEST(TorchpyTest, LoadLibrary) {
   model({});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, SimpleModel) {
   compare_torchpy_jit(path("SIMPLE", simple), path("SIMPLE_JIT", simple_jit));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, ResNet) {
   compare_torchpy_jit(
       path("RESNET", "torch/csrc/deploy/example/generated/resnet"),
       path("RESNET_JIT", "torch/csrc/deploy/example/generated/resnet_jit"));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, Movable) {
   torch::deploy::InterpreterManager m(1);
   torch::deploy::ReplicatedObj obj;
@@ -75,6 +81,7 @@ TEST(TorchpyTest, Movable) {
   obj.acquire_session();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, MultiSerialSimpleModel) {
   torch::deploy::InterpreterManager manager(3);
   torch::deploy::Package p = manager.load_package(path("SIMPLE", simple));
@@ -85,6 +92,7 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
   size_t ninterp = 3;
   std::vector<at::Tensor> outputs;
 
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   for (const auto i : c10::irange(ninterp)) {
     outputs.push_back(model({input.alias()}).toTensor());
   }
@@ -111,6 +119,7 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
   ASSERT_TRUE(ref_output.equal(jit_output_kwargs));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, ThreadedSimpleModel) {
   size_t nthreads = 3;
   torch::deploy::InterpreterManager manager(nthreads);
@@ -124,6 +133,7 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
   std::vector<at::Tensor> outputs;
 
   std::vector<std::future<at::Tensor>> futures;
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   for (const auto i : c10::irange(nthreads)) {
     futures.push_back(std::async(std::launch::async, [&model]() {
       auto input = torch::ones({10, 20});
@@ -147,18 +157,23 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, ThrowsSafely) {
   // See explanation in deploy.h
   torch::deploy::InterpreterManager manager(3);
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(manager.load_package("some garbage path"), c10::Error);
 
   torch::deploy::Package p = manager.load_package(path("SIMPLE", simple));
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(p.load_pickle("some other", "garbage path"), c10::Error);
 
   auto model = p.load_pickle("model", "model.pkl");
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(model(at::IValue("unexpected input")), c10::Error);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, AcquireMultipleSessionsInTheSamePackage) {
   torch::deploy::InterpreterManager m(1);
 
@@ -168,6 +183,7 @@ TEST(TorchpyTest, AcquireMultipleSessionsInTheSamePackage) {
   auto I1 = p.acquire_session();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, AcquireMultipleSessionsInDifferentPackages) {
   torch::deploy::InterpreterManager m(1);
 
@@ -179,6 +195,7 @@ TEST(TorchpyTest, AcquireMultipleSessionsInDifferentPackages) {
   auto I1 = p1.acquire_session();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, TensorSharingNotAllowed) {
   size_t nthreads = 2;
   torch::deploy::InterpreterManager m(nthreads);
@@ -188,9 +205,11 @@ TEST(TorchpyTest, TensorSharingNotAllowed) {
   auto obj = I0.global("torch", "empty")({I0.from_ivalue(2)});
   auto t = obj.toIValue().toTensor();
   // try to feed it to the other interpreter, should error
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   ASSERT_THROW(I1.global("torch", "sigmoid")({t}), c10::Error);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, TaggingRace) {
   // At time of writing, this takes about 7s to run on DEBUG=1.  I think
   // this is OK, but feel free to fiddle with the knobs here to reduce the
@@ -198,6 +217,7 @@ TEST(TorchpyTest, TaggingRace) {
   constexpr int64_t trials = 4;
   constexpr int64_t nthreads = 16;
   torch::deploy::InterpreterManager m(nthreads);
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   for (const auto n : c10::irange(trials)) {
     at::Tensor t = torch::empty(2);
     std::atomic<int64_t> success(0);
@@ -218,6 +238,7 @@ TEST(TorchpyTest, TaggingRace) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, DisarmHook) {
   at::Tensor t = torch::empty(2);
   {
@@ -227,9 +248,11 @@ TEST(TorchpyTest, DisarmHook) {
   } // unload the old interpreter
   torch::deploy::InterpreterManager m(1);
   auto I = m.acquire_one();
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   ASSERT_THROW(I.from_ivalue(t), c10::Error); // NOT a segfault
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, RegisterModule) {
   torch::deploy::InterpreterManager m(2);
   m.register_module_source("foomodule", "def add1(x): return x + 1\n");

--- a/torch/csrc/deploy/test_deploy_gpu.cpp
+++ b/torch/csrc/deploy/test_deploy_gpu.cpp
@@ -13,7 +13,9 @@ int main(int argc, char* argv[]) {
   return rc;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const char* simple = "torch/csrc/deploy/example/generated/simple";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const char* simple_jit = "torch/csrc/deploy/example/generated/simple_jit";
 
 const char* path(const char* envname, const char* path) {
@@ -21,6 +23,7 @@ const char* path(const char* envname, const char* path) {
   return e ? e : path;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchDeployGPUTest, SimpleModel) {
   if (!torch::cuda::is_available()) {
     GTEST_SKIP();

--- a/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
+++ b/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
@@ -8,6 +8,8 @@ int main(int argc, char* argv[]) {
   return rc;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchDeployMissingInterpreter, Throws) {
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(torch::deploy::InterpreterManager(1), c10::Error);
 }

--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -15,9 +15,11 @@ constexpr int kNumCleanupContextRetries = 20;
 constexpr int64_t kInvalidContextId = -1;
 
 // Each thread has a single autograd_context_id valid at any point in time.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static thread_local int64_t current_context_id_ = kInvalidContextId;
 
 // Lock to ensure DistAutogradContainer is initialized only once.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::mutex dist_container_init_lock_;
 
 DistAutogradContainer::DistAutogradContainer(uint32_t num_shards)
@@ -99,6 +101,7 @@ DistAutogradContainer& DistAutogradContainer::getInstance() {
 
 DistAutogradContainer& DistAutogradContainer::getInstanceInternal() {
   // Leaky singleton to avoid module destructor race.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static DistAutogradContainer* container =
       new DistAutogradContainer(computeNumShards());
   return *container;

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -273,6 +273,7 @@ void DistAutogradContext::runGradCallbackForVariable(
 }
 
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local ContextPtr tl_context_ptr;
 } // namespace
 

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -26,7 +26,9 @@ using torch::autograd::ReadyQueue;
 using torch::autograd::validate_outputs;
 using torch::autograd::variable_list;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static constexpr char* kNumBackwardPasses = "num_current_backward_passes";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static constexpr char* kNumAutogradContexts = "num_autograd_contexts";
 
 // This hook does 3 things:
@@ -142,6 +144,7 @@ DistEngine::~DistEngine() {
 
 DistEngine& DistEngine::getInstance() {
   // Leaky singleton to avoid module destructor race.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static DistEngine* engine = new DistEngine();
   return *engine;
 }

--- a/torch/csrc/distributed/rpc/metrics/registry.cpp
+++ b/torch/csrc/distributed/rpc/metrics/registry.cpp
@@ -2,6 +2,7 @@
 namespace torch {
 namespace distributed {
 namespace rpc {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_REGISTRY(
     RpcMetricsHandlerRegistry,
     torch::distributed::rpc::RpcMetricsHandler);

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -176,6 +176,7 @@ bool ProcessGroupAgent::hasPendingMessage() {
   // allgather both send and recv messages in one shot
   std::vector<std::vector<torch::Tensor>> outputSnapshots(1);
 
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   for (const auto i : c10::irange(worldSize)) {
     outputSnapshots[0].emplace_back(
         torch::zeros({2, worldSize}, {torch::kInt64}));

--- a/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.cpp
+++ b/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.cpp
@@ -10,8 +10,10 @@ namespace rpc {
 const std::string REMOTE_PROFILING_KEY_PREFIX = "#remote_op: ";
 constexpr int kAutoIncrementBits = 48;
 /*static */ thread_local c10::optional<std::string>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     RemoteProfilerManager::currentThreadLocalKey_ = c10::nullopt;
 /*static */ RemoteProfilerManager& RemoteProfilerManager::getInstance() {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static RemoteProfilerManager* handler = new RemoteProfilerManager();
   return *handler;
 }

--- a/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.h
+++ b/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.h
@@ -53,6 +53,7 @@ class TORCH_API RemoteProfilerManager {
   local_id_t getNextLocalId();
   std::unordered_map<ProfilingId, std::string, ProfilingId::Hash>
       profiledRpcKeys_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static thread_local c10::optional<std::string> currentThreadLocalKey_;
   std::mutex mutex_;
   local_id_t currentLocalId_;

--- a/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.cpp
+++ b/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.cpp
@@ -16,7 +16,9 @@ std::vector<thread_event_lists> State::results() {
   return results;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 mutexType currentStateStackEntryMutex;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::shared_ptr<StateStackEntry> currentStateStackEntryPtr = nullptr;
 
 void StateStackEntry::pushRange(

--- a/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h
+++ b/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h
@@ -71,7 +71,9 @@ using wLockType = std::unique_lock<std::shared_timed_mutex>;
 #endif
 
 // This is the global stack of ``State``s.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern std::shared_ptr<StateStackEntry> currentStateStackEntryPtr;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern mutexType currentStateStackEntryMutex;
 
 // This class is used to implement a stack of ``State``s.

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -128,6 +128,7 @@ PythonRpcHandler& PythonRpcHandler::getInstance() {
   // release GIL to avoid this situation.
   TORCH_INTERNAL_ASSERT(!PyGILState_Check());
   // Leaky singleton to avoid module destructor race.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static PythonRpcHandler* handler = new PythonRpcHandler();
   handler->init();
   return *handler;

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -226,6 +226,7 @@ const WorkerInfo& RpcAgent::getWorkerInfo() const {
   return workerInfo_;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::shared_ptr<RpcAgent> RpcAgent::currentRpcAgent_ = nullptr;
 
 bool RpcAgent::isCurrentRpcAgentSet() {

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -287,6 +287,7 @@ class TORCH_API RpcAgent {
   std::atomic<bool> rpcAgentRunning_;
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::shared_ptr<RpcAgent> currentRpcAgent_;
   // Add GIL wait time data point to metrics
   virtual void addGilWaitTime(const std::chrono::microseconds gilWaitTime) = 0;

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -9,7 +9,9 @@ namespace distributed {
 namespace rpc {
 
 thread_local std::vector<std::shared_ptr<RRefContext::PendingUserState>>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     RRefContext::userTable_;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local bool RRefContext::recording_ = false;
 
 namespace callback {
@@ -82,6 +84,7 @@ const std::string kNumForks = "num_forks";
 
 RRefContext& RRefContext::getInstance() {
   // Leaky singleton to avoid module destructor races.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static RRefContext* context = new RRefContext(RpcAgent::getCurrentRpcAgent());
   return *context;
 }

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -237,6 +237,7 @@ class TORCH_API RRefContext {
   // If there is any leak on any RRef, this method will throw an error.
   void checkRRefLeaks(bool ignoreRRefLeak);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::atomic<local_id_t> nextLocalId_;
 
   const std::shared_ptr<RpcAgent> agent_;
@@ -304,6 +305,7 @@ class TORCH_API RRefContext {
 
   // Thread local states to keep UserRRefs deserialized from user function
   // arguments.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static thread_local std::vector<std::shared_ptr<PendingUserState>> userTable_;
   // A flag indicating whether subsequently created UserRRefs should be added to
   // the thread_local userTable_. The flag is set to true before serializing
@@ -328,6 +330,7 @@ class TORCH_API RRefContext {
   // without confirmation is OK, because the creator would either call to_here
   // or forward the UserRRef, and both would then require confirmations from the
   // owner.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static thread_local bool recording_;
 };
 

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -34,6 +34,7 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<local_id_t> RRefContext::nextLocalId_{0};
 
 //////////////////////////  RRefForkData  /////////////////////////////////

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -299,6 +299,7 @@ class TORCH_API TensorPipeAgent : public RpcAgent {
   // TODO: To achieve better performance we can have a pipe pool per
   // client that can be configured using RpcBackendOptions.
   struct ClientPipe {
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     explicit ClientPipe(std::shared_ptr<tensorpipe::Pipe> pipe) : pipe_(pipe) {}
     std::shared_ptr<tensorpipe::Pipe> pipe_;
     mutable std::mutex mutex_;
@@ -342,6 +343,7 @@ class TORCH_API TensorPipeAgent : public RpcAgent {
   struct TimeoutMessageMetadata {
     TimeoutMessageMetadata(
         uint64_t messageId_,
+        // NOLINTNEXTLINE(modernize-pass-by-value)
         std::shared_ptr<AtomicJitFuture> responseFuture_,
         std::chrono::milliseconds timeout_)
         : messageId(messageId_),

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.h
@@ -46,6 +46,7 @@ class TensorpipeDeviceTypeConverter {
 extern TORCH_API std::array<
     std::atomic<const TensorpipeDeviceTypeConverter*>,
     static_cast<size_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     device_type_converter_registry;
 
 class TORCH_API TensorpipeDeviceTypeConverterRegistrar {

--- a/torch/csrc/distributed/rpc/types.cpp
+++ b/torch/csrc/distributed/rpc/types.cpp
@@ -7,6 +7,7 @@ namespace rpc {
 // Thread local flag to enforce rref JIT pickling to be allowed only
 // in the scope of an rpc call. For other scopes like when model is
 // saved by calling torch.save(), rref is not allowed to be pickled directly.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static thread_local bool allowJitRRefPickle = false;
 
 bool getAllowJitRRefPickle() {

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -316,7 +316,9 @@ parseWireSections(const void* data, size_t data_size) {
   return out;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static const char* kMeta = "meta";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static const char* kPayload = "payload";
 }; // namespace
 

--- a/torch/csrc/dl.c
+++ b/torch/csrc/dl.c
@@ -1,18 +1,22 @@
 #include <Python.h>
 #include <dlfcn.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyObject* module;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static PyMethodDef TorchDlMethods[] = {
   {NULL, NULL, 0, NULL}
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static struct PyModuleDef torchdlmodule = {
-   PyModuleDef_HEAD_INIT,
-   "torch._dl",
-   NULL,
-   -1,
-   TorchDlMethods
+    PyModuleDef_HEAD_INIT,
+    "torch._dl",
+    NULL,
+    -1,
+    TorchDlMethods
+    // NOLINTNEXTLINE(clang-diagnostic-missing-field-initializers)
 };
 
 PyMODINIT_FUNC PyInit__dl(void)

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -66,6 +66,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
   // torch.Storage()
   if (num_args == 0) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (allocator) {
       self->cdata = THPStorage_(newWithAllocator)(0, allocator);
     } else {
@@ -79,6 +80,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   // torch.Storage(size)
   if (num_args == 1 && THPUtils_checkLong(first_arg)) {
     int64_t size = THPUtils_unpackLong(first_arg);
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (allocator) {
       self->cdata = THPStorage_(newWithAllocator)(size, allocator);
     } else {
@@ -103,6 +105,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
     try {
       for (Py_ssize_t i = 0; i < length; i++) {
         item = PySequence_GetItem(first_arg, i);
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         scalar_t value = THPUtils_(unpackReal)(item.get());
 #if !defined(THC_GENERIC_FILE)
         self->cdata->unsafe_data<scalar_t>()[i] = value;

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -61,6 +61,7 @@ static PyObject * THPStorage_(new)(PyObject *_self, PyObject *noargs)
   HANDLE_TH_ERRORS
   auto self = (THPStorage*)_self;
   THWStoragePtr new_storage(THWStorage_(new)(LIBRARY_STATE_NOARGS));
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   PyObject *_ret = THPStorage_(New)(new_storage);
   new_storage.release();
   return _ret;

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -251,10 +251,12 @@ static PyObject * THPStorage_(shareCuda)(PyObject *_self, PyObject *noargs)
   THPObjectPtr _event_sync_required(Py_None);
   Py_INCREF(Py_None);
   if (THWStorage_(data)(LIBRARY_STATE storage)) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     size_t base_size;
     void *base_ptr = c10::cuda::CUDACachingAllocator::getBaseAllocation(THWStorage_(data)(LIBRARY_STATE storage), &base_size);
     ptrdiff_t offset_bytes = (char*)storage->data<scalar_t>() - (char*)base_ptr;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     cudaIpcMemHandle_t handle;
     THCudaCheck(cudaIpcGetMemHandle(&handle, base_ptr));
 
@@ -270,7 +272,7 @@ static PyObject * THPStorage_(shareCuda)(PyObject *_self, PyObject *noargs)
     _ref_counter = PyBytes_FromString((sent_data->handle()).c_str());
     _ref_counter_offset = THPUtils_packInt64(sent_data->offset());
 
-
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     cudaIpcEventHandle_t ipc_event_handle;
 
 #ifndef __HIP_PLATFORM_HCC__
@@ -346,11 +348,15 @@ static PyObject * THPStorage_(releaseIPCCounter)(PyObject *_unused, PyObject *ar
 }
 
 static std::string THPStorage_(bytesAsHandleString)(PyObject *handle) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   char* buffer;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   Py_ssize_t handle_size;
   if (PyBytes_AsStringAndSize(handle, &buffer, &handle_size) == -1) {
+    // NOLINTNEXTLINE(bugprone-string-constructor)
     return nullptr;
   }
+  // NOLINTNEXTLINE(bugprone-string-constructor)
   THPUtils_assert(
       handle_size == CUDA_IPC_HANDLE_SIZE, "incorrect handle size");
   return std::string(buffer, handle_size);
@@ -394,6 +400,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
         THPStorage_(bytesAsHandleString)(_event_handle);
     auto ipc_event_handle = reinterpret_cast<const cudaIpcEventHandle_t*>(
         s_ipc_event_handle.c_str());
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     cudaEvent_t event;
     cudaIpcOpenEventHandle(&event, *ipc_event_handle);
     AT_CUDA_CHECK(
@@ -408,6 +415,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
 
   // Offset the basePtr to reconstruct the real storage
   // devPtr = basePtr + storage_offset
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   void* devPtr = basePtr.get();
   devPtr = (char*)devPtr + storage_offset_bytes;
 

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -23,6 +23,7 @@ void THPStorage_(writeFileRaw)(THWStorage *self, io fd, bool save_size)
 #ifndef THC_GENERIC_FILE
   data = THWStorage_(data)(LIBRARY_STATE self);
 #else
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::unique_ptr<char[]> cpu_data(new char[size_bytes]);
   data = (scalar_t*)cpu_data.get();
   THCudaCheck(cudaMemcpy(
@@ -54,9 +55,11 @@ void THPStorage_(writeFileRaw)(THWStorage *self, io fd, bool save_size)
   } else {
     int64_t buffer_size = std::min(numel, (int64_t)5000);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(scalar_t)]);
     for (int64_t i = 0; i < numel; i += buffer_size) {
       size_t to_convert = std::min(numel - i, buffer_size);
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (sizeof(scalar_t) == 2) {
         torch::utils::THP_encodeInt16Buffer(
             (uint8_t*)le_buffer.get(),
@@ -123,6 +126,7 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage)
 #ifndef THC_GENERIC_FILE
   data = THWStorage_(data)(LIBRARY_STATE storage);
 #else
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::unique_ptr<char[]> cpu_data(new char[size * sizeof(scalar_t)]);
   data = (scalar_t*)cpu_data.get();
 #endif
@@ -135,6 +139,7 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage)
   } else {
     int64_t buffer_size = std::min(size, (int64_t)5000);
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(scalar_t)]);
 
 
@@ -142,6 +147,7 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage)
       size_t to_convert = std::min(size - i, buffer_size);
       doRead(file, le_buffer.get(), sizeof(scalar_t) * to_convert);
 
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (sizeof(scalar_t) == 2) {
         torch::utils::THP_decodeInt16Buffer(
             (int16_t*)data + i,

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -9,6 +9,7 @@ namespace torch {
 namespace jit {
 
 struct TORCH_API GraphFunction : public Function {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   GraphFunction(
       c10::QualifiedName name,
       std::shared_ptr<Graph> graph,

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -20,8 +20,10 @@ class ObjectAttributeError : public std::runtime_error {
   ObjectAttributeError(const std::string& what) : std::runtime_error(what) {}
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct TORCH_API Object {
   Object() = default;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Object(ObjectPtr _ivalue) : _ivalue_(std::move(_ivalue)) {}
   Object(std::shared_ptr<CompilationUnit> cu, const c10::ClassTypePtr& type);
   Object(

--- a/torch/csrc/jit/backends/backend_debug_handler.h
+++ b/torch/csrc/jit/backends/backend_debug_handler.h
@@ -132,6 +132,7 @@ class TORCH_API BackendDebugInfoRecorder {
   NodeToDebugHandle generate_debug_handles(const std::shared_ptr<Graph>& graph);
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::atomic<DebugHandleType> unique_debug_handle_;
   BackendDebugInfoMapType handles_to_inlined_callstack_ptrs_;
 };

--- a/torch/csrc/jit/backends/backend_debug_info.cpp
+++ b/torch/csrc/jit/backends/backend_debug_info.cpp
@@ -11,6 +11,7 @@ static auto cls = torch::class_<PyTorchBackendDebugInfoDummy>(
                       kBackendDebugInfoClass)
                       .def(torch::init<>());
 #else
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto cls = torch::class_<PyTorchBackendDebugInfo>(
                       kBackendUtilsNamespace,
                       kBackendDebugInfoClass)

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -17,6 +17,7 @@ namespace codegen {
 namespace {
 
 class CudaKernelGenerator : private OptInConstDispatch {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static constexpr char* kTab = "  ";
 
  public:

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -18,8 +18,10 @@ class TensorView;
 // We're going to keep data related to the computeAt pass for each TensorView in
 // this structure, this will allow us to keep a single entry in a map from a
 // TensorView to this one.
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class ComputeAtData {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ComputeAtData() = default;
   ComputeAtData(TensorView* tv);
 
@@ -153,9 +155,12 @@ class ComputeAt {
       TensorView* _consumer,
       unsigned int _consumer_position);
 
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ComputeAt() = delete;
   ~ComputeAt() = default;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ComputeAt(ComputeAt&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ComputeAt& operator=(const ComputeAt& other) = delete;
 };
 

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -494,6 +494,7 @@ class TORCH_CUDA_CU_API OptInDispatch {
   }
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API OptOutMutator {
  public:
   virtual ~OptOutMutator() = default;
@@ -559,6 +560,7 @@ class TORCH_CUDA_CU_API OptOutMutator {
   virtual Statement* mutate(kir::Sync*);
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API OptInMutator {
  public:
   virtual ~OptInMutator() = default;

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -23,6 +23,7 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 int FusionExecutor::fusion_id_counter_ = 0;
 
 std::string FusionExecutor::getStructuredCode(const std::string& kernel) {
@@ -86,6 +87,7 @@ void FusionExecutor::debugCompileFusionFromStr(
 
   if (!kernel_summary.static_smem_allocations.empty()) {
     StatefulExpressionEvaluator static_evaluator(&fusion_);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     unsigned static_smem_size = computeSharedMemory(
         static_evaluator, kernel_summary.static_smem_allocations);
     TORCH_INTERNAL_ASSERT(
@@ -141,6 +143,7 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
 
   if (!kernel_summary.static_smem_allocations.empty()) {
     StatefulExpressionEvaluator static_evaluator(&fusion_);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     unsigned static_smem_size = computeSharedMemory(
         static_evaluator, kernel_summary.static_smem_allocations);
     TORCH_INTERNAL_ASSERT(
@@ -165,6 +168,7 @@ at::Tensor inferAndAlloc(
     bool zero_init = false) {
   FUSER_PERF_SCOPE("inferAndAlloc");
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int64_t> sizes;
   for (auto id : TensorDomain::noReductions(tv->getMaybeRFactorDomain())) {
     auto inferred_val = see.inferValue(id->rawExtent());
@@ -235,6 +239,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
 
   // Lets collect all IterDomains that are bound to a thread binding
   std::unordered_map<ParallelType, std::vector<IterDomain*>, TypeHash>
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       parallel_iter_domains;
   for (auto tv : getUsedTVs()) {
     for (auto id : tv->domain()->domain()) {
@@ -312,12 +317,14 @@ LaunchParams FusionExecutor::computeLaunchParams(
         launch_params.bdimx() * launch_params.bdimy() * launch_params.bdimz();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const uint64_t dynamic_smem_size = computeSharedMemory(
       see,
       kernel_summary.dynamic_smem_allocations,
       true,
       reduction_broadcast_workspace);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const uint64_t static_smem_size =
       computeSharedMemory(see, kernel_summary.static_smem_allocations);
 
@@ -359,6 +366,7 @@ FusionExecutor::GlobalBuffers FusionExecutor::allocGlobalVals(
 std::vector<at::Tensor> FusionExecutor::allocOutputs(
     StatefulExpressionEvaluator& see) {
   FUSER_PERF_SCOPE("allocOutputs");
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Tensor> outputs;
   for (auto output : fusion_.outputs()) {
     TORCH_INTERNAL_ASSERT(
@@ -404,6 +412,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   auto stream = at::cuda::getCurrentCUDAStream();
 
   LaunchParams launch_params;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Tensor> alloced_outputs = outputs;
   GlobalBuffers global_buffers;
   uint64_t rand_offset = 0;
@@ -451,6 +460,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
 
     launch_params = computeLaunchParams(launch_constraints, evaluator);
 
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (outputs.empty() || outputs.size() != fusion_.outputs().size()) {
       alloced_outputs = allocOutputs(evaluator);
     } else {

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -79,6 +79,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   }
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct GlobalBuffers {
     std::vector<at::Tensor> empty_buffers;
     std::vector<at::Tensor> zero_buffers;
@@ -136,6 +137,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
 
   // Counter to be used for kernel name.
   int fusion_id_ = -1;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static int fusion_id_counter_;
 
   GpuLower lowered_;

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -38,6 +38,7 @@ void KernelArgumentHolder::push(const at::Tensor& tensor) {
   int nDims = tensor.ndimension();
 
   c10::ScalarType dtype = tensor.scalar_type();
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::unique_ptr<TensorArgAbstract> tensor_arg = getTensorArg(dtype, nDims);
   tensor_arg->setPointer(tensor.data_ptr());
   for (const auto i : c10::irange(nDims)) {
@@ -55,6 +56,7 @@ void KernelArgumentHolder::push(const IValue& val) {
       "Tried to push an arg to run in a fused kernel, expected a scalar but got, ",
       val);
   switch (val.toScalar().type()) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     case c10::ScalarType::Double:
       arguments_.push_back(std::make_unique<FloatArg>((float)val.toDouble()));
       return;

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
@@ -154,6 +154,7 @@ std::unique_ptr<TensorArgAbstract> getTensorArg(
     c10::ScalarType dtype,
     int nDims);
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class KernelArgumentHolder {
  public:
   // Push a tensor to the arguments

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -77,6 +77,7 @@ bool validateKernelArgTensor(
   // Check the rank of the tensors.
   size_t arg_dim = arg.dim();
   // Note: This requires current Fusion to be active.
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   size_t param_dim =
       TensorDomain::noReductions(param->as<TensorView>()->getRootDomain())
           .size();
@@ -267,6 +268,7 @@ NvrtcFunction nvrtcCompile(
   FUSER_PERF_SCOPE("NVRTC");
 
   // lazily construct context if non-existing yet;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   CUcontext pctx = nullptr;
   AT_CUDA_DRIVER_CHECK(at::globalContext().getNVRTC().cuCtxGetCurrent(&pctx));
   if (!pctx) {
@@ -315,6 +317,7 @@ NvrtcFunction nvrtcCompile(
       "compute_" +
 #endif
       std::to_string(major) + std::to_string(minor);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const char*> args = {
       "--std=c++14", compute.c_str(), "-default-device"};
 #endif
@@ -334,7 +337,9 @@ NvrtcFunction nvrtcCompile(
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint32_t jit_opt_level;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<CUjit_option> options;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<void*> option_vals;
 
   if (ptxas_opt_level) {
@@ -364,6 +369,7 @@ NvrtcFunction nvrtcCompile(
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       size_t logsize;
       at::globalContext().getNVRTC().nvrtcGetProgramLogSize(program, &logsize);
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       std::vector<char> log(logsize);
       at::globalContext().getNVRTC().nvrtcGetProgramLog(program, log.data());
 
@@ -379,6 +385,7 @@ NvrtcFunction nvrtcCompile(
       program, func_name.c_str(), &lowered_kernel_name);
 
   size_t ptx_size = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<char> ptx;
 
   {

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.h
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.h
@@ -16,6 +16,7 @@ namespace cuda {
 
 class TORCH_CUDA_CU_API StatefulExpressionEvaluator : private OptOutDispatch {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit StatefulExpressionEvaluator(Fusion* fusion) : fusion_(fusion) {}
 
   Fusion* fusion() const {

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -17,6 +17,7 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static thread_local Fusion* ACTIVE_FUSION = nullptr;
 
 FusionGuard::FusionGuard(Fusion* fusion) {

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -66,6 +66,7 @@ class TORCH_CUDA_CU_API FusionGuard {
  *
  * The Fusion owns the whole IR graph (Vals and Exprs)
  */
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API Fusion final {
  public:
   Fusion() = default;

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -580,6 +580,7 @@ struct CudaGraphFuser {
     }
 
     bchunk->removeInput(producer_index);
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for (const auto i : c10::irange(nchunks)) {
       bchunk->eraseOutput(nchunks * producer_index);
     }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -18,6 +18,7 @@ class TORCH_CUDA_CU_API IrCloner : private OptInConstDispatch {
   friend class Statement;
 
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit IrCloner(Fusion* new_fusion) : fusion_(new_fusion) {}
 
   Statement* clone(const Statement* statement);
@@ -30,6 +31,7 @@ class TORCH_CUDA_CU_API IrCloner : private OptInConstDispatch {
 
   template <class T>
   std::vector<T*> clone(const std::vector<T*>& container) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<T*> copy;
     copy.reserve(container.size());
     for (auto p : container) {

--- a/torch/csrc/jit/codegen/cuda/iter_visitor.h
+++ b/torch/csrc/jit/codegen/cuda/iter_visitor.h
@@ -30,6 +30,7 @@ namespace cuda {
  * TODO: We may want to have ordering of outputs to inputs. I'm not sure why we
  * would want this, but seems like it would be a reasonable request.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
  public:
   // NOLINTNEXTLINE(modernize-use-override)
@@ -49,6 +50,7 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
   // to inputs based on depth first traversal. Next could be called on a node
   // multiple times.
   virtual std::vector<Statement*> next(Statement* stmt) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (stmt->isVal()) {
       return next(stmt->as<Val>());
     } else if (stmt->isExpr()) {
@@ -69,6 +71,7 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
 
   virtual std::vector<Statement*> next(Expr* expr) {
     FusionGuard::getCurFusion()->assertInFusion(expr, "Cannot traverse expr, ");
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<Statement*> next_stmts{
         expr->inputs().begin(), expr->inputs().end()};
     return next_stmts;
@@ -150,6 +153,7 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
  * outputs to guarentee that we will traverse all outputs of all exprs during
  * the backward traversal.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API BackwardVisitor : public OptOutDispatch {
  public:
   // NOLINTNEXTLINE(modernize-use-override)

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -18,6 +18,7 @@ namespace cuda {
 //!
 //! TODO(kir): const node ptrs
 //!
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct KernelSummary {
   //! List of Write-After-Read (WAR) synchronization barriers
   std::unordered_map<size_t, kir::Sync*> war_hazard_syncs;
@@ -53,6 +54,7 @@ struct KernelSummary {
 //!  by a Fusion object. The goal is to have the Kernel object
 //!  own the Kernel IR nodes
 //!
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API Kernel final : public NonCopyable {
  public:
   Kernel() = default;

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -133,6 +133,7 @@ at::DimVector getPermutationPerSortedStride(const TensorTypePtr& type) {
   const int rank = static_cast<int>(stride_properties->size());
 
   // stores axes with stride_index;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::set<int> ordered_axes;
 
   // TODO: this does not support broadcast yet;
@@ -170,6 +171,7 @@ at::DimVector inversePermutation(
   int rank = static_cast<int>(permuted.size());
 
   if (!reduction_axes.empty()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int red_rank = rank - static_cast<int>(reduction_axes.size());
 
     // see [ NOTE - reduction in graph ] part 1.
@@ -262,6 +264,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   return ret;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 FusionExecutorCache::FusionExecutorCache(std::unique_ptr<Fusion>&& fusion)
     : fusion_(std::move(fusion)) {
   FUSER_PERF_SCOPE("FusionExecutorCache::FusionExecutorCache");
@@ -279,6 +282,7 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
     evictCache(id_lookup_ret.evict_id);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const size_t unique_id = id_lookup_ret.id;
   const int device_index = getCommonDeviceCUDA(inputs);
   TORCH_CHECK(device_index >= 0, "device is not coherent for fusion inputs");
@@ -367,6 +371,7 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
         auto tv_entries =
             ir_utils::filterByType<TensorView>(outputsOfReduction);
 
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         std::vector<TensorView*> tvOutputsOfReduction(
             tv_entries.begin(), tv_entries.end());
 
@@ -456,7 +461,9 @@ void GraphCache::createFusion(const std::shared_ptr<Graph>& graph) {
 
       int rank = static_cast<int>(type->dim().value());
 
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       std::vector<c10::ShapeSymbol> permuted_vec_ss;
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       std::vector<c10::optional<c10::Stride>> permuted_vec_optional_stride;
       for (const auto i : c10::irange(rank)) {
         permuted_vec_ss.emplace_back(
@@ -528,6 +535,7 @@ void GraphCache::createFusion(const std::shared_ptr<Graph>& graph) {
       std::make_unique<FusionExecutorCache>(parseJitIR(graph));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 GraphCache::GraphCache(const std::shared_ptr<Graph>& graph) {
   FUSER_PERF_SCOPE("GraphCache::GraphCache");
   TORCH_INTERNAL_ASSERT(
@@ -571,9 +579,11 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
   // GraphCache need to permute inputs/outputs to accommodate dimension
   // coalescing
   if (requiresPermutation()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<IValue> permuted_inputs;
     permuted_inputs.reserve(inputs.size());
     for (const auto& input : inputs) {
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (input.isTensor()) {
         permuted_inputs.emplace_back(
             input.toTensor().permute(input_permutation_));
@@ -582,6 +592,7 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
       }
     }
     auto outputs = fusion_executor_cache_->runFusionWithInputs(permuted_inputs);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<at::Tensor> permuted_outputs;
     permuted_outputs.reserve(outputs.size());
     for (const auto& output : outputs) {

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -29,6 +29,7 @@ namespace cuda {
 class TORCH_CUDA_CU_API InputsIdLookup {
  public:
   //! constructor where maximum cache size is fixed during init
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit InputsIdLookup(size_t max_cache_size = 10)
       : max_cache_size_(max_cache_size){};
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -576,6 +576,7 @@ class TORCH_CUDA_CU_API Sync : public Expr {
 };
 
 // TODO(kir): promote to IR node
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API Scope {
  public:
   Scope() = default;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
@@ -21,6 +21,7 @@ namespace kir {
 //! to handle invalid IR states as much as possible.
 //!
 class TORCH_CUDA_CU_API IrPrinter : private OptInConstDispatch {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static constexpr char* kTab = "  ";
 
  public:

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -18,6 +18,7 @@ namespace fuser {
 namespace cuda {
 
 // TODO(kir): revisit this
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local GpuLower* active_gpu_lower = nullptr;
 
 void GpuLower::replaceSymbolicSizes() {

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -14,12 +14,14 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_CUDA_CU_API GpuLower {
   class KernelIrMapper;
 
  public:
   GpuLower() = default;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit GpuLower(Fusion* fusion) : fusion_(fusion) {
     lower();
   }

--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -52,6 +52,7 @@ namespace {
 // CudaFusionManager is not thread safe!
 // TODO: we should make the tradeoff here to use thread_local instead of global
 // singleton;
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class CudaFusionManager {
  public:
   static CudaFusionManager& getManager() {
@@ -153,6 +154,7 @@ class CudaFusionManager {
     const int rank = static_cast<int>(stride_properties->size());
 
     // stores axes with stride_index;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::set<int> ordered_axes;
 
     // TODO: this does not support broadcast yet;
@@ -221,6 +223,7 @@ void compileCudaFusionGroup(Node* fusion_node) {
   // insert meta information after itself).
   TypePropagate(graph);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int32_t fusion_cache_id =
       CudaFusionManager::getManager().registerOrGetCacheId(graph);
   fusion_node->i_(attr::cache_id, fusion_cache_id);

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -57,6 +57,7 @@ class IrParser {
   };
 
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   IrParser(std::shared_ptr<Graph> graph) : graph_(std::move(graph)) {
     if (init_registry_) {
       registerJitOperator();
@@ -67,6 +68,7 @@ class IrParser {
   // Fuses pointwise ops with loop unrolling (factor = 4).
   std::unique_ptr<Fusion> parse() {
     auto fusion = std::make_unique<Fusion>();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     FusionGuard fg(fusion.get());
     auto block = graph_->block();
 
@@ -544,6 +546,7 @@ class IrParser {
     if (val->type()->isSubtypeOf(static_cast<c10::TypePtr>(FloatType::get()))) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       CgValue cg_val;
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (auto ival = constant_as<float>(val)) {
         cg_val = new Float(ival.value());
       } else {
@@ -555,6 +558,7 @@ class IrParser {
                    static_cast<c10::TypePtr>(IntType::get()))) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       CgValue cg_val;
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (auto ival = constant_as<int>(val)) {
         cg_val = new Int(ival.value());
       } else {
@@ -566,6 +570,7 @@ class IrParser {
                    static_cast<c10::TypePtr>(BoolType::get()))) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       CgValue cg_val;
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (auto ival = constant_as<bool>(val)) {
         cg_val = new Bool(ival.value());
       } else {
@@ -608,7 +613,9 @@ class IrParser {
       Symbol,
       std::vector<std::pair<std::shared_ptr<Operator>, RegistrationEntry>>>
       jit_operator_registry_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::unordered_set<Symbol> jit_reduction_op_registry_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool init_registry_;
 };
 
@@ -617,7 +624,9 @@ std::unordered_map<
     std::vector<
         std::pair<std::shared_ptr<Operator>, IrParser::RegistrationEntry>>>
     IrParser::jit_operator_registry_;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::unordered_set<Symbol> IrParser::jit_reduction_op_registry_;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool IrParser::init_registry_ = true;
 
 } // namespace

--- a/torch/csrc/jit/codegen/cuda/register_interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/register_interface.cpp
@@ -28,6 +28,7 @@ class RegisterInterface {
   }
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static RegisterInterface register_interface_;
 } // namespace
 

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -23,6 +23,7 @@ namespace {
 
 std::vector<int> reductionAxes(TensorView* tv) {
   size_t n_dims = tv->nDims();
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int> reduction_axes;
   for (const auto i : c10::irange(n_dims)) {
     if (tv->axis(i)->isReduction()) {
@@ -236,8 +237,10 @@ ReductionParams reductionHeuristic(
   // 5. Distributing work across blocks
 
   // WARNING: Current device for codegen may not be the target device
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int device_max_threads_per_multiprocessor =
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerMultiProcessor;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int device_multiprocessor_count =
       at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 

--- a/torch/csrc/jit/codegen/fuser/arg_spec.h
+++ b/torch/csrc/jit/codegen/fuser/arg_spec.h
@@ -18,6 +18,7 @@ namespace fuser {
 // Note: the device to run on is included in the arg spec because kernels
 //  are compiled per-device.
 struct TORCH_API ArgSpec {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ArgSpec(at::TensorList inputs, const int _device)
       : descs_{c10::fmap<TensorDesc>(inputs)},
         hash_code_{c10::get_hash(_device, inputs.size(), descs_)},

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -52,6 +52,7 @@ void codegenOutputQuery(
   } else if (nvrtc_major <= 8 && prop->major > 6) { // 8 supports 2-6.x
     major = 6;
     minor = 0;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
     major = 7;
     minor = (prop->major == 7 && prop->minor <= 2) ? prop->minor : 0;
@@ -91,6 +92,7 @@ FusedKernelCUDA::FusedKernelCUDA(
       device_(device) {
   // Initializes driver's API context (if necessary)
   // NOLINTNEXTLINE(modernize-use-nullptr)
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   CUcontext pctx = 0;
   AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxGetCurrent(&pctx));
   if (!pctx) {
@@ -139,6 +141,7 @@ FusedKernelCUDA::FusedKernelCUDA(
       "compute_" +
 #endif
       std::to_string(major) + std::to_string(minor);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const std::vector<const char*> args = {
       "--std=c++14", compute.c_str(), "-default-device"};
 #endif
@@ -148,6 +151,7 @@ FusedKernelCUDA::FusedKernelCUDA(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     size_t logsize;
     AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLogSize(program, &logsize));
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<char> log(logsize);
     AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLog(program, log.data()));
     std::stringstream cu;
@@ -250,6 +254,7 @@ void FusedKernelCUDA::launch_raw(
   at::cuda::set_device(prior_device);
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 FusedKernelCUDA::~FusedKernelCUDA() {
   nvrtc().cuModuleUnload(module_);
 }
@@ -274,6 +279,7 @@ static std::shared_ptr<FusedKernel> createFusionKernel(
       has_random);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterFusionBackend reg(DeviceType::CUDA, createFusionKernel);
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/fuser/fused_kernel.h
+++ b/torch/csrc/jit/codegen/fuser/fused_kernel.h
@@ -16,6 +16,7 @@ namespace fuser {
 struct FusedKernel {
   TH_DISALLOW_COPY_AND_ASSIGN(FusedKernel);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   FusedKernel(
       std::string name,
       std::string code,

--- a/torch/csrc/jit/codegen/fuser/interface.cpp
+++ b/torch/csrc/jit/codegen/fuser/interface.cpp
@@ -21,6 +21,7 @@ namespace detail {
 #if defined(FBCODE_CAFFE2)
 bool cpu_fuser_enabled = true;
 #else
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool cpu_fuser_enabled = false;
 #endif
 

--- a/torch/csrc/jit/codegen/fuser/kernel_spec.h
+++ b/torch/csrc/jit/codegen/fuser/kernel_spec.h
@@ -56,6 +56,7 @@ struct TORCH_API KernelSpec {
   // Note: assumes the spec is a single block
   // Note: This is the appropriate place to generalize if you want to add other
   //  passes to upfront compilation that walk the graph.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   KernelSpec(const int64_t _key, const std::shared_ptr<Graph>& _graph)
       : key_{_key},
         graph_{_graph},

--- a/torch/csrc/jit/codegen/fuser/partition_desc.h
+++ b/torch/csrc/jit/codegen/fuser/partition_desc.h
@@ -22,6 +22,7 @@ struct TORCH_API PartitionDesc {
   PartitionDesc(const TensorDesc& _desc, size_t _nSubTensors, size_t _dim)
       : nSubTensors_{_nSubTensors}, dim_{_dim} {
     AT_ASSERT(nSubTensors_ > 1);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<bool> cont = _desc.contiguity;
     if (dim_ > 0) {
       // when we narrow the concatenated output/chunked input

--- a/torch/csrc/jit/codegen/fuser/tensor_desc.h
+++ b/torch/csrc/jit/codegen/fuser/tensor_desc.h
@@ -23,6 +23,7 @@ struct TORCH_API TensorDesc {
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<bool> contiguity;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TensorDesc(const at::ScalarType& type, const std::vector<bool>& contiguity)
       : scalar_type{type}, contiguity{contiguity} {
     if (contiguity.size() == 0) {
@@ -34,6 +35,7 @@ struct TORCH_API TensorDesc {
   }
 
   // Delegating constructors
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TensorDesc(
       const at::ScalarType& type,
       const at::IntArrayRef& sizes,
@@ -43,6 +45,7 @@ struct TORCH_API TensorDesc {
   TensorDesc(const at::Tensor& t)
       : TensorDesc(t.scalar_type(), t.sizes(), t.strides()) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TensorDesc(const c10::TensorTypePtr& type)
       : TensorDesc(
             type->scalarType().value(),
@@ -63,6 +66,7 @@ struct TORCH_API TensorDesc {
       const at::IntArrayRef& sizes,
       const at::IntArrayRef& strides) {
     AT_ASSERT(sizes.size() == strides.size());
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<bool> cont(sizes.size());
     for (size_t i = 0; i < sizes.size(); ++i) {
       const auto expected_stride =

--- a/torch/csrc/jit/cuda/cuda.h
+++ b/torch/csrc/jit/cuda/cuda.h
@@ -13,6 +13,7 @@ class CUDAEvent;
 // c10/cuda/CUDAStream.h.
 class CUDAStream final : public CustomClassHolder {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CUDAStream(
       c10::optional<c10::Device> device = c10::nullopt,
       int64_t priority = 0) {
@@ -23,6 +24,7 @@ class CUDAStream final : public CustomClassHolder {
         c10::cuda::getStreamFromPool(priority < PRIORITY_INDEX, device_index));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CUDAStream(c10::cuda::CUDAStream s) {
     stream_ = std::make_unique<c10::cuda::CUDAStream>(s);
   }
@@ -76,10 +78,12 @@ class CUDAStream final : public CustomClassHolder {
 // aten/src/ATen/cuda/CUDAEvent.h.
 class CUDAEvent final : public CustomClassHolder {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CUDAEvent(
       bool enable_timing = false,
       bool blocking = false,
       bool interprocess = false) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int flags = cudaEventDisableTiming;
     if (enable_timing) {
       flags = cudaEventDefault;
@@ -100,6 +104,7 @@ class CUDAEvent final : public CustomClassHolder {
   }
 
   std::string ipcHandle() {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     cudaIpcEventHandle_t handle;
     event_->ipc_handle(&handle);
     std::string str_handle((const char*)&handle, sizeof(handle));

--- a/torch/csrc/jit/frontend/code_template.h
+++ b/torch/csrc/jit/frontend/code_template.h
@@ -15,7 +15,9 @@ namespace jit {
 // in the top level environment, and then recurses into a parent
 // environment if the key is not found.)
 struct TemplateEnv {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TemplateEnv() : parent(nullptr) {}
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TemplateEnv(TemplateEnv& parent) : parent(&parent) {}
 
   using string_list = std::vector<std::string>;

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -19,6 +19,7 @@ struct SourceRange;
 //  - starting_line_no : represents the line in the original file where the
 //                       code segment started.
 struct Source {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Source(
       std::string text,
       std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
@@ -29,6 +30,7 @@ struct Source {
     calc_line_start_offsets();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Source(
       std::string text,
       c10::optional<std::string> filename,

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -97,6 +97,7 @@ struct TORCH_API TracingState
 // data dependencies, but once they get to the ATen call where we actually have
 // the tracing logic, they get converted into a raw IntArrayRef, and we loose
 // all information. To prevent this, we temporarily stash it in here.
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct ArgumentStash {
   struct IntArrayRefTrace : std::vector<Value*> {
     IntArrayRefTrace(int size) : std::vector<Value*>(size, nullptr) {}
@@ -177,6 +178,7 @@ inline void warn(const char* _reason, const char* _kind = nullptr) {
 TORCH_API void setWarn(warn_fn_type fn);
 
 struct TORCH_API NoWarn {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   NoWarn() : state(getTracingState()) {
     if (state) {
       prev = state->warn;
@@ -193,10 +195,12 @@ struct TORCH_API NoWarn {
 };
 
 struct WithNestedTracingFrame {
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   WithNestedTracingFrame() {
     getTracingState()->enterFrame();
   }
 
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~WithNestedTracingFrame() {
     getTracingState()->leaveFrame();
   }

--- a/torch/csrc/jit/ir/attributes.h
+++ b/torch/csrc/jit/ir/attributes.h
@@ -91,6 +91,7 @@ template <typename T, AttributeKind Kind>
 struct VectorAttributeValue : public AttributeValue {
   using ConstructorType = std::vector<T>;
   using ValueType = std::vector<T>;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   VectorAttributeValue(Symbol name, ConstructorType value_)
       : AttributeValue(name), value_(std::move(value_)) {}
   ValueType& value() {
@@ -148,6 +149,7 @@ struct TORCH_API GraphAttr : public AttributeValue {
 struct TORCH_API GraphsAttr : public AttributeValue {
   using ConstructorType = std::vector<std::shared_ptr<Graph>>;
   using ValueType = std::vector<std::shared_ptr<Graph>>;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   GraphsAttr(Symbol name, ConstructorType value_)
       : AttributeValue(name), value_(std::move(value_)) {}
   ValueType& value() {
@@ -165,6 +167,7 @@ struct TORCH_API GraphsAttr : public AttributeValue {
 struct IRAttributeError : public std::exception {
   IRAttributeError(Symbol name, bool defined) {
     std::stringstream ss;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (!defined) {
       ss << "required keyword attribute '" << name.toUnqualString()
          << "' is undefined";

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1631,6 +1631,7 @@ Value* Graph::insert(
 Node* Graph::create(NodeKind kind, size_t num_outputs) {
   // NB: Node constructor adds node to all_nodes
   auto n = new Node(this, kind);
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   for (const auto i : c10::irange(num_outputs)) {
     n->addOutput();
   }

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -817,6 +817,7 @@ struct TORCH_API Node {
   }
   // The names are returned in order, since name actually is the index.
   std::vector<Symbol> attributeNames() const {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<Symbol> names;
     for (const AVPtr& a : values_) {
       names.push_back(a->name);
@@ -824,6 +825,7 @@ struct TORCH_API Node {
     return names;
   }
   std::vector<const char*> attributeNamesS() const {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<const char*> names;
     for (const AVPtr& a : values_) {
       names.push_back(a->name.toUnqualString());
@@ -892,6 +894,7 @@ struct TORCH_API Node {
     AT_ASSERT(name.is_attr());
     auto it = findAttr(name, false);
     auto nv = AVPtr(new T(name, std::forward<typename T::ConstructorType>(v)));
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (it == values_.end()) {
       values_.push_back(std::move(nv));
     } else {
@@ -903,6 +906,7 @@ struct TORCH_API Node {
   typename T::ValueType& getAttr(Symbol name) const {
     AT_ASSERT(name.is_attr());
     auto it = findAttr(name, true);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     auto* child = dynamic_cast<T*>(it->get());
     if (child == nullptr) {
       throw IRAttributeError(name, true);
@@ -1147,12 +1151,14 @@ struct Graph {
   Node* insert_before_;
 
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Graph(ScopePtr scope_root)
       : next_unique_(0),
         current_scope_(std::move(scope_root)),
         block_(new Block(this, nullptr)),
         insert_before_(return_node()) {}
 
+  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   Graph() : Graph(c10::make_intrusive<Scope>()) {}
 
   at::ArrayRef<Value*> inputs() {
@@ -1405,10 +1411,12 @@ struct WithInsertPoint {
  * the new one, and restores the original scope when the object is destroyed.
  */
 struct WithCurrentScope {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   WithCurrentScope(Graph& g, ScopePtr scope)
       : graph_(&g), prev_scope_(g.current_scope()) {
     g.set_current_scope(std::move(scope));
   }
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~WithCurrentScope() {
     graph_->set_current_scope(prev_scope_);
   }
@@ -1418,6 +1426,7 @@ struct WithCurrentScope {
   ScopePtr prev_scope_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 inline Value::Value(Node* node_, size_t offset_)
     : node_(node_),
       offset_(offset_),
@@ -1552,6 +1561,7 @@ struct OperatorSet {
 };
 
 template <typename T>
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct OperatorMap {
   // Type aliasing
   using OpMapType = typename std::pair<std::shared_ptr<Operator>, T>;
@@ -1559,10 +1569,12 @@ struct OperatorMap {
   using MapType = std::unordered_map<Symbol, ValueType>;
 
   OperatorMap() = default;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit OperatorMap(
       std::initializer_list<std::pair<std::shared_ptr<Operator>, T>> init) {
     insert(init);
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit OperatorMap(std::initializer_list<std::pair<const char*, T>> init) {
     insert(init);
   }
@@ -1631,6 +1643,7 @@ struct OperatorMap {
 
   // TODO: return iterator
   std::vector<OpMapType> getAllKeysAndValues() const {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<OpMapType> keys_values;
     for (auto& symbol_mapping : map) {
       auto& vec = symbol_mapping.second;

--- a/torch/csrc/jit/ir/named_value.h
+++ b/torch/csrc/jit/ir/named_value.h
@@ -35,6 +35,7 @@ struct NamedValue {
           (!std::is_same<decay_t<T>, NamedValue>::value &&
            !std::is_same<decay_t<T>, Value*>::value &&
            !std::is_same<decay_t<T>, IValue>::value)>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   NamedValue(T&& t) : NamedValue(IValue(std::forward<T>(t))) {}
 
   template <

--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -61,6 +61,7 @@ class JitLoggingConfig {
   std::string logging_levels;
   std::unordered_map<std::string, size_t> files_to_levels;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   JitLoggingConfig() {
     const char* jit_log_level = std::getenv("PYTORCH_JIT_LOG_LEVEL");
     logging_levels.assign(jit_log_level == nullptr ? "" : jit_log_level);

--- a/torch/csrc/jit/mobile/debug_info.cpp
+++ b/torch/csrc/jit/mobile/debug_info.cpp
@@ -16,7 +16,9 @@ namespace {
 std::pair<std::vector<StackEntry>, std::string> getStackTraceWithModuleHierarchy(
     const DebugInfoTuple& source_callstack,
     const std::string& caller_name) {
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   constexpr size_t kSourceRange = 1;
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   constexpr size_t kModuleInstanceInfo = 2;
   std::vector<StackEntry> entries;
 

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -137,6 +137,7 @@ std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
 std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
     std::vector<IValue> bytecode_ivalues) {
   constexpr uint64_t min_version_with_schema = 6;
+  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   if (_get_model_bytecode_version(bytecode_ivalues) < min_version_with_schema) {
     TORCH_WARN(
         "Only models with bytecode version 6 and above contain operator schema information. Please re-export your model to generate it");
@@ -147,6 +148,7 @@ std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
     return result;
   }
   // loop over all the functions in the bytecode
+  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   for (int i = 1; i < bytecode_ivalues.size(); i++) {
     // descend to the operators list
     auto method_tuple = bytecode_ivalues.at(i).toTuple()->elements();

--- a/torch/csrc/jit/passes/concat_opt.cpp
+++ b/torch/csrc/jit/passes/concat_opt.cpp
@@ -335,6 +335,7 @@ class ConcatExpander {
       TORCH_INTERNAL_ASSERT(cat_inp_tensor_type);
       TORCH_INTERNAL_ASSERT(cat_inp_tensor_type->dim());
       auto cat_inp_tensortype_sizes = cat_inp_tensor_type->sizes();
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       int end_idx = start_idx + *cat_inp_tensortype_sizes[cat_dim_value];
       auto end = graph_->insertConstant(end_idx);
 

--- a/torch/csrc/jit/passes/frozen_graph_optimizations.cpp
+++ b/torch/csrc/jit/passes/frozen_graph_optimizations.cpp
@@ -16,6 +16,7 @@ void OptimizeFrozenGraph(
   removeDropout(graph);
   // run a couple times to capture Conv -> Mul -> Add etc
   if (optimize_numerics) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for (const auto i : c10::irange(2)) {
       FoldFrozenConvBatchnorm(graph);
       FoldFrozenConvAddOrSub(graph);

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -829,6 +829,7 @@ struct GraphFuser {
     }
 
     bchunk->removeInput(producer_index);
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for (const auto i : c10::irange(nchunks)) {
       bchunk->eraseOutput(nchunks * producer_index);
     }

--- a/torch/csrc/jit/passes/peephole_non_tensor.cpp
+++ b/torch/csrc/jit/passes/peephole_non_tensor.cpp
@@ -8,6 +8,7 @@ namespace torch {
 namespace jit {
 
 struct PeepholeOptimizeNonTensorImpl {
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   PeepholeOptimizeNonTensorImpl(const std::shared_ptr<Graph>& graph)
       : graph_(graph) {}
 

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -36,6 +36,7 @@ pointwise ops)
 - Supporting returning partially evaluated shape compute graph
 */
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool symbolic_shape_analysis_test_mode = false;
 
 namespace torch {
@@ -52,7 +53,9 @@ bool symbolicShapeAnalysisTestModeEnabled() {
 }
 
 // TODO: better registration mechanism
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::mutex lock;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::unordered_map<std::string, std::shared_ptr<Graph>> operator_functions;
 
 c10::optional<size_t> normIndex(int64_t index, size_t len) {
@@ -90,6 +93,7 @@ struct SymbolicShapeAnalyzer {
     for (size_t i = 0; i < node_->inputs().size(); i++) {
       auto type = node_->input(i)->type();
       if (auto tt = type->castRaw<TensorType>()) {
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         c10::SymbolicShape symbolic_shapes = tt->symbolic_sizes();
 
         // for testing, we don't insert complete tensor shapes and rely on our
@@ -231,6 +235,7 @@ struct SymbolicShapeAnalyzer {
     for (size_t i = 0; i < symbolic_set.size(); ++i) {
       Value* v = symbolic_set[i];
       Value* dominating_value = v;
+      // NOLINTNEXTLINE(modernize-loop-convert)
       for (size_t j = 0; j < symbolic_set.size(); ++j) {
         if (dominating_value->node()->isDominatedBy(symbolic_set[j]->node())) {
           dominating_value = symbolic_set[j];

--- a/torch/csrc/jit/python/python_ivalue.h
+++ b/torch/csrc/jit/python/python_ivalue.h
@@ -49,6 +49,7 @@ struct C10_EXPORT ConcretePyObjectHolder final : PyObjectHolder {
     // when using C++. The reason is unclear.
     try {
       pybind11::gil_scoped_acquire ag;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
       static py::object& extractorFn = *new py::object(
           py::module::import("torch._jit_internal").attr("_extract_tensors"));
       return extractorFn(py_obj_).cast<std::vector<at::Tensor>>();

--- a/torch/csrc/jit/resource_guard.h
+++ b/torch/csrc/jit/resource_guard.h
@@ -13,6 +13,7 @@ class ResourceGuard {
       : _destructor(std::move(destructor)), _released(false) {}
 
   // NOLINTNEXTLINE(bugprone-exception-escape)
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~ResourceGuard() {
     if (!_released)
       _destructor();

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -67,6 +67,7 @@ static_assert(
     "ArgumentInfo is expected to be a 32-bit struct");
 
 struct ArgumentSpec {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ArgumentSpec(size_t num_flat_tensor_inputs, size_t num_flat_optional_inputs) {
     hash_code =
         c10::hash_combine(num_flat_tensor_inputs, num_flat_optional_inputs);
@@ -100,7 +101,9 @@ struct ArgumentSpec {
       // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
       at::Device device = t->device();
       arg.dev_type_ =
+          // NOLINTNEXTLINE(bugprone-signed-char-misuse)
           static_cast<std::underlying_type<DeviceType>::type>(device.type());
+      // NOLINTNEXTLINE(bugprone-signed-char-misuse)
       arg.device_ = device.index();
       arg.type_ = static_cast<unsigned>(t->scalar_type());
     }
@@ -233,9 +236,11 @@ static_assert(
 struct CompleteArgumentInfo;
 
 struct CompleteArgumentSpec {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CompleteArgumentSpec(bool with_grad, at::ArrayRef<IValue> inputs)
       : hash_code(0), ninputs(inputs.size()) {
     int32_t all_dims = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const int32_t num_inputs = inputs.size();
     for (int32_t i = 0; i < num_inputs; i++) {
       if (!inputs[i].isTensor())
@@ -247,6 +252,7 @@ struct CompleteArgumentSpec {
     data.resize(ninputs + all_dims * 2);
 
     // and reinterpret our data array as these structs
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     auto* pods = reinterpret_cast<CompleteArgumentInfoPOD*>(data.data());
     int64_t* next_dim = sizes_strides();
     int32_t total_dims = 0;
@@ -260,8 +266,10 @@ struct CompleteArgumentSpec {
           pod.type = static_cast<int>(t.scalar_type());
           // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
           at::Device device = t.device();
+          // NOLINTNEXTLINE(bugprone-signed-char-misuse)
           pod.dev_type = static_cast<std::underlying_type<DeviceType>::type>(
               device.type());
+          // NOLINTNEXTLINE(bugprone-signed-char-misuse)
           pod.device = device.index();
           pod.requires_grad = with_grad && t.requires_grad();
           total_dims += t.ndimension();

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -161,6 +161,7 @@ struct CaptureList {
         case CAPTURE_LIST: {
           c10::List<at::Tensor> lst;
           auto size = *size_it++;
+          // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
           for (const auto i : c10::irange(size)) {
             lst.emplace_back(var_capture_it->unpack(saved_for));
             var_capture_it++;
@@ -444,6 +445,7 @@ struct DifferentiableGraphOp {
       for (auto& tensor : lst) {
         tensor = detach(tensor);
       }
+      // NOLINTNEXTLINE(performance-move-const-arg)
       v = std::move(lst);
     }
   }

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -38,6 +38,7 @@ struct ExecutionPlan {
 // They is only valid only right after you call getDebugState() and should never
 // be used again once another GraphExecutor function is called.
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct GraphExecutorState {
   const Graph* graph = nullptr;
   ExecutionPlan fallback; // XXX: members of this field are optional

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -42,6 +42,7 @@ using c10::ivalue::Future;
 using TaskLauncher = std::function<void(std::function<void()>)>;
 
 struct TORCH_API Code {
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   Code() : pImpl(nullptr) {}
   explicit Code(interpreter::CodeImpl* pImpl);
   // remaining_bailout_depth is irrelevant in a `Code` object unless the `Code`
@@ -110,6 +111,7 @@ struct Suspend : public std::exception {
     return "Suspend";
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Suspend(c10::intrusive_ptr<Future> future_)
       : future(std::move(future_)) {}
 
@@ -120,6 +122,7 @@ struct Suspend : public std::exception {
 // through (and only through) the forward pass manually, other
 // thread local settings are propagated with ThreadLocalState
 struct InterpreterContinuation {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   InterpreterContinuation(
       const InterpreterState& state_,
       Stack stack_,

--- a/torch/csrc/jit/runtime/operator.h
+++ b/torch/csrc/jit/runtime/operator.h
@@ -54,6 +54,7 @@ using OperationCreator = Operation (*)(const Node*);
 // the concrete operator nature.
 struct TORCH_API Operator {
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct C10Operator final {
     c10::OperatorHandle handle_;
     Operation op_;
@@ -62,6 +63,7 @@ struct TORCH_API Operator {
     std::string schema_string_;
     mutable c10::optional<c10::AliasAnalysisKind> alias_analysis_;
   };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct JitOnlyOperator final {
     // The only valid transition for schema_ is from right->left, i.e.
     // when the schema gets parsed.

--- a/torch/csrc/jit/runtime/register_distributed_ops.cpp
+++ b/torch/csrc/jit/runtime/register_distributed_ops.cpp
@@ -23,6 +23,7 @@ namespace jit {
 
 namespace {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto workerInfo =
     torch::class_<dist_rpc::WorkerInfo>("dist_rpc", "WorkerInfo")
         .def(torch::init<std::string, int64_t>());
@@ -173,6 +174,7 @@ void prepare_and_call_rpc_op(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterOperators reg_rpc_ops(
     {Operator(
          fmt::format(

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -2071,6 +2071,7 @@ TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
       });
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterOperators reg1(
     {OperatorGenerator(
          TORCH_SELECTIVE_SCHEMA("prim::rangelist(int n) -> int[]"),
@@ -2829,6 +2830,7 @@ RegisterOperators reg2({
         [](Stack* stack) {
           c10::List<c10::complex<double>> l = pop(stack).toComplexDoubleList();
           c10::complex<double> sum = 0.0;
+          // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
           for (int i = 0; i < l.size(); i++) {
             sum = sum + l.extract(i);
           }

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -374,6 +374,7 @@ RegisterOperators logging_operators(
          },
          aliasAnalysisFromSchema())});
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 void hashValue(Stack* stack) {
   auto value = pop(stack);
   push(stack, value.hash());

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -854,8 +854,10 @@ float StaticRuntime::benchmark_model(
 bool display_ivalue(const IValue& iv) {
   if (iv.isTensor()) {
     std::cout << "Tensor " << iv.toTensor().toString() << " {";
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     for (auto i = 0; i < iv.toTensor().sizes().size(); ++i) {
       std::cout << iv.toTensor().sizes()[i];
+      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       if (iv.toTensor().sizes().size() > i + 1) {
         std::cout << ", ";
       }
@@ -887,6 +889,7 @@ bool display_ivalue(const IValue& iv) {
 void display_pnode_info(const ProcessedNode& pnode) {
   pnode.node()->print(std::cout, 0, nullptr, false);
   const std::vector<const IValue*>& inputs = pnode.inputs();
+  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   for (auto i = 0; i < inputs.size(); ++i) {
     std::cout << "\ti" << i << ": ";
     if (!display_ivalue(*inputs[i])) {
@@ -894,6 +897,7 @@ void display_pnode_info(const ProcessedNode& pnode) {
     }
   }
   const std::vector<IValue>& outputs = pnode.outputs();
+  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   for (auto i = 0; i < outputs.size(); ++i) {
     std::cout << "\to" << i << ": ";
     if (!display_ivalue(outputs[i])) {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1408,6 +1408,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::repeat, aten_repeat, [](Node* n) -> SROperator {
   };
 });
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::div, aten_div, [](Node* n) -> SROperator {
   if (!n->matches(torch::schema(
           "aten::div.Tensor(Tensor self, Tensor other) -> Tensor")) &&
@@ -1509,6 +1510,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::argmin, aten_argmin, [](Node* n) -> SROperator {
   };
 });
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::layer_norm, aten_layer_norm, [](Node* n) -> SROperator {
   if (!n->matches(torch::schema(
           "aten::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> Tensor"))) {
@@ -1559,6 +1561,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::layer_norm, aten_layer_norm, [](Node* n) -> SROp
   };
 });
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::norm, aten_norm, [](Node* n) -> SROperator {
   if (!n->matches(torch::schema(
           "aten::norm.ScalarOpt_dtype(Tensor self, Scalar? p, *, ScalarType dtype) -> Tensor")) &&

--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -8,6 +8,7 @@
 namespace torch {
 namespace jit {
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::mutex lock;
 
 const std::string shape_compute_functions =
@@ -336,9 +337,11 @@ static const OperatorMap<std::string>& get_schema_to_function_graph() {
 }
 
 std::unordered_map<const FunctionSchema*, std::shared_ptr<Graph>>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     cached_schema_to_graph;
 
 // CompilationUnit that holds all these Functions and keeps them alive.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 CompilationUnit compilation_unit;
 
 void loadModule(const CompilationUnit& module) {

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -102,6 +102,7 @@ std::vector<char> CallStackDebugInfoPickler::pickle(
     elements.reserve(3);
     elements.emplace_back(debug_handle);
     int64_t source_range_tag{kInvalidSourceRangeTag};
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     const auto source_range =
         std::get<kDebugInfoTupleSourceRangeIndex>(it.second);
     const SourceRange& sr = source_range.findSourceRangeThatGenerated()
@@ -113,6 +114,7 @@ std::vector<char> CallStackDebugInfoPickler::pickle(
     }
     elements.emplace_back(source_range_tag);
     elements.emplace_back(std::get<kDebugInfoTupleNodeNameIndex>(it.second));
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     const auto inlined_cs_ptr =
         std::get<kDebugInfoTupleInlinedCSIndex>(it.second);
     elements.emplace_back(css_.serialize(inlined_cs_ptr, source_range_tags));

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -353,9 +353,11 @@ SourceRangeRecords getBackendSourceRanges(const Module& m) {
             std::get<kDebugInfoTupleSourceRangeIndex>(it.second);
         sr_records.emplace_back(
             std::numeric_limits<size_t>::max(), source_range);
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         auto cs_ptr = std::get<kDebugInfoTupleInlinedCSIndex>(it.second);
         if (cs_ptr) {
           for (const auto& e : cs_ptr->vec()) {
+            // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
             const auto sr = std::get<kSourceRange>(e);
             sr_records.emplace_back(std::numeric_limits<size_t>::max(), sr);
           }
@@ -869,6 +871,7 @@ std::vector<std::string> export_opnames(const script::Module& m) {
 // Thread local flag (only happens in export, i.e. on server side)
 // to control if instructions for bytecode default inputs are emitted
 // or not. It's the major difference between bytecode v5 and v6.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local bool emitBytecodeDefaultInputs =
     caffe2::serialize::kProducedBytecodeVersion <= 5 ? true : false;
 bool BytecodeEmitDefaultValueForUnspecifiedArgMode::is_enabled() {

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -31,6 +31,7 @@ class HasRand : public IRVisitor {
 };
 
 template <typename Node>
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class NodeFinder : public IRVisitor {
  public:
   void visit(const Node* v) override {
@@ -53,6 +54,7 @@ class NodeFinder : public IRVisitor {
   std::vector<Node*> nodes;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class VarFinder : public IRVisitor {
  public:
   void visit(const Var* v) override {
@@ -83,6 +85,7 @@ class VarFinder : public IRVisitor {
 // Finds all kinds of write operations to the provided Buf.
 class WritesToBuf : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   WritesToBuf(const Buf* target) : target_(target) {}
 
   std::vector<const Stmt*> writes() {
@@ -114,6 +117,7 @@ class WritesToBuf : public IRVisitor {
 
 class StmtsReadingBuf : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   StmtsReadingBuf(const Buf* target) : target_(target) {}
 
   std::vector<const Stmt*> reads() {

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -17,9 +17,11 @@ class TORCH_API CodeGen {
   class CallArg;
 
   template <typename... Ts>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CodeGen(Stmt* stmt, Ts... ts)
       : stmt_(stmt), buffer_args_({BufferArg(ts)...}) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CodeGen(
       Stmt* stmt,
       std::vector<BufferArg> buffer_args,
@@ -136,6 +138,7 @@ class CodeGen::CallArg {
   template <typename T>
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-const-cast)
   CallArg(const std::vector<T>& buffer)
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       : data_(const_cast<T*>(buffer.data())) {}
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
@@ -165,6 +168,7 @@ class CodeGen::CallArg {
   void* data_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class RegisterCodeGenList {
  public:
   TORCH_API static RegisterCodeGenList& GetInstance() {
@@ -185,6 +189,7 @@ class RegisterCodeGenList {
  private:
   template <class CodeGenType>
   friend class RegisterCodeGen;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   RegisterCodeGenList() = default;
   TORCH_API void AddStmtFactoryMethod(
       const std::string& name,
@@ -204,6 +209,7 @@ class RegisterCodeGen {
            const std::vector<CodeGen::BufferArg>& params,
            at::Device device,
            const std::string& kernel_func_name) {
+          // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
           std::unique_ptr<CodeGen> method(
               new CodeGenType(stmt, params, device, kernel_func_name));
           return method;

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -22,6 +22,7 @@ namespace tensorexpr {
 // A class that analyzes the given program relevant for Cuda backends.
 class CudaAnalysis : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   CudaAnalysis() {
     gpu_block_extents_ = {new IntImm(1), new IntImm(1), new IntImm(1)};
     gpu_thread_extents_ = {new IntImm(1), new IntImm(1), new IntImm(1)};
@@ -71,6 +72,7 @@ class CudaAnalysis : public IRVisitor {
 // execution parameters, then if those params differ from the max mask each dim.
 class GPUMetaVarRewriter : public IRMutator {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit GPUMetaVarRewriter(const CudaAnalysis* cuda_analysis)
       : cuda_analysis_(cuda_analysis) {
     gpu_block_vars_ = {
@@ -107,6 +109,7 @@ class GPUMetaVarRewriter : public IRMutator {
 
  private:
   // When processing a block, stores the contents of each sub-segment.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   class Segment {
    public:
     void reset(bool mask) {

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -109,6 +109,7 @@ class TORCH_API SimpleIREvaluator : public CodeGen {
 
   template <typename... Ts>
   void operator()(const Ts&... ts) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<CallArg> args({CallArg(ts)...});
     call(args);
   }
@@ -137,15 +138,19 @@ class ExprEval {
   ExprEval(const ExprHandle& expr, Ts... ts)
       : ExprEval(expr, {BufferArg(ts)...}) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ExprEval(const ExprHandle& expr, const std::vector<BufferArg>& buffer_args)
       : dtype_(expr.dtype()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<BufferArg> buffer_args_extended = buffer_args;
     Placeholder ret_buf("ret_val", dtype_, {1});
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<const Expr*> indices;
     const Expr* zero = new IntImm(0);
     for (size_t i = 0; i < ret_buf.data()->ndim(); i++) {
       indices.push_back(zero);
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     Stmt* store_stmt =
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
         new Store(ret_buf.data(), indices, expr.node());
@@ -177,6 +182,7 @@ class ExprEval {
   }
 
   void call(const std::vector<CallArg>& call_args) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<CallArg> call_args_extended = call_args;
     switch (dtype_.scalar_type()) {
 #define TYPE_CASE(Type, Name)                           \
@@ -190,6 +196,7 @@ class ExprEval {
       AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
 #undef TYPE_CASE
       case ScalarType::Bool: {
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         std::vector<unsigned char> ret_val_arg(1);
         // NOLINTNEXTLINE(modernize-use-emplace)
         call_args_extended.push_back(CallArg(ret_val_arg.data()));
@@ -202,6 +209,7 @@ class ExprEval {
   }
 
   void call_raw(const std::vector<void*>& args) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<void*> args_extended = args;
     switch (dtype_.scalar_type()) {
 #define TYPE_CASE(Type, Name)                    \
@@ -214,6 +222,7 @@ class ExprEval {
       AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
 #undef TYPE_CASE
       case ScalarType::Bool: {
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         std::vector<unsigned char> ret_val_arg(1);
         args_extended.push_back(ret_val_arg.data());
         codegen_->call_raw(args_extended);

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -187,12 +187,14 @@ class TORCH_API Buf : public ExprNode<Buf> {
     base_handle_->set_name_hint(name_hint);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Buf(const std::string& name_hint,
       const std::vector<const Expr*>& dims,
       Dtype dtype,
       const Expr* initializer = nullptr)
       : Buf(new Var(name_hint, kHandle), dims, dtype, initializer) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Buf(Var* var,
       std::vector<const Expr*> dims,
       Dtype dtype,

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -45,6 +45,7 @@ class HalfChecker : public IRVisitor {
   bool hasHalf_{false};
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class HalfRewriter : public IRMutator {
   const Expr* mutate(const Load* v) override {
     const Expr* child = IRMutator::mutate(v);

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -134,6 +134,7 @@ class BinaryOpNode : public ExprNode<Op> {
     return ExprHandle(new Op(lhs.node(), rhs.node()));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   BinaryOpNode(
       const Expr* lhs_v,
       const Expr* rhs_v,
@@ -312,6 +313,7 @@ Expr* getImmediateByType(ScalarType immType, T initialVal) {
 #define TYPE_CASE(Type, Name) \
   case ScalarType::Name:      \
     return new Name##Imm(initialVal);
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
 #undef TYPE_CASE
     default:
@@ -569,6 +571,7 @@ class TORCH_API CompareSelect : public ExprNode<CompareSelect> {
         compare_op_(cmp_op),
         bias_(bias) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CompareSelect(
       const Expr* lhs,
       const Expr* rhs,
@@ -643,6 +646,7 @@ class TORCH_API Intrinsics : public ExprNode<Intrinsics> {
   static ExprHandle make(
       IntrinsicsOp op_type,
       const std::vector<ExprHandle>& params) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<const Expr*> params_nodes(params.size());
     for (size_t i = 0; i < params.size(); i++) {
       params_nodes[i] = params[i].node();
@@ -732,6 +736,7 @@ class TORCH_API Intrinsics : public ExprNode<Intrinsics> {
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Intrinsics(IntrinsicsOp op_type, Dtype dtype)
       : ExprNodeBase(IntrinsicsDtype(op_type, dtype)),
         params_({}),
@@ -741,6 +746,7 @@ class TORCH_API Intrinsics : public ExprNode<Intrinsics> {
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Intrinsics(IntrinsicsOp op_type, const Expr* v1)
       : ExprNodeBase(IntrinsicsDtype(op_type, v1->dtype())),
         params_({v1}),
@@ -750,6 +756,7 @@ class TORCH_API Intrinsics : public ExprNode<Intrinsics> {
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Intrinsics(IntrinsicsOp op_type, const Expr* v1, const Expr* v2)
       : ExprNodeBase(IntrinsicsDtype(op_type, v1->dtype(), v2->dtype())),
         params_({v1, v2}),
@@ -759,6 +766,7 @@ class TORCH_API Intrinsics : public ExprNode<Intrinsics> {
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Intrinsics(IntrinsicsOp op_type, const std::vector<const Expr*>& params)
       : ExprNodeBase(IntrinsicsDtype(op_type, params)),
         params_(params),

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -189,6 +189,7 @@ const Expr* IRMutator::mutate(const Load* v) {
 const Expr* IRMutator::mutate(Buf* v) {
   const Var* var = v->base_handle();
   Var* var_new =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       dynamic_cast<Var*>(const_cast<Expr*>(var->accept_mutator(this)));
   if (!var_new) {
     return nullptr;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1849,6 +1849,7 @@ c10::optional<class ModRound*> isModRound(const Term* e) {
         // divisor=multiplier=2, denom=t/7.
         Expr* c = evaluateOp(new Div(divisor, multiplier));
         divisor = multiplier;
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
         denom = IRSimplifier::simplify(new Div(other, c));
       } else {
         return c10::nullopt;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -91,6 +91,7 @@ inline const Expr* newBinaryOpOfType(
     const Expr* rhs,
     bool option) {
   switch (expr_type) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     case IRNodeType::kAdd:
       return new Add(lhs, rhs);
     case IRNodeType::kSub:
@@ -146,6 +147,7 @@ inline Expr* evaluateOp(const Expr* v) {
 class Term : public ExprNode<Term> {
  public:
   template <class... Args>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Term(HashProvider& hasher, const Expr* s, Args... ts)
       : ExprNodeBase(promoteTypesVar(s, ts...)), scalar_(s), hasher_(hasher) {
     CHECK(s->isConstant());
@@ -153,6 +155,7 @@ class Term : public ExprNode<Term> {
     sort();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Term(HashProvider& hasher, const Expr* s, std::vector<const Expr*> v)
       : ExprNodeBase(promoteTypesVec(s, v)),
         variables_(std::move(v)),
@@ -162,6 +165,7 @@ class Term : public ExprNode<Term> {
   }
 
   // Convenience constructor from a map of hash -> var, used when merging Terms.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Term(
       HashProvider& hasher,
       const Expr* s,
@@ -212,6 +216,7 @@ class Term : public ExprNode<Term> {
 class Polynomial : public ExprNode<Polynomial> {
  public:
   template <class... Args>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Polynomial(HashProvider& hasher, const Expr* s, Args... ts)
       : ExprNodeBase(promoteTypesVar(s, ts...)), scalar_(s), hasher_(hasher) {
     CHECK(s->isConstant());
@@ -219,6 +224,7 @@ class Polynomial : public ExprNode<Polynomial> {
     sort();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Polynomial(HashProvider& hasher, const Expr* s, std::vector<const Term*> v)
       : ExprNodeBase(promoteTypesVec(s, v)),
         variables_(std::move(v)),
@@ -228,6 +234,7 @@ class Polynomial : public ExprNode<Polynomial> {
   }
 
   // Helper constructor for list of terms with no scalar component.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Polynomial(HashProvider& hasher, std::vector<const Term*> terms)
       : ExprNodeBase(promoteTypesVec(terms)),
         variables_(std::move(terms)),
@@ -238,6 +245,7 @@ class Polynomial : public ExprNode<Polynomial> {
 
   // Convenience constructor for map of hash -> var, used when merging
   // Polynomials.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Polynomial(
       HashProvider& hasher,
       const Expr* s,
@@ -288,6 +296,7 @@ class RoundOff : public BinaryOpNode<RoundOff> {
 class MaxTerm : public ExprNode<MaxTerm> {
  public:
   template <class... Args>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   MaxTerm(HashProvider& hasher, const Expr* s, bool p, Args... ts)
       : ExprNodeBase(s ? promoteTypesVar(s, ts...) : promoteTypesVar(ts...)),
         scalar_(s),
@@ -297,6 +306,7 @@ class MaxTerm : public ExprNode<MaxTerm> {
     uniquefy();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   MaxTerm(
       HashProvider& hasher,
       const Expr* s,
@@ -347,6 +357,7 @@ class MaxTerm : public ExprNode<MaxTerm> {
 class MinTerm : public ExprNode<MinTerm> {
  public:
   template <class... Args>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   MinTerm(HashProvider& hasher, const Expr* s, bool p, Args... ts)
       : ExprNodeBase(s ? promoteTypesVar(s, ts...) : promoteTypesVar(ts...)),
         scalar_(s),
@@ -356,6 +367,7 @@ class MinTerm : public ExprNode<MinTerm> {
     uniquefy();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   MinTerm(
       HashProvider& hasher,
       const Expr* s,
@@ -542,6 +554,7 @@ class TORCH_API TermExpander : public IRSimplifierBase {
 
  public:
   using IRSimplifierBase::mutate;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TermExpander(PolynomialTransformer* simplifier) : simplifier_(simplifier) {}
   bool check_safe() {
     return eliminated_allocations_.empty();

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1144,6 +1144,7 @@ std::pair<ScalarType, std::vector<BufHandle>> processCatList(
 Tensor* computeCatWoConditionals(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape) {
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   auto input_list = c10::get<BufList>(inputs[0]);
   auto arg_dim = inputs[1];
   auto cat_info = processCatList(input_list);
@@ -1225,6 +1226,7 @@ Tensor* computeCat(
   if (device == at::kCPU && getCatWoConditionals()) {
     return computeCatWoConditionals(inputs, outputShape);
   }
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   auto inputList = c10::get<BufList>(inputs[0]);
   auto argDim = inputs[1];
   auto catInfo = processCatList(inputList);
@@ -2319,6 +2321,7 @@ Tensor* tensorexpr::computeOperandValue(
                         idx = i5 + i4*2 + i3*2 + i2*18 + i1*18
                         B[i1,i2,i3,i4,i5] = A[idx/(3*2), (idx/3)%2, idx%3]
             */
+            // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
             ExprHandle cur_stride = 1;
             std::vector<const Expr*> dims, indices;
             for (size_t idx = 0; idx < view_dims.size(); idx++) {
@@ -2342,6 +2345,7 @@ Tensor* tensorexpr::computeOperandValue(
               // then it's 3 for dim_idx = 1, and then it's 3*2 for dim_idx = 0.
               stride = stride * A.dim(dim_idx);
             }
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
             return A.load(orig_buf_indexes);
           });
     }

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1044,6 +1044,7 @@ bool isConditionalFromCat(
     std::vector<const Expr*>* comp_values,
     std::vector<const Expr*>* sub_exprs) {
   const Var* var = nullptr;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Expr* comp_value;
   if (isConditionOptimizable(ite->condition(), &var, &comp_value)) {
     if (*cond_var == nullptr) {

--- a/torch/csrc/jit/tensorexpr/mem_arena.h
+++ b/torch/csrc/jit/tensorexpr/mem_arena.h
@@ -9,6 +9,7 @@ namespace tensorexpr {
 class KernelScopedObject;
 
 // An arena that manages all the underlying kernel-scoped objects.
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class KernelArena {
  public:
   static KernelArena* GetCurrentKernelArena();

--- a/torch/csrc/jit/tensorexpr/operators/reduction.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/reduction.cpp
@@ -115,7 +115,9 @@ Tensor* computeMean(
     mean_dims_expr = c10::fmap<ExprHandle>(*mean_dims);
   } else {
     // When dims argument is not specified, reduce over all dimensions
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     for (int64_t idx = 0; idx < InputBuf.ndim(); idx++) {
+      // NOLINTNEXTLINE(modernize-use-emplace)
       mean_dims_expr.push_back(idx);
     }
   }
@@ -134,6 +136,7 @@ Tensor* computeAdaptiveAvgPool2d(
     dtype = Dtype(*outputType);
   }
   BufHandle ResultBuf("adaptive_avgpool2d", outputShape, dtype);
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   auto out_size_param = c10::get<IntList>(inputs[1]);
   return new Tensor(
       ResultBuf.node(),

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -127,6 +127,7 @@ class TORCH_API Reducer {
 // This is intended to be expanded in the loopnest and not make it to codegen.
 class TORCH_API ReduceOp : public ExprNode<ReduceOp> {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ReduceOp(
       const Expr* body,
       std::vector<const Var*> reduce_args,
@@ -159,6 +160,7 @@ class TORCH_API ReduceOp : public ExprNode<ReduceOp> {
 
 class Sum : public Reducer {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   Sum()
       : Reducer(ExprHandle(0), [](ExprHandle a, ExprHandle b) {
           return a + b;

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -51,6 +51,7 @@ class Scope;
 class AccessInfo {
  public:
   AccessInfo() = default;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   AccessInfo(
       SimplifierHashType h,
       const Buf* b,
@@ -220,6 +221,7 @@ using AccessHashMap =
 // Represents a scope block and holds all accesses contained within it.
 class Scope {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Scope(const Block* b, std::shared_ptr<Scope> parent, size_t conditionId = 0)
       : block_(b), parent_(std::move(parent)), conditionId_(conditionId) {}
 
@@ -317,6 +319,7 @@ class Scope {
  */
 class TORCH_API RegisterizerAnalysis : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   RegisterizerAnalysis()
       : currentScope_(std::make_shared<Scope>(nullptr, nullptr, 0)) {}
   ~RegisterizerAnalysis() override = default;
@@ -376,6 +379,7 @@ class TORCH_API RegisterizerAnalysis : public IRVisitor {
  */
 class TORCH_API RegisterizerReplacer : public IRMutator {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   RegisterizerReplacer(std::vector<std::shared_ptr<AccessInfo>>& vec)
       : infoSet_(vec) {
     buildReplacements();
@@ -388,6 +392,7 @@ class TORCH_API RegisterizerReplacer : public IRMutator {
   Stmt* mutate(const Block* v) override;
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct ReplacerScope {
     std::unordered_map<const Stmt*, std::deque<std::shared_ptr<AccessInfo>>>
         initializerPoints_;

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -64,6 +64,7 @@ Stmt* StmtNode<Op>::accept_mutator(IRMutator* mutator) {
 class TORCH_API Block : public StmtNode<Block> {
  public:
   static Block* make(const std::vector<Stmt*>& stmts) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<Stmt*> valid_stmts;
     for (auto& stmt : stmts) {
       if (!stmt) {
@@ -159,7 +160,9 @@ class TORCH_API Block : public StmtNode<Block> {
           "Block replace Stmt with existing parent", new_stmt);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<Stmt*> stmts(stmts_.begin(), stmts_.end());
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<Stmt*> cloned_stmts(stmts.size());
     bool found = false;
     for (int i = 0; i < static_cast<int>(stmts.size()); ++i) {
@@ -198,6 +201,7 @@ class TORCH_API Block : public StmtNode<Block> {
     stmts_.clear();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Block(const std::vector<Stmt*>& stmts) {
     for (Stmt* s : stmts) {
       if (!s) {
@@ -257,6 +261,7 @@ class TORCH_API Block : public StmtNode<Block> {
   }
 
   static const Block* getSharedParent(const Stmt* p1, const Stmt* p2) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::unordered_set<const Block*> enclosing;
 
     const Stmt* p1_p = p1;
@@ -743,6 +748,7 @@ class TORCH_API For : public StmtNode<For> {
 // TODO: make IR nodes extensible.
 class TORCH_API AtomicAdd : public StmtNode<AtomicAdd> {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   AtomicAdd(const Buf* buf, std::vector<const Expr*> indices, const Expr* value)
       : buf_(buf), indices_(std::move(indices)), value_(value) {}
 
@@ -821,6 +827,7 @@ class TORCH_API ExternalCall : public StmtNode<ExternalCall> {
     return args_;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ExternalCall(
       const Buf* buf,
       std::string func_name,

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -14,11 +14,13 @@ namespace tensorexpr {
 
 class TORCH_API Tensor : KernelScopedObject {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Tensor(const Buf* buf, const std::vector<const Var*>& args, const Expr* body)
       : buf_(buf) {
     stmt_ = constructStmt(args, body, {}, {});
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Tensor(
       const Buf* buf,
       const std::vector<const Var*>& args,
@@ -60,13 +62,16 @@ class Placeholder {
  public:
   Placeholder() = default;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Placeholder(const BufHandle& data) : data_(data.node()) {
     if (data_->base_handle()->dtype() != kHandle) {
       throw malformed_input("Placeholder dtype must be Handle");
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<ExprHandle> stride_handles(ndim());
     for (int i = (int)ndim() - 1; i >= 0; i--) {
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (i == ndim() - 1) {
         stride_handles[i] = 1;
       } else {
@@ -76,15 +81,18 @@ class Placeholder {
     strides_ = ExprHandleVectorToExprVector(stride_handles);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Placeholder(
       const std::string& name,
       const Dtype& dtype,
       const std::vector<ExprHandle>& dims)
       : Placeholder(BufHandle(name, dims, dtype)) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Placeholder(const std::vector<ExprHandle>& dims, const Dtype& dtype)
       : Placeholder(BufHandle("_", dims, dtype)) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Placeholder(const std::vector<ExprHandle>& dims)
       : Placeholder(BufHandle("_", dims, kFloat)) {}
 
@@ -178,36 +186,48 @@ Tensor* Reduce(
     const InitFunc& init_func,
     const BodyFunc& body_func,
     const std::vector<DimArg>& reduce_args) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const Expr*> dims;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const Var*> vars;
   unpack_dim_args(dim_args, &dims, &vars);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const Expr*> reduce_dims;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const Var*> reduce_vars;
   unpack_dim_args(reduce_args, &reduce_dims, &reduce_vars);
 
   // If reduce_vars is empty, then it's not a reduction, but rather a simple
   // copy
   if (reduce_vars.empty()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const Expr* body =
         Reducer::getReduceBody(body_func, VarVectorToVarHandleVector(vars))
             .node();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     Buf* func_result = new Buf(func_name, dims, body->dtype());
     return new Tensor(func_result, vars, body);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const Var*> all_vars;
   all_vars.insert(all_vars.end(), vars.begin(), vars.end());
   all_vars.insert(all_vars.end(), reduce_vars.begin(), reduce_vars.end());
 
   ExprHandle body =
       Reducer::getReduceBody(body_func, VarVectorToVarHandleVector(all_vars));
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<const Expr*> output_args(vars.begin(), vars.end());
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Expr* init_expr = new Cast(
       body.dtype(), init_func(VarVectorToVarHandleVector(vars)).node());
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   Buf* func_result = new Buf(func_name, dims, body.dtype(), init_expr);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const ReduceOp* reduce_op =
       reducer(func_result, body, output_args, reduce_vars);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   Tensor* t =
       new Tensor(func_result, vars, reduce_dims, reduce_vars, reduce_op);
   return t;
@@ -266,24 +286,28 @@ TORCH_API Tensor* Reduce(
 
 template <typename... Ts>
 inline ExprHandle Tensor::load(const Ts&... ts) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<ExprHandle> params({ExprHandle(ts)...});
   return Load::make(BufHandle(this->buf()), params);
 }
 
 template <typename T>
 inline ExprHandle Tensor::load(const std::vector<T>& args) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<ExprHandle> params(args.begin(), args.end());
   return Load::make(BufHandle(this->buf()), params);
 }
 
 template <typename... Ts>
 inline ExprHandle Placeholder::load(const Ts&... ts) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<ExprHandle> params({ExprHandle(ts)...});
   return ExprHandle(new Load(data(), ExprHandleVectorToExprVector(params)));
 }
 
 template <typename T>
 inline ExprHandle Placeholder::load(const std::vector<T>& args) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<ExprHandle> params(args.begin(), args.end());
   return ExprHandle(new Load(data(), ExprHandleVectorToExprVector(params)));
 }
@@ -294,12 +318,14 @@ inline ExprHandle Placeholder::load(const std::vector<ExprHandle>& args) const {
 
 template <typename... Ts>
 inline ExprHandle BufHandle::load(const Ts&... ts) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<ExprHandle> params({ExprHandle(ts)...});
   return Load::make(*this, params);
 }
 
 template <typename T>
 inline ExprHandle BufHandle::load(const std::vector<T>& args) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<ExprHandle> params(args.begin(), args.end());
   return Load::make(*this, params);
 }

--- a/torch/csrc/jit/tensorexpr/unique_name_manager.h
+++ b/torch/csrc/jit/tensorexpr/unique_name_manager.h
@@ -18,6 +18,7 @@ using VarNameMap = std::unordered_map<const Var*, std::string>;
 // A manager to get unique names from vars.
 // It starts with the name hints of the var and append "_" + $counter until it
 // hits a unique name.
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_API UniqueNameManager {
  public:
   const std::string& get_unique_name(const VarHandle& v);

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -17,6 +17,7 @@ using VarMapping = std::vector<std::pair<const Var*, const Expr*>>;
 
 class VarSubMutator : public IRMutator {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   VarSubMutator(const VarMapping& var_mapping) {
     for (const auto& entry : var_mapping) {
       const Var* key_var = entry.first;
@@ -38,6 +39,7 @@ class VarSubMutator : public IRMutator {
 
   const Expr* mutate(const ReduceOp* var) override {
     auto body = var->body()->accept_mutator(this);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<const Var*> new_inner;
 
     for (auto* v : var->reduce_args()) {

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -202,6 +202,7 @@ void THPUtils_invalidArguments(PyObject *given_args, PyObject *given_kwargs,
   std::vector<std::string> option_strings;
   va_list option_list;
   va_start(option_list, num_options);
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   for(const auto i : c10::irange(num_options))
     option_strings.emplace_back(va_arg(option_list, const char*));
   va_end(option_list);

--- a/torch/csrc/utils/byte_order.cpp
+++ b/torch/csrc/utils/byte_order.cpp
@@ -236,6 +236,7 @@ void THP_encodeInt16Buffer(uint8_t* dst, const int16_t* src, THPByteOrder order,
 {
   memcpy(dst, src, sizeof(int16_t) * len);
   if (order != THP_nativeByteOrder()) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for(const auto i : c10::irange(len)) {
       swapBytes16(dst);
       dst += sizeof(int16_t);
@@ -247,6 +248,7 @@ void THP_encodeInt32Buffer(uint8_t* dst, const int32_t* src, THPByteOrder order,
 {
   memcpy(dst, src, sizeof(int32_t) * len);
   if (order != THP_nativeByteOrder()) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for(const auto i : c10::irange(len)) {
       swapBytes32(dst);
       dst += sizeof(int32_t);
@@ -258,6 +260,7 @@ void THP_encodeInt64Buffer(uint8_t* dst, const int64_t* src, THPByteOrder order,
 {
   memcpy(dst, src, sizeof(int64_t) * len);
   if (order != THP_nativeByteOrder()) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for(const auto i : c10::irange(len)) {
       swapBytes64(dst);
       dst += sizeof(int64_t);
@@ -269,6 +272,7 @@ void THP_encodeFloatBuffer(uint8_t* dst, const float* src, THPByteOrder order, s
 {
   memcpy(dst, src, sizeof(float) * len);
   if (order != THP_nativeByteOrder()) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for(const auto i : c10::irange(len)) {
       swapBytes32(dst);
       dst += sizeof(float);
@@ -280,6 +284,7 @@ void THP_encodeDoubleBuffer(uint8_t* dst, const double* src, THPByteOrder order,
 {
   memcpy(dst, src, sizeof(double) * len);
   if (order != THP_nativeByteOrder()) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
     for(const auto i : c10::irange(len)) {
       swapBytes64(dst);
       dst += sizeof(double);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -288,6 +288,7 @@ inline at::Tensor PythonArgs::tensor(int i) {
 
 inline c10::optional<at::Tensor> PythonArgs::optionalTensor(int i) {
   at::Tensor t = tensor(i);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   if (t.defined()) {
     return t;
   } else {
@@ -306,6 +307,7 @@ inline std::vector<at::Scalar> PythonArgs::scalarlist(int i) {
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Scalar> res(size);
   for(const auto idx : c10::irange(size)) {
     PyObject* obj = tuple ? PyTuple_GET_ITEM(arg.get(), idx) : PyList_GET_ITEM(arg.get(), idx);
@@ -330,6 +332,7 @@ inline std::vector<at::Tensor> PythonArgs::tensorlist(int i) {
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Tensor> res(size);
   for(const auto idx : c10::irange(size)) {
     PyObject* obj = tuple ? PyTuple_GET_ITEM(arg.get(), idx) : PyList_GET_ITEM(arg.get(), idx);
@@ -346,6 +349,7 @@ inline torch::List<c10::optional<at::Tensor>> PythonArgs::list_of_optional_tenso
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   torch::List<c10::optional<at::Tensor>> res;
   res.reserve(size);
   for(const auto idx : c10::irange(size)) {
@@ -391,6 +395,7 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(int i, std::vector<in
   auto tuple = PyTuple_Check(arg);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   const auto size2 = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<int64_t> res(size2);
   for(const auto idx : c10::irange(size2)) {
     PyObject* obj = tuple ? PyTuple_GET_ITEM(arg, idx) : PyList_GET_ITEM(arg, idx);
@@ -427,6 +432,7 @@ inline std::vector<double> PythonArgs::getDoublelist(int i) {
   auto tuple = PyTuple_Check(arg);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<double> res(size);
   for(const auto idx : c10::irange(size)) {
     PyObject* obj = tuple ? PyTuple_GET_ITEM(arg, idx) : PyList_GET_ITEM(arg, idx);
@@ -537,6 +543,7 @@ inline std::vector<at::Dimname> parseDimnameList(PyObject* arg) {
   auto tuple = PyTuple_Check(arg);
   // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<at::Dimname> res;
   res.reserve(size);
   for(const auto idx : c10::irange(size)) {

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -109,10 +109,11 @@ static py::object PyObject_FastGetAttrString(PyObject *obj, const char *name)
 
     /* Attribute referenced by (char *)name */
     if (tp->tp_getattr != nullptr) {
-        // This is OK per https://bugs.python.org/issue39620
-        res = (*tp->tp_getattr)(obj, const_cast<char*>(name));
-        if (res == nullptr) {
-          PyErr_Clear();
+      // This is OK per https://bugs.python.org/issue39620
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      res = (*tp->tp_getattr)(obj, const_cast<char*>(name));
+      if (res == nullptr) {
+        PyErr_Clear();
         }
     }
     /* Attribute referenced by (PyObject *)name */

--- a/torch/csrc/utils/tensor_flatten.h
+++ b/torch/csrc/utils/tensor_flatten.h
@@ -25,7 +25,7 @@ inline std::vector<at::Tensor> unflatten_dense_tensors(const at::Tensor& flat, a
   return at::unflatten_dense_tensors(flat, tensors);
 }
 
-
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct TensorGroup {
   std::vector<at::Tensor> tensors;
   size_t size = 0;


### PR DESCRIPTION
This PR suppresses clang-tidy warnings in the codebase (for now) so that we can re-enable clang-tidy checks on master.

I ran this script to add the `NOLINTNEXTLINE` comments (on a devserver):
```bash
python3 setup.py develop

# Uses same script that's run on CI and adds the -j (parallel), -s (add comments), -k (continue if diagnostic errors are found) options
python3 tools/clang_tidy.py \
  -j \
  -s \
  -k \
  -v \
  --paths torch/csrc/ \
  -g"-torch/csrc/jit/passes/onnx/helper.cpp" \
  -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp" \
  -g"-torch/csrc/jit/serialization/onnx.cpp" \
  -g"-torch/csrc/jit/serialization/export.cpp" \
  -g"-torch/csrc/jit/serialization/import.cpp" \
  -g"-torch/csrc/jit/serialization/import_legacy.cpp" \
  -g"-torch/csrc/onnx/init.cpp" \
  -g"-torch/csrc/cuda/nccl.*" \
  -g"-torch/csrc/cuda/python_nccl.cpp" \
  -g"-torch/csrc/autograd/FunctionsManual.cpp" \
  -g"-torch/csrc/generic/*.cpp" \
  -g"-torch/csrc/jit/codegen/cuda/runtime/*" \
  -g"-torch/csrc/deploy/interpreter/interpreter.cpp" \
  -g"-torch/csrc/deploy/interpreter/interpreter.h" \
  -g"-torch/csrc/deploy/interpreter/interpreter_impl.h" \
  -g"-torch/csrc/deploy/interpreter/test_main.cpp"
```

Test plan:
Verified changes by re-running the script (without the `-s` option) and seeing no warnings/errors.