### PR TITLE
[Caffe2][Testing] Check for equality first in assertTensorEqualsWithType<float>

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -651,8 +651,8 @@ TEST(TensorTest, CopyAndAssignment) {
   Tensor y(x);
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   Tensor z = x;
-  testing::assertTensorEquals(x, y);
-  testing::assertTensorEquals(x, z);
+  testing::assertTensorEquals(x, y, 0);
+  testing::assertTensorEquals(x, z, 0);
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -26,13 +26,16 @@ void assertTensorEqualsWithType<float>(
     float eps) {
   CAFFE_ENFORCE_EQ(tensor1.sizes(), tensor2.sizes());
   for (auto idx = 0; idx < tensor1.numel(); ++idx) {
-    CAFFE_ENFORCE_LT(
-        fabs(tensor1.data<float>()[idx] - tensor2.data<float>()[idx]),
-        eps,
-        "Mismatch at index ",
-        idx,
-        " exceeds threshold of ",
-        eps);
+    // When a == b, a - b may not be equal to 0
+    if (tensor1.data<float>()[idx] != tensor2.data<float>()[idx]) {
+      CAFFE_ENFORCE_LT(
+          fabs(tensor1.data<float>()[idx] - tensor2.data<float>()[idx]),
+          eps,
+          "Mismatch at index ",
+          idx,
+          " exceeds threshold of ",
+          eps);
+    }
   }
 }
 } // namespace


### PR DESCRIPTION
Test Plan: Modified existing unit test to test for eps = 0. It would fail without the equality test first.

Reviewed By: ajyu

Differential Revision: D29423770

