### PR TITLE
Bump docker image tag for clang-tidy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -311,8 +311,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: linux.2xlarge
     container:
-      # ubuntu18.04-cuda10.2-py3.6-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:b5a795a1165938adc6ccdab36bfa59bb3829ad47
+      # ubuntu20.04-cuda11.2-py3.8-tidy11
+      image: ghcr.io/pytorch/cilint-clang-tidy:6e81eee1f23596060ac64cfec9b1f4953eb12931
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2


### PR DESCRIPTION
The new tag should fix the "Missing <omp.h>" error message on clang-tidy runs.

Test Plan:
Ran the clang-tidy job using the diff from #60976. 

Expected Output:
There should be no clang diagnostic errors.
