### PR TITLE
Fix IMethodTest.GetArgumentNames with camelCase after #61856

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/expanding-array.cpp
   ${TORCH_API_TEST_DIR}/fft.cpp
   ${TORCH_API_TEST_DIR}/functional.cpp
+  ${TORCH_API_TEST_DIR}/imethod.cpp
   ${TORCH_API_TEST_DIR}/integration.cpp
   ${TORCH_API_TEST_DIR}/init.cpp
   ${TORCH_API_TEST_DIR}/jit.cpp

--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -8,7 +8,6 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/expanding-array.cpp
   ${TORCH_API_TEST_DIR}/fft.cpp
   ${TORCH_API_TEST_DIR}/functional.cpp
-  ${TORCH_API_TEST_DIR}/imethod.cpp
   ${TORCH_API_TEST_DIR}/integration.cpp
   ${TORCH_API_TEST_DIR}/init.cpp
   ${TORCH_API_TEST_DIR}/jit.cpp

--- a/test/cpp/api/imethod.cpp
+++ b/test/cpp/api/imethod.cpp
@@ -8,6 +8,7 @@
 using namespace ::testing;
 using namespace caffe2;
 
+// TODO(T96218435): Enable the following tests in OSS.
 TEST(IMethodTest, CallMethod) {
   auto script_model = torch::jit::load(getenv("SIMPLE_JIT"));
   auto script_method = script_model.get_method("forward");

--- a/test/cpp/api/imethod.cpp
+++ b/test/cpp/api/imethod.cpp
@@ -30,15 +30,21 @@ TEST(IMethodTest, CallMethod) {
 }
 
 TEST(IMethodTest, GetArgumentNames) {
-  auto script_model = torch::jit::load(getenv("SIMPLE_JIT"));
-  auto script_method = script_model.get_method("forward");
+  auto scriptModel = torch::jit::load(getenv("SIMPLE_JIT"));
+  auto scriptMethod = scriptModel.get_method("forward");
+
+  auto& scriptNames = scriptMethod.getArgumentNames();
+  EXPECT_EQ(scriptNames.size(), 2);
+  EXPECT_STREQ(scriptNames[0].c_str(), "self");
+  EXPECT_STREQ(scriptNames[1].c_str(), "input");
 
   torch::deploy::InterpreterManager manager(3);
-  torch::deploy::Package p = manager.load_package(getenv("SIMPLE"));
-  auto py_model = p.load_pickle("model", "model.pkl");
-  torch::deploy::PythonMethodWrapper py_method(py_model, "forward");
+  torch::deploy::Package package = manager.load_package(getenv("SIMPLE"));
+  auto pyModel = package.load_pickle("model", "model.pkl");
+  torch::deploy::PythonMethodWrapper pyMethod(pyModel, "forward");
 
-  // TODO(whc) implement and test these
-  EXPECT_THROW(script_method.getArgumentNames(), std::runtime_error);
-  EXPECT_THROW(py_method.getArgumentNames(), std::runtime_error);
+  auto& pyNames = pyMethod.getArgumentNames();
+  EXPECT_EQ(pyNames.size(), 2);
+  EXPECT_STREQ(pyNames[0].c_str(), "input");
+  EXPECT_STREQ(pyNames[1].c_str(), "kwargs");
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #61985

Fix IMethodTest.GetArgumentNames after D29648756.

Differential Revision: [D29828807](https://our.internmc.facebook.com/intern/diff/D29828807/)