### PR TITLE
Delete dead code in Tensor::to implementation

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -72,7 +72,7 @@ Tensor to(
       .layout(layout)
       .device(device)
       .pinned_memory(pin_memory)
-      .merge_memory_format(optional_memory_format);
+      .memory_format(optional_memory_format);
 
   TORCH_CHECK(!options.has_layout() || self.layout() == options.layout(),
            "to(options) doesn't support converting to a different layout, "

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -67,18 +67,12 @@ Tensor to(
   bool copy,
   c10::optional<c10::MemoryFormat> optional_memory_format
 ) {
-  // See [Note: hacky wrapper removal for TensorOptions]
-  TensorOptions options_ = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
-
-  TORCH_CHECK(
-    !(options_.has_memory_format() && optional_memory_format.has_value()),
-    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
-    "the redundant setter.");
-  auto options = options_.merge_memory_format(optional_memory_format);
-
-  TORCH_CHECK(options.requires_grad_opt() == c10::nullopt,
-           "to(options) expects unset requires_grad flag, but got "
-           "options.requires_grad set as ", options.requires_grad());
+  TensorOptions options = TensorOptions()
+      .dtype(dtype)
+      .layout(layout)
+      .device(device)
+      .pinned_memory(pin_memory)
+      .merge_memory_format(optional_memory_format);
 
   TORCH_CHECK(!options.has_layout() || self.layout() == options.layout(),
            "to(options) doesn't support converting to a different layout, "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61458 [WIP] Refactor Tensor::to
* **#61435 Delete dead code in Tensor::to implementation**

Deleted the following:
- I couldn't find the NOTE mentioned so I deleted the reference to it
- The memory_format check (because it always passes)
- The requires_grad check (because it always passes)

Test Plan:
- run tests

Differential Revision: [D29636872](https://our.internmc.facebook.com/intern/diff/D29636872)