### PR TITLE
Enable `bfloat16` in NCCL

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -7,7 +7,7 @@ from torch.testing._internal.common_utils import (TestCase, run_tests,
                                                   IS_WINDOWS, load_tests,
                                                   TEST_WITH_ROCM,
                                                   sandcastle_skip_if)
-from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU
+from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, SM60OrLater
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes
 import re
 HIP_VERSION = 0.0 if torch.version.hip is None else float(re.search(r"^\d+\.\d+", torch.version.hip)[0])
@@ -22,7 +22,7 @@ if not TEST_CUDA:
     TestCase = object  # noqa: F811
 
 
-datatypes = [torch.float, torch.bfloat16]
+datatypes = [torch.float, torch.bfloat16] if SM60OrLater or TEST_WITH_ROCM else [torch.float]
 
 class TestNCCL(TestCase):
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -21,7 +21,7 @@ if not TEST_CUDA:
     print('CUDA not available, skipping tests', file=sys.stderr)
     TestCase = object  # noqa: F811
 
-if (SM60OrLater and torch.cuda.nccl.version() >= 3003) or TEST_WITH_ROCM:
+if (SM60OrLater and torch.cuda.nccl.version() >= (2, 10, 3)) or TEST_WITH_ROCM:
     datatypes = [torch.float, torch.bfloat16]
 else:
     datatypes = [torch.float]

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -21,8 +21,7 @@ if not TEST_CUDA:
     print('CUDA not available, skipping tests', file=sys.stderr)
     TestCase = object  # noqa: F811
 
-
-datatypes = [torch.float, torch.bfloat16] if SM60OrLater or TEST_WITH_ROCM else [torch.float]
+datatypes = [torch.float, torch.bfloat16] if (SM60OrLater and torch.cuda.nccl.version() >= 3003) or TEST_WITH_ROCM else [torch.float]
 
 class TestNCCL(TestCase):
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -21,7 +21,10 @@ if not TEST_CUDA:
     print('CUDA not available, skipping tests', file=sys.stderr)
     TestCase = object  # noqa: F811
 
-datatypes = [torch.float, torch.bfloat16] if (SM60OrLater and torch.cuda.nccl.version() >= 3003) or TEST_WITH_ROCM else [torch.float]
+if (SM60OrLater and torch.cuda.nccl.version() >= 3003) or TEST_WITH_ROCM:
+    datatypes = [torch.float, torch.bfloat16]
+else:
+    datatypes = [torch.float]
 
 class TestNCCL(TestCase):
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -22,7 +22,7 @@ if not TEST_CUDA:
     TestCase = object  # noqa: F811
 
 
-datatypes = [torch.float, torch.bfloat16] if TEST_WITH_ROCM else [torch.float]
+datatypes = [torch.float, torch.bfloat16]
 
 class TestNCCL(TestCase):
 

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -90,7 +90,7 @@ ncclDataType_t to_nccl_data_type(c10::ScalarType type) {
       return ncclDataType_t::ncclUint8;
     case at::kBool:
       return ncclDataType_t::ncclUint8;
-#if defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301
+#if (defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301) || defined(__CUDA_BF16_TYPES_EXIST__)
     case at::kBFloat16:
       return ncclDataType_t::ncclBfloat16;
 #endif

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -90,7 +90,7 @@ ncclDataType_t to_nccl_data_type(c10::ScalarType type) {
       return ncclDataType_t::ncclUint8;
     case at::kBool:
       return ncclDataType_t::ncclUint8;
-#if (defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301) || defined(__CUDA_BF16_TYPES_EXIST__)
+#if (defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301) || (defined(__CUDA_BF16_TYPES_EXIST__) && NCCL_VERSION_MIN(2, 10, 1))
     case at::kBFloat16:
       return ncclDataType_t::ncclBfloat16;
 #endif

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -8,6 +8,13 @@
 #include <cstddef>
 #include <vector>
 
+// Duplicate of macro in cuda_nccl_gpu.h
+#define NCCL_VERSION_MIN(major, minor, patch) \
+  ((NCCL_MAJOR > major) ||                    \
+   ((NCCL_MAJOR == major) &&                  \
+    ((NCCL_MINOR > minor) ||                  \
+     ((NCCL_MINOR == minor) && (NCCL_PATCH >= patch)))))
+
 namespace torch {
 namespace cuda {
 namespace nccl {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -63,7 +63,7 @@ std::map<at::ScalarType, ncclDataType_t> ncclDataType = {
     {at::kLong, ncclInt64},
     {at::kHalf, ncclHalf},
     {at::kBool, ncclUint8},
-#if defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301
+#if defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301 || defined(__CUDA_BF16_TYPES_EXIST__)
     {at::kBFloat16, ncclBfloat16},
 #endif
 };

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -63,7 +63,7 @@ std::map<at::ScalarType, ncclDataType_t> ncclDataType = {
     {at::kLong, ncclInt64},
     {at::kHalf, ncclHalf},
     {at::kBool, ncclUint8},
-#if defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301 || defined(__CUDA_BF16_TYPES_EXIST__)
+#if (defined(__HIP_PLATFORM_HCC__) && TORCH_HIP_VERSION >= 301) || (defined(__CUDA_BF16_TYPES_EXIST__) && NCCL_VERSION_MIN(2, 10, 1))
     {at::kBFloat16, ncclBfloat16},
 #endif
 };


### PR DESCRIPTION
NCCL upstream 2.10.1-3 recently enabled `bfloat16` support. Trying it out initially to see if anything breaks.

CC @ptrblck 