### PR TITLE
Enable `torch.isclose` to suppport bool tensors

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -128,13 +128,13 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
 
   // Computes allowed and actual error
   Tensor cast_self, cast_other;
+  cast_self = self.scalar_type() == at::kBool ? self.to(at::get_default_dtype()) : self;
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    cast_self = self.to(at::get_default_dtype());
     cast_other = other.to(at::get_default_dtype());
   } else {
-    cast_self = self;
     cast_other = other;
   }
+
   Tensor allowed_error = atol + (rtol * cast_other).abs();
   Tensor actual_error = (cast_self - cast_other).abs();
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -127,14 +127,16 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
   // by the default scalar type then this may cause an incorrect result.
 
   // Computes allowed and actual error
-  Tensor cast_other;
+  Tensor cast_self, cast_other;
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
+    cast_self = self.to(at::get_default_dtype());
     cast_other = other.to(at::get_default_dtype());
   } else {
+    cast_self = self;
     cast_other = other;
   }
   Tensor allowed_error = atol + (rtol * cast_other).abs();
-  Tensor actual_error = (self - cast_other).abs();
+  Tensor actual_error = (cast_self - cast_other).abs();
 
   // Computes finite closeness
   close.__ior__(at::isfinite(actual_error).__iand__(actual_error <= allowed_error));

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -244,8 +244,6 @@ class TestTesting(TestCase):
             expected = test[2]
             self.assertEqual(actual.item(), expected)
 
-    # torch.close is not implemented for bool tensors
-    # see https://github.com/pytorch/pytorch/issues/33048
     def test_isclose_comparetensors_bool(self, device):
         tests = (
             (True, True, True),
@@ -254,9 +252,7 @@ class TestTesting(TestCase):
             (False, True, False),
         )
 
-        with self.assertRaises(RuntimeError):
-            self._isclose_helper(tests, device, torch.bool, False)
-
+        self._isclose_helper(tests, device, torch.bool, False)
         self._comparetensors_helper(tests, device, torch.bool, False)
 
     @dtypes(torch.uint8,


### PR DESCRIPTION
Fixes #60533