### PR TITLE
Use the new URL for docs preview link

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -461,7 +461,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "See rendered docs at https://d28slxzaq48q8t.cloudfront.net/$PR_NUMBER/"
+          echo "See rendered docs at https://docs-preview.pytorch.org/$PR_NUMBER/"
       - name: Archive artifacts into zip
         run: |
           zip -r pytorch_github_io.zip "${GITHUB_WORKSPACE}/pytorch.github.io"

--- a/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
@@ -459,7 +459,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "See rendered docs at https://d28slxzaq48q8t.cloudfront.net/$PR_NUMBER/"
+          echo "See rendered docs at https://docs-preview.pytorch.org/$PR_NUMBER/"
       - name: Archive artifacts into zip
         run: |
           zip -r pytorch_github_io.zip "${GITHUB_WORKSPACE}/pytorch.github.io"


### PR DESCRIPTION
This is all set up on CloudFront now with a custom domain, so we don't need the long default cloudfront domain anymore
