### PR TITLE
[torch] Add improvements to multiprocessing library

### DIFF
--- a/test/distributed/elastic/multiprocessing/bin/zombie_test.py
+++ b/test/distributed/elastic/multiprocessing/bin/zombie_test.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+
+if __name__ == "__main__":
+    time.sleep(600)
+    print("finished work")


### PR DESCRIPTION
Summary:
* Add tests that test for zombie processes
* Add parent termination handlers that terminate child processes if parent dies due to SIGTERM or SIGINT

Test Plan: buck test mode/dev-nosan //caffe2/test/distributed/elastic/multiprocessing:api_test

Differential Revision: D29479207

