### PR TITLE
Disable cppcoreguidelines-non-private-member-variables-in-classes

### DIFF
--- a/.clang-tidy-oss
+++ b/.clang-tidy-oss
@@ -1,5 +1,6 @@
 ---
 # NOTE there must be no spaces before the '-', so put the comma last.
+# We are using a separate clang-tidy config because FB internal CI fails if we set 'WarningsAsErrors'
 InheritParentConfig: true
 Checks: '
 bugprone-*,
@@ -22,6 +23,7 @@ cppcoreguidelines-*,
 -cppcoreguidelines-pro-type-union-access,
 -cppcoreguidelines-pro-type-vararg,
 -cppcoreguidelines-special-member-functions,
+-cppcoreguidelines-non-private-member-variables-in-classes,
 -facebook-hte-RelativeInclude,
 hicpp-exception-baseclass,
 hicpp-avoid-goto,


### PR DESCRIPTION
This PR disables the `cppcoreguidelines-non-private-member-variables-in-classes` check. PyTorch makes use of `protected` members throughout the codebase, and we do not want to perform this clang-tidy check in CI to improve signal-to-noise.

Relevant failure: https://github.com/pytorch/pytorch/pull/61871/checks?check_run_id=3146453417