### PR TITLE
Remove Input Pointer Caching for XNNPack

### DIFF
--- a/aten/src/ATen/native/xnnpack/Common.h
+++ b/aten/src/ATen/native/xnnpack/Common.h
@@ -41,9 +41,6 @@ struct ContextConv2D final {
   std::array<int64_t, 2> output_padding_;
   std::array<int64_t, 2> stride_;
   std::array<int64_t, 2> dilation_;
-  const float* cached_input_ptr{nullptr};
-  const float* cached_output_ptr{nullptr};
-  size_t input_height{0}, input_width{0}, batch_size{0}, input_channels{0};
   bool transposed_;
   int64_t groups_;
 

--- a/aten/src/ATen/native/xnnpack/Convolution.cpp
+++ b/aten/src/ATen/native/xnnpack/Convolution.cpp
@@ -324,54 +324,34 @@ Tensor run(
 
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   xnn_status setup_status;
-  if ((context.cached_input_ptr != padded_input_nhwc.data_ptr<float>()) ||
-      (context.cached_output_ptr != output.data_ptr<float>()) ||
-      (padded_input_nhwc.size(Layout::Activation4D::batch) !=
-        static_cast<int64_t>(context.batch_size)) ||
-      (padded_input_nhwc.size(Layout::Activation4D::channels) !=
-        static_cast<int64_t>(context.input_channels)) ||
-      (padded_input_nhwc.size(Layout::Activation4D::height) !=
-        static_cast<int64_t>(context.input_height)) ||
-      (padded_input_nhwc.size(Layout::Activation4D::width) !=
-        static_cast<int64_t>(context.input_width))
-      ) {
 
-      if (context.transposed_) {
-        setup_status = xnn_setup_deconvolution2d_nhwc_f32(
-          context.op.get(),                                      // operator
-          padded_input_nhwc.size(Layout::Activation4D::batch),   // batch_size
-          padded_input_nhwc.size(Layout::Activation4D::height),  // input_height
-          padded_input_nhwc.size(Layout::Activation4D::width),   // input_width
-          context.output_padding_[0],                            // adjustment_height
-          context.output_padding_[1],                            // adjustment_width
-          padded_input_nhwc.data_ptr<float>(),                   // input
-          output.data_ptr<float>(),                              // output
-          caffe2::pthreadpool_());                               // threadpool
+  if (context.transposed_) {
+    setup_status = xnn_setup_deconvolution2d_nhwc_f32(
+      context.op.get(),                                      // operator
+      padded_input_nhwc.size(Layout::Activation4D::batch),   // batch_size
+      padded_input_nhwc.size(Layout::Activation4D::height),  // input_height
+      padded_input_nhwc.size(Layout::Activation4D::width),   // input_width
+      context.output_padding_[0],                            // adjustment_height
+      context.output_padding_[1],                            // adjustment_width
+      padded_input_nhwc.data_ptr<float>(),                   // input
+      output.data_ptr<float>(),                              // output
+      caffe2::pthreadpool_());                               // threadpool
 
-      } else {
-        setup_status = xnn_setup_convolution2d_nhwc_f32(
-          context.op.get(),                                      // operator
-          padded_input_nhwc.size(Layout::Activation4D::batch),   // batch_size
-          padded_input_nhwc.size(Layout::Activation4D::height),  // input_height
-          padded_input_nhwc.size(Layout::Activation4D::width),   // input_width
-          padded_input_nhwc.data_ptr<float>(),                   // input
-          output.data_ptr<float>(),                              // output
-          caffe2::pthreadpool_());
-      }
-
-      TORCH_CHECK(
-          xnn_status_success == setup_status,
-          (context.transposed_ ? "xnn_setup_deconvolution2d_nhwc_f32 failed!"
-                               : "xnn_setup_convolution2d_nhwc_f32 failed!"));
-
-      // Cache values to avoid setup for the next round
-      context.cached_input_ptr = padded_input_nhwc.data_ptr<float>();
-      context.cached_output_ptr = output.data_ptr<float>();
-      context.batch_size = padded_input_nhwc.size(Layout::Activation4D::batch);
-      context.input_channels = padded_input_nhwc.size(Layout::Activation4D::channels);
-      context.input_height = padded_input_nhwc.size(Layout::Activation4D::height);
-      context.input_width = padded_input_nhwc.size(Layout::Activation4D::width);
+  } else {
+    setup_status = xnn_setup_convolution2d_nhwc_f32(
+      context.op.get(),                                      // operator
+      padded_input_nhwc.size(Layout::Activation4D::batch),   // batch_size
+      padded_input_nhwc.size(Layout::Activation4D::height),  // input_height
+      padded_input_nhwc.size(Layout::Activation4D::width),   // input_width
+      padded_input_nhwc.data_ptr<float>(),                   // input
+      output.data_ptr<float>(),                              // output
+      caffe2::pthreadpool_());
   }
+
+  TORCH_CHECK(
+      xnn_status_success == setup_status,
+      (context.transposed_ ? "xnn_setup_deconvolution2d_nhwc_f32 failed!"
+                            : "xnn_setup_convolution2d_nhwc_f32 failed!"));
 
   const xnn_status run_status = xnn_run_operator(
       context.op.get(),         // operator


### PR DESCRIPTION
Summary:
We no longer need to cache the Input Pointer as XNNPACK has implemented a more robust approach where indirection buffer does not need to be recalculated even if activation tensor pointer changes, as long as tensor dimensions are the same.

This reverses the changes in https://github.com/pytorch/pytorch/pull/42840/files

Differential Revision: D29777605

