### PR TITLE
Refactor RecordFunction to use CustomClass 

### DIFF
--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -5,6 +5,7 @@
 #include <c10/macros/Export.h>
 #include <c10/util/Optional.h>
 #include <c10/util/SmallVector.h>
+#include <torch/custom_class.h>
 
 #include <array>
 #include <atomic>
@@ -93,7 +94,7 @@ typedef c10::SmallVector<uint64_t, kSoftLimitCallbacks> CallbackHandles;
 typedef std::vector<std::unique_ptr<ObserverContext>> ObserverContextList;
 typedef uint64_t RecordFunctionHandle;
 
-struct TORCH_API RecordFunction {
+struct TORCH_API RecordFunction : torch::CustomClassHolder {
   // Default constructor is used with before function called afterwards:
   //  scope - record scope that this function tracks
   //  pre_sampled - whether this RecordFunction was already pre-sampled with

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -5,7 +5,6 @@
 #include <c10/macros/Export.h>
 #include <c10/util/Optional.h>
 #include <c10/util/SmallVector.h>
-#include <torch/custom_class.h>
 
 #include <array>
 #include <atomic>

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -504,9 +504,6 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       # TODO: Delete this line once https://github.com/pytorch/pytorch/pull/55889 lands
       set_source_files_properties(../torch/csrc/jit/serialization/export.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
-
-      # TODO: Delete this when https://github.com/pytorch/pytorch/issues/35026 is fixed
-      set_source_files_properties(../torch/csrc/autograd/record_function_ops.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
     endif()
   endif()
   list(APPEND TORCH_SRCS ${LIBTORCH_CMAKE_SRCS})

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -36,6 +36,7 @@ ALLOW_LIST = [
     # Internal, profiler-specific ops
     ("profiler::_call_end_callbacks_on_jit_fut*", datetime.date(9999, 1, 1)),
     ("profiler::_record_function_enter", datetime.date(9999, 1, 1)),
+    ("profiler::_record_function_exit", datetime.date(9999, 1, 1)),
     ("aten::_cholesky_helper", datetime.date(9999, 1, 1)),
     ("aten::_lstsq_helper", datetime.date(9999, 1, 1)),
     ("aten::_syevd_helper", datetime.date(9999, 1, 1)),

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -429,7 +429,7 @@ class record_function(ContextDecorator):
         # NOTE: type is required by jit.script. However, type hint it as
         # Optional[...] will cause it infer to be None due to delayed
         # initialization in __enter__. RecordFunction is not for public usage.
-        self.rec: List["torch.classes.profiler.RecordFunction"] = []  # type: ignore[name-defined]
+        self.rec: List["torch.classes.profiler._RecordFunction"] = []  # type: ignore[name-defined]
 
     def __enter__(self):
         self.rec.append(torch.ops.profiler._record_function_enter(self.name))
@@ -470,7 +470,14 @@ class record_function(ContextDecorator):
 
     @property
     def handle(self):
-        return self.rec[0]
+        """This property exists purely because existing tests are using this
+        internal object for their purposes.
+        """
+        if len(self.rec) == 1:
+            return self.rec[0]
+        else:
+            raise RuntimeError(
+                "Malformed record_function.handle access, this only occurs if you access handle before __enter__ or after __exit__ of this context manager.")
 
 
 class emit_nvtx(object):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -426,9 +426,10 @@ class record_function(ContextDecorator):
     def __init__(self, name: str):
         self.name: str = name
 
-        # NOTE: type hint it as Optional[...] will cause it infer to be None
-        # due to delayed initialization in __enter__.
-        self.rec: List["torch.classes.profiler.RecordFunction"] = []
+        # NOTE: type is required by jit.script. However, type hint it as
+        # Optional[...] will cause it infer to be None due to delayed
+        # initialization in __enter__. RecordFunction is not for public usage.
+        self.rec: List["torch.classes.profiler.RecordFunction"] = []  # type: ignore[name-defined]
 
     def __enter__(self):
         self.rec.append(torch.ops.profiler._record_function_enter(self.name))

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -477,7 +477,10 @@ class record_function(ContextDecorator):
             return self.rec[0]
         else:
             raise RuntimeError(
-                "Malformed record_function.handle access, this only occurs if you access handle before __enter__ or after __exit__ of this context manager.")
+                "Malformed record_function.handle access, this only occurs if "
+                "you access handle before __enter__ or after __exit__ of this "
+                "context manager."
+            )
 
 
 class emit_nvtx(object):

--- a/torch/autograd/profiler_legacy.py
+++ b/torch/autograd/profiler_legacy.py
@@ -186,7 +186,7 @@ def _parse_legacy_records(thread_records):
                     duplicate = (
                         prev_record.name() == record.name()
                         and prev_record.kind() == record.kind()
-                        and prev_record.node_id() == record.node_id()
+                        and prev_record.start_us() == record.start_us()
                     )
                     if duplicate:
                         filtered_handles.add(record_key)

--- a/torch/autograd/profiler_legacy.py
+++ b/torch/autograd/profiler_legacy.py
@@ -186,7 +186,7 @@ def _parse_legacy_records(thread_records):
                     duplicate = (
                         prev_record.name() == record.name()
                         and prev_record.kind() == record.kind()
-                        and prev_record.start_us() == record.start_us()
+                        and prev_record.node_id() == record.node_id()
                     )
                     if duplicate:
                         filtered_handles.add(record_key)

--- a/torch/csrc/autograd/record_function_ops.cpp
+++ b/torch/csrc/autograd/record_function_ops.cpp
@@ -57,7 +57,7 @@ c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut(
 
 // Internal only, do not use directly, use Python's record_function()
 TORCH_LIBRARY_FRAGMENT(profiler, m) {
-    m.class_<at::RecordFunction>("RecordFunction");
+    m.class_<at::RecordFunction>("_RecordFunction");
     m.def("_record_function_enter", &record_function_enter);
     m.def("_record_function_exit", &record_function_exit);
 }
@@ -69,7 +69,7 @@ c10::AliasAnalysisKind aliasAnalysisFromSchema() {
 
 jit::RegisterOperators reg_fut_ops({
     jit::Operator(
-        "profiler::_call_end_callbacks_on_jit_fut(__torch__.torch.classes.profiler.RecordFunction x, Future(t) y) -> Future(t)",
+        "profiler::_call_end_callbacks_on_jit_fut(__torch__.torch.classes.profiler._RecordFunction x, Future(t) y) -> Future(t)",
         [](jit::Stack* stack) {
           // Pop inputs, which should be a future and a tensor
           auto fut = jit::pop(stack).toFuture();

--- a/torch/csrc/autograd/record_function_ops.cpp
+++ b/torch/csrc/autograd/record_function_ops.cpp
@@ -1,4 +1,3 @@
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/record_function.h>
 #include <ATen/ThreadLocalState.h>
 
@@ -16,40 +15,31 @@ namespace profiler {
 
 // Creates a new profiling scope using RecordFunction and invokes its starting
 // callbacks.
-at::Tensor record_function_enter(const std::string& name) {
-  auto rec = std::make_unique<at::RecordFunction>(at::RecordScope::USER_SCOPE);
+c10::intrusive_ptr<at::RecordFunction> record_function_enter(const std::string& name) {
+  auto rec = c10::make_intrusive<at::RecordFunction>(at::RecordScope::USER_SCOPE);
   rec->before(name);
-  return at::cpp_custom_type_hack::create(std::move(rec), at::TensorOptions());
-}
-
-at::RecordFunction& getRecordFunctionFromTensor(const at::Tensor& handle) {
-  auto& rec = at::cpp_custom_type_hack::cast<at::RecordFunction>(handle);
   return rec;
 }
 
 // Ends the profiling scope created with record_function_enter.
-void record_function_exit(const at::Tensor& handle) {
-  // We don't actually need to do anything with handle just need to persist the
-  // lifetime until now.
-  auto& rec = getRecordFunctionFromTensor(handle);
-  rec.end();
+void record_function_exit(const c10::intrusive_ptr<at::RecordFunction>& rec) {
+  rec->end();
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut(
-    const at::Tensor& handle,
+    const c10::intrusive_ptr<at::RecordFunction>& rec,
     const c10::intrusive_ptr<c10::ivalue::Future>& fut) {
   // Profiling callback that ends the associated record_function
   // and returns the value of the passed in future.
   std::function<c10::IValue(c10::ivalue::Future&)> futureProfilingFunc =
-      [handle](c10::ivalue::Future& fut) {
+      [rec](c10::ivalue::Future& fut) {
         TORCH_INTERNAL_ASSERT(
-            handle.defined(),
+            rec.defined(),
             "Undefined RecordFunction handle. This can happen if the handle is "
             "not correctly persisted and is destroyed before the future is "
             "realized.");
 
-        auto& rec = getRecordFunctionFromTensor(handle);
-        rec.end();
+        rec->end();
         // Note: this future is returned to the user to ensure that a call to wait()
         // ensures that profiling callbacks have ran. To ensure that this is
         // transparent, we must make this future propagate the value of the RPC
@@ -67,6 +57,7 @@ c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut(
 
 // Internal only, do not use directly, use Python's record_function()
 TORCH_LIBRARY_FRAGMENT(profiler, m) {
+    m.class_<at::RecordFunction>("RecordFunction");
     m.def("_record_function_enter", &record_function_enter);
     m.def("_record_function_exit", &record_function_exit);
 }
@@ -78,12 +69,12 @@ c10::AliasAnalysisKind aliasAnalysisFromSchema() {
 
 jit::RegisterOperators reg_fut_ops({
     jit::Operator(
-        "profiler::_call_end_callbacks_on_jit_fut(Tensor x, Future(t) y) -> Future(t)",
-        [](jit::Stack& stack) {
+        "profiler::_call_end_callbacks_on_jit_fut(__torch__.torch.classes.profiler.RecordFunction x, Future(t) y) -> Future(t)",
+        [](jit::Stack* stack) {
           // Pop inputs, which should be a future and a tensor
           auto fut = jit::pop(stack).toFuture();
-          auto tensor = jit::pop(stack).toTensor();
-          auto profiledFut = _call_end_callbacks_on_fut(tensor, fut);
+          auto rec = jit::pop(stack).toCustomClass<at::RecordFunction>();
+          auto profiledFut = _call_end_callbacks_on_fut(rec, fut);
           // return future that completes when profiling callbacks have run.
           jit::push(stack, std::move(profiledFut));
         },

--- a/torch/csrc/autograd/record_function_ops.h
+++ b/torch/csrc/autograd/record_function_ops.h
@@ -6,11 +6,11 @@ namespace autograd {
 namespace profiler {
 // Creates a new profiling scope using RecordFunction and invokes its starting
 // callbacks.
-TORCH_API at::Tensor record_function_enter(const std::string& name);
+TORCH_API c10::intrusive_ptr<at::RecordFunction> record_function_enter(const std::string& name);
 
 // Schedules RecordFunction's end callbacks to be run on completion of a future.
 TORCH_API c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut(
-    const at::Tensor& handle,
+    const c10::intrusive_ptr<at::RecordFunction>& rec,
     const c10::intrusive_ptr<c10::ivalue::Future>& fut);
 
 } // namespace profiler

--- a/torch/csrc/distributed/rpc/torchscript_functions.cpp
+++ b/torch/csrc/distributed/rpc/torchscript_functions.cpp
@@ -21,10 +21,7 @@ c10::intrusive_ptr<JitFuture> rpcTorchscript(
     std::vector<c10::IValue>& stack,
     const float rpcTimeoutSeconds,
     const bool isAsyncExecution) {
-  // This dummy tensor holds an at::RecordFunction when profiling is enabled.
-  // This is because at::RecordFunction is not yet registered as a TorchScript
-  // custom class (https://github.com/pytorch/pytorch/issues/35026)
-  at::Tensor handle = at::zeros(1);
+  c10::intrusive_ptr<at::RecordFunction> rec;
   auto shouldProfile = torch::autograd::profiler::profilerEnabled() &&
       !torch::distributed::rpc::RemoteProfilerManager::getInstance()
            .isCurrentKeySet();
@@ -35,7 +32,7 @@ c10::intrusive_ptr<JitFuture> rpcTorchscript(
             .qualifiedName(), /* name of torchscript function being run */
         RpcAgent::getCurrentRpcAgent()->getWorkerInfo().name_,
         dstWorkerName);
-    handle = torch::autograd::profiler::record_function_enter(rpcAsyncJitKey);
+    rec = torch::autograd::profiler::record_function_enter(rpcAsyncJitKey);
     auto& remoteProfilerManager =
         torch::distributed::rpc::RemoteProfilerManager::getInstance();
     remoteProfilerManager.setCurrentKey(rpcAsyncJitKey);
@@ -75,7 +72,7 @@ c10::intrusive_ptr<JitFuture> rpcTorchscript(
   }));
   if (shouldProfile) {
     auto profiledFutPtr =
-        torch::autograd::profiler::_call_end_callbacks_on_fut(handle, futPtr);
+        torch::autograd::profiler::_call_end_callbacks_on_fut(rec, futPtr);
     return profiledFutPtr;
   }
   return futPtr;

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -191,7 +191,7 @@ def script_fork_wait_throw(invalue):
 
 
 @torch.jit.script
-def call_rpc_with_profiling(handle: torch.classes.profiler.RecordFunction, dst_worker_name: str) -> Tensor:
+def call_rpc_with_profiling(handle: torch.classes.profiler._RecordFunction, dst_worker_name: str) -> Tensor:
     # Call rpc_async from within ScriptFunction and ensure that we can attach
     # profiling callbacks. Note that handle here is a Tensor representation of
     # RecordFunction.
@@ -207,7 +207,7 @@ def call_rpc_torchscript_with_record_function(dst_worker_name: str, block: str) 
 
 
 @torch.jit.script
-def call_fork_with_profiling(handle: torch.classes.profiler.RecordFunction) -> Tensor:
+def call_fork_with_profiling(handle: torch.classes.profiler._RecordFunction) -> Tensor:
     # Call fork from within ScriptFunction and ensure that we can attach profiling
     # callbacks to the resulting future. Note that handle here is a Tensor
     # representation of RecordFunction.

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -153,8 +153,11 @@ def record_function_on_caller_rpc_async(dst_worker_name: str, block: str) -> Ten
     t: Tensor = torch.ones(1)
     with record_function(block) as rf:
         fut1 = rpc.rpc_async(dst_worker_name, script_add_ones, (t, ))
+        zero = torch.zeros_like(t)
         fut2 = rpc.rpc_async(dst_worker_name, script_add_ones, (t, ))
-        res = fut1.wait() + fut2.wait()
+        # see https://github.com/pytorch/pytorch/pull/62710#discussion_r694680279
+        # for why adding zero is needed in this case.
+        res = fut1.wait() + fut2.wait() + zero
     return res
 
 

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -191,7 +191,7 @@ def script_fork_wait_throw(invalue):
 
 
 @torch.jit.script
-def call_rpc_with_profiling(handle: Tensor, dst_worker_name: str) -> Tensor:
+def call_rpc_with_profiling(handle: torch.classes.profiler.RecordFunction, dst_worker_name: str) -> Tensor:
     # Call rpc_async from within ScriptFunction and ensure that we can attach
     # profiling callbacks. Note that handle here is a Tensor representation of
     # RecordFunction.
@@ -207,7 +207,7 @@ def call_rpc_torchscript_with_record_function(dst_worker_name: str, block: str) 
 
 
 @torch.jit.script
-def call_fork_with_profiling(handle: Tensor) -> Tensor:
+def call_fork_with_profiling(handle: torch.classes.profiler.RecordFunction) -> Tensor:
     # Call fork from within ScriptFunction and ensure that we can attach profiling
     # callbacks to the resulting future. Note that handle here is a Tensor
     # representation of RecordFunction.


### PR DESCRIPTION
Fixes #35026.

There used to be a try in #35596 but is long left behind and then abandoned. This PR redo it on relative new codebase.

And #62390 is related, this PR should remove additional `zeros` and `empty` op from profiling trace. Whether there will be a performance improvement is to be measured.

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @ilia-cher @robieta @chaekit @gdankel @bitfort @ngimel @orionr @nbcsm @guotuofeng @guyang3532 @gaoteng-git