### PR TITLE
[skip ci] Write minidumps on exceptions during tests

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -280,6 +280,9 @@ jobs:
       - name: Preserve github env variables for use in docker
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Prepare crash dump folder
+        run: |
+          mkdir -p pytorch_crashes
       - name: Test PyTorch
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
@@ -309,6 +312,7 @@ jobs:
             --tty \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -v "${GITHUB_WORKSPACE}/pytorch_crashes:/tmp/pytorch_crashes" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
             sh -c 'sudo chown -R jenkins . && pip install dist/*.whl && '$TEST_COMMAND
@@ -341,6 +345,15 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - uses: actions/upload-artifact@v2
+        name: Upload crash reports
+        if: always()
+        with:
+          name: crash-reports-${{ matrix.config }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            pytorch_crashes/*.dmp
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
+++ b/.github/workflows/pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
@@ -273,6 +273,9 @@ jobs:
       - name: Preserve github env variables for use in docker
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Prepare crash dump folder
+        run: |
+          mkdir -p pytorch_crashes
       - name: Test PyTorch
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
@@ -302,6 +305,7 @@ jobs:
             --tty \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -v "${GITHUB_WORKSPACE}/pytorch_crashes:/tmp/pytorch_crashes" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
             sh -c 'sudo chown -R jenkins . && pip install dist/*.whl && '$TEST_COMMAND
@@ -334,6 +338,15 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - uses: actions/upload-artifact@v2
+        name: Upload crash reports
+        if: always()
+        with:
+          name: crash-reports-${{ matrix.config }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            pytorch_crashes/*.dmp
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/pytorch-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/pytorch-linux-bionic-py3.8-gcc9-coverage.yml
@@ -274,6 +274,9 @@ jobs:
       - name: Preserve github env variables for use in docker
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Prepare crash dump folder
+        run: |
+          mkdir -p pytorch_crashes
       - name: Test PyTorch
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
@@ -303,6 +306,7 @@ jobs:
             --tty \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -v "${GITHUB_WORKSPACE}/pytorch_crashes:/tmp/pytorch_crashes" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
             sh -c 'sudo chown -R jenkins . && pip install dist/*.whl && '$TEST_COMMAND
@@ -335,6 +339,15 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - uses: actions/upload-artifact@v2
+        name: Upload crash reports
+        if: always()
+        with:
+          name: crash-reports-${{ matrix.config }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            pytorch_crashes/*.dmp
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -273,6 +273,9 @@ jobs:
       - name: Preserve github env variables for use in docker
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Prepare crash dump folder
+        run: |
+          mkdir -p pytorch_crashes
       - name: Test PyTorch
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
@@ -302,6 +305,7 @@ jobs:
             --tty \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -v "${GITHUB_WORKSPACE}/pytorch_crashes:/tmp/pytorch_crashes" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
             sh -c 'sudo chown -R jenkins . && pip install dist/*.whl && '$TEST_COMMAND
@@ -334,6 +338,15 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - uses: actions/upload-artifact@v2
+        name: Upload crash reports
+        if: always()
+        with:
+          name: crash-reports-${{ matrix.config }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            pytorch_crashes/*.dmp
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/pytorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -273,6 +273,9 @@ jobs:
       - name: Preserve github env variables for use in docker
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Prepare crash dump folder
+        run: |
+          mkdir -p pytorch_crashes
       - name: Test PyTorch
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
@@ -302,6 +305,7 @@ jobs:
             --tty \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -v "${GITHUB_WORKSPACE}/pytorch_crashes:/tmp/pytorch_crashes" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
             sh -c 'sudo chown -R jenkins . && pip install dist/*.whl && '$TEST_COMMAND
@@ -334,6 +338,15 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - uses: actions/upload-artifact@v2
+        name: Upload crash reports
+        if: always()
+        with:
+          name: crash-reports-${{ matrix.config }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            pytorch_crashes/*.dmp
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
@@ -274,6 +274,9 @@ jobs:
       - name: Preserve github env variables for use in docker
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Prepare crash dump folder
+        run: |
+          mkdir -p pytorch_crashes
       - name: Test PyTorch
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
@@ -303,6 +306,7 @@ jobs:
             --tty \
             --user jenkins \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -v "${GITHUB_WORKSPACE}/pytorch_crashes:/tmp/pytorch_crashes" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}" \
             sh -c 'sudo chown -R jenkins . && pip install dist/*.whl && '$TEST_COMMAND
@@ -335,6 +339,15 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - uses: actions/upload-artifact@v2
+        name: Upload crash reports
+        if: always()
+        with:
+          name: crash-reports-${{ matrix.config }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            pytorch_crashes/*.dmp
       - name: Clean up docker images
         if: always()
         run: |

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -15,7 +15,8 @@ import tempfile
 
 import torch
 from torch.utils import cpp_extension
-from torch.testing._internal.common_utils import FILE_SCHEMA, IS_IN_CI, TEST_WITH_ROCM, shell, set_cwd
+from torch.testing._internal.common_utils import FILE_SCHEMA, IS_IN_CI, TEST_WITH_ROCM, \
+    shell, set_cwd, has_breakpad
 import torch.distributed as dist
 from typing import Dict, Optional, Tuple, List, Any
 from typing_extensions import TypedDict
@@ -1233,6 +1234,10 @@ def main():
         print(f'Exporting past test times from S3 to {test_times_filename}, no tests will be run.')
         export_S3_test_times(test_times_filename, pull_job_times_from_S3())
         return
+
+    if has_breakpad():
+        # Write crash dumps on unstructured exceptions (e.g. SIGSEGV) to /tmp/pytorch_crashes
+        torch.utils._crash_handler.enable_minidumps()
 
     specified_test_cases_filename = options.run_specified_test_cases
     if specified_test_cases_filename:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1235,9 +1235,13 @@ def main():
         export_S3_test_times(test_times_filename, pull_job_times_from_S3())
         return
 
+    print("checking breakpad")
     if has_breakpad():
         # Write crash dumps on unstructured exceptions (e.g. SIGSEGV) to /tmp/pytorch_crashes
+        print("breakpad present, enabling minidumps")
         torch.utils._crash_handler.enable_minidumps()
+    else:
+        print("breakpad missing")
 
     specified_test_cases_filename = options.run_specified_test_cases
     if specified_test_cases_filename:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61159
* **#61158**
* #60990

When a test fails with a segfault, write a crash dump and store it as an artifact so it can be downloaded for later debugging.