### PR TITLE
Fixing the case when starter nodes depend on get_attr node

### DIFF
--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -629,12 +629,12 @@ class _SplitterBase:
 
     def starter_nodes(self) -> Tuple[NodeSet, NodeSet]:
         """
-        Finds nodes that consume module inputs or getattr nodes.
+        Finds nodes that consume module inputs or get_attr nodes.
         """
         starter_cpu_nodes: NodeSet = set()
         starter_acc_nodes: NodeSet = set()
         for node in self.module.graph.nodes:
-            if node.op not in {"placeholder", "getattr"}:
+            if node.op not in {"placeholder", "get_attr"}:
                 continue
             for user in node.users:
                 if user in self.acc_nodes:


### PR DESCRIPTION
Summary: There was a typo that we caught until recently, thus making this fix.

Differential Revision: D29924190

