### PR TITLE
ns for fx: fix typing issue in weight extraction

### DIFF
--- a/torch/quantization/ns/utils.py
+++ b/torch/quantization/ns/utils.py
@@ -393,7 +393,8 @@ def maybe_dequantize_first_two_tensor_args_and_handle_tuples(f):
     def inner(*args, **kwargs):
         a0, a1, *a_other = args
 
-        if isinstance(a0, tuple) and isinstance(a1, tuple):
+        if (isinstance(a0, tuple) and isinstance(a1, tuple)) or \
+                (isinstance(a0, list) and isinstance(a1, list)):
             results = []
             for el0, el1 in zip(a0, a1):
                 new_args = (el0, el1, *a_other)

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -20,16 +20,14 @@ from .ns_types import (
 
 from typing import List, Optional, Dict, Callable
 
-# TODO(future PR): change signature to torch.Tensor and fix the LSTM
-# issues.
-def mod_weight_detach(mod: nn.Module) -> List[torch.Tensor]:
-    return [mod.weight.detach()]  # type: ignore[operator]
+def mod_weight_detach(mod: nn.Module) -> torch.Tensor:
+    return mod.weight.detach()  # type: ignore[operator]
 
-def mod_0_weight_detach(mod: nn.Module) -> List[torch.Tensor]:
-    return [mod[0].weight.detach()]  # type: ignore[index]
+def mod_0_weight_detach(mod: nn.Module) -> torch.Tensor:
+    return mod[0].weight.detach()  # type: ignore[index]
 
-def mod_weight_bias_0(mod: nn.Module) -> List[torch.Tensor]:
-    return [mod._weight_bias()[0]]  # type: ignore[operator]
+def mod_weight_bias_0(mod: nn.Module) -> torch.Tensor:
+    return mod._weight_bias()[0]  # type: ignore[operator]
 
 def get_lstm_weight(mod: nn.Module) -> List[torch.Tensor]:
     res = []
@@ -247,7 +245,7 @@ def extract_weight_from_node(
                 weight = weight_extraction_fn(mod)
                 return {
                     'type': res_type,
-                    'values': weight,
+                    'values': [weight],
                     'prev_node_name': node.name,
                     'prev_node_target_type': str(type(mod)),
                     'ref_node_name': node.name,

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -732,6 +732,13 @@ class QuantizationTestCase(TestCase):
                                         values_0.shape == values_1.shape,
                                         f"Layer {layer_name}, {model_name_0} and {model_name_1} " +
                                         f"have a shape mismatch at idx {idx}.")
+                                elif isinstance(values_0, list):
+                                    values_0 = values_0[0]
+                                    values_1 = values_1[0]
+                                    self.assertTrue(
+                                        values_0.shape == values_1.shape,
+                                        f"Layer {layer_name}, {model_name_0} and {model_name_1} " +
+                                        f"have a shape mismatch at idx {idx}.")
                                 else:
                                     assert isinstance(values_0, tuple), \
                                         f"unhandled type {type(values_0)}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62047
* __->__ #62041
* #62038

Summary:

Before this PR, weights of conv and linear modules were extracted
as lists, in order to match the signature of LSTM weights.

After this PR, weight extraction preserves the type of the weights,
so extracted weights of conv and linear have a different type
from LSTM weights.  The comparison util functions are updated to
handle the LSTM weight type of `List[tensor]`.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
python test/test_quantization.py TestFXNumericSuiteCoreAPIsModels
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29853626](https://our.internmc.facebook.com/intern/diff/D29853626)