### PR TITLE
Initial ModuleInfo implementation

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -76,6 +76,7 @@ TESTS = [
     'test_mkldnn',
     'test_model_dump',
     'test_module_init',
+    'test_modules',
     'test_multiprocessing',
     'test_multiprocessing_spawn',
     'distributed/test_nccl',

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import TestCase, run_tests, freeze_rng_state
@@ -12,7 +11,7 @@ class TestModule(TestCase):
     def test_forward(self, device, dtype, module_info):
         module_cls = module_info.module_cls
         module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
-                                                      requires_grad=False)
+                                                       requires_grad=False)
         for module_input in module_inputs:
             if module_input.forward_input is None:
                 continue

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -6,6 +6,8 @@ from torch.testing._internal.common_utils import TestCase, run_tests, freeze_rng
 class TestModule(TestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
+    precision = 1e-5
+    rel_tol = 1e-5
 
     @modules(module_db)
     def test_forward(self, device, dtype, module_info):

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1,0 +1,41 @@
+from copy import deepcopy
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_modules import module_db, modules
+from torch.testing._internal.common_utils import TestCase, run_tests, freeze_rng_state
+
+
+class TestModule(TestCase):
+    _do_cuda_memory_leak_check = True
+    _do_cuda_non_default_stream = True
+
+    @modules(module_db)
+    def test_forward(self, device, dtype, module_info):
+        module_cls = module_info.module_cls
+        module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
+                                                      requires_grad=False)
+        for module_input in module_inputs:
+            if module_input.forward_input is None:
+                continue
+
+            with freeze_rng_state():
+                # === Instantiate the module. ===
+                args, kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
+                m = module_cls(*args, **kwargs)
+                m.to(device).to(dtype)
+
+                # === Do forward pass. ===
+                args, kwargs = module_input.forward_input.args, module_input.forward_input.kwargs
+                outputs = m(*args, **kwargs)
+
+                # === Compare outputs to a reference if one is specified. ===
+                # TODO: Handle precision
+                reference_fn = module_input.reference_fn
+                if reference_fn is not None:
+                    ref_outputs = reference_fn(m, *args, **kwargs)
+                    self.assertEqual(outputs, ref_outputs)
+
+
+instantiate_device_type_tests(TestModule, globals())
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -1,0 +1,203 @@
+import torch
+from copy import deepcopy
+from functools import wraps, partial
+from itertools import chain
+from torch.testing import floating_types
+from torch.testing._internal.common_device_type import (
+    _TestParametrizer, _dtype_test_suffix, _update_param_kwargs, skipIf)
+from torch.testing._internal.common_nn import nllloss_reference
+from torch.testing._internal.common_utils import make_tensor
+from typing import List
+
+
+# List of all namespaces containing modules to test.
+MODULE_NAMESPACES = [
+    torch.nn.modules,
+    torch.nn.qat.modules,
+    torch.nn.quantizable.modules,
+    torch.nn.quantized.modules,
+]
+
+# Modules that shouldn't be tested for one reason or another.
+MODULES_TO_SKIP = {
+    torch.nn.Module,  # abstract base class
+    torch.nn.Container,  # deprecated
+    torch.nn.NLLLoss2d,  # deprecated
+    torch.nn.quantized.modules._ConvNd,  # abstract base class
+    torch.nn.quantized.MaxPool2d,  # aliases to nn.MaxPool2d
+}
+
+# List of all module classes to test.
+MODULE_CLASSES = list(chain(*[[getattr(namespace, module_name) for module_name in namespace.__all__]
+                              for namespace in MODULE_NAMESPACES]))
+MODULE_CLASSES = [cls for cls in MODULE_CLASSES if cls not in MODULES_TO_SKIP]
+
+# Dict of module class -> common name. Useful for making test names more intuitive.
+# Example: torch.nn.modules.linear.Linear -> "nn.Linear"
+MODULE_CLASS_NAMES = {}
+for namespace in MODULE_NAMESPACES:
+    for module_name in namespace.__all__:
+        module_cls = getattr(namespace, module_name)
+        namespace_name = namespace.__name__.replace('torch.', '').replace('.modules', '')
+        MODULE_CLASS_NAMES[module_cls] = f'{namespace_name}.{module_name}'
+
+
+class modules(_TestParametrizer):
+    """ Decorator for specifying a list of modules over which to run a test. """
+    def __init__(self, module_info_list):
+        self.module_info_list = module_info_list
+
+    def _parametrize_test(self, test, generic_cls, device_cls):
+        for module_info in self.module_info_list:
+            # TODO: Factor some of this out since it's similar to OpInfo.
+            for dtype in floating_types():
+                # Construct the test name.
+                test_name = '{}_{}_{}{}'.format(test.__name__,
+                                                module_info.name.replace('.', '_'),
+                                                device_cls.device_type,
+                                                _dtype_test_suffix(dtype))
+
+                # Construct parameter kwargs to pass to the test.
+                param_kwargs = {'module_info': module_info}
+                _update_param_kwargs(param_kwargs, 'dtype', dtype)
+
+                try:
+                    active_decorators = []
+                    if module_info.should_skip(generic_cls.__name__, test.__name__, device_cls.device_type, dtype):
+                        active_decorators.append(skipIf(True, "Skipped!"))
+
+                    if module_info.decorators is not None:
+                        for decorator in module_info.decorators:
+                            # Can't use isinstance as it would cause a circular import
+                            if decorator.__class__.__name__ == 'DecorateInfo':
+                                if decorator.is_active(generic_cls.__name__, test.__name__,
+                                                       device_cls.device_type, dtype):
+                                    active_decorators += decorator.decorators
+                            else:
+                                active_decorators.append(decorator)
+
+                    @wraps(test)
+                    def test_wrapper(*args, **kwargs):
+                        return test(*args, **kwargs)
+
+                    for decorator in active_decorators:
+                        test_wrapper = decorator(test_wrapper)
+
+                    yield (test_wrapper, test_name, param_kwargs)
+                except Exception as ex:
+                    # Provides an error message for debugging before rethrowing the exception
+                    print("Failed to instantiate {0} for module {1}!".format(test_name, module_info.name))
+                    raise ex
+
+
+def formatted_module_name(module_cls):
+    """ Returns the common name of the module class formatted for use in test names. """
+    return MODULE_CLASS_NAMES[module_cls].replace('.', '_')
+
+
+class FunctionInput(object):
+    """ Contains args and kwargs to pass as input to a function. """
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class ModuleInput(object):
+    """ Contains args / kwargs for module instantiation + forward pass. """
+    __slots__ = ['constructor_input', 'forward_input', 'desc', 'reference_fn']
+
+    def __init__(self, constructor_input, forward_input=None, desc='', reference_fn=None):
+        self.constructor_input = constructor_input  # Inputs to pass during construction
+        self.forward_input = forward_input  # Inputs to pass to forward()
+        self.desc = desc  # Description for this set of inputs
+        self.reference_fn = reference_fn  # Reference function for comparison; expected signature:
+                                          # reference_fn(module, parameters, *args, **kwargs)
+
+        if reference_fn is not None:
+
+            @wraps(reference_fn)
+            def copy_reference_fn(m, *args, **kwargs):
+                # Copy inputs to avoid undesired side effects from calling the reference.
+                args, kwargs = deepcopy(args), deepcopy(kwargs)
+
+                # Note that module parameters are passed in for convenience.
+                return reference_fn(m, list(m.parameters()), *args, **kwargs)
+
+            self.reference_fn = copy_reference_fn
+
+
+class ModuleInfo(object):
+    """ Module information to be used in testing. """
+
+    def __init__(self,
+                 module_cls,  # Class object for the module under test
+                 *,
+                 module_inputs_func,  # Function to generate module inputs
+                 skips=[],  # Indicates which tests to skip
+                 decorators=None,  # Additional decorators to apply to generated tests
+                 ):
+        self.module_cls = module_cls
+        self.module_inputs_func = module_inputs_func
+        self.skips = skips
+        self.decorators = decorators
+
+    def should_skip(self, cls_name, test_name, device_type, dtype):
+        return any(si.is_active(cls_name, test_name, device_type, dtype) for si in self.skips)
+
+    @property
+    def name(self):
+        return formatted_module_name(self.module_cls)
+
+
+def module_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, **kwargs):
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    module_inputs = [
+        ModuleInput(constructor_input=FunctionInput(10, 8),
+                    forward_input=FunctionInput(make_input((4, 10))),
+                    reference_fn=lambda m, p, i: torch.mm(i, p[0].t()) + p[1].view(1, -1).expand(4, 8)),
+        ModuleInput(constructor_input=FunctionInput(10, 8, bias=False),
+                    forward_input=FunctionInput(make_input((4, 10))),
+                    desc='no_bias',
+                    reference_fn=lambda m, p, i: torch.mm(i, p[0].t())),
+        ModuleInput(constructor_input=FunctionInput(3, 5),
+                    forward_input=FunctionInput(make_input(3)),
+                    desc='no_batch_dim',
+                    reference_fn=lambda m, p, i: torch.mm(i.view(1, -1), p[0].t()).view(-1) + p[1])
+    ]
+
+    return module_inputs
+
+
+def module_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_grad, **kwargs):
+    cases = [
+        ('', {}),
+        ('ignore_index', {'ignore_index': 2}),
+        ('weights', {'weight': torch.randn(10, device=device, dtype=dtype)}),
+        ('weights_ignore_index', {'weight': torch.randn(10, device=device, dtype=dtype), 'ignore_index': 2}),
+        ('weights_ignore_index_neg', {'weight': torch.randn(10, device=device, dtype=dtype), 'ignore_index': -1})
+    ]
+    module_inputs = []
+    for desc, constructor_kwargs in cases:
+
+        def reference_fn(m, p, i, t, constructor_kwargs=constructor_kwargs):
+            return nllloss_reference(i, t, **constructor_kwargs)
+
+        module_inputs.append(
+            ModuleInput(constructor_input=FunctionInput(**constructor_kwargs),
+                        forward_input=FunctionInput(torch.rand(15, 10, device=device, dtype=dtype).log_softmax(dim=1),
+                                                    torch.empty(15, device=device).uniform_().mul(10).floor().long()),
+                        desc=desc,
+                        reference_fn=reference_fn)
+        )
+
+    return module_inputs
+
+
+# Database of ModuleInfo entries in alphabetical order.
+module_db: List[ModuleInfo] = [
+    ModuleInfo(torch.nn.Linear,
+               module_inputs_func=module_inputs_torch_nn_Linear),
+    ModuleInfo(torch.nn.NLLLoss,
+               module_inputs_func=module_inputs_torch_nn_NLLLoss)
+]

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -43,7 +43,7 @@ for namespace in MODULE_NAMESPACES:
 
 
 class modules(_TestParametrizer):
-    """ Decorator for specifying a list of modules over which to run a test. """
+    """ PROTOTYPE: Decorator for specifying a list of modules over which to run a test. """
     def __init__(self, module_info_list):
         self.module_info_list = module_info_list
 
@@ -170,12 +170,14 @@ def module_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, **k
 
 
 def module_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_grad, **kwargs):
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
     cases = [
         ('', {}),
         ('ignore_index', {'ignore_index': 2}),
-        ('weights', {'weight': torch.randn(10, device=device, dtype=dtype)}),
-        ('weights_ignore_index', {'weight': torch.randn(10, device=device, dtype=dtype), 'ignore_index': 2}),
-        ('weights_ignore_index_neg', {'weight': torch.randn(10, device=device, dtype=dtype), 'ignore_index': -1})
+        ('weights', {'weight': make_input(10)}),
+        ('weights_ignore_index', {'weight': make_input(10), 'ignore_index': 2}),
+        ('weights_ignore_index_neg', {'weight': make_input(10), 'ignore_index': -1})
     ]
     module_inputs = []
     for desc, constructor_kwargs in cases:
@@ -185,7 +187,7 @@ def module_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_grad, **
 
         module_inputs.append(
             ModuleInput(constructor_input=FunctionInput(**constructor_kwargs),
-                        forward_input=FunctionInput(torch.rand(15, 10, device=device, dtype=dtype).log_softmax(dim=1),
+                        forward_input=FunctionInput(make_input((15, 10)).log_softmax(dim=1),
                                                     torch.empty(15, device=device).uniform_().mul(10).floor().long()),
                         desc=desc,
                         reference_fn=reference_fn)


### PR DESCRIPTION
This PR contains the initial version of `ModuleInfo` for use in testing modules. The design philosophy taken here is to start small and simple and build out / refactor as needed when more test coverage or `ModuleInfo` entries are added. As such, it's not intended for general usage yet. The PR contains the following:

* (new file) `torch/testing/_internal/common_modules.py`
  * `ModuleInfo` definition - metadata for each module to use in testing
  * `module_db` - the actual `ModuleInfo` database; currently contains entries for two modules
  * `ModuleInput` - analogous to `SampleInput` from OpInfo; contains `FunctionInput`s for both constructor and forward pass inputs
      * Constructor and forward pass inputs are tied together within a `ModuleInput` because they are likely correlated
  * `FunctionInput` - just contains args and kwargs to pass to a function (is there a nicer way to do this?)
  * `@modules` decorator - analogous to `@ops`; specifies a set of modules to run a test over
  * Some constants used to keep track of all modules under torch.nn:
      * `MODULE_NAMESPACES` - list of all namespaces containing modules
      * `MODULE_CLASSES` - list of all module class objects
      * `MODULE_CLASS_NAMES` - dict from module class object to nice name (e.g. torch.nn.Linear -> "nn.Linear")
* (new file) `test/test_modules.py`
    * Uses the above to define tests over modules
    * Currently, there is one test for demonstration, `test_forward`, which instantiates a module, runs its forward pass, and compares it to a reference, if one is defined