### PR TITLE
[caffe2] update make_mnist_db and make_image_db to move strings into DB::Put()

### DIFF
--- a/binaries/make_image_db.cc
+++ b/binaries/make_image_db.cc
@@ -243,7 +243,6 @@ void ConvertImageDataset(
 
   constexpr auto key_max_length = 256;
   char key_cstr[key_max_length];
-  string value;
   int count = 0;
   for (auto i = 0; i < lines.size(); i++) {
     // Get serialized proto for this entry
@@ -255,7 +254,7 @@ void ConvertImageDataset(
     DCHECK_LE(key_len, sizeof(key_cstr));
 
     // Put in db
-    transaction->Put(string(key_cstr), value);
+    transaction->Put(string(key_cstr), std::move(value));
 
     if (++count % 1000 == 0) {
       // Commit the current writes.

--- a/binaries/make_mnist_db.cc
+++ b/binaries/make_mnist_db.cc
@@ -91,7 +91,6 @@ void convert_dataset(const char* image_filename, const char* label_filename,
   int count = 0;
   const int kMaxKeyLength = 11;
   char key_cstr[kMaxKeyLength];
-  string value;
 
   TensorProtos protos;
   TensorProto* data = protos.add_protos();
@@ -119,11 +118,10 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     }
     label->set_int32_data(0, static_cast<int>(label_value));
     snprintf(key_cstr, kMaxKeyLength, "%08d", item_id);
-    protos.SerializeToString(&value);
     string keystr(key_cstr);
 
     // Put in db
-    transaction->Put(keystr, value);
+    transaction->Put(keystr, protos.SerializeAsString());
     if (++count % 1000 == 0) {
       transaction->Commit();
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60919**

Update make_mnist_db.cc and make_image_db.cc to work with the DB API changes
in D29204425.  This is similar to the changes to make_cifar_db.cc landed in
D29374754.

Differential Revision: [D29447314](https://our.internmc.facebook.com/intern/diff/D29447314/)