### PR TITLE
Bugfix for TorchScript torch.nn.functional.lp_pool and pad handling

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -881,6 +881,56 @@ class TestJit(JitTestCase):
         dropout.eval()
         m_dropout.eval()
         self.assertEqual(dropout(input) + 1, m_dropout(input))
+		
+    def test_nn_lp_pool2d(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l = torch.nn.LPPool2d(2, 3)
+                self.n = torch.nn.LPPool2d(2, (7, 1))
+
+            def forward(self, x):
+                return (self.l(x),
+                        self.n(x),
+                        torch.nn.functional.lp_pool2d(x, float(2), 3),
+                        torch.nn.functional.lp_pool2d(x, 2, 3),
+                        torch.nn.functional.lp_pool2d(x, float(2), (7, 1)))
+
+        self.checkModule(Mod(), (torch.rand(1, 3, 7, 7),))
+
+    def test_nn_lp_pool1d(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l = torch.nn.LPPool1d(2, 3)
+                self.n = torch.nn.LPPool1d(2, 7)
+
+            def forward(self, x):
+                return (self.l(x),
+                        self.n(x),
+                        torch.nn.functional.lp_pool1d(x, float(2), 3),
+                        torch.nn.functional.lp_pool1d(x, 2, 3),
+                        torch.nn.functional.lp_pool1d(x, float(2), 7))
+
+        self.checkModule(Mod(), (torch.rand(1, 3, 7),))
+
+    def test_nn_padding_functional(self):
+        class Mod(nn.Module):
+            def __init__(self, *pad):
+                super().__init__()
+                self.pad = pad
+
+            def forward(self, x):
+                return F.pad(x, self.pad, mode='constant', value=3.5)
+
+        inputs = [
+            (Mod(1, 2), torch.randn(1, 3, 4)), # 1D
+            (Mod(1, 2, 3, 4), torch.randn(1, 3, 4)), # 2D
+            (Mod(1, 2, 3, 4, 5, 6), torch.randn(1, 3, 4)), # 3D
+        ]
+
+        for m, inp in inputs:
+            self.checkModule(m, (inp,))
 
     def test_nn_padding(self):
         class Mod(nn.Module):
@@ -906,7 +956,7 @@ class TestJit(JitTestCase):
 
         for m, inp in inputs:
             self.checkModule(m, (inp,))
-
+			
     def test_script_autograd_grad(self):
         def test_simple_grad(x, y):
             # type: (Tensor, Tensor) -> List[Optional[Tensor]]

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,5 +1,5 @@
 r"""Functional interface"""
-from typing import Callable, List, Optional, Tuple, Any
+from typing import Callable, List, Optional, Tuple, Any # TODO: ```, Any``` can be removed once Union[int, float] is available
 import math
 import warnings
 
@@ -927,15 +927,17 @@ def max_unpool3d(
     output_size = _unpool_output_size(input, kernel_size, _stride, padding, output_size)
     return torch._C._nn.max_unpool3d(input, indices, output_size, _stride, padding)
 
+# TODO: can be removed once Union[int, float] is available
 def _union_int_float(norm_type: Any) -> float:
     if torch.jit.isinstance(norm_type, int):
         return float(norm_type)
     elif torch.jit.isinstance(norm_type, float):
         return norm_type
     raise ValueError("Expected norm_type to be of type int or float")
+# /TODO
 
 def lp_pool2d(
-    input: Tensor, norm_type: Any,
+    input: Tensor, norm_type: Any, # TODO: change Any to Union[int, float] once it is available
     kernel_size: BroadcastingList2[int],
     stride: Optional[BroadcastingList2[int]] = None,
     ceil_mode: bool = False
@@ -946,7 +948,7 @@ def lp_pool2d(
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
-    norm_type_ = _union_int_float(norm_type)
+    norm_type_ = _union_int_float(norm_type) # TODO: can be removed once Union[int, float] is available
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool2d, (input,), input, norm_type_, kernel_size, stride=stride, ceil_mode=ceil_mode
@@ -960,7 +962,7 @@ def lp_pool2d(
     return (torch.sign(out) * relu(torch.abs(out))).mul(kw * kh).pow(1.0 / norm_type_)
 
 def lp_pool1d(
-    input: Tensor, norm_type: Any,
+    input: Tensor, norm_type: Any, # TODO: change Any to Union[int, float] once it is available
     kernel_size: BroadcastingList1[int],
     stride: Optional[BroadcastingList1[int]] = None,
     ceil_mode: bool = False
@@ -971,7 +973,7 @@ def lp_pool1d(
 
     See :class:`~torch.nn.LPPool1d` for details.
     """
-    norm_type_ = _union_int_float(norm_type)
+    norm_type_ = _union_int_float(norm_type) # TODO: can be removed once Union[int, float] is available
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool1d, (input,), input, norm_type_, kernel_size, stride=stride, ceil_mode=ceil_mode
@@ -4095,7 +4097,7 @@ def affine_grid(theta: Tensor, size: List[int], align_corners: Optional[bool] = 
     return torch.affine_grid_generator(theta, size, align_corners)
 
 
-def _pad(input: Tensor, pad: BroadcastingList1[int], mode: str = "constant", value: Any = 0) -> Tensor:
+def _pad(input: Tensor, pad: BroadcastingList1[int], mode: str = "constant", value: Any = 0) -> Tensor: # TODO: change Any to Union[int, float] once it is available
     r"""Pads tensor.
 
     Padding size:
@@ -4153,7 +4155,7 @@ def _pad(input: Tensor, pad: BroadcastingList1[int], mode: str = "constant", val
         torch.Size([3, 9, 7, 3])
 
     """
-    value_ = _union_int_float(value)
+    value_ = _union_int_float(value) # TODO: can be removed once Union[int, float] is available
     if has_torch_function_unary(input):
         return handle_torch_function(_pad, (input,), input, pad, mode=mode, value=value_)
     assert len(pad) % 2 == 0, "Padding length must be divisible by 2"

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -963,8 +963,8 @@ def lp_pool2d(
 
 def lp_pool1d(
     input: Tensor, norm_type: Any, # TODO: change Any to Union[int, float] once it is available
-    kernel_size: BroadcastingList1[int],
-    stride: Optional[BroadcastingList1[int]] = None,
+    kernel_size: int,
+    stride: Optional[int] = None,
     ceil_mode: bool = False
 ) -> Tensor:
     r"""Applies a 1D power-average pooling over an input signal composed of


### PR DESCRIPTION
Fixes #60258

1. lp_pool and pad complain when ```int``` instead of ```float``` values get passed. As ```Union[int, float]``` is unsupported by TorchScript. I use a helper function ```_union_int_float``` and the ```Any``` data type to solve the issue. Other data types throw an ```ValueError```.
2. lp_pool should use ```BroadcastingList``` for kernel_size
3. pad should use ```BroadcastingList``` for pad
