### PR TITLE
[Static Runtime] Enable ListConstructUnpack pass

### DIFF
--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -43,6 +43,7 @@ set(JIT_TEST_SRCS
   ${JIT_TEST_ROOT}/test_custom_operators.cpp
   ${JIT_TEST_ROOT}/test_dce.cpp
   ${JIT_TEST_ROOT}/test_eliminate_dict_construct_getitem.cpp
+  ${JIT_TEST_ROOT}/test_eliminate_tuple_construct_unpack.cpp
   ${JIT_TEST_ROOT}/test_fuser.cpp
   ${JIT_TEST_ROOT}/test_graph_executor.cpp
   ${JIT_TEST_ROOT}/test_graph_iterator.cpp

--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -42,6 +42,7 @@ set(JIT_TEST_SRCS
   ${JIT_TEST_ROOT}/test_custom_class_registrations.cpp
   ${JIT_TEST_ROOT}/test_custom_operators.cpp
   ${JIT_TEST_ROOT}/test_dce.cpp
+  ${JIT_TEST_ROOT}/test_eliminate_dict_construct_getitem.cpp
   ${JIT_TEST_ROOT}/test_fuser.cpp
   ${JIT_TEST_ROOT}/test_graph_executor.cpp
   ${JIT_TEST_ROOT}/test_graph_iterator.cpp

--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -43,6 +43,7 @@ set(JIT_TEST_SRCS
   ${JIT_TEST_ROOT}/test_custom_operators.cpp
   ${JIT_TEST_ROOT}/test_dce.cpp
   ${JIT_TEST_ROOT}/test_eliminate_dict_construct_getitem.cpp
+  ${JIT_TEST_ROOT}/test_eliminate_list_construct_unpack.cpp
   ${JIT_TEST_ROOT}/test_eliminate_tuple_construct_unpack.cpp
   ${JIT_TEST_ROOT}/test_fuser.cpp
   ${JIT_TEST_ROOT}/test_graph_executor.cpp

--- a/test/cpp/jit/test_eliminate_dict_construct_getitem.cpp
+++ b/test/cpp/jit/test_eliminate_dict_construct_getitem.cpp
@@ -1,0 +1,230 @@
+#include <gtest/gtest.h>
+
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/passes/eliminate_dict_construct_getitem.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
+#include <torch/csrc/jit/testing/file_check.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+void compareTensors(const IValue& expected, const IValue& actual) {
+  EXPECT_TRUE(expected.isTensor());
+  EXPECT_TRUE(actual.isTensor());
+  EXPECT_TRUE(expected.toTensor().equal(actual.toTensor()));
+}
+
+c10::IValue runGraph(
+    std::shared_ptr<Graph> graph,
+    const std::vector<c10::IValue>& args) {
+  auto graph_exec = GraphExecutor(graph, "");
+
+  Stack stack(args);
+  graph_exec.run(stack);
+
+  if (stack.size() == 1) {
+    return stack[0];
+  }
+  return c10::ivalue::Tuple::create(stack);
+}
+
+std::shared_ptr<Graph> makeGraph(const std::string& ir_src) {
+  auto graph = std::make_shared<Graph>();
+  parseIR(ir_src, graph.get());
+  return graph;
+}
+
+} // namespace
+
+TEST(EliminateDictConstructGetItemTest, SingleKeyGet_SingleKeyDict) {
+  const auto src = R"IR(
+    graph(%0: Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : Dict(int, Tensor) = prim::DictConstruct(%1, %0)
+        %3 : Tensor = aten::__getitem__(%2, %1)
+        return (%3)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  std::vector<c10::IValue> args{at::randn({2, 2})};
+
+  auto expected = runGraph(graph, args);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  auto actual = runGraph(graph, args);
+  compareTensors(expected, actual);
+
+  testing::FileCheck().check("return (%0)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItemTest, SingleKeyGet_MultiKeyDict) {
+  const auto src = R"IR(
+    graph(%0: Tensor, %1: Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=2]()
+        %4 : Dict(int, Tensor) = prim::DictConstruct(%2, %0, %3, %1)
+        %5 : Tensor = aten::__getitem__(%4, %3)
+        return (%5)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  std::vector<c10::IValue> args{at::randn({2, 2}), at::randn({2, 2})};
+
+  auto expected = runGraph(graph, args);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  auto actual = runGraph(graph, args);
+  compareTensors(expected, actual);
+
+  testing::FileCheck().check("return (%1)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItemTest, SingleKeyGet_InputArgKey) {
+  const auto src = R"IR(
+    graph(%0: Tensor, %1: int):
+        %2 : Dict(int, Tensor) = prim::DictConstruct(%1, %0)
+        %3 : Tensor = aten::__getitem__(%2, %1)
+        return (%3)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  std::vector<c10::IValue> args{at::randn({2, 2}), 1};
+
+  auto expected = runGraph(graph, args);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  auto actual = runGraph(graph, args);
+  compareTensors(expected, actual);
+
+  testing::FileCheck().check("return (%0)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItemTest, SingleKeyGet_ManyPureOps) {
+  // This src has ops other than __getitem__ that do not mutate
+  // the dict.
+  const auto src = R"IR(
+    graph(%0: Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : Dict(int, Tensor) = prim::DictConstruct(%1, %0)
+        %3 : Tensor = aten::__getitem__(%2, %1)
+        %4 : int = aten::len(%2)
+        %5 : Dict(int, Tensor) = aten::copy(%2)
+        %6 : int[] = aten::keys(%2)
+        %7 : Tensor[] = aten::values(%2)
+        %8 : bool = aten::__contains__(%2, %1)
+        return (%3)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  std::vector<c10::IValue> args{at::randn({2, 2})};
+
+  auto expected = runGraph(graph, args);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  auto actual = runGraph(graph, args);
+  compareTensors(expected, actual);
+
+  testing::FileCheck().check("return (%0)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItemTest, MultiKeyGet_MultiKeyDict) {
+  const auto src = R"IR(
+    graph(%0: Tensor, %1: Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=2]()
+        %4 : Dict(int, Tensor) = prim::DictConstruct(%2, %0, %3, %1)
+        %5 : Tensor = aten::__getitem__(%4, %2)
+        %6 : Tensor = aten::__getitem__(%4, %3)
+        %7 : Tensor = aten::matmul(%5, %6)
+        return (%7)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  std::vector<c10::IValue> args{at::randn({2, 2}), at::randn({2, 2})};
+
+  auto expected = runGraph(graph, args);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  auto actual = runGraph(graph, args);
+  compareTensors(expected, actual);
+
+  testing::FileCheck().check("aten::matmul(%0, %1)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItemTest, NoOptimization_MissingKey) {
+  const auto src = R"IR(
+    graph(%0: Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : int = prim::Constant[value=2]()
+        %3 : Dict(int, Tensor) = prim::DictConstruct(%1, %0)
+        %4 : Tensor = aten::__getitem__(%3, %2)
+        return (%4)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  // The return value should not change.
+  testing::FileCheck().check("return (%4)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItemTest, NoOptimization_InputArgKey) {
+  const auto src = R"IR(
+    graph(%0: Tensor, %1: int):
+        %2 : int = prim::Constant[value=1]()
+        %3 : Dict(int, Tensor) = prim::DictConstruct(%2, %0)
+        %4 : Tensor = aten::__getitem__(%3, %1)
+        return (%4)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  // The return value should not change.
+  testing::FileCheck().check("return (%4)")->run(*graph);
+}
+
+TEST(EliminateDictConstructGetItem, NoOptimization_DictModified) {
+  // Making the optimization isn't safe here because the dict is mutated
+  // between constructing the dict and accessing it.
+  const auto src = R"IR(
+    graph(%0: Tensor, %1: Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : Dict(int, Tensor) = prim::DictConstruct(%2, %0)
+        aten::_set_item(%3, %2, %1)
+        %4 : Tensor = aten::__getitem__(%3, %2)
+        return (%4)
+    )IR";
+
+  auto graph = makeGraph(src);
+
+  EliminateDictConstructGetItem(graph);
+  graph->lint();
+
+  // The return value should not change.
+  testing::FileCheck().check("return (%4)")->run(*graph);
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/test_eliminate_list_construct_unpack.cpp
+++ b/test/cpp/jit/test_eliminate_list_construct_unpack.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <test/cpp/jit/test_utils.h>
+#include <torch/csrc/jit/passes/eliminate_list_construct_unpack.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+void TestEliminateListConstructUnpack(
+    const std::string& src,
+    const std::vector<c10::IValue>& args,
+    const std::string& expected_string) {
+  testGraphPass(src, args, expected_string, EliminateListConstructUnpack);
+}
+
+} // namespace
+
+TEST(EliminateListConstructUnpack, OptimizationApplied_SingleArg) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor):
+            %1 : Tensor[] = prim::ListConstruct(%0)
+            %2 : Tensor = prim::ListUnpack(%1)
+            return (%2)
+    )IR";
+  const std::vector<IValue> args{at::randn({1})};
+  const std::string expected_string = "return (%0)";
+  TestEliminateListConstructUnpack(src, args, expected_string);
+}
+
+TEST(EliminateListConstructUnpack, OptimizationApplied_MultiArg) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor):
+            %2 : Tensor[] = prim::ListConstruct(%0, %1)
+            %3 : Tensor, %4 : Tensor = prim::ListUnpack(%2)
+            return (%3, %4)
+    )IR";
+  const std::vector<IValue> args{at::randn({1}), at::randn({1})};
+  const std::string expected_string = "return (%0, %1)";
+  TestEliminateListConstructUnpack(src, args, expected_string);
+}
+
+TEST(EliminateListConstructUnpack, OptimizationNotApplied_ListMutated) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor):
+            %2 : int = prim::Constant[value=0]()
+            %3 : Tensor[] = prim::ListConstruct(%0, %1)
+            %4 : Tensor[] = aten::_set_item(%3, %2, %1)
+            %5 : Tensor, %6 : Tensor = prim::ListUnpack(%3)
+            return (%5, %6)
+    )IR";
+  const std::vector<IValue> args{at::randn({1}), at::randn({1})};
+  const std::string expected_string = "return (%5, %6)";
+  TestEliminateListConstructUnpack(src, args, expected_string);
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/test_eliminate_tuple_construct_unpack.cpp
+++ b/test/cpp/jit/test_eliminate_tuple_construct_unpack.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#include <test/cpp/jit/test_utils.h>
+#include <torch/csrc/jit/passes/eliminate_tuple_construct_unpack.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+void TestEliminateTupleConstructUnpack(
+    const std::string& src,
+    const std::vector<c10::IValue>& args,
+    const std::string& expected_string) {
+  testGraphPass(src, args, expected_string, EliminateTupleConstructUnpack);
+}
+
+void TestEliminateTupleUnpackConstruct(
+    const std::string& src,
+    const std::vector<c10::IValue>& args,
+    const std::string& expected_string) {
+  testGraphPass(src, args, expected_string, EliminateTupleUnpackConstruct);
+}
+
+} // namespace
+
+TEST(EliminateTupleConstructUnpack, SingleArg) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor):
+            %1 : Tensor[] = prim::TupleConstruct(%0)
+            %2 : Tensor = prim::TupleUnpack(%1)
+            return (%2)
+    )IR";
+  const std::vector<IValue> args{at::randn({2})};
+  const std::string expected_string = "return (%0)";
+  TestEliminateTupleConstructUnpack(src, args, expected_string);
+}
+
+TEST(EliminateTupleConstructUnpack, MultiArg) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor):
+            %2 : Tensor[] = prim::TupleConstruct(%0, %1)
+            %3 : Tensor, %4 : Tensor = prim::TupleUnpack(%2)
+            return (%3, %4)
+    )IR";
+  const std::vector<IValue> args{at::randn({2}), at::randn({2})};
+  const std::string expected_string = "return (%0, %1)";
+  TestEliminateTupleConstructUnpack(src, args, expected_string);
+}
+
+TEST(EliminateTupleUnpackConstruct, OptimizationApplied) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor):
+            %2 : (Tensor, Tensor) = prim::TupleConstruct(%0, %1)
+
+            %3 : Tensor, %4 : Tensor = prim::TupleUnpack(%2)
+            %5 : (Tensor, Tensor) = prim::TupleConstruct(%3, %4)
+            return (%5)
+        )IR";
+
+  const std::vector<IValue> args{at::randn({1}), at::randn({1})};
+  const std::string expected_string = "return (%2)";
+  TestEliminateTupleUnpackConstruct(src, args, expected_string);
+}
+
+TEST(EliminateTupleUnpackConstruct, NoOptimization_Reorder) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor):
+            %2 : (Tensor, Tensor) = prim::TupleConstruct(%0, %1)
+
+            %3 : Tensor, %4 : Tensor = prim::TupleUnpack(%2)
+            %5 : (Tensor, Tensor) = prim::TupleConstruct(%4, %3)
+            return (%5)
+    )IR";
+
+  const std::vector<IValue> args{at::randn({1}), at::randn({1})};
+  const std::string expected_string = "return (%5)";
+  TestEliminateTupleUnpackConstruct(src, args, expected_string);
+}
+
+TEST(EliminateTupleUnpackConstruct, NoOptimization_SubsetConstructed) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor, %2 : Tensor):
+            %3 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%0, %1, %2)
+
+            %4 : Tensor, %5 : Tensor, %6 : Tensor = prim::TupleUnpack(%3)
+            %7 : (Tensor, Tensor) = prim::TupleConstruct(%4, %5)
+            return (%7)
+    )IR";
+
+  const std::vector<IValue> args{
+      at::randn({1}), at::randn({1}), at::randn({1})};
+  const std::string expected_string = "return (%7)";
+  TestEliminateTupleUnpackConstruct(src, args, expected_string);
+}
+
+TEST(EliminateTupleUnpackConstruct, NoOptimization_DifferentTuples) {
+  const std::string src = R"IR(
+        graph(%0 : Tensor, %1 : Tensor, %2 : Tensor, %3 : Tensor):
+            %4 : (Tensor, Tensor) = prim::TupleConstruct(%0, %1)
+            %5 : (Tensor, Tensor) = prim::TupleConstruct(%3, %4)
+
+            %6 : Tensor, %7 : Tensor = prim::TupleUnpack(%4)
+            %8 : Tensor, %9 : Tensor = prim::TupleUnpack(%5)
+
+            %10 : (Tensor, Tensor) = prim::TupleConstruct(%6, %8)
+            return (%10)
+    )IR";
+
+  const std::vector<IValue> args{
+      at::randn({1}), at::randn({1}), at::randn({1}), at::randn({1})};
+  const std::string expected_string = "return (%10)";
+  TestEliminateTupleUnpackConstruct(src, args, expected_string);
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/test_utils.h
+++ b/test/cpp/jit/test_utils.h
@@ -89,12 +89,27 @@ bool almostEqual(const at::Tensor& a, const at::Tensor& b);
 
 bool exactlyEqual(const at::Tensor& a, const at::Tensor& b);
 
+// Compare tensors or tuples of tensors
+bool exactlyEqual(const IValue& a, const IValue& b);
+
 std::pair<at::Tensor, at::Tensor> lstm(
     at::Tensor input,
     at::Tensor hx,
     at::Tensor cx,
     at::Tensor w_ih,
     at::Tensor w_hh);
+
+c10::IValue runGraph(
+    std::shared_ptr<Graph> graph,
+    const std::vector<c10::IValue>& args);
+
+std::shared_ptr<Graph> makeGraph(const std::string& ir_src);
+
+void testGraphPass(
+    const std::string& src,
+    const std::vector<c10::IValue>& args,
+    const std::string& expected_string,
+    std::function<void(std::shared_ptr<Graph>&)> o);
 
 } // namespace jit
 } // namespace torch

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -194,6 +194,7 @@ core_sources_full_mobile = [
     "torch/csrc/jit/passes/remove_redundant_profiles.cpp",
     "torch/csrc/jit/passes/remove_exceptions.cpp",
     "torch/csrc/jit/passes/decompose_ops.cpp",
+    "torch/csrc/jit/passes/eliminate_dict_construct_getitem.cpp",
     "torch/csrc/jit/passes/erase_number_types.cpp",
     "torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp",
     "torch/csrc/jit/passes/freeze_module.cpp",

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -195,6 +195,7 @@ core_sources_full_mobile = [
     "torch/csrc/jit/passes/remove_exceptions.cpp",
     "torch/csrc/jit/passes/decompose_ops.cpp",
     "torch/csrc/jit/passes/eliminate_dict_construct_getitem.cpp",
+    "torch/csrc/jit/passes/eliminate_tuple_construct_unpack.cpp",
     "torch/csrc/jit/passes/erase_number_types.cpp",
     "torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp",
     "torch/csrc/jit/passes/freeze_module.cpp",

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -195,6 +195,7 @@ core_sources_full_mobile = [
     "torch/csrc/jit/passes/remove_exceptions.cpp",
     "torch/csrc/jit/passes/decompose_ops.cpp",
     "torch/csrc/jit/passes/eliminate_dict_construct_getitem.cpp",
+    "torch/csrc/jit/passes/eliminate_list_construct_unpack.cpp",
     "torch/csrc/jit/passes/eliminate_tuple_construct_unpack.cpp",
     "torch/csrc/jit/passes/erase_number_types.cpp",
     "torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp",

--- a/torch/csrc/jit/passes/eliminate_dict_construct_getitem.cpp
+++ b/torch/csrc/jit/passes/eliminate_dict_construct_getitem.cpp
@@ -1,0 +1,69 @@
+#include <torch/csrc/jit/passes/eliminate_dict_construct_getitem.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+std::unordered_map<Value*, Value*> GetKeyValuesFromDictNode(Node* dict) {
+  TORCH_CHECK(
+      dict->inputs().size() % 2 == 0,
+      "DictConstruct should have an even number of inputs");
+  std::unordered_map<Value*, Value*> key_values;
+
+  for (size_t i = 0; i < dict->inputs().size(); i += 2) {
+    auto* key = dict->input(i);
+    auto* value = dict->input(i + 1);
+    key_values.emplace(key, value);
+  }
+
+  return key_values;
+}
+
+void UpdateGetItemUses(Node* dict, const std::vector<Node*>& dict_users) {
+  auto key_values = GetKeyValuesFromDictNode(dict);
+
+  for (auto* user : dict_users) {
+    auto* target_key = user->input(1);
+    auto kv = key_values.find(target_key);
+    if (kv != key_values.end()) {
+      // Replace all uses of the getitem call with the value in the
+      // DictConstruct call.
+      user->output()->replaceAllUsesWith(kv->second);
+    }
+  }
+}
+
+bool IsPureOp(const NodeKind& kind) {
+  return kind == aten::__getitem__ || kind == aten::len || kind == aten::copy ||
+      kind == aten::keys || kind == aten::values || kind == aten::__contains__;
+}
+
+} // namespace
+
+void EliminateDictConstructGetItem(std::shared_ptr<Graph>& graph) {
+  for (Node* n : graph->nodes()) {
+    bool dict_mutated = false;
+    std::vector<Node*> users;
+    if (n->kind() == prim::DictConstruct) {
+      auto* dict = n->output();
+      for (auto& use : dict->uses()) {
+        auto* user = use.user;
+        if (!IsPureOp(user->kind())) {
+          dict_mutated = true;
+          break;
+        }
+
+        if (user->kind() == aten::__getitem__) {
+          users.push_back(user);
+        }
+      }
+      if (!dict_mutated) {
+        UpdateGetItemUses(n, users);
+      }
+    }
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/eliminate_dict_construct_getitem.h
+++ b/torch/csrc/jit/passes/eliminate_dict_construct_getitem.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+/* Given:
+ *   %2 : Dict = prim::DictConstruct(%key, %value)
+ *   %3 : Tensor = aten::__getitem__(%2, %key)
+ *   %4 : Tensor = op(%3)
+ * Produces:
+ *   %2 : Dict = prim::DictConstruct(%key, %value)
+ *   %3 : Tensor = aten::__getitem__(%2, %key)
+ *   %4 : Tensor = op(%value)
+ *
+ * This only happens if the only uses of the DictConstruct output are
+ * __getitem__s; the optimization is not safe if the dict is mutated!
+ *
+ * The calls to DictConstruct / __getitem__ can then be removed via
+ * dead code elimination.
+ */
+TORCH_API void EliminateDictConstructGetItem(std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/eliminate_list_construct_unpack.cpp
+++ b/torch/csrc/jit/passes/eliminate_list_construct_unpack.cpp
@@ -1,0 +1,56 @@
+#include <torch/csrc/jit/passes/eliminate_list_construct_unpack.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+void UpdateUnpackUses(Node* list, const std::vector<Node*>& list_unpack_users) {
+  size_t nInputs = list->inputs().size();
+  for (auto* user : list_unpack_users) {
+    TORCH_CHECK(
+        nInputs == user->outputs().size(),
+        "The number of ListConstruct inputs and the number of ListUnpack outputs should be same.")
+    // Replace all uses of the ListUnpack outputs with the value in the
+    // ListConstruct call.
+    for (size_t i = 0; i < nInputs; ++i) {
+      user->output(i)->replaceAllUsesWith(list->input(i));
+    }
+  }
+}
+
+bool IsPureOp(const NodeKind& kind) {
+  return kind == prim::ListUnpack || kind == aten::__getitem__ ||
+      kind == aten::len || kind == aten::copy;
+}
+
+} // namespace
+
+void EliminateListConstructUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
+  for (Node* n : graph->nodes()) {
+    bool list_mutated = false;
+    std::vector<Node*> users;
+
+    if (n->kind() != prim::ListConstruct) {
+      continue;
+    }
+    auto* list = n->output();
+    for (auto& use : list->uses()) {
+      auto* user = use.user;
+      if (!IsPureOp(user->kind())) {
+        list_mutated = true;
+        break;
+      }
+
+      if (user->kind() == prim::ListUnpack) {
+        users.push_back(user);
+      }
+    }
+    if (!list_mutated) {
+      UpdateUnpackUses(n, users);
+    }
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/eliminate_list_construct_unpack.h
+++ b/torch/csrc/jit/passes/eliminate_list_construct_unpack.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+/* Given:
+ *          %3:Tensor[] = prim::ListConstruct(%0, %1)
+ *          %4:Tensor, %5:Tensor = prim ::ListUnpack(%3)
+ *          some op (%4, %5)
+ *
+ * Result:
+ *          %3:Tensor[] = prim::ListConstruct(%0, %1)
+ *          %4:Tensor, %5:Tensor = prim ::ListUnpack(%3)
+ *          some op (%0, %1)
+ */
+void EliminateListConstructUnpack(std::shared_ptr<torch::jit::Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/eliminate_tuple_construct_unpack.cpp
+++ b/torch/csrc/jit/passes/eliminate_tuple_construct_unpack.cpp
@@ -1,0 +1,56 @@
+#include <torch/csrc/jit/passes/eliminate_tuple_construct_unpack.h>
+
+namespace torch {
+namespace jit {
+
+void EliminateTupleConstructUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
+  auto block = graph->block();
+  for (auto it = block->nodes().rbegin(); it != block->nodes().rend(); ++it) {
+    auto* node = *it;
+    if (node->kind() != prim::TupleUnpack) {
+      continue;
+    }
+    auto* src = node->input()->node();
+    if (src->kind() != prim::TupleConstruct) {
+      continue;
+    }
+
+    TORCH_CHECK(
+        src->inputs().size() == node->outputs().size(),
+        "The number of TupleConstruct inputs and the number of TupleUnpack outputs should be same.");
+    size_t nInputs = src->inputs().size();
+    for (size_t i = 0; i < nInputs; ++i) {
+      node->output(i)->replaceAllUsesWith(src->input(i));
+    }
+  }
+}
+
+void EliminateTupleUnpackConstruct(std::shared_ptr<torch::jit::Graph>& graph) {
+  auto block = graph->block();
+  for (auto it = block->nodes().rbegin(); it != block->nodes().rend(); ++it) {
+    auto* node = *it;
+    if (node->kind() != prim::TupleConstruct) {
+      continue;
+    }
+    size_t nInputs = node->inputs().size();
+    auto* src0 = node->input(0)->node();
+    if (src0->outputs().size() != nInputs ||
+        src0->kind() != prim::TupleUnpack) {
+      continue;
+    }
+    bool shouldEliminate = true;
+    for (size_t i = 0; i < nInputs; ++i) {
+      auto* src = node->input(i)->node();
+      if (src != src0 || node->input(i) != src->output(i)) {
+        shouldEliminate = false;
+        break;
+      }
+    }
+    if (shouldEliminate) {
+      node->output()->replaceAllUsesWith(src0->input());
+    }
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/eliminate_tuple_construct_unpack.h
+++ b/torch/csrc/jit/passes/eliminate_tuple_construct_unpack.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+/* Given:
+ *          %3:Tensor[] = prim::TupleConstruct(%0, %1)
+ *          %4:Tensor, %5:Tensor = prim ::TupleUnpack(%3)
+ *          some op (%4, %5)
+ *
+ * Result:
+ *          %3:Tensor[] = prim::TupleConstruct(%0, %1)
+ *          %4:Tensor, %5:Tensor = prim ::TupleUnpack(%3)
+ *          some op (%0, %1)
+ */
+void EliminateTupleConstructUnpack(std::shared_ptr<torch::jit::Graph>& graph);
+
+/* Given:
+ *          %1:Tensor, %2:Tensor = prim ::TupleUnpack(%0)
+ *          %3:Tensor[] = prim::TupleConstruct(%1, %2)
+ *          some op (%3)
+ *
+ * Result:
+ *          %1:Tensor, %2:Tensor = prim ::TupleUnpack(%0)
+ *          %3:Tensor[] = prim::TupleConstruct(%1, %2)
+ *          some op (%0)
+ */
+void EliminateTupleUnpackConstruct(std::shared_ptr<torch::jit::Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/eliminate_dict_construct_getitem.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
@@ -63,6 +64,7 @@ void OptimizeGraph(
   ConstantPropagation(graph);
   RemoveTensorMutation(graph);
   ConstantPropagation(graph);
+  EliminateDictConstructGetItem(graph);
   EliminateDeadCode(graph);
   FuseInferenceOpsForSparseNN(graph);
   UseVariadicCat(graph);

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/eliminate_dict_construct_getitem.h>
+#include <torch/csrc/jit/passes/eliminate_tuple_construct_unpack.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
@@ -65,6 +66,8 @@ void OptimizeGraph(
   RemoveTensorMutation(graph);
   ConstantPropagation(graph);
   EliminateDictConstructGetItem(graph);
+  EliminateTupleConstructUnpack(graph);
+  EliminateTupleUnpackConstruct(graph);
   EliminateDeadCode(graph);
   FuseInferenceOpsForSparseNN(graph);
   UseVariadicCat(graph);

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/eliminate_dict_construct_getitem.h>
+#include <torch/csrc/jit/passes/eliminate_list_construct_unpack.h>
 #include <torch/csrc/jit/passes/eliminate_tuple_construct_unpack.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
@@ -68,6 +69,7 @@ void OptimizeGraph(
   EliminateDictConstructGetItem(graph);
   EliminateTupleConstructUnpack(graph);
   EliminateTupleUnpackConstruct(graph);
+  EliminateListConstructUnpack(graph);
   EliminateDeadCode(graph);
   FuseInferenceOpsForSparseNN(graph);
   UseVariadicCat(graph);


### PR DESCRIPTION
Summary:
* Moved the pass to `torch/csrc/jit/passes` so it can be accessed by static runtime
* Added more robust tests + changed minor stylistic details in the pass implementation

Differential Revision: D30107568

