### PR TITLE
Run Windows smoke tests with gflags in test dir

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -1,5 +1,7 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
+pushd test
+
 set GFLAGS_EXE="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe"
 if exist %GFLAGS_EXE% (
     echo Some smoke tests
@@ -15,7 +17,6 @@ echo Copying over test times file
 copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"
 
 echo Run nn tests
-pushd test
 
 if "%RUN_SMOKE_TESTS_ONLY%"=="1" (
     :: Download specified test cases to run


### PR DESCRIPTION
Previous testing yielded the torch.version ModuleNotFound error when I ran the smoke tests from the pytorch root directory. 

This PR simply reorders the commands to run the smoke tests within the test directory, which passes in this series of runs: 
https://github.com/seemethere/test-repo/actions/runs/1050734298 (the failures are due to missing credentials during uploading stats, which we don't need here)

This PR will enable the new AMI with Windows SDK to be deployed, as deploying the AMI will re-enable smoke tests, which only pass with this change.