### PR TITLE
[Static Runtime] Add is_frozen to StaticModule ctor

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -147,7 +147,7 @@ static void BM_long_static_memory_optimization(benchmark::State& state) {
   auto mod = getLongScriptModel();
   torch::jit::StaticModuleOptions opts;
   opts.optimize_memory = state.range(1);
-  torch::jit::StaticModule smod(mod, opts);
+  torch::jit::StaticModule smod(mod, false, opts);
 
   const auto N = state.range(0);
   auto a = torch::randn({N, N});

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -130,7 +130,7 @@ void testStaticRuntime(
 
   for (bool enable_out_variant : {true, false}) {
     torch::jit::StaticModule smodule(
-        module, {true, enable_out_variant, enable_out_variant});
+        module, false, {true, enable_out_variant, enable_out_variant});
     auto actual = smodule(args, {});
     smodule.runtime().check_for_memory_leak();
     // first run
@@ -867,7 +867,7 @@ TEST(StaticRuntime, CleanUpMemory) {
               enable_out_variant,
               optimize_memory,
               optimize_graph_output_memory};
-          torch::jit::StaticModule smod(mod, opts);
+          torch::jit::StaticModule smod(mod, false, opts);
 
           for (int batch_size : {1, 8, 32}) {
             for (int i = 0; i < 2; ++i) {

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -86,6 +86,7 @@ class TORCH_API StaticModule {
 
   explicit StaticModule(
       const torch::jit::Module& m,
+      bool is_frozen = false,
       const StaticModuleOptions& opts = StaticModuleOptions());
 
   typedef enum {


### PR DESCRIPTION
Summary: Add is_frozen to StaticModule ctor so we can skip freezing in StaticModule.

Differential Revision: D29807431

