### PR TITLE
[ONNX] Fix controlflow shape inference with contrib op

### DIFF
--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -383,8 +383,8 @@ void ONNXMergeIfBlockOutputShapes(Node* node) {
   };
 
   auto mergeTensorType = [&findCommonShape](
-                             const TensorTypePtr a,
-                             const TensorTypePtr b) -> TensorTypePtr {
+                             TensorTypePtr a,
+                             TensorTypePtr b) -> TensorTypePtr {
     if (a && b) {
       const auto& a_shape = a->symbolic_sizes();
       const auto& b_shape = b->symbolic_sizes();
@@ -399,8 +399,8 @@ void ONNXMergeIfBlockOutputShapes(Node* node) {
   };
 
   auto mergeListType = [&mergeTensorType](
-                           const ListTypePtr a,
-                           const ListTypePtr b) -> ListTypePtr {
+                           ListTypePtr a,
+                           ListTypePtr b) -> ListTypePtr {
     if (a && b) {
       auto a_tensor_type = a->getElementType()->cast<TensorType>();
       auto b_tensor_type = b->getElementType()->cast<TensorType>();

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -382,9 +382,8 @@ void ONNXMergeIfBlockOutputShapes(Node* node) {
     return ::c10::SymbolicShape();
   };
 
-  auto mergeTensorType = [&findCommonShape](
-                             TensorTypePtr a,
-                             TensorTypePtr b) -> TensorTypePtr {
+  auto mergeTensorType =
+      [&findCommonShape](TensorTypePtr a, TensorTypePtr b) -> TensorTypePtr {
     if (a && b) {
       const auto& a_shape = a->symbolic_sizes();
       const auto& b_shape = b->symbolic_sizes();
@@ -399,8 +398,7 @@ void ONNXMergeIfBlockOutputShapes(Node* node) {
   };
 
   auto mergeListType = [&mergeTensorType](
-                           ListTypePtr a,
-                           ListTypePtr b) -> ListTypePtr {
+                           ListTypePtr a, ListTypePtr b) -> ListTypePtr {
     if (a && b) {
       auto a_tensor_type = a->getElementType()->cast<TensorType>();
       auto b_tensor_type = b->getElementType()->cast<TensorType>();

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.h
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.h
@@ -6,6 +6,7 @@ namespace torch {
 namespace jit {
 
 std::vector<Value*> FixupONNXControlflowNode(Node* n, int opset_version);
+void FixupONNXControlflowNodeOutputs(Node* n);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1199,7 +1199,7 @@ void ProcessConstantValueMap(Node* n, int opset_version) {
 }
 
 // Any additional post process that are specific to individual node kind.
-void SpecialPostProcess(Node* n, int opset_version) {
+void SpecialPostProcess(Node* n) {
   switch (n->kind()) {
     case ::c10::onnx::SequenceInsert: {
       // Special case when input sequence to SequenceInsert is empty.
@@ -1345,16 +1345,14 @@ void SpecialPostProcess(Node* n, int opset_version) {
       if (!IsValidONNXControlflowNode(n)) {
         break;
       }
-      FixupONNXControlflowNode(n, opset_version);
+      FixupONNXControlflowNodeOutputs(n);
       break;
     }
     case ::c10::onnx::Loop: {
       if (!IsValidONNXControlflowNode(n)) {
         break;
       }
-      for (size_t i = 0; i < n->outputs().size(); ++i) {
-        n->output(i)->setType(n->blocks().at(0)->outputs().at(i + 1)->type());
-      }
+      FixupONNXControlflowNodeOutputs(n);
       break;
     }
   }
@@ -1572,7 +1570,7 @@ void ONNXShapeTypeInference(
     }
   }
 
-  SpecialPostProcess(n, opset_version);
+  SpecialPostProcess(n);
 
   if (IsValidONNXNode(n)) {
     ProcessConstantValueMap(n, opset_version);

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -198,7 +198,21 @@ void UpdateTorchValueByOnnxValueInfo(
   }
 }
 
-bool IsSupportedNode(const Node* n) {
+bool IsValidONNXControlflowNode(const Node* n) {
+  // Skip when block size is zero. This is when the node is being created,
+  // and doesn't have subblocks attached yet. Run shape inference for these nodes
+  // later, when the subgraph has already completed shape inferencing.
+  auto node_kind = n->kind();
+  if (node_kind == ::c10::onnx::Loop || node_kind == ::c10::onnx::If) {
+    if (n->blocks().size() == 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool IsValidONNXNode(const Node* n) {
   auto node_kind = n->kind();
 
   if (!node_kind.is_onnx()) {
@@ -206,18 +220,14 @@ bool IsSupportedNode(const Node* n) {
     return false;
   }
 
-  // Skip when block size is zero. This is when the node is first created,
-  // doesn't have subblocks attached yet. Run shape inference for these nodes
-  // when the subgraph has already completed shape inferencing.
-  if (node_kind == ::c10::onnx::Loop || node_kind == ::c10::onnx::If) {
-    if (n->blocks().size() == 0) {
-      return false;
-    }
-    for (auto b : n->blocks()) {
-      for (auto b_n : b->nodes()) {
-        if (!IsSupportedNode(b_n)) {
-          return false;
-        }
+  if (!IsValidONNXControlflowNode(n)) {
+    return false;
+  }
+
+  for (auto b : n->blocks()) {
+    for (auto b_n : b->nodes()) {
+      if (!IsValidONNXNode(b_n)) {
+        return false;
       }
     }
   }
@@ -1330,6 +1340,24 @@ void SpecialPostProcess(Node* n) {
       }
       break;
     }
+    case ::c10::onnx::If: {
+      if (!IsValidONNXControlflowNode(n)) {
+        break;
+      }
+      for (size_t i = 0; i < n->outputs().size(); ++i) {
+        n->output(i)->setType(n->blocks().at(0)->outputs().at(i)->type());
+      }
+      break;
+    }
+    case ::c10::onnx::Loop: {
+      if (!IsValidONNXControlflowNode(n)) {
+        break;
+      }
+      for (size_t i = 0; i < n->outputs().size(); ++i) {
+        n->output(i)->setType(n->blocks().at(0)->outputs().at(i + 1)->type());
+      }
+      break;
+    }
   }
 }
 
@@ -1489,74 +1517,75 @@ void ONNXShapeTypeInference(
   SetGraphInputTypeReliable(n->owningGraph());
   GRAPH_UPDATE(
       "Running ONNX shape inference for node: ", n->kind().toDisplayString());
-  if (!IsSupportedNode(n)) {
-    UpdateReliable(n);
-    return;
-  }
-  // Create a Graph containing only the single node n.
-  // This graph is later converted to ONNX to run shape inference.
-  auto n_graph = std::make_shared<Graph>();
-  auto clone_node = CloneNodeToGraph(n, n_graph, params_dict, opset_version);
-  n_graph->insertNode(clone_node);
+  if (IsValidONNXNode(n)) {
+    // Create a Graph containing only the single node n.
+    // This graph is later converted to ONNX to run shape inference.
+    auto n_graph = std::make_shared<Graph>();
+    auto clone_node = CloneNodeToGraph(n, n_graph, params_dict, opset_version);
+    n_graph->insertNode(clone_node);
 
-  // Register all node outputs as graph outputs.
-  for (auto output : clone_node->outputs()) {
-    n_graph->registerOutput(output);
-  }
-
-  // Use scalar_type_analysis without low precision cast
-  ScalarTypeAnalysisForONNX(n_graph, false, opset_version);
-
-  GRAPH_DEBUG("Original torch graph: ", n->owningGraph()->toString());
-  GRAPH_DEBUG(
-      "Cloned torch graph to run shape inference: ", n_graph->toString());
-
-  if (IsGraphValidForInference(n_graph)) {
-    // TODO: Some ops have conversion happen at Peephole pass.
-    //       The conversion here is incomplete for these ops.
-    //       e.g: ListConstruct, ListUnpack, etc.
-    std::shared_ptr<onnx::ModelProto> model_proto;
-    SymbolDimMap symbol_map;
-    ConvertGraphToONNXProto(n_graph, model_proto, symbol_map, opset_version);
-    GRAPH_DEBUG(
-        "ONNX graph to run shape inference: ", prettyPrint(*model_proto));
-
-    // infer shape
-    try {
-      onnx::shape_inference::InferShapes(*model_proto);
-      UpdateOutputTypeByONNXProto(n, clone_node, *model_proto, symbol_map);
-    } catch (std::runtime_error& ex) {
-      // TODO: include this as warning once we have a more consolidated warning
-      // system.
-      GRAPH_DEBUG(
-          "ONNX shape inference fails with: ",
-          ex.what(),
-          " on graph: ",
-          n_graph->toString());
-      // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-      const char shape_err[] = "ShapeInferenceError";
-      // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-      const char type_err[] = "TypeInferenceError";
-      // NOLINTNEXTLINE(modernize-use-nullptr)
-      if ((strstr(ex.what(), shape_err) == NULL) &&
-          // NOLINTNEXTLINE(modernize-use-nullptr)
-          (strstr(ex.what(), type_err) == NULL))
-        throw;
+    // Register all node outputs as graph outputs.
+    for (auto output : clone_node->outputs()) {
+      n_graph->registerOutput(output);
     }
+
+    // Use scalar_type_analysis without low precision cast
+    ScalarTypeAnalysisForONNX(n_graph, false, opset_version);
+
+    GRAPH_DEBUG("Original torch graph: ", n->owningGraph()->toString());
     GRAPH_DEBUG(
-        "ONNX graph after shape inference: ", prettyPrint(*model_proto));
+        "Cloned torch graph to run shape inference: ", n_graph->toString());
+
+    if (IsGraphValidForInference(n_graph)) {
+      // TODO: Some ops have conversion happen at Peephole pass.
+      //       The conversion here is incomplete for these ops.
+      //       e.g: ListConstruct, ListUnpack, etc.
+      std::shared_ptr<onnx::ModelProto> model_proto;
+      SymbolDimMap symbol_map;
+      ConvertGraphToONNXProto(n_graph, model_proto, symbol_map, opset_version);
+      GRAPH_DEBUG(
+          "ONNX graph to run shape inference: ", prettyPrint(*model_proto));
+
+      // infer shape
+      try {
+        onnx::shape_inference::InferShapes(*model_proto);
+        UpdateOutputTypeByONNXProto(n, clone_node, *model_proto, symbol_map);
+      } catch (std::runtime_error& ex) {
+        // TODO: include this as warning once we have a more consolidated warning
+        // system.
+        GRAPH_DEBUG(
+            "ONNX shape inference fails with: ",
+            ex.what(),
+            " on graph: ",
+            n_graph->toString());
+        // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+        const char shape_err[] = "ShapeInferenceError";
+        // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+        const char type_err[] = "TypeInferenceError";
+        // NOLINTNEXTLINE(modernize-use-nullptr)
+        if ((strstr(ex.what(), shape_err) == NULL) &&
+            // NOLINTNEXTLINE(modernize-use-nullptr)
+            (strstr(ex.what(), type_err) == NULL))
+          throw;
+      }
+      GRAPH_DEBUG(
+          "ONNX graph after shape inference: ", prettyPrint(*model_proto));
+    }
   }
 
   SpecialPostProcess(n);
-  ProcessConstantValueMap(n, opset_version);
-  if (n->kind() != prim::ListConstruct) {
-    for (auto input : n->inputs()) {
-      if (input->node()->kind() == prim::ListConstruct) {
-        UpdateReliable(input, AreInputsReliableOrStatic(input->node()));
+
+  if (IsValidONNXNode(n)) {
+    ProcessConstantValueMap(n, opset_version);
+    if (n->kind() != prim::ListConstruct) {
+      for (auto input : n->inputs()) {
+        if (input->node()->kind() == prim::ListConstruct) {
+          UpdateReliable(input, AreInputsReliableOrStatic(input->node()));
+        }
       }
     }
+    UpdateReliable(n);
   }
-  UpdateReliable(n);
 
   GRAPH_DEBUG(
       "Torch graph after shape inference:", n->owningGraph()->toString());

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1583,8 +1583,8 @@ void ONNXShapeTypeInference(
         }
       }
     }
-    UpdateReliable(n);
   }
+  UpdateReliable(n);
 
   GRAPH_DEBUG(
       "Torch graph after shape inference:", n->owningGraph()->toString());

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -200,8 +200,8 @@ void UpdateTorchValueByOnnxValueInfo(
 
 bool IsValidONNXControlflowNode(const Node* n) {
   // Skip when block size is zero. This is when the node is being created,
-  // and doesn't have subblocks attached yet. Run shape inference for these nodes
-  // later, when the subgraph has already completed shape inferencing.
+  // and doesn't have subblocks attached yet. Run shape inference for these
+  // nodes later, when the subgraph has already completed shape inferencing.
   auto node_kind = n->kind();
   if (node_kind == ::c10::onnx::Loop || node_kind == ::c10::onnx::If) {
     if (n->blocks().size() == 0) {
@@ -1551,8 +1551,8 @@ void ONNXShapeTypeInference(
         onnx::shape_inference::InferShapes(*model_proto);
         UpdateOutputTypeByONNXProto(n, clone_node, *model_proto, symbol_map);
       } catch (std::runtime_error& ex) {
-        // TODO: include this as warning once we have a more consolidated warning
-        // system.
+        // TODO: include this as warning once we have a more consolidated
+        // warning system.
         GRAPH_DEBUG(
             "ONNX shape inference fails with: ",
             ex.what(),


### PR DESCRIPTION
`ONNXShapeTypeInference` for node `n` is skipped if `n` is non ONNX namespace, or if `n` contains any non ONNX namespace nodes. This prevents controlflow nodes containing contrib ops from running `SpecialPostProcess`, which sets up correct node output shape/type information in rare cases.

This PR depends on opset 14 export https://github.com/pytorch/pytorch/pull/59486