### PR TITLE
[Model Averaging] Refactor averagers to accept parameters instead of a module

### DIFF
--- a/torch/distributed/algorithms/model_averaging/averagers.py
+++ b/torch/distributed/algorithms/model_averaging/averagers.py
@@ -13,7 +13,7 @@ class PeriodicModelAverager:
     using the subgroups created by :meth:`~torch.distributed.new_subgroups`.
 
     Args:
-        module (torch.nn.Module): The module where its parameters will be averaged.
+        params (Iterator[torch.nn.Parameter]): The model parameters to be averaged.
         period (int): The number of steps per model averaging.
                       Usually the period should be greater than ``1`` to reduce the communication cost.
                       Otherwise, only DDP needs to be used.
@@ -46,7 +46,7 @@ class PeriodicModelAverager:
         >>>  # In the first 100 steps, run global gradient averaging like normal DDP at every step.
         >>>  # After 100 steps, run model averaging every 4 steps.
         >>>  # Note that ``warmup_steps`` must be the same as ``start_localSGD_iter`` used in ``PostLocalSGDState``.
-        >>>  averager = averagers.PeriodicModelAverager(model, warmup_steps=100, period=4)
+        >>>  averager = averagers.PeriodicModelAverager(model.parameters(), warmup_steps=100, period=4)
         >>>  for step in range(0, 20):
         >>>     optimizer.zero_grad()
         >>>     loss = loss_fn(output, labels)
@@ -62,12 +62,12 @@ class PeriodicModelAverager:
 
     def __init__(
         self,
-        module,
+        params,
         period,
         warmup_steps=0,
         process_group=None,
     ):
-        self.module = module
+        self.params = list(params)
         if warmup_steps < 0:
             raise ValueError("Arg ``warmup_steps`` must be a non-negative number.")
         self.warmup_steps = warmup_steps
@@ -92,6 +92,9 @@ class PeriodicModelAverager:
         and it can be divided by ``period``, where ``step`` is increased by 1
         at each iteration in the training loop.
         """
-        if self.step >= self.warmup_steps and (self.step - self.warmup_steps) % self.period == 0:
-            utils.average_parameters(self.module, self.process_group)
+        if (
+            self.step >= self.warmup_steps
+            and (self.step - self.warmup_steps) % self.period == 0
+        ):
+            utils.average_parameters(self.params, self.process_group)
         self.step += 1

--- a/torch/distributed/algorithms/model_averaging/averagers.py
+++ b/torch/distributed/algorithms/model_averaging/averagers.py
@@ -96,5 +96,5 @@ class PeriodicModelAverager:
             self.step >= self.warmup_steps
             and (self.step - self.warmup_steps) % self.period == 0
         ):
-            utils.average_parameters(self.params, self.process_group)
+            utils.average_parameters(iter(self.params), self.process_group)
         self.step += 1

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -1,20 +1,26 @@
 # flake8: noqa C101
+import itertools
+from typing import Iterator
+
 import torch
 import torch.distributed as dist
 
 
-def average_parameters(module: torch.nn.Module, process_group: dist.ProcessGroup):
+def average_parameters(
+    params: Iterator[torch.nn.Parameter], process_group: dist.ProcessGroup
+):
     """
-    Averages all the parameters of a given module.
+    Averages all the given parameters.
     For allreduce efficiency, all the parameters are flattened into a contiguous buffer.
-    Thus, it requires extra memory of the same size as the module's parameters.
+    Thus, it requires extra memory of the same size as the given parameters.
     """
     group_to_use = process_group if process_group is not None else dist.group.WORLD
     # Do not update any parameter if not in the process group.
     if dist._rank_not_in_group(group_to_use):
         return
 
-    flat_params = torch.cat([p.data.view(-1) for p in module.parameters()])
+    params_it1, params_it2 = itertools.tee(params)
+    flat_params = torch.cat([p.data.view(-1) for p in params_it1])
     flat_params /= dist.get_world_size(group_to_use)
     # Make sure the allreduce will not conflict with any other ongoing process group.
     if torch.cuda.is_available():
@@ -22,6 +28,6 @@ def average_parameters(module: torch.nn.Module, process_group: dist.ProcessGroup
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0
-    for p in module.parameters():
+    for p in params_it2:
         p.data = flat_params[offset : offset + p.numel()].view_as(p)
         offset += p.numel()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62132
* #62131
* #62111
* __->__ #62105

This is for the preparation of wrapping the averager as an optimizer, which can only accept parameters rather than a module.

Proposal: https://github.com/pytorch/pytorch/issues/59699
Differential Revision: [D29883693](https://our.internmc.facebook.com/intern/diff/D29883693/)