### PR TITLE
Improve TorchScript module getattr() to be same as python class getattr() method

### DIFF
--- a/test/jit/test_attr.py
+++ b/test/jit/test_attr.py
@@ -1,0 +1,36 @@
+from torch.testing import FileCheck
+from torch.testing._internal.jit_utils import JitTestCase
+import torch
+
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+
+class TestGetDefaultAttr(JitTestCase):
+    def test_getattr_with_default(self):
+
+        class A(torch.nn.Module):
+            def __init__(self):
+                super(A, self).__init__()
+                self.init_attr_val = 1.0
+
+            def forward(self, x):
+                y = getattr(self, "init_attr_val")  # noqa: B009
+                w : list[float] = [1.0]
+                z = getattr(self, "missing", w)  # noqa: B009
+                z.append(y)
+                return z
+
+        result = A().forward(0.0)
+        self.assertEqual(2, len(result))
+        graph = torch.jit.script(A()).graph
+
+        # The "init_attr_val" attribute exists
+        FileCheck().check("prim::GetAttr[name=\"init_attr_val\"]").run(graph)
+        # The "missing" attribute does not exist, so there should be no corresponding GetAttr in AST
+        FileCheck().check_not("missing").run(graph)
+        # instead the getattr call will emit the default value, which is a list with one float element
+        FileCheck().check("float[] = prim::ListConstruct").run(graph)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -58,6 +58,7 @@ from jit.test_module_apis import TestModuleAPIs  # noqa: F401
 from jit.test_script_profile import TestScriptProfile  # noqa: F401
 from jit.test_convert_activation import TestFunctionalToInplaceActivation, TestInplaceToFunctionalActivation  # noqa: F401
 from jit.test_parametrization import TestParametrization  # noqa: F401
+from jit.test_attr import TestGetDefaultAttr  # noqa: F401
 
 # Torch
 from torch import Tensor


### PR DESCRIPTION
Issue: https://github.com/pytorch/pytorch/issues/56909

Note the emitted code for such a call will either be a) getattr() call with first two args if the
attribute name (which must be a string literal) is determined to be valid based on the hasAttr() result,
or b) just the AST node for the default value (the 3rd arg) alone with no getattr call at all.

Test code:

```
import torch
import numpy as np

class Shape:
    def __init__(self):
        self.center = 1.0

def f(x):
    s = Shape()
    return getattr(s, "missing", [])

y = torch.jit.script(f)
print(y.graph)
```
Output:
```
graph(%x : Tensor):
  %s.1 : __torch__.Shape = prim::CreateObject()
  %2 : NoneType = prim::CallMethod[name="__init__"](%s.1) # ts.py:10:8
  %4 : Tensor[] = prim::ListConstruct()
  return (%4)
```

Another example:
```
import torch

class Shape:
    def __init__(self):
        self.center = 1.0


def f(x):
    s = Shape()
    y = getattr(s, "center")
    w : list[float] = [1.0]
    z = getattr(s, "missing", w)
    z.append(y)
    return z


y = torch.jit.script(f)
print(y.graph)
--- output ---

graph(%x : Tensor):
  %5 : float = prim::Constant[value=1.]() # ts.py:12:23
  %s.1 : __torch__.Shape = prim::CreateObject()
  %2 : NoneType = prim::CallMethod[name="__init__"](%s.1) # ts.py:10:8
  %center : float = prim::GetAttr[name="center"](%s.1)
  %w.1 : float[] = prim::ListConstruct(%5)
  %11 : float[] = aten::append(%w.1, %center) # ts.py:14:4
  return (%w.1)
```
Fixes #{56969}
