### PR TITLE
Update cpp_extension.py

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -773,12 +773,12 @@ class BuildExtension(build_ext, object):
                 cuda_str_version = cuda_version.group(1)
                 cuda_ver = packaging.version.parse(cuda_str_version)
                 torch_cuda_version = packaging.version.parse(torch.version.cuda)
-                if cuda_ver.major != torch_cuda_version.major:  # type: ignore[attr-defined]
-                    raise RuntimeError(CUDA_MISMATCH_MESSAGE.format(
-                        cuda_str_version, torch.version.cuda))
-                elif cuda_ver.minor != torch_cuda_version.minor:  # type: ignore[attr-defined]
-                    warnings.warn(CUDA_MISMATCH_WARN.format(
-                        cuda_str_version, torch.version.cuda))
+                if cuda_ver != torch_cuda_version:
+                    # major/minor attributes are only available in setuptools>=49.6.0
+                    if getattr(cuda_ver, "major", float("nan")) != getattr(torch_cuda_version, "major", float("nan")):
+                        raise RuntimeError(CUDA_MISMATCH_MESSAGE.format(cuda_str_version, torch.version.cuda))
+                    warnings.warn(CUDA_MISMATCH_WARN.format(cuda_str_version, torch.version.cuda))
+
         else:
             raise RuntimeError(CUDA_NOT_FOUND_MESSAGE)
 


### PR DESCRIPTION
By default, majority of Python-3.[6789] installation comes with `pkg_resources.packaging` version 16.8 (or `setuptool` older than 49.6.0), which does not have major/minor properties on Version package, as one can observe in https://github.com/pypa/setuptools/blob/v49.5.0/pkg_resources/_vendor/packaging/version.py
On the other hand, compare operators exists, so why not use it to check for version equality

Fixes #61036


