### PR TITLE
Remote whitespace introduced by #61438

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -57,7 +57,7 @@ C10_HOST_DEVICE static void reduce_fraction(size_t &numerator, size_t &denominat
 }
 
 //template for changing MAX_NUM_THREADS based on op dtype
-template <typename T> 
+template <typename T>
 struct mnt_wrapper {
   static constexpr int MAX_NUM_THREADS = 512;
 };


### PR DESCRIPTION
Since it's a one-character change it feels faster to fix than revert

Verified with `(! git --no-pager grep -In '[[:blank:]]$' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above lines have trailing spaces; please remove them"; false))` from the lint check