### PR TITLE
Enable parallel clang-tidy on ec2 runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -329,7 +329,7 @@ jobs:
           # deploy/interpreter files are excluded due to using macros and other techniquies
           # that are not easily converted to accepted c++
           python3 tools/linter/clang_tidy.py \
-            -j \
+            --parallel \
             --verbose \
             --paths torch/csrc/ \
             --diff-file pr.diff \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -267,7 +267,7 @@ jobs:
 
   clang-tidy:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11
       image: ghcr.io/pytorch/cilint-clang-tidy:7f0b4616100071a4813318bfdbd5b06ae36c5272
@@ -329,6 +329,7 @@ jobs:
           # deploy/interpreter files are excluded due to using macros and other techniquies
           # that are not easily converted to accepted c++
           python3 tools/linter/clang_tidy.py \
+            -j \
             --verbose \
             --paths torch/csrc/ \
             --diff-file pr.diff \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60871 [test] Run parallel clang-tidy on codebase (failure expected)
* **#60870 Enable parallel clang-tidy on ec2 runner**
* #60869 Print stdout and stderr to console on parallel runs

This PR makes `clang-tidy` run on our self-hosted runner in a parallel fashion.

Fixes #60867
Test Plan: #60871

Differential Revision: [D29434240](https://our.internmc.facebook.com/intern/diff/D29434240)