### PR TITLE
[static_runtime] Implement aten::linear

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -438,6 +438,11 @@ const auto full_like_script = R"JIT(
       return (b.clone())
 )JIT";
 
+const auto linear_script = R"JIT(
+  def forward(self, inp: Tensor, weights: Tensor, bias: Optional[Tensor]) -> Tensor:
+      return torch.linear(inp, weights, bias).clone()
+)JIT";
+
 // dict of tuple of list
 const auto nested_output_script_0 = R"JIT(
   def forward(self, a, b):

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -643,6 +643,28 @@ TEST(StaticRuntime, IndividualOps_FullLike) {
   testStaticRuntime(full_like_script, args, args2);
 }
 
+TEST(StaticRuntime, Linear) {
+  auto input = at::randn({1, 2});
+  auto weights = at::randn({1, 2});
+  auto bias = at::randn({1, 1});
+
+  std::vector<IValue> args{input, weights, bias};
+  std::vector<IValue> args_no_bias{input, weights, c10::nullopt};
+
+  auto input2 = at::randn({2, 3});
+  auto weights2 = at::randn({2, 3});
+  auto bias2 = at::randn({2, 2});
+
+  std::vector<IValue> args2{input2, weights2, bias2};
+  std::vector<IValue> args2_no_bias{input2, weights2, c10::nullopt};
+
+  testStaticRuntime(linear_script, args);
+  testStaticRuntime(linear_script, args_no_bias);
+
+  testStaticRuntime(linear_script, args, args2);
+  testStaticRuntime(linear_script, args, args2_no_bias);
+}
+
 TEST(StaticRuntime, LongModel) {
   torch::jit::Module mod = getLongScriptModel();
   auto a = torch::randn({2, 2});


### PR DESCRIPTION
Summary: Add out variant wrapper for `aten::linear` in the static runtime

Test Plan: `buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D29684236

