### PR TITLE
Support variable_list extracted as multiple variables for custom autograd.

### DIFF
--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -187,6 +187,12 @@ struct ExtractVariables : IterArgs<ExtractVariables> {
     is_var_.push_back(true);
     list_.emplace_back(x);
   }
+  void operator()(const std::vector<at::Tensor>& x) {
+    for(auto x_ : x){
+      is_var_.push_back(true);
+      list_.emplace_back(x_);
+    }
+  }
   template <typename T>
   void operator()(const T& x) {
     is_var_.push_back(false);


### PR DESCRIPTION
This PR is for supporting Variable List extracted as multiple variables for custom autograd. 
To enable operators like LSTM and GRU, which use Tensor List as Parameters, and do custom autograd in IPEX implementation.  
