### PR TITLE
for shared-memory handles, use an atomic counter, instead of potentially colliding random numbers

### DIFF
--- a/aten/src/ATen/MapAllocator.cpp
+++ b/aten/src/ATen/MapAllocator.cpp
@@ -1,11 +1,13 @@
 #include <ATen/MapAllocator.h>
 
 #include <atomic>
+#include <string>
 #if ATOMIC_INT_LOCK_FREE == 2
 #define AT_ATOMIC_IPC_REFCOUNT 1
 #endif
 
 #include <c10/core/CPUAllocator.h>
+#include <c10/util/C++17.h>
 #include <c10/util/Unicode.h>
 
 /* stuff for mapped files */
@@ -14,16 +16,35 @@
 #endif
 
 #if defined(HAVE_MMAP)
-#include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#endif
+
+#if !defined(_MSC_VER) || defined(HAVE_MMAP)
+#include <sys/types.h>
 #include <unistd.h>
+#elif defined(_MSC_VER)
+#include <c10/util/win32-headers.h>
 #endif
 
 namespace at {
 
 static constexpr int64_t map_alloc_alignment = 64;
+
+TORCH_API std::string NewProcessWideShmHandle()
+{
+  static std::atomic<uint64_t> counter;
+  std::string handle = "/torch_";
+#ifdef _MSC_VER
+  handle += c10::guts::to_string(GetCurrentProcessId());
+#else
+  handle += c10::guts::to_string(getpid());
+#endif
+  handle += "_";
+  handle += c10::guts::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+  return handle;
+}
 
 #if defined(_WIN32) || defined(HAVE_MMAP)
 

--- a/aten/src/ATen/MapAllocator.h
+++ b/aten/src/ATen/MapAllocator.h
@@ -18,6 +18,8 @@ enum MappedAllocatorModes {
 // the non-file descriptor constructor
 enum WithFd { WITH_FD };
 
+TORCH_API std::string NewProcessWideShmHandle();
+
 class TORCH_API MapAllocator {
  public:
   MapAllocator(std::string filename, int flags, size_t size);

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -6,7 +6,8 @@
 
 #include <torch/csrc/utils/python_numbers.h>
 #include <ATen/MapAllocator.h>
-#include <random>
+#include <atomic>
+#include <string>
 
 static PyObject * THPStorage_(sharedDecref)(PyObject *_self, PyObject *noargs)
 {
@@ -40,24 +41,11 @@ static PyObject * THPStorage_(sharedIncref)(PyObject *_self, PyObject *noargs)
 }
 
 #ifndef THC_GENERIC_FILE
-// TODO: move this somewhere - we only need one version
-static std::string THPStorage_(__newHandle)() {
-  static std::random_device rd;
-  std::string handle = "/torch_";
-#ifdef _MSC_VER
-  handle += std::to_string(GetCurrentProcessId());
-#else
-  handle += std::to_string(getpid());
-#endif
-  handle += "_";
-  handle += std::to_string(rd());
-  return handle;
-}
 
 static THWStorage* THPStorage_(newFilenameStorage)(ptrdiff_t size)
 {
   int flags = at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_EXCLUSIVE;
-  std::string handle = THPStorage_(__newHandle)();
+  std::string handle = at::NewProcessWideShmHandle();
   return THWStorage_(newWithDataAndAllocator)(
       THManagedMapAllocator::makeDataPtr("", handle.c_str(), flags, size * sizeof(scalar_t)), size, /* allocator */ nullptr);
 }
@@ -142,7 +130,7 @@ static THWStorage* THPStorage_(newFdStorage)(ptrdiff_t size)
               at::ALLOCATOR_MAPPED_EXCLUSIVE |
               at::ALLOCATOR_MAPPED_KEEPFD |
               at::ALLOCATOR_MAPPED_UNLINK;
-  std::string handle = THPStorage_(__newHandle)();
+  std::string handle = at::NewProcessWideShmHandle();
   auto sptr = at::MapAllocator::makeDataPtr(handle.c_str(), flags, size * sizeof(scalar_t), nullptr);
   return THWStorage_(newWithDataAndAllocator)(std::move(sptr), size, /* allocator */ nullptr);
 }


### PR DESCRIPTION
These handles, used for shared-memory tensors, can collide.

E.g. see https://github.com/pytorch/pytorch/issues/60626#issuecomment-869919018
