### PR TITLE
[dte] scaffolding for c2 operator broadcasting fastpath (1/x)

### DIFF
--- a/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
@@ -20,8 +20,11 @@ int getSizeFromDims(const std::vector<int>& dims) {
   return tot;
 }
 
-template <class OP>
-struct FP16PairWiseCPUFunctor : public OP {
+template <class Functor>
+struct FP16PairWiseCPUFunctor {
+  explicit FP16PairWiseCPUFunctor(bool allow_broadcast_fastpath=false)
+    : functor(allow_broadcast_fastpath) {}
+
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -30,7 +33,7 @@ struct FP16PairWiseCPUFunctor : public OP {
       const TIn* B,
       TOut* C,
       CPUContext* context) const {
-    OP::Forward(A_dims, B_dims, A, B, C, context);
+    functor.Forward(A_dims, B_dims, A, B, C, context);
 
     return true;
   }
@@ -54,11 +57,13 @@ struct FP16PairWiseCPUFunctor : public OP {
     fbgemm::RoundToFloat16(
         B, B_fp16.data(), B_sz, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
-    OP::Forward(A_dims, B_dims, A_fp16.data(), B_fp16.data(), C, context);
+    functor.Forward(A_dims, B_dims, A_fp16.data(), B_fp16.data(), C, context);
     fbgemm::RoundToFloat16(C, C, A_sz, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
     return true;
   }
+
+  Functor functor;
 };
 } // namespace
 
@@ -67,7 +72,7 @@ OPERATOR_SCHEMA(SumFakeFp16).NumInputs(1, INT_MAX).NumOutputs(1, INT_MAX);
 
 REGISTER_CPU_OPERATOR(
     AddFakeFp16,
-    BinaryElementwiseOp<
+    BinaryElementwiseBroadcastOp<
         TensorTypes<float, int, long>,
         CPUContext,
         FP16PairWiseCPUFunctor<AddFunctor<CPUContext>>>);
@@ -75,7 +80,7 @@ OPERATOR_SCHEMA(AddFakeFp16).NumInputs(2).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(
     DivFakeFp16,
-    BinaryElementwiseOp<
+    BinaryElementwiseBroadcastOp<
         TensorTypes<float, double>,
         CPUContext,
         FP16PairWiseCPUFunctor<DivFunctor<CPUContext>>>);
@@ -83,7 +88,7 @@ OPERATOR_SCHEMA(DivFakeFp16).NumInputs(2).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(
     MulFakeFp16,
-    BinaryElementwiseOp<
+    BinaryElementwiseBroadcastOp<
         TensorTypes<float>,
         CPUContext,
         FP16PairWiseCPUFunctor<MulFunctor<CPUContext>>>);
@@ -91,7 +96,7 @@ OPERATOR_SCHEMA(MulFakeFp16).NumInputs(2).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(
     SubFakeFp16,
-    BinaryElementwiseOp<
+    BinaryElementwiseBroadcastOp<
         TensorTypes<float>,
         CPUContext,
         FP16PairWiseCPUFunctor<SubFunctor<CPUContext>>>);

--- a/caffe2/ideep/operators/elementwise_sum_op.cc
+++ b/caffe2/ideep/operators/elementwise_sum_op.cc
@@ -12,7 +12,7 @@ class IDEEPSumOp final : public IDEEPOperator {
   USE_IDEEP_DEF_ALIASES();
   USE_IDEEP_OPERATOR_FUNCTIONS();
   using FALLBACK_SUM = IDEEPFallbackOp<SumOp<CPUContext>, SkipIndices<0>>;
-  using FALLBACK_ADD = IDEEPFallbackOp<BinaryElementwiseOp<
+  using FALLBACK_ADD = IDEEPFallbackOp<BinaryElementwiseBroadcastOp<
     NumericTypes, CPUContext, AddFunctor<CPUContext>>, SkipIndices<0>>;
 
   IDEEPSumOp(const OperatorDef& operator_def, Workspace* ws)

--- a/caffe2/ideep/operators/operator_fallback_ideep.cc
+++ b/caffe2/ideep/operators/operator_fallback_ideep.cc
@@ -205,15 +205,15 @@ REGISTER_IDEEP_OPERATOR(
         SignFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Div,
-    IDEEPFallbackOp<BinaryElementwiseOp<
+    IDEEPFallbackOp<BinaryElementwiseBroadcastOp<
       NumericTypes, CPUContext, DivFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Mul,
     IDEEPFallbackOp<
-        BinaryElementwiseOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>>);
+        BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Sub,
-    IDEEPFallbackOp<BinaryElementwiseOp<
+    IDEEPFallbackOp<BinaryElementwiseBroadcastOp<
       NumericTypes, CPUContext, SubFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Tanh,
@@ -231,7 +231,7 @@ REGISTER_IDEEP_OPERATOR(
 
 REGISTER_IDEEP_OPERATOR(
     AddGradient,
-    IDEEPFallbackOp<BinaryElementwiseGradientOp<
+    IDEEPFallbackOp<BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CPUContext,
         AddFunctor<CPUContext>>>);
@@ -243,7 +243,7 @@ REGISTER_IDEEP_OPERATOR(
         TanhGradientFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     MulGradient,
-    IDEEPFallbackOp<BinaryElementwiseGradientOp<
+    IDEEPFallbackOp<BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CPUContext,
         MulFunctor<CPUContext>>>);

--- a/caffe2/operators/elementwise_add_gradient_op.cc
+++ b/caffe2/operators/elementwise_add_gradient_op.cc
@@ -7,7 +7,7 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     AddGradient,
-    BinaryElementwiseGradientOp<
+    BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CPUContext,
         AddFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_add_op.cc
+++ b/caffe2/operators/elementwise_add_op.cc
@@ -4,6 +4,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Add,
-    BinaryElementwiseOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>);
+    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_add_op.h
+++ b/caffe2/operators/elementwise_add_op.h
@@ -13,6 +13,9 @@ namespace caffe2 {
 
 template <class Context>
 struct AddFunctor {
+  explicit AddFunctor(bool allow_broadcast_fastpath=false)
+    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
+
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -58,7 +61,8 @@ struct AddFunctor {
         TGrad(1),
         dC,
         dA,
-        context);
+        context,
+        allow_broadcast_fastpath_);
     math::ReduceSum(
         C_dims.size(),
         C_dims.data(),
@@ -66,9 +70,12 @@ struct AddFunctor {
         TGrad(1),
         dC,
         dB,
-        context);
+        context,
+        allow_broadcast_fastpath_);
     return true;
   }
+
+  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_add_op_gpu.cc
+++ b/caffe2/operators/elementwise_add_op_gpu.cc
@@ -6,10 +6,10 @@ namespace caffe2 {
 
 REGISTER_CUDA_OPERATOR(
     Add,
-    BinaryElementwiseOp<NumericTypes, CUDAContext, AddFunctor<CUDAContext>>);
+    BinaryElementwiseBroadcastOp<NumericTypes, CUDAContext, AddFunctor<CUDAContext>>);
 REGISTER_CUDA_OPERATOR(
     AddGradient,
-    BinaryElementwiseGradientOp<
+    BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CUDAContext,
         AddFunctor<CUDAContext>>);

--- a/caffe2/operators/elementwise_div_gradient_op.cc
+++ b/caffe2/operators/elementwise_div_gradient_op.cc
@@ -21,7 +21,8 @@ void ComputeDivGradient(
     const TOut* C,
     TGrad* dA,
     TGrad* dB,
-    CPUContext* context) {
+    CPUContext* context,
+    bool allow_broadcast_fastpath) {
   const int A_size =
       // NOLINTNEXTLINE(modernize-use-transparent-functors)
       std::accumulate(A_dims, A_dims + ndim, 1, std::multiplies<int>());
@@ -97,7 +98,8 @@ bool DivFunctor<CPUContext>::Backward(
         C,
         nullptr,
         dB,
-        context);
+        context,
+        allow_broadcast_fastpath_);
     math::Div(
         A_dims.size(),
         A_dims.data(),
@@ -118,7 +120,8 @@ bool DivFunctor<CPUContext>::Backward(
         C,
         dA,
         dB,
-        context);
+        context,
+        allow_broadcast_fastpath_);
   }
   return true;
 }
@@ -127,7 +130,7 @@ template <>
 class BinaryElementwiseWithArgsGradientOp<
     NumericTypes,
     CPUContext,
-    BinaryFunctorWithDefaultCtor<DivFunctor<CPUContext>>,
+    BinaryFunctorWithBroadcastOptionsCtor<DivFunctor<CPUContext>>,
     SameTypeAsInput,
     SameTypeAsInput>
     final : public Operator<CPUContext> {
@@ -267,12 +270,12 @@ class BinaryElementwiseWithArgsGradientOp<
   const std::string axis_str_;
   const std::string order_;
 
-  BinaryFunctorWithDefaultCtor<DivFunctor<CPUContext>> functor_;
+  BinaryFunctorWithBroadcastOptionsCtor<DivFunctor<CPUContext>> functor_;
 };
 
 REGISTER_CPU_OPERATOR(
     DivGradient,
-    BinaryElementwiseGradientOp<
+    BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CPUContext,
         DivFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_div_op.cc
+++ b/caffe2/operators/elementwise_div_op.cc
@@ -5,6 +5,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Div,
-    BinaryElementwiseOp<NumericTypes, CPUContext, DivFunctor<CPUContext>>);
+    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, DivFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_div_op.h
+++ b/caffe2/operators/elementwise_div_op.h
@@ -10,6 +10,9 @@ namespace caffe2 {
 
 template <class Context>
 struct DivFunctor {
+  explicit DivFunctor(bool allow_broadcast_fastpath=false)
+    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
+
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -41,6 +44,8 @@ struct DivFunctor {
       TGrad* dA_data,
       TGrad* dB_data,
       Context* context) const;
+
+  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_mul_gradient_op.cc
+++ b/caffe2/operators/elementwise_mul_gradient_op.cc
@@ -22,7 +22,8 @@ void ComputeMulGradient(
     const TIn* B,
     TGrad* dA,
     TGrad* dB,
-    CPUContext* context) {
+    CPUContext* context,
+    bool allow_broadcast_fastpath) {
   const auto A_size = c10::multiply_integers(A_dims, A_dims + ndim);
   const auto B_size = c10::multiply_integers(B_dims, B_dims + ndim);
   const auto C_size = c10::multiply_integers(C_dims, C_dims + ndim);
@@ -234,7 +235,8 @@ bool MulFunctor<CPUContext>::Backward(
         B,
         dA,
         dB,
-        context);
+        context,
+        allow_broadcast_fastpath_);
   }
 
   return true;
@@ -287,7 +289,7 @@ template bool MulFunctor<CPUContext>::Backward<int64_t, int64_t, int64_t>(
 
 REGISTER_CPU_OPERATOR(
     MulGradient,
-    BinaryElementwiseGradientOp<
+    BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CPUContext,
         MulFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_mul_op.cc
+++ b/caffe2/operators/elementwise_mul_op.cc
@@ -4,6 +4,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Mul,
-    BinaryElementwiseOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>);
+    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_mul_op.h
+++ b/caffe2/operators/elementwise_mul_op.h
@@ -10,6 +10,9 @@ namespace caffe2 {
 
 template <class Context>
 struct MulFunctor {
+  explicit MulFunctor(bool allow_broadcast_fastpath=false)
+    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
+
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -41,6 +44,8 @@ struct MulFunctor {
       TGrad* dA_data,
       TGrad* dB_data,
       Context* context) const;
+
+  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_sub_gradient_op.cc
+++ b/caffe2/operators/elementwise_sub_gradient_op.cc
@@ -7,7 +7,7 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     SubGradient,
-    BinaryElementwiseGradientOp<
+    BinaryElementwiseGradientBroadcastOp<
         NumericTypes,
         CPUContext,
         SubFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_sub_op.cc
+++ b/caffe2/operators/elementwise_sub_op.cc
@@ -4,6 +4,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Sub,
-    BinaryElementwiseOp<NumericTypes, CPUContext, SubFunctor<CPUContext>>);
+    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, SubFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_sub_op.h
+++ b/caffe2/operators/elementwise_sub_op.h
@@ -13,6 +13,9 @@ namespace caffe2 {
 
 template <class Context>
 struct SubFunctor {
+  explicit SubFunctor(bool allow_broadcast_fastpath=false)
+    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
+
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -58,7 +61,8 @@ struct SubFunctor {
         TGrad(1),
         dC,
         dA,
-        context);
+        context,
+        allow_broadcast_fastpath_);
     math::ReduceSum(
         C_dims.size(),
         C_dims.data(),
@@ -66,9 +70,12 @@ struct SubFunctor {
         TGrad(-1),
         dC,
         dB,
-        context);
+        context,
+        allow_broadcast_fastpath_);
     return true;
   }
+
+  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/expand_op.h
+++ b/caffe2/operators/expand_op.h
@@ -17,7 +17,8 @@ class ExpandOp final : public Operator<Context> {
 
   template <class... Args>
   explicit ExpandOp(Args&&... args)
-      : Operator<Context>(std::forward<Args>(args)...) {}
+      : Operator<Context>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(bool, "allow_broadcast_fastpath", allow_broadcast_fastpath_, false) {}
 
   bool RunOnDevice() override {
     return DispatchHelper<InputTypes>::call(this, Input(0));
@@ -61,9 +62,12 @@ class ExpandOp final : public Operator<Context> {
         T(1),
         X.template data<T>(),
         Y->template mutable_data<T>(),
-        &context_);
+        &context_,
+        allow_broadcast_fastpath_);
     return true;
   }
+
+  const bool allow_broadcast_fastpath_;
 };
 
 template <typename InputTypes, class Context>
@@ -73,7 +77,8 @@ class ExpandGradientOp final : public Operator<Context> {
 
   template <class... Args>
   explicit ExpandGradientOp(Args&&... args)
-      : Operator<Context>(std::forward<Args>(args)...) {}
+      : Operator<Context>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(bool, "allow_broadcast_fastpath", allow_broadcast_fastpath_, false) {}
 
   bool RunOnDevice() override {
     return DispatchHelper<InputTypes>::call(this, Input(0));
@@ -106,9 +111,12 @@ class ExpandGradientOp final : public Operator<Context> {
         T(1),
         dY.template data<T>(),
         dX->template mutable_data<T>(),
-        &context_);
+        &context_,
+        allow_broadcast_fastpath_);
     return true;
   }
+
+  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/quantization/server/elementwise_add_dnnlowp_op.cc
+++ b/caffe2/quantization/server/elementwise_add_dnnlowp_op.cc
@@ -13,7 +13,7 @@ using namespace std;
 using namespace dnnlowp;
 
 using AddFp32Op =
-    BinaryElementwiseOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>;
+    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>;
 
 template <typename T>
 class AddDNNLowPOp : public BinaryElementwiseDNNLowPOp<T, AddFp32Op> {

--- a/caffe2/quantization/server/elementwise_mul_dnnlowp_op.cc
+++ b/caffe2/quantization/server/elementwise_mul_dnnlowp_op.cc
@@ -9,7 +9,7 @@ using namespace std;
 using namespace dnnlowp;
 
 using MulFp32Op =
-    BinaryElementwiseOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>;
+    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>;
 
 template <typename T>
 class MulDNNLowPOp : public BinaryElementwiseDNNLowPOp<T, MulFp32Op> {

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -126,7 +126,8 @@ TORCH_API void Broadcast(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Computes inv_std from variance.
 template <typename T, class Context>

--- a/caffe2/utils/math/reduce.cu
+++ b/caffe2/utils/math/reduce.cu
@@ -491,7 +491,8 @@ void MomentsCUDA(
       const T alpha,                                                   \
       const T* X,                                                      \
       T* Y,                                                            \
-      CUDAContext* context) {                                          \
+      CUDAContext* context,                                            \
+      bool) {                                                          \
     ReduceTensorCUDA<T, Reducer>(                                      \
         ndim, X_dims, Y_dims, Reducer(), kInit, alpha, X, Y, context); \
   }
@@ -550,7 +551,8 @@ DELEGATE_CUDA_REDUCE_FUNCTION(double, ReduceSum, cub::Sum, 0.0)
       const T alpha,                                  \
       const T* X,                                     \
       T* Y,                                           \
-      CUDAContext* context) {                         \
+      CUDAContext* context,                           \
+      bool) {                                         \
     int scale = 1;                                    \
     for (int i = 0; i < ndim; ++i) {                  \
       if (Y_dims[i] == 1) {                           \
@@ -580,7 +582,8 @@ CAFFE2_SPECIALIZED_CUDA_REDUCE_MEAN(float)
       const T* X,                                                \
       T* mean,                                                   \
       T* var,                                                    \
-      CUDAContext* context) {                                    \
+      CUDAContext* context,                                      \
+      bool) {                                                    \
     MomentsCUDA<T>(ndim, X_dims, Y_dims, X, mean, var, context); \
   }
 CAFFE2_SPECIALIZED_CUDA_MOMENTS(float)

--- a/caffe2/utils/math/reduce.h
+++ b/caffe2/utils/math/reduce.h
@@ -32,7 +32,8 @@ TORCH_API void ReduceMin(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Y = alpha * ReduceMax(X)
 template <typename T, class Context>
@@ -43,7 +44,8 @@ TORCH_API void ReduceMax(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Y = alpha * ReduceSum(X)
 template <typename T, class Context>
@@ -54,7 +56,8 @@ TORCH_API void ReduceSum(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Y = alpha * ReduceMean(X)
 template <typename T, class Context>
@@ -65,7 +68,8 @@ TORCH_API void ReduceMean(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Y = alpha * ReduceL1(X)
 template <typename T, class Context>
@@ -76,7 +80,8 @@ TORCH_API void ReduceL1(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Y = alpha * ReduceL2(X)
 template <typename T, class Context>
@@ -87,7 +92,8 @@ TORCH_API void ReduceL2(
     const T alpha,
     const T* X,
     T* Y,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 // Computes mean and variance over axes.
 template <typename T, class Context>
@@ -98,7 +104,8 @@ TORCH_API void Moments(
     const T* X,
     T* mean,
     T* var,
-    Context* context);
+    Context* context,
+    bool allow_broadcast_fastpath=false);
 
 } // namespace math
 

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -476,7 +476,8 @@ C10_EXPORT void BroadcastImpl(
     const T alpha,
     const T* X,
     T* Y,
-    CPUContext* context) {
+    CPUContext* context,
+    bool allow_broadcast_fastpath) {
   CAFFE_ENFORCE_LE(X_ndim, Y_ndim);
   std::vector<int> X_dims_vector(Y_ndim);
   const int d = Y_ndim - X_ndim;
@@ -510,8 +511,10 @@ C10_EXPORT void BroadcastImpl(
       const T alpha,                                                        \
       const T* X,                                                           \
       T* Y,                                                                 \
-      CPUContext* context) {                                                \
-    BroadcastImpl<T>(X_ndim, X_dims, Y_ndim, Y_dims, alpha, X, Y, context); \
+      CPUContext* context,                                                  \
+      bool allow_broadcast_fastpath) {                                      \
+    BroadcastImpl<T>(X_ndim, X_dims, Y_ndim, Y_dims, alpha, X, Y,           \
+                     context, allow_broadcast_fastpath);                    \
   }
 CAFFE2_SPECIALIZED_BROADCAST(std::int32_t)
 CAFFE2_SPECIALIZED_BROADCAST(std::int64_t)

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -2892,7 +2892,8 @@ CAFFE2_CUDA_EXPORT void BroadcastCUDAImpl(
       const T alpha,                                 \
       const T* X,                                    \
       T* Y,                                          \
-      CUDAContext* context) {                        \
+      CUDAContext* context,                          \
+      bool) {                                        \
     CAFFE_ENFORCE_LE(X_ndim, Y_ndim);                \
     DISPATCH_FUNCTION_BY_VALUE_WITH_TYPE_1(          \
         Y_ndim,                                      \

--- a/caffe2/utils/math_test.cc
+++ b/caffe2/utils/math_test.cc
@@ -456,18 +456,21 @@ class BroadcastTest : public testing::Test {
     ASSERT_EQ(X_data.size(), X_.numel());
     cpu_context_->CopyFromCPU<float>(
         X_data.size(), X_data.data(), X_.mutable_data<float>());
-    math::Broadcast<float, CPUContext>(
-        X_dims.size(),
-        X_dims.data(),
-        Y_dims.size(),
-        Y_dims.data(),
-        1.0f,
-        X_.data<float>(),
-        Y_.mutable_data<float>(),
-        cpu_context_.get());
-    ASSERT_EQ(Y_data.size(), Y_.numel());
-    for (const auto i : c10::irange(Y_data.size())) {
-      EXPECT_FLOAT_EQ(Y_data[i], Y_.data<float>()[i]);
+    for (bool allow_broadcast_fastpath : {false, true}) {
+      math::Broadcast<float, CPUContext>(
+          X_dims.size(),
+          X_dims.data(),
+          Y_dims.size(),
+          Y_dims.data(),
+          1.0f,
+          X_.data<float>(),
+          Y_.mutable_data<float>(),
+          cpu_context_.get(),
+          allow_broadcast_fastpath);
+      ASSERT_EQ(Y_data.size(), Y_.numel());
+      for (const auto i : c10::irange(Y_data.size())) {
+        EXPECT_FLOAT_EQ(Y_data[i], Y_.data<float>()[i]);
+      }
     }
   }
 


### PR DESCRIPTION
Summary: This diff is a big no-op that just sets up scaffolding for passing the "allow_broadcast_fastpath" from caffe2 operator protos created in Python down to C++. To facilitate this, we create helper template wrappers that pass a flag for "allow_broadcast_fastpath" down to elementwise functors. This flag will determine whether to try and take the broadcast fastpath, which we will add in subsequent diffs.

Test Plan: sandcastle + let github CI run

Differential Revision: D28154475

