### PR TITLE
[reland][bc-breaking] reference option for linear produce a pattern instead of reference linear module (#61892)

### DIFF
--- a/torch/nn/intrinsic/qat/modules/linear_relu.py
+++ b/torch/nn/intrinsic/qat/modules/linear_relu.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn.qat as nnqat
 import torch.nn.intrinsic as nni
 import torch.nn.functional as F
@@ -36,3 +37,12 @@ class LinearReLU(nnqat.Linear, nni._FusedModule):
     @classmethod
     def from_float(cls, mod):
         return super(LinearReLU, cls).from_float(mod)
+
+    def to_float(self):
+        linear = torch.nn.Linear(self.in_features, self.out_features)
+        linear.weight = torch.nn.Parameter(self.weight.detach())
+        linear.bias = None
+        if self.bias is not None:
+            linear.bias = torch.nn.Parameter(self.bias.detach())
+        relu = torch.nn.ReLU()
+        return torch.nn.intrinsic.LinearReLU(linear, relu)

--- a/torch/nn/intrinsic/qat/modules/linear_relu.py
+++ b/torch/nn/intrinsic/qat/modules/linear_relu.py
@@ -39,9 +39,8 @@ class LinearReLU(nnqat.Linear, nni._FusedModule):
         return super(LinearReLU, cls).from_float(mod)
 
     def to_float(self):
-        linear = torch.nn.Linear(self.in_features, self.out_features)
+        linear = torch.nn.Linear(self.in_features, self.out_features, self.bias is not None)
         linear.weight = torch.nn.Parameter(self.weight.detach())
-        linear.bias = None
         if self.bias is not None:
             linear.bias = torch.nn.Parameter(self.bias.detach())
         relu = torch.nn.ReLU()

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.intrinsic import LinearReLU
@@ -49,3 +50,11 @@ class Linear(nn.Linear):
         qat_linear.weight = mod.weight
         qat_linear.bias = mod.bias
         return qat_linear
+
+    def to_float(self):
+        linear = torch.nn.Linear(self.in_features, self.out_features)
+        linear.weight = torch.nn.Parameter(self.weight.detach())
+        if self.bias is not None:
+            linear.bias = torch.nn.Parameter(self.bias.detach())
+        linear.train(self.training)
+        return linear

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -52,7 +52,7 @@ class Linear(nn.Linear):
         return qat_linear
 
     def to_float(self):
-        linear = torch.nn.Linear(self.in_features, self.out_features)
+        linear = torch.nn.Linear(self.in_features, self.out_features, self.bias is not None)
         linear.weight = torch.nn.Parameter(self.weight.detach())
         if self.bias is not None:
             linear.bias = torch.nn.Parameter(self.bias.detach())

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -852,6 +852,7 @@ class QuantizationTestCase(TestCase):
                 print()
             self.checkGraphModuleNodes(
                 qgraph_to_check, expected_node, expected_node_occurrence, expected_node_list)
+            # TODO: change this to return prepared model, qgraph and result
             return result
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62277

Summary:

This PR changes is_reference=True for linear to produce a pattern consists of dequant - float linear - quant instead of reference linear module, this is useful for future transformations to custom backends, it is also helpful to simplify the implementation for
convert in the future.

Test Plan:
python test/test_quantization.py TestQuantizeFxOps

Imported from OSS

Reviewed By: vkuzo

Differential Revision: [D29941079](https://our.internmc.facebook.com/intern/diff/D29941079)