### PR TITLE
[4/n] Update vulkan test path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,6 +644,7 @@ jobs:
           set -ex
           export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
           export JOB_BASE_NAME="$CIRCLE_JOB"
+          export IN_WHEEL_TEST=1
           ${PARALLEL_FLAGS}
           cd workspace
           EOL

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -174,6 +174,7 @@ jobs:
           set -ex
           export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
           export JOB_BASE_NAME="$CIRCLE_JOB"
+          export IN_WHEEL_TEST=1
           ${PARALLEL_FLAGS}
           cd workspace
           EOL

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -277,12 +277,30 @@ test_libtorch() {
 
 test_vulkan() {
   if [[ "$BUILD_ENVIRONMENT" == *vulkan-linux* ]]; then
+    if [[ -n "$IN_WHEEL_TEST" ]]; then
+      echo "Testing vulkan with the install folder"
+      # Rename the build folder when running test to ensure it
+      # is not depended on the folder
+      mv "$BUILD_DIR" "$BUILD_RENAMED_DIR"
+      TEST_BASE_DIR="$TORCH_TEST_DIR"
+      ln -sf "$TORCH_LIB_DIR"/libtorch* "$TEST_BASE_DIR"
+      ln -sf "$TORCH_LIB_DIR"/libc10* "$TEST_BASE_DIR"
+    else
+      echo "Testing vulkan with the build folder"
+      TEST_BASE_DIR="$BUILD_BIN_DIR"
+    fi
+
     export VK_ICD_FILENAMES=/var/lib/jenkins/swiftshader/build/Linux/vk_swiftshader_icd.json
     # NB: the ending test_vulkan must match the current function name for the current
     # test reporting process (in print_test_stats.py) to function as expected.
     TEST_REPORTS_DIR=test/test-reports/cpp-vulkan/test_vulkan
     mkdir -p $TEST_REPORTS_DIR
-    build/bin/vulkan_test --gtest_output=xml:$TEST_REPORTS_DIR/vulkan_test.xml
+    "$TEST_BASE_DIR"/vulkan_test --gtest_output=xml:$TEST_REPORTS_DIR/vulkan_test.xml
+
+    if [[ -n "$IN_WHEEL_TEST" ]]; then
+      # Restore the build folder to avoid any impact on other tests
+      mv "$BUILD_RENAMED_DIR" "$BUILD_DIR"
+    fi
   fi
 }
 


### PR DESCRIPTION
Fixes #62380

* update `test_vulkan` function to call wheel install folder {sitepackages}/torch instead of build/ folder
* add `IN_WHEEL_TEST` to limit the change for `pytorch_linux_test` only
* add symbolic link for shared libraries which are called by the tests (this is a bit hacky and should be fixed the rpath before compiling -- similar to https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/test.sh#L204-L208).

### Test plan
check if all ci workflows pass