### PR TITLE
[quant][fx][perf] improve runtime of prepare step for large models

### DIFF
--- a/torch/quantization/fx/prepare.py
+++ b/torch/quantization/fx/prepare.py
@@ -875,11 +875,6 @@ def insert_observers_for_model(
 
     for node in nodes_before_observation:
 
-        # check for matches
-        root_node, matched_nodes, pattern, qhandler, qconfig = matches.get(
-            node.name, (None, None, None, None, None))
-        equalization_qconfig = equalization_config_map.get(node.name, None)
-
         if node.op == 'placeholder':
             # if a graph input is in fp32, it does not need observation
             # if a graph input is in int8, we assume the observation happens
@@ -887,7 +882,11 @@ def insert_observers_for_model(
             pass
 
         elif node.op in ('call_module', 'call_method', 'call_function', 'output'):
-            modules = dict(model.named_modules(remove_duplicate=False))
+            # check for matches
+            root_node, matched_nodes, pattern, qhandler, qconfig = matches.get(
+                node.name, (None, None, None, None, None))
+            equalization_qconfig = equalization_config_map.get(node.name, None)
+
             this_node_dtype = node_name_to_target_dtype[node.name]
             output_not_a_tensor = this_node_dtype is None
             # TODO(future PR): consider stopping matching getitem
@@ -901,6 +900,7 @@ def insert_observers_for_model(
             ) and (not node.op == 'output')
 
             if not skip_inserting_observers:
+                modules = dict(model.named_modules(remove_duplicate=False))
                 if node.op != 'output':
                     # this modifies node inplace
                     maybe_insert_input_observers_for_node(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61132**

Summary:
For large models, the insert_observers_for_model function was taking a long time, especially for the case where not all the nodes are being quantized

For example for a model with 21000 nodes of which only ~50 are being quantized the breakdown of prepare_fx vs convert fx was

prepare_fx 979 seconds
convert_fx 9 seconds

The main reason was because we were doing some unnecessary computation for all nodes in this function, this PR just moves them to where they are actually used

After this PR
prepare_fx 26 seconds
convert_fx 9 seconds

Test Plan:
Existing tests

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29522303](https://our.internmc.facebook.com/intern/diff/D29522303)