### PR TITLE
Add DataPipes Graph Functions

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -77,15 +77,6 @@ def create_temp_dir_and_files():
             (temp_sub_dir, temp_sub_file1_name, temp_sub_file2_name)]
 
 
-class NumbersDataset(IterDataPipe):
-    def __init__(self, size=10):
-        self.size = size
-
-    def __iter__(self):
-        for i in range(self.size):
-            yield i
-
-
 class TestIterableDataPipeBasic(TestCase):
 
     def setUp(self):
@@ -137,7 +128,7 @@ class TestIterableDataPipeBasic(TestCase):
                 rec[1].close()
         self.assertEqual(count, len(self.temp_files))
 
-    #TODO(VitalyFedyunin): Generates unclosed buffer warning, need to investigate
+    # TODO(VitalyFedyunin): Generates unclosed buffer warning, need to investigate
     def test_readfilesfromtar_iterable_datapipe(self):
         temp_dir = self.temp_dir.name
         temp_tarfile_pathname = os.path.join(temp_dir, "test_tar.tar")
@@ -164,7 +155,7 @@ class TestIterableDataPipeBasic(TestCase):
                 self.assertEqual(data_ref[1].read(), f.read())
             data_ref[1].close()
 
-    #TODO(VitalyFedyunin): Generates unclosed buffer warning, need to investigate
+    # TODO(VitalyFedyunin): Generates unclosed buffer warning, need to investigate
     def test_readfilesfromzip_iterable_datapipe(self):
         temp_dir = self.temp_dir.name
         temp_zipfile_pathname = os.path.join(temp_dir, "test_zip.zip")
@@ -232,7 +223,7 @@ class TestIterableDataPipeBasic(TestCase):
         datapipe4.add_handler(_png_decoder)
         _helper(cached, datapipe4, channel_first=True)
 
-    #TODO(VitalyFedyunin): Generates unclosed buffer warning, need to investigate
+    # TODO(VitalyFedyunin): Generates unclosed buffer warning, need to investigate
     def test_groupbykey_iterable_datapipe(self):
         temp_dir = self.temp_dir.name
         temp_tarfile_pathname = os.path.join(temp_dir, "test_tar.tar")
@@ -461,7 +452,7 @@ def _worker_init_fn(worker_id):
 
 class TestFunctionalIterDataPipe(TestCase):
 
-    #TODO(VitalyFedyunin): If dill installed this test fails
+    # TODO(VitalyFedyunin): If dill installed this test fails
     def _test_picklable(self):
         arr = range(10)
         picklable_datapipes: List[Tuple[Type[IterDataPipe], IterDataPipe, Tuple, Dict[str, Any]]] = [
@@ -542,7 +533,7 @@ class TestFunctionalIterDataPipe(TestCase):
         for x, y in zip(map_dp_nl, input_dp_nl):
             self.assertEqual(x, torch.tensor(y, dtype=torch.float))
 
-    #TODO(VitalyFedyunin): If dill installed this test fails
+    # TODO(VitalyFedyunin): If dill installed this test fails
     def _test_map_datapipe_nested_level(self):
 
         input_dp = IDP([list(range(10)) for _ in range(3)])
@@ -904,7 +895,7 @@ class TestFunctionalIterDataPipe(TestCase):
 
 
 class TestFunctionalMapDataPipe(TestCase):
-    #TODO(VitalyFedyunin): If dill installed this test fails
+    # TODO(VitalyFedyunin): If dill installed this test fails
     def _test_picklable(self):
         arr = range(10)
         picklable_datapipes: List[
@@ -1282,7 +1273,8 @@ class TestGraph(TestCase):
         expected : Dict[Any, Any] = {mapped_dp: {numbers_dp: {}}}
         self.assertEqual(expected, graph)
 
-    #TODO(VitalyFedyunin): This test is incorrect because of 'buffer' nature of fork fake implementation, update fork first and fix this test too
+    # TODO(VitalyFedyunin): This test is incorrect because of 'buffer' nature 
+    # of the fork fake implementation, update fork first and fix this test too
     def test_traverse_forked(self):
         numbers_dp = NumbersDataset(size=50)
         dp0, dp1, dp2 = numbers_dp.fork(3)

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1273,7 +1273,7 @@ class TestGraph(TestCase):
         expected : Dict[Any, Any] = {mapped_dp: {numbers_dp: {}}}
         self.assertEqual(expected, graph)
 
-    # TODO(VitalyFedyunin): This test is incorrect because of 'buffer' nature 
+    # TODO(VitalyFedyunin): This test is incorrect because of 'buffer' nature
     # of the fork fake implementation, update fork first and fix this test too
     def test_traverse_forked(self):
         numbers_dp = NumbersDataset(size=50)

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -40,6 +40,17 @@ except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = skipIf(not HAS_TORCHVISION, "no torchvision")
 
+try:
+    import dill
+    # XXX: By default, dill writes the Pickler dispatch table to inject its
+    # own logic there. This globally affects the behavior of the standard library
+    # pickler for any user who transitively depends on this module!
+    # Undo this extension to avoid altering the behavior of the pickler globally.
+    dill.extend(use_dill=False)
+    HAS_DILL = True
+except ImportError:
+    HAS_DILL = False
+skipIfNoDill = skipIf(not HAS_DILL, "no dill")
 
 T_co = TypeVar('T_co', covariant=True)
 
@@ -1266,6 +1277,7 @@ class NumbersDataset(IterDataPipe):
 
 
 class TestGraph(TestCase):
+    @skipIfNoDill
     def test_simple_traverse(self):
         numbers_dp = NumbersDataset(size=50)
         mapped_dp = numbers_dp.map(lambda x: x * 10)
@@ -1275,6 +1287,7 @@ class TestGraph(TestCase):
 
     # TODO(VitalyFedyunin): This test is incorrect because of 'buffer' nature
     # of the fork fake implementation, update fork first and fix this test too
+    @skipIfNoDill
     def test_traverse_forked(self):
         numbers_dp = NumbersDataset(size=50)
         dp0, dp1, dp2 = numbers_dp.fork(3)

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1279,7 +1279,7 @@ class TestGraph(TestCase):
         numbers_dp = NumbersDataset(size=50)
         mapped_dp = numbers_dp.map(lambda x: x * 10)
         graph = torch.utils.data.graph.traverse(mapped_dp)
-        expected = {mapped_dp: {numbers_dp: {}}}
+        expected : Dict[Any, Any] = {mapped_dp: {numbers_dp: {}}}
         self.assertEqual(expected, graph)
 
     #TODO(VitalyFedyunin): This test is incorrect because of 'buffer' nature of fork fake implementation, update fork first and fix this test too

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -11,7 +11,7 @@ reduce_ex_hook = None
 def stub_unpickler():
     return "STUB"
 
-
+# TODO(VitalyFedyunin): Make sure it works without dill module installed
 def list_connected_datapipes(scan_obj):
 
     f = io.BytesIO()

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -1,0 +1,43 @@
+import io
+import pickle
+import copyreg
+
+from torch.utils.data import IterableDataset
+
+reduce_ex_hook = None
+
+
+def stub_unpickler():
+    return "STUB"
+
+
+def list_connected_datapipes(scan_obj):
+
+    f = io.BytesIO()
+    p = pickle.Pickler(f)  # Not going to work for lambdas, but dill infinite loops on typing and can't be used as is
+
+    def stub_pickler(obj):
+        return stub_unpickler, ()
+
+    captured_connections = []
+
+    def reduce_hook(obj):
+        if obj == scan_obj:
+            raise NotImplementedError
+        else:
+            captured_connections.append(obj)
+            return stub_unpickler, ()
+
+    # TODO(VitalyFedyunin):  Better do it as `with` context for safety
+    IterableDataset.set_reduce_ex_hook(reduce_hook)
+    p.dump(scan_obj)
+    IterableDataset.set_reduce_ex_hook(None)
+    return captured_connections
+
+
+def traverse(datapipe):
+    items = list_connected_datapipes(datapipe)
+    d = {datapipe: {}}
+    for item in items:
+        d[datapipe].update(traverse(item))
+    return d

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -1,6 +1,5 @@
 import io
 import pickle
-import copyreg
 
 from torch.utils.data import IterableDataset
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -4,6 +4,8 @@ import copyreg
 
 from torch.utils.data import IterableDataset
 
+from typing import Any, Dict
+
 reduce_ex_hook = None
 
 
@@ -37,7 +39,7 @@ def list_connected_datapipes(scan_obj):
 
 def traverse(datapipe):
     items = list_connected_datapipes(datapipe)
-    d = {datapipe: {}}
+    d : Dict[Any, Any]  = {datapipe: {}}
     for item in items:
         d[datapipe].update(traverse(item))
     return d

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -38,7 +38,7 @@ def list_connected_datapipes(scan_obj):
 
 def traverse(datapipe):
     items = list_connected_datapipes(datapipe)
-    d : Dict[Any, Any]  = {datapipe: {}}
+    d: Dict[Any, Any] = {datapipe: {}}
     for item in items:
         d[datapipe].update(traverse(item))
     return d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61312 Sort imports of test_datapipe.py
* #61237 Adding backward compatibility for sharding support in old DataLoader
* #61236 Implement usage of `is_shardable` and `apply_sharding`
* **#61235 Add DataPipes Graph Functions**
* #61234 [DataLoader] Adding demux and mux DataPipe-s

Differential Revision: [D29588834](https://our.internmc.facebook.com/intern/diff/D29588834)