### PR TITLE
[torch/elastic] Fix the agent store key prefix used by workers

### DIFF
--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -187,7 +187,8 @@ def _env_rendezvous_handler(url: str, timeout: timedelta = default_pg_timeout, *
     use_torchelastic_store = os.environ.get("TORCHELASTIC_USE_AGENT_STORE", None)
 
     if use_torchelastic_store == str(True):
-        worker_process_prefix = "/worker"
+        attempt = os.environ["TORCHELASTIC_RESTART_COUNT"]
+        worker_process_prefix = f"/worker/attempt_{attempt}"
         # When TORCHELASTIC_USE_AGENT_STORE is set up, the worker process is assumed
         # to be invoked by the torchelastic agent. Torchelastic agent creates a tcp daemon thread
         # on the GROUP_RANK=0, as a result all user worker processes should create store with: daemon=False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61590**

This PR fixes the bug where the state of the first run of a failed training job leaks to the secondary runs due to constant worker key prefix.

Differential Revision: [D29682743](https://our.internmc.facebook.com/intern/diff/D29682743/)