### PR TITLE
add aten symbols for amin and amax

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -192,6 +192,8 @@ _(aten, any) \
 _(aten, arange) \
 _(aten, argmax) \
 _(aten, argmin) \
+_(aten, amax) \
+_(aten, amin) \
 _(aten, as_strided) \
 _(aten, as_tensor) \
 _(aten, atan2) \


### PR DESCRIPTION
This is for an xla-side PR to add a `torch.amin` lowering. I see we have symbols for `argmin/argmax`, but not `amin/amax`. According the docs, [`amin`](https://pytorch.org/docs/stable/generated/torch.amin.html) and [`argmin`](https://pytorch.org/docs/stable/generated/torch.argmin.html) don't look like aliases.

XLA PR: https://github.com/pytorch/xla/pull/3034

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61550 add aten symbols for amin and amax**

Differential Revision: [D29668123](https://our.internmc.facebook.com/intern/diff/D29668123)