### PR TITLE
FIX Adds header in nnapi_backend_preprocess

### DIFF
--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/backends/backend.h>
 #include <torch/csrc/jit/backends/backend_preprocess.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/torch.h>
 
 namespace py = pybind11;
 

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <torch/torch.h>
 #include <torch/csrc/jit/backends/backend.h>
 #include <torch/csrc/jit/backends/backend_preprocess.h>
 #include <torch/csrc/jit/python/pybind_utils.h>

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <torch/torch.h>
 #include <torch/csrc/jit/backends/backend.h>
 #include <torch/csrc/jit/backends/backend_preprocess.h>
 #include <torch/csrc/jit/python/pybind_utils.h>


### PR DESCRIPTION
When trying to compile `master` I am getting:

```
../torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp:97:20: error: ‘Tensor’ is not a member of ‘t
orch’; did you mean ‘tensors’?                                                                            
   97 |   c10::List<torch::Tensor> weights(   
```

with:

```
export USE_DISTRIBUTED=0
export USE_MKLDNN=0
export USE_FBGEMM=0
export USE_NNPACK=0
export USE_QNNPACK=0
export USE_XNNPACK=0
export USE_CUDNN=1
export BUILD_CAFFE2=0
```