### PR TITLE
Add TorchVitals for DataLoader

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import torch
+import torch.utils.data
 import numpy as np
 
 import contextlib
@@ -2933,6 +2934,14 @@ class TestBasicVitalSigns(TestCase):
             self.assertTrue(torch.set_vital('Dataloader', 'basic_unit_test', 'TEST_VALUE_STRING'))
             self.assertIn('TEST_VALUE_STRING', torch.read_vitals())
             self.assertIn('CUDA.used', torch.read_vitals())
+
+    def test_dataloader_vitals(self):
+        with torch_vital_set('ON'):
+            inps = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
+            tgts = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
+            dataset = torch.utils.data.TensorDataset(inps, tgts)
+            loader = torch.utils.data.DataLoader(dataset, batch_size=2)
+            self.assertIn('Dataloader.enabled\t\t True', torch.read_vitals())
 
 
 class TestVitalSignsCuda(TestCase):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -295,6 +295,8 @@ class DataLoader(Generic[T_co]):
 
         self.check_worker_number_rationality()
 
+        torch.set_vital('Dataloader', 'enabled', 'True')  # type: ignore[attr-defined]
+
     def _get_iterator(self) -> '_BaseDataLoaderIter':
         if self.num_workers == 0:
             return _SingleProcessDataLoaderIter(self)


### PR DESCRIPTION
Summary:
Add TorchVitals for Dataloader, this indicates that the data loader was enabled.

This is a no-op if TORCH_VITALS environment variable is not set.

Test Plan: buck test mode/dbg caffe2/test:torch -- --regex vitals

Reviewed By: VitalyFedyunin

Differential Revision: D29445146

