### PR TITLE
Smart Decay for Adam - Caffe2

### DIFF
--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -33,6 +33,38 @@ class TestAdam(hu.HypothesisTestCase):
             return param_out, mom1_out, mom2_out
 
     @staticmethod
+    def ref_smart_decay_adam(param, mom1, mom2, last_seen, grad, LR, ITER,
+                             beta1, beta2, epsilon):
+
+        for name in ('param', 'mom1', 'mom2', 'last_seen', 'grad',
+                     'LR', 'ITER', 'beta1', 'beta2', 'epsilon'):
+            print("{} {} {}".format(name, locals()['name'], type(locals()['name'])))
+
+
+        t = ITER + 1
+        k = t - last_seen
+        k = k.flatten()[0]
+
+        last_seen_out = t * np.ones_like(last_seen)
+
+        # Make up for lost minibatches.
+        mom2_out = (beta2**k * mom2) + (1 - beta2) * np.square(grad)
+        param_out = param
+        m = mom1
+
+        # For catchup
+        for _ in range(k - 1):
+            m *= beta1
+            update = m / (np.sqrt(mom2_out) + epsilon)
+            param_out += LR * update
+        # For the single step update
+        mom1_out = m * beta1 + grad * (1 - beta1)
+        grad_out = mom1_out / (np.sqrt(mom2_out) + epsilon)
+        param_out += + LR * grad_out
+
+        return param_out, mom1_out, mom2_out, last_seen_out
+
+    @staticmethod
     def ref_row_wise_adam(param, mom1, mom2, grad, LR, ITER,
                           beta1, beta2, epsilon, output_grad=False):
         t = ITER + 1
@@ -193,8 +225,87 @@ class TestAdam(hu.HypothesisTestCase):
                              allow_nan=False, allow_infinity=False),
            data_strategy=st.data(),
            **hu.gcs)
+    def test_smart_decay_sparse_adam(self, inputs, ITER, LR, beta1, beta2, epsilon,
+                                     data_strategy, gc, dc):
+        param, mom1, mom2, grad = inputs
+        mom2 = np.absolute(mom2)
+        _iter, _lr = ITER, LR  # Keep the scalar types for reference
+        ITER = np.array([ITER], dtype=np.int64)
+        LR = np.array([LR], dtype=np.float32)
+
+        # Here we will define the last_seen tensor as being randomly from 0 to ITER
+        # (the value of t to be tested will be ITER+1)
+        last_seen = data_strategy.draw(
+            hypothesis.extra.numpy.arrays(
+                dtype=np.int64,
+                shape=(param.shape[0],),
+                elements=st.integers(min_value=0, max_value=_iter),
+                unique=False,
+            )
+        )
+
+        # Create an indexing array containing values which index into grad
+        indices = data_strategy.draw(
+            hu.tensor(
+                max_dim=1,
+                min_value=1,
+                max_value=grad.shape[0],
+                dtype=np.int64,
+                elements=st.sampled_from(np.arange(grad.shape[0])),
+            ),
+        )
+
+        # Verify that the generated indices are unique
+        hypothesis.assume(
+            np.array_equal(
+                np.unique(indices.flatten()),
+                np.sort(indices.flatten())))
+
+        # Sparsify grad
+        grad = grad[indices]
+
+        op = core.CreateOperator(
+            "SmartDecaySparseAdam",
+            ["param", "mom1", "mom2", "last_seen", "indices", "grad", "lr", "iter"],
+            ["param", "mom1", "mom2", "last_seen"],
+            beta1=beta1, beta2=beta2, epsilon=epsilon)
+
+        def ref_sparse(param, mom1, mom2, last_seen, indices, grad, LR, ITER):
+            param_out = np.copy(param)
+            mom1_out = np.copy(mom1)
+            mom2_out = np.copy(mom2)
+            last_seen_out = np.copy(last_seen)
+
+            for i, index in enumerate(indices):
+                param_out[index], mom1_out[index], mom2_out[index], last_seen_out[index] = \
+                    self.ref_smart_decay_adam(param[index], mom1[index], mom2[index], last_seen[index],
+                                              grad[i], LR, ITER,
+                                              beta1, beta2, epsilon)
+            return (param_out, mom1_out, mom2_out, last_seen_out)
+
+        # Iter lives on the CPU
+        input_device_options = {'iter': hu.cpu_do}
+
+        self.assertReferenceChecks(
+            gc, op,
+            [param, mom1, mom2, last_seen, indices, grad, LR, ITER],
+            ref_sparse,
+            input_device_options=input_device_options)
+
+    @given(inputs=hu.tensors(n=4),
+           ITER=st.integers(min_value=0, max_value=10000),
+           LR=st.floats(min_value=0.01, max_value=0.99,
+                        allow_nan=False, allow_infinity=False),
+           beta1=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           beta2=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           epsilon=st.floats(min_value=0.01, max_value=0.99,
+                             allow_nan=False, allow_infinity=False),
+           data_strategy=st.data(),
+           **hu.gcs)
     def test_sparse_adam_output_grad(self, inputs, ITER, LR, beta1, beta2, epsilon,
-                         data_strategy, gc, dc):
+                                     data_strategy, gc, dc):
         param, mom1, mom2, grad = inputs
         mom2 = np.absolute(mom2)
         ITER = np.array([ITER], dtype=np.int64)
@@ -227,7 +338,7 @@ class TestAdam(hu.HypothesisTestCase):
             beta1=beta1, beta2=beta2, epsilon=epsilon)
 
         def ref_sparse_output_grad(param, mom1, mom2, indices, grad, LR, ITER,
-                                beta1, beta2, epsilon, output_grad):
+                                   beta1, beta2, epsilon, output_grad):
             param_out = np.copy(param)
             mom1_out = np.copy(mom1)
             mom2_out = np.copy(mom2)
@@ -346,7 +457,7 @@ class TestAdam(hu.HypothesisTestCase):
            data_strategy=st.data(),
            **hu.gcs)
     def test_row_wise_sparse_adam_output_grad(self, inputs, ITER, LR, beta1, beta2,
-                                  epsilon, data_strategy, gc, dc):
+                                              epsilon, data_strategy, gc, dc):
         param, mom1, grad = inputs
         ITER = np.array([ITER], dtype=np.int64)
         LR = np.array([LR], dtype=np.float32)
@@ -390,7 +501,7 @@ class TestAdam(hu.HypothesisTestCase):
             beta1=beta1, beta2=beta2, epsilon=epsilon)
 
         def ref_row_wise_sparse_output_grad(param, mom1, mom2, indices, grad, LR, ITER,
-                                        beta1, beta2, epsilon, output_grad):
+                                            beta1, beta2, epsilon, output_grad):
             param_out = np.copy(param)
             mom1_out = np.copy(mom1)
             mom2_out = np.copy(mom2)

--- a/caffe2/sgd/adam_op.h
+++ b/caffe2/sgd/adam_op.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffe2/core/operator.h"
+#include "caffe2/core/tensor.h"
 
 namespace caffe2 {
 
@@ -49,6 +50,43 @@ void adam_compute(
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
     nw[i] = w[i] + lr[0] * correction * mi / (std::sqrt(vi) + eps_hat);
+  }
+}
+
+template <typename Context>
+void adam_compute_smart_decay(
+    int N,
+    long int t,
+    const float* w,
+    const float* g,
+    const float* m,
+    const float* v,
+    const int64_t* lastSeenIn,
+    float* nw,
+    float* nm,
+    float* nv,
+    int64_t* lastSeenOut,
+    float beta1,
+    float beta2,
+    float eps_hat,
+    //float correction,
+    const float* lr,
+    Context* /*context*/) {
+  float k = (float)(t - lastSeenIn[0]);
+  lastSeenOut[0] = t;
+  for (auto i = 0; i < N; ++i) {
+    float gi = g[i];
+    // The number of steps since this param was last seen.
+    // We don't need integer precision for k.  Float is fine and it's faster to convert here.
+    // Same as sparse Adam except v is decayed by beta2^k rather than beta2
+    // Catchup = \sum_{i=1}^{k-1}\beta_1^i = \beta_1 \left(\frac{1-\beta_1^k}{1-\beta_1}\right)
+    float catchup = 0.0;
+    if (k > 1) {
+        catchup = m[i] * beta1 * (1 - powf(beta1, k)) / (1 - beta1);
+    }
+    float mi = nm[i] = m[i] * powf(beta1, k) + gi * (1 - beta1);
+    float vi = nv[i] = v[i] * powf(beta2, k) + gi * gi * (1 - beta2);
+    nw[i] = w[i] + (lr[0] * (mi + catchup)) / (std::sqrt(vi) + eps_hat);
   }
 }
 
@@ -507,6 +545,86 @@ class SparseAdamOp final : public Operator<Context> {
   T enableRAdam_;
   INPUT_TAGS(PARAM, MOMENT_1, MOMENT_2, INDICES, GRAD, LR, ITER);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1, OUTPUT_MOMENT_2, OUTPUT_GRAD);
+};
+
+template <typename T, class Context>
+class SmartDecaySparseAdamOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  SmartDecaySparseAdamOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        beta1_(this->template GetSingleArgument<float>("beta1", 0.9f)),
+        beta2_(this->template GetSingleArgument<float>("beta2", 0.999f)),
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {}
+
+  bool RunOnDevice() override {
+    // Enforce shapes
+    CAFFE_ENFORCE_EQ(Input(PARAM).numel(), Input(MOMENT_1).numel());
+    CAFFE_ENFORCE_EQ(Input(PARAM).numel(), Input(MOMENT_2).numel());
+    CAFFE_ENFORCE_EQ(Input(PARAM).size(0), Input(LAST_SEEN).numel());
+    CAFFE_ENFORCE_EQ(
+        Input(PARAM).size_from_dim(1),
+        Input(GRAD).size_from_dim(Input(INDICES).dim()));
+    CAFFE_ENFORCE_EQ(Input(LR).numel(), 1);
+
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, Input(INDICES));
+  }
+
+  template <typename SIndex>
+  bool DoRunWithType() {
+    const auto* lr = Input(LR).template data<T>();
+    const auto iter =
+        OperatorBase::Input<Tensor>(ITER, CPU).template data<int64_t>()[0];
+
+    const int64_t t = iter + 1;
+
+    auto block_size = Input(PARAM).numel() / Input(PARAM).size(0);
+    auto n = Input(GRAD).numel() / block_size;
+
+    const auto* paramIn = Input(PARAM).template data<T>();
+    const auto* indices = Input(INDICES).template data<SIndex>();
+    const auto* gradIn = Input(GRAD).template data<T>();
+    const auto* moment1In = Input(MOMENT_1).template data<T>();
+    const auto* moment2In = Input(MOMENT_2).template data<T>();
+    const int64_t* lastSeenIn = Input(LAST_SEEN).template data<int64_t>();
+    auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<T>();
+    auto* moment1Out = Output(OUTPUT_MOMENT_1)->template mutable_data<T>();
+    auto* moment2Out = Output(OUTPUT_MOMENT_2)->template mutable_data<T>();
+    int64_t* lastSeenOut = Output(OUTPUT_LAST_SEEN)->template mutable_data<int64_t>();
+
+    for (auto i = 0; i < n; ++i) {
+        auto idx = indices[i];
+        auto offsetI = i * block_size;
+        auto offsetIdx = idx * block_size;
+        adam_compute_smart_decay(
+            block_size,
+            t,
+            paramIn + offsetIdx,
+            gradIn + offsetI,
+            moment1In + offsetIdx,
+            moment2In + offsetIdx,
+            lastSeenIn + idx,
+            paramOut + offsetIdx,
+            moment1Out + offsetIdx,
+            moment2Out + offsetIdx,
+            lastSeenOut + idx,
+            beta1_,
+            beta2_,
+            epsilon_,
+            lr,
+            &context_);
+    }
+
+    return true;
+  }
+
+ protected:
+  T beta1_;
+  T beta2_;
+  T epsilon_;
+  INPUT_TAGS(PARAM, MOMENT_1, MOMENT_2, LAST_SEEN, INDICES, GRAD, LR, ITER);
+  OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1, OUTPUT_MOMENT_2, OUTPUT_LAST_SEEN);
 };
 
 template <typename T, class Context>


### PR DESCRIPTION
Summary:

We want to decay learning parameters properly.  Previously this was not done when a parameter is absent from a minibatch.  We fix this by keeping track of missed minibatches and making decay catch up accordingly.

The exponential moving averages (EMA) for the first and second moments used in Adam are updated only for parameters seen in a minibatch.  Actually, for these parameters, 0 should be added to the EMAs and the EMAs should then be decayed by multiplying by beta1 and beta2 respectively.

To avoid the computational overhead of touching every parameter for every minibatch, we:
* keep track of the last time a parameter is seen
* instead of decaying the EMAs by multiplying by beta1 and beta2, we multiply by beta1^k and beta2^k, where k is the number of minibatches since the parameter was last seen
* we calculate the amount of momentum that would have been discharged over the missed minibatches and update the weight accordingly.

Differential Revision: D29654246

