### PR TITLE
[ONNX] Remove strip_doc_string param from torch.onnx.export() function.

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -557,27 +557,27 @@ class TestUtilityFuns(TestCase):
             assert node.kind() != "onnx::Shape"
         assert len(list(graph.nodes())) == 1
 
-    def test_strip_doc_string(self):
+    def test_verbose(self):
         class MyModule(torch.nn.Module):
             def forward(self, input):
                 return torch.exp(input)
         x = torch.randn(3, 4)
 
-        def is_model_stripped(f, strip_doc_string=None):
-            if strip_doc_string is None:
+        def is_model_stripped(f, verbose=None):
+            if verbose is None:
                 torch.onnx.export(MyModule(), x, f, opset_version=self.opset_version)
             else:
-                torch.onnx.export(MyModule(), x, f, strip_doc_string=strip_doc_string,
+                torch.onnx.export(MyModule(), x, f, verbose=verbose,
                                   opset_version=self.opset_version)
             model = onnx.load(io.BytesIO(f.getvalue()))
             model_strip = copy.copy(model)
             onnx.helper.strip_doc_string(model_strip)
             return model == model_strip
 
-        # test strip_doc_string=True (default)
+        # test verbose=False (default)
         self.assertTrue(is_model_stripped(io.BytesIO()))
-        # test strip_doc_string=False
-        self.assertFalse(is_model_stripped(io.BytesIO(), False))
+        # test verbose=True
+        self.assertFalse(is_model_stripped(io.BytesIO(), True))
 
     # NB: remove this test once DataParallel can be correctly handled
     def test_error_on_data_parallel(self):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -198,7 +198,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Must be provided when exporting a ScriptModule or ScriptFunction, ignored otherwise.
             Used to determine the type and shape of the outputs without tracing the execution of
             the model. A single object is treated as equivalent to a tuple of one element.
-        strip_doc_string (bool, default True): [Deprecated and ignored. Will be removed in next release]
+        strip_doc_string (bool, default True): [Deprecated and ignored. Will be removed in next PyTorch release]
             Do not include the field ``doc_string``` from the exported model. Otherwise the field will
             mention the source code locations for ``model``.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -108,8 +108,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Besides, if this is False, any optimization that may adjust graph inputs will
             be skipped - for example, Conv and BatchNorm fusion.
         verbose (bool, default False): if True, prints a description of the
-            model being exported to stdout. And the final ONNX graph will include the field
-            ``doc_string``` from the exported model which mentions the source code locations
+            model being exported to stdout. In addition, the final ONNX graph will include the
+            field ``doc_string``` from the exported model which mentions the source code locations
             for ``model``.
         training (enum, default TrainingMode.EVAL):
             * ``TrainingMode.EVAL``: export the model in inference mode. In this case, optimizations
@@ -198,6 +198,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Must be provided when exporting a ScriptModule or ScriptFunction, ignored otherwise.
             Used to determine the type and shape of the outputs without tracing the execution of
             the model. A single object is treated as equivalent to a tuple of one element.
+        strip_doc_string (bool, default True): [Deprecated and ignored. Will be removed in next release]
+            Do not include the field ``doc_string``` from the exported model. Otherwise the field will
+            mention the source code locations for ``model``.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
 
             By default the exported model will have the shapes of all input and output tensors

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -320,18 +320,10 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 
     from torch.onnx import utils
     return utils.export(model, args, f, export_params, verbose, training,
-<<<<<<< HEAD
                         input_names, output_names, operator_export_type, opset_version,
                         _retain_param_name, do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
                         custom_opsets, enable_onnx_checker, use_external_data_format)
-=======
-                        input_names, output_names, aten,
-                        operator_export_type, opset_version, _retain_param_name,
-                        do_constant_folding, example_outputs, strip_doc_string, dynamic_axes,
-                        keep_initializers_as_inputs, custom_opsets, enable_onnx_checker,
-                        use_external_data_format)
->>>>>>> Update the default value of argument in export().
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -320,10 +320,18 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 
     from torch.onnx import utils
     return utils.export(model, args, f, export_params, verbose, training,
+<<<<<<< HEAD
                         input_names, output_names, operator_export_type, opset_version,
                         _retain_param_name, do_constant_folding, example_outputs,
                         strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
                         custom_opsets, enable_onnx_checker, use_external_data_format)
+=======
+                        input_names, output_names, aten,
+                        operator_export_type, opset_version, _retain_param_name,
+                        do_constant_folding, example_outputs, (not verbose), dynamic_axes,
+                        keep_initializers_as_inputs, custom_opsets, enable_onnx_checker,
+                        use_external_data_format)
+>>>>>>> Update the default value of argument in export().
 
 
 def export_to_pretty_string(*args, **kwargs):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -199,8 +199,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Used to determine the type and shape of the outputs without tracing the execution of
             the model. A single object is treated as equivalent to a tuple of one element.
         strip_doc_string (bool, default True): [Deprecated and ignored. Will be removed in next PyTorch release]
-            Do not include the field ``doc_string``` from the exported model. Otherwise the field will
-            mention the source code locations for ``model``.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
 
             By default the exported model will have the shapes of all input and output tensors

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -328,7 +328,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 =======
                         input_names, output_names, aten,
                         operator_export_type, opset_version, _retain_param_name,
-                        do_constant_folding, example_outputs, (not verbose), dynamic_axes,
+                        do_constant_folding, example_outputs, strip_doc_string, dynamic_axes,
                         keep_initializers_as_inputs, custom_opsets, enable_onnx_checker,
                         use_external_data_format)
 >>>>>>> Update the default value of argument in export().

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -108,7 +108,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Besides, if this is False, any optimization that may adjust graph inputs will
             be skipped - for example, Conv and BatchNorm fusion.
         verbose (bool, default False): if True, prints a description of the
-            model being exported to stdout.
+            model being exported to stdout. And the final ONNX graph will include the field
+            ``doc_string``` from the exported model which mentions the source code locations
+            for ``model``.
         training (enum, default TrainingMode.EVAL):
             * ``TrainingMode.EVAL``: export the model in inference mode. In this case, optimizations
               (e.g., fusing Conv and BatchNorm ops) may adjust graph inputs by modifying model params
@@ -196,9 +198,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Must be provided when exporting a ScriptModule or ScriptFunction, ignored otherwise.
             Used to determine the type and shape of the outputs without tracing the execution of
             the model. A single object is treated as equivalent to a tuple of one element.
-        strip_doc_string (bool, default True): do not include the field
-            ``doc_string``` from the exported model. Otherwise the field will mention the source
-            code locations for ``model``.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
 
             By default the exported model will have the shapes of all input and output tensors

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -81,6 +81,9 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
+    if strip_doc_string is not None:
+        warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
+                      "next release. It's combined with `verbose' argument now.")
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
             _retain_param_name=_retain_param_name, do_constant_folding=do_constant_folding,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -84,8 +84,8 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
             _retain_param_name=_retain_param_name, do_constant_folding=do_constant_folding,
-            example_outputs=example_outputs, strip_doc_string=strip_doc_string,
-            dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
+            example_outputs=example_outputs, dynamic_axes=dynamic_axes,
+            keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets, enable_onnx_checker=enable_onnx_checker,
             use_external_data_format=use_external_data_format)
 
@@ -634,7 +634,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             input_names=None, output_names=None, operator_export_type=None,
             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
             opset_version=None, _retain_param_name=False, do_constant_folding=True,
-            strip_doc_string=True, dynamic_axes=None, keep_initializers_as_inputs=None,
+            dynamic_axes=None, keep_initializers_as_inputs=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
             enable_onnx_checker=True, use_external_data_format=False,
             onnx_shape_inference=True):
@@ -702,12 +702,12 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             if export_params:
                 proto, export_map = graph._export_onnx(
                     params_dict, opset_version, dynamic_axes, defer_weight_export,
-                    operator_export_type, strip_doc_string, val_keep_init_as_ip, custom_opsets,
+                    operator_export_type, not verbose, val_keep_init_as_ip, custom_opsets,
                     val_add_node_names, val_use_external_data_format, model_file_location)
             else:
                 proto, export_map = graph._export_onnx(
                     {}, opset_version, dynamic_axes, False, operator_export_type,
-                    strip_doc_string, val_keep_init_as_ip, custom_opsets, val_add_node_names,
+                    not verbose, val_keep_init_as_ip, custom_opsets, val_add_node_names,
                     val_use_external_data_format, model_file_location)
 
             if enable_onnx_checker and \

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -76,7 +76,7 @@ def select_model_mode_for_export(model, mode):
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
+           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
            enable_onnx_checker=None, use_external_data_format=False):
     if operator_export_type is None:


### PR DESCRIPTION
As of now, the "strip_doc_string" parameter was described as below:

strip_doc_string (bool, default True): do not include the field
            ``doc_string``` from the exported model. Otherwise the field will mention the source
            code locations for ``model``.

This is usually useless to users who want to transform a PyTorch model to ONNX one. Only when the user wants to debug the export process, these source code locations could provide benefits.

To make the export() function more friendly by providing less parameters, we combined "strip_doc_string" into "verbose" parameter. If a user set verbose to True, it means the users need some log information for debugging the export process and this is similar with the purpose of strip_doc_string parameter.

But the usage of these 2 arguments are opposite: setting verbose to True means we want to print log information to help debug, which means strip_doc_string should be False. And this is how we replace strip_doc_string with verbose argument in this PR.

This PR will still keep it in torch.onnx.export() function for backward support while the usage of it has been combined with verbose argument.