### PR TITLE
[static runtime] Remove hasOperation() check

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1357,7 +1357,6 @@ ProcessedNode::ProcessedNode(
   }
   {
     const Operator& op = node->getOperator();
-    TORCH_CHECK(op.hasOperation());
     op_ = op.getOperation(node);
     VLOG(1) << "Fallback interpreter for node: " << PrintNode(node);
   }


### PR DESCRIPTION
Summary:
glow::FusionGroup is JitOnlyOperator that produces an Operation when passed a Node* https://fburl.com/ybwfn3bl

hasOperation doesn't return true in that case https://fburl.com/19wd10aw

by removing the hasOperation() check, the Operation gets successfully materialized, and static runtime enables successfully and runs ok. Will check that the outputs match with jit interpreter

Test Plan:
Test with 281805158_2
```
./buck-out/gen/admarket/lib/ranking/prediction_replayer/replayer --model_inference_type_target=DISAGG_ACCELERATOR --prediction_replayer_force_model_type=inline_cvr_post_imp_model --prediction_replayer_force_model=281805158_2 --prediction_replayer_target_tier=127.0.0.1:7447 --prediction_replayer_input_stream_filename=/data/users/ansha/tmp/adfinder/filter_requests_inline_cvr_post_imp_model_1000_2021_04_29 --ignore_model_id_mismatch --check_performance --fully_remote_sr_connection_options="overall_timeout:10000000,processing_timeout:10000000" --use_new_encoding_for_ads_services --use_new_encoding_from_model_id_to_shard_id --sigrid_force_model_dir=/data/users/ansha/tmp/adfinder/281805158_2/ --sigrid_predictor_model_suffix=.predictor.disagg.local —use_new_encoding_from_model_id_to_shard_id=true --prediction_replayer_force_model_kind=19 --pytorch_predictor_static_runtime_enable=true --prediction_replayer_target_qps=1
```

```
NNPI_LOG_LEVEL=0 USE_INF_API=1 ./buck-out/gen/sigrid/predictor/sigrid_remote_predictor_glow_nnpi \
  --force_models=281805158_2 \
  --sigrid_predictor_model_suffix=.predictor.disagg.remote_other \
  --gflags_config_path=sigrid/predictor/gflags/predictor_gflags_ads_perf_glow_nnpi_pyper_v1 \
  --smc_server_port=7447 \
  --sigrid_predictor_tier_name=sigrid.predictor.perf.dianshi_staticruntime_debug_0604.test.storage \
  --predictor_storage_smc_tier=sigrid.predictor.perf.dianshi_staticruntime_debug_0604.test.storage \
  --predictor_storage_smc_tier_v2=sigrid.predictor.perf.dianshi_staticruntime_debug_0604.test.storage \
  --torch_glow_min_fusion_group_size=30 \
  --glow_enable_sanitize_inputs=100 \
  --sigrid_force_model_dir=/data/users/ansha/tmp/adfinder/281805158_2/ \
  --pytorch_predictor_static_runtime_enable=true \
  --pytorch_predictor_glow_enable=true \
  --pytorch_predictor_enable_loading_xl_format_on_cpu=false \
  --pytorch_disagg_acc_input_dump_path=/tmp/
```

Reviewed By: hlu1

Differential Revision: D29647043

