### PR TITLE
Return only complex from stft

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -625,6 +625,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
             const optional<int64_t> win_lengthOpt, const c10::optional<Tensor>& window_opt,
             const bool normalized, const optional<bool> onesidedOpt,
             const bool return_complex) {
+  TORCH_CHECK(return_complex, "stft requires return_complex=True")
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> window_maybe_owned = at::borrow_from_optional_tensor(window_opt);
   const Tensor& window = *window_maybe_owned;
@@ -639,8 +640,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
       SS << "None"; \
     } \
     SS << ", normalized=" << normalized << ", onesided="; \
-    write_opt(SS, onesidedOpt) << ", return_complex="; \
-    SS <<  return_complex << ") "
+    write_opt(SS, onesidedOpt) << ") "
 
   TORCH_CHECK(!window.defined() || window.device() == self.device(),
               "stft input and window must be on the same device but got self on ",
@@ -650,7 +650,6 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
   auto hop_length = hop_lengthOpt.value_or(n_fft >> 2);
   auto win_length = win_lengthOpt.value_or(n_fft);
 
-  TORCH_CHECK(return_complex, "stft requires return_complex=True")
 
   if (!at::isFloatingType(self.scalar_type()) && !at::isComplexType(self.scalar_type())) {
     std::ostringstream ss;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3978,7 +3978,7 @@
 # missing the `pad_mode` and `center` arguments, which are taken care of at
 # `torch.functional.py`. They shall be moved here once we have mapping between
 # Python strings and C++ Enum in codegen.
-- func: stft(Tensor self, int n_fft, int? hop_length=None, int? win_length=None, Tensor? window=None, bool normalized=False, bool? onesided=None, bool? return_complex=None) -> Tensor
+- func: stft(Tensor self, int n_fft, int? hop_length=None, int? win_length=None, Tensor? window=None, bool normalized=False, bool? onesided=None, bool return_complex=True) -> Tensor
   variants: function, method
 
 - func: istft(Tensor self, int n_fft, int? hop_length=None, int? win_length=None, Tensor? window=None, bool center=True, bool normalized=False, bool? onesided=None, int? length=None, bool return_complex=False) -> Tensor

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -112,6 +112,7 @@ allow_list = [
     ("aten::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams", datetime.date(2021, 8, 15)),
     ("aten::_cumsum", datetime.date(2021, 8, 31)),
     ("aten::_cumprod", datetime.date(2021, 8, 31)),
+    ("aten::stft", datetime.date(2021, 10, 31)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -822,7 +822,7 @@ class TestFFT(TestCase):
             result = []
             for xi in x:
                 ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center)
-                result.append(torch.from_numpy(np.stack([ri.real, ri.imag], -1)))
+                result.append(torch.from_numpy(ri))
             result = torch.stack(result, 0)
             if input_1d:
                 result = result[0]
@@ -840,7 +840,7 @@ class TestFFT(TestCase):
                                 center=center)
                 # NB: librosa defaults to np.complex64 output, no matter what
                 # the input dtype
-                ref_result = torch.view_as_complex(librosa_stft(x, n_fft, hop_length, win_length, window, center))
+                ref_result = librosa_stft(x, n_fft, hop_length, win_length, window, center)
                 self.assertEqual(result, ref_result, atol=7e-6, rtol=0, msg='stft comparison against librosa', exact_dtype=True)
             else:
                 self.assertRaises(expected_error,

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -840,7 +840,7 @@ class TestFFT(TestCase):
                                 center=center)
                 # NB: librosa defaults to np.complex64 output, no matter what
                 # the input dtype
-                ref_result = librosa_stft(x, n_fft, hop_length, win_length, window, center)
+                ref_result = torch.view_as_complex(librosa_stft(x, n_fft, hop_length, win_length, window, center))
                 self.assertEqual(result, ref_result, atol=7e-6, rtol=0, msg='stft comparison against librosa', exact_dtype=True)
             else:
                 self.assertRaises(expected_error,

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -837,14 +837,11 @@ class TestFFT(TestCase):
                 window = None
             if expected_error is None:
                 result = x.stft(n_fft, hop_length, win_length, window,
-                                center=center, return_complex=False)
+                                center=center)
                 # NB: librosa defaults to np.complex64 output, no matter what
                 # the input dtype
                 ref_result = librosa_stft(x, n_fft, hop_length, win_length, window, center)
-                self.assertEqual(result, ref_result, atol=7e-6, rtol=0, msg='stft comparison against librosa', exact_dtype=False)
-                # With return_complex=True, the result is the same but viewed as complex instead of real
-                result_complex = x.stft(n_fft, hop_length, win_length, window, center=center, return_complex=True)
-                self.assertEqual(result_complex, torch.view_as_complex(result))
+                self.assertEqual(result, ref_result, atol=7e-6, rtol=0, msg='stft comparison against librosa', exact_dtype=True)
             else:
                 self.assertRaises(expected_error,
                                   lambda: x.stft(n_fft, hop_length, win_length, window, center=center))
@@ -901,13 +898,13 @@ class TestFFT(TestCase):
             }
 
             # Functional interface
-            x_stft = torch.stft(x, pad_mode=pad_mode, return_complex=True, **common_kwargs)
+            x_stft = torch.stft(x, pad_mode=pad_mode, **common_kwargs)
             x_roundtrip = torch.istft(x_stft, return_complex=dtype.is_complex,
                                       length=x.size(-1), **common_kwargs)
             self.assertEqual(x_roundtrip, x)
 
             # Tensor method interface
-            x_stft = x.stft(pad_mode=pad_mode, return_complex=True, **common_kwargs)
+            x_stft = x.stft(pad_mode=pad_mode, **common_kwargs)
             x_roundtrip = torch.istft(x_stft, return_complex=dtype.is_complex,
                                       length=x.size(-1), **common_kwargs)
             self.assertEqual(x_roundtrip, x)
@@ -1052,7 +1049,6 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'complex'):
             x.stft(10, pad_mode='constant', onesided=True)
 
-    # stft is currently warning that it requires return-complex while an upgrader is written
     @onlyOnCPUAndCUDA
     @skipCPUIfNoFFT
     def test_stft_requires_complex(self, device):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -445,13 +445,8 @@ class Tensor(torch._C._TensorBase):
     def stft(self, n_fft: int, hop_length: Optional[int] = None,
              win_length: Optional[int] = None, window: 'Optional[Tensor]' = None,
              center: bool = True, pad_mode: str = 'reflect', normalized: bool = False,
-             onesided: Optional[bool] = None, return_complex: Optional[bool] = True):
-        r"""See :func:`torch.stft`
-
-        .. warning::
-          This function changed signature at version 0.4.1. Calling with
-          the previous signature may cause error or return incorrect result.
-        """
+             onesided: Optional[bool] = None, return_complex: bool = True):
+        r"""See :func:`torch.stft`"""
         if has_torch_function_unary(self):
             return handle_torch_function(
                 Tensor.stft, (self,), self, n_fft, hop_length=hop_length,

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -445,7 +445,7 @@ class Tensor(torch._C._TensorBase):
     def stft(self, n_fft: int, hop_length: Optional[int] = None,
              win_length: Optional[int] = None, window: 'Optional[Tensor]' = None,
              center: bool = True, pad_mode: str = 'reflect', normalized: bool = False,
-             onesided: Optional[bool] = None, return_complex: Optional[bool] = None):
+             onesided: Optional[bool] = None, return_complex: Optional[bool] = True):
         r"""See :func:`torch.stft`
 
         .. warning::

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -374,14 +374,12 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
          win_length: Optional[int] = None, window: Optional[Tensor] = None,
          center: bool = True, pad_mode: str = 'reflect', normalized: bool = False,
          onesided: Optional[bool] = None,
-         return_complex: Optional[bool] = None) -> Tensor:
+         return_complex: Optional[bool] = True) -> Tensor:
     r"""Short-time Fourier transform (STFT).
 
     .. warning::
-        From version 1.8.0, :attr:`return_complex` must always be given
-        explicitly for real inputs and `return_complex=False` has been
-        deprecated. Strongly prefer `return_complex=True` as in a future
-        pytorch release, this function will only return complex tensors.
+        From version 1.10.0, :attr:`return_complex` must always be True, using
+        False was removed.
 
         Note that :func:`torch.view_as_real` can be used to recover a real
         tensor with an extra last dimension for real and imaginary components.
@@ -439,14 +437,8 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
     * If :attr:`normalized` is ``True`` (default is ``False``), the function
       returns the normalized STFT results, i.e., multiplied by :math:`(\text{frame\_length})^{-0.5}`.
 
-    * If :attr:`return_complex` is ``True`` (default if input is complex), the
-      return is a ``input.dim() + 1`` dimensional complex tensor. If ``False``,
-      the output is a ``input.dim() + 2`` dimensional real tensor where the last
-      dimension represents the real and imaginary components.
-
-    Returns either a complex tensor of size :math:`(* \times N \times T)` if
-    :attr:`return_complex` is true, or a real tensor of size :math:`(* \times N
-    \times T \times 2)`. Where :math:`*` is the optional batch size of
+    Returns a complex tensor of size :math:`(* \times N \times T)`. Where
+    :math:`*` is the optional batch size of
     :attr:`input`, :math:`N` is the number of frequencies where STFT is applied
     and :math:`T` is the total number of frames used.
 
@@ -476,6 +468,9 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
         return_complex (bool, optional): whether to return a complex tensor, or
             a real tensor with an extra last dimension for the real and
             imaginary components.
+
+            .. versionchanged: 1.10
+               Only accepts True
 
     Returns:
         Tensor: A tensor containing the STFT result with shape described above

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -374,7 +374,7 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
          win_length: Optional[int] = None, window: Optional[Tensor] = None,
          center: bool = True, pad_mode: str = 'reflect', normalized: bool = False,
          onesided: Optional[bool] = None,
-         return_complex: Optional[bool] = True) -> Tensor:
+         return_complex: bool = True) -> Tensor:
     r"""Short-time Fourier transform (STFT).
 
     The STFT computes the Fourier transform of short overlapping windows of the

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -377,13 +377,6 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
          return_complex: Optional[bool] = True) -> Tensor:
     r"""Short-time Fourier transform (STFT).
 
-    .. warning::
-        From version 1.10.0, :attr:`return_complex` must always be True, using
-        False was removed.
-
-        Note that :func:`torch.view_as_real` can be used to recover a real
-        tensor with an extra last dimension for real and imaginary components.
-
     The STFT computes the Fourier transform of short overlapping windows of the
     input. This giving frequency components of the signal as they change over
     time. The interface of this function is modeled after the librosa_ stft function.
@@ -442,10 +435,6 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
     :attr:`input`, :math:`N` is the number of frequencies where STFT is applied
     and :math:`T` is the total number of frames used.
 
-    .. warning::
-      This function changed signature at version 0.4.1. Calling with the
-      previous signature may cause error or return incorrect result.
-
     Args:
         input (Tensor): the input tensor
         n_fft (int): size of Fourier transform
@@ -471,6 +460,9 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
 
             .. versionchanged: 1.10
                Only accepts True
+               Note that :func:`torch.view_as_real` can be used to recover a real
+               tensor with an extra last dimension for real and imaginary components.
+
 
     Returns:
         Tensor: A tensor containing the STFT result with shape described above

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -894,7 +894,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.std: lambda input, dim=None: -1,
         torch.std_mean: lambda input, dim=None: -1,
         torch.stft: (lambda input, n_fft, hop_length=None, win_length=None, window=None, center=True,
-                     pad_mode='reflect', normalized=False, onesided=True, return_complex=None: -1),
+                     pad_mode='reflect', normalized=False, onesided=True, return_complex=True: -1),
         torch.sub: lambda input, other, out=None: -1,
         torch.subtract: lambda input, other, out=None: -1,
         torch.sum: lambda input, dim=None: -1,


### PR DESCRIPTION
Fixes the first half of #55948.

The first commit changes `torch.stft` to require (and set as default) `return_complex=True`

The second part: allow only complex input to `torch.istft` is still TBD. There is some trickiness around the current code, it does something like
```
if complex(input):
  input = torch.view_as_real(input)
# check input is compliant
input = reconstruct_complex(input)
```

so the code that checks the input needs to be carefully rewritten