### PR TITLE
don't mutate results from parse_native_yaml

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -124,6 +124,7 @@ TESTS = [
     'test_openmp',
     'test_profiler',
     'test_incorrect_dispatch_key_ops',
+    'test_gen_backend_stubs',
     "distributed/test_launcher",
     'distributed/nn/jit/test_instantiator',
     'distributed/rpc/test_faulty_agent',

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -71,36 +71,37 @@ class LineLoader(YamlLoader):
         mapping['__line__'] = node.start_mark.line + 1
         return mapping
 
-_GLOBAL_PARSE_NATIVE_YAML_CACHE = {}
-
 # Parse native_functions.yaml into a sequence of NativeFunctions and Backend Indices.
 ParsedYaml = namedtuple('ParsedYaml', ['native_functions', 'backend_indices'])
-def parse_native_yaml(path: str) -> ParsedYaml:
-    global _GLOBAL_PARSE_NATIVE_YAML_CACHE
-    if path not in _GLOBAL_PARSE_NATIVE_YAML_CACHE:
-        with open(path, 'r') as f:
-            es = yaml.load(f, Loader=LineLoader)
-        assert isinstance(es, list)
-        rs: List[NativeFunction] = []
-        bs: Dict[DispatchKey, Dict[OperatorName, BackendMetadata]] = defaultdict(dict)
-        for e in es:
-            assert isinstance(e.get('__line__'), int), e
-            loc = Location(path, e['__line__'])
-            funcs = e.get('func')
-            with context(lambda: f'in {loc}:\n  {funcs}'):
-                func, m = NativeFunction.from_yaml(e, loc)
-                rs.append(func)
-                BackendIndex.grow_index(bs, m)
-        error_check_native_functions(rs)
-        # Default dict is to prevent the codegen from barfing when we have a dispatch key that has no kernels yet.
-        indices: Dict[DispatchKey, BackendIndex] = defaultdict(lambda: BackendIndex(
-            dispatch_key=DispatchKey.Undefined, use_out_as_primary=True, external=False, index={}))
-        for k, v in bs.items():
-            # All structured in-tree operators are implemented in terms of their out operator.
-            indices[k] = BackendIndex(dispatch_key=k, use_out_as_primary=True, external=False, index=v)
-        _GLOBAL_PARSE_NATIVE_YAML_CACHE[path] = ParsedYaml(rs, indices)
+@dataclass(frozen=True)
+class ParsedYaml:
+    native_functions: List[NativeFunction]
+    backend_indices: Dict[DispatchKey, BackendIndex]
 
-    return _GLOBAL_PARSE_NATIVE_YAML_CACHE[path]
+@functools.cache
+def parse_native_yaml(path: str) -> ParsedYaml:
+    with open(path, 'r') as f:
+        es = yaml.load(f, Loader=LineLoader)
+    assert isinstance(es, list)
+    rs: List[NativeFunction] = []
+    bs: Dict[DispatchKey, Dict[OperatorName, BackendMetadata]] = defaultdict(dict)
+    for e in es:
+        assert isinstance(e.get('__line__'), int), e
+        loc = Location(path, e['__line__'])
+        funcs = e.get('func')
+        with context(lambda: f'in {loc}:\n  {funcs}'):
+            func, m = NativeFunction.from_yaml(e, loc)
+            rs.append(func)
+            BackendIndex.grow_index(bs, m)
+    error_check_native_functions(rs)
+    # Default dict is to prevent the codegen from barfing when we have a dispatch key that has no kernels yet.
+    indices: Dict[DispatchKey, BackendIndex] = defaultdict(lambda: BackendIndex(
+        dispatch_key=DispatchKey.Undefined, use_out_as_primary=True, external=False, index={}))
+    for k, v in bs.items():
+        # All structured in-tree operators are implemented in terms of their out operator.
+        indices[k] = BackendIndex(dispatch_key=k, use_out_as_primary=True, external=False, index=v)
+
+    return ParsedYaml(rs, indices)
 
 # Some assertions are already performed during parsing, but those are only within a single NativeFunction.
 # Assertions here are meant to be performed across NativeFunctions.

--- a/tools/codegen/gen_backend_stubs.py
+++ b/tools/codegen/gen_backend_stubs.py
@@ -4,6 +4,7 @@ import os
 import yaml
 import re
 from collections import namedtuple, Counter, defaultdict
+from copy import copy
 from typing import List, Dict, Union, Sequence, Optional
 from tools.codegen.gen import FileManager, get_grouped_native_functions, parse_native_yaml
 from tools.codegen.model import (BackendIndex, BackendMetadata, DispatchKey,
@@ -174,7 +175,7 @@ def main() -> None:
 
     run(options.source_yaml, options.output_dir, options.dry_run, options.impl_path)
 
-def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[str]) -> None:
+def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[str] = None) -> None:
 
     # Assumes that this file lives at PYTORCH_ROOT/tools/codegen/gen_backend_stubs.py
     pytorch_root = pathlib.Path(__file__).parent.parent.parent.absolute()
@@ -188,6 +189,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     native_yaml_path = os.path.join(pytorch_root, 'aten/src/ATen/native/native_functions.yaml')
     parsed_yaml = parse_native_yaml(native_yaml_path)
     native_functions, backend_indices = parsed_yaml.native_functions, parsed_yaml.backend_indices
+    backend_indices = copy(backend_indices)
     grouped_native_functions = get_grouped_native_functions(native_functions)
     parsed_backend_yaml = parse_backend_yaml(source_yaml, grouped_native_functions, backend_indices)
     backend_key = parsed_backend_yaml.backend_key


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61989 don't mutate results from parse_native_yaml**
* #61295 add basic regex test to detect invalid CompositeExplicitAutograd ops that are implemented with DispatchStub
* #61133 fix eig.e bug - it uses DispatchStub and therefore isn't backend agnostic

Differential Revision: [D29830204](https://our.internmc.facebook.com/intern/diff/D29830204)