### PR TITLE
Ignore LNK4099 for debug binary libtorch builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(MSVC)
   foreach(flag_var
       CMAKE_SHARED_LINKER_FLAGS CMAKE_STATIC_LINKER_FLAGS
       CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS)
-    string(APPEND ${flag_var} " /ignore:4049 /ignore:4217")
+    string(APPEND ${flag_var} " /ignore:4049 /ignore:4217 /ignore:4099")
   endforeach(flag_var)
 
   # Try harder

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -258,9 +258,9 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   add_definitions("/DNOMINMAX")
 
   set(CMAKE_SHARED_LINKER_FLAGS
-      "${CMAKE_SHARED_LINKER_FLAGS} /ignore:4049 /ignore:4217")
+      "${CMAKE_SHARED_LINKER_FLAGS} /ignore:4049 /ignore:4217 /ignore:4099")
   set(CMAKE_EXE_LINKER_FLAGS
-      "${CMAKE_EXE_LINKER_FLAGS} /ignore:4049 /ignore:4217")
+      "${CMAKE_EXE_LINKER_FLAGS} /ignore:4049 /ignore:4217 /ignore:4099")
 endif()
 
 # ---[ If we are building on ios, or building with opengl support, we will


### PR DESCRIPTION
Fixes #61979

Test plan:
This CI shouldn't break
and https://github.com/pytorch/pytorch/pull/62061: note that in the debug build, the warnings no longer appear https://app.circleci.com/pipelines/github/pytorch/pytorch/354629/workflows/275ccec1-1dd4-4a50-99f7-c57817935a64/jobs/14947739