### PR TITLE
Move windows periodic jobs to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9273,41 +9273,6 @@ workflows:
             - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           build_environment: "pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
-      - pytorch_windows_build:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.3"
-          name: periodic_pytorch_windows_cuda11.3_build
-          python_version: "3.8"
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.28.29333"
-          vc_year: "2019"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.3"
-          executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.3_test1
-          python_version: "3.8"
-          requires:
-            - periodic_pytorch_windows_cuda11.3_build
-          test_name: pytorch-windows-test1
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.28.29333"
-          vc_year: "2019"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.3"
-          executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.3_test2
-          python_version: "3.8"
-          requires:
-            - periodic_pytorch_windows_cuda11.3_build
-          test_name: pytorch-windows-test2
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.28.29333"
-          vc_year: "2019"
 
   # The following allows these jobs to run on ci-all and release branches
   debuggable-scheduled-ci:

--- a/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
@@ -31,41 +31,6 @@
             - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           build_environment: "pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
-      - pytorch_windows_build:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.3"
-          name: periodic_pytorch_windows_cuda11.3_build
-          python_version: "3.8"
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.28.29333"
-          vc_year: "2019"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.3"
-          executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.3_test1
-          python_version: "3.8"
-          requires:
-            - periodic_pytorch_windows_cuda11.3_build
-          test_name: pytorch-windows-test1
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.28.29333"
-          vc_year: "2019"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.3"
-          executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.3_test2
-          python_version: "3.8"
-          requires:
-            - periodic_pytorch_windows_cuda11.3_build
-          test_name: pytorch-windows-test2
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.28.29333"
-          vc_year: "2019"
 
   # The following allows these jobs to run on ci-all and release branches
   debuggable-scheduled-ci:

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -27,6 +27,7 @@ def PyTorchWindowsWorkflow(
     on_pull_request: bool = False,
     only_build_on_pull_request: bool = False,
     num_test_shards: int = 1,
+    is_scheduled: str = None,
 ) -> PyTorchWorkflow:
     return {
         "build_environment": build_environment,
@@ -34,6 +35,7 @@ def PyTorchWindowsWorkflow(
         "cuda_version": cuda_version,
         "on_pull_request": on_pull_request,
         "only_build_on_pull_request": only_build_on_pull_request and on_pull_request,
+        "is_scheduled": is_scheduled,
         "num_test_shards": num_test_shards,
     }
 
@@ -50,12 +52,14 @@ def PyTorchLinuxWorkflow(
     on_pull_request: bool = False,
     enable_doc_jobs: bool = False,
     num_test_shards: int = 1,
+    is_scheduled: str = None,
 ) -> PyTorchWorkflow:
     return {
         "build_environment": build_environment,
         "docker_image_base": docker_image_base,
         "test_runner_type": test_runner_type,
         "on_pull_request": on_pull_request,
+        "is_scheduled": is_scheduled,
         "enable_doc_jobs": enable_doc_jobs,
         "num_test_shards": num_test_shards,
     }
@@ -95,7 +99,14 @@ WINDOWS_WORKFLOWS = [
         cuda_version="11.1",
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         num_test_shards=2,
-    )
+    ),
+    PyTorchWindowsWorkflow(
+        build_environment="periodic-pytorch-win-vs2019-cuda11-cudnn8-py3",
+        cuda_version="11.3",
+        test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        is_scheduled="45 0,4,8,12,16,20 * * *",
+    ),
 ]
 
 LINUX_WORKFLOWS = [

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import jinja2
 
@@ -27,7 +27,7 @@ def PyTorchWindowsWorkflow(
     on_pull_request: bool = False,
     only_build_on_pull_request: bool = False,
     num_test_shards: int = 1,
-    is_scheduled: str = None,
+    is_scheduled: Optional[str] = None,
 ) -> PyTorchWorkflow:
     return {
         "build_environment": build_environment,
@@ -52,7 +52,7 @@ def PyTorchLinuxWorkflow(
     on_pull_request: bool = False,
     enable_doc_jobs: bool = False,
     num_test_shards: int = 1,
-    is_scheduled: str = None,
+    is_scheduled: Optional[str] = None,
 ) -> PyTorchWorkflow:
     return {
         "build_environment": build_environment,

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -7,10 +7,15 @@ on:
 {%- if on_pull_request %}
   pull_request:
 {%- endif %}
+{%- if is_scheduled %}
+  schedule:
+    - cron: !{{ is_scheduled }}
+{%- else %}
   push:
     branches:
       - master
       - release/*
+{%- endif %}
   workflow_dispatch:
 
 env:

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -3,7 +3,7 @@
 name: Windows CI (!{{ build_environment }})
 
 on:
-{%- if on_pull_request or is_scheduled %}
+{%- if on_pull_request %}
   pull_request:
 {%- endif %}
 {%- if is_scheduled %}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -3,7 +3,7 @@
 name: Windows CI (!{{ build_environment }})
 
 on:
-{%- if on_pull_request %}
+{%- if on_pull_request or is_scheduled %}
   pull_request:
 {%- endif %}
 {%- if is_scheduled %}

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -4,7 +4,6 @@
 name: Windows CI (periodic-pytorch-win-vs2019-cuda11-cudnn8-py3)
 
 on:
-  pull_request:
   schedule:
     - cron: 45 0,4,8,12,16,20 * * *
   workflow_dispatch:

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -4,6 +4,7 @@
 name: Windows CI (periodic-pytorch-win-vs2019-cuda11-cudnn8-py3)
 
 on:
+  pull_request:
   schedule:
     - cron: 45 0,4,8,12,16,20 * * *
   workflow_dispatch:

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -1,26 +1,17 @@
+# @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/windows_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: Windows CI (!{{ build_environment }})
+name: Windows CI (periodic-pytorch-win-vs2019-cuda11-cudnn8-py3)
 
 on:
-{%- if on_pull_request %}
-  pull_request:
-{%- endif %}
-{%- if is_scheduled %}
   schedule:
-    - cron: !{{ is_scheduled }}
-{%- else %}
-  push:
-    branches:
-      - master
-      - release/*
-{%- endif %}
+    - cron: 45 0,4,8,12,16,20 * * *
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: !{{ build_environment }}
+  BUILD_ENVIRONMENT: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3
   BUILD_WHEEL: 1
-  CUDA_VERSION: "!{{ cuda_version }}"
+  CUDA_VERSION: "11.3"
   IN_CI: 1
   INSTALL_WINDOWS_SDK: 1
   PYTHON_VERSION: "3.8"
@@ -28,20 +19,18 @@ env:
   VC_PRODUCT: "BuildTools"
   VC_VERSION: ""
   VC_YEAR: "2019"
-{%- if cuda_version != "cpu" %}
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
-{%- endif %}
 
 concurrency:
-  group: !{{ build_environment }}-${{ github.event.pull_request.number || github.sha }}
+  group: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: "windows.4xlarge"
     env:
-      JOB_BASE_NAME: !{{ build_environment }}-build
+      JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
@@ -55,7 +44,6 @@ jobs:
         shell: powershell
         run: |
           .\.circleci\scripts\vs_install.ps1
-{%- if cuda_version != "cpu" %}
       - name: Install Cuda
         shell: bash
         run: |
@@ -64,7 +52,6 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
-{%- endif %}
       - name: Build
         shell: bash
         run: |
@@ -90,14 +77,10 @@ jobs:
           path: C:\w\build-results
 
   generate-test-matrix:
-{%- if only_build_on_pull_request %}
-    if: ${{ github.repository_owner == 'pytorch' && github.event_name == 'push' }}
-{%- else %}
     if: ${{ github.repository_owner == 'pytorch' }}
-{%- endif %}
     runs-on: ubuntu-18.04
     env:
-      NUM_TEST_SHARDS: !{{ num_test_shards }}
+      NUM_TEST_SHARDS: 2
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
@@ -114,13 +97,10 @@ jobs:
           echo "::set-output name=matrix::${MATRIX}"
 
   test:
-{%- if only_build_on_pull_request %}
-    if: ${{ github.event_name == 'push' }}
-{%- endif %}
-    runs-on: !{{ test_runner_type }}
+    runs-on: windows.8xlarge.nvidia.gpu
     env:
-      JOB_BASE_NAME: !{{ build_environment }}-test
-      NUM_TEST_SHARDS: !{{ num_test_shards }}
+      JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-test
+      NUM_TEST_SHARDS: 2
       TEST_CONFIG: ${{ matrix.test_config }}
     needs:
       - build
@@ -141,7 +121,6 @@ jobs:
         shell: powershell
         run: |
           .\.circleci\scripts\vs_install.ps1
-{%- if cuda_version != "cpu" %}
       - name: Install Cuda
         shell: bash
         run: |
@@ -150,7 +129,6 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
-{%- endif %}
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download PyTorch Build Artifacts
         with:
@@ -201,11 +179,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-{%- if only_build_on_pull_request %}
-    if:  ${{ github.event_name == 'push' && always() }}
-{%- else %}
     if: always()
-{%- endif %}
     needs:
       - test
     runs-on: ubuntu-18.04
@@ -246,7 +220,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_SECRET_ACCESS_KEY }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: !{{ build_environment }}-test
+          JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}


### PR DESCRIPTION
Moves periodic 11.3 windows jobs to GHA.

Test plan:
https://github.com/pytorch/pytorch/pull/61003/checks?check_run_id=2947910829

Does NOT yet move the debuggable CI part yet