### PR TITLE
[pruner] fix activation handles logic

### DIFF
--- a/test/ao/sparsity/test_pruner.py
+++ b/test/ao/sparsity/test_pruner.py
@@ -122,6 +122,7 @@ class TestBasePruner(TestCase):
 
     def test_prepare(self):
         model = Model()
+        x = torch.ones(128, 16)
         pruner = SimplePruner(model, None, None)
         pruner.prepare()
         for g in pruner.module_groups:
@@ -133,9 +134,11 @@ class TestBasePruner(TestCase):
             assert hasattr(module, "parametrizations")
             # Assume that this is the 1st/only parametrization
             assert type(module.parametrizations.weight[0]) == PruningParametrization
+        assert model(x).shape == (128, 16)
 
     def test_prepare_bias(self):
         model = ModelB()
+        x = torch.ones(128, 16)
         pruner = SimplePruner(model, None, None)
         pruner.prepare()
         for g in pruner.module_groups:
@@ -147,9 +150,11 @@ class TestBasePruner(TestCase):
             assert hasattr(module, "parametrizations")
             # Assume that this is the 1st/only parametrization
             assert type(module.parametrizations.weight[0]) == PruningParametrization
+        assert model(x).shape == (128, 16)
 
     def test_convert(self):
         model = Model()
+        x = torch.ones(128, 16)
         pruner = SimplePruner(model, None, None)
         pruner.prepare()
         pruner.convert()
@@ -157,9 +162,11 @@ class TestBasePruner(TestCase):
             module = g['module']
             assert not hasattr(module, "parametrizations")
             assert not hasattr(module, 'mask')
+        assert model(x).shape == (128, 16)
 
     def test_convert_bias(self):
         model = ModelB()
+        x = torch.ones(128, 16)
         pruner = SimplePruner(model, None, None)
         pruner.prepare()
         pruner.convert()
@@ -167,6 +174,7 @@ class TestBasePruner(TestCase):
             module = g['module']
             assert not hasattr(module, "parametrizations")
             assert not hasattr(module, 'mask')
+        assert model(x).shape == (128, 16)
 
     def test_step(self):
         model = Model()

--- a/torch/ao/sparsity/experimental/pruner/base_pruner.py
+++ b/torch/ao/sparsity/experimental/pruner/base_pruner.py
@@ -59,8 +59,8 @@ class BasePruner(abc.ABC):
 
         self.module_groups = []
         self.enable_mask_update = False
-        self.activation_handle = None
-        self.bias_handle = None
+        self.activation_handles = []
+        self.bias_handles = []
 
         self.model = model
         # If no config -- try getting all the supported layers
@@ -132,15 +132,14 @@ class BasePruner(abc.ABC):
                                                  param(module.mask),
                                                  unsafe=True)
 
-            self.activation_handle = module.register_forward_hook(
+            self.activation_handles.append(module.register_forward_hook(
                 ActivationReconstruction(module.parametrizations.weight[0])
-            )
+            ))
 
             if module.bias is not None:
                 module.register_parameter('_bias', nn.Parameter(module.bias.detach()))
                 module.bias = None
-            self.bias_handle = module.register_forward_hook(self.bias_hook)
-
+            self.bias_handles.append(module.register_forward_hook(self.bias_hook))
 
     def convert(self, use_path=False, *args, **kwargs):
         for config in self.module_groups:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61592**

Add activation handles for each layer (stored in a list), so they can each be removed.

We don't remove them in the `convert` in eager mode because we aren't modifying output/input layer dimensions. We will need this in Fx mode though.

Differential Revision: [D29682789](https://our.internmc.facebook.com/intern/diff/D29682789/)