### PR TITLE
Remove star imports

### DIFF
--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -18,7 +18,8 @@ from model_defs.dcgan import _netD, _netG, weights_init, bsz, imgsz, nz
 from model_defs.op_test import DummyNet, ConcatNet, PermuteNet, PReluNet, FakeQuantNet
 from model_defs.emb_seq import EmbeddingNetwork1, EmbeddingNetwork2
 
-from test_pytorch_common import TestCase, run_tests, skipIfNoLapack, skipIfUnsupportedMinOpsetVersion, disableScriptTest
+from torch.testing._internal.common_utils import TestCase, run_tests, skipIfNoLapack
+from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, disableScriptTest
 
 import torch
 import torch.onnx

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -1,4 +1,4 @@
-from test_pytorch_common import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 import torch
 import torch.onnx

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -1,5 +1,5 @@
-
-from test_pytorch_common import TestCase, run_tests, flatten, skipIfNoLapack
+from test_pytorch_common import flatten
+from torch.testing._internal.common_utils import TestCase, run_tests, skipIfNoLapack
 
 import torch
 import torch.onnx

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -8,8 +8,6 @@ import torch.autograd.function as function
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(-1, pytorch_test_dir)
 
-# from torch.testing._internal.common_utils import *  # noqa: F401,F403
-
 torch.set_default_tensor_type("torch.FloatTensor")
 
 BATCH_SIZE = 2

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -8,7 +8,7 @@ import torch.autograd.function as function
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(-1, pytorch_test_dir)
 
-from torch.testing._internal.common_utils import *  # noqa: F401,F403
+# from torch.testing._internal.common_utils import *  # noqa: F401,F403
 
 torch.set_default_tensor_type("torch.FloatTensor")
 

--- a/test/onnx/test_pytorch_helper.py
+++ b/test/onnx/test_pytorch_helper.py
@@ -8,7 +8,7 @@ from pytorch_helper import PyTorchModule
 import unittest
 from caffe2.python.core import workspace
 
-from test_pytorch_common import skipIfNoLapack
+from torch.testing._internal.common_utils import skipIfNoLapack
 
 
 class TestCaffe2Backend(unittest.TestCase):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -36,7 +36,8 @@ from caffe2.python.operator_test.torch_integration_test import (generate_rois_ro
 import onnx
 import caffe2.python.onnx.backend as c2
 
-from test_pytorch_common import skipIfTravis, skipIfNoLapack, skipIfNoCuda
+from torch.testing._internal.common_utils import skipIfNoLapack
+from test_pytorch_common import skipIfTravis, skipIfNoCuda
 from test_pytorch_common import BATCH_SIZE, RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 from test_pytorch_common import skipIfUnsupportedOpsetVersion, skipIfUnsupportedMinOpsetVersion
 import verify

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -15,9 +15,9 @@ from model_defs.lstm_flattening_result import (LstmFlatteningResultWithSeqLength
 from model_defs.rnn_model_with_packed_sequence import (RnnModelWithPackedSequence,
                                                        RnnModelWithPackedSequenceWithState,
                                                        RnnModelWithPackedSequenceWithoutState)
+from torch.testing._internal.common_utils import skipIfNoLapack
 from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, skipIfUnsupportedOpsetVersion,
-                                 skipIfNoLapack, disableScriptTest, skipIfONNXShapeInference,
-                                 skipIfUnsupportedMaxOpsetVersion)
+                                 disableScriptTest, skipIfONNXShapeInference, skipIfUnsupportedMaxOpsetVersion)
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 from typing import List, Tuple, Optional, Dict

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1,4 +1,4 @@
-from test_pytorch_common import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 import torch
 import torch.onnx

--- a/test/onnx/test_verify.py
+++ b/test/onnx/test_verify.py
@@ -4,7 +4,7 @@ from torch.nn import Module, Parameter
 import caffe2.python.onnx.backend as backend
 from verify import verify
 
-from test_pytorch_common import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 
 class TestVerify(TestCase):

--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -62,11 +62,11 @@ class DeterminationTest(unittest.TestCase):
     def test_test_file(self):
         """Test files trigger themselves and dependent tests"""
         self.assertEqual(
-            self.determined_tests(["test/test_jit.py"]), ["test_jit_profiling", "test_jit"]
+            self.determined_tests(["test/test_jit.py"]), ["test_jit"]
         )
         self.assertEqual(
             self.determined_tests(["test/jit/test_custom_operators.py"]),
-            ["test_jit_profiling", "test_jit"],
+            ["test_jit"],
         )
         self.assertEqual(
             self.determined_tests(["test/quantization/eager/test_quantize_eager_ptq.py"]),
@@ -78,7 +78,6 @@ class DeterminationTest(unittest.TestCase):
         self.assertEqual(
             self.determined_tests(["torch/testing/_internal/common_quantization.py"]),
             [
-                "test_jit_profiling",
                 "test_jit",
                 "test_quantization",
             ],

--- a/test/test_jit_fuser_legacy.py
+++ b/test/test_jit_fuser_legacy.py
@@ -1,6 +1,7 @@
 import sys
-sys.argv.append("--jit_executor=legacy")
-from test_jit_fuser import *  # noqa: F403
+
+from torch.testing._internal.common_utils import run_tests
 
 if __name__ == '__main__':
+    sys.argv.append("--jit_executor=legacy")
     run_tests()

--- a/test/test_jit_legacy.py
+++ b/test/test_jit_legacy.py
@@ -1,8 +1,11 @@
+import unittest
 import sys
-sys.argv.append("--jit_executor=legacy")
-from test_jit import *  # noqa: F403
+
+from torch.testing._internal.common_utils import run_tests
+
 
 if __name__ == '__main__':
+    sys.argv.append("--jit_executor=legacy")
     run_tests()
     import test_jit_py3
     suite = unittest.findTestCases(test_jit_py3)

--- a/test/test_jit_profiling.py
+++ b/test/test_jit_profiling.py
@@ -1,11 +1,11 @@
 import unittest
 import sys
 
-sys.argv.append("--jit_executor=profiling")
-
 from torch.testing._internal.common_utils import run_tests
 
+
 if __name__ == '__main__':
+    sys.argv.append("--jit_executor=profiling")
     run_tests()
     import test_jit_py3
     suite = unittest.findTestCases(test_jit_py3)

--- a/test/test_jit_profiling.py
+++ b/test/test_jit_profiling.py
@@ -1,8 +1,10 @@
+import unittest
 import sys
-sys.argv.append("--jit_executor=profiling")
-from test_jit import *  # noqa: F403
+
+from torch.testing._internal.common_utils import run_tests
 
 if __name__ == '__main__':
+    sys.argv.append("--jit_executor=profiling")
     run_tests()
     import test_jit_py3
     suite = unittest.findTestCases(test_jit_py3)

--- a/test/test_jit_profiling.py
+++ b/test/test_jit_profiling.py
@@ -1,10 +1,11 @@
 import unittest
 import sys
 
+sys.argv.append("--jit_executor=profiling")
+
 from torch.testing._internal.common_utils import run_tests
 
 if __name__ == '__main__':
-    sys.argv.append("--jit_executor=profiling")
     run_tests()
     import test_jit_py3
     suite = unittest.findTestCases(test_jit_py3)

--- a/test/test_jit_simple.py
+++ b/test/test_jit_simple.py
@@ -1,8 +1,10 @@
+import unittest
 import sys
-sys.argv.append("--jit_executor=simple")
-from test_jit import *  # noqa: F403
+
+from torch.testing._internal.common_utils import run_tests
 
 if __name__ == '__main__':
+    sys.argv.append("--jit_executor=simple")
     run_tests()
     import test_jit_py3
     suite = unittest.findTestCases(test_jit_py3)

--- a/torch/quantization/fx/fuse.py
+++ b/torch/quantization/fx/fuse.py
@@ -22,7 +22,7 @@ from .graph_module import (
     FusedGraphModule
 )
 
-from .fusion_patterns import *  # noqa: F401,F403
+from .fusion_patterns import FuseHandler
 
 from .quantization_types import Pattern
 


### PR DESCRIPTION
Fixes #49416.

Usage of star imports is determined by

```shell
$ git grep -n -E "import [*]" | grep -v __init__.py
```