### PR TITLE
[Static Runtime] Enable TupleConstruct/TupleUnpack optimizations in static runtime

### DIFF
--- a/test/jit/test_peephole.py
+++ b/test/jit/test_peephole.py
@@ -571,3 +571,94 @@ class TestPeephole(JitTestCase):
         FileCheck().check("graph").check("):").check_next("aten::Int") \
                    .check_next("ListConstruct").check_next("return").run(foo.graph)
         self.assertEqual(foo(0, 1, 2, 3), [1, 3])
+
+    def test_peephole_dict_getitem_simple(self):
+        @torch.jit.script
+        def foo(a: int, b: int):
+            d = {0: a, 1: b}
+            x = d[1]
+            y = d[0]
+            return x, y
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check_not("DictConstruct").check_not("__getitem__").run(foo.graph)
+        self.assertEqual(foo(0, 1), (1, 0))
+
+    def test_peephole_dict_getitem_no_optimization_missing_key(self):
+        @torch.jit.script
+        def foo():
+            d = {0: 1}
+            return d[2]
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("__getitem__").run(foo.graph)
+
+    def test_peephole_dict_getitem_no_optimization_get_input_arg(self):
+        # Here we don't know if the input arg is in the dict, so we can't
+        # make the optimization.
+        @torch.jit.script
+        def foo(a: int):
+            d = {0: 1}
+            return d[a]
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("__getitem__").run(foo.graph)
+        self.assertEqual(foo(0), 1)
+
+    def test_peephole_dict_getitem_no_optimization_dict_modified(self):
+        @torch.jit.script
+        def foo():
+            d = {0: 1}
+            d[0] = 2
+            return d[0]
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("__getitem__").run(foo.graph)
+        self.assertEqual(foo(), 2)
+
+    def test_peephole_dict_getitem_no_optimization_overlapping_keys(self):
+        @torch.jit.script
+        def foo():
+            d = {0: 1, 0: 2}  # noqa: F601
+            return d[0]
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("__getitem__").run(foo.graph)
+
+    def test_peephole_dict_getitem_no_optimization_keys_might_overlap(self):
+        @torch.jit.script
+        def foo(x: int):
+            d = {0: 1, x: 2}
+            return d[x]
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("__getitem__").run(foo.graph)
+
+    def test_peephole_dict_len(self):
+        @torch.jit.script
+        def foo():
+            d = {0: 1, 1: 2}
+            return len(d)
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check_not("DictConstruct").check_not("len").run(foo.graph)
+        self.assertEqual(foo(), 2)
+
+    def test_peephole_dict_len_no_optimization_overlapping_keys(self):
+        @torch.jit.script
+        def foo():
+            d = {0: 1, 0: 2}  # noqa: F601
+            return len(d)
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("len").run(foo.graph)
+        self.assertEqual(foo(), 1)
+
+    def test_peephole_dict_len_no_optimization_keys_might_overlap(self):
+        @torch.jit.script
+        def foo(x: int):
+            d = {0: 1, x: 2}
+            return len(d)
+
+        self.run_pass("peephole", foo.graph)
+        FileCheck().check("DictConstruct").check("len").run(foo.graph)

--- a/torch/csrc/jit/passes/peephole_list_idioms.h
+++ b/torch/csrc/jit/passes/peephole_list_idioms.h
@@ -5,7 +5,54 @@
 namespace torch {
 namespace jit {
 
-// Peephole Optimizes List Ops such as len(li) and li[1].
+// Peephole Optimizes List and Dict Ops such as len(li) and li[1].
+// 1. Construct/Unpack optimizations
+// Given a function like this:
+//    def foo(a, b):
+//        li = [a, b]
+//        x, y = li
+//        return x, y
+// This pass produces (after dead code elimination):
+//    def foo(a, b):
+//        return a, b
+//
+// This is only applied to lists that are not modified.
+//
+// 2. getitem optimizations
+// Given a function like this:
+//     def foo(a, b):
+//         li = [a, b]
+//         x = li[0]
+//         return x
+// This pass produces (after dead code elimination):
+//     def foo(a, b):
+//         return a
+//
+// This optimization can only happen if the list is not modified.
+// A similar optimization is applied to dicts, with the additional
+// requirement that the dict has constant, non overlapping keys.
+//
+// 3. len optimizations
+// Given a function like this:
+//     def foo():
+//         li = [1, 2]
+//         return len(li)
+// This pass produces (after dead code elimination):
+//     def foo():
+//         return 2
+//
+// This has the same requirements as the getitem optimizations.
+//
+// 4. ListConstruct + ListConstruct
+// Given a function like this:
+//     def foo():
+//         return [1, 2] + [3, 4]
+// This pass produces (after dead code elimination):
+//     def foo():
+//         return [1, 2, 3, 4]
+//
+// This is only applied to lists that are not modified.
+//
 // Currently this is invoked as part of PeepholeOptimize
 // return true if graph is modified.
 // If `refine_list_len` is true will attempt to refine the len of lists through

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/peephole.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
@@ -63,7 +64,12 @@ void OptimizeGraph(
   ConstantPropagation(graph);
   RemoveTensorMutation(graph);
   ConstantPropagation(graph);
-  EliminateDeadCode(graph);
+  // PeepholeOptimize will call EliminateDeadCode if it changes
+  // the graph.
+  if (!PeepholeOptimize(graph)) {
+    EliminateDeadCode(graph);
+  }
+
   FuseInferenceOpsForSparseNN(graph);
   UseVariadicCat(graph);
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/lower_tuples.h>
 #include <torch/csrc/jit/passes/peephole.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
@@ -69,6 +70,7 @@ void OptimizeGraph(
   if (!PeepholeOptimize(graph)) {
     EliminateDeadCode(graph);
   }
+  LowerSimpleTuples(graph);
 
   FuseInferenceOpsForSparseNN(graph);
   UseVariadicCat(graph);


### PR DESCRIPTION
Summary:
Eliminate `EliminateTupleConstructUnpack` and `EliminateTupleUnpackConstruct` were two existing optimizations that were not enabled in static runtime. This diff:

* Moves the implementation from `torch/fb/opt/jit_graph_passes` to `torch/csrc/jit/passes`. These passes do not touch FB-only ops, so there is no reason for them to be in FB-only folders.
* Changed small stylistic things implementation to conform with the style of the other JIT passes
* Adds a more robust set of unit tests

Differential Revision: D30027299

