### PR TITLE
Fix numerical issue of rowwise normalization in Caffe2 and internal tests.

### DIFF
--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/SmallVector.h>


### PR DESCRIPTION
Summary: Fix numerical issue of rowwise normalization in Caffe2 and internal tests.

Make Caffe2 LayerNorm consistent with PyTorch after https://github.com/pytorch/pytorch/pull/59987

Test Plan: buck test mode/opt //dper3/dper3/modules/tests:xdeepint_test -- --exact 'dper3/dper3/modules/tests:xdeepint_test - test_xdeepint_with_full_features_with_interactions_3 (dper3.dper3.modules.tests.xdeepint_test.XdeepInt_Test)'

Differential Revision: D29431597

