### PR TITLE
Apply for MOBILE_MODULE_LOAD_STATS Logging

### DIFF
--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -3,6 +3,7 @@
 #include <c10/util/ThreadLocalDebugInfo.h>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace torch {
 
@@ -75,12 +76,14 @@ class MobileModuleObserver {
   virtual void onEnterLoadModel(const int32_t) {}
   virtual void onExitLoadModel(
       const int32_t,
-      const std::unordered_map<std::string, std::string>&) {}
+      const std::unordered_map<std::string, std::string>&) {
+  } // key: filename, value: file content
   virtual void onFailLoadModel(const int32_t, const char*) {}
   virtual void onFailLoadModel(
       const int32_t,
       const char*,
       const std::unordered_map<std::string, std::string>&) {}
+  virtual std::vector<std::string> getExtraFile() = 0;
 };
 
 class MobileObserverConfig {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61480**

Append mobile_info.json and producer_info.json into extra_files and parse the jsons from “model_info.json” in onExitLoadModel.

Differential Revision: [D29608014](https://our.internmc.facebook.com/intern/diff/D29608014/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29608014/)!