### PR TITLE
Add logical op symbol

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -535,6 +535,10 @@ _(aten, native_zero) \
 _(aten, special_ndtr) \
 _(aten, nextafter) \
 _(aten, special_ndtri) \
+_(aten, logical_and) \
+_(aten, logical_not) \
+_(aten, logical_or) \
+_(aten, logical_xor) \
 _(aten, bitwise_and) \
 _(aten, bitwise_not) \
 _(aten, bitwise_or) \


### PR DESCRIPTION
This is for xla side [pr](https://github.com/pytorch/xla/pull/3054) to add logical op lowering