### PR TITLE
ns for fx: change weight extraction to direct mapping

### DIFF
--- a/torch/quantization/_numeric_suite_fx.py
+++ b/torch/quantization/_numeric_suite_fx.py
@@ -130,14 +130,9 @@ def _extract_weights_one_model(
     results: NSResultsType,
 ) -> None:
     torch._C._log_api_usage_once("quantization_api._numeric_suite_fx._extract_weights_one_model")
-    base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
-    type_a_related_to_b = \
-        get_type_a_related_to_b(base_name_to_sets_of_related_ops)
-
     for node, ref_name in nodes_and_names_to_instrument:
         res_type = NSSingleResultValuesType.WEIGHT.value
-        extracted_weight = \
-            extract_weight_from_node(node, model, type_a_related_to_b)
+        extracted_weight = extract_weight_from_node(node, model)
         if extracted_weight:
             if ref_name not in results:
                 results[ref_name] = {res_type: {}}

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -2,7 +2,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.quantized.dynamic as nnqd
+import torch.nn.quantized as nnq
+import torch.nn.intrinsic.qat as nniqat
+import torch.nn.qat as nnqat
 import torch.nn.intrinsic as nni
+import torch.nn.intrinsic.quantized as nniq
 toq = torch.ops.quantized
 from torch.fx import GraphModule
 from torch.fx.graph import Node
@@ -12,10 +16,35 @@ from .utils import getattr_from_fqn, return_first_non_observer_node
 from .ns_types import (
     NSSingleResultValuesType,
     NSSingleResultType,
-    NSNodeTargetType,
 )
 
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Dict, Callable
+
+# TODO(future PR): change signature to torch.Tensor and fix the LSTM
+# issues.
+def mod_weight_detach(mod: nn.Module) -> List[torch.Tensor]:
+    return [mod.weight.detach()]  # type: ignore[operator]
+
+def mod_0_weight_detach(mod: nn.Module) -> List[torch.Tensor]:
+    return [mod[0].weight.detach()]  # type: ignore[index]
+
+def mod_weight_bias_0(mod: nn.Module) -> List[torch.Tensor]:
+    return [mod._weight_bias()[0]]  # type: ignore[operator]
+
+def get_lstm_weight(mod: nn.Module) -> List[torch.Tensor]:
+    res = []
+    for idx, param_name in enumerate(mod._flat_weights_names):  # type: ignore[arg-type]
+        if 'weight_ih_l' in param_name or 'weight_hh_l' in param_name:
+            param_value = mod._flat_weights[idx].detach()  # type: ignore[index]
+            res.append(param_value)
+    return res
+
+def get_qlstm_weight(mod: nn.Module) -> List[torch.Tensor]:
+    res = []
+    for weight_value in mod._all_weight_values:  # type: ignore[union-attr]
+        res.append(weight_value.param.__getstate__()[0][4][0].__getstate__()[0][0])
+        res.append(weight_value.param.__getstate__()[0][4][1].__getstate__()[0][0])
+    return res
 
 def get_conv_mod_weight(mod: nn.Module) -> torch.Tensor:
     if (
@@ -59,84 +88,130 @@ def get_lstm_mod_weights(mod: nn.Module) -> List[torch.Tensor]:
         return res
 
 def get_conv_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
-    # TODO(future PR): docblock
-    # TODO(future PR): handle non standard weights (i.e. after reshape, etc)
-    if node.target in (F.conv1d, F.conv2d, F.conv3d):
-        # traverse backwards from the weight arg, accounting for any observers
+    # traverse backwards from the weight arg, accounting for any observers
+    weight_arg_node = node.args[1]
+    assert isinstance(weight_arg_node, Node)
+    weight_node = return_first_non_observer_node(weight_arg_node, gm)
+    assert isinstance(weight_node, Node)
+    assert weight_node.op == 'get_attr'
+    weight = getattr_from_fqn(gm, weight_node.target)  # type: ignore[arg-type]
+    return weight.detach()
+
+def get_qconv_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
+    # qconv state is arg 1
+    qconv_state_node = node.args[1]
+    assert isinstance(qconv_state_node, Node)
+    assert qconv_state_node.op == 'get_attr'
+    qconv_state_obj = getattr_from_fqn(gm, qconv_state_node.target)  # type: ignore[arg-type]
+    return qconv_state_obj.weight()
+
+def get_linear_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
+    # traverse backwards from the weight arg, accounting for any observers
+    # supported patterns:
+    # weight -> obs -> linear
+    # weight -> to(torch.float16) -> dequantize -> linear
+    linear_second_arg = node.args[1]
+    assert isinstance(linear_second_arg, Node)
+
+    if linear_second_arg.op == 'call_module':
+        # weight -> obs -> linear
         weight_arg_node = node.args[1]
         assert isinstance(weight_arg_node, Node)
-        weight_node = return_first_non_observer_node(weight_arg_node, gm)
+        weight_node = weight_arg_node.args[0]
         assert isinstance(weight_node, Node)
         assert weight_node.op == 'get_attr'
         weight = getattr_from_fqn(gm, weight_node.target)  # type: ignore[arg-type]
         return weight.detach()
-    else:
-        assert node.target in (
-            toq.conv1d, toq.conv2d, toq.conv3d, toq.conv1d_relu,
-            toq.conv2d_relu, toq.conv3d_relu)
-        # qconv state is arg 1
-        qconv_state_node = node.args[1]
-        assert isinstance(qconv_state_node, Node)
-        assert qconv_state_node.op == 'get_attr'
-        qconv_state_obj = getattr_from_fqn(gm, qconv_state_node.target)  # type: ignore[arg-type]
-        return qconv_state_obj.weight()
-
-def get_linear_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
-    # TODO(future PR): better docblock, with example FX IR
-    if node.target in (F.linear,):
-        # traverse backwards from the weight arg, accounting for any observers
-        # supported patterns:
-        # weight -> obs -> linear
+    elif linear_second_arg.op == 'call_method':
         # weight -> to(torch.float16) -> dequantize -> linear
-        linear_second_arg = node.args[1]
-        assert isinstance(linear_second_arg, Node)
-
-        if linear_second_arg.op == 'call_module':
-            # weight -> obs -> linear
-            weight_arg_node = node.args[1]
-            assert isinstance(weight_arg_node, Node)
-            weight_node = weight_arg_node.args[0]
-            assert isinstance(weight_node, Node)
-            assert weight_node.op == 'get_attr'
-            weight = getattr_from_fqn(gm, weight_node.target)  # type: ignore[arg-type]
-            return weight.detach()
-        elif linear_second_arg.op == 'call_method':
-            # weight -> to(torch.float16) -> dequantize -> linear
-            assert linear_second_arg.op == 'call_method'
-            dequant_node = node.args[1]
-            assert isinstance(dequant_node, Node)
-            to_fp16_node = dequant_node.args[0]
-            assert isinstance(to_fp16_node, Node)
-            # extract the dtype, so we can cast to it before returning
-            target_dtype = to_fp16_node.args[1]
-            weight_node = to_fp16_node.args[0]
-            assert isinstance(weight_node, Node)
-            assert weight_node.op == 'get_attr'
-            weight = getattr_from_fqn(gm, weight_node.target)  # type: ignore[arg-type]
-            # return the weight with fp16 cast
-            return weight.detach().to(target_dtype)
-        else:
-            assert linear_second_arg.op == 'get_attr'
-            weight = getattr_from_fqn(gm, linear_second_arg.target)  # type: ignore[arg-type]
-            return weight.detach()
-
+        assert linear_second_arg.op == 'call_method'
+        dequant_node = node.args[1]
+        assert isinstance(dequant_node, Node)
+        to_fp16_node = dequant_node.args[0]
+        assert isinstance(to_fp16_node, Node)
+        # extract the dtype, so we can cast to it before returning
+        target_dtype = to_fp16_node.args[1]
+        weight_node = to_fp16_node.args[0]
+        assert isinstance(weight_node, Node)
+        assert weight_node.op == 'get_attr'
+        weight = getattr_from_fqn(gm, weight_node.target)  # type: ignore[arg-type]
+        # return the weight with fp16 cast
+        return weight.detach().to(target_dtype)
     else:
-        assert node.target in (toq.linear, toq.linear_relu)
-        # packed weight is arg 1
-        packed_weight_node = node.args[1]
-        assert isinstance(packed_weight_node, Node)
-        assert packed_weight_node.op == 'get_attr'
-        packed_weight = getattr_from_fqn(gm, packed_weight_node.target)  # type: ignore[arg-type]
-        # TODO(future PR): why does packed_weight.unpack() not work?
-        # TODO(future PR): discuss if we even need to unpack, or if the
-        #   caller can handle the unpacking
-        (weight, _bias), _name = packed_weight.__getstate__()
-        return weight
+        assert linear_second_arg.op == 'get_attr'
+        weight = getattr_from_fqn(gm, linear_second_arg.target)  # type: ignore[arg-type]
+        return weight.detach()
+
+def get_qlinear_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
+    assert node.target in (toq.linear, toq.linear_relu)
+    # packed weight is arg 1
+    packed_weight_node = node.args[1]
+    assert isinstance(packed_weight_node, Node)
+    assert packed_weight_node.op == 'get_attr'
+    packed_weight = getattr_from_fqn(gm, packed_weight_node.target)  # type: ignore[arg-type]
+    # TODO(future PR): why does packed_weight.unpack() not work?
+    (weight, _bias), _name = packed_weight.__getstate__()
+    return weight
+
+OP_TO_TYPE_TO_WEIGHT_EXTRACTION_FN: Dict[str, Dict[Callable, Callable]] = {
+    'call_module': {
+        # Conv
+        nn.Conv1d: mod_weight_detach,
+        nn.Conv2d: mod_weight_detach,
+        nn.Conv3d: mod_weight_detach,
+        nni.ConvReLU1d: mod_0_weight_detach,
+        nni.ConvReLU2d: mod_0_weight_detach,
+        nni.ConvReLU3d: mod_0_weight_detach,
+        nnq.Conv1d: mod_weight_bias_0,
+        nniqat.ConvBn1d: mod_weight_detach,
+        nniqat.ConvBnReLU1d: mod_weight_detach,
+        nniq.ConvReLU1d: mod_weight_bias_0,
+        nnq.Conv2d: mod_weight_bias_0,
+        nnqat.Conv2d: mod_weight_detach,
+        nniqat.ConvBn2d: mod_weight_detach,
+        nniqat.ConvBnReLU2d: mod_weight_detach,
+        nniqat.ConvReLU2d: mod_weight_detach,
+        nniq.ConvReLU2d: mod_weight_bias_0,
+        nnq.Conv3d: mod_weight_bias_0,
+        nnqat.Conv3d: mod_weight_detach,
+        nniqat.ConvBn3d: mod_weight_detach,
+        nniqat.ConvBnReLU3d: mod_weight_detach,
+        nniqat.ConvReLU3d: mod_weight_detach,
+        nniq.ConvReLU3d: mod_weight_bias_0,
+        # Linear
+        nn.Linear: mod_weight_detach,
+        nnq.Linear: mod_weight_bias_0,
+        nni.LinearReLU: mod_0_weight_detach,
+        nniq.LinearReLU: mod_weight_bias_0,
+        nnqat.Linear: mod_weight_detach,
+        nnqd.Linear: mod_weight_bias_0,
+        nniqat.LinearReLU: mod_weight_detach,
+        nn.modules.linear.NonDynamicallyQuantizableLinear: mod_weight_detach,
+        # LSTM
+        nn.LSTM: get_lstm_weight,
+        nnqd.LSTM: get_qlstm_weight,
+    },
+    'call_function': {
+        # Conv
+        F.conv1d: get_conv_fun_weight,
+        F.conv2d: get_conv_fun_weight,
+        F.conv3d: get_conv_fun_weight,
+        toq.conv1d: get_qconv_fun_weight,
+        toq.conv2d: get_qconv_fun_weight,
+        toq.conv3d: get_qconv_fun_weight,
+        toq.conv1d_relu: get_qconv_fun_weight,
+        toq.conv2d_relu: get_qconv_fun_weight,
+        toq.conv3d_relu: get_qconv_fun_weight,
+        # Linear
+        F.linear: get_linear_fun_weight,
+        toq.linear: get_qlinear_fun_weight,
+        toq.linear_relu: get_qlinear_fun_weight,
+    },
+}
 
 def extract_weight_from_node(
     node: Node,
     gm: GraphModule,
-    type_a_related_to_b: Set[Tuple[NSNodeTargetType, NSNodeTargetType]],
 ) -> Optional[NSSingleResultType]:
     res_type = NSSingleResultValuesType.WEIGHT.value
 
@@ -147,94 +222,38 @@ def extract_weight_from_node(
         fqn = gm._node_name_to_scope[node.name][0]  # type: ignore[index]
 
     if node.op == 'call_function':
-
-        related_to_linear = node.target in (F.linear,) or \
-            (node.target, F.linear) in type_a_related_to_b
-        related_to_conv1d = node.target in (F.conv1d,) or \
-            (node.target, F.conv1d) in type_a_related_to_b
-        related_to_conv2d = node.target in (F.conv2d,) or \
-            (node.target, F.conv2d) in type_a_related_to_b
-        related_to_conv3d = node.target in (F.conv3d,) or \
-            (node.target, F.conv3d) in type_a_related_to_b
-
-        if related_to_linear:
-            weight = get_linear_fun_weight(node, gm)
-            return {
-                'type': res_type,
-                'values': [weight],
-                'prev_node_name': node.name,
-                'prev_node_target_type': str(node.target),
-                'ref_node_name': node.name,
-                'index_within_arg': 0,
-                'index_of_arg': 0,
-                'fqn': fqn,
-            }
-        elif (related_to_conv1d or related_to_conv2d or related_to_conv3d):
-            weight = get_conv_fun_weight(node, gm)
-            return {
-                'type': res_type,
-                'values': [weight],
-                'prev_node_name': node.name,
-                'prev_node_target_type': str(node.target),
-                'ref_node_name': node.name,
-                'index_within_arg': 0,
-                'index_of_arg': 0,
-                'fqn': fqn,
-            }
+        function_mapping = OP_TO_TYPE_TO_WEIGHT_EXTRACTION_FN['call_function']
+        for target_fn_type, weight_extraction_fn in function_mapping.items():
+            if node.target == target_fn_type:
+                weight = weight_extraction_fn(node, gm)
+                return {
+                    'type': res_type,
+                    'values': [weight],
+                    'prev_node_name': node.name,
+                    'prev_node_target_type': str(node.target),
+                    'ref_node_name': node.name,
+                    'index_within_arg': 0,
+                    'index_of_arg': 0,
+                    'fqn': fqn,
+                }
 
     elif node.op == 'call_module':
         # for call_module, we need to look up the modules to do the type check
         assert isinstance(node.target, str)
         mod = getattr_from_fqn(gm, node.target)
-
-        # check that A is one the modules we need
-        # assume B is related (this is done by graph matcher)
-        related_to_conv1d_mod = isinstance(mod, nn.Conv1d) or \
-            (type(mod), nn.Conv1d) in type_a_related_to_b
-        related_to_conv2d_mod = isinstance(mod, nn.Conv2d) or \
-            (type(mod), nn.Conv2d) in type_a_related_to_b
-        related_to_conv3d_mod = isinstance(mod, nn.Conv3d) or \
-            (type(mod), nn.Conv3d) in type_a_related_to_b
-        related_to_linear_mod = isinstance(mod, nn.Linear) or \
-            (type(mod), nn.Linear) in type_a_related_to_b
-        related_to_lstm_mod = isinstance(mod, nn.LSTM) or \
-            (type(mod), nn.LSTM) in type_a_related_to_b
-
-        if related_to_conv1d_mod or related_to_conv2d_mod or related_to_conv3d_mod:
-            weights = [get_conv_mod_weight(mod)]
-            return {
-                'type': res_type,
-                'values': weights,
-                'prev_node_name': node.name,
-                'prev_node_target_type': str(type(mod)),
-                'ref_node_name': node.name,
-                'index_within_arg': 0,
-                'index_of_arg': 0,
-                'fqn': fqn,
-            }
-        elif related_to_lstm_mod:
-            weights = get_lstm_mod_weights(mod)
-            return {
-                'type': res_type,
-                'values': weights,
-                'prev_node_name': node.name,
-                'prev_node_target_type': str(type(mod)),
-                'ref_node_name': node.name,
-                'index_within_arg': 0,
-                'index_of_arg': 0,
-                'fqn': fqn,
-            }
-        elif related_to_linear_mod:
-            weights = [get_linear_mod_weight(mod)]
-            return {
-                'type': res_type,
-                'values': weights,
-                'prev_node_name': node.name,
-                'prev_node_target_type': str(type(mod)),
-                'ref_node_name': node.name,
-                'index_within_arg': 0,
-                'index_of_arg': 0,
-                'fqn': fqn,
-            }
+        module_mapping = OP_TO_TYPE_TO_WEIGHT_EXTRACTION_FN['call_module']
+        for target_mod_type, weight_extraction_fn in module_mapping.items():
+            if type(mod) == target_mod_type:
+                weight = weight_extraction_fn(mod)
+                return {
+                    'type': res_type,
+                    'values': weight,
+                    'prev_node_name': node.name,
+                    'prev_node_target_type': str(type(mod)),
+                    'ref_node_name': node.name,
+                    'index_within_arg': 0,
+                    'index_of_arg': 0,
+                    'fqn': fqn,
+                }
 
     return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62047
* #62041
* __->__ #62038

Summary:

Updates the logic to extract weights from nodes to use a
direct mapping from type to weight extraction function.

This is needed for a future PR which will allow users to
specify custom weight extraction functions for user defined
types.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
python test/test_quantization.py TestFXNumericSuiteCoreAPIsModels
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29853627](https://our.internmc.facebook.com/intern/diff/D29853627)