### PR TITLE
[package] minor cleanups to internal APIs

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -433,8 +433,6 @@ node [shape=box];
     def add_dependency(self, module_name: str, dependencies=True):
         """Given a module, add it to the dependency graph according to patterns
         specified by the user.
-
-        This method can be overriden to customize handling of dependencies.
         """
         if (
             module_name in self.dependency_graph


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61434
* **#61428**

I was reading this code again after a while and didn't understand as
quickly as I would have liked. Some of the function names are no longer
accurate, etc.

This PR renames these functions to be in the same language of
"dependencies" that the rest of the API uses. I think the resulting
usage of the APIs is more clear than before

Differential Revision: [D29620946](https://our.internmc.facebook.com/intern/diff/D29620946)