### PR TITLE
[DDP Comm Hook] Use a single tensor instead of a tensor list as the comm hook result

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -429,11 +429,12 @@ class AbstractDistributedDataParallelTest(object):
         self, state: object, bucket: dist.GradBucket
     ) -> torch.futures.Future:
         fut = torch.futures.Future()
-        fut.set_result([torch.ones_like(bucket.get_tensor())])
+        fut.set_result(torch.ones_like(bucket.get_tensor()))
 
         def fut_then(fut):
             # Add ones to fut's result.
-            return [t + torch.ones_like(t) for t in fut.value()]
+            t = fut.value()
+            return t + torch.ones_like(t)
 
         return fut.then(fut_then)
 

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1985,7 +1985,7 @@ class DistributedDataParallelTest(
         ) -> torch.futures.Future:
             def div_by_world_size(fut):
                 # Divide the result by 2 * world_size.
-                return [t / self.world_size for t in fut.wait()]
+                return fut.wait()[0] / self.world_size
 
             # Prepare allreduced grad bucket tensors by running an async work.
             fut = process_group.allreduce([bucket.get_tensor()]).get_future()

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1694,11 +1694,11 @@ class DistributedDataParallelTest(
 
             def mult(fut):
                 # Multiply the result by 10.
-                return [10 * t for t in fut.value()]
+                return 10 * fut.value()[0]
 
             def div(fut):
                 # Divide the result by 2.
-                return [0.5 * t for t in fut.value()]
+                return 0.5 * fut.value()
 
             return fut.then(mult).then(div)
 

--- a/torch/csrc/distributed/c10d/python_comm_hook.cpp
+++ b/torch/csrc/distributed/c10d/python_comm_hook.cpp
@@ -47,15 +47,12 @@ at::Tensor PythonCommHook::parseHookResult(const c10::IValue& result) {
   if (result.isPyObject()) {
     py::gil_scoped_acquire ag;
     py::object obj = torch::jit::toPyObject(result);
-    /*
-    auto value = torch::jit::toIValue(
-        obj, c10::ListType::create(c10::TensorType::get()));
-    */
     auto value = torch::jit::toIValue(obj, c10::TensorType::get());
     return value.toTensor();
   }
 
-  // Only if the hook is an `allreduce_hook`.
+  // Only if the hook is an `allreduce_hook`, as the vanilla allreduce returns a
+  // tensor vector.
   return result.toTensorVector()[0];
 }
 

--- a/torch/csrc/distributed/c10d/python_comm_hook.cpp
+++ b/torch/csrc/distributed/c10d/python_comm_hook.cpp
@@ -39,8 +39,7 @@ c10::intrusive_ptr<c10::ivalue::Future> PythonCommHook::runHook(
   }
 }
 
-std::vector<at::Tensor> PythonCommHook::parseHookResult(
-    const c10::IValue& result) {
+at::Tensor PythonCommHook::parseHookResult(const c10::IValue& result) {
   TORCH_INTERNAL_ASSERT(
       result.isPyObject() || result.isTensorList(),
       "expected the hook result is either a PyObject or TensorList");
@@ -48,13 +47,16 @@ std::vector<at::Tensor> PythonCommHook::parseHookResult(
   if (result.isPyObject()) {
     py::gil_scoped_acquire ag;
     py::object obj = torch::jit::toPyObject(result);
+    /*
     auto value = torch::jit::toIValue(
         obj, c10::ListType::create(c10::TensorType::get()));
-
-    return value.toTensorVector();
+    */
+    auto value = torch::jit::toIValue(obj, c10::TensorType::get());
+    return value.toTensor();
   }
 
-  return result.toTensorVector();
+  // Only if the hook is an `allreduce_hook`.
+  return result.toTensorVector()[0];
 }
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/python_comm_hook.h
+++ b/torch/csrc/distributed/c10d/python_comm_hook.h
@@ -23,7 +23,7 @@ class TORCH_PYTHON_API PythonCommHook : public CommHookInterface {
 
   c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;
 
-  std::vector<at::Tensor> parseHookResult(const c10::IValue& result) override;
+at::Tensor parseHookResult(const c10::IValue& result) override;
 
  private:
   // Only needed for stateful communication.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1469,7 +1469,6 @@ void Reducer::finalize_backward() {
       // following the same logic in `initialize_buckets`.
       populate_bucket_views_out(replica, future_result[i]);
     }
-    replica.contents.copy_(future_result);
 
     // Unset allreduce division factor, as it may change in next backwards pass
     // when running with DDP join mode.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1461,16 +1461,15 @@ void Reducer::finalize_backward() {
     auto future_result = comm_hook_ == nullptr
         ? detail::parseCppCommHookResult(bucket.future_work->value())
         : comm_hook_->parseHookResult(bucket.future_work->value());
-    for (const auto i : c10::irange(future_result.size())) {
-      auto& replica = bucket.replicas[i];
-      if (bucket.expect_sparse_gradient) {
-        replica.contents.copy_(future_result[i]);
-      } else {
-        // Reinitialize only `bucket_views_out` with the future_result by
-        // following the same logic in `initialize_buckets`.
-        populate_bucket_views_out(replica, future_result[i]);
-      }
+    auto& replica = bucket.replicas[0];
+    if (bucket.expect_sparse_gradient) {
+      replica.contents.copy_(future_result);
+    } else {
+      // Reinitialize only `bucket_views_out` with the future_result by
+      // following the same logic in `initialize_buckets`.
+      populate_bucket_views_out(replica, future_result[i]);
     }
+    replica.contents.copy_(future_result);
 
     // Unset allreduce division factor, as it may change in next backwards pass
     // when running with DDP join mode.

--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -61,7 +61,7 @@ def fp16_compress_hook(
         # Decompress in place to reduce the peak memory.
         # See: https://github.com/pytorch/pytorch/issues/45968
         decompressed_tensor.copy_(fut.value()[0])
-        return [decompressed_tensor]
+        return decompressed_tensor
 
     return fut.then(decompress)
 
@@ -94,7 +94,7 @@ def fp16_compress_wrapper(
             # Decompress in place to reduce the peak memory.
             # See: https://github.com/pytorch/pytorch/issues/45968
             decompressed_tensor.copy_(fut.value()[0])
-            return [decompressed_tensor]
+            return decompressed_tensor
 
         # Decompress after hook has run.
         return fut.then(decompress)

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -477,7 +477,13 @@ def powerSGD_hook(
             idx += tensor.numel()
 
         # Since these Ps will be orthogonalized later, no need to divide them by world size.
-        return dist.all_reduce(state.p_memory_dict[bucket_index], group=group_to_use, async_op=True).get_future().wait()[0]
+        return (
+            dist.all_reduce(
+                state.p_memory_dict[bucket_index], group=group_to_use, async_op=True
+            )
+            .get_future()
+            .wait()[0]
+        )
 
     def compute_qs(fut):
         state.p_memory_dict[bucket_index] = fut.value()[0]
@@ -493,7 +499,13 @@ def powerSGD_hook(
         # For warm-start, can take one such step at a time, and alternate between them.
 
         # Allreduce Qs.
-        return dist.all_reduce(state.q_memory_dict[bucket_index], group=group_to_use, async_op=True).get_future().wait()[0]
+        return (
+            dist.all_reduce(
+                state.q_memory_dict[bucket_index], group=group_to_use, async_op=True
+            )
+            .get_future()
+            .wait()[0]
+        )
 
     def decompress(fut):
         state.q_memory_dict[bucket_index] = fut.value().div_(world_size)
@@ -695,7 +707,13 @@ def batched_powerSGD_hook(
         # one left multiplication and one right multiplication.
         # For warm-start, can take one such step at a time, and alternate between them.
 
-        return dist.all_reduce(state.q_memory_dict[bucket_index], group=group_to_use, async_op=True).get_future().wait()[0]
+        return (
+            dist.all_reduce(
+                state.q_memory_dict[bucket_index], group=group_to_use, async_op=True
+            )
+            .get_future()
+            .wait()[0]
+        )
 
     def decompress(fut):
         state.q_memory_dict[bucket_index] = fut.value().div_(world_size)

--- a/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
@@ -110,7 +110,7 @@ def quantization_pertensor_hook(
                 quantized_tensor, all_ranks_s_and_z[r][0], all_ranks_s_and_z[r][1]
             )
 
-        return [aggregated_dequantized_tensor / world_size]
+        return aggregated_dequantized_tensor / world_size
 
     return fut.then(quantize_and_allgather).then(dequantize_and_aggregate)
 
@@ -203,11 +203,11 @@ def quantization_perchannel_hook(
                 quantized_tensor, all_ranks_s_and_z[r][0], all_ranks_s_and_z[r][1]
             )
 
-        return [
+        return (
             torch.flatten(aggregated_dequantized_tensor).cuda(tensor.device)[
                 : tensor.size()[0]
             ]
             / world_size
-        ]
+        )
 
     return fut.then(quantize_and_allgather).then(dequantize_and_aggregate)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62074
* #62073

Since SPMD mode is retired, the comm hook result will always be a single tensor.

This can improve comm hook developer experience, as no need to add an extra `[0]` to the precursor future result.

#Closes: https://github.com/pytorch/pytorch/issues/61914

Differential Revision: [D29864732](https://our.internmc.facebook.com/intern/diff/D29864732/)