### PR TITLE
Manually call lazyInitCUDA in structured CUDA calls

### DIFF
--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -356,10 +356,12 @@ if (strides.empty()) {
             else:
                 expanded_topts = "optTypeMetaToScalarType(options.dtype_opt()), options.layout_opt(), " \
                     "options.device_opt(), options.pinned_memory_opt()"
+                empty_init = ""
                 if self.backend_index.dispatch_key == DispatchKey.CPU:
                     empty_impl = "at::native::empty_cpu"
                     empty_strided_impl = "at::native::empty_strided_cpu"
                 elif self.backend_index.dispatch_key == DispatchKey.CUDA:
+                    empty_init = "globalContext().lazyInitCUDA();"
                     empty_impl = "at::native::empty_cuda"
                     empty_strided_impl = "at::native::empty_strided_cuda"
                 elif self.backend_index.dispatch_key == DispatchKey.CompositeExplicitAutograd:
@@ -368,6 +370,7 @@ if (strides.empty()) {
                 else:
                     raise AssertionError("unsupported dispatch key")
                 return f"""{maybe_set_guard_line}
+{empty_init}
 if (strides.empty()) {{
     outputs_[output_idx] = {empty_impl}(sizes, {expanded_topts}, options.memory_format_opt());
 }} else {{


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61882 Manually call lazyInitCUDA in structured CUDA calls**

If you directly call the native implementation that bypasses the
initialization, which is bad!  This probably slows things down a little
though...

Fixes problem uncovered by #61642

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D29783856](https://our.internmc.facebook.com/intern/diff/D29783856)