### PR TITLE
DO NOT MERGE, Rebuilding ROCM Stable image

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -6,7 +6,7 @@ install_magma() {
     # "install" hipMAGMA into /opt/rocm/magma by copying after build
     git clone https://bitbucket.org/icl/magma.git
     pushd magma
-    git checkout aed4e285084763113ce5757393d4008e27b5194b
+    git checkout 878b1ce02e9cfe4a829be22c8f911e9c0b6bd88f
     cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
     echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
     echo 'LIB += -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib -Wl,--rpath,$(MKLROOT)/lib -Wl,--rpath,/opt/rocm/magma/lib' >> make.inc


### PR DESCRIPTION
This reverts commit e2b42c6f52f906bf149843e00fecbfdde314c1b7.

Should rebuild:
```
❯ git rev-parse HEAD:.circleci/docker
bd62158e54445164d8748395febd095db42d268c
```
