### PR TITLE
Add support of variadic length/type argument in `result_type`

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -1166,6 +1166,7 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   m.impl("result_type.Scalar", static_cast<ScalarType (*)(const Tensor&, const Scalar&)>(native::result_type));
   m.impl("result_type.Scalar_Tensor", static_cast<ScalarType (*)(const Scalar&, const Tensor&)>(native::result_type));
   m.impl("result_type.Scalar_Scalar", static_cast<ScalarType (*)(const Scalar&, const Scalar&)>(native::result_type));
+  m.impl("result_type.TensorList", static_cast<ScalarType (*)(TensorList)>(native::result_type));
 
 #undef BINARY_POINTWISE_VA
 #undef BINARY_POINTWISE

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -253,7 +253,7 @@ Tensor & _cat_out_cpu(TensorList tensors, int64_t dim, Tensor& result) {
 }
 
 Tensor _cat_cpu(TensorList tensors, int64_t dim) {
-  ScalarType high_type = result_type(tensors);
+  ScalarType high_type = at::result_type(tensors);
   Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
   return native::_cat_out_cpu(tensors, dim, result);
 }
@@ -1517,14 +1517,14 @@ bool inline maybe_native_stack(Tensor& result, TensorList tensors, int64_t dim) 
 
 Tensor _stack(TensorList tensors, int64_t dim) {
   dim = maybe_wrap_dim(dim, tensors[0].dim() + 1);
-  ScalarType high_type = result_type(tensors);
+  ScalarType high_type = at::result_type(tensors);
   Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
   return at::native::_stack_out(get_stack_inputs(tensors, dim), dim, result);
 }
 
 Tensor _stack_cpu(TensorList tensors, int64_t dim) {
   dim = maybe_wrap_dim(dim, tensors[0].dim() + 1);
-  ScalarType high_type = result_type(tensors);
+  ScalarType high_type = at::result_type(tensors);
   Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
   return at::native::_stack_out_cpu(tensors, dim, result);
 }

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -125,6 +125,12 @@ ResultTypeState update_result_type_state(const Scalar& scalar, const ResultTypeS
   return new_state;
 }
 
+ResultTypeState update_result_type_state(const ScalarType& dtype, const ResultTypeState& in_state) {
+  ResultTypeState new_state = in_state;
+  new_state.dimResult = promote_skip_undefined(in_state.dimResult, dtype);
+  return new_state;
+}
+
 ScalarType result_type(const ResultTypeState& in_state) {
   return combine_categories(in_state.dimResult, combine_categories(in_state.zeroResult, in_state.wrappedResult));
 }
@@ -133,6 +139,22 @@ ScalarType result_type(TensorList tensors) {
   ResultTypeState state = {};
   for (const Tensor& tensor : tensors) {
     state = update_result_type_state(tensor, state);
+  }
+  return result_type(state);
+}
+
+ScalarType _result_type_scalars(ScalarList scalars) {
+  ResultTypeState state = {};
+  for (const Scalar& scalar : scalars) {
+    state = update_result_type_state(scalar, state);
+  }
+  return result_type(state);
+}
+
+ScalarType _result_type_dtypes(ArrayRef<ScalarType> dtypes) {
+  ResultTypeState state = {};
+  for (const ScalarType& dtype : dtypes) {
+    state = update_result_type_state(dtype, state);
   }
   return result_type(state);
 }
@@ -151,7 +173,7 @@ ScalarType result_type(const Tensor &tensor, const Scalar& other) {
 }
 
 ScalarType result_type(const Scalar& scalar, const Tensor &tensor) {
-  return at::result_type(tensor, scalar);
+  return native::result_type(tensor, scalar);
 }
 
 ScalarType result_type(const Scalar& scalar1, const Scalar& scalar2) {

--- a/aten/src/ATen/native/TypeProperties.h
+++ b/aten/src/ATen/native/TypeProperties.h
@@ -13,6 +13,4 @@ struct ResultTypeState {
 TORCH_API ResultTypeState update_result_type_state(const Tensor& tensor, const ResultTypeState& in_state);
 TORCH_API ScalarType result_type(const ResultTypeState& state);
 
-TORCH_API ScalarType result_type(TensorList tensors);
-
 }}

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -406,7 +406,7 @@ void parallel_cat(Tensor &out, const TensorList &inputs, int64_t dimension,
 } // namespace
 
 Tensor cat_cuda(TensorList inputs, int64_t dimension) {
-  ScalarType high_type = result_type(inputs);
+  ScalarType high_type = at::result_type(inputs);
   Tensor out = at::empty({0}, inputs.front().options().dtype(high_type));
   at::native::cat_out_cuda(inputs, dimension, out);
   return out;
@@ -447,7 +447,7 @@ Tensor& cat_out_cuda(TensorList inputs, int64_t dimension, Tensor& out) {
   int nDims = 0;
 
   // Check for type promotion
-  TORCH_CHECK(canCast(result_type(inputs), out.scalar_type()), "torch.cat(): input types ",
+  TORCH_CHECK(canCast(at::result_type(inputs), out.scalar_type()), "torch.cat(): input types ",
                       " can't be cast to the desired output type ",
                       out.scalar_type());
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5431,6 +5431,15 @@
 - func: item(Tensor self) -> Scalar
   variants: method
 
+- func: result_type.TensorList(Tensor[] tensors) -> ScalarType
+  variants: function
+
+- func: _result_type_scalars(Scalar[] scalars) -> ScalarType
+  variants: function
+
+- func: _result_type_dtypes(ScalarType[] dtypes) -> ScalarType
+  variants: function
+
 - func: result_type.Tensor(Tensor tensor, Tensor other) -> ScalarType
   variants: function
 

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -52,6 +52,7 @@ namespace at {
 class OptionalTensorRef;
 class Tensor;
 using TensorList = ArrayRef<Tensor>;
+using ScalarList = ArrayRef<Scalar>;
 
 using Stream = c10::Stream;
 

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import itertools
+from numbers import Number
 import unittest
 
 import torch
@@ -410,33 +411,45 @@ class TestTypePromotion(TestCase):
         # Floating dtypes are not listed here because the `numpy.result_type` may behave differently
         # if inputs of mixed dtypes are given. The tests for floating type inputs are left to
         # `test_result_type` and `test_result_type_tensor_vs_scalar`.
-        dtypes = [torch.bool, torch.uint8, torch.int16, torch.int64]
+        dtypes = [
+            torch.bool, torch.uint8, torch.int8, torch.int16, torch.int64,
+            torch.float16, torch.float32, torch.float64,
+            torch.complex64, torch.complex128,
+        ]
         inputs = [
             True,  # bool scalar
             10,  # int scalar
+            10.0,  # float scalar
+            10j,  # complex scalar
             *[torch.tensor([1, 2, 3], dtype=dtype) for dtype in dtypes],  # tensors
             *dtypes,  # tensors
         ]
 
-        def _expected_func(*inputs):
-            def _convert_to_numpy_input(x):
-                if isinstance(x, torch.Tensor):
-                    return x.cpu().numpy()
-                if isinstance(x, bool):
-                    return np.bool_(x)
-                if isinstance(x, int):
-                    return np.int64(x)
-                return torch.tensor([1], dtype=x).numpy().dtype
-            inputs = [_convert_to_numpy_input(x) for x in inputs]
-            return np.result_type(*inputs)
+        def result_type_ref(args):
+            assert len(args) > 0
+            tensor = torch.tensor([True])
+            tensor_0dim = torch.tensor(True)
+            scalar = True
 
-        for x1 in inputs:
-            for x2 in inputs:
-                for x3 in inputs:
-                    actual = torch.result_type(x1, x2, x3)  # torch.dtype
-                    expected = _expected_func(x1, x2, x3)  # numpy.dtype
-                    self.assertIsInstance(actual, torch.dtype)
-                    self.assertEqual(repr(actual).split(".")[-1], expected.name)
+            for arg in args:
+                if isinstance(arg, torch.dtype):
+                    tensor = tensor + torch.tensor([1], dtype=arg)
+                elif isinstance(arg, torch.Tensor):
+                    if arg.ndim == 0:
+                        tensor_0dim = tensor_0dim + arg
+                    else:
+                        tensor = tensor + arg
+                elif isinstance(arg, Number):
+                    scalar = (scalar + torch.tensor(arg)).item()
+                else:
+                    raise AssertionError("unknown type")
+
+            return ((tensor + tensor_0dim) + scalar).dtype
+
+        for x1, x2, x3 in itertools.product(inputs, repeat=3):
+            actual = torch.result_type(x1, x2, x3)
+            expected = result_type_ref([x1, x2, x3])
+            self.assertEqual(actual, expected)
 
     @float_double_default_dtype
     def test_can_cast(self, device):

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -421,7 +421,8 @@ class TestTypePromotion(TestCase):
             10,  # int scalar
             10.0,  # float scalar
             10j,  # complex scalar
-            *[torch.tensor([1, 2, 3], dtype=dtype) for dtype in dtypes],  # tensors
+            *[torch.tensor([1, 2, 3], dtype=dtype, device=device) for dtype in dtypes],  # tensors
+            *[torch.tensor([1, 2, 3], dtype=dtype) for dtype in dtypes],  # cpu tensors
             *dtypes,  # tensors
         ]
 
@@ -436,9 +437,9 @@ class TestTypePromotion(TestCase):
                     tensor = tensor + torch.tensor([1], dtype=arg)
                 elif isinstance(arg, torch.Tensor):
                     if arg.ndim == 0:
-                        tensor_0dim = tensor_0dim + arg
+                        tensor_0dim = tensor_0dim.cpu() + arg
                     else:
-                        tensor = tensor + arg
+                        tensor = tensor + arg.cpu()
                 elif isinstance(arg, Number):
                     scalar = (scalar + torch.tensor(arg)).item()
                 else:

--- a/tools/codegen/api/python.py
+++ b/tools/codegen/api/python.py
@@ -1065,6 +1065,8 @@ def arg_parser_unpack_method(t: Type, has_default: bool) -> str:
             return 'doublelist'
         elif str(t) == 'Scalar[]':
             return 'scalarlist'
+        elif str(t) == 'ScalarType[]':
+            return 'scalartypelist'
     raise RuntimeError(f'type \'{t}\' is not supported by PythonArgParser')
 
 # Return RHS expression for python argument using PythonArgParser output.

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -117,6 +117,7 @@ blocklist = [
     'div_out',
     'true_divide', 'true_divide_', 'true_divide_out',
     'floor_divide', 'floor_divide_', 'floor_divide_out',
+    'result_type',
 ]
 
 binary_ops = ('add', 'sub', 'mul', 'div', 'pow', 'lshift', 'rshift', 'mod', 'truediv',

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8195,27 +8195,6 @@ Example::
     tensor([ 0,  1,  2,  3])
 """)
 
-
-add_docstr(torch.result_type,
-           r"""
-result_type(tensor1, tensor2) -> dtype
-
-Returns the :class:`torch.dtype` that would result from performing an arithmetic
-operation on the provided input tensors. See type promotion :ref:`documentation <type-promotion-doc>`
-for more information on the type promotion logic.
-
-Args:
-    tensor1 (Tensor or Number): an input tensor or number
-    tensor2 (Tensor or Number): an input tensor or number
-
-Example::
-
-    >>> torch.result_type(torch.tensor([1, 2], dtype=torch.int), 1.0)
-    torch.float32
-    >>> torch.result_type(torch.tensor([1, 2], dtype=torch.uint8), torch.tensor(1))
-    torch.uint8
-""")
-
 add_docstr(torch.row_stack,
            r"""
 row_stack(tensors, *, out=None) -> Tensor

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1632,8 +1632,8 @@ lu.__doc__ = _lu_impl.__doc__
 def align_tensors(*tensors):
     raise RuntimeError('`align_tensors` not yet implemented.')
 
-def result_type(*arrays_and_dtypes):
-    """result_type(*arrays_and_dtypes) -> dtype
+def result_type(*arrays_and_dtypes: Union[Tensor, torch.dtype, bool, int, float, complex]) -> torch.dtype:
+    """result_type(*arrays_and_dtypes: Union[Tensor, dtype, bool, int, float, complex]) -> dtype
 
 Returns the :class:`torch.dtype` that would result from performing an arithmetic
 operation on the provided input tensors. See type promotion :ref:`documentation <type-promotion-doc>`
@@ -1653,7 +1653,7 @@ Example::
 """
 
     tensors = []
-    scalars = []
+    scalars: List[Union[bool, int, float, complex]] = []
     dtypes = []
     for x in arrays_and_dtypes:
         if isinstance(x, (bool, int, float, complex)):
@@ -1663,12 +1663,12 @@ Example::
         else:
             tensors.append(x)
     if tensors:
-        dtypes.append(_VF.result_type(tensors))
+        dtypes.append(_VF.result_type(tensors))  # type: ignore[attr-defined]
     if scalars:
-        scalar_dtype = _VF._result_type_scalars(scalars)
+        scalar_dtype = _VF._result_type_scalars(scalars)  # type: ignore[arg-type]
         if dtypes:
             tensor_dtype = _VF._result_type_dtypes(dtypes)
-            return _VF.result_type(_VF.tensor([], dtype=tensor_dtype),
+            return _VF.result_type(_VF.tensor([], dtype=tensor_dtype),  # type: ignore[attr-defined]
                                    _VF.tensor(0, dtype=scalar_dtype).item())
         else:
             return scalar_dtype

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -31,6 +31,7 @@ __all__ = [
     'norm',
     'meshgrid',
     'pca_lowrank',
+    'result_type',
     'split',
     'stft',
     'svd_lowrank',
@@ -1630,3 +1631,30 @@ lu.__doc__ = _lu_impl.__doc__
 
 def align_tensors(*tensors):
     raise RuntimeError('`align_tensors` not yet implemented.')
+
+def result_type(*arrays_and_dtypes):
+    tensors = []
+    scalars = []
+    dtypes = []
+    for x in arrays_and_dtypes:
+        if isinstance(x, (bool, int, float, complex)):
+            scalars.append(x)
+        elif isinstance(x, torch.dtype):
+            dtypes.append(x)
+        else:
+            tensors.append(x)
+    if tensors:
+        dtypes.append(_VF.result_type(tensors))
+    if scalars:
+        scalar_dtype = _VF._result_type_scalars(scalars)
+        if dtypes:
+            tensor_dtype = _VF._result_type_dtypes(dtypes)
+            return _VF.result_type(_VF.tensor([], dtype=tensor_dtype),
+                                   _VF.tensor(0, dtype=scalar_dtype).item())
+        else:
+            return scalar_dtype
+    else:
+        if dtypes:
+            return _VF._result_type_dtypes(dtypes)
+        else:
+            raise TypeError("at least one argument is required.")

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1667,10 +1667,10 @@ Example::
             tensors.append(x)
         else:
             raise TypeError(f"result_type(): cannot interpret '{x}' as a data type")
-    if dtypes:
+    if len(dtypes) > 0:
         dtype = _VF._result_type_dtypes(dtypes)
         tensors.append(torch.tensor([], dtype=dtype))
-    if scalars:
+    if len(scalars) > 0:
         scalar_dtype = _VF._result_type_scalars(scalars)  # type: ignore[arg-type]
         if tensors:
             tensor_dtype = _VF.result_type(tensors)  # type: ignore[attr-defined]

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1633,6 +1633,25 @@ def align_tensors(*tensors):
     raise RuntimeError('`align_tensors` not yet implemented.')
 
 def result_type(*arrays_and_dtypes):
+    """result_type(*arrays_and_dtypes) -> dtype
+
+Returns the :class:`torch.dtype` that would result from performing an arithmetic
+operation on the provided input tensors. See type promotion :ref:`documentation <type-promotion-doc>`
+for more information on the type promotion logic.
+
+Args:
+    arrays_and_dtypes (Tensor, Number or dtype): input tensors, numbers or dtypes
+
+Example::
+
+    >>> torch.result_type(torch.tensor([1, 2], dtype=torch.int), 1.0)
+    torch.float32
+    >>> torch.result_type(torch.tensor([1, 2], dtype=torch.uint8), torch.tensor(1))
+    torch.uint8
+    >>> torch.result_type(torch.int32, torch.float32)
+    torch.float32
+"""
+
     tensors = []
     scalars = []
     dtypes = []


### PR DESCRIPTION
Fixes #51284 (cc/ @mruberry, @heitorschueroff, @rgommers, @emcastillo, @kmaehashi)

This PR adds support of variadic length/type argument in `torch.result_type` for the compatibility with NumPy’s interface and Python array API standard.

```
>>> torch.result_type(torch.int8, torch.tensor([1], dtype=torch.uint8), 10)
torch.int16
```

Reference: https://github.com/pytorch/pytorch/issues/51284#issuecomment-854845484

TODO:
- [x] tests