### PR TITLE
[pytorch] Add broadcasting support to add_relu kernel

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -368,8 +368,16 @@ Tensor add_relu(const Tensor& self, const Tensor& other, const Scalar& alpha) {
   return add_relu_impl(result, self, other, alpha);
 }
 
+Tensor add_relu(const Tensor& self, const Scalar& other, const Scalar& alpha) {
+  return add_relu(self, wrapped_scalar_tensor(other), alpha);
+}
+
 Tensor& add_relu_(Tensor& self, const Tensor& other, const Scalar& alpha) {
   return add_relu_impl(self, self, other, alpha);
+}
+
+Tensor& add_relu_(Tensor& self, const Scalar& other, const Scalar& alpha) {
+  return add_relu_(self, wrapped_scalar_tensor(other), alpha);
 }
 
 TORCH_IMPL_FUNC(copysign_out) (

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -415,6 +415,16 @@
   dispatch:
     CPU: add_relu_out
 
+- func: _add_relu.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
+  variants: function
+  dispatch:
+    CPU: add_relu
+
+- func: _add_relu_.Scalar(Tensor(a!) self, Scalar other, Scalar alpha=1) -> Tensor(a!)
+  variants: function
+  dispatch:
+    CPU: add_relu_
+
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
   device_check: NoCheck   # TensorIterator

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11618,6 +11618,15 @@ class TestAddRelu(TestCase):
 
         self.assertTrue(torch.allclose(add_relu_res, relu_res))
 
+    def test_add_relu_broadcasting(self):
+        a = torch.rand((1, 32))
+        b = 1
+        b_scalar = torch.ones(1, 32)
+        res = torch._VF._add_relu(a, b)
+        broadcasted_res = torch._VF._add_relu(a, b_scalar)
+
+        self.assertTrue(torch.allclose(broadcasted_res, res))
+
 
 def add_test(test, decorator=None):
     def add(test_name, fn):


### PR DESCRIPTION
Summary: add_relu is not working with broadcasting. This registers a scalar version of add_relu in native_functions that casts to tensor before calling the regular function. TensorIterator handles broadcasting analogously to existing add.

Test Plan:
ran this script

```
import torch.jit
import torch.nn as nn
import torch.nn.functional as F
from torch.utils.mobile_optimizer import optimize_for_mobile

class Net(nn.Module):
    def __init__(self):
        super(Net, self).__init__()

    def forward(self, x):
        x = x.add(1)
        x = F.relu(x)
        return x

net = torch.jit.script(Net())
opt = optimize_for_mobile(net)
print(opt(torch.ones(1,32)))

```

old output
```
RuntimeError: 0INTERNAL ASSERT FAILED at "caffe2/torch/csrc/jit/ir/alias_analysis.cpp":533, please report a bug to PyTorch. We don't have an op for aten::_add_relu but it isn't a special case.  Argument types: Tensor, int, int
```

new output

```
tensor([[2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2.,
         2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2.]])
```

confirmed vectorize code is called by setting breakpoint here https://fburl.com/code/iz8z46um

unit test

```
buck test //caffe2/test:torch -- test_add_relu_broadcasting

Reviewed By: kimishpatel

Differential Revision: D29641768

