### PR TITLE
Fix ConnectionError in download_mnist

### DIFF
--- a/tools/download_mnist.py
+++ b/tools/download_mnist.py
@@ -40,7 +40,7 @@ def download(destination_path: str, resource: str, quiet: bool) -> None:
             try:
                 hook = None if quiet else report_download_progress
                 urlretrieve(url, destination_path, reporthook=hook)
-            except URLError as e:
+            except (URLError, ConnectionError) as e:
                 print('Failed to download (trying next):\n{}'.format(e))
                 continue
             finally:


### PR DESCRIPTION
Fixes issues like the following error. Note that `ConnectionResetError` is a subclass of `ConnectionError`.

```
+ python tools/download_mnist.py --quiet -d test/cpp/api/mnist
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz ...
Traceback (most recent call last):
  File "tools/download_mnist.py", line 93, in <module>
    main()
  File "tools/download_mnist.py", line 86, in main
    download(path, resource, options.quiet)
  File "tools/download_mnist.py", line 42, in download
    urlretrieve(url, destination_path, reporthook=hook)
  File "/opt/conda/lib/python3.6/urllib/request.py", line 277, in urlretrieve
    block = fp.read(bs)
  File "/opt/conda/lib/python3.6/http/client.py", line 463, in read
    n = self.readinto(b)
  File "/opt/conda/lib/python3.6/http/client.py", line 507, in readinto
    n = self.fp.readinto(b)
  File "/opt/conda/lib/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
ConnectionResetError: [Errno 104] Connection reset by peer
```
