### PR TITLE
Initialize RRefs only when explicitly asked for.

### DIFF
--- a/test/distributed/_sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_sharded_tensor/test_sharded_tensor.py
@@ -32,7 +32,7 @@ class MyShardedModel2(torch.nn.Module):
     def __init__(self, spec=None, group=None):
         super(MyShardedModel2, self).__init__()
         if spec is not None:
-            self.sharded_tensor2 = _sharded_tensor.empty(spec, 10, 20, process_group=group)
+            self.sharded_tensor2 = _sharded_tensor.empty(spec, 10, 20, process_group=group, init_rrefs=True)
         else:
             self.sharded_tensor2 = None
         self.random_tensor2 = torch.nn.Parameter(torch.rand(2, 2))
@@ -42,7 +42,7 @@ class MyShardedModel1(torch.nn.Module):
     def __init__(self, spec=None, group=None):
         super(MyShardedModel1, self).__init__()
         if spec is not None:
-            self.sharded_tensor1 = _sharded_tensor.empty(spec, 10, 20, process_group=group)
+            self.sharded_tensor1 = _sharded_tensor.empty(spec, 10, 20, process_group=group, init_rrefs=True)
         else:
             self.sharded_tensor1 = None
         self.random_tensor1 = torch.nn.Parameter(torch.rand(2, 2))
@@ -128,7 +128,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
             ],
         )
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(torch.Size([10, 20]), sharded_tensor_metadata.size)
         self.assertEqual(torch.float, sharded_tensor_metadata.dtype)
@@ -137,11 +137,11 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
         self.assertEqual(torch.contiguous_format, sharded_tensor_metadata.memory_format)
         self.assertEqual(False, sharded_tensor_metadata.pin_memory)
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, requires_grad=True)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, requires_grad=True, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(True, sharded_tensor_metadata.requires_grad)
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, dtype=torch.double)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, dtype=torch.double, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(torch.double, sharded_tensor_metadata.dtype)
 
@@ -156,7 +156,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
             ],
         )
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, pin_memory=True)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, pin_memory=True, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(True, sharded_tensor_metadata.pin_memory)
 
@@ -175,7 +175,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
                     "rank:3/cuda:3",
                 ],
             )
-            sharded_tensor = _sharded_tensor.empty(spec, 10, 20)
+            sharded_tensor = _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
             # Validate local shard.
             local_shards = sharded_tensor.local_shards()
@@ -227,7 +227,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
                 "rank:3/cuda:3",
             ],
         )
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
         # Validate local shard.
         local_shards = sharded_tensor.local_shards()
@@ -278,7 +278,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
         )
 
         pg = dist.new_group(ranks=[1, 2, 3])
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, process_group=pg)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, process_group=pg, init_rrefs=True)
 
         # Validate local shard.
         local_shards = sharded_tensor.local_shards()
@@ -332,7 +332,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
                 "rank:3/cuda:3",
             ],
         )
-        sharded_tensor = _sharded_tensor.empty(spec, 16, 20)
+        sharded_tensor = _sharded_tensor.empty(spec, 16, 20, init_rrefs=True)
 
         # Validate local shards.
         local_shards = sharded_tensor.local_shards()
@@ -435,19 +435,17 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
             _sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, 'RPC was not initialized'):
+        with self.assertRaisesRegex(RuntimeError, 'RPC Framework needs to be initialized'):
+            st = _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
+
+        with self.assertRaisesRegex(RuntimeError, 'ShardedTensor created with init_rrefs=False'):
             st = _sharded_tensor.empty(spec, 10, 20)
             st.remote_shards()
 
         self.init_rpc()
-
-        # ShardedTensor was initialized before RPC.
-        with self.assertRaisesRegex(RuntimeError, 'RPC was not initialized'):
-            st.remote_shards()
-
         spec = ChunkShardingSpec(dim=0, placements=["workerfoo/cuda:1"])
         with self.assertRaisesRegex(ValueError, 'Invalid worker name'):
-            _sharded_tensor.empty(spec, 10, 20)
+            _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -467,7 +465,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:1/cuda:1"])
         with self.assertRaisesRegex(ValueError, 'Default ProcessGroup and RPC ranks must be the same'):
-            _sharded_tensor.empty(spec, 10, 20)
+            _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -520,19 +518,19 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
         )
 
         # Test with *args
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 20)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
         self.assertEqual(torch.Size([10, 20]), sharded_tensor.size())
 
         # Test with single *args
-        sharded_tensor = _sharded_tensor.empty(spec, 10)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, init_rrefs=True)
         self.assertEqual(torch.Size([10]), sharded_tensor.size())
 
         # Test with list
-        sharded_tensor = _sharded_tensor.empty(spec, [10, 20])
+        sharded_tensor = _sharded_tensor.empty(spec, [10, 20], init_rrefs=True)
         self.assertEqual(torch.Size([10, 20]), sharded_tensor.size())
 
         # Test with tuple
-        sharded_tensor = _sharded_tensor.empty(spec, (10, 20))
+        sharded_tensor = _sharded_tensor.empty(spec, (10, 20), init_rrefs=True)
         self.assertEqual(torch.Size([10, 20]), sharded_tensor.size())
 
         with self.assertRaises(TypeError):
@@ -636,6 +634,8 @@ class TestShardedTensorChunked(ShardedTensorTestBase, MultiProcessTestCase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_load_state_dict_errors(self):
+        self.init_rpc()
+
         dist.init_process_group(
             backend="nccl",
             world_size=self.world_size,
@@ -707,7 +707,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
             )
         ])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(torch.Size([10, 10]), sharded_tensor_metadata.size)
         self.assertEqual(torch.float, sharded_tensor_metadata.dtype)
@@ -716,11 +716,11 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
         self.assertEqual(torch.contiguous_format, sharded_tensor_metadata.memory_format)
         self.assertEqual(False, sharded_tensor_metadata.pin_memory)
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, requires_grad=True)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, requires_grad=True, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(True, sharded_tensor_metadata.requires_grad)
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, dtype=torch.double)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, dtype=torch.double, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(torch.double, sharded_tensor_metadata.dtype)
 
@@ -748,7 +748,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
             )
         ])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, pin_memory=True)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, pin_memory=True, init_rrefs=True)
         sharded_tensor_metadata = sharded_tensor.metadata()
         self.assertEqual(True, sharded_tensor_metadata.pin_memory)
 
@@ -780,7 +780,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
             )
         ])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), sharded_tensor.size())
         self.assertEqual(1, len(sharded_tensor.local_shards()))
 
@@ -902,7 +902,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
             ),
         ])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 5)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 5, init_rrefs=True)
         self.assertEqual((10, 5), sharded_tensor.size())
         if self.rank <= 1:
             self.assertEqual(1, len(sharded_tensor.local_shards()))
@@ -963,7 +963,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
 
         pg = dist.new_group(ranks=[1, 2, 3])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 5, process_group=pg)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 5, process_group=pg, init_rrefs=True)
         self.assertEqual((10, 5), sharded_tensor.size())
         if self.rank == 1 or self.rank == 3:
             # Verify local shard.
@@ -1028,7 +1028,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
             )
         ])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), sharded_tensor.size())
 
         if self.rank <= 1:
@@ -1097,7 +1097,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase, MultiProcessTestCase):
             )
         ])
 
-        sharded_tensor = _sharded_tensor.empty(spec, 10, 10)
+        sharded_tensor = _sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), sharded_tensor.size())
         self.assertEqual(1, len(sharded_tensor.local_shards()))
 
@@ -1167,7 +1167,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
             pin_memory=False,
         )
 
-        sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata)
+        sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata, init_rrefs=True)
         self.assertEqual((10, 10), sharded_tensor.size())
         self.assertEqual(1, len(sharded_tensor.local_shards()))
 
@@ -1233,7 +1233,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
             memory_format=torch.contiguous_format,
             pin_memory=False,
         )
-        sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata, new_pg)
+        sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata, new_pg, init_rrefs=True)
 
         if self.rank == 1 or self.rank == 3:
             # Verify local shard.
@@ -1305,28 +1305,28 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
 
         empty_local_shards = []
         with self.assertRaisesRegex(RuntimeError, 'does not match number of local shards metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(empty_local_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(empty_local_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_num_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata),
             _sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)
         ]
         with self.assertRaisesRegex(RuntimeError, 'does not match number of local shards metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_num_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_num_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_size_shards = [_sharded_tensor.Shard(torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata)]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor is incompatible with'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_size_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_size_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_device_shards = [_sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor device does not match with local Shard placement'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_device_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_device_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_dtype_shards = [
             _sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=torch.int), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor dtype does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_dtype_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_dtype_shards, sharded_tensor_metadata, init_rrefs=True)
 
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
@@ -1336,25 +1336,25 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
             _sharded_tensor.Shard(sparse_tensor, local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor layout does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_layout_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_layout_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_requires_grad_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor requires_grad does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_requires_grad_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_requires_grad_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_pin_memory_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, pin_memory=True), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor pin_memory does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_pin_memory_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_pin_memory_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_memory_format_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_memory_format_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_memory_format_shards, sharded_tensor_metadata, init_rrefs=True)
 
 
     @with_comms
@@ -1393,7 +1393,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
         local_shards = [_sharded_tensor.Shard(torch.randn(local_shard_size, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
         with self.assertRaisesRegex(ValueError, "overlap"):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata, init_rrefs=True)
 
 
     @with_comms
@@ -1432,4 +1432,4 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
         local_shards = [_sharded_tensor.Shard(torch.randn(local_shard_size, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
         with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(local_shards, sharded_tensor_metadata, init_rrefs=True)

--- a/test/distributed/_sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_sharded_tensor/test_sharded_tensor.py
@@ -1336,25 +1336,29 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase, MultiProcessTestCa
             _sharded_tensor.Shard(sparse_tensor, local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor layout does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_layout_shards, sharded_tensor_metadata, init_rrefs=True)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(
+                wrong_layout_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_requires_grad_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor requires_grad does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_requires_grad_shards, sharded_tensor_metadata, init_rrefs=True)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(
+                wrong_requires_grad_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_pin_memory_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, pin_memory=True), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Local shard tensor pin_memory does not match with sharded_tensor_metadata'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_pin_memory_shards, sharded_tensor_metadata, init_rrefs=True)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(
+                wrong_pin_memory_shards, sharded_tensor_metadata, init_rrefs=True)
 
         wrong_memory_format_shards = [
             _sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata)
         ]
         with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
-            sharded_tensor = _sharded_tensor.init_from_local_shards(wrong_memory_format_shards, sharded_tensor_metadata, init_rrefs=True)
+            sharded_tensor = _sharded_tensor.init_from_local_shards(
+                wrong_memory_format_shards, sharded_tensor_metadata, init_rrefs=True)
 
 
     @with_comms

--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -17,7 +17,9 @@ def empty(
         requires_grad=False,
         pin_memory=False,
         memory_format=torch.contiguous_format,
-        process_group=None,):
+        process_group=None,
+        init_rrefs=False,
+    ):
     """
     Creates an empty :class:`ShardedTensor`. Needs to be called on all ranks in an SPMD fashion.
 
@@ -40,6 +42,10 @@ def empty(
             returned Tensor. Default: ``torch.contiguous_format``.
         process_group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
+        init_rrefs (bool, optional): Whether or not to initialize
+            :class:`torch.distributed.rpc.RRef`s pointing to remote shards.
+            Need to initialize the RPC Framework if specified as ``True``.
+            Default: ``False``.
 
     Returns:
         A :class:`ShardedTensor` object on each rank
@@ -52,12 +58,16 @@ def empty(
         requires_grad=requires_grad,
         pin_memory=pin_memory,
         memory_format=memory_format,
-        process_group=process_group)
+        process_group=process_group,
+        init_rrefs=init_rrefs,
+    )
 
 def init_from_local_shards(
         local_shards: List[Shard],
         sharded_tensor_metadata: ShardedTensorMetadata,
-        process_group=None):
+        process_group=None,
+        init_rrefs=False,
+    ):
     """
     Creates an :class:`ShardedTensor` from local shards and the global metadata.
     Needs to be called on all ranks in an SPMD fashion.
@@ -74,6 +84,10 @@ def init_from_local_shards(
     Keyword args:
         process_group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
+        init_rrefs (bool, optional): Whether or not to initialize
+            :class:`torch.distributed.rpc.RRef`s pointing to remote shards.
+            Need to initialize the RPC Framework if specified as ``True``.
+            Default: ``False``.
 
     Returns:
         A :class:`ShardedTensor` object handle on this rank
@@ -81,7 +95,9 @@ def init_from_local_shards(
     return ShardedTensor._init_from_local_shards(
         local_shards,
         sharded_tensor_metadata,
-        process_group=process_group)
+        process_group=process_group,
+        init_rrefs=init_rrefs
+    )
 
 def state_dict_hook(module, destination, prefix, local_metadata):
     """

--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -18,8 +18,7 @@ def empty(
         pin_memory=False,
         memory_format=torch.contiguous_format,
         process_group=None,
-        init_rrefs=False,
-    ):
+        init_rrefs=False):
     """
     Creates an empty :class:`ShardedTensor`. Needs to be called on all ranks in an SPMD fashion.
 
@@ -66,8 +65,7 @@ def init_from_local_shards(
         local_shards: List[Shard],
         sharded_tensor_metadata: ShardedTensorMetadata,
         process_group=None,
-        init_rrefs=False,
-    ):
+        init_rrefs=False):
     """
     Creates an :class:`ShardedTensor` from local shards and the global metadata.
     Needs to be called on all ranks in an SPMD fashion.

--- a/torch/distributed/_sharded_tensor/api.py
+++ b/torch/distributed/_sharded_tensor/api.py
@@ -96,14 +96,15 @@ class ShardedTensorMetadata(object):
             self.layout,
             self.requires_grad,
             mem_format_encoding,
-            self.pin_memory
+            self.pin_memory,
         )
 
     def __setstate__(
         self,
         state,
     ):
-        self.shards_metadata, self.size, self.dtype, self.layout, self.requires_grad, mem_format_encoding, self.pin_memory = state
+        (self.shards_metadata, self.size, self.dtype, self.layout,
+            self.requires_grad, mem_format_encoding, self.pin_memory) = state
 
         if mem_format_encoding == 0:
             self.memory_format = torch.contiguous_format
@@ -161,6 +162,10 @@ class ShardedTensor(object):
             the default process group will be used. If specified the ShardedTensor is only
             built on ranks that are part of this process group and the provided ``sharding_spec``
             is applied in the context of this process group.
+        init_rrefs (bool, optional): Whether or not to initialize
+            :class:`torch.distributed.rpc.RRef`s pointing to remote shards.
+            Need to initialize the RPC Framework if specified as ``True``.
+            Default: ``False``.
     """
 
     def __init__(
@@ -173,10 +178,11 @@ class ShardedTensor(object):
         pin_memory=False,
         memory_format=torch.contiguous_format,
         process_group=None,
+        init_rrefs=False,
     ):
         # prepare initialization, initialize fields like
         # _process_group, _local_shards, etc.
-        self._prepare_init(process_group=process_group)
+        self._prepare_init(process_group=process_group, init_rrefs=init_rrefs)
 
         if dtype is None:
             dtype = torch.get_default_dtype()
@@ -222,8 +228,8 @@ class ShardedTensor(object):
         # do post initialization (i.e. register sharded_tensor_id, initialize_rpc)
         self._post_init()
 
-    def _prepare_init(self, process_group=None):
-        self._rpc_initialized = False
+    def _prepare_init(self, process_group=None, init_rrefs=False):
+        self._init_rrefs = init_rrefs
         self._sharded_tensor_id = None
         if rpc._is_current_rpc_agent_set():
             # Validate PG and RPC ranks match.
@@ -254,7 +260,11 @@ class ShardedTensor(object):
             _sharded_tensor_current_id += 1
 
         # Initialize RPC if available.
-        if rpc._is_current_rpc_agent_set():
+        if self._init_rrefs:
+            if not rpc._is_current_rpc_agent_set():
+                raise RuntimeError(
+                    'RPC Framework needs to be initialized using'
+                    ' torch.distributed.rpc.init_rpc if init_rrefs is set to True')
             self._init_rpc()
 
     def __del__(self):
@@ -265,7 +275,6 @@ class ShardedTensor(object):
                 _sharded_tensor_map.pop(self._sharded_tensor_id)  # type: ignore[call-overload]
 
     def _init_rpc(self):
-        self._rpc_initialized = True
         self._remote_shards = {}
 
         # Gather all the sharded tensor ids.
@@ -306,7 +315,8 @@ class ShardedTensor(object):
         cls,
         local_shards: List[Shard],
         sharded_tensor_metadata: ShardedTensorMetadata,
-        process_group=None
+        process_group=None,
+        init_rrefs=False,
     ):
         shards_metadata = sharded_tensor_metadata.shards_metadata
 
@@ -319,7 +329,7 @@ class ShardedTensor(object):
         sharded_tensor = cls.__new__(cls)
 
         # prepare initialization
-        sharded_tensor._prepare_init(process_group=process_group)
+        sharded_tensor._prepare_init(process_group=process_group, init_rrefs=init_rrefs)
 
         sharded_tensor._metadata = sharded_tensor_metadata
 
@@ -591,11 +601,12 @@ class ShardedTensor(object):
         Returns a Dict[int, RRef] with keys being the RPC rank and values
         being RRefs to shards on that rank. Need to initialize the
         RPC framework for this functionality.
+
+        Raises an exception if ShardedTensor was created with ``init_rrefs=False``
         """
-        if not self._rpc_initialized:
+        if not self._init_rrefs:
             raise RuntimeError(
-                "RPC was not initialized before creating the ShardedTensor. Please initialize it using "
-                "torch.distributed.rpc.init_rpc before creating the ShardedTensor for remote_shards support"
+                'ShardedTensor created with init_rrefs=False, no RRefs to remote shards available'
             )
         return self._remote_shards
 
@@ -620,7 +631,7 @@ class ShardedTensor(object):
             distributed_c10d.get_world_size(),
         )
 
-        return self._local_shards, self._metadata, pg_state, self._sharding_spec
+        return self._local_shards, self._metadata, pg_state, self._sharding_spec, self._init_rrefs
 
     def __setstate__(self, state):
         self._sharded_tensor_id = None
@@ -629,8 +640,7 @@ class ShardedTensor(object):
                 'Need to initialize default process group using '
                 '"init_process_group" before loading ShardedTensor')
 
-        self._local_shards, self._metadata, pg_state, self._sharding_spec = state
-        self._rpc_initialized = False
+        self._local_shards, self._metadata, pg_state, self._sharding_spec, self._init_rrefs = state
 
         # Setup process group
         global _CURRENT_PROCESS_GROUP

--- a/torch/distributed/_sharded_tensor/api.py
+++ b/torch/distributed/_sharded_tensor/api.py
@@ -231,16 +231,6 @@ class ShardedTensor(object):
     def _prepare_init(self, process_group=None, init_rrefs=False):
         self._init_rrefs = init_rrefs
         self._sharded_tensor_id = None
-        if rpc._is_current_rpc_agent_set():
-            # Validate PG and RPC ranks match.
-            pg_rank = dist.get_rank()
-            rpc_rank = rpc.get_worker_info().id
-            if pg_rank != rpc_rank:
-                raise ValueError(
-                    f'Default ProcessGroup and RPC ranks must be '
-                    f'the same for ShardedTensor, found process group rank: '
-                    f'{pg_rank} and RPC rank: {rpc_rank}'
-                )
 
         self._process_group = (
             process_group
@@ -275,6 +265,16 @@ class ShardedTensor(object):
                 _sharded_tensor_map.pop(self._sharded_tensor_id)  # type: ignore[call-overload]
 
     def _init_rpc(self):
+        # Validate PG and RPC ranks match.
+        pg_rank = dist.get_rank()
+        rpc_rank = rpc.get_worker_info().id
+        if pg_rank != rpc_rank:
+            raise ValueError(
+                f'Default ProcessGroup and RPC ranks must be '
+                f'the same for ShardedTensor, found process group rank: '
+                f'{pg_rank} and RPC rank: {rpc_rank}'
+            )
+
         self._remote_shards = {}
 
         # Gather all the sharded tensor ids.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62618
* #62242

ShardedTensor implicitly initialized RRefs to remote shards if the
RPC framework was initialized. Although, there are use cases where the RPC
framework might be initialized for a different purpose but users would not
prefer that ShardedTensor initializes RRefs as well.

As a result, I've made RRef initialization explcitit in ShardedTensor APIs.

Differential Revision: [D30056833](https://our.internmc.facebook.com/intern/diff/D30056833/)