### PR TITLE
[fx] fix subgraph API call_module warning about no owning module

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2255,8 +2255,10 @@ class TestFX(JitTestCase):
 
         conv = [n for n in a.graph.nodes if n.target == "net_b.net_c.conv"][-1]
         with a.graph.inserting_before(conv):
-            dropout = a.graph.call_module(module_name="net_b.net_c.dropout",
-                                          args=conv.args)
+            with warnings.catch_warnings(record=True) as w:
+                dropout = a.graph.call_module(module_name="net_b.net_c.dropout",
+                                              args=conv.args)
+                self.assertEqual(len(w), 0)
 
         conv.replace_all_uses_with(dropout)
         a.graph.erase_node(conv)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -603,7 +603,7 @@ class Graph:
             as :meth:`Graph.create_node`.
         """
         if (self.owning_module and
-                self.owning_module.get_submodule(module_name) is not None):
+                self.owning_module.get_submodule(module_name) is None):
             warnings.warn("Attempted to insert a call_module Node with "
                           "no underlying reference in the owning "
                           "GraphModule! Call "


### PR DESCRIPTION
Summary: seems like a small oversight(?), current test fails when warnings are recorded. discovered this when calling `graph.call_module(existing_call_module_node.target)` and it raised a warning

Test Plan: `buck test //caffe2/test:fx`

Differential Revision: D29637799

