### PR TITLE
Add build/.ninja_log to artifacts for Windows

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -128,5 +128,8 @@ python setup.py install --cmake && sccache --show-stats && (
 
     :: export test times so that potential sharded tests that'll branch off this build will use consistent data
     python test/run_test.py --export-past-test-times %PYTORCH_FINAL_PACKAGE_DIR%/.pytorch-test-times.json
+
+    :: Also save build/.ninja_log as an artifact
+    copy /Y "build\.ninja_log" "%PYTORCH_FINAL_PACKAGE_DIR%\"
   )
 )


### PR DESCRIPTION
Being able to download the .ninja_log allows for better debugging. There may be a follow-up PR to convert this to a better tracefile.

This PR only handles windows as it is already handled for linux here:
https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L248-L252

Test plan:
Check the artifacts for a windows job and see if we see .ninja_log
