### PR TITLE
Minor bug fix in the warning message

### DIFF
--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -584,7 +584,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
     if not use_env:
         log.warning(
             "--use_env is deprecated and will be removed in future releases.\n"
-            " Please read local_rank from `os.environ('LOCAL_RANK')` instead."
+            " Please read local_rank from `os.environ['LOCAL_RANK']` instead."
         )
         cmd_args.append(f"--local_rank={macros.local_rank}")
     cmd_args.extend(args.training_script_args)


### PR DESCRIPTION
The current example code does not work. The correct one is like this: https://github.com/pytorch/pytorch/blob/cb7d813275a13a4233951e7cbcbb8351dbb0fd87/torch/distributed/run.py#L266