### PR TITLE
Port `addcdiv` to structured kernels.

### DIFF
--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -19,6 +19,27 @@ TORCH_META_FUNC(addcmul)
   build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
 }
 
+TORCH_META_FUNC(addcdiv)
+(const Tensor& self,
+ const Tensor& tensor1,
+ const Tensor& tensor2,
+ const Scalar& value) {
+  if (isIntegralType(tensor1.scalar_type(), /*includeBool=*/true) &&
+      isIntegralType(tensor2.scalar_type(), /*includeBool=*/true)) {
+    TORCH_CHECK(
+        false,
+        "Integer division with addcdiv is no longer supported, and in a future  ",
+        "release addcdiv will perform a true division of tensor1 and tensor2. ",
+        "The historic addcdiv behavior can be implemented as ",
+        "(input + value * torch.trunc(tensor1 / tensor2)).to(input.dtype) ",
+        "for integer inputs and as ",
+        "(input + value * tensor1 / tensor2) for float inputs. ",
+        "The future addcdiv behavior is just the latter implementation: ",
+        "(input + value * tensor1 / tensor2), for all dtypes.");
+  }
+  build_ternary_op(maybe_get_output(), self, tensor1, tensor2);
+}
+
 } // namespace meta
 namespace native {
 
@@ -31,49 +52,13 @@ TORCH_IMPL_FUNC(addcmul_out)
   addcmul_stub(device_type(), *this, value);
 }
 
-Tensor addcdiv(
-    const Tensor& self,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    const Scalar& value) {
-  Tensor result = at::empty({0}, self.options());
-  return at::addcdiv_out(result, self, tensor1, tensor2, value);
-}
-
-Tensor& addcdiv_(
-    Tensor& self,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    const Scalar& value) {
-  return at::addcdiv_out(self, self, tensor1, tensor2, value);
-}
-
-Tensor& addcdiv_out(const Tensor& self,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    const Scalar& value,
-    Tensor& result) {
-  if (isIntegralType(tensor1.scalar_type(), /*includeBool=*/ true)
-      && isIntegralType(tensor2.scalar_type(), /*includeBool=*/ true)) {
-    TORCH_CHECK(false,
-      "Integer division with addcdiv is no longer supported, and in a future  ",
-      "release addcdiv will perform a true division of tensor1 and tensor2. ",
-      "The historic addcdiv behavior can be implemented as ",
-      "(input + value * torch.trunc(tensor1 / tensor2)).to(input.dtype) ",
-      "for integer inputs and as ",
-      "(input + value * tensor1 / tensor2) for float inputs. ",
-      "The future addcdiv behavior is just the latter implementation: ",
-      "(input + value * tensor1 / tensor2), for all dtypes.");
-  }
-  checkBackend("addcdiv_cpu", result, self.options().backend());
-  auto iter = at::TensorIteratorConfig()
-    .add_output(result)
-    .add_input(self)
-    .add_input(tensor1)
-    .add_input(tensor2)
-    .build();
-  addcdiv_stub(iter.device_type(), iter, value);
-  return result;
+TORCH_IMPL_FUNC(addcdiv_out)
+(const Tensor& self,
+ const Tensor& tensor1,
+ const Tensor& tensor2,
+ const Scalar& value,
+ const Tensor& result) {
+  addcdiv_stub(device_type(), *this, value);
 }
 
 DEFINE_DISPATCH(addcmul_stub);

--- a/aten/src/ATen/native/PointwiseOps.h
+++ b/aten/src/ATen/native/PointwiseOps.h
@@ -15,7 +15,7 @@ using structured_pointwise_fn = void (*)(TensorIteratorBase&, const Scalar& scal
 using pointwise_fn_double = void (*)(TensorIterator&, const Scalar&, double);
 
 DECLARE_DISPATCH(structured_pointwise_fn, addcmul_stub);
-DECLARE_DISPATCH(pointwise_fn, addcdiv_stub);
+DECLARE_DISPATCH(structured_pointwise_fn, addcdiv_stub);
 DECLARE_DISPATCH(pointwise_fn_double, smooth_l1_backward_stub);
 DECLARE_DISPATCH(pointwise_fn_double, huber_backward_stub);
 DECLARE_DISPATCH(pointwise_fn, mse_backward_stub);

--- a/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp
@@ -28,7 +28,7 @@ static void addcmul_cpu_kernel(TensorIteratorBase& iter, const Scalar& value) {
   });
 }
 
-static void addcdiv_cpu_kernel(TensorIterator& iter, const Scalar& value) {
+static void addcdiv_cpu_kernel(TensorIteratorBase& iter, const Scalar& value) {
   ScalarType dtype = iter.dtype(0);
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(dtype, "addcdiv_cpu_out", [&] {
     scalar_t scalar_val = value.to<scalar_t>();

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -21,7 +21,7 @@ void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   });
 }
 
-void addcdiv_cuda_kernel(TensorIterator& iter, const Scalar& value) {
+void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.dtype(), "addcdiv_cuda", [&]() {
     // note(mkozuki): If scalar_t is fp16 or bfloat16, cast scalar to float
     // and do math in fp32 for better accuracy.

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6032,12 +6032,6 @@
   dispatch:
     CPU, CUDA: addbmm
 
-- func: addcdiv_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
-  device_check: NoCheck   # TensorIterator
-  variants: method
-  dispatch:
-    CompositeExplicitAutograd: addcdiv_
-
 - func: random_.from(Tensor(a!) self, int from, int? to, *, Generator? generator=None) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: method
@@ -6599,15 +6593,21 @@
   variants: method
 
 - func: addcdiv.out(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  structured_inherits: TensorIteratorBase
   device_check: NoCheck   # TensorIterator
   dispatch:
     CPU, CUDA: addcdiv_out
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+  structured_delegate: addcdiv.out
   device_check: NoCheck   # TensorIterator
   variants: method, function
-  dispatch:
-    CompositeExplicitAutograd: addcdiv
+
+- func: addcdiv_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
+  structured_delegate: addcdiv.out
+  device_check: NoCheck   # TensorIterator
+  variants: method
 
 - func: cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
   python_module: nn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#62319 Port `addcdiv` to structured kernels.**
* #62318 Port `addcmul` kernels to structured kernels.

Tracking issue: #55070

Differential Revision: [D29961996](https://our.internmc.facebook.com/intern/diff/D29961996)