### PR TITLE
[DataLoader] Fix collate_fn for subclass of numpy object

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1885,6 +1885,7 @@ except RuntimeError as e:
             np.int16: torch.int16,
             np.int8: torch.int8,
             np.uint8: torch.uint8,
+            np.bool_: torch.bool,
         }
 
         for dt, tt in dtypes.items():

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1871,6 +1871,43 @@ except RuntimeError as e:
         self.assertEqual(arr, _utils.collate.default_collate(arr))
 
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_numpy_types(self):
+        import numpy as np
+
+        dtypes = {
+            np.float64: torch.float64,
+            np.float32: torch.float32,
+            np.float16: torch.float16,
+            np.complex64: torch.complex64,
+            np.complex128: torch.complex128,
+            np.int64: torch.int64,
+            np.int32: torch.int32,
+            np.int16: torch.int16,
+            np.int8: torch.int8,
+            np.uint8: torch.uint8,
+        }
+
+        for dt, tt in dtypes.items():
+            arr = np.array([0, 1], dtype=dt)
+            res = _utils.collate.default_collate(arr)
+            self.assertEqual(torch.tensor([0, 1], dtype=tt), res)
+
+            arr = np.array([[0], [1]], dtype=dt)
+            res = _utils.collate.default_collate(arr)
+            self.assertEqual(torch.tensor([[0], [1]], dtype=tt), res)
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_numpy_subtypes(self):
+        import numpy as np
+
+        class SubArray(np.ndarray):
+            pass
+
+        arr = np.zeros(10, dtype=np.int32).view(SubArray)
+        res = _utils.collate.default_collate(arr)
+        self.assertEqual(torch.zeros(10, dtype=torch.int32), res)
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_default_collate_bad_numpy_types(self):
         import numpy as np
 

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -6,7 +6,6 @@ static methods.
 """
 
 import collections
-import re
 try:
     import numpy as np
     HAS_NUMPY = True

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -23,7 +23,7 @@ def default_convert(data):
     if HAS_NUMPY:
         if isinstance(data, np.ndarray):
             return data
-        elif isinstance(data, np.number):
+        elif isinstance(data, (np.bool_, np.number)):
             return torch.as_tensor(data)
     if isinstance(data, torch.Tensor):
         return data
@@ -50,7 +50,7 @@ def default_collate(batch):
     if HAS_NUMPY:
         if isinstance(elem, np.ndarray):
             return default_collate([torch.as_tensor(b) for b in batch])
-        elif isinstance(elem, np.number):
+        elif isinstance(elem, (np.bool_, np.number)):
             return torch.as_tensor(batch)
     if isinstance(elem, torch.Tensor):
         out = None


### PR DESCRIPTION

Fixes #61665

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61769 [DataLoader] Fix collate_fn for subclass of numpy object**

Previously, we used module name and type name to check numpy objects, which is hard coded and doesn't work with subclass of numpy object. Now, we will use `isinstance` to carry out the type checking for NumPy.

Differential Revision: [D29737480](https://our.internmc.facebook.com/intern/diff/D29737480)