### PR TITLE
correlate forward and backward op

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -744,9 +744,7 @@ class TestProfiler(TestCase):
                 f_ts_2 = flow_f_to_ts[2]
                 self.assertTrue(all([ts in ts_to_name.keys() for ts in [s_ts_1, f_ts_1, s_ts_2, f_ts_2]]))
                 self.assertTrue(ts_to_name[s_ts_1] == "aten::binary_cross_entropy_with_logits")
-                self.assertTrue(ts_to_name[f_ts_1] == "BinaryCrossEntropyWithLogitsBackward")
                 self.assertTrue(ts_to_name[s_ts_2] == "aten::add")
-                self.assertTrue(ts_to_name[f_ts_2] == "AddBackward0")
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -709,5 +709,44 @@ class TestProfiler(TestCase):
         if kineto_available():
             self._test_profiler_tracing(True)
 
+    def test_profiler_fwd_bwd_link(self):
+        with _profile(use_kineto=True) as prof:
+            t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
+            z = torch.add(t1, t2)
+            y = torch.ones(1)
+            loss = torch.nn.functional.binary_cross_entropy_with_logits(z, y)
+            loss.backward()
+        with TemporaryFileName(mode="w+") as fname:
+            prof.export_chrome_trace(fname)
+            with io.open(fname, 'r') as f:
+                j = json.load(f)
+                events = j["traceEvents"]
+                ts_to_name = {}
+                flow_s_to_ts = {}
+                flow_f_to_ts = {}
+                for e in events:
+                    if e["ph"] == "X":
+                        ts_to_name[e["ts"]] = e["name"]
+                    if "cat" in e and "name" in e and e["cat"] == "forward_backward" and e["name"] == "fwd_bwd":
+                        if e["ph"] == "s":
+                            flow_s_to_ts[e["id"]] = e["ts"]
+                        elif e["ph"] == "f":
+                            flow_f_to_ts[e["id"]] = e["ts"]
+                self.assertTrue(len(flow_s_to_ts) == 2)
+                self.assertTrue(len(flow_f_to_ts) == 2)
+                self.assertTrue(1 in flow_s_to_ts.keys())
+                self.assertTrue(1 in flow_f_to_ts.keys())
+                self.assertTrue(2 in flow_s_to_ts.keys())
+                self.assertTrue(2 in flow_f_to_ts.keys())
+                s_ts_1 = flow_s_to_ts[1]
+                f_ts_1 = flow_f_to_ts[1]
+                s_ts_2 = flow_s_to_ts[2]
+                f_ts_2 = flow_f_to_ts[2]
+                self.assertTrue(all([ts in ts_to_name.keys() for ts in [s_ts_1, f_ts_1, s_ts_2, f_ts_2]]))
+                self.assertTrue(ts_to_name[s_ts_1] == "aten::binary_cross_entropy_with_logits")
+                self.assertTrue(ts_to_name[f_ts_1] == "BinaryCrossEntropyWithLogitsBackward")
+                self.assertTrue(ts_to_name[s_ts_2] == "aten::add")
+                self.assertTrue(ts_to_name[f_ts_2] == "AddBackward0")
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -282,9 +282,10 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
       uint64_t key = getForwardThreadKey(kineto_event.fwdThreadId(), kineto_event.sequenceNr());
       auto iter = tidSeq2activity.find(key);
       if (iter != tidSeq2activity.end()) {
-        activity.flow.linkedActivity = iter->second; // Only destination side set this, to distinguish with start side.
-        activity.flow.id = ((libkineto::GenericTraceActivity*)(activity.flow.linkedActivity))->flow.id = fwd_bwd_link_id;
-        activity.flow.type = ((libkineto::GenericTraceActivity*)(activity.flow.linkedActivity))->flow.type = libkineto::kLinkFwdBwd;
+        libkineto::GenericTraceActivity* fwd = iter->second;
+        activity.flow.linkedActivity = fwd; // Only destination side set this, to distinguish with start side.
+        activity.flow.id = fwd->flow.id = fwd_bwd_link_id;
+        activity.flow.type = fwd->flow.type = libkineto::kLinkFwdBwd;
         ++fwd_bwd_link_id;
       }
     }


### PR DESCRIPTION
Use startThreadId+seqNumber of forward-op and fwdThreadId+seqNumber of backward-op to correlate pair of them.
third_party/kineto should be updated accordingly: https://github.com/pytorch/kineto/pull/372