### PR TITLE
Fix --dry-run option in tools/linter/clang_tidy.py

### DIFF
--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -377,6 +377,8 @@ def main() -> None:
                 shutil.copyfile(fname, mapped_fname)
 
     pwd = os.getcwd() + "/"
+    if options.dry_run:
+        print(clang_tidy_output)
     for line in clang_tidy_output.splitlines():
         if line.startswith(pwd):
             print(line[len(pwd):])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60745 Add -I<directory> option to tools/linter/clang_tidy.py
* #60744 Add --print-include-paths option to tools/linter/clang_tidy.py
* **#60743 Fix --dry-run option in tools/linter/clang_tidy.py**

Fixes #60741

Test Plan:

Run this command:
```
python3 tools/linter/clang_tidy.py --paths torch/csrc/fx --dry-run
```
Output:
```
clang-tidy -p build -config '{"InheritParentConfig": true, "Checks": " bugprone-*, -bugprone-forward-declaration-namespace, -bugprone-macro-parentheses, -bugprone-lambda-function-name, -bugprone-reserved-identifier, cppcoreguidelines-*, -cppcoreguidelines-avoid-magic-numbers, -cppcoreguidelines-interfaces-global-init, -cppcoreguidelines-macro-usage, -cppcoreguidelines-owning-memory, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-type-cstyle-cast, -cppcoreguidelines-pro-type-reinterpret-cast, -cppcoreguidelines-pro-type-static-cast-downcast, -cppcoreguidelines-pro-type-union-access, -cppcoreguidelines-pro-type-vararg, -cppcoreguidelines-special-member-functions, -facebook-hte-RelativeInclude, hicpp-exception-baseclass, hicpp-avoid-goto, modernize-*, -modernize-concat-nested-namespaces, -modernize-return-braced-init-list, -modernize-use-auto, -modernize-use-default-member-init, -modernize-use-using, -modernize-use-trailing-return-type, performance-*, -performance-noexcept-move-constructor, -performance-unnecessary-value-param, ", "HeaderFilterRegex": "torch/csrc/.*", "AnalyzeTemporaryDtors": false, "CheckOptions": null}' torch/csrc/fx/fx_init.cpp
```

Differential Revision: [D29394538](https://our.internmc.facebook.com/intern/diff/D29394538)