### PR TITLE
Docs: fix intersphinx links to common base classes

### DIFF
--- a/torch/nn/__init__.py
+++ b/torch/nn/__init__.py
@@ -5,6 +5,9 @@ from . import init
 from . import utils
 
 
+Module.__module__ = "torch.nn"
+
+
 def factory_kwargs(kwargs):
     r"""
     Given kwargs, returns a canonicalized dict of factory kwargs that can be directly passed

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -22,6 +22,10 @@ from .lbfgs import LBFGS
 from . import lr_scheduler
 from . import swa_utils
 
+
+Optimizer.__module__ = "torch.optim"
+
+
 del adadelta
 del adagrad
 del adam

--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -11,6 +11,37 @@ from torch.utils.data._decorator import \
      argument_validation, runtime_validation_disabled, runtime_validation)
 
 
+Sampler.__module__ = "torch.utils.data"
+SequentialSampler.__module__ = "torch.utils.data"
+RandomSampler.__module__ = "torch.utils.data"
+SubsetRandomSampler.__module__ = "torch.utils.data"
+WeightedRandomSampler.__module__ = "torch.utils.data"
+BatchSampler.__module__ = "torch.utils.data"
+
+Dataset.__module__ = "torch.utils.data"
+IterableDataset.__module__ = "torch.utils.data"
+TensorDataset.__module__ = "torch.utils.data"
+ConcatDataset.__module__ = "torch.utils.data"
+ChainDataset.__module__ = "torch.utils.data"
+Subset.__module__ = "torch.utils.data"
+random_split.__module__ = "torch.utils.data"
+MapDataPipe.__module__ = "torch.utils.data"
+IterDataPipe.__module__ = "torch.utils.data"
+
+DistributedSampler.__module__ = "torch.utils.data"
+
+DataLoader.__module__ = "torch.utils.data"
+_DatasetKind.__module__ = "torch.utils.data"
+get_worker_info.__module__ = "torch.utils.data"
+
+functional_datapipe.__module__ = "torch.utils.data"
+guaranteed_datapipes_determinism.__module__ = "torch.utils.data"
+non_deterministic.__module__ = "torch.utils.data"
+argument_validation.__module__ = "torch.utils.data"
+runtime_validation_disabled.__module__ = "torch.utils.data"
+runtime_validation.__module__ = "torch.utils.data"
+
+
 __all__ = ['Sampler', 'SequentialSampler', 'RandomSampler',
            'SubsetRandomSampler', 'WeightedRandomSampler', 'BatchSampler',
            'DistributedSampler', 'Dataset', 'IterableDataset', 'TensorDataset',


### PR DESCRIPTION
When using Sphinx with a project that depends on PyTorch, any classes that subclass Dataset or Module won't be able to resolve the correct path to the documentation for these classes using intersphinx. This PR solves the issue using the suggestion at https://stackoverflow.com/questions/40018681

I don't think setting `__module__` has any adverse side effects, but this is something worth thinking about. 

I'm sure there are many other classes that may need this treatment, but these are the only two I've encountered so far (and likely the most commonly subclassed classes).

Fixes #60979

@mruberry @brianjo @ydcjeff @calebrob6