### PR TITLE
torch.nn.utils.clip_grad_norm_: remove device syncs

### DIFF
--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -40,19 +40,12 @@ def clip_grad_norm_(
         total_norm = norms[0] if len(norms) == 1 else torch.max(torch.stack(norms))
     else:
         total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), norm_type).to(device) for p in parameters]), norm_type)
-    if total_norm.isnan() or total_norm.isinf():
-        if error_if_nonfinite:
-            raise RuntimeError(
-                f'The total norm of order {norm_type} for gradients from '
-                '`parameters` is non-finite, so it cannot be clipped. To disable '
-                'this error and scale the gradients by the non-finite norm anyway, '
-                'set `error_if_nonfinite=False`')
-        else:
-            warnings.warn("Non-finite norm encountered in torch.nn.utils.clip_grad_norm_; continuing anyway. "
-                          "Note that the default behavior will change in a future release to error out "
-                          "if a non-finite total norm is encountered. At that point, setting "
-                          "error_if_nonfinite=false will be required to retain the old behavior.",
-                          FutureWarning, stacklevel=2)
+    if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
+        raise RuntimeError(
+            f'The total norm of order {norm_type} for gradients from '
+            '`parameters` is non-finite, so it cannot be clipped. To disable '
+            'this error and scale the gradients by the non-finite norm anyway, '
+            'set `error_if_nonfinite=False`')
     clip_coef = max_norm / (total_norm + 1e-6)
     if clip_coef < 1:
         for p in parameters:


### PR DESCRIPTION
Fixes #60691

### Changes

Per the discussion in the above issue, this PR makes 2 changes:
1. When `error_if_nonfinite=False`, the NaN/Inf checks are truly skipped, and no device synchronization occurs.
    - Additionally, when performing the checks, the 2 results are combined with `torch.logical_or` to incur only a single sync (instead of 2 in the happy/finite path).
2. The `clip_coef` conditional is removed, in favor of a call to `clamp(..., max=1.0)` and an unconditional multiplication.

### Testing

- The existing unit tests for `clip_grad_norm_` pass.
- I have manually profiled the example program from #60691, and verified that:
    - No synchronizations occur when using `error_if_nonfinite=False`.
    - A single synchronization occurs when using `error_if_nonfinite=True`.
