### PR TITLE
[torch/distributed] remove outdated FutureWarning in distributed/elastic/util/store.py

### DIFF
--- a/torch/distributed/elastic/utils/store.py
+++ b/torch/distributed/elastic/utils/store.py
@@ -49,9 +49,6 @@ def synchronize(
     Note: The data on the path is not deleted, as a result there can be stale data if
         you use the same key_prefix twice.
     """
-    warnings.warn(
-        "This is an experimental API and will be changed in future.", FutureWarning
-    )
     store.set_timeout(timedelta(seconds=barrier_timeout))
     store.set(f"{key_prefix}{rank}", data)
     agent_data = get_all(store, key_prefix, world_size)


### PR DESCRIPTION
Summary:
Addresses: https://github.com/pytorch/pytorch/issues/60717

This warning should have been removed since this code is no longer in "experimental" mode.

Test Plan: N/A - just removing experimental warning that should've been removed.

Differential Revision: D29412972

