### PR TITLE
Improve error messages of `torch.testing.assert_close` for sparse inputs

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1289,7 +1289,7 @@ class TestAssertCloseSparseCOO(TestCase):
         expected = torch.sparse_coo_tensor(expected_indices, expected_values, size=(2, 2))
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(AssertionError, re.escape("number of specified values")):
+            with self.assertRaisesRegex(AssertionError, re.escape("number of specified values in sparse COO tensors")):
                 fn()
 
     def test_mismatching_indices_msg(self):
@@ -1308,7 +1308,7 @@ class TestAssertCloseSparseCOO(TestCase):
         expected = torch.sparse_coo_tensor(expected_indices, expected_values, size=(2, 2))
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(AssertionError, re.escape("The failure occurred for the indices")):
+            with self.assertRaisesRegex(AssertionError, re.escape("Sparse COO indices")):
                 fn()
 
     def test_mismatching_values_msg(self):
@@ -1327,7 +1327,7 @@ class TestAssertCloseSparseCOO(TestCase):
         expected = torch.sparse_coo_tensor(expected_indices, expected_values, size=(2, 2))
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(AssertionError, re.escape("The failure occurred for the values")):
+            with self.assertRaisesRegex(AssertionError, re.escape("Sparse COO values")):
                 fn()
 
 
@@ -1358,7 +1358,7 @@ class TestAssertCloseSparseCSR(TestCase):
         expected = torch.sparse_csr_tensor(expected_crow_indices, expected_col_indices, expected_values, size=(2, 2))
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(AssertionError, re.escape("The failure occurred for the crow_indices")):
+            with self.assertRaisesRegex(AssertionError, re.escape("Sparse CSR crow_indices")):
                 fn()
 
     def test_mismatching_col_indices_msg(self):
@@ -1373,7 +1373,7 @@ class TestAssertCloseSparseCSR(TestCase):
         expected = torch.sparse_csr_tensor(expected_crow_indices, expected_col_indices, expected_values, size=(2, 2))
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(AssertionError, re.escape("The failure occurred for the col_indices")):
+            with self.assertRaisesRegex(AssertionError, re.escape("Sparse CSR col_indices")):
                 fn()
 
     def test_mismatching_values_msg(self):
@@ -1388,7 +1388,7 @@ class TestAssertCloseSparseCSR(TestCase):
         expected = torch.sparse_csr_tensor(expected_crow_indices, expected_col_indices, expected_values, size=(2, 2))
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(AssertionError, re.escape("The failure occurred for the values")):
+            with self.assertRaisesRegex(AssertionError, re.escape("Sparse CSR values")):
                 fn()
 
 

--- a/torch/testing/_asserts.py
+++ b/torch/testing/_asserts.py
@@ -105,23 +105,42 @@ def _check_sparse_coo_members_individually(
     """
 
     @functools.wraps(check_tensors)
-    def wrapper(actual: Tensor, expected: Tensor, **kwargs: Any) -> Optional[_TestingErrorMeta]:
+    def wrapper(
+        actual: Tensor,
+        expected: Tensor,
+        msg: Optional[Union[str, Callable[[Tensor, Tensor, Diagnostics], str]]] = None,
+        **kwargs: Any,
+    ) -> Optional[_TestingErrorMeta]:
         if not actual.is_sparse:
-            return check_tensors(actual, expected, **kwargs)
+            return check_tensors(actual, expected, msg=msg, **kwargs)
 
         if actual._nnz() != expected._nnz():
             return _TestingErrorMeta(
-                AssertionError, f"The number of specified values does not match: {actual._nnz()} != {expected._nnz()}"
+                AssertionError,
+                (
+                    f"The number of specified values in sparse COO tensors does not match: "
+                    f"{actual._nnz()} != {expected._nnz()}"
+                ),
             )
 
         kwargs_equal = dict(kwargs, rtol=0, atol=0)
-        error_meta = check_tensors(actual._indices(), expected._indices(), **kwargs_equal)
+        error_meta = check_tensors(
+            actual._indices(),
+            expected._indices(),
+            msg=msg or functools.partial(_make_mismatch_msg, identifier="Sparse COO indices"),
+            **kwargs_equal,
+        )
         if error_meta:
-            return error_meta.amend_msg(postfix="\n\nThe failure occurred for the indices.")
+            return error_meta
 
-        error_meta = check_tensors(actual._values(), expected._values(), **kwargs)
+        error_meta = check_tensors(
+            actual._values(),
+            expected._values(),
+            msg=msg or functools.partial(_make_mismatch_msg, identifier="Sparse COO values"),
+            **kwargs,
+        )
         if error_meta:
-            return error_meta.amend_msg(postfix="\n\nThe failure occurred for the values.")
+            return error_meta
 
         return None
 
@@ -141,22 +160,42 @@ def _check_sparse_csr_members_individually(
     """
 
     @functools.wraps(check_tensors)
-    def wrapper(actual: Tensor, expected: Tensor, **kwargs: Any) -> Optional[_TestingErrorMeta]:
+    def wrapper(
+        actual: Tensor,
+        expected: Tensor,
+        msg: Optional[Union[str, Callable[[Tensor, Tensor, Diagnostics], str]]] = None,
+        **kwargs: Any,
+    ) -> Optional[_TestingErrorMeta]:
         if not actual.is_sparse_csr:
-            return check_tensors(actual, expected, **kwargs)
+            return check_tensors(actual, expected, msg=msg, **kwargs)
 
         kwargs_equal = dict(kwargs, rtol=0, atol=0)
-        error_meta = check_tensors(actual.crow_indices(), expected.crow_indices(), **kwargs_equal)
+        error_meta = check_tensors(
+            actual.crow_indices(),
+            expected.crow_indices(),
+            msg=msg or functools.partial(_make_mismatch_msg, identifier="Sparse CSR crow_indices"),
+            **kwargs_equal,
+        )
         if error_meta:
-            return error_meta.amend_msg(postfix="\n\nThe failure occurred for the crow_indices.")
+            return error_meta
 
-        error_meta = check_tensors(actual.col_indices(), expected.col_indices(), **kwargs_equal)
+        error_meta = check_tensors(
+            actual.col_indices(),
+            expected.col_indices(),
+            msg=msg or functools.partial(_make_mismatch_msg, identifier="Sparse CSR col_indices"),
+            **kwargs_equal,
+        )
         if error_meta:
-            return error_meta.amend_msg(postfix="\n\nThe failure occurred for the col_indices.")
+            return error_meta
 
-        error_meta = check_tensors(actual.values(), expected.values(), **kwargs)
+        error_meta = check_tensors(
+            actual.values(),
+            expected.values(),
+            msg=msg or functools.partial(_make_mismatch_msg, identifier="Sparse CSR values"),
+            **kwargs,
+        )
         if error_meta:
-            return error_meta.amend_msg(postfix="\n\nThe failure occurred for the values.")
+            return error_meta
 
         return None
 


### PR DESCRIPTION
This utilizes the feature introduced in #60091 to modify the header of the error message.

Before:

```python
AssertionError: Tensor-likes are not equal!

Mismatched elements: 1 / 2 (50.0%)
Greatest absolute difference: 1 at index 1
Greatest relative difference: 0.3333333432674408 at index 1

The failure occurred for the values.
```

After:

```python
AssertionError: Sparse COO values of tensor-likes are not equal!

Mismatched elements: 1 / 2 (50.0%)
Greatest absolute difference: 1 at index 1
Greatest relative difference: 0.3333333432674408 at index 1
```