### PR TITLE
remove `randn?` from `torch.testing` namespace

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_utils import (TestCase, run_tests, skipIfNoL
 from torch.autograd import Variable, Function, detect_anomaly, kineto_available
 from torch.autograd.function import InplaceFunction
 import torch.autograd.forward_ad as fwAD
-from torch.testing import randn_like
 from torch.testing._internal.common_methods_invocations import (
     unpack_variables,
     mask_not_all_zeros,
@@ -5684,7 +5683,7 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
 
     self_variable = f_args_variable[0]
     if isinstance(output_variable, torch.Tensor) and output_variable.requires_grad and self_variable is not None:
-        output_variable.backward(randn_like(output_variable))
+        output_variable.backward(torch.randn_like(output_variable))
         test_case.assertEqualTypeString(self_variable, self_variable.grad)
         test_case.assertEqual(self_variable.size(), self_variable.grad.size())
 
@@ -8061,7 +8060,7 @@ class TestAutogradDeviceType(TestCase):
     @deviceCountAtLeast(1)
     @dtypes(torch.float, torch.double)
     def test_requires_grad_factory(self, devices, dtype):
-        fns = [torch.ones_like, torch.testing.randn_like]
+        fns = [torch.ones_like, torch.randn_like]
         x = torch.randn(2, 3, dtype=dtype, device=devices[0])
 
         for fn in fns:

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1363,7 +1363,7 @@ def gradgradcheck(
         # If grad_outputs is not specified, create random Tensors of the same
         # shape, type, and device as the outputs
         def randn_like(x):
-            y = torch.testing.randn_like(
+            y = torch.randn_like(
                 x if (x.is_floating_point() or x.is_complex()) else x.double(), memory_format=torch.legacy_contiguous_format)
             if gen_non_contig_grad_outputs:
                 y = torch.testing.make_non_contiguous(y)

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -1,3 +1,4 @@
 from ._core import *  # noqa: F403
 from ._asserts import *  # noqa: F403
 from ._check_kernel_launches import *  # noqa: F403
+from ._deprecated import *  # noqa: F403

--- a/torch/testing/_core.py
+++ b/torch/testing/_core.py
@@ -35,12 +35,7 @@ __all__ = [
     "integral_types",
     "integral_types_and",
     "make_non_contiguous",
-    "rand_like",
-    "randn_like",
 ]
-
-rand_like = torch.rand_like
-randn_like = torch.randn_like
 
 # Helper function that returns True when the dtype is an integral dtype,
 # False otherwise.

--- a/torch/testing/_deprecated.py
+++ b/torch/testing/_deprecated.py
@@ -1,0 +1,31 @@
+"""This module exists since the `torch.testing` exposed a lot of stuff that shouldn't have been public. Although this
+was never documented anywhere, some other internal FB projects as well as downstream OSS projects might use this. Thus,
+they sill go through a deprecation cycle before we internalize them.
+"""
+
+import functools
+import warnings
+from typing import Any, Callable, Optional
+
+import torch
+
+
+__all__ = ["rand", "randn"]
+
+
+def warn_deprecated(fn: Callable, instructions: str, name: Optional[str] = None) -> Callable:
+    if name is None:
+        name = fn.__name__
+
+    msg = f"torch.testing.{name} is deprecated and will be removed in the future. {instructions.strip()}"
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        warnings.warn(msg, FutureWarning)
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+rand = warn_deprecated(torch.rand, "Use torch.rand instead.")
+randn = warn_deprecated(torch.randn, "Use torch.randn instead.")

--- a/torch/testing/_deprecated.py
+++ b/torch/testing/_deprecated.py
@@ -1,6 +1,6 @@
 """This module exists since the `torch.testing` exposed a lot of stuff that shouldn't have been public. Although this
 was never documented anywhere, some other internal FB projects as well as downstream OSS projects might use this. Thus,
-they sill go through a deprecation cycle before we internalize them.
+we don't internalize without warning, but still go through a deprecation cycle.
 """
 
 import functools


### PR DESCRIPTION
I'm guessing they had some legitimate use in the past, but currently they are simply aliased from the `torch` namespace.