### PR TITLE
[fx] introduce `__fx_create_arg__` dunder method for controlling custom classes are handled as node args

### DIFF
--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -84,8 +84,10 @@ class TracerBase:
 
         Can be override to support more trace-specific types.
         """
+        if not isinstance(a, Proxy) and hasattr(a, '__fx_create_arg__'):
+            return a.__fx_create_arg__(self)
         # aggregates
-        if isinstance(a, tuple) and hasattr(a, '_fields'):
+        elif isinstance(a, tuple) and hasattr(a, '_fields'):
             # NamedTuple constructors don't seem to like getting a generator
             # expression as an argument to their constructor, so build this
             # intermediate tuple and unpack it into the NamedTuple constructor


### PR DESCRIPTION
Summary: These changes would allow objects to control how they are handled when they are an argument to a torch.fx call_module node from within their source. Previously, we have been using a custom Tracer with an overridden create_arg() method and branching based on class name to handle args that are unusual (data classes, etc).

Differential Revision: D27976120

