### PR TITLE
Torch deploy for fx.grapm_module with non-torch dependencie

### DIFF
--- a/torch/_deploy.py
+++ b/torch/_deploy.py
@@ -9,6 +9,13 @@ def _save_storages(importer, obj):
     serialized_storages = []
     serialized_dtypes = []
 
+    importer = importer if isinstance(importer, torch.package.PackageImporter) else None
+    importers: Importer
+    if importer is not None:
+        importers = OrderedImporter(importer, sys_importer)
+    else:
+        importers = sys_importer
+
     def persistent_id(obj):
         # FIXME: the docs say that persistent_id should only return a string
         # but torch store returns tuples. This works only in the binary protocol
@@ -19,16 +26,20 @@ def _save_storages(importer, obj):
             serialized_storages.append(obj)
             serialized_dtypes.append(obj.dtype)
             return ('storage', len(serialized_storages) - 1)
+
+        if hasattr(obj, "__reduce_deploy__"):
+            if _serialized_reduces.get(id(obj)) is None:
+                _serialized_reduces[id(obj)] = (
+                    "reduce_deploy",
+                    id(obj),
+                    *obj.__reduce_deploy__(importers),
+                )
+            return _serialized_reduces[id(obj)]
+
         return None
 
     # Write the pickle data for `obj`
     data_buf = io.BytesIO()
-    importer = importer if isinstance(importer, torch.package.PackageImporter) else None
-    importers: Importer
-    if importer is not None:
-        importers = OrderedImporter(importer, sys_importer)
-    else:
-        importers = sys_importer
     pickler = create_pickler(data_buf, importers)
     pickler.persistent_id = persistent_id
     pickler.dump(obj)
@@ -42,9 +53,16 @@ def _load_storages(id, zip_reader, obj_bytes, serialized_storages):
         typename = _maybe_decode_ascii(saved_id[0])
         data = saved_id[1:]
 
-        assert typename == 'storage', \
-            f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
-        return serialized_storages[data[0]]
+        if typename == 'storage':
+            return serialized_storages[data[0]]
+
+        if typename == 'reduce_deploy':
+            reduce_id, func, args = data
+            if reduce_id not in _loaded_reduces:
+                _loaded_reduces[reduce_id] = func(_raw_packages[zip_reader], *args)
+            return _loaded_reduces[reduce_id]
+
+        return None
 
 
     importer: Importer
@@ -66,3 +84,5 @@ def _get_package(zip_reader):
 
 _raw_packages: dict = {}
 _deploy_objects: dict = {}
+_serialized_reduces: dict = {}
+_loaded_reduces: dict = {}

--- a/torch/csrc/deploy/example/fx/examples.py
+++ b/torch/csrc/deploy/example/fx/examples.py
@@ -1,0 +1,16 @@
+import torch.fx
+try:
+    from .some_dependency import a_non_torch_leaf
+except ImportError:
+    from some_dependency import a_non_torch_leaf
+
+
+torch.fx.wrap('a_non_torch_leaf')
+class SimpleWithLeaf(torch.nn.Module):
+    def __init__(self, N, M):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.rand(N, M))
+
+    def forward(self, input):
+        output = self.weight + a_non_torch_leaf(1, input)
+        return output

--- a/torch/csrc/deploy/example/fx/some_dependency.py
+++ b/torch/csrc/deploy/example/fx/some_dependency.py
@@ -1,0 +1,4 @@
+# dependency for torch package
+
+def a_non_torch_leaf(a: int, b):
+    return a * b

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -68,17 +68,29 @@ def reduce_graph_module(body: Dict[Any, Any], import_block: str) -> torch.nn.Mod
     # making `code` into a property and adding a docstring to it
     fn_src = body.get('_code') or body['code']
     forward = _forward_from_src(import_block + fn_src, {})
-    return _deserialize_graph_module(forward, body, None)
+    return _deserialize_graph_module(forward, body)
 
 
 def reduce_package_graph_module(importer: PackageImporter,
                                 body: Dict[Any, Any],
                                 generated_module_name: str) -> torch.nn.Module:
     forward = importer.import_module(generated_module_name).forward
-    return _deserialize_graph_module(forward, body, importer)
+    return _deserialize_graph_module(forward, body)
 
 
-def _deserialize_graph_module(forward, body: Dict[Any, Any], importer: Optional[PackageImporter]) -> torch.nn.Module:
+def reduce_deploy_graph_module(importer: PackageImporter,
+                               body: Dict[Any, Any],
+                               import_block: str,
+                               tracer_cls: Type) -> torch.nn.Module:
+    ns = dict()
+    ns["__builtins__"] = importer.patched_builtins
+    fn_src = body.get('_code')
+    assert fn_src is not None
+    forward = _forward_from_src(import_block + fn_src, ns)
+    return _deserialize_graph_module(forward, body, tracer_cls)
+
+
+def _deserialize_graph_module(forward, body: Dict[Any, Any], tracer_cls: Type = None) -> torch.nn.Module:
     """
     Deserialize a GraphModule given the dictionary of the original module,
     using the code to reconstruct the graph. We delete the actual graph before
@@ -95,11 +107,17 @@ def _deserialize_graph_module(forward, body: Dict[Any, Any], importer: Optional[
     # Try to retrieve the forward source in a backward-compatible way
     CodeOnlyModule.forward = forward
 
-    from ._symbolic_trace import Tracer
+    if tracer_cls is None:
+        from ._symbolic_trace import Tracer
+        tracer_cls = Tracer
 
-    # we shouldn't trace into any of the submodules, they were not
-    # because they were not traced in the original GraphModule
-    class KeepModules(Tracer):
+    # This is a workaround for a mypy linter issue related to
+    # passing base class as an argument - https://github.com/python/mypy/issues/5865.
+    cls_tracer : Any = tracer_cls
+
+    class KeepModules(cls_tracer):
+        # we shouldn't trace into any of the submodules,
+        # because they were not traced in the original GraphModule
         def is_leaf_module(self, _: torch.nn.Module, __: str) -> bool:
             return True
 
@@ -518,6 +536,15 @@ class {module_name}(torch.nn.Module):
         cls.__call__ = wrapped_call
 
         return python_code
+
+    # Passing Tracer as argument allows subclasses extending fx.GraphModule
+    # define their own Tracer (extending fx.Tracer).
+    def __reduce_deploy__(self, importer: Importer, tracer_cls: Type = None):
+        dict_without_graph = self.__dict__.copy()
+        python_code = self.recompile()
+        import_block = _format_import_block(python_code.globals, importer)
+        del dict_without_graph['_graph']
+        return (reduce_deploy_graph_module, (dict_without_graph, import_block, tracer_cls))
 
     def __reduce_package__(self, exporter: PackageExporter):
         generated_module_name = f'fx-generated._{exporter.get_unique_id()}'


### PR DESCRIPTION
Summary:
This diff enables torch deploy for fx.graph_module with non-torch dependencies . Here are the issues currently preventing this and are fixed in this change:
-  Pickle is used as an internal format to transmit objects between interpreters. It needs to serialize python code, but to be able to get the source code for imports from python_code.globals it needs access to the PackageImporter. Currently a regular _reduce_ function is used which doesn't have the notion of custom importer.
- When deserializing pickled objects on an interpreter, it is passing empty globals to exec, thus it will not be able to resolve non-torch imports located in the package. We need to be able to point exec to our custom PackageImporter.
- Subclasses extending fx.graph_module should be able to optionally provide their own Tracer (extending fx.Tracer).

As a solution a new reducer is introduced (_reduce_deploy_) for torch deploy workflow. Reducer will be registered in _deploy.py (entry point for C++ torch deploy API) when saving the object transmitting it between interpreters. It allows us to pass a proper PackageImporter for each interpreter for pickling/unpickling fx.graph_module. It also defines an api for passing custom fx.Tracer when needed.

Test Plan:
Added UT to cover changes.
```
buck test //caffe2/torch/csrc/deploy:test_deploy
```
```
buck test caffe2/test:fx
```

Differential Revision: D29690088

