### PR TITLE
Fix `torch.median` crash on empty tensor

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -479,6 +479,12 @@ Tensor median_impl(const Tensor& self, bool ignore_nan) {
     scalar_t* first = in.data_ptr<scalar_t>();
     scalar_t* last = first + size;
 
+    // Return nan for empty tensors
+    if (size == 0) {
+      *op = std::numeric_limits<scalar_t>::quiet_NaN();
+      return;
+    }
+
     // For torch.median, if there are nan values return nan
     if (!ignore_nan && std::any_of(first, last, _isnan<scalar_t>)) {
       *op = std::numeric_limits<scalar_t>::quiet_NaN();

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -468,22 +468,21 @@ std::tuple<Tensor&, Tensor&> median_with_indices_impl(
 // Computes the median of all values in the input
 Tensor median_impl(const Tensor& self, bool ignore_nan) {
   NoNamesGuard guard;
+  const int64_t size = self.numel();
+
+  // Return nan for empty tensors
+  if (size <= 0) {
+    return at::full({}, std::numeric_limits<float>::quiet_NaN()).to(self.options());
+  }
 
   // Clone the input tensor so we can partition it around the median value
   Tensor in = self.clone();
   Tensor out = at::empty({}, self.options());
-  const int64_t size = self.numel();
 
   AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, in.scalar_type(), "median_cpu", [&] {
     scalar_t* op = out.data_ptr<scalar_t>();
     scalar_t* first = in.data_ptr<scalar_t>();
     scalar_t* last = first + size;
-
-    // Return nan for empty tensors
-    if (size == 0) {
-      *op = std::numeric_limits<scalar_t>::quiet_NaN();
-      return;
-    }
 
     // For torch.median, if there are nan values return nan
     if (!ignore_nan && std::any_of(first, last, _isnan<scalar_t>)) {

--- a/aten/src/ATen/native/cuda/Sorting.cu
+++ b/aten/src/ATen/native/cuda/Sorting.cu
@@ -379,7 +379,10 @@ Tensor median_impl(const Tensor& self, bool ignore_nan) {
   NoNamesGuard guard;
 
   int64_t size = self.numel();
-  TORCH_CHECK(size > 0, "median() input tensor cannot be empty");
+  // Return nan for empty tensors
+  if (size <= 0) {
+    return at::full({}, std::numeric_limits<float>::quiet_NaN()).to(self.options());
+  }
 
   // Sort input tensor to efficiently query for median element
   Tensor sorted = std::get<0>(self.flatten().sort());

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1872,6 +1872,7 @@ class TestReductions(TestCase):
 
         nan = float('nan')
         check(torch.median, nan, [], nan)
+        check(torch.median, [], [], nan)
         check(torch.nanmedian, nan, [], nan)
         check(torch.median, nan, [0], [nan, 0])
         check(torch.nanmedian, nan, [0], [nan, 0])


### PR DESCRIPTION
`torch.tensor([]).median()` returns `nan`, which mimics the behavior of `np.median`
Add test to `TestReductions.test_median_corner_cases`
Fixes https://github.com/pytorch/pytorch/issues/61656