### PR TITLE
[Model Averaging] Skip model averaging for the first K steps

### DIFF
--- a/torch/distributed/algorithms/model_averaging/averagers.py
+++ b/torch/distributed/algorithms/model_averaging/averagers.py
@@ -6,7 +6,7 @@ import torch.distributed.algorithms.model_averaging.utils as utils
 
 class PeriodicModelAverager:
     r"""
-    Averages parameters periodically or during the warm-up stage.
+    Averages parameters periodically after the warm-up stage.
 
     This can be used for running `post-local SDG <https://arxiv.org/abs/1808.07217>`_,
     by running :class:`~torch.nn.DistributedDataParallel` (DDP)
@@ -18,7 +18,7 @@ class PeriodicModelAverager:
                       Usually the period should be greater than ``1`` to reduce the communication cost.
                       Otherwise, only DDP needs to be used.
         warmup_steps (int): The number of warm-up steps. During this stage,
-                            ``period`` is viewed as 1, and the parameters are averaged at every step.
+                            model averaging is skipped.
         process_group: The process group to be used for all-reduce.
                        If ``None``, the default process group, which
                        is created by :func:`torch.distributed.init_process_group`,
@@ -28,20 +28,24 @@ class PeriodicModelAverager:
 
         >>>  import torch
         >>>  import torch.distributed as dist
+        >>>  import torch.distributed.algorithms.ddp_comm_hooks.post_localSGD_hook as post_localSGD
         >>>  import torch.distributed.algorithms.model_averaging.averagers as averagers
         >>>  import torch.nn as nn
         >>>
         >>>  dist.init_process_group("nccl", rank=rank, world_size=16)
         >>>  torch.cuda.set_device(rank)
         >>>  module = nn.Linear(1, 1, bias=False).to(rank)
-        >>>  subgroup, subgroups = dist.new_subgroups()
-        >>>  # Gradients are averaged by each intra-node subgroup during the backward pass.
         >>>  model = nn.parallel.DistributedDataParallel(
-        >>>     module, device_ids=[rank], output_device=rank, process_group=subgroup
+        >>>     module, device_ids=[rank], output_device=rank
         >>>  )
+        >>>  # Register a post-localSGD communication hook.
+        >>>  subgroup, subgroups = dist.new_subgroups()
+        >>>  state = PostLocalSGDState(subgroup=subgroup, start_localSGD_iter=100)
+        >>>  model.register_comm_hook(state, post_localSGD_hook)
         >>>
-        >>>  # In the first 100 steps, run model averaging every step.
+        >>>  # In the first 100 steps, run global gradient averaging like normal DDP at every step.
         >>>  # After 100 steps, run model averaging every 4 steps.
+        >>>  # Note that ``warmup_steps`` must be the same as ``start_localSGD_iter`` used in ``PostLocalSGDState``.
         >>>  averager = averagers.PeriodicModelAverager(model, warmup_steps=100, period=4)
         >>>  for step in range(0, 20):
         >>>     optimizer.zero_grad()
@@ -84,10 +88,10 @@ class PeriodicModelAverager:
 
     def average_parameters(self):
         r"""
-        Averages parameters if ``step`` is less than ``warmup_steps``,
-        or it can be divided by ``period``, where ``step`` is increased by 1
+        Averages parameters if ``step`` is no less than ``warmup_steps``
+        and it can be divided by ``period``, where ``step`` is increased by 1
         at each iteration in the training loop.
         """
-        if self.step < self.warmup_steps or self.step % self.period == 0:
+        if self.step >= self.warmup_steps and self.step % self.period == 0:
             utils.average_parameters(self.module, self.process_group)
         self.step += 1

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1007,12 +1007,12 @@ class DistributedTest:
             param = next(model.parameters())
             tensor = torch.ones_like(param.data) * rank
             expected_avg_tensor = torch.ones_like(param.data) * sum(range(world_size)) / world_size
-            averager = averagers.PeriodicModelAverager(model, warmup_steps=10, period=4)
+            averager = averagers.PeriodicModelAverager(model, warmup_steps=12, period=4)
             for step in range(0, 20):
                 # Reset the parameters at every step.
                 param.data = copy.deepcopy(tensor)
                 averager.average_parameters()
-                if step < 10 or step % 4 == 0:
+                if step >= 12 and step % 4 == 0:
                     self.assertEqual(param.data, expected_avg_tensor)
                 else:
                     # No model averaging, so the parameters are not updated.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Model averager now must be combined with post-localSGD DDP communication hook. It will skip model averaging for the first K steps, because post-localSGD communication hook will run global gradient averaging during this phase.

Differential Revision: [D29523738](https://our.internmc.facebook.com/intern/diff/D29523738/)