### PR TITLE
don't return in __init__ functions

### DIFF
--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -99,7 +99,7 @@ class FunctionMeta(type):
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})
         cls._backward_cls = backward_fn
 
-        return super(FunctionMeta, cls).__init__(name, bases, attrs)
+        super(FunctionMeta, cls).__init__(name, bases, attrs)
 
 
 # mypy doesn't understand `with_metaclass` from torch._six

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -71,7 +71,7 @@ class ProxyableClassMeta(type):
     """
     def __init__(cls, name, bases, attrs):
         _proxyable_classes.setdefault(cls)
-        return super().__init__(name, bases, attrs)
+        super().__init__(name, bases, attrs)
 
     def __call__(cls, *args, **kwargs):
         instance = cls.__new__(cls)  # type: ignore[call-overload]

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -298,7 +298,7 @@ class ScriptMeta(type):
                     delattr(self, name)
 
         cls.__init__ = init_then_script  # type: ignore[misc]
-        return super(ScriptMeta, cls).__init__(name, bases, attrs)
+        super(ScriptMeta, cls).__init__(name, bases, attrs)
 
 
 class _CachedForward(object):


### PR DESCRIPTION
Fix some warnings from a code analyzer