### PR TITLE
Fix subnet counting and re-enable check for multiple onnxifi ops in AOT

### DIFF
--- a/caffe2/opt/backend_cutting_test.cc
+++ b/caffe2/opt/backend_cutting_test.cc
@@ -52,7 +52,7 @@ TEST(BackendCuttingTest, unit) {
   net.add_external_output("N1");
   auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
   auto net_opt = cutResult.net;
-  EXPECT_EQ(1, cutResult.numberOfSubnets);
+  EXPECT_EQ(0, cutResult.numberOfSubnets);
   EXPECT_EQ(1, net_opt.op_size());
   EXPECT_EQ(1, net_opt.external_input_size());
   EXPECT_EQ(1, net_opt.external_output_size());
@@ -81,7 +81,7 @@ TEST(BackendCuttingTest, line) {
   op->add_output("Y");
   auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
   auto net_opt = cutResult.net;
-  EXPECT_EQ(1, cutResult.numberOfSubnets);
+  EXPECT_EQ(0, cutResult.numberOfSubnets);
   EXPECT_EQ(3, net_opt.op_size());
 }
 
@@ -117,7 +117,7 @@ TEST(BackendCuttingTest, convergedPaths) {
 
   auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
   auto net_opt = cutResult.net;
-  EXPECT_EQ(1, cutResult.numberOfSubnets);
+  EXPECT_EQ(0, cutResult.numberOfSubnets);
   EXPECT_EQ(3, net_opt.op_size());
 };
 
@@ -155,6 +155,6 @@ TEST(BackendCuttingTest, skipPath) {
 
   auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
   auto net_opt = cutResult.net;
-  EXPECT_EQ(2, cutResult.numberOfSubnets);
+  EXPECT_EQ(0, cutResult.numberOfSubnets);
   EXPECT_EQ(4, net_opt.op_size());
 }

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -1484,7 +1484,7 @@ void OnnxifiTransformer::transform(
     WriteProtoToTextFile(*pred_net, "debug_full_opt_net.pb_txt", false);
   }
   if (opts_.verify_only_single_subnet && cutResult.numberOfSubnets > 1) {
-    CAFFE_THROW("Multiple Onnxifi ops were created: ", cutResult.numberOfSubnets, " subnets found");
+    CAFFE_THROW("Multiple Onnxifi ops were created: ", cutResult.numberOfSubnets, " subnets were found. There may be unsupported operators in the model.");
   }
 }
 


### PR DESCRIPTION
Summary: Count the number of onnxifi ops rather than just number of subnets, since when the subnet size < min_ops, it isn't turned into an onnxifi op.

Test Plan:
Runs which ran into the "Did not find a partition with an SLS node" error now report "multiple onnxifi ops found"
From https://fb.workplace.com/groups/527892364588452/permalink/807802049930814/:
```
buck run mode/opt-clang -c python.package_style=inplace sigrid/predictor/scripts:rerun_aot -- --manifold_url="https://manifold.facebook.net/v0/read/tree/2021-06-30/onnxifi_caffe2_net_aot_input_arguments_01-55-32_711d9476?bucketName=dper3_job_meta&apiKey=dper3_job_meta-key&timeoutMsec=5000&withPayload=1"

```
Reran some failures from last week which now pass AOT:
From https://fb.workplace.com/groups/527892364588452/permalink/807802049930814/,
https://fb.workplace.com/groups/243933520351820/permalink/572715897473579/

```
buck run mode/opt-clang -c python.package_style=inplace sigrid/predictor/scripts:rerun_aot -- --manifold_url="https://manifold.facebook.net/v0/read/tree/2021-07-09/onnxifi_caffe2_net_aot_input_arguments_05-31-08_ef5393a6?bucketName=dper3_job_meta&apiKey=dper3_job_meta-key&timeoutMsec=5000&withPayload=1"
```
```
buck run mode/opt-clang -c python.package_style=inplace sigrid/predictor/scripts:rerun_aot -- --manifold_url="https://manifold.facebook.net/v0/read/tree/2021-07-12/onnxifi_caffe2_net_aot_input_arguments_14-44-34_cfdf3053?bucketName=dper3_job_meta&apiKey=dper3_job_meta-key&timeoutMsec=5000&withPayload=1"
```
```
buck run mode/opt-clang -c python.package_style=inplace sigrid/predictor/scripts:rerun_aot -- --manifold_url="https://manifold.facebook.net/v0/read/tree/2021-07-13/onnxifi_caffe2_net_aot_input_arguments_04-03-30_162e7e53?bucketName=dper3_job_meta&apiKey=dper3_job_meta-key&timeoutMsec=5000&withPayload=1"
```

Reviewed By: khabinov

Differential Revision: D29796893

