### PR TITLE
[dte] broadcast fastpath implementations for reduce utility functions (2/x)

### DIFF
--- a/caffe2/utils/math/broadcast.cc
+++ b/caffe2/utils/math/broadcast.cc
@@ -6,6 +6,19 @@
 namespace caffe2 {
 namespace math {
 
+bool can_use_broadcast_fastpath(int ndim, const int* dims) {
+  int index_of_last_singleton = -1;
+  int index_of_first_non_singleton = ndim;
+  for (int i = 0; i < ndim; i++) {
+    if (dims[i] == 1) {
+      index_of_last_singleton = i;
+    } else if (index_of_first_non_singleton == ndim) {
+      index_of_first_non_singleton = i;
+    }
+  }
+  return index_of_last_singleton < index_of_first_non_singleton;
+}
+
 #define CAFFE2_SPECIALIZED_AFFINE_CHANNEL(T)                        \
   template <>                                                       \
   C10_EXPORT void AffineChannel<T, CPUContext, StorageOrder::NCHW>( \

--- a/caffe2/utils/math/broadcast.h
+++ b/caffe2/utils/math/broadcast.h
@@ -7,6 +7,8 @@
 namespace caffe2 {
 namespace math {
 
+bool can_use_broadcast_fastpath(int ndim, const int* dims);
+
 template <typename T, class Context, StorageOrder kOrder>
 TORCH_API void AffineChannel(
     const int N,


### PR DESCRIPTION
Summary: In this diff we add a broadcast fastpath for reduce utility functions. These functions are used by various elementwise ops, whose tests we update to exercise the new functionality.

Test Plan: Added test cases to elementwise ops (which will exercise the new reducer functionality) that will be run by CI. It's worth noting there's still no code (outside of the new test cases) that takes the new code paths added -- the user must explicitly request  `allow_broadcast_fastpath=True`, and nothing outside of the added tests currently does so.

Differential Revision: D29938264

