### PR TITLE
Bump protobuf version in CircleCI docker images

### DIFF
--- a/.circleci/docker/common/install_db.sh
+++ b/.circleci/docker/common/install_db.sh
@@ -2,23 +2,6 @@
 
 set -ex
 
-# This function installs protobuf 2.6
-install_protobuf_26() {
-  pb_dir="/usr/temp_pb_install_dir"
-  mkdir -p $pb_dir
-
-  # On the nvidia/cuda:9-cudnn7-devel-centos7 image we need this symlink or
-  # else it will fail with
-  #   g++: error: ./../lib64/crti.o: No such file or directory
-  ln -s /usr/lib64 "$pb_dir/lib64"
-
-  curl -LO "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
-  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-2.6.1.tar.gz
-  pushd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
-  popd
-  rm -rf $pb_dir
-}
-
 install_ubuntu() {
   apt-get update
   apt-get install -y --no-install-recommends \

--- a/.circleci/docker/common/install_protobuf.sh
+++ b/.circleci/docker/common/install_protobuf.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-# This function installs protobuf 2.6
-install_protobuf_26() {
+# This function installs protobuf 3.17
+install_protobuf_317() {
   pb_dir="/usr/temp_pb_install_dir"
   mkdir -p $pb_dir
 
@@ -12,37 +12,32 @@ install_protobuf_26() {
   #   g++: error: ./../lib64/crti.o: No such file or directory
   ln -s /usr/lib64 "$pb_dir/lib64"
 
-  curl -LO "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
-  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-2.6.1.tar.gz
-  pushd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
+  curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz"
+  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-all-3.17.3.tar.gz
+  # -j2 to balance memory usage and speed.
+  # naked `-j` seems to use too much memory.
+  pushd "$pb_dir" && ./configure && make -j2 && make -j2 check && sudo make -j2 install && sudo ldconfig
   popd
   rm -rf $pb_dir
 }
 
 install_ubuntu() {
-  # Ubuntu 14.04 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
-  # so we install that here if on 14.04
-  # Ubuntu 14.04 also has cmake 2.8.12 as the default option, so we will
+  # Ubuntu 14.04 has cmake 2.8.12 as the default option, so we will
   # install cmake3 here and use cmake3.
   apt-get update
   if [[ "$UBUNTU_VERSION" == 14.04 ]]; then
     apt-get install -y --no-install-recommends cmake3
-    install_protobuf_26
-  else
-    apt-get install -y --no-install-recommends \
-            libprotobuf-dev \
-            protobuf-compiler
   fi
 
   # Cleanup
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+  install_protobuf_317
 }
 
 install_centos() {
-  # Centos7 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
-  # so we always install install that here
-  install_protobuf_26
+  install_protobuf_317
 }
 
 # Install base packages depending on the base OS

--- a/.circleci/docker/common/install_vision.sh
+++ b/.circleci/docker/common/install_vision.sh
@@ -2,23 +2,6 @@
 
 set -ex
 
-# This function installs protobuf 2.6
-install_protobuf_26() {
-  pb_dir="/usr/temp_pb_install_dir"
-  mkdir -p $pb_dir
-
-  # On the nvidia/cuda:9-cudnn7-devel-centos7 image we need this symlink or
-  # else it will fail with
-  #   g++: error: ./../lib64/crti.o: No such file or directory
-  ln -s /usr/lib64 "$pb_dir/lib64"
-
-  curl -LO "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
-  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-2.6.1.tar.gz
-  pushd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
-  popd
-  rm -rf $pb_dir
-}
-
 install_ubuntu() {
   apt-get update
   apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Needed to update ONNX to 1.10 (#62039) because that introduces uses
of the "reserved" protobuf feature.

Also:
* Remove protobuf install code from scripts where it was unused.
* Add `-j` flag to make commands to speed things up.
