### PR TITLE
[fx] add support for custom tracer in __reduce_package__

### DIFF
--- a/test/package/package_a/test_all_leaf_modules_tracer.py
+++ b/test/package/package_a/test_all_leaf_modules_tracer.py
@@ -1,0 +1,6 @@
+from torch.fx import Tracer
+
+
+class TestAllLeafModulesTracer(Tracer):
+    def is_leaf_module(self, m, qualname):
+        return True

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -532,7 +532,9 @@ class Tracer(TracerBase):
         else:
             self.root = torch.nn.Module()
             fn = root
-        self.graph = Graph()
+
+        tracer_cls: Optional['Tracer'] = getattr(self, '__class__', None)
+        self.graph = Graph(tracer_cls=tracer_cls)
 
         # When we encounter a Tensor value that's not a parameter, we look if it
         # is some other attribute on the model. Construct a dict mapping Tensor

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -16,6 +16,7 @@ import warnings
 
 if TYPE_CHECKING:
     from .graph_module import GraphModule  # noqa: F401
+    from ._symbolic_trace import Tracer   # noqa: F401
 
 
 # Mapping of builtins to their `typing` equivalent.
@@ -282,7 +283,7 @@ class Graph:
 
     For the semantics of operations represented in the ``Graph``, please see :class:`Node`.
     """
-    def __init__(self, owning_module: Optional["GraphModule"] = None):
+    def __init__(self, owning_module: Optional["GraphModule"] = None, tracer_cls: Optional["Tracer"] = None):
         """
         Construct an empty Graph.
         """
@@ -293,6 +294,7 @@ class Graph:
         self._graph_namespace = _Namespace()
         self._owners = 0
         self._owning_module = owning_module
+        self._tracer_cls = tracer_cls
         self._pytree_info: Optional[_PyTreeInfo] = None
 
     @property


### PR DESCRIPTION
Summary: Adds support for specifying a custom Tracer to use when deserializing a GraphModule from a torch package, similar to `__reduce_deploy__`.

Differential Revision: D30019214

