### PR TITLE
[Docs] Fix docs for torch.chunk

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1493,10 +1493,14 @@ chunk(input, chunks, dim=0) -> List of Tensors
 Attempts to split a tensor into the specified number of chunks. Each chunk is a view of
 the input tensor.
 
-..warning::
-    This function may return less then the specified number of chunks! 
-    For a function that always returns exactly the specified number of chunks, 
-    see :func:`torch.tensor_split`
+
+.. note::
+
+    This function may return less then the specified number of chunks!
+    
+.. seealso::
+
+    :func:`torch.tensor_split` a function that always returns exactly the specified number of chunks
     
 If the tensor size along the given dimesion :attr:`dim` is divisible by :attr:`chunks`,
 all returned chunks will be the same size.
@@ -1509,6 +1513,28 @@ Arguments:
     input (Tensor): the tensor to split
     chunks (int): number of chunks to return
     dim (int): dimension along which to split the tensor
+    
+Example::
+    >>> torch.arange(11).chunk(6)
+    (tensor([0, 1]),
+     tensor([2, 3]),
+     tensor([4, 5]),
+     tensor([6, 7]),
+     tensor([8, 9]),
+     tensor([10]))
+    >>> torch.arange(12).chunk(6)
+    (tensor([0, 1]),
+     tensor([2, 3]),
+     tensor([4, 5]),
+     tensor([6, 7]),
+     tensor([8, 9]),
+     tensor([10, 11]))
+    >>> torch.arange(13).chunk(6)
+    (tensor([0, 1, 2]),
+     tensor([3, 4, 5]),
+     tensor([6, 7, 8]),
+     tensor([ 9, 10, 11]),
+     tensor([12]))
 """)
 
 add_docstr(torch.unsafe_chunk,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1490,11 +1490,20 @@ add_docstr(torch.chunk,
            r"""
 chunk(input, chunks, dim=0) -> List of Tensors
 
-Splits a tensor into a specific number of chunks. Each chunk is a view of
+Attempts to split a tensor into the specified number of chunks. Each chunk is a view of
 the input tensor.
 
-Last chunk will be smaller if the tensor size along the given dimension
-:attr:`dim` is not divisible by :attr:`chunks`.
+..warning::
+    This function may return less then the specified number of chunks! 
+    For a function that always returns exactly the specified number of chunks, 
+    see :func:`torch.tensor_split`
+    
+If the tensor size along the given dimesion :attr:`dim` is divisible by :attr:`chunks`,
+all returned chunks will be the same size.
+If the tensor size along the given dimension :attr:`dim` is not divisible by :attr:`chunks`,
+all returned chunks will be the same size, except the last one.
+If such division is not possible, this function may return less
+than the specified number of chunks.
 
 Arguments:
     input (Tensor): the tensor to split

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1497,11 +1497,11 @@ the input tensor.
 .. note::
 
     This function may return less then the specified number of chunks!
-    
+
 .. seealso::
 
     :func:`torch.tensor_split` a function that always returns exactly the specified number of chunks
-    
+
 If the tensor size along the given dimesion :attr:`dim` is divisible by :attr:`chunks`,
 all returned chunks will be the same size.
 If the tensor size along the given dimension :attr:`dim` is not divisible by :attr:`chunks`,
@@ -1513,7 +1513,7 @@ Arguments:
     input (Tensor): the tensor to split
     chunks (int): number of chunks to return
     dim (int): dimension along which to split the tensor
-    
+
 Example::
     >>> torch.arange(11).chunk(6)
     (tensor([0, 1]),


### PR DESCRIPTION
torch.chunk may return less than the requested number of chunks silently if some undocumented division constraints are not met. The functionality that users expect is provided by another function: torch.tensor_split

This has led to confusion countless times and who knows how many systems out there are fragile because of this.
My changes describe the discrepancy, show an example and direct users to the usually preferred function.

Issues mentioning this problem:
https://github.com/pytorch/pytorch/issues/9382
https://github.com/torch/torch7/issues/617

I considered documenting the constraint for when an unexpected number of chunks may be returned (it is  chunks*chunks>input.size[dim] ), so that users could quickly tell if their code may be affected. Please let me know if you think this should be in the docs or not.