### PR TITLE
Remove fetch in clang-tidy setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -290,8 +290,6 @@ jobs:
         run: |
           cd "${GITHUB_WORKSPACE}"
           set -eux
-          git remote add upstream https://github.com/pytorch/pytorch
-          git fetch upstream "$GITHUB_BASE_REF"
 
           if [ ! -d build ]; then
             git submodule update --init --recursive


### PR DESCRIPTION
This was necessary previously since we'd have to diff against upstream in order to figure out what to run in clang-tidy, but now we pull this from GitHub #60045 so we can delete this part of the workflow
