### PR TITLE
Implement usage of `is_shardable` and `apply_sharding`

### DIFF
--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -10,6 +10,26 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Sized, Tuple, 
 T_co = TypeVar('T_co', covariant=True)
 
 
+@functional_datapipe('sharding_filter')
+class ShardingFilterIterDataPipe(IterDataPipe):
+    def __init__(self, source_datapipe):
+        self.source_datapipe = source_datapipe
+        self.num_of_instances = 1
+        self.instance_id = 0
+
+    def is_shardable(self):
+        return True
+
+    def apply_sharding(self, num_of_instances, instance_id):
+        self.num_of_instances = num_of_instances
+        self.instance_id = instance_id
+
+    def __iter__(self):
+        for i, item in enumerate(self.source_datapipe):
+            if i % self.num_of_instances == self.instance_id:
+                yield item
+
+
 @functional_datapipe('batch')
 class BatchIterDataPipe(IterDataPipe[List[T_co]]):
     r""" :class:`BatchIterDataPipe`.

--- a/torch/utils/data/sharding.py
+++ b/torch/utils/data/sharding.py
@@ -1,0 +1,22 @@
+import torch.utils.data.graph
+
+
+def apply_sharding(datapipe, num_of_instances, instance_id):
+    graph = torch.utils.data.graph.traverse(datapipe)
+
+    def traverse_graph(graph):
+        results = set()
+        for datapipe, sub_graph in graph.items():
+            results.add(datapipe)
+            sub_items = traverse_graph(sub_graph)
+            for item in sub_items:
+                results.add(item)
+        return results
+
+    all_pipes = traverse_graph(graph)
+
+    for pipe in all_pipes:
+        if hasattr(pipe, 'is_shardable'):
+            if pipe.is_shardable():
+                if hasattr(pipe, 'apply_sharding'):
+                    pipe.apply_sharding(num_of_instances, instance_id)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61312 Sort imports of test_datapipe.py
* #61237 Adding backward compatibility for sharding support in old DataLoader
* **#61236 Implement usage of `is_shardable` and `apply_sharding`**
* #61235 Add DataPipes Graph Functions
* #61234 [DataLoader] Adding demux and mux DataPipe-s

Differential Revision: [D29588835](https://our.internmc.facebook.com/intern/diff/D29588835)