### PR TITLE
Enable check trace when tracing a mkldnn model

### DIFF
--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -993,7 +993,7 @@ class TestMkldnn(TestCase):
                 loaded(*inputs).to_dense())
 
     def _test_tracing(self, module, inputs):
-        traced = torch.jit.trace(module, inputs, check_trace=False)
+        traced = torch.jit.trace(module, inputs)
         self.assertEqual(
             module(*inputs).to_dense(),
             traced(*inputs).to_dense())

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -148,7 +148,7 @@ def _clone_inputs(args):
             # TODO: figure out one liner to .clone() and set requires_grad
             v = (
                 a.detach()
-                .clone(memory_format=torch.preserve_format)
+                .clone(memory_format=None if a.is_mkldnn else torch.preserve_format)
                 .requires_grad_(a.requires_grad)
             )
             if a.grad is not None:
@@ -485,6 +485,10 @@ def _check_trace(
                         orig = orig.dequantize()
                     if ref.is_quantized:
                         ref = ref.dequantize()
+                    if orig.is_mkldnn:
+                        orig = orig.to_dense()
+                    if ref.is_mkldnn:
+                        ref = ref.to_dense()
                     torch.testing.assert_allclose(
                         orig.double(),
                         ref.double(),


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/43039, when tracing a MKLDNN model with setting **check_trace=True**, there has an error: **RuntimeError: unsupported memory format option Preserve**, this PR is to solve this problem.
