### PR TITLE
[fx] [normalize arg] type_hint for slice

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -930,6 +930,16 @@ terrible spacing
         traced(input)
         self.assertEqual(traced(input), ref_outs)
 
+    def test_normalize_args_for_getitem_with_slices(self):
+        def test(x):
+            return x[::, ::, ::]
+
+        input = torch.randn(1, 2, 3, 4)
+        traced = torch.fx.symbolic_trace(test)
+        ShapeProp(traced).propagate(input)
+        traced = NormalizeArgs(traced).transform()
+        self.assertEqual(traced(input), test(input))
+
     def test_normalize_modules_exhaustive(self):
         """
         Exhaustively test `Node.normalized_arguments` on all standard


### PR DESCRIPTION
Summary:
When creating type hint, we only go into list or tuple. Then when we trying to get type, we should do something similar, otherwise, we could run into non-type object when creating typehint.

For `getitem` node, args could be `(input_tensor, (slice(...), slice(...))`. We want to get the type for slice rather going into slice.

Test Plan: Added a unit test

Differential Revision: D29570202

