### PR TITLE
[Static runtime] Add unit tests to ops bmm and addmm

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -466,3 +466,13 @@ const auto nested_output_script_3 = R"JIT(
     h = {"e": e, "f": f}
     return [g, h]
 )JIT";
+
+const auto bmm_script = R"JIT(
+  def forward(self, inp: Tensor, mat2: Tensor):
+   return torch.bmm(inp, mat2).clone()
+)JIT";
+
+const auto addmm_script = R"JIT(
+  def forward(self, inp: Tensor, mat1: Tensor, mat2: Tensor, beta: float, alpha: float):
+   return torch.addmm(inp, mat1, mat2, alpha=alpha, beta=beta).clone()
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -306,6 +306,36 @@ TEST(StaticRuntime, LayerNorm) {
   }
 }
 
+TEST(StaticRuntime, Bmm) {
+  auto a = at::randn({10, 4, 5});
+  auto b = at::randn({10, 5, 6});
+
+  auto c = at::randn({12, 5, 6});
+  auto d = at::randn({12, 6, 7});
+
+  std::vector<IValue> args{a, b};
+  std::vector<IValue> args1{c, d};
+  testStaticRuntime(bmm_script, args);
+  testStaticRuntime(bmm_script, args1);
+  testStaticRuntime(bmm_script, args, args1);
+}
+
+TEST(StaticRuntime, Addmm) {
+  auto inp1 = at::randn({5});
+  auto mat1 = at::randn({3, 4});
+  auto mat2 = at::randn({4, 5});
+
+  auto inp2 = at::randn({3, 7});
+  auto mat3 = at::randn({3, 6});
+  auto mat4 = at::randn({6, 7});
+
+  std::vector<IValue> args{inp1, mat1, mat2, 1.0, 2.0};
+  std::vector<IValue> args1{inp2, mat3, mat4, 2.0, 1.0};
+  testStaticRuntime(addmm_script, args);
+  testStaticRuntime(addmm_script, args1);
+  testStaticRuntime(addmm_script, args, args1);
+}
+
 TEST(StaticRuntime, IndividualOps_Binary) {
   auto a = at::randn({2, 3});
   auto b = at::ones({2, 3});


### PR DESCRIPTION
Summary: Add unit tests to bmm and addmm operators in static runtime.

Test Plan:
buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest

{F628935117}

Reviewed By: hlu1

Differential Revision: D29459679

