### PR TITLE
ns for fx: fix bug for user function in weight extraction

### DIFF
--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -1631,7 +1631,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             torch.quantization.ns.weight_utils.get_linear_fun_weight
 
         # test compare weights
-        results = _extract_weights_impl(
+        results = extract_weights(
             'a', m1, 'b', m2,
             base_name_to_sets_of_related_ops=base_name_to_sets_of_related_ops,
             op_to_type_to_weight_extraction_fn=op_to_type_to_weight_extraction_fn)

--- a/torch/quantization/_numeric_suite_fx.py
+++ b/torch/quantization/_numeric_suite_fx.py
@@ -191,7 +191,9 @@ def extract_weights(
     op_to_type_to_weight_extraction_fn: Optional[Dict[str, Dict[Callable, Callable]]] = None,
 ) -> NSResultsType:
     torch._C._log_api_usage_once("quantization_api._numeric_suite_fx.extract_weights")
-    base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
+    if base_name_to_sets_of_related_ops is None:
+        base_name_to_sets_of_related_ops = \
+            get_base_name_to_sets_of_related_ops()
     type_a_related_to_b = \
         get_type_a_related_to_b(base_name_to_sets_of_related_ops)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62334
* __->__ #62333

Summary:

We incorrectly ignored any custom relationships the user specified
in the `extract_weights` API.  Fixing this and adding a test case.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_defined_function
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29963502](https://our.internmc.facebook.com/intern/diff/D29963502)