### PR TITLE
Remove VS install step unless necessary from GHA Windows workflows

### DIFF
--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -2,7 +2,7 @@
 # Where to find the links: https://docs.microsoft.com/en-us/visualstudio/releases/2019/history#release-dates-and-build-numbers
 
 # BuildTools from S3
-$VS_DOWNLOAD_LINK = "https://s3.amazonaws.com/ossci-windows/vs${env:VC_VERSION}_BuildTools.exe"
+$VS_DOWNLOAD_LINK = "https://s3.amazonaws.com/ossci-windows/vs${env:VS_VERSION}_BuildTools.exe"
 $COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
 $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStudio.Workload.VCTools",
                                                      "--add Microsoft.Component.MSBuild",
@@ -20,13 +20,13 @@ if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
 
 curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
 if ($LASTEXITCODE -ne 0) {
-    echo "Download of the VS 2019 Version ${env:VC_VERSION} installer failed"
+    echo "Download of the VS 2019 Version ${env:VS_VERSION} installer failed"
     exit 1
 }
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
-    $vc_version_major = [int] ${env:VC_VERSION}.split(".")[0]
-    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VC_VERSION}, ${env:vc_version_major + 1})" -property installationPath
+    $VS_VERSION_major = [int] ${env:VS_VERSION}.split(".")[0]
+    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VS_VERSION}, ${env:VS_VERSION_major + 1})" -property installationPath
     if ($existingPath -ne $null) {
         echo "Found existing BuildTools installation in $existingPath"
         exit 0

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -1,8 +1,8 @@
 # https://developercommunity.visualstudio.com/t/install-specific-version-of-vs-component/1142479
-# https://docs.microsoft.com/en-us/visualstudio/releases/2019/history#release-dates-and-build-numbers
+# Where to find the links: https://docs.microsoft.com/en-us/visualstudio/releases/2019/history#release-dates-and-build-numbers
 
-# 16.8.6 BuildTools
-$VS_DOWNLOAD_LINK = "https://s3.amazonaws.com/ossci-windows/vs16.8.6_BuildTools.exe"
+# BuildTools from S3
+$VS_DOWNLOAD_LINK = "https://s3.amazonaws.com/ossci-windows/vs${env:VC_VERSION}_BuildTools.exe"
 $COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
 $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStudio.Workload.VCTools",
                                                      "--add Microsoft.Component.MSBuild",
@@ -20,30 +20,25 @@ if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
 
 curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
 if ($LASTEXITCODE -ne 0) {
-    echo "Download of the VS 2019 Version 16.8.6 installer failed"
+    echo "Download of the VS 2019 Version ${env:VC_VERSION} installer failed"
     exit 1
 }
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
-    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[16, 17)" -property installationPath
+    $vc_version_major = [int] $VC_VERSION.split(".")[0]
+    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:vc_version_major}, ${env:vc_version_major + 1})" -property installationPath
     if ($existingPath -ne $null) {
         echo "Found existing BuildTools installation in $existingPath"
-        $VS_UNINSTALL_ARGS = @("uninstall", "--installPath", "`"$existingPath`"", "--quiet","--wait")
-        $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_UNINSTALL_ARGS -NoNewWindow -Wait -PassThru
-        $exitCode = $process.ExitCode
-        if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
-            echo "Original BuildTools uninstall failed with code $exitCode"
-            exit 1
-        }
-        echo "Original BuildTools uninstalled"
+        exit 0
     }
 }
 
 $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_INSTALL_ARGS -NoNewWindow -Wait -PassThru
 Remove-Item -Path vs_installer.exe -Force
 $exitCode = $process.ExitCode
+echo $exitCode
 if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
-    echo "VS 2017 installer exited with code $exitCode, which should be one of [0, 3010]."
+    echo "VS 2019 installer exited with code $exitCode, which should be one of [0, 3010]."
     curl.exe --retry 3 -kL $COLLECT_DOWNLOAD_LINK --output Collect.exe
     if ($LASTEXITCODE -ne 0) {
         echo "Download of the VS Collect tool failed."
@@ -51,6 +46,6 @@ if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     }
     Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
     New-Item -Path "C:\w\build-results" -ItemType "directory" -Force
-    Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
+    Copy-Item -Path "${PWD}\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
     exit 1
 }

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -18,12 +18,6 @@ if (${env:INSTALL_WINDOWS_SDK} -eq "1") {
     $VS_INSTALL_ARGS += "--add Microsoft.VisualStudio.Component.Windows10SDK.19041"
 }
 
-curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
-if ($LASTEXITCODE -ne 0) {
-    echo "Download of the VS 2019 Version ${env:VS_VERSION} installer failed"
-    exit 1
-}
-
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
     $VS_VERSION_major = [int] ${env:VS_VERSION}.split(".")[0]
     $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VS_VERSION}, ${env:VS_VERSION_major + 1})" -property installationPath
@@ -33,6 +27,23 @@ if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswher
     }
 }
 
+echo "Removing all VS installers and installations for a clean start."
+$process = Start-Process "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\resources\app\layout\InstallCleanup.exe" -ArgumentList @("-i") -NoNewWindow -Wait -PassThru
+$exitCode = $process.ExitCode
+if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
+    echo "Installation cleanup failed with code $exitCode"
+    exit 1
+}
+echo "Visual Studio and installers successfully uninstalled."
+
+echo "Downloading VS installer from S3."
+curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
+if ($LASTEXITCODE -ne 0) {
+    echo "Download of the VS 2019 Version ${env:VS_VERSION} installer failed"
+    exit 1
+}
+
+echo "Installing Visual Studio version ${env:VS_VERSION}."
 $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_INSTALL_ARGS -NoNewWindow -Wait -PassThru
 Remove-Item -Path vs_installer.exe -Force
 $exitCode = $process.ExitCode

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -26,7 +26,7 @@ if ($LASTEXITCODE -ne 0) {
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
     $vc_version_major = [int] $VC_VERSION.split(".")[0]
-    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:vc_version_major}, ${env:vc_version_major + 1})" -property installationPath
+    $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VC_VERSION}, ${env:vc_version_major + 1})" -property installationPath
     if ($existingPath -ne $null) {
         echo "Found existing BuildTools installation in $existingPath"
         exit 0

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -47,7 +47,6 @@ echo "Installing Visual Studio version ${env:VS_VERSION}."
 $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_INSTALL_ARGS -NoNewWindow -Wait -PassThru
 Remove-Item -Path vs_installer.exe -Force
 $exitCode = $process.ExitCode
-echo $exitCode
 if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     echo "VS 2019 installer exited with code $exitCode, which should be one of [0, 3010]."
     curl.exe --retry 3 -kL $COLLECT_DOWNLOAD_LINK --output Collect.exe
@@ -57,6 +56,6 @@ if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     }
     Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
     New-Item -Path "C:\w\build-results" -ItemType "directory" -Force
-    Copy-Item -Path "${PWD}\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
+    Copy-Item -Path "${env:TEMP}\vslogs.zip" -Destination "C:\w\build-results\"
     exit 1
 }

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -25,7 +25,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe") {
-    $vc_version_major = [int] $VC_VERSION.split(".")[0]
+    $vc_version_major = [int] ${env:VC_VERSION}.split(".")[0]
     $existingPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products "Microsoft.VisualStudio.Product.BuildTools" -version "[${env:VC_VERSION}, ${env:vc_version_major + 1})" -property installationPath
     if ($existingPath -ne $null) {
         echo "Found existing BuildTools installation in $existingPath"

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -26,7 +26,8 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: "16.8.6"
+  VC_VERSION: ""
+  VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
 {%- if cuda_version != "cpu" %}
   TORCH_CUDA_ARCH_LIST: "7.0"

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -26,7 +26,7 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: ""
+  VC_VERSION: "16.8.6"
   VC_YEAR: "2019"
 {%- if cuda_version != "cpu" %}
   TORCH_CUDA_ARCH_LIST: "7.0"
@@ -51,6 +51,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
 {%- if cuda_version != "cpu" %}
       - name: Install Cuda
         shell: bash
@@ -141,6 +145,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
 {%- if cuda_version != "cpu" %}
       - name: Install Cuda
         shell: bash

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -51,10 +51,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
 {%- if cuda_version != "cpu" %}
       - name: Install Cuda
         shell: bash
@@ -145,10 +141,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
 {%- if cuda_version != "cpu" %}
       - name: Install Cuda
         shell: bash

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -17,7 +17,7 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: ""
+  VC_VERSION: "16.8.6"
   VC_YEAR: "2019"
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -17,7 +17,8 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: "16.8.6"
+  VC_VERSION: ""
+  VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -20,7 +20,7 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: ""
+  VC_VERSION: "16.8.6"
   VC_YEAR: "2019"
 
 concurrency:

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -20,7 +20,8 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: "16.8.6"
+  VC_VERSION: ""
+  VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
 
 concurrency:

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -41,6 +41,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
       - name: Build
         shell: bash
         env:
@@ -114,6 +118,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download PyTorch Build Artifacts
         with:

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -41,10 +41,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
       - name: Build
         shell: bash
         env:
@@ -118,10 +114,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download PyTorch Build Artifacts
         with:

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -20,7 +20,7 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: ""
+  VC_VERSION: "16.8.6"
   VC_YEAR: "2019"
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -43,10 +43,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |
@@ -128,10 +124,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -43,6 +43,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |
@@ -124,6 +128,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -20,7 +20,8 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: "16.8.6"
+  VC_VERSION: ""
+  VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -42,6 +42,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |
@@ -123,6 +127,10 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
+      - name: Install Visual Studio 2019 toolchain
+        shell: powershell
+        run: |
+          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -19,7 +19,8 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: "16.8.6"
+  VC_VERSION: ""
+  VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -19,7 +19,7 @@ env:
   PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
-  VC_VERSION: ""
+  VC_VERSION: "16.8.6"
   VC_YEAR: "2019"
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -42,10 +42,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |
@@ -127,10 +123,6 @@ jobs:
         shell: bash
         run: |
           git clean -xdf
-      - name: Install Visual Studio 2019 toolchain
-        shell: powershell
-        run: |
-          .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
         shell: bash
         run: |


### PR DESCRIPTION
~~This should only be merged after our AMI has been deployed after https://github.com/fairinternal/pytorch-gha-infra/pull/1. (And will likely fail our current windows jobs)~~

I have revised this PR to install VS only when it's not already installed.

This should save ~5min per Windows workflow. 
![image](https://user-images.githubusercontent.com/31798555/125141598-7e886c80-e0e3-11eb-9fe0-bb9e6bcc14f1.png)
