### PR TITLE
Cast some vars only used in macros that are sometimes empty to void

### DIFF
--- a/aten/src/ATen/native/MaxUnpooling.cpp
+++ b/aten/src/ATen/native/MaxUnpooling.cpp
@@ -72,6 +72,7 @@ Tensor max_unpooling2d_forward_out_cpu_frame(
           oheight,
           "x",
           owidth);
+      (void)error_index;
     }
   }
   return output;
@@ -203,6 +204,7 @@ Tensor max_unpooling3d_forward_out_cpu_frame(
             oH,
             "x",
             oW);
+        (void)error_index;
       }
     }
   }
@@ -382,6 +384,7 @@ static void max_unpooling2d_backward_out_cpu_frame(
         owidth,
         ", oheight= ",
         oheight);
+    (void)error_index;
   }
 }
 
@@ -526,6 +529,7 @@ static void max_unpooling3d_backward_out_cpu_frame(
         oW,
         ",oH= ",
         oH);
+    (void)error_index;
   }
 }
 

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -64,6 +64,7 @@ TORCH_META_FUNC(replication_pad1d_backward) (
   {
     // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     nbatch = input.size(0);
+    (void)nbatch;
     dimw++;
     dimslices++;
   }


### PR DESCRIPTION
Summary: These are sometimes unused and thus llvm-13 errors out

Test Plan: nfc

Reviewed By: drodriguez

Differential Revision: D30030754

