### PR TITLE
Add `expecttest` to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,7 +348,7 @@ in `test/test_jit.py`. Your command would be:
 python test/test_jit.py TestJit.test_Sequential
 ```
 
-The `hypothesis` library must be installed to run the tests. `mypy` is
+The `expecttest` and `hypothesis` libraries must be installed to run the tests. `mypy` is
 an optional dependency, and `pytest` may help run tests more selectively.
 All these packages can be installed with `conda` or `pip`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Python dependencies required for development
 astunparse
+expecttest
 future
 numpy
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Python dependencies required for development
 astunparse
-expecttest
 future
 numpy
 psutil


### PR DESCRIPTION
Now expecttest is an independent library but `CONTRIBUTING.md` and `requirements.txt` do not mention the need of the library.

Related: https://github.com/pytorch/pytorch/pull/60658 