### PR TITLE
Fix LTC_SAVE_TENSORS_FMT for TorchScript backend

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
@@ -26,7 +26,7 @@ class TSBackendImpl : public BackendImplInterface {
 
   std::unique_ptr<ir::LoweringContext> CreateLoweringContext(
       const std::string& name, Device device) const override {
-    LTC_LOG(FATAL) << "Not implemented yet.";
+    return std::make_unique<ts_backend::TSLoweringContext>(name, device);
   }
 
   lazy_tensors::ComputationClient* GetComputationClient() const override {
@@ -64,7 +64,10 @@ class TSBackendImpl : public BackendImplInterface {
 
   lazy_tensors::StatusOr<std::string> GetComputationBackendText(
       const lazy_tensors::GenericComputation* computation) const override {
-    LTC_LOG(FATAL) << "Not implemented yet.";
+    auto ts_computation = static_cast<
+        const torch_lazy_tensors::compiler::ts_backend::GenericComputationTS*>(
+        computation);
+    return ts_computation->executor()->graph()->toString();
   }
 };
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
@@ -8,7 +8,9 @@ namespace ts_backend {
 
 TSLoweringContext::TSLoweringContext(const std::string& name, Device device)
     : ir::LoweringContext(name, device),
-      graph_(std::make_shared<torch::jit::Graph>()) {}
+      graph_(std::make_shared<torch::jit::Graph>()) {
+  lowering_ = NodeLowering::Create(this);
+}
 
 TSLoweringContext::TSLoweringContext(
     const std::string& name, Device device,


### PR DESCRIPTION
Test Plan:

LTC_SAVE_TENSORS_FILE=/tmp/traces LTC_SAVE_TENSORS_FMT=backend python ./example.py