### PR TITLE
Limit smoke tests on PRs to just one config

### DIFF
--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -204,7 +204,7 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$USE_CUDA" == 1 ]]; then
+            if [[ -n $GITHUB_HEAD_REF && "$BUILD_ENVIRONMENT" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh

--- a/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/periodic-pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -175,7 +175,7 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$USE_CUDA" == 1 ]]; then
+            if [[ -n $GITHUB_HEAD_REF && "$BUILD_ENVIRONMENT" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -152,7 +152,7 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$USE_CUDA" == 1 ]]; then
+            if [[ -n $GITHUB_HEAD_REF && "$BUILD_ENVIRONMENT" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -170,7 +170,7 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$USE_CUDA" == 1 ]]; then
+            if [[ -n $GITHUB_HEAD_REF && "$BUILD_ENVIRONMENT" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -169,7 +169,7 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$USE_CUDA" == 1 ]]; then
+            if [[ -n $GITHUB_HEAD_REF && "$BUILD_ENVIRONMENT" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh


### PR DESCRIPTION
When coming across the short runtime of a periodic job on this PR, I realized the current smoke tests on PRs set up was flawed. Previously an attempt for better future compatibility, our conditional for running smoke tests only was for USE_CUDA=1 on Windows. 

This is BAD and has unintended consequences, such as misleading results when a ci/scheduled workflow is triggered but fails to test the full test suite. e.g., with PR #62266 https://github.com/pytorch/pytorch/pull/62266/checks?check_run_id=3174266720