### PR TITLE
[Static Runtime] Implement prim::isinstance and prim::TypeCheck

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -517,3 +517,25 @@ const auto var_cat_script = R"JIT(
   def forward(self, inp1: Tensor, inp2: Tensor, dim: int):
    return torch.cat([inp1, inp2], dim).clone()
 )JIT";
+
+const auto isinstance_int_script = R"JIT(
+  def forward(self, a: Any):
+      return isinstance(a, int)
+)JIT";
+
+const auto isinstance_tensor_script = R"JIT(
+  def forward(self, a: Any):
+      return isinstance(a, torch.Tensor)
+)JIT";
+
+const auto isinstance_many_types_script = R"JIT(
+  def forward(self, a: Any):
+      return isinstance(a, (bool, int))
+)JIT";
+
+const auto typecheck_ir = R"IR(
+graph(%a.1 : Tensor,
+      %b.1 : Tensor):
+  %t0 : Float(2, 2, strides=[2, 1], device=cpu), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::TypeCheck[types=[Float(2, 2, strides=[2, 1], device=cpu), Float(3, 3, strides=[3, 1])]](%a.1, %b.1)
+  return (%t0, %t1, %type_matched)
+)IR";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/static/fusion.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
@@ -12,7 +14,7 @@ using namespace torch::jit;
 using c10::IValue;
 
 C10_DECLARE_bool(
-    static_runtime_enable_fast_math);
+  static_runtime_enable_fast_math);
 
 namespace {
 static at::Tensor getTensor(const at::IValue& ival) {
@@ -107,15 +109,88 @@ void compareResults(const IValue& expect, const IValue& actual, const bool use_a
   }
 }
 
-// Given a model/function in jit script, run the model/function
+// Test scripts passed to testStaticRuntme can either be IR or JIT.
+// The logic for running the script and producing a corresponding StaticModule
+// is a bit different for each case. This logic is encapsulated within concrete
+// implementations of this class, and testStaticRuntime is only aware of this
+// interface.
+class StaticRuntimeTestContext {
+ public:
+  virtual ~StaticRuntimeTestContext() = default;
+
+  virtual IValue getExpected(const std::vector<IValue>& args) = 0;
+  virtual torch::jit::StaticModule makeStaticModule(
+      StaticModuleOptions opt) const = 0;
+};
+
+class ModuleStaticRuntimeTestContext : public StaticRuntimeTestContext {
+ public:
+  explicit ModuleStaticRuntimeTestContext(const std::string& source_jit)
+      : module_("module") {
+    module_.define(source_jit);
+  }
+
+  IValue getExpected(const std::vector<IValue>& args) override {
+    return module_.forward(args);
+  }
+
+  torch::jit::StaticModule makeStaticModule(
+      StaticModuleOptions opt) const override {
+    return torch::jit::StaticModule(module_, opt);
+  }
+
+ private:
+  Module module_;
+};
+
+class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
+ public:
+  explicit GraphStaticRuntimeContext(const std::string& source_ir) {
+    graph_ = std::make_shared<Graph>();
+    std::unordered_map<std::string, Value*> vmap;
+    parseIR(source_ir, graph_.get(), vmap);
+
+    graph_exec_ = GraphExecutor(graph_, "");
+  }
+
+  IValue getExpected(const std::vector<IValue>& args) override {
+    Stack stack(args);
+    graph_exec_.run(stack);
+
+    if (stack.size() == 1) {
+      return stack[0];
+    }
+    return c10::ivalue::Tuple::create(stack);
+  }
+
+  torch::jit::StaticModule makeStaticModule(
+      StaticModuleOptions opt) const override {
+    return torch::jit::StaticModule(graph_, opt);
+  }
+
+ private:
+  std::shared_ptr<Graph> graph_;
+  GraphExecutor graph_exec_;
+};
+
+std::unique_ptr<StaticRuntimeTestContext> makeTestContext(
+    const std::string& source) {
+  try {
+    return std::make_unique<ModuleStaticRuntimeTestContext>(source);
+    // Could not parse as TorchScript, assume it's IR
+  } catch (const std::runtime_error&) {
+    return std::make_unique<GraphStaticRuntimeContext>(source);
+  }
+}
+
+// Given a model/function in jit or IR script, run the model/function
 // with the jit interpreter and static runtime, and compare the results
 void testStaticRuntime(
-    const std::string& jit_script,
+    const std::string& source,
     const std::vector<IValue>& args,
     const std::vector<IValue>& args2 = {},
     const bool use_allclose = false) {
-  script::Module module("module");
-  module.define(jit_script);
+  auto test_context = makeTestContext(source);
 
   std::vector<IValue> args_tensors, args_copy;
   for (const auto& ival : args) {
@@ -126,11 +201,11 @@ void testStaticRuntime(
     }
   }
 
-  auto expect = module.forward(args);
+  auto expect = test_context->getExpected(args);
 
   for (bool enable_out_variant : {true, false}) {
-    torch::jit::StaticModule smodule(
-        module, {true, enable_out_variant, enable_out_variant});
+    auto smodule = test_context->makeStaticModule(
+        {true, enable_out_variant, enable_out_variant});
     auto actual = smodule(args, {});
     smodule.runtime().check_for_memory_leak();
     // first run
@@ -139,13 +214,13 @@ void testStaticRuntime(
     // args2 is used to check for dynamic shapes
     // it also exercises the memory planner
     if (!args2.empty()) {
-      expect = module.forward(args2);
+      expect = test_context->getExpected(args2);
       actual = smodule(args2, {});
       smodule.runtime().check_for_memory_leak();
       // second run
       compareResults(expect, actual, use_allclose);
 
-      expect = module.forward(args);
+      expect = test_context->getExpected(args);
       actual = smodule(args, {});
       smodule.runtime().check_for_memory_leak();
       // third run
@@ -958,4 +1033,34 @@ TEST(ProcessedNode, VerifyOutputsNotOverlappingWithImmutableInputsWithMutableArg
 
   pnode.Output(0) = a;
   EXPECT_TRUE(pnode.verify_outputs_not_overlapping_with_immutable_inputs());
+}
+
+TEST(StaticRuntime, IndividualOps_isinstance) {
+  auto a = at::randn({2, 2});
+  auto b = at::randn({2, 2, 2});
+
+  std::vector<at::IValue> args{a};
+  std::vector<at::IValue> args2{b};
+
+  testStaticRuntime(isinstance_int_script, args);
+  testStaticRuntime(isinstance_int_script, args, args2);
+
+  testStaticRuntime(isinstance_tensor_script, args);
+  testStaticRuntime(isinstance_tensor_script, args, args2);
+
+  testStaticRuntime(isinstance_many_types_script, args);
+  testStaticRuntime(isinstance_many_types_script, args, args2);
+}
+
+TEST(StaticRuntime, IndividualOps_TypeCheck) {
+  auto a = at::zeros({2, 2}, at::kFloat);
+  a.to(at::kCPU);
+  auto b = at::ones({3, 3}, at::kFloat);
+  auto c = at::ones({2, 2, 2}, at::kFloat);
+
+  std::vector<IValue> args_correct = {a, b};
+  std::vector<IValue> args_incorrect = {a, c};
+
+  testStaticRuntime(typecheck_ir, args_correct);
+  testStaticRuntime(typecheck_ir, args_correct, args_incorrect);
 }

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -336,5 +336,62 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(aten::to, aten_to, [](Node* n) -> SROperator {
   };
 });
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    prim::isinstance,
+    prim_isinstance,
+    [](Node* n) -> SROperator {
+      if (!n->matches(
+              torch::schema("prim::isinstance(Any to_check) -> bool"))) {
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+      return [](ProcessedNode* p_node) {
+        auto input_type = p_node->Input(0).type();
+
+        auto* node = p_node->node();
+        std::vector<TypePtr> candidates = node->tys(attr::types);
+        for (const auto& candidate_type : candidates) {
+          if (input_type->isSubtypeOf(candidate_type)) {
+            p_node->Output(0) = true;
+            return;
+          }
+        }
+
+        p_node->Output(0) = false;
+      };
+    });
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    prim::TypeCheck,
+    prim_TypeCheck,
+    [](Node* n) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        auto* node = p_node->node();
+        const size_t num_inputs = node->inputs().size();
+        TORCH_INTERNAL_ASSERT(
+            num_inputs && num_inputs + 1 == node->outputs().size());
+
+        auto expected_types = node->tys(attr::types);
+
+        for (size_t i = 0; i < num_inputs; i++) {
+          p_node->Output(i) = p_node->Input(i);
+        }
+
+        for (size_t i = 0; i < num_inputs; i++) {
+          auto& input_tensor = p_node->Input(i).toTensor();
+          auto* expected_type = expected_types[i]->castRaw<TensorType>();
+          if (input_tensor.defined() &&
+              !expected_type->matchTensor(input_tensor)) {
+            p_node->Output(num_inputs) = false;
+            return;
+          }
+        }
+
+        p_node->Output(num_inputs) = true;
+      };
+    });
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
Implement two new prim operators for static runtime: `isinstance` and `TypeCheck`. `isinstance` is very straightforward, but there were a few wrinkles with implementing `TypeCheck`:

1. There is no way to directly generate `TypeCheck` nodes from TorchScript, they are generated by the JIT at runtime. This makes testing a little difficult.

2. The behavior of `prim::TypeCheck` as implemented here does not match up 1:1 with the version implemented in the interpreter! This is because grad mode is disabled in static runtime. Here's an example.

IR is the same as the one included in this test, but with `requires_grad == 1`
```
graph(%a.1 : Tensor,
      %b.1 : Tensor):
  %t0 : Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::TypeCheck[types=[Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), Float(3, 3, strides=[3, 1])]](%a.1, %b.1)
  return (%t0, %t1, %type_matched)
```

And in the test setup:
```
auto a = at::zeros({2, 2}, at::kFloat);
a.to(at::kCPU);
a.set_requires_grad(true);
auto b = at::ones({3, 3}, at::kFloat);

std::vector<IValue> args_correct = {a, b};

// prim::TypeCheck should be true with args_correct,
// but we get false when using static runtime!
```

Differential Revision: D29743862

