### PR TITLE
[doc] document that torch.numel can work with torch.Size

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7130,7 +7130,8 @@ numel(input) -> int
 
 Returns the total number of elements in the :attr:`input` tensor.
 
-This function can also be used with a ``torch.Size`` tensor, but has to be called on it directly and not passed as an argument. See the example.
+This function can also be used with a ``torch.Size`` tensor, but has to be called on it directly and
+not passed as an argument. See the example.
 
 Args:
     {input}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7130,6 +7130,8 @@ numel(input) -> int
 
 Returns the total number of elements in the :attr:`input` tensor.
 
+This function can also be used with a ``torch.Size`` tensor, but has to be called on it directly and not passed as an argument. See the example.
+
 Args:
     {input}
 
@@ -7140,6 +7142,10 @@ Example::
     120
     >>> a = torch.zeros(4,4)
     >>> torch.numel(a)
+    16
+    >>> a.numel()
+    16
+    >>> a.shape.numel()
     16
 
 """.format(**common_args))


### PR DESCRIPTION
I see `torch.Size.numel()` is a valid use/input for `numel` here https://github.com/pytorch/pytorch/issues/49372, but I don't see it being documented here https://pytorch.org/docs/stable/generated/torch.numel.html or having its own doc entry. So this PR documents and exemplifies it.

Fixes #https://github.com/pytorch/pytorch/issues/61231

@mruberry 