### PR TITLE
adding a build_start_time_epoch to build meta info

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -700,6 +700,7 @@ def build_info() -> ReportMetaMeta:
         "build_branch": os.environ.get("CIRCLE_BRANCH", ""),
         "build_job": os.environ.get("JOB_BASE_NAME", ""),
         "build_workflow_id": os.environ.get("CIRCLE_WORKFLOW_ID", ""),
+        "build_start_time_epoch": int(os.path.getmtime(os.path.realpath(__file__))),
     }
 
 


### PR DESCRIPTION
Adding a `build_start_time_epoch` as a normal field in scribe reporting.
This should fix #60591.

The decision was made because:
- we would like only one build (test CI job) start time as partition key string
  - the alternative is to report the duration on each test case individually which would result in duplicate numeric value upload.
- we would be easily calculate the wall-time of a test job from `MAX('time') - build_start_time_epoch` for all reporting messages with the same normal keys.

Test Plan
CI should report the extra normal field.