### PR TITLE
[Static Runtime] Add missing unit tests for static runtime ops

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -341,6 +341,16 @@ const auto div_scalar_mode = R"JIT(
       return torch.div(a, b, rounding_mode=c).clone()
 )JIT";
 
+const auto mul_tensor = R"JIT(
+  def forward(self, a: Tensor, b: Tensor):
+      return torch.mul(a, b).clone()
+)JIT";
+
+const auto mul_scalar = R"JIT(
+  def forward(self, a: Tensor, b: int):
+      return torch.mul(a, b).clone()
+)JIT";
+
 const auto log_tensor = R"JIT(
   def forward(self, inp: Tensor):
       a = torch.log(inp).clone()
@@ -365,6 +375,31 @@ const auto sub_tensor_alpha = R"JIT(
 const auto sub_scalar_alpha = R"JIT(
   def forward(self, a: Tensor, b: float, c: int):
       return torch.sub(a, b, alpha=c).clone()
+)JIT";
+
+const auto nan_to_num_script = R"JIT(
+  def forward(self, a: Tensor, nan: float, posinf: float, neginf: float):
+      return torch.nan_to_num(a, nan, posinf, neginf).clone()
+)JIT";
+
+const auto stack_dim = R"JIT(
+  def forward(self, a: Tensor, b: Tensor, dim: int):
+      return torch.stack((a, b), dim = dim).clone()
+)JIT";
+
+const auto stack_three = R"JIT(
+  def forward(self, a: Tensor, b: Tensor, c: Tensor):
+      return torch.stack((a, b, c)).clone()
+)JIT";
+
+const auto relu_script = R"JIT(
+  def forward(self, a: Tensor):
+      return torch.relu(a).clone()
+)JIT";
+
+const auto tanh_script = R"JIT(
+  def forward(self, a):
+      return torch.tanh(a).clone()
 )JIT";
 
 const std::string layer_norm_with_weights = R"JIT(

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -94,7 +94,9 @@ std::unique_ptr<StaticRuntimeTestContext> makeTestContext(
 
 void compareTensorLists(
     const std::vector<IValue>& l, /* expects */
-    const std::vector<IValue>& r /* values */) {
+    const std::vector<IValue>& r, /* values */
+    const bool use_allclose,
+    const bool use_equalnan) {
   EXPECT_TRUE(l.size() == r.size());
   for (int i = 0; i < l.size(); ++i) {
     ASSERT_TRUE(l[i].isTensor());
@@ -104,22 +106,16 @@ void compareTensorLists(
     if (!l[i].toTensor().defined()) {
       EXPECT_TRUE(!r[i].toTensor().defined());
     } else {
-      EXPECT_TRUE(l[i].toTensor().equal(r[i].toTensor()));
-    }
-  }
-}
-
-void compareTensorLists(
-    const std::vector<at::Tensor>& l, /* expects */
-    const std::vector<at::Tensor>& r /* values */) {
-  EXPECT_TRUE(l.size() == r.size());
-  for (int i = 0; i < l.size(); ++i) {
-    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
-    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
-    if (!l[i].defined()) {
-      EXPECT_TRUE(!r[i].defined());
-    } else {
-      EXPECT_TRUE(l[i].equal(r[i]));
+      if (use_allclose) {
+        EXPECT_TRUE(at::allclose(
+            l[i].toTensor(),
+            r[i].toTensor(),
+            /*rtol*/ 1e-05,
+            /*atol*/ 1e-08,
+            use_equalnan));
+      } else {
+        EXPECT_TRUE(l[i].toTensor().equal(r[i].toTensor()));
+      }
     }
   }
 }
@@ -127,13 +123,19 @@ void compareTensorLists(
 void compareResults(
     const IValue& expect,
     const IValue& actual,
-    const bool use_allclose = false) {
+    const bool use_allclose = false,
+    const bool use_equalnan = false) {
   if (expect.isTensor()) {
     VLOG(2) << "expect " << expect.toTensor() << std::endl;
     VLOG(2) << "output " << actual.toTensor() << std::endl;
     EXPECT_TRUE(actual.isTensor());
     if (use_allclose) {
-      EXPECT_TRUE(at::allclose(expect.toTensor(), actual.toTensor()));
+      EXPECT_TRUE(at::allclose(
+          expect.toTensor(),
+          actual.toTensor(),
+          /*rtol*/ 1e-05,
+          /*atol*/ 1e-08,
+          use_equalnan));
     } else {
       EXPECT_TRUE(expect.toTensor().equal(actual.toTensor()));
     }
@@ -176,7 +178,8 @@ void testStaticRuntime(
     const std::string& source,
     const std::vector<IValue>& args,
     const std::vector<IValue>& args2,
-    const bool use_allclose) {
+    const bool use_allclose,
+    const bool use_equalnan) {
   auto test_context = makeTestContext(source);
 
   std::vector<IValue> args_tensors, args_copy;
@@ -196,7 +199,7 @@ void testStaticRuntime(
     auto actual = smodule(args, {});
     smodule.runtime().check_for_memory_leak();
     // first run
-    compareResults(expect, actual, use_allclose);
+    compareResults(expect, actual, use_allclose, use_equalnan);
 
     // args2 is used to check for dynamic shapes
     // it also exercises the memory planner
@@ -205,24 +208,24 @@ void testStaticRuntime(
       actual = smodule(args2, {});
       smodule.runtime().check_for_memory_leak();
       // second run
-      compareResults(expect, actual, use_allclose);
+      compareResults(expect, actual, use_allclose, use_equalnan);
 
       expect = test_context->getExpected(args);
       actual = smodule(args, {});
       smodule.runtime().check_for_memory_leak();
       // third run
-      compareResults(expect, actual, use_allclose);
+      compareResults(expect, actual, use_allclose, use_equalnan);
     } else {
       // run static runtime again to exercise the memory planner
       actual = smodule(args, {});
       smodule.runtime().check_for_memory_leak();
       // second run
-      compareResults(expect, actual, use_allclose);
+      compareResults(expect, actual, use_allclose, use_equalnan);
     }
   }
 
   // make sure inputs were not modified
-  compareTensorLists(args_tensors, args_copy);
+  compareTensorLists(args_tensors, args_copy, use_allclose, use_equalnan);
 }
 
 } // namespace test

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -23,7 +23,8 @@ void testStaticRuntime(
     const std::string& source,
     const std::vector<c10::IValue>& args,
     const std::vector<c10::IValue>& args2 = {},
-    const bool use_allclose = false);
+    const bool use_allclose = false,
+    const bool use_equalnan = false);
 
 } // namespace test
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1267,7 +1267,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::sub, aten_sub, [](Node* n) -> SROperator {
         : at::native::wrapped_scalar_tensor(p_node->Input(1).toScalar());
 
     if (p_node->Output(0).isNone()) {
-      p_node->Output(0) = at::cpu::sub(in0_t, in1_t);
+      p_node->Output(0) = at::cpu::sub(in0_t, in1_t, alpha);
     } else {
       auto& out_t = p_node->Output(0).toTensor();
       fastResizeToZero(out_t);


### PR DESCRIPTION
Summary:
Added tests for the following ops:

* `aten::mul`
* `aten::nan_to_num`
* `aten::stack`
* `aten::relu`
* `aten::tanh`

Reviewed By: hlu1

Differential Revision: D29914217

