### PR TITLE
Port `float_power` kernel to structured kernels

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7290,23 +7290,37 @@
   variants: method
 
 - func: float_power.Tensor_Tensor_out(Tensor self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  dispatch:
+    CPU, CUDA: float_power_Tensor_Tensor_out
 
 - func: float_power.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor
+  structured_delegate: float_power.Tensor_Tensor_out
   variants: function, method
 
 - func: float_power.Scalar_out(Scalar self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  dispatch:
+    CPU, CUDA: float_power_Scalar_out
 
 - func: float_power.Scalar(Scalar self, Tensor exponent) -> Tensor
+  structured_delegate: float_power.Scalar_out
 
 - func: float_power.Tensor_Scalar_out(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  dispatch:
+    CPU, CUDA: float_power_Tensor_Scalar_out
 
 - func: float_power.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor
+  structured_delegate: float_power.Tensor_Scalar_out
   variants: function, method
 
 - func: float_power_.Scalar(Tensor(a!) self, Scalar exponent) -> Tensor(a!)
+  structured_delegate: float_power.Tensor_Scalar_out
   variants: method
 
 - func: float_power_.Tensor(Tensor(a!) self, Tensor exponent) -> Tensor(a!)
+  structured_delegate: float_power.Tensor_Tensor_out
   variants: method
 
 - func: normal_(Tensor(a!) self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor(a!)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -569,6 +569,16 @@
   self: zeros_like(grad)
   value: grad.sum()
 
+- name: float_power.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor
+  self: pow_backward(grad, self, exponent)
+
+- name: float_power.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor
+  self: pow_backward_self(grad, self, exponent)
+  exponent: pow_backward_exponent(grad, self, exponent, result)
+
+- name: float_power.Scalar(Scalar self, Tensor exponent) -> Tensor
+  exponent: pow_backward_exponent(grad, self, exponent, result)
+
 - name: floor(Tensor self) -> Tensor
   self: zeros_like(grad)
   result: auto_element_wise

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -102,7 +102,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'eig', 'lerp', 'linalg_vector_norm', 'cumprod', 'prod', 'index_copy', 'lu', 'unfold', 'unfold_backward',
     'index', 'masked_fill', 'cross', 'lu_unpack', 'renorm', '_view_as_real_physical', '_conj_physical',
     'scatter', 'scatter_add', 'sigmoid', 'sigmoid_backward',
-    'conj_physical_'
+    'conj_physical_', 'float_power'
 }
 
 GRADIENT_IMPLEMENTED_FOR_SPARSE_COMPLEX = {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6372,7 +6372,10 @@ op_db: List[OpInfo] = [
            ),
     OpInfo('float_power',
            dtypes=all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool),
+           backward_dtypes=all_types_and_complex_and(torch.bfloat16, torch.bool),
+           backward_dtypesIfCUDA=all_types_and_complex_and(torch.bfloat16, torch.half),
            sample_inputs_func=sample_inputs_pow,
+           supports_inplace_autograd=False,
            skips=(
                SkipInfo('TestCommon', 'test_conj_view', device_type='cuda'),),),
     OpInfo('prod',


### PR DESCRIPTION
Porting `torch.float_power` to structured kernel
Related #55070