### PR TITLE
[1/N] Nnapi backend delegation preprocess

### DIFF
--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
@@ -1,0 +1,46 @@
+#include <torch/csrc/jit/backends/backend.h>
+#include <torch/csrc/jit/backends/backend_exception.h>
+
+namespace torch {
+namespace jit {
+
+class NnapiBackend : public PyTorchBackendInterface {
+ public:
+  // Constructor.
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  explicit NnapiBackend() {}
+  // NOLINTNEXTLINE(modernize-use-override)
+  virtual ~NnapiBackend() = default;
+
+  bool is_available() override {
+    return true;
+  }
+
+  // Function stub
+  // TODO: implement compile
+  c10::impl::GenericDict compile(
+      c10::IValue processed,
+      c10::impl::GenericDict method_compile_spec) override {
+    auto handles =
+        c10::Dict<std::string, std::vector<std::tuple<std::string, int64_t>>>();
+    return c10::impl::toGenericDict(handles);
+  }
+
+  // Function stub
+  // TODO: implement execute
+  c10::impl::GenericList execute(
+      c10::IValue handle,
+      c10::impl::GenericList inputs) override {
+    c10::List<at::Tensor> output_list;
+    return c10::impl::toList(output_list);
+  }
+};
+
+namespace {
+constexpr auto backend_name = "nnapi";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto cls = torch::jit::backend<NnapiBackend>(backend_name);
+} // namespace
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
@@ -4,6 +4,9 @@
 namespace torch {
 namespace jit {
 
+// This file has no implementation yet, but the declarations are necessary to
+// register the backend properly and test preprocess
+// TODO T91991928: implement compile() and execute()
 class NnapiBackend : public PyTorchBackendInterface {
  public:
   // Constructor.

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -6,9 +6,12 @@
 namespace py = pybind11;
 
 // Converts model to nnapi and serializes it for mobile
-// Returns a dictionary string with one entry
+// Returns a dictionary string with one entry:
 // Key: "NnapiModule"
 // Value: a string of the nnapi module, saved for mobile
+//
+// method_compile_spec should contain an input Tensor with the following format:
+// {"forward": {"inputs": Tensor}}
 c10::IValue preprocess(
     const torch::jit::Module& mod,
     const c10::Dict<c10::IValue, c10::IValue>& method_compile_spec,

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -1,0 +1,45 @@
+#include <pybind11/pybind11.h>
+#include <torch/csrc/jit/backends/backend.h>
+#include <torch/csrc/jit/backends/backend_preprocess.h>
+#include <torch/csrc/jit/python/pybind_utils.h>
+
+namespace py = pybind11;
+
+// Converts model to nnapi and serializes it for mobile
+// Returns a dictionary string with one entry
+// Key: "NnapiModule"
+// Value: a string of the nnapi module, saved for mobile
+c10::IValue preprocess(
+    const torch::jit::Module& mod,
+    const c10::Dict<c10::IValue, c10::IValue>& method_compile_spec,
+    const torch::jit::BackendDebugHandleGenerator& generate_debug_handles) {
+  // Import the python function for converting modules to nnapi
+  py::gil_scoped_acquire gil;
+  py::object pyModule = py::module_::import("torch.backends._nnapi.prepare");
+  py::object pyMethod = pyModule.attr("convert_model_to_nnapi");
+
+  // Wrap the c module in a RecursiveScriptModule and call the python conversion
+  // function on it
+  auto out =
+      py::module::import("torch.jit._recursive").attr("wrap_cpp_module")(mod);
+  out.attr("eval")();
+  // TODO: throw exception if compile_spec doesn't contain inputs
+  torch::Tensor inp =
+      method_compile_spec.at("forward").toGenericDict().at("inputs").toTensor();
+  auto nnapi_pyModel = pyMethod(out, inp);
+
+  // Cast the returned py object and save it for mobile
+  std::stringstream ss;
+  auto nnapi_model = py::cast<torch::jit::Module>(nnapi_pyModel.attr("_c"));
+  nnapi_model._save_for_mobile(ss);
+
+  c10::Dict<c10::IValue, c10::IValue> dict(
+      c10::StringType::get(), c10::StringType::get());
+  dict.insert("NnapiModule", ss.str());
+  return dict;
+}
+
+constexpr auto backend_name = "nnapi";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto pre_reg =
+    torch::jit::backend_preprocess_register(backend_name, preprocess);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61499**

Added a preprocess function for the delegate to Nnapi backend (internal and external files). 

In the past we had functions and classes for converting to the Nnapi backend. Now, these functions and classes will be wrapped by the delegate API.

### nnapi_backend_preprocess.cpp:

Contains the preprocess function, which uses Pybind to call an existing python function, `convert_model_to_nnapi()`.
- The model is wrapped by a `RecursiveScriptModule`, so that `convert_model_to_nnapi()` can run correctly, since when jumping from Python to C++ to Python, the model loses its original wrapper.
- A tensor, which includes shape, data type, and quantization information, is passed through preprocess's compile_spec to `convert_model_to_nnapi()`.
- Finally, the Nnapi model is serialized for mobile and returned as a string.
### nnapi_backend_lib.cpp:
Contains stub functions for compile and execute, and is necessary for the Nnapi backend to be registered correctly. These will be implemented in a future PR.

**TODO:** implement execute and compile for the delegate API; throw exceptions for incorrect an compile_spec; add OSS tests
**Testing:** Tests were done locally (see D29647123). A simple module was lowered to Nnapi, saved locally, and examined.

Differential Revision: [D29563351](https://our.internmc.facebook.com/intern/diff/D29563351/)