### PR TITLE
add channels last support for ReplicationPad2d and ReplicationPad3d

### DIFF
--- a/aten/src/ATen/native/Padding.h
+++ b/aten/src/ATen/native/Padding.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at { namespace native {
+
+using padding_fn = void(*)(const Tensor& output, const Tensor& input, IntArrayRef padding_size);
+DECLARE_DISPATCH(padding_fn, replication_pad1d_kernel);
+DECLARE_DISPATCH(padding_fn, replication_pad2d_kernel);
+DECLARE_DISPATCH(padding_fn, replication_pad3d_kernel);
+
+using padding_backward_fn = void(*)(const Tensor& grad_input, const Tensor& grad_output, IntArrayRef padding_size);
+DECLARE_DISPATCH(padding_backward_fn, replication_pad1d_backward_kernel);
+DECLARE_DISPATCH(padding_backward_fn, replication_pad2d_backward_kernel);
+DECLARE_DISPATCH(padding_backward_fn, replication_pad3d_backward_kernel);
+
+struct PaddingIndexr {
+  int pad_start;
+  int input_start;
+  int output_start;
+  int64_t input_size;
+
+  PaddingIndexr(int p_start, int64_t i_size)
+    : pad_start(p_start)
+    , input_start(std::max(0, -p_start))
+    , output_start(std::max(0, p_start))
+    , input_size(i_size) {}
+};
+
+struct ReplicationPadIndexr : PaddingIndexr {
+  using PaddingIndexr::PaddingIndexr;
+
+  int64_t get(int64_t output_index) {
+    int64_t input_index;
+    if (output_index < pad_start) {
+      input_index = pad_start;
+    } else if (output_index >= pad_start && output_index < input_size + pad_start) {
+      input_index = output_index;
+    } else {
+      input_index = input_size + pad_start - 1;
+    }
+    return input_index - output_start + input_start;
+  }
+};
+
+struct ReflectionPadIndexr : PaddingIndexr {
+  using PaddingIndexr::PaddingIndexr;
+
+  int64_t get(int64_t output_index) {
+    int64_t input_index;
+    if (output_index < pad_start) {
+      input_index = pad_start * 2 - output_index;
+    } else if (output_index >= pad_start && output_index < input_size + pad_start) {
+      input_index = output_index;
+    } else {
+      input_index = (input_size + pad_start - 1) * 2 - output_index;
+    }
+    return input_index - output_start + input_start;
+  }
+};
+
+struct PaddingParams {
+  int64_t ndim;
+  int64_t nbatch;
+  int64_t channels;
+  int64_t input_depth;
+  int64_t input_height;
+  int64_t input_width;
+  int64_t output_depth;
+  int64_t output_height;
+  int64_t output_width;
+
+  PaddingParams(const Tensor& input, const Tensor& output, bool is_batch_mode) {
+    ndim = input.ndimension();
+    if (is_batch_mode) {
+      // 1D: NCW
+      // 2D: NCHW
+      // 3D: NCDHW
+      nbatch = input.size(0);
+      channels = input.size(1);
+      input_depth = (ndim == 5) ? input.size(-3) : 1;
+      input_height = (ndim >= 4) ? input.size(-2) : 1;
+      input_width = input.size(-1);
+      output_depth = (ndim == 5) ? output.size(-3) : 1;
+      output_height = (ndim >= 4) ? output.size(-2) : 1;
+      output_width = output.size(-1);
+    } else {
+      // 1D: CW
+      // 2D: CHW
+      // 3D: CDHW
+      nbatch = 1;
+      channels = input.size(0);
+      input_depth = (ndim == 4) ? input.size(-3) : 1;
+      input_height = (ndim >= 3) ? input.size(-2) : 1;
+      input_width = input.size(-1);
+      output_depth = (ndim == 4) ? output.size(-3) : 1;
+      output_height = (ndim >= 3) ? output.size(-2) : 1;
+      output_width = output.size(-1);
+    }
+  }
+};
+
+}} // namespace at::native

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -1,7 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
-#include <ATen/Parallel.h>
-#include <algorithm>
+#include <ATen/native/Padding.h>
 
 namespace at {
 
@@ -53,28 +52,16 @@ TORCH_META_FUNC(replication_pad1d_backward) (
   const Tensor& input,
   IntArrayRef paddingSize
 ) {
-  int64_t dimw = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
   TORCH_CHECK(paddingSize.size() == 2, "padding size is expected to be 2");
   int64_t pad_l = paddingSize[0];
   int64_t pad_r = paddingSize[1];
+  int64_t dimw = -1;
 
-  if (input.ndimension() == 3)
-  {
-    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-    nbatch = input.size(0);
-    dimw++;
-    dimslices++;
-  }
-
-  /* sizes */
   int64_t iwidth = input.size(dimw);
-  int64_t owidth  = iwidth + pad_l + pad_r;
+  int64_t owidth = iwidth + pad_l + pad_r;
 
   TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth,
-      " Got: ", gradOutput.size(dimw));
+      "gradOutput width unexpected. Expected: ", owidth, " Got: ", gradOutput.size(dimw));
 
   set_output(input.sizes(), input.options());
 }
@@ -100,8 +87,7 @@ TORCH_META_FUNC(replication_pad2d) (
       "Expected 3D or 4D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
       input.sizes());
 
-  if (input.dim() == 4)
-  {
+  if (input.dim() == 4) {
     nbatch = input.size(0);
     dimw++;
     dimh++;
@@ -113,65 +99,46 @@ TORCH_META_FUNC(replication_pad2d) (
   int64_t iheight = input.size(dimh);
   int64_t iwidth = input.size(dimw);
   int64_t oheight = iheight + pad_t + pad_b;
-  int64_t owidth  = iwidth + pad_l + pad_r;
+  int64_t owidth = iwidth + pad_l + pad_r;
 
   TORCH_CHECK(owidth >= 1 || oheight >= 1,
       "input (H: ", iheight, ", W: ", iwidth, " ) is too small."
       " Calculated output H: ", oheight, " W: ", owidth);
 
+  auto memory_format = input.suggest_memory_format();
   if (input.dim() == 3) {
     set_output({nslices, oheight, owidth}, input.options());
   } else {
-    set_output({nbatch, nslices, oheight, owidth}, input.options());
+    set_output({nbatch, nslices, oheight, owidth}, input.options().memory_format(memory_format));
   }
 }
 
-} // namespace meta
+TORCH_META_FUNC(replication_pad2d_backward) (
+  const Tensor& gradOutput,
+  const Tensor& input,
+  IntArrayRef paddingSize
+) {
+  TORCH_CHECK(paddingSize.size() == 4, "padding size is expected to be 4");
+  int64_t pad_l = paddingSize[0];
+  int64_t pad_r = paddingSize[1];
+  int64_t pad_t = paddingSize[2];
+  int64_t pad_b = paddingSize[3];
+  int64_t dimh = -2;
+  int64_t dimw = -1;
 
-
-static inline void shapeCheck3d(
-    const Tensor& input,
-    int pleft, int pright,
-    int ptop, int pbottom,
-    int pfront, int pback) {
-  int dimw = 3;
-  int dimh = 2;
-  int dimd = 1;
-  int dimslices = 0;
-
-  // allow batch size of 0-dim.
-  bool valid_dims = input.size(1) != 0 && input.size(2) != 0 && input.size(3) != 0;
-  TORCH_CHECK(
-      (input.dim() == 4 && input.size(0) != 0 && valid_dims) ||
-      (input.dim() == 5 && valid_dims && input.size(4) != 0),
-      "Expected 4D or 5D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
-      input.sizes());
-
-  if (input.dim() == 5)
-  {
-    dimw++;
-    dimh++;
-    dimd++;
-    dimslices++;
-  }
-
-  /* sizes */
-  // int64_t nslices = input.size(dimslices);
-  int64_t idepth = input.size(dimd);
   int64_t iheight = input.size(dimh);
   int64_t iwidth = input.size(dimw);
-  int64_t odepth = idepth + pfront + pback;
-  int64_t oheight = iheight + ptop + pbottom;
-  int64_t owidth  = iwidth + pleft + pright;
+  int64_t oheight = iheight + pad_t + pad_b;
+  int64_t owidth = iwidth + pad_l + pad_r;
 
-  TORCH_CHECK(owidth >= 1 || oheight >= 1 || odepth >= 1,
-      "input (D: ", idepth, " H: ", iheight, ", W: ", iwidth,
-      ") is too small."
-      " Calculated output D: ", odepth, " H: ", oheight, " W: ", owidth);
+  TORCH_CHECK(owidth == gradOutput.size(dimw),
+      "gradOutput width unexpected. Expected: ", owidth, ", Got: ", gradOutput.size(dimw));
+  TORCH_CHECK(oheight == gradOutput.size(dimh),
+      "gradOutput height unexpected. Expected: ", oheight, ", Got: ", gradOutput.size(dimh));
 
+  auto memory_format = input.suggest_memory_format();
+  set_output(input.sizes(), input.options().memory_format(memory_format));
 }
-
-namespace meta {
 
 TORCH_META_FUNC(replication_pad3d) (
   const Tensor& input, IntArrayRef paddingSize
@@ -189,853 +156,12 @@ TORCH_META_FUNC(replication_pad3d) (
   int64_t dimslices = 0;
   int64_t nbatch = 1;
 
-  shapeCheck3d(input, pleft, pright, ptop, pbottom, pfront, pback);
-
-  if (input.dim() == 5)
-  {
-    nbatch = input.size(0);
-    dimw++;
-    dimh++;
-    dimd++;
-    dimslices++;
-  }
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t idepth = input.size(dimd);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t odepth = idepth + pfront + pback;
-  int64_t oheight = iheight + ptop + pbottom;
-  int64_t owidth  = iwidth + pleft + pright;
-
-  /* resize output */
-  if (input.dim() == 4) {
-    set_output({nslices, odepth, oheight, owidth}, input.options());
-  } else {
-    set_output({nbatch, nslices, odepth, oheight, owidth}, input.options());
-  }
-}
-
-} // namespace meta
-
-namespace native {
-
-namespace {
-template <typename scalar_t>
-static void replication_pad1d_out_frame(
-    scalar_t *input_p, scalar_t *output_p,
-    long nslices,
-    long iwidth,
-    long owidth,
-    int pad_l, int pad_r)
-{
-  int iStartX = std::max(0, -pad_l);
-  int oStartX = std::max(0, pad_l);
-
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    long ip_x;
-    for (auto k = start; k < end; k++)
-    {
-      for (long j = 0; j < owidth; j++) {
-        if (j < pad_l) {
-          ip_x = pad_l;
-        } else if (j >= pad_l && j < iwidth + pad_l) {
-          ip_x = j;
-        } else {
-          ip_x = iwidth + pad_l - 1;
-        }
-        ip_x = ip_x - oStartX + iStartX;
-
-        scalar_t *dest_p = output_p + k*owidth + j;
-        scalar_t *src_p = input_p + k*iwidth + ip_x;
-        *dest_p = *src_p;
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad1d_out_batch(
-    scalar_t *input_data, scalar_t *output_data,
-    long nslices,
-    long iwidth,
-    long owidth,
-    int pad_l, int pad_r,
-    int nbatch)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
-      scalar_t *input_p = input_data+p*nslices*iwidth;
-      scalar_t *output_p = output_data+p*nslices*owidth;
-      replication_pad1d_out_frame(input_p, output_p, nslices, iwidth, owidth, pad_l, pad_r);
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad1d_backward_out_frame(
-    scalar_t *ginput_p, scalar_t *goutput_p,
-    long nslices,
-    long iwidth,
-    long owidth,
-    int pad_l, int pad_r)
-{
-  int iStartX = std::max(0, -pad_l);
-  int oStartX = std::max(0, pad_l);
-
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    long ip_x;
-    for (auto k = start; k < end; k++)
-    {
-      for (long j = 0; j < owidth; j++) {
-        if (j < pad_l) {
-          ip_x = pad_l;
-        } else if (j >= pad_l && j < iwidth + pad_l) {
-          ip_x = j;
-        } else {
-          ip_x = iwidth + pad_l - 1;
-        }
-        ip_x = ip_x - oStartX + iStartX;
-
-        scalar_t *src_p = goutput_p + k*owidth + j;
-        scalar_t *dest_p = ginput_p + k*iwidth + ip_x;
-        *dest_p += *src_p;
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad1d_backward_out_batch(
-    scalar_t *ginput_data, scalar_t *goutput_data,
-    long nslices,
-    long iwidth,
-    long owidth,
-    int pad_l, int pad_r,
-    int nbatch)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
-      scalar_t *ginput_p = ginput_data + p * nslices * iwidth;
-      scalar_t *goutput_p = goutput_data + p * nslices * owidth;
-      replication_pad1d_backward_out_frame(ginput_p, goutput_p,
-        nslices, iwidth, owidth, pad_l, pad_r);
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad2d_out_frame(
-    scalar_t *input_p, scalar_t *output_p,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight,
-    int64_t owidth, int64_t oheight,
-    int pad_l, int pad_r,
-    int pad_t, int pad_b)
-{
-  int iStartX = std::max(0, -pad_l);
-  int iStartY = std::max(0, -pad_t);
-  int oStartX = std::max(0, pad_l);
-  int oStartY = std::max(0, pad_t);
-
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++)
-    {
-      for (int64_t i = 0; i < oheight; i++) {
-        for (int64_t j = 0; j < owidth; j++) {
-          if (j < pad_l) {
-            ip_x = pad_l;
-          } else if (j >= pad_l && j < iwidth + pad_l) {
-            ip_x = j;
-          } else {
-            ip_x = iwidth + pad_l - 1;
-          }
-          ip_x = ip_x - oStartX + iStartX;
-
-          if (i < pad_t) {
-            ip_y = pad_t;
-          } else if (i >= pad_t && i < iheight + pad_t) {
-            ip_y = i;
-          } else {
-            ip_y = iheight + pad_t - 1;
-          }
-          ip_y = ip_y - oStartY + iStartY;
-
-          scalar_t *dest_p = output_p + k*owidth*oheight + i * owidth + j;
-          scalar_t *src_p = input_p + k*iwidth*iheight + ip_y * iwidth + ip_x;
-          *dest_p = *src_p;
-        }
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad2d_out_batch(
-    scalar_t *input_data, scalar_t *output_data,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight,
-    int64_t owidth, int64_t oheight,
-    int pad_l, int pad_r,
-    int pad_t, int pad_b,
-    int nbatch)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
-      scalar_t *input_p = input_data+p*nslices*iwidth*iheight;
-      scalar_t *output_p = output_data+p*nslices*owidth*oheight;
-      replication_pad2d_out_frame(input_p, output_p, nslices,
-          iwidth, iheight, owidth, oheight, pad_l, pad_r, pad_t, pad_b);
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad2d_backward_out_frame(
-    scalar_t *ginput_p, scalar_t *goutput_p,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight,
-    int64_t owidth, int64_t oheight,
-    int pad_l, int pad_r,
-    int pad_t, int pad_b)
-{
-  int iStartX = std::max(0, -pad_l);
-  int iStartY = std::max(0, -pad_t);
-  int oStartX = std::max(0, pad_l);
-  int oStartY = std::max(0, pad_t);
-
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++)
-    {
-      for (int64_t i = 0; i < oheight; i++) {
-        for (int64_t j = 0; j < owidth; j++) {
-          if (j < pad_l) {
-            ip_x = pad_l;
-          } else if (j >= pad_l && j < iwidth + pad_l) {
-            ip_x = j;
-          } else {
-            ip_x = iwidth + pad_l - 1;
-          }
-          ip_x = ip_x - oStartX + iStartX;
-
-          if (i < pad_t) {
-            ip_y = pad_t;
-          } else if (i >= pad_t && i < iheight + pad_t) {
-            ip_y = i;
-          } else {
-            ip_y = iheight + pad_t - 1;
-          }
-          ip_y = ip_y - oStartY + iStartY;
-
-          scalar_t *src_p = goutput_p + k*owidth*oheight + i * owidth + j;
-          scalar_t *dest_p = ginput_p + k*iwidth*iheight + ip_y * iwidth + ip_x;
-          *dest_p += *src_p;
-        }
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad2d_backward_out_batch(
-    scalar_t *ginput_data, scalar_t *goutput_data,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight,
-    int64_t owidth, int64_t oheight,
-    int pad_l, int pad_r,
-    int pad_t, int pad_b,
-    int nbatch)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
-      scalar_t *ginput_p = ginput_data + p * nslices * iheight * iwidth;
-      scalar_t *goutput_p = goutput_data + p * nslices * oheight * owidth;
-      replication_pad2d_backward_out_frame(ginput_p, goutput_p, nslices,
-          iwidth, iheight, owidth, oheight, pad_l, pad_r, pad_t, pad_b);
-    }
-  });
-}
-
-Tensor& replication_pad2d_backward_out_cpu_template(
-    Tensor& gradInput,
-    const Tensor& gradOutput_,
-    const Tensor& input,
-    IntArrayRef paddingSize)
-{
-  TORCH_CHECK(paddingSize.size() == 4, "padding size is expected to be 4");
-  int pad_l = paddingSize[0];
-  int pad_r = paddingSize[1];
-  int pad_t = paddingSize[2];
-  int pad_b = paddingSize[3];
-  int dimw = 2;
-  int dimh = 1;
-  int dimslices = 0;
-  int64_t nbatch = 1;
-
-  if (input.dim() == 4)
-  {
-    nbatch = input.size(0);
-    dimw++;
-    dimh++;
-    dimslices++;
-  }
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t oheight = iheight + pad_t + pad_b;
-  int64_t owidth  = iwidth + pad_l + pad_r;
-
-  TORCH_CHECK(owidth == gradOutput_.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
-      gradOutput_.size(dimw));
-  TORCH_CHECK(oheight == gradOutput_.size(dimh),
-      "gradOutput height unexpected. Expected: ", oheight, ", Got: ",
-      gradOutput_.size(dimh));
-
-  /* get contiguous gradOutput */
-  auto gradOutput = gradOutput_.contiguous();
-
-  /* resize */
-  gradInput.resize_as_(input);
-  if (gradInput.numel() == 0) {
-    return gradInput;
-  }
-
-  gradInput.zero_();
-
-  /* backprop */
-  if (input.dim() == 3)
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      input.scalar_type(), "replication_pad2d_backward_cpu", [&] {
-      replication_pad2d_backward_out_frame<scalar_t>(
-        gradInput.data_ptr<scalar_t>(),
-        gradOutput.data_ptr<scalar_t>(),
-        nslices,
-        iwidth, iheight,
-        owidth, oheight,
-        pad_l, pad_r,
-        pad_t, pad_b);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      input.scalar_type(), "replication_pad2d_backward_cpu", [&] {
-      replication_pad2d_backward_out_batch<scalar_t>(
-        gradInput.data_ptr<scalar_t>(),
-        gradOutput.data_ptr<scalar_t>(),
-        nslices,
-        iwidth, iheight,
-        owidth, oheight,
-        pad_l, pad_r,
-        pad_t, pad_b,
-        nbatch);
-      }
-    );
-  }
-  return gradInput;
-}
-
-template <typename scalar_t>
-static void replication_pad3d_out_frame(
-    scalar_t *input_p, scalar_t *output_p,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight, int64_t idepth,
-    int64_t owidth, int64_t oheight, int64_t odepth,
-    int pleft, int pright,
-    int ptop, int pbottom,
-    int pfront, int pback)
-{
-  int iStartX = std::max(0, -pleft);
-  int iStartY = std::max(0, -ptop);
-  int iStartZ = std::max(0, -pfront);
-  int oStartX = std::max(0, pleft);
-  int oStartY = std::max(0, ptop);
-  int oStartZ = std::max(0, pfront);
-
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    int64_t ip_x, ip_y, ip_z;
-    for (auto k = start; k < end; k++) {
-      for (int64_t z = 0; z < odepth; z++) {
-        for (int64_t i = 0; i < oheight; i++) {
-          for (int64_t j = 0; j < owidth; j++) {
-            if (j < pleft) {
-              ip_x = pleft;
-            } else if (j >= pleft && j < iwidth + pleft) {
-              ip_x = j;
-            } else {
-              ip_x = iwidth + pleft - 1;
-            }
-            ip_x = ip_x - oStartX + iStartX;
-
-            if (i < ptop) {
-              ip_y = ptop;
-            } else if (i >= ptop && i < iheight + ptop) {
-              ip_y = i;
-            } else {
-              ip_y = iheight + ptop - 1;
-            }
-            ip_y = ip_y - oStartY + iStartY;
-
-            if (z < pfront) {
-              ip_z = pfront;
-            } else if (z >= pfront && z < idepth + pfront) {
-              ip_z = z;
-            } else {
-              ip_z = idepth + pfront - 1;
-            }
-            ip_z = ip_z - oStartZ + iStartZ;
-
-            scalar_t *dest_p = output_p + k * owidth * oheight * odepth +
-              z * owidth * oheight + i * owidth + j;
-            scalar_t *src_p = input_p + k * iwidth * iheight * idepth +
-              ip_z * iwidth * iheight + ip_y * iwidth + ip_x;
-            *dest_p = *src_p;
-          }
-        }
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad3d_out_batch(
-    scalar_t *input_data, scalar_t *output_data,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight, int64_t idepth,
-    int64_t owidth, int64_t oheight, int64_t odepth,
-    int pleft, int pright,
-    int ptop, int pbottom,
-    int pfront, int pback,
-    int nbatch)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
-      scalar_t *input_p = input_data + p * nslices * iwidth * iheight * idepth;
-      scalar_t *output_p = output_data + p * nslices * owidth * oheight * odepth;
-      replication_pad3d_out_frame(input_p, output_p, nslices,
-          iwidth, iheight, idepth, owidth, oheight, odepth,
-          pleft, pright, ptop, pbottom, pfront, pback);
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad3d_backward_out_frame(
-    scalar_t *ginput_p, scalar_t *goutput_p,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight, int64_t idepth,
-    int64_t owidth, int64_t oheight, int64_t odepth,
-    int pleft, int pright,
-    int ptop, int pbottom,
-    int pfront, int pback)
-{
-  int iStartX = std::max(0, -pleft);
-  int iStartY = std::max(0, -ptop);
-  int iStartZ = std::max(0, -pfront);
-  int oStartX = std::max(0, pleft);
-  int oStartY = std::max(0, ptop);
-  int oStartZ = std::max(0, pfront);
-
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    int64_t ip_x, ip_y, ip_z;
-    for (auto k = start; k < end; k++) {
-      for (int64_t z = 0; z < odepth; z++) {
-        for (int64_t i = 0; i < oheight; i++) {
-          for (int64_t j = 0; j < owidth; j++) {
-            if (j < pleft) {
-              ip_x = pleft;
-            } else if (j >= pleft && j < iwidth + pleft) {
-              ip_x = j;
-            } else {
-              ip_x = iwidth + pleft - 1;
-            }
-            ip_x = ip_x - oStartX + iStartX;
-
-            if (i < ptop) {
-              ip_y = ptop;
-            } else if (i >= ptop && i < iheight + ptop) {
-              ip_y = i;
-            } else {
-              ip_y = iheight + ptop - 1;
-            }
-            ip_y = ip_y - oStartY + iStartY;
-
-            if (z < pfront) {
-              ip_z = pfront;
-            } else if (z >= pfront && z < idepth + pfront) {
-              ip_z = z;
-            } else {
-              ip_z = idepth + pfront - 1;
-            }
-            ip_z = ip_z - oStartZ + iStartZ;
-
-            scalar_t *src_p = goutput_p + k * owidth * oheight * odepth +
-              z * owidth * oheight + i * owidth + j;
-            scalar_t *dest_p = ginput_p + k * iwidth * iheight * idepth +
-              ip_z * iwidth * iheight + ip_y * iwidth + ip_x;
-            *dest_p += *src_p;
-          }
-        }
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void replication_pad3d_backward_out_batch(
-    scalar_t *ginput_data, scalar_t *goutput_data,
-    int64_t nslices,
-    int64_t iwidth, int64_t iheight, int64_t idepth,
-    int64_t owidth, int64_t oheight, int64_t odepth,
-    int pleft, int pright,
-    int ptop, int pbottom,
-    int pfront, int pback,
-    int nbatch)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
-      scalar_t *ginput_p = ginput_data + p * nslices * idepth * iheight * iwidth;
-      scalar_t *goutput_p = goutput_data + p * nslices * odepth * oheight * owidth;
-      replication_pad3d_backward_out_frame(ginput_p, goutput_p, nslices,
-          iwidth, iheight, idepth, owidth, oheight, odepth,
-          pleft, pright, ptop, pbottom, pfront, pback);
-    }
-  });
-}
-
-Tensor& replication_pad3d_backward_out_cpu_template(
-    Tensor& gradInput,
-    const Tensor& gradOutput_,
-    const Tensor& input,
-    IntArrayRef paddingSize)
-{
-  TORCH_CHECK(paddingSize.size() == 6, "padding size is expected to be 6");
-  int pleft = paddingSize[0];
-  int pright = paddingSize[1];
-  int ptop = paddingSize[2];
-  int pbottom = paddingSize[3];
-  int pfront = paddingSize[4];
-  int pback = paddingSize[5];
-  int dimw = 3;
-  int dimh = 2;
-  int dimd = 1;
-  int dimslices = 0;
-  int64_t nbatch = 1;
-
-  if (input.dim() == 5)
-  {
-    nbatch = input.size(0);
-    dimw++;
-    dimh++;
-    dimd++;
-    dimslices++;
-  }
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t idepth = input.size(dimd);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t odepth = idepth + pfront + pback;
-  int64_t oheight = iheight + ptop + pbottom;
-  int64_t owidth  = iwidth + pleft + pright;
-
-
-  shapeCheck3d(input, pleft, pright,
-      ptop, pbottom, pfront, pback);
-
-  /* get contiguous gradOutput */
-  auto gradOutput = gradOutput_.contiguous();
-
-  /* resize */
-  gradInput.resize_as_(input);
-  if (gradInput.numel() == 0) {
-    return gradInput;
-  }
-  gradInput.zero_();
-
-  /* backprop */
-  if (input.dim() == 4)
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      input.scalar_type(), "replication_pad3d_backward_cpu", [&] {
-      replication_pad3d_backward_out_frame<scalar_t> (
-        gradInput.data_ptr<scalar_t>(),
-        gradOutput.data_ptr<scalar_t>(),
-        nslices,
-        iwidth, iheight, idepth,
-        owidth, oheight, odepth,
-        pleft, pright,
-        ptop, pbottom,
-        pfront, pback);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      input.scalar_type(), "replication_pad3d_backward_cpu", [&] {
-      replication_pad3d_backward_out_batch<scalar_t> (
-        gradInput.data_ptr<scalar_t>(),
-        gradOutput.data_ptr<scalar_t>(),
-        nslices,
-        iwidth, iheight, idepth,
-        owidth, oheight, odepth,
-        pleft, pright,
-        ptop, pbottom,
-        pfront, pback,
-        nbatch);
-      }
-    );
-  }
-  return gradInput;
-}
-} // namespace
-
-TORCH_IMPL_FUNC(replication_pad1d_out_cpu) (
-  const Tensor& input_, IntArrayRef paddingSize, const Tensor& output
-) {
-  constexpr int64_t dimw = -1;
-  constexpr int64_t dimslices = -2;
-
-  int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
-
-  /* get contiguous input */
-  auto input = input_.contiguous();
-
-  int64_t nbatch = 1;
-  if (input.ndimension() == 3) {
-    nbatch = input.size(0);
-  }
-
-  /* sizes */
-  long nslices = input.size(dimslices);
-  long iwidth = input.size(dimw);
-  long owidth = output.size(dimw);
-
-  if (input.ndimension() == 2)
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad1d_cpu", [&] {
-      auto input_data = input.data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      replication_pad1d_out_frame<scalar_t>(
-        input_data,
-        output_data,
-        nslices,
-        iwidth,
-        owidth,
-        pad_l, pad_r);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad1d_cpu", [&] {
-      auto input_data = input.data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      replication_pad1d_out_batch<scalar_t>(
-        input_data,
-        output_data,
-        nslices,
-        iwidth,
-        owidth,
-        pad_l, pad_r,
-        nbatch);
-      }
-    );
-  }
-}
-
-TORCH_IMPL_FUNC(replication_pad1d_backward_out_cpu) (
-  const Tensor& gradOutput_, const Tensor& input, IntArrayRef paddingSize, const Tensor& gradInput
-) {
-  int64_t dimw = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
-  int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
-
-  if (input.ndimension() == 3)
-  {
-    nbatch = input.size(0);
-    dimw++;
-    dimslices++;
-  }
-
-  /* get contiguous gradOutput */
-  auto gradOutput = gradOutput_.contiguous();
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t iwidth  = input.size(dimw);
-  int64_t owidth  = gradOutput.size(dimw);
-
-  TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth,
-      " Got: ", gradOutput_.size(dimw));
-
-  if (gradInput.numel() == 0) {
-    return;
-  }
-
-  gradInput.zero_();
-
-  /* backprop */
-  if (input.ndimension() == 2)
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      input.scalar_type(), "replication_pad1d_backward_cpu", [&] {
-      scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-      scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-
-      replication_pad1d_backward_out_frame<scalar_t> (
-        gradInput_data,
-        gradOutput_data,
-        nslices,
-        iwidth,
-        owidth,
-        pad_l, pad_r);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      input.scalar_type(), "replication_pad1d_backward_cpu", [&] {
-      scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-      scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-
-      replication_pad1d_backward_out_batch<scalar_t> (
-        gradInput_data,
-        gradOutput_data,
-        nslices,
-        iwidth,
-        owidth,
-        pad_l, pad_r,
-        nbatch);
-      }
-    );
-  }
-}
-
-TORCH_IMPL_FUNC(replication_pad2d_out_cpu) (
-  const Tensor& input_, IntArrayRef paddingSize, const Tensor& output
-) {
-  int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
-  int64_t pad_t = paddingSize[2];
-  int64_t pad_b = paddingSize[3];
-  int64_t dimw = 2;
-  int64_t dimh = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
-  if (input_.dim() == 4) {
-    nbatch = input_.size(0);
-    dimw++;
-    dimh++;
-    dimslices++;
-  }
-
-  int64_t nslices = input_.size(dimslices);
-  int64_t iheight = input_.size(dimh);
-  int64_t iwidth = input_.size(dimw);
-  int64_t oheight = iheight + pad_t + pad_b;
-  int64_t owidth  = iwidth + pad_l + pad_r;
-
-  /* get contiguous input */
-  auto input = input_.contiguous();
-
-  /* resize output */
-  if (input.dim() == 3)
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad2d_cpu", [&] {
-      auto input_data = input.data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      replication_pad2d_out_frame<scalar_t> (input_data, output_data,
-        nslices,
-        iwidth, iheight,
-        owidth, oheight,
-        pad_l, pad_r,
-        pad_t, pad_b);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad2d_cpu", [&] {
-      auto input_data = input.data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      replication_pad2d_out_batch<scalar_t> (input_data, output_data,
-        nslices,
-        iwidth, iheight,
-        owidth, oheight,
-        pad_l, pad_r,
-        pad_t, pad_b,
-        nbatch);
-      }
-    );
-  }
-}
-
-Tensor& replication_pad2d_backward_out_cpu(const Tensor& gradOutput,
-    const Tensor& input,
-    IntArrayRef paddingSize,
-    Tensor& gradInput)
-{
-  replication_pad2d_backward_out_cpu_template(
-      gradInput, gradOutput, input, paddingSize);
-  return gradInput;
-}
-
-Tensor replication_pad2d_backward_cpu(
-    const Tensor& gradOutput,
-    const Tensor& input,
-    IntArrayRef paddingSize)
-{
-  auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  replication_pad2d_backward_out_cpu_template(
-      gradInput, gradOutput, input, paddingSize);
-  return gradInput;
-}
-
-TORCH_IMPL_FUNC(replication_pad3d_out_cpu) (
-  const Tensor& input_, IntArrayRef paddingSize, const Tensor& output
-) {
-  int64_t pleft = paddingSize[0];
-  int64_t pright = paddingSize[1];
-  int64_t ptop = paddingSize[2];
-  int64_t pbottom = paddingSize[3];
-  int64_t pfront = paddingSize[4];
-  int64_t pback = paddingSize[5];
-  int64_t dimw = 3;
-  int64_t dimh = 2;
-  int64_t dimd = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
-
-  /* get contiguous input */
-  auto input = input_.contiguous();
+  bool valid_dims = input.size(1) != 0 && input.size(2) != 0 && input.size(3) != 0;
+  TORCH_CHECK(
+      (input.dim() == 4 && input.size(0) != 0 && valid_dims) ||
+      (input.dim() == 5 && valid_dims && input.size(4) != 0),
+      "Expected 4D or 5D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
+      input.sizes());
 
   if (input.dim() == 5) {
     nbatch = input.size(0);
@@ -1047,59 +173,121 @@ TORCH_IMPL_FUNC(replication_pad3d_out_cpu) (
 
   /* sizes */
   int64_t nslices = input.size(dimslices);
-  int64_t idepth  = input.size(dimd);
+  int64_t idepth = input.size(dimd);
   int64_t iheight = input.size(dimh);
-  int64_t iwidth  = input.size(dimw);
-  int64_t odepth  = output.size(dimd);
-  int64_t oheight = output.size(dimh);
-  int64_t owidth  = output.size(dimw);
+  int64_t iwidth = input.size(dimw);
+  int64_t odepth = idepth + pfront + pback;
+  int64_t oheight = iheight + ptop + pbottom;
+  int64_t owidth = iwidth + pleft + pright;
 
-  /* resize output */
+  TORCH_CHECK(owidth >= 1 || oheight >= 1 || odepth >= 1,
+      "input (D: ", idepth, " H: ", iheight, ", W: ", iwidth,
+      ") is too small."
+      " Calculated output D: ", odepth, " H: ", oheight, " W: ", owidth);
+
+  auto memory_format = input.suggest_memory_format();
   if (input.dim() == 4) {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad3d_cpu", [&] {
-      auto input_data = input.data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      replication_pad3d_out_frame<scalar_t>(
-        input_data, output_data, nslices, iwidth, iheight, idepth,
-        owidth, oheight, odepth, pleft, pright, ptop, pbottom, pfront,
-        pback);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad3d_cpu", [&] {
-      auto input_data = input.data_ptr<scalar_t>();
-      auto output_data = output.data_ptr<scalar_t>();
-      replication_pad3d_out_batch<scalar_t>(
-        input_data, output_data, nslices, iwidth, iheight, idepth,
-        owidth, oheight, odepth, pleft, pright, ptop, pbottom, pfront,
-        pback,
-        nbatch);
-      }
-    );
+    set_output({nslices, odepth, oheight, owidth}, input.options());
+  } else {
+    set_output({nbatch, nslices, odepth, oheight, owidth}, input.options().memory_format(memory_format));
   }
 }
 
-Tensor& replication_pad3d_backward_out_cpu(const Tensor& gradOutput,
-    const Tensor& input,
-    IntArrayRef paddingSize,
-    Tensor& gradInput)
-{
-  replication_pad3d_backward_out_cpu_template(
-      gradInput, gradOutput, input, paddingSize);
-  return gradInput;
+TORCH_META_FUNC(replication_pad3d_backward) (
+  const Tensor& gradOutput,
+  const Tensor& input,
+  IntArrayRef paddingSize
+) {
+  TORCH_CHECK(paddingSize.size() == 6, "padding size is expected to be 6");
+  int64_t pleft = paddingSize[0];
+  int64_t pright = paddingSize[1];
+  int64_t ptop = paddingSize[2];
+  int64_t pbottom = paddingSize[3];
+  int64_t pfront = paddingSize[4];
+  int64_t pback = paddingSize[5];
+  int64_t dimd = -3;
+  int64_t dimh = -2;
+  int64_t dimw = -1;
+
+  int64_t idepth = input.size(dimd);
+  int64_t iheight = input.size(dimh);
+  int64_t iwidth = input.size(dimw);
+  int64_t odepth = idepth + pfront + pback;
+  int64_t oheight = iheight + ptop + pbottom;
+  int64_t owidth = iwidth + pleft + pright;
+
+  TORCH_CHECK(owidth == gradOutput.size(dimw),
+      "gradOutput width unexpected. Expected: ", owidth, ", Got: ", gradOutput.size(dimw));
+  TORCH_CHECK(oheight == gradOutput.size(dimh),
+      "gradOutput height unexpected. Expected: ", oheight, ", Got: ", gradOutput.size(dimh));
+  TORCH_CHECK(odepth == gradOutput.size(dimd),
+      "gradOutput depth unexpected. Expected: ", odepth, ", Got: ", gradOutput.size(dimd));
+
+  auto memory_format = input.suggest_memory_format();
+  set_output(input.sizes(), input.options().memory_format(memory_format));
 }
 
-Tensor replication_pad3d_backward_cpu(
-    const Tensor& gradOutput,
-    const Tensor& input,
-    IntArrayRef paddingSize)
-{
-  auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  replication_pad3d_backward_out_cpu_template(
-      gradInput, gradOutput, input, paddingSize);
-  return gradInput;
+} // namespace meta
+
+namespace native { 
+
+TORCH_IMPL_FUNC(replication_pad1d_out_cpu) (
+  const Tensor& input, IntArrayRef paddingSize, const Tensor& output
+) {
+  replication_pad1d_kernel(kCPU, output, input, paddingSize);
 }
+
+TORCH_IMPL_FUNC(replication_pad1d_backward_out_cpu) (
+  const Tensor& gradOutput, const Tensor& input, IntArrayRef paddingSize, const Tensor& gradInput
+) {
+  if (gradInput.numel() == 0) {
+    return;
+  }
+
+  gradInput.zero_();
+  replication_pad1d_backward_kernel(kCPU, gradInput, gradOutput, paddingSize);
+}
+
+TORCH_IMPL_FUNC(replication_pad2d_out_cpu) (
+  const Tensor& input, IntArrayRef paddingSize, const Tensor& output
+) {
+  replication_pad2d_kernel(kCPU, output, input, paddingSize);
+}
+
+TORCH_IMPL_FUNC(replication_pad2d_backward_out_cpu) (
+  const Tensor& gradOutput, const Tensor& input, IntArrayRef paddingSize, const Tensor& gradInput
+) {
+  if (gradInput.numel() == 0) {
+    return;
+  }
+
+  gradInput.zero_();
+  replication_pad2d_backward_kernel(kCPU, gradInput, gradOutput, paddingSize);
+}
+
+TORCH_IMPL_FUNC(replication_pad3d_out_cpu) (
+  const Tensor& input, IntArrayRef paddingSize, const Tensor& output
+) {
+  replication_pad3d_kernel(kCPU, output, input, paddingSize);
+}
+
+TORCH_IMPL_FUNC(replication_pad3d_backward_out_cpu) (
+  const Tensor& gradOutput, const Tensor& input, IntArrayRef paddingSize, const Tensor& gradInput
+) {
+  if (gradInput.numel() == 0) {
+    return;
+  }
+
+  gradInput.zero_();
+  replication_pad3d_backward_kernel(kCPU, gradInput, gradOutput, paddingSize);
+}
+
+DEFINE_DISPATCH(replication_pad1d_kernel);
+DEFINE_DISPATCH(replication_pad1d_backward_kernel);
+DEFINE_DISPATCH(replication_pad2d_kernel);
+DEFINE_DISPATCH(replication_pad2d_backward_kernel);
+DEFINE_DISPATCH(replication_pad3d_kernel);
+DEFINE_DISPATCH(replication_pad3d_backward_kernel);
+
 } // at::native
 } // at

--- a/aten/src/ATen/native/cpu/PaddingKernel.cpp
+++ b/aten/src/ATen/native/cpu/PaddingKernel.cpp
@@ -1,0 +1,366 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/native/Padding.h>
+#include <ATen/native/cpu/utils.h>
+
+namespace at { namespace native {
+
+namespace {
+
+template <typename scalar_t, typename Indexr>
+void cpu_padding(
+    const Tensor& output_,
+    const Tensor& input_,
+    int p_left, int p_right,
+    int p_top, int p_bottom,
+    int p_front, int p_back,
+    bool is_batch_mode) {
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+
+  scalar_t* input_data = input.data_ptr<scalar_t>();
+  scalar_t* output_data = output.data_ptr<scalar_t>();
+
+  PaddingParams p(input, output, is_batch_mode);
+
+  Indexr width_indexr(p_left, p.input_width);
+  Indexr height_indexr(p_top, p.input_height);
+  Indexr depth_indexr(p_front, p.input_depth);
+
+  // parallel on dim N, C
+  at::parallel_for(0, p.nbatch * p.channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; i++) {
+      scalar_t* input_ptr = input_data + i * p.input_depth * p.input_height * p.input_width;
+      scalar_t* output_ptr = output_data + i * p.output_depth * p.output_height * p.output_width;
+
+      for (int64_t od = 0; od < p.output_depth; od++) {
+        int64_t id = depth_indexr.get(od);
+
+        for (int64_t oh = 0; oh < p.output_height; oh++) {
+          int64_t ih = height_indexr.get(oh);
+
+          for (int64_t ow = 0; ow < p.output_width; ow++) {
+            int64_t iw = width_indexr.get(ow);
+
+            int64_t input_offset = id * p.input_height * p.input_width + ih * p.input_width + iw;
+            int64_t output_offset = od * p.output_height * p.output_width + oh * p.output_width + ow;
+            output_ptr[output_offset] = input_ptr[input_offset];
+          }
+        }
+      }
+    }
+  });
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t, typename Indexr>
+void cpu_padding_channels_last(
+    const Tensor& output_,
+    const Tensor& input_,
+    int p_left, int p_right,
+    int p_top, int p_bottom,
+    int p_front, int p_back) {
+  auto memory_format = input_.suggest_memory_format();
+
+  auto input = input_.contiguous(memory_format);
+  auto output = output_.contiguous(memory_format);
+
+  scalar_t* input_data = input.data_ptr<scalar_t>();
+  scalar_t* output_data = output.data_ptr<scalar_t>();
+
+  PaddingParams p(input, output, /* is_batch_mode */ true);
+
+  Indexr width_indexr(p_left, p.input_width);
+  Indexr height_indexr(p_top, p.input_height);
+  Indexr depth_indexr(p_front, p.input_depth);
+
+  using Vec = vec::Vectorized<scalar_t>;
+  // parallel on dim N, {D}, H, W
+  at::parallel_for(0, p.nbatch * p.output_depth * p.output_height * p.output_width, 0, [&](int64_t begin, int64_t end) {
+    int64_t n = 0;
+    int64_t od = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, n, p.nbatch, od, p.output_depth, oh, p.output_height, ow, p.output_width);
+
+    int64_t size = p.channels;
+    int64_t len = size - (size % Vec::size());
+    for (int64_t i = begin; i < end; i++) {
+      int64_t id = depth_indexr.get(od);
+      int64_t ih = height_indexr.get(oh);
+      int64_t iw = width_indexr.get(ow);
+
+      scalar_t* in = input_data + (n * p.input_depth * p.input_height * p.input_width +
+          id * p.input_height * p.input_width + ih * p.input_width + iw) * p.channels;
+      scalar_t* out = output_data + i * p.channels;
+      int64_t d = 0;
+      for (; d < len; d += Vec::size()) {
+        Vec out_vec = Vec::loadu(in + d);
+        out_vec.store(out + d);
+      }
+      for (; d < size; d++) {
+        out[d] = in[d];
+      }
+
+      // move on to next output index
+      data_index_step(n, p.nbatch, od, p.output_depth, oh, p.output_height, ow, p.output_width);
+    }
+  });
+
+  if (!output_.is_contiguous(memory_format)) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t, typename Indexr>
+void cpu_padding_backward(
+    const Tensor& grad_input_,
+    const Tensor& grad_output_,
+    int p_left, int p_right,
+    int p_top, int p_bottom,
+    int p_front, int p_back,
+    bool is_batch_mode) {
+  auto grad_output = grad_output_.contiguous();
+  auto grad_input = grad_input_.contiguous();
+
+  scalar_t* grad_output_data = grad_output.data_ptr<scalar_t>();
+  scalar_t* grad_input_data = grad_input.data_ptr<scalar_t>();
+
+  PaddingParams p(grad_input, grad_output, is_batch_mode);
+
+  Indexr width_indexr(p_left, p.input_width);
+  Indexr height_indexr(p_top, p.input_height);
+  Indexr depth_indexr(p_front, p.input_depth);
+
+  // parallel on dim N, C
+  at::parallel_for(0, p.nbatch * p.channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; i++) {
+      scalar_t* grad_input_ptr = grad_input_data + i * p.input_depth * p.input_height * p.input_width;
+      scalar_t* grad_output_ptr = grad_output_data + i * p.output_depth * p.output_height * p.output_width;
+
+      for (int64_t od = 0; od < p.output_depth; od++) {
+        int64_t id = depth_indexr.get(od);
+
+        for (int64_t oh = 0; oh < p.output_height; oh++) {
+          int64_t ih = height_indexr.get(oh);
+
+          for (int64_t ow = 0; ow < p.output_width; ow++) {
+            int64_t iw = width_indexr.get(ow);
+
+            int64_t input_offset = id * p.input_height * p.input_width + ih * p.input_width + iw;
+            int64_t output_offset = od * p.output_height * p.output_width + oh * p.output_width + ow;
+            grad_input_ptr[input_offset] += grad_output_ptr[output_offset];
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous()) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+template <typename scalar_t, typename Indexr>
+void cpu_padding_backward_channels_last(
+    const Tensor& grad_input_,
+    const Tensor& grad_output_,
+    int p_left, int p_right,
+    int p_top, int p_bottom,
+    int p_front, int p_back) {
+  auto memory_format = grad_output_.suggest_memory_format();
+
+  auto grad_output = grad_output_.contiguous(memory_format);
+  auto grad_input = grad_input_.contiguous(memory_format);
+
+  scalar_t* grad_output_data = grad_output.data_ptr<scalar_t>();
+  scalar_t* grad_input_data = grad_input.data_ptr<scalar_t>();
+
+  PaddingParams p(grad_input, grad_output, /* is_batch_mode */ true);
+
+  Indexr width_indexr(p_left, p.input_width);
+  Indexr height_indexr(p_top, p.input_height);
+  Indexr depth_indexr(p_front, p.input_depth);
+
+  using Vec = vec::Vectorized<scalar_t>;
+  // parallel on dim N
+  at::parallel_for(0, p.nbatch, 0, [&](int64_t begin, int64_t end) {
+    int64_t size = p.channels;
+    int64_t len = size - (size % Vec::size());
+    for (int64_t n = begin; n < end; n++) {
+      for (int64_t od = 0; od < p.output_depth; od++) {
+        int64_t id = depth_indexr.get(od);
+
+        for (int64_t oh = 0; oh < p.output_height; oh++) {
+          int64_t ih = height_indexr.get(oh);
+
+          for (int64_t ow = 0; ow < p.output_width; ow++) {
+            int64_t iw = width_indexr.get(ow);
+
+            scalar_t* gin = grad_input_data + (n * p.input_depth * p.input_height * p.input_width +
+                id * p.input_height * p.input_width + ih * p.input_width + iw) * p.channels;
+            scalar_t* gout = grad_output_data + (n * p.output_depth * p.output_height * p.output_width +
+                od * p.output_height * p.output_width + oh * p.output_width + ow) * p.channels;
+            int64_t d = 0;
+            for (; d < len; d += Vec::size()) {
+              Vec gin_vec = Vec::loadu(gin + d) + Vec::loadu(gout + d);
+              gin_vec.store(gin + d);
+            }
+            for (; d < size; d++) {
+              gin[d] += gout[d];
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous(memory_format)) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+void replication_pad1d_kernel_impl(
+    const Tensor& output,
+    const Tensor& input,
+    IntArrayRef padding_size) {
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad1d", [&] {
+    bool is_batch_mode = input.ndimension() == static_cast<int64_t>(3);
+    cpu_padding<scalar_t, ReplicationPadIndexr>(
+        output, input, padding_size[0], padding_size[1], /* p_top */ 0, /* p_bottom */ 0, /* p_front */ 0, /* p_back */ 0,
+        is_batch_mode);
+  });
+}
+
+void replication_pad1d_backward_kernel_impl(
+    const Tensor& grad_input,
+    const Tensor& grad_output,
+    IntArrayRef padding_size) {
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(grad_output.scalar_type(), "replication_pad1d_backward", [&] {
+    bool is_batch_mode = grad_output.ndimension() == static_cast<int64_t>(3);
+    cpu_padding_backward<scalar_t, ReplicationPadIndexr>(
+        grad_input, grad_output, padding_size[0], padding_size[1], /* p_top */ 0, /* p_bottom */ 0, /* p_front */ 0, /* p_back */ 0,
+        is_batch_mode);
+  });
+}
+
+void replication_pad2d_kernel_impl(
+    const Tensor& output,
+    const Tensor& input,
+    IntArrayRef padding_size) {
+  switch(input.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad2d", [&] {
+        bool is_batch_mode = input.ndimension() == static_cast<int64_t>(4);
+        cpu_padding<scalar_t, ReplicationPadIndexr>(
+            output, input, padding_size[0], padding_size[1], padding_size[2], padding_size[3], /* p_front */ 0, /* p_back */ 0,
+            is_batch_mode);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad2d_channels_last", [&] {
+        cpu_padding_channels_last<scalar_t, ReplicationPadIndexr>(
+            output, input, padding_size[0], padding_size[1], padding_size[2], padding_size[3], /* p_front */ 0, /* p_back */ 0);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+void replication_pad2d_backward_kernel_impl(
+    const Tensor& grad_input,
+    const Tensor& grad_output,
+    IntArrayRef padding_size) {
+  switch(grad_output.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(grad_output.scalar_type(), "replication_pad2d_backward", [&] {
+        bool is_batch_mode = grad_output.ndimension() == static_cast<int64_t>(4);
+        cpu_padding_backward<scalar_t, ReplicationPadIndexr>(
+            grad_input, grad_output, padding_size[0], padding_size[1], padding_size[2], padding_size[3], /* p_front */ 0, /* p_back */ 0,
+            is_batch_mode);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(grad_output.scalar_type(), "replication_pad2d_backward_channels_last", [&] {
+        cpu_padding_backward_channels_last<scalar_t, ReplicationPadIndexr>(
+            grad_input, grad_output, padding_size[0], padding_size[1], padding_size[2], padding_size[3], /* p_front */ 0, /* p_back */ 0);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+void replication_pad3d_kernel_impl(
+    const Tensor& output,
+    const Tensor& input,
+    IntArrayRef padding_size) {
+  switch(input.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad3d", [&] {
+        bool is_batch_mode = input.ndimension() == static_cast<int64_t>(5);
+        cpu_padding<scalar_t, ReplicationPadIndexr>(
+            output, input, padding_size[0], padding_size[1], padding_size[2], padding_size[3], padding_size[4], padding_size[5],
+            is_batch_mode);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast3d: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(input.scalar_type(), "replication_pad3d_channels_last", [&] {
+        cpu_padding_channels_last<scalar_t, ReplicationPadIndexr>(
+            output, input, padding_size[0], padding_size[1], padding_size[2], padding_size[3], padding_size[4], padding_size[5]);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast3d, Contiguous");
+  }
+}
+
+void replication_pad3d_backward_kernel_impl(
+    const Tensor& grad_input,
+    const Tensor& grad_output,
+    IntArrayRef padding_size) {
+  switch(grad_output.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(grad_output.scalar_type(), "replication_pad3d_backward", [&] {
+        bool is_batch_mode = grad_output.ndimension() == static_cast<int64_t>(5);
+        cpu_padding_backward<scalar_t, ReplicationPadIndexr>(
+            grad_input, grad_output, padding_size[0], padding_size[1], padding_size[2], padding_size[3], padding_size[4], padding_size[5],
+            is_batch_mode);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast3d: {
+      AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(grad_output.scalar_type(), "replication_pad3d_backward_channels_last", [&] {
+        cpu_padding_backward_channels_last<scalar_t, ReplicationPadIndexr>(
+            grad_input, grad_output, padding_size[0], padding_size[1], padding_size[2], padding_size[3], padding_size[4], padding_size[5]);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast3d, Contiguous");
+  }
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(replication_pad1d_kernel, &replication_pad1d_kernel_impl);
+REGISTER_DISPATCH(replication_pad1d_backward_kernel, &replication_pad1d_backward_kernel_impl);
+REGISTER_DISPATCH(replication_pad2d_kernel, &replication_pad2d_kernel_impl);
+REGISTER_DISPATCH(replication_pad2d_backward_kernel, &replication_pad2d_backward_kernel_impl);
+REGISTER_DISPATCH(replication_pad3d_kernel, &replication_pad3d_kernel_impl);
+REGISTER_DISPATCH(replication_pad3d_backward_kernel, &replication_pad3d_backward_kernel_impl);
+
+}} // at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9092,15 +9092,14 @@
 
 - func: replication_pad2d_backward.grad_input(Tensor grad_output, Tensor self, int[4] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
+  structured: True
   dispatch:
     CPU: replication_pad2d_backward_out_cpu
     CUDA: replication_pad2d_backward_out_cuda
 
 - func: replication_pad2d_backward(Tensor grad_output, Tensor self, int[4] padding) -> Tensor
   python_module: nn
-  dispatch:
-    CPU: replication_pad2d_backward_cpu
-    CUDA: replication_pad2d_backward_cuda
+  structured_delegate: replication_pad2d_backward.grad_input
 
 - func: replication_pad3d.out(Tensor self, int[6] padding, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
@@ -9115,15 +9114,14 @@
 
 - func: replication_pad3d_backward.grad_input(Tensor grad_output, Tensor self, int[6] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
+  structured: True
   dispatch:
     CPU: replication_pad3d_backward_out_cpu
     CUDA: replication_pad3d_backward_out_cuda
 
 - func: replication_pad3d_backward(Tensor grad_output, Tensor self, int[6] padding) -> Tensor
   python_module: nn
-  dispatch:
-    CPU: replication_pad3d_backward_cpu
-    CUDA: replication_pad3d_backward_cuda
+  structured_delegate: replication_pad3d_backward.grad_input
 
 - func: upsample_linear1d.vec(Tensor input, int[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor
   python_module: nn

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -877,6 +877,7 @@ aten_native_source_codegen_list = [
     "aten/src/ATen/native/cpu/MaxPooling.cpp",
     "aten/src/ATen/native/cpu/MaxPoolKernel.cpp",
     "aten/src/ATen/native/cpu/MultinomialKernel.cpp",
+    "aten/src/ATen/native/cpu/PaddingKernel.cpp",
     "aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp",
     "aten/src/ATen/native/cpu/PowKernel.cpp",
     "aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61338 add channels last support for FractionalMaxPool2d and FractionalMaxPool3d
* #62170 add channels last support for ReflectionPad2d and ReflectionPad3d
* **#62169 add channels last support for ReplicationPad2d and ReplicationPad3d**
* #60935 add channels last support for AdaptiveMaxPool3d on CPU
* #60620 add channels last support for BatchNorm3d on CPU
* #60619 add channels last support for AvgPool3d on CPU
* #60618 add channels last support for MaxPool3d on CPU
* #60617 add channels last support for AdaptiveAvgPool3d on CPU

update backward with structured kernel

add test cases for channels last path

update build_variables.bzl