### PR TITLE
Update faq.rst so OOM section mentions checkpoint

### DIFF
--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -83,8 +83,7 @@ this way (and remember that you will need at least twice the size of the
 weights, since you also need to store the gradients.)
 
 **Consider checkpointing**
-You can trade-off memory for compute memory by using checkpoint ` <https://pytorch.org/docs/stable/checkpoint.html>`. 
-
+You can trade-off memory for compute by using checkpoint ` <https://pytorch.org/docs/stable/checkpoint.html>`. 
 
 My GPU memory isn't freed properly
 ----------------------------------

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -82,8 +82,8 @@ to `blow through your memory <https://github.com/pytorch/pytorch/issues/958>`_
 this way (and remember that you will need at least twice the size of the
 weights, since you also need to store the gradients.)
 
-**Consider checkpointing**
-You can trade-off memory for compute by using checkpoint ` <https://pytorch.org/docs/stable/checkpoint.html>`. 
+**Consider checkpointing.**
+You can trade-off memory for compute by using `checkpoint <https://pytorch.org/docs/stable/checkpoint.html>`_. 
 
 My GPU memory isn't freed properly
 ----------------------------------

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -83,7 +83,7 @@ this way (and remember that you will need at least twice the size of the
 weights, since you also need to store the gradients.)
 
 **Consider checkpointing.**
-You can trade-off memory for compute by using `checkpoint <https://pytorch.org/docs/stable/checkpoint.html>`_. 
+You can trade-off memory for compute by using `checkpoint <https://pytorch.org/docs/stable/checkpoint.html>`_.
 
 My GPU memory isn't freed properly
 ----------------------------------

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -62,7 +62,7 @@ Here, ``intermediate`` remains live even while ``h`` is executing,
 because its scope extrudes past the end of the loop.  To free it
 earlier, you should ``del intermediate`` when you are done with it.
 
-**Don't run RNNs on sequences that are too large.**
+**Avoid running RNNs on sequences that are too large.**
 The amount of memory required to backpropagate through an RNN scales
 linearly with the length of the RNN input; thus, you will run out of memory
 if you try to feed an RNN a sequence that is too long.
@@ -81,6 +81,10 @@ scales quadratically with the number of features.  It is very easy
 to `blow through your memory <https://github.com/pytorch/pytorch/issues/958>`_
 this way (and remember that you will need at least twice the size of the
 weights, since you also need to store the gradients.)
+
+**Consider checkpointing**
+You can trade-off memory for compute memory by using checkpoint ` <https://pytorch.org/docs/stable/checkpoint.html>`. 
+
 
 My GPU memory isn't freed properly
 ----------------------------------


### PR DESCRIPTION
This FAQ has a section for CUDA OOMs where there are lots of don'ts. This limits modeling solution. Deep nets can blow up memory due to output caching during training. 
It's a known problem with a known solution: to trade-off compute for memory via checkpointing. 
FAQ should mention it.
