### PR TITLE
[static runtime][pyper] temporarily disable NNC for startup time

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -23,7 +23,7 @@
 
 C10_DEFINE_bool(
     static_runtime_enable_fast_math,
-    true,
+    false,
     "If on, static runtime may use use optimizations that cause accurary loss "
     "vs the jit interpreter");
 


### PR DESCRIPTION
Summary: Temporarily disable NNC, which generates kernels per instance of the ops enabled with NNC

Test Plan:
Test with model from https://fb.quip.com/gbrdA7l0Y7Nb#aAeACA6PDg5
tw ansha_sr_mc_candi_288468456_1

Differential Revision: D30081187

