### PR TITLE
Port `addcmul` kernels to structured kernels.

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -831,6 +831,15 @@ void TensorIteratorBase::build_comparison_op(const Tensor& out, const Tensor& a,
   build(config);
 }
 
+void TensorIteratorBase::build_ternary_op(const Tensor& out, const Tensor& a,
+    const Tensor& b, const Tensor& c) {
+  build(TensorIteratorConfig()
+      .add_owned_output(out)
+      .add_owned_input(a)
+      .add_owned_input(b)
+      .add_owned_input(c));
+}
+
 // This cannot be a function because TensorIteratorConfig is not
 // copyable or movable, so it can't be returned from the function.
 #define BINARY_OP_CONFIG()                              \

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -352,6 +352,7 @@ public:
   void build_unary_op(const Tensor& out, const Tensor& a);
   void build_unary_force_boolean_op(const Tensor& out, const Tensor& a);
   void build_comparison_op(const Tensor& out, const Tensor& a, const Tensor& b);
+  void build_ternary_op(const Tensor& out, const Tensor& a, const Tensor& b, const Tensor& c);
 
 #undef TORCH_DISALLOW_TEMPORARIES
 protected:

--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -9,39 +9,26 @@
 #include <ATen/NamedTensorUtils.h>
 
 namespace at {
+namespace meta {
+
+TORCH_META_FUNC(addcmul)
+(const Tensor& self,
+ const Tensor& tensor1,
+ const Tensor& tensor2,
+ const Scalar& value) {
+  build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
+}
+
+} // namespace meta
 namespace native {
 
-Tensor addcmul(
-    const Tensor& self,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    const Scalar& value) {
-  Tensor result = at::empty({0}, self.options());
-  return at::addcmul_out(result, self, tensor1, tensor2, value);
-}
-
-Tensor& addcmul_(
-    Tensor& self,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    const Scalar& value) {
-  return at::addcmul_out(self, self, tensor1, tensor2, value);
-}
-
-Tensor& addcmul_out(const Tensor& self,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    const Scalar& value,
-    Tensor& result) {
-  checkBackend("addcmul_cpu", result, self.options().backend());
-  auto iter = at::TensorIteratorConfig()
-    .add_output(result)
-    .add_input(self)
-    .add_input(tensor1)
-    .add_input(tensor2)
-    .build();
-  addcmul_stub(iter.device_type(), iter, value);
-  return result;
+TORCH_IMPL_FUNC(addcmul_out)
+(const Tensor& self,
+ const Tensor& tensor1,
+ const Tensor& tensor2,
+ const Scalar& value,
+ const Tensor& result) {
+  addcmul_stub(device_type(), *this, value);
 }
 
 Tensor addcdiv(

--- a/aten/src/ATen/native/PointwiseOps.h
+++ b/aten/src/ATen/native/PointwiseOps.h
@@ -11,9 +11,10 @@ struct TensorIterator;
 namespace native {
 
 using pointwise_fn = void (*)(TensorIterator&, const Scalar& scalar);
+using structured_pointwise_fn = void (*)(TensorIteratorBase&, const Scalar& scalar);
 using pointwise_fn_double = void (*)(TensorIterator&, const Scalar&, double);
 
-DECLARE_DISPATCH(pointwise_fn, addcmul_stub);
+DECLARE_DISPATCH(structured_pointwise_fn, addcmul_stub);
 DECLARE_DISPATCH(pointwise_fn, addcdiv_stub);
 DECLARE_DISPATCH(pointwise_fn_double, smooth_l1_backward_stub);
 DECLARE_DISPATCH(pointwise_fn_double, huber_backward_stub);

--- a/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp
@@ -10,7 +10,7 @@ namespace at {
 namespace native {
 namespace {
 
-static void addcmul_cpu_kernel(TensorIterator& iter, const Scalar& value) {
+static void addcmul_cpu_kernel(TensorIteratorBase& iter, const Scalar& value) {
   ScalarType dtype = iter.dtype(0);
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(dtype, "addcmul_cpu_out", [&] {
     scalar_t scalar_val = value.to<scalar_t>();

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -9,7 +9,7 @@
 
 namespace at { namespace native {
 
-void addcmul_cuda_kernel(TensorIterator& iter, const Scalar& value) {
+void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.dtype(), "addcmul_cuda", [&]() {
     // note(mkozuki): If scalar_t is fp16 or bfloat16, cast scalar to float
     // and do math in fp32 for better accuracy.

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6582,21 +6582,21 @@
 - func: _gather_sparse_backward(Tensor self, int dim, Tensor index, Tensor grad) -> Tensor
 
 - func: addcmul.out(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  structured_inherits: TensorIteratorBase
   device_check: NoCheck   # TensorIterator
   dispatch:
     CPU, CUDA: addcmul_out
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+  structured_delegate: addcmul.out
   device_check: NoCheck   # TensorIterator
   variants: method, function
-  dispatch:
-    CompositeExplicitAutograd: addcmul
 
 - func: addcmul_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
+  structured_delegate: addcmul.out
   device_check: NoCheck   # TensorIterator
   variants: method
-  dispatch:
-    CompositeExplicitAutograd: addcmul_
 
 - func: addcdiv.out(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -263,6 +263,7 @@ class TestForeach(TestCase):
         self._pointwise_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False, values=values)
         self._pointwise_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True, values=values)
 
+    @skipMeta
     @ops(foreach_pointwise_op_db)
     def test_pointwise_op_fastpath(self, device, dtype, op):
         disable_fastpath = dtype in torch.testing.get_all_int_dtypes() + [torch.bool]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62319 Port `addcdiv` to structured kernels.
* **#62318 Port `addcmul` kernels to structured kernels.**

Tracking issue: #55070

This PR introduces the method `TensorIteratorBase::build_ternary_op` for building a
`TensorIteratorBase` for 3-input 1-output kernel.

Differential Revision: [D29961997](https://our.internmc.facebook.com/intern/diff/D29961997)