### PR TITLE
[Static Runtime] Remove wrappers for aten::cat

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -752,6 +752,8 @@ TEST(StaticRuntime, IndividualOps_VarCat) {
   // 3D tensors - cat dim = 2
   std::vector<IValue> args3 = {at::randn({4, 5, 6}), at::randn({4, 5, 7}), 2};
   testStaticRuntime(var_cat_script, args3);
+
+  testStaticRuntime(var_cat_script, args1, args2);
 }
 
 TEST(StaticRuntime, LongModel) {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -415,24 +415,6 @@ REGISTER_OPERATOR_FUNCTOR(aten::nan_to_num, aten_nan_to_num, [](Node* n) -> SROp
     at::native::nan_to_num_out(in0_t, in1_d, in2_d, in3_d, out_t);
   };
 });
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(aten::cat, aten_cat, [](Node* n) -> SROperator {
-  if (!n->matches(
-          torch::schema("aten::cat(Tensor[] tensors, int dim=0) -> Tensor"))) {
-    LogAndDumpSchema(n);
-    return nullptr;
-  }
-  return [](ProcessedNode* p_node) {
-    const auto in0_tl = p_node->Input(0).toTensorVector();
-    const auto in1_i = p_node->Input(1).toInt();
-    if (p_node->Output(0).isNone()) {
-      p_node->Output(0) = create_empty_from(in0_tl[0]);
-    }
-    auto& out_t = p_node->Output(0).toTensor();
-    fastResizeToZero(out_t);
-    at::native::_cat_out_cpu(in0_tl, in1_i, out_t);
-  };
-});
 
 // Split out into a function to appease MSVC's pre-processor
 SROperator aten_stack(Node* n) {


### PR DESCRIPTION
Summary:
The wrapper for aten::cat is no longer needed after the variadic cat change.
Also added a simple test to test dynamic shapes, i.e., input tensors in args2 are larger than in args1.

Differential Revision: D29864600

