### PR TITLE
[ONNX] add tests for custom_opsets param from torch.onnx.export() function.

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -301,7 +301,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             * VALUE (int): opset version
 
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
-            the opset version is set to 1.
+            the opset version is set to 1. Only custom opset domain name and version should be
+            indicated through this argument.
 
         enable_onnx_checker (bool, default True): If True the onnx model checker will be run
             to ensure the exported model is a valid ONNX model.


### PR DESCRIPTION
`custom_opsets` arg from torch.onnx.export() is no needed to be removed.
Add some description and tests for easier understanding.
