### PR TITLE
[caffe2] break one circular dependency between Caffe2 and ATen-cpu

### DIFF
--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -16,8 +16,9 @@
 #include <c10/util/ArrayRef.h>
 
 #if !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
+#include <c10/core/GeneratorImpl.h>
 #include <ATen/core/DistributionsHelper.h>
-#include <ATen/CPUGeneratorImpl.h>
+#include <ATen/core/MT19937RNGEngine.h>
 #else
 #include "caffe2/core/distributions_stubs.h"
 #endif
@@ -47,7 +48,38 @@ TORCH_API uint32_t RandomNumberSeed();
 class TORCH_API CPUContext final : public BaseContext {
  public:
 #if !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
-  typedef at::CPUGeneratorImpl rand_gen_type;
+  class rand_gen_type {
+   public:
+    explicit rand_gen_type(uint64_t seed_in = default_rng_seed_val)
+        : engine_{seed_in} {}
+
+    uint32_t random() {
+      return engine_();
+    }
+    uint64_t random64() {
+      uint32_t random1 = engine_();
+      uint32_t random2 = engine_();
+      return (static_cast<uint64_t>(random1) << 32) | random2;
+    }
+
+    c10::optional<float> next_float_normal_sample() {
+      return next_float_normal_sample_;
+    }
+    c10::optional<double> next_double_normal_sample() {
+      return next_double_normal_sample_;
+    }
+    void set_next_float_normal_sample(c10::optional<float> randn) {
+      next_float_normal_sample_ = randn;
+    }
+    void set_next_double_normal_sample(c10::optional<double> randn) {
+      next_double_normal_sample_ = randn;
+    }
+
+   private:
+    at::mt19937 engine_;
+    c10::optional<float> next_float_normal_sample_;
+    c10::optional<double> next_double_normal_sample_;
+  };
 #else
   typedef std::mt19937 rand_gen_type;
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62632

Update the caffe2/core/context.h to directly use `at::mt19937` instead of the
`at::CPUGeneratorImpl` wrapper class from the ATen-cpu library.

Using `at::CPUGeneratorImpl` causes circular dependencies between the ATen and
caffe2 code.  In particular the `at::CPUGeneratorImpl::get_state()` logic
depends on CPU Tensor functionality that currently depends on code from
caffe2.

Differential Revision: [D29915701](https://our.internmc.facebook.com/intern/diff/D29915701/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29915701/)!