### PR TITLE
Use manywheel-cpu docker image for binary CPU builds

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -62,7 +62,7 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
   if [[ "$PACKAGE_TYPE" == conda ]]; then
     export DOCKER_IMAGE="pytorch/conda-cuda"
   elif [[ "$DESIRED_CUDA" == cpu ]]; then
-    export DOCKER_IMAGE="pytorch/manylinux-cuda100"
+    export DOCKER_IMAGE="pytorch/manylinux-cpu"
   else
     export DOCKER_IMAGE="pytorch/manylinux-cuda${DESIRED_CUDA:2}"
   fi


### PR DESCRIPTION
This was set to use the [CUDA 10.0 image](https://hub.docker.com/r/pytorch/manylinux-cuda100) which hasn't been updated in quite a while, so fix it to use the up-to-date [cpu image](https://hub.docker.com/r/pytorch/manylinux-cpu) instead
