### PR TITLE
[ONNX] minor doc improvements and cleanup

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -307,11 +307,11 @@ If the operator is an ATen operator (shows up in the TorchScript graph with the 
 
 * Define the symbolic function in ``torch/onnx/symbolic_opset<version>.py``, for example
   `torch/onnx/symbolic_opset9.py <https://github.com/pytorch/pytorch/blob/master/torch/onnx/symbolic_opset9.py>`_.
-  Make sure the function has the same name as the ATen function, which may declared in
+  Make sure the function has the same name as the ATen function, which may be declared in
   ``torch/_C/_VariableFunctions.pyi`` or ``torch/nn/functional.pyi`` (these files are generated at
   build time, so will not appear in your checkout until you build PyTorch).
 * The first arg is always the ONNX graph that is being built for export.
-  Other arg names must EXACTLY match the names in ``_VariableFunctions.pyi``,
+  Other arg names must EXACTLY match the names in the ``.pyi`` file,
   because dispatch is done with keyword arguments.
 * In the symbolic function, if the operator is in the
   `ONNX standard operator set <https://github.com/onnx/onnx/blob/master/docs/Operators.md>`_,
@@ -365,8 +365,8 @@ See the ``symbolic_opset*.py`` files for more examples.
 torch.autograd.Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the operator is defined in a sub-class of :class:`torch.autograd.Function`,
-there are two ways to export it.
+If the operator is a sub-class of :class:`torch.autograd.Function`, there are two ways
+to export it.
 
 Static Symbolic Method
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -388,11 +388,11 @@ PythonOp Symbolic
 ~~~~~~~~~~~~~~~~~
 
 Alternatively, you can register a custom symbolic function.
-This gives the symoblic function access to more info through the
+This gives the symbolic function access to more info through the
 TorchScript ``Node`` object for the original operation, which gets passed in as the second
 argument (after the ``Graph`` object).
 
-All autograd ``Function``s are emitted in the TorchScript graph as ``prim::PythonOp`` nodes.
+All autograd ``Function``\ s appear in the TorchScript graph as ``prim::PythonOp`` nodes.
 In order to differentiate between different ``Function`` subclasses, the
 symbolic function should use the ``name`` kwarg which gets set to the name of the class.
 
@@ -400,11 +400,12 @@ symbolic function should use the ``name`` kwarg which gets set to the name of th
 the ``prim`` namespace, so for this use case, there's a back door: register the
 symbolic for ``"::prim_PythonOp"``.
 
-Please also consider adding shape inference logic when you regiester a custom symbolic function
-via setType API. This can help the exporter to obtain correct shape inference.
-An example of setType is test_aten_embedding_2 in test_operators.py.
-Although it is not required to add shape inference logic,
-the exporter emits a warning message if it is not added.
+Custom symbolic functions should add type and shape information by calling ``setType(...)``
+on Value objects before returning them (implemented in C++ by
+``torch::jit::Value::setType``). This is not required, but it can help the exporter's
+shape and type inference for down-stream nodes. For a non-trivial example of ``setType``, see
+``test_aten_embedding_2`` in
+`test_operators.py <https://github.com/pytorch/pytorch/blob/master/test/onnx/test_operators.py>`_.
 
 The example below shows how you can access ``requires_grad`` via the ``Node`` object::
 
@@ -430,13 +431,17 @@ The example below shows how you can access ``requires_grad`` via the ``Node`` ob
             print("arg {}: {}, requires grad: {}".format(i, arg, requires_grad))
 
         name = kwargs["name"]
+        ret = None
         if name == "MyClip":
-            return g.op("Clip", args[0], min_f=args[1])
+            ret = g.op("Clip", args[0], min_f=args[1])
         elif name == "MyRelu":
-            return g.op("Relu", args[0])
+            ret = g.op("Relu", args[0])
         else:
             # Logs a warning and returns None
             return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
+        # Copy type and shape from original node.
+        ret.setType(n.type())
+        return ret
 
     from torch.onnx import register_custom_op_symbolic
     register_custom_op_symbolic("::prim_PythonOp", symbolic_pythonop, 1)

--- a/test/jit/test_export_modes.py
+++ b/test/jit/test_export_modes.py
@@ -76,9 +76,8 @@ class TestExportModes(JitTestCase):
 
         x = torch.rand(3, 4)
         y = torch.rand(3, 4)
-        f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
-            ModelWithAtenNotONNXOp(), (x, y), f,
+            ModelWithAtenNotONNXOp(), (x, y), None,
             add_node_names=False,
             do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
@@ -91,11 +90,10 @@ class TestExportModes(JitTestCase):
             def forward(self, x, y):
                 return torch.fmod(x, y)
 
-        f = io.BytesIO()
         x = torch.randn(3, 4, dtype=torch.float32)
         y = torch.randn(3, 4, dtype=torch.float32)
         torch.onnx.export_to_pretty_string(
-            ModelWithAtenFmod(), (x, y), f,
+            ModelWithAtenFmod(), (x, y), None,
             add_node_names=False,
             do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN)

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -1115,9 +1115,8 @@ class TestTracer(JitTestCase):
             def forward(self, x, w):
                 return torch.matmul(x, w).detach()
 
-        f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
-            Mod(), (torch.rand(3, 4), torch.rand(4, 5)), f)
+            Mod(), (torch.rand(3, 4), torch.rand(4, 5)), None)
 
     def test_trace_slice_full_dim(self):
         def foo(x):

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -896,20 +896,20 @@ class TestOperators(TestCase):
     def test_aten_embedding_1(self):
         _onnx_opset_version = 12
 
-        @parse_args('v', 'v', 'i', 'b', 'b')
+        @parse_args("v", "v", "i", "b", "b")
         def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
             custom_attributes_json = (
-                '{'
+                "{"
                 f'"padding_idx":{str(padding_idx)},'
                 f'"scale_grad_by_freq":{str(scale_grad_by_freq).lower()},'
                 f'"sparse":{str(sparse).lower()}'
-                '}'
+                "}"
             )
-            output = g.op("com.microsoft::ATenOp", weight, indices, name_s='aten::embedding',
+            output = g.op("com.microsoft::ATenOp", weight, indices, name_s="aten::embedding",
                           custom_attributes_json_s=custom_attributes_json)
             return output
 
-        register_custom_op_symbolic('::embedding', embedding, _onnx_opset_version)
+        register_custom_op_symbolic("::embedding", embedding, _onnx_opset_version)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -926,32 +926,32 @@ class TestOperators(TestCase):
         y = torch.randn(1, 8)
         self.assertONNX(model, (x, y), opset_version=_onnx_opset_version)
 
-        unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
+        unregister_custom_op_symbolic("::embedding", _onnx_opset_version)
 
     # This is test_aten_embedding_1 with shape inference on custom symbolic aten::embedding.
     def test_aten_embedding_2(self):
         _onnx_opset_version = 12
 
-        @parse_args('v', 'v', 'i', 'b', 'b')
+        @parse_args("v", "v", "i", "b", "b")
         def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
             custom_attributes_json = (
-                '{'
+                "{"
                 f'"padding_idx":{str(padding_idx)},'
                 f'"scale_grad_by_freq":{str(scale_grad_by_freq).lower()},'
                 f'"sparse":{str(sparse).lower()}'
-                '}'
+                "}"
             )
-            output = g.op("com.microsoft::ATenOp", weight, indices, name_s='aten::embedding',
+            output = g.op("com.microsoft::ATenOp", weight, indices, name_s="aten::embedding",
                           custom_attributes_json_s=custom_attributes_json)
 
             # do shape inference and set it via setType
             indices_shape = _get_tensor_sizes(indices)
-            if indices_shape is not None and hasattr(weight.type(), 'with_sizes'):
+            if indices_shape is not None and hasattr(weight.type(), "with_sizes"):
                 output_type = weight.type().with_sizes(indices_shape + [_get_tensor_dim_size(weight, 1)])
                 output.setType(output_type)
             return output
 
-        register_custom_op_symbolic('::embedding', embedding, _onnx_opset_version)
+        register_custom_op_symbolic("::embedding", embedding, _onnx_opset_version)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -966,10 +966,10 @@ class TestOperators(TestCase):
         model = Model()
         x = torch.ones(32, dtype=torch.long)
         y = torch.randn(1, 8)
-        self.assertONNX(model, (x, y), opset_version=_onnx_opset_version, input_names=['input_1', 'input_2'],
-                        dynamic_axes={"input_1": {0: "dim_0"}, 'input_2': {0: "dim_1", 1: "dim_2"}})
+        self.assertONNX(model, (x, y), opset_version=_onnx_opset_version, input_names=["input_1", "input_2"],
+                        dynamic_axes={"input_1": {0: "dim_0"}, "input_2": {0: "dim_1", 1: "dim_2"}})
 
-        unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
+        unregister_custom_op_symbolic("::embedding", _onnx_opset_version)
 
 if __name__ == "__main__":
     no_onnx_dep_flag = "--no-onnx"

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -331,9 +331,24 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                         custom_opsets, enable_onnx_checker, use_external_data_format)
 
 
-def export_to_pretty_string(*args, **kwargs):
+def export_to_pretty_string(*args, **kwargs) -> str:
     r"""
-    Same as :func:`export`, but returns a text representation of the exported model.
+    Similar to :func:`export`, but returns a text representation of the ONNX
+    model. Only differences in args listed below. All other args are the same
+    as :func:`export`.
+
+    Args:
+      f:  Deprecated and ignored. Will be removed in the next release of
+          PyTorch.
+      add_node_names (bool, default True): Whether or not to set
+          NodeProto.name. This makes no difference unless
+          ``google_printer=True``.
+      google_printer (bool, default False): If False, will return a custom,
+          compact representation of the model. If True will return the
+          protobuf's `Message::DebugString()`, which is more verbose.
+
+    Returns:
+      A UTF-8 str containing a human-readable representation of the ONNX model.
     """
     from torch.onnx import utils
     return utils.export_to_pretty_string(*args, **kwargs)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -86,16 +86,16 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             operator_export_type = OperatorExportTypes.ONNX
 
     if enable_onnx_checker is not None:
-        warnings.warn("`enable_onnx_checker' is deprecated and ignored. It will be removed in "
-                      "the next PyTorch release. To proceed despite ONNX checker failures, you "
-                      "can catch torch.onnx.ONNXCheckerError.")
+        warnings.warn("'enable_onnx_checker' is deprecated and ignored. It will be removed in "
+                      "the next PyTorch release. To proceed despite ONNX checker failures, "
+                      "catch torch.onnx.ONNXCheckerError.")
     if _retain_param_name is not None:
-        warnings.warn("`_retain_param_name' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release. The code now will work as it is True to keep the original "
-                      "parameter names in the final ONNX graph.")
+        warnings.warn("'_retain_param_name' is deprecated and ignored. "
+                      "It will be removed in the next PyTorch release.")
     if strip_doc_string is not None:
-        warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release. It's combined with `verbose' argument now. ")
+        warnings.warn("`strip_doc_string' is deprecated and ignored. It will be removed in "
+                      "the next PyTorch release. The behavior is now controlled by the "
+                      "'verbose' arg")
 
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
@@ -542,9 +542,14 @@ def _model_to_graph(model, args, verbose=False,
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                            google_printer=False, opset_version=None, _retain_param_name=True,
+                            google_printer=False, opset_version=None, _retain_param_name=None,
                             keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
                             do_constant_folding=True, dynamic_axes=None):
+    if f is not None:
+        warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
+    if _retain_param_name is not None:
+        warnings.warn("'_retain_param_name' is deprecated and ignored. "
+                      "It will be removed in the next PyTorch release.")
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, google_printer,


### PR DESCRIPTION
* Fix some bad formatting and clarify things in onnx.rst.
* In `export_to_pretty_string`:
    * Add documentation for previously undocumented args.
    * Document that `f` arg is ignored and mark it deprecated.
* Use double quotes for string literals in test_operators.py.
