### PR TITLE
[pruning] Speedup activation reconstruction

### DIFF
--- a/torch/ao/sparsity/__init__.py
+++ b/torch/ao/sparsity/__init__.py
@@ -1,5 +1,6 @@
 # Parametrizations
 from .experimental.pruner.parametrization import PruningParametrization
+from .experimental.pruner.parametrization import ActivationReconstruction
 
 # Pruner
 from .experimental.pruner.base_pruner import BasePruner

--- a/torch/ao/sparsity/experimental/pruner/base_pruner.py
+++ b/torch/ao/sparsity/experimental/pruner/base_pruner.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 from torch.nn.utils import parametrize
 
-from .parametrization import PruningParametrization
+from .parametrization import PruningParametrization, ActivationReconstruction
 
 SUPPORTED_MODULES = {
     nn.Linear
@@ -122,7 +122,11 @@ class BasePruner(abc.ABC):
                 module.register_buffer('mask', torch.tensor(module.weight.shape[0]))
             param = config.get('parametrization', PruningParametrization)
             parametrize.register_parametrization(module, 'weight',
-                                                 param(module.mask))
+                                                 param(module.mask),
+                                                 allow_resize=True)
+            module.register_forward_hook(
+                ActivationReconstruction(module.parametrizations.weight[0])
+            )
 
     def convert(self, use_path=False, *args, **kwargs):
         for config in self.module_groups:

--- a/torch/ao/sparsity/experimental/pruner/parametrization.py
+++ b/torch/ao/sparsity/experimental/pruner/parametrization.py
@@ -20,14 +20,7 @@ class ActivationReconstruction:
     def __call__(self, module, input, output):
         max_outputs = self.param.original_outputs
         pruned_outputs = self.param.pruned_outputs
-        original_out = output.shape[1] + len(pruned_outputs)
-        zeros = torch.zeros((output.shape[0], 1))
-        cols = []
-        jdx = 0
-        for idx in range(original_out):
-            if idx in pruned_outputs:
-                cols.append(zeros)
-            else:
-                cols.append(output[:, jdx].reshape((-1, 1)))
-                jdx += 1
-        return torch.hstack(cols)
+        reconstructed_tensor = torch.zeros((output.shape[0], len(max_outputs)))
+        valid_columns = list(max_outputs - pruned_outputs)
+        reconstructed_tensor[:, valid_columns] = output
+        return reconstructed_tensor

--- a/torch/ao/sparsity/experimental/pruner/parametrization.py
+++ b/torch/ao/sparsity/experimental/pruner/parametrization.py
@@ -1,12 +1,33 @@
+import torch
 from torch import nn
 
 
 class PruningParametrization(nn.Module):
-    def __init__(self, original_rows):
+    def __init__(self, original_outputs):
         super().__init__()
-        self.original_rows = set(range(original_rows))
-        self.pruned_rows = set()  # Will contain indicies of rows to prune
+        self.original_outputs = set(range(original_outputs.item()))
+        self.pruned_outputs = set()  # Will contain indicies of outputs to prune
 
     def forward(self, x):
-        valid_rows = self.original_rows - self.pruned_rows
-        return x[list(valid_rows)]
+        valid_outputs = self.original_outputs - self.pruned_outputs
+        return x[list(valid_outputs)]
+
+
+class ActivationReconstruction:
+    def __init__(self, parametrization):
+        self.param = parametrization
+
+    def __call__(self, module, input, output):
+        max_outputs = self.param.original_outputs
+        pruned_outputs = self.param.pruned_outputs
+        original_out = output.shape[1] + len(pruned_outputs)
+        zeros = torch.zeros((output.shape[0], 1))
+        cols = []
+        jdx = 0
+        for idx in range(original_out):
+            if idx in pruned_outputs:
+                cols.append(zeros)
+            else:
+                cols.append(output[:, jdx].reshape((-1, 1)))
+                jdx += 1
+        return torch.hstack(cols)


### PR DESCRIPTION
Summary: Vectorized reconstruction without for loops

Test Plan:
`buck test mode/dev-nosan //caffe2/test:ao -- TestBasePruner`

https://pxl.cl/1KSJQ

Differential Revision: D29370805

