### PR TITLE
[pytorch][JIT] Widen exception caught by ScriptList casting

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -108,7 +108,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
       try {
         auto script_list = py::cast<ScriptList>(obj);
         return script_list.list_;
-      } catch (py::cast_error& e) {
+      } catch (...) {
       }
 
       // If not (i.e. it is a regular Python list), make a new


### PR DESCRIPTION
Summary:
This commit widens the exception caught by the try-catch block that checks if
an object passed to a scripted function is a `ScriptList`. It turns out that
there are internal tests that do not throw a `py::cast_error` so catching only
that is not sufficient.

Test Plan: Ran the failing tests in T94889011.

Differential Revision: D29560815

