### PR TITLE
model_dump working with delegate models

### DIFF
--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -119,8 +119,8 @@ def hierarchical_pickle(data):
         }
     if isinstance(data, torch.utils.show_pickle.FakeObject):
         typename = f"{data.module}.{data.name}"
-        if typename.startswith("__torch__."):
-            assert data.args == ()
+        if typename.startswith("__torch__.") or typename.startswith("torch.jit.LoweredModule."):
+            # assert data.args == ()
             return {
                 "__module_type__": typename,
                 "state": hierarchical_pickle(data.state),

--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -120,7 +120,7 @@ def hierarchical_pickle(data):
     if isinstance(data, torch.utils.show_pickle.FakeObject):
         typename = f"{data.module}.{data.name}"
         if typename.startswith("__torch__.") or typename.startswith("torch.jit.LoweredModule."):
-            # assert data.args == ()
+            assert data.args == ()
             return {
                 "__module_type__": typename,
                 "state": hierarchical_pickle(data.state),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61043**
* #61007

Model_dump work with delegate models by adding the prefix "torch.jit.LoweredModule." as a module prefix.

Test: 

use model_dump to successfully display the structure of a lowered model.

Differential Revision: [D29464860](https://our.internmc.facebook.com/intern/diff/D29464860/)