### PR TITLE
Bug  of hipify 

### DIFF
--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -481,8 +481,11 @@ def get_hip_file_path(filepath):
     dirpath = dirpath.replace('cuda', 'hip')
     dirpath = dirpath.replace('THC', 'THH')
 
-    root = root.replace('cuda', 'hip')
-    root = root.replace('CUDA', 'HIP')
+    if ext == '.cuh' or ext == '.hpp':
+        root = root
+    else:
+        root = root.replace('cuda', 'hip')
+        root = root.replace('CUDA', 'HIP')
     # Special case to handle caffe2/core/THCCachingAllocator
     if dirpath != "caffe2/core":
         root = root.replace('THC', 'THH')


### PR DESCRIPTION
if *.cuh name have cuda then source code file which call this,could not take effect ,due to could not find it

Fixes #{issue number}
