### PR TITLE
remove print for status on scribe sending

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -743,8 +743,8 @@ def send_report_to_scribe(reports: Dict[str, TestFile]) -> None:
             for test_case in test_suite.test_cases.values()
         ]
     )
-    res = send_to_scribe(logs)
-    print(res)
+    # no need to print send result as exceptions will be captured and print later.
+    send_to_scribe(logs)
 
 
 def assemble_s3_object(


### PR DESCRIPTION
Following up on #61768.

Currently the printout is hugely long because each test case returns a status code OK without an exception.
This should be avoided when no exception was raised from send_to_scribe. 

Removing the log printing when response without error