### PR TITLE
Revert gh-55217: SumKernel (BFloat16): use float as accumulation type

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -742,26 +742,4 @@ inline Vectorized<BFloat16> convert_float_bfloat16(const Vectorized<float>& a, c
 
 #endif
 
-struct Vec2f {
-  Vectorized<float> val0, val1;
-  Vec2f() {}
-  Vec2f(float v) : val0(v), val1(v) {}
-  Vec2f(Vectorized<float> v0, Vectorized<float> v1) : val0(v0), val1(v1) {}
-  operator Vectorized<BFloat16>() const {
-    return convert_float_bfloat16(val0, val1);
-  }
-};
-inline Vec2f& operator+= (Vec2f& a, const Vec2f& b) {
-  a.val0 += b.val0;
-  a.val1 += b.val1;
-  return a;
-}
-inline Vec2f& operator+= (Vec2f& a, const Vectorized<BFloat16>& b) {
-  Vectorized<float> b0, b1;
-  std::tie(b0, b1) = convert_bfloat16_float(b);
-  a.val0 += b0;
-  a.val1 += b1;
-  return a;
-}
-
 }}}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61083 Add BFloat16 support to CPU nansum
* #61082 Use cascade-summation to improve nansum accuracy
* **#61081 Revert gh-55217: SumKernel (BFloat16): use float as accumulation type**

A similar concept was implemented in gh-60387 which made this dead
code (scalar_t in multi_row_sum will never be BFloat16 or Half).