### PR TITLE
Support for target with class probs in CrossEntropyLoss

### DIFF
--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -487,6 +487,45 @@ Tensor nll_loss(const Tensor & self, const Tensor & target, const c10::optional<
   return std::get<0>(at::nll_loss_forward(self, target, weight, reduction, ignore_index));
 }
 
+Tensor nll_loss_prob_target(
+    const Tensor& self,
+    const Tensor& target,
+    const Tensor& weight,
+    int64_t reduction) {
+  const auto n_classes = self.size(1);
+  TORCH_CHECK(
+      !weight.defined() || (weight.dim() == 1 && weight.numel() == n_classes),
+      "weight tensor should be defined either for all ",
+      n_classes,
+      " classes or no classes"
+      " but got weight tensor of shape: ",
+      weight.sizes());
+
+  Tensor ret;
+  if (weight.defined()) {
+    // Expand weight to the correct number of dims for broadcasting with input / target
+    auto weight_bc_shape = std::vector<int64_t>(self.dim(), 1);
+    weight_bc_shape[1] = weight.size(0);
+    Tensor weight_ = weight.view(weight_bc_shape);
+
+    ret = -(self * target * weight_).sum(1);
+    if (reduction == Reduction::Mean) {
+      // Compute weighted mean
+      ret = ret.sum() / (target * weight_).sum();
+    } else if (reduction == Reduction::Sum) {
+      ret = ret.sum();
+    }
+  } else {
+    ret = -(self * target).sum(1);
+    if (reduction == Reduction::Mean) {
+      ret = ret.mean();
+    } else if (reduction == Reduction::Sum) {
+      ret = ret.sum();
+    }
+  }
+  return ret;
+}
+
 Tensor nll_loss_nd(
     const Tensor& self,
     const Tensor& target,
@@ -511,43 +550,55 @@ Tensor nll_loss_nd(
   Tensor ret;
   Tensor input_ = self;
   Tensor target_ = target;
-  if (input_.dim() == 2) {
-    ret = at::nll_loss(input_, target_, weight, reduction, ignore_index);
-  } else if (input_.dim() == 4) {
-    ret = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+  if (input_.sizes() == target_.sizes()) {
+    // Assume soft targets when input and target shapes are the same
+    TORCH_CHECK(at::isFloatingType(target.scalar_type()),
+        "Expected floating point type for target with class probabilities, got ", target.scalar_type());
+    TORCH_CHECK(ignore_index < 0, "ignore_index is not supported for floating point target");
+
+    // See [Note: hacky wrapper removal for optional tensor]
+    c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight);
+    const Tensor& weight_ = *weight_maybe_owned;
+    ret = nll_loss_prob_target(input_, target_, weight_, reduction);
   } else {
-    // dim == 3 or dim > 4
-    auto n = input_.sizes()[0];
-    auto c = input_.sizes()[1];
-    auto out_size = input_.sizes().slice(2).vec();
-    out_size.insert(out_size.begin(), n);
-    if (target_.sizes().slice(1) != input_.sizes().slice(2)) {
-      TORCH_CHECK(
-          false,
-          "Expected target size ",
-          IntArrayRef(out_size),
-          ", got ",
-          target_.sizes());
-    }
-    input_ = input_.contiguous();
-    target_ = target_.contiguous();
-    // support empty batches, see #15870
-    if (input_.numel() > 0) {
-      input_ = input_.view({n, c, 1, -1});
-    } else {
-      input_ = input_.view({n, c, 0, 0});
-    }
-    if (target_.numel() > 0) {
-      target_ = target_.view({n, 1, -1});
-    } else {
-      target_ = target_.view({n, 0, 0});
-    }
-    if (!(reduction == Reduction::None)) {
+    if (input_.dim() == 2) {
+      ret = at::nll_loss(input_, target_, weight, reduction, ignore_index);
+    } else if (input_.dim() == 4) {
       ret = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
     } else {
-      auto out =
-          at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
-      ret = out.view(out_size);
+      // dim == 3 or dim > 4
+      auto n = input_.sizes()[0];
+      auto c = input_.sizes()[1];
+      auto out_size = input_.sizes().slice(2).vec();
+      out_size.insert(out_size.begin(), n);
+      if (target_.sizes().slice(1) != input_.sizes().slice(2)) {
+        TORCH_CHECK(
+            false,
+            "Expected target size ",
+            IntArrayRef(out_size),
+            ", got ",
+            target_.sizes());
+      }
+      input_ = input_.contiguous();
+      target_ = target_.contiguous();
+      // support empty batches, see #15870
+      if (input_.numel() > 0) {
+        input_ = input_.view({n, c, 1, -1});
+      } else {
+        input_ = input_.view({n, c, 0, 0});
+      }
+      if (target_.numel() > 0) {
+        target_ = target_.view({n, 1, -1});
+      } else {
+        target_ = target_.view({n, 0, 0});
+      }
+      if (!(reduction == Reduction::None)) {
+        ret = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+      } else {
+        auto out =
+            at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+        ret = out.view(out_size);
+      }
     }
   }
   return ret;

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -479,10 +479,7 @@ Tensor cross_entropy_loss_prob_target(
 
     switch (reduction) {
       case Reduction::Mean:
-        // Note: The computation is as follows to maintain consistency between the hard label and one-hot
-        // soft label cases. TODO: Change this to the more correct form:
-        //ret = -(input * target * weight_).sum(1).mean();
-        ret = -(input * target * weight_).sum() / (target * weight_).sum();
+        ret = -(input * target * weight_).sum(1).mean();
         break;
       case Reduction::Sum:
         ret = -(input * target * weight_).sum();

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -5,6 +5,7 @@
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/SmallBuffer.h>
 
 namespace at {
 namespace meta {
@@ -473,7 +474,8 @@ Tensor cross_entropy_loss_prob_target(
   auto input = at::log_softmax(self, 1, self.scalar_type());
   if (weight.defined()) {
     // Expand weight to the correct number of dims for broadcasting with input / target
-    auto weight_bc_shape = std::vector<int64_t>(input.dim(), 1);
+    auto weight_bc_shape = SmallBuffer<int64_t, 5>(input.dim());
+    std::fill(weight_bc_shape.begin(), weight_bc_shape.end(), 1);
     weight_bc_shape[1] = weight.size(0);
     Tensor weight_ = weight.view(weight_bc_shape);
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16774,8 +16774,8 @@ class TestNNDeviceType(NNTestCase):
             for reduction in ['none', 'mean', 'sum']:
                 # Ensure result with unit weights is equivalent to result without weights.
                 m = torch.nn.CrossEntropyLoss(reduction=reduction)
-                m_unit = torch.nn.CrossEntropyLoss(weight=torch.ones(C, dtype=target.dtype),
-                                                   reduction=reduction)
+                unit_weight = weight=torch.ones(C, device=device, dtype=target.dtype)
+                m_unit = torch.nn.CrossEntropyLoss(weight=unit_weight, reduction=reduction)
                 output = m(input, target)
                 output_unit = m_unit(input, target)
                 self.assertEqual(output, output_unit)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16747,7 +16747,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(result_long, result_byte)
             self.assertEqual(grad_long, grad_byte)
 
-    def test_nll_loss_one_hot_target(self, device):
+    def test_cross_entropy_loss_one_hot_target(self, device):
         # Test with k-dimensional loss.
         for k in range(5):
             N, C = 5, 4
@@ -16764,7 +16764,7 @@ class TestNNDeviceType(NNTestCase):
             for reduction in ['none', 'mean', 'sum']:
                 # Ensure loss computed with class indices matches loss
                 # computed with one-hot class probs.
-                m = torch.nn.NLLLoss(weight=weight)
+                m = torch.nn.CrossEntropyLoss(weight=weight)
                 output = m(input, target)
                 output_one_hot = m(input, target_one_hot)
                 self.assertTrue(torch.allclose(output, output_one_hot))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16772,7 +16772,6 @@ class TestNNDeviceType(NNTestCase):
             target = torch.randn(N, C, *other_dims, device=device, requires_grad=True)
 
             for reduction in ['none', 'mean', 'sum']:
-                print('reduction:', reduction)
                 # Ensure result with unit weights is equivalent to result without weights.
                 m = torch.nn.CrossEntropyLoss(reduction=reduction)
                 m_unit = torch.nn.CrossEntropyLoss(weight=torch.ones(C, dtype=target.dtype),
@@ -16796,7 +16795,6 @@ class TestNNDeviceType(NNTestCase):
             target_one_hot = target_one_hot.permute(0, -1, *range(1, target_one_hot.dim() - 1))
 
             for reduction, w in product(['none', 'mean', 'sum'], [None, weight]):
-                print('reduction:', reduction, 'weight:', w, 'k:', k)
                 # Ensure loss computed with class indices matches loss
                 # computed with one-hot class probs.
                 m = torch.nn.CrossEntropyLoss(weight=w, reduction=reduction)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16774,7 +16774,7 @@ class TestNNDeviceType(NNTestCase):
             for reduction in ['none', 'mean', 'sum']:
                 # Ensure result with unit weights is equivalent to result without weights.
                 m = torch.nn.CrossEntropyLoss(reduction=reduction)
-                unit_weight = weight=torch.ones(C, device=device, dtype=target.dtype)
+                unit_weight = torch.ones(C, device=device, dtype=target.dtype)
                 m_unit = torch.nn.CrossEntropyLoss(weight=unit_weight, reduction=reduction)
                 output = m(input, target)
                 output_unit = m_unit(input, target)

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -707,8 +707,7 @@ TORCH_MODULE(NLLLoss);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CrossEntropyLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Creates a criterion that combines :func:`nn.LogSoftmax` and
-/// :func:`nn.NLLLoss` in one single class.
+/// Creates a criterion that computes cross entropy loss between input and target.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.CrossEntropyLoss to learn
 /// about the exact behavior of this module.
 ///

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2477,10 +2477,9 @@ def nll_loss(
         input: :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
             in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
             in the case of K-dimensional loss. `input` is expected to be log-probabilities.
-        target: If containing class indices, shape :math:`(N)` where each value is
-            :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
-            :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
-            same shape as the input.
+        target: :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
+            or :math:`(N, d_1, d_2, ..., d_K)` where :math:`K \geq 1` for
+            K-dimensional loss.
         weight (Tensor, optional): a manual rescaling weight given to each
             class. If given, has to be a Tensor of size `C`
         size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
@@ -2490,9 +2489,7 @@ def nll_loss(
             when reduce is ``False``. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets. Note that
-            :attr:`ignore_index` is only applicable when the target contains class indices.
-            Default: -100
+            ``True``, the loss is averaged over non-ignored targets. Default: -100
         reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
             losses are averaged or summed over observations for each minibatch depending
             on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2477,9 +2477,10 @@ def nll_loss(
         input: :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
             in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
             in the case of K-dimensional loss. `input` is expected to be log-probabilities.
-        target: :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
-            or :math:`(N, d_1, d_2, ..., d_K)` where :math:`K \geq 1` for
-            K-dimensional loss.
+        target: If containing class indices, shape :math:`(N)` where each value is
+            :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
+            :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
+            same shape as the input.
         weight (Tensor, optional): a manual rescaling weight given to each
             class. If given, has to be a Tensor of size `C`
         size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
@@ -2489,7 +2490,9 @@ def nll_loss(
             when reduce is ``False``. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets. Default: -100
+            ``True``, the loss is averaged over non-ignored targets. Note that
+            :attr:`ignore_index` is only applicable when the target contains class indices.
+            Default: -100
         reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
             losses are averaged or summed over observations for each minibatch depending
             on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
@@ -2778,9 +2781,10 @@ def cross_entropy(
             in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
             in the case of K-dimensional loss. `input` is expected to contain unnormalized scores
             (often referred to as logits).
-        target (Tensor) : :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
-            or :math:`(N, d_1, d_2, ..., d_K)` where :math:`K \geq 1` for
-            K-dimensional loss.
+        target (Tensor) : If containing class indices, shape :math:`(N)` where each value is
+            :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
+            :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
+            same shape as the input.
         weight (Tensor, optional): a manual rescaling weight given to each
             class. If given, has to be a Tensor of size `C`
         size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
@@ -2790,7 +2794,9 @@ def cross_entropy(
             when reduce is ``False``. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets. Default: -100
+            ``True``, the loss is averaged over non-ignored targets. Note that
+            :attr:`ignore_index` is only applicable when the target contains class indices.
+            Default: -100
         reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
             losses are averaged or summed over observations for each minibatch depending
             on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2768,8 +2768,7 @@ def cross_entropy(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""This criterion combines `log_softmax` and `nll_loss` in a single
-    function.
+    r"""This criterion computes the cross entropy loss between input and target.
 
     See :class:`~torch.nn.CrossEntropyLoss` for details.
 
@@ -2807,8 +2806,15 @@ def cross_entropy(
 
     Examples::
 
+        >>> # Example of target with class indices
         >>> input = torch.randn(3, 5, requires_grad=True)
         >>> target = torch.randint(5, (3,), dtype=torch.int64)
+        >>> loss = F.cross_entropy(input, target)
+        >>> loss.backward()
+        >>>
+        >>> # Example of target with class probabilities
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5).softmax(dim=1)
         >>> loss = F.cross_entropy(input, target)
         >>> loss.backward()
     """

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -107,40 +107,61 @@ class NLLLoss(_WeightedLoss):
     The `input` given through a forward call is expected to contain
     log-probabilities of each class. `input` has to be a Tensor of size either
     :math:`(minibatch, C)` or :math:`(minibatch, C, d_1, d_2, ..., d_K)`
-    with :math:`K \geq 1` for the `K`-dimensional case (described later).
+    with :math:`K \geq 1` for the `K`-dimensional case. The latter is useful for
+    higher dimension inputs, such as computing NLL loss per-pixel for 2D images.
 
     Obtaining log-probabilities in a neural network is easily achieved by
     adding a  `LogSoftmax`  layer in the last layer of your network.
     You may use `CrossEntropyLoss` instead, if you prefer not to add an extra
     layer.
 
-    The `target` that this loss expects should be a class index in the range :math:`[0, C-1]`
-    where `C = number of classes`; if `ignore_index` is specified, this loss also accepts
-    this class index (this index may not necessarily be in the class range).
+    The `target` that this criterion expects should contain either:
 
-    The unreduced (i.e. with :attr:`reduction` set to ``'none'``) loss can be described as:
+    - Class indices in the range :math:`[0, C-1]` where :math:`C` is the number of classes; if
+      `ignore_index` is specified, this loss also accepts this class index (this index
+      may not necessarily be in the class range). The unreduced (i.e. with :attr:`reduction`
+      set to ``'none'``) loss for this case can be described as:
 
-    .. math::
-        \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
-        l_n = - w_{y_n} x_{n,y_n}, \quad
-        w_{c} = \text{weight}[c] \cdot \mathbb{1}\{c \not= \text{ignore\_index}\},
+      .. math::
+          \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
+          l_n = - w_{y_n} x_{n,y_n} \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\},
 
-    where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and
-    :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
-    (default ``'mean'``), then
+      where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and
+      :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
+      (default ``'mean'``), then
 
-    .. math::
-        \ell(x, y) = \begin{cases}
-            \sum_{n=1}^N \frac{1}{\sum_{n=1}^N w_{y_n}} l_n, &
-            \text{if reduction} = \text{`mean';}\\
-            \sum_{n=1}^N l_n,  &
-            \text{if reduction} = \text{`sum'.}
-        \end{cases}
+      .. math::
+          \ell(x, y) = \begin{cases}
+              \sum_{n=1}^N \frac{1}{\sum_{n=1}^N w_{y_n} \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\}} l_n, &
+               \text{if reduction} = \text{`mean';}\\
+                \sum_{n=1}^N l_n,  &
+                \text{if reduction} = \text{`sum'.}
+            \end{cases}
 
-    Can also be used for higher dimension inputs, such as 2D images, by providing
-    an input of size :math:`(minibatch, C, d_1, d_2, ..., d_K)` with :math:`K \geq 1`,
-    where :math:`K` is the number of dimensions, and a target of appropriate shape
-    (see below). In the case of images, it computes NLL loss per-pixel.
+    - Probabilities over classes; useful when labels beyond a single class per minibatch item
+      are required, such as for blended labels, label smoothing, etc. The unreduced (i.e. with
+      :attr:`reduction` set to ``'none'``) loss for this case can be described as:
+
+      .. math::
+          \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
+          l_n = - \sum_{c=1}^C w_c x_{n,c} y_{n,c}
+
+      where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight,
+      :math:`N` is the batch size, and :math:`C` is the number of classes. If
+      :attr:`reduction` is not ``'none'`` (default ``'mean'``), then
+
+      .. math::
+          \ell(x, y) = \begin{cases}
+              \sum_{n=1}^N \frac{1}{\sum_{n=1}^N \sum_{c=1}^C w_c y_{n,c}} l_n, &
+               \text{if reduction} = \text{`mean';}\\
+                \sum_{n=1}^N l_n,  &
+                \text{if reduction} = \text{`sum'.}
+            \end{cases}
+
+    .. note::
+        The performance of this criterion is generally better when `target` contains class
+        indices, as this allows for optimized computation. Consider providing `target` as
+        class probabilities only when a single class label per minibatch item is too restrictive.
 
     Args:
         weight (Tensor, optional): a manual rescaling weight given to each
@@ -154,7 +175,8 @@ class NLLLoss(_WeightedLoss):
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When
             :attr:`size_average` is ``True``, the loss is averaged over
-            non-ignored targets.
+            non-ignored targets. Note that :attr:`ignore_index` is only applicable
+            when the target contains class indices.
         reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
             losses are averaged or summed over observations for each minibatch depending
             on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
@@ -171,16 +193,17 @@ class NLLLoss(_WeightedLoss):
         - Input: :math:`(N, C)` where `C = number of classes`, or
           :math:`(N, C, d_1, d_2, ..., d_K)` with :math:`K \geq 1`
           in the case of `K`-dimensional loss.
-        - Target: :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`, or
-          :math:`(N, d_1, d_2, ..., d_K)` with :math:`K \geq 1` in the case of
-          K-dimensional loss.
-        - Output: scalar.
-          If :attr:`reduction` is ``'none'``, then the same size as the target: :math:`(N)`, or
-          :math:`(N, d_1, d_2, ..., d_K)` with :math:`K \geq 1` in the case
-          of K-dimensional loss.
+        - Target: If containing class indices, shape :math:`(N)` where each value is
+          :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
+          :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
+          same shape as the input.
+        - Output: If :attr:`reduction` is ``'none'``, shape :math:`(N)` or
+          :math:`(N, d_1, d_2, ..., d_K)` with :math:`K \geq 1` in the case of K-dimensional loss.
+          Otherwise, scalar.
 
     Examples::
 
+        >>> # Example of target with class indices
         >>> m = nn.LogSoftmax(dim=1)
         >>> loss = nn.NLLLoss()
         >>> # input is of size N x C = 3 x 5
@@ -190,6 +213,11 @@ class NLLLoss(_WeightedLoss):
         >>> output = loss(m(input), target)
         >>> output.backward()
         >>>
+        >>> # Example of target with class probabilities
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5).softmax(dim=1)
+        >>> output = loss(m(input), target)
+        >>> output.backward()
         >>>
         >>> # 2D loss example (used, for example, with image inputs)
         >>> N, C = 5, 4
@@ -1027,38 +1055,59 @@ class CrossEntropyLoss(_WeightedLoss):
     This is particularly useful when you have an unbalanced training set.
 
     The `input` is expected to contain raw, unnormalized scores for each class.
-
     `input` has to be a Tensor of size either :math:`(minibatch, C)` or
-    :math:`(minibatch, C, d_1, d_2, ..., d_K)`
-    with :math:`K \geq 1` for the `K`-dimensional case (described later).
+    :math:`(minibatch, C, d_1, d_2, ..., d_K)` with :math:`K \geq 1` for the
+    `K`-dimensional case. The latter is useful for higher dimension inputs, such
+    as computing cross entropy loss per-pixel for 2D images.
 
-    This criterion expects a class index in the range :math:`[0, C-1]` as the
-    `target` for each value of a 1D tensor of size `minibatch`; if `ignore_index`
-    is specified, this criterion also accepts this class index (this index may not
-    necessarily be in the class range).
+    The `target` that this criterion expects should contain either:
 
-    The loss can be described as:
+    - Class indices in the range :math:`[0, C-1]` where :math:`C` is the number of classes; if
+      `ignore_index` is specified, this loss also accepts this class index (this index
+      may not necessarily be in the class range). The unreduced (i.e. with :attr:`reduction`
+      set to ``'none'``) loss for this case can be described as:
 
-    .. math::
-        \text{loss}(x, class) = -\log\left(\frac{\exp(x[class])}{\sum_j \exp(x[j])}\right)
-                       = -x[class] + \log\left(\sum_j \exp(x[j])\right)
+      .. math::
+          \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
+          l_n = - w_{y_n} \log \frac{\exp(x_{n,y_n})}{\sum_{c=1}^C \exp(x_{n,c})}
+          \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\}
 
-    or in the case of the :attr:`weight` argument being specified:
+      where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and
+      :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
+      (default ``'mean'``), then
 
-    .. math::
-        \text{loss}(x, class) = weight[class] \left(-x[class] + \log\left(\sum_j \exp(x[j])\right)\right)
+      .. math::
+          \ell(x, y) = \begin{cases}
+              \sum_{n=1}^N \frac{1}{\sum_{n=1}^N w_{y_n} \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\}} l_n, &
+               \text{if reduction} = \text{`mean';}\\
+                \sum_{n=1}^N l_n,  &
+                \text{if reduction} = \text{`sum'.}
+            \end{cases}
 
-    The losses are averaged across observations for each minibatch. If the
-    :attr:`weight` argument is specified then this is a weighted average:
+    - Probabilities over classes; useful when labels beyond a single class per minibatch item
+      are required, such as for blended labels, label smoothing, etc. The unreduced (i.e. with
+      :attr:`reduction` set to ``'none'``) loss for this case can be described as:
 
-    .. math::
-        \text{loss} = \frac{\sum^{N}_{i=1} loss(i, class[i])}{\sum^{N}_{i=1} weight[class[i]]}
+      .. math::
+          \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
+          l_n = - \sum_{c=1}^C w_c \log \frac{\exp(x_{n,c})}{\exp(\sum_{i=1}^C x_{n,i})} y_{n,c}
 
-    Can also be used for higher dimension inputs, such as 2D images, by providing
-    an input of size :math:`(minibatch, C, d_1, d_2, ..., d_K)` with :math:`K \geq 1`,
-    where :math:`K` is the number of dimensions, and a target of appropriate shape
-    (see below).
+      where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight,
+      :math:`N` is the batch size, and :math:`C` is the number of classes. If
+      :attr:`reduction` is not ``'none'`` (default ``'mean'``), then
 
+      .. math::
+          \ell(x, y) = \begin{cases}
+              \sum_{n=1}^N \frac{1}{\sum_{n=1}^N \sum_{c=1}^C w_c y_{n,c}} l_n, &
+               \text{if reduction} = \text{`mean';}\\
+                \sum_{n=1}^N l_n,  &
+                \text{if reduction} = \text{`sum'.}
+            \end{cases}
+
+    .. note::
+        The performance of this criterion is generally better when `target` contains class
+        indices, as this allows for optimized computation. Consider providing `target` as
+        class probabilities only when a single class label per minibatch item is too restrictive.
 
     Args:
         weight (Tensor, optional): a manual rescaling weight given to each class.
@@ -1070,7 +1119,8 @@ class CrossEntropyLoss(_WeightedLoss):
             when :attr:`reduce` is ``False``. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets.
+            ``True``, the loss is averaged over non-ignored targets. Note that
+            :attr:`ignore_index` is only applicable when the target contains class indices.
         reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
             losses are averaged or summed over observations for each minibatch depending
             on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
@@ -1087,20 +1137,26 @@ class CrossEntropyLoss(_WeightedLoss):
         - Input: :math:`(N, C)` where `C = number of classes`, or
           :math:`(N, C, d_1, d_2, ..., d_K)` with :math:`K \geq 1`
           in the case of `K`-dimensional loss.
-        - Target: :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`, or
-          :math:`(N, d_1, d_2, ..., d_K)` with :math:`K \geq 1` in the case of
-          K-dimensional loss.
-        - Output: scalar.
-          If :attr:`reduction` is ``'none'``, then the same size as the target:
-          :math:`(N)`, or
-          :math:`(N, d_1, d_2, ..., d_K)` with :math:`K \geq 1` in the case
-          of K-dimensional loss.
+        - Target: If containing class indices, shape :math:`(N)` where each value is
+          :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
+          :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
+          same shape as the input.
+        - Output: If :attr:`reduction` is ``'none'``, shape :math:`(N)` or
+          :math:`(N, d_1, d_2, ..., d_K)` with :math:`K \geq 1` in the case of K-dimensional loss.
+          Otherwise, scalar.
 
     Examples::
 
+        >>> # Example of target with class indices
         >>> loss = nn.CrossEntropyLoss()
         >>> input = torch.randn(3, 5, requires_grad=True)
         >>> target = torch.empty(3, dtype=torch.long).random_(5)
+        >>> output = loss(input, target)
+        >>> output.backward()
+        >>>
+        >>> # Example of target with class probabilities
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5).softmax(dim=1)
         >>> output = loss(input, target)
         >>> output.backward()
     """

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1039,9 +1039,10 @@ class CrossEntropyLoss(_WeightedLoss):
           l_n = - w_{y_n} \log \frac{\exp(x_{n,y_n})}{\sum_{c=1}^C \exp(x_{n,c})}
           \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\}
 
-      where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and
-      :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
-      (default ``'mean'``), then
+      where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight,
+      :math:`C` is the number of classes, and :math:`N` spans the minibatch dimension as well as
+      :math:`d_1, ..., d_k` for the `K`-dimensional case. If
+      :attr:`reduction` is not ``'none'`` (default ``'mean'``), then
 
       .. math::
           \ell(x, y) = \begin{cases}
@@ -1063,7 +1064,8 @@ class CrossEntropyLoss(_WeightedLoss):
           l_n = - \sum_{c=1}^C w_c \log \frac{\exp(x_{n,c})}{\exp(\sum_{i=1}^C x_{n,i})} y_{n,c}
 
       where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight,
-      :math:`N` is the batch size, and :math:`C` is the number of classes. If
+      :math:`C` is the number of classes, and :math:`N` spans the minibatch dimension as well as
+      :math:`d_1, ..., d_k` for the `K`-dimensional case. If
       :attr:`reduction` is not ``'none'`` (default ``'mean'``), then
 
       .. math::

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1068,7 +1068,7 @@ class CrossEntropyLoss(_WeightedLoss):
 
       .. math::
           \ell(x, y) = \begin{cases}
-              \sum_{n=1}^N \frac{1}{\sum_{n=1}^N \sum_{c=1}^C w_c y_{n,c}} l_n, &
+              \frac{\sum_{n=1}^N l_n}{N}, &
                \text{if reduction} = \text{`mean';}\\
                 \sum_{n=1}^N l_n,  &
                 \text{if reduction} = \text{`sum'.}

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4014,7 +4014,6 @@ def cross_entropy_loss_reference(input, target, weight=None, ignore_index=-100, 
             input,
             target,
             weight=weight,
-            ignore_index=ignore_index,
             reduction=reduction)
     else:
         return nlllossNd_reference(

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4782,6 +4782,42 @@ criterion_tests = [
         check_bfloat16=False,
     ),
     dict(
+        module_name='CrossEntropyLoss',
+        constructor_args_fn=lambda: (torch.rand(3),),
+        cpp_constructor_args='torch::nn::CrossEntropyLossOptions().weight(torch::rand(3))',
+        input_size=(5, 3),
+        target_fn=lambda: torch.rand(5, 3).softmax(dim=1),
+        reference_fn=lambda i, t, m:
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m)),
+        check_sum_reduction=True,
+        desc='2d_prob_target_weights',
+        check_bfloat16=False,
+    ),
+    dict(
+        module_name='CrossEntropyLoss',
+        constructor_args_fn=lambda: (torch.rand(3),),
+        cpp_constructor_args='torch::nn::CrossEntropyLossOptions().weight(torch::rand(3))',
+        input_size=(5, 3, 4),
+        target_fn=lambda: torch.rand(5, 3, 4).softmax(dim=1),
+        reference_fn=lambda i, t, m:
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m)),
+        check_sum_reduction=True,
+        desc='3d_prob_target_weights',
+        check_bfloat16=False,
+    ),
+    dict(
+        module_name='CrossEntropyLoss',
+        constructor_args_fn=lambda: (torch.rand(3),),
+        cpp_constructor_args='torch::nn::CrossEntropyLossOptions().weight(torch::rand(3))',
+        input_size=(5, 3, 4, 2),
+        target_fn=lambda: torch.rand(5, 3, 4, 2).softmax(dim=1),
+        reference_fn=lambda i, t, m:
+            loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m), weight=get_weight(m)),
+        check_sum_reduction=True,
+        desc='4d_prob_target_weights',
+        check_bfloat16=False,
+    ),
+    dict(
         module_name='PoissonNLLLoss',  # Default is log_input=True, full=False
         input_size=(2, 3, 4, 5),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4001,8 +4001,7 @@ def cross_entropy_loss_prob_target_reference(input, target, weight=None, reducti
 
     output = -(input * target * weight).sum(dim=1)
     if reduction == 'mean':
-        total_weight = (weight * target).sum()
-        return output.sum() / total_weight
+        return output.mean()
     elif reduction == 'sum':
         return output.sum()
     return output


### PR DESCRIPTION
Fixes #11959

Alternative approach to creating a new `CrossEntropyLossWithSoftLabels` class. This PR simply adds support for "soft targets" AKA class probabilities to the existing `CrossEntropyLoss` and `NLLLoss` classes.

Implementation is dumb and simple right now, but future work can add higher performance kernels for this case.