### PR TITLE
Fixed simple typo in PyTorch Contribution Guide.

### DIFF
--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -243,7 +243,7 @@ Common Mistakes To Avoid
    -  When is it OK not to add a test? Sometimes a change can't be
       conveniently tested, or the change is so obviously correct (and
       unlikely to be broken) that it's OK not to test it. On the
-      contrary, if a change is seems likely (or is known to be likely)
+      contrary, if a change seems likely (or is known to be likely)
       to be accidentally broken, it's important to put in the time to
       work out a testing strategy.
 


### PR DESCRIPTION
Removes redundant and ungrammatical instance of the word "is".
![image](https://user-images.githubusercontent.com/887860/124173052-8e1b0c00-da78-11eb-88f1-d417ae1e28ba.png)
