### PR TITLE
Do not modify saved variables in-place for spectral norm during power iteration

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4289,6 +4289,15 @@ class TestNN(NNTestCase):
 
                     gradcheck(fn, (m.parametrizations.weight.original,))
 
+    def test_new_spectral_norm_executed_twice_single_forward(self):
+        inputs = torch.tensor([[1., 2.], [-1., -2.]])
+        m = nn.Linear(2, 2)
+        m = torch.nn.utils.parametrizations.spectral_norm(m)
+        x = m(inputs)
+        # Use the same module again in the same forward
+        x = m(x)
+        loss = x.sum().backward()
+
     def test_new_spectral_norm_load_state_dict(self):
         for activate_times in (0, 3):
             inp = torch.randn(2, 3)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4220,6 +4220,9 @@ class TestNN(NNTestCase):
                     out1 = wrapped_m(input)
                     return out0 + out1
 
+                # Make sure we can compute gradients wrt to all the parameters in the case
+                # of double forward
+                fn(input.clone().requires_grad_()).sum().backward()
                 gradcheck(fn, (input.clone().requires_grad_(),), check_batched_grad=False)
 
                 # test removing
@@ -4288,15 +4291,6 @@ class TestNN(NNTestCase):
                         return wrapped_m(input)
 
                     gradcheck(fn, (m.parametrizations.weight.original,))
-
-    def test_new_spectral_norm_executed_twice_single_forward(self):
-        inputs = torch.tensor([[1., 2.], [-1., -2.]])
-        m = nn.Linear(2, 2)
-        m = torch.nn.utils.parametrizations.spectral_norm(m)
-        x = m(inputs)
-        # Use the same module again in the same forward
-        x = m(x)
-        loss = x.sum().backward()
 
     def test_new_spectral_norm_load_state_dict(self):
         for activate_times in (0, 3):

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -103,12 +103,8 @@ class _SpectralNorm(Module):
             if self.training:
                 self._power_method(weight_mat, self.n_power_iterations)
             # See above on why we need to clone
-            if self.n_power_iterations > 0:
-                u = self._u.clone(memory_format=torch.contiguous_format)
-                v = self._v.clone(memory_format=torch.contiguous_format)
-            else:
-                u = self._u
-                v = self._v
+            u = self._u.clone(memory_format=torch.contiguous_format)
+            v = self._v.clone(memory_format=torch.contiguous_format)
             # The proper way of computing this should be through F.bilinear, but
             # it seems to have some efficiency issues:
             # https://github.com/pytorch/pytorch/issues/58093

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -84,6 +84,11 @@ class _SpectralNorm(Module):
 
         # Precondition
         assert weight_mat.ndim > 1
+
+        if n_power_iterations > 0:
+            # See above for why we need this clone
+            self._u = self._u.clone(memory_format=torch.contiguous_format)
+            self._v = self._v.clone(memory_format=torch.contiguous_format)
         for _ in range(n_power_iterations):
             # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
             # are the first left and right singular vectors.
@@ -92,9 +97,6 @@ class _SpectralNorm(Module):
                                   dim=0, eps=self.eps, out=self._u)   # type: ignore[has-type]
             self._v = F.normalize(torch.mv(weight_mat.t(), self._u),
                                   dim=0, eps=self.eps, out=self._v)   # type: ignore[has-type]
-        # See above on why we need to clone
-        self._u = self._u.clone(memory_format=torch.contiguous_format)
-        self._v = self._v.clone(memory_format=torch.contiguous_format)
 
     def forward(self, weight: torch.Tensor) -> torch.Tensor:
         if weight.ndim == 1:


### PR DESCRIPTION
Interestingly enough, the original code did have a mechanism that aims to prevent this very issue:
but it performs a clone AFTER modifying u and v in-place.
This wouldn't work though because we can later use the cloned u and v in operations that save for backward, and the next time we execute forward, we modify the same cloned u and v in-place.
So if the idea is that we want to avoid modifying saved variable in-place we should clone it BEFORE the in-place operation.
