### PR TITLE
delegate optional comparison operators to the underlying value type's operators

### DIFF
--- a/c10/test/util/optional_test.cpp
+++ b/c10/test/util/optional_test.cpp
@@ -1,5 +1,6 @@
 #include <c10/util/Optional.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -7,6 +8,14 @@
 #include <string>
 
 namespace {
+
+using testing::Eq;
+using testing::Ge;
+using testing::Gt;
+using testing::Le;
+using testing::Lt;
+using testing::Ne;
+using testing::Not;
 
 template <typename T>
 class OptionalTest : public ::testing::Test {
@@ -88,6 +97,83 @@ TYPED_TEST(OptionalTest, Initialized) {
     EXPECT_EQ(opt.value(), val);
     EXPECT_EQ(*opt, val);
   }
+}
+
+class SelfCompareTest : public testing::TestWithParam<c10::optional<int>> {};
+
+TEST_P(SelfCompareTest, SelfCompare) {
+  c10::optional<int> x = GetParam();
+  EXPECT_THAT(x, Eq(x));
+  EXPECT_THAT(x, Le(x));
+  EXPECT_THAT(x, Ge(x));
+  EXPECT_THAT(x, Not(Ne(x)));
+  EXPECT_THAT(x, Not(Lt(x)));
+  EXPECT_THAT(x, Not(Gt(x)));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    nullopt,
+    SelfCompareTest,
+    testing::Values(c10::nullopt));
+INSTANTIATE_TEST_SUITE_P(
+    int,
+    SelfCompareTest,
+    testing::Values(c10::make_optional(2)));
+
+TEST(OptionalTest, Nullopt) {
+  c10::optional<int> x = 2;
+
+  EXPECT_THAT(c10::nullopt, Not(Eq(x)));
+  EXPECT_THAT(x, Not(Eq(c10::nullopt)));
+
+  EXPECT_THAT(x, Ne(c10::nullopt));
+  EXPECT_THAT(c10::nullopt, Ne(x));
+
+  EXPECT_THAT(x, Not(Lt(c10::nullopt)));
+  EXPECT_THAT(c10::nullopt, Lt(x));
+
+  EXPECT_THAT(x, Not(Le(c10::nullopt)));
+  EXPECT_THAT(c10::nullopt, Le(x));
+
+  EXPECT_THAT(x, Gt(c10::nullopt));
+  EXPECT_THAT(c10::nullopt, Not(Gt(x)));
+
+  EXPECT_THAT(x, Ge(c10::nullopt));
+  EXPECT_THAT(c10::nullopt, Not(Ge(x)));
+}
+
+// Ensure comparisons work...
+using CmpTestTypes = testing::Types<
+    // between two optionals
+    std::pair<c10::optional<int>, c10::optional<int>>,
+    // between an optional and a value
+    std::pair<c10::optional<int>, int>,
+    // between a value and an optional
+    std::pair<int, c10::optional<int>>>;
+template <typename T>
+class CmpTest : public testing::Test {};
+TYPED_TEST_SUITE(CmpTest, CmpTestTypes);
+
+TYPED_TEST(CmpTest, Cmp) {
+  TypeParam pair = {2, 3};
+  auto x = pair.first;
+  auto y = pair.second;
+
+  EXPECT_THAT(x, Not(Eq(y)));
+
+  EXPECT_THAT(x, Ne(y));
+
+  EXPECT_THAT(x, Lt(y));
+  EXPECT_THAT(y, Not(Lt(x)));
+
+  EXPECT_THAT(x, Le(y));
+  EXPECT_THAT(y, Not(Le(x)));
+
+  EXPECT_THAT(x, Not(Gt(y)));
+  EXPECT_THAT(y, Gt(x));
+
+  EXPECT_THAT(x, Not(Ge(y)));
+  EXPECT_THAT(y, Ge(x));
 }
 
 } // namespace

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -964,7 +964,7 @@ constexpr bool operator==(const optional<T>& x, const optional<T>& y) {
 
 template <class T>
 constexpr bool operator!=(const optional<T>& x, const optional<T>& y) {
-  return !(x == y);
+  return x ? *x != y : bool(y);
 }
 
 template <class T>
@@ -974,17 +974,17 @@ constexpr bool operator<(const optional<T>& x, const optional<T>& y) {
 
 template <class T>
 constexpr bool operator>(const optional<T>& x, const optional<T>& y) {
-  return (y < x);
+  return x && *x > y;
 }
 
 template <class T>
 constexpr bool operator<=(const optional<T>& x, const optional<T>& y) {
-  return !(y < x);
+  return x ? *x <= y : !y;
 }
 
 template <class T>
 constexpr bool operator>=(const optional<T>& x, const optional<T>& y) {
-  return !(x < y);
+  return x ? *x >= y : !y;
 }
 
 // 20.5.9, Comparison with nullopt


### PR DESCRIPTION
Fixes #62566
