### PR TITLE
[ROCm] Skip test_masked_scatter_large_tensor_cuda

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5911,6 +5911,8 @@ else:
         dst = dst.masked_scatter(mask, src)
         self.assertEqual(dst, torch.tensor([True, True, True], device=device))
 
+    # refer https://github.com/pytorch/pytorch/issues/60190
+    @skipIfRocm
     @onlyCUDA
     @largeTensorTest('30GB')
     def test_masked_scatter_large_tensor(self, device):


### PR DESCRIPTION
Refer https://github.com/pytorch/pytorch/issues/60190. Skipping unit test until hipcub issue is fixed.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>


