### PR TITLE
Fix clang-tidy line filtering logic

### DIFF
--- a/tools/linter/clang_tidy/run.py
+++ b/tools/linter/clang_tidy/run.py
@@ -401,11 +401,11 @@ def find_changed_lines(diff: str) -> Dict[str, List[Tuple[int, int]]]:
         e.msg += ", run 'pip install unidiff'"  # type: ignore[attr-defined]
         raise e
 
-    files = collections.defaultdict(list)
+    files: Any = collections.defaultdict(list)
 
     for file in unidiff.PatchSet(diff):
         for hunk in file:
-            added_line_nos = [ line.target_line_no for line in hunk if line.is_added ]
+            added_line_nos = [line.target_line_no for line in hunk if line.is_added]
 
             if len(added_line_nos) == 0:
                 continue
@@ -415,8 +415,8 @@ def find_changed_lines(diff: str) -> Dict[str, List[Tuple[int, int]]]:
             i = 1
             ranges = [[added_line_nos[0], added_line_nos[0]]]
             while i < len(added_line_nos):
-                if added_line_nos[i] != added_line_nos[i-1] + 1:
-                    ranges[-1][1] = added_line_nos[i-1]
+                if added_line_nos[i] != added_line_nos[i - 1] + 1:
+                    ranges[-1][1] = added_line_nos[i - 1]
                     ranges.append([added_line_nos[i], added_line_nos[i]])
                 i += 1
             ranges[-1][1] = added_line_nos[-1]

--- a/tools/linter/clang_tidy/run.py
+++ b/tools/linter/clang_tidy/run.py
@@ -405,14 +405,23 @@ def find_changed_lines(diff: str) -> Dict[str, List[Tuple[int, int]]]:
 
     for file in unidiff.PatchSet(diff):
         for hunk in file:
-            start = hunk[0].target_line_no
-            if start is None:
-                start = 1
-            end = int(hunk[-1].target_line_no or 0)
-            if end == 0:
+            added_line_nos = [ line.target_line_no for line in hunk if line.is_added ]
+
+            if len(added_line_nos) == 0:
                 continue
 
-            files[file.path].append((start, end))
+            # Convert list of line numbers to ranges
+            # Eg: [1, 2, 3, 12, 13, 14, 15] becomes [[1,3], [12, 15]]
+            i = 1
+            ranges = [[added_line_nos[0], added_line_nos[0]]]
+            while i < len(added_line_nos):
+                if added_line_nos[i] != added_line_nos[i-1] + 1:
+                    ranges[-1][1] = added_line_nos[i-1]
+                    ranges.append([added_line_nos[i], added_line_nos[i]])
+                i += 1
+            ranges[-1][1] = added_line_nos[-1]
+
+            files[file.path].append(*ranges)
 
     return dict(files)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62211
* __->__ #62210

Fixes #62204 

Test Plan:
#62211 clang-tidy should only error on the added lines (and not on context/removals)

Differential Revision: [D29917897](https://our.internmc.facebook.com/intern/diff/D29917897)