### PR TITLE
[Static Runtime] Refactor fb op tests to use testStaticRuntime

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1,23 +1,23 @@
 #include <gtest/gtest.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
-#include <torch/csrc/jit/ir/irparser.h>
-#include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/static/fusion.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
 #include "deep_wide_pt.h"
 #include "test_scripts.h"
+#include "test_utils.h"
 
 using namespace caffe2;
 using namespace torch;
 using namespace torch::jit;
+using namespace torch::jit::test;
 using c10::IValue;
 
-C10_DECLARE_bool(
-  static_runtime_enable_fast_math);
+C10_DECLARE_bool(static_runtime_enable_fast_math);
 
 namespace {
-static at::Tensor getTensor(const at::IValue& ival) {
+
+at::Tensor getTensor(const at::IValue& ival) {
   if (ival.isTensor()) {
     return ival.toTensor();
   } else if (ival.isTensorList()) {
@@ -34,208 +34,15 @@ static at::Tensor getTensor(const at::IValue& ival) {
   }
 }
 
-void compareTensorLists(
-    const std::vector<IValue>& l, /* expects */
-    const std::vector<IValue>& r /* values */) {
-  EXPECT_TRUE(l.size() == r.size());
-  for (int i = 0; i < l.size(); ++i) {
-    ASSERT_TRUE(l[i].isTensor());
-    ASSERT_TRUE(r[i].isTensor());
-    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
-    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
-    if (!l[i].toTensor().defined()) {
-      EXPECT_TRUE(!r[i].toTensor().defined());
-    } else {
-      EXPECT_TRUE(l[i].toTensor().equal(r[i].toTensor()));
-    }
-  }
-}
+bool testCanEnableStaticRuntime(const std::string& jit_script) {
+  script::Module module("module");
+  module.define(jit_script);
 
-void compareTensorLists(
-    const std::vector<at::Tensor>& l, /* expects */
-    const std::vector<at::Tensor>& r /* values */) {
-  EXPECT_TRUE(l.size() == r.size());
-  for (int i = 0; i < l.size(); ++i) {
-    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
-    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
-    if (!l[i].defined()) {
-      EXPECT_TRUE(!r[i].defined());
-    } else {
-      EXPECT_TRUE(l[i].equal(r[i]));
-    }
-  }
-}
+  Method method = module.get_method("forward");
+  auto graph = module.get_method("forward").graph();
 
-void compareResults(const IValue& expect, const IValue& actual, const bool use_allclose=false) {
-  if (expect.isTensor()) {
-    VLOG(2) << "expect " << expect.toTensor() << std::endl;
-    VLOG(2) << "output " << actual.toTensor() << std::endl;
-    EXPECT_TRUE(actual.isTensor());
-    if (use_allclose) {
-      EXPECT_TRUE(at::allclose(expect.toTensor(), actual.toTensor()));
-    } else {
-      EXPECT_TRUE(expect.toTensor().equal(actual.toTensor()));
-    }
-    return;
-  } else if (expect.isTuple()) {
-    EXPECT_TRUE(actual.isTuple());
-    auto lhs = expect.toTuple()->elements();
-    auto rhs = actual.toTuple()->elements();
-    EXPECT_TRUE(lhs.size() == rhs.size());
-    for (size_t i = 0; i < lhs.size(); i++) {
-      compareResults(lhs[i], rhs[i]);
-    }
-  } else if (expect.isList()) {
-    EXPECT_TRUE(actual.isList());
-    auto lhs = expect.toList();
-    auto rhs = actual.toList();
-    EXPECT_TRUE(lhs.size() == rhs.size());
-    for (size_t i = 0; i < lhs.size(); i++) {
-      compareResults(lhs[i], rhs[i]);
-    }
-  } else if (expect.isGenericDict()) {
-    EXPECT_TRUE(actual.isGenericDict());
-    auto lhs = expect.toGenericDict();
-    auto rhs = actual.toGenericDict();
-    EXPECT_TRUE(lhs.size() == rhs.size());
-    for (auto& lh : lhs) {
-      auto f = rhs.find(lh.key());
-      EXPECT_FALSE(f == rhs.end());
-      compareResults(lh.value(), f->value());
-    }
-  } else {
-    // fall back to the default comparison impl in IValue
-    EXPECT_TRUE(expect == actual);
-  }
-}
-
-// Test scripts passed to testStaticRuntme can either be IR or JIT.
-// The logic for running the script and producing a corresponding StaticModule
-// is a bit different for each case. This logic is encapsulated within concrete
-// implementations of this class, and testStaticRuntime is only aware of this
-// interface.
-class StaticRuntimeTestContext {
- public:
-  virtual ~StaticRuntimeTestContext() = default;
-
-  virtual IValue getExpected(const std::vector<IValue>& args) = 0;
-  virtual torch::jit::StaticModule makeStaticModule(
-      StaticModuleOptions opt) const = 0;
-};
-
-class ModuleStaticRuntimeTestContext : public StaticRuntimeTestContext {
- public:
-  explicit ModuleStaticRuntimeTestContext(const std::string& source_jit)
-      : module_("module") {
-    module_.define(source_jit);
-  }
-
-  IValue getExpected(const std::vector<IValue>& args) override {
-    return module_.forward(args);
-  }
-
-  torch::jit::StaticModule makeStaticModule(
-      StaticModuleOptions opt) const override {
-    return torch::jit::StaticModule(module_, /* is_frozen */ false, opt);
-  }
-
- private:
-  Module module_;
-};
-
-class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
- public:
-  explicit GraphStaticRuntimeContext(const std::string& source_ir) {
-    graph_ = std::make_shared<Graph>();
-    std::unordered_map<std::string, Value*> vmap;
-    parseIR(source_ir, graph_.get(), vmap);
-
-    graph_exec_ = GraphExecutor(graph_, "");
-  }
-
-  IValue getExpected(const std::vector<IValue>& args) override {
-    Stack stack(args);
-    graph_exec_.run(stack);
-
-    if (stack.size() == 1) {
-      return stack[0];
-    }
-    return c10::ivalue::Tuple::create(stack);
-  }
-
-  torch::jit::StaticModule makeStaticModule(
-      StaticModuleOptions opt) const override {
-    return torch::jit::StaticModule(graph_, opt);
-  }
-
- private:
-  std::shared_ptr<Graph> graph_;
-  GraphExecutor graph_exec_;
-};
-
-std::unique_ptr<StaticRuntimeTestContext> makeTestContext(
-    const std::string& source) {
-  try {
-    return std::make_unique<ModuleStaticRuntimeTestContext>(source);
-    // Could not parse as TorchScript, assume it's IR
-  } catch (const std::runtime_error&) {
-    return std::make_unique<GraphStaticRuntimeContext>(source);
-  }
-}
-
-// Given a model/function in jit or IR script, run the model/function
-// with the jit interpreter and static runtime, and compare the results
-void testStaticRuntime(
-    const std::string& source,
-    const std::vector<IValue>& args,
-    const std::vector<IValue>& args2 = {},
-    const bool use_allclose = false) {
-  auto test_context = makeTestContext(source);
-
-  std::vector<IValue> args_tensors, args_copy;
-  for (const auto& ival : args) {
-    if (ival.isTensor()) {
-      args_tensors.emplace_back(ival);
-      const at::Tensor& t = ival.toTensor();
-      args_copy.emplace_back(t.clone());
-    }
-  }
-
-  auto expect = test_context->getExpected(args);
-
-  for (bool enable_out_variant : {true, false}) {
-    auto smodule = test_context->makeStaticModule(
-        {true, enable_out_variant, enable_out_variant});
-    auto actual = smodule(args, {});
-    smodule.runtime().check_for_memory_leak();
-    // first run
-    compareResults(expect, actual, use_allclose);
-
-    // args2 is used to check for dynamic shapes
-    // it also exercises the memory planner
-    if (!args2.empty()) {
-      expect = test_context->getExpected(args2);
-      actual = smodule(args2, {});
-      smodule.runtime().check_for_memory_leak();
-      // second run
-      compareResults(expect, actual, use_allclose);
-
-      expect = test_context->getExpected(args);
-      actual = smodule(args, {});
-      smodule.runtime().check_for_memory_leak();
-      // third run
-      compareResults(expect, actual, use_allclose);
-    } else {
-      // run static runtime again to exercise the memory planner
-      actual = smodule(args, {});
-      smodule.runtime().check_for_memory_leak();
-      // second run
-      compareResults(expect, actual, use_allclose);
-    }
-  }
-
-  // make sure inputs were not modified
-  compareTensorLists(args_tensors, args_copy);
+  // here we do not freeze graph
+  return canEnableStaticRuntime(graph);
 }
 
 bool testHasInplaceOp(const std::string& jit_script) {
@@ -245,11 +52,11 @@ bool testHasInplaceOp(const std::string& jit_script) {
   Method method = module.get_method("forward");
   auto graph = module.get_method("forward").graph();
 
-  torch::jit::AliasDb alias_db(graph);
-  return torch::jit::HasInplaceOp(graph, alias_db);
+  AliasDb alias_db(graph);
+  return HasInplaceOp(graph, alias_db);
 }
 
-static Node* getNodeWithKind(const torch::jit::StaticModule& smodule, const string& kind) {
+Node* getNodeWithKind(const StaticModule& smodule, const std::string& kind) {
   for (auto& pnode : smodule.nodes()) {
     if (std::string(pnode.node()->kind().toQualString()) == kind) {
       return pnode.node();
@@ -258,16 +65,6 @@ static Node* getNodeWithKind(const torch::jit::StaticModule& smodule, const stri
   return nullptr;
 }
 
-bool testCanEnableStaticRuntime(const std::string& jit_script) {
-  script::Module module("module");
-  module.define(jit_script);
-
-  Method method = module.get_method("forward");
-  auto graph = module.get_method("forward").graph();
-
-  // here we do not freeze graph
-  return torch::jit::canEnableStaticRuntime(graph);
-}
 } // namespace
 
 TEST(StaticRuntime, InPlace) {
@@ -999,7 +796,9 @@ TEST(StaticRuntime, FusionPass) {
   }
 }
 
-TEST(ProcessedNode, VerifyOutputsNotOverlappingWithImmutableInputsWithImmutableArguments) {
+TEST(
+    ProcessedNode,
+    VerifyOutputsNotOverlappingWithImmutableInputsWithImmutableArguments) {
   script::Module module("module");
   // Not using out= variant.
   module.define(sigmoid_script);
@@ -1017,7 +816,9 @@ TEST(ProcessedNode, VerifyOutputsNotOverlappingWithImmutableInputsWithImmutableA
   EXPECT_FALSE(pnode.verify_outputs_not_overlapping_with_immutable_inputs());
 }
 
-TEST(ProcessedNode, VerifyOutputsNotOverlappingWithImmutableInputsWithMutableArguments) {
+TEST(
+    ProcessedNode,
+    VerifyOutputsNotOverlappingWithImmutableInputsWithMutableArguments) {
   script::Module module("module");
   // Using out= variant.
   module.define(sigmoid_inplace_script);

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -1,0 +1,230 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#include "caffe2/benchmarks/static_runtime/test_utils.h"
+
+#include <ATen/core/ivalue.h>
+#include <gtest/gtest.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
+#include <memory>
+#include <unordered_map>
+
+using namespace torch::jit;
+using namespace torch;
+using c10::IValue;
+
+namespace torch {
+namespace jit {
+namespace test {
+
+namespace {
+
+// Test scripts passed to testStaticRuntime can either be IR or JIT.
+// The logic for running the script and producing a corresponding StaticModule
+// is a bit different for each case. This logic is encapsulated within concrete
+// implementations of this class, and testStaticRuntime is only aware of this
+// interface.
+class StaticRuntimeTestContext {
+ public:
+  virtual ~StaticRuntimeTestContext() = default;
+
+  virtual IValue getExpected(const std::vector<IValue>& args) = 0;
+  virtual StaticModule makeStaticModule(
+      const StaticModuleOptions& opt) const = 0;
+};
+
+class ModuleStaticRuntimeTestContext : public StaticRuntimeTestContext {
+ public:
+  explicit ModuleStaticRuntimeTestContext(const std::string& source_jit)
+      : module_("module") {
+    module_.define(source_jit);
+  }
+
+  IValue getExpected(const std::vector<IValue>& args) override {
+    return module_.forward(args);
+  }
+
+  StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
+    return torch::jit::StaticModule(module_, /* is_frozen */ false, opt);
+  }
+
+ private:
+  Module module_;
+};
+
+class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
+ public:
+  explicit GraphStaticRuntimeContext(const std::string& source_ir) {
+    graph_ = std::make_shared<Graph>();
+    std::unordered_map<std::string, Value*> vmap;
+    parseIR(source_ir, graph_.get(), vmap);
+
+    graph_exec_ = GraphExecutor(graph_, "");
+  }
+
+  IValue getExpected(const std::vector<IValue>& args) override {
+    Stack stack(args);
+    graph_exec_.run(stack);
+
+    if (stack.size() == 1) {
+      return stack[0];
+    }
+    return c10::ivalue::Tuple::create(stack);
+  }
+
+  StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
+    return StaticModule(graph_, opt);
+  }
+
+ private:
+  std::shared_ptr<Graph> graph_;
+  GraphExecutor graph_exec_;
+};
+
+std::unique_ptr<StaticRuntimeTestContext> makeTestContext(
+    const std::string& source) {
+  try {
+    return std::make_unique<ModuleStaticRuntimeTestContext>(source);
+    // Could not parse as TorchScript, assume it's IR
+  } catch (const std::runtime_error&) {
+    return std::make_unique<GraphStaticRuntimeContext>(source);
+  }
+}
+
+void compareTensorLists(
+    const std::vector<IValue>& l, /* expects */
+    const std::vector<IValue>& r /* values */) {
+  EXPECT_TRUE(l.size() == r.size());
+  for (int i = 0; i < l.size(); ++i) {
+    ASSERT_TRUE(l[i].isTensor());
+    ASSERT_TRUE(r[i].isTensor());
+    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
+    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
+    if (!l[i].toTensor().defined()) {
+      EXPECT_TRUE(!r[i].toTensor().defined());
+    } else {
+      EXPECT_TRUE(l[i].toTensor().equal(r[i].toTensor()));
+    }
+  }
+}
+
+void compareTensorLists(
+    const std::vector<at::Tensor>& l, /* expects */
+    const std::vector<at::Tensor>& r /* values */) {
+  EXPECT_TRUE(l.size() == r.size());
+  for (int i = 0; i < l.size(); ++i) {
+    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
+    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
+    if (!l[i].defined()) {
+      EXPECT_TRUE(!r[i].defined());
+    } else {
+      EXPECT_TRUE(l[i].equal(r[i]));
+    }
+  }
+}
+
+void compareResults(
+    const IValue& expect,
+    const IValue& actual,
+    const bool use_allclose = false) {
+  if (expect.isTensor()) {
+    VLOG(2) << "expect " << expect.toTensor() << std::endl;
+    VLOG(2) << "output " << actual.toTensor() << std::endl;
+    EXPECT_TRUE(actual.isTensor());
+    if (use_allclose) {
+      EXPECT_TRUE(at::allclose(expect.toTensor(), actual.toTensor()));
+    } else {
+      EXPECT_TRUE(expect.toTensor().equal(actual.toTensor()));
+    }
+    return;
+  } else if (expect.isTuple()) {
+    EXPECT_TRUE(actual.isTuple());
+    auto lhs = expect.toTuple()->elements();
+    auto rhs = actual.toTuple()->elements();
+    EXPECT_TRUE(lhs.size() == rhs.size());
+    for (size_t i = 0; i < lhs.size(); i++) {
+      compareResults(lhs[i], rhs[i]);
+    }
+  } else if (expect.isList()) {
+    EXPECT_TRUE(actual.isList());
+    auto lhs = expect.toList();
+    auto rhs = actual.toList();
+    EXPECT_TRUE(lhs.size() == rhs.size());
+    for (size_t i = 0; i < lhs.size(); i++) {
+      compareResults(lhs[i], rhs[i]);
+    }
+  } else if (expect.isGenericDict()) {
+    EXPECT_TRUE(actual.isGenericDict());
+    auto lhs = expect.toGenericDict();
+    auto rhs = actual.toGenericDict();
+    EXPECT_TRUE(lhs.size() == rhs.size());
+    for (auto& lh : lhs) {
+      auto f = rhs.find(lh.key());
+      EXPECT_FALSE(f == rhs.end());
+      compareResults(lh.value(), f->value());
+    }
+  } else {
+    // fall back to the default comparison impl in IValue
+    EXPECT_TRUE(expect == actual);
+  }
+}
+
+} // namespace
+
+void testStaticRuntime(
+    const std::string& source,
+    const std::vector<IValue>& args,
+    const std::vector<IValue>& args2,
+    const bool use_allclose) {
+  auto test_context = makeTestContext(source);
+
+  std::vector<IValue> args_tensors, args_copy;
+  for (const auto& ival : args) {
+    if (ival.isTensor()) {
+      args_tensors.emplace_back(ival);
+      const at::Tensor& t = ival.toTensor();
+      args_copy.emplace_back(t.clone());
+    }
+  }
+
+  auto expect = test_context->getExpected(args);
+
+  for (bool enable_out_variant : {true, false}) {
+    auto smodule = test_context->makeStaticModule(
+        {true, enable_out_variant, enable_out_variant});
+    auto actual = smodule(args, {});
+    smodule.runtime().check_for_memory_leak();
+    // first run
+    compareResults(expect, actual, use_allclose);
+
+    // args2 is used to check for dynamic shapes
+    // it also exercises the memory planner
+    if (!args2.empty()) {
+      expect = test_context->getExpected(args2);
+      actual = smodule(args2, {});
+      smodule.runtime().check_for_memory_leak();
+      // second run
+      compareResults(expect, actual, use_allclose);
+
+      expect = test_context->getExpected(args);
+      actual = smodule(args, {});
+      smodule.runtime().check_for_memory_leak();
+      // third run
+      compareResults(expect, actual, use_allclose);
+    } else {
+      // run static runtime again to exercise the memory planner
+      actual = smodule(args, {});
+      smodule.runtime().check_for_memory_leak();
+      // second run
+      compareResults(expect, actual, use_allclose);
+    }
+  }
+
+  // make sure inputs were not modified
+  compareTensorLists(args_tensors, args_copy);
+}
+
+} // namespace test
+} // namespace jit
+} // namespace torch

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -1,0 +1,30 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace c10 {
+struct IValue;
+}
+
+namespace torch {
+namespace jit {
+
+struct Node;
+class StaticModule;
+
+namespace test {
+
+// Given a model/function in jit or IR script, run the model/function
+// with the jit interpreter and static runtime, and compare the results
+void testStaticRuntime(
+    const std::string& source,
+    const std::vector<c10::IValue>& args,
+    const std::vector<c10::IValue>& args2 = {},
+    const bool use_allclose = false);
+
+} // namespace test
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Summary: `testStaticRuntime` was previously only available in `test_static_runtime.cc`. It has been moved to a common library `test_utils` to facilitate code re-use. This also lets us test dynamic shapes in `test_fb_operators`

Differential Revision: D29858928

