### PR TITLE
Refactor metadata_map with flattened key/value pair

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -216,8 +216,6 @@ class BytecodeDeserializer final {
   mobile::Module deserialize(
       c10::optional<at::Device> device,
       ExtraFilesMap& extra_files);
-  std::unordered_map<std::string, std::string> deserializeMetadata(
-      c10::optional<at::Device> device);
   void deserialize_only_extra(
       c10::optional<at::Device> device,
       ExtraFilesMap& extra_files);
@@ -230,8 +228,6 @@ class BytecodeDeserializer final {
       mobile::CompilationUnit& mcu);
   c10::IValue readArchive(
       const std::string& archive_name,
-      std::shared_ptr<mobile::CompilationUnit> mcu);
-  std::unordered_map<std::string, std::string> readMobileMetadata(
       std::shared_ptr<mobile::CompilationUnit> mcu);
   /**
    * Loads operators by looking them up in the Dispatcher and returns
@@ -477,13 +473,6 @@ void BytecodeDeserializer::parseMethods(
   }
 }
 
-std::unordered_map<std::string, std::string> BytecodeDeserializer::
-    deserializeMetadata(c10::optional<at::Device> device) {
-  device_ = device;
-  auto mcu = std::make_shared<mobile::CompilationUnit>();
-  return readMobileMetadata(mcu);
-}
-
 void BytecodeDeserializer::deserialize_only_extra(
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
@@ -529,28 +518,12 @@ mobile::Module BytecodeDeserializer::deserialize(
         readArchive("mobile_debug_handles", mcu).toTuple()->elements();
   }
   parseMethods(bvals, debug_handles, *mcu);
-  auto meta_dict = readMobileMetadata(mcu);
-  auto m = mobile::Module(readArchive("data", mcu).toObject(), meta_dict, mcu);
+  auto m = mobile::Module(readArchive("data", mcu).toObject(), mcu);
 #if defined(SYMBOLICATE_MOBILE_DEBUG_HANDLE)
   MobileDebugTable debug_table = MobileDebugTable(reader_, compilation_unit_);
   m.setDebugTable(std::move(debug_table));
 #endif
   return m;
-}
-
-std::unordered_map<std::string, std::string> BytecodeDeserializer::
-    readMobileMetadata(std::shared_ptr<mobile::CompilationUnit> mcu) {
-  std::unordered_map<std::string, std::string> res;
-  if (!reader_->hasRecord("metadata.pkl")) {
-    return res;
-  }
-  auto ivalue_dict = readArchive("metadata", mcu).toGenericDict();
-  for (const auto& it : ivalue_dict) {
-    const auto key = it.key().toString()->string();
-    const auto value = it.value().toString()->string();
-    res[key] = value;
-  }
-  return res;
 }
 
 c10::IValue BytecodeDeserializer::readArchive(
@@ -657,12 +630,21 @@ mobile::Module _load_for_mobile_impl(
   auto observer = torch::observerConfig().getModuleObserver();
   // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.rand)
   auto instance_key = std::rand();
+  // Copy extra_files to metadata_map
+  std::unordered_map<std::string, std::string> metadata_map;
   if (observer) {
     observer->onEnterLoadModel(instance_key);
+    auto defaultExtraFileList = observer->getDefaultExtraFiles();
+    // Add files in defaultExtraFileList to metadata_map
+    for (const auto& fileName : defaultExtraFileList) {
+      metadata_map.insert(std::make_pair(fileName, ""));
+    }
   }
+
   const size_t model_size = rai != nullptr ? rai->size() : 0;
   auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
   BytecodeDeserializer deserializer(std::move(reader), module_load_options);
+  deserializer.deserialize_only_extra(device, metadata_map);
   std::string error_message;
   auto guard = c10::make_scope_exit([&]() {
     if (!observer) {
@@ -672,25 +654,19 @@ mobile::Module _load_for_mobile_impl(
     observer->onFailLoadModel(
         instance_key,
         error_message.empty() ? "Unknown exception" : error_message.c_str(),
-        deserializer.deserializeMetadata(device));
+        metadata_map);
   });
 
   try {
     mobile::Module result = deserializer.deserialize(device, extra_files);
     if (observer) {
-      auto defaultExtraFileList = observer->getDefaultExtraFiles();
-      // Copy extra_files to metadata_map
-      auto metadata_map = extra_files;
-      for (const auto& fileName : defaultExtraFileList) {
-        metadata_map.insert(std::make_pair(fileName, ""));
-      }
-      // Deserialize mobile_info.json and producer_info.json
-      deserializer.deserialize_only_extra(device, metadata_map);
+      // Add model_name and model_size to metadata_map
       metadata_map.insert(std::make_pair("model_name", result.name()));
       metadata_map.insert(
           std::make_pair("model_size", c10::guts::to_string(model_size)));
       observer->onExitLoadModel(instance_key, metadata_map);
     }
+    result.setMetadata(metadata_map);
     guard.release();
     return result;
   } catch (c10::Error& error) {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -164,10 +164,8 @@ void Method::run(Stack& stack) const {
   /* if the metadata dict doesn't contain "model_name", copy the metadata and
   set the value of "model_name" as name() */
   std::unordered_map<std::string, std::string> copied_metadata =
-      owner_->metadata();
-  if (owner_->metadata().find("model_name") == owner_->metadata().end()) {
-    copied_metadata["model_name"] = owner_->name();
-  }
+      owner_->getMetadata();
+
   if (observer) {
     observer->onEnterRunMethod(
         copied_metadata, instance_key, function_->name());

--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -56,15 +56,7 @@ class TORCH_API Module {
       // NOLINTNEXTLINE(modernize-pass-by-value)
       c10::intrusive_ptr<c10::ivalue::Object> object,
       std::shared_ptr<CompilationUnit> cu)
-      : object_(object),
-        metadata_(std::unordered_map<std::string, std::string>()),
-        cu_(std::move(cu)) {}
-  Module(
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      c10::intrusive_ptr<c10::ivalue::Object> object,
-      std::unordered_map<std::string, std::string> metadata,
-      std::shared_ptr<CompilationUnit> cu)
-      : object_(object), metadata_(std::move(metadata)), cu_(std::move(cu)) {}
+      : object_(object), cu_(std::move(cu)) {}
   Module() = default;
   Method get_method(const std::string& method_name) const;
   template <typename... Types>
@@ -95,8 +87,12 @@ class TORCH_API Module {
   }
   /// True if the module is in training mode.
   bool is_training() const;
-  const std::unordered_map<std::string, std::string> metadata() const {
+  const std::unordered_map<std::string, std::string> getMetadata() const {
     return metadata_;
+  }
+  void setMetadata(
+      const std::unordered_map<std::string, std::string>& metadata) {
+    metadata_ = metadata;
   }
   const std::vector<Method> get_methods() const;
 

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -84,6 +84,8 @@ class MobileModuleObserver {
       const char*,
       const std::unordered_map<std::string, std::string>&) {}
   virtual std::vector<std::string> getDefaultExtraFiles() = 0;
+  virtual std::unordered_map<std::string, std::string> processMetadataFromExtra(
+      const std::unordered_map<std::string, std::string>&) = 0;
 };
 
 class MobileObserverConfig {

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -3,6 +3,7 @@
 #include <c10/util/ThreadLocalDebugInfo.h>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace torch {
 
@@ -75,12 +76,14 @@ class MobileModuleObserver {
   virtual void onEnterLoadModel(const int32_t) {}
   virtual void onExitLoadModel(
       const int32_t,
-      const std::unordered_map<std::string, std::string>&) {}
+      const std::unordered_map<std::string, std::string>&) {
+  } // key: filename, value: file content
   virtual void onFailLoadModel(const int32_t, const char*) {}
   virtual void onFailLoadModel(
       const int32_t,
       const char*,
       const std::unordered_map<std::string, std::string>&) {}
+  virtual std::vector<std::string> getDefaultExtraFiles() = 0;
 };
 
 class MobileObserverConfig {


### PR DESCRIPTION
Summary: In the previous diff, metadata_map contains mobile_info.json and producer_info.json. We need to parse json each time when we log the required information. This diff helps to flatten the content in the files into key/value pair. It allows logger to directly loop through the metadata_map and log the information.

Test Plan:
Since 3D Photo is disabled for current FB app, testings are only performed on CC scanner.

# Test On CC Scanner
**Test content with LOG(WARNING)**
{P429123273}

**Scuba Logger Output**

1. MOBILE_MODULE_LOAD_STATS

{F631884673}

2.  MOBILE_MODULE_STATS

{F631884787}

Differential Revision: D29690702

