### PR TITLE
[7/N] Nnapi backend delegation preprocess: compile_spec sanity check

### DIFF
--- a/test/jit/test_backend_nnapi.py
+++ b/test/jit/test_backend_nnapi.py
@@ -87,7 +87,7 @@ method_compile_spec must use the following format:
         # No dictionary under the forward key
         compile_spec = {"forward": 1}
         with self.assertRaisesRegex(RuntimeError,
-                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, " \
+                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, "
                                     "under it's \"forward\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
@@ -95,7 +95,7 @@ method_compile_spec must use the following format:
         # No inputs key (in the dictionary under the forward key)
         compile_spec = {"forward": {"not inputs": args}}
         with self.assertRaisesRegex(RuntimeError,
-                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, " \
+                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, "
                                     "under it's \"forward\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)

--- a/test/jit/test_backend_nnapi.py
+++ b/test/jit/test_backend_nnapi.py
@@ -76,7 +76,8 @@ class TestNnapiBackend(TestNNAPI):
         errorMsgTail = r"""
 method_compile_spec should contain a Tensor or Tensor List which bundles input parameters: shape, dtype, quantization, and dimorder.
 For input shapes, use 0 for run/load time flexible input.
-method_compile_spec must use the following format: {"forward": {"inputs": at::Tensor}} OR {"forward": {"inputs": c10::List<at::Tensor>}}"""
+method_compile_spec must use the following format:
+{"forward": {"inputs": at::Tensor}} OR {"forward": {"inputs": c10::List<at::Tensor>}}"""
 
         # No forward key
         compile_spec = {"backward": {"inputs": args}}
@@ -86,14 +87,16 @@ method_compile_spec must use the following format: {"forward": {"inputs": at::Te
         # No dictionary under the forward key
         compile_spec = {"forward": 1}
         with self.assertRaisesRegex(RuntimeError,
-                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
+                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, " \
+                                    "under it's \"forward\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
 
         # No inputs key (in the dictionary under the forward key)
         compile_spec = {"forward": {"not inputs": args}}
         with self.assertRaisesRegex(RuntimeError,
-                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
+                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, " \
+                                    "under it's \"forward\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
 

--- a/test/jit/test_backend_nnapi.py
+++ b/test/jit/test_backend_nnapi.py
@@ -76,36 +76,36 @@ class TestNnapiBackend(TestNNAPI):
         errorMsgTail = r"""
 method_compile_spec should contain a Tensor or Tensor List which bundles input parameters: shape, dtype, quantization, and dimorder.
 For input shapes, use 0 for run/load time flexible input.
-compile_spec must use the following format: {"forward": {"inputs": at::Tensor}} OR {"forward": {"inputs": c10::List<at::Tensor>}}"""
+method_compile_spec must use the following format: {"forward": {"inputs": at::Tensor}} OR {"forward": {"inputs": c10::List<at::Tensor>}}"""
 
         # No forward key
         compile_spec = {"backward": {"inputs": args}}
-        with self.assertRaisesRegex(RuntimeError, "compile_spec does not contain the \"forward\" key." + errorMsgTail):
+        with self.assertRaisesRegex(RuntimeError, "method_compile_spec does not contain the \"forward\" key." + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
 
         # No dictionary under the forward key
         compile_spec = {"forward": 1}
         with self.assertRaisesRegex(RuntimeError,
-                                    "compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
+                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
 
         # No inputs key (in the dictionary under the forward key)
         compile_spec = {"forward": {"not inputs": args}}
         with self.assertRaisesRegex(RuntimeError,
-                                    "compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
+                                    "method_compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
 
         # No Tensor or TensorList under the inputs key
         compile_spec = {"forward": {"inputs": 1}}
         with self.assertRaisesRegex(RuntimeError,
-                                    "compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key."
+                                    "method_compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
         compile_spec = {"forward": {"inputs": [1]}}
         with self.assertRaisesRegex(RuntimeError,
-                                    "compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key."
+                                    "method_compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key."
                                     + errorMsgTail):
             torch._C._jit_to_backend("nnapi", traced, compile_spec)
 

--- a/test/jit/test_backend_nnapi.py
+++ b/test/jit/test_backend_nnapi.py
@@ -67,6 +67,48 @@ class TestNnapiBackend(TestNNAPI):
         # Argument input is a Tensor in a list
         self.call_lowering_to_nnapi(traced, [args])
 
+    # Test exceptions for incorrect compile specs
+    def test_compile_spec_santiy(self):
+        args = torch.tensor([[1.0, -1.0, 2.0, -2.0]]).unsqueeze(-1).unsqueeze(-1)
+        module = torch.nn.PReLU()
+        traced = torch.jit.trace(module, args)
+
+        errorMsgTail = r"""
+method_compile_spec should contain a Tensor or Tensor List which bundles input parameters: shape, dtype, quantization, and dimorder.
+For input shapes, use 0 for run/load time flexible input.
+compile_spec must use the following format: {"forward": {"inputs": at::Tensor}} OR {"forward": {"inputs": c10::List<at::Tensor>}}"""
+
+        # No forward key
+        compile_spec = {"backward": {"inputs": args}}
+        with self.assertRaisesRegex(RuntimeError, "compile_spec does not contain the \"forward\" key." + errorMsgTail):
+            torch._C._jit_to_backend("nnapi", traced, compile_spec)
+
+        # No dictionary under the forward key
+        compile_spec = {"forward": 1}
+        with self.assertRaisesRegex(RuntimeError,
+                                    "compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
+                                    + errorMsgTail):
+            torch._C._jit_to_backend("nnapi", traced, compile_spec)
+
+        # No inputs key (in the dictionary under the forward key)
+        compile_spec = {"forward": {"not inputs": args}}
+        with self.assertRaisesRegex(RuntimeError,
+                                    "compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key."
+                                    + errorMsgTail):
+            torch._C._jit_to_backend("nnapi", traced, compile_spec)
+
+        # No Tensor or TensorList under the inputs key
+        compile_spec = {"forward": {"inputs": 1}}
+        with self.assertRaisesRegex(RuntimeError,
+                                    "compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key."
+                                    + errorMsgTail):
+            torch._C._jit_to_backend("nnapi", traced, compile_spec)
+        compile_spec = {"forward": {"inputs": [1]}}
+        with self.assertRaisesRegex(RuntimeError,
+                                    "compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key."
+                                    + errorMsgTail):
+            torch._C._jit_to_backend("nnapi", traced, compile_spec)
+
     def tearDown(self):
         # Change dtype back to default (Otherwise, other unit tests will complain)
         torch.set_default_dtype(self.default_dtype)

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -41,18 +41,18 @@ c10::IValue preprocess(
   c10::IValue inp;
   std::string error = "";
   if (!method_compile_spec.contains("forward")) {
-    error = "compile_spec does not contain the \"forward\" key.";
+    error = R"(method_compile_spec does not contain the "forward" key.)";
   } else {
     auto innerDict = method_compile_spec.at("forward");
     if (!innerDict.isGenericDict() ||
         !innerDict.toGenericDict().contains("inputs")) {
       error =
-          "compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key.";
+          R"(method_compile_spec does not contain a dictionary with an "inputs" key, under it's "forward" key.)";
     } else {
       inp = innerDict.toGenericDict().at("inputs");
       if (!inp.isTensor() && !inp.isTensorList()) {
         error =
-            "compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key.";
+            R"(method_compile_spec does not contain either a Tensor or TensorList, under it's "inputs" key.)";
       }
     }
   }
@@ -62,7 +62,7 @@ c10::IValue preprocess(
         "\nmethod_compile_spec should contain a Tensor or Tensor List which bundles input parameters:"
         " shape, dtype, quantization, and dimorder."
         "\nFor input shapes, use 0 for run/load time flexible input."
-        "\ncompile_spec must use the following format: "
+        "\nmethod_compile_spec must use the following format: "
         "{\"forward\": {\"inputs\": at::Tensor}} OR {\"forward\": {\"inputs\": c10::List<at::Tensor>}}");
   }
 

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -62,8 +62,8 @@ c10::IValue preprocess(
         "\nmethod_compile_spec should contain a Tensor or Tensor List which bundles input parameters:"
         " shape, dtype, quantization, and dimorder."
         "\nFor input shapes, use 0 for run/load time flexible input."
-        "\nmethod_compile_spec must use the following format: "
-        "{\"forward\": {\"inputs\": at::Tensor}} OR {\"forward\": {\"inputs\": c10::List<at::Tensor>}}");
+        "\nmethod_compile_spec must use the following format:"
+        "\n{\"forward\": {\"inputs\": at::Tensor}} OR {\"forward\": {\"inputs\": c10::List<at::Tensor>}}");
   }
 
   // Convert input to a Tensor or a python list of Tensors

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -21,7 +21,7 @@ namespace py = pybind11;
 // Example input Tensor:
 // torch.tensor([[1.0, -1.0, 2.0, -2.0]]).unsqueeze(-1).unsqueeze(-1)
 //
-// In the future, preprocess will accept a dedicated object, NnapiArg
+// In the future, preprocess will accept a dedicated object
 c10::IValue preprocess(
     const torch::jit::Module& mod,
     const c10::Dict<c10::IValue, c10::IValue>& method_compile_spec,
@@ -36,9 +36,39 @@ c10::IValue preprocess(
       py::module::import("torch.jit._recursive").attr("wrap_cpp_module")(mod);
   out.attr("eval")();
 
+  // Test that method_compile_spec contains the necessary keys and
+  // Tensor/TensorList input
+  c10::IValue inp;
+  std::string error = "";
+  if (!method_compile_spec.contains("forward")) {
+    error = "compile_spec does not contain the \"forward\" key.";
+  } else {
+    auto innerDict = method_compile_spec.at("forward");
+    if (!innerDict.isGenericDict() ||
+        !innerDict.toGenericDict().contains("inputs")) {
+      error =
+          "compile_spec does not contain a dictionary with an \"inputs\" key, under it's \"forward\" key.";
+    } else {
+      inp = innerDict.toGenericDict().at("inputs");
+      if (!inp.isTensor() && !inp.isTensorList()) {
+        error =
+            "compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key.";
+      }
+    }
+  }
+  if (error.size() != 0) {
+    throw std::runtime_error(
+        error +
+        "\nmethod_compile_spec should contain a Tensor or Tensor List which bundles input parameters:"
+        " shape, dtype, quantization, and dimorder."
+        "\nFor input shapes, use 0 for run/load time flexible input."
+        "\ncompile_spec must use the following format: "
+        "{\"forward\": {\"inputs\": at::Tensor}} OR {\"forward\": {\"inputs\": c10::List<at::Tensor>}}");
+  }
+
   // Convert input to a Tensor or a python list of Tensors
-  auto inp = method_compile_spec.at("forward").toGenericDict().at("inputs");
   py::object nnapi_pyModel;
+
   if (inp.isTensor()) {
     nnapi_pyModel = pyMethod(out, inp.toTensor());
   } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62225
* __->__ #62213

Added sanity checks in preprocess function for Android NNAPI delegate.
`preprocess()` requires some input metadata passed through its `method_compile_spec` function argument.

`preprocess()` now throws specific error messages, if it cannot find the correct input arguments.
Example error message:
```
RuntimeError: method_compile_spec does not contain the "forward" key.
method_compile_spec should contain a Tensor or Tensor List which bundles input parameters: shape, dtype, quantization, and dimorder.
For input shapes, use 0 for run/load time flexible input.
method_compile_spec must use the following format:
{"forward": {"inputs": at::Tensor}} OR {"forward": {"inputs": c10::List<at::Tensor>}}
```

nnapi_backend_preprocess.cpp: contains sanity check implementation
test_backend_nnapi.py: sanity check unit tests

Test: Ran `python test/test_jit.py TestNnapiBackend` in OSS successfully.

TODO: Using Tensors to pass input parameters is a temporary hack. When a dedicated object is implemented, update the sanity check error message.

Differential Revision: [D29917004](https://our.internmc.facebook.com/intern/diff/D29917004/)