### PR TITLE
[test] Run parallel clang-tidy on codebase (failure expected)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -332,7 +332,6 @@ jobs:
             -j \
             --verbose \
             --paths torch/csrc/ \
-            --diff-file pr.diff \
             -g"-torch/csrc/jit/passes/onnx/helper.cpp" \
             -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp" \
             -g"-torch/csrc/jit/serialization/onnx.cpp" \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60871 [test] Run parallel clang-tidy on codebase (failure expected)**
* #60870 Enable parallel clang-tidy on ec2 runner
* #60869 Print stdout and stderr to console on parallel runs

