### PR TITLE
Add --print-include-paths option to tools/linter/clang_tidy.py

### DIFF
--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -201,6 +201,9 @@ def run_clang_tidy(options: Any, line_filters: List[Dict[str, Any]], files: Iter
         with open(options.config_file) as config:
             # Here we convert the YAML config file to a JSON blob.
             command += ["-config", json.dumps(yaml.load(config, Loader=yaml.SafeLoader))]
+    if options.print_include_paths:
+        command += ["--extra-arg", "-v"]
+
     command += options.extra_args
 
     if line_filters:
@@ -324,6 +327,11 @@ def parse_options() -> Any:
         "--parallel",
         action="store_true",
         help="Run clang tidy in parallel per-file (requires ninja to be installed).",
+    )
+    parser.add_argument(
+        "--print-include-paths",
+        action="store_true",
+        help="Print the search paths used for include directives"
     )
     parser.add_argument("-s", "--suppress-diagnostics", action="store_true",
                         help="Add NOLINT to suppress clang-tidy violations")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60745 Add -I<directory> option to tools/linter/clang_tidy.py
* **#60744 Add --print-include-paths option to tools/linter/clang_tidy.py**
* #60743 Fix --dry-run option in tools/linter/clang_tidy.py

Fixes #60739

Test Plan:

Run this comand:
```
python3 tools/linter/clang_tidy.py --paths torch/csrc/fx --print-include-paths
```

Output (varies from machine to machine):
```
(clang-tidy output)
.
.
.

clang -cc1 version 11.0.0 based upon LLVM 11.0.0 default target x86_64-unknown-linux-gnu
ignoring nonexistent directory "nccl/include"
ignoring nonexistent directory "/include"
ignoring duplicate directory ".."
ignoring duplicate directory "../aten/src"
ignoring duplicate directory "../third_party/onnx"
ignoring duplicate directory ".."
ignoring duplicate directory ".."
ignoring duplicate directory "../torch/lib"
ignoring duplicate directory "../torch/../third_party/gloo"
  as it is a non-system directory that duplicates a system directory
ignoring duplicate directory "../third_party/ideep/mkl-dnn/src/../include"
  as it is a non-system directory that duplicates a system directory
#include "..." search starts here:
#include <...> search starts here:
 aten/src
 ../aten/src
 .
 ..
 ../cmake/../third_party/benchmark/include
 caffe2/contrib/aten
 ../third_party/onnx
 third_party/onnx
 ../third_party/foxi
 third_party/foxi
 ../torch/../aten/src/TH
 caffe2/aten/src
 third_party
 ../torch/../third_party/valgrind-headers
 ../torch/csrc
 ../torch/csrc/api/include
 ../torch/lib
 ../torch/lib/libshm
 ../torch/csrc/api
 third_party/ideep/mkl-dnn/include
 ../third_party/fmt/include
 third_party/gloo
 ../torch/../third_party/gloo
 ../cmake/../third_party/googletest/googlemock/include
 ../cmake/../third_party/googletest/googletest/include
 ../third_party/protobuf/src
 /data/users/eltonpinto/miniconda3/envs/pytorch/include
 ../third_party/gemmlowp
 ../third_party/neon2sse
 ../third_party/XNNPACK/include
 ../third_party
 ../cmake/../third_party/eigen
 /home/eltonpinto/local/miniconda3/envs/pytorch/include/python3.8
 /home/eltonpinto/local/miniconda3/envs/pytorch/lib/python3.8/site-packages/numpy/core/include
 ../cmake/../third_party/pybind11/include
 /usr/local/cuda-11.3/include
 ../third_party/ideep/mkl-dnn/src/../include
 ../third_party/ideep/include
 /usr/lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8
 /usr/lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/x86_64-redhat-linux
 /usr/lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/backward
 /usr/local/include
 /usr/lib64/clang/11.0.0/include
 /usr/include

.
.
.
(more clang-tidy output)
```

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)

Differential Revision: [D29395398](https://our.internmc.facebook.com/intern/diff/D29395398)