### PR TITLE
[NO MERGE] To add differentiable AdamW

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -491,6 +491,9 @@ class TestOptim(TestCase):
         if opt == differentiable.adam:
             differentiable.adam(model, step, states["exp_avgs"], states["exp_avg_sqs"], states["max_exp_avg_sqs"],
                                 [epoch + 1], amsgrad=False, beta1=0.99, beta2=0.99, lr=0.5, weight_decay=0., eps=0.001)
+        if opt == differentiable.adamw:
+            differentiable.adamw(model, step, states["exp_avgs"], states["exp_avg_sqs"], states["max_exp_avg_sqs"],
+                                 [epoch + 1], amsgrad=False, beta1=0.99, beta2=0.99, lr=0.5, weight_decay=0., eps=0.001)
 
     def _call_functional_optimizer(self, opt, model, step, states, epoch):
         if opt == functional.sgd:
@@ -498,6 +501,9 @@ class TestOptim(TestCase):
         if opt == functional.adam:
             functional.adam(model, step, states["exp_avgs"], states["exp_avg_sqs"], states["max_exp_avg_sqs"],
                             [epoch + 1], amsgrad=False, beta1=0.99, beta2=0.99, lr=0.5, weight_decay=0., eps=0.001)
+        if opt == functional.adamw:
+            functional.adamw(model, step, states["exp_avgs"], states["exp_avg_sqs"], states["max_exp_avg_sqs"],
+                             [epoch + 1], amsgrad=False, beta1=0.99, beta2=0.99, lr=0.5, weight_decay=0., eps=0.001)
 
     def test_differentiable_sgd(self):
         model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
@@ -516,6 +522,15 @@ class TestOptim(TestCase):
         model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
         with self.assertRaisesRegex(RuntimeError, "Output 0 of UnbindBackward is a view and is being modified inplace"):
             self._inner_loop_functional_optimizers(functional.adam, model)
+
+    def test_differentiable_adamw(self):
+        model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
+        self._inner_loop_differentiable_optimizers(differentiable.adamw, model)
+
+    def test_differentiability_functional_adamw(self):
+        model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
+        with self.assertRaisesRegex(RuntimeError, "Output 0 of UnbindBackward is a view and is being modified inplace"):
+            self._inner_loop_functional_optimizers(functional.adamw, model)
 
     def test_sparse_adam(self):
         self._test_rosenbrock_sparse(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61259
* #61258
* #61257
* #61256
* #61255
* **#61254**
* #61253
* #61252

This PR has been created as proof of concept to show current functional optimizers cannot be used as differentiable optimizers. Specifically current functional Optimizers are performing updates as

```
                           param.add_(update, alpha=-lr)
```

which is giving error: ```Output 0 of UnbindBackward is a view and is being modified inplace```    when we call optimizer to optimize over a path of steps

```
        def inner_loop(model):
            initial_loss = model[0].exp().sum()
            for epoch in range(10):
                loss = model[0].exp().sum()
                step, = autograd.grad(loss, model, create_graph=True)
                self._call_functional_optimizer(opt, model, step)

            return model[0].sum()
        torch.autograd.gradcheck(lambda inp: inner_loop(inp.clone()), model[0])
```

However changing the update method to the form below, letting the test, path optimization to succeed perfectly.


```
                             params[i] = params[i] - update * lr
```

Note that, separate _differentiable.py has been added in order to avoid breaking of CI tests those are depending on calling of functional optimizers such as distributed optimizers .