### PR TITLE
[Pytorch Edge] Black Box Compatibility API

### DIFF
--- a/torch/csrc/jit/mobile/backport.cpp
+++ b/torch/csrc/jit/mobile/backport.cpp
@@ -94,7 +94,7 @@ bool _backport_for_mobile_impl(
   if (!backportManager.hasBytecodeBackportFunction(to_version + 1)) {
     return false;
   }
-  int64_t from_version = _get_model_bytecode_version(istream_adapter);
+  auto from_version = _get_model_bytecode_version(istream_adapter);
   return backportManager.backport(
       istream_adapter, writer, from_version, to_version);
 }

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/jit/mobile/model_compatibility.h>
 #include <torch/csrc/jit/serialization/import_read.h>
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -141,7 +142,6 @@ std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
 std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
     std::vector<IValue> bytecode_ivalues) {
   constexpr uint64_t min_version_with_schema = 6;
-  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   if (_get_model_bytecode_version(bytecode_ivalues) < min_version_with_schema) {
     TORCH_WARN(
         "Only models with bytecode version 6 and above contain operator schema information. Please re-export your model to generate it");
@@ -173,6 +173,94 @@ std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
         result.emplace(op_name, OperatorInfo{(int)op.at(2).toInt()});
       } else { // no schema information use default
         result.emplace(op_name, OperatorInfo{});
+      }
+    }
+  }
+  return result;
+}
+
+/********************** Compatibility Checker **********************/
+
+ModelCompatibilityInfo ModelCompatibilityInfo::get(std::istream& in) {
+  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
+  return get(std::move(rai));
+}
+
+ModelCompatibilityInfo ModelCompatibilityInfo::get(
+    const std::string& filename) {
+  std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
+  return get(std::move(rai));
+}
+
+ModelCompatibilityInfo ModelCompatibilityInfo::get(
+    std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai) {
+  if (!check_zip_file(rai)) {
+    TORCH_CHECK(
+        false, "Failed to open zip file for model compatibility information");
+  }
+  PyTorchStreamReader reader(std::move(rai));
+  auto bytecode_values = get_bytecode_ivalues(reader);
+  uint64_t model_bytecode_version =
+      _get_model_bytecode_version(bytecode_values);
+  auto model_info = _get_model_ops_and_info(bytecode_values);
+  return ModelCompatibilityInfo{model_bytecode_version, model_info};
+}
+
+ModelCompatCheckResult is_compatible(
+    RuntimeCompatibilityInfo runtime_info,
+    ModelCompatibilityInfo model_info) {
+  ModelCompatCheckResult result = {ModelCompatibilityStatus::OK, {}};
+  // Check that the models bytecode version is less than or equal to
+  // kMaxSupportedBytecodeVersion from the runtime
+  if (model_info.bytecode_version > runtime_info.bytecode_version) {
+    result.status = ModelCompatibilityStatus::ERROR;
+    std::ostringstream s;
+    s << "model bytecode version " << model_info.bytecode_version
+      << "is greater than the runtimes " << runtime_info.bytecode_version;
+    result.errors.emplace_back(s.str());
+  }
+
+  // Check operators
+  std::unordered_map<std::string, OperatorInfo> operator_info =
+      model_info.operator_info;
+  for (auto const& op : operator_info) {
+    std::string op_name = op.first;
+    OperatorInfo model_op_info = op.second;
+
+    // Check if operator not present in runtime
+    if (runtime_info.operator_info.find(op_name) ==
+        runtime_info.operator_info.end()) {
+      result.status = ModelCompatibilityStatus::ERROR;
+      std::ostringstream s;
+      s << "Operator '" << op_name << "' missing from runtime (not found)";
+      result.errors.push_back(s.str());
+    } else {
+      OperatorInfo runtime_op_info = runtime_info.operator_info.at(op_name);
+
+      // If the runtime op has no schema information its a false alarm and isn't
+      // actually useable
+      if (!runtime_op_info.num_schema_args.has_value()) {
+        result.status = ModelCompatibilityStatus::ERROR;
+        std::ostringstream s;
+        s << "Operator '" << op_name
+          << "' missing from runtime (missing schema)";
+        result.errors.push_back(s.str());
+      } else {
+        // Check if the model operator has schema information. If it doesn't
+        // then the model is from a bytecode version < 6 and we are done. If the
+        // model has more args than the runtime, then the runtime can't know
+        // what to do so we aren't compatible. If the runtime has more args than
+        // the model then we can just use default values and be fine.
+        if (model_op_info.num_schema_args.has_value() &&
+            (model_op_info.num_schema_args.value() >
+             runtime_op_info.num_schema_args.value())) {
+          std::ostringstream s;
+          s << "Operator schema for'" << op_name << "' has "
+            << model_op_info.num_schema_args.value()
+            << " args in model but only "
+            << runtime_op_info.num_schema_args.value() << " in the runtime";
+          result.errors.push_back(s.str());
+        }
       }
     }
   }

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -1,5 +1,4 @@
 #include <ATen/core/ivalue.h>
-#include <c10/util/irange.h>
 #include <caffe2/serialize/file_adapter.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/compilation_unit.h> // removed after using simple type_resolver/obj_loader
@@ -59,38 +58,42 @@ std::vector<IValue> get_bytecode_ivalues(PyTorchStreamReader& reader) {
 /********************** Bytecode **********************/
 
 // Forward declare
-int64_t _get_model_bytecode_version(
+uint64_t _get_model_bytecode_version(
     const std::vector<IValue>& bytecode_ivalues);
 
-int64_t _get_model_bytecode_version(std::istream& in) {
+uint64_t _get_model_bytecode_version(std::istream& in) {
   std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
   return _get_model_bytecode_version(std::move(rai));
 }
 
-int64_t _get_model_bytecode_version(const std::string& filename) {
+uint64_t _get_model_bytecode_version(const std::string& filename) {
   std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
   return _get_model_bytecode_version(std::move(rai));
 }
 
-int64_t _get_model_bytecode_version(std::shared_ptr<ReadAdapterInterface> rai) {
+uint64_t _get_model_bytecode_version(
+    std::shared_ptr<ReadAdapterInterface> rai) {
   if (!check_zip_file(rai)) {
-    TORCH_WARN(
-        "The input model might not be generated from _save_for_mobile()");
-    return -1;
+    TORCH_CHECK(
+        false,
+        "Failed to open .ptl file please ensure the model was exported for mobile");
   }
   PyTorchStreamReader reader(std::move(rai));
   auto bytecode_values = get_bytecode_ivalues(reader);
   return _get_model_bytecode_version(bytecode_values);
 }
 
-int64_t _get_model_bytecode_version(
+uint64_t _get_model_bytecode_version(
     const std::vector<IValue>& bytecode_ivalues) {
   if (!bytecode_ivalues.empty() && bytecode_ivalues[0].isInt()) {
     int64_t model_version = bytecode_ivalues[0].toInt();
-    return model_version;
+    TORCH_CHECK(
+        model_version > 0,
+        "Expected model bytecode version > 0 got ",
+        model_version);
+    return static_cast<uint64_t>(model_version);
   }
-  TORCH_WARN("Fail to get bytecode version.");
-  return -1;
+  TORCH_CHECK(false, "Failed to get bytecode version.");
 }
 
 /********************** Operators and Info **********************/

--- a/torch/csrc/jit/mobile/model_compatibility.h
+++ b/torch/csrc/jit/mobile/model_compatibility.h
@@ -49,5 +49,32 @@ TORCH_API std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
 TORCH_API std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
     std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai);
 
+// The family of methods below return the compatibility information of a model
+struct ModelCompatibilityInfo {
+  uint64_t bytecode_version;
+  std::unordered_map<std::string, OperatorInfo> operator_info;
+
+  // Factory Methods
+  static TORCH_API ModelCompatibilityInfo get(std::istream& in);
+  static TORCH_API ModelCompatibilityInfo get(const std::string& filename);
+  static TORCH_API ModelCompatibilityInfo
+  get(std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai);
+};
+
+enum ModelCompatibilityStatus {
+  OK = 1,
+  ERROR = 2,
+};
+
+struct ModelCompatCheckResult {
+  ModelCompatibilityStatus status;
+  std::vector<std::string> errors;
+};
+// Takes in information about a runtime and a model and returns if the two are
+// compatible
+TORCH_API ModelCompatCheckResult is_compatible(
+    RuntimeCompatibilityInfo runtime_info,
+    ModelCompatibilityInfo model_info);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/mobile/model_compatibility.h
+++ b/torch/csrc/jit/mobile/model_compatibility.h
@@ -18,14 +18,15 @@ namespace torch {
 namespace jit {
 
 // The family of methods below to get bytecode version from a model
-TORCH_API int64_t _get_model_bytecode_version(std::istream& in);
+// Throws if not passed in a well formed model
+TORCH_API uint64_t _get_model_bytecode_version(std::istream& in);
 
-TORCH_API int64_t _get_model_bytecode_version(const std::string& filename);
+TORCH_API uint64_t _get_model_bytecode_version(const std::string& filename);
 
-TORCH_API int64_t _get_model_bytecode_version(
+TORCH_API uint64_t _get_model_bytecode_version(
     std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai);
 
-int64_t _get_model_bytecode_version(
+uint64_t _get_model_bytecode_version(
     const std::vector<c10::IValue>& bytecode_ivalues);
 
 std::vector<c10::IValue> get_bytecode_ivalues(

--- a/torch/csrc/jit/mobile/runtime_compatibility.cpp
+++ b/torch/csrc/jit/mobile/runtime_compatibility.cpp
@@ -47,5 +47,10 @@ std::unordered_map<std::string, OperatorInfo> _get_runtime_ops_and_info() {
   return result;
 }
 
+RuntimeCompatibilityInfo get_runtime_compatibility_info() {
+  return RuntimeCompatibilityInfo{
+      _get_runtime_bytecode_version(), _get_runtime_ops_and_info()};
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/mobile/runtime_compatibility.h
+++ b/torch/csrc/jit/mobile/runtime_compatibility.h
@@ -15,10 +15,17 @@ struct OperatorInfo {
   c10::optional<int> num_schema_args;
 };
 
+struct RuntimeCompatibilityInfo {
+  uint64_t bytecode_version;
+  std::unordered_map<std::string, OperatorInfo> operator_info;
+};
+
 TORCH_API uint64_t _get_runtime_bytecode_version();
 
 TORCH_API std::unordered_map<std::string, OperatorInfo>
 _get_runtime_ops_and_info();
+
+TORCH_API RuntimeCompatibilityInfo get_runtime_compatibility_info();
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
It would be nice if the compatibility api was just kinda plug and play with no care about the internals of the api at all. Thats what this diff aims to provide.

The general usage would be something like

  RuntimeCompatibilityInfo runtime_info = get_runtime_compatibility_info();
  ModelCompatibilityInfo model_info = get_model_compatibility_info(<model_path>);
  bool compatible = is_compatible(runtime_info, model_info);

Currently RuntimeCompatibilityInfo and ModelCompatibilityInfo are exactly the same, but it seemed feasible to me that they may end up diverging as more information is added to the api (such as a min supported bytecode version being exposed from the runtime).

Test Plan: unit test and ci

Differential Revision: D29624080

