### PR TITLE
fix cuda mem leak check not properly run on master_builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,11 +283,15 @@ pytorch_params: &pytorch_params
     build_only:
       type: string
       default: ""
+    ci_master:
+      type: string
+      default: ""
   environment:
     BUILD_ENVIRONMENT: << parameters.build_environment >>
     DOCKER_IMAGE: << parameters.docker_image >>
     USE_CUDA_DOCKER_RUNTIME: << parameters.use_cuda_docker_runtime >>
     BUILD_ONLY: << parameters.build_only >>
+    CI_MASTER: << pipeline.parameters.run_master_build >>
   resource_class: << parameters.resource_class >>
 
 pytorch_android_params: &pytorch_android_params

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -67,6 +67,7 @@ add_to_env_file() {
 }
 
 add_to_env_file IN_CI 1
+add_to_env_file CI_MASTER "${CI_MASTER:-}"
 add_to_env_file COMMIT_SOURCE "${CIRCLE_BRANCH:-}"
 add_to_env_file BUILD_ENVIRONMENT "${BUILD_ENVIRONMENT}"
 add_to_env_file CIRCLE_PULL_REQUEST "${CIRCLE_PULL_REQUEST}"

--- a/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
@@ -15,11 +15,15 @@ pytorch_params: &pytorch_params
     build_only:
       type: string
       default: ""
+    ci_master:
+      type: string
+      default: ""
   environment:
     BUILD_ENVIRONMENT: << parameters.build_environment >>
     DOCKER_IMAGE: << parameters.docker_image >>
     USE_CUDA_DOCKER_RUNTIME: << parameters.use_cuda_docker_runtime >>
     BUILD_ONLY: << parameters.build_only >>
+    CI_MASTER: << pipeline.parameters.run_master_build >>
   resource_class: << parameters.resource_class >>
 
 pytorch_android_params: &pytorch_android_params

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -55,7 +55,8 @@ else
   export PYTORCH_TEST_SKIP_NOARCH=1
 fi
 
-if [[ -n "$IN_PULL_REQUEST" ]] && [[ -z "$CI_MASTER" ]]; then
+if [[ -n "$IN_PULL_REQUEST" ]] && [[ -z "$CI_MASTER" || "$CI_MASTER" == "false" ]]; then
+  # skip expensive checks when on PR and CI_MASTER flag is not set
   export PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=1
 else
   export PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=0

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -55,7 +55,7 @@ else
   export PYTORCH_TEST_SKIP_NOARCH=1
 fi
 
-if [[ -n "$IN_PULL_REQUEST" ]]; then
+if [[ -n "$IN_PULL_REQUEST" ]] && [[ -z "$CI_MASTER" ]]; then
   export PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=1
 else
   export PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=0


### PR DESCRIPTION
This is the non-ghstack version of the pull request of #60742

Apparently circleci sets environment variable differently depending on whether one creates PR from fork repo or not. 


Test plan
search for `PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK` in logs below:
- Before adding ci/master label:
  - This is validate working previously
- After adding ci/master label:
  - build workflow (`PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=1`):  https://circleci.com/api/v1.1/project/github/pytorch/pytorch/14394630/output/107/0?file=true&allocation-id=60d5f588a55ae50282aeb654-0-build%2F5CD3D81
  - master_build workflow (`PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=0`): https://circleci.com/api/v1.1/project/github/pytorch/pytorch/14394139/output/107/0?file=true&allocation-id=60d5f235a55ae50282aead90-0-build%2F7DFA4C37