### PR TITLE
lint_setup should not require elevated privileges

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -190,10 +190,10 @@ jobs:
           set -x
           scversion="v0.7.2"
           wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-          mkdir -p ~/local/bin
-          cp "shellcheck-${scversion}/shellcheck" ~/local/bin/
+          mkdir -p ~/.local/bin
+          cp "shellcheck-${scversion}/shellcheck" ~/.local/bin/
           rm -r "shellcheck-${scversion}"
-          ~/local/bin/shellcheck --version
+          ~/.local/bin/shellcheck --version
       - name: Extract scripts from GitHub Actions workflows
         if: always() && steps.install_shellcheck.outcome == 'success'
         run: |
@@ -203,7 +203,6 @@ jobs:
       - name: Run ShellCheck
         if: always() && steps.install_shellcheck.outcome == 'success'
         run: |
-          export PATH=~/local/bin:$PATH
           if ! tools/linter/run_shellcheck.sh .extracted_scripts .jenkins/pytorch; then
             echo
             echo 'ShellCheck gave a nonzero exit code. Please fix the warnings'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,14 +19,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements
         id: requirements
-        run: pip install -r requirements.txt
+        run: pip3 install -r requirements.txt --user
       - name: Ensure consistent CircleCI YAML config
         if: always() && steps.requirements.outcome == 'success'
         run: cd .circleci && ./ensure-consistency.py
       - name: Lint native_functions.yaml
         if: always() && steps.requirements.outcome == 'success'
         run: |
-          pip install ruamel.yaml==0.17.4
+          pip3 install ruamel.yaml==0.17.4 --user
           .github/scripts/lint_native_functions.py
       - name: Ensure correct trailing newlines
         if: always() && steps.requirements.outcome == 'success'
@@ -159,10 +159,10 @@ jobs:
       - name: Install requirements
         id: requirements
         run: |
-          pip install -r requirements.txt
+          pip3 install -r requirements.txt --user
       - name: Install Jinja2
         run: |
-          pip install Jinja2==3.0.1
+          pip3 install Jinja2==3.0.1 --user
       - name: Checkout PyTorch
         uses: actions/checkout@v2
       - name: Regenerate workflows
@@ -190,9 +190,10 @@ jobs:
           set -x
           scversion="v0.7.2"
           wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-          sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
+          mkdir -p ~/local/bin
+          cp "shellcheck-${scversion}/shellcheck" ~/local/bin/
           rm -r "shellcheck-${scversion}"
-          shellcheck --version
+          ~/local/bin/shellcheck --version
       - name: Extract scripts from GitHub Actions workflows
         if: always() && steps.install_shellcheck.outcome == 'success'
         run: |
@@ -202,6 +203,7 @@ jobs:
       - name: Run ShellCheck
         if: always() && steps.install_shellcheck.outcome == 'success'
         run: |
+          export PATH=~/local/bin:$PATH
           if ! tools/linter/run_shellcheck.sh .extracted_scripts .jenkins/pytorch; then
             echo
             echo 'ShellCheck gave a nonzero exit code. Please fix the warnings'
@@ -275,8 +277,8 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          pip install typing-extensions # for tools/linter/translate_annotations.py
-          pip install -r requirements-flake8.txt
+          pip3 install typing-extensions --user # for tools/linter/translate_annotations.py
+          pip3 install -r requirements-flake8.txt --user
           flake8 --version
       - name: Run flake8
         run: |
@@ -398,7 +400,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          pip install cmakelint
+          pip3 install cmakelint --user
           cmakelint --version
       - name: Run cmakelint
         run: |
@@ -420,11 +422,11 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          pip install -r requirements.txt
-          pip install numpy==1.20 # https://github.com/pytorch/pytorch/pull/60472
-          pip install expecttest==0.1.3 mypy==0.812
+          pip3 install -r requirements.txt --user
+          pip3 install numpy==1.20 --user # https://github.com/pytorch/pytorch/pull/60472
+          pip3 install expecttest==0.1.3 mypy==0.812 --user
           # Needed to check tools/render_junit.py
-          pip install junitparser rich
+          pip3 install junitparser rich --user
       - name: Run autogen
         run: |
           set -eux

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ setup_lint:
 		$(PYTHON) tools/actions_local_runner.py --file .github/workflows/lint.yml \
 		--job 'shellcheck' --step 'Install ShellCheck' --no-quiet; \
 	fi
-	pip install jinja2
-	pip install -r tools/linter/clang_tidy/requirements.txt
+	$(PYTHON) -mpip install jinja2 --user
+	$(PYTHON) -mpip install -r tools/linter/clang_tidy/requirements.txt --user
 	$(PYTHON) -m tools.linter.install.clang_tidy
 
 quick_checks:


### PR DESCRIPTION
s/pip/pip3/ (because unversioned pip can reference either pip2 or pip3
depending on setup)
Always invoke `pip install` with user option (otherwise, unless one is
using conda environment, it will try to install in system folder, which
should not be writable to regular users)

Do not install shellcheck in `/usr/bin`, but rather rely on `~/.local/bin` and add it to the PATH
