### PR TITLE
[ONNX] Support lstm_cell symbolic

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3724,6 +3724,22 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(LSTMModel(), (input, h0, c0))
 
     @skipIfUnsupportedMinOpsetVersion(9)
+    def test_lstm_cell(self):
+        class LSTMCellModel(torch.nn.Module):
+            def __init__(self, bias):
+                super().__init__()
+                self.lstm_cell = torch.nn.LSTMCell(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, bias=bias)
+
+            def forward(self, x, h0, c0):
+                return self.lstm_cell(x, (h0, c0))
+
+        input = torch.randn(BATCH_SIZE, RNN_INPUT_SIZE)
+        h0 = torch.randn(BATCH_SIZE, RNN_HIDDEN_SIZE)
+        c0 = torch.randn(BATCH_SIZE, RNN_HIDDEN_SIZE)
+        for bias in [True, False]:
+            self.run_test(LSTMCellModel(bias), (input, h0, c0))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_lstm_default_init_state(self):
         class LSTMModel(torch.nn.Module):
             def __init__(self):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2318,6 +2318,17 @@ def lstm(g, *args):
         return _lstm_full(g, *args)
 
 
+def lstm_cell(g, self, hidden, w_ih, w_hh, b_ih, b_hh):
+    input = sym_help._unsqueeze_helper(g, self, [0])
+    hidden = sym_help._unpack_list(hidden)
+    hidden = [sym_help._unsqueeze_helper(g, x, [0]) for x in hidden]
+    weight = (w_ih, w_hh, b_ih, b_hh) if sym_help._is_tensor(b_ih) else (w_ih, w_hh)
+    has_biases = True if sym_help._is_tensor(b_ih) else False
+    _, h_outs, c_outs = _generic_rnn(g, 'LSTM', input, hidden, weight, has_biases, num_layers=1,
+                                     dropout=0, train=0, bidirectional=False, batch_first=False)
+    return sym_help._squeeze_helper(g, h_outs, [0]), sym_help._squeeze_helper(g, c_outs, [0])
+
+
 def _one_hidden_rnn(kind):
     @parse_args("v", "v", "v", "i", "i", "f", "i", "i", "i")
     def _rnn_full(g, input, hidden, weight_v, has_biases, num_layers, dropout, train, bidirectional, batch_first):


### PR DESCRIPTION
In Silero Text-To-Speech model `torch.hub.load(repo_or_dir='snakers4/silero-models',
                                                                          model='silero_tts',
                                                                          language=language,
                                                                          speaker=speaker)`, it has aten::lstm_cell, which is a one layer cell of lstm. This PR supports it.
