### PR TITLE
[static runtime] Add DCHECK to ensure that outputs do not overlap with Immutable inputs

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -168,6 +168,16 @@ bool testHasInplaceOp(const std::string& jit_script) {
   torch::jit::AliasDb alias_db(graph);
   return torch::jit::HasInplaceOp(graph, alias_db);
 }
+
+static Node* getNodeWithKind(const torch::jit::StaticModule& smodule, const string& kind) {
+  for (auto& pnode : smodule.nodes()) {
+    if (std::string(pnode.node()->kind().toQualString()) == kind) {
+      return pnode.node();
+    }
+  }
+  return nullptr;
+}
+
 } // namespace
 
 TEST(StaticRuntime, InPlace) {
@@ -856,4 +866,40 @@ TEST(StaticRuntime, FusionPass) {
       EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
     }
   }
+}
+
+TEST(ProcessedNode, VerifyOutputsNotOverlappingWithImmutableInputsWithImmutableArguments) {
+  script::Module module("module");
+  // Not using out= variant.
+  module.define(sigmoid_script);
+  torch::jit::StaticModule smodule(module);
+  Node* sigmoid_node = getNodeWithKind(smodule, "aten::sigmoid");
+  const at::IValue a = torch::randn({2, 3});
+  at::IValue b = torch::randn({3, 1});
+  std::vector<const IValue*> ivalue_inputs{&a};
+  ProcessedNode pnode(sigmoid_node, std::move(ivalue_inputs), true);
+
+  pnode.Output(0) = b;
+  EXPECT_TRUE(pnode.verify_outputs_not_overlapping_with_immutable_inputs());
+
+  pnode.Output(0) = a;
+  EXPECT_FALSE(pnode.verify_outputs_not_overlapping_with_immutable_inputs());
+}
+
+TEST(ProcessedNode, VerifyOutputsNotOverlappingWithImmutableInputsWithMutableArguments) {
+  script::Module module("module");
+  // Using out= variant.
+  module.define(sigmoid_inplace_script);
+  torch::jit::StaticModule smodule(module);
+  Node* sigmoid_node = getNodeWithKind(smodule, "aten::sigmoid");
+  const at::IValue a = torch::randn({2, 3});
+  at::IValue b = torch::randn({3, 1});
+  std::vector<const IValue*> ivalue_inputs{&a};
+  ProcessedNode pnode(sigmoid_node, std::move(ivalue_inputs), true);
+
+  pnode.Output(0) = b;
+  EXPECT_TRUE(pnode.verify_outputs_not_overlapping_with_immutable_inputs());
+
+  pnode.Output(0) = a;
+  EXPECT_TRUE(pnode.verify_outputs_not_overlapping_with_immutable_inputs());
 }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/runtime/static/impl.h>
 
+#include <ATen/MemoryOverlap.h>
 #include <ATen/core/interned_strings.h>
 #include <c10/core/CPUAllocator.h>
 #include <c10/core/InferenceMode.h>
@@ -1301,6 +1302,7 @@ ProcessedNode::ProcessedNode(
 }
 
 void ProcessedNode::run() {
+  DCHECK(verify_outputs_not_overlapping_with_immutable_inputs());
   if (fn_) {
     fn_(this);
   } else if (native_fn_) {
@@ -1321,6 +1323,31 @@ void ProcessedNode::run() {
       Output(i) = std::move(stack[i]);
     }
   }
+}
+
+bool ProcessedNode::verify_outputs_not_overlapping_with_immutable_inputs()
+    const {
+  auto schema = node()->maybeSchema();
+  if (!schema || schema->is_mutable()) {
+    return true;
+  }
+  for (const IValue* in : inputs_) {
+    if (!in->isTensor()) {
+      continue;
+    }
+    const auto& in_t = in->toTensor();
+    for (const IValue& out : outputs_) {
+      if (!out.isTensor()) {
+        continue;
+      }
+      const auto& out_t = out.toTensor();
+      at::MemOverlapStatus status = at::get_overlap_status(in_t, out_t);
+      if (status != at::MemOverlapStatus::NO) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -382,6 +382,8 @@ class ProcessedNode {
     return static_cast<bool>(fn_);
   }
 
+  bool verify_outputs_not_overlapping_with_immutable_inputs() const;
+
  private:
   Node* node_;
   c10::optional<Operation> op_;


### PR DESCRIPTION
Summary: This change adds a `DCHECK` to ensure that outputs do not overlap with mutable inputs.

Test Plan:
Added unittests as follows:

- `ProcessedNode.VerifyOutputsNotOverlappingWithMutableInputsWithImmutableArguments`
- `ProcessedNode.VerifyOutputsNotOverlappingWithMutableInputsWithMutableArguments`

Differential Revision: D29564158

