### PR TITLE
Implement IMethod::getArgumentNames()

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -664,6 +664,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/api/src/data/samplers/sequential.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/data/samplers/stream.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/enum.cpp
+      ${TORCH_SRC_DIR}/csrc/api/src/imethod.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/serialize.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/jit.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/init.cpp

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -552,6 +552,7 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/data/samplers/sequential.cpp",
     "torch/csrc/api/src/data/samplers/stream.cpp",
     "torch/csrc/api/src/enum.cpp",
+    "torch/csrc/api/src/imethod.cpp",
     "torch/csrc/api/src/jit.cpp",
     "torch/csrc/api/src/serialize.cpp",
     "torch/csrc/api/src/nn/init.cpp",

--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ATen/core/ivalue.h>
+#include <vector>
 
 namespace torch {
 
@@ -25,13 +26,19 @@ class IMethod {
 
   virtual c10::IValue operator()(
       std::vector<c10::IValue> args,
-      const IValueMap& kwargs = IValueMap()) = 0;
+      const IValueMap& kwargs = IValueMap()) const = 0;
 
   // Returns an ordered list of argument names, possible in both
   // script and python methods.  This is a more portable dependency
   // than a ScriptMethod FunctionSchema, which has more information
   // than can be generally expected from a python method.
-  virtual std::vector<std::string> getArgumentNames() = 0;
+  const std::vector<std::string>& getArgumentNames();
+
+ protected:
+  virtual void setArgumentNames(std::vector<std::string>& argumentNames) const = 0;
+
+ private:
+  std::vector<std::string> argumentNames_;
 };
 
 } // namespace torch

--- a/torch/csrc/api/src/imethod.cpp
+++ b/torch/csrc/api/src/imethod.cpp
@@ -1,0 +1,16 @@
+#include <torch/imethod.h>
+
+namespace torch {
+
+const std::vector<std::string>& IMethod::getArgumentNames()
+{
+  // TODO(jwtan): Deal with empty parameter list.
+  if (!argumentNames_.empty()) {
+    return argumentNames_;
+  }
+
+  setArgumentNames(argumentNames_);
+  return argumentNames_;
+}
+
+} // namespace torch

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -274,5 +274,23 @@ void LoadBalancer::free(int where) {
   TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
+void PythonMethodWrapper::setArgumentNames(
+    std::vector<std::string>& argumentNamesOut) const {
+  auto session = model_.acquire_session();
+  auto iArgumentNames =
+      session
+          .global("GetArgumentNamesModule", "getArgumentNames")(
+              {session.from_movable(model_)})
+          .toIValue();
+  TORCH_INTERNAL_ASSERT(iArgumentNames.isList());
+  auto argumentNames = iArgumentNames.toListRef();
+
+  argumentNamesOut.reserve(argumentNames.size());
+  for (auto& argumentName : argumentNames) {
+    TORCH_INTERNAL_ASSERT(argumentName.isString());
+    argumentNamesOut.push_back(argumentName.toStringRef());
+  }
+}
+
 } // namespace deploy
 } // namespace torch

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -228,7 +228,7 @@ class PythonMethodWrapper : public torch::IMethod {
 
   c10::IValue operator()(
       std::vector<c10::IValue> args,
-      const IValueMap& kwargs = IValueMap()) override {
+      const IValueMap& kwargs = IValueMap()) const override {
     // TODO(whc) ideally, pickle the method itself as replicatedobj, to skip
     // this lookup each time
     auto model_session = model_.acquire_session();
@@ -236,11 +236,9 @@ class PythonMethodWrapper : public torch::IMethod {
     return method.call_kwargs(args, kwargs).toIValue();
   }
 
-  std::vector<std::string> getArgumentNames() override {
-    throw std::runtime_error("getArgumentNames not yet implemented");
-  }
-
  private:
+  void setArgumentNames(std::vector<std::string>&) const override;
+
   torch::deploy::ReplicatedObj model_;
   std::string method_name_;
 };

--- a/torch/csrc/jit/api/method.h
+++ b/torch/csrc/jit/api/method.h
@@ -31,7 +31,7 @@ struct TORCH_API Method : public torch::IMethod {
 
   c10::IValue operator()(
       std::vector<c10::IValue> stack,
-      const Kwargs& kwargs = Kwargs()) override;
+      const Kwargs& kwargs = Kwargs()) const override;
 
   // Run method async. Invocation on this function would invokes a JIT
   // interpreter that executes ops inline, one by one, on caller's thread. A
@@ -58,15 +58,13 @@ struct TORCH_API Method : public torch::IMethod {
     return function_->get_executor();
   }
 
-  std::vector<std::string> getArgumentNames() override {
-    throw std::runtime_error("getArgumentNames not yet implemented");
-  }
-
   Function& function() const {
     return *function_;
   }
 
  private:
+  void setArgumentNames(std::vector<std::string>&) const override;
+
   // Methods are uniqued onwed by a single module. This raw pointer allows
   // looking up the module.
   ObjectPtr owner_;

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -219,7 +219,8 @@ void Method::run(Stack& stack) {
   function_->run(stack);
 }
 
-IValue Method::operator()(std::vector<IValue> stack, const Kwargs& kwargs) {
+IValue Method::operator()(std::vector<IValue> stack, const Kwargs& kwargs)
+    const {
   stack.insert(stack.begin(), owner()._ivalue()); // self
   RECORD_TORCHSCRIPT_FUNCTION(name(), stack);
   return (*function_)(std::move(stack), kwargs);
@@ -234,6 +235,15 @@ c10::intrusive_ptr<c10::ivalue::Future> Method::run_async(
 
   function_->getSchema().checkAndNormalizeInputs(stack, kwargs);
   return function_->runAsync(stack, std::move(taskLauncher));
+}
+
+void Method::setArgumentNames(
+    std::vector<std::string>& argumentNamesOut) const {
+  TORCH_INTERNAL_ASSERT(function_);
+  argumentNamesOut.reserve(function_->getSchema().arguments().size());
+  for (auto& argument : function_->getSchema().arguments()) {
+    argumentNamesOut.push_back(argument.name());
+  }
 }
 
 IValue Module::operator()(std::vector<IValue> inputs) {


### PR DESCRIPTION
Summary:
This diff did the following few things:
1. It implemented IMethod::getArgumentNames() for all IMethod's subclasses.
2. It refactors PyTorchDeployPredictor to use IMethod for model executions.

Test Plan:
[... ~/fbsource/fbcode/caffe2] buck test mode/dev caffe2/fb/predictor:pytorch_predictor_test -- PyTorchDeployPredictor
[... ~/fbsource/fbcode/caffe2] buck test mode/dev caffe2/fb/predictor:pytorch_predictor_test -- PyTorchPredictor

Reviewed By: wconstab

Differential Revision: D29648756

