### PR TITLE
[ONNX] Add supplementary tests and description for custom_opsets param from torch.onnx.export() function.

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -31,9 +31,9 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=True, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=True,
+           opset_version=None, _retain_param_name=None, do_constant_folding=True,
+           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=None,
            use_external_data_format=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -303,7 +303,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             * VALUE (int): opset version
 
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
-            the opset version is set to 1.
+            the opset version is set to 1. Only custom opset domain name and version should be
+            indicated through this argument.
 
         enable_onnx_checker (bool, default True): Deprecated and ignored. Will be removed in next
             Pytorch release.


### PR DESCRIPTION
`custom_opsets` arg from torch.onnx.export() is no needed to be removed.
Add some supplementary description and tests for easier understanding.