### PR TITLE
Add coverage files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,6 @@ core.*
 
 # Generated if you use the pre-commit script for clang-tidy
 pr.diff
+
+# coverage files
+*/**/.coverage.*


### PR DESCRIPTION
Fixes failures when coverage is turned on: https://github.com/pytorch/pytorch/runs/2966295169 https://github.com/pytorch/pytorch/runs/2964409741

Test Plan:

```bash
$ echo hi > test/.coverage.jit.1625168654.4504092
$ git status
$
```