### PR TITLE
Add Model Parallel Support to ZeRO

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -248,22 +248,6 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
             with self.assertRaises(ValueError):
                 ZeroRedundancyOptimizer(input, optimizer_class=SGD, lr=0.1)
 
-    def test_same_param_device(self):
-        """Check that ZeroRedundancyOptimizer raises an exception if the input
-        parameters are sharded on multiple devices.
-
-        NOTE: This test should be removed once support for sharding a rank's
-        model parameters across multiple devices is added.
-        """
-        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
-            return
-        self.dist_init(self.rank)
-
-        # Move the parameters to cuda:0 and cuda:1 respectively
-        params = [torch.Tensor(1).to(0), torch.Tensor(1).to(1)]
-        with self.assertRaises(ValueError):
-            ZeroRedundancyOptimizer(params, optimizer_class=SGD, lr=0.1)
-
 
 class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     @property
@@ -790,6 +774,101 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     def test_zero_join_cpu(self):
         """Check that the ZeRO join hook allows training with uneven inputs on CPU."""
         self._test_zero_join(torch.device("cpu"))
+
+    def _test_zero_model_parallel(self, parameters_as_bucket_view: bool):
+        # Use two processes each with two GPUs
+        if self.rank >= 2:
+            return
+        NUM_EPOCHS = 3
+        NUM_INPUTS = 5
+        LR = 0.01
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+
+        class ModelParallelModel(torch.nn.Module):
+            def __init__(self, dev0, dev1):
+                super().__init__()
+                self.dev0 = dev0
+                self.dev1 = dev1
+                self.net0 = torch.nn.Linear(10, 10).to(dev0)
+                self.relu = torch.nn.ReLU()
+                self.net1 = torch.nn.Linear(10, 5).to(dev1)
+
+            def forward(self, x):
+                x = x.to(self.dev0)
+                x = self.relu(self.net0(x))
+                x = x.to(self.dev1)
+                return self.net1(x)
+
+        class LocalModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.net0 = torch.nn.Linear(10, 10)
+                self.relu = torch.nn.ReLU()
+                self.net1 = torch.nn.Linear(10, 5)
+
+            def forward(self, x):
+                return self.net1(self.relu(self.net0(x)))
+
+        dev0 = 2 * self.rank
+        dev1 = 2 * self.rank + 1
+        mp_model = ModelParallelModel(dev0, dev1)
+        ddp_model = DDP(mp_model)
+        local_model = LocalModel()
+        cpu_device = torch.device("cpu")
+        # Ensure the parameters are the same across the two models
+        local_model.net0.weight = torch.nn.Parameter(mp_model.net0.weight.detach().clone().to(cpu_device))
+        local_model.net0.bias = torch.nn.Parameter(mp_model.net0.bias.detach().clone().to(cpu_device))
+        local_model.net1.weight = torch.nn.Parameter(mp_model.net1.weight.detach().clone().to(cpu_device))
+        local_model.net1.bias = torch.nn.Parameter(mp_model.net1.bias.detach().clone().to(cpu_device))
+
+        # Compare parity between DDP with model parallelism using ZeRO and
+        # a local model using a local optimizer
+        zero_optim = ZeroRedundancyOptimizer(
+            ddp_model.parameters(),
+            optimizer_class=torch.optim.Adam,
+            parameters_as_bucket_view=parameters_as_bucket_view,
+            lr=LR
+        )
+        local_optim = torch.optim.Adam(local_model.parameters(), lr=LR)
+        inputs = [torch.randn(20, 10) for _ in range(NUM_INPUTS)]
+
+        for _ in range(NUM_EPOCHS):
+            for input in inputs:
+                def closure_local():
+                    local_optim.zero_grad()
+                    local_loss = local_model(input).abs().sum()
+                    local_loss.backward()
+                    return local_loss
+
+                def closure_ddp():
+                    zero_optim.zero_grad()
+                    ddp_loss = ddp_model(input).abs().sum()
+                    ddp_loss.backward()
+                    return ddp_loss
+
+                local_loss = cast(torch.Tensor, local_optim.step(closure=closure_local))
+                ddp_loss = cast(torch.Tensor, zero_optim.step(closure=closure_ddp)).to(cpu_device)
+
+                assert torch.allclose(
+                    local_loss, ddp_loss
+                ), "Losses differ between local optim and ZeroRedundancyOptimizer"
+
+                for local_p, ddp_p in zip(local_model.parameters(), ddp_model.parameters()):
+                    ddp_p = ddp_p.to(cpu_device)
+                    assert torch.allclose(local_p, ddp_p), "Models differ after a step"
+
+    @common_distributed.skip_if_lt_x_gpu(4)
+    def test_zero_model_parallel(self):
+        """
+        Check that ZeRO works with model parallelism where layers are sharded
+        across devices.
+        """
+        if self.rank >= 2:
+            return
+        self.dist_init(self.rank, world_size=2)
+        for parameters_as_bucket_view in [False, True]:
+            self._test_zero_model_parallel(parameters_as_bucket_view)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -432,12 +432,13 @@ class ZeroRedundancyOptimizer(Optimizer):
         """
         handles = []
         if self.parameters_as_bucket_view:
-            for rank, bucket in enumerate(self._buckets):
-                global_rank = _get_global_rank(self.process_group, rank)
-                handles.append(
-                    dist.broadcast(tensor=bucket, src=global_rank,
-                                   group=self.process_group, async_op=True)
-                )
+            for dev_i_buckets in self._buckets:
+                for rank, bucket in enumerate(dev_i_buckets):
+                    global_rank = _get_global_rank(self.process_group, rank)
+                    handles.append(
+                        dist.broadcast(tensor=bucket, src=global_rank,
+                                       group=self.process_group, async_op=True)
+                    )
         else:
             for rank, param_groups in enumerate(self._partition_parameters()):
                 global_rank = _get_global_rank(self.process_group, rank)

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -179,9 +179,9 @@ class ZeroRedundancyOptimizer(Optimizer):
         >>> ddp(inputs).sum().backward()
         >>> opt.step()
 
-    .. note: Currently, ``ZeroRedundancyOptimizer`` requires that all of the
-        passed-in parameters are on the same device and that they are the same
-        dense type.
+    .. warning:
+        Currently, ``ZeroRedundancyOptimizer`` requires that all of the
+        passed-in parameters are the same dense type.
 
     .. warning: ZeroRedundancyOptimizer is experimental and subject to change.
 
@@ -199,7 +199,6 @@ class ZeroRedundancyOptimizer(Optimizer):
     ):
         # Perform type and assumption checks on the input parameters
         self._verify_and_init_params(params)
-        self._verify_same_param_device()
         self._verify_same_dense_param_type()
 
         # NOTE: The parent constructor uses `add_param_group()` which is
@@ -217,6 +216,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         self._param_to_index_cache: Dict[torch.Tensor, int] = {}
         self._partition_parameters_cache: List[List[Dict]] = []
         self._index_to_param_cache: List[torch.Tensor] = []
+        self._device_to_per_rank_params_cache: Dict[torch.device, List[List[torch.Tensor]]] = {}
 
         # Default device for collective communication and buckets
         self._default_device = self._all_params[0].device
@@ -232,7 +232,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
         self.parameters_as_bucket_view = parameters_as_bucket_view
         self._is_trainable_mask = self._get_is_trainable_mask()
-        self._buckets: List[torch.Tensor] = []
+        self._buckets: List[List[torch.Tensor]] = []
         self._build_param_buckets()
 
         # Optional consolidated optimizer state, only populated if this rank
@@ -249,6 +249,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         self._param_to_rank_cache.clear()
         self._index_to_param_cache.clear()
         self._param_to_index_cache.clear()
+        self._device_to_per_rank_params_cache.clear()
 
     def add_param_group(self, param_group: dict) -> None:
         r"""
@@ -385,7 +386,7 @@ class ZeroRedundancyOptimizer(Optimizer):
     @property
     def _param_to_rank(self) -> Dict[torch.Tensor, int]:
         r"""
-        Hash table mapping parameters to their assigned data parallel rank in
+        Dict mapping parameters to their assigned data parallel rank in
         the partition.
         """
         if len(self._param_to_rank_cache) == 0:
@@ -398,7 +399,7 @@ class ZeroRedundancyOptimizer(Optimizer):
     @property
     def _param_to_index(self) -> Dict[torch.Tensor, int]:
         r"""
-        Hash table mapping parameters to their indices in the global optimizer
+        Dict mapping parameters to their indices in the global optimizer
         state.
 
         NOTE: This assumes that the global optimizer state's indexing (in
@@ -411,7 +412,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         return self._param_to_index_cache
 
     @property
-    def _index_to_param(self) -> Dict[int, torch.Tensor]:
+    def _index_to_param(self) -> List[torch.Tensor]:
         r"""
         List mapping parameter indices in the global optimizer scheme to the
         actual params.
@@ -447,6 +448,32 @@ class ZeroRedundancyOptimizer(Optimizer):
                                            group=self.process_group, async_op=True)
                         )
         _ = list(map(lambda x: x.wait(), handles))
+
+    @property
+    def _device_to_per_rank_params(self) -> Dict[torch.device, List[List[torch.Tensor]]]:
+        r"""
+        Dict mapping device to a list of the per-rank parameter lists
+        containing the parameters stored on the device.
+
+        ``dev_0`` maps to a list containing:
+            rank 0's assigned parameters stored on ``dev_0``,
+            rank 1's assigned parameters stored on ``dev_0``,
+            ...
+        ``dev_1`` maps to a list containing:
+            rank 0's assigned parameters stored on ``dev_1``,
+            rank 1's assigned parameters stored on ``dev_1``,
+            ...
+        ...
+        """
+        if len(self._device_to_per_rank_params_cache) == 0:
+            for rank, param_groups in enumerate(self._partition_parameters()):
+                for param_group in param_groups:
+                    for param in param_group["params"]:
+                        device = param.device
+                        if device not in self._device_to_per_rank_params_cache:
+                            self._device_to_per_rank_params_cache[device] = [[] for _ in range(self.world_size)]
+                        self._device_to_per_rank_params_cache[device][rank].append(param)
+        return self._device_to_per_rank_params_cache
 
     def step(
         self,
@@ -601,32 +628,38 @@ class ZeroRedundancyOptimizer(Optimizer):
 
     def _build_param_buckets(self) -> None:
         r"""
-        Builds parameter buckets so that for each device that stores this
-        rank's parameters, there is a bucket (represented as a tensor)
-        containing all of the parameters on that device that are assigned to a
-        given rank, if ``parameters_as_bucket_view`` is enabled.
+        Builds parameter buckets if ``parameters_as_bucket_view`` is enabled so
+        that for each device that stores this rank's parameters, there is a
+        bucket (represented as a tensor) containing all of the parameters on
+        that device that are assigned to a given rank in the parameter update
+        partition.
 
         This function is called in the constructor and any time parameter
         trainability is changed.
 
-        NOTE: The current implementation assumes that each rank stores all of
-        its parameters (i.e. ``self._all_params``) on a single device. This
-        means that there should be exactly ``world_size``-many buckets.
+        .. warning::
+            The current implementation assumes that all of the parameters in a
+            bucket are of the same dense type when allocating the bucket's
+            tensor.
 
-        NOTE: The current implementation assumes that all of the parameters in
-        a bucket are of the same dense type when allocating the bucket's
-        tensor.
+        .. warning::
+            If the model parameters are stored across more than one device,
+            then the storage partitioning must be the same across all
+            processes in order for parameter synchronization to work.
         """
         if not self.parameters_as_bucket_view:
             return
-        for rank, param_groups in enumerate(self._partition_parameters()):
-            # Find the bucket size and dtype, compile the trainable
-            # parameters, and clone the non-trainable parameters
-            bucket_size = 0
-            dtype = None
-            trainable_params = []
-            for param_group in param_groups:
-                for param in param_group["params"]:
+
+        # Bucket B_{i,j}: parameters stored on dev_i assigned to rank j
+        num_devices = len(self._device_to_per_rank_params)
+        self._buckets = [[] for _ in range(num_devices)]
+
+        for dev_i, (device, param_lists) in enumerate(self._device_to_per_rank_params.items()):
+            for params in param_lists:
+                bucket_size = 0
+                dtype = None
+                trainable_params = []
+                for param in params:
                     if not _is_trainable(param):
                         # Clone in case the parameter was previously part of
                         # a bucket to avoid the data from being destroyed
@@ -635,26 +668,20 @@ class ZeroRedundancyOptimizer(Optimizer):
                         bucket_size += param.numel()
                         trainable_params.append(param)
                     dtype = param.dtype  # assumes all same dtype
-            device = self._default_device  # assumes all on single device
 
-            if bucket_size == 0:
-                # Create a dummy bucket if there are no parameters
-                bucket = torch.zeros(1, device=device)
-            else:
-                # Construct the bucket (assuming all dense and same dtype)
-                bucket = torch.empty(bucket_size, dtype=dtype, device=device)
-                offset = 0
-                for param in trainable_params:
-                    offset_next = offset + param.numel()
-                    bucket[offset:offset_next].copy_(param.data.flatten())
-                    param.data = bucket[offset:offset_next].view_as(param.data)
-                    offset = offset_next
-
-            # Either replace the existing bucket or create it
-            if len(self._buckets) != rank:
-                self._buckets[rank] = bucket
-            else:
-                self._buckets.append(bucket)
+                if bucket_size == 0:
+                    # Create a dummy bucket if there are no parameters
+                    bucket = torch.zeros(1, device=device)
+                else:
+                    # Construct the bucket (assuming all dense and same dtype)
+                    bucket = torch.empty(bucket_size, dtype=dtype, device=device)
+                    offset = 0
+                    for param in trainable_params:
+                        offset_next = offset + param.numel()
+                        bucket[offset:offset_next].copy_(param.data.flatten())
+                        param.data = bucket[offset:offset_next].view_as(param.data)
+                        offset = offset_next
+                self._buckets[dev_i].append(bucket)
 
     def _verify_and_init_params(self, params: Any) -> None:
         r"""
@@ -686,30 +713,6 @@ class ZeroRedundancyOptimizer(Optimizer):
                 raise TypeError("params argument should be an iterable of "
                                 "Tensors, but got an iterable containing "
                                 f"{torch.typename(param)}")
-
-    def _verify_same_param_device(self) -> None:
-        r"""
-        Verifies that ZeRO is being used under the single-process single-
-        device regime where a process operates exclusively on a full model
-        replica on a single device.
-
-        The function assumes that ``self._all_params`` has been initialized
-        and is non-empty.
-
-        Raises:
-            ValueError: ``params`` contains parameters across multiple
-                devices.
-
-        NOTE: This function can be removed once support for sharding a rank's
-        model parameters across multiple devices is added.
-        """
-        device = self._all_params[0].device
-        for param in self._all_params[1:]:
-            if param.device != device:
-                raise ValueError("ZeroRedundancyOptimizer assumes that each "
-                                 "rank's model parameters are on the same "
-                                 f"device but got both {device} and "
-                                 f"{param.device}")
 
     def _verify_same_dense_param_type(self) -> None:
         r"""

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -455,6 +455,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         Dict mapping device to a list of the per-rank parameter lists
         containing the parameters stored on the device.
 
+        Let ``dev_i`` denote the ``i``th device for this rank. Then:
         ``dev_0`` maps to a list containing:
             rank 0's assigned parameters stored on ``dev_0``,
             rank 1's assigned parameters stored on ``dev_0``,


### PR DESCRIPTION
**Overview:**
The existing `ZeroRedundancyOptimizer` implementation assumes that all model parameters are stored on the same device (due to the recent [refactor](https://github.com/pytorch/pytorch/pull/59834)). This change allows model parameters to be sharded across multiple devices, as in the DDP with Model Parallelism example [here](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).

The only logic affected is the bucketing strategy used when `parameters_as_bucket_view=True`. Let `n` denote the world size and `k` denote the number of devices per process.
- Previously, `k = 1`, and `self._buckets` was a `List[torch.Tensor]`, where `self._buckets[j]` is a tensor (i.e. bucket) containing the parameters assigned to rank `j` for `j = 0, ..., n - 1`.
- Now, `self._buckets` is a `List[List[torch.Tensor]]`, where `self._buckets[i][j]` is a tensor containing the parameters stored on device `i` assigned to rank `j` for `i = 0, ..., k - 1` and `j = 0, ..., n - 1`.

This bucket construction uses an auxiliary data structure `self._device_to_per_rank_params`, which is a `Dict[torch.device, List[List[torch.Tensor]]]`. It maps:
- `dev_0` to `[rank 0's assigned parameters on dev_0, rank 1's assigned parameters on dev_1, ...]`, 
- `...`
- `dev_{k-1}` to `[rank 0's assigned parameters on dev_{k-1}, rank 1's assigned parameters on dev_{k-1}, ...]`

I removed the invariant checker `_verify_same_param_device()` and its corresponding test since it is no longer an invariant.

**Test Plan:**
I added a new test `test_zero_model_parallel()` that checks for parity between a DDP model with model parallelism using `ZeroRedundancyOptimizer` and a local model with the same architecture using a local optimizer. I also verified that the existing tests still pass.
