### PR TITLE
Fix clang-tidy error in pre-commit script

### DIFF
--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -4,16 +4,10 @@ set -e
 echo "Running pre-commit flake8"
 python3 tools/linter/flake8_hook.py
 
-if [ $(which clang-tidy) ]
-then
-  echo "Running pre-commit clang-tidy"
-  git diff HEAD > pr.diff
-  python3 -m tools.linter.clang_tidy --diff-file "pr.diff"
-  rm pr.diff
-else
-  echo "WARNING: Couldn't find clang-tidy executable."
-  echo "  Please install it if you want local clang-tidy checks."
-fi
+echo "Running pre-commit clang-tidy"
+git diff HEAD > pr.diff
+python3 -m tools.linter.clang_tidy --diff-file "pr.diff"
+rm pr.diff
 
 echo "Running pre-commit clang-format"
 tools/linter/git-clang-format HEAD~ --force

--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -2,21 +2,14 @@
 set -e
 
 echo "Running pre-commit flake8"
-python tools/linter/flake8_hook.py
+python3 tools/linter/flake8_hook.py
 
 if [ $(which clang-tidy) ]
 then
   echo "Running pre-commit clang-tidy"
   git diff HEAD > pr.diff
-  python tools/linter/clang_tidy \
-    --paths torch/csrc \
-    --diff-file "pr.diff" \
-    -g"-torch/csrc/jit/passes/onnx/helper.cpp" \
-    -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp" \
-    -g"-torch/csrc/jit/serialization/onnx.cpp" \
-    -g"-torch/csrc/jit/serialization/export.cpp" \
-    -g"-torch/csrc/jit/serialization/import.cpp" \
-    -j
+  python3 -m tools.linter.clang_tidy --diff-file "pr.diff"
+  rm pr.diff
 else
   echo "WARNING: Couldn't find clang-tidy executable."
   echo "  Please install it if you want local clang-tidy checks."


### PR DESCRIPTION
Fixes a clang-tidy error in the git-pre-commit script. See log below for the error it fixes.

```
Running pre-commit flake8
Running pre-commit clang-tidy
usage: clang_tidy [-h] [-e CLANG_TIDY_EXE] [-g GLOB] [-x REGEX] [-c COMPILE_COMMANDS_DIR] [--diff-file DIFF_FILE] [-p PATHS [PATHS ...]] [-n] [-v] [-q] [--config-file CONFIG_FILE] [--print-include-paths] [-I INCLUDE_DIR] [-s]
                  [--disable-progress-bar]
                  [extra_args [extra_args ...]]
clang_tidy: error: unrecognized arguments: -j
```

It gets rid of the redundant binary check because `tools.linter.clang_tidy` already does this.

Test plan:

Run `tools/git-pre-commit`. It should not show a clang-tidy error.