### PR TITLE
[pytorch] don't LOG by default when everything is fine

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -479,14 +479,14 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     ncclDebugLevel = "UNSET";
   }
 
-  LOG(INFO) << "[Rank " << rank_
-            << "] ProcessGroupNCCL initialized with following options:"
-            << "\nNCCL_ASYNC_ERROR_HANDLING: " << asyncErrorHandling_
-            << "\nNCCL_BLOCKING_WAIT: " << blockingWait_
-            << "\nTIMEOUT(ms): " << options_->timeout.count()
-            << "\nUSE_HIGH_PRIORITY_STREAM: "
-            << options_->is_high_priority_stream
-            << "\nNCCL_DEBUG: " << ncclDebugLevel;
+  VLOG(2) << "[Rank " << rank_
+          << "] ProcessGroupNCCL initialized with following options:"
+          << "\nNCCL_ASYNC_ERROR_HANDLING: " << asyncErrorHandling_
+          << "\nNCCL_BLOCKING_WAIT: " << blockingWait_
+          << "\nTIMEOUT(ms): " << options_->timeout.count()
+          << "\nUSE_HIGH_PRIORITY_STREAM: "
+          << options_->is_high_priority_stream
+          << "\nNCCL_DEBUG: " << ncclDebugLevel;
 }
 
 void ProcessGroupNCCL::setSequenceNumberForGroup() {
@@ -578,10 +578,10 @@ void ProcessGroupNCCL::abortTimedOutCollectives(
 
 void ProcessGroupNCCL::ncclCommWatchdog() {
   try {
-    LOG(INFO) << "[Rank " << rank_ << "] NCCL watchdog thread started!";
+    VLOG(2) << "[Rank " << rank_ << "] NCCL watchdog thread started!";
     ncclCommWatchdogInternal();
-    LOG(INFO) << "[Rank " << rank_
-              << "] NCCL watchdog thread terminated normally";
+    VLOG(2) << "[Rank " << rank_
+            << "] NCCL watchdog thread terminated normally";
   } catch (std::exception& e) {
     LOG(INFO) << "[Rank " << rank_
               << "] NCCL watchdog thread terminated with exception: "


### PR DESCRIPTION
Summary:
These logs are added in D24183463 (https://github.com/pytorch/pytorch/commit/c83314e9829822fcdc765e0b1eb9585a6b114c83) for debugging.

However in fbcode they appear in everyone's job. A normal job that runs fine should ideally not print extra logs. So I changed some that I observed to VLOG.

Test Plan: no longer see these logs when training

Differential Revision: D29810706



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang