### PR TITLE
Sparse CSR: increase dtype test coverage

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -516,9 +516,6 @@ class OpInfo(object):
                  # the following metadata relates to sparse support and is used in test_sparse.py
                  supports_sparse=False,  # whether the op supports sparse inputs
 
-                 # the following metadata relates to CSR layout support and is used in test_sparse_csr.py
-                 supports_sparse_csr=False,  # whether the op supports sparse_csr inputs
-
                  # the following metadata relates to complex support and is checked in test_ops.py
                  test_conjugated_samples=True,
                  ):
@@ -7664,7 +7661,6 @@ op_db: List[OpInfo] = [
 unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo)]
 spectral_funcs = [op for op in op_db if isinstance(op, SpectralFuncInfo)]
 sparse_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse is True]
-sparse_csr_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse_csr is True]
 shape_funcs = [op for op in op_db if isinstance(op, ShapeFuncInfo)]
 
 # TODO: review porting these to make_tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -516,6 +516,9 @@ class OpInfo(object):
                  # the following metadata relates to sparse support and is used in test_sparse.py
                  supports_sparse=False,  # whether the op supports sparse inputs
 
+                 # the following metadata relates to CSR layout support and is used in test_sparse_csr.py
+                 supports_sparse_csr=False,  # whether the op supports sparse_csr inputs
+
                  # the following metadata relates to complex support and is checked in test_ops.py
                  test_conjugated_samples=True,
                  ):
@@ -7661,6 +7664,7 @@ op_db: List[OpInfo] = [
 unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo)]
 spectral_funcs = [op for op in op_db if isinstance(op, SpectralFuncInfo)]
 sparse_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse is True]
+sparse_csr_unary_ufuncs = [op for op in op_db if isinstance(op, UnaryUfuncInfo) and op.supports_sparse_csr is True]
 shape_funcs = [op for op in op_db if isinstance(op, ShapeFuncInfo)]
 
 # TODO: review porting these to make_tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60657 Enable sparse_csr.to_dense() for bool, float16, bfloat16 and complex
* **#60656 Sparse CSR: increase dtype test coverage**

This PR uses `torch.testing.get_all_dtypes()` for dtype parametrisation
of tests in `test_sparse_csr.py`. It adds previously excluded from tests
bool, half, bfloat16, complex dtypes. `torch.complex32` is omitted due
to lack of coverage and lack of specialized `AT_DISPATCH...`.
The process of adding more dtypes to tests releaved that `.to_dense()`
doesn't work for all dtypes.

Differential Revision: [D29408058](https://our.internmc.facebook.com/intern/diff/D29408058)