### PR TITLE
Fix CUDA_KERNEL_ASSERT ambiguous symbol in NDEBUG mode

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -352,7 +352,14 @@ __host__ __device__
         const char* assertion,
         const char* file,
         unsigned int line,
-        const char* function) throw();
+        const char* function) throw()
+// We match the declaration of __assert_fail exactly how it is in glibc in case
+// parts of the program are compiled with different NDEBUG settings. Otherwise
+// we might get 'ambiguous declaration' error.
+#ifdef __GNUC__
+        __attribute__((__noreturn__))
+#endif
+        ;
 #endif
 }
 #endif // NDEBUG

--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -35,6 +35,11 @@ TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
 #endif
 }
 
+TEST(ExceptionTest, CUDA_KERNEL_ASSERT) {
+  // This function always throws even in NDEBUG mode
+  ASSERT_DEATH_IF_SUPPORTED({ CUDA_KERNEL_ASSERT(false); }, "Assert");
+}
+
 TEST(WarningTest, JustPrintWarning) {
   TORCH_WARN("I'm a warning");
 }


### PR DESCRIPTION
Summary: If NDEBUG is applied inconsistently in compilation we might get 'ambiguous declaration' error. Let's make sure that the forward declaration matches glibc including all specifiers.

Test Plan: sandcastle

Differential Revision: D30030051

