### PR TITLE
[DDP Communication Hook] Renaming C++ calls to match python API closer

### DIFF
--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -93,7 +93,7 @@ std::vector<at::Tensor> GradBucket::getGradients() const {
   per_parameter_tensors.reserve(num_parameters);
   for (const auto i : c10::irange(num_parameters)) {
     per_parameter_tensors.push_back(
-        tensor_.slice(0, offsets_[i], offsets_[i] + lengths_[i])
+        buffer_.slice(0, offsets_[i], offsets_[i] + lengths_[i])
             .view(sizes_vec_[i]));
   }
   return per_parameter_tensors;

--- a/torch/csrc/distributed/c10d/comm.hpp
+++ b/torch/csrc/distributed/c10d/comm.hpp
@@ -24,7 +24,7 @@ class TORCH_API GradBucket {
       const std::vector<c10::IntArrayRef>& sizes_vec,
       const std::vector<at::Tensor>& parameters)
       : index_(index),
-        tensor_(tensor),
+        buffer_(tensor),
         offsets_(offsets),
         lengths_(lengths),
         sizes_vec_(sizes_vec),
@@ -35,18 +35,18 @@ class TORCH_API GradBucket {
     return index_;
   }
 
-  const at::Tensor& getTensor() const {
-    return tensor_;
+  const at::Tensor& getBuffer() const {
+    return buffer_;
   }
 
-  // Returns a mutable tensor compared with the above method.
-  at::Tensor& getTensorRef() {
-    return tensor_;
+  // Returns a mutable buffer compared with the above method.
+  at::Tensor& getBufferRef() {
+    return buffer_;
   }
 
-  // Overwrites the tensor at a specific index.
-  void setTensor(at::Tensor& tensor) {
-    tensor_ = tensor;
+  // Overwrites the buffer at a specific index.
+  void setBuffer(at::Tensor& buffer) {
+    buffer_ = buffer;
   }
 
   // Each tensor in the list that getGradients corresponds to a
@@ -68,9 +68,9 @@ class TORCH_API GradBucket {
 
  private:
   size_t index_;
-  at::Tensor tensor_;
+  at::Tensor buffer_;
 
-  // Per-variable info in tensor_.
+  // Per-variable info in buffer_.
   std::vector<size_t> offsets_;
   std::vector<size_t> lengths_;
   std::vector<c10::IntArrayRef> sizes_vec_;

--- a/torch/csrc/distributed/c10d/default_comm_hooks.cpp
+++ b/torch/csrc/distributed/c10d/default_comm_hooks.cpp
@@ -8,7 +8,7 @@ namespace c10d {
 
 c10::intrusive_ptr<c10::ivalue::Future> AllReduceCommHook::runHook(
     GradBucket& bucket) {
-  std::vector<at::Tensor> tensors = {bucket.getTensorRef()};
+  std::vector<at::Tensor> tensors = {bucket.getBufferRef()};
   // Apply the division first to avoid overflow, especially for FP16.
   tensors[0] /= state_->getSize();
   return state_->allreduce(tensors)->getFuture();
@@ -16,7 +16,7 @@ c10::intrusive_ptr<c10::ivalue::Future> AllReduceCommHook::runHook(
 
 c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
     GradBucket& bucket) {
-  auto& tensor = bucket.getTensorRef();
+  auto& tensor = bucket.getBufferRef();
   tensor.copy_(tensor.to(torch::kFloat16));
   std::vector<at::Tensor> tensors = {tensor};
   // Apply the division first to avoid overflow.
@@ -38,7 +38,7 @@ c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
 
 c10::intrusive_ptr<c10::ivalue::Future> _AllReduceBySumCommHook::
     runHook(GradBucket& bucket) {
-  std::vector<at::Tensor> tensors = {bucket.getTensorRef()};
+  std::vector<at::Tensor> tensors = {bucket.getBufferRef()};
   return state_->allreduce(tensors)->getFuture();
 }
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -286,7 +286,7 @@ Returns:
 )")
       .def(
           "buffer",
-          &::c10d::GradBucket::getTensor,
+          &::c10d::GradBucket::getBuffer,
           py::call_guard<py::gil_scoped_release>(),
           R"(
 Returns:
@@ -321,8 +321,8 @@ Returns:
 )")
       .def(
           "set_buffer",
-          &::c10d::GradBucket::setTensor,
-          py::arg("tensor"),
+          &::c10d::GradBucket::setBuffer,
+          py::arg("buffer"),
           py::call_guard<py::gil_scoped_release>(),
           R"(
 Replaces the tensor in the bucket with the input tensor buffer.


### PR DESCRIPTION
Summary:
Renamed the following
1. getTensor -> getBuffer
2. getTensorRef -> getBufferRef
3. setTensor -> setBuffer
and all associated private variables as well

Reviewed By: SciPioneer

Differential Revision: D30069124

