### PR TITLE
[quant] Add from_blob_quantized_per_tensor API

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -218,15 +218,15 @@ Tensor from_blob_quantized_per_tensor_affine(
     void* data,
     IntArrayRef sizes,
     std::function<void(void*)> deleter,
-    float scale,
-    int64_t zeroPoint,
+    const float scale,
+    const int64_t zeroPoint,
     const TensorOptions& options) {
   auto dtype = typeMetaToScalarType(options.dtype());
   TORCH_CHECK(
       isQIntType(dtype),
-      "from_blob_quantized_per_tensor_affine expects QInt dtypes");
+      "from_blob_quantized_per_tensor_affine expects QInt dtypes, got ", dtype);
 
-  std::size_t itemsize = options.dtype().itemsize();
+  const std::size_t itemsize = options.dtype().itemsize();
   std::size_t size = 1;
   for (std::int64_t s : sizes) {
     size *= static_cast<std::size_t>(s);

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -231,28 +231,22 @@ Tensor from_blob_quantized_per_tensor_affine(
   for (std::int64_t s : sizes) {
     size *= static_cast<std::size_t>(s);
   }
-  const auto datasize = size * itemsize;
+  const std::size_t datasize = size * itemsize;
 
-  DataPtr dataPtr = InefficientStdFunctionContext::makeDataPtr(
+  DataPtr data_ptr = InefficientStdFunctionContext::makeDataPtr(
       data, deleter, options.device());
 
-  auto storage = c10::make_intrusive<StorageImpl>(
-      StorageImpl::use_byte_size_t(),
-      datasize,
-      std::move(dataPtr),
-      /*allocator=*/nullptr,
-      /*resizable=*/false);
+  Storage storage{Storage::use_byte_size_t{}, datasize, std::move(data_ptr)};
 
   QuantizerPtr quantizer =
       make_per_tensor_affine_quantizer(scale, zeroPoint, dtype);
 
   Tensor qtensor = at::detail::make_tensor<QTensorImpl>(
-      storage,
+      std::move(storage),
       at::DispatchKeySet(options.computeDispatchKey()),
       options.dtype(),
       quantizer);
   get_qtensorimpl(qtensor)->set_sizes_contiguous(sizes);
-
   return qtensor;
 }
 

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -221,19 +221,20 @@ Tensor from_blob_quantized_per_tensor_affine(
     float scale,
     int64_t zeroPoint,
     const TensorOptions& options) {
-
   auto dtype = typeMetaToScalarType(options.dtype());
-  TORCH_CHECK(isQIntType(dtype), "from_blob_quantized_per_tensor_affine expects QInt dtypes");
+  TORCH_CHECK(
+      isQIntType(dtype),
+      "from_blob_quantized_per_tensor_affine expects QInt dtypes");
 
   std::size_t itemsize = options.dtype().itemsize();
   std::size_t size = 1;
-   for (std::int64_t s : sizes) {
-     size *= static_cast<std::size_t>(s);
-   }
+  for (std::int64_t s : sizes) {
+    size *= static_cast<std::size_t>(s);
+  }
   const auto datasize = size * itemsize;
 
-  DataPtr dataPtr =
-    InefficientStdFunctionContext::makeDataPtr(data, deleter, options.device());
+  DataPtr dataPtr = InefficientStdFunctionContext::makeDataPtr(
+      data, deleter, options.device());
 
   auto storage = c10::make_intrusive<StorageImpl>(
       StorageImpl::use_byte_size_t(),
@@ -242,10 +243,14 @@ Tensor from_blob_quantized_per_tensor_affine(
       /*allocator=*/nullptr,
       /*resizable=*/false);
 
-  QuantizerPtr quantizer = make_per_tensor_affine_quantizer(scale, zeroPoint, dtype);
+  QuantizerPtr quantizer =
+      make_per_tensor_affine_quantizer(scale, zeroPoint, dtype);
 
   Tensor qtensor = at::detail::make_tensor<QTensorImpl>(
-      storage, at::DispatchKeySet(options.computeDispatchKey()), options.dtype(), quantizer);
+      storage,
+      at::DispatchKeySet(options.computeDispatchKey()),
+      options.dtype(),
+      quantizer);
   get_qtensorimpl(qtensor)->set_sizes_contiguous(sizes);
 
   return qtensor;

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -231,8 +231,8 @@ TORCH_API Tensor from_blob_quantized_per_tensor_affine(
     void* data,
     IntArrayRef sizes,
     std::function<void(void*)> deleter,
-    float scale,
-    int64_t zeroPoint,
+    const float scale,
+    const int64_t zeroPoint,
     const TensorOptions& options);
 
 } // namespace at

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -227,4 +227,12 @@ TORCH_API Tensor new_qtensor(
 
 TORCH_API void set_quantizer_(const Tensor& self, ConstQuantizerPtr quantizer);
 
+TORCH_API Tensor from_blob_quantized_per_tensor_affine(
+    void* data,
+    IntArrayRef sizes,
+    std::function<void(void*)> deleter,
+    float scale,
+    int64_t zeroPoint,
+    const TensorOptions& options);
+
 } // namespace at

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -217,8 +217,8 @@ TEST(TestQTensor, QuantizePerChannel4dChannelsLast) {
 }
 
 TEST(TestQTensor, FromBlobQuantizedPerTensor) {
-  auto scale = 0.1;
-  auto zero_point = 10;
+  const double scale = 0.1;
+  const int64_t zero_point = 10;
   std::vector<int64_t> shape = {10, 10};
   auto numel = c10::multiply_integers(shape);
 
@@ -240,5 +240,6 @@ TEST(TestQTensor, FromBlobQuantizedPerTensor) {
   for (auto i = 0; i < numel; ++i) {
     ASSERT_EQ((int)custom_data[i], (int)q_data[i]);
   }
-
+  ASSERT_EQ((float)qtensor.q_scale(), (float)scale);
+  ASSERT_EQ(qtensor.q_zero_point(), zero_point);
 }

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -5,11 +5,13 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <sstream>
 #include <type_traits>
 // For quantize_val
 #include <ATen/native/quantized/affine_quantizer.h>
 #include <c10/core/ScalarType.h>
+#include <ATen/quantized/Quantizer.h>
 
 using namespace at;
 
@@ -212,4 +214,31 @@ TEST(TestQTensor, QuantizePerChannel4dChannelsLast) {
       ASSERT_EQ((int)q_data[i], qval);
     }
   }
+}
+
+TEST(TestQTensor, FromBlobQuantizedPerTensor) {
+  auto scale = 0.1;
+  auto zero_point = 10;
+  std::vector<int64_t> shape = {10, 10};
+  auto numel = c10::multiply_integers(shape);
+
+  TensorOptions options(at::kQUInt8);
+
+  auto custom_vec = std::make_unique<std::vector<uint8_t>>();
+  custom_vec->reserve(numel);
+
+  auto custom_data = custom_vec->data();
+  for (auto i = 0; i < numel; ++i) {
+    custom_data[i] = i;
+  }
+  auto deleteWhenDone = custom_vec.release();
+  auto deleter = [deleteWhenDone](void*) { delete deleteWhenDone; };
+
+  Tensor qtensor = at::from_blob_quantized_per_tensor_affine(custom_data, shape, deleter, scale, zero_point, options);
+
+  uint8_t* q_data = (uint8_t*)qtensor.data_ptr<quint8>();
+  for (auto i = 0; i < numel; ++i) {
+    ASSERT_EQ((int)custom_data[i], (int)q_data[i]);
+  }
+
 }

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -231,9 +231,14 @@ TEST(TestQTensor, FromBlobQuantizedPerTensor) {
   for (auto i = 0; i < numel; ++i) {
     custom_data[i] = i;
   }
+  bool customDataDeleted{false};
   auto deleteWhenDone = custom_vec.release();
-  auto deleter = [deleteWhenDone, custom_data](void* inp) { ASSERT_EQ((void*)inp, (void*)custom_data);  delete deleteWhenDone; };
-
+  auto deleter = [deleteWhenDone, custom_data, &customDataDeleted](void* inp) {
+    ASSERT_EQ((void*)inp, (void*)custom_data);
+    delete deleteWhenDone;
+    customDataDeleted = true;
+  };
+  {
   Tensor qtensor = at::from_blob_quantized_per_tensor_affine(custom_data, shape, deleter, scale, zero_point, options);
 
   uint8_t* q_data = (uint8_t*)qtensor.data_ptr<quint8>();
@@ -242,4 +247,6 @@ TEST(TestQTensor, FromBlobQuantizedPerTensor) {
   }
   ASSERT_EQ((float)qtensor.q_scale(), (float)scale);
   ASSERT_EQ(qtensor.q_zero_point(), zero_point);
+  }
+  TORCH_CHECK(customDataDeleted);
 }

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -217,7 +217,7 @@ TEST(TestQTensor, QuantizePerChannel4dChannelsLast) {
 }
 
 TEST(TestQTensor, FromBlobQuantizedPerTensor) {
-  const double scale = 0.1;
+  const float scale = 0.1;
   const int64_t zero_point = 10;
   std::vector<int64_t> shape = {10, 10};
   auto numel = c10::multiply_integers(shape);
@@ -227,12 +227,12 @@ TEST(TestQTensor, FromBlobQuantizedPerTensor) {
   auto custom_vec = std::make_unique<std::vector<uint8_t>>();
   custom_vec->reserve(numel);
 
-  auto custom_data = custom_vec->data();
+  uint8_t* custom_data = custom_vec->data();
   for (auto i = 0; i < numel; ++i) {
     custom_data[i] = i;
   }
   auto deleteWhenDone = custom_vec.release();
-  auto deleter = [deleteWhenDone](void*) { delete deleteWhenDone; };
+  auto deleter = [deleteWhenDone, custom_data](void* inp) { ASSERT_EQ((void*)inp, (void*)custom_data);  delete deleteWhenDone; };
 
   Tensor qtensor = at::from_blob_quantized_per_tensor_affine(custom_data, shape, deleter, scale, zero_point, options);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62049
* __->__ #61986

Summary:
Adds a new function that accepts qint data blobs as input and creates a quantized tensor using the pre-allocated data and the provided scale and zero_point inputs
Addresses issue https://github.com/pytorch/pytorch/issues/61777

Test Plan:

./build/bin/quantized_test --gtest_filter='TestQTensor.FromBlobQuantizedPerTensor'

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29831135](https://our.internmc.facebook.com/intern/diff/D29831135)