### PR TITLE
changed launch bounds for upsample_linear1d fwd, bwd from 1024 to 512

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -15,7 +15,7 @@ namespace native {
 namespace {
 
 template <typename scalar_t, typename accscalar_t>
-C10_LAUNCH_BOUNDS_1(1024)
+C10_LAUNCH_BOUNDS_1(512)
 __global__ void upsample_linear1d_out_frame(
     const int n,
     const accscalar_t rwidth,
@@ -62,7 +62,7 @@ __global__ void upsample_linear1d_out_frame(
 
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename scalar_t, typename accscalar_t>
-C10_LAUNCH_BOUNDS_1(1024)
+C10_LAUNCH_BOUNDS_1(512)
 __global__ void upsample_linear1d_out_frame_backward(
     const int n,
     const accscalar_t rwidth,
@@ -128,8 +128,8 @@ static void upsample_linear1d_out_cuda_template(
   AT_ASSERT(input_width > 0 && output_width > 0);
 
   const int num_kernels = output_width;
-  const int num_threads =
-      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
+  const int num_threads = 512;
+      //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -173,8 +173,8 @@ static void upsample_linear1d_backward_out_cuda_template(
   grad_input.zero_();
 
   const int num_kernels = output_width;
-  const int num_threads =
-      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
+  const int num_threads = 512;
+      //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(


### PR DESCRIPTION
Changed launch bounds for upsample_linear1d_out_frame and upsample_linear1d_backward_out_frame from 1024 to 512. Shows performance improvement as shown below. Does not completely eliminate lmem usage (lmem usage goes from 40-48 bytes to 8-16 bytes), not sure why. 

Timing data (using Nvidia Titan-V GPU): 
![UpsampleLinear1dTimingData](https://user-images.githubusercontent.com/22803332/124677708-e20d6280-de75-11eb-8187-fb50ec89dc50.PNG)


