### PR TITLE
Implementing transpose for PackedTensorAccessor

### DIFF
--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -2,6 +2,7 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Deprecated.h>
+#include <c10/util/Exception.h>
 #include <stdint.h>
 #include <cstddef>
 
@@ -155,6 +156,14 @@ protected:
   PtrType data_;
   index_t sizes_[N];
   index_t strides_[N];
+  C10_HOST_DEVICE void bounds_check_(index_t i) const {
+    TORCH_CHECK_INDEX(
+        0 <= i && i < N,
+        "Index ",
+        i,
+        " is not within bounds of a tensor of dimension ",
+        N);
+  }
 };
 
 template<typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits, typename index_t = int64_t>
@@ -187,6 +196,22 @@ public:
     const index_t* new_strides = this->strides_ + 1;
     return TensorAccessor<T,N-1,PtrTraits,index_t>(this->data_ + this->strides_[0]*i, new_sizes, new_strides);
   }
+
+  /// Returns a PackedTensorAccessor of the same dimension after transposing the
+  /// two dimensions given. Does not actually move elements; transposition is
+  /// made by permuting the size/stride arrays. If the dimensions are not valid,
+  /// asserts.
+  C10_HOST GenericPackedTensorAccessor<T, N, PtrTraits, index_t> transpose(
+      index_t dim1,
+      index_t dim2) const {
+    this->bounds_check_(dim1);
+    this->bounds_check_(dim2);
+    GenericPackedTensorAccessor<T, N, PtrTraits, index_t> result(
+        this->data_, this->sizes_, this->strides_);
+    std::swap(result.strides_[dim1], result.strides_[dim2]);
+    std::swap(result.sizes_[dim1], result.sizes_[dim2]);
+    return result;
+  }
 };
 
 template<typename T, template <typename U> class PtrTraits, typename index_t>
@@ -212,6 +237,18 @@ public:
   }
   C10_DEVICE const T& operator[](index_t i) const {
     return this->data_[this->strides_[0]*i];
+  }
+
+  // Same as in the general N-dimensional case, but note that in the
+  // 1-dimensional case the returned PackedTensorAccessor will always be an
+  // identical copy of the original
+  C10_HOST GenericPackedTensorAccessor<T, 1, PtrTraits, index_t> transpose(
+      index_t dim1,
+      index_t dim2) const {
+    this->bounds_check_(dim1);
+    this->bounds_check_(dim2);
+    return GenericPackedTensorAccessor<T, 1, PtrTraits, index_t>(
+        this->data_, this->sizes_, this->strides_);
   }
 };
 

--- a/aten/src/ATen/test/packedtensoraccessor_test.cpp
+++ b/aten/src/ATen/test/packedtensoraccessor_test.cpp
@@ -1,0 +1,44 @@
+#include <ATen/Operators.h>
+#include <ATen/test/test_assert.h>
+#include <c10/util/Exception.h>
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/core/TensorAccessor.h>
+
+#include <cassert>
+
+using namespace at;
+
+TEST(PackedtensoraccessorTest, TransposeTest) {
+  manual_seed(123);
+  /* test a 3d tensor */
+  constexpr int dimension = 3;
+  constexpr std::array<long, dimension> sizes{3, 4, 5};
+  Tensor t = rand(sizes, CPU(kFloat));
+  auto original = t.packed_accessor64<float, dimension, DefaultPtrTraits>();
+  auto transposed = original.transpose(0, 2);
+  ASSERT_EQ(original.size(0), transposed.size(2));
+  ASSERT_EQ(original.size(1), transposed.size(1));
+  ASSERT_EQ(original.size(2), transposed.size(0));
+  for (int i = 0; i < sizes[0]; i++) {
+    for (int j = 0; j < sizes[1]; j++) {
+      for (int k = 0; k < sizes[2]; k++) {
+        ASSERT_EQ(original[i][j][k], transposed[k][j][i]);
+      }
+    }
+  }
+
+  /* test the special case of a 1d tensor */
+  int size = 3;
+  t = rand({size}, CPU(kFloat));
+  auto original_1d = t.packed_accessor64<float, 1, DefaultPtrTraits>();
+  auto transposed_1d = original_1d.transpose(0, 0);
+  for (int i = 0; i < size; i++){
+    ASSERT_EQ(original_1d[i], transposed_1d[i]);
+  }
+
+  /* test the error conditions */
+  ASSERT_THROW(original.transpose(2, 5), c10::IndexError);
+  ASSERT_THROW(original_1d.transpose(1, 0), c10::IndexError);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61048**

See https://github.com/pytorch/pytorch/issues/60431

The methods are implemented to match the functionality of THCDeviceTensor, which was used for a similar purpose as TensorAccessor/PackedTensorAccessor.

Corner Case: For the 1d case, transpose returns a PackedTensorAccessor that is an identical copy of the original; this mirrors the behavior of THCDeviceTensor

Differential Revision: [D29459384](https://our.internmc.facebook.com/intern/diff/D29459384/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29459384/)!