### PR TITLE
Add missing docker build to slow gradcheck label-triggered build

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -36,6 +36,9 @@ CONFIG_TREE_DATA = [
                 ("3.6", [
                     ("shard_test", [X(True)]),
                     ("slow_gradcheck", [
+                        # If you update this slow gradcheck, you should
+                        # also update docker_definitions.py to make sure
+                        # the docker image match the config used here
                         (True, [
                             ('shard_test', [XImportant(True)]),
                         ]),

--- a/.circleci/cimodel/data/simple/docker_definitions.py
+++ b/.circleci/cimodel/data/simple/docker_definitions.py
@@ -30,11 +30,18 @@ IMAGE_NAMES = [
     "pytorch-linux-bionic-rocm4.2-py3.6",
 ]
 
+# This entry should be an element from the list above
+# This should contain the image matching the "slow_gradcheck" entry in
+# pytorch_build_data.py
+SLOW_GRADCHECK_IMAGE_NAME = "pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
 
-def get_workflow_jobs():
+def get_workflow_jobs(only_slow_gradcheck=False):
     """Generates a list of docker image build definitions"""
     ret = []
     for image_name in IMAGE_NAMES:
+        if only_slow_gradcheck and image_name is not SLOW_GRADCHECK_IMAGE_NAME:
+            continue
+
         parameters = OrderedDict({
             "name": quote(f"docker-{image_name}"),
             "image_name": quote(image_name),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9187,6 +9187,9 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
+      - docker_build_job:
+          name: "docker-pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
+          image_name: "pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
     when: << pipeline.parameters.run_slow_gradcheck_build >>
   # The following allows the equivalent periodic jobs on GHA to run on CircleCI ci-all and release branches
   debuggable-scheduled-ci:

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -154,7 +154,10 @@ def gen_build_workflows_tree():
         binary_build_definitions.get_nightly_uploads,
     ]
 
-    slow_gradcheck_jobs = pytorch_build_definitions.get_workflow_jobs(only_slow_gradcheck=True)
+    slow_gradcheck_jobs = [
+        pytorch_build_definitions.get_workflow_jobs,
+        cimodel.data.simple.docker_definitions.get_workflow_jobs,
+    ]
 
     return {
         "workflows": {
@@ -172,7 +175,7 @@ def gen_build_workflows_tree():
             },
             "slow_gradcheck_build": {
                 "when": r"<< pipeline.parameters.run_slow_gradcheck_build >>",
-                "jobs": slow_gradcheck_jobs,
+                "jobs": [f(only_slow_gradcheck=True) for f in slow_gradcheck_jobs],
             },
         }
     }

--- a/.github/pytorch-circleci-labels.yml
+++ b/.github/pytorch-circleci-labels.yml
@@ -13,5 +13,9 @@ labels_to_circle_params:
       - run_build
   ci/master:
     parameter: run_master_build
+    set_to_false:
+      - run_build
   ci/slow-gradcheck:
     parameter: run_slow_gradcheck_build
+    set_to_false:
+      - run_build


### PR DESCRIPTION
Currently, when adding the label, it fails like: https://app.circleci.com/pipelines/github/pytorch/pytorch/352569/workflows/d213cbad-edd6-4fe0-a79c-d46f8c0aae85/jobs/14856158