### PR TITLE
Add support for hessian computation with forward AD and vmap

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -1022,6 +1022,10 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   // to the underlying implementation. However, because a BatchedTensor is a
   // Tensor wrapper, it only has one dispatch key (Batched) on it. The resolution
   // here is to just directly call the underlying implementation.
+  m.impl("_make_dual", native::_make_dual);
+  m.impl("is_same_size", native::is_same_size);
+  m.impl("_fw_primal", native::_fw_primal);
+
   m.impl("size.int", static_cast<int64_t (*)(const Tensor&, int64_t)>(native::size));
   m.impl("_add_batch_dim", native::_add_batch_dim);
   m.impl("_remove_batch_dim", native::_remove_batch_dim);

--- a/aten/src/ATen/VmapTransforms.cpp
+++ b/aten/src/ATen/VmapTransforms.cpp
@@ -80,6 +80,17 @@ VmapDimVector VmapPhysicalView::getPhysicalShape(IntArrayRef logical_shape) cons
   return result;
 }
 
+VmapDimVector VmapPhysicalView::getPhysicalStrides(IntArrayRef logical_strides) const {
+  at::VmapDimVector physical_strides;
+  auto batch_strides = tensor().strides().slice(0, numBatchDims());
+  physical_strides.reserve(numBatchDims() + logical_strides.size());
+  physical_strides.insert(
+      physical_strides.end(), batch_strides.begin(), batch_strides.end());
+  physical_strides.insert(
+      physical_strides.end(), logical_strides.begin(), logical_strides.end());
+  return physical_strides;
+}
+
 static BatchDims computeFrontBatchDimsFromLevels(std::bitset<kVmapNumLevels> levels_bitset) {
   BatchDims bdims;
   int64_t dim = 0;

--- a/aten/src/ATen/VmapTransforms.h
+++ b/aten/src/ATen/VmapTransforms.h
@@ -136,6 +136,10 @@ struct TORCH_API VmapPhysicalView {
   // sizes to the logical shape.
   VmapDimVector getPhysicalShape(IntArrayRef logical_shape) const;
 
+  // Maps logical strides to physical strides by pre-pending the batch
+  // strides to the logical strides
+  VmapDimVector getPhysicalStrides(IntArrayRef logical_strides) const;
+
   int64_t numBatchDims() const;
 
  private:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6734,17 +6734,22 @@ class TestAutogradFunctional(TestCase):
     def test_jacobian_create_graph_vectorize(self):
         self._test_jacobian_create_graph(vectorize=True)
 
-    def _check_jacobian_vectorize_correctness(self, f, inputs):
+    def _check_jacobian_vectorize_correctness(self, f, inputs, test_forward_ad=True):
         expected = autogradF.jacobian(f, inputs, vectorize=False)
-        result = autogradF.jacobian(f, inputs, vectorize=True)
-        self.assertEqual(result, expected)
+        result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
+        self.assertEqual(result_backward_mode, expected)
+
+        if test_forward_ad:
+            result_forward_mode = autogradF.jacobian(f, inputs, forward_ad=True, vectorize=True)
+            self.assertEqual(result_forward_mode, expected)
 
     def test_jacobian_vectorize_correctness_simple(self):
         def f(x):
             return 3 * x ** 2
 
         x = torch.randn(2, 3, 5)
-        self._check_jacobian_vectorize_correctness(f, x)
+        # TODO: test forward AD again when `pow` is supported
+        self._check_jacobian_vectorize_correctness(f, x, test_forward_ad=False)
 
     def test_jacobian_vectorize_correctness_multi_input(self):
         def f(x, y):
@@ -6760,7 +6765,8 @@ class TestAutogradFunctional(TestCase):
 
         x = torch.randn(5, 3)
         y = torch.randn(3, 5)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        # TODO: test forward AD again when `sum` is supported
+        self._check_jacobian_vectorize_correctness(f, (x, y), test_forward_ad=False)
 
     def test_jacobian_vectorize_correctness_unrelated_outputs(self):
         def f(x, y):
@@ -6777,14 +6783,16 @@ class TestAutogradFunctional(TestCase):
 
         x = torch.randn(3)
         y = torch.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
+        # TODO: test forward AD again when `sum` is supported
+        self._check_jacobian_vectorize_correctness(f, (x, y), test_forward_ad=False)
 
         # zero-dim input
         def g(x):
             return torch.stack([x, x, x])
 
         x = torch.randn([])
-        self._check_jacobian_vectorize_correctness(g, x)
+        # TODO: test forward AD again when `stack` is supported
+        self._check_jacobian_vectorize_correctness(g, x, test_forward_ad=False)
 
         # Mixed zero-dim input / zero-dim output
         def h(x, y):
@@ -6792,7 +6800,9 @@ class TestAutogradFunctional(TestCase):
 
         x = torch.randn([])
         y = torch.randn(1)
-        self._check_jacobian_vectorize_correctness(h, (x, y))
+
+        # TODO: test forward AD again when `sum` is supported
+        self._check_jacobian_vectorize_correctness(h, (x, y), test_forward_ad=False)
 
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_jacobian_vectorize_correctness_different_devices(self):
@@ -6810,6 +6820,27 @@ class TestAutogradFunctional(TestCase):
         x = torch.randn(3)
         y = torch.randn(3)
         self._check_jacobian_vectorize_correctness(f, (x, y))
+
+    # def test_(self):
+    #     from torch.autograd.functional import jacobian
+
+    #     a = torch.rand(2, 3, requires_grad=True, dtype=torch.double)
+    #     b = torch.rand(4, requires_grad=True, dtype=torch.double)
+    #     c = torch.rand(4, requires_grad=True, dtype=torch.double)
+    #     d = torch.rand(3, 4, requires_grad=True, dtype=torch.double)
+
+    #     def test_fn(a, b, c, d):
+    #         return torch.matmul(a, d) * b.exp() + c.sin(), torch.mean(b * c, dim=0)
+
+    #     def run_test(fn, inputs):
+    #         self.assertEqual(jacobian(fn, inputs, forward_ad=True, vectorize=True), jacobian(fn, inputs))
+
+    #     run_test(test_fn, (a, b, c, d))
+    #     run_test(torch.sin, a)  # element-wise, has batching rule
+    #     run_test(lambda x: torch.mean(x, dim=0), a)  # reduction, batched fallback
+    #     run_test(lambda x: torch.dot(x, b), c)  # matmul-like, has batching rule
+    #     run_test(lambda x: torch.matmul(x, d), a)  # matmul-like operator
+    #     run_test(lambda x: x.view(-1), a)  # view op
 
     def _check_hessian_vectorize_correctness(self, f, inputs):
         expected = autogradF.hessian(f, inputs, vectorize=False)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6739,17 +6739,15 @@ class TestAutogradFunctional(TestCase):
         result_backward_mode = autogradF.jacobian(f, inputs, vectorize=True)
         self.assertEqual(result_backward_mode, expected)
 
-        if test_forward_ad:
-            result_forward_mode = autogradF.jacobian(f, inputs, forward_ad=True, vectorize=True)
-            self.assertEqual(result_forward_mode, expected)
+        result_forward_mode = autogradF.jacobian(f, inputs, forward_ad=True, vectorize=True)
+        self.assertEqual(result_forward_mode, expected)
 
     def test_jacobian_vectorize_correctness_simple(self):
         def f(x):
             return 3 * x ** 2
 
         x = torch.randn(2, 3, 5)
-        # TODO: test forward AD again when `pow` is supported
-        self._check_jacobian_vectorize_correctness(f, x, test_forward_ad=False)
+        self._check_jacobian_vectorize_correctness(f, x)
 
     def test_jacobian_vectorize_correctness_multi_input(self):
         def f(x, y):
@@ -6765,8 +6763,7 @@ class TestAutogradFunctional(TestCase):
 
         x = torch.randn(5, 3)
         y = torch.randn(3, 5)
-        # TODO: test forward AD again when `sum` is supported
-        self._check_jacobian_vectorize_correctness(f, (x, y), test_forward_ad=False)
+        self._check_jacobian_vectorize_correctness(f, (x, y))
 
     def test_jacobian_vectorize_correctness_unrelated_outputs(self):
         def f(x, y):
@@ -6783,16 +6780,14 @@ class TestAutogradFunctional(TestCase):
 
         x = torch.randn(3)
         y = torch.randn(3)
-        # TODO: test forward AD again when `sum` is supported
-        self._check_jacobian_vectorize_correctness(f, (x, y), test_forward_ad=False)
+        self._check_jacobian_vectorize_correctness(f, (x, y))
 
         # zero-dim input
         def g(x):
             return torch.stack([x, x, x])
 
         x = torch.randn([])
-        # TODO: test forward AD again when `stack` is supported
-        self._check_jacobian_vectorize_correctness(g, x, test_forward_ad=False)
+        self._check_jacobian_vectorize_correctness(g, x)
 
         # Mixed zero-dim input / zero-dim output
         def h(x, y):
@@ -6800,9 +6795,7 @@ class TestAutogradFunctional(TestCase):
 
         x = torch.randn([])
         y = torch.randn(1)
-
-        # TODO: test forward AD again when `sum` is supported
-        self._check_jacobian_vectorize_correctness(h, (x, y), test_forward_ad=False)
+        self._check_jacobian_vectorize_correctness(h, (x, y))
 
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_jacobian_vectorize_correctness_different_devices(self):
@@ -6821,31 +6814,13 @@ class TestAutogradFunctional(TestCase):
         y = torch.randn(3)
         self._check_jacobian_vectorize_correctness(f, (x, y))
 
-    # def test_(self):
-    #     from torch.autograd.functional import jacobian
-
-    #     a = torch.rand(2, 3, requires_grad=True, dtype=torch.double)
-    #     b = torch.rand(4, requires_grad=True, dtype=torch.double)
-    #     c = torch.rand(4, requires_grad=True, dtype=torch.double)
-    #     d = torch.rand(3, 4, requires_grad=True, dtype=torch.double)
-
-    #     def test_fn(a, b, c, d):
-    #         return torch.matmul(a, d) * b.exp() + c.sin(), torch.mean(b * c, dim=0)
-
-    #     def run_test(fn, inputs):
-    #         self.assertEqual(jacobian(fn, inputs, forward_ad=True, vectorize=True), jacobian(fn, inputs))
-
-    #     run_test(test_fn, (a, b, c, d))
-    #     run_test(torch.sin, a)  # element-wise, has batching rule
-    #     run_test(lambda x: torch.mean(x, dim=0), a)  # reduction, batched fallback
-    #     run_test(lambda x: torch.dot(x, b), c)  # matmul-like, has batching rule
-    #     run_test(lambda x: torch.matmul(x, d), a)  # matmul-like operator
-    #     run_test(lambda x: x.view(-1), a)  # view op
-
     def _check_hessian_vectorize_correctness(self, f, inputs):
         expected = autogradF.hessian(f, inputs, vectorize=False)
         result = autogradF.hessian(f, inputs, vectorize=True)
         self.assertEqual(result, expected)
+
+        result_forward_mode = autogradF.hessian(f, inputs, forward_ad=True, vectorize=True)
+        self.assertEqual(result_forward_mode, expected)
 
     def test_hessian_vectorize_correctness_simple(self):
         def f(x):
@@ -6874,7 +6849,7 @@ class TestAutogradFunctional(TestCase):
 
         # output unrelated to all inputs
         def f(x, y):
-            return torch.randn([])
+            return torch.ones([])
 
         x = torch.randn(2)
         y = torch.randn(3)

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -790,27 +790,6 @@ class TestVmapAPI(TestCase):
         jacobian = vmap(vjp_mul)(batched_v)
         self.assertEqual(jacobian, torch.diagflat(y))
 
-    def test_vectorized_forward_ad_jacobian(self):
-        from torch.autograd.functional import jacobian
-
-        a = torch.rand(2, 3, requires_grad=True, dtype=torch.double)
-        b = torch.rand(4, requires_grad=True, dtype=torch.double)
-        c = torch.rand(4, requires_grad=True, dtype=torch.double)
-        d = torch.rand(3, 4, requires_grad=True, dtype=torch.double)
-
-        def test_fn(a, b, c, d):
-            return torch.matmul(a, d) * b.exp() + c.sin(), torch.mean(b * c, dim=0)
-
-        def run_test(fn, inputs):
-            self.assertEqual(jacobian(fn, inputs, forward_ad=True, vectorize=True), jacobian(fn, inputs))
-
-        run_test(test_fn, (a, b, c, d))
-        run_test(torch.sin, a)  # element-wise, has batching rule
-        run_test(lambda x: torch.mean(x, dim=0), a)  # reduction, batched fallback
-        run_test(lambda x: torch.dot(x, b), c)  # matmul-like, has batching rule
-        run_test(lambda x: torch.matmul(x, d), a)  # matmul-like operator
-        run_test(lambda x: x.view(-1), a)  # view op
-
     def test_functools_partial(self):
         x = torch.randn(3)
         y = torch.randn(2, 3)

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -790,39 +790,21 @@ class TestVmapAPI(TestCase):
         jacobian = vmap(vjp_mul)(batched_v)
         self.assertEqual(jacobian, torch.diagflat(y))
 
-    def test_batched_tangent_fwd_ad(self):
+    def test_vectorized_forward_ad_jacobian(self):
         from torch.autograd.functional import jacobian
-        import torch.autograd.forward_ad as fwAD
-        from torch._vmap_internals import _vmap
-
-        def reference(func, flattened_input, original_shape):
-            # Helper to make sure functional.jacobian returns a 2D Jacobian
-            def fn(input):
-                input = input.view(original_shape)
-                return torch.flatten(func(input))
-            return jacobian(fn, flattened_input)
-
-        def run_test(func, input):
-            # Stacked one-hot vectors so that we can get each col of the Jacobian
-            grad = torch.eye(input.numel(), dtype=torch.double).reshape(input.numel(), *input.shape)
-
-            def jvp(grad):
-                with fwAD.dual_level():
-                    dual = fwAD.make_dual(input, grad)
-                    dual_out = func(dual)
-                    _, tangent = fwAD.unpack_dual(dual_out)
-                # We want to return 2-D Jacobian
-                return tangent.view(-1)
-            # Transpose here because the batched dimension is prepended and we batched over
-            # a dimension with size of outputs.numel().
-            jac = _vmap(jvp)(grad).transpose(0, 1)
-            self.assertEqual(jac, reference(func, input.flatten(), input.shape))
 
         a = torch.rand(2, 3, requires_grad=True, dtype=torch.double)
-        b = torch.rand(5, requires_grad=True, dtype=torch.double)
-        c = torch.rand(5, requires_grad=True, dtype=torch.double)
+        b = torch.rand(4, requires_grad=True, dtype=torch.double)
+        c = torch.rand(4, requires_grad=True, dtype=torch.double)
         d = torch.rand(3, 4, requires_grad=True, dtype=torch.double)
 
+        def test_fn(a, b, c, d):
+            return torch.matmul(a, d) * b.exp() + c.sin(), torch.mean(b * c, dim=0)
+
+        def run_test(fn, inputs):
+            self.assertEqual(jacobian(fn, inputs, forward_ad=True, vectorize=True), jacobian(fn, inputs))
+
+        run_test(test_fn, (a, b, c, d))
         run_test(torch.sin, a)  # element-wise, has batching rule
         run_test(lambda x: torch.mean(x, dim=0), a)  # reduction, batched fallback
         run_test(lambda x: torch.dot(x, b), c)  # matmul-like, has batching rule

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1592,6 +1592,7 @@
 
 - name: relu(Tensor self) -> Tensor
   self: threshold_backward(grad, self, 0)
+  result: threshold_backward(self_t, self_p, 0)
 
 # NB: `output` instead of `self` saves memory. It avoids saving a copy of self.
 - name: relu_(Tensor(a!) self) -> Tensor(a!)
@@ -2007,6 +2008,7 @@
 - name: threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor
   grad_output: threshold_backward(grad, self, threshold)
   self: zeros_like(grad)
+  result: zeros_like(self_t) + threshold_backward(grad_output_t, self_p, threshold)
 
 - name: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners, float? scales=None) -> Tensor
   grad_output: upsample_linear1d(grad, output_size, align_corners, scales)
@@ -2210,6 +2212,7 @@
 
 - name: stack(Tensor[] tensors, int dim=0) -> Tensor
   tensors: "grad.defined() ? unbind(grad, dim) : std::vector<Tensor>(tensors.size())"
+  result: stack_jvp(tensors, dim)
 
 # fused RNN kernels
 

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -1,12 +1,16 @@
 import torch
 from typing import Tuple, List
 from torch._vmap_internals import _vmap
+import torch.autograd.forward_ad as fwAD
 
 # Utility functions
 
-def _as_tuple(inp, arg_name, fn_name):
+def _as_tuple(inp, arg_name=None, fn_name=None):
     # Ensures that inp is a tuple of Tensors
     # Returns whether or not the original inp was a tuple and the tupled version of the input
+    if arg_name is None and fn_name is None:
+        return _as_tuple_nocheck(inp)
+
     is_inp_tuple = True
     if not isinstance(inp, tuple):
         inp = (inp,)
@@ -22,6 +26,14 @@ def _as_tuple(inp, arg_name, fn_name):
                                 " given {} has type {}.".format(arg_name, fn_name, arg_name, type(el)))
 
     return is_inp_tuple, inp
+
+def _as_tuple_nocheck(x):
+    if isinstance(x, tuple):
+        return x
+    elif isinstance(x, list):
+        return tuple(x)
+    else:
+        return x,
 
 def _tuple_postprocess(res, to_unpack):
     # Unpacks a potentially nested tuple of Tensors
@@ -408,7 +420,60 @@ def _construct_standard_basis_for(tensors: Tuple[torch.Tensor, ...], tensor_nume
     return chunks
 
 
-def jacobian(func, inputs, create_graph=False, strict=False, vectorize=False):
+def _jacfwd(func, inputs, strict=False, vectorize=False):
+    if strict:
+        raise RuntimeError('torch.autograd.functional.jacobian: `strict=True` '
+                            'and `forward_ad=True` are not supported together (yet). '
+                            'Please either set `strict=False` or '
+                            '`forward_ad=False`.')
+    is_inputs_tuple, inputs = _as_tuple(inputs, "inputs", "jacobian")
+    outputs = func(*inputs)
+    is_outputs_tuple, outputs = _as_tuple(outputs,
+                                            "outputs of the user-provided function",
+                                            "jacobian")
+    if vectorize:
+        # See NOTE: [Computing jacobian with vmap and grad for multiple outputs]
+        if strict:
+            raise RuntimeError('torch.autograd.functional.jacobian: `strict=True` '
+                                'and `vectorized=True` are not supported together. '
+                                'Please either set `strict=False` or '
+                                '`vectorize=False`.')
+        input_numels = tuple(input.numel() for input in inputs)
+
+        # Step 1: Prepare tangents
+        tangents = _construct_standard_basis_for(inputs, input_numels)
+
+        # Step 2: Compute vmap over computation with dual tensors
+        def jvp(tangents):
+            with fwAD.dual_level():
+                dual_inputs = tuple(
+                    fwAD.make_dual(input, tangent.view_as(input)) for input, tangent in zip(inputs, tangents))
+                dual_outputs = _as_tuple(func(*dual_inputs))
+                # TODO what if not all outputs are dual tensors
+                return tuple(fwAD.unpack_dual(dual_out)[1] for dual_out in dual_outputs)
+
+        outputs_before_split = _vmap(jvp)(tangents)
+
+        # Step 3: for each of the output tangents, split along dim 0
+        jacobian_input_output = []
+        for jac, output_i in zip(outputs_before_split, outputs):
+            jacobian_output_i_output = []
+            for jac, input_j in zip(jac.split(input_numels, dim=0), inputs):
+                # We need to transpose the Jacobian because in forward AD, the
+                # batch dimension represents that of the inputs
+                jacobian_input_i_output_j = \
+                    jac.permute(*range(1, jac.ndim), 0).reshape(*output_i.shape, *input_j.shape)
+                jacobian_output_i_output.append(jacobian_input_i_output_j)
+            jacobian_input_output.append(jacobian_output_i_output)
+
+        # Omit [Step 4] because everything is already transposed w/ forward AD
+        return _tuple_postprocess(jacobian_input_output, (is_outputs_tuple, is_inputs_tuple))
+    else:
+        raise NotImplementedError("Only vectorized path is implemented")
+
+
+
+def jacobian(func, inputs, create_graph=False, strict=False, vectorize=False, forward_ad=False):
     r"""Function that computes the Jacobian of a given function.
 
     Args:
@@ -474,6 +539,8 @@ def jacobian(func, inputs, create_graph=False, strict=False, vectorize=False):
          tensor([[3., 0.],
                  [0., 3.]]))
     """
+    if forward_ad:
+        return _jacfwd(func, inputs, strict, vectorize)
 
     with torch.enable_grad():
         is_inputs_tuple, inputs = _as_tuple(inputs, "inputs", "jacobian")

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1299,6 +1299,7 @@ def gradgradcheck(
     check_undefined_grad: bool = True,
     check_grad_dtypes: bool = False,
     check_batched_grad: bool = False,
+    check_forward_ad: bool = False,
     fast_mode: bool = False,
 ) -> bool:
     r"""Check gradients of gradients computed via small finite differences
@@ -1386,4 +1387,5 @@ def gradgradcheck(
     return gradcheck(
         new_func, tupled_inputs + tupled_grad_outputs, eps, atol, rtol, raise_exception,
         nondet_tol=nondet_tol, check_undefined_grad=check_undefined_grad,
-        check_grad_dtypes=check_grad_dtypes, check_batched_grad=check_batched_grad, fast_mode=fast_mode)
+        check_grad_dtypes=check_grad_dtypes, check_batched_grad=check_batched_grad,
+        fast_mode=fast_mode, check_forward_ad=check_forward_ad)

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -260,6 +260,7 @@ Tensor _det_lu_based_helper_backward(
   const Tensor& pivs
 );
 
+Tensor stack_jvp(at::TensorList tensors, int64_t dim);
 Tensor cat_jvp(at::TensorList tensors, int64_t dim);
 Tensor cumprod_jvp(Tensor self_t, Tensor self_p, Tensor result, int dim);
 Tensor gather_with_keepdimed_indices(const Tensor& input, int64_t dim, const Tensor& indices, bool keepdim);


### PR DESCRIPTION
This PR does misc things to add support for hessian computation (and thus Jacobian computation) with forward AD + vmap.  We should use `forward_ad=False` and `double_backward_trick=True` as our defaults until more formulas are added, then we can eventually use the faster (need to measure) hessian and jvp computation by default.

We needed the following batched fall-through kernels:
- `make_dual`: Since we now need to construct a dual tensor with a batched tangent, we need to make `make_dual` fall-through to its native implementation
- `is_same_size`: Because `make_dual` is now "batched composite", we need to add batched support for the ops it branches into

When dual tensor holds a batched tangent, we first dispatch to autograd key. We then dispatch to batched kernels when computing forward grads. So generally if we previously added a batching rule for composite autograd implicit op, we now also need to add batching rules (if necessary) for all the ops that composite op branches into:
 - `_reshape_alias`: because of `reshape`
 
Note that we shouldn't have to implement a batching rule or fall-through for `unpack_dual` if we call it with an actual tensor that has forward grads because only the tangent may be batched, but maybe its good to add a sanity check here.

Forward AD formulas added that are used for implementation and testing.
 - `stack`, `relu`, and `threshold_backward` (backward for relu)

Adds some basic testing by modifying previous tests for vectorized Jacobian and Hessian computation. Also adds `check_forward_ad` flag to gradgradcheck. Theres probably something we can do with OpInfos to add the same check as we have now with gradcheck.

Todo:
 - Testing for forward AD formulas, some kind of module test framework
 - Test jvp
 - Implement hvp (not necessarily in this PR)
 - Measure speedup to jvp, hessian computation