### PR TITLE
Add hasattr to torch::deploy interface and hasMethod to PredictorContainer

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -203,6 +203,13 @@ struct TORCH_API ReplicatedObj {
     TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
+  [[nodiscard]] bool hasattr(const char* name) const {
+    TORCH_DEPLOY_TRY
+    auto I = acquire_session();
+    return I.self.hasattr(name);
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
+  }
+
   void unload(const Interpreter* on_this_interpreter = nullptr);
 
  private:

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -494,6 +494,10 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterSessionImpl
     return call_kwargs(obj, args, kwargs);
   }
 
+  bool hasattr(Obj obj, const char* attr) override {
+    return py::hasattr(unwrap(obj), attr);
+  }
+
   Obj attr(Obj obj, const char* attr) override {
     return wrap(unwrap(obj).attr(attr));
   }

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -78,6 +78,7 @@ struct Obj {
       std::vector<at::IValue> args,
       std::unordered_map<std::string, c10::IValue> kwargs);
   Obj call_kwargs(std::unordered_map<std::string, c10::IValue> kwargs);
+  bool hasattr(const char* attr);
   Obj attr(const char* attr);
 
  private:
@@ -116,6 +117,7 @@ struct InterpreterSessionImpl {
       Obj obj,
       std::unordered_map<std::string, c10::IValue> kwargs) = 0;
   virtual Obj attr(Obj obj, const char* attr) = 0;
+  virtual bool hasattr(Obj obj, const char* attr) = 0;
 
  protected:
   int64_t ID(Obj obj) const {
@@ -165,6 +167,12 @@ inline Obj Obj::call_kwargs(
   return interaction_->call_kwargs(*this, std::move(kwargs));
   TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
+inline bool Obj::hasattr(const char* attr) {
+  TORCH_DEPLOY_TRY
+  return interaction_->hasattr(*this, attr);
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
+}
+
 inline Obj Obj::attr(const char* attr) {
   TORCH_DEPLOY_TRY
   return interaction_->attr(*this, attr);

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -132,6 +132,10 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
   kwargs["input"] = input;
   auto jit_output_kwargs = model.call_kwargs(kwargs).toTensor();
   ASSERT_TRUE(ref_output.equal(jit_output_kwargs));
+
+  // test hasattr
+  ASSERT_TRUE(model.hasattr("forward"));
+  ASSERT_FALSE(model.hasattr("make_prediction"));
 }
 
 TEST(TorchpyTest, ThreadedSimpleModel) {


### PR DESCRIPTION
Summary:
Useful to avoid having to implement null checking on the application side.

Note that I did not support the submodule logic in 'hasMethod'.  I would like to hear thoughts on whether this would be valuable or not, or could be added later.

For now, this is useful for the batching diff that follows, where all the relevant methods are at the top level.

Test Plan: Add unit tests

Differential Revision: D30074406

