### PR TITLE
use `rand` over `empty` in flaky test

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -725,7 +725,7 @@ def assert_close_with_inputs(actual: Any, expected: Any) -> Iterator[Callable]:
 
 class TestAssertClose(TestCase):
     def test_mismatching_types_subclasses(self):
-        actual = torch.empty(())
+        actual = torch.rand(())
         expected = torch.nn.Parameter(actual)
 
         for fn in assert_close_with_inputs(actual, expected):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/pull/61694#issuecomment-880641635. cc @krshrimali.
