### PR TITLE
[CUDA graphs] Don't sync between replays for cuda user-mode driver version 11.4+

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -180,11 +180,15 @@ void CUDAGraph::replay() {
   // graph_exec_ may be replayed in any stream.
   AT_CUDA_CHECK(cudaGraphLaunch(graph_exec_, at::cuda::getCurrentCUDAStream()));
 
-  // Temporary workaround for bug in libcuda.so that causes replayed graphs
-  // with certain topologies to be corrupted (kernels elided, internal syncs
-  // ignored) when replayed back to back without a sync in between.
-  // I hate to use a hard sync, but it's the only surefire workaround at the moment.
-  cudaDeviceSynchronize();
+  int version;
+  AT_CUDA_CHECK(cudaDriverGetVersion(&version));
+  if (version < 11040) {
+    // Workaround for bug in libcuda.so that causes replayed graphs with
+    // certain topologies to be corrupted (kernels elided, internal syncs
+    // ignored) when replayed back to back without a sync in between.
+    // The bug is fixed in CUDA 11.4+.
+    cudaDeviceSynchronize();
+  }
 #else
   TORCH_CHECK(false, "CUDA graphs may only be used in Pytorch built with CUDA >= 11.0");
 #endif


### PR DESCRIPTION
The bug in libcuda.so that required https://github.com/pytorch/pytorch/pull/57556 is fixed for libcuda.so versions >= 11.4.

This PR changes replay() to sync after each launch only if the process's in-use libcuda.so is < 11.4.

With all the "enhanced" and "forward" compatibility promises flying around, and the fact that "driver" sometimes means kernel-mode driver and sometimes means user-mode driver (libcuda.so), I wasn't sure if this PR's check suffices to trigger the sync iff the in-use libcuda.so is < 11.4, but Cuda people say what I wrote is reasonable.