### PR TITLE
Generate prefixes for ci workflow

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -158,8 +158,8 @@ class CIWorkflow:
             assert self.test_runner_type in LINUX_RUNNERS, err_message
         if self.arch == 'windows':
             assert self.test_runner_type in WINDOWS_RUNNERS, err_message
-    
-    def generate_workflow_name(self, workflow) -> str:
+
+    def generate_workflow_name(self, workflow: 'CIWorkflow') -> str:
         workflow_name = workflow.build_environment
         if not workflow.on_pull_request:
             workflow_name = "master-only-" + workflow_name

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -207,7 +207,7 @@ WINDOWS_WORKFLOWS = [
     ),
     CIWorkflow(
         arch="windows",
-        build_environment="win-vs2019-cuda11-cudnn8-py3",
+        build_environment="win-vs2019-cuda11.3-cudnn8-py3",
         cuda_version="11.3",
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         num_test_shards=2,

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -150,6 +150,9 @@ class CIWorkflow:
             else:
                 self.num_test_shards_on_pull_request = self.num_test_shards
 
+        # Generate CI workflow name based on workflow configs
+        self.ci_workflow_name = self.generate_workflow_name()
+
         self.assert_valid()
 
     def assert_valid(self) -> None:
@@ -159,16 +162,15 @@ class CIWorkflow:
         if self.arch == 'windows':
             assert self.test_runner_type in WINDOWS_RUNNERS, err_message
 
-    def generate_workflow_name(self, workflow: 'CIWorkflow') -> str:
-        workflow_name = workflow.build_environment
-        if not workflow.on_pull_request:
+    def generate_workflow_name(self) -> str:
+        workflow_name = self.build_environment
+        if not self.on_pull_request:
             workflow_name = "master-only-" + workflow_name
-        if workflow.is_scheduled:
+        if self.is_scheduled:
             workflow_name = "periodic-" + workflow_name
         return workflow_name
 
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
-        workflow.ci_workflow_name = self.generate_workflow_name(workflow)
         output_file_path = GITHUB_DIR / f"workflows/generated-{workflow.ci_workflow_name}.yml"
         with open(output_file_path, "w") as output_file:
             GENERATED = "generated"

--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -3,7 +3,7 @@
 {% block name -%}
 # Template is at:    .github/templates/bazel_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: !{{ build_environment }}
+name: !{{ ci_workflow_name }}
 {%- endblock %}
 
 on:
@@ -27,7 +27,7 @@ on:
     needs: [calculate-docker-image, !{{ ciflow_config.root_job_name }}]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: !{{ build_environment }}-build-and-test
+      JOB_BASE_NAME: !{{ ci_workflow_name }}-build-and-test
       NUM_TEST_SHARDS: !{{ num_test_shards }}
     steps:
       - name: Log in to ECR

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -6,7 +6,7 @@
 {%- block name -%}
 # Template is at:    .github/templates/linux_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: !{{ build_environment }}
+name: !{{ ci_workflow_name }}
 {%- endblock %}
 
 on:
@@ -47,7 +47,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
 
 concurrency:
-  group: !{{ build_environment }}-${{ github.event.pull_request.number || github.sha }}
+  group: !{{ ci_workflow_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -141,7 +141,7 @@ jobs:
     needs: [calculate-docker-image, !{{ ciflow_config.root_job_name }}]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: !{{ build_environment }}-build
+      JOB_BASE_NAME: !{{ ci_workflow_name }}-build
     steps:
       - name: Log in to ECR
         run: |
@@ -288,7 +288,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: !{{ build_environment }}-test
+      JOB_BASE_NAME: !{{ ci_workflow_name }}-test
       TEST_CONFIG: ${{ matrix.config }}
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -489,7 +489,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: !{{ build_environment }}-test
+          JOB_BASE_NAME: !{{ ci_workflow_name }}-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -49,7 +49,7 @@ env:
 {%- endif %}
 
 concurrency:
-  group: !{{ build_environment }}-${{ github.event.pull_request.number || github.sha }}
+  group: !{{ ci_workflow_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -71,7 +71,7 @@ jobs:
     needs: [!{{ ciflow_config.root_job_name }}]
     {%- endif %}
     env:
-      JOB_BASE_NAME: !{{ build_environment }}-build
+      JOB_BASE_NAME: !{{ ci_workflow_name }}-build
       http_proxy: "!{{ squid_proxy }}"
       https_proxy: "!{{ squid_proxy }}"
     steps:
@@ -164,7 +164,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
 {%- endif %}
     env:
-      JOB_BASE_NAME: !{{ build_environment }}-test
+      JOB_BASE_NAME: !{{ ci_workflow_name }}-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       TEST_CONFIG: ${{ matrix.config }}
@@ -312,7 +312,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: !{{ build_environment }}-test
+          JOB_BASE_NAME: !{{ ci_workflow_name }}-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}

--- a/.github/workflows/generated-master-only-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/generated-master-only-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/linux_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7
+name: master-only-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7
 
 on:
   # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7
-  DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7
+  BUILD_ENVIRONMENT: libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7
+  DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7
   SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
   TORCH_CUDA_ARCH_LIST: 5.2
   IN_CI: 1
@@ -24,7 +24,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
 
 concurrency:
-  group: libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-${{ github.event.pull_request.number || github.sha }}
+  group: master-only-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -107,7 +107,7 @@ jobs:
     needs: [calculate-docker-image, ]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-build
+      JOB_BASE_NAME: master-only-libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7-build
     steps:
       - name: Log in to ECR
         run: |

--- a/.github/workflows/generated-master-only-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-master-only-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/linux_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7
+name: master-only-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7
 
 on:
   # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7
-  DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7
+  BUILD_ENVIRONMENT: libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7
+  DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7
   SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
   TORCH_CUDA_ARCH_LIST: 5.2
   IN_CI: 1
@@ -24,7 +24,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
 
 concurrency:
-  group: libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7-${{ github.event.pull_request.number || github.sha }}
+  group: master-only-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -107,7 +107,7 @@ jobs:
     needs: [calculate-docker-image, ]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: libtorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7-build
+      JOB_BASE_NAME: master-only-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-build
     steps:
       - name: Log in to ECR
         run: |

--- a/.github/workflows/generated-master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
+++ b/.github/workflows/generated-master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/linux_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: linux-bionic-cuda10.2-cudnn7-py3.9-gcc7
+name: master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7
 
 on:
   # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
@@ -24,7 +24,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
 
 concurrency:
-  group: linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-${{ github.event.pull_request.number || github.sha }}
+  group: master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -107,7 +107,7 @@ jobs:
     needs: [calculate-docker-image, ]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-build
+      JOB_BASE_NAME: master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-build
     steps:
       - name: Log in to ECR
         run: |
@@ -247,7 +247,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-test
+      JOB_BASE_NAME: master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-test
       TEST_CONFIG: ${{ matrix.config }}
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -446,7 +446,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-test
+          JOB_BASE_NAME: master-only-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}

--- a/.github/workflows/generated-master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/linux_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: linux-xenial-cuda11.1-cudnn8-py3.6-gcc7
+name: master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7
 
 on:
   # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
@@ -24,7 +24,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
 
 concurrency:
-  group: linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-${{ github.event.pull_request.number || github.sha }}
+  group: master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -107,7 +107,7 @@ jobs:
     needs: [calculate-docker-image, ]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-build
+      JOB_BASE_NAME: master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-build
     steps:
       - name: Log in to ECR
         run: |
@@ -247,7 +247,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
-      JOB_BASE_NAME: linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-test
+      JOB_BASE_NAME: master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-test
       TEST_CONFIG: ${{ matrix.config }}
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
@@ -446,7 +446,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-test
+          JOB_BASE_NAME: master-only-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}

--- a/.github/workflows/generated-master-only-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-master-only-win-vs2019-cuda11-cudnn8-py3.yml
@@ -28,7 +28,7 @@ env:
   USE_CUDA: 1
 
 concurrency:
-  group: win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
+  group: master-only-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
       run:
         working-directory: pytorch-${{ github.run_id }}
     env:
-      JOB_BASE_NAME: win-vs2019-cuda11-cudnn8-py3-build
+      JOB_BASE_NAME: master-only-win-vs2019-cuda11-cudnn8-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
     steps:
@@ -120,7 +120,7 @@ jobs:
 
   test:
     env:
-      JOB_BASE_NAME: win-vs2019-cuda11-cudnn8-py3-test
+      JOB_BASE_NAME: master-only-win-vs2019-cuda11-cudnn8-py3-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       TEST_CONFIG: ${{ matrix.config }}
@@ -262,7 +262,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: win-vs2019-cuda11-cudnn8-py3-test
+          JOB_BASE_NAME: master-only-win-vs2019-cuda11-cudnn8-py3-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: periodic-libtorch-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7
+  BUILD_ENVIRONMENT: libtorch-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7
   DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
   SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
   TORCH_CUDA_ARCH_LIST: 5.2

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -315,7 +315,7 @@ jobs:
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Test PyTorch
         env:
-          BUILD_ENVIRONMENT: periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7-${{ matrix.config }}
+          BUILD_ENVIRONMENT: linux-xenial-cuda11.3-cudnn8-py3.6-gcc7-${{ matrix.config }}
         run: |
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.jenkins/pytorch/multigpu-test.sh

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7
+  BUILD_ENVIRONMENT: linux-xenial-cuda11.3-cudnn8-py3.6-gcc7
   DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
   SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
   TORCH_CUDA_ARCH_LIST: 5.2

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/windows_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: periodic-win-vs2019-cuda11-cudnn8-py3
+name: win-vs2019-cuda11-cudnn8-py3
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: periodic-win-vs2019-cuda11-cudnn8-py3
+  BUILD_ENVIRONMENT: win-vs2019-cuda11-cudnn8-py3
   BUILD_WHEEL: 1
   CUDA_VERSION: "11.3"
   IN_CI: 1

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.3-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.3-cudnn8-py3.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/windows_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: win-vs2019-cuda11-cudnn8-py3
+name: win-vs2019-cuda11.3-cudnn8-py3
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: win-vs2019-cuda11-cudnn8-py3
+  BUILD_ENVIRONMENT: win-vs2019-cuda11.3-cudnn8-py3
   BUILD_WHEEL: 1
   CUDA_VERSION: "11.3"
   IN_CI: 1
@@ -28,7 +28,7 @@ env:
   USE_CUDA: 1
 
 concurrency:
-  group: periodic-win-vs2019-cuda11-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
+  group: periodic-win-vs2019-cuda11.3-cudnn8-py3-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
         working-directory: pytorch-${{ github.run_id }}
     needs: [ciflow_should_run]
     env:
-      JOB_BASE_NAME: periodic-win-vs2019-cuda11-cudnn8-py3-build
+      JOB_BASE_NAME: periodic-win-vs2019-cuda11.3-cudnn8-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
     steps:
@@ -128,7 +128,7 @@ jobs:
 
   test:
     env:
-      JOB_BASE_NAME: periodic-win-vs2019-cuda11-cudnn8-py3-test
+      JOB_BASE_NAME: periodic-win-vs2019-cuda11.3-cudnn8-py3-test
       SHARD_NUMBER: ${{ matrix.shard }}
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       TEST_CONFIG: ${{ matrix.config }}
@@ -270,7 +270,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: periodic-win-vs2019-cuda11-cudnn8-py3-test
+          JOB_BASE_NAME: periodic-win-vs2019-cuda11.3-cudnn8-py3-test
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}


### PR DESCRIPTION
Currently we need to specify build_environment with additional info regarding the CI workflow properties such as periodic. and we are missing whether it is running on trunk only.

Proposal to generate these based on parameters like build_environment and others. 