### PR TITLE
Add QConv3d and QConvTranspose1d/2d/3d to operator benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -65,15 +65,30 @@ conv_2d_configs_long = op_bench.cross_product_configs(
 # Configs for Conv3d and ConvTranspose3d
 conv_3d_configs_short = op_bench.config_list(
     attr_names=[
-        'IC', 'OC', 'kernel', 'stride', 'N', 'D', 'H', 'W'
+        'IC', 'OC', 'kernel', 'stride', 'N', 'D', 'H', 'W', 'G', 'pad'
     ],
     attrs=[
-        [64, 64, 3, 1, 8, 4, 16, 16],
+        [64, 64, 3, 1, 8, 4, 16, 16, 1, 0],
     ],
     cross_product_configs={
         'device': ['cpu', 'cuda'],
     },
     tags=['short']
+)
+
+conv_3d_configs_long = op_bench.cross_product_configs(
+    IC=[32, 64],
+    OC=[32, 64],
+    kernel=[3],
+    stride=[1, 2],
+    N=[4],
+    D=[4],
+    H=[32],
+    W=[32],
+    G=[1],
+    pad=[0],
+    device=['cpu', 'cuda'],
+    tags=["long"]
 )
 
 linear_configs_short = op_bench.config_list(

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -807,11 +807,11 @@ class ConvTranspose3d(_ConvTransposeNd):
                  padding=0, output_padding=0, groups=1, bias=True,
                  dilation=1, padding_mode='zeros', device=None, dtype=None):
         factory_kwargs = {'device': device, 'dtype': dtype}
-        kernel_size = _pair(kernel_size)
-        stride = _pair(stride)
-        padding = _pair(padding)
-        dilation = _pair(dilation)
-        output_padding = _pair(output_padding)
+        kernel_size = _triple(kernel_size)
+        stride = _triple(stride)
+        padding = _triple(padding)
+        dilation = _triple(dilation)
+        output_padding = _triple(output_padding)
 
         super(ConvTranspose3d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,


### PR DESCRIPTION
# Problems
In the operator benchmark module `pt.qconv_test`, only `QConv1d`/`QConv2d` are implemented. And the following ops are not implemented yet:
- QConv3d,
- QConvTranspose1d,
- QConvTranspose2d,
- QConvTranspose3d.

When adding these ops, it is found that the constructor of class `ConvTranspose3d` initializes parameters, such as strides, paddings, etc., by `_pair`, but  there are actually 3 axes. So, `_triple` should be used instead.

# Solutions
1. Add the aforementioned ops to `pt.qconv_test` benchmark
2. Update configs for these ops
3. In the constructor of `ConvTranspose3d`, use `_triple` instead of `_pair`.

This PR is a byproduct while we are working on PR https://github.com/pytorch/pytorch/pull/58378 issue https://github.com/pytorch/pytorch/issues/21120