### PR TITLE
Fix error logging in common_distributed.

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -526,7 +526,7 @@ class MultiProcessTestCase(TestCase):
         except Exception as e:
             logger.error(
                 f'Caught exception: \n{traceback.format_exc()} exiting '
-                'process with exit code: {MultiProcessTestCase.TEST_ERROR_EXIT_CODE}')
+                f'process {self.rank} with exit code: {MultiProcessTestCase.TEST_ERROR_EXIT_CODE}')
             # Send error to parent process.
             parent_pipe.send(traceback.format_exc())
             sys.exit(MultiProcessTestCase.TEST_ERROR_EXIT_CODE)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60917**

The second line of error log didn't handle f-string properly.


Before fix:
```
exiting process with exit code: {MultiProcessTestCase.TEST_ERROR_EXIT_CODE}
```

After fix:
```
exiting process 3 with exit code: 10
```

Differential Revision: [D29446574](https://our.internmc.facebook.com/intern/diff/D29446574/)