### PR TITLE
[cuDNN v8 API] cuDNN benchmark, convolution bwd / transposed convolution fwd, `bfloat16`, conv-bias-activation fusion

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -18,6 +18,8 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
     return CUDNN_DATA_HALF;
   } else if (scalar_type == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
+  } else if (scalar_type == at::kBFloat16) {
+    return CUDNN_DATA_BFLOAT16;
   }
   throw std::runtime_error("TensorDescriptor only supports double, float and half tensors");
 }
@@ -73,6 +75,8 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
       return "CUDNN_DATA_DOUBLE";
     case CUDNN_DATA_HALF:
       return "CUDNN_DATA_HALF";
+    case CUDNN_DATA_BFLOAT16:
+      return "CUDNN_DATA_BFLOAT16";
     case CUDNN_DATA_INT8:
       return "CUDNN_DATA_INT8";
     case CUDNN_DATA_INT32:

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -18,10 +18,11 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
     return CUDNN_DATA_HALF;
   } else if (scalar_type == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
+  }
 #ifdef USE_CUDA
 #if AT_CUDNN_ENABLED()
 #if HAS_CUDNN_V8()
-  } else if (scalar_type == at::kBFloat16) {
+    else if (scalar_type == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   }
 #endif

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -18,9 +18,11 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
     return CUDNN_DATA_HALF;
   } else if (scalar_type == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
+#if HAS_CUDNN_V8()
   } else if (scalar_type == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   }
+#endif
   throw std::runtime_error("TensorDescriptor only supports double, float and half tensors");
 }
 
@@ -75,8 +77,10 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
       return "CUDNN_DATA_DOUBLE";
     case CUDNN_DATA_HALF:
       return "CUDNN_DATA_HALF";
+#if HAS_CUDNN_V8()
     case CUDNN_DATA_BFLOAT16:
       return "CUDNN_DATA_BFLOAT16";
+#endif
     case CUDNN_DATA_INT8:
       return "CUDNN_DATA_INT8";
     case CUDNN_DATA_INT32:

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -19,14 +19,10 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
   } else if (scalar_type == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
   }
-#ifdef USE_CUDA
-#if AT_CUDNN_ENABLED()
-#if HAS_CUDNN_V8()
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8200
     else if (scalar_type == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   }
-#endif
-#endif
 #endif
   throw std::runtime_error("TensorDescriptor only supports double, float and half tensors");
 }
@@ -82,13 +78,9 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
       return "CUDNN_DATA_DOUBLE";
     case CUDNN_DATA_HALF:
       return "CUDNN_DATA_HALF";
-#ifdef USE_CUDA
-#if AT_CUDNN_ENABLED()
-#if HAS_CUDNN_V8()
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8200
     case CUDNN_DATA_BFLOAT16:
       return "CUDNN_DATA_BFLOAT16";
-#endif
-#endif
 #endif
     case CUDNN_DATA_INT8:
       return "CUDNN_DATA_INT8";

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -18,10 +18,12 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
     return CUDNN_DATA_HALF;
   } else if (scalar_type == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
+#ifdef USE_CUDA
 #if HAS_CUDNN_V8()
   } else if (scalar_type == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   }
+#endif
 #endif
   throw std::runtime_error("TensorDescriptor only supports double, float and half tensors");
 }
@@ -77,9 +79,11 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
       return "CUDNN_DATA_DOUBLE";
     case CUDNN_DATA_HALF:
       return "CUDNN_DATA_HALF";
+#ifdef USE_CUDA
 #if HAS_CUDNN_V8()
     case CUDNN_DATA_BFLOAT16:
       return "CUDNN_DATA_BFLOAT16";
+#endif
 #endif
     case CUDNN_DATA_INT8:
       return "CUDNN_DATA_INT8";

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -19,10 +19,12 @@ inline cudnnDataType_t getDataType(const at::Tensor& t) {
   } else if (scalar_type == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
 #ifdef USE_CUDA
+#if AT_CUDNN_ENABLED()
 #if HAS_CUDNN_V8()
   } else if (scalar_type == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   }
+#endif
 #endif
 #endif
   throw std::runtime_error("TensorDescriptor only supports double, float and half tensors");
@@ -80,9 +82,11 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
     case CUDNN_DATA_HALF:
       return "CUDNN_DATA_HALF";
 #ifdef USE_CUDA
+#if AT_CUDNN_ENABLED()
 #if HAS_CUDNN_V8()
     case CUDNN_DATA_BFLOAT16:
       return "CUDNN_DATA_BFLOAT16";
+#endif
 #endif
 #endif
     case CUDNN_DATA_INT8:

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -21,6 +21,7 @@ std::string cudnnTypeToString(cudnnDataType_t dtype);
 inline int dataSize(cudnnDataType_t dataType)
 {
   switch (dataType) {
+    case CUDNN_DATA_BFLOAT16:
     case CUDNN_DATA_HALF: return 2;
     case CUDNN_DATA_FLOAT: return 4;
     default: return 8;

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -21,7 +21,9 @@ std::string cudnnTypeToString(cudnnDataType_t dtype);
 inline int dataSize(cudnnDataType_t dataType)
 {
   switch (dataType) {
+#if HAS_CUDNN_V8()
     case CUDNN_DATA_BFLOAT16:
+#endif
     case CUDNN_DATA_HALF: return 2;
     case CUDNN_DATA_FLOAT: return 4;
     default: return 8;

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -12,6 +12,13 @@
 #include <ATen/cuda/ATenCUDAGeneral.h>
 #include <cuda.h>
 
+#ifdef USE_CUDA
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#if AT_CUDNN_ENABLED()
+#include <ATen/native/cudnn/Macros.h> // for the definition of HAS_CUDNN_V8
+#endif
+#endif
+
 namespace at { namespace native {
 
 std::string cudnnTypeToString(cudnnDataType_t dtype);
@@ -21,8 +28,10 @@ std::string cudnnTypeToString(cudnnDataType_t dtype);
 inline int dataSize(cudnnDataType_t dataType)
 {
   switch (dataType) {
+#ifdef USE_CUDA
 #if HAS_CUDNN_V8()
     case CUDNN_DATA_BFLOAT16:
+#endif
 #endif
     case CUDNN_DATA_HALF: return 2;
     case CUDNN_DATA_FLOAT: return 4;

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -12,13 +12,6 @@
 #include <ATen/cuda/ATenCUDAGeneral.h>
 #include <cuda.h>
 
-#ifdef USE_CUDA
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
-#if AT_CUDNN_ENABLED()
-#include <ATen/native/cudnn/Macros.h> // for the definition of HAS_CUDNN_V8
-#endif
-#endif
-
 namespace at { namespace native {
 
 std::string cudnnTypeToString(cudnnDataType_t dtype);
@@ -28,12 +21,8 @@ std::string cudnnTypeToString(cudnnDataType_t dtype);
 inline int dataSize(cudnnDataType_t dataType)
 {
   switch (dataType) {
-#ifdef USE_CUDA
-#if AT_CUDNN_ENABLED()
-#if HAS_CUDNN_V8()
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8200
     case CUDNN_DATA_BFLOAT16:
-#endif
-#endif
 #endif
     case CUDNN_DATA_HALF: return 2;
     case CUDNN_DATA_FLOAT: return 4;

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -29,8 +29,10 @@ inline int dataSize(cudnnDataType_t dataType)
 {
   switch (dataType) {
 #ifdef USE_CUDA
+#if AT_CUDNN_ENABLED()
 #if HAS_CUDNN_V8()
     case CUDNN_DATA_BFLOAT16:
+#endif
 #endif
 #endif
     case CUDNN_DATA_HALF: return 2;

--- a/aten/src/ATen/cudnn/Types.cpp
+++ b/aten/src/ATen/cudnn/Types.cpp
@@ -2,6 +2,13 @@
 
 #include <ATen/ATen.h>
 
+#ifdef USE_CUDA
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#if AT_CUDNN_ENABLED()
+#include <ATen/native/cudnn/Macros.h> // for the definition of HAS_CUDNN_V8
+#endif
+#endif
+
 namespace at { namespace native {
 
 cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
@@ -11,6 +18,9 @@ cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
     return CUDNN_DATA_DOUBLE;
   } else if (dtype == at::kHalf) {
     return CUDNN_DATA_HALF;
+#ifdef USE_CUDA
+#if AT_CUDNN_ENABLED
+#if HAS_CUDNN_V8()
   } else if (dtype == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   } else if (dtype == at::kInt) {
@@ -20,6 +30,9 @@ cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
   } else if (dtype == at::kChar) {
     return CUDNN_DATA_INT8;
   }
+#endif
+#endif
+#endif
   std::string msg("getCudnnDataTypeFromScalarType() not supported for ");
   msg += toString(dtype);
   throw std::runtime_error(msg);

--- a/aten/src/ATen/cudnn/Types.cpp
+++ b/aten/src/ATen/cudnn/Types.cpp
@@ -2,13 +2,6 @@
 
 #include <ATen/ATen.h>
 
-#ifdef USE_CUDA
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
-#if AT_CUDNN_ENABLED()
-#include <ATen/native/cudnn/Macros.h> // for the definition of HAS_CUDNN_V8
-#endif
-#endif
-
 namespace at { namespace native {
 
 cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
@@ -19,9 +12,7 @@ cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
   } else if (dtype == at::kHalf) {
     return CUDNN_DATA_HALF;
   }
-#ifdef USE_CUDA
-#if AT_CUDNN_ENABLED
-#if HAS_CUDNN_V8()
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 8200
   else if (dtype == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   } else if (dtype == at::kInt) {
@@ -31,8 +22,6 @@ cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
   } else if (dtype == at::kChar) {
     return CUDNN_DATA_INT8;
   }
-#endif
-#endif
 #endif
   std::string msg("getCudnnDataTypeFromScalarType() not supported for ");
   msg += toString(dtype);

--- a/aten/src/ATen/cudnn/Types.cpp
+++ b/aten/src/ATen/cudnn/Types.cpp
@@ -18,10 +18,11 @@ cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
     return CUDNN_DATA_DOUBLE;
   } else if (dtype == at::kHalf) {
     return CUDNN_DATA_HALF;
+  }
 #ifdef USE_CUDA
 #if AT_CUDNN_ENABLED
 #if HAS_CUDNN_V8()
-  } else if (dtype == at::kBFloat16) {
+  else if (dtype == at::kBFloat16) {
     return CUDNN_DATA_BFLOAT16;
   } else if (dtype == at::kInt) {
     return CUDNN_DATA_INT32;

--- a/aten/src/ATen/cudnn/Types.cpp
+++ b/aten/src/ATen/cudnn/Types.cpp
@@ -11,6 +11,8 @@ cudnnDataType_t getCudnnDataTypeFromScalarType(const at::ScalarType dtype) {
     return CUDNN_DATA_DOUBLE;
   } else if (dtype == at::kHalf) {
     return CUDNN_DATA_HALF;
+  } else if (dtype == at::kBFloat16) {
+    return CUDNN_DATA_BFLOAT16;
   } else if (dtype == at::kInt) {
     return CUDNN_DATA_INT32;
   } else if (dtype == at::kByte) {

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -56,6 +56,46 @@ using slow_conv_transpose3d_backward_fn = std::tuple<at::Tensor,at::Tensor,at::T
     at::IntArrayRef, at::IntArrayRef, at::IntArrayRef, std::array<bool,3>);
 DECLARE_DISPATCH(slow_conv_transpose3d_backward_fn, slow_conv_transpose3d_backward_stub);
 
+namespace {
+    int cudnnv8_flag = -1;
+    int cudnnv8_debug = -1;
+    bool cudnnv8_heuristic_mode_b = false;
+    uint8_t cudnnv8_debugcount = 0;
+}
+
+static inline bool cudnnv8_enabled() {
+  if (cudnnv8_flag < 0) {
+    auto val = c10::utils::check_env("CUDNN_V8_API_ENABLED");
+    auto debug_val = c10::utils::check_env("CUDNN_V8_API_DEBUG");
+    auto heuristic_val = c10::utils::check_env("USE_HEURISTIC_MODE_B");
+    if (val == true) {
+      cudnnv8_flag = 1;
+    } else {
+      cudnnv8_flag = 0;
+    }
+    if (debug_val == true) {
+      cudnnv8_debug = 1;
+    } else {
+      cudnnv8_debug = 0;
+    }
+    if (heuristic_val == true) {
+      cudnnv8_heuristic_mode_b = true;
+    }
+  }
+  if (cudnnv8_debug == 1 && cudnnv8_debugcount < 10) {
+    TORCH_WARN("CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);
+    cudnnv8_debugcount++;
+  }
+  return cudnnv8_flag == 1;
+}
+
+static inline bool cudnnv8_b() {
+  if (cudnnv8_flag < 0) {
+    cudnnv8_enabled();
+  }
+  return cudnnv8_heuristic_mode_b;
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct ConvParams {
   std::vector<int64_t> stride;

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -65,7 +65,7 @@ static inline bool cudnnv8_enabled_check_debug() {
   static bool cudnnv8_debug = c10::utils::check_env("TORCH_CUDNN_V8_API_DEBUG") == true ? true : false;
   static uint8_t cudnnv8_debugcount = 0;
   if (cudnnv8_debug == 1 && cudnnv8_debugcount < 10) {
-    TORCH_WARN("TORCH_CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " TORHC_CUDNN_USE_HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);
+    TORCH_WARN("TORCH_CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " TORCH_CUDNN_USE_HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);
     cudnnv8_debugcount++;
   }
   return cudnnv8_flag == 1;

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -57,12 +57,12 @@ using slow_conv_transpose3d_backward_fn = std::tuple<at::Tensor,at::Tensor,at::T
 DECLARE_DISPATCH(slow_conv_transpose3d_backward_fn, slow_conv_transpose3d_backward_stub);
 
 namespace {
-  static bool cudnnv8_heuristic_mode_b = c10::utils::check_env("TORCH_CUDNN_USE_HEURISTIC_MODE_B");
+  static bool cudnnv8_heuristic_mode_b = c10::utils::check_env("TORCH_CUDNN_USE_HEURISTIC_MODE_B") == true;
 }
 
 static inline bool cudnnv8_enabled_check_debug() {
-  static bool cudnnv8_flag = c10::utils::check_env("TORCH_CUDNN_V8_API_ENABLED");
-  static bool cudnnv8_debug = c10::utils::check_env("TORCH_CUDNN_V8_API_DEBUG");
+  static bool cudnnv8_flag = c10::utils::check_env("TORCH_CUDNN_V8_API_ENABLED") == true;
+  static bool cudnnv8_debug = c10::utils::check_env("TORCH_CUDNN_V8_API_DEBUG") == true;
   static uint8_t cudnnv8_debugcount = 0;
   if (cudnnv8_debug == 1 && cudnnv8_debugcount < 10) {
     TORCH_WARN("TORCH_CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " TORCH_CUDNN_USE_HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -57,12 +57,12 @@ using slow_conv_transpose3d_backward_fn = std::tuple<at::Tensor,at::Tensor,at::T
 DECLARE_DISPATCH(slow_conv_transpose3d_backward_fn, slow_conv_transpose3d_backward_stub);
 
 namespace {
-  static bool cudnnv8_heuristic_mode_b = c10::utils::check_env("TORCH_CUDNN_USE_HEURISTIC_MODE_B") == true ? true : false;
+  static bool cudnnv8_heuristic_mode_b = c10::utils::check_env("TORCH_CUDNN_USE_HEURISTIC_MODE_B");
 }
 
 static inline bool cudnnv8_enabled_check_debug() {
-  static bool cudnnv8_flag = c10::utils::check_env("TORCH_CUDNN_V8_API_ENABLED") == true ? true : false;
-  static bool cudnnv8_debug = c10::utils::check_env("TORCH_CUDNN_V8_API_DEBUG") == true ? true : false;
+  static bool cudnnv8_flag = c10::utils::check_env("TORCH_CUDNN_V8_API_ENABLED");
+  static bool cudnnv8_debug = c10::utils::check_env("TORCH_CUDNN_V8_API_DEBUG");
   static uint8_t cudnnv8_debugcount = 0;
   if (cudnnv8_debug == 1 && cudnnv8_debugcount < 10) {
     TORCH_WARN("TORCH_CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " TORCH_CUDNN_USE_HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -57,42 +57,21 @@ using slow_conv_transpose3d_backward_fn = std::tuple<at::Tensor,at::Tensor,at::T
 DECLARE_DISPATCH(slow_conv_transpose3d_backward_fn, slow_conv_transpose3d_backward_stub);
 
 namespace {
-    int cudnnv8_flag = -1;
-    int cudnnv8_debug = -1;
-    bool cudnnv8_heuristic_mode_b = false;
-    uint8_t cudnnv8_debugcount = 0;
+  static bool cudnnv8_heuristic_mode_b = c10::utils::check_env("TORCH_CUDNN_USE_HEURISTIC_MODE_B") == true ? true : false;
 }
 
-static inline bool cudnnv8_enabled() {
-  if (cudnnv8_flag < 0) {
-    auto val = c10::utils::check_env("CUDNN_V8_API_ENABLED");
-    auto debug_val = c10::utils::check_env("CUDNN_V8_API_DEBUG");
-    auto heuristic_val = c10::utils::check_env("USE_HEURISTIC_MODE_B");
-    if (val == true) {
-      cudnnv8_flag = 1;
-    } else {
-      cudnnv8_flag = 0;
-    }
-    if (debug_val == true) {
-      cudnnv8_debug = 1;
-    } else {
-      cudnnv8_debug = 0;
-    }
-    if (heuristic_val == true) {
-      cudnnv8_heuristic_mode_b = true;
-    }
-  }
+static inline bool cudnnv8_enabled_check_debug() {
+  static bool cudnnv8_flag = c10::utils::check_env("TORCH_CUDNN_V8_API_ENABLED") == true ? true : false;
+  static bool cudnnv8_debug = c10::utils::check_env("TORCH_CUDNN_V8_API_DEBUG") == true ? true : false;
+  static uint8_t cudnnv8_debugcount = 0;
   if (cudnnv8_debug == 1 && cudnnv8_debugcount < 10) {
-    TORCH_WARN("CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);
+    TORCH_WARN("TORCH_CUDNN_V8_DEBUG ON, V8_FLAG: ", cudnnv8_flag, " TORHC_CUDNN_USE_HEURISTIC_MODE B: ", cudnnv8_heuristic_mode_b);
     cudnnv8_debugcount++;
   }
   return cudnnv8_flag == 1;
 }
 
-static inline bool cudnnv8_b() {
-  if (cudnnv8_flag < 0) {
-    cudnnv8_enabled();
-  }
+static inline bool cudnnv8_use_heur_mode_b() {
   return cudnnv8_heuristic_mode_b;
 }
 

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -190,8 +190,8 @@ auto ConvParams::use_cudnn(const at::Tensor& input, const at::Tensor& weight) co
   if (!input.is_cuda() || !cudnn_enabled) {
     return false;
   }
-  if (input.scalar_type() == at::kBFloat16 || weight.scalar_type() == at::kBFloat16) {
-    return false;
+  if (input.scalar_type() == at::kBFloat16 || weight.scalar_type() == at::kBFloat16)  {
+    return at::native::cudnnv8_enabled();
   }
   if (cudnn_conv_suggest_memory_format(input, weight) == at::MemoryFormat::Contiguous) {
     // bypass dilation checks for channels_last convolution

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -19,13 +19,6 @@
 #include <nnpack.h>
 #endif
 
-#ifdef USE_CUDA
-#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
-#if AT_CUDNN_ENABLED()
-#include <ATen/native/cudnn/Macros.h>
-#endif
-#endif
-
 constexpr int MIOPEN_DIM_MAX = 5;
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -189,7 +189,7 @@ auto ConvParams::use_cudnn(const at::Tensor& input, const at::Tensor& weight) co
   }
   if (!input.is_cuda() || !cudnn_enabled) {
     return false;
-  }
+  } 
   if (input.scalar_type() == at::kBFloat16 || weight.scalar_type() == at::kBFloat16) {
     return false;
   }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -19,6 +19,11 @@
 #include <nnpack.h>
 #endif
 
+#include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
+#if AT_CUDNN_ENABLED()
+#include <ATen/native/cudnn/Macros.h>
+#endif
+
 constexpr int MIOPEN_DIM_MAX = 5;
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -189,7 +189,7 @@ auto ConvParams::use_cudnn(const at::Tensor& input, const at::Tensor& weight) co
   }
   if (!input.is_cuda() || !cudnn_enabled) {
     return false;
-  } 
+  }
   if (input.scalar_type() == at::kBFloat16 || weight.scalar_type() == at::kBFloat16) {
     return false;
   }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -191,7 +191,7 @@ auto ConvParams::use_cudnn(const at::Tensor& input, const at::Tensor& weight) co
     return false;
   }
   if (input.scalar_type() == at::kBFloat16 || weight.scalar_type() == at::kBFloat16)  {
-    return at::native::cudnnv8_enabled();
+    return at::native::cudnnv8_enabled_check_debug();
   }
   if (cudnn_conv_suggest_memory_format(input, weight) == at::MemoryFormat::Contiguous) {
     // bypass dilation checks for channels_last convolution

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -19,9 +19,11 @@
 #include <nnpack.h>
 #endif
 
+#ifdef USE_CUDA
 #include <ATen/cuda/CUDAConfig.h>  // for the definition of AT_CUDNN_ENABLED
 #if AT_CUDNN_ENABLED()
 #include <ATen/native/cudnn/Macros.h>
+#endif
 #endif
 
 constexpr int MIOPEN_DIM_MAX = 5;

--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -555,6 +555,11 @@ Tensor cudnn_convolution_add_relu(
   auto memory_format = cudnn_conv_suggest_memory_format(input_t, weight_t);
   const Tensor input = input_t.contiguous(memory_format);
   const Tensor weight = weight_t.contiguous(memory_format);
+  Tensor z = z_t;
+  if (z.suggest_memory_format() != memory_format) {
+    z = z.to(memory_format);
+  }
+  z = z.contiguous(memory_format);
 
   // FuseFrozenConvAddRelu performs some tensor shape checking
   Tensor output_t = at::detail::empty_cuda(
@@ -583,7 +588,7 @@ Tensor cudnn_convolution_add_relu(
       output_t,
       input,
       weight,
-      z_t,
+      z,
       _alpha,
       _bias,
       stride,
@@ -599,7 +604,7 @@ Tensor cudnn_convolution_add_relu(
       output_t,
       input,
       weight,
-      z_t,
+      z,
       _alpha,
       _bias,
       stride,

--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -494,6 +494,7 @@ Tensor cudnn_convolution_relu(
   }
 
   auto& ctx = at::globalContext();
+  bool benchmark = ctx.benchmarkCuDNN();
   bool allow_tf32 = ctx.allowTF32CuDNN();
   auto _bias = bias_t.has_value()
           ? bias_t.value()
@@ -516,7 +517,7 @@ Tensor cudnn_convolution_relu(
       padding,
       dilation,
       groups,
-      false, // benchmark
+      benchmark, // benchmark
       false, // deterministic
       allow_tf32  // allow_tf32
   );
@@ -532,7 +533,7 @@ Tensor cudnn_convolution_relu(
       padding,
       dilation,
       groups,
-      false, // benchmark
+      benchmark, // benchmark
       false, // deterministic
       allow_tf32  // allow_tf32
   );
@@ -566,6 +567,7 @@ Tensor cudnn_convolution_add_relu(
 
   auto& ctx = at::globalContext();
   bool allow_tf32 = ctx.allowTF32CuDNN();
+  bool benchmark = ctx.benchmarkCuDNN();
   auto _alpha = alpha.has_value() ? alpha.value().to<float>() : 1.0;
   auto _bias = bias_t.has_value()
           ? bias_t.value()
@@ -588,7 +590,7 @@ Tensor cudnn_convolution_add_relu(
       padding,
       dilation,
       groups,
-      false, // benchmark
+      benchmark,
       false, // deterministic
       allow_tf32  // allow_tf32
   );
@@ -604,7 +606,7 @@ Tensor cudnn_convolution_add_relu(
       padding,
       dilation,
       groups,
-      false, // benchmark
+      benchmark,
       false, // deterministic
       allow_tf32  // allow_tf32
   );

--- a/aten/src/ATen/native/cudnn/ConvShared.h
+++ b/aten/src/ATen/native/cudnn/ConvShared.h
@@ -105,4 +105,43 @@ void raw_cudnn_convolution_add_relu_fallback_out(
     bool benchmark,
     bool deterministic,
     bool allow_tf32);
+
+
+#if AT_CUDNN_ENABLED()
+#include <ATen/native/cudnn/Macros.h>
+
+#if HAS_CUDNN_V8()
+void raw_cudnn_convolution_forward_out_v7(
+    const Tensor& output, const Tensor& input, const Tensor& weight,
+    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
+    bool benchmark, bool deterministic, bool allow_tf32);
+
+void raw_cudnn_convolution_backward_input_out_v7(
+    const at::Tensor& grad_input,
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
+    bool benchmark, bool deterministic, bool allow_tf32);
+
+void raw_cudnn_convolution_backward_weight_out_v7(
+    const Tensor& grad_weight, const Tensor& grad_output, const Tensor& input,
+    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
+    bool benchmark, bool deterministic, bool allow_tf32);
+
+void raw_cudnn_convolution_add_relu_out_v7(
+    const Tensor& output,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& z,
+    float alpha,
+    const Tensor& bias,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    bool allow_tf32);
+#endif
+#endif
 }}

--- a/aten/src/ATen/native/cudnn/ConvShared.h
+++ b/aten/src/ATen/native/cudnn/ConvShared.h
@@ -111,6 +111,11 @@ void raw_cudnn_convolution_add_relu_fallback_out(
 #include <ATen/native/cudnn/Macros.h>
 
 #if HAS_CUDNN_V8()
+// v7 functions are preserved here to allow for runtime switching to v7
+// (e.g., TORCH_CUDNN_V8_API_ENABLED=0).
+// Note that v7 forward/backward out can have different behavior from the v8
+// versions, as v7 explicitly splits large tensors as a 32-bit indexing
+// workaround whereas v8 expects cuDNN to handle large tensors.
 void raw_cudnn_convolution_forward_out_v7(
     const Tensor& output, const Tensor& input, const Tensor& weight,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -619,8 +619,6 @@ if (args.params.dataType == CUDNN_DATA_FLOAT) {                                 
 //
 // ---------------------------------------------------------------------
 
-#if !HAS_CUDNN_V8()
-
 void raw_cudnn_convolution_forward_out_32bit(
     const Tensor& output, const Tensor& input, const Tensor& weight,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
@@ -666,7 +664,12 @@ void raw_cudnn_convolution_forward_out_32bit(
   );
 }
 
+
+#if !HAS_CUDNN_V8()
 void raw_cudnn_convolution_forward_out(
+#else
+void raw_cudnn_convolution_forward_out_v7(
+#endif
     const Tensor& output, const Tensor& input, const Tensor& weight,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32) {
@@ -724,7 +727,11 @@ void raw_cudnn_convolution_backward_input_out_32bit(
   );
 }
 
+#if !HAS_CUDNN_V8()
 void raw_cudnn_convolution_backward_input_out(
+#else
+void raw_cudnn_convolution_backward_input_out_v7(
+#endif
     const at::Tensor& grad_input,
     const at::Tensor& grad_output,
     const at::Tensor& weight,
@@ -783,7 +790,11 @@ void raw_cudnn_convolution_backward_weight_out_32bit(
   );
 }
 
+#if !HAS_CUDNN_V8()
 void raw_cudnn_convolution_backward_weight_out(
+#else
+void raw_cudnn_convolution_backward_weight_out_v7(
+#endif
     const Tensor& grad_weight, const Tensor& grad_output, const Tensor& input,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32) {
@@ -834,8 +845,6 @@ void raw_cudnn_convolution_backward_weight_out(
   // Considering the complexity of this issue, it is better not to use cuDNN for this case
   TORCH_INTERNAL_ASSERT(false, "This case should not be dispatched to cuDNN.");
 }
-
-#endif // !HAS_CUDNN_V8()
 
 void raw_cudnn_convolution_add_relu_out(
     const Tensor& output,

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -673,8 +673,6 @@ void raw_cudnn_convolution_forward_out(
   split_batch_dim_to_32bit_out(output, input, weight, padding, stride, dilation, groups, benchmark, deterministic, allow_tf32, 1024 * 1024 * 256, raw_cudnn_convolution_forward_out_32bit);
 }
 
-#endif // !HAS_CUDNN_V8()
-
 // ---------------------------------------------------------------------
 //
 // Convolution backward / Transposed convolution forward
@@ -836,6 +834,8 @@ void raw_cudnn_convolution_backward_weight_out(
   // Considering the complexity of this issue, it is better not to use cuDNN for this case
   TORCH_INTERNAL_ASSERT(false, "This case should not be dispatched to cuDNN.");
 }
+
+#endif // !HAS_CUDNN_V8()
 
 void raw_cudnn_convolution_add_relu_out(
     const Tensor& output,

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -846,7 +846,12 @@ void raw_cudnn_convolution_backward_weight_out_v7(
   TORCH_INTERNAL_ASSERT(false, "This case should not be dispatched to cuDNN.");
 }
 
+#if !HAS_CUDNN_V8()
 void raw_cudnn_convolution_add_relu_out(
+#else
+void raw_cudnn_convolution_add_relu_out_v7(
+#endif
+
     const Tensor& output,
     const Tensor& input,
     const Tensor& weight,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -26,7 +26,7 @@ namespace {
 uint8_t getAlignment(const Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
-  uint64_t address = reinterpret_cast<uint64_t>(t.data_ptr());
+  uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());
   while (address % alignment == 0 && alignment < 16) alignment *= 2;
   return alignment;
 }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -182,7 +182,7 @@ void raw_cudnn_convolution_forward_out(
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32)
 {
-  if (y.numel() > 0) {
+  if (output.numel() > 0) {
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR,
       input, output, weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);
@@ -195,7 +195,7 @@ void raw_cudnn_convolution_backward_input_out(
     const at::Tensor& weight,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32) {
-  if (x.numel() > 0) {
+  if (grad_input.numel() > 0) {
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR,
       grad_input, grad_output, weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);
@@ -206,7 +206,7 @@ void raw_cudnn_convolution_backward_weight_out(
     const Tensor& grad_weight, const Tensor& grad_output, const Tensor& input,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32) {
-  if (w.numel() > 0) {
+  if (grad_weight.numel() > 0) {
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR,
       input, grad_output, grad_weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -112,7 +112,7 @@ void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const
 }
 
 auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, CacheKey key, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, bool deterministic, bool allow_tf32) {
-   auto op = cudnn_frontend::OperationBuilder(desc)
+  auto op = cudnn_frontend::OperationBuilder(desc)
       .setxDesc(getTensorDescriptor(x, 'x', key.x_alignment))
       .setyDesc(getTensorDescriptor(y, 'y', key.y_alignment))
       .setwDesc(getTensorDescriptor(w, 'w', key.w_alignment))
@@ -123,7 +123,6 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
       .setHandle(handle)
       .setOperationGraph(1, ops.data())
       .build();
-
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w'};
   auto variantPack  = cudnn_frontend::VariantPackBuilder().setDataPointers(3, data_ptrs).setUids(3, uids).build();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -174,7 +174,7 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
   for (auto& option : options) {
     plans.emplace_back(std::move(option.plan));
   }
-  return plans; 
+  return plans;
 }
 
 auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, const CacheKey& key, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, bool deterministic, bool allow_tf32) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -162,8 +162,8 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
   for (auto& option : options) {
     plans.emplace_back(std::move(option.plan));
   }
+  std::cout << "find plans: " << plans.size() << std::endl;
   return plans; 
-  //auto tag = options2.front().plan.getTag();
 }
 
 auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, CacheKey key, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, bool deterministic, bool allow_tf32) {
@@ -216,7 +216,7 @@ auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_
   std::array<cudnn_frontend::GeneratorSource const, 2> sources = {heurgen_method, fallback_method};
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   auto plans = generator.cudnnGetPlan(handle, std::move(opGraph), sample_predicate_function);
-  std::cout << plans.size() << std::endl;
+  std::cout << "get plans: " << plans.size() << std::endl;
   return plans;
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -234,17 +234,6 @@ void try_plans(cudnn_frontend::executionPlans_t& plans, const CacheKey& key, con
   TORCH_CHECK(false, "Unable to find an engine to execute this computation");
 }
 
-void try_options(cudnn_frontend::executionOptions_t & options, const CacheKey& key, const cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w) {
-  for (auto& option : options) {
-    try {
-      run_conv_plan(handle, x, y, w, option.plan);
-      engine_cache.emplace(key, std::move(option.plan));
-      return;
-    } catch (cudnn_frontend::cudnnException &e) {} catch(CuDNNError &e) {}
-  }
-  TORCH_CHECK(false, "Unable to find an engine to execute this computation");
-}
-
 void run_single_conv(const cudnnBackendDescriptorType_t operation,
   const Tensor& x, const Tensor& y, const Tensor& w,
   IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -199,7 +199,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   std::for_each(plans.begin(), plans.end(), [&] (cudnn_frontend::ExecutionPlan& plan) {
     size_t curr_workspace_size = plan.getWorkspaceSize();
     if (curr_workspace_size <= max_block_size) {
-      if (curr_workspace_size > max_workspace_size && curr_workspace_size <= max_block_size) {
+      if (curr_workspace_size > max_workspace_size) {
         max_workspace_size = plan.getWorkspaceSize();
       }
       valid_plans.emplace_back(std::move(plan));

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -178,10 +178,6 @@ auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_
       .setHandle(handle)
       .setOperationGraph(1, ops.data())
       .build();
-  auto heuristics = cudnn_frontend::EngineHeuristicsBuilder()
-      .setOperationGraph(opGraph)
-      .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
-      .build();
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w'};
   auto variantPack  = cudnn_frontend::VariantPackBuilder().setDataPointers(3, data_ptrs).setUids(3, uids).build();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -196,7 +196,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   c10::cuda::CUDACachingAllocator::cacheInfo(device, &tmp_bytes, &max_block_size);
   cudnn_frontend::executionPlans_t valid_plans;
 
-  std::for_each(plans.begin(), plans.end(), [&max_workspace_size, &max_block_size, &valid_plans](cudnn_frontend::ExecutionPlan& plan) { 
+  std::for_each(plans.begin(), plans.end(), [&] (cudnn_frontend::ExecutionPlan& plan) {
     size_t curr_workspace_size = plan.getWorkspaceSize();
     if (curr_workspace_size <= max_block_size) {
       if (curr_workspace_size > max_workspace_size && curr_workspace_size <= max_block_size) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -89,7 +89,7 @@ std::unordered_map<CacheKey, cudnn_frontend::ExecutionPlan, ParamsHash<CacheKey>
 
 }
 
-void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, const Tensor& y, const Tensor& x, const Tensor& w, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups, bool deterministic, bool allow_tf32) {
+void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, const Tensor& y, const Tensor& x, const Tensor& w, const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation, int64_t groups, bool deterministic, bool allow_tf32) {
    memset(&key, 0, sizeof(key));
    setConvolutionParams(&key.params, x, w, padding, stride, dilation, groups, deterministic, allow_tf32);
    key.operation = operation;
@@ -98,7 +98,7 @@ void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, c
    key.w_alignment = getAlignment(w);
 }
 
-void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, cudnn_frontend::ExecutionPlan& plan) {
+void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, const cudnn_frontend::ExecutionPlan& plan) {
     auto workspace_size = plan.getWorkspaceSize();
     Tensor workspace;
     workspace = at::empty({workspace_size}, x.options().dtype(kByte));

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -168,7 +168,7 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
 
   std::array<cudnn_frontend::GeneratorSource const, 2> sources = {heurgen_method, fallback_method};
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
-  auto options = generator.cudnnFindPlan<cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE>(handle, std::move(opGraph), variantPack, predicate_function); 
+  auto options = generator.cudnnFindPlan<cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE>(handle, std::move(opGraph), variantPack, predicate_function);
 
   cudnn_frontend::executionPlans_t plans;
   for (auto& option : options) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -159,7 +159,7 @@ const auto get_fallback_method(const cudnn_frontend::OperationGraph &opGraph, co
   auto fallback_method = [&](cudnn_frontend::OperationGraph &opGraph) -> cudnn_frontend::EngineConfigList {
     auto fallback = cudnn_frontend::EngineFallbackListBuilder()
                         .setOperationGraph(opGraph)
-			.setOperation(desc)
+                        .setOperation(desc)
                         .build();
     auto &fallback_list = fallback.getFallbackList();
     cudnn_frontend::EngineConfigList filtered_configs;

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -62,7 +62,7 @@ cudnn_frontend::ConvDesc_v8 getConvDescriptor(cudnnDataType_t dataType, IntArray
     .setPrePadding(convDim, padding.data())
     .setPostPadding(convDim, padding.data())
     .setDilation(convDim, dilation.data());
-  if (scalar_type == kBFloat16) {
+  if (scalar_type == kBFloat16 || scalar_type == kHalf) {
     builder.setDataType(CUDNN_DATA_FLOAT);
   }
   return builder.build();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -295,7 +295,7 @@ auto build_opgraph_fused(const cudnnHandle_t handle, const Tensor & x, const Ten
   const float alpha2 = alpha;
   auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
                    .setxDesc(getTensorDescriptor(x, 'x', key.x_alignment))
-		   // virtual output of conv
+                   // virtual output of conv
                    .setyDesc(getTensorDescriptorWithTypeVirtual(y, 'C', key.y_alignment, precision, true))
                    .setwDesc(getTensorDescriptor(w, 'w', key.w_alignment))
                    .setAlpha(alpha1)
@@ -304,7 +304,7 @@ auto build_opgraph_fused(const cudnnHandle_t handle, const Tensor & x, const Ten
   auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                            .setxDesc(conv_op.getOutputTensor())
                            .setbDesc(getTensorDescriptor(z, 'z', key.z_alignment))
-			   // another virtual output (of add)
+                           // another virtual output (of add)
                            .setyDesc(getTensorDescriptorWithTypeVirtual(y, 'A', key.y_alignment, precision, true))
                            .setpwDesc(addDesc)
                            .setAlpha(alpha1)
@@ -314,13 +314,13 @@ auto build_opgraph_fused(const cudnnHandle_t handle, const Tensor & x, const Ten
   auto add_bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                            .setxDesc(add_op.getOutputTensor())
                            .setbDesc(getTensorDescriptor(b, 'b', key.b_alignment))
-			   // another virtual output (of add bias)
+                           // another virtual output (of add bias)
                            .setyDesc(getTensorDescriptorWithTypeVirtual(y, 'B', key.y_alignment, precision, true))
                            .setpwDesc(addBiasDesc)
                            .build();
   auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                           .setxDesc(add_bias_op.getOutputTensor())
-			  // final output is in original datatype
+                          // final output is in original datatype
                           .setyDesc(getTensorDescriptor(y, 'y', key.y_alignment))
                           .setpwDesc(actDesc)
                           .build();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -69,8 +69,11 @@ uint8_t getAlignment(const Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
   uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());
-  while (address % alignment == 0 && alignment < 128) alignment *= 2;
-  alignment /= 2;
+  for (; alignment < 128; alignment *= 2) {
+    if (address % (alignment * 2)) {
+      return alignment;
+    }
+  }
   return alignment;
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -69,7 +69,8 @@ uint8_t getAlignment(const Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
   uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());
-  while (address % alignment == 0 && alignment < 64) alignment *= 2;
+  while (address % alignment == 0 && alignment < 128) alignment *= 2;
+  alignment /= 2;
   return alignment;
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -644,20 +644,9 @@ void raw_cudnn_convolution_add_relu_out(
       alpha, stride, padding, dilation,
       groups, benchmark, deterministic, allow_tf32);
   } else {
-   raw_cudnn_convolution_add_relu_out_v7(
-   output,
-   input,
-   weight,
-   z,
-   alpha,
-   bias,
-   stride,
-   padding,
-   dilation,
-   groups,
-   benchmark,
-   deterministic,
-   allow_tf32);
+   raw_cudnn_convolution_add_relu_out_v7(output, input, weight, z,
+                                         alpha, bias, stride, padding, dilation,
+                                         groups, benchmark, deterministic, allow_tf32);
   }
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -256,7 +256,7 @@ auto build_opgraph_fused(const cudnnHandle_t handle, const Tensor & x, const Ten
   auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                            .setxDesc(conv_op.getOutputTensor())
                            .setbDesc(getTensorDescriptor(z, 'z', key.z_alignment))
-			   // TODO: is reusing y's alignment good here?
+                           // TODO: is reusing y's alignment good here?
                            .setyDesc(getTensorDescriptor(y, 'A', key.y_alignment))
                            .setpwDesc(addDesc)
                            .setAlpha(alpha1)
@@ -266,7 +266,7 @@ auto build_opgraph_fused(const cudnnHandle_t handle, const Tensor & x, const Ten
   auto add_bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                            .setxDesc(add_op.getOutputTensor())
                            .setbDesc(getTensorDescriptor(b, 'b', key.b_alignment))
-			   // TODO: is reusing y's alignment good here?
+                           // TODO: is reusing y's alignment good here?
                            .setyDesc(getTensorDescriptor(y, 'B', key.y_alignment))
                            .setpwDesc(addBiasDesc)
                            .build();
@@ -300,7 +300,7 @@ const auto get_generator_sources(/*const cudnnBackendDescriptorType_t& desc,*/ c
     auto fallback = cudnn_frontend::EngineFallbackListBuilder()
                         .setOperationGraph(opGraph)
                         //.setOperation(desc)
-			//.setOperation(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                        //.setOperation(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
                         .build();
     auto &fallback_list = fallback.getFallbackList();
     cudnn_frontend::EngineConfigList filtered_configs;
@@ -387,8 +387,8 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
 auto get_plans_from_find_fused(const cudnnHandle_t handle,
                                const Tensor& x, const Tensor& y, const Tensor& w, const Tensor& z, const Tensor& b,
                                const float alpha, const CacheKeyFused& key,
- 		               const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation,
- 			       const bool deterministic, const bool allow_tf32) {
+                               const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation,
+                               const bool deterministic, const bool allow_tf32) {
   auto opGraph = build_opgraph_fused(handle, x, y, w, z, b, alpha, key, padding, stride, dilation);
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr(), z.data_ptr(), b.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w', 'z', 'b'};
@@ -554,8 +554,8 @@ void run_fused_conv(const Tensor& x, const Tensor& y, const Tensor& w, const Ten
   if (!benchmark) {
     cudnn_frontend::EngineConfigList configs = get_configs_from_heuristics_fused(handle,
                                                                                  x, y, w, z, b, alpha, key,
-										 padding, stride, dilation,
-										 deterministic, allow_tf32);
+                                                                                 padding, stride, dilation,
+                                                                                 deterministic, allow_tf32);
     try_configs_fused(configs, key, handle, x, y, w, z, b);
   } else {
     cudnn_frontend::executionPlans_t plans = get_plans_from_find_fused(handle,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -300,7 +300,6 @@ const auto get_generator_sources(const cudnnBackendDescriptorType_t& desc, const
     auto fallback = cudnn_frontend::EngineFallbackListBuilder()
                         .setOperationGraph(opGraph)
                         .setOperation(desc)
-                        //.setOperation(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
                         .build();
     auto &fallback_list = fallback.getFallbackList();
     cudnn_frontend::EngineConfigList filtered_configs;
@@ -638,7 +637,6 @@ void raw_cudnn_convolution_add_relu_out(
     bool allow_tf32) {
   if (output.numel() == 0) { return; }
   if (use_v8()) {
-    //auto bias_ = bias.repeat({output.size(0), 1, 1, 1});
     auto bias_ = bias.view({1, bias.numel(), 1, 1});
     run_fused_conv(input, output, weight, z, bias_,
       alpha, stride, padding, dilation,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -132,8 +132,7 @@ void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, c
 
 void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, const cudnn_frontend::ExecutionPlan& plan) {
     auto workspace_size = plan.getWorkspaceSize();
-    Tensor workspace;
-    workspace = at::empty({workspace_size}, x.options().dtype(kByte));
+    Tensor workspace = at::empty({workspace_size}, x.options().dtype(kByte));
     void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
     int64_t uids[] = {'x', 'y', 'w'};
     auto variantPack = cudnn_frontend::VariantPackBuilder()
@@ -234,8 +233,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
     }
   });
   TORCH_CHECK_WITH(CUDAOutOfMemoryError, max_workspace_size < 1_TiB, "Not enough memory for workspace!");
-  Tensor workspace;
-  workspace = at::empty({max_workspace_size}, x.options().dtype(kByte));
+  Tensor workspace = at::empty({max_workspace_size}, x.options().dtype(kByte));
   auto variantPack  = cudnn_frontend::VariantPackBuilder()
       .setDataPointers(3, data_ptrs)
       .setWorkspacePointer(workspace.data_ptr())

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -242,7 +242,7 @@ auto get_configs_from_heuristics(const cudnnHandle_t handle, const cudnnBackendD
     return plan.getWorkspaceSize() > workspace_size;
   };
 
-  auto sources = get_generator_sources(desc, x, deterministic, allow_tf32, CUDNN_HEUR_MODE_B);
+  auto sources = get_generator_sources(desc, x, deterministic, allow_tf32, CUDNN_HEUR_MODE_INSTANT);
 
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   auto configs = generator.generate_engine_config(opGraph);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -185,21 +185,6 @@ const auto get_generator_sources(const cudnnBackendDescriptorType_t& desc, const
   return sources;
 }
 
-const auto get_fallback_method(const cudnn_frontend::OperationGraph &opGraph, const cudnnBackendDescriptorType_t& desc, const Tensor& x, const bool deterministic, const bool allow_tf32) {
-  // Method for engine config generator based on fallback list
-  auto fallback_method = [&](cudnn_frontend::OperationGraph &opGraph) -> cudnn_frontend::EngineConfigList {
-    auto fallback = cudnn_frontend::EngineFallbackListBuilder()
-                        .setOperationGraph(opGraph)
-                        .setOperation(desc)
-                        .build();
-    auto &fallback_list = fallback.getFallbackList();
-    cudnn_frontend::EngineConfigList filtered_configs;
-    filterEngineConfigs(fallback_list, filtered_configs, deterministic, allow_tf32, x.scalar_type());
-    return filtered_configs;
-  };
-  return fallback_method;
-}
-
 size_t get_available_workspace() {
   int device;
   THCudaCheck(cudaGetDevice(&device));

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -69,7 +69,7 @@ uint8_t getAlignment(const Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
   uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());
-  for (; alignment < 128; alignment *= 2) {
+  for (; alignment < 64; alignment *= 2) {
     if (address % (alignment * 2)) {
       return alignment;
     }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -89,18 +89,18 @@ cudnn_frontend::Tensor getTensorDescriptor(const Tensor &t, const int64_t id, co
 
 cudnn_frontend::ConvDesc_v8 getConvDescriptor(cudnnDataType_t dataType, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, const at::ScalarType scalar_type) {
   uint64_t convDim = stride.size();
-  cudnn_frontend::ConvDescBuilder_v8& builder = cudnn_frontend::ConvDescBuilder()
+  if (scalar_type == kBFloat16 || scalar_type == kHalf) {
+    dataType = CUDNN_DATA_FLOAT;
+  }
+  return cudnn_frontend::ConvDescBuilder()
     .setDataType(dataType)
     .setMathMode(CUDNN_CROSS_CORRELATION)
     .setNDims(convDim)
     .setStrides(convDim, stride.data())
     .setPrePadding(convDim, padding.data())
     .setPostPadding(convDim, padding.data())
-    .setDilation(convDim, dilation.data());
-  if (scalar_type == kBFloat16 || scalar_type == kHalf) {
-    builder.setDataType(CUDNN_DATA_FLOAT);
-  }
-  return builder.build();
+    .setDilation(convDim, dilation.data())
+    .build();
 }
 
 void filterEngineConfigs(

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -280,7 +280,6 @@ auto build_opgraph_fused(const cudnnHandle_t handle, const Tensor & x, const Ten
                            .setAlpha(alpha1)
                            .setAlpha2(alpha2)
                            .build();
-  // auto bias_ = b.view({1, b.numel(), 1, 1});
   auto add_bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                            .setxDesc(add_op.getOutputTensor())
                            .setbDesc(getTensorDescriptor(b, 'b', key.b_alignment))

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -208,7 +208,7 @@ auto build_opgraph(const cudnnHandle_t handle, const cudnnBackendDescriptorType_
   std::array<cudnn_frontend::Operation const *, 1> ops = {&op};
   auto opGraph = cudnn_frontend::OperationGraphBuilder()
       .setHandle(handle)
-      .setOperationGraph(1, ops.data())
+      .setOperationGraph(ops.size(), ops.data())
       .build();
   return opGraph;
 }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -205,6 +205,7 @@ void get_cachekey_fused(CacheKeyFused& key, const Tensor& y, const Tensor& x, co
 }
 
 void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, const cudnn_frontend::ExecutionPlan& plan) {
+  c10::DeviceGuard g(x.options().device());
   auto workspace_size = plan.getWorkspaceSize();
   auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
@@ -218,6 +219,7 @@ void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const
 }
 
 void run_conv_plan_fused(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, const Tensor& z, const Tensor& b, const cudnn_frontend::ExecutionPlan& plan) {
+  c10::DeviceGuard g(x.options().device());
   auto workspace_size = plan.getWorkspaceSize();
   auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr(), z.data_ptr(), b.data_ptr()};
@@ -384,6 +386,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   auto sources = get_generator_sources(desc, x, deterministic, allow_tf32, CUDNN_HEUR_MODE_INSTANT);
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   cudnn_frontend::executionPlans_t valid_plans;
+  c10::DeviceGuard g(x.options().device());
   at::DataPtr workspace_ptr;
   generate_and_filter_plans(handle, opGraph, generator, x, valid_plans, workspace_ptr);
   auto variantPack = cudnn_frontend::VariantPackBuilder()
@@ -413,6 +416,7 @@ auto get_plans_from_find_fused(const cudnnHandle_t handle,
   auto sources = get_generator_sources(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR, x, deterministic, allow_tf32, CUDNN_HEUR_MODE_INSTANT);
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   cudnn_frontend::executionPlans_t valid_plans;
+  c10::DeviceGuard g(x.options().device());
   at::DataPtr workspace_ptr;
   generate_and_filter_plans(handle, opGraph, generator, x, valid_plans, workspace_ptr);
   auto variantPack = cudnn_frontend::VariantPackBuilder()

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -20,8 +20,7 @@
 #include <ATen/TensorUtils.h>
 
 #include <c10/util/env.h>
-
-#include <THC/THC.h>
+#include <c10/cuda/CUDAException.h>
 
 #include <mutex>
 #include <unordered_map>
@@ -312,7 +311,7 @@ const auto get_generator_sources(const cudnnBackendDescriptorType_t& desc, const
 
 size_t get_available_workspace() {
   int device;
-  THCudaCheck(cudaGetDevice(&device));
+  C10_CUDA_CHECK(cudaGetDevice(&device));
   size_t max_block_size = 0;
   size_t tmp_bytes = 0;  // Only used for filling pointer parameters that aren't used later
   c10::cuda::CUDACachingAllocator::cacheInfo(device, &tmp_bytes, &max_block_size);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -383,11 +383,6 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
 // We only get configs from this stage to avoid building unnecessary plans that are never executed
 auto get_configs_from_heuristics(const cudnnHandle_t handle, const cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, const CacheKey& key, const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation, const bool deterministic, const bool allow_tf32) {
   auto opGraph = build_opgraph(handle, desc, x, y, w, key, padding, stride, dilation);
-  size_t workspace_size = get_available_workspace();
-  auto predicate_function = [&](cudnn_frontend::ExecutionPlan const& plan) -> bool {
-    return plan.getWorkspaceSize() > workspace_size;
-  };
-
   auto sources = get_generator_sources(/*desc,*/ x, deterministic, allow_tf32, heuristic_mode);
 
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -31,17 +31,27 @@ namespace at { namespace native {
 namespace {
 
 int v8_flag = -1;
+int debug = -1;
 
 bool use_v8() {
   if (v8_flag < 0) {
     auto val = c10::utils::check_env("CUDNN_V8_API_ENABLED");
+    auto debug_val = c10::utils::check_env("CUDNN_V8_API_DEBUG");
     if (val == true) {
       v8_flag = 1;
     } else {
       v8_flag = 0;
     }
+    if (debug_val == true) {
+      debug = 1;
+    } else {
+      debug = 0;
+    }
   }
-  return v8_flag;
+  if (debug == 1) {
+    TORCH_WARN("CUDNN_V8_DEBUG ON, V8_FLAG: ", v8_flag);
+  }
+  return v8_flag == 1;
 }
 
 // TODO: remove duplicate code in Conv_v7.cpp

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -95,9 +95,10 @@ void filterEngineConfigs(
       if (cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC>(c)) return true;
     }
     if (scalar_type == kFloat && !allow_tf32) {
-      if (cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_DOWN_CONVERT_INPUTS>(c)) return true;
       if (cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_TENSOR_CORE>(c)) return true;
     }
+    // TODO: check under which conditions this is OK
+    if (cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_DOWN_CONVERT_INPUTS>(c)) return true;
     return false;
   };
   cudnn_frontend::filter(from, to, filter);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -274,6 +274,9 @@ void try_configs(cudnn_frontend::EngineConfigList& configs, const CacheKey& key,
       benchmark_cache.emplace(key, plan);
       return;
     } catch (cudnn_frontend::cudnnException &e) {} catch(CuDNNError &e) {}
+      catch (c10::CUDAOutOfMemoryError &e) {
+        cudaGetLastError(); // clear CUDA error
+    }
   }
   TORCH_CHECK(false, "FIND was unable to find an engine to execute this computation");
 }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -195,7 +195,7 @@ void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w'};
   auto variantPack = cudnn_frontend::VariantPackBuilder()
-      .setWorkspacePointer(workspace.data_ptr())
+      .setWorkspacePointer(workspace.has_storage() ? workspace.data_ptr() : NULL)
       .setDataPointers(3, data_ptrs)
       .setUids(3, uids)
       .build();
@@ -208,7 +208,7 @@ void run_conv_plan_fused(cudnnHandle_t handle, const Tensor& x, const Tensor& y,
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr(), z.data_ptr(), b.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w', 'z', 'b'};
   auto variantPack = cudnn_frontend::VariantPackBuilder()
-      .setWorkspacePointer(workspace.data_ptr())
+      .setWorkspacePointer(workspace.has_storage() ? workspace.data_ptr() : NULL)
       .setDataPointers(5, data_ptrs)
       .setUids(5, uids)
       .build();
@@ -372,7 +372,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   auto variantPack = cudnn_frontend::VariantPackBuilder()
       .setDataPointers(3, data_ptrs)
       .setUids(3, uids)
-      .setWorkspacePointer(workspace.data_ptr())
+      .setWorkspacePointer(workspace.has_storage() ? workspace.data_ptr() : NULL)
       .build();
 
   auto options = cudnn_frontend::time_sorted_plan<cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE>(handle, std::move(valid_plans), variantPack);
@@ -401,7 +401,7 @@ auto get_plans_from_find_fused(const cudnnHandle_t handle,
   auto variantPack = cudnn_frontend::VariantPackBuilder()
       .setDataPointers(5, data_ptrs)
       .setUids(5, uids)
-      .setWorkspacePointer(workspace.data_ptr())
+      .setWorkspacePointer(workspace.has_storage() ? workspace.data_ptr() : NULL)
       .build();
 
   auto options = cudnn_frontend::time_sorted_plan<cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE>(handle, std::move(valid_plans), variantPack);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -77,11 +77,48 @@ uint8_t getAlignment(const Tensor &t) {
   return alignment;
 }
 
+// Logic copied from ATen/cudnn/Descriptors.h
+// The stride for a size-1 dimensions is not uniquely determined; in
+// fact, it can be anything you want, because the fact that the
+// tensor is size 1 at this dimension means that you will never actually
+// try advancing your pointer by this stride.
+//
+// However, CuDNN has a much more stringent requirement on strides:
+// if you are passing a contiguous input, it better be the case
+// that the stride for dim i is the product of the sizes of dims
+// i+1 to the end.  This stride is indeed uniquely determined.  This
+// function modifies 'stride' in place so this invariant holds.
+template<typename T>
+static inline void fixSizeOneDimStride(std::vector<T> &sizes, std::vector<T> &strides, bool nhwc) {
+  int64_t z = 1;
+  size_t index = 0;
+  size_t dim = strides.size();
+  std::vector<int64_t> permutation(dim);
+
+  if (nhwc) {
+    permutation[index++] = 1;
+  }
+  for (size_t d = dim-1; d > 1; d--) {
+    permutation[index++] = d;
+  }
+  if (!nhwc) {
+    permutation[index++] = 1;
+  }
+  permutation[index++] = 0;
+  for (size_t d : permutation) {
+    if (sizes[d] == 1) {
+      strides[d] = z;
+    } else {
+      z *= sizes[d];
+    }
+  }
+}
+
 cudnn_frontend::Tensor getTensorDescriptorWithTypeVirtual(const Tensor &t, const int64_t id, const uint8_t alignment, const cudnnDataType_t dataType, const bool _virtual) {
-  auto shape = t.sizes();
+  auto sizes = t.sizes();
   auto strides = t.strides();
   auto r = cudnn_frontend::TensorBuilder()
-    .setDim(shape.size(), shape.data())
+    .setDim(sizes.size(), sizes.data())
     .setStrides(strides.size(), strides.data())
     .setId(id)
     .setAlignment(alignment)
@@ -654,9 +691,9 @@ void raw_cudnn_convolution_add_relu_out(
       alpha, stride, padding, dilation,
       groups, benchmark, deterministic, allow_tf32);
   } else {
-   raw_cudnn_convolution_add_relu_out_v7(output, input, weight, z,
-                                         alpha, bias, stride, padding, dilation,
-                                         groups, benchmark, deterministic, allow_tf32);
+    raw_cudnn_convolution_add_relu_out_v7(output, input, weight, z,
+                                          alpha, bias, stride, padding, dilation,
+                                          groups, benchmark, deterministic, allow_tf32);
   }
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -364,7 +364,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w'};
   // We don't care about getting the best ordering of algos if we're roing to run all of them
-  auto sources = get_generator_sources(/*desc,*/ x, deterministic, allow_tf32, CUDNN_HEUR_MODE_INSTANT); 
+  auto sources = get_generator_sources(x, deterministic, allow_tf32, CUDNN_HEUR_MODE_INSTANT);
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   cudnn_frontend::executionPlans_t valid_plans;
   Tensor workspace;
@@ -417,7 +417,7 @@ auto get_plans_from_find_fused(const cudnnHandle_t handle,
 // We only get configs from this stage to avoid building unnecessary plans that are never executed
 auto get_configs_from_heuristics(const cudnnHandle_t handle, const cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, const CacheKey& key, const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation, const bool deterministic, const bool allow_tf32) {
   auto opGraph = build_opgraph(handle, desc, x, y, w, key, padding, stride, dilation);
-  auto sources = get_generator_sources(/*desc,*/ x, deterministic, allow_tf32, heuristic_mode);
+  auto sources = get_generator_sources(x, deterministic, allow_tf32, heuristic_mode);
 
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   auto configs = generator.generate_engine_config(opGraph);
@@ -614,7 +614,7 @@ void raw_cudnn_convolution_backward_weight_out(
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR,
       input, grad_output, grad_weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);
-  } else { 
+  } else {
     raw_cudnn_convolution_backward_weight_out_v7(
       grad_weight, grad_output, input,
       padding, stride, dilation, groups,


### PR DESCRIPTION
#58414, #58859, #58858 #58860 #58861

We're currently testing performance with both "find" and "get" with this PR. 

CC @zasdfgbnm @ptrblck @ngimel @puririshi98

In addition to the `USE_EXPERIMENTAL_CUDNN_V8_API` build flag, we've added a `CUDNN_V8_API_ENABLED` runtime feature flag.
`USE_EXPERIMENTAL_CUDNN_V8_API=1` will build with v8 API support while keeping all v7 functionality, with v8 usage disabled by default.
`CUDNN_V8_API_ENABLED=1` at runtime on a `USE_EXPERIMENTAL_CUDNN_V8_API=1` build uses the v8 API.
A debug flag `CUDNN_V8_API_DEBUG=1` can be used to verify which API is used when dispatching convolutions.

Note that in v7, `bfloat16` convolutions will dispatch to a native PyTorch implementation, but a fully v8 enabled build will dispatch to cuDNN implementations.