### PR TITLE
[dte] fastpath implementations for mulgrad / divgrad (3/x)

### DIFF
--- a/caffe2/operators/elementwise_mul_gradient_op.cc
+++ b/caffe2/operators/elementwise_mul_gradient_op.cc
@@ -1,6 +1,7 @@
 #include <c10/util/accumulate.h>
 
 #include "caffe2/operators/elementwise_mul_op.h"
+#include "caffe2/utils/math/broadcast.h"
 
 #include <algorithm>
 #include <functional>
@@ -10,6 +11,33 @@
 namespace caffe2 {
 
 namespace {
+
+template <typename TGrad, typename TIn>
+void ComputeMulGradientFastpath(
+    const int A_size,
+    const int B_size,
+    const int C_size,
+    const TGrad* dC,
+    const TIn* A,
+    const TIn* B,
+    TGrad* dA,
+    TGrad* dB) {
+  int A_index = 0;
+  int B_index = 0;
+  for (int C_index = 0; C_index < C_size; ++C_index) {
+    dA[A_index] += dC[C_index] * B[B_index];
+    dB[B_index] += dC[C_index] * A[A_index];
+    A_index++;
+    B_index++;
+    if (A_index >= A_size) {
+      A_index = 0;
+    }
+    if (B_index >= B_size) {
+      B_index = 0;
+    }
+  }
+
+}
 
 template <typename TGrad, typename TIn>
 void ComputeMulGradient(
@@ -29,6 +57,13 @@ void ComputeMulGradient(
   const auto C_size = c10::multiply_integers(C_dims, C_dims + ndim);
   math::Set<TGrad, CPUContext>(A_size, TGrad(0), dA, context);
   math::Set<TGrad, CPUContext>(B_size, TGrad(0), dB, context);
+  if (
+      allow_broadcast_fastpath
+      && math::can_use_broadcast_fastpath(ndim, A_dims)
+      && math::can_use_broadcast_fastpath(ndim, B_dims)) {
+    ComputeMulGradientFastpath(A_size, B_size, C_size, dC, A, B, dA, dB);
+    return;
+  }
   std::vector<int> index(ndim, 0);
   for (int C_index = 0; C_index < C_size; ++C_index) {
     const int A_index =

--- a/caffe2/python/operator_test/elementwise_ops_test.py
+++ b/caffe2/python/operator_test/elementwise_ops_test.py
@@ -352,27 +352,49 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             reference=swish_gradient,
         )
 
-    @given(n=st.integers(1, 6), m=st.integers(4, 6),
+    @given(n=st.integers(1, 6),
+           m=st.integers(4, 6),
+           inplace=st.booleans(),
+           allow_broadcast_fastpath=st.booleans(),
            seed=st.integers(0, 1000), **hu.gcs)
     @settings(deadline=10000)
-    def test_mul_gradient_inplace(self, n, m, gc, dc, seed):
+    def test_mul_gradient_inplace_or_broadcast(
+        self,
+        n: int,
+        m: int,
+        inplace: bool,
+        allow_broadcast_fastpath: bool,
+        gc,
+        dc,
+        seed: int,
+    ):
+        broadcast = not inplace
         np.random.seed(seed)
 
         def mul_gradient(dC, A, B):
-            return [B * dC, A * dC]
+            dA = B * dC
+            dB = A * dC
+            if broadcast:
+                dB = np.sum(dB, axis=0)
+            return [dA, dB]
 
         A = np.random.rand(n, m).astype(np.float32)
-        B = np.random.rand(n, m).astype(np.float32)
+        if broadcast:
+            B = np.random.rand(m).astype(np.float32)
+        else:
+            B = np.random.rand(n, m).astype(np.float32)
         dC = np.random.rand(n, m).astype(np.float32)
         op_dA_inplace = core.CreateOperator(
             "MulGradient",
             ["dC", "A", "B"],
-            ["dC", "dB"],
+            ["dC" if inplace else "dA", "dB"],
+            allow_broadcast_fastpath=allow_broadcast_fastpath,
         )
         op_dB_inplace = core.CreateOperator(
             "MulGradient",
             ["dC", "A", "B"],
-            ["dA", "dC"],
+            ["dA", "dC" if inplace else "dB"],
+            allow_broadcast_fastpath=allow_broadcast_fastpath,
         )
 
         self.assertReferenceChecks(
@@ -389,23 +411,44 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             reference=mul_gradient,
         )
 
-    @given(n=st.integers(1, 6), m=st.integers(4, 6),
+    @given(n=st.integers(1, 6),
+           m=st.integers(4, 6),
+           inplace=st.booleans(),
+           allow_broadcast_fastpath=st.booleans(),
            seed=st.integers(0, 1000), **hu.gcs)
     @settings(deadline=10000)
-    def test_div_gradient_inplace(self, n, m, gc, dc, seed):
+    def test_div_gradient_inplace_or_broadcast(
+        self,
+        n: int,
+        m: int,
+        inplace: bool,
+        allow_broadcast_fastpath: bool,
+        gc,
+        dc,
+        seed: int,
+    ):
+        broadcast = not inplace
         np.random.seed(seed)
 
         def div_gradient(dC, _A, B, C):
-            return [dC / B, -dC * C / B]
+            dA = dC / B
+            dB = -dC * C / B
+            if broadcast:
+                dB = np.sum(dB, axis=0)
+            return [dA, dB]
 
         A = np.random.rand(n, m).astype(np.float32)
-        B = np.random.rand(n, m).astype(np.float32)
+        if broadcast:
+            B = np.random.rand(m).astype(np.float32) + 1.0
+        else:
+            B = np.random.rand(n, m).astype(np.float32) + 1.0
         C = A / B
         dC = np.random.rand(n, m).astype(np.float32)
         op = core.CreateOperator(
             "DivGradient",
             ["dC", "A", "B", "C"],
-            ["dC", "dB"],
+            ["dC" if inplace else "dA", "dB"],
+            allow_broadcast_fastpath=allow_broadcast_fastpath,
         )
 
         self.assertReferenceChecks(
@@ -827,13 +870,22 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             "Div", np.divide, n, m, 1.0, True, False, gc, dc)
 
     @given(n=st.integers(1, 5), m=st.integers(1, 5), broadcast=st.booleans(),
-           **hu.gcs)
+           allow_broadcast_fastpath=st.booleans(), **hu.gcs)
     @settings(deadline=10000)
-    def test_div_legacy_grad(self, n, m, broadcast, gc, dc):
+    def test_div_legacy_grad(
+        self,
+        n: int,
+        m: int,
+        broadcast: bool,
+        allow_broadcast_fastpath: bool,
+        gc,
+        dc
+    ):
         op = core.CreateOperator(
             "DivGradient",
             ["B", "C", "dC"],
             ["dA", "dB"],
+            allow_broadcast_fastpath=allow_broadcast_fastpath,
         )
 
         def div_grad_ref(B, C, dC):

--- a/caffe2/python/operator_test/mul_gradient_benchmark.py
+++ b/caffe2/python/operator_test/mul_gradient_benchmark.py
@@ -12,10 +12,16 @@ from caffe2.python import core, workspace
 def benchmark_mul_gradient(args):
     workspace.FeedBlob("dC", np.random.rand(args.m, args.n).astype(np.float32))
     workspace.FeedBlob("A", np.random.rand(args.m, args.n).astype(np.float32))
-    workspace.FeedBlob("B", np.random.rand(args.m).astype(np.float32))
+    workspace.FeedBlob("B", np.random.rand(args.n).astype(np.float32))
 
     net = core.Net("mynet")
-    net.MulGradient(["dC", "A", "B"], ["dA", "dB"], broadcast=True, axis=0)
+    net.MulGradient(
+        ["dC", "A", "B"],
+        ["dC" if args.inplace else "dA", "dB"],
+        broadcast=True,
+        axis=1,
+        allow_broadcast_fastpath=args.allow_broadcast_fastpath,
+    )
     workspace.CreateNet(net)
 
     workspace.BenchmarkNet(net.Name(), 1, args.iteration, True)
@@ -33,6 +39,12 @@ if __name__ == "__main__":
     parser.add_argument(
         '-i', "--iteration", type=int, default=100,
         help="The number of iterations.")
+    parser.add_argument(
+        "--inplace",
+        action='store_true', help="Whether to perform the op in-place.")
+    parser.add_argument(
+        "--allow-broadcast-fastpath",
+        action='store_true', help="Whether the broadcast fastpath is enabled.")
     args, extra_args = parser.parse_known_args()
     core.GlobalInit(['python'] + extra_args)
     benchmark_mul_gradient(args)


### PR DESCRIPTION
Summary: In this diff we add a broadcast fastpath for MulGradient and DivGradient ops, whose tests we update to exercise the new functionality.

Test Plan: Added test cases to elementwise ops (which will exercise the new MulGradient / DivGradient broadcast fastpath functionality) that will be run by CI. It's worth noting there's still no code (outside of the new test cases) that takes the new code paths added -- the user must explicitly request  allow_broadcast_fastpath=True, and nothing outside of the added tests currently does so.

Differential Revision: D29938273

