### PR TITLE
Add logging for dynamic rendezvous

### DIFF
--- a/test/distributed/elastic/events/lib_test.py
+++ b/test/distributed/elastic/events/lib_test.py
@@ -5,11 +5,21 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.abs
+
+import json
 import logging
 import unittest
+from dataclasses import asdict
 from unittest.mock import patch
 
-from torch.distributed.elastic.events import _get_or_create_logger, Event, EventSource
+from torch.distributed.elastic.events import (
+    Event,
+    EventSource,
+    NodeState,
+    RdzvEvent,
+    _get_or_create_logger,
+    construct_and_record_rdzv_event,
+)
 from torch.testing._internal.common_utils import run_tests
 
 
@@ -47,6 +57,80 @@ class EventLibTest(unittest.TestCase):
         json_event = event.serialize()
         deser_event = Event.deserialize(json_event)
         self.assert_event(event, deser_event)
+
+class RdzvEventLibTest(unittest.TestCase):
+    @patch("torch.distributed.elastic.events.record_rdzv_event")
+    @patch("torch.distributed.elastic.events.get_logging_handler")
+    def test_construct_and_record_rdzv_event(self, get_mock, record_mock):
+        get_mock.return_value = logging.StreamHandler()
+        construct_and_record_rdzv_event(
+            run_id="test_run_id",
+            message="test_message",
+            node_state=NodeState.RUNNING,
+        )
+        record_mock.assert_called_once()
+
+    @patch("torch.distributed.elastic.events.record_rdzv_event")
+    @patch("torch.distributed.elastic.events.get_logging_handler")
+    def test_construct_and_record_rdzv_event_does_not_run_if_invalid_dest(self, get_mock, record_mock):
+        get_mock.return_value = logging.NullHandler()
+        construct_and_record_rdzv_event(
+            run_id="test_run_id",
+            message="test_message",
+            node_state=NodeState.RUNNING,
+        )
+        record_mock.assert_not_called()
+
+    def assert_rdzv_event(self, actual_event: RdzvEvent, expected_event: RdzvEvent):
+        self.assertEqual(actual_event.name, expected_event.name)
+        self.assertEqual(actual_event.run_id, expected_event.run_id)
+        self.assertEqual(actual_event.message, expected_event.message)
+        self.assertEqual(actual_event.hostname, expected_event.hostname)
+        self.assertEqual(actual_event.pid, expected_event.pid)
+        self.assertEqual(actual_event.node_state, expected_event.node_state)
+        self.assertEqual(actual_event.master_endpoint, expected_event.master_endpoint)
+        self.assertEqual(actual_event.rank, expected_event.rank)
+        self.assertEqual(actual_event.local_id, expected_event.local_id)
+        self.assertEqual(actual_event.error_trace, expected_event.error_trace)
+
+    def get_test_rdzv_event(self) -> RdzvEvent:
+        return RdzvEvent(
+            name="test_name",
+            run_id="test_run_id",
+            message="test_message",
+            hostname="test_hostname",
+            pid=1,
+            node_state=NodeState.RUNNING,
+            master_endpoint="test_master_endpoint",
+            rank=3,
+            local_id=4,
+            error_trace="test_error_trace",
+        )
+
+    def test_rdzv_event_created(self):
+        event = self.get_test_rdzv_event()
+        self.assertEqual(event.name, "test_name")
+        self.assertEqual(event.run_id, "test_run_id")
+        self.assertEqual(event.message, "test_message")
+        self.assertEqual(event.hostname, "test_hostname")
+        self.assertEqual(event.pid, 1)
+        self.assertEqual(event.node_state, NodeState.RUNNING)
+        self.assertEqual(event.master_endpoint, "test_master_endpoint")
+        self.assertEqual(event.rank, 3)
+        self.assertEqual(event.local_id, 4)
+        self.assertEqual(event.error_trace, "test_error_trace")
+
+
+    def test_rdzv_event_deserialize(self):
+        event = self.get_test_rdzv_event()
+        json_event = event.serialize()
+        deserialized_event = RdzvEvent.deserialize(json_event)
+        self.assert_rdzv_event(event, deserialized_event)
+        self.assert_rdzv_event(event, RdzvEvent.deserialize(event))
+
+    def test_rdzv_event_str(self):
+        event = self.get_test_rdzv_event()
+        self.assertEqual(str(event), json.dumps(asdict(event)))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/elastic/events/__init__.py
+++ b/torch/distributed/elastic/events/__init__.py
@@ -19,15 +19,25 @@ Example of usage:
 
 """
 
-import os
+import inspect
 import logging
+import os
+import socket
+import traceback
+from enum import Enum
+from typing import Dict, Optional
 
 from torch.distributed.elastic.events.handlers import get_logging_handler
 
-from .api import Event, EventSource, EventMetadataValue  # noqa: F401
+from .api import (  # noqa: F401
+    Event,
+    EventMetadataValue,
+    EventSource,
+    NodeState,
+    RdzvEvent,
+)
 
-_events_logger = None
-
+_events_loggers: Dict[str, logging.Logger] = {}
 
 def _get_or_create_logger(destination: str = "null") -> logging.Logger:
     """
@@ -39,20 +49,85 @@ def _get_or_create_logger(destination: str = "null") -> logging.Logger:
     Args:
         destination: The string representation of the event handler.
             Available handlers found in ``handlers`` module
-        logger: Logger to be extended with the events handler. Method constructs
-            a new logger if None provided.
     """
-    global _events_logger
-    if _events_logger:
-        return _events_logger
-    logging_handler = get_logging_handler(destination)
-    _events_logger = logging.getLogger(f"torchelastic-events-{destination}")
-    _events_logger.setLevel(os.environ.get("LOGLEVEL", "INFO"))
-    # Do not propagate message to the root logger
-    _events_logger.propagate = False
-    _events_logger.addHandler(logging_handler)
-    return _events_logger
+    global _events_loggers
+
+    if destination not in _events_loggers:
+        _events_logger = logging.getLogger(f"torchelastic-events-{destination}")
+        _events_logger.setLevel(os.environ.get("LOGLEVEL", "INFO"))
+        # Do not propagate message to the root logger
+        _events_logger.propagate = False
+
+        logging_handler = get_logging_handler(destination)
+        _events_logger.addHandler(logging_handler)
+
+        # Add the logger to the global dictionary
+        _events_loggers[destination] = _events_logger
+
+    return _events_loggers[destination]
 
 
 def record(event: Event, destination: str = "null") -> None:
     _get_or_create_logger(destination).info(event.serialize())
+
+def record_rdzv_event(event: RdzvEvent) -> None:
+    _get_or_create_logger("dynamic_rendezvous").info(event.serialize())
+
+
+def construct_and_record_rdzv_event(
+    run_id: str,
+    message: str,
+    node_state: NodeState,
+    name: str = "",
+    hostname: str = "",
+    pid: Optional[int] = None,
+    master_endpoint: str = "",
+    local_id: Optional[int] = None,
+    rank: Optional[int] = None,
+) -> None:
+    # We don't want to perform an extra computation if not needed.
+    if isinstance(get_logging_handler("dynamic_rendezvous"), logging.NullHandler):
+        return
+
+    # Set up parameters.
+    if not hostname:
+        hostname = socket.getfqdn()
+    if not pid:
+        pid = os.getpid()
+
+    # Determines which file called this function.
+    callstack = inspect.stack()
+    filename = "no_file"
+    if len(callstack) > 1:
+        stack_depth_1 = callstack[1]
+        filename = os.path.basename(stack_depth_1.filename)
+        if not name:
+            name = stack_depth_1.function
+
+    # Delete the callstack variable. If kept, this can mess with python's
+    # garbage collector as we are holding on to stack frame information in
+    # the inspect module.
+    del callstack
+
+    # Set up error trace if this is an exception
+    if node_state == NodeState.FAILED:
+        error_trace = traceback.format_exc()
+    else:
+        error_trace = ""
+
+    # Initialize event object
+    event = RdzvEvent(
+        name=f"{filename}:{name}",
+        run_id=run_id,
+        message=message,
+        hostname=hostname,
+        pid=pid,
+        node_state=node_state,
+        master_endpoint=master_endpoint,
+        rank=rank,
+        local_id=local_id,
+        error_trace=error_trace,
+    )
+
+    # Finally, record the event.
+    record_rdzv_event(event)

--- a/torch/distributed/elastic/events/api.py
+++ b/torch/distributed/elastic/events/api.py
@@ -9,7 +9,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 
 EventMetadataValue = Union[str, int, float, bool, None]
@@ -53,6 +53,62 @@ class Event:
             data_dict = json.loads(data)
         data_dict["source"] = EventSource[data_dict["source"]]
         return Event(**data_dict)
+
+    def serialize(self) -> str:
+        return json.dumps(asdict(self))
+
+
+class NodeState(str, Enum):
+    """
+    The states that a node can be in rendezvous.
+    """
+
+    INIT = "INIT"
+    RUNNING = "RUNNING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+@dataclass
+class RdzvEvent:
+    """
+    Dataclass to represent any rendezvous event.
+
+    Args:
+        name: Event name. (E.g. Current action being performed)
+        run_id: The run id of the rendezvous
+        message: The message describing the event
+        hostname: Hostname of the node
+        pid: The process id of the node
+        node_state: The state of the node (INIT, RUNNING, SUCCEEDED, FAILED)
+        master_endpoint: The master endpoint for the rendezvous store, if known
+        rank: The rank of the node, if known
+        local_id: The local_id of the node, if defined in dynamic_rendezvous.py
+        error_trace: Error stack trace, if this is an error event.
+    """
+
+    name: str
+    run_id: str
+    message: str
+    hostname: str
+    pid: int
+    node_state: NodeState
+    master_endpoint: str = ""
+    rank: Optional[int] = None
+    local_id: Optional[int] = None
+    error_trace: str = ""
+
+    def __str__(self):
+        return self.serialize()
+
+    @staticmethod
+    def deserialize(data: Union[str, "RdzvEvent"]) -> "RdzvEvent":
+        if isinstance(data, RdzvEvent):
+            return data
+        if isinstance(data, str):
+            data_dict = json.loads(data)
+        data_dict["node_state"] = NodeState[data_dict["node_state"]]
+        return RdzvEvent(**data_dict)
 
     def serialize(self) -> str:
         return json.dumps(asdict(self))

--- a/torch/distributed/elastic/events/handlers.py
+++ b/torch/distributed/elastic/events/handlers.py
@@ -12,9 +12,11 @@ from typing import Dict
 
 _log_handlers: Dict[str, logging.Handler] = {
     "console": logging.StreamHandler(),
+    "dynamic_rendezvous": logging.NullHandler(),
     "null": logging.NullHandler(),
 }
 
 
 def get_logging_handler(destination: str = "null") -> logging.Handler:
+    global _log_handlers
     return _log_handlers[destination]

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import inspect
 import logging
 import os
 import pickle
@@ -18,6 +19,10 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
 
 from torch.distributed import PrefixStore, Store
+from torch.distributed.elastic.events import (
+    NodeState,
+    construct_and_record_rdzv_event,
+)
 
 from .api import (
     RendezvousClosedError,
@@ -27,11 +32,15 @@ from .api import (
     RendezvousStateError,
     RendezvousTimeoutError,
 )
-
 from .utils import _delay, _PeriodicTimer
 
-
 log = logging.getLogger(__name__)
+
+
+def get_method_name(depth=2):
+    if len(inspect.stack()) > depth:
+        return inspect.stack()[depth].function
+    return "no_method_name"
 
 
 Token = Any
@@ -344,7 +353,10 @@ class _BackendRendezvousStateHolder(_RendezvousStateHolder):
     _dead_nodes: List[_NodeDesc]
 
     def __init__(
-        self, backend: RendezvousBackend, settings: RendezvousSettings, cache_duration: int = 1
+        self,
+        backend: RendezvousBackend,
+        settings: RendezvousSettings,
+        cache_duration: int = 1,
     ) -> None:
         self._backend = backend
         self._state = _RendezvousState()
@@ -354,6 +366,14 @@ class _BackendRendezvousStateHolder(_RendezvousStateHolder):
         self._dirty = False
         self._last_sync_time = -1
         self._dead_nodes = []
+
+    def _record(self, message: str, node_state: NodeState = NodeState.RUNNING):
+        construct_and_record_rdzv_event(
+            name=f"{self.__class__.__name__}.{get_method_name()}",
+            run_id=self._settings.run_id,
+            message=message,
+            node_state=node_state,
+        )
 
     @property
     def state(self) -> _RendezvousState:
@@ -402,10 +422,12 @@ class _BackendRendezvousStateHolder(_RendezvousStateHolder):
         if has_set and self._dead_nodes and log.isEnabledFor(logging.DEBUG):
             node_list = ", ".join(f"'{dead_node}'" for dead_node in self._dead_nodes)
 
-            log.debug(
+            msg = (
                 f"As part of the sync operation the node(s) {node_list} have been removed from the "
                 f"rendezvous '{self._settings.run_id}' since they had no heartbeat."
             )
+            self._record(message=msg)
+            log.debug(msg)
 
         self._token = token
 
@@ -510,7 +532,9 @@ class _RendezvousOpExecutor(ABC):
 
     @abstractmethod
     def run(
-        self, state_handler: Callable[[_RendezvousContext, float], _Action], deadline: float
+        self,
+        state_handler: Callable[[_RendezvousContext, float], _Action],
+        deadline: float,
     ) -> None:
         """Executes a rendezvous operation.
 
@@ -556,8 +580,21 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         self._state_holder = state_holder
         self._settings = settings
 
+    def _record(self, message: str, node_state: NodeState = NodeState.RUNNING) -> None:
+        construct_and_record_rdzv_event(
+            name=f"{self.__class__.__name__}.{get_method_name()}",
+            run_id=self._settings.run_id,
+            message=message,
+            node_state=node_state,
+            hostname=self._node.fqdn,
+            pid=self._node.pid,
+            local_id=self._node.local_id,
+        )
+
     def run(
-        self, state_handler: Callable[[_RendezvousContext, float], _Action], deadline: float
+        self,
+        state_handler: Callable[[_RendezvousContext, float], _Action],
+        deadline: float,
     ) -> None:
         """See base class."""
         action = None
@@ -569,15 +606,18 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
             has_set = self._state_holder.sync()
             if has_set is not None:
                 if has_set:
-                    log.debug(
+                    msg = (
                         f"The node '{self._node}' has successfully synced its local changes with "
                         f"other nodes in the rendezvous '{self._settings.run_id}'."
                     )
                 else:
-                    log.debug(
+                    msg = (
                         f"The node '{self._node}' has a stale state and failed to sync its local "
                         f"changes with other nodes in the rendezvous '{self._settings.run_id}'."
                     )
+
+                self._record(message=msg)
+                log.debug(msg)
 
             self._state = self._state_holder.state
 
@@ -620,18 +660,22 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
                 self._state_holder.mark_dirty()
 
     def _keep_alive(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' updated its keep-alive heartbeat time for the rendezvous "
             f"'{self._settings.run_id}'. Pending sync."
         )
+        self._record(message=msg)
+        log.debug(msg)
 
         self._state.last_heartbeats[self._node] = datetime.utcnow()
 
     def _add_to_participants(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' added itself to the participants of round "
             f"{self._state.round} of the rendezvous '{self._settings.run_id}'. Pending sync."
         )
+        self._record(message=msg)
+        log.debug(msg)
 
         state = self._state
 
@@ -653,20 +697,24 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
             self._mark_rendezvous_complete()
 
     def _add_to_wait_list(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' added itself to the wait list of round "
             f"{self._state.round + 1} of the rendezvous '{self._settings.run_id}'. Pending sync."
         )
+        self._record(message=msg)
+        log.debug(msg)
 
         self._state.wait_list.add(self._node)
 
         self._keep_alive()
 
     def _remove_from_participants(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' removed itself from the participants of round "
             f"{self._state.round} of the rendezvous '{self._settings.run_id}'. Pending sync."
         )
+        self._record(message=msg)
+        log.debug(msg)
 
         state = self._state
 
@@ -679,20 +727,24 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         _remove_participant_epilogue(state, self._settings)
 
     def _remove_from_wait_list(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' removed itself from the wait list of round "
             f"{self._state.round + 1} of the rendezvous '{self._settings.run_id}'. Pending sync."
         )
+        self._record(message=msg)
+        log.debug(msg)
 
         self._state.wait_list.remove(self._node)
 
         del self._state.last_heartbeats[self._node]
 
     def _mark_rendezvous_complete(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' marked round {self._state.round} of the rendezvous "
             f"'{self._settings.run_id}' as complete. Pending sync."
         )
+        self._record(message=msg, node_state=NodeState.SUCCEEDED)
+        log.debug(msg)
 
         state = self._state
 
@@ -704,10 +756,12 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
             state.participants[node] = rank
 
     def _mark_rendezvous_closed(self) -> None:
-        log.debug(
+        msg = (
             f"The node '{self._node}' marked the rendezvous '{self._settings.run_id}' as closed. "
             "Pending sync."
         )
+        self._record(message=msg, node_state=NodeState.SUCCEEDED)
+        log.debug(msg)
 
         self._state.closed = True
 
@@ -917,6 +971,23 @@ class DynamicRendezvousHandler(RendezvousHandler):
 
         self._keep_alive_timer = None
 
+    def _record(
+        self,
+        message: str,
+        node_state: NodeState = NodeState.RUNNING,
+        rank: Optional[int] = None,
+    ) -> None:
+        construct_and_record_rdzv_event(
+            name=f"{self.__class__.__name__}.{get_method_name()}",
+            run_id=self._settings.run_id,
+            message=message,
+            node_state=node_state,
+            hostname=self._this_node.fqdn,
+            pid=self._this_node.pid,
+            local_id=self._this_node.local_id,
+            rank=rank,
+        )
+
     @property
     def settings(self) -> RendezvousSettings:
         """Gets the settings of the rendezvous."""
@@ -928,58 +999,93 @@ class DynamicRendezvousHandler(RendezvousHandler):
 
     def next_rendezvous(self) -> Tuple[Store, int, int]:
         """See base class."""
-        log.info(
+        msg = (
             f"The node '{self._this_node}' attempts to join the next round of the rendezvous "
             f"'{self._settings.run_id}'."
         )
+        self._record(message=msg)
+        log.info(msg)
 
-        self._stop_heartbeats()
+        try:
+            self._stop_heartbeats()
 
-        # Delay the execution for a small random amount of time if this is our
-        # first run. This will slightly skew the rendezvous attempts across the
-        # nodes and reduce the load on the backend.
-        if self._state_holder.state.round == 0:
-            _delay(seconds=(0, 0.3))
+            # Delay the execution for a small random amount of time if this is our
+            # first run. This will slightly skew the rendezvous attempts across the
+            # nodes and reduce the load on the backend.
+            if self._state_holder.state.round == 0:
+                _delay(seconds=(0, 0.3))
 
-        exit_op = _RendezvousExitOp()
-        join_op = _RendezvousJoinOp()
+            exit_op = _RendezvousExitOp()
+            join_op = _RendezvousJoinOp()
 
-        deadline = self._get_deadline(self._settings.timeout.join)
+            deadline = self._get_deadline(self._settings.timeout.join)
 
-        self._op_executor.run(exit_op, deadline)
-        self._op_executor.run(join_op, deadline)
+            self._op_executor.run(exit_op, deadline)
+            self._op_executor.run(join_op, deadline)
 
-        self._start_heartbeats()
+            self._start_heartbeats()
 
-        rank, world_size = self._get_world()
-        store = self._get_store()
+            rank, world_size = self._get_world()
+            store = self._get_store()
 
-        log.info(
+        except Exception as e:
+            self._record(
+                message=f"{type(e).__name__}: {str(e)}",
+                node_state=NodeState.FAILED,
+            )
+            raise
+
+        msg = (
             f"The node '{self._this_node}' has joined round {self._state_holder.state.round} of "
             f"the rendezvous '{self._settings.run_id}' as rank {rank} in a world of size "
             f"{world_size}."
         )
+        self._record(message=msg, rank=rank)
+        log.info(msg)
 
         return store, rank, world_size
 
     def is_closed(self) -> bool:
         """See base class."""
-        with self._heartbeat_lock:
-            self._state_holder.sync()
+        try:
+            with self._heartbeat_lock:
+                self._state_holder.sync()
 
-            return self._state_holder.state.closed
+                return self._state_holder.state.closed
+
+        except Exception as e:
+            self._record(
+                message=f"{type(e).__name__}: {str(e)}",
+                node_state=NodeState.FAILED,
+            )
+            raise
 
     def set_closed(self) -> None:
         """See base class."""
-        with self._heartbeat_lock:
-            self._close()
+        try:
+            with self._heartbeat_lock:
+                self._close()
+        except Exception as e:
+            self._record(
+                message=f"{type(e).__name__}: {str(e)}",
+                node_state=NodeState.FAILED,
+            )
+            raise
 
     def num_nodes_waiting(self) -> int:
         """See base class."""
-        with self._heartbeat_lock:
-            self._state_holder.sync()
+        try:
+            with self._heartbeat_lock:
+                self._state_holder.sync()
 
-            return len(self._state_holder.state.wait_list)
+                return len(self._state_holder.state.wait_list)
+
+        except Exception as e:
+            self._record(
+                message=f"{type(e).__name__}: {str(e)}",
+                node_state=NodeState.FAILED,
+            )
+            raise
 
     def get_run_id(self) -> str:
         """See base class."""
@@ -994,12 +1100,20 @@ class DynamicRendezvousHandler(RendezvousHandler):
 
             return True
         except RendezvousError as ex:
-            log.warning(
+            msg = (
                 f"The node '{self._this_node}' has failed to shutdown the rendezvous "
                 f"'{self._settings.run_id}' due to an error of type {type(ex).__name__}."
             )
+            self._record(message=msg, node_state=NodeState.FAILED)
+            log.warning(msg)
 
             return False
+        except Exception as e:
+            self._record(
+                message=f"{type(e).__name__}: {str(e)}",
+                node_state=NodeState.FAILED,
+            )
+            raise
 
     def _close(self) -> None:
         op = _RendezvousCloseOp()
@@ -1008,9 +1122,9 @@ class DynamicRendezvousHandler(RendezvousHandler):
 
         self._op_executor.run(op, deadline)
 
-        log.info(
-            f"The node '{self._this_node}' has closed the rendezvous '{self._settings.run_id}'."
-        )
+        msg = f"The node '{self._this_node}' has closed the rendezvous '{self._settings.run_id}'."
+        self._record(message=msg, node_state=NodeState.SUCCEEDED)
+        log.info(msg)
 
     @staticmethod
     def _keep_alive_weak(weak_self) -> None:
@@ -1028,15 +1142,19 @@ class DynamicRendezvousHandler(RendezvousHandler):
         try:
             self._op_executor.run(op, deadline)
 
-            log.debug(
+            msg = (
                 f"The node '{self._this_node}' has sent a keep-alive heartbeat to the rendezvous "
                 f"'{self._settings.run_id}'."
             )
+            self._record(message=msg)
+            log.debug(msg)
         except RendezvousError as ex:
-            log.warning(
+            msg = (
                 f"The node '{self._this_node}' has failed to send a keep-alive heartbeat to the "
                 f"rendezvous '{self._settings.run_id}' due to an error of type {type(ex).__name__}."
             )
+            self._record(message=msg, node_state=NodeState.FAILED)
+            log.warning(msg)
         finally:
             self._heartbeat_lock.release()
 
@@ -1106,17 +1224,25 @@ def create_handler(
     |                   | 30 seconds.                                          |
     +-------------------+------------------------------------------------------+
     """
-    timeout = RendezvousTimeout(
-        _get_timeout(params, "join"),
-        _get_timeout(params, "last_call"),
-        _get_timeout(params, "close"),
-    )
+    try:
+        timeout = RendezvousTimeout(
+            _get_timeout(params, "join"),
+            _get_timeout(params, "last_call"),
+            _get_timeout(params, "close"),
+        )
 
-    return DynamicRendezvousHandler.from_backend(
-        params.run_id,
-        store,
-        backend,
-        params.min_nodes,
-        params.max_nodes,
-        timeout,
-    )
+        return DynamicRendezvousHandler.from_backend(
+            params.run_id,
+            store,
+            backend,
+            params.min_nodes,
+            params.max_nodes,
+            timeout,
+        )
+    except Exception as e:
+        construct_and_record_rdzv_event(
+            message=f"{type(e).__name__}: {str(e)}",
+            run_id=params.run_id,
+            node_state=NodeState.FAILED,
+        )
+        raise


### PR DESCRIPTION
Summary:
Added scuba logging to the following files:
- dynamic_rendezvous.py
- fb_c10d_rendezvous_backend.py
- c10d_rendezvous_backend.py

Added logging logic for zeus table and tests to:
- scuba.py
- scuba_test.py

TODO: create a c10d/dynamic rendezvous scuba table with relevant information.

To be able to modify oss files without altering their functionality, the event record system is used. In fb environment, the record() method will log to a scuba table, but in oss, it will be a no-op

Test Plan:
The following tests can be run.
```
buck run mode/dev-nosan //caffe2/test/distributed/elastic/events/fb:scuba_test
```
```
buck run mode/dev-nosan //caffe2/test/distributed/elastic/rendezvous:c10d_rendezvous_backend_test
```
```
buck run mode/dev-nosan //caffe2/test/distributed/elastic/rendezvous:dynamic_rendezvous_test
```
```
buck run mode/dev-nosan //caffe2/test/distributed/elastic/events:lib_test
```

Differential Revision: D29643774

