### PR TITLE
TensorAccessor::bounds_check should be a CPU-only funciton

### DIFF
--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -156,7 +156,7 @@ protected:
   PtrType data_;
   index_t sizes_[N];
   index_t strides_[N];
-  C10_HOST_DEVICE void bounds_check_(index_t i) const {
+  C10_HOST void bounds_check_(index_t i) const {
     TORCH_CHECK_INDEX(
         0 <= i && i < N,
         "Index ",


### PR DESCRIPTION
Summary:
This fixes following errors when ROCm compiler is used
```
caffe2/aten/src/ATen/core/TensorAccessor.h:160:5: error: throw is prohibited in AMP-restricted functions
    TORCH_CHECK_INDEX(
    ^
```

Test Plan: CI

Differential Revision: D30059737

