### PR TITLE
[LTC] add shape info to types in TS lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -44,8 +44,6 @@
 namespace torch_lazy_tensors {
 namespace compiler {
 
-using namespace lazy_tensors;
-
 class TSNodeLowering : public NodeLowering {
  public:
   TSNodeLowering(const std::string& name, ts_backend::TSLoweringContext* loctx)
@@ -60,12 +58,12 @@ class TSNodeLowering : public NodeLowering {
       return false;
     }
     LTC_CHECK_EQ(node->num_outputs(), ops.size());
-    if (lazy_tensors::sys_util::GetEnvBool("LTC_IR_TS_SHAPE_TYPES", false)) {
+    if (!lazy_tensors::sys_util::GetEnvBool("LTC_IR_TS_SHAPE_TYPES", false)) {
       for (size_t i = 0; i < ops.size(); ++i) {
         loctx()->AssignOutputOp(ir::Output(node, i), ops[i]);
       }
     } else {
-      auto type_transformer = [](const Shape& shape, const at::TypePtr& type) {
+      auto type_transformer = [](const lazy_tensors::Shape& shape, const at::TypePtr& type) {
         return type->expect<at::TensorType>()
             ->withScalarType(TensorTypeFromLtcType(shape.element_type()))
             ->withSizesStrides(shape.as_sizes(), ComputeShapeStrides(shape));

--- a/lazy_tensor_core/lazy_tensors/shape.h
+++ b/lazy_tensor_core/lazy_tensors/shape.h
@@ -92,6 +92,13 @@ class Shape {
     return MakeSpan(dimensions_);
   }
 
+  std::vector<int64_t> as_sizes() const {
+    if (dynamic_mode_.load()) {
+      throw std::runtime_error("Exact sizes not known");
+    }
+    return dimensions_;
+  }
+
   int tuple_shapes_size() const { return element_shapes_.size(); }
 
   const Shape& tuple_shapes(int index) const {


### PR DESCRIPTION
effect of this changes looks like this

```
graph(%p0 : Float(10, strides=[1]),
      %p1 : Float(10, 500, strides=[500, 1]),
      %p2 : Float(500, strides=[1]),
      %p3 : Float(500, 800, strides=[800, 1]),
      %p4 : Float(1, 50, 4, 4, strides=[800, 16, 4, 1])):
  %2 : int[] = prim::Constant[value=[1, 0]]()
  %3 : int[] = prim::Constant[value=[1, 0]]()
  %4 : Float(500, 10, strides=[10, 1]) = aten::permute(%p1, %3)
  %7 : int[] = prim::Constant[value=[1, 0]]()
  %8 : int[] = prim::Constant[value=[1, 0]]()
  %9 : Float(800, 500, strides=[500, 1]) = aten::permute(%p3, %8)
  %11 : int[] = prim::Constant[value=[1, 800]]()
  %12 : int[] = prim::Constant[value=[1, 800]]()
  %13 : Float(1, 800, strides=[800, 1]) = aten::reshape(%p4, %12)
  %14 : int = prim::Constant[value=1]()
  %15 : int = prim::Constant[value=1]()
  %16 : Float(1, 500, strides=[0, 0]) = aten::addmm(%p2, %13, %9, %14, %15)
  %17 : Float(1, 500, strides=[0, 0]) = aten::relu(%16)
  %18 : int = prim::Constant[value=1]()
  %19 : int = prim::Constant[value=1]()
  %20 : Float(1, 10, strides=[0, 0]) = aten::addmm(%p0, %17, %4, %18, %19)
  return (%20)
```

I will add tests if before landing if this is the right approach.


Note that I did find [ForEachMutableSubshape](https://github.com/pytorch/pytorch/blob/lazy_tensor_staging/lazy_tensor_core/lazy_tensors/shape_util.h#L149) but as far as I understand this I'm not changing the shapes per se but the types.