### PR TITLE
[NO MERGE] To add differentiable RAdam

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -513,6 +513,9 @@ class TestOptim(TestCase):
         if opt == differentiable.rmsprop:
             differentiable.rmsprop(model, step, states["square_avg"], states["grad_avgs"], states["momentum_buffer_list"],
                                    lr=0.5, alpha=0.5, eps=0.001, weight_decay=0.1, momentum=0.1, centered=True)
+        if opt == differentiable.radam:
+            differentiable.radam(model, step, states["exp_avgs"], states["exp_avg_sqs"],
+                                 [epoch + 1], beta1=0.99, beta2=0.99, lr=0.5, weight_decay=0., eps=0.001)
 
     def _call_functional_optimizer(self, opt, model, step, states, epoch):
         if opt == functional.sgd:
@@ -532,6 +535,9 @@ class TestOptim(TestCase):
         if opt == functional.rmsprop:
             functional.rmsprop(model, step, states["square_avg"], states["grad_avgs"], states["momentum_buffer_list"],
                                lr=0.5, alpha=0.5, eps=0.001, weight_decay=0.1, momentum=0.1, centered=True)
+        if opt == functional.radam:
+            functional.radam(model, step, states["exp_avgs"], states["exp_avg_sqs"],
+                             [epoch + 1], beta1=0.99, beta2=0.99, lr=0.5, weight_decay=0., eps=0.001)
 
     def test_differentiable_sgd(self):
         model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
@@ -586,6 +592,15 @@ class TestOptim(TestCase):
         model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
         with self.assertRaisesRegex(RuntimeError, "Output 0 of UnbindBackward is a view and is being modified inplace"):
             self._inner_loop_functional_optimizers(functional.rmsprop, model)
+
+    def test_differentiable_radam(self):
+        model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
+        self._inner_loop_differentiable_optimizers(differentiable.radam, model)
+
+    def test_differentiability_functional_radam(self):
+        model = [torch.randn(1, 2, dtype=torch.double, requires_grad=True)]
+        with self.assertRaisesRegex(RuntimeError, "Output 0 of UnbindBackward is a view and is being modified inplace"):
+            self._inner_loop_functional_optimizers(functional.radam, model)
 
     def test_sparse_adam(self):
         self._test_rosenbrock_sparse(

--- a/torch/optim/_differentiable.py
+++ b/torch/optim/_differentiable.py
@@ -240,3 +240,53 @@ def rmsprop(params: List[Tensor],
             params[i] = params[i] - lr * buf
         else:
             params[i] = params[i] - lr * grad / avg
+
+
+def radam(params: List[Tensor],
+          grads: List[Tensor],
+          exp_avgs: List[Tensor],
+          exp_avg_sqs: List[Tensor],
+          state_steps: List[int],
+          *,
+          beta1: float,
+          beta2: float,
+          lr: float,
+          weight_decay: float,
+          eps: float):
+    r"""Differentiable Functional API that performs RAdam algorithm computation.
+
+    See :class:`~torch.optim.RAdam` for details.
+    """
+
+    for i, param in enumerate(params):
+        grad = grads[i]
+        exp_avg = exp_avgs[i]
+        exp_avg_sq = exp_avg_sqs[i]
+        step = state_steps[i]
+
+        bias_correction1 = 1 - beta1 ** step
+        bias_correction2 = 1 - beta2 ** step
+
+        if weight_decay != 0:
+            grad = grad.add(param, alpha=weight_decay)
+
+        # Decay the first and second moment running average coefficient
+        exp_avg = exp_avg * beta1 + (1 - beta1) * grad
+        exp_avg_sq = exp_avg_sq * beta2 + (1 - beta2) * grad * grad
+
+        # correcting bias for the first moving moment
+        bias_corrected_exp_avg = exp_avg / bias_correction1
+
+        # maximum length of the approximated SMA
+        rho_inf = 2 / (1 - beta2) - 1
+        # compute the length of the approximated SMA
+        rho_t = rho_inf - 2 * step * (beta2 ** step) / bias_correction2
+
+        if rho_t > 5.:
+            # Compute the variance rectification term and update parameters accordingly
+            rect = math.sqrt((rho_t - 4) * (rho_t - 2) * rho_inf / ((rho_inf - 4) * (rho_inf - 2) * rho_t))
+            adaptive_lr = math.sqrt(bias_correction2) / exp_avg_sq.sqrt().add(eps)
+
+            params[i] = params[i] - bias_corrected_exp_avg * lr * adaptive_lr * rect
+        else:
+            params[i] = params[i] - bias_corrected_exp_avg * lr


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61259
* **#61258**
* #61257
* #61256
* #61255
* #61254
* #61253
* #61252

This PR has been created as proof of concept to show current functional optimizers cannot be used as differentiable optimizers. Specifically current functional Optimizers are performing updates as

```
                           param.add_(update, alpha=-lr)
```

which is giving error: ```Output 0 of UnbindBackward is a view and is being modified inplace```    when we call optimizer to optimize over a path of steps

```
        def inner_loop(model):
            initial_loss = model[0].exp().sum()
            for epoch in range(10):
                loss = model[0].exp().sum()
                step, = autograd.grad(loss, model, create_graph=True)
                self._call_functional_optimizer(opt, model, step)

            return model[0].sum()
        torch.autograd.gradcheck(lambda inp: inner_loop(inp.clone()), model[0])
```

However changing the update method to the form below, letting the test, path optimization to succeed perfectly.


```
                             params[i] = params[i] - update * lr
```

Note that, separate _differentiable.py has been added in order to avoid breaking of CI tests those are depending on calling of functional optimizers such as distributed optimizers .