### PR TITLE
Disable ccache for nccl builds

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -22,6 +22,10 @@ if(NOT __NCCL_INCLUDED)
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
         env
+        # TODO: remove these flags when
+        # https://github.com/pytorch/pytorch/issues/13362 is fixed
+        "CCACHE_DISABLE=1"
+        "SCCACHE_DISABLE=1"
         make
         "CXX=${CMAKE_CXX_COMPILER}"
         "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#62208 Disable ccache for nccl builds**

reverts 
https://github.com/pytorch/pytorch/pull/55814
which removed a workaround for:
https://github.com/pytorch/pytorch/issues/13362

Differential Revision: [D29935472](https://our.internmc.facebook.com/intern/diff/D29935472)