### PR TITLE
Move IMethod to OSS and integrate properly with ScriptMethod

### DIFF
--- a/test/cpp/api/imethod.cpp
+++ b/test/cpp/api/imethod.cpp
@@ -1,0 +1,44 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <torch/csrc/deploy/deploy.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+
+using namespace ::testing;
+using namespace caffe2;
+
+TEST(IMethodTest, CallMethod) {
+  auto script_model = torch::jit::load(getenv("SIMPLE_JIT"));
+  auto script_method = script_model.get_method("forward");
+
+  torch::deploy::InterpreterManager manager(3);
+  torch::deploy::Package p = manager.load_package(getenv("SIMPLE"));
+  auto py_model = p.load_pickle("model", "model.pkl");
+  torch::deploy::PythonMethodWrapper py_method(py_model, "forward");
+
+  auto input = torch::ones({10, 20});
+  auto output_py = py_method({input});
+  auto output_script = script_method({input});
+  EXPECT_TRUE(output_py.isTensor());
+  EXPECT_TRUE(output_script.isTensor());
+  auto output_py_tensor = output_py.toTensor();
+  auto output_script_tensor = output_script.toTensor();
+
+  EXPECT_TRUE(output_py_tensor.equal(output_script_tensor));
+  EXPECT_EQ(output_py_tensor.numel(), 200);
+}
+
+TEST(IMethodTest, GetArgumentNames) {
+  auto script_model = torch::jit::load(getenv("SIMPLE_JIT"));
+  auto script_method = script_model.get_method("forward");
+
+  torch::deploy::InterpreterManager manager(3);
+  torch::deploy::Package p = manager.load_package(getenv("SIMPLE"));
+  auto py_model = p.load_pickle("model", "model.pkl");
+  torch::deploy::PythonMethodWrapper py_method(py_model, "forward");
+
+  // TODO(whc) implement and test these
+  EXPECT_THROW(script_method.getArgumentNames(), std::runtime_error);
+  EXPECT_THROW(py_method.getArgumentNames(), std::runtime_error);
+}

--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <ATen/core/ivalue.h>
+
+namespace torch {
+
+class IMethod {
+  /*
+  IMethod provides a portable interface for torch methods, whether
+  they are backed by torchscript or python/deploy.
+
+  This is helpful since torchscript methods provide additional information
+  (e.g. FunctionSchema, Graph) which aren't available in pure python methods.
+
+  Higher level APIs should prefer depending on this interface rather
+  than a specific implementation of it, to promote portability and reuse, and
+  avoid unintentional dependencies on e.g. script methods.
+
+  Note: This API is experimental, and may evolve.
+  */
+ public:
+  using IValueList = std::vector<c10::IValue>;
+  using IValueMap = std::unordered_map<std::string, at::IValue>;
+
+  virtual ~IMethod() = default;
+
+  virtual c10::IValue operator()(
+      std::vector<c10::IValue> args,
+      const IValueMap& kwargs = IValueMap()) = 0;
+
+  // Returns an ordered list of argument names, possible in both
+  // script and python methods.  This is a more portable dependency
+  // than a ScriptMethod FunctionSchema, which has more information
+  // than can be generally expected from a python method.
+  virtual std::vector<std::string> getArgumentNames() = 0;
+};
+
+} // namespace torch

--- a/torch/csrc/jit/api/method.h
+++ b/torch/csrc/jit/api/method.h
@@ -3,6 +3,7 @@
 #include <ATen/core/function.h>
 #include <ATen/core/ivalue.h>
 #include <ATen/core/stack.h>
+#include <torch/csrc/api/include/torch/imethod.h>
 #include <torch/csrc/jit/api/function_impl.h>
 
 namespace torch {
@@ -18,7 +19,7 @@ using ObjectPtr = c10::intrusive_ptr<c10::ivalue::Object>;
 //     ...
 // Note: because Method/Module are exposed to python these
 // classes use python method naming conventions
-struct TORCH_API Method {
+struct TORCH_API Method : public torch::IMethod {
   Method(ObjectPtr owner, Function* function);
 
   // the module that contains this method.
@@ -30,7 +31,7 @@ struct TORCH_API Method {
 
   c10::IValue operator()(
       std::vector<c10::IValue> stack,
-      const Kwargs& kwargs = Kwargs());
+      const Kwargs& kwargs = Kwargs()) override;
 
   // Run method async. Invocation on this function would invokes a JIT
   // interpreter that executes ops inline, one by one, on caller's thread. A
@@ -55,6 +56,10 @@ struct TORCH_API Method {
 
   GraphExecutor& get_executor() {
     return function_->get_executor();
+  }
+
+  std::vector<std::string> getArgumentNames() override {
+    throw std::runtime_error("getArgumentNames not yet implemented");
   }
 
   Function& function() const {


### PR DESCRIPTION
Summary: Expose IMethod interface, which provides a unified interface to either script or python methods backed by torchscript or torchdeploy.

Test Plan: add unit tests.

Reviewed By: suo

Differential Revision: D29463455

