### PR TITLE
copy header file to CONDA env when using python setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -925,6 +925,7 @@ if __name__ == '__main__':
                 'lib/*.pdb',
                 'lib/torch_shm_manager',
                 'lib/*.h',
+                'include/*.h',
                 'include/ATen/*.h',
                 'include/ATen/cpu/*.h',
                 'include/ATen/cpu/vec/vec256/*.h',


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/61695.
For my understanding, users should access same header between using "python setup.py develop" and using "python setup.py install". Missing "'include/*.h'" will not copy the header files under {SRC-DIR}/torch/include to  {INSTALL-DIR}/torch/include
