### PR TITLE
Removed the hypothesis tests for adaptive_avg_pool

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -6,6 +6,7 @@ import numpy as np
 import sys
 import unittest
 import operator
+import random
 
 import torch
 from torch import _VF
@@ -1387,187 +1388,213 @@ class TestQuantizedOps(TestCase):
                              X_hat.q_zero_point()))
 
     """Tests adaptive average pool operation on NHWC quantized tensors."""
-    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
-                                              min_side=1, max_side=10),
-                       qparams=hu.qparams(dtypes=torch.qint8)),
-           output_size_h=st.integers(1, 10),
-           output_size_w=st.integers(1, 10))
-    def test_adaptive_avg_pool2d_nhwc(self, X, output_size_h, output_size_w):
-        X, (scale, zero_point, torch_type) = X
-        H, W = X.shape[-2:]
-        assume(output_size_h <= H)
-        assume(output_size_w <= W)
-        if output_size_h == output_size_w:
-            output_size = output_size_h
-        else:
-            output_size = (output_size_h, output_size_w)
+    def test_adaptive_avg_pool2d_nhwc(self):
+        side_lens = (range(1, 10))
+        dim_lens = (range(3, 4))
+        torch_type = torch.qint8
+        zero_points = (0, 1)
+        combined = [side_lens, dim_lens, zero_points]
+        test_cases = itertools.product(*combined)
+        for test_case in test_cases:
+            output_size_h = random.randint(1, 10)
+            output_size_w = random.randint(1, 10)
+            side_len, dim_len, zero_point = test_case
+            shapes = [side_len] * dim_len
+            X, X_scale, X_zero_point = \
+                _get_random_tensor_and_q_params(shapes, 1.0, zero_point)
+            X = np.array(X)
+            scale = 1
+            H, W = X.shape[-2:]
+            output_size_h = output_size_h if (output_size_h <= H) else H
+            output_size_w = output_size_w if (output_size_w <= W) else W
+            if output_size_h == output_size_w:
+                output_size = output_size_h
+            else:
+                output_size = (output_size_h, output_size_w)
 
-        if X.shape[1] < 176:
-            X = np.repeat(X, 176 / X.shape[1], 1)
+            if X.shape[1] < 176:
+                X = np.repeat(X, 176 / X.shape[1], 1)
 
-        if X.ndim == 4:
-            X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
-            X = torch.from_numpy(X_nchw).permute([0, 3, 1, 2])
-            qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw),
-                                           scale=scale,
-                                           zero_point=zero_point,
-                                           dtype=torch_type).permute([0, 3, 1, 2])
-        else:  # ndim == 3
-            X_nchw = np.ascontiguousarray(X.transpose([1, 2, 0]))
-            X = torch.from_numpy(X_nchw).permute([2, 0, 1])
-            qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw),
-                                           scale=scale,
-                                           zero_point=zero_point,
-                                           dtype=torch_type).permute([2, 0, 1])
-
-        # Run reference on int_repr + round to avoid double rounding error.
-        X_ref = torch.nn.functional.adaptive_avg_pool2d(qX.int_repr().to(torch.double), output_size).round()
-
-        self.assertTrue(qX.stride() != sorted(qX.stride()))
-
-        ops_under_test = {
-            "nn.functional": torch.nn.functional.adaptive_avg_pool2d,
-            "nn.quantized.functional":
-                torch.nn.quantized.functional.adaptive_avg_pool2d
-        }
-        error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-        for name, op in ops_under_test.items():
-            X_hat = op(qX, output_size=output_size)
-            self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
-            # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-            self.assertEqualIgnoreType(X_ref, X_hat.int_repr(), atol=1.0, rtol=0,
-                                       msg=error_message.format(name, X_ref, X_hat.int_repr()))
-            self.assertEqual(scale, X_hat.q_scale(),
-                             msg=error_message.format(name + '.scale', scale, X_hat.q_scale()))
-            self.assertEqual(zero_point, X_hat.q_zero_point(),
-                             msg=error_message.format(name + '.zero_point', scale,
-                                                      X_hat.q_zero_point()))
-
-    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=5,
-                                              min_side=1, max_side=10),
-                       qparams=hu.qparams(dtypes=torch.quint8)),
-           output_size_d=st.integers(1, 10),
-           output_size_h=st.integers(1, 10),
-           output_size_w=st.integers(1, 10))
-    def test_adaptive_avg_pool(self, X, output_size_d, output_size_h,
-                               output_size_w):
-        X, (scale, zero_point, torch_type) = X
-        ndim = X.ndim
-        dim_to_check = []
-        if ndim <= 4:
-            dim_to_check.append(2)
-        if ndim >= 4:
-            dim_to_check.append(3)
-
-        D, H, W = X.shape[-3:]
-        assume(output_size_d <= D)
-        assume(output_size_h <= H)
-        assume(output_size_w <= W)
-
-        X = torch.from_numpy(X)
-        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
-
-        for dim in dim_to_check:
-            if dim == 2:
-                if output_size_h == output_size_w:
-                    output_size = output_size_h
-                else:
-                    output_size = (output_size_h, output_size_w)
-            elif dim == 3:
-                if output_size_d == output_size_h == output_size_w:
-                    output_size = output_size_h
-                else:
-                    output_size = (output_size_d, output_size_h, output_size_w)
+            if X.ndim == 4:
+                X_nchw = np.ascontiguousarray(X.transpose([0, 2, 3, 1]))
+                X = torch.from_numpy(X_nchw).permute([0, 3, 1, 2])
+                qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw),
+                                               scale=scale,
+                                               zero_point=zero_point,
+                                               dtype=torch_type).permute([0, 3, 1, 2])
+            else:  # ndim == 3
+                X_nchw = np.ascontiguousarray(X.transpose([1, 2, 0]))
+                X = torch.from_numpy(X_nchw).permute([2, 0, 1])
+                qX = torch.quantize_per_tensor(torch.from_numpy(X_nchw),
+                                               scale=scale,
+                                               zero_point=zero_point,
+                                               dtype=torch_type).permute([2, 0, 1])
 
             # Run reference on int_repr + round to avoid double rounding error.
-            ref_op = getattr(torch.nn.functional, 'adaptive_avg_pool{}d'.format(dim))
-            X_ref = ref_op(qX.int_repr().to(torch.float), output_size).round()
+            X_ref = torch.nn.functional.adaptive_avg_pool2d(qX.int_repr().to(torch.double), output_size).round()
+
+            self.assertTrue(qX.stride() != sorted(qX.stride()))
 
             ops_under_test = {
-                "nn.functional":
-                    getattr(torch.nn.functional, 'adaptive_avg_pool{}d'.format(dim)),
+                "nn.functional": torch.nn.functional.adaptive_avg_pool2d,
                 "nn.quantized.functional":
-                    getattr(torch.nn.quantized.functional, 'adaptive_avg_pool{}d'.format(dim))
+                    torch.nn.quantized.functional.adaptive_avg_pool2d
             }
-
             error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-
             for name, op in ops_under_test.items():
-                qX_hat = op(qX, output_size=output_size)
+                X_hat = op(qX, output_size=output_size)
+                self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
                 # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-                self.assertEqualIgnoreType(
-                    X_ref, qX_hat.int_repr(), atol=1.0,
-                    rtol=0, msg=error_message.format(name, X_ref, qX_hat))
-                self.assertEqual(
-                    scale, qX_hat.q_scale(),
-                    msg=error_message.format(name + '.scale', scale,
-                                             qX_hat.q_scale()))
-                self.assertEqual(
-                    zero_point, qX_hat.q_zero_point(),
-                    msg=error_message.format(name + '.zero_point', scale,
-                                             qX_hat.q_zero_point()))
+                self.assertEqualIgnoreType(X_ref, X_hat.int_repr(), atol=1.0, rtol=0,
+                                           msg=error_message.format(name, X_ref, X_hat.int_repr()))
+                self.assertEqual(scale, X_hat.q_scale(),
+                                 msg=error_message.format(name + '.scale', scale, X_hat.q_scale()))
+                self.assertEqual(zero_point, X_hat.q_zero_point(),
+                                 msg=error_message.format(name + '.zero_point', scale,
+                                 X_hat.q_zero_point()))
+
+    def test_adaptive_avg_pool(self):
+
+        side_lens = (range(1, 10))
+        dim_lens = (range(3, 5))
+        torch_type = torch.qint8
+        zero_points = (0, 1)
+        combined = [side_lens, dim_lens, zero_points]
+        test_cases = itertools.product(*combined)
+        for test_case in test_cases:
+            output_size_d = random.randint(1, 10)
+            output_size_h = random.randint(1, 10)
+            output_size_w = random.randint(1, 10)
+            side_len, dim_len, zero_point = test_case
+            shapes = [side_len] * dim_len
+            X, X_scale, X_zero_point = \
+                _get_random_tensor_and_q_params(shapes, 1.0, zero_point)
+            X = np.array(X)
+            scale = 1
+            ndim = X.ndim
+            dim_to_check = []
+            if ndim <= 4:
+                dim_to_check.append(2)
+            if ndim >= 4:
+                dim_to_check.append(3)
+
+            D, H, W = X.shape[-3:]
+            output_size_d = output_size_d if (output_size_d <= D) else D
+            output_size_h = output_size_h if (output_size_h <= H) else H
+            output_size_w = output_size_w if (output_size_w <= W) else W
+
+            X = torch.from_numpy(X)
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+
+            for dim in dim_to_check:
+                if dim == 2:
+                    if output_size_h == output_size_w:
+                        output_size = output_size_h
+                    else:
+                        output_size = (output_size_h, output_size_w)
+                elif dim == 3:
+                    if output_size_d == output_size_h == output_size_w:
+                        output_size = output_size_h
+                    else:
+                        output_size = (output_size_d, output_size_h, output_size_w)
+
+                # Run reference on int_repr + round to avoid double rounding error.
+                ref_op = getattr(torch.nn.functional, 'adaptive_avg_pool{}d'.format(dim))
+                X_ref = ref_op(qX.int_repr().to(torch.float), output_size).round()
+
+                ops_under_test = {
+                    "nn.functional":
+                        getattr(torch.nn.functional, 'adaptive_avg_pool{}d'.format(dim)),
+                    "nn.quantized.functional":
+                        getattr(torch.nn.quantized.functional, 'adaptive_avg_pool{}d'.format(dim))
+                }
+
+                error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+
+                for name, op in ops_under_test.items():
+                    qX_hat = op(qX, output_size=output_size)
+                    # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
+                    self.assertEqualIgnoreType(
+                        X_ref, qX_hat.int_repr(), atol=1.0,
+                        rtol=0, msg=error_message.format(name, X_ref, qX_hat))
+                    self.assertEqual(
+                        scale, qX_hat.q_scale(),
+                        msg=error_message.format(name + '.scale', scale,
+                                                 qX_hat.q_scale()))
+                    self.assertEqual(
+                        zero_point, qX_hat.q_zero_point(),
+                        msg=error_message.format(name + '.zero_point', scale,
+                                                 qX_hat.q_zero_point()))
 
     """Tests adaptive average pool operation on NHWC quantized tensors."""
-    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=5,
-                                              min_side=1, max_side=10),
-                       qparams=hu.qparams(dtypes=torch.qint8)),
-           output_size_d=st.integers(1, 10),
-           output_size_h=st.integers(1, 10),
-           output_size_w=st.integers(1, 10))
-    def test_adaptive_avg_pool3d_ndhwc(self, X, output_size_d, output_size_h,
-                                       output_size_w):
-        X, (scale, zero_point, torch_type) = X
-        D, H, W = X.shape[-3:]
-        assume(output_size_d <= D)
-        assume(output_size_h <= H)
-        assume(output_size_w <= W)
-        if output_size_d == output_size_h == output_size_w:
-            output_size = output_size_h
-        else:
-            output_size = (output_size_d, output_size_h, output_size_w)
+    def test_adaptive_avg_pool3d_ndhwc(self):
+        side_lens = (range(1, 10))
+        dim_lens = (range(4, 5))
+        torch_type = torch.qint8
+        zero_point = 0
+        combined = [side_lens, dim_lens]
+        test_cases = itertools.product(*combined)
+        for test_case in test_cases:
+            output_size_d = random.randint(1, 10)
+            output_size_h = random.randint(1, 10)
+            output_size_w = random.randint(1, 10)
+            side_len, dim_len = test_case
+            shapes = [side_len] * dim_len
+            X, X_scale, X_zero_point = \
+                _get_random_tensor_and_q_params(shapes, 1.0, zero_point)
+            X = np.array(X)
+            scale = 1
+            D, H, W = X.shape[-3:]
+            output_size_d = output_size_d if (output_size_d <= D) else D
+            output_size_h = output_size_h if (output_size_h <= H) else H
+            output_size_w = output_size_w if (output_size_w <= W) else W
+            if output_size_d == output_size_h == output_size_w:
+                output_size = output_size_h
+            else:
+                output_size = (output_size_d, output_size_h, output_size_w)
 
-        if X.shape[1] < 176:
-            X = np.repeat(X, 176 / X.shape[1], 1)
+            if X.shape[1] < 176:
+                X = np.repeat(X, 176 / X.shape[1], 1)
 
-        if X.ndim == 5:
-            X_ncdhw = np.ascontiguousarray(X.transpose([0, 2, 3, 4, 1]))
-            X = torch.from_numpy(X_ncdhw).permute([0, 4, 1, 2, 3])
-            qX = torch.quantize_per_tensor(torch.from_numpy(X_ncdhw),
-                                           scale=scale,
-                                           zero_point=zero_point,
-                                           dtype=torch_type).permute([0, 4, 1, 2, 3])
-        else:  # ndim == 4
-            X_ncdhw = np.ascontiguousarray(X.transpose([1, 2, 3, 0]))
-            X = torch.from_numpy(X_ncdhw).permute([3, 0, 1, 2])
-            qX = torch.quantize_per_tensor(torch.from_numpy(X_ncdhw),
-                                           scale=scale,
-                                           zero_point=zero_point,
-                                           dtype=torch_type).permute([3, 0, 1, 2])
+            if X.ndim == 5:
+                X_ncdhw = np.ascontiguousarray(X.transpose([0, 2, 3, 4, 1]))
+                X = torch.from_numpy(X_ncdhw).permute([0, 4, 1, 2, 3])
+                qX = torch.quantize_per_tensor(torch.from_numpy(X_ncdhw),
+                                               scale=scale,
+                                               zero_point=zero_point,
+                                               dtype=torch_type).permute([0, 4, 1, 2, 3])
+            else:  # ndim == 4
+                X_ncdhw = np.ascontiguousarray(X.transpose([1, 2, 3, 0]))
+                X = torch.from_numpy(X_ncdhw).permute([3, 0, 1, 2])
+                qX = torch.quantize_per_tensor(torch.from_numpy(X_ncdhw),
+                                               scale=scale,
+                                               zero_point=zero_point,
+                                               dtype=torch_type).permute([3, 0, 1, 2])
 
-        # Run reference on int_repr + round to avoid double rounding error.
-        X_ref = torch.nn.functional.adaptive_avg_pool3d(
-            qX.int_repr().to(torch.double), output_size).round()
+            # Run reference on int_repr + round to avoid double rounding error.
+            X_ref = torch.nn.functional.adaptive_avg_pool3d(
+                qX.int_repr().to(torch.double), output_size).round()
 
-        self.assertTrue(qX.stride() != sorted(qX.stride()))
+            self.assertTrue(qX.stride() != sorted(qX.stride()))
 
-        ops_under_test = {
-            "nn.functional": torch.nn.functional.adaptive_avg_pool3d,
-            "nn.quantized.functional":
-                torch.nn.quantized.functional.adaptive_avg_pool3d
-        }
-        error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-        for name, op in ops_under_test.items():
-            X_hat = op(qX, output_size=output_size)
-            self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
-            # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-            self.assertEqualIgnoreType(X_ref, X_hat.int_repr(), atol=1.0, rtol=0,
-                                       msg=error_message.format(name, X_ref, X_hat.int_repr()))
-            self.assertEqual(scale, X_hat.q_scale(),
-                             msg=error_message.format(name + '.scale', scale, X_hat.q_scale()))
-            self.assertEqual(zero_point, X_hat.q_zero_point(),
-                             msg=error_message.format(name + '.zero_point', scale,
-                                                      X_hat.q_zero_point()))
+            ops_under_test = {
+                "nn.functional": torch.nn.functional.adaptive_avg_pool3d,
+                "nn.quantized.functional":
+                    torch.nn.quantized.functional.adaptive_avg_pool3d
+            }
+            error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+            for name, op in ops_under_test.items():
+                X_hat = op(qX, output_size=output_size)
+                self.assertTrue(X_hat.stride() != sorted(X_hat.stride()))
+                # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
+                self.assertEqualIgnoreType(X_ref, X_hat.int_repr(), atol=1.0, rtol=0,
+                                           msg=error_message.format(name, X_ref, X_hat.int_repr()))
+                self.assertEqual(scale, X_hat.q_scale(),
+                                 msg=error_message.format(name + '.scale', scale, X_hat.q_scale()))
+                self.assertEqual(zero_point, X_hat.q_zero_point(),
+                                 msg=error_message.format(name + '.zero_point', scale,
+                                 X_hat.q_zero_point()))
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
                                               min_side=1, max_side=10),


### PR DESCRIPTION
Summary: Remove all the hypothesis tests from test_adaptive_avg_pool2d_nhwc, test_adaptive_avg_pool, and test_adaptive_avg_pool3d_ndhwc.

Test Plan: I tested it with buck test //caffe2/test:quantization and all three tests passed. The tests that failed are test_conv2d_api (test_quantized_functional.py), test_conv3d_api (test_quantized_functional.py),

Reviewed By: jerryzh168

Differential Revision: D29432184

