### PR TITLE
[Pytorch Edge] get_model_bytecode int -> uint

### DIFF
--- a/torch/csrc/jit/mobile/backport.cpp
+++ b/torch/csrc/jit/mobile/backport.cpp
@@ -94,7 +94,7 @@ bool _backport_for_mobile_impl(
   if (!backportManager.hasBytecodeBackportFunction(to_version + 1)) {
     return false;
   }
-  int64_t from_version = _get_model_bytecode_version(istream_adapter);
+  auto from_version = _get_model_bytecode_version(istream_adapter);
   return backportManager.backport(
       istream_adapter, writer, from_version, to_version);
 }

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -1,5 +1,4 @@
 #include <ATen/core/ivalue.h>
-#include <c10/util/irange.h>
 #include <caffe2/serialize/file_adapter.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/compilation_unit.h> // removed after using simple type_resolver/obj_loader
@@ -59,38 +58,42 @@ std::vector<IValue> get_bytecode_ivalues(PyTorchStreamReader& reader) {
 /********************** Bytecode **********************/
 
 // Forward declare
-int64_t _get_model_bytecode_version(
+uint64_t _get_model_bytecode_version(
     const std::vector<IValue>& bytecode_ivalues);
 
-int64_t _get_model_bytecode_version(std::istream& in) {
+uint64_t _get_model_bytecode_version(std::istream& in) {
   std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
   return _get_model_bytecode_version(std::move(rai));
 }
 
-int64_t _get_model_bytecode_version(const std::string& filename) {
+uint64_t _get_model_bytecode_version(const std::string& filename) {
   std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
   return _get_model_bytecode_version(std::move(rai));
 }
 
-int64_t _get_model_bytecode_version(std::shared_ptr<ReadAdapterInterface> rai) {
+uint64_t _get_model_bytecode_version(
+    std::shared_ptr<ReadAdapterInterface> rai) {
   if (!check_zip_file(rai)) {
-    TORCH_WARN(
-        "The input model might not be generated from _save_for_mobile()");
-    return -1;
+    TORCH_CHECK(
+        false,
+        "Failed to open .ptl file please ensure the model was exported for mobile");
   }
   PyTorchStreamReader reader(std::move(rai));
   auto bytecode_values = get_bytecode_ivalues(reader);
   return _get_model_bytecode_version(bytecode_values);
 }
 
-int64_t _get_model_bytecode_version(
+uint64_t _get_model_bytecode_version(
     const std::vector<IValue>& bytecode_ivalues) {
   if (!bytecode_ivalues.empty() && bytecode_ivalues[0].isInt()) {
     int64_t model_version = bytecode_ivalues[0].toInt();
-    return model_version;
+    TORCH_CHECK(
+        model_version > 0,
+        "Expected model bytecode version > 0 got ",
+        model_version);
+    return static_cast<uint64_t>(model_version);
   }
-  TORCH_WARN("Fail to get bytecode version.");
-  return -1;
+  TORCH_CHECK(false, "Failed to get bytecode version.");
 }
 
 /********************** Operators and Info **********************/

--- a/torch/csrc/jit/mobile/model_compatibility.h
+++ b/torch/csrc/jit/mobile/model_compatibility.h
@@ -18,14 +18,15 @@ namespace torch {
 namespace jit {
 
 // The family of methods below to get bytecode version from a model
-TORCH_API int64_t _get_model_bytecode_version(std::istream& in);
+// Throws if not passed in a well formed model
+TORCH_API uint64_t _get_model_bytecode_version(std::istream& in);
 
-TORCH_API int64_t _get_model_bytecode_version(const std::string& filename);
+TORCH_API uint64_t _get_model_bytecode_version(const std::string& filename);
 
-TORCH_API int64_t _get_model_bytecode_version(
+TORCH_API uint64_t _get_model_bytecode_version(
     std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai);
 
-int64_t _get_model_bytecode_version(
+uint64_t _get_model_bytecode_version(
     const std::vector<c10::IValue>& bytecode_ivalues);
 
 std::vector<c10::IValue> get_bytecode_ivalues(


### PR DESCRIPTION
Summary: change int to uint to be the same type as the runtimes bytecode. Only affects c++ since python doesn't have uints iirc. Also changed the behavior of the functions from returning -1 and a warning to just throw an exception. Wasnt sure what the proper behavior here would be (returning UINT_MAX seemed gross) so feedback is appreciated.

Test Plan: ci

Differential Revision: D29914072

