### PR TITLE
[caffe2/utils] Add explicit rule to avoid package boundary violation (#60437)

### DIFF
--- a/caffe2/perfkernels/lstm_unit_cpu-impl.h
+++ b/caffe2/perfkernels/lstm_unit_cpu-impl.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <cmath>
+#include <cstdint>
+#include <string.h>
 #include "caffe2/utils/conversions.h"
 
 #if (ENABLE_VECTORIZATION > 0) && !defined(_DEBUG) && !defined(DEBUG)

--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -1,16 +1,5 @@
 #pragma once
 
-#include <caffe2/core/types.h>
-
-#ifdef __CUDA_ARCH__
-// Proxy for including cuda_fp16.h, because common_gpu.h
-// has necessary diagnostic guards.
-#include <caffe2/core/common_gpu.h>
-#endif
-#ifdef __HIP_DEVICE_COMPILE__
-#include <caffe2/core/hip/common_gpu.h>
-#endif
-
 // See Note [hip-clang differences to hcc]
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/60437

Add a rule to wrap conversions.h and depend on that, rather than
relying on a glob which violates package boundaries.

Test Plan: `buck2 build fbcode//caffe2/caffe2:caffe2_core`

Differential Revision: D29370841

