### PR TITLE
Skip codegen checks for `dequantize_self`, `lu_unpack`, `_cudnn_rnn`, and `.*conv.*_backward.*`

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -230,12 +230,12 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     'slow_conv_transpose2d_backward_output_mask', 'slow_conv_transpose3d_backward_output_mask',
     '_embedding_bag', '_embedding_bag_forward_only',
     'mkldnn_convolution_backward', 'cudnn_convolution_backward',
-    'q_per_channel_scales', 'q_per_channel_zero_points'
+    'q_per_channel_scales', 'q_per_channel_zero_points', 'dequantize_self',
 }
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
     # These 'non-view' functions return tensors with storage use_count > 1
     'thnn_conv2d_forward', 'slow_conv3d_forward', 'channel_shuffle',
-    'q_per_channel_zero_points', 'q_per_channel_scales'
+    'q_per_channel_zero_points', 'q_per_channel_scales', 'dequantize_self',
 }
 # END CHECKS FOR [ TensorImpl and Storage Pointer Sanity Checks ]
 


### PR DESCRIPTION
Temporary fix for fb-internal tests. This and similar failures are being discussed here:
https://github.com/pytorch/pytorch/issues/60426
 
Applies the below changes:
 - This may seem counter intuitive because storage check comes before tensor check, but if TensorImpl use count is not enforced, we should also not enforce storage use count. If an op returns one of its inputs as-is, it is possible for this input to already be aliased with another tensor, and hence would have StorageImpl use count greater than one.
 - Also clarify in description that use_count is not necessarily > 1, use_count may but not necessarily return one of its inputs as-is.
 - Allow usage of regex in skip list