### PR TITLE
Add a test case for findDanglingImpls

### DIFF
--- a/test/cpp_extensions/dangling_impl_extension.cpp
+++ b/test/cpp_extensions/dangling_impl_extension.cpp
@@ -1,0 +1,11 @@
+#include <torch/extension.h>
+
+void foo() { }
+
+TORCH_LIBRARY_IMPL(aten, MSNPU, m) {
+  m.impl("foo", foo);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("bar", foo);
+}

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -4,7 +4,9 @@ from torch._python_dispatcher import PythonDispatcher
 
 from collections import namedtuple
 import itertools
+import os
 import re
+import torch.utils.cpp_extension
 
 # TODO: Expand the dispatcher API to be a generic API for interfacing with
 # the dispatcher from Python!
@@ -755,6 +757,32 @@ CompositeImplicitAutograd[alias] (inactive): fn1 :: (Tensor _0) -> (Tensor _0) [
 '''
         )
 
+    def test_find_dangling_impls_default(self):
+        self.assertEqual(0, len(C._dispatch_find_dangling_impls()))
+
+    def test_find_dangling_impls_ext(self):
+        extension_path = os.path.dirname(os.path.abspath(__file__)) + "/cpp_extensions/dangling_impl_extension.cpp"
+        module = torch.utils.cpp_extension.load(
+            name="dangling_impl_extension",
+            sources=[
+                extension_path,
+            ],
+            extra_cflags=["-g"],
+            verbose=True,
+        )
+
+        impls = C._dispatch_find_dangling_impls()
+        self.assertEqual(1, len(impls))
+        self.assertEqual(
+            '''\
+name: aten::foo
+schema: (none)
+MSNPU: registered at {}:5 :: () -> () [ boxed unboxed ]
+'''.format(extension_path),
+            impls[0])
+
+
+
 class TestPythonDispatcher(TestCase):
     def test_basic(self):
         dispatcher = PythonDispatcher()
@@ -885,10 +913,6 @@ CompositeImplicitAutograd[alias] fn_CompositeImplicitAutograd
                 RuntimeError,
                 r"Registration to both CompositeImplicitAutograd and CompositeExplicitAutograd is not allowed"):
             dispatcher.register(["CompositeExplicitAutograd", "CompositeImplicitAutograd"])
-
-    # TODO(jwtan): Use a C++ extension, like msnpu, to introduce a dangling impl and examine the output.
-    def test_find_dangling_impls(self):
-        self.assertEqual(0, len(C._dispatch_find_dangling_impls()))
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61102**

Summary:
This patch added a new test case for findDanglingImpls. The test case introduces a C++ extension which has a dangling impl such that findDanglingImpls can find it and output its information.

Test Plan:
python test/test_dispatch.py TestDispatch.test_find_dangling_impls_ext

Reviewers:

Subscribers:

Tasks:

Tags: