### PR TITLE
[NO MERGE] To add differentiable Adagrad

### DIFF
--- a/torch/optim/_differentiable.py
+++ b/torch/optim/_differentiable.py
@@ -4,6 +4,12 @@ import torch
 from torch import Tensor
 from typing import List, Optional
 
+def _make_sparse(grad, grad_indices, values):
+    size = grad.size()
+    if grad_indices.numel() == 0 or values.numel() == 0:
+        return torch.empty_like(grad)
+    return torch.sparse_coo_tensor(grad_indices, values, size)
+
 def sgd(params: List[Tensor],
         d_p_list: List[Tensor],
         momentum_buffer_list: List[Optional[Tensor]],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61259
* #61258
* #61257
* **#61256**
* #61255
* #61254
* #61253
* #61252

This PR has been created as proof of concept to show current functional optimizers cannot be used as differentiable optimizers. Specifically current functional Optimizers are performing updates as

```
                           param.add_(update, alpha=-lr)
```

which is giving error: ```Output 0 of UnbindBackward is a view and is being modified inplace```    when we call optimizer to optimize over a path of steps

```
        def inner_loop(model):
            initial_loss = model[0].exp().sum()
            for epoch in range(10):
                loss = model[0].exp().sum()
                step, = autograd.grad(loss, model, create_graph=True)
                self._call_functional_optimizer(opt, model, step)

            return model[0].sum()
        torch.autograd.gradcheck(lambda inp: inner_loop(inp.clone()), model[0])
```

However changing the update method to the form below, letting the test, path optimization to succeed perfectly.


```
                             params[i] = params[i] - update * lr
```

Note that, separate _differentiable.py has been added in order to avoid breaking of CI tests those are depending on calling of functional optimizers such as distributed optimizers .