### PR TITLE
Fixed off-by-one bug in Adam Smart Decay

### DIFF
--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -50,17 +50,16 @@ class TestAdam(hu.HypothesisTestCase):
         # Make up for lost minibatches.
         mom2_out = (beta2**k * mom2) + (1 - beta2) * np.square(grad)
         param_out = param
-        m = mom1
+        mom1_out = mom1
 
         # For catchup
-        for _ in range(k - 1):
-            m *= beta1
-            update = m / (np.sqrt(mom2_out) + epsilon)
-            param_out += LR * update
-        # For the single step update
-        mom1_out = m * beta1 + grad * (1 - beta1)
+        assert k >= 1
+        for i in range(k):
+            mom1_out *= beta1
+            if i == k - 1:
+                mom1_out += grad * (1 - beta1)
+            param_out += LR * mom1_out / (np.sqrt(mom2_out) + epsilon)
         grad_out = mom1_out / (np.sqrt(mom2_out) + epsilon)
-        param_out += + LR * grad_out
 
         return param_out, mom1_out, mom2_out, last_seen_out
 
@@ -214,14 +213,14 @@ class TestAdam(hu.HypothesisTestCase):
             input_device_options=input_device_options)
 
     @given(inputs=hu.tensors(n=4),
-           ITER=st.integers(min_value=0, max_value=10000),
-           LR=st.floats(min_value=0.01, max_value=0.99,
+           ITER=st.integers(min_value=0, max_value=10),
+           LR=st.floats(min_value=0.000001, max_value=0.1,
                         allow_nan=False, allow_infinity=False),
-           beta1=st.floats(min_value=0.01, max_value=0.99,
+           beta1=st.floats(min_value=0.0, max_value=0.99999,
                            allow_nan=False, allow_infinity=False),
-           beta2=st.floats(min_value=0.01, max_value=0.99,
+           beta2=st.floats(min_value=0.9, max_value=0.999999,
                            allow_nan=False, allow_infinity=False),
-           epsilon=st.floats(min_value=0.01, max_value=0.99,
+           epsilon=st.floats(min_value=0.00001, max_value=0.99,
                              allow_nan=False, allow_infinity=False),
            data_strategy=st.data(),
            **hu.gcs)

--- a/caffe2/sgd/adam_op.h
+++ b/caffe2/sgd/adam_op.h
@@ -82,7 +82,7 @@ void adam_compute_smart_decay(
     // Catchup = \sum_{i=1}^{k-1}\beta_1^i = \beta_1 \left(\frac{1-\beta_1^k}{1-\beta_1}\right)
     float catchup = 0.0;
     if (k > 1) {
-        catchup = m[i] * beta1 * (1 - powf(beta1, k)) / (1 - beta1);
+        catchup = m[i] * beta1 * (1 - powf(beta1, k-1)) / (1 - beta1);
     }
     float mi = nm[i] = m[i] * powf(beta1, k) + gi * (1 - beta1);
     float vi = nv[i] = v[i] * powf(beta2, k) + gi * gi * (1 - beta2);


### PR DESCRIPTION
Summary:
The initial implementation of Adam with Smart Decay had an off-by-one error.  This was in the summation of the geometric series used to calculate how much built-up momentum would have been discharged in skipped minibatches.

The unit tests should have caught these, but the testing strategy missed this because k, the "number of skipped minibatches" was always either 0 or so high that the impact of the bug was too small.  The impact of the bug was proportional to 1/k.  The testing strategy has also been adjusted to cover this bug.

Differential Revision: D29889309

