### PR TITLE
[TensorExpr] Add a mechanism to register custom TS->NNC lowerings in TensorExprKernel.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -2395,133 +2395,41 @@ c10::optional<ScalarType> findDtypeForValue(const torch::jit::Value* v) {
 
 Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
   auto inputs = v->node()->inputs();
-  switch (v->node()->kind()) {
-    case aten::rand_like:
-      hasRandom_ = true;
-      // fallthrough
-    case aten::add:
-    case aten::sub:
-    case aten::mul:
-    case aten::div:
-    case aten::__and__:
-    case aten::__or__:
-    case aten::__xor__:
-    case aten::__lshift__:
-    case aten::__rshift__:
-    case aten::eq:
-    case aten::ne:
-    case aten::ge:
-    case aten::gt:
-    case aten::le:
-    case aten::lt:
-    case aten::min:
-    case aten::max:
-    case aten::masked_fill:
-    case aten::clamp:
-    case aten::addcmul:
-    case aten::sigmoid:
-    case aten::reciprocal:
-    case aten::neg:
-    case aten::isnan:
-    case aten::relu:
-    case aten::relu6:
-    case aten::leaky_relu:
-    case aten::hardswish:
-    case aten::hardsigmoid:
-    case aten::gelu:
-    case aten::batch_norm:
-    case aten::log:
-    case aten::log10:
-    case aten::log1p:
-    case aten::log2:
-    case aten::exp:
-    case aten::expm1:
-    case aten::erf:
-    case aten::erfc:
-    case aten::cos:
-    case aten::sin:
-    case aten::tan:
-    case aten::type_as:
-    case aten::pow:
-    case aten::fmod:
-    case aten::lerp:
-    case aten::remainder:
-    case aten::acos:
-    case aten::asin:
-    case aten::cosh:
-    case aten::sinh:
-    case aten::atan:
-    case aten::atan2:
-    case aten::tanh:
-    case aten::hardtanh:
-    case aten::hardshrink:
-    case aten::sqrt:
-    case aten::rsqrt:
-    case aten::abs:
-    case aten::ceil:
-    case aten::floor:
-    case aten::round:
-    case aten::trunc:
-    case aten::_cast_Float:
-    case aten::threshold:
-    case aten::where:
-    case aten::frac:
-    case aten::lgamma:
-    case aten::slice:
-    case aten::unsqueeze:
-    case aten::t:
-    case aten::transpose:
-    case aten::expand:
-    case aten::expand_as:
-    case aten::permute:
-    case aten::mm:
-    case aten::matmul:
-    case aten::cat:
-    case aten::view:
-    case aten::reshape:
-    case aten::sum:
-    case aten::softmax:
-    case aten::log_softmax:
-    case aten::conv2d:
-    case aten::addmm:
-    case aten::mean:
-    case aten::adaptive_avg_pool2d:
-    case aten::to: {
-      std::vector<ArgValue> argInputs;
-      if (v->node()->kind() != aten::to) {
-        for (auto inp : inputs) {
-          argInputs.push_back(toArg(inp));
-        }
-      } else {
-        argInputs.push_back(toArg(inputs[0]));
-      }
-      auto outputType = findDtypeForValue(v->node()->output());
-      std::vector<ExprHandle> outputShape = sizesForValue(v);
-      return computeOperandValue(
-          v->node()->kind(), argInputs, outputShape, outputType, device_);
-    } break;
+  auto op = v->node()->kind();
 
-    case prim::ConstantChunk: {
-      return Compute(
-          "prim_constantchunk",
-          c10::fmap<DimArg>(sizesForValue(v)),
-          [this, v](const std::vector<VarHandle>& axes) {
-            auto const& n = v->node();
-            int64_t dim = n->i(attr::dim);
-            int64_t chunks = n->i(attr::chunks);
-            std::vector<ExprHandle> indices(axes.begin(), axes.end());
-            return chunk(
-                bufs_.at(n->input(0)), v->offset(), dim, chunks, indices);
-          });
-    } break;
-
-    default: {
-      std::string msg = std::string("Unhandled node kind (in computeValue): ") +
-          v->node()->kind().toQualString();
-      throw malformed_input(msg);
-    }
+  if (op == aten::rand_like) {
+    hasRandom_ = true;
   }
-  return nullptr;
+
+  if (op == prim::ConstantChunk) {
+    return Compute(
+        "prim_constantchunk",
+        c10::fmap<DimArg>(sizesForValue(v)),
+        [this, v](const std::vector<VarHandle>& axes) {
+          auto const& n = v->node();
+          int64_t dim = n->i(attr::dim);
+          int64_t chunks = n->i(attr::chunks);
+          std::vector<ExprHandle> indices(axes.begin(), axes.end());
+          return chunk(
+              bufs_.at(n->input(0)), v->offset(), dim, chunks, indices);
+        });
+  }
+
+  std::vector<ArgValue> argInputs;
+  if (op != aten::to) {
+    for (auto inp : inputs) {
+      argInputs.push_back(toArg(inp));
+    }
+  } else {
+    argInputs.push_back(toArg(inputs[0]));
+  }
+  auto outputType = findDtypeForValue(v->node()->output());
+  std::vector<ExprHandle> outputShape = sizesForValue(v);
+
+  if (NNCLoweringFunction custom_lowering = getCustomLoweringFor(op)) {
+    return custom_lowering(argInputs, outputShape, outputType, device_);
+  }
+  return computeOperandValue(op, argInputs, outputShape, outputType, device_);
 }
 
 // Return the (lower, upper) loop bounds if they are constants, else nullopt.
@@ -2869,6 +2777,13 @@ Tensor* TensorExprKernel::bindInput(const torch::jit::Value* input) {
   return result;
 }
 
+NNCLoweringFunction TensorExprKernel::getCustomLoweringFor(
+    c10::Symbol op) const {
+  if (custom_lowerings_.count(op))
+    return custom_lowerings_.at(op);
+  return nullptr;
+}
+
 template <typename T>
 std::vector<size_t> reverse_sort_indices(const std::vector<T>& v) {
   // initialize original index locations
@@ -3087,8 +3002,12 @@ void TensorExprKernel::compile() {
       SubgraphUtils::generateNameForGraph(graph_));
 }
 
-TensorExprKernel::TensorExprKernel(const std::shared_ptr<Graph>& subgraph)
-    : graph_(subgraph), code_(subgraph, "") {
+TensorExprKernel::TensorExprKernel(
+    const std::shared_ptr<Graph>& subgraph,
+    std::unordered_map<c10::Symbol, NNCLoweringFunction> custom_lowerings)
+    : graph_(subgraph),
+      code_(subgraph, ""),
+      custom_lowerings_(custom_lowerings) {
   allow_fallback_ = fallbackAllowed();
   if (!allow_fallback_) {
     compile();

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -3007,7 +3007,7 @@ TensorExprKernel::TensorExprKernel(
     std::unordered_map<c10::Symbol, NNCLoweringFunction> custom_lowerings)
     : graph_(subgraph),
       code_(subgraph, ""),
-      custom_lowerings_(custom_lowerings) {
+      custom_lowerings_(std::move(custom_lowerings)) {
   allow_fallback_ = fallbackAllowed();
   if (!allow_fallback_) {
     compile();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60804**

The lowerings are stored as a map c10::Symbol -> std::function and the
signature of thoese functions match the signature of
`computeOperandValue`. Custom lowerings have higher priority over the
standard ones, i.e. we can redefine how a given op is lowered.

In general this feature is aimed at unblocking users whose models
contain ops that are not yet supported by NNC - it allows to quickly add
a custom lowering for a given op.

Differential Revision: [D29409580](https://our.internmc.facebook.com/intern/diff/D29409580)