### PR TITLE
add shortcircuit in isclose for zero tolerances

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -116,7 +116,7 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
   }
 
   // In case of zero tolerances the closeness inequality degenerates to an equality check.
-  // In these cases this short-circuit prevents false positives as detailed below.
+  // In this case, the short-circuit prevents false positives as detailed in the paragraph below.
   if (rtol == 0 && atol == 0){
       return close;
   }

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -115,6 +115,10 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
       close.__ior__((self != self).__iand__(other != other));
   }
 
+  if (rtol == 0 && atol == 0){
+      return close;
+  }
+
   // Note [closeness error computation]
   // atol and rtol are provided as doubles, so the computation
   // rtol * other will produce a float or complex tensor.

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -115,6 +115,8 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
       close.__ior__((self != self).__iand__(other != other));
   }
 
+  // In case of zero tolerances the closeness inequality degenerates to an equality check.
+  // In these cases this short-circuit prevents false positives as detailed below.
   if (rtol == 0 && atol == 0){
       return close;
   }

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -444,6 +444,15 @@ class TestTesting(TestCase):
         with self.assertRaises(RuntimeError):
             torch.isclose(t, t, atol=-1, rtol=-1)
 
+    def test_isclose_equality_shortcut(self):
+        # For values >= 2**53, integers differing by 1 can no longer differentiated by torch.float64 or lower precision
+        # floating point dtypes. Thus, even with rtol == 0 and atol == 0, these tensors would be considered close if
+        # they were not compared as integers.
+        a = torch.tensor(2 ** 53, dtype=torch.int64)
+        b = a + 1
+
+        self.assertFalse(torch.isclose(a, b, rtol=0, atol=0))
+
     @dtypes(torch.bool, torch.long, torch.float, torch.cfloat)
     def test_make_tensor(self, device, dtype):
         def check(size, low, high, requires_grad, noncontiguous):


### PR DESCRIPTION
Fixes #61412.

Large integers gave false positives, because the comparison always takes place in floating point dtypes. This happens, because their integer precision is lower than the range of an integer dtype with the same number of bits. 

For non-extremal values, `isclose` is defined by [this equation]:

```python
abs(a - b) <= atol + rtol * abs(b)
```

For `rtol == 0 and atol==0`, this is equivalent to `a == b`. This PR goes for the low hanging fruit and adds a shortcut for this case that falls back to an actual equality check.