### PR TITLE
[DataLoader] Introduce ConcatMapDataPipe functional datapipe

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -413,15 +413,6 @@ class IDP(IterDataPipe):
         return self.length
 
 
-class MDP_NoLen(MapDataPipe):
-    def __init__(self, input_dp):
-        super().__init__()
-        self.input_dp = input_dp
-
-    def __getitem__(self, index):
-        return self.input_dp[index]
-
-
 class MDP(MapDataPipe):
     def __init__(self, input_dp):
         super().__init__()
@@ -930,19 +921,7 @@ class TestFunctionalMapDataPipe(TestCase):
         self.assertEqual(len(concat_dp), 15)
         for index in range(15):
             self.assertEqual(concat_dp[index], (list(range(10)) + list(range(5)))[index])
-
-        # Test Reset
-        for index in range(15):
-            self.assertEqual(concat_dp[index], (list(range(10)) + list(range(5)))[index])
-
-        input_dp_nl = MDP_NoLen(range(5))
-
-        concat_dp = input_dp1.concat(input_dp_nl)
-        with self.assertRaisesRegex(TypeError, r"instance doesn't have valid length$"):
-            len(concat_dp)
-
-        for index in range(15):
-            self.assertEqual(concat_dp[index], (list(range(10)) + list(range(5)))[index])
+        self.assertEqual(list(concat_dp), list(range(10)) + list(range(5)))
 
     def test_map_datapipe(self):
         arr = range(10)

--- a/torch/utils/data/datapipes/map/__init__.py
+++ b/torch/utils/data/datapipes/map/__init__.py
@@ -1,5 +1,7 @@
 # Functional DataPipe
 from torch.utils.data.datapipes.map.callable import MapMapDataPipe as Map
+from torch.utils.data.datapipes.map.combining import \
+    (ConcatMapDataPipe as Concat)
 
 
-__all__ = ["Map"]
+__all__ = ['Map', 'Concat']

--- a/torch/utils/data/datapipes/map/combining.py
+++ b/torch/utils/data/datapipes/map/combining.py
@@ -1,0 +1,48 @@
+from torch.utils.data import MapDataPipe, functional_datapipe
+from typing import Iterator, Optional, Sized, Tuple, TypeVar
+
+T_co = TypeVar('T_co', covariant=True)
+
+
+@functional_datapipe('concat')
+class ConcatMapDataPipe(MapDataPipe):
+    r""" :class:`ConcatMapDataPipe`.
+
+    Map DataPipe to concatenate multiple Map DataPipes.
+    args:
+        datapipes: Map DataPipes being concatenated
+    """
+    datapipes: Tuple[MapDataPipe]
+    length: Optional[int]
+
+    def __init__(self, *datapipes: MapDataPipe):
+        if len(datapipes) == 0:
+            raise ValueError("Expected at least one DataPipe, but got nothing")
+        if not all(isinstance(dp, MapDataPipe) for dp in datapipes):
+            raise TypeError("Expected all inputs to be `MapDataPipe`")
+        self.datapipes = datapipes  # type: ignore[assignment]
+        self.length = None
+
+    def __getitem__(self, index) -> T_co:
+        offset = 0
+        for dp in self.datapipes:
+            if isinstance(dp, Sized):
+                if index - offset < len(dp):
+                    return dp[index - offset]
+                else:
+                    offset += len(dp)
+            else:
+                # Regard the datapipe with no valid length as unlimited.
+                return dp[index - offset]
+        raise ValueError("Index {} is out of range.".format(index))
+
+    def __len__(self) -> int:
+        if self.length is not None:
+            if self.length == -1:
+                raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
+            return self.length
+        if all(isinstance(dp, Sized) for dp in self.datapipes):
+            self.length = sum(len(dp) for dp in self.datapipes)
+        else:
+            self.length = -1
+        return len(self)

--- a/torch/utils/data/datapipes/map/combining.py
+++ b/torch/utils/data/datapipes/map/combining.py
@@ -1,5 +1,5 @@
 from torch.utils.data import MapDataPipe, functional_datapipe
-from typing import Iterator, Optional, Sized, Tuple, TypeVar
+from typing import Optional, Sized, Tuple, TypeVar
 
 T_co = TypeVar('T_co', covariant=True)
 


### PR DESCRIPTION
As part of #57031, this PR adds the ConcatMapDataPipe functional datapipe for the MapDataPipe class.

We may need to discuss how to treat the datapipes with no valid length. For now, I just use them as if they have infinite length and the `__getitem__` could not go pass them.

Thank you for your time on reviewing this~

cc @ejguan 