### PR TITLE
Wrapped create_type_hint in try/except block so that NormalizeArgs doesn't fail if create_type_hint fails

### DIFF
--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -104,25 +104,29 @@ def get_signature_for_torch_op(op : Callable) -> Optional[List[inspect.Signature
     return signatures
 
 def create_type_hint(x):
-    if isinstance(x, list) or isinstance(x, tuple):
-        # todo(chilli): Figure out the right way for mypy to handle this
-        if isinstance(x, list):
-            def ret_type(x):
-                return List[x]  # type: ignore[valid-type]
-        else:
-            def ret_type(x):
-                return Tuple[x, ...]
-        if len(x) == 0:
-            return ret_type(Any)
-        base_type = x[0]
-        for t in x:
-            if issubclass(t, base_type):
-                continue
-            elif issubclass(base_type, t):
-                base_type = t
+    try:
+        if isinstance(x, list) or isinstance(x, tuple):
+            # todo(chilli): Figure out the right way for mypy to handle this
+            if isinstance(x, list):
+                def ret_type(x):
+                    return List[x]  # type: ignore[valid-type]
             else:
+                def ret_type(x):
+                    return Tuple[x, ...]
+            if len(x) == 0:
                 return ret_type(Any)
-        return ret_type(base_type)
+            base_type = x[0]
+            for t in x:
+                if issubclass(t, base_type):
+                    continue
+                elif issubclass(base_type, t):
+                    base_type = t
+                else:
+                    return ret_type(Any)
+            return ret_type(base_type)
+    except Exception as e:
+        # We tried to create a type hint for list but failed.
+        pass
     return x
 
 def type_matches(signature_type : Any, argument_type : Any):

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -126,6 +126,7 @@ def create_type_hint(x):
             return ret_type(base_type)
     except Exception as e:
         # We tried to create a type hint for list but failed.
+        torch.warnings.warn(f"We were not able to successfully create type hint from the type {x}")
         pass
     return x
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61524 Wrapped create_type_hint in try/except block so that NormalizeArgs doesn't fail if create_type_hint fails**

Differential Revision: [D29746106](https://our.internmc.facebook.com/intern/diff/D29746106)