### PR TITLE
.github: Specify directory to pull reports from

### DIFF
--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -216,7 +216,7 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path:
-            test-reports-*.zip
+            pytorch-${{ github.run_id }}/test-reports-*.zip
       - name: Cleanup workspace
         if: always()
         shell: bash

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -183,7 +183,7 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path:
-            test-reports-*.zip
+            pytorch-${{ github.run_id }}/test-reports-*.zip
       - name: Cleanup workspace
         if: always()
         shell: bash

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -168,7 +168,7 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path:
-            test-reports-*.zip
+            pytorch-${{ github.run_id }}/test-reports-*.zip
       - name: Cleanup workspace
         if: always()
         shell: bash

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -186,7 +186,7 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path:
-            test-reports-*.zip
+            pytorch-${{ github.run_id }}/test-reports-*.zip
       - name: Cleanup workspace
         if: always()
         shell: bash

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -185,7 +185,7 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path:
-            test-reports-*.zip
+            pytorch-${{ github.run_id }}/test-reports-*.zip
       - name: Cleanup workspace
         if: always()
         shell: bash


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#61990 .github: Specify directory to pull reports from**

This adds more specificity to where to pull test reports from since I
believe that actions/upload-artifact doesn't actually respect the
working-directory default

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29831719](https://our.internmc.facebook.com/intern/diff/D29831719)