### PR TITLE
Adding backward compatibility for sharding support in old DataLoader

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1309,7 +1309,7 @@ class TestSharding(TestCase):
         dp1_upd = dp1.filter(lambda x: x % 3 == 1)
         combined_dp = dp0_upd.mux(dp1_upd)
         return combined_dp
-    
+
     @skipIfNoDill
     def test_simple_sharding(self):
         sharded_dp = self._get_pipeline().sharding_filter()

--- a/torch/utils/data/backward_compatibility.py
+++ b/torch/utils/data/backward_compatibility.py
@@ -1,0 +1,8 @@
+import torch.utils.data.sharding
+
+
+def worker_init_fn(worker_id):
+    info = torch.utils.data.get_worker_info()
+    num_workers = info.num_workers
+    datapipe = info.dataset
+    torch.utils.data.sharding.apply_sharding(datapipe, num_workers, worker_id)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61312 Sort imports of test_datapipe.py
* **#61237 Adding backward compatibility for sharding support in old DataLoader**
* #61236 Implement usage of `is_shardable` and `apply_sharding`
* #61235 Add DataPipes Graph Functions
* #61234 [DataLoader] Adding demux and mux DataPipe-s

Differential Revision: [D29588832](https://our.internmc.facebook.com/intern/diff/D29588832)