### PR TITLE
Simplify lambda syntax in SegmentReduce.cpp

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -9,6 +9,7 @@ namespace native {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(_segment_reduce_stub);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(_segment_reduce_backward_stub);
 
 namespace {
@@ -27,6 +28,76 @@ SegmentReductionType get_reduction_enum(const c10::string_view& reduce) {
   }
 }
 
+template <typename T>
+void _segment_reduce_cpu_kernel1(
+    SegmentReductionType reduction,
+    const Tensor& data,
+    const T* lengths_data,
+    int64_t axis,
+    const c10::optional<Scalar>& initial,
+    Tensor& output,
+    int64_t segment_count) {
+  int64_t stride_count = data.numel() / data.size(axis);
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kBFloat16, kHalf, data.scalar_type(), "_segment_reduce_cpu", [&]() {
+        auto* output_data = output.data_ptr<scalar_t>();
+        const auto* values_data = data.data_ptr<scalar_t>();
+        int64_t lengths_cum_sum = 0;
+        for (int64_t i = 0; i < segment_count; ++i) {
+          for (int64_t l = 0; l < stride_count; ++l) {
+            // ===== step1: initialize starting value
+            scalar_t initial_value;
+            if (initial.has_value()) {
+              initial_value = initial.value().to<scalar_t>();
+            } else if (reduction == SegmentReductionType::MAX) {
+              initial_value = -std::numeric_limits<scalar_t>::infinity();
+            } else if (
+                reduction == SegmentReductionType::MEAN ||
+                reduction == SegmentReductionType::SUM) {
+              initial_value = 0;
+            } else if (reduction == SegmentReductionType::MIN) {
+              initial_value = std::numeric_limits<scalar_t>::infinity();
+            }
+
+            // ===== step2: apply reduction
+            for (int64_t j = 0; j < lengths_data[i]; ++j) {
+              int64_t starting_index =
+                  ((lengths_cum_sum + j) * stride_count) + l;
+              const auto data = values_data[starting_index];
+              // TODO: There is no need to branch with every element
+              if (reduction == SegmentReductionType::MAX) {
+                initial_value = at::_isnan(data)
+                    ? data
+                    : std::max<scalar_t>(initial_value, data);
+              } else if (
+                  reduction == SegmentReductionType::MEAN ||
+                  reduction == SegmentReductionType::SUM) {
+                initial_value = initial_value + data;
+              } else if (reduction == SegmentReductionType::MIN) {
+                initial_value = at::_isnan(data)
+                    ? data
+                    : std::min<scalar_t>(initial_value, data);
+              }
+            }
+
+            // ===== step3: finalize reduction
+            TORCH_CHECK(lengths_data[i] >= 0);
+
+            if (lengths_data[i] == 0 && !initial.has_value() &&
+                reduction == SegmentReductionType::MEAN) {
+              initial_value = static_cast<scalar_t>(NAN);
+            } else if (
+                reduction == SegmentReductionType::MEAN &&
+                lengths_data[i] > 0 && !at::_isnan(initial_value)) {
+              initial_value = initial_value / lengths_data[i];
+            }
+            int64_t output_index = (i * stride_count) + l;
+            output_data[output_index] = initial_value;
+          }
+          lengths_cum_sum += lengths_data[i];
+        }
+      });
+}
 Tensor _segment_reduce_cpu_kernel(
     SegmentReductionType reduction,
     const Tensor& data,
@@ -38,77 +109,93 @@ Tensor _segment_reduce_cpu_kernel(
   output_shape[axis] = segment_count;
   auto output = at::empty(output_shape, data.options());
 
-  int64_t stride_count = data.numel() / data.size(axis);
-
-  AT_DISPATCH_INDEX_TYPES(
-      lengths.type(), "_segment_reduce_cpu_kernel1", [&]() {
-        const auto* lengths_data = lengths.data_ptr<index_t>();
-        AT_DISPATCH_FLOATING_TYPES_AND2(
-            kBFloat16,
-            kHalf,
-            data.scalar_type(),
-            "_segment_reduce_cpu",
-            [&]() {
-              auto* output_data = output.data_ptr<scalar_t>();
-              const auto* values_data = data.data_ptr<scalar_t>();
-              int64_t lengths_cum_sum = 0;
-              for (int64_t i = 0; i < segment_count; ++i) {
-                for (int64_t l = 0; l < stride_count; ++l) {
-                  // ===== step1: initialize starting value
-                  scalar_t initial_value;
-                  if (initial.has_value()) {
-                    initial_value = initial.value().to<scalar_t>();
-                  } else if (reduction == SegmentReductionType::MAX) {
-                    initial_value = -std::numeric_limits<scalar_t>::infinity();
-                  } else if (
-                      reduction == SegmentReductionType::MEAN ||
-                      reduction == SegmentReductionType::SUM) {
-                    initial_value = 0;
-                  } else if (reduction == SegmentReductionType::MIN) {
-                    initial_value = std::numeric_limits<scalar_t>::infinity();
-                  }
-
-                  // ===== step2: apply reduction
-                  for (int64_t j = 0; j < lengths_data[i]; ++j) {
-                    int64_t starting_index =
-                        ((lengths_cum_sum + j) * stride_count) + l;
-                    const auto data = values_data[starting_index];
-                    // TODO: There is no need to branch with every element
-                    if (reduction == SegmentReductionType::MAX) {
-                      initial_value = at::_isnan(data)
-                          ? data
-                          : std::max<scalar_t>(initial_value, data);
-                    } else if (
-                        reduction == SegmentReductionType::MEAN ||
-                        reduction == SegmentReductionType::SUM) {
-                      initial_value = initial_value + data;
-                    } else if (reduction == SegmentReductionType::MIN) {
-                      initial_value = at::_isnan(data)
-                          ? data
-                          : std::min<scalar_t>(initial_value, data);
-                    }
-                  }
-
-                  // ===== step3: finalize reduction
-                  TORCH_CHECK(lengths_data[i] >= 0);
-
-                  if (lengths_data[i] == 0 && !initial.has_value() &&
-                      reduction == SegmentReductionType::MEAN) {
-                    initial_value = static_cast<scalar_t>(NAN);
-                  } else if (
-                      reduction == SegmentReductionType::MEAN &&
-                      lengths_data[i] > 0 && !at::_isnan(initial_value)) {
-                    initial_value = initial_value / lengths_data[i];
-                  }
-                  int64_t output_index = (i * stride_count) + l;
-                  output_data[output_index] = initial_value;
-                }
-                lengths_cum_sum += lengths_data[i];
-              }
-            });
-      });
+  AT_DISPATCH_INDEX_TYPES(lengths.type(), "_segment_reduce_cpu_kernel1", [&]() {
+    const auto* lengths_data = lengths.data_ptr<index_t>();
+    _segment_reduce_cpu_kernel1(
+        reduction, data, lengths_data, axis, initial, output, segment_count);
+  });
 
   return output;
+}
+
+template <typename T>
+void _segment_reduce_cpu_backward_kernel1(
+    const Tensor& grad_contig,
+    const Tensor& output_contig,
+    const Tensor& data_contig,
+    SegmentReductionType reduction,
+    const T* lengths_data,
+    int64_t axis,
+    Tensor& grad_input,
+    int64_t segment_count) {
+  int64_t stride_count = data_contig.numel() / data_contig.size(axis);
+  // TODO: Swtich to TensorIterator for better maintainablility and
+  // readability
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kBFloat16,
+      kHalf,
+      data_contig.scalar_type(),
+      "_segment_reduce_cpu",
+      [&]() {
+        auto* output_data = output_contig.data_ptr<scalar_t>();
+        auto* grad_data = grad_contig.data_ptr<scalar_t>();
+        auto* grad_input_data = grad_input.data_ptr<scalar_t>();
+        const auto* values_data = data_contig.data_ptr<scalar_t>();
+
+        int64_t lengths_cum_sum = 0;
+        for (int64_t i = 0; i < segment_count; ++i) {
+          if (lengths_data[i] == 0) {
+            continue;
+          }
+
+          for (int64_t l = 0; l < stride_count; ++l) {
+            int64_t output_index = (i * stride_count) + l;
+
+            if (reduction == SegmentReductionType::MAX ||
+                reduction == SegmentReductionType::MIN) {
+              int64_t counter = 0;
+              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+                int64_t starting_index =
+                    ((lengths_cum_sum + j) * stride_count) + l;
+                if (at::_isnan(values_data[starting_index]) ||
+                    values_data[starting_index] == output_data[output_index]) {
+                  grad_input_data[starting_index] = grad_data[output_index];
+                  counter++;
+                }
+              }
+              // Average gradient based on number of maximum elements in
+              // the segment
+              if (counter < 2) {
+                continue;
+              }
+              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+                int64_t starting_index =
+                    ((lengths_cum_sum + j) * stride_count) + l;
+                if (grad_input_data[starting_index] > 0) {
+                  grad_input_data[starting_index] =
+                      grad_input_data[starting_index] / counter;
+                }
+              }
+            } else if (reduction == SegmentReductionType::MEAN) {
+              auto grad_val = grad_data[output_index] / lengths_data[i];
+              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+                int64_t starting_index =
+                    ((lengths_cum_sum + j) * stride_count) + l;
+                grad_input_data[starting_index] = grad_val;
+              }
+            } else if (reduction == SegmentReductionType::SUM) {
+              const auto& grad_val = grad_data[output_index];
+              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+                int64_t starting_index =
+                    ((lengths_cum_sum + j) * stride_count) + l;
+                grad_input_data[starting_index] = grad_val;
+              }
+            }
+          }
+
+          lengths_cum_sum += lengths_data[i];
+        }
+      });
 }
 
 Tensor _segment_reduce_cpu_backward_kernel(
@@ -123,83 +210,19 @@ Tensor _segment_reduce_cpu_backward_kernel(
   output_shape[axis] = segment_count;
   auto grad_input = at::zeros({data_contig.sizes()}, grad_contig.options());
 
-  int64_t stride_count = data_contig.numel() / data_contig.size(axis);
-
   AT_DISPATCH_INDEX_TYPES(
-      lengths_contig.type(),
-      "_segment_reduce_cpu_backward_kernel1",
-      ([&] {
+      lengths_contig.type(), "_segment_reduce_cpu_backward_kernel1", [&]() {
         const auto* lengths_data = lengths_contig.data_ptr<index_t>();
-        // TODO: Swtich to TensorIterator for better maintainablility and
-        // readability
-        AT_DISPATCH_FLOATING_TYPES_AND2(
-            kBFloat16,
-            kHalf,
-            data_contig.scalar_type(),
-            "_segment_reduce_cpu",
-            ([&]() {
-              auto* output_data = output_contig.data_ptr<scalar_t>();
-              auto* grad_data = grad_contig.data_ptr<scalar_t>();
-              auto* grad_input_data = grad_input.data_ptr<scalar_t>();
-              const auto* values_data = data_contig.data_ptr<scalar_t>();
-
-              int64_t lengths_cum_sum = 0;
-              for (int64_t i = 0; i < segment_count; ++i) {
-                if (lengths_data[i] == 0) {
-                  continue;
-                }
-
-                for (int64_t l = 0; l < stride_count; ++l) {
-                  int64_t output_index = (i * stride_count) + l;
-
-                  if (reduction == SegmentReductionType::MAX ||
-                      reduction == SegmentReductionType::MIN) {
-                    int64_t counter = 0;
-                    for (int64_t j = 0; j < lengths_data[i]; ++j) {
-                      int64_t starting_index =
-                          ((lengths_cum_sum + j) * stride_count) + l;
-                      if (at::_isnan(values_data[starting_index]) ||
-                          values_data[starting_index] ==
-                              output_data[output_index]) {
-                        grad_input_data[starting_index] =
-                            grad_data[output_index];
-                        counter++;
-                      }
-                    }
-                    // Average gradient based on number of maximum elements in
-                    // the segment
-                    if (counter < 2) {
-                      continue;
-                    }
-                    for (int64_t j = 0; j < lengths_data[i]; ++j) {
-                      int64_t starting_index =
-                          ((lengths_cum_sum + j) * stride_count) + l;
-                      if (grad_input_data[starting_index] > 0) {
-                        grad_input_data[starting_index] =
-                            grad_input_data[starting_index] / counter;
-                      }
-                    }
-                  } else if (reduction == SegmentReductionType::MEAN) {
-                    auto grad_val = grad_data[output_index] / lengths_data[i];
-                    for (int64_t j = 0; j < lengths_data[i]; ++j) {
-                      int64_t starting_index =
-                          ((lengths_cum_sum + j) * stride_count) + l;
-                      grad_input_data[starting_index] = grad_val;
-                    }
-                  } else if (reduction == SegmentReductionType::SUM) {
-                    const auto& grad_val = grad_data[output_index];
-                    for (int64_t j = 0; j < lengths_data[i]; ++j) {
-                      int64_t starting_index =
-                          ((lengths_cum_sum + j) * stride_count) + l;
-                      grad_input_data[starting_index] = grad_val;
-                    }
-                  }
-                }
-
-                lengths_cum_sum += lengths_data[i];
-              }
-            }));
-      }));
+        _segment_reduce_cpu_backward_kernel1(
+            grad_contig,
+            output_contig,
+            data_contig,
+            reduction,
+            lengths_data,
+            axis,
+            grad_input,
+            segment_count);
+      });
 
   return grad_input;
 }
@@ -255,9 +278,10 @@ REGISTER_ARCH_DISPATCH(
 REGISTER_AVX_DISPATCH(_segment_reduce_stub, &_segment_reduce_cpu_kernel);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_AVX2_DISPATCH(_segment_reduce_stub, &_segment_reduce_cpu_kernel);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_VSX_DISPATCH(_segment_reduce_stub, &_segment_reduce_cpu_kernel);
 
-// Currently some computation is beind duplicated across forward and backward.
+// Currently some computation is being duplicated across forward and backward.
 // TODO: Cache indices in forward pass to re-use in backward
 Tensor _segment_reduce_backward_kernel(
     const Tensor& grad,
@@ -291,11 +315,14 @@ Tensor _segment_reduce_backward_kernel(
 
 REGISTER_ARCH_DISPATCH(
     _segment_reduce_backward_stub,
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     DEFAULT,
     &_segment_reduce_cpu_backward_kernel);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_AVX_DISPATCH(
     _segment_reduce_backward_stub,
     &_segment_reduce_cpu_backward_kernel);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_AVX2_DISPATCH(
     _segment_reduce_backward_stub,
     &_segment_reduce_cpu_backward_kernel);

--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -41,14 +41,14 @@ Tensor _segment_reduce_cpu_kernel(
   int64_t stride_count = data.numel() / data.size(axis);
 
   AT_DISPATCH_INDEX_TYPES(
-      lengths.type(), "_segment_reduce_cpu_kernel1", ([&] {
+      lengths.type(), "_segment_reduce_cpu_kernel1", [&]() {
         const auto* lengths_data = lengths.data_ptr<index_t>();
         AT_DISPATCH_FLOATING_TYPES_AND2(
             kBFloat16,
             kHalf,
             data.scalar_type(),
             "_segment_reduce_cpu",
-            ([&]() {
+            [&]() {
               auto* output_data = output.data_ptr<scalar_t>();
               const auto* values_data = data.data_ptr<scalar_t>();
               int64_t lengths_cum_sum = 0;
@@ -105,8 +105,8 @@ Tensor _segment_reduce_cpu_kernel(
                 }
                 lengths_cum_sum += lengths_data[i];
               }
-            }));
-      }));
+            });
+      });
 
   return output;
 }


### PR DESCRIPTION
Fixes Windows build by dismantling a combination nested lambdas+preprocessor magic into explicit templates