### PR TITLE
Refactor non-joined process computation

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -731,15 +731,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                 grads = self.zero._join_grad_info.grads[self.zero._join_grad_info.index]
                 self.zero._join_grad_info.index += 1
                 for p, grad in zip(self.zero._all_params, grads):
-                    p.grad = grad.detach().clone().to(self.device)
-
-            @property
-            def device(self):
-                return device
-
-            @property
-            def process_group(self):
-                return dist.group.WORLD
+                    p.grad = grad.detach().clone().to(device)
 
         class _GradientSetter(_Joinable):
             def __init__(self):
@@ -751,6 +743,14 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                 zero_optim = kwargs["zero_optim"]
                 grads = kwargs["grads"]
                 return _SetGradsJoinHook(zero_optim, grads)
+
+            @property
+            def _join_device(self):
+                return device
+
+            @property
+            def _join_process_group(self):
+                return dist.group.WORLD
 
         num_grads_after_joining = NUM_EPOCHS * (world_size - rank - 1)
         grads = grads_at_each_iter[-num_grads_after_joining:]

--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -822,7 +822,6 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         dev1 = 2 * self.rank + 1
         mp_model = ModelParallelModel(dev0, dev1)
         ddp_model = DDP(mp_model)
-        print(ddp_model._join_config)
         local_model = LocalModel()
         cpu_device = torch.device("cpu")
         # Ensure the parameters are the same across the two models

--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -17,7 +17,7 @@ import torch.distributed as dist
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
-from torch.distributed.algorithms.join import _Join, _JoinHook
+from torch.distributed.algorithms.join import _Join, _Joinable, _JoinHook
 from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.distributed.optim.zero_redundancy_optimizer import _broadcast_object
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -717,14 +717,13 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         # A process must still set the remaining gradients after joining, so we
         # define a join hook to do this before the ZeRO join hook
         class _JoinGradInfo():
-            def __init__(self, grads, device):
+            def __init__(self, grads):
                 self.grads = grads  # remaining gradients to set (in order)
                 self.index = 0
-                self.device = device
 
         class _SetGradsJoinHook(_JoinHook):
-            def __init__(self, zero_optim, grads, device):
-                zero_optim._join_grad_info = _JoinGradInfo(grads, device)
+            def __init__(self, zero_optim, grads):
+                zero_optim._join_grad_info = _JoinGradInfo(grads)
                 self.zero = zero_optim
                 super().__init__()
 
@@ -732,26 +731,36 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                 grads = self.zero._join_grad_info.grads[self.zero._join_grad_info.index]
                 self.zero._join_grad_info.index += 1
                 for p, grad in zip(self.zero._all_params, grads):
-                    p.grad = grad.detach().clone().to(self.zero._join_grad_info.device)
+                    p.grad = grad.detach().clone().to(self.device)
 
             @property
             def device(self):
-                return self.zero._join_grad_info.device
+                return device
 
             @property
             def process_group(self):
                 return dist.group.WORLD
 
+        class _GradientSetter(_Joinable):
+            def __init__(self):
+                super().__init__()
+
+            def _join_hook(self, **kwargs):
+                assert "zero_optim" in kwargs
+                assert "grads" in kwargs
+                zero_optim = kwargs["zero_optim"]
+                grads = kwargs["grads"]
+                return _SetGradsJoinHook(zero_optim, grads)
+
         num_grads_after_joining = NUM_EPOCHS * (world_size - rank - 1)
         grads = grads_at_each_iter[-num_grads_after_joining:]
-        set_grads_jh = _SetGradsJoinHook(zero_optim, grads, device)
-        zero_jh = zero_optim._join_hook()
+        gradient_setter = _GradientSetter()
         iter = 0
-        with _Join([set_grads_jh, zero_jh]):
+        with _Join([gradient_setter, zero_optim], zero_optim=zero_optim, grads=grads):
             for _ in range(NUM_EPOCHS):
                 for input in inputs:
-                    # Schedule an all-reduce to indicate not joined
-                    dist.all_reduce(torch.ones(1, device=device), group=dist.group.WORLD)
+                    # Notify join context that this process has not joined
+                    _Join.notify_join_context(gradient_setter)
 
                     # Set gradients manually
                     for p, grad in zip(zero_model.parameters(), grads_at_each_iter[iter]):
@@ -813,6 +822,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         dev1 = 2 * self.rank + 1
         mp_model = ModelParallelModel(dev0, dev1)
         ddp_model = DDP(mp_model)
+        print(ddp_model._join_config)
         local_model = LocalModel()
         cpu_device = torch.device("cpu")
         # Ensure the parameters are the same across the two models

--- a/torch/distributed/algorithms/join.py
+++ b/torch/distributed/algorithms/join.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Any, List, NamedTuple
 
 import torch
 import torch.distributed as dist
@@ -56,6 +56,59 @@ class _JoinHook(ABC):
         """
         ...
 
+
+class _Joinable(ABC):
+    r"""
+    This defines an abstract base class for joinable classes. A joinable class
+    (inheriting from :class:`_Joinable`) should implement a private
+    ``_join_hook()`` method that returns a :class:`_JoinHook` instance.
+    """
+    @abstractmethod
+    def __init__(self):
+        self._join_config = _JoinConfig.construct_disabled_join_config()
+
+    @abstractmethod
+    def _join_hook(self, **kwargs) -> _JoinHook:
+        r"""
+        Returns a :class:`_JoinHook` instance for the given :class:`_Joinable`.
+
+        Arguments:
+            kwargs (dict): a :class:`dict` containing any keyword arguments
+            to modify the behavior of the join hook at run time; all
+            :class:`_Joinable` instances sharing the same join context manager
+            are forwarded the same value for ``kwargs``.
+        """
+        ...
+
+
+class _JoinConfig(NamedTuple):
+    r"""
+    This includes all fields needed from a :class:`_Joinable` instance for the
+    join context manager side.
+    """
+    enable: bool
+    throw_on_early_termination: bool
+    device: torch.device
+    process_group: Any
+    is_first_joinable: bool
+
+    @staticmethod
+    def construct_disabled_join_config():
+        r"""
+        Returns a :class:`_JoinConfig` instance indicating that join-related
+        logic should be disabled, e.g. if the caller is not in a join context
+        manager.
+        """
+        return _JoinConfig(
+            enable=False,
+            throw_on_early_termination=False,
+            device=torch.device("cpu"),
+            process_group=dist.group.WORLD,
+            is_first_joinable=False
+        )
+
+
+
 class _Join():
     r"""
     This class defines the generic join context manager, which allows custom
@@ -65,19 +118,9 @@ class _Join():
     for details about the hook definition.
 
     .. warning::
-        The context manager requires a ``dist.all_reduce(torch.ones(1))`` to be
-        called on every non-joined process each time before it performs its
-        collective communications in order to indicate that the process has not
-        yet joined. For example, this can occur at the beginning of the forward
-        pass.
-
-    .. warning::
-        If ``throw_on_early_termination`` is enabled, then the context manager
-        additionally requires every non-joined process to participate in an
-        all-reduce before it performs its collective communications in order to
-        check if it should terminate due to detecting uneven inputs. This all-
-        reduce should be of the form ``dist.all_reduce(torch.zeros(1))``; if
-        the result is positive, then the process should terminate.
+        The context manager requires each participating :class:`_Joinable` to
+        call the method `notify_join_context()` before its own per-iteration
+        collective communications to ensure correctness.
 
     .. warning::
         The context manager requires that all ``process_group`` attributes in
@@ -85,34 +128,55 @@ class _Join():
         ``_JoinHook`` objects, then the ``device`` of the first is used. The
         process group and device information is used for checking for non-
         joined processes and for notifying processes to terminate if
-        ``throw_on_early_termination`` is eanbled, both of which using an all-
+        ``throw_on_early_termination`` is enabled, both of which using an all-
         reduce.
 
     Arguments:
-        join_hooks (List[_JoinHook]): a list of the :class:`_JoinHook` s to
-            use; the hooks are iterated over in the given order.
+        joinables (List[_Joinable]): a list of the participating
+            :class:`_Joinable` s; their hooks are iterated over in the given
+            order.
 
         enable (bool): a flag enabling uneven input detection; setting to
             ``False`` disables the context manager's functionality and should
             only be set when the user knows the inputs will not be uneven
             (default: ``True``).
 
-        throw_on_early_termination (bool): a flag controlling whether to raise
-            an exception upon detecting uneven inputs (default: ``False``).
+        throw_on_early_termination (bool): a flag controlling whether to throw an
+            exception upon detecting uneven inputs (default: ``False``).
 
     """
     def __init__(
         self,
-        join_hooks: List[_JoinHook],
+        joinables: List[_Joinable],
         enable: bool = True,
         throw_on_early_termination: bool = False,
+        **kwargs,
     ):
-        if len(join_hooks) == 0:
-            raise ValueError("The join context manager requires at least one join hook")
-        self._join_hooks = join_hooks
+        if len(joinables) == 0:
+            raise ValueError("The join context manager requires at least one joinable")
+        self._joinables = joinables
+        self._join_hooks = [joinable._join_hook(**kwargs) for joinable in self._joinables]
         self._enable = enable
         self._throw_on_early_termination = throw_on_early_termination
+        self._set_joinable_configs()
         self._extract_dist_info()
+
+    def _set_joinable_configs(self):
+        r"""
+        Sets the :class:`_JoinConfig` of each participating :class:`_Joinable`.
+        """
+        assert len(self._joinables) > 0
+        assert len(self._joinables) == len(self._join_hooks)
+        is_first_joinable = True
+        for joinable, join_hook in zip(self._joinables, self._join_hooks):
+            joinable._join_config = _JoinConfig(
+                enable=self._enable,
+                throw_on_early_termination=self._throw_on_early_termination,
+                device=join_hook.device,
+                process_group=join_hook.process_group,
+                is_first_joinable=is_first_joinable
+            )
+            is_first_joinable = False
 
     def _extract_dist_info(self):
         r"""
@@ -213,3 +277,55 @@ class _Join():
         # and throws a `RuntimeError` in Python 3.7+ (PEP 479), so we just
         # raise a `RuntimeError` here
         raise RuntimeError(f"Rank {self._rank} exhausted all inputs.")
+
+    @staticmethod
+    def notify_join_context(joinable: _Joinable):
+        r"""
+        Notifies the join context manager that the calling process has not yet
+        joined; then, if ``throw_on_early_termination=True``, checks if uneven
+        inputs have been detected (i.e. if one process has already joined) and
+        throws an exception if so.
+
+        This method should be called from a :class:`_Joinable` object before
+        its per-iteration collective communications. For example, this should
+        be called at the beginning of the forward pass in DDP.
+
+        Only the first :class:`_Joinable` object passed into the context
+        manager performs the collective communications in this method, and
+        for the others, this method is vacuous.
+
+        Arguments:
+            joinable (_Joinable): the :class:`_Joinable` object calling this
+                method.
+
+        Returns:
+            An async work handle for the all-reduce meant to notify the context
+            manager that the process has not yet joined if ``joinable`` is the
+            first one passed into the context manager; ``None`` otherwise.
+        """
+        if not hasattr(joinable, "_join_config"):
+            return None
+
+        join_config = joinable._join_config
+        # First joinable is responsible for the collective communications
+        if not join_config.is_first_joinable or not join_config.enable:
+            return None
+
+        device = join_config.device
+        process_group = join_config.process_group
+
+        # Schedule an all-reduce to indicate that the caller has not yet joined
+        ones = torch.ones(1, device=device)
+        work = dist.all_reduce(ones, group=process_group, async_op=True)
+
+        if join_config.throw_on_early_termination:
+            # Check if uneven inputs have been detected
+            zeros = torch.zeros(1, device=device)
+            dist.all_reduce(zeros, group=process_group)
+            should_throw = zeros.item()
+            if should_throw:
+                raise RuntimeError(
+                    "Detected at least one rank that exhausted inputs. "
+                    "Throwing across all ranks."
+                )
+        return work

--- a/torch/distributed/algorithms/join.py
+++ b/torch/distributed/algorithms/join.py
@@ -48,6 +48,7 @@ class _Joinable(ABC):
     """
     @abstractmethod
     def __init__(self):
+        super(_Joinable, self).__init__()
         self._join_config = _JoinConfig.construct_disabled_join_config()
 
     @abstractmethod
@@ -57,9 +58,9 @@ class _Joinable(ABC):
 
         Arguments:
             kwargs (dict): a :class:`dict` containing any keyword arguments
-            to modify the behavior of the join hook at run time; all
-            :class:`_Joinable` instances sharing the same join context manager
-            are forwarded the same value for ``kwargs``.
+                to modify the behavior of the join hook at run time; all
+                :class:`_Joinable` instances sharing the same join context
+                manager are forwarded the same value for ``kwargs``.
         """
         ...
 

--- a/torch/distributed/algorithms/join.py
+++ b/torch/distributed/algorithms/join.py
@@ -282,7 +282,8 @@ class _Join():
 
         This method should be called from a :class:`_Joinable` object before
         its per-iteration collective communications. For example, this should
-        be called at the beginning of the forward pass in DDP.
+        be called at the beginning of the forward pass in
+        :class:`DistributedDataParallel`.
 
         Only the first :class:`_Joinable` object passed into the context
         manager performs the collective communications in this method, and
@@ -297,8 +298,9 @@ class _Join():
             manager that the process has not yet joined if ``joinable`` is the
             first one passed into the context manager; ``None`` otherwise.
         """
-        if not hasattr(joinable, "_join_config"):
-            return None
+        assert hasattr(joinable, "_join_config"), \
+            f"Check that the {type(joinable)} constructor calls the " \
+            "``_Joinable`` constructor"
 
         join_config = joinable._join_config
         # First joinable is responsible for the collective communications

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, Type
 
 import torch
 import torch.distributed as dist
-from torch.distributed.algorithms.join import _JoinHook
+from torch.distributed.algorithms.join import _Join, _Joinable, _JoinHook
 from torch.optim import Optimizer
 
 __all__ = ["ZeroRedundancyOptimizer"]
@@ -119,15 +119,15 @@ class _ZeROJoinHook(_JoinHook):
         self.zero.step()
 
     @property
-    def device(self):
+    def device(self) -> torch.device:
         return self.zero._default_device
 
     @property
-    def process_group(self):
+    def process_group(self) -> Any:
         return self.zero.process_group
 
 
-class ZeroRedundancyOptimizer(Optimizer):
+class ZeroRedundancyOptimizer(Optimizer, _Joinable):
     r"""
     This class wraps an arbitrary :class:`optim.Optimizer
     <torch.optim.Optimizer>` and shards its states across ranks in the group as
@@ -207,7 +207,8 @@ class ZeroRedundancyOptimizer(Optimizer):
         # between the parent and child.
         self.initialized = False
 
-        super().__init__(self._all_params, defaults)
+        Optimizer.__init__(self, self._all_params, defaults)
+        _Joinable.__init__(self)
         # Now, all parameters are held in both `self._all_params` and
         # `self.param_groups`
 
@@ -367,7 +368,7 @@ class ZeroRedundancyOptimizer(Optimizer):
             self._partition_parameters_cache = [list() for _ in range(self.world_size)]
             sizes = [0] * self.world_size
             for param_group in self.param_groups:
-                param_lists = [list() for _ in range(self.world_size)]
+                param_lists: List[List] = [list() for _ in range(self.world_size)]
                 # Sort the parameters by size (largest first)
                 params_sorted = sorted(param_group["params"], key=lambda t: t.numel(), reverse=True)
                 for param in params_sorted:
@@ -493,6 +494,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
         .. note: Any extra parameters are passed to the base optimizer as-is.
         """
+        _Join.notify_join_context(self)
         # Check if the model trainability has changed
         is_trainable_mask = self._get_is_trainable_mask()
         if is_trainable_mask != self._is_trainable_mask:
@@ -522,12 +524,18 @@ class ZeroRedundancyOptimizer(Optimizer):
 
         return loss
 
-    def _join_hook(self):
+    def _join_hook(self, **kwargs):
         r"""
         Returns the ZeRO join hook, which enables training on uneven inputs by
         shadowing the collective communications in the optimizer step.
 
         Gradients must be properly set before this hook is called.
+
+        Arguments:
+            kwargs (dict): a :class:`dict` containing any keyword arguments
+            to modify the behavior of the join hook at run time; all
+            :class:`_Joinable` instances sharing the same join context manager
+            are forwarded the same value for ``kwargs``.
         """
         return _ZeROJoinHook(self)
 
@@ -752,7 +760,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         """
         assert self._optim_constructor is not None
         self._clear_cache()
-        self.optim = self._optim_constructor(self._partition_parameters()[self.rank], **self._optim_defaults)
+        self.optim: Optimizer = self._optim_constructor(self._partition_parameters()[self.rank], **self._optim_defaults)
         self._sync_param_groups(self.optim.param_groups, self.param_groups)
 
     def _get_is_trainable_mask(self) -> List[bool]:

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -525,9 +525,9 @@ class ZeroRedundancyOptimizer(Optimizer, _Joinable):
 
         Arguments:
             kwargs (dict): a :class:`dict` containing any keyword arguments
-            to modify the behavior of the join hook at run time; all
-            :class:`_Joinable` instances sharing the same join context manager
-            are forwarded the same value for ``kwargs``.
+                to modify the behavior of the join hook at run time; all
+                :class:`_Joinable` instances sharing the same join context
+                manager are forwarded the same value for ``kwargs``.
         """
         return _ZeROJoinHook(self)
 

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -118,14 +118,6 @@ class _ZeROJoinHook(_JoinHook):
         """
         self.zero.step()
 
-    @property
-    def device(self) -> torch.device:
-        return self.zero._default_device
-
-    @property
-    def process_group(self) -> Any:
-        return self.zero.process_group
-
 
 class ZeroRedundancyOptimizer(Optimizer, _Joinable):
     r"""
@@ -538,6 +530,14 @@ class ZeroRedundancyOptimizer(Optimizer, _Joinable):
             are forwarded the same value for ``kwargs``.
         """
         return _ZeROJoinHook(self)
+
+    @property
+    def _join_device(self) -> torch.device:
+        return self._default_device
+
+    @property
+    def _join_process_group(self) -> Any:
+        return self.process_group
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         r"""

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -230,14 +230,6 @@ class _DDPJoinHook(_JoinHook):
         """
         self.ddp._sync_final_model(is_last_joiner)
 
-    @property
-    def device(self):
-        return self.ddp.device
-
-    @property
-    def process_group(self):
-        return self.ddp.process_group
-
 
 class DistributedDataParallel(Module, _Joinable):
     r"""Implements distributed data parallelism that is based on
@@ -691,14 +683,12 @@ class DistributedDataParallel(Module, _Joinable):
         del attrs["process_group"]
         del attrs["reducer"]
         del attrs["logger"]
-        del attrs["_join_config"]
         return attrs
 
     def __setstate__(self, state):
         # If serializable, then the process group should be the default one
         self.process_group = _get_default_group()
         super(DistributedDataParallel, self).__setstate__(state)
-        self._join_config = _JoinConfig.construct_disabled_join_config()
         self.__dict__.setdefault("require_forward_param_sync", True)
         self.__dict__.setdefault("require_backward_grad_sync", True)
         parameters, expect_sparse_gradient = self._build_params_for_reducer()
@@ -1219,6 +1209,14 @@ class DistributedDataParallel(Module, _Joinable):
             self,
             divide_by_initial_world_size=divide_by_initial_world_size
         )
+
+    @property
+    def _join_device(self):
+        return self.device
+
+    @property
+    def _join_process_group(self):
+        return self.process_group
 
     def register_comm_hook(self, state: object, hook: callable):
         r"""

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -12,7 +12,6 @@ from torch.autograd import Function, Variable
 from torch.distributed.algorithms.join import (
     _Join,
     _Joinable,
-    _JoinConfig,
     _JoinHook,
 )
 from torch.utils._pytree import tree_flatten, tree_unflatten

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -5,12 +5,11 @@ import logging
 import os
 import warnings
 from contextlib import contextmanager
-from typing import NamedTuple
 
 import torch
 import torch.distributed as dist
 from torch.autograd import Function, Variable
-from torch.distributed.algorithms.join import _Join, _JoinHook
+from torch.distributed.algorithms.join import _Join, _Joinable, _JoinHook
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 RPC_AVAILABLE = False
@@ -121,11 +120,6 @@ def _dump_DDP_relevant_env_vars():
     print(formatted_output)
 
 
-class _DDPUnevenInputsConfig(NamedTuple):
-    ddp_join_enabled: bool
-    ddp_join_divide_by_initial_world_size: bool
-    ddp_join_throw_on_early_termination: bool
-
 # Add a DDPSink to run various functions when backwards starts, such as
 # queueing call back of out-most backward/graph task,
 # this helps call back is fired after all gradients' calculation
@@ -177,7 +171,7 @@ class _DDPSink(Function):
 
 
 class _DDPJoinHook(_JoinHook):
-    def __init__(self, ddp, divide_by_initial_world_size, enable, throw_on_early_termination):
+    def __init__(self, ddp, divide_by_initial_world_size):
         """
         Sets config variables for internal usage.
         """
@@ -185,13 +179,8 @@ class _DDPJoinHook(_JoinHook):
             "DDP join hook requires passing in a DistributedDataParallel " \
             "instance as the state"
         ddp.logger._set_uneven_input_join()
-        ddp.ddp_uneven_inputs_config = \
-            _DDPUnevenInputsConfig(
-                ddp_join_enabled=enable,
-                ddp_join_divide_by_initial_world_size=divide_by_initial_world_size,
-                ddp_join_throw_on_early_termination=throw_on_early_termination,
-            )
         self.ddp = ddp
+        self.ddp._divide_by_initial_world_size = divide_by_initial_world_size
         super().__init__()
 
     def main_hook(self):
@@ -245,7 +234,7 @@ class _DDPJoinHook(_JoinHook):
         return self.ddp.process_group
 
 
-class DistributedDataParallel(Module):
+class DistributedDataParallel(Module, _Joinable):
     r"""Implements distributed data parallelism that is based on
     ``torch.distributed`` package at the module level.
 
@@ -509,6 +498,7 @@ class DistributedDataParallel(Module):
     ):
 
         super(DistributedDataParallel, self).__init__()
+        _Joinable.__init__(self)
         self.logger = None
         if not any((p.requires_grad for p in module.parameters())):
             self._log_and_throw(
@@ -577,11 +567,6 @@ class DistributedDataParallel(Module):
         self.find_unused_parameters = find_unused_parameters
         self.require_backward_grad_sync = True
         self.require_forward_param_sync = True
-        self.ddp_uneven_inputs_config = _DDPUnevenInputsConfig(
-            ddp_join_enabled=False,
-            ddp_join_divide_by_initial_world_size=False,
-            ddp_join_throw_on_early_termination=False,
-        )
         self.gradient_as_bucket_view = gradient_as_bucket_view
         if hasattr(module, "_ddp_params_and_buffers_to_ignore"):
             self.parameters_to_ignore = module._ddp_params_and_buffers_to_ignore
@@ -605,7 +590,7 @@ class DistributedDataParallel(Module):
                     "Modules with uninitialized parameters can't be used with `DistributedDataParallel`. "
                     "Run a dummy forward pass to correctly initialize the modules"
                 )
-        # used for intra-node param sync and inter-node sync as wel
+        # used for intra-node param sync and inter-node sync as well
         self.broadcast_bucket_size = int(250 * 1024 * 1024)
 
         # reduction bucket size
@@ -891,28 +876,15 @@ class DistributedDataParallel(Module):
             if will_run_grad_reduction:
                 self.logger.set_runtime_stats_and_log()
             self.reducer.prepare_for_forward(will_run_grad_reduction)
-            if self.ddp_uneven_inputs_config.ddp_join_enabled:
-                ones = torch.ones(1, device=self.device)
-                work = dist.all_reduce(ones, group=self.process_group, async_op=True)
-                if self.ddp_uneven_inputs_config.ddp_join_throw_on_early_termination:
-                    # Active ranks schedule an allreduce with zeros, inactive
-                    # ranks schedule them with 1. If the result != 0 it
-                    # indicates at least one rank has terminated and we should
-                    # throw.
-                    zeros = torch.zeros(1, device=self.device)
-                    dist.all_reduce(zeros, group=self.process_group)
-                    should_throw_stop_iteration = zeros.item()
-                    if should_throw_stop_iteration:
-                        # Don't need to log this error as it is an expected error that
-                        # we are passing back to user training with uneven inputs.
-                        raise RuntimeError(
-                            "Detected at least one rank that exhausted inputs. Throwing across all ranks."
-                        )
-                else:
-                    self.reducer._set_forward_pass_work_handle(
-                        work,
-                        self.ddp_uneven_inputs_config.ddp_join_divide_by_initial_world_size,
-                    )
+
+            # Notify the join context that this process has not joined, if
+            # needed
+            work = _Join.notify_join_context(self)
+            if work:
+                self.reducer._set_forward_pass_work_handle(
+                    work,
+                    self._divide_by_initial_world_size
+                )
 
             # Calling _rebuild_buckets before forward compuation,
             # It may allocate new buckets before deallocating old buckets
@@ -926,7 +898,7 @@ class DistributedDataParallel(Module):
             if self.require_forward_param_sync:
                 self._sync_params()
 
-            if self.ddp_uneven_inputs_config.ddp_join_enabled:
+            if self._join_config.enable:
                 # Notify joined ranks whether they should sync in backwards pass or not.
                 self._check_global_requires_backward_grad_sync(is_joined_rank=False)
 
@@ -1213,31 +1185,32 @@ class DistributedDataParallel(Module):
           >>>  # blocking for rank 1's allreduce to complete.
           >>>  torch.cuda.synchronize(device=rank)
         """
-        join_hooks = [
-            self._join_hook(
-                divide_by_initial_world_size=divide_by_initial_world_size,
-                enable=enable,
-                throw_on_early_termination=throw_on_early_termination,
-            )
-        ]
-        return _Join(join_hooks, enable, throw_on_early_termination)
+        return _Join(
+            [self],
+            enable,
+            throw_on_early_termination,
+            divide_by_initial_world_size=divide_by_initial_world_size
+        )
 
     def _join_hook(
         self,
-        divide_by_initial_world_size: bool = True,
-        enable: bool = True,
-        throw_on_early_termination: bool = False,
+        **kwargs,
     ):
         r"""
         Returns the DDP join hook, which enables training on uneven inputs by
         shadowing the collective communications in the forward and backward
         passes.
+
+        Arguments:
+            kwargs (dict): a :class:`dict` containing any keyword arguments
+            to modify the behavior of the join hook at run time; all
+            :class:`_Joinable` instances sharing the same join context manager
+            are forwarded the same value for ``kwargs``.
         """
+        divide_by_initial_world_size = kwargs.get("divide_by_initial_world_size", True)
         return _DDPJoinHook(
             self,
-            divide_by_initial_world_size=divide_by_initial_world_size,
-            enable=enable,
-            throw_on_early_termination=throw_on_early_termination
+            divide_by_initial_world_size=divide_by_initial_world_size
         )
 
     def register_comm_hook(self, state: object, hook: callable):
@@ -1401,7 +1374,7 @@ class DistributedDataParallel(Module):
                 # If we are running DDP with the join manager, we have to agree
                 # upon a rank to sync module buffers from, since rank 0 may
                 # already have been joined and have stale module buffers.
-                if self.ddp_uneven_inputs_config.ddp_join_enabled:
+                if self._join_config.enable:
                     authoritative_rank = self._find_common_rank(
                         self._distributed_rank, True
                     )

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1199,9 +1199,9 @@ class DistributedDataParallel(Module, _Joinable):
 
         Arguments:
             kwargs (dict): a :class:`dict` containing any keyword arguments
-            to modify the behavior of the join hook at run time; all
-            :class:`_Joinable` instances sharing the same join context manager
-            are forwarded the same value for ``kwargs``.
+                to modify the behavior of the join hook at run time; all
+                :class:`_Joinable` instances sharing the same join context
+                manager are forwarded the same value for ``kwargs``.
         """
         divide_by_initial_world_size = kwargs.get("divide_by_initial_world_size", True)
         return _DDPJoinHook(

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5758,8 +5758,8 @@ class DistributedTest:
                     expected_grad = sum(i for i in range(world_size)) / world_size
                     self.assertEqual(net.module.weight.grad.item(), expected_grad)
 
-            join_config = net.ddp_uneven_inputs_config
-            self.assertFalse(join_config.ddp_join_enabled)
+            join_config = net._join_config
+            self.assertFalse(join_config.enable)
             self.validate_net_equivalence(net)
 
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
**Overview:**
This refactors the computation on non-joined processes relating to the join context manager. The concept was inspired by a comment from @pritamdamania.

**Changes:**
This introduces a `_Joinable` abstract base class, which requires a `_join_hook()` method and `_join_device()` and `_join_process_group()` property methods. Any class that we want to be compatible with the generic join context manager should inherit from `_Joinable` and implement `_join_hook()`, `_join_device()`, and `_join_process_group()`. (The `device` and `process_group` information has been moved from `_JoinHook` to `_Joinable`.) 

The generic join context manager now takes in a `List[_Joinable]` instead of `List[_JoinHook]`. The motivation for this is that previously, by passing the `_JoinHook`s into the context manager, the class providing a `_JoinHook` can modify the context manager's behavior, but the context manager cannot modify the class's behavior. This is solved by giving the context manager a reference to the class's instance.

This implementation reserves the field `_join_config` in every `_Joinable` to store a `_JoinConfig` instance, which holds all dynamic fields needed from the `_Joinable` for the join context manager: `enable`, `throw_on_early_termination`, and `is_first_joinable`. ("dynamic" here means that for a given `_Joinable` instance, the values for those fields may change across different join context usages.) In particular, these fields are needed to implement a method `notify_join_context()`, which encapsulates the computation performed on non-joined processes relating to the join context manager --- (1) the all-reduce to indicate that the process has not yet joined and (2) the all-reduce to check whether to throw an exception if `throw_on_uneven_inputs=True`. The idea is that every `_Joinable` class only needs to make a call to `notify_join_context()` before its per-iteration collective communications; it is a simple one-line addition.

Only the first `_Joinable` instance passed into the context manager actually performs the collective communications in `notify_join_context()`. In that case, the method returns an async work handle for the initial all-reduce indicating that the process not yet joined. Otherwise, the method returns `None`. This conditional logic is handled internally without additional input from the user.

**New API:**
Now, the example usage would look like:
```
ddp_model = DistributedDataParallel(...)
zero_optim = ZeroRedundancyOptimizer(ddp_model.parameters(), ...)
with _Join([ddp_model, zero_optim]):
    ...
```
Any arguments meant for a join hook (e.g. `divide_by_initial_world_size`) must be specified as keyword arguments. For example:
```
with _Join([ddp_model, zero_optim], divide_by_initial_world_size=False):
    ...
```
They will be forwarded to every `_join_hook()` function via `**kwargs`. This creates a clear separation between the variables needed by the context manager (`enable` and `throw_on_early_termination`) and those needed by the `_Joinable` class (e.g. `divide_by_initial_world_size`).

**Recap:**
After this change, the relevant information to use the generic join context manager looks like the following (omitting prefix `_` from names):
- Suppose we have a class `C` (e.g. `DistributedDataParallel`) that we want to be able to use the `Join` context.
- We make `C` inherit from `Joinable` and implement `join_hook() -> JoinHook`, `join_device()`, and `join_process_group()`.
- To implement `join_hook()`, we define a `CJoinHook` class inheriting from `JoinHook` and implement `main_hook()` and `post_hook()` as needed. 
- We locate a place before `C`'s per-iteration collective communications and add a call to `Join.notify_join_context()`.
- We call `Joinable.__init__(self)` in `C`'s constructor.
- The `C.join_config` field will be used internally by the context manager. This does not affect `C`'s serializability.
- Run time arguments for `C`'s join hook can be passed in as keyword arguments to the context manager: `with Join([C()], arg1=..., arg2=...):`.

**Test Plan:**
I ran the existing DDP join tests:
```
touch /tmp/barrier && TEMP_DIR="/tmp" BACKEND="nccl" WORLD_SIZE="2" gpurun python test/distributed/test_distributed_fork.py -- TestDistBackendWithFork.test_ddp_uneven_inputs TestDistBackendWithFork.test_ddp_uneven_inputs_stop_iteration_sync_bn TestDistBackendWithFork.test_ddp_grad_div_uneven_inputs TestDistBackendWithFork.test_ddp_uneven_input_join_disable TestDistBackendWithFork.test_ddp_uneven_input_exception
```
I ran the ZeRO join tests:
```
gpurun4 python test/distributed/optim/test_zero_redundancy_optimizer.py TestZeroRedundancyOptimizerDistributed.test_zero_join_gpu TestZeroRedundancyOptimizerDistributed.test_zero_join_cpu
```
