### PR TITLE
Forward fix scribe upload for benchmarks py module

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -395,9 +395,9 @@ test_benchmarks() {
     pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns_profiling_te.json --fuser=te --executor=profiling
     # TODO: Enable these for GHA once we have credentials for forked pull requests
     if [[ -z "${GITHUB_ACTIONS}" ]]; then
-      python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_default.json
-      python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_legacy_old.json
-      python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_profiling_te.json
+      python -m benchmarks.upload_scribe --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_default.json
+      python -m benchmarks.upload_scribe --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_legacy_old.json
+      python -m benchmarks.upload_scribe --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_profiling_te.json
     fi
     assert_git_not_dirty
   fi


### PR DESCRIPTION
Fixes errors like https://app.circleci.com/pipelines/github/pytorch/pytorch/351530/workflows/00030edd-f3bf-407d-8ade-70c3132d320c/jobs/14811736


```
Jul 16 05:50:25 Legend:
Jul 16 05:50:25   Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
Jul 16 05:50:25   OPS: Operations Per Second, computed as 1 / Mean
Jul 16 05:50:25 ================== 24 passed, 2 warnings in 69.45s (0:01:09) ===================
Jul 16 05:50:27 + [[ -z '' ]]
Jul 16 05:50:27 + python benchmarks/upload_scribe.py --pytest_bench_json benchmarks/.data/fastrnns_default.json
Jul 16 05:50:27 Traceback (most recent call last):
Jul 16 05:50:27   File "benchmarks/upload_scribe.py", line 15, in <module>
Jul 16 05:50:27     from tools.stats.scribe import send_to_scribe
Jul 16 05:50:27 ModuleNotFoundError: No module named 'tools'
Jul 16 05:50:27 + cleanup
Jul 16 05:50:27 + retcode=1
```