### PR TITLE
Throw RuntimeError when numpy() is called on a tensor with conjugate or negative bit set

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -145,7 +145,7 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
   TORCH_CHECK(self.element_size() == static_cast<int64_t>(type_meta.itemsize()),
     "Viewing a tensor as a new dtype with a different number of bytes per element is not supported.");
   TORCH_CHECK(!self.is_conj(),
-    "torch.Tensor.view is not supported for conjugate view tensors when converting to non-complex dtype.");
+    "torch.Tensor.view is not supported for conjugate view tensors when converting to a different dtype.");
   TORCH_CHECK(!self.is_neg(),
     "torch.Tensor.view is not supported for tensors with negative bit set when converting to a different dtype.");
   Storage storage = self.storage();

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -146,6 +146,8 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
     "Viewing a tensor as a new dtype with a different number of bytes per element is not supported.");
   TORCH_CHECK(!self.is_conj(),
     "torch.Tensor.view is not supported for conjugate view tensors when converting to non-complex dtype.");
+  TORCH_CHECK(!self.is_neg(),
+    "torch.Tensor.view is not supported for tensors with negative bit set when converting to a different dtype.");
   Storage storage = self.storage();
   auto new_tensor = detail::make_tensor<TensorImpl>(
       std::move(storage), self.key_set(), type_meta);

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -144,6 +144,8 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
   const auto type_meta = c10::scalarTypeToTypeMeta(dtype);
   TORCH_CHECK(self.element_size() == static_cast<int64_t>(type_meta.itemsize()),
     "Viewing a tensor as a new dtype with a different number of bytes per element is not supported.");
+  TORCH_CHECK(!self.is_conj(),
+    "torch.Tensor.view is not supported for conjugate view tensors when converting to non-complex dtype.");
   Storage storage = self.storage();
   auto new_tensor = detail::make_tensor<TensorImpl>(
       std::move(storage), self.key_set(), type_meta);

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1495,10 +1495,12 @@ class TestOldViewOps(TestCase):
 
     @onlyCPU
     def test_conj_neg_view_numpy_error(self, device):
-        self.assertRaisesRegex(RuntimeError, "has conjugate bit set", lambda: torch.tensor([1+2j]).conj().numpy())
-        self.assertRaisesRegex(RuntimeError, "has negative bit set", lambda: torch.tensor([1+2j]).conj().imag.numpy())
-        self.assertRaisesRegex(RuntimeError, "not supported for conjugate view tensors", lambda: torch.tensor([1+2j]).conj().view(torch.float64))
-        self.assertRaisesRegex(RuntimeError, "not supported for tensors with negative bit set", lambda: torch.tensor([1+2j]).conj().imag.view(torch.int32))
+        self.assertRaisesRegex(RuntimeError, "has conjugate bit set", lambda: torch.tensor([1 + 2j]).conj().numpy())
+        self.assertRaisesRegex(RuntimeError, "has negative bit set", lambda: torch.tensor([1 + 2j]).conj().imag.numpy())
+        self.assertRaisesRegex(RuntimeError, "not supported for conjugate view tensors",
+                               lambda: torch.tensor([1 + 2j]).conj().view(torch.float64))
+        self.assertRaisesRegex(RuntimeError, "not supported for tensors with negative bit set",
+                               lambda: torch.tensor([1 + 2j]).conj().imag.view(torch.int32))
 
 instantiate_device_type_tests(TestViewOps, globals())
 instantiate_device_type_tests(TestOldViewOps, globals())

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1493,6 +1493,16 @@ class TestOldViewOps(TestCase):
             x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
             self.assertEqual(x.view(6).shape, [6])
 
+    @onlyCPU
+    def test_conj_neg_view_numpy_error(self, device):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Can't call numpy() on Tensor that has conjugate bit set. Use tensor.resolve_conj().numpy() instead."):
+            torch.tensor([1+2j]).conj().numpy()
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Can't call numpy() on Tensor that has negative bit set. Use tensor.resolve_conj().numpy() instead."):
+            torch.tensor([1+2j]).conj().imag.numpy()
+
 
 instantiate_device_type_tests(TestViewOps, globals())
 instantiate_device_type_tests(TestOldViewOps, globals())

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1498,6 +1498,7 @@ class TestOldViewOps(TestCase):
         self.assertRaisesRegex(RuntimeError, "has conjugate bit set", lambda: torch.tensor([1+2j]).conj().numpy())
         self.assertRaisesRegex(RuntimeError, "has negative bit set", lambda: torch.tensor([1+2j]).conj().imag.numpy())
         self.assertRaisesRegex(RuntimeError, "not supported for conjugate view tensors", lambda: torch.tensor([1+2j]).conj().view(torch.float64))
+        self.assertRaisesRegex(RuntimeError, "not supported for tensors with negative bit set", lambda: torch.tensor([1+2j]).conj().imag.view(torch.int32))
 
 instantiate_device_type_tests(TestViewOps, globals())
 instantiate_device_type_tests(TestOldViewOps, globals())

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1495,14 +1495,9 @@ class TestOldViewOps(TestCase):
 
     @onlyCPU
     def test_conj_neg_view_numpy_error(self, device):
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Can't call numpy() on Tensor that has conjugate bit set. Use tensor.resolve_conj().numpy() instead."):
-            torch.tensor([1+2j]).conj().numpy()
-
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Can't call numpy() on Tensor that has negative bit set. Use tensor.resolve_conj().numpy() instead."):
-            torch.tensor([1+2j]).conj().imag.numpy()
-
+        self.assertRaisesRegex(RuntimeError, "has conjugate bit set", lambda: torch.tensor([1+2j]).conj().numpy())
+        self.assertRaisesRegex(RuntimeError, "has negative bit set", lambda: torch.tensor([1+2j]).conj().imag.numpy())
+        self.assertRaisesRegex(RuntimeError, "not supported for conjugate view tensors", lambda: torch.tensor([1+2j]).conj().view(torch.float64))
 
 instantiate_device_type_tests(TestViewOps, globals())
 instantiate_device_type_tests(TestOldViewOps, globals())

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -106,34 +106,28 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
 }
 
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
-  if (!is_numpy_available()) {
-    throw std::runtime_error("Numpy is not available");
-  }
-  if (tensor.device().type() != DeviceType::CPU) {
-    throw TypeError(
+  TORCH_CHECK(is_numpy_available(), "Numpy is not available");
+
+  TORCH_CHECK(tensor.device().type() == DeviceType::CPU,
       "can't convert %s device type tensor to numpy. Use Tensor.cpu() to "
       "copy the tensor to host memory first.", tensor.device().str().c_str());
-  }
-  if (tensor.layout() != Layout::Strided) {
-      throw TypeError(
-        "can't convert %s layout tensor to numpy."
-        "convert the tensor to a strided layout first.", c10::str(tensor.layout()).c_str());
-  }
-  if (at::GradMode::is_enabled() && tensor.requires_grad()) {
-    throw std::runtime_error(
-        "Can't call numpy() on Tensor that requires grad. "
-        "Use tensor.detach().numpy() instead.");
-  }
-  if (tensor.is_conj()) {
-    throw std::runtime_error(
-        "Can't call numpy() on Tensor that has conjugate bit set. "
-        "Use tensor.resolve_conj().numpy() instead.");
-  }
-  if (tensor.is_neg()) {
-    throw std::runtime_error(
-        "Can't call numpy() on Tensor that has negative bit set. "
-        "Use tensor.resolve_neg().numpy() instead.");
-  }
+
+  TORCH_CHECK(tensor.layout() == Layout::Strided,
+      "can't convert %s layout tensor to numpy."
+      "convert the tensor to a strided layout first.", c10::str(tensor.layout()).c_str());
+
+  TORCH_CHECK(!(at::GradMode::is_enabled() && tensor.requires_grad()),
+      "Can't call numpy() on Tensor that requires grad. "
+      "Use tensor.detach().numpy() instead.");
+
+  TORCH_CHECK(!tensor.is_conj(),
+      "Can't call numpy() on Tensor that has conjugate bit set. ",
+      "Use tensor.resolve_conj().numpy() instead.");
+
+  TORCH_CHECK(!tensor.is_neg(),
+      "Can't call numpy() on Tensor that has negative bit set. "
+      "Use tensor.resolve_neg().numpy() instead.");
+
   auto dtype = aten_to_numpy_dtype(tensor.scalar_type());
   auto sizes = to_numpy_shape(tensor.sizes());
   auto strides = to_numpy_shape(tensor.strides());

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -109,12 +109,14 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   TORCH_CHECK(is_numpy_available(), "Numpy is not available");
 
   TORCH_CHECK(tensor.device().type() == DeviceType::CPU,
-      "can't convert %s device type tensor to numpy. Use Tensor.cpu() to "
-      "copy the tensor to host memory first.", tensor.device().str().c_str());
+      "can't convert ", tensor.device().str().c_str(),
+      " device type tensor to numpy. Use Tensor.cpu() to ",
+      "copy the tensor to host memory first.");
 
-  TORCH_CHECK(tensor.layout() == Layout::Strided,
-      "can't convert %s layout tensor to numpy."
-      "convert the tensor to a strided layout first.", c10::str(tensor.layout()).c_str());
+  TORCH_CHECK_TYPE(tensor.layout() == Layout::Strided,
+      "can't convert ", c10::str(tensor.layout()).c_str(),
+      " layout tensor to numpy.",
+      "convert the tensor to a strided layout first.");
 
   TORCH_CHECK(!(at::GradMode::is_enabled() && tensor.requires_grad()),
       "Can't call numpy() on Tensor that requires grad. "

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -108,7 +108,7 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   TORCH_CHECK(is_numpy_available(), "Numpy is not available");
 
-  TORCH_CHECK(tensor.device().type() == DeviceType::CPU,
+  TORCH_CHECK_TYPE(tensor.device().type() == DeviceType::CPU,
       "can't convert ", tensor.device().str().c_str(),
       " device type tensor to numpy. Use Tensor.cpu() to ",
       "copy the tensor to host memory first.");
@@ -118,7 +118,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
       " layout tensor to numpy.",
       "convert the tensor to a strided layout first.");
 
-  TORCH_CHECK_TYPE(!(at::GradMode::is_enabled() && tensor.requires_grad()),
+  TORCH_CHECK(!(at::GradMode::is_enabled() && tensor.requires_grad()),
       "Can't call numpy() on Tensor that requires grad. "
       "Use tensor.detach().numpy() instead.");
 

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -118,7 +118,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
       " layout tensor to numpy.",
       "convert the tensor to a strided layout first.");
 
-  TORCH_CHECK(!(at::GradMode::is_enabled() && tensor.requires_grad()),
+  TORCH_CHECK_TYPE(!(at::GradMode::is_enabled() && tensor.requires_grad()),
       "Can't call numpy() on Tensor that requires grad. "
       "Use tensor.detach().numpy() instead.");
 

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -124,6 +124,16 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
         "Can't call numpy() on Tensor that requires grad. "
         "Use tensor.detach().numpy() instead.");
   }
+  if (tensor.is_conj()) {
+    throw std::runtime_error(
+        "Can't call numpy() on Tensor that has conjugate bit set. "
+        "Use tensor.resolve_conj().numpy() instead.");
+  }
+  if (tensor.is_neg()) {
+    throw std::runtime_error(
+        "Can't call numpy() on Tensor that has negative bit set. "
+        "Use tensor.resolve_neg().numpy() instead.");
+  }
   auto dtype = aten_to_numpy_dtype(tensor.scalar_type());
   auto sizes = to_numpy_shape(tensor.sizes());
   auto strides = to_numpy_shape(tensor.strides());


### PR DESCRIPTION
Resolves https://github.com/pytorch/pytorch/issues/59945 and https://github.com/pytorch/pytorch/issues/59946

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61925 Throw RuntimeError when numpy() is called on a tensor with conjugate or negative bit set**

bc breaking note: Unlike before, complex_tensor.conj().numpy(),  complex_float_tensor.conj().view(torch.float64), complex_float_tensor.conj().imag.view(torch.int32) now doesn't return a view but instead errors out

Differential Revision: [D29819288](https://our.internmc.facebook.com/intern/diff/D29819288)