### PR TITLE
Enable C2 load rate limiter [2/n]

### DIFF
--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -66,6 +66,7 @@ class LoadOp final : public Operator<Context> {
         db_name_(this->template GetSingleArgument<string>("db", "")),
         db_names_(this->template GetRepeatedArgument<string>("dbs")),
         db_type_(this->template GetSingleArgument<string>("db_type", "")),
+        db_options_(this->template GetSingleArgument<string>("db_options", "")),
         keep_device_(this->template GetSingleArgument<int>("keep_device", 0)),
         load_all_(this->template GetSingleArgument<int>("load_all", 0)),
         allow_incomplete_(
@@ -140,6 +141,9 @@ class LoadOp final : public Operator<Context> {
             : (ws_->RootFolder() + "/" + db_names_[i]);
         std::unique_ptr<DB> in_db(
             caffe2::db::CreateDB(db_type_, full_db_name, caffe2::db::READ));
+        if (!db_options_.empty()) {
+          in_db->SetOptions(db_options_);
+        }
         CAFFE_ENFORCE(
             in_db.get(),
             "Cannot find db implementation of type ",
@@ -302,6 +306,7 @@ class LoadOp final : public Operator<Context> {
   string db_name_;
   std::vector<std::string> db_names_;
   string db_type_;
+  std::string db_options_;
   bool keep_device_;
   bool load_all_;
   bool allow_incomplete_;

--- a/caffe2/python/operator_test/load_save_test.py
+++ b/caffe2/python/operator_test/load_save_test.py
@@ -1,16 +1,13 @@
-import errno
 import hypothesis.strategies as st
 from hypothesis import given, assume, settings
 import io
 import math
 import numpy as np
 import os
-import shutil
 import struct
 import unittest
 from pathlib import Path
 from typing import Dict, Generator, List, NamedTuple, Optional, Tuple, Type
-
 from caffe2.proto import caffe2_pb2
 from caffe2.proto.caffe2_pb2 import BlobSerializationOptions
 from caffe2.python import core, test_util, workspace
@@ -430,6 +427,26 @@ class TestLoadSave(TestLoadSaveBase):
             absolute_path=1,
             dbs=db_files, db_type=self._db_type,
             load_all=False)
+        with self.assertRaises(RuntimeError):
+            workspace.RunOperatorOnce(op)
+
+    def testLoadWithDBOptions(self) -> None:
+        tmp_folder = self.make_tempdir()
+        tmp_file, arrays = self.saveFile(tmp_folder, "db", self._db_type, 0)
+
+        db_files = [tmp_file, tmp_file]
+        workspace.ResetWorkspace()
+        self.assertEqual(len(workspace.Blobs()), 0)
+
+        db_options = b"test_db_options"
+        op = core.CreateOperator(
+            "Load",
+            [], [str(i) for i in range(len(arrays))],
+            absolute_path=1,
+            dbs=db_files, db_type=self._db_type,
+            load_all=False,
+            db_options=db_options,
+        )
         with self.assertRaises(RuntimeError):
             workspace.RunOperatorOnce(op)
 


### PR DESCRIPTION
Summary:
We aim to enable rate limiter in C2 load, with a fix bandwidth limit.
This diff update LoadOp to pass down the manifold db options.

Test Plan:
```
buck test mode/opt caffe2/caffe2/python/operator_test:load_save_test
```

Differential Revision: D29639102

