### PR TITLE
[skip ci] Windows smoke tests in CI typo link fix

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -20,7 +20,7 @@ echo Run nn tests
 
 if "%RUN_SMOKE_TESTS_ONLY%"=="1" (
     :: Download specified test cases to run
-    curl --retry 3 -k https://raw.githubusercontent.com/janeyx99/test-infra/add-windows-smoke-tests/stats/windows_smoke_tests.csv --output .pytorch_specified_test_cases.csv
+    curl --retry 3 -k https://raw.githubusercontent.com/pytorch/test-infra/master/stats/windows_smoke_tests.csv --output .pytorch_specified_test_cases.csv
     if ERRORLEVEL 1 exit /b 1
 
     python run_test.py --exclude-jit-executor --shard 1 2 --verbose --determine-from="%1" --run-specified-test-cases


### PR DESCRIPTION
This is not a functional change but a typo fix where I forgot to update the link to windows_smoke_tests.csv in test_python_first_shard. The windows_smoke_tests.csv is currently the same in pytorch/test-infra and my fork, janeyx99/test-infra, but that will not be the case in the future.