### PR TITLE
Implement NotImplemented fallback kernel and use it to replace usage in VariableType

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5204,86 +5204,6 @@ for shape in [(1,), ()]:
                                     "Output 0 of ComplexViewBackward is a view and is being modified inplace"):
             out += 1
 
-    def test_autograd_not_implemented_boxed_function(self):
-        import torch.utils.cpp_extension
-        count = 0  #  Generate unique library names
-        # We need a way to unload libraries for clean-up purposes too
-
-        # Maybe this test should be somewhere else?
-        def run_test(in_schema, out_schema, fn_src):
-            nonlocal count
-            count += 1
-            ns = f"my_ops{count}"
-
-            cpp_source = f"""
-            using namespace torch;
-            using namespace aten;
-            using namespace torch::autograd;
-
-            {fn_src}
-
-            TORCH_LIBRARY({ns}, m) {{
-            m.def("my_test_op({in_schema}) -> {out_schema} ");
-            }}
-
-            TORCH_LIBRARY_IMPL({ns}, CPU, m) {{
-            m.impl("my_test_op", my_test_op);
-            }}
-
-            TORCH_LIBRARY_IMPL({ns}, Autograd, m) {{
-            m.impl("my_test_op", torch::CppFunction::makeFromBoxedFunction<&autogradNotImplementedFunction>());
-            }}
-            """
-            torch.utils.cpp_extension.load_inline(
-                name=ns,
-                cpp_sources=cpp_source,
-                is_python_module=False,
-                verbose=True,
-            )
-
-            a = torch.tensor(1., requires_grad=True)
-            b = torch.tensor(1.)
-            c = torch.tensor(1.)
-
-            op = getattr(torch.ops, ns).my_test_op
-
-            # If any inputs require grad,
-            d = op(a, b)
-            out = d[0] if isinstance(d, tuple) else d
-            with self.assertRaisesRegex(RuntimeError, f"derivative for {ns}::my_test_op is not implemented"):
-                torch.autograd.grad(out, a)
-
-            # Should not have grad_fn if none require grad
-            d = op(b, c)
-            out = d[0] if isinstance(d, tuple) else d
-            with self.assertRaisesRegex(RuntimeError, "element 0 of tensors does not require grad and does not have a grad_fn"):
-                torch.autograd.grad(out, b)
-
-            # Forward ad raises error as well
-            with fwAD.dual_level():
-                p = torch.rand(2, 3)
-                t = torch.rand(2, 3)
-                dual_input = fwAD.make_dual(p, t)
-                with self.assertRaisesRegex(RuntimeError, f"Trying to use forward AD with {ns}::my_test_op that does not support it."):
-                    op(dual_input, dual_input)
-
-        funcs = (
-            ("Tensor self, Tensor other", "Tensor", """
-torch::Tensor my_test_op(const torch::Tensor& self, const torch::Tensor& other) {
-    return self + other;
-}
-             """),
-            ("Tensor self, Tensor other", "(Tensor, Tensor, int)", """
-std::tuple<torch::Tensor, torch::Tensor, int64_t> my_test_op(const torch::Tensor& self, const torch::Tensor& other) {
-    torch::Tensor a = self - other;
-    torch::Tensor b = self + other;
-    return std::tuple<torch::Tensor, torch::Tensor, int64_t>(a, b, 12);
-}
-            """))
-
-        for in_schema, out_schema, fn_src in funcs:
-            run_test(in_schema, out_schema, fn_src)
-
     def test_autograd_python_custom_function_inplace(self):
         # This is not necessarily the absolute correct behavior, but this is the current
         # one. This test is here to make sure that any change to this behavior is detected
@@ -6108,6 +6028,203 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
         test_case.assertEqualTypeString(self_variable, self_variable.grad)
         test_case.assertEqual(self_variable.size(), self_variable.grad.size())
 
+
+class TestAutogradNotImplementedKernel(TestCase):
+    def _compile_and_load_op(self, in_schema, out_schema, name, fn_src):
+        import torch.utils.cpp_extension
+        # TODO: do we need a way to unload libraries to clean up?
+        # load_inline caches when the same exact code is ran, so no extra work is done when
+        # we attempt to load the same op multiple times
+        ns = f"ns{name}"
+
+        cpp_source = f"""
+        using namespace torch;
+        using namespace aten;
+        using namespace torch::autograd;
+
+        {fn_src}
+
+        TORCH_LIBRARY({ns}, m) {{
+        m.def("{name}({in_schema}) -> {out_schema}");
+        }}
+
+        TORCH_LIBRARY_IMPL({ns}, CPU, m) {{
+        m.impl("{name}", {name});
+        }}
+
+        TORCH_LIBRARY_IMPL({ns}, Autograd, m) {{
+        m.impl("{name}", torch::CppFunction::makeFromBoxedFunction<&autogradNotImplementedFallback>());
+        }}
+        """
+
+        torch.utils.cpp_extension.load_inline(
+            name=ns,
+            cpp_sources=cpp_source,
+            is_python_module=False,
+            verbose=False,
+        )
+        return f"{ns}::{name}", getattr(getattr(torch.ops, ns), name)
+
+    def _get_custom_op(self):
+        def ref(x, y):
+            return x + y
+        func = ("Tensor self, Tensor other", "Tensor", "my_custom_op", """
+                 torch::Tensor my_custom_op(const torch::Tensor& self, const torch::Tensor& other) {
+                     return self + other;
+                 }
+                """)
+        return self._compile_and_load_op(*func), ref
+
+    def _get_custom_op_return_non_tensor(self):
+        def ref(x, y):
+            return x - y, x + y, 12
+        func = ("Tensor self, Tensor other", "(Tensor, Tensor, int)", "ret_non_tensor", """
+                 std::tuple<torch::Tensor, torch::Tensor, int64_t> ret_non_tensor(const torch::Tensor& self, const torch::Tensor& other) {
+                     torch::Tensor a = self - other;
+                     torch::Tensor b = self + other;
+                     return std::tuple<torch::Tensor, torch::Tensor, int64_t>(a, b, 12);
+                 }
+                """)
+        return self._compile_and_load_op(*func), ref
+
+    def _get_custom_inplace_op(self):
+        def ref(x, y):
+            return x.add_(y)
+        inplace_func_info = ("Tensor(a!) self, Tensor other", "Tensor(a!)", "inplace_op", """
+                              torch::Tensor inplace_op(const torch::Tensor& self, const torch::Tensor& other) {
+                                  return self.add_(other);
+                              }
+                             """)
+        return self._compile_and_load_op(*inplace_func_info), ref
+
+    def _get_custom_view_op(self):
+        view_func_info = ("Tensor(a) self, Tensor other", "Tensor(a)", "view_op", """
+                           torch::Tensor view_op(const torch::Tensor& self, const torch::Tensor& other) {
+                               return self.view(-1);
+                           }
+                          """)
+        return self._compile_and_load_op(*view_func_info), None
+
+    def _get_optional_op(self):
+        def ref(self, other):
+            if other is not None:
+                return self + other
+            else:
+                return self.clone()
+        view_func_info = ("Tensor self, Tensor? other", "Tensor", "opt_op", """
+                           torch::Tensor opt_op(const torch::Tensor& self, const c10::optional<at::Tensor>& other) {
+                               if (other.has_value()) {
+                                   return self + other.value();
+                               } else {
+                                   return self.clone();
+                               }
+                           }
+                          """)
+        return self._compile_and_load_op(*view_func_info), ref
+
+    def _get_tensorlist_op(self):
+        def ref(x, y):
+            return x + sum(y)
+        func = ("Tensor self, Tensor[] other", "Tensor", "tensorlist_op", """
+                 torch::Tensor tensorlist_op(const torch::Tensor& self, const at::TensorList& other) {
+                     const auto& res = self.clone();
+                     for (const auto& t : other) {
+                          res.add_(t);
+                     }
+                     return res;
+                 }
+                """)
+        return self._compile_and_load_op(*func), ref
+
+    def test_perform_basic_checks(self):
+        """NotImplemented error is triggered if input requires grad"""
+        funcs = [
+            self._get_custom_op(),
+            self._get_custom_op_return_non_tensor(),
+            self._get_custom_view_op(),
+        ]
+        for (qual_name, op), ref in funcs:
+            a = torch.tensor(1., requires_grad=True)
+            b = torch.tensor(1.)
+            c = torch.tensor(1.)
+
+            # If any inputs require grad,
+            d = op(a, b)
+            out = d[0] if isinstance(d, tuple) else d
+            with self.assertRaisesRegex(RuntimeError, f"derivative for {qual_name} is not implemented"):
+                torch.autograd.grad(out, a)
+
+            # Should not have grad_fn if none require grad
+            d = op(b, c)
+            out = d[0] if isinstance(d, tuple) else d
+            with self.assertRaisesRegex(RuntimeError, "element 0 of tensors does not require grad and does not have a grad_fn"):
+                torch.autograd.grad(out, b)
+
+            # Forward ad raises error as well
+            with fwAD.dual_level():
+                p = torch.rand(2, 3)
+                t = torch.rand(2, 3)
+                dual_input = fwAD.make_dual(p, t)
+                with self.assertRaisesRegex(RuntimeError, f"Trying to use forward AD with {qual_name} that does not support it."):
+                    op(dual_input, dual_input)
+
+            if ref is not None:
+                self.assertEqual(op(a, b), ref(a, b))
+
+    def test_check_inplace(self):
+        """Check basic inplace behavior"""
+        (_, op), ref = self._get_custom_inplace_op()
+        a = torch.tensor(1., requires_grad=True)
+        b = torch.tensor(1.)
+
+        with self.assertRaisesRegex(RuntimeError, "a leaf Variable that requires grad is being used in an in-place operation"):
+            op(a, b)
+        with self.assertRaisesRegex(RuntimeError, "a leaf Variable that requires grad is being used in an in-place operation"):
+            op(b, a)
+        a = a.clone()
+        b = b.clone()
+        c = op(a, b)
+        self.assertEqual(c, ref(a, b))
+
+    def test_tensorlist_input(self):
+        (qual_name, op), ref = self._get_tensorlist_op()
+        a = torch.tensor(1.)
+        b = [torch.tensor(1.), torch.tensor(2., requires_grad=True)]
+        c = op(a, b)
+        with self.assertRaisesRegex(RuntimeError, f"derivative for {qual_name} is not implemented"):
+            torch.autograd.grad(c, b[1])
+        with self.assertRaisesRegex(RuntimeError, "One of the differentiated Tensors does not require grad"):
+            torch.autograd.grad(c, b[0])
+        self.assertEqual(c, ref(a, b))
+
+    def test_inplace_on_view(self):
+        (_, op), _ = self._get_custom_inplace_op()
+
+        b = torch.tensor([1.], requires_grad=True, dtype=torch.double).clone()
+        v = b.view(-1)
+        t = torch.tensor([1.], dtype=torch.double)
+
+        with torch.no_grad():
+            v_nograd = b.view(-1)
+            # in-place when in no-grad mode okay
+            op(v_nograd, t)
+
+        with self.assertRaisesRegex(RuntimeError, "A view was created in no_grad mode"):
+            op(v_nograd, t)
+
+        torch.autograd.gradcheck(op, (v, t))
+        self.assertTrue(op(v, t) is v)
+
+        # Make we use rebase_history so we don't overwrite old grad_fn
+        old_grad_fn = v.grad_fn
+        self.assertTrue(op(v, t).grad_fn is old_grad_fn)
+
+    def test_optional_tensor_input(self):
+        (_, op), ref = self._get_optional_op()
+        a = torch.tensor(1., requires_grad=True)
+        b = torch.tensor(1.)
+        self.assertEqual(op(a, b), ref(a, b))
+        self.assertEqual(op(a, None), ref(a, None))
 
 class TestAutogradComplex(TestCase):
     def test_view_func_for_complex_views(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6030,12 +6030,23 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
 
 
 class TestAutogradNotImplementedKernel(TestCase):
-    def _compile_and_load_op(self, in_schema, out_schema, name, fn_src):
+    def _compile_and_load_op(self, in_schema, out_schema, cpp_args, cpp_ret, name, fn_src, boxed):
         import torch.utils.cpp_extension
         # TODO: do we need a way to unload libraries to clean up?
         # load_inline caches when the same exact code is ran, so no extra work is done when
         # we attempt to load the same op multiple times
+        if boxed:
+            name += "_boxed"
+
         ns = f"ns{name}"
+        schema = f"{name}({in_schema}) -> {out_schema}"
+        fn_src = f"{cpp_ret} {name}({cpp_args}) {{{fn_src}}}"
+        cpp_arg_types = ','.join(' '.join(a.split(' ')[:-1]) for a in cpp_args.split(','))
+
+        if boxed:
+            impl = f'm.impl("{name}", torch::CppFunction::makeFromBoxedFunction<&autogradNotImplementedFallback>());'
+        else:
+            impl = f'm.impl("{name}", autogradNotImplementedFallback2<{cpp_ret}, {cpp_arg_types}>(&{name}, "{schema}"));'
 
         cpp_source = f"""
         using namespace torch;
@@ -6053,7 +6064,7 @@ class TestAutogradNotImplementedKernel(TestCase):
         }}
 
         TORCH_LIBRARY_IMPL({ns}, Autograd, m) {{
-        m.impl("{name}", torch::CppFunction::makeFromBoxedFunction<&autogradNotImplementedFallback>());
+            {impl}
         }}
         """
 
@@ -6063,168 +6074,172 @@ class TestAutogradNotImplementedKernel(TestCase):
             is_python_module=False,
             verbose=False,
         )
-        return f"{ns}::{name}", getattr(getattr(torch.ops, ns), name)
+        return name, getattr(getattr(torch.ops, ns), name)
 
-    def _get_custom_op(self):
+    def _get_custom_op(self, boxed):
         def ref(x, y):
             return x + y
-        func = ("Tensor self, Tensor other", "Tensor", "my_custom_op", """
-                 torch::Tensor my_custom_op(const torch::Tensor& self, const torch::Tensor& other) {
+        func = ("Tensor self, Tensor other", "Tensor",
+                "const torch::Tensor& self, const torch::Tensor& other", "torch::Tensor",
+                "my_custom_op", """
                      return self + other;
-                 }
                 """)
-        return self._compile_and_load_op(*func), ref
+        return self._compile_and_load_op(*func, boxed), ref
 
-    def _get_custom_op_return_non_tensor(self):
+    def _get_custom_op_return_non_tensor(self, boxed):
         def ref(x, y):
             return x - y, x + y, 12
-        func = ("Tensor self, Tensor other", "(Tensor, Tensor, int)", "ret_non_tensor", """
-                 std::tuple<torch::Tensor, torch::Tensor, int64_t> ret_non_tensor(const torch::Tensor& self, const torch::Tensor& other) {
+        func = ("Tensor self, Tensor other", "(Tensor, Tensor, int)",
+                "const torch::Tensor& self, const torch::Tensor& other", "std::tuple<torch::Tensor, torch::Tensor, int64_t>",
+                "ret_non_tensor", """
                      torch::Tensor a = self - other;
                      torch::Tensor b = self + other;
                      return std::tuple<torch::Tensor, torch::Tensor, int64_t>(a, b, 12);
-                 }
                 """)
-        return self._compile_and_load_op(*func), ref
+        return self._compile_and_load_op(*func, boxed), ref
 
-    def _get_custom_inplace_op(self):
+    def _get_custom_inplace_op(self, boxed):
         def ref(x, y):
             return x.add_(y)
-        inplace_func_info = ("Tensor(a!) self, Tensor other", "Tensor(a!)", "inplace_op", """
-                              torch::Tensor inplace_op(const torch::Tensor& self, const torch::Tensor& other) {
+        inplace_func_info = ("Tensor(a!) self, Tensor other", "Tensor(a!)",
+                             "const torch::Tensor& self, const torch::Tensor& other", "torch::Tensor",
+                             "inplace_op", """
                                   return self.add_(other);
-                              }
                              """)
-        return self._compile_and_load_op(*inplace_func_info), ref
+        return self._compile_and_load_op(*inplace_func_info, boxed), ref
 
-    def _get_custom_view_op(self):
-        view_func_info = ("Tensor(a) self, Tensor other", "Tensor(a)", "view_op", """
-                           torch::Tensor view_op(const torch::Tensor& self, const torch::Tensor& other) {
-                               return self.view(-1);
-                           }
+    def _get_custom_view_op(self, boxed):
+        view_func_info = ("Tensor(a) self, Tensor other", "Tensor(a)",
+                          "const torch::Tensor& self, const torch::Tensor& other", "torch::Tensor",
+                          "view_op", """
+                           return self.view(-1);
                           """)
-        return self._compile_and_load_op(*view_func_info), None
+        return self._compile_and_load_op(*view_func_info, boxed), None
 
-    def _get_optional_op(self):
+    def _get_optional_op(self, boxed):
         def ref(self, other):
             if other is not None:
                 return self + other
             else:
                 return self.clone()
-        view_func_info = ("Tensor self, Tensor? other", "Tensor", "opt_op", """
-                           torch::Tensor opt_op(const torch::Tensor& self, const c10::optional<at::Tensor>& other) {
-                               if (other.has_value()) {
-                                   return self + other.value();
-                               } else {
-                                   return self.clone();
-                               }
+        view_func_info = ("Tensor self, Tensor? other", "Tensor",
+                          "const torch::Tensor& self, const c10::optional<at::Tensor>& other", "torch::Tensor",
+                          "opt_op", """
+                           if (other.has_value()) {
+                               return self + other.value();
+                           } else {
+                               return self.clone();
                            }
                           """)
-        return self._compile_and_load_op(*view_func_info), ref
+        return self._compile_and_load_op(*view_func_info, boxed), ref
 
-    def _get_tensorlist_op(self):
+    def _get_tensorlist_op(self, boxed):
         def ref(x, y):
             return x + sum(y)
-        func = ("Tensor self, Tensor[] other", "Tensor", "tensorlist_op", """
-                 torch::Tensor tensorlist_op(const torch::Tensor& self, const at::TensorList& other) {
+        func = ("Tensor self, Tensor[] other", "Tensor",
+                "const torch::Tensor& self, const at::TensorList& other", "torch::Tensor",
+                "tensorlist_op", """
                      const auto& res = self.clone();
                      for (const auto& t : other) {
                           res.add_(t);
                      }
                      return res;
-                 }
                 """)
-        return self._compile_and_load_op(*func), ref
+        return self._compile_and_load_op(*func, boxed), ref
 
     def test_perform_basic_checks(self):
         """NotImplemented error is triggered if input requires grad"""
-        funcs = [
-            self._get_custom_op(),
-            self._get_custom_op_return_non_tensor(),
-            self._get_custom_view_op(),
-        ]
-        for (qual_name, op), ref in funcs:
-            a = torch.tensor(1., requires_grad=True)
-            b = torch.tensor(1.)
-            c = torch.tensor(1.)
+        for boxed in (True, False):
+            funcs = [
+                self._get_custom_op(boxed),
+                self._get_custom_op_return_non_tensor(boxed),
+                self._get_custom_view_op(boxed),
+            ]
+            for (name, op), ref in funcs:
+                a = torch.tensor(1., requires_grad=True)
+                b = torch.tensor(1.)
+                c = torch.tensor(1.)
 
-            # If any inputs require grad,
-            d = op(a, b)
-            out = d[0] if isinstance(d, tuple) else d
-            with self.assertRaisesRegex(RuntimeError, f"derivative for {qual_name} is not implemented"):
-                torch.autograd.grad(out, a)
+                # If any inputs require grad,
+                d = op(a, b)
+                out = d[0] if isinstance(d, tuple) else d
+                with self.assertRaisesRegex(RuntimeError, f"derivative for .*{name} is not implemented"):
+                    torch.autograd.grad(out, a)
 
-            # Should not have grad_fn if none require grad
-            d = op(b, c)
-            out = d[0] if isinstance(d, tuple) else d
-            with self.assertRaisesRegex(RuntimeError, "element 0 of tensors does not require grad and does not have a grad_fn"):
-                torch.autograd.grad(out, b)
+                # Should not have grad_fn if none require grad
+                d = op(b, c)
+                out = d[0] if isinstance(d, tuple) else d
+                with self.assertRaisesRegex(RuntimeError, "element 0 of tensors does not require grad and does not have a grad_fn"):
+                    torch.autograd.grad(out, b)
 
-            # Forward ad raises error as well
-            with fwAD.dual_level():
-                p = torch.rand(2, 3)
-                t = torch.rand(2, 3)
-                dual_input = fwAD.make_dual(p, t)
-                with self.assertRaisesRegex(RuntimeError, f"Trying to use forward AD with {qual_name} that does not support it."):
-                    op(dual_input, dual_input)
+                # Forward ad raises error as well
+                with fwAD.dual_level():
+                    p = torch.rand(2, 3)
+                    t = torch.rand(2, 3)
+                    dual_input = fwAD.make_dual(p, t)
+                    with self.assertRaisesRegex(RuntimeError, f"Trying to use forward AD with .*{name} that does not support it."):
+                        op(dual_input, dual_input)
 
-            if ref is not None:
-                self.assertEqual(op(a, b), ref(a, b))
+                if ref is not None:
+                    self.assertEqual(op(a, b), ref(a, b))
 
     def test_check_inplace(self):
         """Check basic inplace behavior"""
-        (_, op), ref = self._get_custom_inplace_op()
-        a = torch.tensor(1., requires_grad=True)
-        b = torch.tensor(1.)
+        for boxed in (True, False):
+            (_, op), ref = self._get_custom_inplace_op(boxed)
+            a = torch.tensor(1., requires_grad=True)
+            b = torch.tensor(1.)
 
-        with self.assertRaisesRegex(RuntimeError, "a leaf Variable that requires grad is being used in an in-place operation"):
-            op(a, b)
-        with self.assertRaisesRegex(RuntimeError, "a leaf Variable that requires grad is being used in an in-place operation"):
+            with self.assertRaisesRegex(RuntimeError, "a leaf Variable that requires grad is being used in an in-place operation"):
+                op(a, b)
             op(b, a)
-        a = a.clone()
-        b = b.clone()
-        c = op(a, b)
-        self.assertEqual(c, ref(a, b))
+            a = a.clone()
+            b = b.clone()
+            c = op(a, b)
+            self.assertEqual(c, ref(a, b))
 
     def test_tensorlist_input(self):
-        (qual_name, op), ref = self._get_tensorlist_op()
-        a = torch.tensor(1.)
-        b = [torch.tensor(1.), torch.tensor(2., requires_grad=True)]
-        c = op(a, b)
-        with self.assertRaisesRegex(RuntimeError, f"derivative for {qual_name} is not implemented"):
-            torch.autograd.grad(c, b[1])
-        with self.assertRaisesRegex(RuntimeError, "One of the differentiated Tensors does not require grad"):
-            torch.autograd.grad(c, b[0])
-        self.assertEqual(c, ref(a, b))
+        for boxed in (True, False):
+            (name, op), ref = self._get_tensorlist_op(boxed)
+            a = torch.tensor(1.)
+            b = [torch.tensor(1.), torch.tensor(2., requires_grad=True)]
+            c = op(a, b)
+            with self.assertRaisesRegex(RuntimeError, f"derivative for .*{name} is not implemented"):
+                torch.autograd.grad(c, b[1])
+            with self.assertRaisesRegex(RuntimeError, "One of the differentiated Tensors does not require grad"):
+                torch.autograd.grad(c, b[0])
+            self.assertEqual(c, ref(a, b))
 
     def test_inplace_on_view(self):
-        (_, op), _ = self._get_custom_inplace_op()
+        for boxed in (True, False):
+            (_, op), _ = self._get_custom_inplace_op(boxed)
 
-        b = torch.tensor([1.], requires_grad=True, dtype=torch.double).clone()
-        v = b.view(-1)
-        t = torch.tensor([1.], dtype=torch.double)
+            b = torch.tensor([1.], requires_grad=True, dtype=torch.double).clone()
+            v = b.view(-1)
+            t = torch.tensor([1.], dtype=torch.double)
 
-        with torch.no_grad():
-            v_nograd = b.view(-1)
-            # in-place when in no-grad mode okay
-            op(v_nograd, t)
+            with torch.no_grad():
+                v_nograd = b.view(-1)
+                # in-place when in no-grad mode okay
+                op(v_nograd, t)
 
-        with self.assertRaisesRegex(RuntimeError, "A view was created in no_grad mode"):
-            op(v_nograd, t)
+            with self.assertRaisesRegex(RuntimeError, "A view was created in no_grad mode"):
+                op(v_nograd, t)
 
-        torch.autograd.gradcheck(op, (v, t))
-        self.assertTrue(op(v, t) is v)
+            torch.autograd.gradcheck(op, (v, t))
+            self.assertTrue(op(v, t) is v)
 
-        # Make we use rebase_history so we don't overwrite old grad_fn
-        old_grad_fn = v.grad_fn
-        self.assertTrue(op(v, t).grad_fn is old_grad_fn)
+            # Make we use rebase_history so we don't overwrite old grad_fn
+            old_grad_fn = v.grad_fn
+            self.assertTrue(op(v, t).grad_fn is old_grad_fn)
 
     def test_optional_tensor_input(self):
-        (_, op), ref = self._get_optional_op()
-        a = torch.tensor(1., requires_grad=True)
-        b = torch.tensor(1.)
-        self.assertEqual(op(a, b), ref(a, b))
-        self.assertEqual(op(a, None), ref(a, None))
+        for boxed in (True, False):
+            (_, op), ref = self._get_optional_op(boxed)
+            a = torch.tensor(1., requires_grad=True)
+            b = torch.tensor(1.)
+            self.assertEqual(op(a, b), ref(a, b))
+            self.assertEqual(op(a, None), ref(a, None))
 
 class TestAutogradComplex(TestCase):
     def test_view_func_for_complex_views(self):

--- a/tools/autograd/gen_inplace_or_view_type.py
+++ b/tools/autograd/gen_inplace_or_view_type.py
@@ -124,6 +124,12 @@ m.impl("${unqual_operator_name_with_overload}",
 );
 """)
 
+AUTOGRAD_NOT_IMPLEMENTED_REGISTRATION = CodeTemplate("""\
+m.impl("${unqual_operator_name_with_overload}",
+   torch::CppFunction::makeFromBoxedFunction<&torch::autograd::autogradNotImplementedFallback>()
+);
+""")
+
 INPLACE_REDISPATCH = CodeTemplate("""\
 {
   at::AutoDispatchBelowADInplaceOrView guard;

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -404,21 +404,23 @@ def gen_variable_type_func(
     with native_function_manager(f):
         name = cpp.name(f.func)
         formals = gen_formals(f)
-        # NOTE: [ Registering AutogradNotImplemented boxed kernel ]
-        #
-        # When there is no derivatives.yaml entry, we register a generic boxed NotImplemented kernel
-        # to set grad_fn to be NotImplemented, so that forward proceeds as usual but an error is
-        # properly produced on backward.
-        #
-        # There are two cases where still let codegen handle it:
-        # 1) ops that need to reset grad accumulator (we let codegen handle this case because) the
-        #    list is (currently) only accessible in Python and there are only 2 op.
-        # 2) User explicitly specifies DONT_REQUIRE_DERIVATIVE. This basically makes autograd a
-        #    fallthrough with NDEBUG checks. This can be useful for when all outputs are integral.
-        #
+
         if fn.info is None and not get_base_name(f) in RESET_GRAD_ACCUMULATOR and not get_base_name(f) in DONT_REQUIRE_DERIVATIVE:
-            wrapper_registration = (AUTOGRAD_NOT_IMPLEMENTED_REGISTRATION.substitute(
-                unqual_operator_name_with_overload=f.func.name))
+            # NOTE: [ Registering AutogradNotImplemented boxed kernel ]
+            #
+            # When there is no derivatives.yaml entry, we register a generic boxed NotImplemented kernel
+            # to set grad_fn to be NotImplemented, so that forward proceeds as usual but an error is
+            # properly produced on backward.
+            #
+            # There are two cases where still let codegen handle it:
+            # 1) ops that need to reset grad accumulator (we let codegen handle this case because) the
+            #    list is (currently) only accessible in Python and there are only 2 op.
+            # 2) User explicitly specifies DONT_REQUIRE_DERIVATIVE. This basically makes autograd a
+            #    fallthrough with NDEBUG checks. This can be useful for when all outputs are integral.
+            #
+            type_definition = ""
+            wrapper_registration = AUTOGRAD_NOT_IMPLEMENTED_REGISTRATION.substitute(
+                unqual_operator_name_with_overload=f.func.name)
         else:
             type_definition = METHOD_DEFINITION.substitute(
                 return_type=cpp.returns_type(f.func.returns).cpp_type(),

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -30,7 +30,8 @@ from .gen_trace_type import (
 from .gen_inplace_or_view_type import (
     get_view_info, is_tensor_type, is_tensor_list_type, unpack_args, get_base_name,
     use_derived, modifies_arguments, WRAPPER_REGISTRATION, TMP_VAR, METHOD_DEFINITION,
-    ASSIGN_RETURN_VALUE, gen_formals, ALL_VIEW_FUNCTIONS, unpacked_name
+    ASSIGN_RETURN_VALUE, gen_formals, ALL_VIEW_FUNCTIONS, unpacked_name,
+    AUTOGRAD_NOT_IMPLEMENTED_REGISTRATION
 )
 
 from tools.codegen.api.types import (Binding, DispatcherSignature, BaseCType, intArrayRefT,
@@ -403,14 +404,29 @@ def gen_variable_type_func(
     with native_function_manager(f):
         name = cpp.name(f.func)
         formals = gen_formals(f)
-
-        type_definition = METHOD_DEFINITION.substitute(
-            return_type=cpp.returns_type(f.func.returns).cpp_type(),
-            type_wrapper_name=type_wrapper_name(f),
-            type_definition_body=emit_body(fn),
-            formals=formals,
-        )
-        wrapper_registration = gen_wrapper_registration(f)
+        # NOTE: [ Registering AutogradNotImplemented boxed kernel ]
+        #
+        # When there is no derivatives.yaml entry, we register a generic boxed NotImplemented kernel
+        # to set grad_fn to be NotImplemented, so that forward proceeds as usual but an error is
+        # properly produced on backward.
+        #
+        # There are two cases where still let codegen handle it:
+        # 1) ops that need to reset grad accumulator (we let codegen handle this case because) the
+        #    list is (currently) only accessible in Python and there are only 2 op.
+        # 2) User explicitly specifies DONT_REQUIRE_DERIVATIVE. This basically makes autograd a
+        #    fallthrough with NDEBUG checks. This can be useful for when all outputs are integral.
+        #
+        if fn.info is None and not get_base_name(f) in RESET_GRAD_ACCUMULATOR and not get_base_name(f) in DONT_REQUIRE_DERIVATIVE:
+            wrapper_registration = (AUTOGRAD_NOT_IMPLEMENTED_REGISTRATION.substitute(
+                unqual_operator_name_with_overload=f.func.name))
+        else:
+            type_definition = METHOD_DEFINITION.substitute(
+                return_type=cpp.returns_type(f.func.returns).cpp_type(),
+                type_wrapper_name=type_wrapper_name(f),
+                type_definition_body=emit_body(fn),
+                formals=formals,
+            )
+            wrapper_registration = gen_wrapper_registration(f)
 
     # See Note [Manual Backend kernels]
     assert (name in MANUAL_BACKEND) == f.manual_kernel_registration

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -1,4 +1,6 @@
 #include "torch/csrc/autograd/VariableTypeUtils.h"
+#include "torch/csrc/autograd/custom_function.h"
+
 #include "torch/csrc/autograd/FunctionsManual.h"
 
 #include <ATen/RedispatchFunctions.h>

--- a/torch/csrc/autograd/autograd_not_implemented_template.h
+++ b/torch/csrc/autograd/autograd_not_implemented_template.h
@@ -1,0 +1,202 @@
+#pragma once
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/csrc/autograd/autograd.h>
+#include <torch/csrc/autograd/VariableTypeUtils.h>
+#include <torch/csrc/autograd/FunctionsManual.h>
+#include <torch/csrc/jit/frontend/function_schema_parser.h>
+
+namespace torch {
+namespace autograd {
+
+namespace detail {
+
+template <typename F>
+struct ForEachTensor : IterArgs<ForEachTensor<F>> {
+  F fn_;
+  mutable size_t idx_arg_ = 0;
+  mutable size_t idx_tensor_ = 0;
+  ForEachTensor(F fn) : fn_(fn) {}
+  void operator()(const variable_list& tensors) const {
+    for (const auto& t : tensors) {
+      fn_(idx_arg_, idx_tensor_, t);
+      idx_tensor_++;
+    }
+    idx_arg_++;
+  }
+  void operator()(const TensorList& tensors) const {
+    for (const auto& t : tensors) {
+      fn_(idx_tensor_, idx_arg_ , t);
+      idx_tensor_++;
+    }
+    idx_arg_++;
+  }
+  void operator()(const c10::optional<at::Tensor>& x) const {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (x.has_value() && x.value().defined()) {
+      fn_(idx_tensor_, idx_arg_, x.value());
+    }
+    idx_tensor_++;
+    idx_arg_++;
+  }
+  void operator()(const at::Tensor& x) const {
+    fn_(idx_tensor_, idx_arg_, x);
+    idx_tensor_++;
+    idx_arg_++;
+  }
+  template <typename T>
+  void operator()(const T& x) const {
+    // no op
+  }
+};
+
+template <typename F, typename... Args>
+inline void for_each_input_tensor(F fn, Args&&... args) {
+  ForEachTensor<F>(fn).apply(std::forward<Args>(args)...);
+}
+
+// TODO: We do not have access to this because of C++ reasons
+// when building as an extension (why?)- this is available from custom_function.cpp
+bool isFwGradDefined(const c10::optional<Tensor>& t) {
+  return t.has_value() && t->defined() && t->_fw_grad(/*level */ 0).defined();
+}
+
+template <class Mapper, class... Args, size_t... Indices>
+void for_each_tuple(
+    std::tuple<Args...>& tuple,
+    const Mapper& mapper,
+    std::index_sequence<Indices...>) {
+  // We need a context where the parameter pack can be expanded
+  auto l = { (mapper(std::forward<Args>(std::get<Indices>(tuple))), 0)...};
+}
+
+template<typename F>
+void for_each_output_tensor(const at::Tensor& t, F fn) {
+  fn(0, 0, t);
+}
+
+template<typename T, typename F>
+enable_if_t<!std::__is_tuple_like<T>::value> for_each_output_tensor(T& not_tup, F fn) {
+  (ForEachTensor<F>(fn))(not_tup);
+}
+
+template<class... Args, typename F>
+void for_each_output_tensor(std::tuple<Args...>& tup, F fn) {
+  for_each_tuple(tup,  ForEachTensor<F>(fn), std::index_sequence_for<Args...>());
+}
+
+}
+
+template<typename ReturnT, typename... Args>
+struct autogradNotImplementedFallback2 {
+public:
+  autogradNotImplementedFallback2(ReturnT(*op)(Args&&...), std::string schema_string)
+   : op_(op), schema_(torch::jit::parseSchema(schema_string)) {};
+  ReturnT operator() (Args&&... args) {
+    const auto& op_name = schema_.operator_name().name;
+    const auto& arguments = schema_.arguments();
+    const auto& returns = schema_.returns();
+    const auto num_arguments = arguments.size();
+    const auto num_returns = returns.size();
+    // const bool grad_mode = GradMode::is_enabled();
+
+    // Keep track of which outputs are output of in-place modification
+    // so we can rebase_history if necessary
+    std::vector<bool> is_inplace_output;
+    std::vector<bool> is_aliased_output;
+    is_inplace_output.reserve(num_returns);
+    is_aliased_output.reserve(num_returns);
+    for (const auto i : c10::irange(num_returns)) {
+      const auto& alias_info = returns[i].alias_info();
+      is_inplace_output.push_back(alias_info.has_value() && alias_info->isWrite());
+      is_aliased_output.push_back(alias_info.has_value());
+    }
+    std::vector<const at::Tensor*> tensors_requiring_grad;
+    size_t num_tensor_inputs = 0;  // Only used for DEBUG-only checks
+
+    bool any_requires_grad = compute_requires_grad(std::forward<Args>(args)...);
+    // std::cout << "any_requires_grad: " << any_requires_grad << std::endl;
+
+    detail::for_each_input_tensor([&](size_t _, size_t idx_arg, const at::Tensor& t) {
+      TORCH_CHECK(t.defined(), "Expected argument ", idx_arg, " of ", op_name, " to be defined.");
+      if (t.requires_grad()) {
+        tensors_requiring_grad.push_back(&t);
+      }
+      num_tensor_inputs++;
+      TORCH_CHECK_NOT_IMPLEMENTED(!detail::isFwGradDefined(t), "Trying to use forward AD with ", op_name, " that does not support it.");
+    }, std::forward<Args>(args)...);
+
+    std::shared_ptr<NotImplemented> grad_fn;
+    if (any_requires_grad) {
+      grad_fn = std::shared_ptr<NotImplemented>(new NotImplemented(schema_.operator_name().name), deleteNode);
+      // We can avoid creating tensors_requiring_grad vector if we modify collect_next_edges to ignore
+      // inputs that don't require grad
+      grad_fn->set_next_edges(collect_next_edges(tensors_requiring_grad));
+    }
+
+    detail::for_each_input_tensor([&](size_t idx_tensor, size_t idx_arg, const at::Tensor& t) {
+      const auto& alias_info = arguments[idx_arg].alias_info();
+      if (alias_info.has_value() && alias_info->isWrite()) {
+        check_inplace(t, any_requires_grad);
+      }
+    }, std::forward<Args>(args)...);
+
+    #ifndef NDEBUG
+    // See NOTE [ TensorImpl and Storage Pointer Sanity Checks ]
+    std::vector<c10::intrusive_ptr<TensorImpl>> impl_saved;
+    impl_saved.reserve(num_tensor_inputs);
+    std::vector<c10::optional<Storage>> storage_saved;
+    storage_saved.reserve(num_tensor_inputs);
+    detail::for_each_input_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+      storage_saved.push_back(t.has_storage() ? c10::optional<Storage>(t.storage()) : c10::nullopt);
+    }, std::forward<Args>(args)...);
+    detail::for_each_input_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+      impl_saved.push_back(t.getIntrusivePtr());
+    }, std::forward<Args>(args)...);
+    #endif
+    ReturnT outputs;
+    {
+      at::AutoDispatchBelowADInplaceOrView guard;
+      outputs = std::move(op_(std::forward<Args>(args)...));
+    }
+    #ifndef NDEBUG
+    detail::for_each_input_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+      if (storage_saved.at(idx).has_value())
+        AT_ASSERT(storage_saved.at(idx).value().is_alias_of(t.storage()));
+    }, std::forward<Args>(args)...);
+    detail::for_each_input_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+      if (impl_saved.at(idx))
+        AT_ASSERT(impl_saved.at(idx) == t.getIntrusivePtr());
+    }, std::forward<Args>(args)...);
+    // Do we have alias information for tensors in tensorlist outputs?
+    detail::for_each_output_tensor(outputs, [&](size_t idx_tensor, size_t idx_ret, const at::Tensor& t) {
+      if (!is_inplace_output[idx_ret])
+        AT_ASSERT(t.use_count() <= 1);  // Okay to return undefined tensor
+    });
+    // TODO: Add check if view ops return tensor that is aliased with the right input
+    detail::for_each_output_tensor(outputs, [&](size_t idx_tensor, size_t idx_ret, const at::Tensor& t) {
+      if (!is_aliased_output[idx_ret] && t.has_storage())
+        AT_ASSERT(t.storage().use_count() == 1);
+    });
+    #endif
+
+    if (any_requires_grad) {
+      detail::for_each_output_tensor(outputs, [&](size_t idx_tensor, size_t idx_ret, const at::Tensor& t) {
+        if (isDifferentiableType(t.scalar_type())) {
+          if (is_inplace_output[idx_ret]) {
+            rebase_history(const_cast<at::Tensor&>(t), grad_fn);
+          } else {
+            set_history(const_cast<at::Tensor&>(t), grad_fn);
+          }
+        }
+      });
+    }
+    return outputs;
+  }
+private:
+  ReturnT(*op_)(Args&&...);
+  c10::FunctionSchema schema_;
+};
+
+}
+}

--- a/torch/csrc/autograd/autograd_not_implemented_template.h
+++ b/torch/csrc/autograd/autograd_not_implemented_template.h
@@ -35,8 +35,8 @@ struct ForEachTensor : IterArgs<ForEachTensor<F>> {
     // NOLINTNEXTLINE(bugprone-branch-clone)
     if (x.has_value() && x.value().defined()) {
       fn_(idx_tensor_, idx_arg_, x.value());
+      idx_tensor_++;
     }
-    idx_tensor_++;
     idx_arg_++;
   }
   void operator()(const at::Tensor& x) const {
@@ -71,12 +71,12 @@ void for_each_tuple(
 }
 
 template<typename F>
-void for_each_output_tensor(const at::Tensor& t, F fn) {
+void for_each_output_tensor(at::Tensor& t, F fn) {
   fn(0, 0, t);
 }
 
 template<typename T, typename F>
-enable_if_t<!std::__is_tuple_like<T>::value> for_each_output_tensor(T& not_tup, F fn) {
+void for_each_output_tensor(T& not_tup, F fn) {
   (ForEachTensor<F>(fn))(not_tup);
 }
 

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -79,7 +79,8 @@ void autogradNotImplementedFallback(const c10::OperatorHandle& op, DispatchKeySe
   size_t num_tensor_inputs = 0;  // Only used for DEBUG-only checks
 
   _foreach_tensor([&](size_t _, size_t idx_arg, const at::Tensor& t) {
-    TORCH_CHECK(t.defined(), "Expected argument ", idx_arg, " of ", op_name, " to be defined.");
+    // TODO: We need to skip this check if the tensor is optional (how?)
+    // TORCH_CHECK(t.defined(), "Expected argument ", idx_arg, " of ", op_name, " to be defined.");
     if (grad_mode && t.requires_grad()) {
       tensors_requiring_grad.push_back(&t);
     }

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -29,6 +29,28 @@ Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
   }
 }
 
+void _foreach_tensor(
+    const std::function<void (size_t, size_t, const at::Tensor&)>& fn,
+    torch::jit::Stack* stack,
+    size_t stack_start,
+    size_t size) {
+  // Enumerate over tensors in a stack, including ones in TensorLists
+  int idx = 0;
+  for (const auto i : c10::irange(size)) {
+    auto& ivalue = (*stack)[stack_start + i];
+    if (ivalue.isTensor()) {  // true for optional tensor that has value
+      const auto& tensor = ivalue.toTensor();
+      fn(idx, i, tensor);
+      idx++;
+    } if (ivalue.isTensorList()) {
+      for (const auto& tensor : ivalue.toTensorVector()) {
+        fn(idx, i, tensor);
+        idx++;
+      }
+    }
+  }
+}
+
 void autogradNotImplementedFallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
   // Mimics the logic of a VariableType NotImplemented kernel
   const auto& schema = op.schema();
@@ -46,20 +68,26 @@ void autogradNotImplementedFallback(const c10::OperatorHandle& op, DispatchKeySe
     const auto& alias_info = arguments[i].alias_info();
     any_is_inplace |= alias_info.has_value() && alias_info->isWrite();
   }
+  // Keep track of which outputs are output of in-place modification
+  // so we can rebase_history if necessary
   std::vector<bool> is_inplace_output;
+  std::vector<bool> is_aliased_output;
   is_inplace_output.reserve(num_returns);
   for (const auto i : c10::irange(num_returns)) {
     const auto& alias_info = returns[i].alias_info();
     is_inplace_output.push_back(alias_info.has_value() && alias_info->isWrite());
+    is_aliased_output.push_back(alias_info.has_value());
   }
-  // Check fwd grad not defined
+  size_t num_tensor_inputs = 0;  // Only used for DEBUG-only checks
   for (const auto i : c10::irange(num_arguments)) {
     auto& ivalue = (*stack)[stack_start + i];
     if (ivalue.isTensor()) {
+      // ivalues for optional tensors have isTensor = true
       const auto& tensor = VariableType::unpack(ivalue.toTensor(), op_name.c_str(), i);
       if (grad_mode && tensor.requires_grad()) {
         tensors_requiring_grad.push_back(tensor);
       }
+      num_tensor_inputs++;
       TORCH_CHECK_NOT_IMPLEMENTED(!generated::details::isFwGradDefined(tensor), "Trying to use forward AD with ", op_name, " that does not support it.");
     } else if (ivalue.isTensorList()) {
       const auto& tensors = VariableType::unpack(ivalue.toTensorVector(), op_name.c_str(), i);
@@ -67,10 +95,10 @@ void autogradNotImplementedFallback(const c10::OperatorHandle& op, DispatchKeySe
         if (grad_mode && tensor.requires_grad()) {
           tensors_requiring_grad.push_back(tensor);
         }
+        num_tensor_inputs++;
         TORCH_CHECK_NOT_IMPLEMENTED(!generated::details::isFwGradDefined(tensor), "Trying to use forward AD with ", op_name, " that does not support it.");
       }
     }
-    // What about optional tensors?
   }
   const bool any_requires_grad = tensors_requiring_grad.size() > 0;
 
@@ -89,11 +117,47 @@ void autogradNotImplementedFallback(const c10::OperatorHandle& op, DispatchKeySe
     grad_fn = std::shared_ptr<NotImplemented>(new NotImplemented(op_name), deleteNode);
     grad_fn->set_next_edges(collect_next_edges(tensors_requiring_grad));
   }
+
+  #ifndef NDEBUG
+  // See NOTE [ TensorImpl and Storage Pointer Sanity Checks ]
+  std::vector<c10::IValue> stack_copy(*stack);
+  std::vector<c10::intrusive_ptr<TensorImpl>> impl_saved;
+  impl_saved.reserve(num_tensor_inputs);
+  std::vector<c10::optional<Storage>> storage_saved;
+  storage_saved.reserve(num_tensor_inputs);
+  _foreach_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+    storage_saved.push_back(t.has_storage() ? c10::optional<Storage>(t.storage()) : c10::nullopt);
+  }, &stack_copy, stack_start, num_arguments);
+  _foreach_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+    impl_saved.push_back(t.getIntrusivePtr());
+  }, &stack_copy, stack_start, num_arguments);
+  #endif
   {
     at::AutoDispatchBelowADInplaceOrView guard;
     op.redispatchBoxed(dispatch_keys & c10::after_autograd_keyset, stack);
   }
+  #ifndef NDEBUG
+  _foreach_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+    if (storage_saved.at(idx).has_value())
+      AT_ASSERT(storage_saved.at(idx).value().is_alias_of(t.storage()));
+  }, &stack_copy, stack_start, num_arguments);
+  _foreach_tensor([&](size_t idx, size_t _, const at::Tensor& t) {
+    if (impl_saved.at(idx))
+      AT_ASSERT(impl_saved.at(idx) == t.getIntrusivePtr());
+  }, &stack_copy, stack_start, num_arguments);
+  // Do we have alias information for tensors in tensorlist outputs?
+  _foreach_tensor([&](size_t idx_tensor, size_t idx_ret, const at::Tensor& t) {
+    if (!is_inplace_output[idx_ret])
+      AT_ASSERT(t.use_count() <= 1);  // Okay to return undefined tensor
+  }, stack, stack->size() - num_returns, num_returns);
+  // TODO: Add check if view ops return tensor that is aliased with the right input
+  _foreach_tensor([&](size_t idx_tensor, size_t idx_ret, const at::Tensor& t) {
+    if (!is_aliased_output[idx_ret] && t.has_storage())
+      AT_ASSERT(t.storage().use_count() == 1);
+  }, stack, stack->size() - num_returns, num_returns);
+  #endif
   const auto& ret = torch::jit::last(stack, num_returns);
+
   for (const auto return_idx : c10::irange(ret.size())) {
     if (ret[return_idx].isTensor()) {
       const auto& t = ret[return_idx].toTensor();
@@ -105,7 +169,6 @@ void autogradNotImplementedFallback(const c10::OperatorHandle& op, DispatchKeySe
         }
       }
     }
-
   }
 }
 

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
+#include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/ivalue.h>
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/irange.h>
@@ -229,6 +230,8 @@ inline std::vector<c10::optional<Variable>> to_optional(variable_list& output) {
     [](const Variable& var) { return var; });
   return result;
 }
+
+void TORCH_API autogradNotImplementedFunction(const c10::OperatorHandle& op, at::DispatchKeySet dispatch_keys, torch::jit::Stack* stack);
 
 template<class T>
 template<typename X, typename... Args>

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -231,7 +231,7 @@ inline std::vector<c10::optional<Variable>> to_optional(variable_list& output) {
   return result;
 }
 
-void TORCH_API autogradNotImplementedFunction(const c10::OperatorHandle& op, at::DispatchKeySet dispatch_keys, torch::jit::Stack* stack);
+void TORCH_API autogradNotImplementedFallback(const c10::OperatorHandle& op, at::DispatchKeySet dispatch_keys, torch::jit::Stack* stack);
 
 template<class T>
 template<typename X, typename... Args>

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -563,6 +563,14 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
       next_edges.emplace_back();
     }
   }
+  void operator()(const Variable* variable) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (variable->defined()) {
+      next_edges.push_back(impl::gradient_edge(*variable));
+    } else {
+      next_edges.emplace_back();
+    }
+  }
   void operator()(const c10::optional<Variable>& variable) {
     // NOLINTNEXTLINE(bugprone-branch-clone)
     if (variable.has_value() && variable->defined()) {

--- a/torch/extension.h
+++ b/torch/extension.h
@@ -4,3 +4,4 @@
 #include <torch/all.h>
 // Python bindings for the C++ frontend (includes Python.h).
 #include <torch/python.h>
+#include <torch/csrc/autograd/autograd_not_implemented_template.h>


### PR DESCRIPTION
Fixes #62032 

We can also do something similar with templates (see [here](https://gist.github.com/ccfedd1eae450815437915f2487dc265
)).
 - The main appeal for the templated version is that we expect it to be faster (currently it is ~1.5x faster, but the boxed kernel also currently does several more checks)

Benefits of using boxed version of 
 - better UX: users do not need to instantiate their own template with the types of the arguments and returns
 - writing checks is easier because we access to alias info (not really sure how we would do this otherwise unless we tell user to explicitly pass in alias/mutation information?)
 - Reduce compile time ~1.2x faster or 16% reduction.

Next steps:
 - make this an actual fallback when autograd kernel is not registered (BC-breaking)
 - Two ways of addressing possible breakages (as discussed offline with @ezyang):
   - someone hitting performance issues from boxed fallback should just use inference mode
   - someone writing a composite op but registered as CPU or CUDA should actually register as composite
 - With the debug checks, there are more possible breakages unfortunately. The fix would be dependent
   specific case 

### Compile time improvements after replacing codegened kernels
Before:
```
Time               LOC
22.388195991516113 9382
22.91336464881897 9522
22.35034680366516 9543
23.813859462738037 10219
22.55459690093994 9258
total time to compile: 114.02036380767822, total loc: 47924
```
After:
```
Time               LOC
26.092895030975342 11861
27.48097252845764 12449
27.181522607803345 12481
29.233663082122803 13627
25.77803874015808 11544
total time to compile: 135.7670919895172, total loc: 61962

```
### Benchmarking
<details>
<summary>
Latest benchmarking

[repo to replicate](https://github.com/soulitzer/autograd-not-implemented-benchmarking)
</summary>

```----------- Baseline -----------
2021-08-11T19:51:25-04:00
Running ./example-app-baseline
Run on (32 X 4238.08 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 16384 KiB (x4)
Load Average: 1.28, 0.50, 0.57
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
op_call_no_requires_grad        688 ns          688 ns       999897
op_call                         679 ns          679 ns      1019086
op_call_boxed                   738 ns          739 ns       945178
----------- Templated -----------
2021-08-11T19:51:27-04:00
Running ./example-app-templated
Run on (32 X 3606.59 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 16384 KiB (x4)
Load Average: 1.26, 0.51, 0.57
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
op_call_no_requires_grad        839 ns          839 ns       816023
op_call                        1649 ns         1649 ns       421783
op_call_boxed                  1705 ns         1706 ns       408794
----------- Boxed -----------
2021-08-11T19:51:30-04:00
Running ./example-app-boxed
Run on (32 X 3596.95 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 16384 KiB (x4)
Load Average: 3.72, 1.04, 0.74
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
op_call_no_requires_grad        883 ns          883 ns       772852
op_call                        1663 ns         1663 ns       418360
op_call_boxed                  1662 ns         1663 ns       421296

```
</details>

#### Old results for comparison
[code](https://gist.github.com/e74939f2c3993a11555909135fd2ef51)
Boxed kernel:
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
op_requires_grad_no_dispatch          1568 ns         1567 ns       441375
op_no_requires_grad_no_dispatch        838 ns          838 ns       844149
op_no_requires_grad_call               987 ns          987 ns       699862
op_requires_grad_call                 1776 ns         1776 ns       391280
op_requires_grad_call_boxed           1776 ns         1776 ns       387758
```
Templated kernel:
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
op_requires_grad_no_dispatch          1523 ns         1523 ns       451260
op_no_requires_grad_no_dispatch        787 ns          787 ns       885251
op_no_requires_grad_call               772 ns          772 ns       918897
op_requires_grad_call                 1108 ns         1108 ns       630075
op_requires_grad_call_boxed           1179 ns         1179 ns       594634
```