### PR TITLE
[package] error if we try to mock a module in 3.6

### DIFF
--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -130,6 +130,15 @@ class TestDependencyAPI(PackageTestCase):
         with self.assertRaisesRegex(NotImplementedError, "was mocked out"):
             r()
 
+    @skipIf(version_info > (3, 6), "tests specific 3.6 behavior")
+    def test_mock_36_error(self):
+        """Test that an error is properly thrown when we attempt to mock a
+        module in Python 3.6.
+        """
+        with self.assertRaisesRegex(RuntimeError, "upgrade your Python"):
+            with PackageExporter(BytesIO()) as exporter:
+                exporter.mock(["package_a"])
+
     @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_mock_glob(self):
         buffer = BytesIO()

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -8,6 +8,7 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from sys import version_info
 from typing import (
     Any,
     BinaryIO,
@@ -706,6 +707,11 @@ class PackageExporter:
                 If ``allow_empty=True``, no such exception is thrown.
 
         """
+        if version_info < (3, 6):
+            raise RuntimeError(
+                "Python 3.7 or higher is required to mock out modules. "
+                "Please upgrade your Python version."
+            )
         self.patterns[GlobGroup(include, exclude=exclude)] = _PatternInfo(
             _ModuleProviderAction.MOCK, allow_empty
         )

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -707,7 +707,7 @@ class PackageExporter:
                 If ``allow_empty=True``, no such exception is thrown.
 
         """
-        if version_info < (3, 6):
+        if version_info < (3, 7):
             raise RuntimeError(
                 "Python 3.7 or higher is required to mock out modules. "
                 "Please upgrade your Python version."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61469**

This feature is not supported, error out early.

Differential Revision: [D29639797](https://our.internmc.facebook.com/intern/diff/D29639797)