### PR TITLE
[WIP, not for review] Remove copy_bucket_to_grad when optimizer runs as hook

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1380,7 +1380,8 @@ void Reducer::finalize_bucket_dense(Bucket& bucket) {
     }
 
     if (!gradient_as_bucket_view_) {
-      copy_bucket_to_grad(variable, replica, intra_bucket_index, global_unused);
+      // Don't do copy when optimizer runs inplace as part of a comm. hook
+//      copy_bucket_to_grad(variable, replica, intra_bucket_index, global_unused);
     } else {
       const auto& bucket_view_out =
           replica.bucket_views_out[intra_bucket_index];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #61961
* #61756
* #61678

Per title

Differential Revision: [D29809942](https://our.internmc.facebook.com/intern/diff/D29809942/)