### PR TITLE
Enable AutogradXPU DispatchKey for Intel heterogeneous computation platform.

### DIFF
--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -83,6 +83,8 @@ const char* toString(DispatchKey t) {
       return "Autograd";
     case DispatchKey::AutogradCPU:
       return "AutogradCPU";
+    case DispatchKey::AutogradXPU:
+      return "AutogradXPU";
     case DispatchKey::AutogradCUDA:
       return "AutogradCUDA";
     case DispatchKey::AutogradXLA:


### PR DESCRIPTION
Add string wrapper for AutogradXPU to enable this DispatchKey.
We are going to use AutogradXPU as custom autograd backend, which needs this DispatchKey.
This sting wrapper is used to map AutogradXPU to the corresponding DispatchKey.