### PR TITLE
[quant] Add from_blob_quantized_per_channel API

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -235,4 +235,13 @@ TORCH_API Tensor from_blob_quantized_per_tensor_affine(
     const int64_t zeroPoint,
     const TensorOptions& options);
 
+TORCH_API Tensor from_blob_quantized_per_channel_affine(
+    void* data,
+    IntArrayRef sizes,
+    std::function<void(void*)> deleter,
+    const Tensor& scales,
+    const Tensor& zero_points,
+    const int64_t axis,
+    const TensorOptions& options);
+
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62049
* #61986

Summary:
Adds a new function that accepts qint data blobs as input and creates a per-channel quantized tensor using the pre-allocated data and the provided scale and zero_point inputs
Addresses issue #61777

Test Plan:
./build/bin/quantized_test --gtest_filter='TestQTensor.FromBlobQuantizedPerChannel'

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29854136](https://our.internmc.facebook.com/intern/diff/D29854136)