### PR TITLE
[DataLoader] Adding demux and mux DataPipe-s

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -255,6 +255,17 @@ class TestIterableDataPipeBasic(TestCase):
                 rec[i][1].close()
         self.assertEqual(count, 8)
 
+    def test_demux_mux_datapipe(self):
+        numbers = NumbersDataset(10)
+        n1, n2 = numbers.demux(2, lambda x: x % 2)
+        self.assertEqual([0, 2, 4, 6, 8], list(n1))
+        self.assertEqual([1, 3, 5, 7, 9], list(n2))
+
+        numbers = NumbersDataset(10)
+        n1, n2, n3 = numbers.demux(3, lambda x: x % 3)
+        n = n1.mux(n2, n3)
+        self.assertEqual(list(range(10)), list(n))
+
 
 class FileLoggerSimpleHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, logfile=None, **kwargs):

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -76,6 +76,15 @@ def create_temp_dir_and_files():
             (temp_sub_dir, temp_sub_file1_name, temp_sub_file2_name)]
 
 
+class NumbersDataset(IterDataPipe):
+    def __init__(self, size=10):
+        self.size = size
+
+    def __iter__(self):
+        for i in range(self.size):
+            yield i
+
+
 class TestIterableDataPipeBasic(TestCase):
 
     def setUp(self):

--- a/torch/utils/data/standard_pipes.ipynb
+++ b/torch/utils/data/standard_pipes.ipynb
@@ -1,32 +1,11 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3610jvsc74a57bd0eb5e09632d6ea1cbf3eb9da7e37b7cf581db5ed13074b21cc44e159dc62acdab",
-   "display_name": "Python 3.6.10 64-bit ('dataloader': conda)"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Standard flow control and data processing DataPipes"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -53,6 +32,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Batch\n",
     "\n",
@@ -70,9 +51,7 @@
     "Example:\n",
     "\n",
     "Classic batching produce partial batches by default\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -80,10 +59,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n[9]\n"
+      "[0,1,2]\n",
+      "[3,4,5]\n",
+      "[6,7,8]\n",
+      "[9]\n"
      ]
     }
    ],
@@ -94,11 +76,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To drop incomplete batches add `drop_last` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -106,10 +88,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n"
+      "[0,1,2]\n",
+      "[3,4,5]\n",
+      "[6,7,8]\n"
      ]
     }
    ],
@@ -120,11 +104,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Sequential calling of `batch` produce nested batches"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -132,10 +116,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[0, 1, 2], [3, 4, 5]]\n[[6, 7, 8], [9, 10, 11]]\n[[12, 13, 14], [15, 16, 17]]\n[[18, 19, 20], [21, 22, 23]]\n[[24, 25, 26], [27, 28, 29]]\n"
+      "[[0,1,2],[3,4,5]]\n",
+      "[[6,7,8],[9,10,11]]\n",
+      "[[12,13,14],[15,16,17]]\n",
+      "[[18,19,20],[21,22,23]]\n",
+      "[[24,25,26],[27,28,29]]\n"
      ]
     }
    ],
@@ -146,11 +134,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "It is possible to unbatch source data before applying the new batching rule using `unbatch_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -158,10 +146,10 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]\n[20, 21, 22, 23, 24, 25, 26, 27, 28, 29]\n"
+      "[[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]],[[12,13,14],[15,16,17]],[[18,19,20],[21,22,23]],[[24,25,26],[27,28,29]]]\n"
      ]
     }
    ],
@@ -172,6 +160,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Unbatch\n",
     "\n",
@@ -185,9 +175,7 @@
     "    `unbatch_level:int = 1`\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -195,10 +183,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "9\n0\n1\n2\n6\n7\n8\n3\n4\n5\n"
+      "9\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n"
      ]
     }
    ],
@@ -209,11 +206,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "By default unbatching is applied only on the first layer, to unbatch deeper use `unbatch_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -221,10 +218,29 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1]\n[2, 3]\n[4, 5]\n[6, 7]\n[8, 9]\n[10, 11]\n[12, 13]\n[14, 15]\n[16, 17]\n[18, 19]\n[20, 21]\n[22, 23]\n[24, 25]\n[26, 27]\n[28, 29]\n[30, 31]\n[32, 33]\n[34, 35]\n[36, 37]\n[38, 39]\n"
+      "[0,1]\n",
+      "[2,3]\n",
+      "[4,5]\n",
+      "[6,7]\n",
+      "[8,9]\n",
+      "[10,11]\n",
+      "[12,13]\n",
+      "[14,15]\n",
+      "[16,17]\n",
+      "[18,19]\n",
+      "[20,21]\n",
+      "[22,23]\n",
+      "[24,25]\n",
+      "[26,27]\n",
+      "[28,29]\n",
+      "[30,31]\n",
+      "[32,33]\n",
+      "[34,35]\n",
+      "[36,37]\n",
+      "[38,39]\n"
      ]
     }
    ],
@@ -235,11 +251,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Setting `unbatch_level` to `-1` will unbatch to the lowest level"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -247,10 +263,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33\n34\n35\n36\n37\n38\n39\n"
+      "[[[0,1],[2,3],[4,5],[6,7]],[[8,9],[10,11],[12,13],[14,15]],[[16,17],[18,19],[20,21],[22,23]]]\n",
+      "[[[24,25],[26,27],[28,29],[30,31]],[[32,33],[34,35],[36,37],[38,39]]]\n"
      ]
     }
    ],
@@ -261,6 +278,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Map\n",
     "\n",
@@ -274,9 +293,7 @@
     "  - `nesting_level: int = 0`\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -284,10 +301,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n2\n4\n6\n8\n10\n12\n14\n16\n18\n"
+      "0\n",
+      "2\n",
+      "4\n",
+      "6\n",
+      "8\n",
+      "10\n",
+      "12\n",
+      "14\n",
+      "16\n",
+      "18\n"
      ]
     }
    ],
@@ -298,11 +324,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`map` by default applies function to every mini-batch as a whole\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -310,25 +336,28 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2, 0, 1, 2]\n[3, 4, 5, 3, 4, 5]\n[6, 7, 8, 6, 7, 8]\n[9, 9]\n"
+      "0\n",
+      "3\n",
+      "6\n",
+      "9\n"
      ]
     }
    ],
    "source": [
-    "dp = ExampleIterPipe(10).batch(3).map(lambda x: x * 2)\n",
+    "dp = ExampleIterPipe(10).batch(3).map(lambda x: x[0])\n",
     "for i in dp:\n",
     "    print(i)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To apply function on individual items of the mini-batch use `nesting_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -336,10 +365,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[0, 2, 4], [6, 8, 10]]\n[[12, 14, 16], [18]]\n"
+      "[[0,2,4],[6,8,10]]\n",
+      "[[12,14,16],[18]]\n"
      ]
     }
    ],
@@ -350,11 +380,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Setting `nesting_level` to `-1` will apply `map` function to the lowest level possible"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -362,10 +392,10 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[[0, 2, 4], [6, 8, 10]], [[12, 14, 16], [18]]]\n"
+      "[[[0,2,4],[6,8,10]],[[12,14,16],[18]]]\n"
      ]
     }
    ],
@@ -376,6 +406,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Filter\n",
     "\n",
@@ -390,9 +422,7 @@
     "  - `drop_empty_batches = True` whether empty many batches dropped or not.\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -400,10 +430,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n2\n4\n6\n8\n"
+      "0\n",
+      "2\n",
+      "4\n",
+      "6\n",
+      "8\n"
      ]
     }
    ],
@@ -414,11 +448,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Classic `filter` by default applies filter function to every mini-batches as a whole \n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -426,10 +460,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n"
+      "[0,1,2]\n",
+      "[3,4,5]\n",
+      "[6,7,8]\n"
      ]
     }
    ],
@@ -441,11 +477,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "You can apply filter function on individual elements by setting `nesting_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -453,10 +489,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[5]\n[6, 7, 8]\n[9]\n"
+      "[5]\n",
+      "[6,7,8]\n",
+      "[9]\n"
      ]
     }
    ],
@@ -468,11 +506,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "If mini-batch ends with zero elements after filtering default behaviour would be to drop them from the response. You can override this behaviour using `drop_empty_batches` argument.\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -480,10 +518,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[]\n[5]\n[6, 7, 8]\n[9]\n"
+      "[]\n",
+      "[5]\n",
+      "[6,7,8]\n",
+      "[9]\n"
      ]
     }
    ],
@@ -500,10 +541,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[[0, 1, 2], [3]], [[], [10, 11]]]\n[[[12, 13, 14], [15, 16, 17]], [[18, 19]]]\n"
+      "[[[0,1,2],[3]],[[],[10,11]]]\n",
+      "[[[12,13,14],[15,16,17]],[[18,19]]]\n"
      ]
     }
    ],
@@ -515,6 +557,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Shuffle\n",
     "\n",
@@ -529,9 +573,7 @@
     "  - `buffer_size: int = 10000`\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -539,10 +581,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "2\n9\n4\n0\n3\n7\n8\n5\n6\n1\n"
+      "4\n",
+      "9\n",
+      "1\n",
+      "0\n",
+      "2\n",
+      "8\n",
+      "5\n",
+      "3\n",
+      "6\n",
+      "7\n"
      ]
     }
    ],
@@ -553,11 +604,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`shuffle` operates on input mini-batches similar as on individual items"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -565,10 +616,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 1, 2]\n[3, 4, 5]\n[9]\n[6, 7, 8]\n"
+      "[9]\n",
+      "[0,1,2]\n",
+      "[3,4,5]\n",
+      "[6,7,8]\n"
      ]
     }
    ],
@@ -579,11 +633,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To shuffle elements across batches use `shuffle(unbatch_level)` followed by `batch` pattern "
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -591,10 +645,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[2, 1, 0]\n[7, 9, 6]\n[3, 5, 4]\n[8]\n"
+      "[[0,1,2],[3,4,5],[6,7,8]]\n",
+      "[[9]]\n"
      ]
     }
    ],
@@ -605,6 +660,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Collate\n",
     "\n",
@@ -617,9 +674,7 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -627,10 +682,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "tensor([0, 1, 2])\ntensor([3, 4, 5])\ntensor([6, 7, 8])\ntensor([9])\n"
+      "tensor([0, 1, 2])\n",
+      "tensor([3, 4, 5])\n",
+      "tensor([6, 7, 8])\n",
+      "tensor([9])\n"
      ]
     }
    ],
@@ -641,6 +699,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## GroupBy\n",
     "\n",
@@ -658,9 +718,7 @@
     "\n",
     "#### Attention\n",
     "As datasteam can be arbitrary large, grouping is done on best effort basis and there is no guarantee that same key will never present in the different groups. You can call it local groupby where locallity is the one DataPipe process/thread."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -668,10 +726,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 3, 6, 9]\n[1, 4, 7]\n[5, 2, 8]\n"
+      "[0, 3, 9, 6]\n",
+      "[1, 4, 7]\n",
+      "[2, 5, 8]\n"
      ]
     }
    ],
@@ -682,11 +742,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "By default group key function is applied to entire input (mini-batch)"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -694,10 +754,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]\n[[9]]\n"
+      "[<torch.utils.data.dataset.DataChunk object at 0x7f7d2448b470>, <torch.utils.data.dataset.DataChunk object at 0x7f7d2448bb70>, <torch.utils.data.dataset.DataChunk object at 0x7f7d2448b7b8>]\n",
+      "[<torch.utils.data.dataset.DataChunk object at 0x7f7d2448b550>]\n"
      ]
     }
    ],
@@ -708,11 +769,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "It is possible to unnest items from the mini-batches using `unbatch_level` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -720,10 +781,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 3, 6, 9]\n[1, 4, 7]\n[2, 5, 8]\n"
+      "[0, 3, 6, 9]\n",
+      "[1, 4, 7]\n",
+      "[2, 5, 8]\n"
      ]
     }
    ],
@@ -734,11 +797,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "When internal buffer (defined by `buffer_size`) is overfilled, groupby will yield biggest group available"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -746,10 +809,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[9, 3]\n[13, 4, 7]\n[2, 11, 14, 5]\n[0, 6, 12]\n[1, 10]\n[8]\n"
+      "[7, 1, 13]\n",
+      "[6, 9, 3]\n",
+      "[11, 5, 8]\n",
+      "[4, 10]\n",
+      "[0, 12]\n",
+      "[14, 2]\n"
      ]
     }
    ],
@@ -760,11 +828,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "`groupby` will produce `group_size` sized batches on as fast as possible basis"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -772,10 +840,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[6, 3, 12]\n[1, 16, 7]\n[2, 5, 8]\n[14, 11, 17]\n[15, 9, 0]\n[10, 4, 13]\n"
+      "[6, 3, 0]\n",
+      "[10, 16, 13]\n",
+      "[11, 8, 2]\n",
+      "[15, 12, 9]\n",
+      "[4, 1, 7]\n",
+      "[5, 14, 17]\n"
      ]
     }
    ],
@@ -786,11 +859,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Remaining groups must be at least `guaranteed_group_size` big. "
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -798,10 +871,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[11, 2, 5]\n[1, 4, 10]\n[0, 9, 6]\n[14, 8]\n[13, 7]\n[12, 3]\n"
+      "[7, 1, 13]\n",
+      "[3, 6, 9]\n",
+      "[11, 8, 2]\n",
+      "[4, 10]\n",
+      "[0, 12]\n",
+      "[5, 14]\n"
      ]
     }
    ],
@@ -812,11 +890,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Without defined `group_size` function will try to accumulate at least `guaranteed_group_size` elements before yielding resulted group"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -824,10 +902,16 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[3, 6, 9, 12, 0]\n[14, 2, 8, 11, 5]\n[7, 4, 1, 13, 10]\n"
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-29-bc5a4e005a18>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mExampleIterPipe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m15\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshuffle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgroupby\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mx\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/dataset.py\u001b[0m in \u001b[0;36mclass_function\u001b[0;34m(cls, source_dp, *args, **kwargs)\u001b[0m\n\u001b[1;32m     86\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     87\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mclass_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 88\u001b[0;31m             \u001b[0mresult_pipe\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     89\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mis_df\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDFIterDataPipe\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult_pipe\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'_dp_cast_to_df'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     90\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'trace_as_dataframe'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'batch'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'groupby'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'dataframes_as_tuples'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/datapipes/iter/grouping.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, datapipe, group_key_fn, buffer_size, group_size, unbatch_level, guaranteed_group_size, drop_remaining)\u001b[0m\n\u001b[1;32m    239\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    240\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 241\u001b[0;31m             \u001b[0;32massert\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mgroup_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    242\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrop_remaining\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdrop_remaining\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
      ]
     }
    ],
@@ -838,22 +922,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "This behaviour becomes noticable when data is bigger than buffer and some groups getting evicted before gathering all potential items"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[0, 3]\n[1, 4, 7]\n[2, 5, 8]\n[6, 9, 12]\n[10, 13]\n[11, 14]\n"
+      "[0, 3]\n",
+      "[1, 4, 7]\n",
+      "[2, 5, 8]\n",
+      "[6, 9, 12]\n",
+      "[10, 13]\n",
+      "[11, 14]\n"
      ]
     }
    ],
@@ -864,34 +953,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "With randomness involved you might end up with incomplete groups (so next example expected to fail in most cases)"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[14, 5, 11]\n[1, 7, 4, 10]\n[0, 12, 6]\n[8, 2]\n[9, 3]\n"
-     ]
-    },
-    {
+     "ename": "AssertionError",
+     "evalue": "",
      "output_type": "error",
-     "ename": "Exception",
-     "evalue": "('Failed to group items', '[13]')",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-31-673b9dd7fb43>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mdp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mExampleIterPipe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m15\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshuffle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgroupby\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mx\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffer_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m6\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/datapipes/iter/grouping.py\u001b[0m in \u001b[0;36m__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    275\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    276\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mbiggest_size\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrop_remaining\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 277\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Failed to group items'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mbuffer\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mbiggest_key\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    278\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    279\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mbiggest_size\u001b[0m \u001b[0;34m>=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mException\u001b[0m: ('Failed to group items', '[13]')"
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-673b9dd7fb43>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mExampleIterPipe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m15\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshuffle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgroupby\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mx\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffer_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m6\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/dataset.py\u001b[0m in \u001b[0;36mclass_function\u001b[0;34m(cls, source_dp, *args, **kwargs)\u001b[0m\n\u001b[1;32m     86\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     87\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mclass_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 88\u001b[0;31m             \u001b[0mresult_pipe\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     89\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mis_df\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDFIterDataPipe\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult_pipe\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'_dp_cast_to_df'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     90\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'trace_as_dataframe'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'batch'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'groupby'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'dataframes_as_tuples'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/datapipes/iter/grouping.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, datapipe, group_key_fn, buffer_size, group_size, unbatch_level, guaranteed_group_size, drop_remaining)\u001b[0m\n\u001b[1;32m    239\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    240\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 241\u001b[0;31m             \u001b[0;32massert\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mgroup_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    242\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrop_remaining\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdrop_remaining\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
      ]
     }
    ],
@@ -902,22 +985,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To avoid this error and drop incomplete groups, use `drop_remaining` argument"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "[5, 2, 14]\n[4, 7, 13, 1, 10]\n[12, 6, 3, 9]\n[8, 11]\n"
+      "[5, 2, 14]\n",
+      "[4, 7, 13, 1, 10]\n",
+      "[12, 6, 3, 9]\n",
+      "[8, 11]\n"
      ]
     }
    ],
@@ -928,6 +1014,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Zip\n",
     "\n",
@@ -940,20 +1028,22 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "(0, 3)\n(1, 0)\n(2, 4)\n(3, 2)\n(4, 1)\n"
+      "(0, 3)\n",
+      "(1, 0)\n",
+      "(2, 4)\n",
+      "(3, 2)\n",
+      "(4, 1)\n"
      ]
     }
    ],
@@ -965,6 +1055,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Fork\n",
     "\n",
@@ -977,20 +1069,25 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n1\n0\n1\n0\n1\n"
+      "Failed attempt to attribute <class 'list'> __main__.ExampleIterPipe\n",
+      "Failed attempt to attribute <class 'list'> __main__.ExampleIterPipe\n",
+      "0\n",
+      "1\n",
+      "0\n",
+      "1\n",
+      "0\n",
+      "1\n"
      ]
     }
    ],
@@ -1002,6 +1099,95 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demultiplexer\n",
+    "\n",
+    "Function: `demux`\n",
+    "\n",
+    "Description: \n",
+    "\n",
+    "Alternatives:\n",
+    "\n",
+    "Arguments:\n",
+    " \n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "4\n",
+      "7\n"
+     ]
+    }
+   ],
+   "source": [
+    "dp = ExampleIterPipe(10)\n",
+    "dp1, dp2, dp3 = dp.demux(3, lambda x: x % 3)\n",
+    "for i in dp2:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiplexer\n",
+    "\n",
+    "Function: `mux`\n",
+    "\n",
+    "Description: \n",
+    "\n",
+    "Alternatives:\n",
+    "\n",
+    "Arguments:\n",
+    " \n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "0\n",
+      "0\n",
+      "1\n",
+      "10\n",
+      "100\n",
+      "2\n",
+      "20\n",
+      "200\n"
+     ]
+    }
+   ],
+   "source": [
+    "dp1 = ExampleIterPipe(3)\n",
+    "dp2 = ExampleIterPipe(3).map(lambda x: x * 10)\n",
+    "dp3 = ExampleIterPipe(3).map(lambda x: x * 100)\n",
+    "\n",
+    "dp = dp1.mux(dp2, dp3)\n",
+    "for i in dp:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Concat\n",
     "\n",
@@ -1015,20 +1201,24 @@
     "    `dp = dp.concat(*datapipes_list)`\n",
     "\n",
     "Example:\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "0\n1\n2\n3\n0\n1\n2\n"
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "0\n",
+      "1\n",
+      "2\n"
      ]
     }
    ],

--- a/torch/utils/data/standard_pipes.ipynb
+++ b/torch/utils/data/standard_pipes.ipynb
@@ -1,11 +1,32 @@
 {
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3610jvsc74a57bd0eb5e09632d6ea1cbf3eb9da7e37b7cf581db5ed13074b21cc44e159dc62acdab",
+   "display_name": "Python 3.6.10 64-bit ('dataloader': conda)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Standard flow control and data processing DataPipes"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -32,8 +53,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Batch\n",
     "\n",
@@ -51,7 +70,9 @@
     "Example:\n",
     "\n",
     "Classic batching produce partial batches by default\n"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -59,13 +80,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0,1,2]\n",
-      "[3,4,5]\n",
-      "[6,7,8]\n",
-      "[9]\n"
+      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n[9]\n"
      ]
     }
    ],
@@ -76,11 +94,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To drop incomplete batches add `drop_last` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -88,12 +106,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0,1,2]\n",
-      "[3,4,5]\n",
-      "[6,7,8]\n"
+      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n"
      ]
     }
    ],
@@ -104,11 +120,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Sequential calling of `batch` produce nested batches"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -116,14 +132,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[0,1,2],[3,4,5]]\n",
-      "[[6,7,8],[9,10,11]]\n",
-      "[[12,13,14],[15,16,17]]\n",
-      "[[18,19,20],[21,22,23]]\n",
-      "[[24,25,26],[27,28,29]]\n"
+      "[[0, 1, 2], [3, 4, 5]]\n[[6, 7, 8], [9, 10, 11]]\n[[12, 13, 14], [15, 16, 17]]\n[[18, 19, 20], [21, 22, 23]]\n[[24, 25, 26], [27, 28, 29]]\n"
      ]
     }
    ],
@@ -134,11 +146,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "It is possible to unbatch source data before applying the new batching rule using `unbatch_level` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -146,10 +158,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]],[[12,13,14],[15,16,17]],[[18,19,20],[21,22,23]],[[24,25,26],[27,28,29]]]\n"
+      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]\n[20, 21, 22, 23, 24, 25, 26, 27, 28, 29]\n"
      ]
     }
    ],
@@ -160,8 +172,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Unbatch\n",
     "\n",
@@ -175,7 +185,9 @@
     "    `unbatch_level:int = 1`\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -183,19 +195,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "9\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n"
+      "9\n0\n1\n2\n6\n7\n8\n3\n4\n5\n"
      ]
     }
    ],
@@ -206,11 +209,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "By default unbatching is applied only on the first layer, to unbatch deeper use `unbatch_level` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -218,29 +221,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0,1]\n",
-      "[2,3]\n",
-      "[4,5]\n",
-      "[6,7]\n",
-      "[8,9]\n",
-      "[10,11]\n",
-      "[12,13]\n",
-      "[14,15]\n",
-      "[16,17]\n",
-      "[18,19]\n",
-      "[20,21]\n",
-      "[22,23]\n",
-      "[24,25]\n",
-      "[26,27]\n",
-      "[28,29]\n",
-      "[30,31]\n",
-      "[32,33]\n",
-      "[34,35]\n",
-      "[36,37]\n",
-      "[38,39]\n"
+      "[0, 1]\n[2, 3]\n[4, 5]\n[6, 7]\n[8, 9]\n[10, 11]\n[12, 13]\n[14, 15]\n[16, 17]\n[18, 19]\n[20, 21]\n[22, 23]\n[24, 25]\n[26, 27]\n[28, 29]\n[30, 31]\n[32, 33]\n[34, 35]\n[36, 37]\n[38, 39]\n"
      ]
     }
    ],
@@ -251,11 +235,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Setting `unbatch_level` to `-1` will unbatch to the lowest level"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -263,11 +247,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[[0,1],[2,3],[4,5],[6,7]],[[8,9],[10,11],[12,13],[14,15]],[[16,17],[18,19],[20,21],[22,23]]]\n",
-      "[[[24,25],[26,27],[28,29],[30,31]],[[32,33],[34,35],[36,37],[38,39]]]\n"
+      "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33\n34\n35\n36\n37\n38\n39\n"
      ]
     }
    ],
@@ -278,8 +261,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Map\n",
     "\n",
@@ -293,7 +274,9 @@
     "  - `nesting_level: int = 0`\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -301,19 +284,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "0\n",
-      "2\n",
-      "4\n",
-      "6\n",
-      "8\n",
-      "10\n",
-      "12\n",
-      "14\n",
-      "16\n",
-      "18\n"
+      "0\n2\n4\n6\n8\n10\n12\n14\n16\n18\n"
      ]
     }
    ],
@@ -324,11 +298,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "`map` by default applies function to every mini-batch as a whole\n"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -336,28 +310,25 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "0\n",
-      "3\n",
-      "6\n",
-      "9\n"
+      "[0, 1, 2, 0, 1, 2]\n[3, 4, 5, 3, 4, 5]\n[6, 7, 8, 6, 7, 8]\n[9, 9]\n"
      ]
     }
    ],
    "source": [
-    "dp = ExampleIterPipe(10).batch(3).map(lambda x: x[0])\n",
+    "dp = ExampleIterPipe(10).batch(3).map(lambda x: x * 2)\n",
     "for i in dp:\n",
     "    print(i)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To apply function on individual items of the mini-batch use `nesting_level` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -365,11 +336,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[0,2,4],[6,8,10]]\n",
-      "[[12,14,16],[18]]\n"
+      "[[0, 2, 4], [6, 8, 10]]\n[[12, 14, 16], [18]]\n"
      ]
     }
    ],
@@ -380,11 +350,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Setting `nesting_level` to `-1` will apply `map` function to the lowest level possible"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -392,10 +362,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[[0,2,4],[6,8,10]],[[12,14,16],[18]]]\n"
+      "[[[0, 2, 4], [6, 8, 10]], [[12, 14, 16], [18]]]\n"
      ]
     }
    ],
@@ -406,8 +376,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Filter\n",
     "\n",
@@ -422,7 +390,9 @@
     "  - `drop_empty_batches = True` whether empty many batches dropped or not.\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -430,14 +400,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "0\n",
-      "2\n",
-      "4\n",
-      "6\n",
-      "8\n"
+      "0\n2\n4\n6\n8\n"
      ]
     }
    ],
@@ -448,11 +414,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Classic `filter` by default applies filter function to every mini-batches as a whole \n"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -460,12 +426,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0,1,2]\n",
-      "[3,4,5]\n",
-      "[6,7,8]\n"
+      "[0, 1, 2]\n[3, 4, 5]\n[6, 7, 8]\n"
      ]
     }
    ],
@@ -477,11 +441,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "You can apply filter function on individual elements by setting `nesting_level` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -489,12 +453,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[5]\n",
-      "[6,7,8]\n",
-      "[9]\n"
+      "[5]\n[6, 7, 8]\n[9]\n"
      ]
     }
    ],
@@ -506,11 +468,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If mini-batch ends with zero elements after filtering default behaviour would be to drop them from the response. You can override this behaviour using `drop_empty_batches` argument.\n"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -518,13 +480,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[]\n",
-      "[5]\n",
-      "[6,7,8]\n",
-      "[9]\n"
+      "[]\n[5]\n[6, 7, 8]\n[9]\n"
      ]
     }
    ],
@@ -541,11 +500,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[[0,1,2],[3]],[[],[10,11]]]\n",
-      "[[[12,13,14],[15,16,17]],[[18,19]]]\n"
+      "[[[0, 1, 2], [3]], [[], [10, 11]]]\n[[[12, 13, 14], [15, 16, 17]], [[18, 19]]]\n"
      ]
     }
    ],
@@ -557,8 +515,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Shuffle\n",
     "\n",
@@ -573,7 +529,9 @@
     "  - `buffer_size: int = 10000`\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -581,19 +539,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "4\n",
-      "9\n",
-      "1\n",
-      "0\n",
-      "2\n",
-      "8\n",
-      "5\n",
-      "3\n",
-      "6\n",
-      "7\n"
+      "2\n9\n4\n0\n3\n7\n8\n5\n6\n1\n"
      ]
     }
    ],
@@ -604,11 +553,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "`shuffle` operates on input mini-batches similar as on individual items"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -616,13 +565,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[9]\n",
-      "[0,1,2]\n",
-      "[3,4,5]\n",
-      "[6,7,8]\n"
+      "[0, 1, 2]\n[3, 4, 5]\n[9]\n[6, 7, 8]\n"
      ]
     }
    ],
@@ -633,11 +579,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To shuffle elements across batches use `shuffle(unbatch_level)` followed by `batch` pattern "
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -645,11 +591,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[[0,1,2],[3,4,5],[6,7,8]]\n",
-      "[[9]]\n"
+      "[2, 1, 0]\n[7, 9, 6]\n[3, 5, 4]\n[8]\n"
      ]
     }
    ],
@@ -660,8 +605,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Collate\n",
     "\n",
@@ -674,7 +617,9 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -682,13 +627,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "tensor([0, 1, 2])\n",
-      "tensor([3, 4, 5])\n",
-      "tensor([6, 7, 8])\n",
-      "tensor([9])\n"
+      "tensor([0, 1, 2])\ntensor([3, 4, 5])\ntensor([6, 7, 8])\ntensor([9])\n"
      ]
     }
    ],
@@ -699,8 +641,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## GroupBy\n",
     "\n",
@@ -718,7 +658,9 @@
     "\n",
     "#### Attention\n",
     "As datasteam can be arbitrary large, grouping is done on best effort basis and there is no guarantee that same key will never present in the different groups. You can call it local groupby where locallity is the one DataPipe process/thread."
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -726,12 +668,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0, 3, 9, 6]\n",
-      "[1, 4, 7]\n",
-      "[2, 5, 8]\n"
+      "[0, 3, 6, 9]\n[1, 4, 7]\n[5, 2, 8]\n"
      ]
     }
    ],
@@ -742,11 +682,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "By default group key function is applied to entire input (mini-batch)"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -754,11 +694,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[<torch.utils.data.dataset.DataChunk object at 0x7f7d2448b470>, <torch.utils.data.dataset.DataChunk object at 0x7f7d2448bb70>, <torch.utils.data.dataset.DataChunk object at 0x7f7d2448b7b8>]\n",
-      "[<torch.utils.data.dataset.DataChunk object at 0x7f7d2448b550>]\n"
+      "[[0, 1, 2], [3, 4, 5], [6, 7, 8]]\n[[9]]\n"
      ]
     }
    ],
@@ -769,11 +708,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "It is possible to unnest items from the mini-batches using `unbatch_level` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -781,12 +720,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0, 3, 6, 9]\n",
-      "[1, 4, 7]\n",
-      "[2, 5, 8]\n"
+      "[0, 3, 6, 9]\n[1, 4, 7]\n[2, 5, 8]\n"
      ]
     }
    ],
@@ -797,11 +734,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "When internal buffer (defined by `buffer_size`) is overfilled, groupby will yield biggest group available"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -809,15 +746,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[7, 1, 13]\n",
-      "[6, 9, 3]\n",
-      "[11, 5, 8]\n",
-      "[4, 10]\n",
-      "[0, 12]\n",
-      "[14, 2]\n"
+      "[9, 3]\n[13, 4, 7]\n[2, 11, 14, 5]\n[0, 6, 12]\n[1, 10]\n[8]\n"
      ]
     }
    ],
@@ -828,11 +760,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "`groupby` will produce `group_size` sized batches on as fast as possible basis"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -840,15 +772,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[6, 3, 0]\n",
-      "[10, 16, 13]\n",
-      "[11, 8, 2]\n",
-      "[15, 12, 9]\n",
-      "[4, 1, 7]\n",
-      "[5, 14, 17]\n"
+      "[6, 3, 12]\n[1, 16, 7]\n[2, 5, 8]\n[14, 11, 17]\n[15, 9, 0]\n[10, 4, 13]\n"
      ]
     }
    ],
@@ -859,11 +786,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Remaining groups must be at least `guaranteed_group_size` big. "
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -871,15 +798,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[7, 1, 13]\n",
-      "[3, 6, 9]\n",
-      "[11, 8, 2]\n",
-      "[4, 10]\n",
-      "[0, 12]\n",
-      "[5, 14]\n"
+      "[11, 2, 5]\n[1, 4, 10]\n[0, 9, 6]\n[14, 8]\n[13, 7]\n[12, 3]\n"
      ]
     }
    ],
@@ -890,11 +812,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Without defined `group_size` function will try to accumulate at least `guaranteed_group_size` elements before yielding resulted group"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -902,16 +824,10 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-29-bc5a4e005a18>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mExampleIterPipe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m15\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshuffle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgroupby\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mx\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/dataset.py\u001b[0m in \u001b[0;36mclass_function\u001b[0;34m(cls, source_dp, *args, **kwargs)\u001b[0m\n\u001b[1;32m     86\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     87\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mclass_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 88\u001b[0;31m             \u001b[0mresult_pipe\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     89\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mis_df\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDFIterDataPipe\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult_pipe\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'_dp_cast_to_df'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     90\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'trace_as_dataframe'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'batch'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'groupby'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'dataframes_as_tuples'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/datapipes/iter/grouping.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, datapipe, group_key_fn, buffer_size, group_size, unbatch_level, guaranteed_group_size, drop_remaining)\u001b[0m\n\u001b[1;32m    239\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    240\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 241\u001b[0;31m             \u001b[0;32massert\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mgroup_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    242\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrop_remaining\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdrop_remaining\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[3, 6, 9, 12, 0]\n[14, 2, 8, 11, 5]\n[7, 4, 1, 13, 10]\n"
      ]
     }
    ],
@@ -922,27 +838,22 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "This behaviour becomes noticable when data is bigger than buffer and some groups getting evicted before gathering all potential items"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[0, 3]\n",
-      "[1, 4, 7]\n",
-      "[2, 5, 8]\n",
-      "[6, 9, 12]\n",
-      "[10, 13]\n",
-      "[11, 14]\n"
+      "[0, 3]\n[1, 4, 7]\n[2, 5, 8]\n[6, 9, 12]\n[10, 13]\n[11, 14]\n"
      ]
     }
    ],
@@ -953,28 +864,34 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "With randomness involved you might end up with incomplete groups (so next example expected to fail in most cases)"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
-     "ename": "AssertionError",
-     "evalue": "",
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[14, 5, 11]\n[1, 7, 4, 10]\n[0, 12, 6]\n[8, 2]\n[9, 3]\n"
+     ]
+    },
+    {
      "output_type": "error",
+     "ename": "Exception",
+     "evalue": "('Failed to group items', '[13]')",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-673b9dd7fb43>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mExampleIterPipe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m15\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshuffle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgroupby\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mx\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffer_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m6\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/dataset.py\u001b[0m in \u001b[0;36mclass_function\u001b[0;34m(cls, source_dp, *args, **kwargs)\u001b[0m\n\u001b[1;32m     86\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     87\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mclass_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 88\u001b[0;31m             \u001b[0mresult_pipe\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     89\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mis_df\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msource_dp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDFIterDataPipe\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresult_pipe\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'_dp_cast_to_df'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     90\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'trace_as_dataframe'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'batch'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'groupby'\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunction_name\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'dataframes_as_tuples'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/datapipes/iter/grouping.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, datapipe, group_key_fn, buffer_size, group_size, unbatch_level, guaranteed_group_size, drop_remaining)\u001b[0m\n\u001b[1;32m    239\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    240\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 241\u001b[0;31m             \u001b[0;32massert\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mgroup_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mgroup_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    242\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrop_remaining\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdrop_remaining\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-31-673b9dd7fb43>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mdp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mExampleIterPipe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m15\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshuffle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgroupby\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mx\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguaranteed_group_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffer_size\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m6\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/dataset/pytorch/torch/utils/data/datapipes/iter/grouping.py\u001b[0m in \u001b[0;36m__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    275\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    276\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mbiggest_size\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrop_remaining\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 277\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Failed to group items'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mbuffer\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mbiggest_key\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    278\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    279\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mbiggest_size\u001b[0m \u001b[0;34m>=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mguaranteed_group_size\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: ('Failed to group items', '[13]')"
      ]
     }
    ],
@@ -985,25 +902,22 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To avoid this error and drop incomplete groups, use `drop_remaining` argument"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "[5, 2, 14]\n",
-      "[4, 7, 13, 1, 10]\n",
-      "[12, 6, 3, 9]\n",
-      "[8, 11]\n"
+      "[5, 2, 14]\n[4, 7, 13, 1, 10]\n[12, 6, 3, 9]\n[8, 11]\n"
      ]
     }
    ],
@@ -1014,8 +928,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Zip\n",
     "\n",
@@ -1028,22 +940,20 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "(0, 3)\n",
-      "(1, 0)\n",
-      "(2, 4)\n",
-      "(3, 2)\n",
-      "(4, 1)\n"
+      "(0, 3)\n(1, 0)\n(2, 4)\n(3, 2)\n(4, 1)\n"
      ]
     }
    ],
@@ -1055,8 +965,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Fork\n",
     "\n",
@@ -1069,25 +977,20 @@
     "Arguments:\n",
     " \n",
     "Example:"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Failed attempt to attribute <class 'list'> __main__.ExampleIterPipe\n",
-      "Failed attempt to attribute <class 'list'> __main__.ExampleIterPipe\n",
-      "0\n",
-      "1\n",
-      "0\n",
-      "1\n",
-      "0\n",
-      "1\n"
+      "0\n1\n0\n1\n0\n1\n"
      ]
     }
    ],
@@ -1186,8 +1089,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Concat\n",
     "\n",
@@ -1201,24 +1102,20 @@
     "    `dp = dp.concat(*datapipes_list)`\n",
     "\n",
     "Example:\n"
-   ]
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "0\n",
-      "1\n",
-      "2\n",
-      "3\n",
-      "0\n",
-      "1\n",
-      "2\n"
+      "0\n1\n2\n3\n0\n1\n2\n"
      ]
     }
    ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61312 Sort imports of test_datapipe.py
* #61237 Adding backward compatibility for sharding support in old DataLoader
* #61236 Implement usage of `is_shardable` and `apply_sharding`
* #61235 Add DataPipes Graph Functions
* **#61234 [DataLoader] Adding demux and mux DataPipe-s**

Differential Revision: [D29588836](https://our.internmc.facebook.com/intern/diff/D29588836)