### PR TITLE
Fix a size calculation bug in InferCat

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -359,7 +359,7 @@ class TSNodeLowering : public NodeLowering {
     lazy_tensors::Shape output_shape = operands[0].shape();
     size_t cat_dimension_size = 0;
     for (const ir::Output& operand : operands) {
-      cat_dimension_size += output_shape.dimensions(node->dim());
+      cat_dimension_size += operand.shape().dimensions(node->dim());
     }
     output_shape.set_dimensions(node->dim(), cat_dimension_size);
     return output_shape;

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -3674,6 +3674,7 @@ TEST_F(AtenLtcTsTensorTest, TestCat) {
       torch::Tensor xla_b = CopyToDevice(b, device);
       torch::Tensor xla_c = CopyToDevice(c, device);
       torch::Tensor xla_d = torch::cat({xla_a, xla_b, xla_c}, dim);
+      EXPECT_TRUE(d.sizes() == xla_d.sizes() && d.dtype() == xla_d.dtype());
       AllClose(d, xla_d);
     });
   }


### PR DESCRIPTION
Test Plan:
```
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestCat

P429296936
```
