### PR TITLE
implement "xy" indexing for torch.meshgrid

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2163,33 +2163,83 @@ std::vector<Tensor> meshgrid(TensorList tensors,
   int64_t size = tensors.size();
   TORCH_CHECK(size > 0, "meshgrid expects a non-empty TensorList");
 
-  TORCH_CHECK(
-      indexing == "ij",
-      "torch.meshgrid: only \"ij\" indexing is supported at this time, but "
-      "received: ", indexing);
+  for(const auto i: c10::irange(size - 1)){
+    TORCH_CHECK(tensors[i].dtype() == tensors[i+1].dtype(), "meshgrid expects all tensors to have the same dtype");
+    TORCH_CHECK(tensors[i].device() == tensors[i+1].device(), "meshgrid expects all tensors to have the same device");
+  }
+
+  // Input tensors is of type TensorList, which is an alias to a
+  // constant array slice, which doesn't allow for mutations. We may
+  // need to swap our first two elements if indexing is "ij", so we
+  // unconditionally create a vector that we can reorder to keep the
+  // implementation simple.
+  //
+  // We are not concerned with the performance of this relative to
+  // constructor a grid for each input.
+  std::vector<std::reference_wrapper<const Tensor>> tensor_refs(tensors.begin(),
+                                                                tensors.end());
+
+  // Whether or not to swap the first two tensors.
+  //
+  // We only swap if there are at least two* input tensors (obviously)
+  // and if indexing is "xy".
+  //
+  // A reminder about "xy" semantics: "xy" semantics implies that the
+  // output grids are in the cartesian coordinate system. Thus the
+  // first dimension is the "x" axis (corresponding to column) and the
+  // second dimension is the "y" axis (corresponding to row). Tensors,
+  // however, generally consider the first axis to be the row and the
+  // second axis to be the columns. Thus we flip the two dimensions in
+  // contrast to "ij" indexing.
+  //
+  // It turns out that it's easiest to implement this by just swapping
+  // the first two inputs. However, the order of the outputs still
+  // must correspond to the order of the inputs. Thus we also must
+  // swap the outputs if we swapped the inputs.
+  //
+  // * Why do we even support this function for exactly one input?
+  bool swap_first_and_second_tensors;
+
+  if (indexing == "xy") {
+    // We can only swap if there are multiple tensors.
+    swap_first_and_second_tensors = size >= 2;
+    if (swap_first_and_second_tensors) {
+      std::swap(tensor_refs[0], tensor_refs[1]);
+    }
+  } else {
+    // Only "xy" and "ij" are supported, and we already checked for
+    // "xy" above. Only "ij" remains as a valid mode.
+    TORCH_CHECK(indexing == "ij",
+                "torch.meshgrid: indexing must be one of \"xy\" or \"ij\", "
+                "but received: ", indexing);
+    swap_first_and_second_tensors = false;
+  }
 
   std::vector<int64_t> shape(size);
   for(const auto i: c10::irange(size)){
-    switch (tensors[i].dim()) {
+    switch (tensor_refs[i].get().dim()) {
     case 0:
       shape[i] = 1;
       break;
     case 1:
-      shape[i] = tensors[i].size(0);
+      shape[i] = tensor_refs[i].get().size(0);
       break;
     default:
-      AT_ERROR("Expected scalar or 1D tensor in the tensor list but got: ", tensors[i]);
+      TORCH_CHECK(false,
+                  "torch.meshgrid: Expected 0D or 1D tensor in the tensor "
+                  "list but got: ", tensor_refs[i]);
     }
-  }
-  for(const auto i: c10::irange(size - 1)){
-      TORCH_CHECK(tensors[i].dtype() == tensors[i+1].dtype(), "meshgrid expects all tensors to have the same dtype");
-      TORCH_CHECK(tensors[i].device() == tensors[i+1].device(), "meshgrid expects all tensors to have the same device");
   }
   std::vector<Tensor> grids;
   for(const auto i: c10::irange(size)){
     std::vector<int64_t> view_shape(size, 1);
     view_shape[i] = -1;
-    grids.push_back(tensors[i].view(view_shape).expand(shape));
+    grids.push_back(tensor_refs[i].get().view(view_shape).expand(shape));
+  }
+
+  // Remember we need to also swap the outputs if we swapped the inputs.
+  if (swap_first_and_second_tensors) {
+    std::swap(grids[0], grids[1]);
   }
   return grids;
 }

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1409,12 +1409,12 @@ class TestTensorCreation(TestCase):
 
     def test_meshgrid_unsupported_indexing(self):
         with self.assertRaisesRegex(RuntimeError,
-                                    'only "ij" indexing is supported'):
+                                    'indexing must be one of "xy" or "ij"'):
             torch.meshgrid(torch.tensor([1, 2]), indexing='')
 
     def test_meshgrid_non_1d_tensor(self):
         with self.assertRaisesRegex(RuntimeError,
-                                    'Expected scalar or 1D tensor'):
+                                    'Expected 0D or 1D tensor'):
             torch.meshgrid(torch.tensor([[1, 2], [3, 4]]))
 
     def test_meshgrid_inconsistent_dtype(self):
@@ -1453,6 +1453,32 @@ class TestTensorCreation(TestCase):
         expected_grid_c = torch.tensor([[[1, 2],
                                          [1, 2],
                                          [1, 2]]], device=device)
+        self.assertTrue(grid_a.equal(expected_grid_a))
+        self.assertTrue(grid_b.equal(expected_grid_b))
+        self.assertTrue(grid_c.equal(expected_grid_c))
+        self.assertTrue(grid_a2.equal(expected_grid_a))
+        self.assertTrue(grid_b2.equal(expected_grid_b))
+        self.assertTrue(grid_c2.equal(expected_grid_c))
+
+    def test_meshgrid_xy_indexing(self, device):
+        a = torch.tensor(1, device=device)
+        b = torch.tensor([1, 2, 3], device=device)
+        c = torch.tensor([1, 2], device=device)
+        grid_a, grid_b, grid_c = torch.meshgrid([a, b, c], indexing='xy')
+        self.assertEqual(grid_a.shape, torch.Size([3, 1, 2]))
+        self.assertEqual(grid_b.shape, torch.Size([3, 1, 2]))
+        self.assertEqual(grid_c.shape, torch.Size([3, 1, 2]))
+        grid_a2, grid_b2, grid_c2 = torch.meshgrid(a, b, c, indexing='xy')
+        self.assertEqual(grid_a2.shape, torch.Size([3, 1, 2]))
+        self.assertEqual(grid_b2.shape, torch.Size([3, 1, 2]))
+        self.assertEqual(grid_c2.shape, torch.Size([3, 1, 2]))
+        expected_grid_a = torch.ones(3, 1, 2, dtype=torch.int64, device=device)
+        expected_grid_b = torch.tensor([[[1, 1]],
+                                        [[2, 2]],
+                                        [[3, 3]]], device=device)
+        expected_grid_c = torch.tensor([[[1, 2]],
+                                        [[1, 2]],
+                                        [[1, 2]]], device=device)
         self.assertTrue(grid_a.equal(expected_grid_a))
         self.assertTrue(grid_b.equal(expected_grid_b))
         self.assertTrue(grid_c.equal(expected_grid_c))
@@ -1523,9 +1549,14 @@ class TestTensorCreation(TestCase):
             # No indexing in PyTorch corresponds to "ij" indexing in
             # NumPy.
             ({}, {'indexing': 'ij'}),
-            # "ij" is implemented identically in both.
+
+            # No indexing in NumPy corresponds to "xy" indexing in
+            # PyTorch.
+            ({'indexing': 'xy'}, {}),
+
+            # "ij" and "xy" are implemented identically in both.
             ({'indexing': 'ij'}, {'indexing': 'ij'}),
-            # TODO Test "xy" when it is supported in PyTorch.
+            ({'indexing': 'xy'}, {'indexing': 'xy'}),
         ]
         for shapes, (torch_kwargs, numpy_kwargs) in product(cases, indexing_correspondence):
             with self.subTest(shapes=shapes, torch_kwargs=torch_kwargs, numpy_kwargs=numpy_kwargs):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -355,9 +355,8 @@ else:
             `torch.meshgrid(*tensors)` currently has the same behavior
             as calling `numpy.meshgrid(*arrays, indexing='ij')`.
 
-            In the future `torch.meshgrid` will support the
-            `indexing='xy'` and eventually transition to that as the
-            default.
+            In the future `torch.meshgrid` will transition to
+            `indexing='xy'` as the default.
 
             https://github.com/pytorch/pytorch/issues/50276 tracks
             this issue with the goal of migrating to NumPy's behavior.
@@ -371,8 +370,16 @@ else:
             tensors (list of Tensor): list of scalars or 1 dimensional tensors. Scalars will be
                 treated as tensors of size :math:`(1,)` automatically
 
-            indexing: (str, optional): the indexing mode requested.
-                Only "ij" is currently supported.
+            indexing: (str, optional): the indexing mode, either "xy"
+                or "ij", defaults to "ij". See warning for future changes.
+
+                If "xy" is selected, the first dimension corresponds
+                to the cardinality of the second input and the second
+                dimension corresponds to the cardinality of the first
+                input.
+
+                If "ij" is selected, the dimensions are in the same
+                order as the cardinality of the inputs.
 
         Returns:
             seq (sequence of Tensors): If the input has :math:`N`
@@ -409,7 +416,7 @@ else:
             >>> import matplotlib.pyplot as plt
             >>> xs = torch.linspace(-5, 5, steps=100)
             >>> ys = torch.linspace(-5, 5, steps=100)
-            >>> x, y = torch.meshgrid(xs, ys)
+            >>> x, y = torch.meshgrid(xs, ys, indexing='xy')
             >>> z = torch.sin(torch.sqrt(x * x + y * y))
             >>> ax = plt.axes(projection='3d')
             >>> ax.plot_surface(x.numpy(), y.numpy(), z.numpy())

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2901,8 +2901,10 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 def meshgrid(g, tensor_list, indexing: Optional[str] = None):
     if indexing is None:
         indexing = 'ij'
-    elif indexing != 'ij':
+    elif indexing not in {'ij', 'xy'}:
         raise ValueError(f'Unsupported indexing: {indexing}')
+    if indexing == 'xy':
+        tensor_list[0], tensor_list[1] = tensor_list[1], tensor_list[0]
     tensors = [sym_help._reshape_helper(g, t, g.op("Constant", value_t=torch.LongTensor([-1])))
                for t in sym_help._unpack_list(tensor_list)]
     tensors_shape = [g.op("Shape", t) for t in tensors]
@@ -2913,6 +2915,8 @@ def meshgrid(g, tensor_list, indexing: Optional[str] = None):
         shape_i[i] = tensors_shape[i]
         t_reshaped = _reshape_from_tensor(g, t, g.op("Concat", *shape_i, axis_i=0))
         out.append(g.op("Expand", t_reshaped, out_shape))
+    if indexing == 'xy':
+        out[0], out[1] = out[1], out[0]
     return g.op("prim::ListConstruct", *out)
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4609,7 +4609,7 @@ def sample_inputs_meshgrid(op_info: OpInfo, device: torch.device, dtype: torch.d
     ]
 
     sample_inputs = []
-    for shapes, indexing in itertools.product(test_cases, {'ij'}):
+    for shapes, indexing in itertools.product(test_cases, {'xy', 'ij'}):
         input, args = make_inputs(
             [make_tensor(shape, device, dtype, requires_grad=requires_grad)
              for shape in shapes])


### PR DESCRIPTION
This is step 4/7 of #50276. This allows the use of `"xy"` indexing but doesn't change any defaults.