### PR TITLE
linalg.inverse -> linalg.inv

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2716,7 +2716,7 @@ Tensor slogdet_backward(const Tensor& grad_logabsdet,
   };
 
   auto nonsingular_case_backward = [&](const Tensor& grad_logabsdet, const Tensor& self) -> Tensor {
-    // TODO: replace self.inverse with linalg_inverse
+    // TODO: replace self.inverse with linalg_inv
     return unsqueeze_multiple(grad_logabsdet, {-1, -2}, self.dim()) * self.inverse().conj().transpose(-2, -1);
   };
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1861,7 +1861,7 @@ Examples::
 
     >>> A = torch.randn(4, 4)
     >>> Atensorinv = torch.linalg.tensorinv(A, ind=1)
-    >>> Ainv = torch.linalg.inverse(A)
+    >>> Ainv = torch.linalg.inv(A)
     >>> torch.allclose(Atensorinv, Ainv)
     True
 """)


### PR DESCRIPTION
`linalg.inverse` doesn't exist in the API

This is a very minor documentation update.
