### PR TITLE
[countbuild][xplat/caffe2] contbuild with sanitizers

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/pack.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/pack.h
@@ -83,7 +83,7 @@ static inline void pytorch_pack_q8gemm_wrq(
     const size_t nr_block_size = min(nc - nr_block_start, nr);
     for (size_t nr_block_offset = 0; nr_block_offset < nr_block_size;
          nr_block_offset++) {
-      *(packed.as_int32_ptr++) = b ? b[nr_block_start + nr_block_offset] : 0.0f;
+      *(packed.as_int32_ptr++) = b ? b[nr_block_start + nr_block_offset] : 0;
     }
     packed.as_int32_ptr += (nr - nr_block_size);
     for (size_t kr_block_start = 0; kr_block_start < kc; kr_block_start += kr) {

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -41,10 +41,11 @@ struct TORCH_API NotImplemented : public Error {
 struct TORCH_API DelayedError : public Node {
   DelayedError(std::string msg, int num_inputs)
     : msg(std::move(msg)) {
-    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
-    for (const auto i : c10::irange(num_inputs))
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+    for(int i = 0; i < num_inputs; i++) {
       add_input_metadata(Node::undefined_input());
     }
+  }
 
   variable_list apply(variable_list&& inputs) override;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #61724

To improve the stability of xplat/caffe2 code, we are enabling sanitizers (asan, tsan, ubsan) on contbuild.

Differential Revision: [D29348099](https://our.internmc.facebook.com/intern/diff/D29348099/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29348099/)!