### PR TITLE
Silence clang-tidy linter for TorchpyTest.FxModule test

### DIFF
--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -262,6 +262,7 @@ TEST(TorchpyTest, RegisterModule) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TorchpyTest, FxModule) {
   size_t nthreads = 3;
   torch::deploy::InterpreterManager manager(nthreads);


### PR DESCRIPTION
Summary: This will fix [this linter error](https://github.com/pytorch/pytorch/runs/3120335141) introduced with D29690088 (https://github.com/pytorch/pytorch/commit/810e19979d5ab8db09f3cdbbd6d36ecd2ab7b0c5).

Test Plan: N/A (just looked at other examples and tidy doc https://clang.llvm.org/extra/clang-tidy/)

Differential Revision: D29832654

