### PR TITLE
Use better defaults in the clang-tidy wrapper script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -337,7 +337,6 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           python3 -m tools.linter.clang_tidy \
             --diff-file pr.diff \
-            --parallel \
             --verbose \
             "$@" >"${GITHUB_WORKSPACE}"/clang-tidy-output.txt
           cat "${GITHUB_WORKSPACE}"/clang-tidy-output.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -337,10 +337,9 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           # The Docker image has our custom build, so we don't need to install it
           python3 -m tools.linter.clang_tidy \
-            --clang-tidy-exe clang-tidy \
+            --clang-tidy-exe $(which clang-tidy) \
             --diff-file pr.diff \
-            --verbose \
-            --disable-progress-bar 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+            --verbose 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
       - name: Annotate output
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -337,9 +337,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           python3 -m tools.linter.clang_tidy \
             --diff-file pr.diff \
-            --verbose \
-            "$@" >"${GITHUB_WORKSPACE}"/clang-tidy-output.txt
-          cat "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+            --verbose |& tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
       - name: Annotate output
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -337,7 +337,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           python3 -m tools.linter.clang_tidy \
             --diff-file pr.diff \
-            --verbose |& tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+            --verbose 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
       - name: Annotate output
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -335,9 +335,12 @@ jobs:
       - name: Run clang-tidy
         run: |
           cd "${GITHUB_WORKSPACE}"
+          # The Docker image has our custom build, so we don't need to install it
           python3 -m tools.linter.clang_tidy \
+            --clang-tidy-exe clang-tidy \
             --diff-file pr.diff \
-            --verbose 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+            --verbose \
+            --disable-progress-bar 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
       - name: Annotate output
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -337,7 +337,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           # The Docker image has our custom build, so we don't need to install it
           python3 -m tools.linter.clang_tidy \
-            --clang-tidy-exe $(which clang-tidy) \
+            --clang-tidy-exe "$(which clang-tidy)" \
             --diff-file pr.diff \
             --verbose 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
       - name: Annotate output

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -338,8 +338,7 @@ jobs:
           # The Docker image has our custom build, so we don't need to install it
           python3 -m tools.linter.clang_tidy \
             --clang-tidy-exe "$(which clang-tidy)" \
-            --diff-file pr.diff \
-            --verbose 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+            --diff-file pr.diff 2>&1 | tee "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
       - name: Annotate output
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -9,6 +9,7 @@ from typing import List
 
 from tools.linter.clang_tidy.run import run
 from tools.linter.clang_tidy.generate_build_files import generate_build_files
+from tools.linter.install.clang_tidy import INSTALLATION_PATH
 
 
 def clang_search_dirs() -> List[str]:
@@ -75,15 +76,19 @@ DEFAULTS = {
     ],
     "paths": ["torch/csrc/"],
     "include-dir": ["/usr/lib/llvm-11/include/openmp"] + clang_search_dirs(),
+    "clang-tidy-exe": INSTALLATION_PATH,
+    "parallel": True,
+    "compile-commands-dir": "build",
+    "config-file": ".clang-tidy",
 }
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run Clang-Tidy (on your Git changes)")
+    parser = argparse.ArgumentParser(description="clang-tidy wrapper script")
     parser.add_argument(
         "-e",
         "--clang-tidy-exe",
-        default="clang-tidy",
+        default=DEFAULTS["clang-tidy-exe"],
         help="Path to clang-tidy executable",
     )
     parser.add_argument(
@@ -106,7 +111,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-c",
         "--compile-commands-dir",
-        default="build",
+        default=DEFAULTS["compile-commands-dir"],
         help="Path to the folder containing compile_commands.json",
     )
     parser.add_argument(
@@ -129,6 +134,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     parser.add_argument(
         "--config-file",
+        default=DEFAULTS["config-file"],
         help="Path to a clang-tidy config file. Defaults to '.clang-tidy'.",
     )
     parser.add_argument(
@@ -141,6 +147,7 @@ def parse_args() -> argparse.Namespace:
         "-j",
         "--parallel",
         action="store_true",
+        default=DEFAULTS["parallel"],
         help="Run clang tidy in parallel per-file (requires ninja to be installed).",
     )
     parser.add_argument(

--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -175,9 +175,10 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    options = parse_args()
+
     if not pathlib.Path("build").exists():
         generate_build_files()
-    options = parse_args()
 
     # Check if clang-tidy executable exists
     exists = os.access(options.clang_tidy_exe, os.X_OK)
@@ -196,4 +197,5 @@ def main() -> None:
         raise RuntimeError("Warnings found in clang-tidy output!")
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -185,12 +185,11 @@ def main() -> None:
 
     if not exists:
         msg = (
-            "Could not find 'clang-tidy' binary\n"
+            "Could not find '.clang-tidy-bin/clang-tidy'\n"
             "You can install it by running:\n"
             "   python3 tools/linter/install/clang_tidy.py"
         )
-        print(msg)
-        raise RuntimeError("Could not find clang-tidy binary")
+        raise RuntimeError(msg)
 
     return_code = run(options)
     if return_code != 0:

--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -190,7 +190,7 @@ def main() -> None:
             "   python3 tools/linter/install/clang_tidy.py"
         )
         print(msg)
-        exit(1)
+        sys.exit(1)
 
     return_code = run(options)
     if return_code != 0:

--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -180,9 +180,8 @@ def main() -> None:
     options = parse_args()
 
     # Check if clang-tidy executable exists
-    exists = os.access(options.clang_tidy_exe, os.X_OK) or shutil.which(
-        options.clang_tidy_exe
-    )
+    exists = os.access(options.clang_tidy_exe, os.X_OK)
+
     if not exists:
         msg = (
             "Could not find 'clang-tidy' binary\n"
@@ -190,7 +189,7 @@ def main() -> None:
             "   python3 tools/linter/install/clang_tidy.py"
         )
         print(msg)
-        sys.exit(1)
+        raise RuntimeError("Could not find clang-tidy binary")
 
     return_code = run(options)
     if return_code != 0:

--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -60,3 +60,7 @@ def generate_build_files() -> None:
     update_submodules()
     gen_compile_commands()
     run_autogen()
+
+
+if __name__ == "__main__":
+    generate_build_files()

--- a/tools/linter/install/clang_tidy.py
+++ b/tools/linter/install/clang_tidy.py
@@ -10,6 +10,7 @@ PLATFORM_TO_HASH = {
 }
 
 OUTPUT_DIR = os.path.join(PYTORCH_ROOT, ".clang-tidy-bin")
+INSTALLATION_PATH = os.path.join(OUTPUT_DIR, "clang-tidy")
 
 if __name__ == "__main__":
     ok = download("clang-tidy", OUTPUT_DIR, PLATFORM_TO_URL, PLATFORM_TO_HASH)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61674
* #61711
* #61689
* #61672
* **#61651**


This PR sets some QOL defaults to the clang-tidy wrapper script and refactors how defaults are set.

- Runs in parallel
- Custom executable (prints an error message to users asking them to install our custom build)
- `generate_build_files` can now be run as a script

Differential Revision: [D29743661](https://our.internmc.facebook.com/intern/diff/D29743661)