### PR TITLE
Bump docker image tag for clang-tidy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -312,7 +312,7 @@ jobs:
     runs-on: linux.2xlarge
     container:
       # ubuntu20.04-cuda11.2-py3.8-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:6e81eee1f23596060ac64cfec9b1f4953eb12931
+      image: ghcr.io/pytorch/cilint-clang-tidy:d8f0c777964d0dd8a147360de80aed1a13eb613a
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes recent `clang-diagnostic-errors` on clang-tidy runs

See https://github.com/pytorch/test-infra/pull/59
