### PR TITLE
[Not For Landing/Review] [PyTorch Edge] Try to speed up module loading by reserving space in various vectors

### DIFF
--- a/torch/csrc/jit/mobile/function.cpp
+++ b/torch/csrc/jit/mobile/function.cpp
@@ -183,6 +183,22 @@ int64_t Function::getExceptionDebugHandle() const {
   return (pc < code_->debug_handles_.size()) ? code_->debug_handles_[pc] : -1;
 }
 
+void Function::reserveInstructions(size_t num_instructions) {
+  code_->instructions_.reserve(num_instructions);
+}
+
+void Function::reserveDebugHandles(size_t num_debug_handles) {
+  code_->debug_handles_.reserve(num_debug_handles);
+}
+
+void Function::reserveConstants(size_t num_constats) {
+  code_->constants_.reserve(num_constats);
+}
+
+void Function::reserveOperators(size_t num_operators) {
+  code_->operators_.reserve(num_operators);
+}
+
 } // namespace mobile
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/mobile/function.h
+++ b/torch/csrc/jit/mobile/function.h
@@ -83,6 +83,26 @@ class Function {
   // If no corresponding debug handle is found then -1 is returned.
   int64_t getExceptionDebugHandle() const;
 
+  // Reserve space in code_->instructions_ for num_instructions
+  // instructions to avoid resizing the storage every time
+  // a new instruction is added to this function.
+  void reserveInstructions(size_t num_instructions);
+
+  // Reserve space in code_->debug_handles_ for num_debug_handles
+  // debug handles to avoid resizing the storage every time
+  // a new debug handle is added to this function.
+  void reserveDebugHandles(size_t num_debug_handles);
+
+  // Reserve space in code_->constants_ for num_constants
+  // constants to avoid resizing the storage every time
+  // a new constant is added to this function.
+  void reserveConstants(size_t num_constants);
+
+  // Reserve space in code_->operators_ for num_operators
+  // operator functions to avoid resizing the storage every time
+  // a new operator is added to this function.
+  void reserveOperators(size_t num_operators);
+
  private:
   c10::QualifiedName name_;
   std::shared_ptr<Code> code_;

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -390,7 +390,15 @@ void BytecodeDeserializer::parseMethods(
       TORCH_CHECK(
           debug_handles_list.size() == ins_list.size(),
           "The numbers of instructions and debug handles strings do not match.");
+
+      // Reserve space to avoid resizing the internal vector since that
+      // is inefficient.
+      function->reserveDebugHandles(debug_handles_list.size());
     }
+
+    // Reserve space to avoid resizing the internal vector since that
+    // is inefficient.
+    function->reserveInstructions(ins_list.size());
 
     for (size_t i = 0; i < ins_list.size(); ++i) {
       auto ins_item = ins_list[i].toTuple()->elements();
@@ -409,6 +417,7 @@ void BytecodeDeserializer::parseMethods(
       }
     }
 
+    function->reserveOperators(ops_list.size());
     std::unordered_set<std::string> unsupported_op_names =
         load_and_find_unsupported_operator_names(
             ops_list, function.get(), model_version, operator_cache);
@@ -417,6 +426,7 @@ void BytecodeDeserializer::parseMethods(
       print_unsupported_ops_and_throw(unsupported_op_names);
     }
 
+    function->reserveConstants(consts_list.size());
     for (const auto& constant : consts_list) {
       function->append_constant(constant);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #61998
* #61997
* #61996

This change slows down model loading.


A recent post https://fb.workplace.com/groups/pytorch.edge.users/posts/2012215235600341/ about slow model loading with an accompanying perf report (report.html) caused me to look at the report and find hot spots during model loading. This suggested that we spend quite a bit of time resizing various vectors, so it seemed reasonable to reserve their size up-front.

This diff results in an approx 5% speedup in model loading time (from [315ms](https://www.internalfb.com/intern/aibench/details/985617894822114) to [300ms](https://www.internalfb.com/intern/aibench/details/857836732887916)) when run against an 87MB speech model that @jiatong provided.

See https://fb.workplace.com/groups/pytorch.dev/posts/855724575006024/ for the previous post from @jiatong.

Differential Revision: [D29754695](https://our.internmc.facebook.com/intern/diff/D29754695/)