### PR TITLE
Make bazel output less verbose in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,9 @@
 build --copt=--std=c++14
 build --copt=-I.
 build --copt=-isystem --copt bazel-out/k8-fastbuild/bin
+
+# Configuration to disable tty features for environments like CI
+
+build:no-tty --curses no
+build:no-tty --progress_report_interval 10
+build:no-tty --show_progress_rate_limit 10

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -215,7 +215,7 @@ if [[ "$BUILD_ENVIRONMENT" == *-bazel-* ]]; then
 
   get_bazel
 
-  tools/bazel build :torch
+  tools/bazel build --config=no-tty :torch
 else
   # check that setup.py would fail with bad arguments
   echo "The next three invocations are expected to fail with invalid command error messages."


### PR DESCRIPTION
Fixes #62600

Adds `bazel --config=no-tty` that is useful for less verbose output in environments that don't implement full tty like CI.
