### PR TITLE
[vulkan] Reduce submission rate to save CPU cycles

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -102,7 +102,7 @@ struct Command final {
     struct Configuration final {
       static constexpr uint32_t kQuantum = 4u;
       static constexpr uint32_t kReserve = 16u;
-      static constexpr uint32_t kSubmit = 3u;
+      static constexpr uint32_t kSubmit = 16u;
     };
 
     VkDevice device_;


### PR DESCRIPTION
Summary:
Further tweak the submission rate of ops. Before in D28293756 (https://github.com/pytorch/pytorch/commit/bc0965ac853f616b068a18add828fa794877775c), the submission rate was set as high as possible in order to prioritize performance. However, in practice (i.e. when running the model in an app) the high rate of submission increases CPU usage and increases GPU contention which may regress fps.

In the future it would be beneficial to devise a scheme to adaptively set the GPU submission rate.

Test Plan:
Test vulkan ops:

```

cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
cd -
```

Reviewed By: IvanKobzarev

Differential Revision: D29062836

