### PR TITLE
[caffe2] update make_cifar_db to move the string into DB::Put()

### DIFF
--- a/binaries/make_cifar_db.cc
+++ b/binaries/make_cifar_db.cc
@@ -95,16 +95,14 @@ void WriteToDB(const string& filename, const int num_items,
   CAFFE_ENFORCE(data_file, "Unable to open file ", filename);
   char str_buffer[kCIFARImageNBytes];
   int label_value;
-  string serialized_protos;
   std::unique_ptr<db::Transaction> transaction(db->NewTransaction());
   for (int itemid = 0; itemid < num_items; ++itemid) {
     ReadImage(&data_file, &label_value, str_buffer);
     data->set_byte_data(str_buffer, kCIFARImageNBytes);
     label->set_int32_data(0, label_value);
-    protos.SerializeToString(&serialized_protos);
     snprintf(str_buffer, kCIFARImageNBytes, "%05d",
         offset + itemid);
-    transaction->Put(string(str_buffer), serialized_protos);
+    transaction->Put(string(str_buffer), protos.SerializeAsString());
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60692 [caffe2] update make_cifar_db to move the string into DB::Put()**

Update make_cifar_db.cc to work with the DB API changes in D29204425.

Differential Revision: [D29374754](https://our.internmc.facebook.com/intern/diff/D29374754/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29374754/)!