### PR TITLE
.github: Fix --no-build-suffix

### DIFF
--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -65,6 +65,8 @@ class PytorchVersion:
         self.no_build_suffix = no_build_suffix
 
     def get_post_build_suffix(self) -> str:
+        if self.no_build_suffix:
+            return ""
         if self.gpu_arch_type == "cuda":
             return f"+cu{self.gpu_arch_version.replace('.', '')}"
         return f"+{self.gpu_arch_type}{self.gpu_arch_version}"
@@ -87,9 +89,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--no-build-suffix",
-        type=strtobool,
+        action="store_true",
         help="Whether or not to add a build suffix typically (+cpu)",
-        default=os.environ.get("NO_BUILD_SUFFIX", False)
+        default=strtobool(os.environ.get("NO_BUILD_SUFFIX", False))
     )
     parser.add_argument(
         "--gpu-arch-type",

--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -91,7 +91,7 @@ def main() -> None:
         "--no-build-suffix",
         action="store_true",
         help="Whether or not to add a build suffix typically (+cpu)",
-        default=strtobool(os.environ.get("NO_BUILD_SUFFIX", False))
+        default=strtobool(os.environ.get("NO_BUILD_SUFFIX", "False"))
     )
     parser.add_argument(
         "--gpu-arch-type",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62739

Original flag didn't initially work correctly so this makes it actually
output the right thing

Usage:
```
❯ NO_BUILD_SUFFIX=false .github/scripts/generate_pytorch_version.py
1.10.0.dev20210804+cpu

❯ NO_BUILD_SUFFIX=true .github/scripts/generate_pytorch_version.py
1.10.0.dev20210804

❯ .github/scripts/generate_pytorch_version.py
1.10.0.dev20210804+cpu

❯ .github/scripts/generate_pytorch_version.py  --no-build-suffix
1.10.0.dev20210804
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D30107694](https://our.internmc.facebook.com/intern/diff/D30107694)