### PR TITLE
Use python3.6 compatible APIs in clang_tidy.py

### DIFF
--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -186,7 +186,7 @@ def run_shell_commands_in_parallel(commands: Iterable[List[str]]) -> str:
         coros = [run_command(cmd) for cmd in commands]
         return await gather_with_concurrency(multiprocessing.cpu_count(), coros)
 
-    loop = asyncio.get_event_loop();
+    loop = asyncio.get_event_loop()
     results = loop.run_until_complete(helper())
     return "\n".join(results)
 

--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -166,7 +166,7 @@ def run_shell_commands_in_parallel(commands: Iterable[List[str]]) -> str:
     """runs all the commands in parallel with ninja, commands is a List[List[str]]"""
     async def run_command(cmd: List[str]) -> str:
         proc = await asyncio.create_subprocess_shell(
-            shlex.join(cmd),  # type: ignore[attr-defined]
+            ' '.join(shlex.quote(x) for x in cmd),  # type: ignore[attr-defined]
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
@@ -186,7 +186,8 @@ def run_shell_commands_in_parallel(commands: Iterable[List[str]]) -> str:
         coros = [run_command(cmd) for cmd in commands]
         return await gather_with_concurrency(multiprocessing.cpu_count(), coros)
 
-    results = asyncio.run(helper())  # type: ignore[attr-defined]
+    loop = asyncio.get_event_loop();
+    results = loop.run_until_complete(helper())
     return "\n".join(results)
 
 


### PR DESCRIPTION
This PR make `tools/clang_tidy.py` use python 3.6 APIs for `asyncio` and `shlex`. 

I ran into some issues when running this script with the `-j` flag inside of the clang-tidy docker image (which uses python 3.6). Specifically, the functions `asycnio.run` and `shlex.join` are available in python >= 3.8.

This change does not affect CI because we do not run the clang-tidy job in parallel.
