### PR TITLE
Enable dynamically ciflow/slow so that we can run GHA slow tests on PR

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -49,11 +49,16 @@ LINUX_RUNNERS = {
 class CIFlowConfig:
     enabled: bool = False
     labels: Set[str] = field(default_factory=set)
-    trigger_action_only: bool = False
     trigger_action: str = 'unassigned'
     trigger_actor: str = 'pytorchbot'
     root_job_name: str = 'ciflow_should_run'
     root_job_condition: str = ''
+
+    # TODO: Remove this option after ciflow fully rollout.
+    # trigger_action_only controls if we liston only on the trigger_action of a pull_request.
+    # If it's False, we listen on all default pull_request actions, this is useful when
+    # probot is not automated yet.
+    trigger_action_only: bool = False
 
     def gen_root_job_condition(self) -> None:
         # TODO: Make conditions strict

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -54,10 +54,9 @@ class CIFlowConfig:
     root_job_name: str = 'ciflow_should_run'
     root_job_condition: str = ''
 
-    # TODO: Remove this option after ciflow fully rollout.
-    # trigger_action_only controls if we liston only on the trigger_action of a pull_request.
+    # trigger_action_only controls if we listen only on the trigger_action of a pull_request.
     # If it's False, we listen on all default pull_request actions, this is useful when
-    # probot is not automated yet.
+    # ciflow (via probot) is not automated yet.
     trigger_action_only: bool = False
 
     def gen_root_job_condition(self) -> None:

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -49,6 +49,7 @@ LINUX_RUNNERS = {
 class CIFlowConfig:
     enabled: bool = False
     labels: Set[str] = field(default_factory=set)
+    trigger_action_only: bool = False # only trigger the workflow on PR with trigger_action
     trigger_action: str = 'unassigned'
     trigger_actor: str = 'pytorchbot'
     root_job_name: str = 'ciflow_should_run'
@@ -228,6 +229,12 @@ LINUX_WORKFLOWS = [
         enable_nogpu_no_avx2_test=1,
         enable_slow_test=1,
         num_test_shards=2,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels=set(['ciflow/slow']),
+        )
     ),
     CIWorkflow(
         arch="linux",

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -49,7 +49,7 @@ LINUX_RUNNERS = {
 class CIFlowConfig:
     enabled: bool = False
     labels: Set[str] = field(default_factory=set)
-    trigger_action_only: bool = False # only trigger the workflow on PR with trigger_action
+    trigger_action_only: bool = False
     trigger_action: str = 'unassigned'
     trigger_actor: str = 'pytorchbot'
     root_job_name: str = 'ciflow_should_run'

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -9,10 +9,15 @@ on:
   # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
 {%- if on_pull_request %}
   pull_request:
-{%- if ciflow_config.enabled %}
+  {%- if ciflow_config.enabled %}
+    {%- if ciflow_config.trigger_action_only %}
+    types: [!{{ ciflow_config.trigger_action }}]
+    {%- else %}
     types: [opened, synchronize, reopened, !{{ ciflow_config.trigger_action }}]
+    {%- endif %}
+  {%- endif %}
 {%- endif %}
-{%- endif %}
+
 {%- if is_scheduled %}
   schedule:
     - cron: !{{ is_scheduled }}

--- a/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -5,6 +5,8 @@ name: Linux CI (pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7)
 
 on:
   # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
+  pull_request:
+    types: [unassigned]
   push:
     branches:
       - master
@@ -26,9 +28,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/slow'))
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   calculate-docker-image:
     runs-on: linux.2xlarge
-    needs: []
+    needs: [ciflow_should_run]
     env:
       DOCKER_BUILDKIT: 1
     timeout-minutes: 90
@@ -101,7 +109,7 @@ jobs:
 
   build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, ]
+    needs: [calculate-docker-image, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7-build
@@ -199,7 +207,7 @@ jobs:
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
-    needs: []
+    needs: [ciflow_should_run]
     env:
       TEST_RUNNER_TYPE: linux.8xlarge.nvidia.gpu
       ENABLE_JIT_LEGACY_TEST: 1
@@ -225,7 +233,7 @@ jobs:
         run: .github/scripts/generate_pytorch_test_matrix.py
 
   test:
-    needs: [calculate-docker-image, build, generate-test-matrix, ]
+    needs: [calculate-docker-image, build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -366,7 +374,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: always()
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #61987



This PR enables us to run slow GHA tests on PR.

Steps to do (~may only take effect after this PR is merged~ works on this PR)
- Add label `ciflow/slow`
- Assign/unassign pytorchbot
- The job should be running .github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml

The above steps are manual, and after probot can do the dispatch work, the ciflow will be automated.

Related meta RFC issue: #61888

Differential Revision: [D29832758](https://our.internmc.facebook.com/intern/diff/D29832758)