### PR TITLE
[vulkan] Adaptive local work group size

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -102,7 +102,7 @@ struct Command final {
     struct Configuration final {
       static constexpr uint32_t kQuantum = 4u;
       static constexpr uint32_t kReserve = 16u;
-      static constexpr uint32_t kSubmit = 3u;
+      static constexpr uint32_t kSubmit = 16u;
     };
 
     VkDevice device_;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
@@ -36,7 +36,7 @@ void main() {
 
     vec4 sum = texelFetch(uBias, ivec2(pos.z, 0), 0);
 
-    for (int z4 = 0; z4 < uBlock.size.w; ++z4, kstart.x += uBlock.ikernel.x) {
+    for (int z4 = 0; z4 < uBlock.size.w/4; ++z4, kstart.x += uBlock.ikernel.x*4) {
       for (int y = start.y, ky = kstart.y; y < end.y; y += uBlock.dilate.y, ++ky) {
         for (int x = start.x, kx = kstart.x; x < end.x; x += uBlock.dilate.x, kx += 4) {
           const vec4 In = texelFetch(uInput, ivec3(x, y, z4), 0);

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
@@ -12,6 +12,7 @@ layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBia
 layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
+  ivec2 ikernel;
   ivec2 stride;
   ivec2 padding;
   ivec2 dilate;
@@ -33,7 +34,7 @@ void main() {
     vec4 sum = texelFetch(uBias, pos.z, 0);
 
     for (int y = start.y, ky = kstart.y; y < end.y; y += uBlock.dilate.y, ++ky) {
-      for (int x = start.x, kx = kstart.x + ky * uBlock.size.w; x < end.x; x += uBlock.dilate.x, ++kx) {
+      for (int x = start.x, kx = kstart.x + ky * uBlock.ikernel.x; x < end.x; x += uBlock.dilate.x, ++kx) {
         sum = fma(
             texelFetch(uInput, ivec3(x, y, pos.z), 0),
             texelFetch(uKernel, ivec2(kx, pos.z), 0),

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw.glsl
@@ -11,8 +11,11 @@ layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKer
 layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
 layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
+  ivec4 kernel;
+  ivec2 ikernel;
   ivec2 stride;
   ivec2 padding;
+  ivec2 dilate;
   vec2 clamp;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2.glsl
@@ -1,0 +1,99 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
+layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 kernel;
+  ivec2 ikernel;
+  ivec2 stride;
+  ivec2 padding;
+  ivec2 dilate;
+  vec2 clamp;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  const ivec3 pos00 = ivec3(pos.x*2  , pos.y*2  , pos.z);
+  const ivec3 pos10 = ivec3(pos.x*2+1, pos.y*2  , pos.z);
+  const ivec3 pos01 = ivec3(pos.x*2  , pos.y*2+1, pos.z);
+  const ivec3 pos11 = ivec3(pos.x*2+1, pos.y*2+1, pos.z);
+
+  if (all(lessThan(pos00, uBlock.size.xyz))) {
+    const ivec2 ipos00 = pos00.xy * uBlock.stride - uBlock.padding;
+    const ivec2 ipos10 = pos10.xy * uBlock.stride - uBlock.padding;
+    const ivec2 ipos01 = pos01.xy * uBlock.stride - uBlock.padding;
+    const ivec2 ipos11 = pos11.xy * uBlock.stride - uBlock.padding;
+
+    vec4 sum00 = texelFetch(uBias, pos.z, 0);
+    vec4 sum10 = sum00;
+    vec4 sum01 = sum00;
+    vec4 sum11 = sum00;
+
+    for (int z = 0, z4 = 0; z < uBlock.size.w; z += 4, ++z4) {
+      const ivec4 kxs = z + ivec4(0, 1, 2, 3);
+      const vec4 k1 = texelFetch(uKernel, ivec2(kxs.x, pos.z), 0);
+      const vec4 k2 = texelFetch(uKernel, ivec2(kxs.y, pos.z), 0);
+      const vec4 k3 = texelFetch(uKernel, ivec2(kxs.z, pos.z), 0);
+      const vec4 k4 = texelFetch(uKernel, ivec2(kxs.w, pos.z), 0);
+
+      const vec4 In00 = texelFetch(uInput, ivec3(ipos00, z4), 0);
+      const vec4 In10 = texelFetch(uInput, ivec3(ipos10, z4), 0);
+      const vec4 In01 = texelFetch(uInput, ivec3(ipos01, z4), 0);
+      const vec4 In11 = texelFetch(uInput, ivec3(ipos11, z4), 0);
+
+      sum00 = fma(In00.xxxx, k1, sum00);
+      sum00 = fma(In00.yyyy, k2, sum00);
+      sum00 = fma(In00.zzzz, k3, sum00);
+      sum00 = fma(In00.wwww, k4, sum00);
+
+      sum10 = fma(In10.xxxx, k1, sum10);
+      sum10 = fma(In10.yyyy, k2, sum10);
+      sum10 = fma(In10.zzzz, k3, sum10);
+      sum10 = fma(In10.wwww, k4, sum10);
+
+      sum01 = fma(In01.xxxx, k1, sum01);
+      sum01 = fma(In01.yyyy, k2, sum01);
+      sum01 = fma(In01.zzzz, k3, sum01);
+      sum01 = fma(In01.wwww, k4, sum01);
+
+      sum11 = fma(In11.xxxx, k1, sum11);
+      sum11 = fma(In11.yyyy, k2, sum11);
+      sum11 = fma(In11.zzzz, k3, sum11);
+      sum11 = fma(In11.wwww, k4, sum11);
+    }
+
+    imageStore(
+        uOutput,
+        pos00,
+        clamp(sum00, uBlock.clamp.x, uBlock.clamp.y));
+    if (all(lessThan(pos10, uBlock.size.xyz))) {
+      imageStore(
+          uOutput,
+          pos10,
+          clamp(sum10, uBlock.clamp.x, uBlock.clamp.y));
+    }
+    if (all(lessThan(pos01, uBlock.size.xyz))) {
+      imageStore(
+          uOutput,
+          pos01,
+          clamp(sum01, uBlock.clamp.x, uBlock.clamp.y));
+    }
+    if (all(lessThan(pos11, uBlock.size.xyz))) {
+      imageStore(
+          uOutput,
+          pos11,
+          clamp(sum11, uBlock.clamp.x, uBlock.clamp.y));
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2_buffered.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2_buffered.glsl
@@ -1,0 +1,153 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
+layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 kernel;
+  ivec2 ikernel;
+  ivec2 stride;
+  ivec2 padding;
+  ivec2 dilate;
+  vec2 clamp;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  const ivec3 pos00 = ivec3(pos.x*2  , pos.y*2  , pos.z);
+  const ivec3 pos10 = ivec3(pos.x*2+1, pos.y*2  , pos.z);
+  const ivec3 pos01 = ivec3(pos.x*2  , pos.y*2+1, pos.z);
+  const ivec3 pos11 = ivec3(pos.x*2+1, pos.y*2+1, pos.z);
+
+  if (all(lessThan(pos00, uBlock.size.xyz))) {
+    const ivec2 ipos00 = pos00.xy * uBlock.stride - uBlock.padding;
+    const ivec2 ipos10 = pos10.xy * uBlock.stride - uBlock.padding;
+    const ivec2 ipos01 = pos01.xy * uBlock.stride - uBlock.padding;
+    const ivec2 ipos11 = pos11.xy * uBlock.stride - uBlock.padding;
+
+    vec4 sum00 = texelFetch(uBias, pos.z, 0);
+    vec4 sum10 = sum00;
+    vec4 sum01 = sum00;
+    vec4 sum11 = sum00;
+
+    vec4 k1_0 = texelFetch(uKernel, ivec2(0, pos.z), 0);
+    vec4 k2_0 = texelFetch(uKernel, ivec2(1, pos.z), 0);
+    vec4 k3_0 = texelFetch(uKernel, ivec2(2, pos.z), 0);
+    vec4 k4_0 = texelFetch(uKernel, ivec2(3, pos.z), 0);
+
+    vec4 k1_1;
+    vec4 k2_1;
+    vec4 k3_1;
+    vec4 k4_1;
+
+    vec4 In00_0 = texelFetch(uInput, ivec3(ipos00, 0), 0);
+    vec4 In10_0 = texelFetch(uInput, ivec3(ipos10, 0), 0);
+    vec4 In01_0 = texelFetch(uInput, ivec3(ipos01, 0), 0);
+    vec4 In11_0 = texelFetch(uInput, ivec3(ipos11, 0), 0);
+
+    vec4 In00_1;
+    vec4 In10_1;
+    vec4 In01_1;
+    vec4 In11_1;
+
+    for (int z = 0, z4 = 0; z < uBlock.size.w; z += 8, z4+=2) {
+      ivec4 kxs = z + ivec4(4, 5, 6, 7);
+
+      k1_1 = texelFetch(uKernel, ivec2(kxs.x, pos.z), 0);
+      k2_1 = texelFetch(uKernel, ivec2(kxs.y, pos.z), 0);
+      k3_1 = texelFetch(uKernel, ivec2(kxs.z, pos.z), 0);
+      k4_1 = texelFetch(uKernel, ivec2(kxs.w, pos.z), 0);
+
+      In00_1 = texelFetch(uInput, ivec3(ipos00, z4+1), 0);
+      In10_1 = texelFetch(uInput, ivec3(ipos10, z4+1), 0);
+      In01_1 = texelFetch(uInput, ivec3(ipos01, z4+1), 0);
+      In11_1 = texelFetch(uInput, ivec3(ipos11, z4+1), 0);
+
+      sum00 = fma(In00_0.xxxx, k1_0, sum00);
+      sum00 = fma(In00_0.yyyy, k2_0, sum00);
+      sum00 = fma(In00_0.zzzz, k3_0, sum00);
+      sum00 = fma(In00_0.wwww, k4_0, sum00);
+
+      sum10 = fma(In10_0.xxxx, k1_0, sum10);
+      sum10 = fma(In10_0.yyyy, k2_0, sum10);
+      sum10 = fma(In10_0.zzzz, k3_0, sum10);
+      sum10 = fma(In10_0.wwww, k4_0, sum10);
+
+      sum01 = fma(In01_0.xxxx, k1_0, sum01);
+      sum01 = fma(In01_0.yyyy, k2_0, sum01);
+      sum01 = fma(In01_0.zzzz, k3_0, sum01);
+      sum01 = fma(In01_0.wwww, k4_0, sum01);
+
+      sum11 = fma(In11_0.xxxx, k1_0, sum11);
+      sum11 = fma(In11_0.yyyy, k2_0, sum11);
+      sum11 = fma(In11_0.zzzz, k3_0, sum11);
+      sum11 = fma(In11_0.wwww, k4_0, sum11);
+
+      // Next iteration
+      kxs += 4;
+
+      k1_0 = texelFetch(uKernel, ivec2(kxs.x, pos.z), 0);
+      k2_0 = texelFetch(uKernel, ivec2(kxs.y, pos.z), 0);
+      k3_0 = texelFetch(uKernel, ivec2(kxs.z, pos.z), 0);
+      k4_0 = texelFetch(uKernel, ivec2(kxs.w, pos.z), 0);
+
+      In00_0 = texelFetch(uInput, ivec3(ipos00, z4+2), 0);
+      In10_0 = texelFetch(uInput, ivec3(ipos10, z4+2), 0);
+      In01_0 = texelFetch(uInput, ivec3(ipos01, z4+2), 0);
+      In11_0 = texelFetch(uInput, ivec3(ipos11, z4+2), 0);
+
+      sum00 = fma(In00_1.xxxx, k1_1, sum00);
+      sum00 = fma(In00_1.yyyy, k2_1, sum00);
+      sum00 = fma(In00_1.zzzz, k3_1, sum00);
+      sum00 = fma(In00_1.wwww, k4_1, sum00);
+
+      sum10 = fma(In10_1.xxxx, k1_1, sum10);
+      sum10 = fma(In10_1.yyyy, k2_1, sum10);
+      sum10 = fma(In10_1.zzzz, k3_1, sum10);
+      sum10 = fma(In10_1.wwww, k4_1, sum10);
+
+      sum01 = fma(In01_1.xxxx, k1_1, sum01);
+      sum01 = fma(In01_1.yyyy, k2_1, sum01);
+      sum01 = fma(In01_1.zzzz, k3_1, sum01);
+      sum01 = fma(In01_1.wwww, k4_1, sum01);
+
+      sum11 = fma(In11_1.xxxx, k1_1, sum11);
+      sum11 = fma(In11_1.yyyy, k2_1, sum11);
+      sum11 = fma(In11_1.zzzz, k3_1, sum11);
+      sum11 = fma(In11_1.wwww, k4_1, sum11);
+    }
+
+    imageStore(
+        uOutput,
+        pos00,
+        clamp(sum00, uBlock.clamp.x, uBlock.clamp.y));
+    if (all(lessThan(pos10, uBlock.size.xyz))) {
+      imageStore(
+          uOutput,
+          pos10,
+          clamp(sum10, uBlock.clamp.x, uBlock.clamp.y));
+    }
+    if (all(lessThan(pos01, uBlock.size.xyz))) {
+      imageStore(
+          uOutput,
+          pos01,
+          clamp(sum01, uBlock.clamp.x, uBlock.clamp.y));
+    }
+    if (all(lessThan(pos11, uBlock.size.xyz))) {
+      imageStore(
+          uOutput,
+          pos11,
+          clamp(sum11, uBlock.clamp.x, uBlock.clamp.y));
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -90,7 +90,7 @@ Tensor arithmetic_scalar(
           },
           shader_descriptor,
           v_output.extents(),
-          context->gpu().adapter->local_work_group_size(),
+          adaptive_work_group_size(v_output.extents()),
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
@@ -146,7 +146,7 @@ Tensor& arithmetic_scalar_(
           },
           shader_descriptor,
           v_self.extents(),
-          context->gpu().adapter->local_work_group_size(),
+          adaptive_work_group_size(v_self.extents()),
           // Read-Write access triggers an async synchronization if necessory
           // and inserts appropriate barriers if hazards are detected.
           v_self.image(
@@ -216,7 +216,7 @@ Tensor arithmetic_tensor(
           },
           shader_descriptor,
           v_output.extents(),
-          context->gpu().adapter->local_work_group_size(),
+          adaptive_work_group_size(v_output.extents()),
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
@@ -283,7 +283,7 @@ Tensor& arithmetic_tensor_(
           },
           shader_descriptor,
           v_self.extents(),
-          context->gpu().adapter->local_work_group_size(),
+          adaptive_work_group_size(v_self.extents()),
           // Read-Write access triggers an async synchronization if necessory
           // and inserts appropriate barriers if hazards are detected.
           v_self.image(

--- a/aten/src/ATen/native/vulkan/ops/Common.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Common.cpp
@@ -41,6 +41,23 @@ uint32_t width_size(const Tensor& tensor) {
   return sizes[dims - 1];
 }
 
+api::Shader::WorkGroup adaptive_work_group_size(const api::Shader::WorkGroup& global_work_group) {
+  api::Shader::WorkGroup local_group_size = {4, 4, 4};
+  if (global_work_group.data[2u] == 1) {
+    if (global_work_group.data[1u] < 8) {
+      local_group_size.data[0u] = 16;
+      local_group_size.data[1u] = 4;
+      local_group_size.data[2u] = 1;
+    }
+    else {
+      local_group_size.data[0u] = 8;
+      local_group_size.data[1u] = 8;
+      local_group_size.data[2u] = 1;
+    }
+  }
+  return local_group_size;
+}
+
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -40,6 +40,8 @@ uint32_t channels_size(const Tensor& tensor);
 uint32_t height_size(const Tensor& tensor);
 uint32_t width_size(const Tensor& tensor);
 
+api::Shader::WorkGroup adaptive_work_group_size(const api::Shader::WorkGroup& global_work_group);
+
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -13,7 +13,6 @@ namespace {
 using namespace api::utils;
 
 struct Experimentation final {
-  static constexpr bool kUseConv2dOldApi = false;
   static constexpr bool kUseWinogradConvs = false;
 };
 
@@ -57,8 +56,6 @@ Conv2dMethod determine_method(
     const int64_t groups) {
   if (is_depthwise(filter, groups))
     return Conv2dDepthwise;
-  if (Experimentation::kUseConv2dOldApi)
-    return Conv2dOld;
   if (is_pointwise(filter))
     return Conv2dPointwise;
   if (Experimentation::kUseWinogradConvs && is_winograd_n_3(filter, stride, dilation))
@@ -195,122 +192,6 @@ vTensor pack_weights_2d(
   return v_weight;
 }
 
-vTensor pack_weights_2d_old(
-    api::Context* const context,
-    api::Command::Buffer& command_buffer,
-    api::Resource::Pool& pool,
-    const Tensor& weight) {
-  const IntArrayRef src_filter = weight.sizes();
-  const float* const src_weight_ptr = weight.data_ptr<float>();
-
-  const uint32_t OC = src_filter[Layout::Filter::output];
-  const uint32_t OC_4 = at::native::vulkan::api::utils::div_up(OC, 4u);
-  const uint32_t C = src_filter[Layout::Filter::input];
-  const uint32_t C_4 = at::native::vulkan::api::utils::div_up(C, 4u);
-  const uint32_t KH = src_filter[Layout::Filter::height];
-  const uint32_t KW = src_filter[Layout::Filter::width];
-
-  vTensor v_weight{
-    context,
-    &pool,
-    {
-      1,
-      4 * KH * KW,
-      OC_4,
-      4 * C_4
-    },
-    weight.options(),
-  };
-
-  using Future = vTensor::Future<float, vTensor::Access::Write>;
-  Future v_weight_future = v_weight.host<float, vTensor::Access::Write>(command_buffer);
-  Future::Payload v_weight_payload = v_weight_future.wait();
-
-  float* const dst_weight_ptr = v_weight_payload.get();
-  memset(dst_weight_ptr, 0, v_weight.nbytes());
-
-  const float* const src = src_weight_ptr;
-  float* const dst = dst_weight_ptr;
-
-  {
-    uint32_t ridx = 0;
-    const uint32_t oc_4SizeNumel = KW * KH * C_4 * 16;
-    for (uint32_t oc = 0; oc < OC; ++oc) {
-      int oc_4 = oc / 4;
-      int oc_4_i = oc % 4;
-      float* dst_oc = dst + oc_4 * oc_4SizeNumel;
-      for (uint32_t ic = 0; ic < C; ++ic) {
-        int ic_4 = ic / 4;
-        int ic_4_i = ic % 4;
-        float* dst_ic = dst_oc + ic_4 * KW * KH * 16;
-        for (uint32_t ky = 0; ky < KH; ++ky) {
-          float* dst_ky = dst_ic + ky * KW * 16;
-          for (uint32_t kx = 0; kx < KW; ++kx) {
-            float* dst_kx = dst_ky + kx * 16;
-            dst_kx[4 * ic_4_i + oc_4_i] = src[ridx++];
-          }
-        }
-      }
-    }
-
-    // shader KO4C4HW_to_image
-    struct Image3D {
-      float* data_;
-      uint32_t dim0_, dim1_, dim2_;
-
-      Image3D(uint32_t dim0, uint32_t dim1, uint32_t dim2) {
-        dim0_ = dim0;
-        dim1_ = dim1;
-        dim2_ = dim2;
-        data_ = new float[dim0 * dim1 * dim2 * 4];  // TODO: memory leak
-        memset(data_, 0.f, dim0 * dim1 * dim2 * 4 * sizeof(float));
-      }
-
-      inline uint32_t idx(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3) {
-        return i3 + i2 * 4 + i1 * 4 * dim2_ + i0 * 4 * dim2_ * dim1_;
-      }
-
-      void set(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3, float value) {
-        data_[idx(i0, i1, i2, i3)] = value;
-      }
-
-      float get(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3) {
-        return data_[idx(i0, i1, i2, i3)];
-      }
-    } image{4 * C_4, OC_4, KH * KW};
-
-    for (uint32_t sx = 0; sx < C_4; ++sx) {
-      for (uint32_t sy = 0; sy < OC_4; ++sy) {
-        for (uint32_t sz = 0; sz < (KH * KW); ++sz) {
-          for (uint32_t vi = 0; vi < 4; ++vi) {
-            int bufferVIdx = 4 * sx * KH * KW + 4 * sy * C_4 * KH * KW + 4 * sz;
-            image.set(4 * sx + 0, sy, sz, vi, dst[4 * (bufferVIdx + 0) + vi]);
-            image.set(4 * sx + 1, sy, sz, vi, dst[4 * (bufferVIdx + 1) + vi]);
-            image.set(4 * sx + 2, sy, sz, vi, dst[4 * (bufferVIdx + 2) + vi]);
-            image.set(4 * sx + 3, sy, sz, vi, dst[4 * (bufferVIdx + 3) + vi]);
-          }
-        }
-      }
-    }
-
-    // inverse function of nchw_to_image
-    const uint32_t W = 4 * C_4;
-    const uint32_t H = OC_4;
-    const uint32_t D = KH * KW;
-    for (uint32_t sx = 0; sx < W; ++sx) {
-      for (uint32_t sy = 0; sy < H; ++sy) {
-        for (uint32_t sz = 0; sz < D; ++sz) {
-          for (uint32_t szvi = 0; szvi < 4; ++szvi) {
-            dst_weight_ptr[W * sy + sx + (4 * sz + szvi) * W * H] = image.get(sx, sy, sz, szvi);
-          }
-        }
-      }
-    }
-  }
-
-  return v_weight;
-}
-
 vTensor pack_weights_2d_winograd_2_3(
     api::Context* const context,
     api::Command::Buffer& command_buffer,
@@ -421,14 +302,6 @@ vTensor pack_weights(
 
   if (conv_method == Conv2dDepthwise) {
     return pack_weights_dw(
-        context,
-        command_buffer,
-        pool,
-        weight);
-  }
-
-  if (conv_method == Conv2dOld) {
-    return pack_weights_2d_old(
         context,
         command_buffer,
         pool,
@@ -596,496 +469,6 @@ bool usable(const Tensor& input) {
          true;
 }
 
-void conv2d_dw(
-    api::Context* const context,
-    vTensor& v_output,
-    const vTensor& v_input,
-    const vTensor& v_weight,
-    const vTensor& v_bias,
-    const IntArrayRef filter,
-    const IntArrayRef src_filter,
-    const IntArrayRef stride,
-    const IntArrayRef padding,
-    const IntArrayRef dilation,
-    const float output_min,
-    const float output_max) {
-  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && v_weight.has_image());
-  TORCH_CHECK(valid, "Not Implemented!")
-
-  api::Command::Pool& command_pool = context->command().pool;
-  api::Command::Buffer& command_buffer = command_pool.stream();
-  {
-    const struct Block final {
-      uvec3 extents;
-      int32_t src_filter_width;
-      ivec4 kernel;
-      ivec2 stride;
-      ivec2 padding;
-      ivec2 dilate;
-      vec2 clamp;
-    } block {
-      v_output.extents(),
-      safe_downcast<int32_t>(src_filter[Layout::Filter::width]),
-      {
-        safe_downcast<int32_t>(filter[Layout::Filter::width]),
-        safe_downcast<int32_t>(filter[Layout::Filter::height]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
-      },
-      {
-        safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-        safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-        safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
-        safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
-      },
-      {
-        output_min,
-        output_max,
-      },
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(conv2d_dw),
-        v_output.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        // Write-only access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        v_output.image(
-            command_buffer,
-            vTensor::Stage::Compute,
-            vTensor::Access::Write),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_input.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_weight.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_bias.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  command_pool.submit(context->gpu().queue, command_buffer);
-}
-
-void conv2d_pw(
-    api::Context* const context,
-    vTensor& v_output,
-    const vTensor& v_input,
-    const vTensor& v_weight,
-    const vTensor& v_bias,
-    const IntArrayRef filter,
-    const IntArrayRef src_filter,
-    const IntArrayRef stride,
-    const IntArrayRef padding,
-    const IntArrayRef dilation,
-    const float output_min,
-    const float output_max) {
-  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && v_weight.has_image());
-  TORCH_CHECK(valid, "Not Implemented!")
-
-  api::Command::Pool& command_pool = context->command().pool;
-  api::Command::Buffer& command_buffer = command_pool.stream();
-  {
-    const struct Block final {
-      uvec3 extents;
-      int32_t ic;
-      ivec2 stride;
-      ivec2 padding;
-      vec2 clamp;
-    } block {
-      v_output.extents(),
-      safe_downcast<int32_t>(filter[Layout::Filter::input]),
-      {
-        safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-        safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-        safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      },
-      {
-        output_min,
-        output_max,
-      },
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(conv2d_pw),
-        v_output.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        // Write-only access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        v_output.image(
-            command_buffer,
-            vTensor::Stage::Compute,
-            vTensor::Access::Write),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_input.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_weight.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_bias.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  command_pool.submit(context->gpu().queue, command_buffer);
-}
-
-void conv2d(
-    api::Context* const context,
-    vTensor& v_output,
-    const vTensor& v_input,
-    const vTensor& v_weight,
-    const vTensor& v_bias,
-    const IntArrayRef filter,
-    const IntArrayRef src_filter,
-    const IntArrayRef stride,
-    const IntArrayRef padding,
-    const IntArrayRef dilation,
-    const float output_min,
-    const float output_max) {
-  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && v_weight.has_image());
-  TORCH_CHECK(valid, "Not Implemented!")
-
-  api::Command::Pool& command_pool = context->command().pool;
-  api::Command::Buffer& command_buffer = command_pool.stream();
-  {
-    const struct Block final {
-      uvec3 extents;
-      int32_t ic4;
-      ivec4 kernel;
-      ivec2 ikernel;
-      ivec2 stride;
-      ivec2 padding;
-      ivec2 dilate;
-      vec2 clamp;
-      ivec4 src_filter;
-    } block {
-      v_output.extents(),
-      safe_downcast<int32_t>(filter[Layout::Filter::input] / 4),
-      {
-        safe_downcast<int32_t>(filter[Layout::Filter::width]),
-        safe_downcast<int32_t>(filter[Layout::Filter::height]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
-      },
-      {
-        safe_downcast<int32_t>(src_filter[Layout::Filter::width] * 4),
-        safe_downcast<int32_t>(src_filter[Layout::Filter::height]),
-      },
-      {
-        safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-        safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-        safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
-        safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
-      },
-      {
-        output_min,
-        output_max,
-      },
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(conv2d),
-        v_output.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        // Write-only access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        v_output.image(
-            command_buffer,
-            vTensor::Stage::Compute,
-            vTensor::Access::Write),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_input.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_weight.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_bias.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  command_pool.submit(context->gpu().queue, command_buffer);
-}
-
-void conv2d_winograd_2_3(
-    api::Context* const context,
-    vTensor& v_output,
-    const vTensor& v_input,
-    const vTensor& v_weight,
-    const vTensor& v_bias,
-    const IntArrayRef filter,
-    const IntArrayRef src_filter,
-    const IntArrayRef stride,
-    const IntArrayRef padding,
-    const IntArrayRef dilation,
-    const float output_min,
-    const float output_max) {
-  // Winograd(2x2, 3x3) calculates 2x2 tile of output for every subprogram
-  const int64_t out_h_units = div_up(v_output.sizes()[Layout::Activation4D::height], INT64_C(2));
-  const int64_t out_w_units = div_up(v_output.sizes()[Layout::Activation4D::width], INT64_C(2));
-
-  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && v_weight.has_image());
-  TORCH_CHECK(valid, "Not Implemented!")
-
-  api::Command::Pool& command_pool = context->command().pool;
-  api::Command::Buffer& command_buffer = command_pool.stream();
-
-  vTensor v_input_winograd{
-    context,
-    {
-      v_input.sizes()[Layout::Activation4D::batch],
-      v_input.sizes()[Layout::Activation4D::channels],
-      out_h_units*4,
-      out_w_units*4,
-    },
-    v_output.options(),
-  };
-
-  {
-    const struct TransformBlock final {
-      uvec3 extents;
-      uint32_t fill;
-      ivec2 limits;
-      ivec2 padding;
-    } transform_block {
-      v_input_winograd.extents(),
-      0u,
-      {
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
-      },
-      {
-        safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-        safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      },
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(transform_winograd_2_3_sh),
-        v_input_winograd.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        v_input_winograd.image(
-            command_buffer,
-            vTensor::Stage::Compute,
-            vTensor::Access::Write),
-        v_input.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        context->resource().pool.uniform(transform_block).object);
-
-  }
-  {
-    const struct Block final {
-      uvec3 extents;
-      int32_t ic4;
-      vec2 clamp;
-    } block {
-      v_output.extents(),
-      safe_downcast<int32_t>(filter[Layout::Filter::input] / 4),
-      {
-        output_min,
-        output_max,
-      },
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(conv2d_winograd_2_3),
-        {
-          safe_downcast<uint32_t>(out_w_units),
-          safe_downcast<uint32_t>(out_h_units),
-          v_output.extents().data[2u],
-        },
-        context->gpu().adapter->local_work_group_size(),
-        v_output.image(
-            command_buffer,
-            vTensor::Stage::Compute,
-            vTensor::Access::Write),
-        v_input_winograd.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        v_weight.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        v_bias.buffer(
-            command_buffer,
-            vTensor::Stage::Compute),
-        context->resource().pool.uniform(block).object);
-  }
-  command_pool.submit(context->gpu().queue, command_buffer);
-}
-
-void conv2d_old(
-    api::Context* const context,
-    vTensor& v_output,
-    const vTensor& v_input,
-    const vTensor& v_weight,
-    const vTensor& v_bias,
-    const IntArrayRef filter,
-    const IntArrayRef src_filter,
-    const IntArrayRef stride,
-    const IntArrayRef padding,
-    const IntArrayRef dilation,
-    const float output_min,
-    const float output_max) {
-  using namespace api::utils;
-  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && v_weight.has_image());
-  TORCH_CHECK(valid, "Not Implemented!")
-
-  api::Command::Pool& command_pool = context->command().pool;
-  api::Command::Buffer& command_buffer = command_pool.stream();
-  {
-    const int32_t W = v_input.extents().data[0];
-    const int32_t H = v_input.extents().data[1];
-    const int32_t C_4 = v_input.extents().data[2];
-    const int32_t C = 4 * C_4;
-
-    const int32_t OW = v_output.extents().data[0];
-    const int32_t OH = v_output.extents().data[1];
-    const int32_t OC_4 = v_output.extents().data[2];
-    const int32_t OC = 4 * OC_4;
-
-    const struct Block final {
-      int32_t padding_x, padding_y;
-      int32_t kernel_x, kernel_y;
-      int32_t stride_x, stride_y;
-      int32_t dilate_x, dilate_y;
-      int32_t outputSize[4];
-      int32_t inputSize[4];
-      float outputMin;
-      float outputMax;
-    } block {
-      safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-      safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      safe_downcast<int32_t>(filter[Layout::Filter::width]),
-      safe_downcast<int32_t>(filter[Layout::Filter::height]),
-      safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-      safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-      safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
-      safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
-      { OW, OH, OC_4, OC },
-      { W, H, C_4, C },
-      output_min,
-      output_max,
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(conv2d_nogroup_clamp),
-        v_output.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        // Write-only access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        v_output.image(
-          command_buffer,
-          vTensor::Stage::Compute,
-          vTensor::Access::Write),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_input.image(
-          command_buffer,
-          vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_weight.image(
-          command_buffer,
-          vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_bias.buffer(
-          command_buffer,
-          vTensor::Stage::Compute),
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  command_pool.submit(context->gpu().queue, command_buffer);
-}
 
 Tensor convolution(
     const Tensor& input,
@@ -1216,6 +599,210 @@ Conv2dOpContext Conv2dOpContext::create(
   };
 }
 
+void Conv2dOpContext::conv2d_sliding_window(
+    const api::Shader::Descriptor& shader,
+    vTensor& v_output,
+    const vTensor& v_input) const {
+  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && packed_.v_weight.has_image());
+  TORCH_CHECK(valid, "Not Implemented!")
+
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    const struct Block final {
+      uvec3 extents;
+      int32_t ic4;
+      ivec4 kernel;
+      ivec2 ikernel;
+      ivec2 stride;
+      ivec2 padding;
+      ivec2 dilate;
+      vec2 clamp;
+      ivec4 src_filter;
+    } block {
+      v_output.extents(),
+      safe_downcast<int32_t>(packed_.filter[Layout::Filter::input]),
+      {
+        safe_downcast<int32_t>(packed_.filter[Layout::Filter::width]),
+        safe_downcast<int32_t>(packed_.filter[Layout::Filter::height]),
+        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
+        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
+      },
+      {
+        safe_downcast<int32_t>(unpacked_.filter[Layout::Filter::width]),
+        safe_downcast<int32_t>(unpacked_.filter[Layout::Filter::height]),
+      },
+      {
+        safe_downcast<int32_t>(packed_.stride[Layout::Parameter::width]),
+        safe_downcast<int32_t>(packed_.stride[Layout::Parameter::height]),
+      },
+      {
+        safe_downcast<int32_t>(packed_.padding[Layout::Parameter::width]),
+        safe_downcast<int32_t>(packed_.padding[Layout::Parameter::height]),
+      },
+      {
+        safe_downcast<int32_t>(packed_.dilation[Layout::Parameter::width]),
+        safe_downcast<int32_t>(packed_.dilation[Layout::Parameter::height]),
+      },
+      {
+        packed_.output_min,
+        packed_.output_max,
+      },
+    };
+
+    context->dispatch(
+        command_buffer,
+        {
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        },
+        shader,
+        v_output.extents(),
+        context->gpu().adapter->local_work_group_size(),
+        // Write-only access bypasses synchronization but inserts appropriate
+        // barriers if necessary.
+        v_output.image(
+            command_buffer,
+            vTensor::Stage::Compute,
+            vTensor::Access::Write),
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
+        v_input.image(
+            command_buffer,
+            vTensor::Stage::Compute),
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
+        packed_.v_weight.image(
+            command_buffer,
+            vTensor::Stage::Compute),
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
+        packed_.v_bias.image(
+            command_buffer,
+            vTensor::Stage::Compute),
+        // Object lifetime is managed by the resource pool.
+        // It is OK not to keep track of the handle.
+        context->resource().pool.uniform(block).object);
+  }
+  command_pool.submit(context->gpu().queue, command_buffer);
+}
+
+void Conv2dOpContext::conv2d_winograd_2_3(
+    vTensor& v_output,
+    const vTensor& v_input) const {
+  // Winograd(2x2, 3x3) calculates 2x2 tile of output for every subprogram
+  const int64_t out_h_units = div_up(v_output.sizes()[Layout::Activation4D::height], INT64_C(2));
+  const int64_t out_w_units = div_up(v_output.sizes()[Layout::Activation4D::width], INT64_C(2));
+
+  bool valid = C10_LIKELY(v_output.has_image() && v_input.has_image() && packed_.v_weight.has_image());
+  TORCH_CHECK(valid, "Not Implemented!")
+
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  vTensor v_input_winograd{
+    context,
+    {
+      v_input.sizes()[Layout::Activation4D::batch],
+      v_input.sizes()[Layout::Activation4D::channels],
+      out_h_units*4,
+      out_w_units*4,
+    },
+    v_output.options(),
+  };
+
+  {
+    const struct TransformBlock final {
+      uvec3 extents;
+      uint32_t fill;
+      ivec2 limits;
+      ivec2 padding;
+    } transform_block {
+      v_input_winograd.extents(),
+      0u,
+      {
+        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
+        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
+      },
+      {
+        safe_downcast<int32_t>(packed_.padding[Layout::Parameter::width]),
+        safe_downcast<int32_t>(packed_.padding[Layout::Parameter::height]),
+      },
+    };
+
+    context->dispatch(
+        command_buffer,
+        {
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        },
+        VK_KERNEL(transform_winograd_2_3_sh),
+        v_input_winograd.extents(),
+        context->gpu().adapter->local_work_group_size(),
+        v_input_winograd.image(
+            command_buffer,
+            vTensor::Stage::Compute,
+            vTensor::Access::Write),
+        v_input.image(
+            command_buffer,
+            vTensor::Stage::Compute),
+        context->resource().pool.uniform(transform_block).object);
+
+  }
+  {
+    const struct Block final {
+      uvec3 extents;
+      int32_t ic4;
+      vec2 clamp;
+    } block {
+      v_output.extents(),
+      safe_downcast<int32_t>(packed_.filter[Layout::Filter::input] / 4),
+      {
+        packed_.output_min,
+        packed_.output_max,
+      },
+    };
+
+    context->dispatch(
+        command_buffer,
+        {
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        },
+        VK_KERNEL(conv2d_winograd_2_3),
+        {
+          safe_downcast<uint32_t>(out_w_units),
+          safe_downcast<uint32_t>(out_h_units),
+          v_output.extents().data[2u],
+        },
+        context->gpu().adapter->local_work_group_size(),
+        v_output.image(
+            command_buffer,
+            vTensor::Stage::Compute,
+            vTensor::Access::Write),
+        v_input_winograd.image(
+            command_buffer,
+            vTensor::Stage::Compute),
+        packed_.v_weight.image(
+            command_buffer,
+            vTensor::Stage::Compute),
+        packed_.v_bias.buffer(
+            command_buffer,
+            vTensor::Stage::Compute),
+        context->resource().pool.uniform(block).object);
+  }
+  command_pool.submit(context->gpu().queue, command_buffer);
+}
+
 Tensor Conv2dOpContext::run(const Tensor& input_arg) const {
   api::Context* const context = api::context();
 
@@ -1238,51 +825,27 @@ Tensor Conv2dOpContext::run(const Tensor& input_arg) const {
     input.options(),
   };
 
-  {
-    void (*conv_func) (
-      api::Context* const,
-      vTensor&,
-      const vTensor&,
-      const vTensor&,
-      const vTensor&,
-      const IntArrayRef,
-      const IntArrayRef,
-      const IntArrayRef,
-      const IntArrayRef,
-      const IntArrayRef,
-      const float,
-      const float
-    );
-    switch(method_) {
-      case Conv2dDepthwise:
-        conv_func = &conv2d_dw;
-        break;
-      case Conv2dPointwise:
-        conv_func = &conv2d_pw;
-        break;
-      case Conv2dOld:
-        conv_func = &conv2d_old;
-        break;
-      case Conv2dWinograd_2_3:
-        conv_func = &conv2d_winograd_2_3;
-        break;
-      default:
-        conv_func = &conv2d;
-        break;
-    }
-    conv_func(
-      context,
-      v_output,
-      v_input,
-      packed_.v_weight,
-      packed_.v_bias,
-      packed_.filter,
-      unpacked_.filter,
-      packed_.stride,
-      packed_.padding,
-      packed_.dilation,
-      packed_.output_min,
-      packed_.output_max);
+  switch(method_) {
+    case Conv2dWinograd_2_3:
+      conv2d_winograd_2_3(v_output, v_input);
+    case Conv2dDepthwise:
+      conv2d_sliding_window(
+        VK_KERNEL(conv2d_dw),
+        v_output,
+        v_input);
+      break;
+    case Conv2dPointwise:
+      conv2d_sliding_window(
+        VK_KERNEL(conv2d_pw),
+        v_output,
+        v_input);
+      break;
+    default:
+      conv2d_sliding_window(
+        VK_KERNEL(conv2d),
+        v_output,
+        v_input);
+      break;
   }
 
   return convert(v_output);

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -13,7 +13,6 @@ namespace ops {
 enum Conv2dMethod {
   Conv2dDepthwise,
   Conv2dPointwise,
-  Conv2dOld,
   Conv2dSlidingWindow,
   Conv2dWinograd_2_3,
 };
@@ -60,6 +59,15 @@ class Conv2dOpContext final : public torch::jit::CustomClassHolder {
       const Conv2dMethod method,
       const c10::optional<Scalar>& output_min = c10::nullopt,
       const c10::optional<Scalar>& output_max = c10::nullopt);
+
+  void conv2d_sliding_window(
+      const api::Shader::Descriptor& shader,
+      vTensor& v_output,
+      const vTensor& v_input) const;
+
+  void conv2d_winograd_2_3(
+      vTensor& v_output,
+      const vTensor& v_input) const;
 
  private:
   struct {

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/vulkan/ops/Tensor.h>
+#include <ATen/native/vulkan/ops/Common.h>
 #include <c10/util/accumulate.h>
 
 namespace at {
@@ -790,7 +791,7 @@ void vTensor::View::CMD::copy_buffer_to_image(
       },
       VK_KERNEL(nchw_to_image),
       extents,
-      view_.context_->gpu().adapter->local_work_group_size(),
+      adaptive_work_group_size(extents),
       image,
       buffer,
       view_.context_->resource().pool.uniform(block).object);
@@ -848,7 +849,7 @@ void vTensor::View::CMD::copy_image_to_buffer(
       },
       VK_KERNEL(image_to_nchw),
       view_.extents(),
-      view_.context_->gpu().adapter->local_work_group_size(),
+      adaptive_work_group_size(view_.extents()),
       image,
       buffer,
       view_.context_->resource().pool.uniform(block).object);

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -73,7 +73,7 @@ Tensor upsample_nearest2d(
           },
           VK_KERNEL(upsample_nearest2d),
           v_output.extents(),
-          context->gpu().adapter->local_work_group_size(),
+          adaptive_work_group_size(v_output.extents()),
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(


### PR DESCRIPTION
Summary:
Instead of using a fixed local work group size of {4,4,4}, adjust the size based on the global size in order to minimize the number of inactive invocations.

## Perf improvements from this change
On aloha portal devices, in conjunction with the below diff that tweaks the conv2d_pw shader to calculate a 4x4 output, benchmark latency of the xirp14b model was reduced from ~8.7 ms to ~6.6 ms.

Test Plan:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
cd -
```

Reviewed By: IvanKobzarev

Differential Revision: D28724591

