### PR TITLE
This is first attempt to get rid of cpp_custom_type_hack.

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -606,9 +606,7 @@ class record_function(ContextDecorator):
         self.name: str = name
         # Whether or not we should run record function's end callbacks when exiting.
         self.run_callbacks_on_exit: bool = True
-        # Stores underlying RecordFunction as a tensor. TODO: move to custom
-        # class (https://github.com/pytorch/pytorch/issues/35026).
-        self.handle: torch.Tensor = torch.zeros(1)
+        self.handle: torch.classes.profiler._RecordFunctionHolder()
 
     def __enter__(self):
         self.handle = torch.ops.profiler._record_function_enter(self.name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60720 bowang test change
* **#60719 This is first attempt to get rid of cpp_custom_type_hack.**

To minimize the change, main changes:
1) Introduce RecordFunctionHolder and make it visible in Python.
2) modify record_function_enter return type from the hacky Tensor to RecordFunctionHolder
3) modify record_function_exit to take RecordFunctionHolder (instead of Tensor)

Alternative:
- In profiler, $ holder = torch.classes.profiler._RecordFunctionHolder()
- use holder.enter(name) and holder.exit()
- didn't choose b/c there are quite a few places which depend on current record_function_enter/exit ops

Follow up:
- merge record_function_enter_new and record_function_enter
- merge record_function_exit_new and record_function_exit
- modify C++ references of those two functions to use the clean interface.
- get rid of cpp_custom_type_hack.

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: