### PR TITLE
Fix setArgumentNames and make Script/Python consistent

### DIFF
--- a/test/cpp/api/imethod.cpp
+++ b/test/cpp/api/imethod.cpp
@@ -35,9 +35,8 @@ TEST(IMethodTest, GetArgumentNames) {
   auto scriptMethod = scriptModel.get_method("forward");
 
   auto& scriptNames = scriptMethod.getArgumentNames();
-  EXPECT_EQ(scriptNames.size(), 2);
-  EXPECT_STREQ(scriptNames[0].c_str(), "self");
-  EXPECT_STREQ(scriptNames[1].c_str(), "input");
+  EXPECT_EQ(scriptNames.size(), 1);
+  EXPECT_STREQ(scriptNames[0].c_str(), "input");
 
   torch::deploy::InterpreterManager manager(3);
   torch::deploy::Package package = manager.load_package(getenv("SIMPLE"));
@@ -45,7 +44,6 @@ TEST(IMethodTest, GetArgumentNames) {
   torch::deploy::PythonMethodWrapper pyMethod(pyModel, "forward");
 
   auto& pyNames = pyMethod.getArgumentNames();
-  EXPECT_EQ(pyNames.size(), 2);
+  EXPECT_EQ(pyNames.size(), 1);
   EXPECT_STREQ(pyNames[0].c_str(), "input");
-  EXPECT_STREQ(pyNames[1].c_str(), "kwargs");
 }

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -289,10 +289,9 @@ void LoadBalancer::free(int where) {
 void PythonMethodWrapper::setArgumentNames(
     std::vector<std::string>& argumentNamesOut) const {
   auto session = model_.acquire_session();
+  auto method = session.self.attr(method_name_.c_str());
   auto iArgumentNames =
-      session
-          .global("GetArgumentNamesModule", "getArgumentNames")(
-              {session.from_movable(model_)})
+      session.global("GetArgumentNamesModule", "getArgumentNames")({method})
           .toIValue();
   TORCH_INTERNAL_ASSERT(iArgumentNames.isList());
   auto argumentNames = iArgumentNames.toListRef();

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -240,8 +240,12 @@ c10::intrusive_ptr<c10::ivalue::Future> Method::run_async(
 void Method::setArgumentNames(
     std::vector<std::string>& argumentNamesOut) const {
   TORCH_INTERNAL_ASSERT(function_);
-  argumentNamesOut.reserve(function_->getSchema().arguments().size());
-  for (auto& argument : function_->getSchema().arguments()) {
+  auto& arguments = function_->getSchema().arguments();
+  argumentNamesOut.reserve(arguments.size());
+  for (auto& argument : arguments) {
+    if (argument.name() == "self") {
+      continue;
+    }
     argumentNamesOut.push_back(argument.name());
   }
 }


### PR DESCRIPTION
Summary:
For PythonMethodWrapper::setArgumentNames, make sure to use the correct method
specified by method_name_ rather than using the parent model_ obj which itself
_is_ callable, but that callable is not the right signature to extract.

For Python vs Script, unify the behavior to avoid the 'self' parameter, so we only
list the argument names to the unbound arguments which is what we need in practice.

Test Plan: update unit test and it passes

Reviewed By: alanwaketan

Differential Revision: D29965283

