### PR TITLE
Remove AVX detection code that duplicates FindAVX.cmake

### DIFF
--- a/caffe2/contrib/fakelowp/CMakeLists.txt
+++ b/caffe2/contrib/fakelowp/CMakeLists.txt
@@ -10,8 +10,8 @@ if(USE_FAKELOWP)
 
   # We will only build the perf kernel files if the compiler supports avx2
   # extensions.
-  if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
-    add_library(caffe2_fakelowp_ops OBJECT ${FAKELOWP_CPU_SRCS})  
+  if(CXX_AVX2_FOUND)
+    add_library(caffe2_fakelowp_ops OBJECT ${FAKELOWP_CPU_SRCS})
     add_dependencies(caffe2_fakelowp_ops fbgemm cpuinfo Caffe2_PROTO c10 aten_op_header_gen)
     target_include_directories(caffe2_fakelowp_ops BEFORE
       PRIVATE $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>)

--- a/caffe2/perfkernels/CMakeLists.txt
+++ b/caffe2/perfkernels/CMakeLists.txt
@@ -21,7 +21,7 @@ set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} ${common_srcs})
 
 # We will only build the perf kernel files if the compiler supports avx2
 # extensions.
-if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
+if(CXX_AVX2_FOUND)
   add_library(Caffe2_perfkernels_avx STATIC ${avx_srcs})
   add_library(Caffe2_perfkernels_avx2 STATIC ${avx2_srcs})
   add_dependencies(Caffe2_perfkernels_avx Caffe2_PROTO)

--- a/caffe2/quantization/server/CMakeLists.txt
+++ b/caffe2/quantization/server/CMakeLists.txt
@@ -63,7 +63,7 @@ list(APPEND Caffe2_CPU_SRCS
   #"${CMAKE_CURRENT_SOURCE_DIR}/sigmoid_test.cc")
   #"${CMAKE_CURRENT_SOURCE_DIR}/tanh_test.cc")
 
-if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
+if(CXX_AVX2_FOUND)
   add_library(caffe2_dnnlowp_avx2_ops OBJECT ${caffe2_dnnlowp_avx2_ops_SRCS})
   add_dependencies(caffe2_dnnlowp_avx2_ops fbgemm Caffe2_PROTO c10)
   target_include_directories(caffe2_dnnlowp_avx2_ops BEFORE

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1700,7 +1700,9 @@ if(NOT INTERN_BUILD_MOBILE)
   endif()
 
   find_package(VSX) # checks VSX
-  find_package(AVX) # checks AVX and AVX2
+  # checks AVX and AVX2. Already called once in MiscCheck.cmake. Called again here for clarity --
+  # cached results will be used so no extra overhead.
+  find_package(AVX)
 
   # we don't set -mavx and -mavx2 flags globally, but only for specific files
   # however, we want to enable the AVX codepaths, so we still need to

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -115,30 +115,13 @@ cmake_pop_check_state()
 
 # ---[ Check if the compiler has AVX/AVX2 support. We only check AVX2.
 if(NOT INTERN_BUILD_MOBILE)
-  cmake_push_check_state(RESET)
-  if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_REQUIRED_FLAGS "/arch:AVX2")
-  else()
-    set(CMAKE_REQUIRED_FLAGS "-mavx2")
-  endif()
-  CHECK_CXX_SOURCE_COMPILES(
-      "#include <immintrin.h>
-      int main() {
-        __m256i a, b;
-        a = _mm256_set1_epi8 (1);
-        b = a;
-        _mm256_add_epi8 (a,a);
-        __m256i x;
-        _mm256_extract_epi64(x, 0); // we rely on this in our AVX2 code
-        return 0;
-      }" CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
-  if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
+  find_package(AVX) # checks AVX and AVX2
+  if(CXX_AVX2_FOUND)
     message(STATUS "Current compiler supports avx2 extension. Will build perfkernels.")
     # Also see CMakeLists.txt under caffe2/perfkernels.
     set(CAFFE2_PERF_WITH_AVX 1)
     set(CAFFE2_PERF_WITH_AVX2 1)
   endif()
-  cmake_pop_check_state()
 endif()
 # ---[ Check if the compiler has AVX512 support.
 cmake_push_check_state(RESET)


### PR DESCRIPTION
This PR deletes some code in `MiscCheck.cmake` that perform the exact
same functionality as `FindAVX.cmake`.
