### PR TITLE
Fix mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -36,7 +36,7 @@ files =
     test/test_torch.py,
     test/test_type_hints.py,
     test/test_type_info.py,
-    test/test_utils.py,
+    test/test_utils.py
 
 #
 # `exclude` is a regex, not a list of paths like `files` (sigh)


### PR DESCRIPTION
Fixes CI regression caused by #61119
Unlike Python, `.ini` string lists could not  end with trailing comma.

Fixes CI on master