### PR TITLE
Allow disabled tests to be re-enabled with IGNORE_DISABLED_ISSUES

### DIFF
--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -5,8 +5,22 @@ import json
 import os
 import pathlib
 import re
-from typing import Any, Callable, Dict, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 from urllib.request import urlopen
+
+# PYTORCH_IGNORE_DISABLED_ISSUES should only be set during CI (along with IN_CI) as a
+# comma-separated list of issue numbers. The intent is to re-enable any disabled tests
+# associated with the issues in this list.
+#
+# There is normally no reason to use this locally as the disabled tests list should not
+# affect your local development and every test should be enabled. If for whatever reason
+# you would like to use this during local development, please note the following caveat:
+#
+# Whenever you set OR reset PYTORCH_IGNORE_DISABLED_ISSUES, you should delete the existing
+# .pytorch-disabled-tests.json and redownload/parse the file for your change to apply, as
+# PYTORCH_IGNORE_DISABLED_ISSUES is used during the parsing stage. To download the files,
+# run test/run_test.py with IN_CI=1.
+IGNORE_DISABLED_ISSUES: List[str] = os.getenv('PYTORCH_IGNORE_DISABLED_ISSUES', '').split(',')
 
 SLOW_TESTS_FILE = '.pytorch-slow-tests.json'
 DISABLED_TESTS_FILE = '.pytorch-disabled-tests.json'
@@ -63,7 +77,9 @@ def get_disabled_tests(dirpath: str, filename: str = DISABLED_TESTS_FILE) -> Opt
         for item in the_response['items']:
             title = item['title']
             key = 'DISABLED '
-            if title.startswith(key):
+            issue_url = item['html_url']
+            issue_number = issue_url.split('/')[-1]
+            if title.startswith(key) and issue_number not in IGNORE_DISABLED_ISSUES:
                 test_name = title[len(key):].strip()
                 body = item['body']
                 platforms_to_skip = []

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -38,7 +38,7 @@ import tempfile
 import json
 import __main__  # type: ignore[import]
 import errno
-from typing import cast, Any, Dict, List, Iterable, Iterator, Optional, Union
+from typing import cast, Any, Dict, Iterable, Iterator, Optional, Union
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -425,17 +425,6 @@ TEST_WITH_SLOW = os.getenv('PYTORCH_TEST_WITH_SLOW', '0') == '1'
 # run *only* slow tests.  (I could have done an enum, but
 # it felt a little awkward.
 TEST_SKIP_FAST = os.getenv('PYTORCH_TEST_SKIP_FAST', '0') == '1'
-
-# Enables tests disabled by existing issues (these tests are disabled by default)
-# This is usually used locally or during fix PRs. This will enable
-# ALL disabled tests, even if PYTORCH_IGNORE_DISABLED_ISSUES is set to a smaller set.
-# This does NOT interfere with other test disablement and only disables tests
-# marked by issues.
-RUN_DISABLED_TESTS = os.getenv('PYTORCH_RUN_DISABLED_TESTS', '0') == '1'
-
-# A list of issue numbers. This will re-enable any disabled tests associated with
-# the issues in this list.
-IGNORE_DISABLED_ISSUES: List[str] = os.getenv('PYTORCH_IGNORE_DISABLED_ISSUES', '').split(',')
 
 # Disables noarch tests; all but one CI configuration disables these.  We don't
 # disable them for local runs because you still want to run them
@@ -910,23 +899,21 @@ def check_if_enable(test: unittest.TestCase):
         getattr(test, test._testMethodName).__dict__['slow_test'] = True
         if not TEST_WITH_SLOW:
             raise unittest.SkipTest("test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test")
-    if not RUN_DISABLED_TESTS and not IS_SANDCASTLE and disabled_tests_dict is not None:
+    if not IS_SANDCASTLE and disabled_tests_dict is not None:
         if test_name in disabled_tests_dict:
             issue_url, platforms = disabled_tests_dict[test_name]
-            issue_number = issue_url.split('/')[-1]
-            if issue_number not in IGNORE_DISABLED_ISSUES:
-                platform_to_conditional: Dict = {
-                    "mac": IS_MACOS,
-                    "macos": IS_MACOS,
-                    "windows": IS_WINDOWS,
-                    "linux": IS_LINUX
-                }
-                if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
-                    raise unittest.SkipTest(
-                        f"Test is disabled because an issue exists disabling it: {issue_url}" +
-                        f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}." +
-                        " To enable, set the environment variable PYTORCH_RUN_DISABLED_TESTS=1 or " +
-                        f"IGNORE_DISABLED_ISSUES={issue_number}")
+            platform_to_conditional: Dict = {
+                "mac": IS_MACOS,
+                "macos": IS_MACOS,
+                "windows": IS_WINDOWS,
+                "linux": IS_LINUX
+            }
+            if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
+                raise unittest.SkipTest(
+                    f"Test is disabled because an issue exists disabling it: {issue_url}" +
+                    f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}. " +
+                    "If you're seeing this on your local machine and would like to enable this test, " +
+                    "please make sure IN_CI is not set and you are not using the flag --import-disabled-tests.")
     if TEST_SKIP_FAST:
         if not getattr(test, test._testMethodName).__dict__.get('slow_test', False):
             raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -428,14 +428,14 @@ TEST_SKIP_FAST = os.getenv('PYTORCH_TEST_SKIP_FAST', '0') == '1'
 
 # Enables tests disabled by existing issues (these tests are disabled by default)
 # This is usually used locally or during fix PRs. This will enable
-# ALL disabled tests, even if IGNORE_DISABLED_ISSUES is set to a smaller set.
+# ALL disabled tests, even if PYTORCH_IGNORE_DISABLED_ISSUES is set to a smaller set.
 # This does NOT interfere with other test disablement and only disables tests
 # marked by issues.
 RUN_DISABLED_TESTS = os.getenv('PYTORCH_RUN_DISABLED_TESTS', '0') == '1'
 
 # A list of issue numbers. This will re-enable any disabled tests associated with
 # the issues in this list.
-IGNORE_DISABLED_ISSUES: List[str] = os.getenv('IGNORE_DISABLED_ISSUES', '').split(',')
+IGNORE_DISABLED_ISSUES: List[str] = os.getenv('PYTORCH_IGNORE_DISABLED_ISSUES', '').split(',')
 
 # Disables noarch tests; all but one CI configuration disables these.  We don't
 # disable them for local runs because you still want to run them


### PR DESCRIPTION
Part 1 of fixing https://github.com/pytorch/pytorch/issues/62359

Test plan: 
1. Check out this PR and run `python setup.py install`. 
2. The test we will be running requires CUDA. If you don't have CUDA, you can try this on another device or simply comment out the skipIf statement before the `test_jit_cuda_extension` test in `test_cpp_extensions_jit.py`
3. Run: `IN_CI=1 python test/run_test.py -i test_cpp_extensions_jit -- -k test_jit_cuda_extension` and notice that it should skip. If it doesn't skip, edit test/.pytorch-disabled-tests.json: modify the platforms list of the first issue (61655) to include whatever platform you are on (macos or linux), and just run `python test/test_cpp_extensions_jit.py -v -k test_jit_cuda_extension --import-disabled-tests` to make sure it skips.
4. Now `export PYTORCH_IGNORE_DISABLED_ISSUES=61655` or `export PYTORCH_IGNORE_DISABLED_ISSUES=34952,61655`.
5. `rm test/.pytorch-*` to clear the cached files.
6. Run the same command as in step 5 and note that it SHOULDN'T skip. It should run.