### PR TITLE
Split zeta_kernel out of BinaryMiscOpsKernel.cu

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -4,7 +4,6 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/cuda/Math.cuh>
-#include <ATen/native/Math.h>
 #include <ATen/NumericUtils.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
@@ -69,20 +68,11 @@ void xlog1py_kernel_cuda(TensorIteratorBase& iter) {
   });
 }
 
-void zeta_kernel_cuda(TensorIteratorBase& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "zeta_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t x, scalar_t q) -> scalar_t {
-      return zeta<scalar_t, /*is_cuda=*/true>(x, q);
-    });
-  });
-}
-
 REGISTER_DISPATCH(smooth_l1_stub, &smooth_l1_kernel_cuda);
 REGISTER_DISPATCH(huber_stub, &huber_kernel_cuda);
 REGISTER_DISPATCH(mse_stub, &mse_kernel_cuda);
 REGISTER_DISPATCH(xlogy_stub, &xlogy_kernel_cuda);
 REGISTER_DISPATCH(xlog1py_stub, &xlog1py_kernel_cuda);
-REGISTER_DISPATCH(zeta_stub, &zeta_kernel_cuda);
 
 // DO NOT ADD ANY NEW KERNELS HERE
 // CUDA compilation times grow quickly.  It's perfectly acceptable to have a file per kernel.

--- a/aten/src/ATen/native/cuda/ZetaKernel.cu
+++ b/aten/src/ATen/native/cuda/ZetaKernel.cu
@@ -1,0 +1,21 @@
+#include <ATen/Dispatch.h>
+#include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/BinaryOps.h>
+#include <ATen/native/Math.h>
+
+namespace at { namespace native {
+namespace {
+
+void zeta_kernel_cuda(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "zeta_cuda", [&]() {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t x, scalar_t q) -> scalar_t {
+      return zeta<scalar_t, /*is_cuda=*/true>(x, q);
+    });
+  });
+}
+
+}  // namespace (anonymous)
+
+REGISTER_DISPATCH(zeta_stub, &zeta_kernel_cuda);
+
+}} // namespace at::native


### PR DESCRIPTION
`BinaryMiscOpsKernel.cu` takes 4 m 30 s to compile on my machine, which is the second slowest after `PowKernel.cu`. Moving the zeta kernel into it's own file takes 3 m 30 s, and reduces `BinaryMiscOpsKernel.cu` compile time to 1 m.
