### PR TITLE
ignore and clear cudaErrorNotReady errors

### DIFF
--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -93,6 +93,9 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
       return true;
     } else if (err != cudaErrorNotReady) {
       C10_CUDA_CHECK(err);
+    } else {
+      // ignore and clear the error if not ready
+      cudaGetLastError();
     }
 
     return false;

--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -187,6 +187,10 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
     hipEvent_t hip_event = static_cast<hipEvent_t>(event);
     const hipError_t err = hipEventQuery(hip_event);
     if (err != hipErrorNotReady) C10_HIP_CHECK(err);
+    else {
+      // ignore and clear the error if not ready
+      hipGetLastError();
+    }
     return (err == hipSuccess);
   }
 

--- a/aten/src/THC/THCCachingHostAllocator.cpp
+++ b/aten/src/THC/THCCachingHostAllocator.cpp
@@ -174,6 +174,8 @@ struct HostAllocator
 
       cudaError_t err = cudaEventQuery(event);
       if (err == cudaErrorNotReady) {
+        // ignore and clear the error if not ready
+        cudaGetLastError();
         break;
       } else if (err != cudaSuccess) {
         return err;

--- a/c10/cuda/CUDAStream.h
+++ b/c10/cuda/CUDAStream.h
@@ -118,6 +118,9 @@ class C10_CUDA_API CUDAStream {
       return true;
     } else if (err != cudaErrorNotReady) {
       C10_CUDA_CHECK(err);
+    } else {
+      // ignore and clear the error if not ready
+      cudaGetLastError();
     }
 
     return false;

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -167,8 +167,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     const cudaError_t err = cudaEventQuery(cuda_event);
     if (err != cudaErrorNotReady) {
       C10_CUDA_CHECK(err);
-    }
-    else {
+    } else {
       // ignore and clear the error if not ready
       cudaGetLastError();
     }

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -168,6 +168,10 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     if (err != cudaErrorNotReady) {
       C10_CUDA_CHECK(err);
     }
+    else {
+      // ignore and clear the error if not ready
+      cudaGetLastError();
+    }
     return (err == cudaSuccess);
   }
 

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -310,7 +310,12 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
 
   static bool IsStreamFree(const DeviceOption& option, StreamId stream_id) {
     auto stream = CUDAContext::cuda_stream(option.device_id(), stream_id);
-    return cudaStreamQuery(stream) == cudaSuccess;
+    auto status = cudaStreamQuery(stream);
+    if (status == cudaErrorNotReady) {
+      // ignore and clear the error if not ready
+      cudaGetLastError();
+    }
+    return status == cudaSuccess;
   }
 
   at::Device device() const override {

--- a/caffe2/core/event_gpu.cc
+++ b/caffe2/core/event_gpu.cc
@@ -163,6 +163,9 @@ EventStatus EventQueryCUDA(const Event* event) {
       std::unique_lock<std::mutex> lock(wrapper->mutex_recorded_);
       wrapper->err_msg_ = err_msg;
       wrapper->status_ = EventStatus::EVENT_FAILED;
+    } else {
+      // ignore and clear the error if not ready
+      cudaGetLastError();
     }
   }
   return static_cast<EventStatus>(wrapper->status_.load());


### PR DESCRIPTION
Follow-up to #18584. This PR covers the remaining places where event or stream query might result in not ready errors.
