### PR TITLE
[fx2trt] flatten converter

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -288,4 +288,4 @@ class TRTInterpreter(BaseTRTInterpreter):
             module = copy.deepcopy(module)
         module = module.cpu().float()
         module = NormalizeArgs(module).transform()
-        super().__init__(module, input_specs, logger_level)
+        super().__init__(module, input_specs, logger_level=logger_level)


### PR DESCRIPTION
Summary: Add acc_ops.flatten converter. Also migrate to oss acc tacer for trt interpreter.

Test Plan: unit test

Reviewed By: khabinov

Differential Revision: D29861555

