### PR TITLE
.github: Clone pytorch to separate directory

### DIFF
--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -48,10 +48,6 @@ jobs:
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
@@ -146,10 +142,6 @@ jobs:
       run:
         working-directory: pytorch-${{ github.run_id }}
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -44,14 +44,14 @@ jobs:
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -138,14 +138,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -92,12 +92,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf .
 
   generate-test-matrix:
 {%- if only_build_on_pull_request %}
@@ -202,6 +205,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf .
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -34,6 +34,7 @@ env:
   USE_CUDA: 1
 {%- endif %}
 
+
 concurrency:
   group: !{{ build_environment }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -41,6 +42,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build
     steps:
@@ -52,6 +56,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -137,6 +142,9 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Clean workspace
         shell: bash
@@ -146,6 +154,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -100,7 +100,7 @@ jobs:
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
-          rm -rf .
+          rm -rf ./*
 
   generate-test-matrix:
 {%- if only_build_on_pull_request %}
@@ -210,7 +210,7 @@ jobs:
         shell: bash
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
-          rm -rf .
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -33,14 +33,14 @@ jobs:
     env:
       JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -118,14 +118,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -37,10 +37,6 @@ jobs:
     env:
       JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
@@ -126,10 +122,6 @@ jobs:
       run:
         working-directory: pytorch-${{ github.run_id }}
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -23,6 +23,7 @@ env:
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
 
+
 concurrency:
   group: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -30,6 +31,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
@@ -41,6 +45,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -117,6 +122,9 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Clean workspace
         shell: bash
@@ -126,6 +134,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -79,12 +79,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf .
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -180,6 +183,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf .
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -87,7 +87,7 @@ jobs:
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
-          rm -rf .
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
-          rm -rf .
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -80,7 +80,7 @@ jobs:
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
-          rm -rf .
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -173,7 +173,7 @@ jobs:
         shell: bash
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
-          rm -rf .
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -72,12 +72,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf .
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -165,6 +168,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf .
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -34,14 +34,14 @@ jobs:
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cpu-py3-build
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -111,14 +111,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -24,6 +24,7 @@ env:
   VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
 
+
 concurrency:
   group: pytorch-win-vs2019-cpu-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -31,6 +32,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cpu-py3-build
     steps:
@@ -42,6 +46,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -110,6 +115,9 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Clean workspace
         shell: bash
@@ -119,6 +127,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -38,10 +38,6 @@ jobs:
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cpu-py3-build
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
@@ -119,10 +115,6 @@ jobs:
       run:
         working-directory: pytorch-${{ github.run_id }}
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -26,6 +26,7 @@ env:
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
 
+
 concurrency:
   group: pytorch-win-vs2019-cuda10-cudnn7-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -33,6 +34,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda10-cudnn7-py3-build
     steps:
@@ -44,6 +48,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -120,6 +125,9 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Clean workspace
         shell: bash
@@ -129,6 +137,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -82,12 +82,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf .
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -183,6 +186,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf .
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -36,14 +36,14 @@ jobs:
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda10-cudnn7-py3-build
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -121,14 +121,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -40,10 +40,6 @@ jobs:
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda10-cudnn7-py3-build
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
@@ -129,10 +125,6 @@ jobs:
       run:
         working-directory: pytorch-${{ github.run_id }}
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -90,7 +90,7 @@ jobs:
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
-          rm -rf .
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -191,7 +191,7 @@ jobs:
         shell: bash
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
-          rm -rf .
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -39,10 +39,6 @@ jobs:
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
@@ -128,10 +124,6 @@ jobs:
       run:
         working-directory: pytorch-${{ github.run_id }}
     steps:
-      - name: Clean workspace
-        shell: bash
-        run: |
-          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -81,12 +81,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf .
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -182,6 +185,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf .
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -25,6 +25,7 @@ env:
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
 
+
 concurrency:
   group: pytorch-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -32,6 +33,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
@@ -43,6 +47,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -119,6 +124,9 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Clean workspace
         shell: bash
@@ -128,6 +136,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -35,14 +35,14 @@ jobs:
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -120,14 +120,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Clean workspace
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/*"
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -89,7 +89,7 @@ jobs:
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
-          rm -rf .
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -190,7 +190,7 @@ jobs:
         shell: bash
         # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
-          rm -rf .
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61932 .github: Clone pytorch to separate directory**

Clones pytorch to a separate directory for each run so that they do not
overlap with each other

To avoid errors like 
![image](https://user-images.githubusercontent.com/1700823/126393228-ef70b103-0312-497a-9b3f-a5046b88d537.png)


Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29801875](https://our.internmc.facebook.com/intern/diff/D29801875)