### PR TITLE
ns for fx: fix nit in default qlinear weight extraction function

### DIFF
--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -141,7 +141,6 @@ def get_linear_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
         return weight.detach()
 
 def get_qlinear_fun_weight(node: Node, gm: GraphModule) -> torch.Tensor:
-    assert node.target in (toq.linear, toq.linear_relu)
     # packed weight is arg 1
     packed_weight_node = node.args[1]
     assert isinstance(packed_weight_node, Node)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62334
* #62333

Summary:

Removes the assert for node type in default qlinear weight extraction
function. Without the assert, user defined functions can now use
this util function without failing this check.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs

// further tests will be in follow-up fb-only diffs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29963501](https://our.internmc.facebook.com/intern/diff/D29963501)