### PR TITLE
[Not for review/repro] Repro for https://github.com/pytorch/pytorch/issues/61982

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -132,6 +132,8 @@ class _DDPSink(Function):
     @staticmethod
     def forward(ctx, reducer, *inputs):
         ctx.reducer = reducer
+        cand_ret = tuple(i.clone() for i in inputs)
+        return cand_ret
         return inputs
 
     @staticmethod


### PR DESCRIPTION
Summary:
Repro for https://github.com/pytorch/pytorch/issues/61982. Training
with static graph does not work if in-place operation is done on view tensor
that is returned by DDPSink.

We can fix this with `clone` of the tensors in DDPSink forward pass, but that
might incur a nontrivial perf hit. On the other hand, user can also clone the
output tensor in their training loop to fix the issue, or not use inplace
modification.

Test Plan: CI

Differential Revision: D29884341

