### PR TITLE
[iOS GPU] Add tanh and clamp to support GAN

### DIFF
--- a/aten/src/ATen/native/metal/ops/MetalClamp.mm
+++ b/aten/src/ATen/native/metal/ops/MetalClamp.mm
@@ -29,8 +29,41 @@ Tensor& hardtanh_(Tensor& input, const Scalar& min_val, const Scalar& max_val) {
   return input;
 }
 
+Tensor hardtanh(
+    const Tensor& input,
+    const Scalar& min_val,
+    const Scalar& max_val) {
+  TORCH_CHECK(input.is_metal());
+  IntArrayRef outputSize = input.sizes();
+  if (input.numel() == 0) {
+    return makeTensor({outputSize.vec()}, input.options());
+  }
+  MetalTensorImplStorage mt{outputSize.vec()};
+  MetalCommandBuffer* commandBuffer = getCommandBuffer(input);
+  mt.texture()->allocateTemporaryStorage(outputSize, commandBuffer);
+  MPSImage* Y = mt.texture()->image();
+  float min = min_val.toFloat();
+  float max = max_val.toFloat();
+  MPSImage* X = imageFromTensor(input);
+  MPSCNNClampOp* clampOp = [MPSCNNClampOp newWithTextures:@[ X, Y ]
+                                                     Args:@[ @(min), @(max) ]];
+  [clampOp encode:commandBuffer.buffer];
+  auto output = makeTensor(std::move(mt), input.options());
+  return output;
+}
+
+at::Tensor clamp(
+    const at::Tensor& input,
+    const c10::optional<at::Scalar>& min,
+    const c10::optional<at::Scalar>& max) {
+  TORCH_CHECK(min.has_value() && max.has_value());
+  return hardtanh(input, min.value(), max.value());
+}
+
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl("hardtanh_", TORCH_FN(hardtanh_));
+  m.impl("hardtanh", TORCH_FN(hardtanh));
+  m.impl("clamp", TORCH_FN(clamp));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalNeurons.mm
+++ b/aten/src/ATen/native/metal/ops/MetalNeurons.mm
@@ -81,6 +81,7 @@ Tensor tanh(const Tensor& input) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
+  m.impl("tanh", tanh);
   m.impl("relu", TORCH_FN(relu));
   m.impl("relu_", TORCH_FN(relu_));
   m.impl("sigmoid", TORCH_FN(sigmoid));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61383**

Since we already have the support for hardtanh, it's easy to add support for clamp. GPU is 40% ish faster.

Differential Revision: [D29572933](https://our.internmc.facebook.com/intern/diff/D29572933/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29572933/)!