### PR TITLE
Enable ncclAvg for reductions

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -282,6 +282,20 @@ class ProcessGroupNCCLTest(TestCase):
                 tensors[i],
             )
 
+        # Avg (only available for NCCL 2.10+)
+        if hasattr(c10d.ReduceOp, "AVG"):
+            tensors = [torch.tensor([i + 1]).cuda(i) for i in range(self.num_gpus)]
+
+            allreduce(tensors, c10d.ReduceOp.AVG)
+
+            for i in range(self.num_gpus):
+                # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
+                ndev = float(self.num_gpus)
+                self.assertEqualIgnoreType(
+                    torch.tensor([ndev * (ndev + 1.) / (2. * ndev)]),
+                    tensors[i],
+                )
+
         # Product
         tensors = []
         for i in range(self.num_gpus):

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -51,8 +51,7 @@ const std::map<ReduceOp, ncclRedOp_t> ncclOp = {
     {ReduceOp::MAX, ncclMax},
     {ReduceOp::SUM, ncclSum},
     {ReduceOp::PRODUCT, ncclProd},
-#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
-                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#ifdef NCCL_HAS_AVG
     {ReduceOp::AVG, ncclAvg},
 #endif
 };
@@ -91,8 +90,7 @@ ncclRedOp_t getNcclReduceOp(const ReduceOp reduceOp, at::Tensor& input) {
         // represent a bool (see ncclDataType mapping).
         return ncclMax;
       }
-#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
-                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#ifdef NCCL_HAS_AVG
       if (reduceOp == ReduceOp::AVG) {
         TORCH_CHECK(false, "Cannot use ReduceOp.AVG with boolean inputs");
       }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -91,9 +91,12 @@ ncclRedOp_t getNcclReduceOp(const ReduceOp reduceOp, at::Tensor& input) {
         // represent a bool (see ncclDataType mapping).
         return ncclMax;
       }
+#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
+                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
       if (reduceOp == ReduceOp::AVG) {
         TORCH_CHECK(false, "Cannot use ReduceOp.AVG with boolean inputs");
       }
+#endif
     }
     return ncclOp.at(reduceOp);
   } catch (const std::out_of_range& e) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -51,6 +51,10 @@ const std::map<ReduceOp, ncclRedOp_t> ncclOp = {
     {ReduceOp::MAX, ncclMax},
     {ReduceOp::SUM, ncclSum},
     {ReduceOp::PRODUCT, ncclProd},
+#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
+                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+    {ReduceOp::AVG, ncclAvg},
+#endif
 };
 
 // NCCL type typing
@@ -80,11 +84,16 @@ ncclDataType_t getNcclDataType(at::ScalarType type) {
 
 ncclRedOp_t getNcclReduceOp(const ReduceOp reduceOp, at::Tensor& input) {
   try {
-    if (reduceOp == ReduceOp::SUM && input.scalar_type() == at::kBool) {
-      // For bool tensors, map sum to max, which both represent a bitwise or.
-      // This is to prevent overflow issues with sum, since we use uint8 to
-      // represent a bool (see ncclDataType mapping).
-      return ncclMax;
+    if (input.scalar_type() == at::kBool) {
+      if (reduceOp == ReduceOp::SUM) {
+        // For bool tensors, map sum to max, which both represent a bitwise or.
+        // This is to prevent overflow issues with sum, since we use uint8 to
+        // represent a bool (see ncclDataType mapping).
+        return ncclMax;
+      }
+      if (reduceOp == ReduceOp::AVG) {
+        TORCH_CHECK(false, "Cannot use ReduceOp.AVG with boolean inputs");
+      }
     }
     return ncclOp.at(reduceOp);
   } catch (const std::out_of_range& e) {

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -7,6 +7,10 @@ namespace c10d {
 
 enum class ReduceOp : std::uint8_t {
   SUM = 0,
+#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
+                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+  AVG,
+#endif
   PRODUCT,
   MIN,
   MAX,

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -3,12 +3,17 @@
 #include <chrono>
 #include <cstdint>
 
+
+#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
+                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#define NCCL_HAS_AVG 1
+#endif
+
 namespace c10d {
 
 enum class ReduceOp : std::uint8_t {
   SUM = 0,
-#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
-                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#ifdef NCCL_HAS_AVG
   AVG,
 #endif
   PRODUCT,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -485,12 +485,13 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
       py::call_guard<py::gil_scoped_release>());
 
   py::enum_<::c10d::ReduceOp>(module, "ReduceOp", R"(
-An enum-like class for available reduction operations: ``SUM``, ``PRODUCT``,
-``MIN``, ``MAX``, ``BAND``, ``BOR``, and ``BXOR``.
+An enum-like class for available reduction operations: ``SUM``, ``AVG``,
+``PRODUCT``, ``MIN``, ``MAX``, ``BAND``, ``BOR``, and ``BXOR``.
 
 ``BAND``, ``BOR``, and ``BXOR`` reductions are not available when
 using the ``NCCL`` backend.
 
+``AVG`` divides values by the world size before summing across ranks.
 ``AVG`` is only available with the ``NCCL`` backend,
 and only for NCCL versions 2.10 or later.
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -488,8 +488,11 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
 An enum-like class for available reduction operations: ``SUM``, ``PRODUCT``,
 ``MIN``, ``MAX``, ``BAND``, ``BOR``, and ``BXOR``.
 
-Note that ``BAND``, ``BOR``, and ``BXOR`` reductions are not available when
+``BAND``, ``BOR``, and ``BXOR`` reductions are not available when
 using the ``NCCL`` backend.
+
+``AVG`` is only available with the ``NCCL`` backend,
+and only for NCCL versions 2.10 or later.
 
 Additionally, ``MAX``, ``MIN`` and ``PRODUCT`` are not supported for complex tensors.
 
@@ -497,6 +500,10 @@ The values of this class can be accessed as attributes, e.g., ``ReduceOp.SUM``.
 They are used in specifying strategies for reduction collectives, e.g.,
 :func:`reduce`, :func:`all_reduce_multigpu`, etc.)")
       .value("SUM", ::c10d::ReduceOp::SUM)
+#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
+                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+      .value("AVG", ::c10d::ReduceOp::AVG)
+#endif
       .value("PRODUCT", ::c10d::ReduceOp::PRODUCT)
       .value("MIN", ::c10d::ReduceOp::MIN)
       .value("MAX", ::c10d::ReduceOp::MAX)

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -500,8 +500,7 @@ The values of this class can be accessed as attributes, e.g., ``ReduceOp.SUM``.
 They are used in specifying strategies for reduction collectives, e.g.,
 :func:`reduce`, :func:`all_reduce_multigpu`, etc.)")
       .value("SUM", ::c10d::ReduceOp::SUM)
-#if defined(NCCL_MAJOR) && ((NCCL_MAJOR > 2) || \
-                            (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#ifdef NCCL_HAS_AVG
       .value("AVG", ::c10d::ReduceOp::AVG)
 #endif
       .value("PRODUCT", ::c10d::ReduceOp::PRODUCT)


### PR DESCRIPTION
[ncclAvg](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html?highlight=ncclavg#c.ncclAvg) is a new `ncclRedOpt_t` that fuses a div-by-world-size with ncclAllReduce, Reduce, or ReduceScatter. This PR adds support.

This PR and https://github.com/pytorch/pytorch/pull/62140 lay the foundation for to DDP allreduce+average grad tensors in place with a single nccl call without additional memory pass(es) to flatten or average or unflatten. I'll write the necessary DDP changes once this PR and https://github.com/pytorch/pytorch/pull/62140 land.