### PR TITLE
Update dataloader.py

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1134,7 +1134,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             if success:
                 return data
             else:
-                raise RuntimeError('DataLoader timed out after {} seconds'.format(self._timeout))
+                raise TimeoutError('DataLoader timed out after {} seconds'.format(self._timeout))
         elif self._pin_memory:
             while self._pin_memory_thread.is_alive():
                 success, data = self._try_get_data()


### PR DESCRIPTION

I have dataloaders that stream tensors from the internet.

Sometimes the daemons they communicate with are unresponsive towards a specific worker, and the worker can timeout.

I would like to handle these errors by resetting the dataloader to allow models to continue, however the class of error is not specifically defined in this version of Pytorch, and it instead uses a generic Runtime Error, 

This merge would fix that with the specific TimeoutError exception