### PR TITLE
[quant][fix] Update quantization c++ tests to not run if CPU_STATIC_DISPATCH is specified

### DIFF
--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -14,6 +14,7 @@
 #include <ATen/quantized/Quantizer.h>
 
 using namespace at;
+#ifndef ATEN_CPU_STATIC_DISPATCH
 
 TEST(TestQTensor, QuantDequantAPIs) {
   auto num_elements = 10;
@@ -279,3 +280,4 @@ TEST(TestQTensor, FromBlobQuantizedPerChannel) {
   }
   TORCH_CHECK(customDataDeleted);
 }
+#endif // ATEN_CPU_STATIC_DISPATCH


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62197

Summary:
For build configs with ATEN_CPU_STATIC_DISPATCH defined, quantization tests will fail since they
require QuantizedCPU dispatch to be enabled.
This will fix some internal test failures like https://www.internalfb.com/intern/test/844424941811803?ref_report_id=0 which are run under the `caffe2_aten_cpu_inference` project

Test Plan:
buck test @mode/dev //caffe2/aten:quantized_test

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29912742](https://our.internmc.facebook.com/intern/diff/D29912742)