### PR TITLE
Adding super calls to JIT test case setUp and tearDown

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -45,9 +45,9 @@ class TestCppExtensionJIT(common.TestCase):
     """
 
     def setUp(self):
+        super().setUp()
         # cpp extensions use relative paths. Those paths are relative to
         # this file, so we'll change the working directory temporarily
-        super().setUp()
         self.old_working_dir = os.getcwd()
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -52,9 +52,9 @@ class TestCppExtensionJIT(common.TestCase):
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     def tearDown(self):
+        super().tearDown()
         # return the working directory (see setUp)
         os.chdir(self.old_working_dir)
-        super().tearDown()
 
     @classmethod
     def setUpClass(cls):

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -47,12 +47,14 @@ class TestCppExtensionJIT(common.TestCase):
     def setUp(self):
         # cpp extensions use relative paths. Those paths are relative to
         # this file, so we'll change the working directory temporarily
+        super().setUp()
         self.old_working_dir = os.getcwd()
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     def tearDown(self):
         # return the working directory (see setUp)
         os.chdir(self.old_working_dir)
+        super().tearDown()
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This issue was surfaced when adding this issue: https://github.com/pytorch/pytorch/issues/61655 did not manage to skip the appropriate test case. 

I then investigated and realized it was because the setUp code that does the test disabling is not called because another defined setUp overrode the parent class' setUp.

I am not sure if that was intentional--if so we would have to adopt the child class' code to call the check_if_enable function in common_utils.