### PR TITLE
[package] ensure we don't write files twice to the archive.

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -190,6 +190,8 @@ class PackageExporter:
 
         self.zip_file = torch._C.PyTorchFileWriter(f)
         self.zip_file.set_min_version(6)
+        self._written_files: Set[str] = set()
+
         self.serialized_reduces: Dict[int, Any] = {}
 
         # A graph tracking all the modules and pickle objects added to this
@@ -824,8 +826,15 @@ node [shape=box];
         self.close()
 
     def _write(self, filename, str_or_bytes):
+        if filename in self._written_files:
+            raise AssertionError(
+                f"Tried to write file '{filename}', but it already exists in this archive. "
+                "Please file a bug."
+            )
+        self._written_files.add(filename)
+
         if is_mangled(filename):
-            raise RuntimeError(
+            raise AssertionError(
                 f"Tried to save a torch.package'd module as '{filename}'. "
                 "Directly saving torch.package'd modules is not allowed."
             )

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -16,6 +16,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Union,
 )
 from urllib.parse import quote


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61371 [package] ensure we don't write files twice to the archive.**

The ZIP format allows for writing multiple files with the same name. But
this is handled poorly by most tooling (including our own), so doing so
produces weird behavior depending on the implementation of the ZIP
reader.

Since we have no valid use case for writing multiple files with the same
name to a `torch.package`, just ban it.

Differential Revision: [D29595518](https://our.internmc.facebook.com/intern/diff/D29595518)