### PR TITLE
[NO MERGE] To add differentiable Adadelta

### DIFF
--- a/torch/optim/_differentiable.py
+++ b/torch/optim/_differentiable.py
@@ -136,3 +136,28 @@ def adamw(params: List[Tensor],
         step_size = lr / bias_correction1
 
         params[i] = params[i] - step_size * exp_avg / denom
+
+
+def adadelta(params: List[Tensor],
+             grads: List[Tensor],
+             square_avgs: List[Tensor],
+             acc_deltas: List[Tensor],
+             *,
+             lr: float,
+             rho: float,
+             eps: float,
+             weight_decay: float):
+    r"""Differentiable Functional API that performs Adadelta algorithm computation.
+
+    See :class:`~torch.optim.Adadelta` for details.
+    """
+
+    for i, (param, grad, square_avg, acc_delta) in enumerate(zip(params, grads, square_avgs, acc_deltas)):
+        if weight_decay != 0:
+            grad = grad.add(param, alpha=weight_decay)
+
+        square_avg = square_avg * rho + (1 - rho) * grad * grad
+        std = square_avg.add(eps).sqrt_()
+        delta = acc_delta.add(eps).sqrt_().div_(std).mul_(grad)
+        params[i] = params[i] - lr * delta
+        acc_delta = rho * acc_delta + (1 - rho) * delta * delta


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61259
* #61258
* #61257
* #61256
* **#61255**
* #61254
* #61253
* #61252

This PR has been created as proof of concept to show current functional optimizers cannot be used as differentiable optimizers. Specifically current functional Optimizers are performing updates as

```
                           param.add_(update, alpha=-lr)
```

which is giving error: ```Output 0 of UnbindBackward is a view and is being modified inplace```    when we call optimizer to optimize over a path of steps

```
        def inner_loop(model):
            initial_loss = model[0].exp().sum()
            for epoch in range(10):
                loss = model[0].exp().sum()
                step, = autograd.grad(loss, model, create_graph=True)
                self._call_functional_optimizer(opt, model, step)

            return model[0].sum()
        torch.autograd.gradcheck(lambda inp: inner_loop(inp.clone()), model[0])
```

However changing the update method to the form below, letting the test, path optimization to succeed perfectly.


```
                             params[i] = params[i] - update * lr
```

Note that, separate _differentiable.py has been added in order to avoid breaking of CI tests those are depending on calling of functional optimizers such as distributed optimizers .