### PR TITLE
SGX Caffe2 Target

### DIFF
--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -2,6 +2,10 @@
 #include <chrono>
 #include <random>
 
+#if defined(__SGX_ENABLED__)
+#include "sgx_trts.h"
+#endif
+
 #ifndef _WIN32
 #include <fcntl.h>
 #include <unistd.h>
@@ -57,7 +61,9 @@ static uint64_t readURandomLong() {
 /**
  * Gets a non deterministic random number number from either the
  * /dev/urandom or the current time. For CUDA, gets random from
- * std::random_device and adds a transformation on it.
+ * std::random_device and adds a transformation on it. For Intel SGX
+ * we get the random from sgx_read_rand as reading from /dev/urandom is
+ * prohibited on that platfrom.
  *
  * FIXME: The behavior in this function is from legacy code
  * (THRandom_seed/THCRandom_seed) and is probably not the right thing to do,
@@ -76,6 +82,10 @@ uint64_t getNonDeterministicRandom(bool is_cuda) {
     s = (uint64_t)std::chrono::high_resolution_clock::now()
             .time_since_epoch()
             .count();
+#elif defined(__SGX_ENABLED__)
+    TORCH_CHECK(
+        sgx_read_rand((unsigned char*)&s, sizeof(s)) == SGX_SUCCESS,
+        "Could not generate random number with sgx_read_rand.");
 #else
     s = readURandomLong();
 #endif

--- a/c10/util/math_compat.h
+++ b/c10/util/math_compat.h
@@ -5,7 +5,8 @@
 // Android NDK platform < 21 with libstdc++ has spotty C++11 support.
 // Various hacks in this header allow the rest of the codebase to use
 // standard APIs.
-#if defined(__ANDROID__) && __ANDROID_API__ < 21 && defined(__GLIBCXX__)
+#if (defined(__ANDROID__) && __ANDROID_API__ < 21 && defined(__GLIBCXX__)) || \
+    defined(__NEWLIB__)
 #include <stdexcept>
 
 namespace std {
@@ -84,6 +85,7 @@ inline double nexttoward(double x, long double y) {
   throw std::runtime_error("std::nexttoward is not present on older Android");
 }
 
+#if !defined(__NEWLIB__)
 // TODO: this function needs to be implemented and tested. Currently just throw
 // an error.
 inline float hypot(float x, float y) {
@@ -92,6 +94,11 @@ inline float hypot(float x, float y) {
 inline double hypot(double x, double y) {
   throw std::runtime_error("std::hypot is not implemented on older Android");
 }
+#else
+inline float hypot(float x, float y) {
+  return hypot((double)x, (double)y);
+}
+#endif
 
 // TODO: this function needs to be implemented and tested. Currently just throw
 // an error.
@@ -108,6 +115,7 @@ inline double igammac(double x, double y) {
   throw std::runtime_error("igammac is not implemented on older Android");
 }
 
+#if !defined(__NEWLIB__)
 // TODO: this function needs to be implemented and tested. Currently just throw
 // an error.
 inline float nextafter(float x, float y) {
@@ -118,7 +126,13 @@ inline double nextafter(double x, double y) {
   throw std::runtime_error(
       "std::nextafter is not implemented on older Android");
 }
+#else
+inline float nextafter(float x, float y) {
+  return nextafter((double)x, (double)y);
+}
+#endif
 
+#if !defined(__NEWLIB__)
 // TODO: this function needs to be implemented and tested. Currently just throw
 // an error.
 inline float exp2(float x) {
@@ -127,6 +141,11 @@ inline float exp2(float x) {
 inline double exp2(double x) {
   throw std::runtime_error("std::exp2 is not implemented on older Android");
 }
+#else
+inline float exp2(float x) {
+  return exp2((double)x);
+}
+#endif
 
 // Define integral versions the same way as more recent libstdc++
 template <typename T>
@@ -208,9 +227,11 @@ typename __gnu_cxx::__promote_2<T, U>::__type remainder(T x, U y) {
 inline float log2(float arg) {
   return ::log(arg) / ::log(2.0);
 }
+#if !defined(__NEWLIB__)
 inline double log2(double arg) {
   return ::log(arg) / ::log(2.0);
 }
+#endif
 inline long double log2(long double arg) {
   return ::log(arg) / ::log(2.0);
 }

--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -1,6 +1,5 @@
 #include <c10/util/Backtrace.h>
 #include <c10/util/signal_handler.h>
-#include <fmt/format.h>
 
 #if defined(C10_SUPPORTS_SIGNAL_HANDLER)
 
@@ -8,6 +7,7 @@
 #include <cxxabi.h>
 #include <dirent.h>
 #include <dlfcn.h>
+#include <fmt/format.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/caffe2/experiments/operators/fully_connected_op_sparse.h
+++ b/caffe2/experiments/operators/fully_connected_op_sparse.h
@@ -83,9 +83,16 @@ void Sparse_mm<float, CPUContext>(
     const float* b,
     float* c,
     CPUContext* /*context*/) {
+
+  #ifdef CAFFE2_USE_MKL
+
   float alpha = 1.0, beta = 0.;
   mkl_scsrmm("N", &m, &n, &k, &alpha, "GLNC",
              acsr, ja, ia, ia+1, b, &n, &beta, c, &n);
+
+  #else
+  throw std::runtime_error("Not compiled with MKL");
+  #endif
 }
 
 }

--- a/caffe2/serialize/crc_alt.h
+++ b/caffe2/serialize/crc_alt.h
@@ -125,6 +125,10 @@ uint32_t crc32_16bytes_prefetch(const void* data, size_t length, uint32_t previo
     #else
       # error "Unknown Apple platform"
     #endif
+#elif defined(__SGX_ENABLED__)
+  // nothing to do here since the newlibc in the SGX toolchain
+  // sets this flag just fine and the SGX compiler will cause a
+  // compile error when we try to redefine it
 #elif defined(__ARMEB__)
   #define __BYTE_ORDER __BIG_ENDIAN
 #elif defined(__BYTE_ORDER__)

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -320,6 +320,7 @@ core_sources_full = core_sources_full_mobile + [
 ]
 
 libtorch_core_sources = sorted(core_sources_common + core_sources_full + core_trainer_sources)
+libtorch_core_mobile_sources = sorted(core_sources_common + core_sources_full_mobile + core_trainer_sources)
 
 # These files are the only ones that are supported on Windows.
 libtorch_distributed_base_sources = [
@@ -441,7 +442,7 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/autograd/VariableTypeManual.cpp",
     "torch/csrc/autograd/FunctionsManual.cpp",
     "torch/csrc/jit/api/module_save.cpp",
-    "torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp",
+    # "torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp",
     "torch/csrc/jit/mobile/backport.cpp",
     "torch/csrc/jit/mobile/backport_manager.cpp",
     # To be included for eager symbolication in lite interpreter
@@ -468,6 +469,15 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
 
 def libtorch_sources(gencode_pattern = ":generate-code[{}]"):
     return libtorch_generated_sources(gencode_pattern) + libtorch_core_sources + libtorch_distributed_sources + libtorch_extra_sources
+
+sgx_sources_to_exclude = [
+    "torch/csrc/jit/tensorexpr/llvm_codegen.cpp",
+    "torch/csrc/jit/tensorexpr/llvm_jit.cpp",
+    "torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp",
+]
+
+def libtorch_sgx_sources(gencode_pattern = ":generate-code[{}]"):
+    return libtorch_generated_sources(gencode_pattern) + [i for i in libtorch_core_mobile_sources if i not in sgx_sources_to_exclude] + [i for i in libtorch_extra_sources if i not in sgx_sources_to_exclude]
 
 libtorch_cuda_core_sources = [
     "torch/csrc/CudaIPCTypes.cpp",


### PR DESCRIPTION
Summary: This diff adds a target that is used to build the SGX version of pytorch, including the c10, aten and caffe2 targets.

Test Plan:
-The SGX target is tested by the "pytorch demo and tests" diff in this stack. We keep this diff separated so that pytorch reviewers can focus on the relevant changes.
-Since there are a few diffs that needed changes to the buck files used in the regular pytorch targets, we need to make sure that our changes do break any non-failing tests.

Differential Revision: D29018578

