### PR TITLE
[NO MERGE] To add differentiable Adam

### DIFF
--- a/torch/optim/_differentiable.py
+++ b/torch/optim/_differentiable.py
@@ -1,4 +1,6 @@
-r"""Functional interface"""
+r"""Differentiable Functional interface"""
+import math
+import torch
 from torch import Tensor
 from typing import List, Optional
 
@@ -38,3 +40,50 @@ def sgd(params: List[Tensor],
                 d_p = buf
 
         params[i] = params[i] - d_p * lr
+
+
+def adam(params: List[Tensor],
+         grads: List[Tensor],
+         exp_avgs: List[Tensor],
+         exp_avg_sqs: List[Tensor],
+         max_exp_avg_sqs: List[Tensor],
+         state_steps: List[int],
+         *,
+         amsgrad: bool,
+         beta1: float,
+         beta2: float,
+         lr: float,
+         weight_decay: float,
+         eps: float):
+    r"""Differentiable Functional API that performs Adam algorithm computation.
+
+    See :class:`~torch.optim.Adam` for details.
+    """
+
+    for i, param in enumerate(params):
+
+        grad = grads[i]
+        exp_avg = exp_avgs[i]
+        exp_avg_sq = exp_avg_sqs[i]
+        step = state_steps[i]
+
+        bias_correction1 = 1 - beta1 ** step
+        bias_correction2 = 1 - beta2 ** step
+
+        if weight_decay != 0:
+            grad = grad.add(param, alpha=weight_decay)
+
+        # Decay the first and second moment running average coefficient
+        exp_avg = exp_avg * beta1 + (1 - beta1) * grad
+        exp_avg_sq = exp_avg_sq * beta2 + (1 - beta2) * grad * grad
+        if amsgrad:
+            # Maintains the maximum of all 2nd moment running avg. till now
+            torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
+            # Use the max. for normalizing running avg. of gradient
+            denom = (max_exp_avg_sqs[i].sqrt() / math.sqrt(bias_correction2)).add_(eps)
+        else:
+            denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
+
+        step_size = lr / bias_correction1
+
+        params[i] = params[i] - step_size * exp_avg / denom


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61259
* #61258
* #61257
* #61256
* #61255
* #61254
* **#61253**
* #61252

This PR has been created as proof of concept to show current functional optimizers cannot be used as differentiable optimizers. Specifically current functional Optimizers are performing updates as

```
                           param.add_(update, alpha=-lr)
```

which is giving error: ```Output 0 of UnbindBackward is a view and is being modified inplace```    when we call optimizer to optimize over a path of steps

```
        def inner_loop(model):
            initial_loss = model[0].exp().sum()
            for epoch in range(10):
                loss = model[0].exp().sum()
                step, = autograd.grad(loss, model, create_graph=True)
                self._call_functional_optimizer(opt, model, step)

            return model[0].sum()
        torch.autograd.gradcheck(lambda inp: inner_loop(inp.clone()), model[0])
```

However changing the update method to the form below, letting the test, path optimization to succeed perfectly.


```
                             params[i] = params[i] - update * lr
```

Note that, separate _differentiable.py has been added in order to avoid breaking of CI tests those are depending on calling of functional optimizers such as distributed optimizers .