### PR TITLE
Fix quicklint

### DIFF
--- a/.github/workflows/periodic-pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/periodic-pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -149,6 +149,7 @@ jobs:
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
+          AWS_DEFAULT_REGION: us-east-1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pytorch-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -151,6 +151,7 @@ jobs:
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
+          AWS_DEFAULT_REGION: us-east-1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pytorch-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -151,6 +151,7 @@ jobs:
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
+          AWS_DEFAULT_REGION: us-east-1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -57,7 +57,7 @@ C10_HOST_DEVICE static void reduce_fraction(size_t &numerator, size_t &denominat
 }
 
 //template for changing MAX_NUM_THREADS based on op dtype
-template <typename T> 
+template <typename T>
 struct mnt_wrapper {
   static constexpr int MAX_NUM_THREADS = 512;
 };


### PR DESCRIPTION
Fix two lint related errors in master by (#61774) and (#61438)

```
make quicklint && make quick_checks                                                                   (pytorch) 
✓ mypy (skipped typestub generation)
✓ flake8
✓ quick-checks: Ensure no unqualified noqa
✓ quick-checks: Ensure canonical include
✓ quick-checks: Ensure no direct cub include
✓ quick-checks: Ensure no unqualified type ignore
✓ quick-checks: Ensure no tabs
✓ quick-checks: Ensure no trailing spaces
✓ quick-checks: Ensure no non-breaking spaces
✓ quick-checks: Ensure no versionless Python shebangs
✓ quick-checks: Ensure correct trailing newlines
✓ cmakelint: Run cmakelint
✓ shellcheck: Regenerate workflows
✓ shellcheck: Assert that regenerating the workflows didn't change them
✓ shellcheck: Extract scripts from GitHub Actions workflows
✓ shellcheck: Run ShellCheck
✓ clang-tidy: Run clang-tidy
✓ quick-checks: Ensure no unqualified noqa
✓ quick-checks: Ensure canonical include
✓ quick-checks: Ensure no direct cub include
✓ quick-checks: Ensure no unqualified type ignore
✓ quick-checks: Ensure no trailing spaces
✓ quick-checks: Ensure no tabs
✓ quick-checks: Ensure no non-breaking spaces
✓ quick-checks: Ensure no versionless Python shebangs
✓ quick-checks: Ensure correct trailing newlines
```