### PR TITLE
[quant][fix] Removes spewy warning for reduce_range usage

### DIFF
--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -451,7 +451,7 @@ class TestFakeQuantizeOps(TestCase):
     def test_fq_serializable_per_tensor(self):
         observer = default_observer
         quant_min = 0
-        quant_max = 255
+        quant_max = 127
         for FakeQuantizeClass in [FakeQuantize, _LearnableFakeQuantize]:
             fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
             X = torch.tensor([-5, -3.5, -2, 0, 3, 5, 7], dtype=torch.float32)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -829,6 +829,8 @@ class HistogramObserver(_ObserverBase):
         dtype: torch.dtype = torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
+        quant_min=None,
+        quant_max=None,
         factory_kwargs=None,
     ) -> None:
         # bins: The number of bins used for histogram calculation.
@@ -836,6 +838,8 @@ class HistogramObserver(_ObserverBase):
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
+            quant_min=quant_min,
+            quant_max=quant_max,
             factory_kwargs=factory_kwargs,
         )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
@@ -1333,13 +1337,13 @@ def load_observer_state_dict(mod, obs_dict):
 
 
 # Restrict activations to be in the range (0,127)
-default_observer = MinMaxObserver.with_args(reduce_range=True)
+default_observer = MinMaxObserver.with_args(quant_min=0, quant_max=127)
 default_placeholder_observer = PlaceholderObserver
 default_debug_observer = RecordingObserver
 default_weight_observer = MinMaxObserver.with_args(
     dtype=torch.qint8, qscheme=torch.per_tensor_symmetric
 )
-default_histogram_observer = HistogramObserver.with_args(reduce_range=True)
+default_histogram_observer = HistogramObserver.with_args(quant_min=0, quant_max=127)
 default_per_channel_weight_observer = PerChannelMinMaxObserver.with_args(
     dtype=torch.qint8, qscheme=torch.per_channel_symmetric
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61419**

Summary: Addresses #61054. The issue stemmed from `torch.quantization.default_qconfig` setting
`reduce_range=True` which caused the error message "UserWarning: Please use quant_min and quant_max to specify the range for observers".

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: