### PR TITLE
Add fill_ binding

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -502,6 +502,13 @@ at::Tensor LazyNativeFunctions::expand(const at::Tensor& self,
       lazy_tensors::util::ToVector<lazy_tensors::int64>(size)));
 }
 
+at::Tensor& LazyNativeFunctions::fill_(at::Tensor & self, const at::Scalar & value) {
+  LTC_FN_COUNTER("lazy::");
+  LazyTensor self_tensor = bridge::GetLtcTensor(self);
+  LazyTensor::fill_(self_tensor, value);
+  return self;
+}
+
 at::Tensor LazyNativeFunctions::ge(const at::Tensor& self,
                                    const at::Scalar& other) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -20,6 +20,7 @@ supported:
   - empty.memory_format
   - empty_strided
   - expand
+  - fill_.Scalar
   - leaky_relu
   - leaky_relu_backward
   - mm


### PR DESCRIPTION
Only the top-level tensor binding was needed, since LazyTensor::fill_
is already implemented in terms of setting a new generation of ir value.
