### PR TITLE
Skip Bfloat16 support when building for VSX

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/functional.h
+++ b/aten/src/ATen/cpu/vec/vec256/functional.h
@@ -1,4 +1,6 @@
 #pragma once
 
 #include <ATen/cpu/vec/vec256/functional_base.h>
+#if !defined(__VSX__)  || !defined(CPU_CAPABILITY_VSX)
 #include <ATen/cpu/vec/vec256/functional_bfloat16.h>
+#endif


### PR DESCRIPTION
Copy-paste ifdef guard from vec256/vec256.h
Probably fixes https://github.com/pytorch/pytorch/issues/61575

