### PR TITLE
reduce max_num_threads for complex double ops in reduce_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -68,7 +68,6 @@ struct mnt_wrapper <c10::complex<double>>{
 };
 
 struct ReduceConfig {
-
   static constexpr int BLOCK_X = 0;
   static constexpr int BLOCK_Y = 1;
   static constexpr int CTA = 2;
@@ -79,7 +78,8 @@ struct ReduceConfig {
     : element_size_bytes(element_size_bytes)
     , num_inputs(num_inputs)
     , num_outputs(num_outputs) {}
-  int element_size_bytes;
+  
+	int element_size_bytes;
   int num_inputs;
   int num_outputs;
   int step_input = 1;
@@ -1035,7 +1035,7 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
   }
 
   // Adjust block_width and block_height
-	config.set_block_dimension<scalar_t>(dim0, dim1);
+  config.set_block_dimension<scalar_t>(dim0, dim1);
 
   int block_width = config.block_width;
   int block_height = config.block_height;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -56,12 +56,22 @@ C10_HOST_DEVICE static void reduce_fraction(size_t &numerator, size_t &denominat
   denominator /= a;
 }
 
+//template for changing MAX_NUM_THREADS based on op dtype
+template <typename T> 
+struct mnt_wrapper {
+  static constexpr int MAX_NUM_THREADS = 512;
+};
+
+template <>
+struct mnt_wrapper <c10::complex<double>>{
+  static constexpr int MAX_NUM_THREADS = 256;
+};
+
 struct ReduceConfig {
   static constexpr int BLOCK_X = 0;
   static constexpr int BLOCK_Y = 1;
   static constexpr int CTA = 2;
 
-  static constexpr int MAX_NUM_THREADS = 512;
   static constexpr int input_vec_size = 4;
 
   ReduceConfig(int element_size_bytes, int num_outputs, int num_inputs)
@@ -85,9 +95,9 @@ struct ReduceConfig {
   bool vectorize_input = false;
   int output_vec_size = 1;
 
-  void set_block_dimension(int64_t dim0, int64_t dim1, bool is_complex_double=false) {
-    //const int max_num_threads = MAX_NUM_THREADS / output_vec_size;
-    const int max_num_threads = is_complex_double ? MAX_NUM_THREADS / (output_vec_size * 2) : MAX_NUM_THREADS / output_vec_size;
+  template <typename T>
+  void set_block_dimension(int64_t dim0, int64_t dim1) {
+    const int max_num_threads = mnt_wrapper<T>::MAX_NUM_THREADS / output_vec_size;
     
     int dim0_pow2 = dim0 < max_num_threads ? static_cast<int>(last_pow2(dim0)) : max_num_threads;
     int dim1_pow2 = dim1 < max_num_threads ? static_cast<int>(last_pow2(dim1)) : max_num_threads;
@@ -202,6 +212,7 @@ struct ReduceConfig {
     return div_up(num_inputs, step_input);
   }
 };
+
 
 std::ostream& operator<<(std::ostream& out, const ReduceConfig& config);
 
@@ -1025,11 +1036,9 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
     }
   }
 
-  bool is_complex_double = (std::is_same<scalar_t, c10::complex<double>>::value);
 
   // Adjust block_width and block_height
-  //config.set_block_dimension(dim0, dim1);
-  config.set_block_dimension(dim0, dim1, is_complex_double);
+  config.set_block_dimension<scalar_t>(dim0, dim1);
 
   int block_width = config.block_width;
   int block_height = config.block_height;
@@ -1110,13 +1119,8 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
   reduce.accumulate = iter.should_accumulate();
   reduce.final_output = iter.is_final_output();
 
-  //launch_reduce_kernel<ReduceConfig::MAX_NUM_THREADS>(config, reduce);
+  launch_reduce_kernel<mnt_wrapper<scalar_t>::MAX_NUM_THREADS>(config, reduce);
    
-  if (is_complex_double) {
-    launch_reduce_kernel<ReduceConfig::MAX_NUM_THREADS / 2>(config, reduce);
-  } else {
-    launch_reduce_kernel<ReduceConfig::MAX_NUM_THREADS>(config, reduce);
-  }
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -78,7 +78,6 @@ struct ReduceConfig {
     : element_size_bytes(element_size_bytes)
     , num_inputs(num_inputs)
     , num_outputs(num_outputs) {}
-  
   int element_size_bytes;
   int num_inputs;
   int num_outputs;
@@ -98,7 +97,6 @@ struct ReduceConfig {
   template <typename T>
   void set_block_dimension(int64_t dim0, int64_t dim1) {
     const int max_num_threads = mnt_wrapper<T>::MAX_NUM_THREADS / output_vec_size;
-    
     int dim0_pow2 = dim0 < max_num_threads ? static_cast<int>(last_pow2(dim0)) : max_num_threads;
     int dim1_pow2 = dim1 < max_num_threads ? static_cast<int>(last_pow2(dim1)) : max_num_threads;
     block_width = std::min(dim0_pow2, int(at::cuda::warp_size()));
@@ -1036,10 +1034,8 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
     }
   }
 
-
   // Adjust block_width and block_height
   config.set_block_dimension<scalar_t>(dim0, dim1);
-
   int block_width = config.block_width;
   int block_height = config.block_height;
 
@@ -1120,7 +1116,6 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
   reduce.final_output = iter.is_final_output();
 
   launch_reduce_kernel<mnt_wrapper<scalar_t>::MAX_NUM_THREADS>(config, reduce);
-   
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -78,7 +78,6 @@ struct ReduceConfig {
     : element_size_bytes(element_size_bytes)
     , num_inputs(num_inputs)
     , num_outputs(num_outputs) {}
-  
 	int element_size_bytes;
   int num_inputs;
   int num_outputs;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -78,7 +78,7 @@ struct ReduceConfig {
     : element_size_bytes(element_size_bytes)
     , num_inputs(num_inputs)
     , num_outputs(num_outputs) {}
-	int element_size_bytes;
+  int element_size_bytes;
   int num_inputs;
   int num_outputs;
   int step_input = 1;

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -68,6 +68,7 @@ struct mnt_wrapper <c10::complex<double>>{
 };
 
 struct ReduceConfig {
+
   static constexpr int BLOCK_X = 0;
   static constexpr int BLOCK_Y = 1;
   static constexpr int CTA = 2;
@@ -1034,9 +1035,9 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
   }
 
   // Adjust block_width and block_height
-  config.set_block_dimension<scalar_t>(dim0, dim1);
-  
-	int block_width = config.block_width;
+	config.set_block_dimension<scalar_t>(dim0, dim1);
+
+  int block_width = config.block_width;
   int block_height = config.block_height;
 
   if (iter.ndim() == 0 || reduction_on_fastest_striding_dimension) {

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -211,7 +211,6 @@ struct ReduceConfig {
   }
 };
 
-
 std::ostream& operator<<(std::ostream& out, const ReduceConfig& config);
 
 template<int nt, int output_vec_size, typename R>
@@ -1036,7 +1035,8 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
 
   // Adjust block_width and block_height
   config.set_block_dimension<scalar_t>(dim0, dim1);
-  int block_width = config.block_width;
+  
+	int block_width = config.block_width;
   int block_height = config.block_height;
 
   if (iter.ndim() == 0 || reduction_on_fastest_striding_dimension) {


### PR DESCRIPTION
reduce_kernel currently has a all-purpose MAX_NUM_THREADS of 512, which causes register spilling in various kernel instantiations for the various ops that use it as a template (ReduceLogicKernel, ReduceMinMaxKernel, ReduceMomentKernel, ReduceNormKernel, and ReduceSumProdKernel). This is a coarse first attempt at mitigating spillage by reducing max_num_threads to 256 for all complex double ops, which are by far the most common and egregious offenders, while keeping it 512 for the other normal ops, the large majority of which are fine. Besides complex double ops, the remaining kernels which exhibit lmem usage are ReduceMinMax double, long, and BFloat16; ReduceMomentKernel BFloat16, Half, float, and double; and ReduceNorm double.

The proposed fix manages to eliminate lmem usage and massively improve runtime (by 3-5x) for complex double ops. All other ops are unaffected and have the same runtime; if they used lmem before, they still do now. We would still strongly recommend further testing of input shapes and ops as well as looking into if there's a cleaner approach to doing this.

We tested the following ops for both complex double instantiations, as well as testing torch.max and torch.argmax with doubles to make sure they didn't break. We didn't include the double instantiations in the timing data, since they remain unchanged post-fix vs pre-fix. Timing data for the complex double ops below (all done on Nvidia Titan-V GPU):

torch.mean: 
![MeanTimingData](https://user-images.githubusercontent.com/22803332/125005623-0f424800-e011-11eb-864e-8419485a9c76.PNG)

torch.linalg.norm:
![NormTimingData](https://user-images.githubusercontent.com/22803332/125005649-179a8300-e011-11eb-96e1-54e18c85a336.PNG)

torch.sum:
![SumTimingData](https://user-images.githubusercontent.com/22803332/125005655-1b2e0a00-e011-11eb-928e-ee5941608fb2.PNG)
