### PR TITLE
[bc-breaking] Dispatch index_put with boolean mask argument to masked_fill

### DIFF
--- a/aten/src/ATen/TensorIndexing.cpp
+++ b/aten/src/ATen/TensorIndexing.cpp
@@ -46,11 +46,15 @@ static inline void set_item(const Tensor& self, ArrayRef<TensorIndex> indices, c
 
   {
     at::AutoDispatchBelowADInplaceOrView guard;
+    at::Device self_device = self.device();
+
     // TODO: This qint special case looks very suspicious...
     if (isQIntType(self.scalar_type())) {
       value = at::indexing::scalarToTensor(v, device(kCPU).dtype(kFloat), at::Device(kCPU));
-    } else {
+    } else if (self_device.is_cuda()) {
       value = at::indexing::scalarToTensor(v, self.options(), at::Device(kCPU));
+    } else {
+      value = at::indexing::scalarToTensor(v, self.options(), self_device);
     }
   }
 

--- a/aten/src/ATen/TensorIndexing.cpp
+++ b/aten/src/ATen/TensorIndexing.cpp
@@ -50,7 +50,7 @@ static inline void set_item(const Tensor& self, ArrayRef<TensorIndex> indices, c
     if (isQIntType(self.scalar_type())) {
       value = at::indexing::scalarToTensor(v, device(kCPU).dtype(kFloat), at::Device(kCPU));
     } else {
-      value = at::indexing::scalarToTensor(v, self.options(), self.device());
+      value = at::indexing::scalarToTensor(v, self.options(), at::Device(kCPU));
     }
   }
 

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -352,7 +352,7 @@ static inline void copy_to(const Tensor& dst, const Tensor& src) {
     // appear. Users can workaround that case by dst[index..] = src.reshape(..)
     dst.copy_(src);
     return;
-  } else if (src.sizes().size() == 0) {
+  } else if (src.sizes().size() == 0 && src.device().type() == at::kCPU) {
     dst.fill_(src.item());
     return;
   }

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -352,6 +352,9 @@ static inline void copy_to(const Tensor& dst, const Tensor& src) {
     // appear. Users can workaround that case by dst[index..] = src.reshape(..)
     dst.copy_(src);
     return;
+  } else if (src.sizes().size() == 0) {
+    dst.fill_(src.item());
+    return;
   }
   auto src_view = src.view(slicePrefix1sSize(src.sizes()));
   c10::MaybeOwned<Tensor> b_src = expand_inplace(dst, src_view, "setitem");

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -510,7 +510,7 @@ Tensor & _index_put_impl_(Tensor & self, const torch::List<c10::optional<Tensor>
     }
   }
   auto value_ = value;
-  if (value.device() != self.device() && value.numel() == 1) {
+  if (value.device() != self.device() && value.numel() == 1 && value.dim() == 0) {
     value_ = value.to(self.device());
   }
   at::assert_no_overlap(self, value);

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -508,7 +508,7 @@ Tensor & _index_put_impl_(Tensor & self, const torch::List<c10::optional<Tensor>
     }
   }
   auto value_ = value;
-  if (value.device() != self.device()) {
+  if (value.device() != self.device() && value.numel() == 1) {
     value_ = value.to(self.device());
   }
   at::assert_no_overlap(self, value);

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -297,12 +297,14 @@ const Tensor& value){
   }
   int64_t num_ind = 0;
   Tensor mask;
+  auto self_device = self.device();
   for (const c10::optional<Tensor> i: indices) {
     if (!i.has_value() || !(*i).defined()){
       num_ind++;
     } else {
       Tensor index = std::move(*i);
-      if ((index.scalar_type() != kByte && index.scalar_type() != kBool) || mask.defined()){
+      if ((index.scalar_type() != kByte && index.scalar_type() != kBool) ||
+          index.device() != self_device || mask.defined()){
         return std::make_tuple(false, Tensor());
       } else {
         mask = index;

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -796,6 +796,22 @@ class TestIndexing(TestCase):
         r = v[c > 0]
         self.assertEqual(r.shape, (num_ones, 3))
 
+    def test_jit_indexing(self, device):
+        def fn1(x):
+            x[x < 50] = 1.0
+            return x
+        def fn2(x):
+            x[0:50] = 1.0
+            return x
+        scripted_fn1 = torch.jit.script(fn1)
+        scripted_fn2 = torch.jit.script(fn2)
+        data = torch.arange(100, device=device, dtype=torch.float)
+        out = scripted_fn1(data.detach().clone())
+        ref = torch.tensor(np.concatenate((np.ones(50), np.arange(50, 100))), device=device, dtype=torch.float)
+        self.assertEqual(out, ref)
+        out = scripted_fn2(data.detach().clone())
+        self.assertEqual(out, ref)
+
     def test_int_indices(self, device):
         v = torch.randn(5, 7, 3, device=device)
         self.assertEqual(v[[0, 4, 2]].shape, (3, 7, 3))

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -800,9 +800,11 @@ class TestIndexing(TestCase):
         def fn1(x):
             x[x < 50] = 1.0
             return x
+        
         def fn2(x):
             x[0:50] = 1.0
             return x
+        
         scripted_fn1 = torch.jit.script(fn1)
         scripted_fn2 = torch.jit.script(fn2)
         data = torch.arange(100, device=device, dtype=torch.float)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -800,11 +800,11 @@ class TestIndexing(TestCase):
         def fn1(x):
             x[x < 50] = 1.0
             return x
-        
+
         def fn2(x):
             x[0:50] = 1.0
             return x
-        
+
         scripted_fn1 = torch.jit.script(fn1)
         scripted_fn2 = torch.jit.script(fn2)
         data = torch.arange(100, device=device, dtype=torch.float)

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -371,7 +371,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   if (isQIntType(self_.scalar_type())) {
     value = valueToTensor(device(kCPU).dtype(kFloat), py_value, at::Device(kCPU));
   } else {
-    value = valueToTensor(self_.options(), py_value, self_device);
+    value = valueToTensor(self_.options(), py_value, at::Device(kCPU));
   }
 
   // handle simple types: ellipsis, none, bool

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -370,8 +370,10 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   // TODO: This qint special case looks very suspicious...
   if (isQIntType(self_.scalar_type())) {
     value = valueToTensor(device(kCPU).dtype(kFloat), py_value, at::Device(kCPU));
-  } else {
+  } else if (self_device.is_cuda()) {
     value = valueToTensor(self_.options(), py_value, at::Device(kCPU));
+  } else {
+    value = valueToTensor(self_.options(), py_value, self_device);
   }
 
   // handle simple types: ellipsis, none, bool


### PR DESCRIPTION
#57515

Based on @ngimel 's branch, with a few tweaks to determine when to copy value tensors to device memory/additional tests.
bc-breaking note: Previously, if in `x[index]=value` `value` was a 0-d tensor with device different from `x`'s device, it resulted in a RuntimeError. Now this case is handled by copying `value` to the correct device. 