### PR TITLE
[Tools] Update path in clang_format_utils after #60473

### DIFF
--- a/tools/linter/clang_format_utils.py
+++ b/tools/linter/clang_format_utils.py
@@ -10,7 +10,7 @@ import urllib.error
 HOST_PLATFORM = platform.system()
 
 # PyTorch directory root, derived from the location of this file.
-PYTORCH_ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+PYTORCH_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 # This dictionary maps each platform to the S3 object URL for its clang-format binary.
 PLATFORM_TO_CF_URL = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60782**

PR #60473 introduced a new folders nesting level, this change updates
clang_format_utils.py to accordingly adjust the way it sets up root
path.

Differential Revision: [D29403622](https://our.internmc.facebook.com/intern/diff/D29403622)