### PR TITLE
Add getMethod to PytorchPredictorContainer

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -239,8 +239,9 @@ class PythonMethodWrapper : public torch::IMethod {
   // ReplicatedObj which represents a python method, and
   // is therefore callable and has argument names accessible.
  public:
+  // TODO(whc) make bound method pickleable, then directly construct from that
   PythonMethodWrapper(
-      torch::deploy::ReplicatedObj& model,
+      torch::deploy::ReplicatedObj model,
       std::string method_name)
       : model_(std::move(model)), method_name_(std::move(method_name)) {}
 


### PR DESCRIPTION
Summary:
Implement getMethod in the container in a similar way to getPredictor,
using either Deploy or Script functionality depending on how the container
was initialized and how the gflag deploy override are set.

Test Plan: Add new unit test

Differential Revision: D29346969

