### PR TITLE
Fix deterministic index put on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -254,7 +254,7 @@ void index_put_with_sort_kernel(Tensor & self, const c10::List<c10::optional<Ten
       Tensor value_ = value;
       if (value_numel < linearindex_numel && value_numel == 1) {
         value_ = at::native::repeat(value, {(long) linearindex_numel});
-	value_numel = value_.numel();
+        value_numel = value_.numel();
       }
       TORCH_INTERNAL_ASSERT(linearindex_numel == value_numel, "number of flattened indices did not match number of elements in the value tensor but got more than one value", linearIndex.numel()*sliceSize*nElemBefore, value.numel());
       const int UNROLL = 4;

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -779,6 +779,16 @@ class TestIndexing(TestCase):
 
             self.assertEqual(output, input_list)
 
+    @onlyCUDA
+    def test_index_put_deterministic(self, device):
+        a = torch.arange(10, dtype=torch.float, device=device)
+        a[a>2.] = 1
+        torch.use_deterministic_algorithms(True) 
+        b = torch.arange(10, dtype=torch.float, device=device)
+        b[b>2.] = 1
+        torch.use_deterministic_algorithms(False)
+        self.assertEqual(a, b)
+
     def test_multiple_byte_mask(self, device):
         v = torch.randn(5, 7, 3, device=device)
         # note: these broadcast together and are transposed to the first dim

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -785,7 +785,7 @@ class TestIndexing(TestCase):
         torch.use_deterministic_algorithms(False)
         a = torch.arange(10, dtype=torch.float, device=device)
         a[a>2.] = 1
-        torch.use_deterministic_algorithms(True) 
+        torch.use_deterministic_algorithms(True)
         b = torch.arange(10, dtype=torch.float, device=device)
         b[b>2.] = 1
         torch.use_deterministic_algorithms(deterministic)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -781,12 +781,14 @@ class TestIndexing(TestCase):
 
     @onlyCUDA
     def test_index_put_deterministic(self, device):
+        deterministic = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(False)
         a = torch.arange(10, dtype=torch.float, device=device)
         a[a>2.] = 1
         torch.use_deterministic_algorithms(True) 
         b = torch.arange(10, dtype=torch.float, device=device)
         b[b>2.] = 1
-        torch.use_deterministic_algorithms(False)
+        torch.use_deterministic_algorithms(deterministic)
         self.assertEqual(a, b)
 
     def test_multiple_byte_mask(self, device):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -784,10 +784,10 @@ class TestIndexing(TestCase):
         deterministic = torch.are_deterministic_algorithms_enabled()
         torch.use_deterministic_algorithms(False)
         a = torch.arange(10, dtype=torch.float, device=device)
-        a[a>2.] = 1
+        a[a > 2] = 1
         torch.use_deterministic_algorithms(True)
         b = torch.arange(10, dtype=torch.float, device=device)
-        b[b>2.] = 1
+        b[b > 2] = 1
         torch.use_deterministic_algorithms(deterministic)
         self.assertEqual(a, b)
 


### PR DESCRIPTION
#61032
The issue was caused by the fill value not being explicitly "broadcasted" to match the number of elements specified by the indices.

CC @ptrblck 