### PR TITLE
Force mypy colors in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -406,6 +406,7 @@ jobs:
       - name: Run mypy
         run: |
           set -eux
+          export MYPY_FORCE_COLOR=1
           STATUS=
           for CONFIG in mypy*.ini; do
             if ! mypy --config="$CONFIG"; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -404,12 +404,14 @@ jobs:
           time python -mtools.codegen.gen -s aten/src/ATen -d build/aten/src/ATen
           time python -mtools.pyi.gen_pyi --native-functions-path aten/src/ATen/native/native_functions.yaml --deprecated-functions-path "tools/autograd/deprecated.yaml"
       - name: Run mypy
+        env:
+          MYPY_FORCE_COLOR: 1
         run: |
           set -eux
           export MYPY_FORCE_COLOR=1
           STATUS=
           for CONFIG in mypy*.ini; do
-            if ! mypy --config="$CONFIG"; then
+            if ! mypy --config="$CONFIG" --color-output; then
               STATUS=fail
             fi
           done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -406,9 +406,11 @@ jobs:
       - name: Run mypy
         env:
           MYPY_FORCE_COLOR: 1
+          TERM: xterm-color
         run: |
           set -eux
           export MYPY_FORCE_COLOR=1
+          export TERM=xterm-color
           STATUS=
           for CONFIG in mypy*.ini; do
             if ! mypy --config="$CONFIG" --color-output; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -409,11 +409,9 @@ jobs:
           TERM: xterm-color
         run: |
           set -eux
-          export MYPY_FORCE_COLOR=1
-          export TERM=xterm-color
           STATUS=
           for CONFIG in mypy*.ini; do
-            if ! mypy --config="$CONFIG" --color-output; then
+            if ! mypy --config="$CONFIG"; then
               STATUS=fail
             fi
           done

--- a/tools/linter/mypy_wrapper.py
+++ b/tools/linter/mypy_wrapper.py
@@ -152,6 +152,7 @@ def run(
             args + [
                 # don't special-case the last line
                 '--no-error-summary',
+                '--color-output',
                 f'--config-file={config}',
             ] + filtered
         )

--- a/tools/linter/mypy_wrapper.py
+++ b/tools/linter/mypy_wrapper.py
@@ -152,7 +152,6 @@ def run(
             args + [
                 # don't special-case the last line
                 '--no-error-summary',
-                '--color-output',
                 f'--config-file={config}',
             ] + filtered
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61392
* **#61391**

Both the [GitHub Actions log viewer](https://github.community/t/ansi-color-output-in-webview/17621) and the HUD PR page log viewer support ANSI color codes so turn those on via this [secret env variable](https://github.com/python/mypy/issues/7771)

Differential Revision: [D29602686](https://our.internmc.facebook.com/intern/diff/D29602686)