### PR TITLE
[Static Runtime] Disable ListUnpack fusion if its output is reachable from graph output

### DIFF
--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -1330,6 +1330,55 @@ TEST(AliasRegistrationTest, AliasMoveAtenListOp) {
       vmap["y"]->node(), vmap["9"]->node()));
 }
 
+TEST(
+    AliasRegistrationTest,
+    AliasMoveForTupleConstructWithSingleUseAsGraphOutput) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  auto graph_string = R"IR(
+  graph():
+    %x : Tensor = prim::MakeTestTensor()
+    %y : Tensor = prim::MakeTestTensor()
+    %z : (Tensor) = prim::TupleConstruct(%x, %y)
+    return (%z))IR";
+
+  torch::jit::parseIR(graph_string, graph.get(), vmap);
+  AliasDb aliasDb(graph);
+
+  EXPECT_TRUE(!aliasDb.mayAlias(vmap["x"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["z"], vmap["x"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["z"], vmap["y"]));
+}
+
+TEST(AliasRegistrationTest, WildcardAliasForTupleConstructWithUses) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  auto graph_string = R"IR(
+  graph():
+    %x : Tensor = prim::MakeTestTensor()
+    %y : Tensor = prim::MakeTestTensor()
+    %z : Tensor = prim::MakeTestTensor()
+    %0 : int = prim::Constant[value=0]()
+    %a : (Tensor) = prim::TupleConstruct(%x, %y)
+    %b : (Tensor) = prim::TupleConstruct(%z)
+    %c : Tensor = prim::TupleIndex(%a, %0)
+    %d : Tensor = prim::TupleIndex(%b, %0)
+    return (%c, %d))IR";
+
+  torch::jit::parseIR(graph_string, graph.get(), vmap);
+  AliasDb aliasDb(graph);
+
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["x"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["x"], vmap["z"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["z"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["a"], vmap["x"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["a"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["a"], vmap["z"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["x"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["z"]));
+}
+
 TEST(AliasRegistrationTest, PureWithAnnotationsShouldError2) {
   auto registry = torch::RegisterOperators().op(
       "foo::rand12(Tensor(a) arg1) -> Tensor(b)",

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -234,6 +234,7 @@ class AliasDb {
   c10::optional<AliasTypeSet> mapTypeToAliasTypeSetPtr(
       const TypePtr& type) const;
   bool functionalNonEscapingListUse(const Use& use) const;
+  bool functionalNonEscapingTupleUse(const Use& use) const;
 
   std::shared_ptr<Graph> graph_;
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -84,8 +84,8 @@ void OptimizeGraph(
   // to exposed folders.
 #ifdef FBCODE_CAFFE2
   if (opts.enable_out_variant) {
-    FuseListUnpack(graph);
     ReplaceWithCopy(graph);
+    FuseListUnpack(graph);
     EnableStaticRuntimeLayerNorm(graph);
   }
 #endif


### PR DESCRIPTION
Summary:
This change fixes a bug in ListUnpack fusion that throws type conversion errors at runtime when one of the `ListUnpack` node's output is unmanaged.

Currently, the fused ops (e.g., sigrid_transform) operates based on an assumption that `!output(0).isNone()` imples `output(i).isTensor()` for all `i`. This is invalid when one of its outputs is unmanaged, gets reset to `None` after each iteration.

Note that the current approach replies on `AliasDb` to detect indirect leaking from `ListUnpack` to the graph's output.

Test Plan:
Modified/Added the following tests to cover the code change:

- StaticRuntime.FuseEquallySplitListUnpack
- StaticRuntime.NoFuseWithGraphOutputEquallySplitListUnpack
- StaticRuntime.NoFuseWithMultipleUsesEquallySplitListUnpack

Differential Revision: D29979402

