### PR TITLE
Remove relative paths for clang-tidy annotations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -366,6 +366,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           cd "${GITHUB_WORKSPACE}"
+          sed --in-place 's/^\.\.\///g' clang-tidy-output.txt
           tools/linter/translate_annotations.py \
             --file=clang-tidy-output.txt \
             --regex='^(?P<filename>.*?):(?P<lineNumber>\d+):(?P<columnNumber>\d+): (?P<errorDesc>.*?) \[(?P<errorCode>.*)\]' \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62005
* **#62004**

Some of the files checked by clang tidy are compiled from a sibling directory, so the files all start with something like `../torch`. This ends up messing with `translate_annotations.py` which runs from the repo root. This fixes it by chopping off any relative paths in the clang tidy output.

Differential Revision: [D29835446](https://our.internmc.facebook.com/intern/diff/D29835446)