### PR TITLE
Callable activation function support for Transformer modules (C++)

### DIFF
--- a/c10/util/variant.h
+++ b/c10/util/variant.h
@@ -2226,7 +2226,7 @@ class impl : public copy_assignment<traits<Ts...>> {
 
  public:
   MPARK_INHERITING_CTOR(impl, super)
-  using super::operator=;
+  impl& operator=(const impl& other) = default;
 
   template <std::size_t I, typename Arg>
   inline void assign(Arg&& arg) {

--- a/test/cpp/api/transformer.cpp
+++ b/test/cpp/api/transformer.cpp
@@ -20,7 +20,7 @@ void set_parameter_to_constants(Model& model, const torch::TensorOptions& tensor
 
 // a generic function to provide consistent encoder/decoder layer for all the transformer tests
 template<typename T_LAYER, typename T_OPTIONS>
-T_LAYER get_a_test_layer(const torch::TensorOptions& tensor_options) {
+T_LAYER get_a_test_layer(const torch::TensorOptions& tensor_options, bool use_callable_activation) {
   int64_t d_model = 4;
   int64_t nhead = 2;
   int64_t dim_feedforward = 16;
@@ -31,6 +31,9 @@ T_LAYER get_a_test_layer(const torch::TensorOptions& tensor_options) {
   if (tensor_options.device() == torch::kCUDA) {
     layer->to(torch::kCUDA);
   }
+  if (use_callable_activation) {
+    layer.get()->options.activation([&](const torch::Tensor& t) {return torch::nn::functional::relu(t);});
+  }
 
   // set constant weights of the model
   set_parameter_to_constants<T_LAYER>(layer, tensor_options);
@@ -38,13 +41,14 @@ T_LAYER get_a_test_layer(const torch::TensorOptions& tensor_options) {
   return layer;
 }
 
-void transformer_encoder_layer_test_helper(bool is_cuda) {
+void transformer_encoder_layer_test_helper(bool is_cuda, bool use_callable_activation) {
   // this is a deterministic test for TransformerEncoderLayer
   torch::Device device = is_cuda ? torch::kCUDA : torch::kCPU;
   torch::TensorOptions tensor_options = torch::TensorOptions().dtype(torch::kFloat32).device(device);
 
   TransformerEncoderLayer model =
-    get_a_test_layer<TransformerEncoderLayer, TransformerEncoderLayerOptions>(tensor_options);
+    get_a_test_layer<TransformerEncoderLayer, TransformerEncoderLayerOptions>(
+      tensor_options, use_callable_activation);
 
   // relu test case 1
   torch::Tensor encoder_input = torch::tensor({{{20, 30, 40, 50}}}, tensor_options);
@@ -153,14 +157,16 @@ void transformer_encoder_layer_test_helper(bool is_cuda) {
 }
 
 TEST_F(TransformerTest, TransformerEncoderLayer) {
-  transformer_encoder_layer_test_helper(false);
+  transformer_encoder_layer_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ false);
+  transformer_encoder_layer_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, TransformerEncoderLayer_CUDA) {
-  transformer_encoder_layer_test_helper(true);
+  transformer_encoder_layer_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ false);
+  transformer_encoder_layer_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ true);
 }
 
-void transformer_decoder_layer_test_helper(bool is_cuda){
+void transformer_decoder_layer_test_helper(bool is_cuda, bool use_callable_activation){
 
   torch::Device device = is_cuda ? torch::kCUDA : torch::kCPU;
   torch::TensorOptions tensor_options = torch::TensorOptions()
@@ -168,7 +174,7 @@ void transformer_decoder_layer_test_helper(bool is_cuda){
 
   TransformerDecoderLayer model = get_a_test_layer<
     TransformerDecoderLayer,
-    TransformerDecoderLayerOptions>(tensor_options);
+    TransformerDecoderLayerOptions>(tensor_options, use_callable_activation);
 
   // deterministic input
   torch::Tensor decoder_input = torch::tensor({{{20, 30, 40, 50}}},
@@ -310,14 +316,16 @@ void transformer_decoder_layer_test_helper(bool is_cuda){
 }
 
 TEST_F(TransformerTest, TransformerDecoderLayer){
-  transformer_decoder_layer_test_helper(false);
+  transformer_decoder_layer_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ false);
+  transformer_decoder_layer_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, TransformerDecoderLayer_CUDA){
-    transformer_decoder_layer_test_helper(true);
+  transformer_decoder_layer_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ false);
+  transformer_decoder_layer_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ true);
 }
 
-void transformer_decoder_layer_test_helper_gelu(bool is_cuda) {
+void transformer_decoder_layer_test_helper_gelu(bool is_cuda, bool use_callable_activation) {
 
   torch::Device device = is_cuda ? torch::kCUDA : torch::kCPU;
   torch::TensorOptions tensor_options = torch::TensorOptions()
@@ -325,8 +333,12 @@ void transformer_decoder_layer_test_helper_gelu(bool is_cuda) {
 
   TransformerDecoderLayer model = get_a_test_layer<
     TransformerDecoderLayer,
-    TransformerDecoderLayerOptions>(tensor_options);
-  model.get()->options.activation(torch::kGELU);
+    TransformerDecoderLayerOptions>(tensor_options, use_callable_activation);
+  if (use_callable_activation) {
+    model.get()->options.activation([&](const torch::Tensor& t) {return torch::nn::functional::gelu(t);});
+  } else {
+    model.get()->options.activation(torch::kGELU);
+  }
 
   // deterministic input
   torch::Tensor decoder_input = torch::tensor({{{20, 30, 40, 50}}},
@@ -405,20 +417,23 @@ void transformer_decoder_layer_test_helper_gelu(bool is_cuda) {
 }
 
 TEST_F(TransformerTest, TransformerDecoderLayer_gelu) {
-  transformer_decoder_layer_test_helper_gelu(false);
+  transformer_decoder_layer_test_helper_gelu(/*is_cuda=*/ false, /*use_callable_activation=*/ false);
+  transformer_decoder_layer_test_helper_gelu(/*is_cuda=*/ false, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, TransformerDecoderLayer_gelu_CUDA) {
-  transformer_decoder_layer_test_helper_gelu(true);
+  transformer_decoder_layer_test_helper_gelu(/*is_cuda=*/ true, /*use_callable_activation=*/ false);
+  transformer_decoder_layer_test_helper_gelu(/*is_cuda=*/ true, /*use_callable_activation=*/ true);
 }
 
-void transformer_encoder_test_helper(bool is_cuda) {
+void transformer_encoder_test_helper(bool is_cuda, bool use_callable_activation) {
   // this is a deterministic test for TransformerEncoderLayer
   torch::Device device = is_cuda ? torch::kCUDA : torch::kCPU;
   torch::TensorOptions tensor_options = torch::TensorOptions().dtype(torch::kFloat32).device(device);
 
   TransformerEncoderLayer encoder_layer =
-    get_a_test_layer<TransformerEncoderLayer, TransformerEncoderLayerOptions>(tensor_options);
+    get_a_test_layer<TransformerEncoderLayer, TransformerEncoderLayerOptions>(
+      tensor_options, use_callable_activation);
 
   TransformerEncoder model(TransformerEncoderOptions(encoder_layer, 1));
   if (is_cuda) {
@@ -522,11 +537,13 @@ void transformer_encoder_test_helper(bool is_cuda) {
 }
 
 TEST_F(TransformerTest, TransformerEncoder) {
-  transformer_encoder_test_helper(false);
+  transformer_encoder_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ false);
+  transformer_encoder_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, TransformerEncoder_CUDA) {
-  transformer_encoder_test_helper(true);
+  transformer_encoder_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ false);
+  transformer_encoder_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, PrettyPrintTransformerEncoderLayer) {
@@ -606,7 +623,7 @@ TEST_F(TransformerTest, PrettyPrintTransformerDecoderLayer) {
       ")");
 }
 
-void transformer_decoder_test_helper(bool is_cuda) {
+void transformer_decoder_test_helper(bool is_cuda, bool use_callable_activation) {
   // this is a deterministic test for TransformerDecoder
   torch::Device device = is_cuda ? torch::kCUDA : torch::kCPU;
   torch::TensorOptions tensor_options =
@@ -614,7 +631,7 @@ void transformer_decoder_test_helper(bool is_cuda) {
 
   TransformerDecoderLayer decoder_layer = get_a_test_layer<
     TransformerDecoderLayer,
-    TransformerDecoderLayerOptions>(tensor_options);
+    TransformerDecoderLayerOptions>(tensor_options, use_callable_activation);
 
   TransformerDecoder model(TransformerDecoderOptions(decoder_layer, 1));
   if (is_cuda) {
@@ -1021,11 +1038,13 @@ void transformer_decoder_test_helper(bool is_cuda) {
 }
 
 TEST_F(TransformerTest, TransformerDecoder) {
-  transformer_decoder_test_helper(false);
+  transformer_decoder_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ false);
+  transformer_decoder_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, TransformerDecoder_CUDA) {
-  transformer_decoder_test_helper(true);
+  transformer_decoder_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ false);
+  transformer_decoder_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ true);
 }
 
 
@@ -1077,20 +1096,24 @@ TEST_F(TransformerTest, PrettyPrintTransformerDecoder) {
       ")");
 }
 
-void transformer_test_helper(bool is_cuda) {
+void transformer_test_helper(bool is_cuda, bool use_callable_activation) {
     // this is a deterministic test for Transformere
     torch::Device device = is_cuda ? torch::kCUDA : torch::kCPU;
     torch::TensorOptions tensor_options = torch::TensorOptions().dtype(torch::kFloat32).device(device);
 
     // transformer created encoder/decoder
-    Transformer model(TransformerOptions()
+    auto options = TransformerOptions()
       .d_model(4)
       .nhead(2)
       .num_encoder_layers(2)
       .num_decoder_layers(1)
       .dim_feedforward(16)
       .dropout(0.0)
-      .activation(torch::kReLU));
+      .activation(torch::kReLU);
+    if (use_callable_activation) {
+      options.activation([&](const torch::Tensor& t) { return torch::nn::functional::relu(t); });
+    }
+    Transformer model(options);
 
     set_parameter_to_constants<Transformer>(model, tensor_options);
     if (tensor_options.device() == torch::kCUDA) {
@@ -1160,11 +1183,13 @@ void transformer_test_helper(bool is_cuda) {
 }
 
 TEST_F(TransformerTest, Transformer) {
-  transformer_test_helper(false);
+  transformer_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ false);
+  transformer_test_helper(/*is_cuda=*/ false, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, Transformer_CUDA) {
-  transformer_test_helper(true);
+  transformer_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ false);
+  transformer_test_helper(/*is_cuda=*/ true, /*use_callable_activation=*/ true);
 }
 
 TEST_F(TransformerTest, TransformerArgsCorrectness) {

--- a/torch/csrc/api/include/torch/nn/options/transformer.h
+++ b/torch/csrc/api/include/torch/nn/options/transformer.h
@@ -20,7 +20,7 @@ namespace nn {
 /// ```
 struct TORCH_API TransformerOptions {
 
-  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU>;
+  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
 
   // The following constructors are commonly used
   // Please don't add more unless it is proved as a common usage

--- a/torch/csrc/api/include/torch/nn/options/transformer.h
+++ b/torch/csrc/api/include/torch/nn/options/transformer.h
@@ -6,6 +6,7 @@
 #include <torch/enum.h>
 
 #include <torch/nn/modules/container/any.h>
+#include <torch/nn/options/transformerlayer.h>
 
 namespace torch {
 namespace nn {
@@ -19,8 +20,6 @@ namespace nn {
 /// auto options = TransformerOptions().d_model(4).nhead(2).dropout(0.0);
 /// ```
 struct TORCH_API TransformerOptions {
-
-  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
 
   // The following constructors are commonly used
   // Please don't add more unless it is proved as a common usage

--- a/torch/csrc/api/include/torch/nn/options/transformerlayer.h
+++ b/torch/csrc/api/include/torch/nn/options/transformerlayer.h
@@ -8,6 +8,8 @@
 namespace torch {
 namespace nn {
 
+using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
+
 /// Options for the `TransformerEncoderLayer`
 ///
 /// Example:
@@ -15,8 +17,6 @@ namespace nn {
 /// auto options = TransformerEncoderLayer(512, 8).dropout(0.2);
 /// ```
 struct TORCH_API TransformerEncoderLayerOptions {
-
-  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
 
   /* implicit */ TransformerEncoderLayerOptions(int64_t d_model, int64_t nhead);
 
@@ -46,8 +46,6 @@ struct TORCH_API TransformerEncoderLayerOptions {
 /// TransformerDecoderLayer model(TransformerDecoderLayerOptions(512, 8).dropout(0.2));
 /// ```
 struct TORCH_API TransformerDecoderLayerOptions {
-
-  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
 
   TransformerDecoderLayerOptions(int64_t d_model, int64_t nhead);
 

--- a/torch/csrc/api/include/torch/nn/options/transformerlayer.h
+++ b/torch/csrc/api/include/torch/nn/options/transformerlayer.h
@@ -16,7 +16,7 @@ namespace nn {
 /// ```
 struct TORCH_API TransformerEncoderLayerOptions {
 
-  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU>;
+  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
 
   /* implicit */ TransformerEncoderLayerOptions(int64_t d_model, int64_t nhead);
 
@@ -32,7 +32,7 @@ struct TORCH_API TransformerEncoderLayerOptions {
   /// the dropout value, default is 0.1
   TORCH_ARG(double, dropout) = 0.1;
 
-  /// the activation function of intermediate layer, either ``torch::kReLU`` or ``torch::GELU``, default is ``torch::kReLU``
+  /// the activation function of intermediate layer, can be ``torch::kReLU``, ``torch::GELU``, or a unary callable. Default: ``torch::kReLU``
   TORCH_ARG(activation_t, activation) = torch::kReLU;
 };
 
@@ -47,7 +47,7 @@ struct TORCH_API TransformerEncoderLayerOptions {
 /// ```
 struct TORCH_API TransformerDecoderLayerOptions {
 
-  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU>;
+  using activation_t = c10::variant<enumtype::kReLU, enumtype::kGELU, std::function<Tensor(const Tensor&)> >;
 
   TransformerDecoderLayerOptions(int64_t d_model, int64_t nhead);
 
@@ -63,7 +63,7 @@ struct TORCH_API TransformerDecoderLayerOptions {
   /// dropout value. Default: 1
   TORCH_ARG(double, dropout) = 0.1;
 
-  /// activation function of intermediate layer, can be either ``torch::kGELU`` or ``torch::kReLU``. Default: ``torch::kReLU``
+  /// activation function of intermediate layer, can be ``torch::kGELU``, ``torch::kReLU``, or a unary callable. Default: ``torch::kReLU``
   TORCH_ARG(activation_t, activation) = torch::kReLU;
 };
 

--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -71,8 +71,11 @@ Tensor TransformerEncoderLayerImpl::forward(
   else if (c10::get_if<enumtype::kReLU>(&options.activation())) {
     src2 = linear2(dropout(F::relu(linear1(ret))));
   }
-  else {
-    TORCH_CHECK(false, "activation should be kGELU/kReLU, not ", torch::enumtype::get_enum_name(options.activation()));
+  else if (c10::get_if<std::function<Tensor(const Tensor&)> >(&options.activation())) {
+    auto callable_activation = *c10::get_if<std::function<Tensor(const Tensor&)> >(&options.activation());
+    src2 = linear2(dropout(callable_activation(linear1(ret))));
+  } else {
+    TORCH_CHECK(false, "activation should be kGELU, kReLU, or a callable");
   }
 
   // add & norm
@@ -185,10 +188,11 @@ Tensor TransformerDecoderLayerImpl::activation(const Tensor& input){
     return F::gelu(input);
   } else if (c10::get_if<enumtype::kReLU>(&options.activation())) {
     return F::relu(input);
+  } else if(c10::get_if<std::function<Tensor(const Tensor&)> >(&options.activation())) {
+    auto callable_activation = *c10::get_if<std::function<Tensor(const Tensor&)> >(&options.activation());
+    return callable_activation(input);
   } else {
-    TORCH_CHECK(false,
-      "Unknown activation: ",
-      torch::enumtype::get_enum_name(options.activation()));
+    TORCH_CHECK(false, "activation should be kGELU, kReLU, or a callable");
   }
 }
 


### PR DESCRIPTION
Fixes #60747

Enhances the C++ versions of `Transformer`, `TransformerEncoderLayer`, and `TransformerDecoderLayer` to support callables as their activation functions. The old way of specifying activation function still works as well.
