### PR TITLE
escape backward slash in stack trace in Windows to slash

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -6,6 +6,7 @@
 
 #include <sstream>
 #include <stdexcept>
+#include <regex>
 
 #ifdef USE_KINETO
 #include <libkineto.h>
@@ -367,7 +368,12 @@ std::string dtypesToStr(const std::vector<std::string>& types) {
 
 std::string stacksToStr(const std::vector<std::string>& stacks) {
   std::ostringstream oss;
-  std::copy(stacks.begin(), stacks.end(), std::ostream_iterator<std::string>(oss, ";"));
+  std::transform(
+      stacks.begin(),
+      stacks.end(),
+      std::ostream_iterator<std::string>(oss, ";"),
+      // replace the windows backstash with forward slash
+      [](std::string s)-> std::string { return std::regex_replace(s, std::regex("\\"), "/"); });
   auto rc = oss.str();
   rc.pop_back();
   return "\"" + rc + "\"";

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -372,8 +372,10 @@ std::string stacksToStr(const std::vector<std::string>& stacks) {
       stacks.begin(),
       stacks.end(),
       std::ostream_iterator<std::string>(oss, ";"),
-      // replace the windows backstash with forward slash
-      [](std::string s)-> std::string { return std::regex_replace(s, std::regex("\\"), "/"); });
+      // replace the windows backslash with forward slash
+      [](std::string s) -> std::string {
+        return std::regex_replace(s, std::regex("\\"), "/");
+      });
   auto rc = oss.str();
   rc.pop_back();
   return "\"" + rc + "\"";

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -6,7 +6,6 @@
 
 #include <sstream>
 #include <stdexcept>
-#include <regex>
 
 #ifdef USE_KINETO
 #include <libkineto.h>
@@ -372,9 +371,12 @@ std::string stacksToStr(const std::vector<std::string>& stacks) {
       stacks.begin(),
       stacks.end(),
       std::ostream_iterator<std::string>(oss, ";"),
-      // replace the windows backslash with forward slash
       [](std::string s) -> std::string {
-        return std::regex_replace(s, std::regex("\\\\"), "/");
+#ifdef _WIN32
+        // replace the windows backslash with forward slash
+        std::replace(s.begin(), s.end(), '\\', '/');
+#endif
+        return s;
       });
   auto rc = oss.str();
   rc.pop_back();

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -374,7 +374,7 @@ std::string stacksToStr(const std::vector<std::string>& stacks) {
       std::ostream_iterator<std::string>(oss, ";"),
       // replace the windows backslash with forward slash
       [](std::string s) -> std::string {
-        return std::regex_replace(s, std::regex("\\"), "/");
+        return std::regex_replace(s, std::regex("\\\\"), "/");
       });
   auto rc = oss.str();
   rc.pop_back();


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/60187