### PR TITLE
Print stdout and stderr to console on parallel runs

### DIFF
--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -170,8 +170,8 @@ def run_shell_commands_in_parallel(commands: Iterable[List[str]]) -> str:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
-        stdout, _ = await proc.communicate()
-        return stdout.decode()
+        stdout, stderr = await proc.communicate()
+        return f">>>\nstdout:\n{stdout.decode()}\nstderr:\n{stderr.decode()}\n<<<"
 
     async def gather_with_concurrency(n: int, tasks: List[Any]) -> Any:
         semaphore = asyncio.Semaphore(n)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60871 [test] Run parallel clang-tidy on codebase (failure expected)
* #60870 Enable parallel clang-tidy on ec2 runner
* **#60869 Print stdout and stderr to console on parallel runs**

Differential Revision: [D29434155](https://our.internmc.facebook.com/intern/diff/D29434155)