### PR TITLE
[PyTorch] Fix quantized Conv1d module parameters

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -246,6 +246,8 @@ class TestStaticQuantizedModule(QuantizationTestCase):
             batch_size, in_channels_per_group, input_feature_map_size,
             out_channels_per_group, groups, kernel_size, X_scale, X_zero_point,
             W_scale, W_zero_point, use_bias, use_channelwise)
+        # Make sure the weight shape is correct
+        self.assertTrue(qconv_module.weight().shape == W_q.shape)
 
         qconv_module.set_weight_bias(W_q, b)
         qconv_module.scale = Y_scale

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -12,7 +12,6 @@ import torch.nn.intrinsic.qat as nniqat
 from torch._ops import ops
 from torch.nn.common_types import _size_1_t
 from torch.nn.modules.utils import _single, _pair, _triple
-from torch.nn.quantized.modules.utils import _pair_from_first
 from torch.nn.quantized.modules.utils import _quantize_weight
 from torch.nn.utils import fuse_conv_bn_weights
 
@@ -284,10 +283,10 @@ class Conv1d(_ConvNd):
                  device=None,
                  dtype=None):
         factory_kwargs = {'device': device, 'dtype': dtype}
-        kernel_size = _pair_from_first(kernel_size)
-        stride = _pair_from_first(stride)
-        padding = _pair_from_first(padding)
-        dilation = _pair_from_first(dilation)
+        kernel_size = _single(kernel_size)
+        stride = _single(stride)
+        padding = padding if isinstance(padding, str) else _single(padding)
+        dilation = _single(dilation)
 
         # Subclasses of _ConvNd needs to call _init rather than __init__. See
         # discussion on PR #49702


### PR DESCRIPTION
Summary:
In `torch/nn/quantized/module/conv.py`, Conv1d is making a scaler `kernel_size` into a tuple with size 2 by repeating `kernel_size` value. This logic is breaking `Conv1d` because internally it's unsqueezing the input with shape N, C, L to N, C, 1, L in [`qconv.cpp`](https://github.com/pytorch/pytorch/blob/06dfaadfc6357ed909ed15c7ef79d503c49d9475/aten/src/ATen/native/quantized/cpu/qconv.cpp#L841). Applying aforementioned kernel to this input shape will produce negative output shape in [`ConvUtils.h`](https://github.com/pytorch/FBGEMM/blob/203f7ff6e07d62b042e7d755fd1f4789d978e4d1/include/fbgemm/ConvUtils.h#L118-L119), if kernel_size > 1.

Here I'm modifying the processing logic for `kernel_size` and a few other parameters, to follow the pattern of [`torch/nn/module/conv.py`](https://github.com/pytorch/pytorch/blob/aae2a3c95ee6d62e834a5e6890a12f7ecf0dd17f/torch/nn/modules/conv.py#L284-L287).

Test Plan: Rely on unit test

Differential Revision: D29957556

