### PR TITLE
Fix modernize-use-equals-default nolint failures in torch/csrcs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -366,7 +366,7 @@ jobs:
           # FunctionsManual.cpp is excluded to keep this diff clean. It will be fixed
           # in a follow up PR.
           # /torch/csrc/generic/*.cpp is excluded because those files aren't actually built.
-          # deploy/interpreter files are excluded due to using macros and other techniquies
+          # deploy/interpreter files are excluded due to using macros and other techniques
           # that are not easily converted to accepted c++
           python3 tools/linter/clang_tidy.py \
             --parallel \

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -32,8 +32,7 @@ private:
 };
 }
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-OpRegistrationListener::~OpRegistrationListener() {}
+OpRegistrationListener::~OpRegistrationListener()= default;
 
 Dispatcher::Dispatcher()
 : operators_()
@@ -42,8 +41,7 @@ Dispatcher::Dispatcher()
 , listeners_(std::make_unique<detail::RegistrationListenerList>())
 , mutex_() {}
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-Dispatcher::~Dispatcher() {}
+Dispatcher::~Dispatcher() = default;
 
 C10_EXPORT Dispatcher& Dispatcher::realSingleton() {
   static Dispatcher _singleton;

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -729,9 +729,8 @@ struct Cell {
   using hidden_type = hidden_type_tmpl;
   using cell_params = cell_params_tmpl;
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~Cell() {} // This is really dumb, but enables projects with
-                     // -Wnon-virtual-dtor to compile...
+  virtual ~Cell() = default; // This is really dumb, but enables projects with
+                             // -Wnon-virtual-dtor to compile...
 
   virtual hidden_type operator()(
       const Tensor& input,
@@ -846,9 +845,8 @@ template<typename io_type, typename hidden_type, typename param_type>
 struct Layer {
   using output_type = LayerOutput<io_type, hidden_type>;
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~Layer() {} // This is really dumb, but enables projects with
-                      // -Wnon-virtual-dtor to compile...
+  virtual ~Layer() = default; // This is really dumb, but enables projects with
+                              // -Wnon-virtual-dtor to compile...
   virtual output_type operator()(
       const io_type& input,
       const hidden_type& input_hidden,

--- a/aten/src/ATen/native/metal/MetalGuardImpl.cpp
+++ b/aten/src/ATen/native/metal/MetalGuardImpl.cpp
@@ -5,8 +5,7 @@ namespace at {
 namespace detail {
 
 struct MetalGuardImpl final : public c10::impl::DeviceGuardImplInterface {
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  MetalGuardImpl() {}
+  MetalGuardImpl() = default;
 
   explicit MetalGuardImpl(DeviceType t) {
     TORCH_INTERNAL_ASSERT(t == DeviceType::Metal);

--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -44,16 +44,12 @@ MAKE_SMART_PTR(Execution)
 #undef MAKE_SMART_PTR
 
 struct NnapiCompilation : torch::jit::CustomClassHolder {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,modernize-use-equals-default)
-  NnapiCompilation() {
-    // Could possibly call load_platform_library here, but error reporting
-    // can be complicated if the constructor is called during model loading.
-    // Instead, delay all work until the explicit init call.
-  }
+  // Could possibly call load_platform_library here, but error reporting
+  // can be complicated if the constructor is called during model loading.
+  // Instead, delay all work until the explicit init call.
+  NnapiCompilation() = default;
 
-  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
-  ~NnapiCompilation() {
-  }
+  ~NnapiCompilation() = default;
 
   void init(
       at::Tensor serialized_model_tensor,

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -208,8 +208,7 @@ Tensor PerChannelAffineFloatQParamsQuantizer::dequantize(const Tensor& qtensor) 
   return rtensor;
 }
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-Quantizer::~Quantizer() {}
+Quantizer::~Quantizer() = default;
 
 C10_EXPORT void set_quantizer_(const Tensor& self, ConstQuantizerPtr quantizer) {
   get_qtensorimpl(self)->set_quantizer_(quantizer);

--- a/aten/src/ATen/test/variant_test.cpp
+++ b/aten/src/ATen/test/variant_test.cpp
@@ -11,12 +11,9 @@ namespace enumtype {
   // error: default initialization of an object of const type 'const enumtype::Enum1'
   // without a user-provided default constructor
   // ```
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  struct Enum1 { Enum1() {}; };
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  struct Enum2 { Enum2() {}; };
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  struct Enum3 { Enum3() {}; };
+  struct Enum1 { Enum1() = default; };
+  struct Enum2 { Enum2() = default; };
+  struct Enum3 { Enum3()  = default; };
 } // namespace enumtype
 
 struct enum_name {

--- a/aten/src/ATen/test/vulkan_test.cpp
+++ b/aten/src/ATen/test/vulkan_test.cpp
@@ -436,8 +436,7 @@ class Conv2d : public BaseOp {
 
 class OpsList {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  OpsList() {}
+  OpsList() = default;
   OpsList(std::vector<std::unique_ptr<BaseOp>>& _ops) : ops(std::move(_ops)) {}
 
   auto runDual(at::Tensor& in, at::Tensor& vin) {

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -51,7 +51,6 @@ void reportMemoryUsageToProfiler(void* ptr, int64_t alloc_size, Device device) {
   }
 }
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-MemoryReportingInfoBase::MemoryReportingInfoBase() {}
+MemoryReportingInfoBase::MemoryReportingInfoBase() = default;
 
 } // namespace c10

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -103,10 +103,7 @@ void free_cpu(void* data) {
 }
 
 struct C10_API DefaultCPUAllocator final : at::Allocator {
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  DefaultCPUAllocator() {}
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  ~DefaultCPUAllocator() override {}
+  DefaultCPUAllocator() = default;
   at::DataPtr allocate(size_t nbytes) const override {
     void* data = alloc_cpu(nbytes);
     profiledCPUMemoryReporter().New(data, nbytes);

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -449,8 +449,7 @@ at::DataPtr PlacementDeleteContext::makeDataPtr(
       device};
 }
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-AutogradMetaInterface::~AutogradMetaInterface() {}
+AutogradMetaInterface::~AutogradMetaInterface() = default;
 
 // Setting requires_grad to true on inference tensor outside InferenceMode
 // is forbidden.  Ideally it would also be illegal inside InferenceMode.

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -19,7 +19,7 @@ class C10_CUDA_API CUDAOutOfMemoryError : public c10::Error {
 // block inside of already allocated area.
 class C10_CUDA_API FreeMemoryCallback {
  public:
-  virtual ~FreeMemoryCallback(){};
+  virtual ~FreeMemoryCallback() = default;
   virtual bool Execute() = 0;
 };
 

--- a/c10/test/util/either_test.cpp
+++ b/c10/test/util/either_test.cpp
@@ -1168,6 +1168,7 @@ class ClassWithDestructorCallback {
 
   ClassWithDestructorCallback& operator=(
       const ClassWithDestructorCallback& rhs) = delete;
+
  private:
   const DestructorCallback* _destructorCallback;
 

--- a/c10/test/util/either_test.cpp
+++ b/c10/test/util/either_test.cpp
@@ -1161,20 +1161,16 @@ class ClassWithDestructorCallback {
  public:
   ClassWithDestructorCallback(const DestructorCallback* destructorCallback)
       : _destructorCallback(destructorCallback) {}
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  ClassWithDestructorCallback(const ClassWithDestructorCallback& rhs)
-      : _destructorCallback(rhs._destructorCallback) {}
 
   ~ClassWithDestructorCallback() {
     _destructorCallback->call();
   }
 
+  ClassWithDestructorCallback& operator=(
+      const ClassWithDestructorCallback& rhs) = delete;
  private:
   const DestructorCallback* _destructorCallback;
 
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ClassWithDestructorCallback& operator=(
-      const ClassWithDestructorCallback& rhs) = delete;
 };
 class OnlyMoveableClassWithDestructorCallback {
  public:

--- a/c10/test/util/registry_test.cpp
+++ b/c10/test/util/registry_test.cpp
@@ -13,8 +13,7 @@ class Foo {
   explicit Foo(int x) {
     // LOG(INFO) << "Foo " << x;
   }
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~Foo() {}
+  virtual ~Foo() = default;
 };
 
 C10_DECLARE_REGISTRY(FooRegistry, Foo, int);

--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -76,8 +76,7 @@ TEST(TypeMetaTest, TypeMeta) {
 class ClassAllowAssignment {
  public:
   ClassAllowAssignment() : x(42) {}
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  ClassAllowAssignment(const ClassAllowAssignment& src) : x(src.x) {}
+  ClassAllowAssignment(const ClassAllowAssignment& src) = default;
   ClassAllowAssignment& operator=(const ClassAllowAssignment& src) = default;
   int x;
 };

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -23,7 +23,7 @@ enum class C10_API_ENUM DebugInfoKind : uint8_t {
 class C10_API DebugInfoBase {
  public:
   DebugInfoBase() {}
-  virtual ~DebugInfoBase() {}
+  virtual ~DebugInfoBase() = default;
 };
 
 // Thread local debug information is propagated across the forward

--- a/tools/linter/clang_tidy.py
+++ b/tools/linter/clang_tidy.py
@@ -373,6 +373,10 @@ def main() -> None:
                 {"name": name, "lines": lines} for name, lines, in changed_files.items()
             ]
             files = list(changed_files.keys())
+            # Since header files are excluded, add .cpp file if it exists in the same folder
+            cpp_files = [f[:-1] + "cpp" for f in files if f.endswith(".h")]
+            cpp_files = [f for f in cpp_files if os.path.exists(f)]
+            files = list(set(files + cpp_files))
     else:
         line_filters = []
         files = get_all_files(paths)

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -29,7 +29,7 @@ struct CudaIPCSentData final {
   at::Device device_;
 
   CudaIPCSentData(
-      const std::string& handle,
+      std::string handle,
       int64_t offset,
       int64_t* counter_ptr,
       at::Device device);
@@ -78,13 +78,13 @@ struct CudaIPCSentDataLimbo final {
 
 struct CudaIPCRefCountersFile final {
   CudaIPCRefCountersFile(
-      const std::string& handle,
+      std::string handle,
       uint64_t size,
       at::DataPtr data_ptr)
       : next_offset_(0),
         size_(size),
         used_slots_(0),
-        handle_(handle),
+        handle_(std::move(handle)),
         refcounted_shared_mem_(std::move(data_ptr)) {}
 
   int64_t* counter_ptr() {
@@ -135,8 +135,6 @@ namespace c10 {
 namespace {
 class CudaIPCCollectCallback : public FreeMemoryCallback {
  public:
-  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
-  ~CudaIPCCollectCallback() {};
   bool Execute() override {
     return torch::CudaIPCCollect();
   }

--- a/torch/csrc/autograd/forward_grad.cpp
+++ b/torch/csrc/autograd/forward_grad.cpp
@@ -6,19 +6,11 @@ namespace {
     // See discussion in forward_grad.h for why these are global variables and not
     // thread local
 
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    static std::mutex all_forward_levels_mutex_;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    static uint64_t next_forward_idx_ = 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    static std::vector<std::shared_ptr<ForwardADLevel>> all_forward_levels_;
+    std::mutex all_forward_levels_mutex_;
+    uint64_t next_forward_idx_ = 0;
+    std::vector<std::shared_ptr<ForwardADLevel>> all_forward_levels_;
 
     const static at::Tensor singleton_undefined_tensor;
-
-    // Temporary flag to disable forward mode
-    // TODO(alband) remove these when perf issues are solved
-    // NOLINTNEXTLINE(clang-diagnostic-unused-variable,cppcoreguidelines-avoid-non-const-global-variables)
-    static bool is_forward_grad_enabled = false;
 }
 
 uint64_t ForwardADLevel::get_next_idx() {

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -84,7 +84,6 @@ struct ForwardGrad;
 #define EXPECTED_MAX_LEVEL 2
 
 struct TORCH_API ForwardADLevel {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ForwardADLevel(uint64_t idx) : idx_(idx) {}
   ~ForwardADLevel();
 
@@ -111,8 +110,7 @@ private:
 };
 
 struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
-  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
-  ForwardGrad() {}
+  ForwardGrad() = default;
 
   // This function must only be called when AutogradMeta or SavedVariable is
   // being destructed as it ensures that:

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -63,8 +63,7 @@ struct TORCH_API UndefinedGradBackward : public Node {
   UndefinedGradBackward(edge_list&& next_edges)
     : Node(std::move(next_edges)) {}
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  UndefinedGradBackward() {}
+  UndefinedGradBackward() = default;
 
   variable_list apply(variable_list&& inputs) override;
 };

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -31,8 +31,7 @@ Scatter::Scatter(
       streams_(streams),
       unsqueeze_scalars_(unsqueeze_scalars) {}
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-Scatter::~Scatter() {}
+Scatter::~Scatter() = default;
 
 variable_list Scatter::apply(variable_list&& inputs) {
   AT_ASSERT(inputs.size() == 1);
@@ -52,7 +51,6 @@ variable_list Scatter::apply(variable_list&& inputs) {
       // NOLINTNEXTLINE(performance-move-const-arg)
       std::move(input), device_indices, chunk_sizes_, dim_, streams_);
 
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::vector<Variable> variables;
   variables.reserve(tensors.size());
   for (auto& tensor : tensors) {
@@ -75,8 +73,7 @@ variable_list Scatter::apply(variable_list&& inputs) {
 Gather::Gather(const at::Device& destination_device, int64_t dim)
     : destination_device_(destination_device), dim_(dim) {}
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-Gather::~Gather() {}
+Gather::~Gather() = default;
 
 variable_list Gather::apply(variable_list&& inputs) {
   bool all_are_zero_dim = true;

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -357,7 +357,6 @@ struct TORCH_API LegacyEvent {
 // a std::vector resize from taking a large amount of time inside
 // a profiling  event
 struct RangeEventList {
-  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   RangeEventList() {
     events_.reserve(kReservedCapacity);
   }
@@ -370,7 +369,6 @@ struct RangeEventList {
 
   std::vector<LegacyEvent> consolidate() {
     std::lock_guard<std::mutex> lock(mutex_);
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<LegacyEvent> result;
     result.insert(
         result.begin(),

--- a/torch/csrc/distributed/autograd/context/container.h
+++ b/torch/csrc/distributed/autograd/context/container.h
@@ -92,6 +92,11 @@ class TORCH_API DistAutogradContainer {
   // Returns the current thread local context id for this thread.
   static int64_t currentContextId();
 
+  DistAutogradContainer(const DistAutogradContainer&) = delete;
+  DistAutogradContainer& operator=(const DistAutogradContainer&) = delete;
+  DistAutogradContainer(DistAutogradContainer&&) = delete;
+  DistAutogradContainer& operator=(DistAutogradContainer&&) = delete;
+
  private:
   // Number of shards for the map storing autograd contexts. We'd like this
   // to be a power of 2 and we don't expect a value much higher than the
@@ -112,18 +117,8 @@ class TORCH_API DistAutogradContainer {
     std::unordered_map<int64_t, ContextPtr> contexts;
   };
 
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistAutogradContainer();
   ~DistAutogradContainer() = default;
-
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistAutogradContainer(const DistAutogradContainer&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistAutogradContainer& operator=(const DistAutogradContainer&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistAutogradContainer(DistAutogradContainer&&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistAutogradContainer& operator=(DistAutogradContainer&&) = delete;
 
   static DistAutogradContainer& getInstanceInternal();
 

--- a/torch/csrc/distributed/autograd/engine/dist_engine.h
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.h
@@ -56,19 +56,14 @@ class TORCH_API DistEngine {
   // to distributed autograd.
   std::unordered_map<std::string, int> getDebugInfo() const;
 
+  DistEngine(const DistEngine&) = delete;
+  DistEngine& operator=(const DistEngine&) = delete;
+  DistEngine(DistEngine&&) = delete;
+  DistEngine& operator=(DistEngine&&) = delete;
  private:
   // Make sure this is a singleton.
   DistEngine();
   ~DistEngine();
-
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistEngine(const DistEngine&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistEngine& operator=(const DistEngine&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistEngine(DistEngine&&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  DistEngine& operator=(DistEngine&&) = delete;
 
   // Validates the input roots for the backward computations and retrieves the
   // appropriate root edges and corresponding gradients. Populates root_edges

--- a/torch/csrc/distributed/rpc/metrics/RpcMetricsHandler.h
+++ b/torch/csrc/distributed/rpc/metrics/RpcMetricsHandler.h
@@ -19,8 +19,7 @@ class RpcMetricsHandler {
   virtual void accumulateMetric(const std::string& name, double value) = 0;
   // Increment a count for the metric given by the name.
   virtual void incrementMetric(const std::string& name) = 0;
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~RpcMetricsHandler() {}
+  virtual ~RpcMetricsHandler() = default;
 };
 
 // Configuration struct for metrics handling.

--- a/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.h
+++ b/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.h
@@ -39,17 +39,14 @@ class TORCH_API RemoteProfilerManager {
   // case that many RPCs are being profiled.
   void eraseKey(const ProfilingId& globallyUniqueId);
 
+  RemoteProfilerManager(const RemoteProfilerManager& other) = delete;
+  RemoteProfilerManager operator=(const RemoteProfilerManager& other) = delete;
+  RemoteProfilerManager(RemoteProfilerManager&&) = delete;
+  RemoteProfilerManager& operator=(RemoteProfilerManager&&) = delete;
+
  private:
   RemoteProfilerManager();
   ~RemoteProfilerManager() = default;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  RemoteProfilerManager(const RemoteProfilerManager& other) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  RemoteProfilerManager operator=(const RemoteProfilerManager& other) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  RemoteProfilerManager(RemoteProfilerManager&&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  RemoteProfilerManager& operator=(RemoteProfilerManager&&) = delete;
   local_id_t getNextLocalId();
   std::unordered_map<ProfilingId, std::string, ProfilingId::Hash>
       profiledRpcKeys_;

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -82,19 +82,16 @@ class PYBIND11_EXPORT PythonRpcHandler {
   // referenced by a given RRef.
   const RRefTypeFunctions& getRRefTypeFunctions() const;
 
+  PythonRpcHandler(const PythonRpcHandler&) = delete;
+  PythonRpcHandler& operator=(const PythonRpcHandler&) = delete;
+  PythonRpcHandler(PythonRpcHandler&&) = delete;
+  PythonRpcHandler& operator=(PythonRpcHandler&&) = delete;
+
  private:
   void init();
   PythonRpcHandler();
   ~PythonRpcHandler() = default;
 
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  PythonRpcHandler(const PythonRpcHandler&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  PythonRpcHandler& operator=(const PythonRpcHandler&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  PythonRpcHandler(PythonRpcHandler&&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  PythonRpcHandler& operator=(PythonRpcHandler&&) = delete;
 
   // Ref to `torch.distributed.rpc.internal._run_function`.
   py::object pyRunFunction_;

--- a/torch/csrc/distributed/rpc/request_callback.h
+++ b/torch/csrc/distributed/rpc/request_callback.h
@@ -16,8 +16,7 @@ class TORCH_API RequestCallback {
       Message& request,
       std::vector<c10::Stream> streams) const;
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~RequestCallback() {}
+  virtual ~RequestCallback() = default;
 
  protected:
   // RpcAgent implementation should invoke ``RequestCallback`` to process

--- a/torch/csrc/distributed/rpc/rpc_command_base.h
+++ b/torch/csrc/distributed/rpc/rpc_command_base.h
@@ -20,8 +20,7 @@ class RpcCommandBase {
   virtual ~RpcCommandBase() = 0;
 };
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-inline RpcCommandBase::~RpcCommandBase() {}
+inline RpcCommandBase::~RpcCommandBase() = default;
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/csrc/distributed/rpc/rref_proto.h
+++ b/torch/csrc/distributed/rpc/rref_proto.h
@@ -18,13 +18,11 @@ class TORCH_API RRefMessageBase : public RpcCommandBase {
   RRefMessageBase(const RRefId& rrefId, MessageType type)
       : rrefId_(rrefId), type_(type) {}
 
-  // NOLINTNEXTLINE(modernize-use-override)
-  virtual ~RRefMessageBase() override = default;
+  ~RRefMessageBase() override = default;
 
   const RRefId& rrefId();
 
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  virtual c10::intrusive_ptr<Message> toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static at::IValue fromMessage(const Message& message, MessageType type);
 
  protected:
@@ -39,13 +37,9 @@ class TORCH_API ForkMessageBase : public RRefMessageBase {
   ForkMessageBase(const RRefId& rrefId, const ForkId& forkId, MessageType type)
       : RRefMessageBase(rrefId, type), forkId_(forkId) {}
 
-  // NOLINTNEXTLINE(modernize-use-override)
-  virtual ~ForkMessageBase() override = default;
-
   const ForkId& forkId();
 
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  virtual c10::intrusive_ptr<Message> toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::pair<RRefId, ForkId> fromMessage(
       const Message& message,
       MessageType type);
@@ -164,8 +158,7 @@ class TORCH_API RRefForkRequest final : public ForkMessageBase {
 
 class TORCH_API RRefAck final : public RpcCommandBase {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  RRefAck() {}
+  RRefAck() = default;
 
   c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<RRefAck> fromMessage(const Message& message);

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -106,6 +106,7 @@ class ComputeAt {
   ComputeAt() = delete;
   ComputeAt(ComputeAt&) = delete;
   ComputeAt& operator=(const ComputeAt& other) = delete;
+
  private:
   TensorView* producer_;
   TensorView* consumer_;

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -103,6 +103,9 @@ class ComputeAt {
       TensorView* _consumer,
       unsigned int _consumer_position);
 
+  ComputeAt() = delete;
+  ComputeAt(ComputeAt&) = delete;
+  ComputeAt& operator=(const ComputeAt& other) = delete;
  private:
   TensorView* producer_;
   TensorView* consumer_;
@@ -155,13 +158,7 @@ class ComputeAt {
       TensorView* _consumer,
       unsigned int _consumer_position);
 
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ComputeAt() = delete;
   ~ComputeAt() = default;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ComputeAt(ComputeAt&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ComputeAt& operator=(const ComputeAt& other) = delete;
 };
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -38,7 +38,6 @@ void KernelArgumentHolder::push(const at::Tensor& tensor) {
   int nDims = tensor.ndimension();
 
   c10::ScalarType dtype = tensor.scalar_type();
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   std::unique_ptr<TensorArgAbstract> tensor_arg = getTensorArg(dtype, nDims);
   tensor_arg->setPointer(tensor.data_ptr());
   for (const auto i : c10::irange(nDims)) {

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
@@ -51,50 +51,43 @@ struct TensorArgCodegen<T, 0> {
 };
 
 struct ArgAbstract {
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~ArgAbstract() {}
+  virtual ~ArgAbstract() = default;
   virtual void* arg() = 0;
 };
 
 struct ULongArg : public ArgAbstract {
   uint64_t val_;
-  ULongArg(uint64_t _val) : val_(_val){};
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  void* arg() {
+  ULongArg(uint64_t _val) : val_(_val) {}
+  void* arg() override {
     return &val_;
   }
 };
 
 struct LongArg : public ArgAbstract {
   int64_t val_;
-  LongArg(int64_t _val) : val_(_val){};
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  void* arg() {
+  LongArg(int64_t _val) : val_(_val) {}
+  void* arg() override {
     return &val_;
   }
 };
 
 struct IntArg : public ArgAbstract {
   int val_;
-  IntArg(int _val) : val_(_val){};
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  void* arg() {
+  IntArg(int _val) : val_(_val) {}
+  void* arg() override {
     return &val_;
   }
 };
 
 struct FloatArg : public ArgAbstract {
   float val_;
-  FloatArg(float _val) : val_(_val){};
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  void* arg() {
+  FloatArg(float _val) : val_(_val) {}
+  void* arg() override {
     return &val_;
   }
 };
 
 struct TensorArgAbstract : ArgAbstract {
-  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
-  virtual ~TensorArgAbstract(){};
   virtual void setSize(int i, int64_t size) = 0;
   virtual void setStride(int i, int64_t stride) = 0;
   virtual void setPointer(void* ptr) = 0;
@@ -102,6 +95,7 @@ struct TensorArgAbstract : ArgAbstract {
 
 // This should match the tensor used in the code generation (almost exactly)
 template <typename TENSOR_TYPE>
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct TensorArg : public TensorArgAbstract {
   TENSOR_TYPE instance_;
 
@@ -154,7 +148,6 @@ std::unique_ptr<TensorArgAbstract> getTensorArg(
     c10::ScalarType dtype,
     int nDims);
 
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class KernelArgumentHolder {
  public:
   // Push a tensor to the arguments

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -31,15 +31,13 @@ class IrBuilder;
 //!
 class Passkey {
   friend class IrBuilder;
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  Passkey() {}
+  Passkey() = default;
 };
 
 class TORCH_CUDA_CU_API NamedScalar : public Val {
  public:
-  // NOLINTNEXTLINE(modernize-pass-by-value)
   NamedScalar(Passkey, std::string name, DataType dtype)
-      : Val(ValType::KirNamedScalar, dtype, true, true), name_(name) {}
+      : Val(ValType::KirNamedScalar, dtype, true, true), name_(std::move(name)) {}
 
   explicit NamedScalar(Passkey, const fuser::cuda::NamedScalar* node)
       : Val(node), name_(node->name()) {}

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -37,7 +37,8 @@ class Passkey {
 class TORCH_CUDA_CU_API NamedScalar : public Val {
  public:
   NamedScalar(Passkey, std::string name, DataType dtype)
-      : Val(ValType::KirNamedScalar, dtype, true, true), name_(std::move(name)) {}
+      : Val(ValType::KirNamedScalar, dtype, true, true),
+        name_(std::move(name)) {}
 
   explicit NamedScalar(Passkey, const fuser::cuda::NamedScalar* node)
       : Val(node), name_(node->name()) {}

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -254,7 +254,6 @@ void FusedKernelCUDA::launch_raw(
   at::cuda::set_device(prior_device);
 }
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
 FusedKernelCUDA::~FusedKernelCUDA() {
   nvrtc().cuModuleUnload(module_);
 }

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -19,7 +19,6 @@ struct SourceRange;
 //  - starting_line_no : represents the line in the original file where the
 //                       code segment started.
 struct Source {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit Source(
       std::string text,
       std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
@@ -30,7 +29,6 @@ struct Source {
     calc_line_start_offsets();
   }
 
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Source(
       std::string text,
       c10::optional<std::string> filename,

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -195,12 +195,10 @@ struct TORCH_API NoWarn {
 };
 
 struct WithNestedTracingFrame {
-  // NOLINTNEXTLINE(modernize-use-equals-default)
   WithNestedTracingFrame() {
     getTracingState()->enterFrame();
   }
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~WithNestedTracingFrame() {
     getTracingState()->leaveFrame();
   }

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1631,8 +1631,8 @@ Value* Graph::insert(
 Node* Graph::create(NodeKind kind, size_t num_outputs) {
   // NB: Node constructor adds node to all_nodes
   auto n = new Node(this, kind);
-  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   for (const auto i : c10::irange(num_outputs)) {
+    (void)i;
     n->addOutput();
   }
   return n;

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -817,7 +817,6 @@ struct TORCH_API Node {
   }
   // The names are returned in order, since name actually is the index.
   std::vector<Symbol> attributeNames() const {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<Symbol> names;
     for (const AVPtr& a : values_) {
       names.push_back(a->name);
@@ -825,7 +824,6 @@ struct TORCH_API Node {
     return names;
   }
   std::vector<const char*> attributeNamesS() const {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<const char*> names;
     for (const AVPtr& a : values_) {
       names.push_back(a->name.toUnqualString());
@@ -906,7 +904,6 @@ struct TORCH_API Node {
   typename T::ValueType& getAttr(Symbol name) const {
     AT_ASSERT(name.is_attr());
     auto it = findAttr(name, true);
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     auto* child = dynamic_cast<T*>(it->get());
     if (child == nullptr) {
       throw IRAttributeError(name, true);
@@ -1151,15 +1148,11 @@ struct Graph {
   Node* insert_before_;
 
  public:
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-  Graph(ScopePtr scope_root)
+  Graph(ScopePtr scope_root = c10::make_intrusive<Scope>())
       : next_unique_(0),
         current_scope_(std::move(scope_root)),
         block_(new Block(this, nullptr)),
         insert_before_(return_node()) {}
-
-  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
-  Graph() : Graph(c10::make_intrusive<Scope>()) {}
 
   at::ArrayRef<Value*> inputs() {
     return block_->inputs();

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1411,12 +1411,10 @@ struct WithInsertPoint {
  * the new one, and restores the original scope when the object is destroyed.
  */
 struct WithCurrentScope {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   WithCurrentScope(Graph& g, ScopePtr scope)
       : graph_(&g), prev_scope_(g.current_scope()) {
     g.set_current_scope(std::move(scope));
   }
-  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~WithCurrentScope() {
     graph_->set_current_scope(prev_scope_);
   }

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -32,9 +32,6 @@ class MobileDebugInfo : public c10::DebugInfoBase {
     op_idx_ = op_idx;
   }
 
-  // NOLINTNEXTLINE(modernize-use-equals-default,modernize-use-override)
-  virtual ~MobileDebugInfo() {}
-
  private:
   std::string model_name_;
   std::string method_name_;

--- a/torch/csrc/jit/passes/onnx/constant_map.h
+++ b/torch/csrc/jit/passes/onnx/constant_map.h
@@ -39,11 +39,9 @@ class ConstantValueMap {
   static void ClearMaps();
   ~ConstantValueMap() = default;
 
- private:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  ConstantValueMap(){};
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ConstantValueMap& operator=(const ConstantValueMap&) = delete;
+ private:
+  ConstantValueMap() = default;
 
   std::unordered_map<std::string, size_t> rankMap;
   std::unordered_map<std::string, c10::SymbolicShape> shapeMap;

--- a/torch/csrc/jit/passes/onnx/constant_map.h
+++ b/torch/csrc/jit/passes/onnx/constant_map.h
@@ -40,6 +40,7 @@ class ConstantValueMap {
   ~ConstantValueMap() = default;
 
   ConstantValueMap& operator=(const ConstantValueMap&) = delete;
+
  private:
   ConstantValueMap() = default;
 

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -29,8 +29,7 @@ class MemoryDAG;
  */
 class TORCH_API MemoryDAGBuilder {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  MemoryDAGBuilder() {}
+  MemoryDAGBuilder() = default;
   MemoryDAGBuilder(const MemoryDAGBuilder&) = delete;
   MemoryDAGBuilder& operator=(const MemoryDAGBuilder&) = delete;
 

--- a/torch/csrc/jit/resource_guard.h
+++ b/torch/csrc/jit/resource_guard.h
@@ -13,7 +13,6 @@ class ResourceGuard {
       : _destructor(std::move(destructor)), _released(false) {}
 
   // NOLINTNEXTLINE(bugprone-exception-escape)
-  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~ResourceGuard() {
     if (!_released)
       _destructor();

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -42,7 +42,7 @@ using c10::ivalue::Future;
 using TaskLauncher = std::function<void(std::function<void()>)>;
 
 struct TORCH_API Code {
-  Code()  = default;
+  Code() = default;
   explicit Code(interpreter::CodeImpl* pImpl);
   // remaining_bailout_depth is irrelevant in a `Code` object unless the `Code`
   // is directly created by `GraphExecutor` in which case it's likely to contain

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -42,8 +42,7 @@ using c10::ivalue::Future;
 using TaskLauncher = std::function<void(std::function<void()>)>;
 
 struct TORCH_API Code {
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  Code() : pImpl(nullptr) {}
+  Code()  = default;
   explicit Code(interpreter::CodeImpl* pImpl);
   // remaining_bailout_depth is irrelevant in a `Code` object unless the `Code`
   // is directly created by `GraphExecutor` in which case it's likely to contain

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -39,7 +39,6 @@ class ScopedVarName {
   ScopedVarName(const ScopedVarName&) = delete;
   ScopedVarName& operator=(const ScopedVarName&) = delete;
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~ScopedVarName() noexcept(false) {
     mapping_->erase(var_);
   }

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -22,7 +22,6 @@ namespace tensorexpr {
 // A class that analyzes the given program relevant for Cuda backends.
 class CudaAnalysis : public IRVisitor {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   CudaAnalysis() {
     gpu_block_extents_ = {new IntImm(1), new IntImm(1), new IntImm(1)};
     gpu_thread_extents_ = {new IntImm(1), new IntImm(1), new IntImm(1)};

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -160,7 +160,6 @@ class TORCH_API ReduceOp : public ExprNode<ReduceOp> {
 
 class Sum : public Reducer {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
   Sum()
       : Reducer(ExprHandle(0), [](ExprHandle a, ExprHandle b) {
           return a + b;

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -319,7 +319,6 @@ class Scope {
  */
 class TORCH_API RegisterizerAnalysis : public IRVisitor {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default,cppcoreguidelines-pro-type-member-init)
   RegisterizerAnalysis()
       : currentScope_(std::make_shared<Scope>(nullptr, nullptr, 0)) {}
   ~RegisterizerAnalysis() override = default;
@@ -392,7 +391,6 @@ class TORCH_API RegisterizerReplacer : public IRMutator {
   Stmt* mutate(const Block* v) override;
 
  private:
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct ReplacerScope {
     std::unordered_map<const Stmt*, std::deque<std::shared_ptr<AccessInfo>>>
         initializerPoints_;


### PR DESCRIPTION
Test-plan: Compile + clang-tidy