### PR TITLE
[nnc] Serialize initialization of LLVM targets

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -367,7 +367,7 @@ namespace {
 // Global mutex to protect LLVM initialization.  TargetRegistry::lookupTarget
 // in particular is not thread-safe.
 static std::mutex llvmInitMutex;
-}
+} // namespace
 
 LLVMCodeGenImpl::LLVMCodeGenImpl(
     Stmt* stmt,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57334
* **#60996**



We've had a bug report of weird LLVM initialization errors, e.g.,
```
Unexpected failure in LLVM JIT: Cannot choose between targets "x86-64" and "x86-64"
```

While I haven't repro'ed that exact message, I did run a stress-test that
compiles on many threads simultaneously, and it deadlocks in
TargetRegistry::lookupTarget.  And in fact I remember debugging this before in
a different system, and finding "Clients are responsible for avoid race
conditions in registration" in
https://llvm.org/doxygen/TargetRegistry_8cpp_source.html.

So yeah, let's lock this thing.

Differential Revision: [D29471343](https://our.internmc.facebook.com/intern/diff/D29471343/)

Differential Revision: [D29471343](https://our.internmc.facebook.com/intern/diff/D29471343)