### PR TITLE
[torch][segment_reduce] Update default values when initial value is not set

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -92,7 +92,8 @@ Tensor _segment_reduce_cpu_kernel(
                   // ===== step3: finalize reduction
                   TORCH_CHECK(lengths_data[i] >= 0);
 
-                  if (lengths_data[i] == 0 && !initial.has_value()) {
+                  if (lengths_data[i] == 0 && !initial.has_value() &&
+                      reduction == SegmentReductionType::MEAN) {
                     initial_value = static_cast<scalar_t>(NAN);
                   } else if (
                       reduction == SegmentReductionType::MEAN &&
@@ -229,7 +230,6 @@ Tensor segment_reduce_kernel(
   if (!unsafe) {
     auto min_length = lengths_value.min().item<int64_t>();
     TORCH_CHECK((min_length >= 0), "lengths contains negative value!");
-    TORCH_CHECK(min_length != 0 || initial.has_value());
     TORCH_CHECK(lengths_value.sum().item<int64_t>() == data.size(axis));
   }
 

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -50,23 +50,25 @@ Tensor _get_complete_sum(const Tensor& lengths) {
   TORCH_CHECK(segment_count < INT_MAX);
   auto offsets = at::empty({segment_count + 1}, lengths.options());
   offsets[0].zero_();
-  auto* lengths_data_ptr = lengths.data_ptr<int64_t>();
-  auto* offsets_data_ptr = offsets.data_ptr<int64_t>();
 
-  CUB_WRAPPER(
-      cub::DeviceScan::InclusiveSum,
-      lengths_data_ptr,
-      offsets_data_ptr + 1,
-      segment_count,
-      at::cuda::getCurrentCUDAStream());
-
+  AT_DISPATCH_INDEX_TYPES(
+      lengths.type(), "_segment_reduce_cuda_backward_kernel1", ([&] {
+        auto* lengths_data_ptr = lengths.data_ptr<index_t>();
+        auto* offsets_data_ptr = offsets.data_ptr<index_t>();
+        CUB_WRAPPER(
+            cub::DeviceScan::InclusiveSum,
+            lengths_data_ptr,
+            offsets_data_ptr + 1,
+            segment_count,
+            at::cuda::getCurrentCUDAStream());
+      }));
   return offsets;
 }
 
-template <typename scalar_t>
+template <typename scalar_t, typename index_t>
 __global__ static void post_sum_div_kernel(
     scalar_t* output_data,
-    const int64_t* lengths_data,
+    const index_t* lengths_data,
     const int64_t segment_count,
     bool is_initial_set,
     scalar_t initial) {
@@ -84,13 +86,13 @@ __global__ static void post_sum_div_kernel(
   }
 }
 
-template <typename scalar_t>
-__global__ static void segment_reduce_forward_kernel(
+template <typename scalar_t, typename index_t>
+__global__ void segment_reduce_forward_kernel(
     SegmentReductionType reduction,
     scalar_t* output_data,
     scalar_t* values_data,
-    const int64_t* lengths_data,
-    const int64_t* lengths_cumsum_data,
+    const index_t* lengths_data,
+    const index_t* lengths_cumsum_data,
     const int64_t segment_count,
     const int64_t stride_count,
     bool is_initial_set,
@@ -135,15 +137,15 @@ __global__ static void segment_reduce_forward_kernel(
   output_data[output_index] = initial_value;
 }
 
-template <typename scalar_t>
-__global__ static void segment_reduce_backward_kernel(
+template <typename scalar_t, typename index_t>
+__global__ void segment_reduce_backward_kernel(
     SegmentReductionType reduction,
     scalar_t* grad_input_data,
     scalar_t* grad_data,
     scalar_t* output_data,
     const scalar_t* values_data,
-    const int64_t* lengths_data,
-    const int64_t* lengths_cumsum_data,
+    const index_t* lengths_data,
+    const index_t* lengths_cumsum_data,
     const int64_t segment_count,
     const int64_t stride_count) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -215,10 +217,8 @@ Tensor _segment_reduce_cuda_backward_kernel(
   auto grad_input = at::zeros({data_contig.sizes()}, grad_contig.options());
 
   int64_t stride_count = data_contig.numel() / data_contig.size(axis);
-  const auto* lengths_data = lengths_contig.data_ptr<int64_t>();
 
   auto offsets = _get_complete_sum(lengths_contig);
-  auto* offsets_data = offsets.data_ptr<int64_t>();
 
   constexpr int threads_per_block = 256;
   int64_t num_blocks =
@@ -227,35 +227,41 @@ Tensor _segment_reduce_cuda_backward_kernel(
 
   num_blocks = std::max(num_blocks, (int64_t)1);
 
-  // TODO: Swtich to TensorIterator for better maintainablility and readability
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      kBFloat16,
-      kHalf,
-      data_contig.scalar_type(),
-      "_segment_reduce_cpu",
-      ([&]() {
-        auto* output_data = output_contig.data_ptr<scalar_t>();
-        auto* grad_data = grad_contig.data_ptr<scalar_t>();
-        auto* grad_input_data = grad_input.data_ptr<scalar_t>();
-        const auto* values_data = data_contig.data_ptr<scalar_t>();
+  AT_DISPATCH_INDEX_TYPES(
+      lengths_contig.type(), "_segment_reduce_cuda_backward_kernel1", ([&] {
+        const auto* lengths_data = lengths_contig.data_ptr<index_t>();
+        auto* offsets_data = offsets.data_ptr<index_t>();
 
-        segment_reduce_backward_kernel<scalar_t>
-            <<<num_blocks,
-               threads_per_block,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                reduction,
-                grad_input_data,
-                grad_data,
-                output_data,
-                values_data,
-                lengths_data,
-                offsets_data,
-                segment_count,
-                stride_count);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        // TODO: Swtich to TensorIterator for better maintainablility and
+        // readability
+        AT_DISPATCH_FLOATING_TYPES_AND2(
+            kBFloat16,
+            kHalf,
+            data_contig.scalar_type(),
+            "_segment_reduce_cpu",
+            ([&]() {
+              auto* output_data = output_contig.data_ptr<scalar_t>();
+              auto* grad_data = grad_contig.data_ptr<scalar_t>();
+              auto* grad_input_data = grad_input.data_ptr<scalar_t>();
+              const auto* values_data = data_contig.data_ptr<scalar_t>();
+
+              segment_reduce_backward_kernel<scalar_t>
+                  <<<num_blocks,
+                     threads_per_block,
+                     0,
+                     at::cuda::getCurrentCUDAStream()>>>(
+                      reduction,
+                      grad_input_data,
+                      grad_data,
+                      output_data,
+                      values_data,
+                      lengths_data,
+                      offsets_data,
+                      segment_count,
+                      stride_count);
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+            }));
       }));
-
   return grad_input;
 }
 
@@ -271,10 +277,8 @@ Tensor _segment_reduce_cuda_kernel(
   auto output = at::empty(output_shape, data.options());
 
   int64_t stride_count = data.numel() / data.size(axis);
-  const auto* lengths_data = lengths.data_ptr<int64_t>();
 
   auto offsets = _get_complete_sum(lengths);
-  auto* offsets_data_ptr = offsets.data_ptr<int64_t>();
 
   constexpr int threads_per_block = 256;
   int64_t num_blocks =
@@ -282,111 +286,115 @@ Tensor _segment_reduce_cuda_kernel(
       threads_per_block;
 
   num_blocks = std::max(num_blocks, (int64_t)1);
-  auto* lengths_data_ptr = lengths.data_ptr<int64_t>();
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      data.scalar_type(),
-      "segment_reduce_cuda",
-      [&]() {
-        auto* data_data_ptr = data.data_ptr<scalar_t>();
-        auto* output_data_ptr = output.data_ptr<scalar_t>();
+  AT_DISPATCH_INDEX_TYPES(
+      lengths.type(), "_segment_reduce_cuda_kernel1", ([&] {
+        auto* offsets_data_ptr = offsets.data_ptr<index_t>();
+        auto* lengths_data_ptr = lengths.data_ptr<index_t>();
+        AT_DISPATCH_FLOATING_TYPES_AND2(
+            at::ScalarType::Half,
+            at::ScalarType::BFloat16,
+            data.scalar_type(),
+            "segment_reduce_cuda",
+            [&]() {
+              auto* data_data_ptr = data.data_ptr<scalar_t>();
+              auto* output_data_ptr = output.data_ptr<scalar_t>();
 
-        // initialize starting value
-        scalar_t initial_value;
-        if (initial.has_value()) {
-          initial_value = initial.value().to<scalar_t>();
-        } else if (reduction == SegmentReductionType::MAX) {
-          initial_value = -std::numeric_limits<scalar_t>::infinity();
-        } else if (
-            reduction == SegmentReductionType::MEAN ||
-            reduction == SegmentReductionType::SUM) {
-          initial_value = 0;
-        } else if (reduction == SegmentReductionType::MIN) {
-          initial_value = std::numeric_limits<scalar_t>::infinity();
-        }
+              // initialize starting value
+              scalar_t initial_value;
+              if (initial.has_value()) {
+                initial_value = initial.value().to<scalar_t>();
+              } else if (reduction == SegmentReductionType::MAX) {
+                initial_value = -std::numeric_limits<scalar_t>::infinity();
+              } else if (
+                  reduction == SegmentReductionType::MEAN ||
+                  reduction == SegmentReductionType::SUM) {
+                initial_value = 0;
+              } else if (reduction == SegmentReductionType::MIN) {
+                initial_value = std::numeric_limits<scalar_t>::infinity();
+              }
 
-        if (output_shape.size() > 1) {
-          segment_reduce_forward_kernel<scalar_t>
-              <<<num_blocks,
-                 threads_per_block,
-                 0,
-                 at::cuda::getCurrentCUDAStream()>>>(
-                  reduction,
-                  output_data_ptr,
-                  data_data_ptr,
-                  lengths_data_ptr,
-                  offsets_data_ptr,
-                  segment_count,
-                  stride_count,
-                  initial.has_value(),
-                  initial_value);
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
-        } else {
-          if (reduction == SegmentReductionType::MAX) {
-            CustomMax max_op{};
-            CUB_WRAPPER(
-                cub::DeviceSegmentedReduce::Reduce,
-                data_data_ptr,
-                output_data_ptr,
-                segment_count,
-                offsets_data_ptr,
-                offsets_data_ptr + 1,
-                max_op,
-                initial_value,
-                at::cuda::getCurrentCUDAStream());
-          } else if (reduction == SegmentReductionType::MEAN) {
-            CustomSum sum_op{};
-            CUB_WRAPPER(
-                cub::DeviceSegmentedReduce::Reduce,
-                data_data_ptr,
-                output_data_ptr,
-                segment_count,
-                offsets_data_ptr,
-                offsets_data_ptr + 1,
-                sum_op,
-                initial_value,
-                at::cuda::getCurrentCUDAStream());
+              if (output_shape.size() > 1) {
+                segment_reduce_forward_kernel<scalar_t>
+                    <<<num_blocks,
+                       threads_per_block,
+                       0,
+                       at::cuda::getCurrentCUDAStream()>>>(
+                        reduction,
+                        output_data_ptr,
+                        data_data_ptr,
+                        lengths_data_ptr,
+                        offsets_data_ptr,
+                        segment_count,
+                        stride_count,
+                        initial.has_value(),
+                        initial_value);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              } else {
+                if (reduction == SegmentReductionType::MAX) {
+                  CustomMax max_op{};
+                  CUB_WRAPPER(
+                      cub::DeviceSegmentedReduce::Reduce,
+                      data_data_ptr,
+                      output_data_ptr,
+                      segment_count,
+                      offsets_data_ptr,
+                      offsets_data_ptr + 1,
+                      max_op,
+                      initial_value,
+                      at::cuda::getCurrentCUDAStream());
+                } else if (reduction == SegmentReductionType::MEAN) {
+                  CustomSum sum_op{};
+                  CUB_WRAPPER(
+                      cub::DeviceSegmentedReduce::Reduce,
+                      data_data_ptr,
+                      output_data_ptr,
+                      segment_count,
+                      offsets_data_ptr,
+                      offsets_data_ptr + 1,
+                      sum_op,
+                      initial_value,
+                      at::cuda::getCurrentCUDAStream());
 
-            post_sum_div_kernel<scalar_t>
-                <<<num_blocks,
-                   threads_per_block,
-                   0,
-                   at::cuda::getCurrentCUDAStream()>>>(
-                    output_data_ptr,
-                    lengths_data_ptr,
-                    segment_count,
-                    initial.has_value(),
-                    initial_value);
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
-          } else if (reduction == SegmentReductionType::MIN) {
-            CustomMin min_op{};
-            CUB_WRAPPER(
-                cub::DeviceSegmentedReduce::Reduce,
-                data_data_ptr,
-                output_data_ptr,
-                segment_count,
-                offsets_data_ptr,
-                offsets_data_ptr + 1,
-                min_op,
-                initial_value,
-                at::cuda::getCurrentCUDAStream());
-          } else if (reduction == SegmentReductionType::SUM) {
-            CustomSum sum_op{};
-            CUB_WRAPPER(
-                cub::DeviceSegmentedReduce::Reduce,
-                data_data_ptr,
-                output_data_ptr,
-                segment_count,
-                offsets_data_ptr,
-                offsets_data_ptr + 1,
-                sum_op,
-                initial_value,
-                at::cuda::getCurrentCUDAStream());
-          }
-        }
-      });
+                  post_sum_div_kernel<scalar_t>
+                      <<<num_blocks,
+                         threads_per_block,
+                         0,
+                         at::cuda::getCurrentCUDAStream()>>>(
+                          output_data_ptr,
+                          lengths_data_ptr,
+                          segment_count,
+                          initial.has_value(),
+                          initial_value);
+                  C10_CUDA_KERNEL_LAUNCH_CHECK();
+                } else if (reduction == SegmentReductionType::MIN) {
+                  CustomMin min_op{};
+                  CUB_WRAPPER(
+                      cub::DeviceSegmentedReduce::Reduce,
+                      data_data_ptr,
+                      output_data_ptr,
+                      segment_count,
+                      offsets_data_ptr,
+                      offsets_data_ptr + 1,
+                      min_op,
+                      initial_value,
+                      at::cuda::getCurrentCUDAStream());
+                } else if (reduction == SegmentReductionType::SUM) {
+                  CustomSum sum_op{};
+                  CUB_WRAPPER(
+                      cub::DeviceSegmentedReduce::Reduce,
+                      data_data_ptr,
+                      output_data_ptr,
+                      segment_count,
+                      offsets_data_ptr,
+                      offsets_data_ptr + 1,
+                      sum_op,
+                      initial_value,
+                      at::cuda::getCurrentCUDAStream());
+                }
+              }
+            });
+      }));
 
   return output;
 }

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -126,7 +126,8 @@ __global__ void segment_reduce_forward_kernel(
 
   // ===== step3: finalize reduction
   CUDA_KERNEL_ASSERT(lengths_data[row_id] >= 0);
-  if (lengths_data[row_id] == 0 && !is_initial_set) {
+  if (lengths_data[row_id] == 0 && !is_initial_set &&
+      reduction == SegmentReductionType::MEAN) {
     initial_value = static_cast<scalar_t>(NAN);
   } else if (
       reduction == SegmentReductionType::MEAN && lengths_data[row_id] > 0 &&

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -15,6 +15,19 @@ reductions = ["max", "mean", "min", "sum"]
 length_types = [torch.long, torch.int]
 
 
+def get_default_value(initial_value, reduction):
+    if initial_value is not None:
+        return initial_value
+    if reduction == "max":
+        return -float("Inf")
+    elif reduction == "mean":
+        return float("nan")
+    elif reduction == "min":
+        return float("Inf")
+    elif reduction == "sum":
+        return 0.0
+
+
 class TestSegmentReductions(TestCase):
     def _test_common(
         self,
@@ -91,28 +104,29 @@ class TestSegmentReductions(TestCase):
     def test_simple_1d(self, device, dtype):
         lengths = [1, 2, 3, 0]
         data = [1, float("nan"), 3, 4, 5, 5]
-        check_backward = True
 
         for reduction in reductions:
-            if reduction == "max":
-                initial_value = 0
-                expected_result = [1, float("nan"), 5, initial_value]
-                expected_grad = [1, 1, 0, 0, 0.5, 0.5]
-            elif reduction == "mean":
-                initial_value = 0
-                expected_result = [1, float("nan"), 4.666, initial_value]
-                expected_grad = [1.0, 0.5, 0.5, 0.333, 0.333, 0.333]
-            elif reduction == "min":
-                initial_value = 1000  # some high number
-                expected_result = [1, float("nan"), 4, initial_value]
-                expected_grad = [1.0, 1.0, 0, 1, 0, 0]
-            elif reduction == "sum":
-                initial_value = 0
-                expected_result = [1, float("nan"), 14, initial_value]
-                expected_grad = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-            for axis in [0, -1]:
-                for unsafe in [True, False]:
-                    for initial in [initial_value, None]:
+            for initial in [0, None]:
+                check_backward = True if initial is not None else False
+                initial_value = initial
+                default_value = get_default_value(initial_value, reduction)
+                if reduction == "max":
+                    expected_result = [1, float("nan"), 5, default_value]
+                    expected_grad = [1, 1, 0, 0, 0.5, 0.5]
+                elif reduction == "mean":
+                    expected_result = [1, float("nan"), 4.666, default_value]
+                    expected_grad = [1.0, 0.5, 0.5, 0.333, 0.333, 0.333]
+                elif reduction == "min":
+                    if initial is not None:
+                        initial_value = 1000  # some high number
+                        default_value = get_default_value(initial_value, reduction)
+                    expected_result = [1, float("nan"), 4, default_value]
+                    expected_grad = [1.0, 1.0, 0, 1, 0, 0]
+                elif reduction == "sum":
+                    expected_result = [1, float("nan"), 14, default_value]
+                    expected_grad = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+                for axis in [0, -1]:
+                    for unsafe in [True, False]:
                         for length_type in length_types:
                             self._test_common(
                                 reduction,
@@ -131,78 +145,79 @@ class TestSegmentReductions(TestCase):
 
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_multi_d_simple(self, device, dtype):
-        check_backward = True
         axis = 0
         lengths = [1, 2, 3, 0]
         data = [[1, 1], [float("nan"), 1], [3, float("nan")], [4, 1], [3, 2], [2, 3]]
 
         for reduction in reductions:
-            if reduction == "max":
-                initial_value = 0
-                expected_result = [
-                    [1, 1],
-                    [float("nan"), float("nan")],
-                    [4, 3],
-                    [initial_value, initial_value],
-                ]
-                expected_grad = [
-                    [1, 1],
-                    [1, 0],
-                    [0, 1],
-                    [1, 0],
-                    [0, 0],
-                    [0, 1],
-                ]
-            elif reduction == "mean":
-                initial_value = 0
-                expected_result = [
-                    [1, 1],
-                    [float("nan"), float("nan")],
-                    [3, 2],
-                    [initial_value, initial_value],
-                ]
-                expected_grad = [
-                    [1.0, 1.0],
-                    [0.5, 0.5],
-                    [0.5, 0.5],
-                    [0.333, 0.333],
-                    [0.333, 0.333],
-                    [0.333, 0.333],
-                ]
-            elif reduction == "min":
-                initial_value = 1000  # some high number
-                expected_result = [
-                    [1, 1],
-                    [float("nan"), float("nan")],
-                    [2, 1],
-                    [initial_value, initial_value],
-                ]
-                expected_grad = [
-                    [1.0, 1.0],
-                    [1, 0],
-                    [0, 1],
-                    [0, 1],
-                    [0, 0],
-                    [1, 0],
-                ]
-            elif reduction == "sum":
-                initial_value = 0
-                expected_result = [
-                    [1, 1],
-                    [float("nan"), float("nan")],
-                    [9, 6],
-                    [initial_value, initial_value],
-                ]
-                expected_grad = [
-                    [1.0, 1.0],
-                    [1.0, 1.0],
-                    [1.0, 1.0],
-                    [1.0, 1.0],
-                    [1.0, 1.0],
-                    [1.0, 1.0],
-                ]
-            for unsafe in [True, False]:
-                for initial in [initial_value, None]:
+            for initial in [0, None]:
+                check_backward = True if initial is not None else False
+                initial_value = initial
+                default_value = get_default_value(initial_value, reduction)
+                if reduction == "max":
+                    expected_result = [
+                        [1, 1],
+                        [float("nan"), float("nan")],
+                        [4, 3],
+                        [default_value, default_value],
+                    ]
+                    expected_grad = [
+                        [1, 1],
+                        [1, 0],
+                        [0, 1],
+                        [1, 0],
+                        [0, 0],
+                        [0, 1],
+                    ]
+                elif reduction == "mean":
+                    expected_result = [
+                        [1, 1],
+                        [float("nan"), float("nan")],
+                        [3, 2],
+                        [default_value, default_value],
+                    ]
+                    expected_grad = [
+                        [1.0, 1.0],
+                        [0.5, 0.5],
+                        [0.5, 0.5],
+                        [0.333, 0.333],
+                        [0.333, 0.333],
+                        [0.333, 0.333],
+                    ]
+                elif reduction == "min":
+                    if initial is not None:
+                        initial_value = 1000  # some high number
+                        default_value = get_default_value(initial_value, reduction)
+                    expected_result = [
+                        [1, 1],
+                        [float("nan"), float("nan")],
+                        [2, 1],
+                        [default_value, default_value],
+                    ]
+                    expected_grad = [
+                        [1.0, 1.0],
+                        [1, 0],
+                        [0, 1],
+                        [0, 1],
+                        [0, 0],
+                        [1, 0],
+                    ]
+                elif reduction == "sum":
+                    expected_result = [
+                        [1, 1],
+                        [float("nan"), float("nan")],
+                        [9, 6],
+                        [default_value, default_value],
+                    ]
+                    expected_grad = [
+                        [1.0, 1.0],
+                        [1.0, 1.0],
+                        [1.0, 1.0],
+                        [1.0, 1.0],
+                        [1.0, 1.0],
+                        [1.0, 1.0],
+                    ]
+                for unsafe in [True, False]:
                     self._test_common(
                         reduction,
                         device,
@@ -228,14 +243,13 @@ class TestSegmentReductions(TestCase):
         check_backward = False
 
         for reduction in reductions:
+            initial_value = 0
             if reduction == "max":
-                initial_value = 0
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
                     np.max(data, axis=0).tolist(),
                 ]
             elif reduction == "mean":
-                initial_value = 0
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
                     np.mean(data, axis=0).tolist(),
@@ -247,26 +261,24 @@ class TestSegmentReductions(TestCase):
                     np.min(data, axis=0).tolist(),
                 ]
             elif reduction == "sum":
-                initial_value = 0
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
                     np.sum(data, axis=0).tolist(),
                 ]
             for unsafe in [True, False]:
-                for initial in [initial_value, None]:
-                    self._test_common(
-                        reduction,
-                        device,
-                        dtype,
-                        unsafe,
-                        axis,
-                        initial_value,
-                        data,
-                        lengths,
-                        expected_result,
-                        expected_grad,
-                        check_backward,
-                    )
+                self._test_common(
+                    reduction,
+                    device,
+                    dtype,
+                    unsafe,
+                    axis,
+                    initial_value,
+                    data,
+                    lengths,
+                    expected_result,
+                    expected_grad,
+                    check_backward,
+                )
 
 
 instantiate_device_type_tests(TestSegmentReductions, globals())

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_utils import (
 
 
 reductions = ["max", "mean", "min", "sum"]
+length_types = [torch.long, torch.int]
 
 
 class TestSegmentReductions(TestCase):
@@ -28,8 +29,9 @@ class TestSegmentReductions(TestCase):
         expected_arr,
         expected_grad_arr,
         check_backward,
+        lengths_dtype=torch.int,
     ):
-        lengths = torch.tensor(lengths_arr, device=device)
+        lengths = torch.tensor(lengths_arr, device=device, dtype=lengths_dtype)
         data = torch.tensor(
             data_arr,
             device=device,
@@ -111,19 +113,21 @@ class TestSegmentReductions(TestCase):
             for axis in [0, -1]:
                 for unsafe in [True, False]:
                     for initial in [initial_value, None]:
-                        self._test_common(
-                            reduction,
-                            device,
-                            dtype,
-                            unsafe,
-                            axis,
-                            initial_value,
-                            data,
-                            lengths,
-                            expected_result,
-                            expected_grad,
-                            check_backward,
-                        )
+                        for length_type in length_types:
+                            self._test_common(
+                                reduction,
+                                device,
+                                dtype,
+                                unsafe,
+                                axis,
+                                initial_value,
+                                data,
+                                lengths,
+                                expected_result,
+                                expected_grad,
+                                check_backward,
+                                length_type,
+                            )
 
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_multi_d_simple(self, device, dtype):


### PR DESCRIPTION
Summary:
Same as title.
Mainly this concludes the initially planned features from the op. Only missing functionality is to do reduction on any axis (currently axis 0 only is supported).

Test Plan: Updated unit test.

Differential Revision: D29552037

