### PR TITLE
[do not merge] Test if minidumps are written on segfaults

### DIFF
--- a/test/jit/test_jit_utils.py
+++ b/test/jit/test_jit_utils.py
@@ -19,6 +19,9 @@ if __name__ == '__main__':
 
 # Tests various JIT-related utility functions.
 class TestJitUtils(JitTestCase):
+    def test_segfault(self):
+        torch.bincount(input=torch.tensor([9223372036854775807]))
+
     # Tests that POSITIONAL_OR_KEYWORD arguments are captured.
     def test_get_callable_argument_names_positional_or_keyword(self):
         def fn_positional_or_keyword_args_only(x, y):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61159**
* #61158
* #60990

This introduces a segfaulting test which should write out a minidump that can be downloaded from the GHA artifact store
