### PR TITLE
[torch] Make `torch.distributed.launch` restarts to 0, remove unnecessary `-use_env` warning

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -139,6 +139,7 @@ will not pass ``--local_rank`` when you specify this flag.
 """
 
 import logging
+import warnings
 
 from torch.distributed.run import get_args_parser, run
 
@@ -159,11 +160,22 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
+def launch(args):
+    if args.no_python and not args.use_env:
+        raise ValueError(
+            "When using the '--no_python' flag,"
+            " you must also set the '--use_env' flag."
+        )
+    run(args)
+
+
 def main(args=None):
-    logger.warning(
-        "The module torch.distributed.launch is deprecated "
-        "and going to be removed in future."
-        "Migrate to torch.distributed.run"
+    warnings.warn(
+        "The module torch.distributed.launch is deprecated\n"
+        "and will be removed in future. Use torch.distributed.run.\n"
+        "Note that --use_env is set by default in torch.distributed.run.\n"
+        "If your script expects `--local_rank` argument to be set, please\n"
+        "change it to read from `os.environ('LOCAL_RANK')` instead.", FutureWarning
     )
     args = parse_args(args)
     run(args)

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -322,7 +322,7 @@ def get_args_parser() -> ArgumentParser:
         "--max_restarts",
         action=env,
         type=int,
-        default=3,
+        default=0,
         help="Maximum number of worker group restarts before failing.",
     )
     parser.add_argument(
@@ -570,11 +570,6 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
                 cmd_args.append("-m")
             cmd_args.append(args.training_script)
         else:
-            if not use_env:
-                raise ValueError(
-                    "When using the '--no_python' flag,"
-                    " you must also set the '--use_env' flag."
-                )
             if args.module:
                 raise ValueError(
                     "Don't use both the '--no_python' flag"
@@ -582,10 +577,6 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
                 )
             cmd = args.training_script
     if not use_env:
-        log.warning(
-            "--use_env is deprecated and will be removed in future releases.\n"
-            " Please read local_rank from `os.environ('LOCAL_RANK')` instead."
-        )
         cmd_args.append(f"--local_rank={macros.local_rank}")
     cmd_args.extend(args.training_script_args)
 


### PR DESCRIPTION
Summary: Make `torch.distributed.launch` restarts to 0, remove unnecessary `-use_env` warning

Test Plan:
sandcastle

    python -m torch.distributed.launch --nproc_per_node 2 main.py -> uses 0 restarts
    python -m torch.distributed.run --nproc_per_node 2 main.py -> uses default for torchelastic, 0 restarts

Differential Revision: D29413019

