### PR TITLE
[PyTorch] Expose bias() and unpack() API of LinearPackedParamsBase to Python layer

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -455,7 +455,14 @@ torch::class_<LinearPackedParamsBase> register_linear_params() {
                 }
 #endif // USE_PYTORCH_QNNPACK
                 TORCH_CHECK(false, "Unknown qengine");
-              });
+              })
+              .def("bias", [](const c10::intrusive_ptr<LinearPackedParamsBase>& self) {
+                   at::Tensor weight;
+                   c10::optional<at::Tensor> bias;
+                   std::tie(weight, bias) = self->unpack();
+                   return bias;
+                 })
+              .def("unpack", &LinearPackedParamsBase::unpack);
   return register_linear_params;
 }
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2310,6 +2310,20 @@ class TestQuantizedOps(TestCase):
         result = torch.ops.quantized.linear_dynamic(X, w_packed)
         self.assertEqual(result.shape, (0, 2))
 
+    @override_qengines
+    def test_linear_bias_unpack(self):
+        """
+        Verifies the correctness of bias() and unpack() API for LinearPackedParamBase.
+        """
+        bias_float = torch.ones(2, dtype=torch.float)
+        w = torch.randn((2, 2), dtype=torch.float)
+        qw = torch.quantize_per_tensor(w, scale=1.0, zero_point=0, dtype=torch.qint8)
+        w_packed = torch.ops.quantized.linear_prepack(qw, bias_float)
+        # test bias()
+        self.assertEqual(w_packed.bias(), bias_float)
+        # test unpack()
+        self.assertEqual(w_packed.unpack()[0], qw)
+
     def test_advanced_indexing(self):
         """
         Verifies that the x[:, [0], :, :] syntax works for quantized tensors.


### PR DESCRIPTION
Summary: Exposing `bias()` and `unpack()` for `LinearPackedParamsBase`. This is useful for inspecting linear op attributes.

Test Plan:
print(itr.bias())
print(itr.unpack()[0].size())

tensor([ 0.0878, -0.0881])
torch.Size([2, 160])

Differential Revision: D29767704

