### PR TITLE
[not for land] hack for replacing torch.add with toq.add via Python AST

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -45,9 +45,9 @@ def _compile_and_register_class(obj, rcb, qualified_name):
 
     return script_class
 
-def make_stub(func, name):
+def make_stub(func, name, parent_module=None):
     rcb = _jit_internal.createResolutionCallbackFromClosure(func)
-    ast = get_jit_def(func, name, self_name="RecursiveScriptModule")
+    ast = get_jit_def(func, name, self_name="RecursiveScriptModule", parent_module=parent_module)
     return ScriptMethodStub(rcb, ast, func)
 
 def make_stub_from_method(nn_module, method_name):
@@ -62,7 +62,7 @@ def make_stub_from_method(nn_module, method_name):
     #   forward = _forward
     # In this case, the actual function object will have the name `_forward`,
     # even though we requested a stub for `forward`.
-    return make_stub(func, method_name)
+    return make_stub(func, method_name, parent_module=nn_module)
 
 
 def make_stubs_from_exported_methods(mod):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62652

Summary:

POC for replacing `torch.add` with `torch.ops.quantized.add` in the
Python AST before it's handed off to the `torch.jit.script` compiler.
Not for land, just hacking for now. In detail:

1. mock `_auto_quant_state` on the module (the real object would be
created by the auto quantization code).
2. add a hook to `torch.jit.script` to modify the AST if
`_auto_quant_state` is present on current module
3. logic to rewrite Python AST and swap `torch.add` with `torch.ops.quantized.add`

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_torch_jit_script_ast_rewrite
python test/test_quantization.py TestQuantizeFx.test_naive_ast_rewrite
```

Reviewers:

Subscribers:

Tasks:

Tags: