### PR TITLE
Add -I<directory> option to tools/linter/clang_tidy.py

### DIFF
--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -203,6 +203,9 @@ def run_clang_tidy(options: Any, line_filters: List[Dict[str, Any]], files: Iter
             command += ["-config", json.dumps(yaml.load(config, Loader=yaml.SafeLoader))]
     if options.print_include_paths:
         command += ["--extra-arg", "-v"]
+    if options.include_dir:
+        for dir in options.include_dir:
+            command += ["--extra-arg", f"-I{dir}"]
 
     command += options.extra_args
 
@@ -332,6 +335,12 @@ def parse_options() -> Any:
         "--print-include-paths",
         action="store_true",
         help="Print the search paths used for include directives"
+    )
+    parser.add_argument(
+        "-I",
+        "--include-dir",
+        action="append",
+        help="Add the specified directory to the search path for include files",
     )
     parser.add_argument("-s", "--suppress-diagnostics", action="store_true",
                         help="Add NOLINT to suppress clang-tidy violations")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60745 Add -I<directory> option to tools/linter/clang_tidy.py**
* #60744 Add --print-include-paths option to tools/linter/clang_tidy.py
* #60743 Fix --dry-run option in tools/linter/clang_tidy.py

Fixes #60739 

Test Plan:

Run this command:
```
python3 tools/linter/clang_tidy.py --paths torch/csrc/fx -I/usr/include/path -I/usr/include/another/path --print-include-paths
```

Output:

If the paths don't exist, you should see this:
```
ignoring nonexistent directory "/usr/include/path"
ignoring nonexistent directory "/usr/include/another/path"
```

If the paths exist, you should see them listed.

Differential Revision: [D29395227](https://our.internmc.facebook.com/intern/diff/D29395227)