### PR TITLE
Add compare_set in distributed docs

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -298,6 +298,7 @@ Key-Value Stores: :class:`~torch.distributed.TCPStore`,
 .. autofunction:: torch.distributed.Store.set
 .. autofunction:: torch.distributed.Store.get
 .. autofunction:: torch.distributed.Store.add
+.. autofunction:: torch.distributed.Store.compare_set
 .. autofunction:: torch.distributed.Store.wait
 .. autofunction:: torch.distributed.Store.num_keys
 .. autofunction:: torch.distributed.Store.delete_key


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61351 Add compare_set in distributed docs**

Accidentally missed adding this because I thought the functions under Store were auto documented.
![image](https://user-images.githubusercontent.com/14858254/124798010-e773b700-df20-11eb-9e6b-f9793601e49c.png)


Preview: https://docs-preview.pytorch.org/61351/distributed.html#torch.distributed.Store.compare_set

Differential Revision: [D29588206](https://our.internmc.facebook.com/intern/diff/D29588206)