### PR TITLE
[c10d] Fix test_collective_hang flakiness

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -48,6 +48,10 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
                 err = f"Ranks {faulty_rank} failed to pass monitoredBarrier"
             else:
                 err = "Please check rank 0 logs for faulty rank"
+
+            # Gloo can sometimes throw the following error if a rank exits early
+            # before rank 0 calls into the allreduce.
+            err += "|Connection closed by peer"
             with self.assertRaisesRegex(RuntimeError, err):
                 wrapper_pg.allreduce([tensor])
 

--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -51,7 +51,7 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
 
             # Gloo can sometimes throw the following error if a rank exits early
             # before rank 0 calls into the allreduce.
-            err += "|Connection closed by peer"
+            err += "|Connection closed by peer|Connection reset by peer"
             with self.assertRaisesRegex(RuntimeError, err):
                 wrapper_pg.allreduce([tensor])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60662 [c10d] Fix test_collective_hang flakiness**

Fixes this flaky test. Basically, sometimes a rank can exit the test
early before rank 0 calls into allreduce. In this case Gloo will throw
connection reset error on all other ranks.

Closes https://github.com/pytorch/pytorch/issues/60652

Differential Revision: [D29364806](https://our.internmc.facebook.com/intern/diff/D29364806/)