### PR TITLE
[Static Runtime] testStaticRuntime verifies that # of nodes is at least 2

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -48,7 +48,7 @@ const auto list_unpack_script = R"JIT(
     c = [a, b]
     x, y = c
     z = x + y
-    return z
+    return z.clone()
 )JIT";
 
 const auto list_unpack_script_2 = R"JIT(

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -197,6 +197,12 @@ void testStaticRuntime(
     auto smodule = test_context->makeStaticModule(
         {true, enable_out_variant, enable_out_variant});
     auto actual = smodule(args, {});
+    if (actual.isTensor()) {
+      EXPECT_GE(smodule.nodes().size(), 2)
+          << "If we only have one node, the output of the op we are testing is "
+          << "not being managed by the memory planner! A failure here "
+          << "can typically be fixed by clone()ing the output of the test script.";
+    }
     smodule.runtime().check_for_memory_leak();
     // first run
     compareResults(expect, actual, use_allclose, use_equalnan);


### PR DESCRIPTION
Summary: This allows us to catch cases where an out variant is being tested but the test author forgot to call `.clone()` in the test script. More than 2 ops does not guarantee that the memory planner is being exercised, but less than 2 guarantees that it is not being used.

Differential Revision: D30058050

