### PR TITLE
[Vulkan] Softmax Along Channel Dim

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/softmax.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/softmax.glsl
@@ -1,0 +1,46 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
+  ivec4 size;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+// This implementation is suboptimal and should be revisted.
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (pos.z == 0 && all(lessThan(pos, uBlock.size.xyz))) {
+    float sum = 0;
+    for (int z = 0; z < uBlock.size.z - 1; ++z) {
+      const vec4 input_exp = exp(
+        texelFetch(uInput, ivec3(pos.x, pos.y, z), 0)
+      );
+      sum += (input_exp.x + input_exp.y + input_exp.z + input_exp.w);
+    }
+
+    const vec4 last_input_exp = exp(
+      texelFetch(uInput, ivec3(pos.x, pos.y, uBlock.size.z - 1), 0)
+    );
+    sum += (
+      last_input_exp.x +
+      (uBlock.size.w >= 1 ? last_input_exp.y : 0) +
+      (uBlock.size.w >= 2 ? last_input_exp.z : 0) +
+      (uBlock.size.w == 3 ? last_input_exp.w : 0)
+    );
+
+    for (int z = 0; z < uBlock.size.z; ++z) {
+      const ivec3 curr_pos = ivec3(pos.x, pos.y, z);
+      const vec4 input_exp = exp(texelFetch(uInput, curr_pos, 0));
+      imageStore(uOutput, curr_pos, input_exp / sum);
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -1,0 +1,115 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor softmax(
+    const at::Tensor& input_arg,
+    const int64_t dim,
+    const bool half_to_float) {
+  TORCH_CHECK(
+      input_arg.dim() == 4,
+      "Vulkan softmax expects 4-dimensional input!");
+
+  TORCH_CHECK(
+      dim == 1,
+      "Vulkan softmax expects dim == 1 (channel)");
+
+  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
+  const vTensor& v_input = convert(input);
+  const IntArrayRef v_input_sizes = v_input.sizes();
+
+  TORCH_CHECK(
+      v_input_sizes[Layout::Activation4D::batch] == 1,
+      "Vulkan softmax expects batch dim == 1");
+
+  api::Context* const context = api::context();
+
+  c10::SmallVector<int64_t, 4u> output_sizes{
+    v_input_sizes[Layout::Activation4D::batch],
+    v_input_sizes[Layout::Activation4D::channels],
+    v_input_sizes[Layout::Activation4D::height],
+    v_input_sizes[Layout::Activation4D::width],
+  };
+
+  vTensor v_output{
+    context,
+    output_sizes,
+    v_input.options(),
+  };
+
+  const api::Shader::WorkGroup global_work_group_size = {
+    safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::width]),
+    safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::height]),
+    1,
+  };
+  const api::Shader::WorkGroup local_work_group_size = {8, 8, 1};
+
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    if C10_LIKELY(v_input.has_image()) {
+      const struct Block final {
+        uvec3 iextents;
+        int last_texel_end_offset;
+      } block {
+        v_input.extents(),
+        safe_downcast<int32_t>(
+            (v_input_sizes[Layout::Activation4D::channels] - 1) % 4
+        )
+      };
+
+      context->dispatch(
+          command_buffer,
+          {
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          },
+          VK_KERNEL(softmax),
+          global_work_group_size,
+          local_work_group_size,
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
+          v_output.image(
+              command_buffer,
+              vTensor::Stage::Compute,
+              vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
+          v_input.image(
+              command_buffer,
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
+    }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
+  command_pool.submit(context->gpu().queue, command_buffer);
+
+  return convert(v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl("_softmax", TORCH_FN(softmax));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1339,6 +1339,29 @@ TEST(VulkanAPITest, sigmoid_) {
   ASSERT_TRUE(check);
 }
 
+TEST(VulkanAPITest, softmax) {
+  at::Tensor test_in[] = {
+    at::rand({1, 196, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+    at::rand({1, 197, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+    at::rand({1, 198, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+    at::rand({1, 199, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+  };
+
+  for (auto in_cpu : test_in) {
+    const auto out_cpu = at::softmax(in_cpu, 1);
+
+    const auto in_vulkan = in_cpu.vulkan();
+    const auto out_vulkan = at::softmax(in_vulkan, 1);
+
+    const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+    if (!check) {
+      showRtol(out_cpu, out_vulkan.cpu());
+    }
+
+    ASSERT_TRUE(check);
+  }
+}
+
 TEST(VulkanAPITest, tanh) {
   if (!at::is_vulkan_available()) {
     return;


### PR DESCRIPTION
Summary:
Added naive implementation of vulkan softmax (not using shared memory)

Based off of naive implementation of mean, found here:

https://github.com/pytorch/pytorch/blob/2565a33c9812ee4b764b7da1f0ad4a3bd857d811/aten/src/ATen/native/vulkan/glsl/mean.glsl

Test Plan:
After building:

```
build/bin/vulkan_api_test
```

{F635874375}

Differential Revision: D29793150

