### PR TITLE
[dte] fastpath implementation for broadcast utility function (4/x)

### DIFF
--- a/caffe2/python/operator_test/reduce_ops_test.py
+++ b/caffe2/python/operator_test/reduce_ops_test.py
@@ -15,13 +15,15 @@ import itertools as it
 
 class TestReduceOps(serial.SerializedTestCase):
     def run_reduce_op_test_impl(
-            self, op_name, X, axes, keepdims, ref_func, gc, dc):
+            self, op_name, X, axes, keepdims, ref_func, gc, dc, allow_broadcast_fastpath):
+        extra_args = dict(allow_broadcast_fastpath=True) if allow_broadcast_fastpath else {}
         if axes is None:
             op = core.CreateOperator(
                 op_name,
                 ["X"],
                 ["Y"],
                 keepdims=keepdims,
+                **extra_args,
             )
         else:
             op = core.CreateOperator(
@@ -30,6 +32,7 @@ class TestReduceOps(serial.SerializedTestCase):
                 ["Y"],
                 axes=axes,
                 keepdims=keepdims,
+                **extra_args,
             )
 
         def ref(X):
@@ -37,79 +40,94 @@ class TestReduceOps(serial.SerializedTestCase):
                 X, axis=None if axes is None else tuple(axes),
                 keepdims=keepdims)]
 
-        self.assertReferenceChecks(gc, op, [X], ref)
+        with self.set_disable_serialized_check(allow_broadcast_fastpath):
+            self.assertReferenceChecks(gc, op, [X], ref)
         self.assertDeviceChecks(dc, op, [X], [0])
         self.assertGradientChecks(gc, op, [X], 0, [0])
 
     def run_reduce_op_test(
-            self, op_name, X, keepdims, num_axes, ref_func, gc, dc):
+            self, op_name, X, keepdims, num_axes, ref_func, gc, dc, allow_broadcast_fastpath=False):
         self.run_reduce_op_test_impl(
-            op_name, X, None, keepdims, ref_func, gc, dc)
+            op_name, X, None, keepdims, ref_func, gc, dc, allow_broadcast_fastpath)
 
         num_dims = len(X.shape)
         if num_dims < num_axes:
             self.run_reduce_op_test_impl(
-                op_name, X, range(num_dims), keepdims, ref_func, gc, dc)
+                op_name, X, range(num_dims), keepdims, ref_func, gc, dc, allow_broadcast_fastpath)
         else:
             for axes in it.combinations(range(num_dims), num_axes):
                 self.run_reduce_op_test_impl(
-                    op_name, X, axes, keepdims, ref_func, gc, dc)
+                    op_name, X, axes, keepdims, ref_func, gc, dc, allow_broadcast_fastpath)
 
     @serial.given(
-        X=hu.tensor(max_dim=3, dtype=np.float32), keepdims=st.booleans(),
+        X=hu.tensor(max_dim=3, dtype=np.float32),
+        keepdims=st.booleans(),
+        allow_broadcast_fastpath=st.booleans(),
         num_axes=st.integers(1, 3), **hu.gcs)
-    def test_reduce_min(self, X, keepdims, num_axes, gc, dc):
+    def test_reduce_min(self, X, keepdims, allow_broadcast_fastpath, num_axes, gc, dc):
         X_dims = X.shape
         X_size = X.size
         X = np.arange(X_size, dtype=np.float32)
         np.random.shuffle(X)
         X = X.reshape(X_dims)
         self.run_reduce_op_test(
-            "ReduceMin", X, keepdims, num_axes, np.min, gc, dc)
+            "ReduceMin", X, keepdims, num_axes, np.min, gc, dc,
+            allow_broadcast_fastpath=allow_broadcast_fastpath)
 
     @serial.given(
-        X=hu.tensor(max_dim=3, dtype=np.float32), keepdims=st.booleans(),
+        X=hu.tensor(max_dim=3, dtype=np.float32),
+        keepdims=st.booleans(),
+        allow_broadcast_fastpath=st.booleans(),
         num_axes=st.integers(1, 3), **hu.gcs)
-    def test_reduce_max(self, X, keepdims, num_axes, gc, dc):
+    def test_reduce_max(self, X, keepdims, allow_broadcast_fastpath, num_axes, gc, dc):
         X_dims = X.shape
         X_size = X.size
         X = np.arange(X_size, dtype=np.float32)
         np.random.shuffle(X)
         X = X.reshape(X_dims)
         self.run_reduce_op_test(
-            "ReduceMax", X, keepdims, num_axes, np.max, gc, dc)
+            "ReduceMax", X, keepdims, num_axes, np.max, gc, dc,
+            allow_broadcast_fastpath=allow_broadcast_fastpath)
 
     @given(n=st.integers(0, 5), m=st.integers(0, 5), k=st.integers(0, 5),
            t=st.integers(0, 5), keepdims=st.booleans(),
+           allow_broadcast_fastpath=st.booleans(),
            num_axes=st.integers(1, 3), **hu.gcs)
     @settings(deadline=10000)
-    def test_reduce_sum(self, n, m, k, t, keepdims, num_axes, gc, dc):
+    def test_reduce_sum(self, n, m, k, t, keepdims, allow_broadcast_fastpath, num_axes, gc, dc):
         X = np.random.randn(n, m, k, t).astype(np.float32)
         self.run_reduce_op_test(
-            "ReduceSum", X, keepdims, num_axes, np.sum, gc, dc)
+            "ReduceSum", X, keepdims, num_axes, np.sum, gc, dc,
+            allow_broadcast_fastpath=allow_broadcast_fastpath)
 
     @serial.given(X=hu.tensor(dtype=np.float32), keepdims=st.booleans(),
-           num_axes=st.integers(1, 4), **hu.gcs)
-    def test_reduce_mean(self, X, keepdims, num_axes, gc, dc):
+                  allow_broadcast_fastpath=st.booleans(),
+                  num_axes=st.integers(1, 4), **hu.gcs)
+    def test_reduce_mean(self, X, keepdims, allow_broadcast_fastpath, num_axes, gc, dc):
         self.run_reduce_op_test(
-            "ReduceMean", X, keepdims, num_axes, np.mean, gc, dc)
+            "ReduceMean", X, keepdims, num_axes, np.mean, gc, dc,
+            allow_broadcast_fastpath=allow_broadcast_fastpath)
 
     @given(n=st.integers(1, 3), m=st.integers(1, 3), k=st.integers(1, 3),
-           keepdims=st.booleans(), num_axes=st.integers(1, 3), **hu.gcs_cpu_only)
+           keepdims=st.booleans(), allow_broadcast_fastpath=st.booleans(),
+           num_axes=st.integers(1, 3), **hu.gcs_cpu_only)
     @settings(deadline=10000)
-    def test_reduce_l1(self, n, m, k, keepdims, num_axes, gc, dc):
+    def test_reduce_l1(self, n, m, k, keepdims, allow_broadcast_fastpath, num_axes, gc, dc):
         X = np.arange(n * m * k, dtype=np.float32) - 0.5
         np.random.shuffle(X)
         X = X.reshape((m, n, k))
         self.run_reduce_op_test(
-            "ReduceL1", X, keepdims, num_axes, getNorm(1), gc, dc)
+            "ReduceL1", X, keepdims, num_axes, getNorm(1), gc, dc,
+            allow_broadcast_fastpath=allow_broadcast_fastpath)
 
     @serial.given(n=st.integers(1, 5), m=st.integers(1, 5), k=st.integers(1, 5),
-           keepdims=st.booleans(), num_axes=st.integers(1, 3), **hu.gcs_cpu_only)
-    def test_reduce_l2(self, n, m, k, keepdims, num_axes, gc, dc):
+                  keepdims=st.booleans(), allow_broadcast_fastpath=st.booleans(),
+                  num_axes=st.integers(1, 3), **hu.gcs_cpu_only)
+    def test_reduce_l2(self, n, m, k, keepdims, allow_broadcast_fastpath, num_axes, gc, dc):
         X = np.random.randn(n, m, k).astype(np.float32)
         self.run_reduce_op_test(
-            "ReduceL2", X, keepdims, num_axes, getNorm(2), gc, dc)
+            "ReduceL2", X, keepdims, num_axes, getNorm(2), gc, dc,
+            allow_broadcast_fastpath=allow_broadcast_fastpath)
 
 
 def getNorm(p):

--- a/caffe2/python/serialized_test/serialized_test_util.py
+++ b/caffe2/python/serialized_test/serialized_test_util.py
@@ -1,22 +1,23 @@
 
 
 
-
-
-import argparse
-from caffe2.proto import caffe2_pb2
-from caffe2.python import gradient_checker
-import caffe2.python.hypothesis_test_util as hu
-from caffe2.python.serialized_test import coverage
-import hypothesis as hy
 import inspect
-import numpy as np
 import os
 import shutil
 import sys
 import tempfile
 import threading
+from contextlib import contextmanager
 from zipfile import ZipFile
+
+import argparse
+import hypothesis as hy
+import numpy as np
+
+import caffe2.python.hypothesis_test_util as hu
+from caffe2.proto import caffe2_pb2
+from caffe2.python import gradient_checker
+from caffe2.python.serialized_test import coverage
 
 operator_test_type = 'operator_test'
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -258,6 +259,15 @@ class SerializedTestCase(hu.HypothesisTestCase):
                 atol,
                 rtol,
             )
+
+    @contextmanager
+    def set_disable_serialized_check(self, val: bool):
+        orig = getattr(_output_context, 'disable_serialized_check', False)
+        try:
+            _output_context.disable_serialized_check = val
+            yield
+        finally:
+            _output_context.disable_serialized_check = orig
 
 
 def testWithArgs():

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -32,6 +32,7 @@
 #include "caffe2/utils/cpu_neon.h"
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/fixed_divisor.h"
+#include "caffe2/utils/math/broadcast.h"
 
 #include "Eigen/Core"
 #include "Eigen/Dense"
@@ -487,14 +488,29 @@ C10_EXPORT void BroadcastImpl(
     X_dims_vector[i] = X_dims[i - d];
   }
   X_dims = X_dims_vector.data();
+  CAFFE_ENFORCE_EQ(X_dims_vector.size(), Y_ndim);
+  const int X_size =
+      // NOLINTNEXTLINE(modernize-use-transparent-functors)
+      std::accumulate(X_dims, X_dims + Y_ndim, 1, std::multiplies<int>());
   const int Y_size =
       // NOLINTNEXTLINE(modernize-use-transparent-functors)
       std::accumulate(Y_dims, Y_dims + Y_ndim, 1, std::multiplies<int>());
-  std::vector<int> index(Y_ndim, 0);
-  for (int Y_index = 0; Y_index < Y_size; ++Y_index) {
-    const int X_index = utils::GetIndexFromDims(Y_ndim, X_dims, index.data());
-    Y[Y_index] = X[X_index];
-    utils::IncreaseIndexInDims(Y_ndim, Y_dims, index.data());
+  if (allow_broadcast_fastpath && can_use_broadcast_fastpath(Y_ndim, X_dims)) {
+    int X_index = 0;
+    for (int Y_index = 0; Y_index < Y_size; ++Y_index) {
+      Y[Y_index] = X[X_index];
+      X_index++;
+      if (X_index >= X_size) {
+        X_index = 0;
+      }
+    }
+  } else {
+    std::vector<int> index(Y_ndim, 0);
+    for (int Y_index = 0; Y_index < Y_size; ++Y_index) {
+      const int X_index = utils::GetIndexFromDims(Y_ndim, X_dims, index.data());
+      Y[Y_index] = X[X_index];
+      utils::IncreaseIndexInDims(Y_ndim, Y_dims, index.data());
+    }
   }
   Scale<T, T, CPUContext>(Y_size, alpha, Y, Y, context);
 }

--- a/caffe2/utils/math_test.cc
+++ b/caffe2/utils/math_test.cc
@@ -490,11 +490,17 @@ TEST_F(BroadcastTest, BroadcastFloatTest) {
   RunBroadcastTest({1}, {2}, {1.0f}, {1.0f, 1.0f});
   RunBroadcastTest({1}, {2, 2}, {1.0f}, {1.0f, 1.0f, 1.0f, 1.0f});
   RunBroadcastTest({2, 1}, {2, 2}, {1.0f, 2.0f}, {1.0f, 1.0f, 2.0f, 2.0f});
+  RunBroadcastTest({1, 2}, {2, 2}, {1.0f, 2.0f}, {1.0f, 2.0f, 1.0f, 2.0f});
   RunBroadcastTest(
       {2, 1},
       {2, 2, 2},
       {1.0f, 2.0f},
       {1.0f, 1.0f, 2.0f, 2.0f, 1.0f, 1.0f, 2.0f, 2.0f});
+  RunBroadcastTest(
+      {1, 2},
+      {2, 2, 2},
+      {1.0f, 2.0f},
+      {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f});
 }
 
 class RandFixedSumTest : public testing::Test {


### PR DESCRIPTION
Summary: This diff adds a broadcast fastpath for the caffe2 broadcast utility function, which just copies the contents of a smaller tensor into a larger one. We also update the tests to exercise the new functionality.

Test Plan: unit tests + let CI run

Differential Revision: D29938285

