### PR TITLE
[pytorch] fix a build failure caused by ignoring an error return value

### DIFF
--- a/c10/cuda/CUDAStream.h
+++ b/c10/cuda/CUDAStream.h
@@ -119,7 +119,7 @@ class C10_CUDA_API CUDAStream {
       C10_CUDA_CHECK(err);
     } else {
       // ignore and clear the error if not ready
-      cudaGetLastError();
+      (void)cudaGetLastError();
     }
 
     return false;

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -169,7 +169,7 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
       C10_CUDA_CHECK(err);
     } else {
       // ignore and clear the error if not ready
-      cudaGetLastError();
+      (void)cudaGetLastError();
     }
     return (err == cudaSuccess);
   }

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -313,7 +313,7 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
     auto status = cudaStreamQuery(stream);
     if (status == cudaErrorNotReady) {
       // ignore and clear the error if not ready
-      cudaGetLastError();
+      (void)cudaGetLastError();
     }
     return status == cudaSuccess;
   }

--- a/caffe2/core/event_gpu.cc
+++ b/caffe2/core/event_gpu.cc
@@ -165,7 +165,7 @@ EventStatus EventQueryCUDA(const Event* event) {
       wrapper->status_ = EventStatus::EVENT_FAILED;
     } else {
       // ignore and clear the error if not ready
-      cudaGetLastError();
+      (void)cudaGetLastError();
     }
   }
   return static_cast<EventStatus>(wrapper->status_.load());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62247

Cast the return value of `cudaGetLastError()` to void, to tell the compiler
that we are explicitly ignoring it.  Otherwise this causes a build failure
when the `-Werror` and `-Wunused-result` compiler flags are used, which is the
case for FB internal builds.

Differential Revision: [D29923802](https://our.internmc.facebook.com/intern/diff/D29923802/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29923802/)!