### PR TITLE
Fix cub issue for PyTorch LTS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,9 @@ jobs:
         run: |
           set -eux
           python torch/testing/check_kernel_launches.py |& tee ${GITHUB_WORKSPACE}/cuda_kernel_launch_checks.txt
+      - name: Ensure no direct cub include
+        run: |
+          (! git grep -I -no $'#include <cub/' --  ./aten  ':(exclude)aten/src/ATen/cuda/CubUtils.cuh' || (echo "The above files have direct cub include; please include ATen/cuda/CubUtils.cuh instead and wrap your cub calls in at::native namespace if necessary"; false))
 
   flake8-py3:
     runs-on: ubuntu-18.04

--- a/aten/src/ATen/cuda/CubUtils.cuh
+++ b/aten/src/ATen/cuda/CubUtils.cuh
@@ -1,0 +1,10 @@
+#pragma once
+
+// include cub in a safe manner
+#undef CUB_NS_POSTFIX //undef to avoid redefinition warnings
+#undef CUB_NS_PREFIX
+#define CUB_NS_PREFIX namespace at{ namespace native{
+#define CUB_NS_POSTFIX }}
+#include <cub/cub.cuh>
+#undef CUB_NS_POSTFIX
+#undef CUB_NS_PREFIX

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -17,10 +17,8 @@
 #include <THC/THCThrustAllocator.cuh>
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
-#include <thrust/transform.h>
 #include <THC/THCAtomics.cuh>
 
-#include <cub/cub.cuh>
 
 #include <c10/macros/Macros.h>
 
@@ -847,93 +845,6 @@ Tensor index_select_cuda(const Tensor& self, int64_t dim, const Tensor& index) {
   index_select_out_cuda(out, self, dim, index);
   return out;
 }
-
-template<typename T>
-struct NonZeroOp
-{
-    __host__ __device__ __forceinline__ bool operator()(const T& a) const {
-      return (a!=T(0));
-    }
-};
-
-template<typename scalar_t>
-void nonzero_cuda_out_impl(const Tensor& self, Tensor& out){
-  Tensor self_ = self.contiguous();
-  int N = self_.numel();
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-// compute number of nonzero elements
-  size_t temp_storage_bytes=0;
-  auto& allocator = *c10::cuda::CUDACachingAllocator::get();
-  auto num_nonzeros = allocator.allocate(sizeof(int));
-  cub::TransformInputIterator<bool, NonZeroOp<scalar_t>, scalar_t*> itr(self_.data_ptr<scalar_t>(), NonZeroOp<scalar_t>());
-  cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, itr, (int*)num_nonzeros.get(), N, stream);
-  auto temp_storage = allocator.allocate(temp_storage_bytes);
-  cub::DeviceReduce::Sum(temp_storage.get(), temp_storage_bytes, itr, (int*)num_nonzeros.get(), N, stream);
-  int num_nonzeros_h;
-  C10_CUDA_CHECK(cudaMemcpyAsync(&num_nonzeros_h, num_nonzeros.get(), sizeof(int), cudaMemcpyDeviceToHost, stream));
-  //need to synchronize to make sure data is available on the host
-  C10_CUDA_CHECK(cudaStreamSynchronize(stream));
-  //expected output size is num_nonzeros x ndim
-  //we are producing output with size {num_nonzeros, ndim} and strides {num_nonzeros, 1} (that is, transposed ndim x num_nonzeros output)
-  //we are able to directly use passed output with this size and strides, and we can also (per contract)
-  //resize passed output with incorrect sizes anyway we want.
-  //However, out with correct sizes and incorrect strides will have to be copied to from the intermediate we've produced.
-  bool need_to_copy = out.dim() == 2 && out.sizes()[0] == num_nonzeros_h && out.sizes()[1] == self.dim() && !out.t().is_contiguous();
-  at::Tensor out_temp = need_to_copy ?
-    at::native::empty_cuda({self.dim(), num_nonzeros_h}, optTypeMetaToScalarType(out.options().dtype_opt()),
-                           out.options().layout_opt(), out.options().device_opt(), out.options().pinned_memory_opt()) :
-    out.resize_({self.dim(), num_nonzeros_h});
-  //Scalars are expected to produce output of size (1,0), so we can't write to it
-  if (self.dim() > 0) {
-    cub::CountingInputIterator<int64_t> counting_itr(0);
-    temp_storage_bytes = 0;
-    cub::DeviceSelect::Flagged(nullptr, temp_storage_bytes, counting_itr, itr,
-      out_temp.data_ptr<int64_t>(), (int*)num_nonzeros.get(), N, stream);
-    temp_storage = allocator.allocate(temp_storage_bytes);
-    cub::DeviceSelect::Flagged(temp_storage.get(), temp_storage_bytes, counting_itr, itr,
-      out_temp.data_ptr<int64_t>(), (int*)num_nonzeros.get(), N, stream);
-    if (num_nonzeros_h > 0 && self.dim() > 1){
-        int64_t div = 1;
-        auto thrust_allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
-        for (int dim = self.dim()-1; dim >= 0; dim--){
-            int64_t dim_size = self.sizes()[dim];
-            thrust::transform(
-              thrust::cuda::par(thrust_allocator).on(stream),
-              thrust::device_ptr<int64_t>(out_temp.data_ptr<int64_t>()),
-              thrust::device_ptr<int64_t>(out_temp.data_ptr<int64_t>()) + num_nonzeros_h,
-              thrust::device_ptr<int64_t>(out_temp.data_ptr<int64_t>()) + num_nonzeros_h * dim,
-              [=] C10_HOST_DEVICE (const int64_t val) {return (val/div) % dim_size;}
-            );
-            div *= dim_size;
-        }
-    }
-  }
-  if (need_to_copy) {
-    out.copy_(out_temp.t());
-  } else {
-    //transpose out so it is correct size
-    Tensor out_ = out_temp.t();
-    out.set_(out_);
-  }
-}
-
-Tensor& nonzero_out_cuda(Tensor& out, const Tensor& self){
-  TORCH_CHECK(self.numel() < std::numeric_limits<int>::max(), "nonzero is not supported for tensors with more than INT_MAX elements, \
-  file a support request");
-  TORCH_CHECK(out.dtype() == at::kLong, "Expected object of scalar type ", at::kLong, " as out, but got ", out.dtype());
-  TORCH_CHECK(self.device() == out.device(), "expected self and out to be on the same device, but got out on ",
-  out.device(), " and self on ", self.device());
-  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half,
-    self.scalar_type(), "nonzero_cuda",
-    [&] {nonzero_cuda_out_impl<scalar_t>(self, out);});
-  return out;
-}
-
-Tensor nonzero_cuda(const Tensor& self){
-  Tensor out = at::native::empty_cuda({0}, kLong, self.options().layout_opt(), self.options().device_opt(), self.options().pinned_memory_opt());
-  return nonzero_out_cuda(out, self);
-}
-
 
 } // native
 } // at

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -1,0 +1,118 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <ATen/cuda/detail/KernelUtils.h>
+#include <ATen/cuda/detail/OffsetCalculator.cuh> //for MAX_DIMS
+#include <ATen/cuda/CubUtils.cuh>
+
+
+namespace at {
+namespace native {
+
+namespace{
+template<typename T>
+struct NonZeroOp
+{
+    __host__ __device__ __forceinline__ bool operator()(const T& a) const {
+      return (a!=T(0));
+    }
+};
+
+//TODO: actually support int64_t index_t
+template<typename index_t>
+struct TensorDims {
+  index_t sizes[MAX_DIMS];
+};
+
+template<typename index_t>
+__global__ void write_indices(int64_t * inp, TensorDims<index_t> dims, int ndim, index_t n){
+    CUDA_KERNEL_LOOP(index, n) { // this assumed int (not int64_t) index
+      index_t div = 1;
+      int64_t idx_flat = inp[index];
+      for (int dim = ndim-1; dim >= 0; dim--){
+        auto dim_size = dims.sizes[dim];
+        inp[index + dim*n] = (idx_flat/div) % dim_size;
+        div *= dim_size;
+      }
+    }
+}
+
+
+} //anonymous namespace
+
+template<typename scalar_t>
+void nonzero_cuda_out_impl(const Tensor& self, Tensor& out){
+  Tensor self_ = self.contiguous();
+  int N = self_.numel();
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+// compute number of nonzero elements
+  size_t temp_storage_bytes=0;
+  auto& allocator = *c10::cuda::CUDACachingAllocator::get();
+  auto num_nonzeros = allocator.allocate(sizeof(int));
+  cub::TransformInputIterator<bool, NonZeroOp<scalar_t>, scalar_t*> itr(self_.data_ptr<scalar_t>(), NonZeroOp<scalar_t>());
+  cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, itr, (int*)num_nonzeros.get(), N, stream);
+  auto temp_storage = allocator.allocate(temp_storage_bytes);
+  cub::DeviceReduce::Sum(temp_storage.get(), temp_storage_bytes, itr, (int*)num_nonzeros.get(), N, stream);
+  int num_nonzeros_h;
+  C10_CUDA_CHECK(cudaMemcpyAsync(&num_nonzeros_h, num_nonzeros.get(), sizeof(int), cudaMemcpyDeviceToHost, stream));
+  //need to synchronize to make sure data is available on the host
+  C10_CUDA_CHECK(cudaStreamSynchronize(stream));
+  //expected output size is num_nonzeros x ndim
+  //we are producing output with size {num_nonzeros, ndim} and strides {num_nonzeros, 1} (that is, transposed ndim x num_nonzeros output)
+  //we are able to directly use passed output with this size and strides, and we can also (per contract)
+  //resize passed output with incorrect sizes anyway we want.
+  //However, out with correct sizes and incorrect strides will have to be copied to from the intermediate we've produced.
+  bool need_to_copy = out.dim() == 2 && out.sizes()[0] == num_nonzeros_h && out.sizes()[1] == self.dim() && !out.t().is_contiguous();
+  at::Tensor out_temp = need_to_copy ?
+    at::native::empty_cuda({self.dim(), num_nonzeros_h}, optTypeMetaToScalarType(out.options().dtype_opt()),
+                           out.options().layout_opt(), out.options().device_opt(), out.options().pinned_memory_opt()) :
+    out.resize_({self.dim(), num_nonzeros_h});
+  //Scalars are expected to produce output of size (1,0), so we can't write to it
+  if (self.dim() > 0) {
+    cub::CountingInputIterator<int64_t> counting_itr(0);
+    temp_storage_bytes = 0;
+    cub::DeviceSelect::Flagged(nullptr, temp_storage_bytes, counting_itr, itr,
+      out_temp.data_ptr<int64_t>(), (int*)num_nonzeros.get(), N, stream);
+    temp_storage = allocator.allocate(temp_storage_bytes);
+    cub::DeviceSelect::Flagged(temp_storage.get(), temp_storage_bytes, counting_itr, itr,
+      out_temp.data_ptr<int64_t>(), (int*)num_nonzeros.get(), N, stream);
+    if (num_nonzeros_h > 0 && self.dim() > 1){
+        TensorDims<int> dims;
+        for (int i=0; i<self.dim(); i++){
+            dims.sizes[i] = self.sizes()[i];
+        }
+        const int nthreads = 256;
+        const int nblocks = (num_nonzeros_h + nthreads -1)/nthreads;
+        write_indices<<<nblocks, nthreads, 0, stream>>>(out_temp.data_ptr<int64_t>(),
+        dims, self.dim(), num_nonzeros_h);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+  }
+  if (need_to_copy) {
+    out.copy_(out_temp.t());
+  } else {
+    //transpose out so it is correct size
+    Tensor out_ = out_temp.t();
+    out.set_(out_);
+  }
+}
+
+Tensor& nonzero_out_cuda(Tensor& out, const Tensor& self){
+  TORCH_CHECK(self.numel() < std::numeric_limits<int>::max(), "nonzero is not supported for tensors with more than INT_MAX elements, \
+  file a support request");
+  TORCH_CHECK(out.dtype() == at::kLong, "Expected object of scalar type ", at::kLong, " as out, but got ", out.dtype());
+  TORCH_CHECK(self.device() == out.device(), "expected self and out to be on the same device, but got out on ",
+  out.device(), " and self on ", self.device());
+  TORCH_CHECK(self.dim() <= MAX_DIMS, "nonzero is not supported for tensor with more than ", MAX_DIMS, " dimensions");
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half,
+    self.scalar_type(), "nonzero_cuda",
+    [&] {nonzero_cuda_out_impl<scalar_t>(self, out);});
+  return out;
+}
+
+Tensor nonzero_cuda(const Tensor& self){
+  Tensor out = at::native::empty_cuda({0}, kLong, self.options().layout_opt(), self.options().device_opt(), self.options().pinned_memory_opt());
+  return nonzero_out_cuda(out, self);
+}
+} //namespace::native
+} //namespace::at

--- a/aten/src/ATen/native/cuda/Randperm.cu
+++ b/aten/src/ATen/native/cuda/Randperm.cu
@@ -1,0 +1,83 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/native/TensorFactories.h>
+#include <ATen/cuda/CubUtils.cuh>
+
+#include <limits>
+
+namespace at {
+namespace native {
+
+Tensor& randperm_out_cuda(Tensor& result, int64_t n, c10::optional<Generator> generator) {
+  TORCH_CHECK(n >= 0, "n must be non-negative, got", n);
+  TORCH_CHECK(!generator.has_value() || (generator.has_value() && result.device() == generator->device()), "Expected a '", result.device(), "' generator device but found '", generator->device(), "'");
+  check_supported_max_int_with_precision(n, result);
+
+  result.resize_({n});
+
+  if (n < 30000) {  // For small inputs, we offload it to CPU instead.
+    auto result_cpu = at::empty({n}, result.options().device(kCPU));
+    randperm_out(result_cpu, n, generator);
+    return result.copy_(result_cpu);
+  }
+
+#if 0
+  // This if condition should never be true because if n >= 30000 and the tensor has a Half type,
+  // check_supported_max_int_with_precision should have reported an error. This snippet is commented out but left here
+  // for the sake of clarity, because Half in thrust is spotty, and we do not want future change unaware of this.
+  if (result.scalar_type() == at::ScalarType::Half) {  // Half in thrust is spotty. Avoid.
+    auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
+    return result.copy_(randperm_out_cuda(result_float, n, generator));
+  }
+#endif
+
+  // Generate random values for the keys array
+  AT_DISPATCH_ALL_TYPES(
+    result.scalar_type(), "randperm_out_cuda", [&] {
+      TORCH_CHECK(n <= std::numeric_limits<int>::max(),
+        "randperm of tensors larger than INT_MAX is not supported yet in pytorch");
+
+      auto keys = at::empty(result.sizes(), result.options()).random_(generator);
+      auto range = at::arange(n, result.options());
+      auto keys_tmp = at::empty_like(keys);
+
+      // shuffled_data points to the underlying data of the output tensor if the tensor is contiguous; otherwise it
+      // points to a new tensor.
+      Tensor shuffled;
+      scalar_t *shuffled_data;
+      if (result.is_contiguous()) {
+        shuffled_data = result.data_ptr<scalar_t>();
+      } else {
+        shuffled = at::empty(n, result.options());
+        shuffled_data = shuffled.data_ptr<scalar_t>();
+      }
+
+      // Use the sorted order of keys to rearrange the result array
+      size_t temp_storage_bytes = 0;
+
+      cub::DeviceRadixSort::SortPairs(
+        nullptr, temp_storage_bytes,
+        keys.data_ptr<scalar_t>(), keys_tmp.data_ptr<scalar_t>(),
+        range.data_ptr<scalar_t>(), shuffled_data, n,
+        0, sizeof(scalar_t) * 8, at::cuda::getCurrentCUDAStream());
+      auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+      auto dataPtr = allocator.allocate(temp_storage_bytes);
+      cub::DeviceRadixSort::SortPairs(
+        dataPtr.get(), temp_storage_bytes,
+        keys.data_ptr<scalar_t>(), keys_tmp.data_ptr<scalar_t>(),
+        range.data_ptr<scalar_t>(), shuffled_data, n,
+        0, sizeof(scalar_t) * 8, at::cuda::getCurrentCUDAStream());
+
+      if (!result.is_contiguous()) {
+        result.copy_(shuffled);
+      }
+    }
+  );
+
+  return result;
+}
+
+
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -4,7 +4,7 @@
 #include <THC/THCNumerics.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <THC/THCGeneral.h>
-#include <cub/device/device_scan.cuh>
+#include <ATen/cuda/CubUtils.cuh>
 
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -8,17 +8,10 @@
 #include <c10/util/Exception.h>
 
 #include <THC/THCGeneral.h>
-#include <THC/THCThrustAllocator.cuh>
-#include <thrust/device_ptr.h>
-#include <thrust/sort.h>
-#include <thrust/execution_policy.h>
-#include <thrust/sequence.h>
-#include <cub/cub.cuh>
 
 #include <algorithm>
 #include <cstddef>
 #include <cmath>
-#include <limits>
 
 namespace at {
 namespace native {
@@ -76,76 +69,6 @@ Tensor empty_strided_cuda(IntArrayRef size, IntArrayRef stride, c10::optional<Sc
   auto t = at::native::empty_cuda({0}, dtype_opt, layout_opt, device_opt, pin_memory_opt);
   at::native::resize_impl_cuda_(t.unsafeGetTensorImpl(), size, stride);
   return t;
-}
-
-Tensor& randperm_out_cuda(Tensor& result, int64_t n, c10::optional<Generator> generator) {
-  TORCH_CHECK(n >= 0, "n must be non-negative, got", n);
-  TORCH_CHECK(!generator.has_value() || (generator.has_value() && result.device() == generator->device()), "Expected a '", result.device(), "' generator device but found '", generator->device(), "'");
-  check_supported_max_int_with_precision(n, result);
-
-  result.resize_({n});
-
-  if (n < 30000) {  // For small inputs, we offload it to CPU instead.
-    auto result_cpu = at::empty({n}, result.options().device(kCPU));
-    randperm_out(result_cpu, n, generator);
-    return result.copy_(result_cpu);
-  }
-
-#if 0
-  // This if condition should never be true because if n >= 30000 and the tensor has a Half type,
-  // check_supported_max_int_with_precision should have reported an error. This snippet is commented out but left here
-  // for the sake of clarity, because Half in thrust is spotty, and we do not want future change unaware of this.
-  if (result.scalar_type() == at::ScalarType::Half) {  // Half in thrust is spotty. Avoid.
-    auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
-    return result.copy_(randperm_out_cuda(result_float, n, generator));
-  }
-#endif
-
-  // Generate random values for the keys array
-  AT_DISPATCH_ALL_TYPES(
-    result.scalar_type(), "randperm_out_cuda", [&] {
-      TORCH_CHECK(n <= std::numeric_limits<int>::max(),
-        "randperm of tensors larger than INT_MAX is not supported yet in pytorch");
-
-      auto keys = at::empty(result.sizes(), result.options()).random_(generator);
-      auto range = at::arange(n, result.options());
-      auto keys_tmp = at::empty_like(keys);
-
-      // shuffled_data points to the underlying data of the output tensor if the tensor is contiguous; otherwise it
-      // points to a new tensor.
-      Tensor shuffled;
-      scalar_t *shuffled_data;
-      if (result.is_contiguous()) {
-        shuffled_data = result.data_ptr<scalar_t>();
-      } else {
-        shuffled = at::empty(n, result.options());
-        shuffled_data = shuffled.data_ptr<scalar_t>();
-      }
-
-      // Use the sorted order of keys to rearrange the result array
-      void *d_temp_storage = nullptr;
-      size_t temp_storage_bytes = 0;
-
-      cub::DeviceRadixSort::SortPairs(
-        nullptr, temp_storage_bytes,
-        keys.data_ptr<scalar_t>(), keys_tmp.data_ptr<scalar_t>(),
-        range.data_ptr<scalar_t>(), shuffled_data, n,
-        0, sizeof(scalar_t) * 8, at::cuda::getCurrentCUDAStream());
-      auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
-      auto dataPtr = allocator.allocate(temp_storage_bytes);
-      cub::DeviceRadixSort::SortPairs(
-        dataPtr.get(), temp_storage_bytes,
-        keys.data_ptr<scalar_t>(), keys_tmp.data_ptr<scalar_t>(),
-        range.data_ptr<scalar_t>(), shuffled_data, n,
-        0, sizeof(scalar_t) * 8, at::cuda::getCurrentCUDAStream());
-
-      if (!result.is_contiguous()) {
-        result.copy_(shuffled);
-      }
-    }
-  );
-
-  return result;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3052,7 +3052,7 @@ class TestRandomTensorCreation(TestCase):
             torch.rand(size, size, out=res2)
             self.assertEqual(res1, res2)
 
-    @slowTest
+    @onlyCUDA
     def test_randperm(self, device):
         if device == 'cpu':
             rng_device = None
@@ -3072,6 +3072,7 @@ class TestRandomTensorCreation(TestCase):
                 res2 = torch.empty(0, dtype=dtype, device=device)
                 torch.randperm(n, out=res2, dtype=dtype, device=device)
                 self.assertEqual(res1, res2, atol=0, rtol=0)
+                self.assertEqual(res1.sort().values.long(), torch.arange(n, device=device))
 
         # Default type is long
         for n in (100, 10000):
@@ -3101,6 +3102,7 @@ class TestRandomTensorCreation(TestCase):
                 res = torch.randperm(n, dtype=torch.long, device=device)
             torch.randperm(n, out=non_contiguous_tensor)
             self.assertEqual(non_contiguous_tensor, res)
+            self.assertEqual(res.sort().values.long(), torch.arange(n, device=device))
 
     # Test exceptions when device and generator types are incompatible
     @onlyCUDA


### PR DESCRIPTION
Cherry-pick of fix for https://github.com/pytorch/pytorch/issues/55027 into PyTorch LTS branch.

Changes:
1. Cherry pick https://github.com/pytorch/pytorch/pull/55292.
2. Due to https://github.com/pytorch/pytorch/pull/54751 and https://github.com/pytorch/pytorch/pull/54367, the `nonzero_out_cuda` and `randperm_out_cuda` method arguments had changed since then. So I reverted the argument change back, and squashed the change to one commit.