### PR TITLE
[Static Runtime] Add tests for all aten ops

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -591,3 +591,81 @@ graph(%a.1 : Tensor,
   %t0 : Float(2, 2, strides=[2, 1], device=cpu), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::TypeCheck[types=[Float(2, 2, strides=[2, 1], device=cpu), Float(3, 3, strides=[3, 1])]](%a.1, %b.1)
   return (%t0, %t1, %type_matched)
 )IR";
+
+const auto index_without_none_script = R"JIT(
+  def forward(self, a: Tensor, idx: Tensor):
+      return a[idx].clone()
+)JIT";
+
+const auto index_with_none_script = R"JIT(
+  def forward(self, a: Tensor, idx: Tensor):
+      return a[idx, None].clone()
+)JIT";
+
+const auto index_with_two_tensors_script = R"JIT(
+  def forward(self, a: Tensor, idx_a: Tensor, idx_b: Tensor):
+      return a[idx_a, idx_b].clone()
+)JIT";
+
+const auto clamp_min_int_script = R"JIT(
+  def forward(self, a: Tensor, b: int):
+      return torch.clamp_min(a, b).clone()
+)JIT";
+
+const auto clamp_min_float_script = R"JIT(
+  def forward(self, a: Tensor, b: float):
+      return torch.clamp_min(a, b).clone()
+)JIT";
+
+const auto argmin_script = R"JIT(
+  def forward(self, a: Tensor):
+      return torch.argmin(a).clone()
+)JIT";
+
+const auto argmin_with_dim_script = R"JIT(
+  def forward(self, a: Tensor, dim: int):
+      return torch.argmin(a, dim).clone()
+)JIT";
+
+const auto argmin_with_keep_dim_script = R"JIT(
+  def forward(self, a: Tensor, dim: int):
+      return torch.argmin(a, dim, True).clone()
+)JIT";
+
+const auto getitem_tensor_script = R"JIT(
+  def forward(self, key: Tensor):
+      d = {key: 1}
+      return d[key]
+)JIT";
+
+const auto getitem_int_script = R"JIT(
+  def forward(self, key: int):
+      d = {key: 1}
+      return d[key]
+)JIT";
+
+const auto getitem_str_script = R"JIT(
+  def forward(self, key: str):
+      d = {key: 1}
+      return d[key]
+)JIT";
+
+const auto transpose_script = R"JIT(
+  def forward(self, a: Tensor, dim1: int, dim2: int):
+      return torch.transpose(a, dim1, dim2).clone()
+)JIT";
+
+const auto permute_script = R"JIT(
+  def forward(self, a: Tensor, dims: List[int]):
+      return torch.permute(a, dims).clone()
+)JIT";
+
+const auto slice_script = R"JIT(
+  def forward(self, a: Tensor, dim: int, start: int, end: int, step: int):
+    return a.slice(dim, start, end, step).clone()
+)JIT";
+
+const auto narrow_with_int_script = R"JIT(
+  def forward(self, a: Tensor, dim: int, start: int, length: int):
+      return a.narrow(dim, start, length).clone()
+)JIT";


### PR DESCRIPTION
Summary: This diff includes tests for all `aten` ops that did not already have test coverage.

Test Plan: `buck test //caffe2/benchmarks/static_runtime/static_runtime:static_runtime_cpptest`

Differential Revision: D29968280

