### PR TITLE
[ONNX] Remove argument _retain_param_name from torch.onnx.export() function.

### DIFF
--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -728,22 +728,6 @@ class TestOperators(TestCase):
         x = torch.randn(2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: torch.cumsum(x, dim=1), x, opset_version=11)
 
-    def test_retain_param_name_disabled(self):
-        class MyModule(Module):
-            def __init__(self):
-                super(MyModule, self).__init__()
-                self.fc1 = nn.Linear(4, 5, bias=False)
-                self.fc1.weight.data.fill_(2.)
-                self.fc2 = nn.Linear(5, 6, bias=False)
-                self.fc2.weight.data.fill_(3.)
-
-            def forward(self, x):
-                return self.fc2(self.fc1(x))
-
-        x = torch.randn(3, 4).float()
-        self.assertONNX(MyModule(), (x,), _retain_param_name=False,
-                        keep_initializers_as_inputs=True)
-
     def test_c2_op(self):
         class MyModel(torch.nn.Module):
             def __init__(self):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -289,7 +289,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         # This test checks that given this edge condition, the model can be loaded and executed
         # in Caffe2 backend correctly.
         torch.onnx._export(model, input, f, verbose=True, export_type=ExportTypes.ZIP_ARCHIVE,
-                           input_names=["input1", "fc1.bias"], _retain_param_name=False,
+                           input_names=["input1", "fc1.bias"],
                            keep_initializers_as_inputs=True)
 
         f.seek(0)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7924,7 +7924,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(32, 3)
         f = io.BytesIO()
-        torch.onnx._export(test_model, (x,), f, _retain_param_name=True, do_constant_folding=False)
+        torch.onnx._export(test_model, (x,), f, do_constant_folding=False)
         loaded_model = onnx.load_from_string(f.getvalue())
 
         actual_list = [p.name for p in loaded_model.graph.initializer]
@@ -7974,7 +7974,7 @@ class TestONNXRuntime(unittest.TestCase):
         example_output = (test_model(x, y),)
         f = io.BytesIO()
 
-        torch.onnx.export(test_model, (x, y), f, example_outputs=example_output, _retain_param_name=True, do_constant_folding=False)
+        torch.onnx.export(test_model, (x, y), f, example_outputs=example_output, do_constant_folding=False)
         loaded_model = onnx.load_from_string(f.getvalue())
 
         actual_list = [p.name for p in loaded_model.graph.initializer]

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -187,8 +187,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         opset_version (int, default 9):
             Must be ``== _onnx_main_opset or in _onnx_stable_opsets``,
             defined in torch/onnx/symbolic_helper.py.
-        _retain_param_name (bool, default True): [Deprecated and ignored. Will be removed in next release]
-            If True, will keep the original parameter names of model in final ONNX graph.
+        _retain_param_name (bool, default True): [Deprecated and ignored. Will be removed in next PyTorch
+            release]
         do_constant_folding (bool, default False): Apply the constant-folding optimization.
             Constant-folding will replace some of the ops that have all constant inputs
             with pre-computed constant nodes.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -187,7 +187,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         opset_version (int, default 9):
             Must be ``== _onnx_main_opset or in _onnx_stable_opsets``,
             defined in torch/onnx/symbolic_helper.py.
-        _retain_param_name (bool, default True): [DEPRECATED. Backend logic is working as it's True.]
+        _retain_param_name (bool, default True): [Deprecated and ignored. Will be removed in next release]
             If True, will keep the original parameter names of model in final ONNX graph.
         do_constant_folding (bool, default False): Apply the constant-folding optimization.
             Constant-folding will replace some of the ops that have all constant inputs

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -187,6 +187,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         opset_version (int, default 9):
             Must be ``== _onnx_main_opset or in _onnx_stable_opsets``,
             defined in torch/onnx/symbolic_helper.py.
+        _retain_param_name (bool, default True): [DEPRECATED. Backend logic is working as it's True.]
+            If True, will keep the original parameter names of model in final ONNX graph.
         do_constant_folding (bool, default False): Apply the constant-folding optimization.
             Constant-folding will replace some of the ops that have all constant inputs
             with pre-computed constant nodes.

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -81,6 +81,10 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
+    if _retain_param_name is not None:
+        warnings.warn("`_retain_param_name' is DEPRECATED. Please stop using it."
+                      "The code now will work as it is True to keep the original "
+                      "parameter names in the final ONNX graph.")
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
             do_constant_folding=do_constant_folding, example_outputs=example_outputs,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -82,8 +82,8 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
         else:
             operator_export_type = OperatorExportTypes.ONNX
     if _retain_param_name is not None:
-        warnings.warn("`_retain_param_name' is DEPRECATED. Please stop using it."
-                      "The code now will work as it is True to keep the original "
+        warnings.warn("`_retain_param_name' is deprecated and ignored. Will be removed in "
+                      "next release. The code now will work as it is True to keep the original "
                       "parameter names in the final ONNX graph.")
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -570,8 +570,8 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
         args = _decide_input_format(model, args)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type,
-                                                        example_outputs, _retain_param_name,
-                                                        val_do_constant_folding, fixed_batch_size=fixed_batch_size,
+                                                        example_outputs, val_do_constant_folding,
+                                                        fixed_batch_size=fixed_batch_size,
                                                         training=training, dynamic_axes=dynamic_axes,
                                                         export_params=export_params,
                                                         keep_initializers_as_inputs=val_keep_init_as_ip)


### PR DESCRIPTION
As of now, the "_retain_param_name" parameter has no description in PyTorch docs website. According to code, this argument determines if we keep the original parameter names of PyTorch model in the final ONNX graph. If this is False, those original parameter names will be replaced with a series of integers starting from 1.

Since setting numbers as parameter names make no sense to users, we remove this argument from the torch.onnx.export() function to increase user experience of calling this function.

This PR will still keep it in torch.onnx.export() function for backward support while all backend logic has been changed to work as _retain_param_name is set to True.