### PR TITLE
[skip-ci] Bump docker image tag

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:7f0b4616100071a4813318bfdbd5b06ae36c5272
+      image: ghcr.io/pytorch/cilint-clang-tidy:b5a795a1165938adc6ccdab36bfa59bb3829ad47
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
@@ -332,6 +332,7 @@ jobs:
             --verbose \
             --paths torch/csrc/ \
             --diff-file pr.diff \
+            --include-dir /usr/lib/llvm-11/include/openmp \
             -g"-torch/csrc/jit/passes/onnx/helper.cpp" \
             -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp" \
             -g"-torch/csrc/jit/serialization/onnx.cpp" \


### PR DESCRIPTION
This PR bumps the docker image tag for clang-tidy. The new image runs ubuntu-20.04 (and therefore has python3.8 by default).