### PR TITLE
reland D29801875: .github: Clone pytorch to separate directory

### DIFF
--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -34,6 +34,7 @@ env:
   USE_CUDA: 1
 {%- endif %}
 
+
 concurrency:
   group: !{{ build_environment }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -41,6 +42,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build
     steps:
@@ -48,10 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -91,12 +92,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf ./*
 
   generate-test-matrix:
 {%- if only_build_on_pull_request %}
@@ -130,6 +134,7 @@ jobs:
       JOB_BASE_NAME: !{{ build_environment }}-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      TEST_CONFIG: ${{ matrix.config }}
     needs:
       - build
       - generate-test-matrix
@@ -137,15 +142,15 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -201,6 +206,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -23,6 +23,7 @@ env:
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
 
+
 concurrency:
   group: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -30,6 +31,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
@@ -37,10 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -78,12 +79,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -110,6 +114,7 @@ jobs:
       JOB_BASE_NAME: periodic-pytorch-win-vs2019-cuda11-cudnn8-py3-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      TEST_CONFIG: ${{ matrix.config }}
     needs:
       - build
       - generate-test-matrix
@@ -117,15 +122,15 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -179,6 +184,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -24,6 +24,7 @@ env:
   VS_VERSION: "16.8.6"
   VC_YEAR: "2019"
 
+
 concurrency:
   group: pytorch-win-vs2019-cpu-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -31,6 +32,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cpu-py3-build
     steps:
@@ -38,10 +42,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -71,12 +72,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -103,6 +107,7 @@ jobs:
       JOB_BASE_NAME: pytorch-win-vs2019-cpu-py3-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      TEST_CONFIG: ${{ matrix.config }}
     needs:
       - build
       - generate-test-matrix
@@ -110,15 +115,15 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -164,6 +169,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -26,6 +26,7 @@ env:
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
 
+
 concurrency:
   group: pytorch-win-vs2019-cuda10-cudnn7-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -33,6 +34,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda10-cudnn7-py3-build
     steps:
@@ -40,10 +44,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -81,12 +82,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -113,6 +117,7 @@ jobs:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda10-cudnn7-py3-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      TEST_CONFIG: ${{ matrix.config }}
     needs:
       - build
       - generate-test-matrix
@@ -120,15 +125,15 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -182,6 +187,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -25,6 +25,7 @@ env:
   TORCH_CUDA_ARCH_LIST: "7.0"
   USE_CUDA: 1
 
+
 concurrency:
   group: pytorch-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -32,6 +33,9 @@ concurrency:
 jobs:
   build:
     runs-on: "windows.4xlarge"
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda11-cudnn8-py3-build
     steps:
@@ -39,10 +43,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -80,12 +81,15 @@ jobs:
           if-no-files-found: error
           name: ${{ env.BUILD_ENVIRONMENT }}
           path: C:\${{ github.run_id }}\build-results
-      - name: Cleanup build-results
+      - name: Cleanup build-results and workspaces
+        if: always()
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
+        # Should remove the entirety of pytorch-${{ github.run_id }}
         run: |
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
+          rm -rf ./*
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -112,6 +116,7 @@ jobs:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda11-cudnn8-py3-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      TEST_CONFIG: ${{ matrix.config }}
     needs:
       - build
       - generate-test-matrix
@@ -119,15 +124,15 @@ jobs:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: pytorch-${{ github.run_id }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Clean workspace (including things in .gitignore)
-        shell: bash
-        run: |
-          git clean -xdf
+          path: pytorch-${{ github.run_id }}
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -181,6 +186,12 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Cleanup workspace
+        if: always()
+        shell: bash
+        # Should remove the entirety of pytorch-${{ github.run_id }}
+        run: |
+          rm -rf ./*
 
   # this is a separate step from test because the log files from test are too
   # long: basically, GitHub tries to render all of the log files when you click


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61972 reland D29801875: .github: Clone pytorch to separate directory**

This reverts commit 716567504c8b4da8d764d9674595c2095b62080c.

Also includes change to add the TEST_CONFIG env variable so that test
reports get uploaded correctly.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29821858](https://our.internmc.facebook.com/intern/diff/D29821858)