### PR TITLE
Add getPyInterpreter() API

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -107,6 +107,10 @@ PyInterpreterHolder self_interpreter;
 
 } // anonymous namespace
 
+c10::impl::PyInterpreter* getPyInterpreter() {
+  return self_interpreter.get();
+}
+
 namespace py = pybind11;
 
 PyObject *THPVariableClass = nullptr;

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -51,3 +51,5 @@ inline const at::Tensor& THPVariable_Unpack(THPVariable* var) {
 inline const at::Tensor& THPVariable_Unpack(PyObject* obj) {
   return THPVariable_Unpack(reinterpret_cast<THPVariable*>(obj));
 }
+
+THP_API c10::impl::PyInterpreter* getPyInterpreter();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62660
* __->__ #62659
* #62658

It turns out that it is occasionally useful to be able to access the
PyInterpreter object from other Python bindings (see next diff in the
stack).  Make it publicly available.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D30074926](https://our.internmc.facebook.com/intern/diff/D30074926)