### PR TITLE
[ONNX] Deprecate enable_onnx_checker argument in torch.onnx.export()

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9507,15 +9507,16 @@ class TestONNXRuntime(unittest.TestCase):
 
         register_custom_op_symbolic("custom_namespace::custom_add", invalid_symbolic, 9)
 
-        x = torch.randn(2, 3, 4, requires_grad=False)
-        y = torch.randn(2, 3, 4, requires_grad=False)
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
 
         test_model = CustomAddModule()
         f = io.BytesIO()
 
         with self.assertRaises(RuntimeError) as cm:
             torch.onnx.export(test_model, (x, y), f)
-        assert len(f.getvalue()) > 0, "ONNX graph was not generated."
+
+        self.assertTrue(f.getvalue(), "ONNX graph was not generated")
 
 
 def make_test(name, base, layer, bidirectional, initial_state,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9515,8 +9515,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         try:
             torch.onnx.export(test_model, (x, y), f)
-            assert False, "Invalid graph was not detected by ONNX checker."
-        except Exception:
+            raise Exception("Invalid graph was not detected by ONNX checker.")
+        except RuntimeError:
             assert len(f.getvalue()) > 0, "ONNX graph was not generated."
 
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9478,43 +9478,43 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(10, 5)
         self.run_test(M(), (x,))
 
-    def test_invalid_onnx_proto_checker(self):
-        op_source = """
-        #include <torch/script.h>
+    # def test_invalid_onnx_proto_checker(self):
+    #     op_source = """
+    #     #include <torch/script.h>
 
-        torch::Tensor custom_add(torch::Tensor self, torch::Tensor other) {
-          return self + other;
-        }
+    #     torch::Tensor custom_add(torch::Tensor self, torch::Tensor other) {
+    #       return self + other;
+    #     }
 
-        static auto registry =
-          torch::RegisterOperators("custom_namespace::custom_add", &custom_add);
-        """
+    #     static auto registry =
+    #       torch::RegisterOperators("custom_namespace::custom_add", &custom_add);
+    #     """
 
-        torch.utils.cpp_extension.load_inline(
-            name="custom_add",
-            cpp_sources=op_source,
-            is_python_module=False,
-            verbose=True,
-        )
+    #     torch.utils.cpp_extension.load_inline(
+    #         name="custom_add",
+    #         cpp_sources=op_source,
+    #         is_python_module=False,
+    #         verbose=True,
+    #     )
 
-        class InvalidONNXModel(torch.nn.Module):
-            def forward(self, a, b):
-                return torch.ops.custom_namespace.custom_add(a, b)
+    #     class InvalidONNXModel(torch.nn.Module):
+    #         def forward(self, a, b):
+    #             return torch.ops.custom_namespace.custom_add(a, b)
 
-        def symbolic_custom_add(g, self, other):
-            other_constant = g.op("Constant", value_t)
-            # return g.op("Add", self, other, test_i=1)
-            return g.op("Add", output_i=0)
+    #     def symbolic_custom_add(g, self, other):
+    #         other_constant = g.op("Constant", value_t)
+    #         # return g.op("Add", self, other, test_i=1)
+    #         return g.op("Add", output_i=0)
 
-        from torch.onnx import register_custom_op_symbolic
-        register_custom_op_symbolic("custom_namespace::custom_add", symbolic_custom_add, 9)
+    #     from torch.onnx import register_custom_op_symbolic
+    #     register_custom_op_symbolic("custom_namespace::custom_add", symbolic_custom_add, 9)
 
-        x = torch.randn(2, 3, 4, requires_grad=False)
-        # y = torch.randn(2, 3, 4, requires_grad=False)
-        y = torch.randint(2, (2, 3, 4))
+    #     x = torch.randn(2, 3, 4, requires_grad=False)
+    #     # y = torch.randn(2, 3, 4, requires_grad=False)
+    #     y = torch.randint(2, (2, 3, 4))
 
-        model = InvalidONNXModel()
-        self.run_test(model, (x, y))
+    #     model = InvalidONNXModel()
+    #     self.run_test(model, (x, y))
 
 
 def make_test(name, base, layer, bidirectional, initial_state,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1,6 +1,7 @@
 import unittest
 import onnxruntime
 import torch
+import torch.utils.cpp_extension
 
 import numpy as np
 import io
@@ -9476,6 +9477,44 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(10, 5)
         self.run_test(M(), (x,))
+
+    def test_invalid_onnx_proto_checker(self):
+        op_source = """
+        #include <torch/script.h>
+
+        torch::Tensor custom_add(torch::Tensor self, torch::Tensor other) {
+          return self + other;
+        }
+
+        static auto registry =
+          torch::RegisterOperators("custom_namespace::custom_add", &custom_add);
+        """
+
+        torch.utils.cpp_extension.load_inline(
+            name="custom_add",
+            cpp_sources=op_source,
+            is_python_module=False,
+            verbose=True,
+        )
+
+        class InvalidONNXModel(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.ops.custom_namespace.custom_add(a, b)
+
+        def symbolic_custom_add(g, self, other):
+            other_constant = g.op("Constant", value_t)
+            # return g.op("Add", self, other, test_i=1)
+            return g.op("Add", output_i=0)
+
+        from torch.onnx import register_custom_op_symbolic
+        register_custom_op_symbolic("custom_namespace::custom_add", symbolic_custom_add, 9)
+
+        x = torch.randn(2, 3, 4, requires_grad=False)
+        # y = torch.randn(2, 3, 4, requires_grad=False)
+        y = torch.randint(2, (2, 3, 4))
+
+        model = InvalidONNXModel()
+        self.run_test(model, (x, y))
 
 
 def make_test(name, base, layer, bidirectional, initial_state,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1,7 +1,6 @@
 import unittest
 import onnxruntime
 import torch
-import torch.utils.cpp_extension
 import torchvision
 
 import numpy as np
@@ -9502,7 +9501,7 @@ class TestONNXRuntime(unittest.TestCase):
         finally:
             unregister_custom_op_symbolic("::add", 1)
 
-        self.assertTrue(f.getvalue(), "ONNX graph was not generated")
+        self.assertTrue(f.getvalue(), "ONNX graph was not exported.")
         loaded_model = onnx.load_from_string(f.getvalue())
 
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -303,6 +303,10 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1.
 
+        enable_onnx_checker (bool, default True): [DEPRECATED. Backend logic is working as it's True.]
+            If True the onnx model checker will be run to ensure the exported model is a valid ONNX
+            model. If it is an invalid ONNX model, an exception will be thrown out and the onnx
+            model file will still be generated.
         use_external_data_format (bool, default False): If True, then some of the model
             parameters are stored in external data files and not in the ONNX model file itself.
             Models larger than 2GB cannot be exported in one file because of size limits imposed
@@ -319,7 +323,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                         input_names, output_names, operator_export_type, opset_version,
                         _retain_param_name, do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, use_external_data_format)
+                        custom_opsets, enable_onnx_checker, use_external_data_format)
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -303,10 +303,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1.
 
-        enable_onnx_checker (bool, default True): [Deprecated and ignored. Will be removed in next
-            Pytorch release] If True the onnx model checker will be run to ensure the exported
-            model is a valid ONNX model. If it is an invalid ONNX model, an exception will be
-            thrown out and the onnx model file will still be generated.
+        enable_onnx_checker (bool, default True): Deprecated and ignored. Will be removed in next
+            Pytorch release.
         use_external_data_format (bool, default False): If True, then some of the model
             parameters are stored in external data files and not in the ONNX model file itself.
             Models larger than 2GB cannot be exported in one file because of size limits imposed
@@ -316,6 +314,10 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If True,  argument ``f`` must be a string specifying the location of the model.
             The external data files will be stored in the same directory as ``f``.
             This argument is ignored unless ``operator_export_type=OperatorExportTypes.ONNX``.
+
+    Raises:
+      ONNXCheckerError: If the ONNX checker detects an invalid ONNX graph. And the proto file will
+        still be generated even this error occurred.
     """
 
     from torch.onnx import utils

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -303,10 +303,10 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1.
 
-        enable_onnx_checker (bool, default True): [Deprecated and ignored. Will be removed in next release]
-            If True the onnx model checker will be run to ensure the exported model is a valid ONNX
-            model. If it is an invalid ONNX model, an exception will be thrown out and the onnx
-            model file will still be generated.
+        enable_onnx_checker (bool, default True): [Deprecated and ignored. Will be removed in next
+            Pytorch release] If True the onnx model checker will be run to ensure the exported
+            model is a valid ONNX model. If it is an invalid ONNX model, an exception will be
+            thrown out and the onnx model file will still be generated.
         use_external_data_format (bool, default False): If True, then some of the model
             parameters are stored in external data files and not in the ONNX model file itself.
             Models larger than 2GB cannot be exported in one file because of size limits imposed

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -316,8 +316,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             This argument is ignored unless ``operator_export_type=OperatorExportTypes.ONNX``.
 
     Raises:
-      ONNXCheckerError: If the ONNX checker detects an invalid ONNX graph. And the proto file will
-        still be generated even this error occurred.
+      ONNXCheckerError: If the ONNX checker detects an invalid ONNX graph. Will still export the
+        model to the file ``f`` even if this is raised.
     """
 
     from torch.onnx import utils

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -303,7 +303,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1.
 
-        enable_onnx_checker (bool, default True): [DEPRECATED. Backend logic is working as it's True.]
+        enable_onnx_checker (bool, default True): [Deprecated and ignored. Will be removed in next release]
             If True the onnx model checker will be run to ensure the exported model is a valid ONNX
             model. If it is an invalid ONNX model, an exception will be thrown out and the onnx
             model file will still be generated.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -303,8 +303,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1.
 
-        enable_onnx_checker (bool, default True): If True the onnx model checker will be run
-            to ensure the exported model is a valid ONNX model.
         use_external_data_format (bool, default False): If True, then some of the model
             parameters are stored in external data files and not in the ONNX model file itself.
             Models larger than 2GB cannot be exported in one file because of size limits imposed
@@ -321,7 +319,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                         input_names, output_names, operator_export_type, opset_version,
                         _retain_param_name, do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, enable_onnx_checker, use_external_data_format)
+                        custom_opsets, use_external_data_format)
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -83,7 +83,7 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             operator_export_type = OperatorExportTypes.ONNX
     if enable_onnx_checker is not None:
         warnings.warn("`enable_onnx_checker' is deprecated and ignored. Will be removed in "
-                      "next release. The code now will work as it is True so that the onnx "
+                      "next PyTorch release. The code now will work as it is True so that the onnx "
                       "model checker is always run to ensure the exported model is a valid ONNX model.")
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -743,8 +743,8 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             else:
                 raise RuntimeError("Unknown export type")
 
-            # Only run checker if we are using ONNX export type and
-            # large model format export in not enabled.
+            # The ONNX checker only works for ONNX graph. So if the operator_export_type is not ONNX,
+            # we can skip this check.
             # If large model format export is enabled, proto will only contain data location instead of
             # raw data and _check_onnx_proto() will fail because it can only handle the raw ONNX proto
             # string in memory.

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -82,9 +82,9 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
         else:
             operator_export_type = OperatorExportTypes.ONNX
     if enable_onnx_checker is not None:
-        warnings.warn("`enable_onnx_checker' is DEPRECATED. Please stop using it."
-                      "The code now will work as it is True so that the onnx model checker "
-                      "will be run to ensure the exported model is a valid ONNX model.")
+        warnings.warn("`enable_onnx_checker' is deprecated and ignored. Will be removed in "
+                      "next release. The code now will work as it is True so that the onnx "
+                      "model checker is always run to ensure the exported model is a valid ONNX model.")
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
             _retain_param_name=_retain_param_name, do_constant_folding=do_constant_folding,
@@ -743,10 +743,12 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             else:
                 raise RuntimeError("Unknown export type")
 
-            if operator_export_type is OperatorExportTypes.ONNX and \
-               not val_use_external_data_format:
-                # Only run checker if we are using ONNX export type and
-                # large model format export in not enabled.
+            # Only run checker if we are using ONNX export type and
+            # large model format export in not enabled.
+            # If large model format export is enabled, proto will only contain data location instead of
+            # raw data and _check_onnx_proto() will fail because it can only handle the raw ONNX proto 
+            # string in memory.
+            if (operator_export_type is OperatorExportTypes.ONNX) and (not val_use_external_data_format):
                 _check_onnx_proto(proto)
     finally:
         assert __IN_ONNX_EXPORT

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -86,8 +86,7 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             _retain_param_name=_retain_param_name, do_constant_folding=do_constant_folding,
             example_outputs=example_outputs, strip_doc_string=strip_doc_string,
             dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
-            custom_opsets=custom_opsets, enable_onnx_checker=enable_onnx_checker,
-            use_external_data_format=use_external_data_format)
+            custom_opsets=custom_opsets, use_external_data_format=use_external_data_format)
 
 
 def _is_constant_tensor_list(node):
@@ -636,8 +635,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             opset_version=None, _retain_param_name=False, do_constant_folding=True,
             strip_doc_string=True, dynamic_axes=None, keep_initializers_as_inputs=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
-            enable_onnx_checker=True, use_external_data_format=False,
-            onnx_shape_inference=True):
+            use_external_data_format=False, onnx_shape_inference=True):
 
     if isinstance(model, torch.nn.DataParallel):
         raise ValueError("torch.nn.DataParallel is not supported by ONNX "
@@ -710,13 +708,6 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                     strip_doc_string, val_keep_init_as_ip, custom_opsets, val_add_node_names,
                     val_use_external_data_format, model_file_location)
 
-            if enable_onnx_checker and \
-                operator_export_type is OperatorExportTypes.ONNX and \
-                    not val_use_external_data_format:
-                # Only run checker if enabled and we are using ONNX export type and
-                # large model format export in not enabled.
-                _check_onnx_proto(proto)
-
             if export_type == ExportTypes.PROTOBUF_FILE:
                 assert(len(export_map) == 0)
                 with torch.serialization._open_file_like(f, "wb") as opened_file:
@@ -747,6 +738,12 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                         opened_file.write(v)
             else:
                 raise RuntimeError("Unknown export type")
+
+            if operator_export_type is OperatorExportTypes.ONNX and \
+                not val_use_external_data_format:
+                # Only run checker if we are using ONNX export type and
+                # large model format export in not enabled.
+                _check_onnx_proto(proto)
     finally:
         assert __IN_ONNX_EXPORT
         __IN_ONNX_EXPORT = False

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -81,6 +81,10 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
+    if enable_onnx_checker is not None:
+        warnings.warn("`enable_onnx_checker' is DEPRECATED. Please stop using it."
+                      "The code now will work as it is True so that the onnx model checker "
+                      "will be run to ensure the exported model is a valid ONNX model.")
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
             _retain_param_name=_retain_param_name, do_constant_folding=do_constant_folding,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -746,7 +746,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             # Only run checker if we are using ONNX export type and
             # large model format export in not enabled.
             # If large model format export is enabled, proto will only contain data location instead of
-            # raw data and _check_onnx_proto() will fail because it can only handle the raw ONNX proto 
+            # raw data and _check_onnx_proto() will fail because it can only handle the raw ONNX proto
             # string in memory.
             if (operator_export_type is OperatorExportTypes.ONNX) and (not val_use_external_data_format):
                 _check_onnx_proto(proto)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -75,7 +75,7 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            opset_version=None, _retain_param_name=True, do_constant_folding=True,
            example_outputs=None, strip_doc_string=True, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_external_data_format=False):
+           enable_onnx_checker=None, use_external_data_format=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -740,7 +740,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                 raise RuntimeError("Unknown export type")
 
             if operator_export_type is OperatorExportTypes.ONNX and \
-                not val_use_external_data_format:
+               not val_use_external_data_format:
                 # Only run checker if we are using ONNX export type and
                 # large model format export in not enabled.
                 _check_onnx_proto(proto)


### PR DESCRIPTION
As of now, the "enable_onnx_checker" parameter was described as below:

enable_onnx_checker (bool, default True): If True the ONNX model checker will be run to ensure the exported model is a valid ONNX model.

An invalid ONNX graph is useless to users so such checker should be done for each call.

In this PR, we will still write the model to an ONNX file even it is invalid. And the exception will be thrown after the ONNX file has been created. This enables user output an invalid ONNX graph for debug.

This PR will still keep it in torch.onnx.export() function for backward support while all backend logic has been changed to work as enable_onnx_checker is set to True.

