### PR TITLE
[torch] Limit the size of the worker failures for torch.elastic.mp

### DIFF
--- a/test/distributed/elastic/multiprocessing/bin/zombie_test.py
+++ b/test/distributed/elastic/multiprocessing/bin/zombie_test.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+
+if __name__ == "__main__":
+    time.sleep(600)
+    print("finished work")

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -10,6 +10,7 @@ import abc
 import functools
 import json
 import os
+import signal
 import socket
 import time
 import traceback
@@ -24,7 +25,11 @@ import torch.distributed.elastic.utils.store as store_util
 from torch.distributed import Store
 from torch.distributed.elastic.events import Event, EventSource, record
 from torch.distributed.elastic.metrics import prof, put_metric
-from torch.distributed.elastic.multiprocessing import ProcessFailure, Std
+from torch.distributed.elastic.multiprocessing import (
+    ProcessFailure,
+    Std,
+    SignalException,
+)
 from torch.distributed.elastic.utils.logging import get_logger
 
 
@@ -488,9 +493,12 @@ class SimpleElasticAgent(ElasticAgent):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _shutdown(self) -> None:
+    def _shutdown(self, death_sig: signal.Signals = signal.SIGTERM) -> None:
         """
         Cleans up any resources that were allocated during the agent's work.
+
+        Args:
+            death_sig: Signal to send to the child process, SIGTERM is default
         """
         raise NotImplementedError()
 
@@ -696,16 +704,23 @@ class SimpleElasticAgent(ElasticAgent):
     @prof
     def run(self, role: str = DEFAULT_ROLE) -> RunResult:
         start_time = time.monotonic()
+        shutdown_called: bool = False
         try:
             result = self._invoke_run(role)
             self._total_execution_time = int(time.monotonic() - start_time)
             self._record_metrics(result)
             self._record_worker_events(result)
             return result
+        except SignalException as e:
+            log.warning(f"Received {e.sigval} death signal, shutting down workers")
+            self._shutdown(e.sigval)
+            shutdown_called = True
+            raise
         finally:
+            if not shutdown_called:
+                self._shutdown()
             # record the execution time in case there were any exceptions during run.
             self._total_execution_time = int(time.monotonic() - start_time)
-            self._shutdown()
 
     def get_agent_status_event(self, state: WorkerState) -> Event:
         raw_error = traceback.format_exc() if state == WorkerState.FAILED else None
@@ -891,6 +906,9 @@ class SimpleElasticAgent(ElasticAgent):
             log.info(
                 f"Done waiting for other agents. Elapsed: {time.time() - start} seconds"
             )
+        except SignalException as e:
+            log.warn(f"Got termination signal: {e.sigval}")
+            raise
         except Exception:
             log.exception(
                 f"Error waiting on exit barrier. Elapsed: {time.time() - start} seconds"

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -9,6 +9,7 @@
 
 import os
 import shutil
+import signal
 import tempfile
 from typing import Any, Dict, Optional, Tuple
 
@@ -183,9 +184,9 @@ class LocalElasticAgent(SimpleElasticAgent):
 
         return self._pcontext.pids()
 
-    def _shutdown(self) -> None:
+    def _shutdown(self, death_sig: signal.Signals = signal.SIGTERM) -> None:
         if self._pcontext:
-            self._pcontext.close()
+            self._pcontext.close(death_sig)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -72,6 +72,7 @@ from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
     ProcessFailure,
     RunProcsResult,
     Std,
+    SignalException,
     SubprocessContext,
     _validate_full_rank,
     to_map,

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -18,6 +18,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from enum import IntFlag
 from multiprocessing import synchronize
+from types import FrameType
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
 
 import torch.multiprocessing as mp
@@ -33,6 +34,50 @@ IS_MACOS = sys.platform == "darwin"
 
 
 log = logging.getLogger(__name__)
+
+
+class SignalException(Exception):
+    """
+    Exception is raised inside the torchelastic agent process by the termination handler
+    if the death signal got received by the process.
+    """
+
+    def __init__(self, msg: str, sigval: signal.Signals) -> None:
+        super().__init__(msg)
+        self.sigval = sigval
+
+
+def _terminate_process_handler(signum: int, frame: FrameType) -> None:
+    """Termination handler that raises exceptions on the main process.
+
+    When the process receives death signal(SIGTERM, SIGINT), this termination handler will
+    be invoked. It raises the ``SignalException`` exception that should be processed by the
+    user code. Python does not terminate process after the termination handler is finished,
+    so the exception should not be silently ignored, otherwise the process will never
+    be terminated.
+    """
+    sigval = signal.Signals(signum)
+    raise SignalException(f"Process {os.getpid()} got signal: {sigval}", sigval=sigval)
+
+
+def _get_kill_signal() -> signal.Signals:
+    """
+    Get the kill signal. SIGKILL for unix, CTRL_C_EVENT for windows.
+    """
+    if IS_WINDOWS:
+        return signal.CTRL_C_EVENT  # type: ignore[attr-defined] # noqa: F821
+    else:
+        return signal.SIGKILL
+
+
+def _get_default_signal() -> signal.Signals:
+    """
+    Get the default termination signal. SIGTERM for unix, CTRL_C_EVENT for windows.
+    """
+    if IS_WINDOWS:
+        return signal.CTRL_C_EVENT  # type: ignore[attr-defined] # noqa: F821
+    else:
+        return signal.SIGTERM
 
 
 def _validate_full_rank(d: Dict[int, Any], nprocs: int, what: str):
@@ -185,6 +230,10 @@ class PContext(abc.ABC):
         """
         Start processes using parameters defined in the constructor.
         """
+        signal.signal(signal.SIGTERM, _terminate_process_handler)
+        signal.signal(signal.SIGINT, _terminate_process_handler)
+        signal.signal(signal.SIGHUP, _terminate_process_handler)
+        signal.signal(signal.SIGQUIT, _terminate_process_handler)
         self._start()
         self._stdout_tail.start()
         self._stderr_tail.start()
@@ -214,6 +263,23 @@ class PContext(abc.ABC):
         on timeout expiry. Negative timeout values are interpreted as "wait-forever".
         A timeout value of zero simply queries the status of the processes (e.g. equivalent
         to a poll).
+
+        ..note: Multiprocesing library registers SIGTERM and SIGINT signal handlers that raise
+                ``SignalException`` when the signals received. It is up to the consumer of the code
+                to properly handle the exception. It is important not to swallow the exception otherwise
+                the process would not terminate. Example of the typical workflow can be:
+
+        .. code-block:: python
+            pc = start_processes(...)
+            try:
+                pc.wait(1)
+                .. do some other work
+            except SignalException as e:
+                pc.shutdown(e.sigval, timeout=30)
+
+        If SIGTERM or SIGINT occurs, the code above will try to shutdown child processes by propagating
+        received signal. If child processes will not terminate in the timeout time, the process will send
+        the SIGKILL.
         """
 
         if timeout == 0:
@@ -239,15 +305,28 @@ class PContext(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _close(self) -> None:
+    def _close(self, death_sig: signal.Signals, timeout: int = 30) -> None:
         r"""
         Terminates all processes managed by this context and cleans up any
         meta resources (e.g. redirect, error_file files).
         """
         raise NotImplementedError()
 
-    def close(self) -> None:
-        self._close()
+    def close(
+        self, death_sig: Optional[signal.Signals] = None, timeout: int = 30
+    ) -> None:
+        r"""
+        Terminates all processes managed by this context and cleans up any
+        meta resources (e.g. redirect, error_file files).
+
+        Args:
+            death_sig: Death signal to terminate porcesses.
+            timeout: Time to wait for processes to finish, if process is
+                still alive after this time, it will be terminated via SIGKILL.
+        """
+        if not death_sig:
+            death_sig = _get_default_signal()
+        self._close(death_sig=death_sig, timeout=timeout)
         if self._stdout_tail:
             self._stdout_tail.stop()
         if self._stderr_tail:
@@ -447,11 +526,35 @@ class MultiprocessContext(PContext):
         assert self._pc is not None  # assertion for mypy type checking
         return {local_rank: pid for local_rank, pid in enumerate(self._pc.pids())}
 
-    def _close(self) -> None:
-        if self._pc:
-            for proc in self._pc.processes:
-                proc.terminate()
-                proc.join()
+    def _close(self, death_sig: signal.Signals, timeout: int = 30) -> None:
+        if not self._pc:
+            return
+        log.warning(f"Closing processes via signal {death_sig}")
+        for proc in self._pc.processes:
+            try:
+                os.kill(proc.pid, death_sig)
+            except ProcessLookupError:
+                # If the process exited because of some reason,
+                # `ProcessLookupError` will be rasied, it is safe to ignore it.
+                pass
+        end = time.monotonic() + timeout
+        for proc in self._pc.processes:
+            time_to_wait = end - time.monotonic()
+            if time_to_wait <= 0:
+                break
+            proc.join(time_to_wait)
+        log.warning(
+            f"Unable to shutdown processes via {death_sig}, forcefully exitting via {_get_kill_signal()}"
+        )
+        for proc in self._pc.processes:
+            if proc.is_alive():
+                try:
+                    os.kill(proc.pid, _get_kill_signal())
+                except ProcessLookupError:
+                    # If the process exited because of some reason,
+                    # `ProcessLookupError` will be rasied, it is safe to ignore it.
+                    pass
+            proc.join()
 
 
 class SubprocessHandler:
@@ -465,7 +568,6 @@ class SubprocessHandler:
         entrypoint: str,
         args: Tuple,
         env: Dict[str, str],
-        preexec_fn: Optional[Callable],
         stdout: str,
         stderr: str,
     ):
@@ -476,44 +578,27 @@ class SubprocessHandler:
         env_vars.update(env)
 
         args_str = (entrypoint, *[str(e) for e in args])
-        self.proc: subprocess.Popen = self._popen(args_str, env_vars, preexec_fn)
+        self.proc: subprocess.Popen = self._popen(args_str, env_vars)
 
-    def _popen(
-        self, args: Tuple, env: Dict[str, str], preexec_fn: Optional[Callable]
-    ) -> subprocess.Popen:
-        if IS_WINDOWS:
-            # Reset preexec_fn on windows, since windows does not support it
-            preexec_fn = None
-
+    def _popen(self, args: Tuple, env: Dict[str, str]) -> subprocess.Popen:
         return subprocess.Popen(
             # pyre-fixme[6]: Expected `Union[typing.Sequence[Union[_PathLike[bytes],
             #  _PathLike[str], bytes, str]], bytes, str]` for 1st param but got
             #  `Tuple[str, *Tuple[Any, ...]]`.
             args=args,
             env=env,
-            preexec_fn=preexec_fn,
             stdout=self._stdout,
             stderr=self._stderr,
         )
 
-    def close(self):
-        self.proc.terminate()
-        self.proc.wait()
+    def close(self, death_sig: Optional[signal.Signals] = None) -> None:
+        if not death_sig:
+            death_sig = _get_default_signal()
+        self.proc.send_signal(death_sig)
         if self._stdout:
             self._stdout.close()
         if self._stderr:
             self._stderr.close()
-
-
-def _pr_set_pdeathsig() -> None:
-    """
-    Sets PR_SET_PDEATHSIG to ensure a child process is
-    terminated appropriately.
-
-    See http://stackoverflow.com/questions/1884941/ for more information.
-    For libc.so.6 read http://www.linux-m68k.org/faq/glibcinfo.html
-    """
-    mp._prctl_pr_set_pdeathsig(signal.SIGTERM)  # type: ignore[attr-defined]
 
 
 class SubprocessContext(PContext):
@@ -560,7 +645,6 @@ class SubprocessContext(PContext):
                 entrypoint=self.entrypoint,  # type: ignore[arg-type] # entrypoint is always a str
                 args=self.args[local_rank],
                 env=self.envs[local_rank],
-                preexec_fn=_pr_set_pdeathsig,
                 stdout=self.stdouts[local_rank],
                 stderr=self.stderrs[local_rank],
             )
@@ -616,7 +700,21 @@ class SubprocessContext(PContext):
             for local_rank, sh in self.subprocess_handlers.items()
         }
 
-    def _close(self) -> None:
-        if self.subprocess_handlers:
-            for handler in self.subprocess_handlers.values():
-                handler.close()
+    def _close(self, death_sig: signal.Signals, timeout: int = 30) -> None:
+        if not self.subprocess_handlers:
+            return
+        log.warning(f"Sending processes {death_sig}")
+        for handler in self.subprocess_handlers.values():
+            handler.close(death_sig=death_sig)
+        end = time.monotonic() + timeout
+        for handler in self.subprocess_handlers.values():
+            time_to_wait = end - time.monotonic()
+            if time_to_wait <= 0:
+                break
+            handler.proc.wait(time_to_wait)
+        log.warning(
+            f"Unable to shutdown processes via {death_sig}, forcefully exitting via {_get_kill_signal()}"
+        )
+        for handler in self.subprocess_handlers.values():
+            handler.close(death_sig=_get_kill_signal())
+            handler.proc.wait()

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -160,6 +160,8 @@ class ProcessFailure:
 
 GlobalRank = int
 
+_MAX_OTHER_FAILURES_SIZE = 8
+
 _FAILURE_FORMAT_TEMPLATE = """[${idx}]:
   time: ${time}
   rank: ${rank} (local_rank: ${local_rank})
@@ -175,7 +177,7 @@ ${section}
 Root Cause:
 ${root_failure}
 ${section}
-Other Failures:
+Other Failures(first ${other_failures_size}):
 ${other_failures}
 ${boarder}
 """
@@ -241,7 +243,7 @@ class ChildFailedError(Exception):
             width = max(width, w)
             if rank == root_rank:
                 root_failure_fmt = fmt
-            else:
+            elif len(other_failures_fmt) < _MAX_OTHER_FAILURES_SIZE:
                 other_failures_fmt.append(fmt)
 
         # upper boundary on width
@@ -252,6 +254,7 @@ class ChildFailedError(Exception):
             title=title.center(width),
             section=section_delim * width,
             root_failure=root_failure_fmt,
+            other_failures_size=_MAX_OTHER_FAILURES_SIZE,
             other_failures="\n".join(other_failures_fmt or ["  <NO_OTHER_FAILURES>"]),
         )
 


### PR DESCRIPTION
Summary:
The diff limits the size of failure messages to 1+`_MAX_OTHER_FAILURES_SIZE`, where _MAX_OTHER_FAILURES_SIZE is 8.

If there are many processes launched, the worker processes that did not fail first will be put in the 'Other failures' section. In situations when there are many workers, the 'Other failures' section will be huge, which contaminates logs.

Test Plan:
~/fbsource/fbcode/buck-out/gen/caffe2/launch.par --nnodes=1 --nproc_per_node=32 main.py

Before Change: P431400432

After Change: P431399930

Differential Revision: D29870155

