### PR TITLE
ns for fx: expose hook to define custom weight extraction functions

### DIFF
--- a/torch/quantization/_numeric_suite_fx.py
+++ b/torch/quantization/_numeric_suite_fx.py
@@ -128,11 +128,13 @@ def _extract_weights_one_model(
     model: GraphModule,
     nodes_and_names_to_instrument: List[Tuple[Node, str]],
     results: NSResultsType,
+    op_to_type_to_weight_extraction_fn: Optional[Dict[str, Dict[Callable, Callable]]] = None,
 ) -> None:
     torch._C._log_api_usage_once("quantization_api._numeric_suite_fx._extract_weights_one_model")
     for node, ref_name in nodes_and_names_to_instrument:
         res_type = NSSingleResultValuesType.WEIGHT.value
-        extracted_weight = extract_weight_from_node(node, model)
+        extracted_weight = extract_weight_from_node(
+            node, model, op_to_type_to_weight_extraction_fn)
         if extracted_weight:
             if ref_name not in results:
                 results[ref_name] = {res_type: {}}
@@ -146,6 +148,7 @@ def _extract_weights_impl(
     gm_b: GraphModule,
     base_name_to_sets_of_related_ops: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
     unmatchable_types_map: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
+    op_to_type_to_weight_extraction_fn: Optional[Dict[str, Dict[Callable, Callable]]] = None,
 ) -> NSResultsType:
     torch._C._log_api_usage_once("quantization_api._numeric_suite_fx._extract_weights_impl")
     matched_subgraph_pairs = get_matching_subgraph_pairs(
@@ -163,9 +166,11 @@ def _extract_weights_impl(
     # populate the results, one model at a time
     results: NSResultsType = {}
     _extract_weights_one_model(
-        model_name_a, gm_a, nodes_and_names_to_instrument_a, results)
+        model_name_a, gm_a, nodes_and_names_to_instrument_a, results,
+        op_to_type_to_weight_extraction_fn)
     _extract_weights_one_model(
-        model_name_b, gm_b, nodes_and_names_to_instrument_b, results)
+        model_name_b, gm_b, nodes_and_names_to_instrument_b, results,
+        op_to_type_to_weight_extraction_fn)
 
     # fill in missing fqn entries
     maybe_add_missing_fqns(results)
@@ -183,6 +188,7 @@ def extract_weights(
     model_b: nn.Module,
     base_name_to_sets_of_related_ops: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
     unmatchable_types_map: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
+    op_to_type_to_weight_extraction_fn: Optional[Dict[str, Dict[Callable, Callable]]] = None,
 ) -> NSResultsType:
     torch._C._log_api_usage_once("quantization_api._numeric_suite_fx.extract_weights")
     base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
@@ -202,7 +208,7 @@ def extract_weights(
         gm_b._node_name_to_scope = model_b._node_name_to_scope
     return _extract_weights_impl(
         model_name_a, gm_a, model_name_b, gm_b, base_name_to_sets_of_related_ops,
-        unmatchable_types_map)
+        unmatchable_types_map, op_to_type_to_weight_extraction_fn)
 
 
 def _add_loggers_one_model(

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -151,65 +151,70 @@ def get_qlinear_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
     (weight, _bias), _name = packed_weight.__getstate__()
     return weight
 
-OP_TO_TYPE_TO_WEIGHT_EXTRACTION_FN: Dict[str, Dict[Callable, Callable]] = {
-    'call_module': {
-        # Conv
-        nn.Conv1d: mod_weight_detach,
-        nn.Conv2d: mod_weight_detach,
-        nn.Conv3d: mod_weight_detach,
-        nni.ConvReLU1d: mod_0_weight_detach,
-        nni.ConvReLU2d: mod_0_weight_detach,
-        nni.ConvReLU3d: mod_0_weight_detach,
-        nnq.Conv1d: mod_weight_bias_0,
-        nniqat.ConvBn1d: mod_weight_detach,
-        nniqat.ConvBnReLU1d: mod_weight_detach,
-        nniq.ConvReLU1d: mod_weight_bias_0,
-        nnq.Conv2d: mod_weight_bias_0,
-        nnqat.Conv2d: mod_weight_detach,
-        nniqat.ConvBn2d: mod_weight_detach,
-        nniqat.ConvBnReLU2d: mod_weight_detach,
-        nniqat.ConvReLU2d: mod_weight_detach,
-        nniq.ConvReLU2d: mod_weight_bias_0,
-        nnq.Conv3d: mod_weight_bias_0,
-        nnqat.Conv3d: mod_weight_detach,
-        nniqat.ConvBn3d: mod_weight_detach,
-        nniqat.ConvBnReLU3d: mod_weight_detach,
-        nniqat.ConvReLU3d: mod_weight_detach,
-        nniq.ConvReLU3d: mod_weight_bias_0,
-        # Linear
-        nn.Linear: mod_weight_detach,
-        nnq.Linear: mod_weight_bias_0,
-        nni.LinearReLU: mod_0_weight_detach,
-        nniq.LinearReLU: mod_weight_bias_0,
-        nnqat.Linear: mod_weight_detach,
-        nnqd.Linear: mod_weight_bias_0,
-        nniqat.LinearReLU: mod_weight_detach,
-        nn.modules.linear.NonDynamicallyQuantizableLinear: mod_weight_detach,
-        # LSTM
-        nn.LSTM: get_lstm_weight,
-        nnqd.LSTM: get_qlstm_weight,
-    },
-    'call_function': {
-        # Conv
-        F.conv1d: get_conv_fun_weight,
-        F.conv2d: get_conv_fun_weight,
-        F.conv3d: get_conv_fun_weight,
-        toq.conv1d: get_qconv_fun_weight,
-        toq.conv2d: get_qconv_fun_weight,
-        toq.conv3d: get_qconv_fun_weight,
-        toq.conv1d_relu: get_qconv_fun_weight,
-        toq.conv2d_relu: get_qconv_fun_weight,
-        toq.conv3d_relu: get_qconv_fun_weight,
-        # Linear
-        F.linear: get_linear_fun_weight,
-        toq.linear: get_qlinear_fun_weight,
-        toq.linear_relu: get_qlinear_fun_weight,
-    },
-}
+def get_op_to_type_to_weight_extraction_fn() -> Dict[str, Dict[Callable, Callable]]:
+
+    op_to_type_to_weight_extraction_fn: Dict[str, Dict[Callable, Callable]] = {
+        'call_module': {
+            # Conv
+            nn.Conv1d: mod_weight_detach,
+            nn.Conv2d: mod_weight_detach,
+            nn.Conv3d: mod_weight_detach,
+            nni.ConvReLU1d: mod_0_weight_detach,
+            nni.ConvReLU2d: mod_0_weight_detach,
+            nni.ConvReLU3d: mod_0_weight_detach,
+            nnq.Conv1d: mod_weight_bias_0,
+            nniqat.ConvBn1d: mod_weight_detach,
+            nniqat.ConvBnReLU1d: mod_weight_detach,
+            nniq.ConvReLU1d: mod_weight_bias_0,
+            nnq.Conv2d: mod_weight_bias_0,
+            nnqat.Conv2d: mod_weight_detach,
+            nniqat.ConvBn2d: mod_weight_detach,
+            nniqat.ConvBnReLU2d: mod_weight_detach,
+            nniqat.ConvReLU2d: mod_weight_detach,
+            nniq.ConvReLU2d: mod_weight_bias_0,
+            nnq.Conv3d: mod_weight_bias_0,
+            nnqat.Conv3d: mod_weight_detach,
+            nniqat.ConvBn3d: mod_weight_detach,
+            nniqat.ConvBnReLU3d: mod_weight_detach,
+            nniqat.ConvReLU3d: mod_weight_detach,
+            nniq.ConvReLU3d: mod_weight_bias_0,
+            # Linear
+            nn.Linear: mod_weight_detach,
+            nnq.Linear: mod_weight_bias_0,
+            nni.LinearReLU: mod_0_weight_detach,
+            nniq.LinearReLU: mod_weight_bias_0,
+            nnqat.Linear: mod_weight_detach,
+            nnqd.Linear: mod_weight_bias_0,
+            nniqat.LinearReLU: mod_weight_detach,
+            nn.modules.linear.NonDynamicallyQuantizableLinear: mod_weight_detach,
+            # LSTM
+            nn.LSTM: get_lstm_weight,
+            nnqd.LSTM: get_qlstm_weight,
+        },
+        'call_function': {
+            # Conv
+            F.conv1d: get_conv_fun_weight,
+            F.conv2d: get_conv_fun_weight,
+            F.conv3d: get_conv_fun_weight,
+            toq.conv1d: get_qconv_fun_weight,
+            toq.conv2d: get_qconv_fun_weight,
+            toq.conv3d: get_qconv_fun_weight,
+            toq.conv1d_relu: get_qconv_fun_weight,
+            toq.conv2d_relu: get_qconv_fun_weight,
+            toq.conv3d_relu: get_qconv_fun_weight,
+            # Linear
+            F.linear: get_linear_fun_weight,
+            toq.linear: get_qlinear_fun_weight,
+            toq.linear_relu: get_qlinear_fun_weight,
+        },
+    }
+
+    return op_to_type_to_weight_extraction_fn
 
 def extract_weight_from_node(
     node: Node,
     gm: GraphModule,
+    op_to_type_to_weight_extraction_fn: Optional[Dict[str, Dict[Callable, Callable]]] = None,
 ) -> Optional[NSSingleResultType]:
     res_type = NSSingleResultValuesType.WEIGHT.value
 
@@ -219,8 +224,11 @@ def extract_weight_from_node(
     if hasattr(gm, '_node_name_to_scope'):
         fqn = gm._node_name_to_scope[node.name][0]  # type: ignore[index]
 
+    if op_to_type_to_weight_extraction_fn is None:
+        op_to_type_to_weight_extraction_fn = get_op_to_type_to_weight_extraction_fn()
+
     if node.op == 'call_function':
-        function_mapping = OP_TO_TYPE_TO_WEIGHT_EXTRACTION_FN['call_function']
+        function_mapping = op_to_type_to_weight_extraction_fn['call_function']
         for target_fn_type, weight_extraction_fn in function_mapping.items():
             if node.target == target_fn_type:
                 weight = weight_extraction_fn(node, gm)
@@ -239,7 +247,7 @@ def extract_weight_from_node(
         # for call_module, we need to look up the modules to do the type check
         assert isinstance(node.target, str)
         mod = getattr_from_fqn(gm, node.target)
-        module_mapping = OP_TO_TYPE_TO_WEIGHT_EXTRACTION_FN['call_module']
+        module_mapping = op_to_type_to_weight_extraction_fn['call_module']
         for target_mod_type, weight_extraction_fn in module_mapping.items():
             if type(mod) == target_mod_type:
                 weight = weight_extraction_fn(mod)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62047
* #62041
* #62038

Summary:

Adds a hook for user to define a weight extraction function for a
custom type.

Example usage:
```
op_to_type_to_weight_extraction_fn = \
    get_op_to_type_to_weight_extraction_fn()
op_to_type_to_weight_extraction_fn['call_function'][_wrapped_linear] = \
    torch.quantization.ns.weight_utils.get_linear_fun_weight

results = extract_weights_impl(
    'a', m1, 'b', m2,
    op_to_type_to_weight_extraction_fn=op_to_type_to_weight_extraction_fn)
```

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_defined_function
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29853625](https://our.internmc.facebook.com/intern/diff/D29853625)