### PR TITLE
[fx] add __eq__ to GraphModule

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -661,6 +661,26 @@ class {module_name}(torch.nn.Module):
         new_gm._is_replica = True
         return new_gm
 
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, other) -> bool:
+        """
+        Checks equality of ``GraphModule``s with `other` where equality is
+        defined as: underlying graph nodes are equal and their order in
+        the node list is topologically equivalent.
+
+        Assumes `self` and `other` graphs are valid, i.e. have topologically
+        ordered node lists.
+        """
+        # Check graphs contains same set of nodes
+        if (
+            len(self.graph.nodes) != len(other.graph.nodes)
+            or set(self.graph.nodes) != set(other.graph.nodes)
+        ):
+            return False
+        return True
+
 # workarounds for issues in __torch_function__
 
 # WAR for __torch_function__ not handling tensor lists,


### PR DESCRIPTION
Summary:
Defines equality of ``GraphModule``s as equality of underlying graph nodes, up to topological equivalence.

This makes use of equality at ``Node`` level, which defaults to `is` when `__eq__` is not implemented (as currently). Because of this, if a module is traced twice, the resulting ``GraphModule``s are not 'equal', because the underlying ``Node``s do not pass `is` equality. This could be supported by implementing `__eq__` in ``Node`` as well.

Test Plan:
```buck test mode/dev //caffe2/test:fx
```
```
Summary
  Pass: 623
  Skip: 328
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_linalg_inv_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_sigmoid_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_fft_irfft_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_rsqrt_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_outer_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_dsplit_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_sinc_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_fft_irfftn_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_maximum_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ↻ caffe2/test:fx - test_get_torch_func_signature_exhaustive_logaddexp2_meta_float32 (test_fx.TestOperatorSignaturesMETA)
    ...and 318 more not shown...
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/2533274857065372
```

Differential Revision: D29945856

