### PR TITLE
Fix fx patch module name

### DIFF
--- a/torch/csrc/fx/fx_init.cpp
+++ b/torch/csrc/fx/fx_init.cpp
@@ -125,7 +125,7 @@ void initFx(PyObject* module) {
 
   static struct PyModuleDef path = {
       PyModuleDef_HEAD_INIT,
-      "patch", /* name of module */
+      "torch._C._fx", /* name of module */
       "", /* module documentation, may be NULL */
       -1, /* size of per-interpreter state of the module, or -1 if the module
             keeps state in global variables. */


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60927
* **#61062**

Instead of being 'patch' this should be the import-able name of the module (it's defined as `_fx` on the `torch._C` module, so the full name should be `torch._C._fx`). This now works correctly:

```python
>>> import torch._C._fx
>>> dir(torch._C._fx)
['__doc__', '__loader__', '__name__', '__package__', '__spec__', 'patch_function']
```

Differential Revision: [D29497018](https://our.internmc.facebook.com/intern/diff/D29497018)