### PR TITLE
docs: add `nn.CrossMapLRN2d` in torch.nn

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -192,6 +192,7 @@ Normalization Layers
     nn.InstanceNorm3d
     nn.LayerNorm
     nn.LocalResponseNorm
+    nn.CrossMapLRN2d
 
 Recurrent Layers
 ----------------


### PR DESCRIPTION
fix #60561

