### PR TITLE
hacky conditional recompile depending on generated code

### DIFF
--- a/aten/src/ATen/native/cudnn/ConvPlaceholders.cpp
+++ b/aten/src/ATen/native/cudnn/ConvPlaceholders.cpp
@@ -150,14 +150,13 @@ Tensor cudnn_convolution_deprecated2(
   return at::cudnn_convolution(input_t, weight_t, padding, stride, dilation, groups, benchmark, deterministic, at::globalContext().allowTF32CuDNN());
 }
 
-Tensor cudnn_convolution_deprecated3(
-    const Tensor& input_t, const Tensor& weight_t,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark)
-{
-  return at::cudnn_convolution(input_t, weight_t, padding, stride, dilation, groups, benchmark, true, at::globalContext().allowTF32CuDNN());
-}
-
+//Tensor cudnn_convolution_deprecated3(
+//    const Tensor& input_t, const Tensor& weight_t,
+//    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
+//    int64_t groups, bool benchmark)
+//{
+//  return at::cudnn_convolution(input_t, weight_t, padding, stride, dilation, groups, benchmark, true, at::globalContext().allowTF32CuDNN());
+//}
 
 // TODO (@zasdfgbnm): this is here only for compatibility, remove this in the future
 Tensor cudnn_convolution_transpose_deprecated(

--- a/aten/src/ATen/native/cudnn/ConvPlaceholders.cpp
+++ b/aten/src/ATen/native/cudnn/ConvPlaceholders.cpp
@@ -150,6 +150,15 @@ Tensor cudnn_convolution_deprecated2(
   return at::cudnn_convolution(input_t, weight_t, padding, stride, dilation, groups, benchmark, deterministic, at::globalContext().allowTF32CuDNN());
 }
 
+Tensor cudnn_convolution_deprecated3(
+    const Tensor& input_t, const Tensor& weight_t,
+    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
+    int64_t groups, bool benchmark)
+{
+  return at::cudnn_convolution(input_t, weight_t, padding, stride, dilation, groups, benchmark, true, at::globalContext().allowTF32CuDNN());
+}
+
+
 // TODO (@zasdfgbnm): this is here only for compatibility, remove this in the future
 Tensor cudnn_convolution_transpose_deprecated(
     const Tensor& input, const Tensor& weight, const c10::optional<Tensor>& bias_opt /* optional */,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1322,10 +1322,9 @@
   dispatch:
     CUDA: cudnn_convolution_deprecated2
 
-- func: cudnn_convolution.deprecated3(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark) -> Tensor
-  dispatch:
-    CUDA: cudnn_convolution_deprecated3
-
+#- func: cudnn_convolution.deprecated3(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark) -> Tensor
+#  dispatch:
+#    CUDA: cudnn_convolution_deprecated3
 
 - func: cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1322,6 +1322,11 @@
   dispatch:
     CUDA: cudnn_convolution_deprecated2
 
+- func: cudnn_convolution.deprecated3(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark) -> Tensor
+  dispatch:
+    CUDA: cudnn_convolution_deprecated3
+
+
 - func: cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   dispatch:
     CUDA: cudnn_convolution

--- a/aten/src/ATen/templates/Functions_Delta.h
+++ b/aten/src/ATen/templates/Functions_Delta.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// ${generated_comment}
+
+#include <c10/core/Scalar.h>
+#include <ATen/Tensor.h>
+#include <c10/core/Storage.h>
+#include <ATen/core/Generator.h>
+#include <c10/util/Deprecated.h>
+#include <ATen/DeviceGuard.h>
+#include <c10/core/TensorOptions.h>
+#include <ATen/core/Reduction.h>
+#include <c10/util/Optional.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/Context.h>
+#include <ATen/TracerMode.h>
+#include <ATen/Operators.h>
+#include <ATen/Operators_Delta.h>
+
+${static_dispatch_extra_headers}
+
+namespace at {
+
+${function_definitions}
+
+
+}

--- a/aten/src/ATen/templates/Operators_Delta.h
+++ b/aten/src/ATen/templates/Operators_Delta.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// ${generated_comment}
+
+#include <c10/core/Scalar.h>
+#include <c10/core/TensorOptions.h>
+#include <c10/core/QScheme.h>
+#include <tuple>
+#include <vector>
+
+// Extension writers: do you write wrapper functions? Are you frustrated with
+// resolving overloads of operators? Are you frustrated with dealing with
+// pointer-to-methods and resolving overloads of pointer-to-methods?? Look no
+// further, this is the utility for you.
+//
+// Given an operator schema: aten::op.overload(...
+//
+// Use ATEN_FN2(op, overload) to get a *function* version of the operator
+// that is guaranteed to not be overloaded. This means that you can safely
+// decltype(&ATEN_FN2(op, overload)) it. NB: the 2 means this macro takes 2 args.
+//
+// Given an operator schema without an overload name: aten::op(...
+//
+// Use ATEN_FN(op) to get an unambiguous *function* version of the operator.
+//
+// There is some interesting behavior for out= operations.
+// ATEN_FN2(sin, out) gives a function that is *faithful* to the schema;
+// that is, the order of arguments is exactly what it looks like in the schema.
+
+#define ATEN_FN2(op_name, overload) at::_ops::op_name##_##overload::call
+#define ATEN_FN(op_name) at::_ops::op_name::call
+
+// Separately, ATEN_OP(op) and ATEN_OP2(op, overload) define a class containing compile-time
+// metadata about a given aten operator.
+// Notable data on the class includes:
+// - ATEN_OP2(add, Tensor)::name // returns the string name: "add"
+// - ATEN_OP2(add, Tensor)::overload_name // returns the string overload name: "Tensor"
+// - ATEN_OP2(add, Tensor)::schema // returns the C++ schema type: at::Tensor (const at::Tensor &, const at::Tensor &, const at::Scalar &)
+// - ATEN_OP2(add, Tensor)::schema_str // returns the string jit type: "add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
+
+#define ATEN_OP2(op_name, overload) at::_ops::op_name##_##overload
+#define ATEN_OP(op_name) at::_ops::op_name
+
+// WARNING: Please do not call any of the ops in the _ops namespace directly.
+// Use the ATEN_FN macros. We do not guarantee stability of the naming
+// scheme for the functions in at::_ops
+
+// See Note [The ATen Operators API] for details of the at::_ops namespace
+namespace c10 {
+
+template<typename T>
+class optional;
+template<typename T>
+class List;
+class Stream;
+struct Storage;
+
+}
+
+namespace at {
+
+class Tensor;
+struct Dimname;
+struct Generator;
+using TensorList = c10::ArrayRef<Tensor>;
+using DimnameList = c10::ArrayRef<Dimname>;
+using Stream = c10::Stream;
+using Storage = c10::Storage;
+using QScheme = c10::QScheme;
+
+namespace _ops {
+
+${declarations}
+
+}} // namespace at::_ops

--- a/aten/src/ATen/templates/RedispatchFunctions_Delta.h
+++ b/aten/src/ATen/templates/RedispatchFunctions_Delta.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// ${generated_comment}
+
+#include <c10/core/Scalar.h>
+#include <ATen/Tensor.h>
+#include <ATen/Operators_Delta.h>
+#include <c10/core/Storage.h>
+#include <ATen/core/Generator.h>
+#include <c10/util/Deprecated.h>
+#include <ATen/DeviceGuard.h>
+#include <c10/core/TensorOptions.h>
+#include <ATen/core/Reduction.h>
+#include <c10/util/Optional.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/Context.h>
+#include <ATen/TracerMode.h>
+
+namespace at {
+
+namespace redispatch {
+    ${function_redispatch_definitions}
+} // namespace redispatch
+
+}

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -2,6 +2,7 @@
 #include <unordered_map>
 #include <string>
 #include <ATen/ATen.h>
+#include <ATen/Functions_Delta.h>
 #include <c10/macros/Macros.h>
 #include <caffe2/core/context.h>
 #include <caffe2/core/operator.h>

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -221,6 +221,16 @@ if(INTERN_BUILD_ATEN_OPS)
       message(STATUS ${generated_cpp})
       message(FATAL_ERROR "Failed to get generated_cpp list")
   endif()
+
+  set(GEN_COMMAND2
+          "${PYTHON_EXECUTABLE}" -m tools.codegen.gen --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen --do_sed
+          )
+
+  #  message(FATAL_ERROR "sed ${GEN_COMMAND}")
+  execute_process(
+          COMMAND ${GEN_COMMAND2}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+  )
   # FIXME: the file/variable name lists cpp, but these list both cpp and .h files
   file(READ ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_cpp.txt generated_cpp)
   file(READ ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_cpp.txt-cuda cuda_generated_cpp)

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -226,7 +226,6 @@ if(INTERN_BUILD_ATEN_OPS)
           "${PYTHON_EXECUTABLE}" -m tools.codegen.gen --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen --do_sed
           )
 
-  #  message(FATAL_ERROR "sed ${GEN_COMMAND}")
   execute_process(
           COMMAND ${GEN_COMMAND2}
           WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -230,6 +230,7 @@ if(INTERN_BUILD_ATEN_OPS)
           COMMAND ${GEN_COMMAND2}
           WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
   )
+
   # FIXME: the file/variable name lists cpp, but these list both cpp and .h files
   file(READ ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_cpp.txt generated_cpp)
   file(READ ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_cpp.txt-cuda cuda_generated_cpp)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -975,14 +975,14 @@ if(BUILD_PYTHON)
   find_package(PythonInterp 3.0)
   find_package(PythonLibs 3.0)
 
-  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3)
-    message(FATAL_ERROR
-      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 2 has reached end-of-life and is no longer supported by PyTorch.")
-  endif()
-  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3.6)
-    message(FATAL_ERROR
-      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 3.5 is no longer supported by PyTorch.")
-  endif()
+#  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3)
+#    message(FATAL_ERROR
+#      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 2 has reached end-of-life and is no longer supported by PyTorch.")
+#  endif()
+#  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3.6)
+#    message(FATAL_ERROR
+#      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 3.5 is no longer supported by PyTorch.")
+#  endif()
 
   # When building pytorch, we pass this in directly from setup.py, and
   # don't want to overwrite it because we trust python more than cmake

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -975,14 +975,14 @@ if(BUILD_PYTHON)
   find_package(PythonInterp 3.0)
   find_package(PythonLibs 3.0)
 
-#  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3)
-#    message(FATAL_ERROR
-#      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 2 has reached end-of-life and is no longer supported by PyTorch.")
-#  endif()
-#  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3.6)
-#    message(FATAL_ERROR
-#      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 3.5 is no longer supported by PyTorch.")
-#  endif()
+  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3)
+    message(FATAL_ERROR
+      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 2 has reached end-of-life and is no longer supported by PyTorch.")
+  endif()
+  if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3.6)
+    message(FATAL_ERROR
+      "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 3.5 is no longer supported by PyTorch.")
+  endif()
 
   # When building pytorch, we pass this in directly from setup.py, and
   # don't want to overwrite it because we trust python more than cmake

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -32,6 +32,7 @@
 #include "torch/csrc/utils/cuda_lazy_init.h"
 
 #include <ATen/ATen.h>
+#include <ATen/Functions_Delta.h>
 
 #include <functional>
 #include <initializer_list>

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -249,6 +249,14 @@ class NativeFunction:
     # a constructor defined for all the fields we specify.  No need
     # to explicitly write it out.
 
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        d = dict(self.__dict__)
+        d.pop("loc")
+        return hash(d.__repr__())
+
     # We parse both the NativeFunction + backend-specific information about it, which it stored in a corresponding BackendIndex.
     @staticmethod
     def from_yaml(
@@ -304,7 +312,7 @@ class NativeFunction:
         assert isinstance(structured, bool), f'not a bool: {structured}'
 
         structured_delegate_s = e.pop('structured_delegate', None)
-        assert structured_delegate_s is None or isinstance(structured_delegate_s, str), f'not a str: {structured_delegate}'
+        assert structured_delegate_s is None or isinstance(structured_delegate_s, str), f'not a str: {structured_delegate_s}'
         structured_delegate: Optional[OperatorName] = None
         if structured_delegate_s is not None:
             structured_delegate = OperatorName.parse(structured_delegate_s)
@@ -635,6 +643,7 @@ class BackendIndex:
         elif isinstance(g, NativeFunctionsGroup):
             f = self.primary(g)
         else:
+            assert False
             assert_never(f)
         if f.func.name not in self.index:
             return None

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -312,7 +312,7 @@ class NativeFunction:
         assert isinstance(structured, bool), f'not a bool: {structured}'
 
         structured_delegate_s = e.pop('structured_delegate', None)
-        assert structured_delegate_s is None or isinstance(structured_delegate_s, str), f'not a str: {structured_delegate_s}'
+        assert structured_delegate_s is None or isinstance(structured_delegate_s, str), f'not a str: {structured_delegate}'
         structured_delegate: Optional[OperatorName] = None
         if structured_delegate_s is not None:
             structured_delegate = OperatorName.parse(structured_delegate_s)
@@ -643,7 +643,6 @@ class BackendIndex:
         elif isinstance(g, NativeFunctionsGroup):
             f = self.primary(g)
         else:
-            assert False
             assert_never(f)
         if f.func.name not in self.index:
             return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61915**

for the simple case of just adding a declaration to `native_functions.yaml` this cuts down the number of recompiled files by ~90% (~1100 -> ~170).

the basic idea is to factor out the additions to the generated headers into `*_Delta.h` and update the call sites in **only generated code** to include those headers as well. this way existing code that includes the original generated headers won't recompile.

obviously this isn't nearly ready for production (i.e. just a proof of concept) but i'll try to see if i can fix it up