### PR TITLE
[torch][repeat_interleave] Remove stream sync when output_size is given for scalar repeats

### DIFF
--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -71,11 +71,9 @@ Tensor repeat_interleave(
     int64_t repeats,
     c10::optional<int64_t> dim,
     c10::optional<int64_t> output_size) {
-  return at::native::repeat_interleave(
-      self,
-      at::tensor({repeats}, self.options().dtype(kLong)),
-      dim,
-      output_size);
+  at::Tensor repeats_ =
+      at::empty(1, self.options().dtype(at::kLong)).fill_(repeats);
+  return at::native::repeat_interleave(self, repeats_, dim, output_size);
 }
 
 } // namespace native


### PR DESCRIPTION
Summary: Same as title. Simple change on tensor creation.

Test Plan: Rely on existing signals and verify manually that sync is not happening.

Differential Revision: D29461773

