### PR TITLE
going back to use packaging.version.parse instead

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -20,7 +20,7 @@ from .hipify.hipify_python import get_hip_file_path, GeneratedFileCleaner
 from typing import List, Optional, Union
 
 from setuptools.command.build_ext import build_ext
-from pkg_resources import packaging, parse_version  # type: ignore[attr-defined]
+from pkg_resources import packaging  # type: ignore[attr-defined]
 
 IS_WINDOWS = sys.platform == 'win32'
 LIB_EXT = '.pyd' if IS_WINDOWS else '.so'
@@ -771,8 +771,8 @@ class BuildExtension(build_ext, object):
             cuda_version = re.search(r'release (\d+[.]\d+)', cuda_version_str)
             if cuda_version is not None:
                 cuda_str_version = cuda_version.group(1)
-                cuda_ver = parse_version(cuda_str_version)
-                torch_cuda_version = parse_version(torch.version.cuda)  # type: ignore[arg-type]
+                cuda_ver = packaging.version.parse((cuda_str_version)
+                torch_cuda_version = packaging.version.parse((torch.version.cuda)  # type: ignore[arg-type]
                 if cuda_ver.major != torch_cuda_version.major:  # type: ignore[attr-defined]
                     raise RuntimeError(CUDA_MISMATCH_MESSAGE.format(
                         cuda_str_version, torch.version.cuda))

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -772,7 +772,7 @@ class BuildExtension(build_ext, object):
             if cuda_version is not None:
                 cuda_str_version = cuda_version.group(1)
                 cuda_ver = packaging.version.parse(cuda_str_version)
-                torch_cuda_version = packaging.version.parse(torch.version.cuda)  # type: ignore[arg-type]
+                torch_cuda_version = packaging.version.parse(torch.version.cuda)
                 if cuda_ver.major != torch_cuda_version.major:  # type: ignore[attr-defined]
                     raise RuntimeError(CUDA_MISMATCH_MESSAGE.format(
                         cuda_str_version, torch.version.cuda))

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -771,8 +771,8 @@ class BuildExtension(build_ext, object):
             cuda_version = re.search(r'release (\d+[.]\d+)', cuda_version_str)
             if cuda_version is not None:
                 cuda_str_version = cuda_version.group(1)
-                cuda_ver = packaging.version.parse((cuda_str_version)
-                torch_cuda_version = packaging.version.parse((torch.version.cuda)  # type: ignore[arg-type]
+                cuda_ver = packaging.version.parse(cuda_str_version)
+                torch_cuda_version = packaging.version.parse(torch.version.cuda)  # type: ignore[arg-type]
                 if cuda_ver.major != torch_cuda_version.major:  # type: ignore[attr-defined]
                     raise RuntimeError(CUDA_MISMATCH_MESSAGE.format(
                         cuda_str_version, torch.version.cuda))

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -20,7 +20,7 @@ from .hipify.hipify_python import get_hip_file_path, GeneratedFileCleaner
 from typing import List, Optional, Union
 
 from setuptools.command.build_ext import build_ext
-from pkg_resources import packaging
+from pkg_resources import packaging  #type: ignore[attr-defined]
 
 IS_WINDOWS = sys.platform == 'win32'
 LIB_EXT = '.pyd' if IS_WINDOWS else '.so'

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -20,7 +20,7 @@ from .hipify.hipify_python import get_hip_file_path, GeneratedFileCleaner
 from typing import List, Optional, Union
 
 from setuptools.command.build_ext import build_ext
-from pkg_resources import packaging  # type: ignore[attr-defined]
+from pkg_resources import packaging
 
 IS_WINDOWS = sys.platform == 'win32'
 LIB_EXT = '.pyd' if IS_WINDOWS else '.so'

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -20,7 +20,7 @@ from .hipify.hipify_python import get_hip_file_path, GeneratedFileCleaner
 from typing import List, Optional, Union
 
 from setuptools.command.build_ext import build_ext
-from pkg_resources import packaging  #type: ignore[attr-defined]
+from pkg_resources import packaging  # type: ignore[attr-defined]
 
 IS_WINDOWS = sys.platform == 'win32'
 LIB_EXT = '.pyd' if IS_WINDOWS else '.so'


### PR DESCRIPTION
I think this may be related to https://app.circleci.com/pipelines/github/pytorch/vision/9352/workflows/9c8afb1c-6157-4c82-a5c8-105c5adac57d/jobs/687003

Apparently `pkg_resource.parse_version` returns a type of `pkg_resources.extern.packaging.version.Version` instead of `packaging.version.Version` and seems on some older version of the setuptools it doesn't support `.major/minor` operation. changing it back to using `packaging.version.parse`

Test Plan:
CI
