### PR TITLE
[Model Averaging] Enforce a synchronization before allreduce parameters

### DIFF
--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -16,6 +16,9 @@ def average_parameters(module: torch.nn.Module, process_group: dist.ProcessGroup
 
     flat_params = torch.cat([p.data.view(-1) for p in module.parameters()])
     flat_params /= dist.get_world_size(group_to_use)
+    # Make sure the allreduce will not conflict with any other ongoing process group.
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60891**

This fix is particularly useful for local SGD when the averaging period is very small, which may cause the conflict between gradient allreduce within per-machine subgroup and the global parameter allreduce by the communication world.

Proposal: https://github.com/pytorch/pytorch/issues/59699
Differential Revision: [D29434597](https://our.internmc.facebook.com/intern/diff/D29434597/)