### PR TITLE
[Static Runtime] Ensure that unittests only use out variants or native ops

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -343,8 +343,8 @@ TEST(StaticRuntime, IndividualOps_Mul) {
   std::vector<IValue> scalar_args1{a, 42};
   std::vector<IValue> scalar_args2{c, 42};
 
-  testStaticRuntime(mul_scalar, scalar_args1);
-  testStaticRuntime(mul_scalar, scalar_args1, scalar_args2);
+  testStaticRuntime(mul_scalar, scalar_args1, /*args2=*/{}, /*use_allclose=*/false, /*use_equalnan=*/false, /*expect_fallback=*/true);
+  testStaticRuntime(mul_scalar, scalar_args1, scalar_args2, /*use_allclose=*/false, /*use_equalnan=*/false, /*expect_fallback=*/true);
 }
 
 TEST(StaticRuntime, IndividualOps_Log) {
@@ -455,8 +455,8 @@ TEST(StaticRuntime, IndividualOps_Norm) {
   auto dtype = at::ScalarType::Float;
 
   std::vector<IValue> args2{a, 2};
-  testStaticRuntime(norm_2arg, args2);
-  testStaticRuntime(norm_2arg, args2, {b, 2});
+  testStaticRuntime(norm_2arg, args2, /*args2=*/{}, /*use_allclose=*/false, /*use_equalnan=*/false, /*expect_fallback=*/true);
+  testStaticRuntime(norm_2arg, args2, {b, 2}, /*use_allclose=*/false, /*use_equalnan=*/false, /*expect_fallback=*/true);
 
   std::vector<IValue> args3{a, 2, dtype};
   testStaticRuntime(norm_3arg, args3);
@@ -485,7 +485,8 @@ TEST(StaticRuntime, IndividualOps_Reshape) {
   testStaticRuntime(reshape_script_3, args);
   testStaticRuntime(reshape_script_4, args);
   testStaticRuntime(reshape_script_5, args);
-  testStaticRuntime(reshape_inplace_script, args);
+  // tensor.sigmoid_ is delegated to the interpreter.
+  testStaticRuntime(reshape_inplace_script, args, /*args2=*/{}, /*use_allclose=*/false, /*use_equalnan=*/false, /*expect_fallback=*/true);
   testStaticRuntime(reshape_incontiguous_script, args);
 
   testStaticRuntime(reshape_script_1, args, args1);
@@ -493,7 +494,8 @@ TEST(StaticRuntime, IndividualOps_Reshape) {
   testStaticRuntime(reshape_script_3, args, args1);
   testStaticRuntime(reshape_script_4, args, args1);
   testStaticRuntime(reshape_script_5, args, args1);
-  testStaticRuntime(reshape_inplace_script, args, args1);
+  // tensor.sigmoid_ is delegated to the interpreter.
+  testStaticRuntime(reshape_inplace_script, args, args1, /*use_allclose=*/false, /*use_equalnan=*/false, /*expect_fallback=*/true);
   testStaticRuntime(reshape_incontiguous_script, args, args1);
 }
 

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -7,6 +7,7 @@
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/ops.h>
 #include <memory>
 #include <unordered_map>
 
@@ -120,6 +121,17 @@ void compareTensorLists(
   }
 }
 
+void checkNoInterpreterOp(const StaticModule& smodule) {
+  static const std::unordered_set<std::string> fb_only_ops{"aten::add"};
+  for (const auto& pnode : smodule.nodes()) {
+    auto op_name = pnode.node()->kind().toQualString();
+    if (disableUnsafeMathOp(op_name) || fb_only_ops.count(op_name) > 0) {
+      continue;
+    }
+    EXPECT_TRUE(pnode.has_out_variant() || pnode.has_native_op());
+  }
+}
+
 void compareResults(
     const IValue& expect,
     const IValue& actual,
@@ -179,7 +191,8 @@ void testStaticRuntime(
     const std::vector<IValue>& args,
     const std::vector<IValue>& args2,
     const bool use_allclose,
-    const bool use_equalnan) {
+    const bool use_equalnan,
+    const bool expect_fallback) {
   auto test_context = makeTestContext(source);
 
   std::vector<IValue> args_tensors, args_copy;
@@ -196,6 +209,9 @@ void testStaticRuntime(
   for (bool enable_out_variant : {true, false}) {
     auto smodule = test_context->makeStaticModule(
         {true, enable_out_variant, enable_out_variant});
+    if (enable_out_variant && !expect_fallback) {
+      checkNoInterpreterOp(smodule);
+    }
     auto actual = smodule(args, {});
     if (actual.isTensor()) {
       EXPECT_GE(smodule.nodes().size(), 2)

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -24,7 +24,8 @@ void testStaticRuntime(
     const std::vector<c10::IValue>& args,
     const std::vector<c10::IValue>& args2 = {},
     const bool use_allclose = false,
-    const bool use_equalnan = false);
+    const bool use_equalnan = false,
+    const bool expect_fallback = false);
 
 } // namespace test
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -409,6 +409,10 @@ class TORCH_API ProcessedNode {
     return static_cast<bool>(fn_);
   }
 
+  bool has_native_op() const {
+    return static_cast<bool>(native_fn_);
+  }
+
   bool verify_outputs_not_overlapping_with_immutable_inputs() const;
 
  private:

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -128,6 +128,7 @@ inline void fastResizeToZero(at::Tensor& t) {
 
 // check if an op has an out variant registered in Static Runtime
 bool opIsRegistered(const c10::Symbol& op_name);
+bool disableUnsafeMathOp(const char* op_name);
 // check if Static Runtime can run an op natively.
 // prim ops that are implemented directly in the jit interpreter are implemented
 // as native ops in Static Runtime


### PR DESCRIPTION
Summary:
This change ensures that unittests only use out variants or native ops.

- Our unittests currently assume that a graph fed to the static runtime correctly replaces an interpreter op for its corresponding out variant / native op, but it's not checked by the unittest. This change ensures that.

- We relied on manual inspection of log messages to see if an out variant is used for a specific workload even for unittesting. This change frees us from doing that.

- `aten::add` is excluded from this check since it's only enabled for an internal workload. Also some unittests are excluded by using `expect_interpreter_op  = true` since they are written to use interpreter ops by design.

Test Plan: Ran `buck run //caffe2/benchmarks/static_runtime:static_runtime_cpptest` successfully.

Differential Revision: D29952381

