### PR TITLE
Foreach Test Refactor: Pointwise, Min/Max-imum

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -19,7 +19,7 @@ std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, 
     tensor_lists.emplace_back(tensors2.vec());
     tensor_lists.emplace_back(std::move(vec_res));
 
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, input[0].scalar_type(), "foreach_pointwise_op_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op_cuda", [&]() {
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;
         multi_tensor_apply<4>(tensor_lists,
                               PointwiseOpScalarFunctor<scalar_t,
@@ -40,7 +40,7 @@ void foreach_pointwise_op_(TensorList input, TensorList tensors1, TensorList ten
     tensor_lists.emplace_back(tensors1.vec());
     tensor_lists.emplace_back(tensors2.vec());
 
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, input[0].scalar_type(), "foreach_pointwise_op__cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op__cuda", [&]() {
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;
         multi_tensor_apply<3>(tensor_lists,
                               PointwiseOpScalarFunctor<scalar_t,
@@ -60,7 +60,7 @@ void foreach_pointwise_op_(TensorList input, TensorList tensors1, TensorList ten
     tensor_lists.emplace_back(tensors1.vec());
     tensor_lists.emplace_back(tensors2.vec());
 
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, input[0].scalar_type(), "foreach_pointwise_op__cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op__cuda", [&]() {
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;
         multi_tensor_apply<3, opmath_t>(tensor_lists,
                                         scalars,
@@ -87,7 +87,7 @@ std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, 
     tensor_lists.emplace_back(tensors2.vec());
     tensor_lists.emplace_back(std::move(vec_res));
 
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, input[0].scalar_type(), "foreach_pointwise_op_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, input[0].scalar_type(), "foreach_pointwise_op_cuda", [&]() {
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;
         multi_tensor_apply<4, opmath_t>(tensor_lists,
                                         scalars,
@@ -171,7 +171,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList
     tensor_lists.emplace_back(tensors2.vec());                                                             \
     tensor_lists.emplace_back(std::move(vec_res));                                                         \
                                                                                                            \
-    AT_DISPATCH_ALL_TYPES_AND(kHalf, tensors1[0].scalar_type(), "foreach_maximum_minimum_op_cuda", [&]() { \
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, tensors1[0].scalar_type(), "foreach_maximum_minimum_op_cuda", [&]() { \
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;                                                 \
         auto op = []  GPU_LAMBDA (opmath_t a, opmath_t b) -> opmath_t {                                    \
             opmath_t c = a OP b ? a : b;                                                                   \

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -16,7 +16,7 @@ void addcmul_cuda_kernel(TensorIterator& iter, const Scalar& value) {
     using accscalar_t = at::acc_type<scalar_t, true>;
     auto alpha = value.to<accscalar_t>();
     gpu_kernel(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b, scalar_t c) -> scalar_t {
-      return a + alpha * b * c;
+      return a + alpha * (static_cast<accscalar_t>(b) * static_cast<accscalar_t>(c));
     });
   });
 }

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -8,7 +8,8 @@ from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, onlyCUDA, skipCUDAIfRocm, skipMeta, ops)
 from torch._six import inf, nan
-from torch.testing._internal.common_methods_invocations import foreach_unary_op_db, foreach_binary_op_db, make_tensor
+from torch.testing._internal.common_methods_invocations import \
+    (foreach_unary_op_db, foreach_binary_op_db, foreach_pointwise_op_db, foreach_minmax_op_db, make_tensor)
 
 # Includes some values such that N * N won't be a multiple of 4,
 # which should ensure we test the vectorized and non-vectorized
@@ -22,7 +23,12 @@ class RegularFuncWrapper:
     def __init__(self, func):
         self.func = func
 
-    def __call__(self, inputs, **kwargs):
+    def __call__(self, inputs, values=None, **kwargs):
+        if values is not None:
+            assert len(inputs) == 3
+            if isinstance(values, Number):
+                values = [values for _ in range(len(inputs[0]))]
+            return [self.func(*i, value=values[idx], **kwargs) for idx, i in enumerate(zip(*inputs))]
         if len(inputs) == 2 and isinstance(inputs[1], Number):
             # binary op with tensorlist and scalar.
             inputs[1] = [inputs[1] for _ in range(len(inputs[0]))]
@@ -34,11 +40,16 @@ class ForeachFuncWrapper:
     def __init__(self, func, n_expected_cudaLaunchKernels):
         self.func = func
         self.n_expected_cudaLaunchKernels = n_expected_cudaLaunchKernels
-        self._is_inplace = func.__name__.endswith('_')
+        # Some foreach functions don't have in-place implementations.
+        self._is_inplace = False if func is None else func.__name__.endswith('_')
 
     def __call__(self, inputs, is_cuda, is_fastpath, **kwargs):
         actual = None
-        if is_cuda and torch.autograd.kineto_available():
+        if (
+            is_cuda and
+            torch.autograd.kineto_available() and
+            torch.profiler.ProfilerActivity.CUDA in torch.profiler._supported_kineto_activities()
+        ):
             with torch.profiler.profile(activities=(torch.profiler.ProfilerActivity.CPU,)) as p:
                 actual = self.func(*inputs, **kwargs)
             for e in p.key_averages():
@@ -68,18 +79,6 @@ class TestForeach(TestCase):
             ForeachFuncWrapper(op.inplace_variant, n_expected_cudaLaunchKernels),
             RegularFuncWrapper(op.ref_inplace),
         )
-
-    # todo(mkozuki): remove this method once `TestForeach` is refactored with `@op` decorator.
-    def _get_test_data(self, device, dtype, N):
-        if dtype in [torch.bfloat16, torch.bool, torch.float16]:
-            tensors = [torch.randn(N, N, device=device).to(dtype) for _ in range(N)]
-        elif dtype in torch.testing.get_all_int_dtypes():
-            # Constrains the range between 1 and 10 for less stress on int8 tensors.
-            tensors = [torch.randint(1, 10, (N, N), device=device, dtype=dtype) for _ in range(N)]
-        else:
-            tensors = [torch.randn(N, N, device=device, dtype=dtype) for _ in range(N)]
-
-        return tensors
 
     def _binary_test(self, dtype, op, ref, inputs, is_fastpath, is_inplace, *, alpha=None):
         ref_inputs = [[t.clone().detach() for t in inputs[0]], inputs[1]] if is_inplace else inputs
@@ -244,60 +243,47 @@ class TestForeach(TestCase):
             ]:
                 self._test_binary_op_scalarlist(device, dtype, op, N, scalarlist, False, False)
 
-    def _test_pointwise_op(self, device, dtype, foreach_op, foreach_op_, torch_op):
+    def _pointwise_test(self, dtype, op, ref, inputs, is_fastpath, is_inplace, *, values=None):
+        ref_inputs = [[t.clone().detach() for t in inputs[0]], inputs[1], inputs[2]] if is_inplace else inputs
+        try:
+            actual = op(inputs, self.is_cuda, is_fastpath)
+        except RuntimeError as e:
+            with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                ref(ref_inputs)
+        else:
+            expected = ref(ref_inputs)
+            self.assertEqual(expected, actual)
+        if values is not None:
+            try:
+                actual = op(inputs + [values], self.is_cuda, is_fastpath)
+            except RuntimeError as e:
+                with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                    ref(ref_inputs, values=values)
+            else:
+                expected = ref(ref_inputs, values=values)
+                self.assertEqual(expected, actual)
+
+    def _test_pointwise_op(self, device, dtype, opinfo, N, is_fastpath, disable_fastpath):
+        n_expected_cudaLaunchKernels = N if disable_fastpath else 1
+        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
+        inputs = [
+            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
+            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
+            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
+        ]
+        self._pointwise_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False, values=None)
+        self._pointwise_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True, values=None)
+
+    @ops(foreach_pointwise_op_db)
+    def test_pointwise_op_fastpath(self, device, dtype, op):
+        disable_fastpath = dtype in torch.testing.get_all_int_dtypes() + [torch.bool]
         for N in N_values:
-            # Constrains the range a bit for int8 tensors.
-            values = [2 + (i % 5) for i in range(N)]
-            for vals in [values[0], values]:
-                tensors = self._get_test_data(device, dtype, N)
-                tensors1 = self._get_test_data(device, dtype, N)
-                tensors2 = self._get_test_data(device, dtype, N)
+            self._test_pointwise_op(device, dtype, op, N, True, disable_fastpath)
 
-                # Mimics cuda kernel dtype flow.  With fp16/bf16 input, runs in fp32 and casts output back to fp16/bf16.
-                control_dtype = torch.float32 if (self.device_type == 'cuda' and
-                                                  (dtype is torch.float16 or dtype is torch.bfloat16)) else dtype
-
-                if not isinstance(vals, list):
-                    expected = [torch_op(tensors[i].to(dtype=control_dtype),
-                                         tensors1[i].to(dtype=control_dtype),
-                                         tensors2[i].to(dtype=control_dtype),
-                                         value=values[0]).to(dtype=dtype) for i in range(N)]
-                else:
-                    expected = [torch_op(tensors[i].to(dtype=control_dtype),
-                                         tensors1[i].to(dtype=control_dtype),
-                                         tensors2[i].to(dtype=control_dtype),
-                                         value=values[i]).to(dtype=dtype) for i in range(N)]
-
-                res = foreach_op(tensors, tensors1, tensors2, vals)
-                foreach_op_(tensors, tensors1, tensors2, vals)
-                self.assertEqual(res, tensors)
-
-                if (dtype is torch.float16 or dtype is torch.bfloat16) and TEST_WITH_ROCM:
-                    self.assertEqual(tensors, expected, atol=3.e-3, rtol=self.dtype_precisions[dtype][0])
-                else:
-                    self.assertEqual(tensors, expected)
-
-                # test error cases
-                for op in [torch._foreach_addcmul, torch._foreach_addcmul_, torch._foreach_addcdiv, torch._foreach_addcdiv_]:
-                    tensors = self._get_test_data(device, dtype, N)
-                    tensors1 = self._get_test_data(device, dtype, N)
-                    tensors2 = self._get_test_data(device, dtype, N)
-
-                    with self.assertRaisesRegex(RuntimeError, "Tensor list must have same number of elements as scalar list."):
-                        op(tensors, tensors1, tensors2, [2 for _ in range(N + 1)])
-
-                    with self.assertRaisesRegex(RuntimeError, "Tensor list must have same number of elements as scalar list."):
-                        op(tensors, tensors1, tensors2, [2 for _ in range(N - 1)])
-
-                    msg = "Tensor lists must have the same number of tensors, got {} and {}".format(N + 1, N)
-
-                    tensors = self._get_test_data(device, dtype, N + 1)
-                    with self.assertRaisesRegex(RuntimeError, msg):
-                        op(tensors, tensors1, tensors2, [2 for _ in range(N)])
-
-                    tensors1 = self._get_test_data(device, dtype, N + 1)
-                    with self.assertRaisesRegex(RuntimeError, msg):
-                        op(tensors, tensors1, tensors2, [2 for _ in range(N)])
+    @ops(foreach_pointwise_op_db)
+    def test_pointwise_op_slowpath(self, device, dtype, op):
+        for N in N_values:
+            self._test_pointwise_op(device, dtype, op, N, False, False)
 
     # note(mkozuki): fastpath test uses dtypes which fastpath implementation supports.
     # To confirm the dtypes of `OpInfo` cover the dtypes that the function support,
@@ -353,105 +339,64 @@ class TestForeach(TestCase):
         for N in N_values:
             self._test_unary(device, dtype, op, N, is_fastpath=False)
 
-    #
-    # Pointwise ops
-    #
-    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
-    def test_addcmul(self, device, dtype):
-        if self.device_type == 'cpu':
-            if dtype == torch.half:
-                with self.assertRaisesRegex(RuntimeError, r"\"addcmul_cpu_out\" not implemented for \'Half\'"):
-                    self._test_pointwise_op(device, dtype, torch._foreach_addcmul,
-                                            torch._foreach_addcmul_, torch.addcmul)
-                return
+    def _minmax_test(self, opinfo, inputs, is_fastpath, n_expected_cudaLaunchKernels):
+        op, ref, _, _ = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
+        self.assertEqual(ref(inputs), op(inputs, self.is_cuda, is_fastpath))
 
-        self._test_pointwise_op(device, dtype, torch._foreach_addcmul, torch._foreach_addcmul_, torch.addcmul)
-
-    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
-    def test_addcdiv(self, device, dtype):
-        if dtype in [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8]:
-            with self.assertRaisesRegex(RuntimeError,
-                                        "Integer division with addcdiv is no longer supported, and in a future"):
-                self._test_pointwise_op(device, dtype, torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv)
-            return
-
-        if self.device_type == 'cpu':
-            if dtype == torch.half:
-                with self.assertRaisesRegex(RuntimeError, r"\"addcdiv_cpu_out\" not implemented for \'Half\'"):
-                    self._test_pointwise_op(device, dtype, torch._foreach_addcdiv,
-                                            torch._foreach_addcdiv_, torch.addcdiv)
-                return
-        self._test_pointwise_op(device, dtype, torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv)
-
-    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_complex=False))
-    def test_min_max(self, device, dtype):
+    # note(mkozuki): in-place of foreach_minimum and foreach_maximum aren't implemented.
+    # @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_complex=False))
+    @ops(foreach_minmax_op_db)
+    def test_minmax_fastpath(self, device, dtype, op):
         for N in N_values:
-            tensors1 = self._get_test_data(device, dtype, N)
-            tensors2 = self._get_test_data(device, dtype, N)
+            inputs = tuple(op.sample_inputs(device, dtype, N) for _ in range(2))
+            self._minmax_test(op, inputs, True, N if dtype == torch.bool else 1)
 
-            # Mimics cuda kernel dtype flow.  With fp16/bf16 input, runs in fp32 and casts output back to fp16/bf16.
-            control_dtype = torch.float32 if (self.device_type == 'cuda' and
-                                              (dtype is torch.float16 or dtype is torch.bfloat16)) else dtype
+    @dtypes(*torch.testing.get_all_dtypes(include_half=True, include_bfloat16=True, include_complex=False))
+    @ops(foreach_minmax_op_db)
+    def test_minmax_slowpath(self, device, dtype, op):
+        for N in N_values:
+            inputs = tuple(op.sample_inputs(device, dtype, N, noncontiguous=True) for _ in range(2))
+            self._minmax_test(op, inputs, False, 1)
 
-            expected_max = [torch.max(tensors1[i].to(dtype=control_dtype),
-                                      tensors2[i].to(dtype=control_dtype)).to(dtype=dtype) for i in range(N)]
+    # note(mkozuki): ForeachFuncInfo's of both `_foreach_maximum` and `_foreach_minimum` include integer types.
+    # so, manually limit dtypes to fp types for inf&nan tests.
+    @dtypes(*torch.testing.get_all_fp_dtypes(include_bfloat16=True, include_half=True))
+    @ops(foreach_minmax_op_db)
+    def test_minmax_float_inf_nan(self, device, dtype, op):
+        inputs = (
+            [
+                torch.tensor([float('inf')], device=device, dtype=dtype),
+                torch.tensor([-float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('nan')], device=device, dtype=dtype),
+                torch.tensor([float('nan')], device=device, dtype=dtype)
+            ],
+            [
+                torch.tensor([-float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('nan')], device=device, dtype=dtype)
+            ],
+        )
+        self._minmax_test(op, inputs, True, 1)
 
-            expected_min = [torch.min(tensors1[i].to(dtype=control_dtype),
-                                      tensors2[i].to(dtype=control_dtype)).to(dtype=dtype) for i in range(N)]
-
-            res_max = torch._foreach_maximum(tensors1, tensors2)
-            self.assertEqual(res_max, expected_max)
-
-            res_min = torch._foreach_minimum(tensors1, tensors2)
-            self.assertEqual(res_min, expected_min)
-
-    @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=True, include_bfloat16=False)))
-    def test_max_min_float_inf_nan(self, device, dtype):
-        a = [
-            torch.tensor([float('inf')], device=device, dtype=dtype),
-            torch.tensor([-float('inf')], device=device, dtype=dtype),
-            torch.tensor([float('nan')], device=device, dtype=dtype),
-            torch.tensor([float('nan')], device=device, dtype=dtype)
-        ]
-
-        b = [
-            torch.tensor([-float('inf')], device=device, dtype=dtype),
-            torch.tensor([float('inf')], device=device, dtype=dtype),
-            torch.tensor([float('inf')], device=device, dtype=dtype),
-            torch.tensor([float('nan')], device=device, dtype=dtype)
-        ]
-
-        expected = [torch.max(a1, b1) for a1, b1 in zip(a, b)]
-        res = torch._foreach_maximum(a, b)
-        self.assertEqual(expected, res)
-
-        expected = [torch.min(a1, b1) for a1, b1 in zip(a, b)]
-        res = torch._foreach_minimum(a, b)
-        self.assertEqual(expected, res)
-
-    @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=True, include_bfloat16=False)))
-    def test_max_min_inf_nan(self, device, dtype):
-        a = [
-            torch.tensor([inf], device=device, dtype=dtype),
-            torch.tensor([-inf], device=device, dtype=dtype),
-            torch.tensor([nan], device=device, dtype=dtype),
-            torch.tensor([nan], device=device, dtype=dtype)
-        ]
-
-        b = [
-            torch.tensor([-inf], device=device, dtype=dtype),
-            torch.tensor([inf], device=device, dtype=dtype),
-            torch.tensor([inf], device=device, dtype=dtype),
-            torch.tensor([nan], device=device, dtype=dtype)
-        ]
-
-        expected_max = [torch.max(a1, b1) for a1, b1 in zip(a, b)]
-        res_max = torch._foreach_maximum(a, b)
-        self.assertEqual(expected_max, res_max)
-
-        expected_min = [torch.min(a1, b1) for a1, b1 in zip(a, b)]
-        res_min = torch._foreach_minimum(a, b)
-        self.assertEqual(expected_min, res_min)
+    @ops(foreach_minmax_op_db)
+    @dtypes(*torch.testing.get_all_fp_dtypes(include_bfloat16=True, include_half=True))
+    def test_minmax_inf_nan(self, device, dtype, op):
+        inputs = (
+            [
+                torch.tensor([inf], device=device, dtype=dtype),
+                torch.tensor([-inf], device=device, dtype=dtype),
+                torch.tensor([nan], device=device, dtype=dtype),
+                torch.tensor([nan], device=device, dtype=dtype)
+            ],
+            [
+                torch.tensor([-inf], device=device, dtype=dtype),
+                torch.tensor([inf], device=device, dtype=dtype),
+                torch.tensor([inf], device=device, dtype=dtype),
+                torch.tensor([nan], device=device, dtype=dtype)
+            ],
+        )
+        self._minmax_test(op, inputs, True, 1)
 
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
@@ -646,38 +591,33 @@ class TestForeach(TestCase):
         else:
             self.assertEqual(actual, tensors1)
 
-    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=True))
-    def test_pointwise_op_tensors_on_different_devices(self, device, dtype):
-        if self.device_type != 'cuda':
-            self.skipTest('CUDA is necessary for tests with tensors on different devices')
+    @onlyCUDA
+    @ops(foreach_pointwise_op_db)
+    def test_pointwise_op_tensors_on_different_devices(self, device, dtype, op):
+        # tensors1: ['cuda', 'cpu]
+        # tensors2: ['cuda', 'cpu]
+        # tensors3: ['cuda', 'cpu]
+        _cuda_tensors = op.sample_inputs(device, dtype, 3, same_size=True)
+        _cpu_tensors = op.sample_inputs('cpu', dtype, 3, same_size=True)
+        tensors1, tensors2, tensors3 = list(tensors for tensors in zip(_cuda_tensors, _cpu_tensors))
 
-        pointwise_ops = [
-            (torch._foreach_addcmul, torch._foreach_addcmul_, torch.addcmul),
-            (torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv),
-        ]
-        for foreach_op, foreach_op_, native_op in pointwise_ops:
-            # tensors1: ['cuda', 'cpu]
-            # tensors2: ['cuda', 'cpu]
-            # tensors3: ['cuda', 'cpu]
-            _cuda_tensors = self._get_test_data(device, dtype, 3)
-            _cpu_tensors = self._get_test_data('cpu', dtype, 3)
-            tensors1, tensors2, tensors3 = list(tensors for tensors in zip(_cuda_tensors, _cpu_tensors))
-
-            try:
-                actual = foreach_op(tensors1, tensors2, tensors3)
-            except RuntimeError as e:
-                with self.assertRaisesRegex(type(e), re.escape(str(e))):
-                    expected = [native_op(t1, t2, t3) for t1, t2, t3 in zip(tensors1, tensors2, tensors3)]
-            else:
+        foreach_op, foreach_op_ = op.method_variant, op.inplace_variant
+        native_op, native_op_ = op.ref, op.ref_inplace
+        try:
+            actual = foreach_op(tensors1, tensors2, tensors3)
+        except RuntimeError as e:
+            with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 expected = [native_op(t1, t2, t3) for t1, t2, t3 in zip(tensors1, tensors2, tensors3)]
-                self.assertEqual(expected, actual)
-            try:
-                foreach_op_(tensors1, tensors2, tensors3)
-            except RuntimeError as e:
-                with self.assertRaisesRegex(type(e), re.escape(str(e))):
-                    [getattr(t1, native_op.__name__ + '_')(t2, t3) for t1, t2, t3 in zip(tensors1, tensors3, tensors3)]
-            else:
-                self.assertEqual(expected, tensors1)
+        else:
+            expected = [native_op(t1, t2, t3) for t1, t2, t3 in zip(tensors1, tensors2, tensors3)]
+            self.assertEqual(expected, actual)
+        try:
+            foreach_op_(tensors1, tensors2, tensors3)
+        except RuntimeError as e:
+            with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                [native_op_(t1, t2, t3) for t1, t2, t3 in zip(tensors1, tensors3, tensors3)]
+        else:
+            self.assertEqual(expected, tensors1)
 
 
 instantiate_device_type_tests(TestForeach, globals())

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -7,7 +7,6 @@ import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, TEST_WITH_SLOW
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, onlyCUDA, skipCUDAIfRocm, skipMeta, ops)
-from torch._six import inf, nan
 from torch.testing._internal.common_methods_invocations import \
     (foreach_unary_op_db, foreach_binary_op_db, foreach_pointwise_op_db, foreach_minmax_op_db, make_tensor)
 
@@ -375,25 +374,6 @@ class TestForeach(TestCase):
                 torch.tensor([float('inf')], device=device, dtype=dtype),
                 torch.tensor([float('inf')], device=device, dtype=dtype),
                 torch.tensor([float('nan')], device=device, dtype=dtype)
-            ],
-        )
-        self._minmax_test(op, inputs, True, 1)
-
-    @ops(foreach_minmax_op_db)
-    @dtypes(*torch.testing.get_all_fp_dtypes(include_bfloat16=True, include_half=True))
-    def test_minmax_inf_nan(self, device, dtype, op):
-        inputs = (
-            [
-                torch.tensor([inf], device=device, dtype=dtype),
-                torch.tensor([-inf], device=device, dtype=dtype),
-                torch.tensor([nan], device=device, dtype=dtype),
-                torch.tensor([nan], device=device, dtype=dtype)
-            ],
-            [
-                torch.tensor([-inf], device=device, dtype=dtype),
-                torch.tensor([inf], device=device, dtype=dtype),
-                torch.tensor([inf], device=device, dtype=dtype),
-                torch.tensor([nan], device=device, dtype=dtype)
             ],
         )
         self._minmax_test(op, inputs, True, 1)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4673,6 +4673,32 @@ foreach_binary_op_db: List[OpInfo] = [
     ),
 ]
 
+foreach_pointwise_op_db: List[ForeachFuncInfo] = [
+    ForeachFuncInfo(
+        "addcmul",
+        dtypesIfCPU=all_types_and_complex(),
+        dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16),
+    ),
+    ForeachFuncInfo(
+        "addcdiv",
+        dtypesIfCPU=all_types_and_complex(),
+        dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16),
+    ),
+]
+
+foreach_minmax_op_db: List[ForeachFuncInfo] = [
+    ForeachFuncInfo(
+        "maximum",
+        dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
+        dtypesIfCUDA=all_types_and(torch.float16, torch.bool),
+    ),
+    ForeachFuncInfo(
+        "minimum",
+        dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
+        dtypesIfCUDA=all_types_and(torch.float16, torch.bool),
+    ),
+]
+
 def reference_sign(x):
     if x.dtype == np.bool_:
         # `np.sign` doesn't support `bool`.


### PR DESCRIPTION
- rewrite pointwise unittests using `ops` decorator
- rewrite minimum&maximum unittests using `ops` decorator
- enable minimum/maximum fastpath for BFloat16
- remove _test_data method

#58833 

cc: @ptrblck @ngimel 