### PR TITLE
Type annotate `torch.nn.Module` ctor

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -300,10 +300,14 @@ class {module_name}(torch.nn.Module):
             model_str += f"{tab*2}self.{module_name} = {module_str}\n"
 
         for buffer_name, buffer in self._buffers.items():
+            if buffer is None:
+                continue
             model_str += f"{tab*2}self.register_buffer('{buffer_name}', torch.empty({list(buffer.shape)}))\n"
 
         for param_name, param in self._parameters.items():
-            model_str += f"{tab*2}self.{param_name} = torch.nn.Parameter(torch.empty({list(buffer.shape)}))\n"
+            if param is None:
+                continue
+            model_str += f"{tab*2}self.{param_name} = torch.nn.Parameter(torch.empty({list(param.shape)}))\n"
 
         model_str += f"{tab*2}self.load_state_dict(torch.load(r'{folder}/state_dict.pt'))\n"
         model_str += f"{_addindent(self.code, 4)}\n"

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -665,7 +665,7 @@ def check_module_initialized(mod):
     # This is to avoid importing torch.distributed.nn
     if not hasattr(mod, 'remote_parameters'):
         for name, param in mod._parameters.items():
-            if param is not None and  torch.nn.parameter.is_lazy(param):
+            if param is not None and torch.nn.parameter.is_lazy(param):
                 raise RuntimeError("'{}' has uninitialized parameters {}. Did you forget to run a forward pass?"
                                    .format(torch.typename(type(mod)), name))
         for name, buf in mod._buffers.items():

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -665,11 +665,11 @@ def check_module_initialized(mod):
     # This is to avoid importing torch.distributed.nn
     if not hasattr(mod, 'remote_parameters'):
         for name, param in mod._parameters.items():
-            if torch.nn.parameter.is_lazy(param):
+            if param is not None and  torch.nn.parameter.is_lazy(param):
                 raise RuntimeError("'{}' has uninitialized parameters {}. Did you forget to run a forward pass?"
                                    .format(torch.typename(type(mod)), name))
         for name, buf in mod._buffers.items():
-            if torch.nn.parameter.is_lazy(buf):
+            if buf is not None and torch.nn.parameter.is_lazy(buf):
                 raise RuntimeError("'{}' has uninitialized buffers {}. Did you forget to run a forward pass?"
                                    .format(torch.typename(type(mod)), name))
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -167,6 +167,7 @@ class ModuleList(Module):
     """
 
     _modules: Dict[str, Module]  # type: ignore[assignment]
+
     def __init__(self, modules: Optional[Iterable[Module]] = None) -> None:
         super(ModuleList, self).__init__()
         if modules is not None:
@@ -425,6 +426,7 @@ class ParameterList(Module):
     """
 
     _parameters: Dict[str, Parameter]  # type: ignore[assignment]
+
     def __init__(self, parameters: Optional[Iterable['Parameter']] = None) -> None:
         super(ParameterList, self).__init__()
         self._initialized = True

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -425,7 +425,7 @@ class ParameterList(Module):
                 return x
     """
 
-    _parameters: Dict[str, Parameter]  # type: ignore[assignment]
+    _parameters: Dict[str, 'Parameter']  # type: ignore[assignment]
 
     def __init__(self, parameters: Optional[Iterable['Parameter']] = None) -> None:
         super(ParameterList, self).__init__()

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -7,7 +7,7 @@ import torch
 from .module import Module
 from torch._jit_internal import _copy_to_script_wrapper
 
-from typing import Any, Iterable, Iterator, Mapping, Optional, TYPE_CHECKING, overload, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, TYPE_CHECKING, overload, Tuple, TypeVar, Union
 
 if TYPE_CHECKING:
     from torch.nn import Parameter
@@ -70,6 +70,8 @@ class Sequential(Module):
                   ('relu2', nn.ReLU())
                 ]))
     """
+
+    _modules: Dict[str, Module]  # type: ignore[assignment]
 
     @overload
     def __init__(self, *args: Module) -> None:
@@ -164,6 +166,7 @@ class ModuleList(Module):
                 return x
     """
 
+    _modules: Dict[str, Module]  # type: ignore[assignment]
     def __init__(self, modules: Optional[Iterable[Module]] = None) -> None:
         super(ModuleList, self).__init__()
         if modules is not None:
@@ -297,6 +300,8 @@ class ModuleDict(Module):
                 return x
     """
 
+    _modules: Dict[str, Module]  # type: ignore[assignment]
+
     def __init__(self, modules: Optional[Mapping[str, Module]] = None) -> None:
         super(ModuleDict, self).__init__()
         if modules is not None:
@@ -419,6 +424,7 @@ class ParameterList(Module):
                 return x
     """
 
+    _parameters: Dict[str, Parameter]  # type: ignore[assignment]
     def __init__(self, parameters: Optional[Iterable['Parameter']] = None) -> None:
         super(ParameterList, self).__init__()
         self._initialized = True
@@ -560,6 +566,8 @@ class ParameterDict(Module):
                 x = self.params[choice].mm(x)
                 return x
     """
+
+    _parameters: Dict[str, 'Parameter']  # type: ignore[assignment]
 
     def __init__(self, parameters: Optional[Mapping[str, 'Parameter']] = None) -> None:
         super(ParameterDict, self).__init__()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -247,23 +247,23 @@ class Module:
     training: bool
     _is_full_backward_hook: Optional[bool]
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initializes internal Module state, shared by both nn.Module and ScriptModule.
         """
         torch._C._log_api_usage_once("python.nn_module")
 
         self.training = True
-        self._parameters = OrderedDict()
-        self._buffers = OrderedDict()
-        self._non_persistent_buffers_set = set()
-        self._backward_hooks = OrderedDict()
+        self._parameters: Dict[str, Optional[Parameter]] = OrderedDict()
+        self._buffers: Dict[str, Optional[Tensor]] = OrderedDict()
+        self._non_persistent_buffers_set: Set[str] = set()
+        self._backward_hooks: Dict[int, Callable] = OrderedDict()
         self._is_full_backward_hook = None
-        self._forward_hooks = OrderedDict()
-        self._forward_pre_hooks = OrderedDict()
-        self._state_dict_hooks = OrderedDict()
-        self._load_state_dict_pre_hooks = OrderedDict()
-        self._modules = OrderedDict()
+        self._forward_hooks: Dict[int, Callable] = OrderedDict()
+        self._forward_pre_hooks: Dict[int, Callable] = OrderedDict()
+        self._state_dict_hooks: Dict[int, Callable] = OrderedDict()
+        self._load_state_dict_pre_hooks: Dict[int, Callable] = OrderedDict()
+        self._modules: Dict[str, Optional['Module']] = OrderedDict()
 
     forward: Callable[..., Any] = _forward_unimplemented
 
@@ -571,6 +571,7 @@ class Module:
                         param.grad.data = grad_applied
                     else:
                         assert param.grad.is_leaf
+                        # type: ignore[union-attr]
                         self._parameters[key].grad = grad_applied.requires_grad_(param.grad.requires_grad)
 
         for key, buf in self._buffers.items():

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -571,8 +571,8 @@ class Module:
                         param.grad.data = grad_applied
                     else:
                         assert param.grad.is_leaf
-                        # type: ignore[union-attr]
-                        self._parameters[key].grad = grad_applied.requires_grad_(param.grad.requires_grad)
+                        self._parameters[key].grad = grad_applied.requires_grad_(  # type: ignore[union-attr]
+                            param.grad.requires_grad)
 
         for key, buf in self._buffers.items():
             if buf is not None:

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -120,7 +120,7 @@ class SpectralNorm:
 
         fn = SpectralNorm(name, n_power_iterations, dim, eps)
         weight = module._parameters[name]
-        if isinstance(weight, torch.nn.parameter.UninitializedParameter):
+        if isinstance(weight, torch.nn.parameter.UninitializedParameter) or weight is None:
             raise ValueError(
                 'The module passed to `SpectralNorm` can\'t have uninitialized parameters. '
                 'Make sure to run the dummy forward before applying spectral normalization')

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -120,7 +120,9 @@ class SpectralNorm:
 
         fn = SpectralNorm(name, n_power_iterations, dim, eps)
         weight = module._parameters[name]
-        if isinstance(weight, torch.nn.parameter.UninitializedParameter) or weight is None:
+        if weight is None:
+            raise ValueError(f'`SpectralNorm` cannot be applied as parameter `{name}` is None')
+        if isinstance(weight, torch.nn.parameter.UninitializedParameter):
             raise ValueError(
                 'The module passed to `SpectralNorm` can\'t have uninitialized parameters. '
                 'Make sure to run the dummy forward before applying spectral normalization')


### PR DESCRIPTION
Annotate generic types
Fix some type violations
Override `_modules` and `_parameters` in `Sequential`, `ModuleList`, `ModuleDict`, etc

Dismantle pyramid of doom in `Module._apply`, by replacing:
```
for k,v in dict_.items():
   if v is not None:
      ....
```
with
```
for k,v in dict_.items():
   if v is None:
      continue
   ....
```
Fixes #45497
