### PR TITLE
docs: add `permute` in torch docs

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -101,6 +101,7 @@ Indexing, Slicing, Joining, Mutating Ops
     moveaxis
     narrow
     nonzero
+    permute
     reshape
     row_stack
     scatter


### PR DESCRIPTION
fix #60181
