### PR TITLE
DO NOT MERGE until after 30/sep/2021: remove unnecessary torch.meshgrid overloads

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2152,12 +2152,6 @@ std::vector<Tensor> unbind(const Tensor& self, Dimname dim) {
   return at::unbind(self, dimname_to_position(self, dim));
 }
 
-std::vector<Tensor> meshgrid(TensorList tensors) {
-  TORCH_WARN_ONCE("torch.meshgrid: in an upcoming release, it will be required to pass the "
-                  "indexing argument.");
-  return native::meshgrid(tensors, /*indexing=*/"ij");
-}
-
 std::vector<Tensor> meshgrid(TensorList tensors,
                              c10::string_view indexing) {
   int64_t size = tensors.size();

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5420,12 +5420,7 @@
   device_check: NoCheck
   device_guard: False
 
-- func: meshgrid(Tensor[] tensors) -> Tensor[]
-
-# TODO: Two weeks after this lands, combine these two overloads,
-#       making "indexing" optional. These are temporarily distinct for
-#       forward-compatibility reasons.
-- func: meshgrid.indexing(Tensor[] tensors, *, str indexing) -> Tensor[]
+- func: meshgrid(Tensor[] tensors, *, str indexing='ij') -> Tensor[]
 
 - func: cartesian_prod(Tensor[] tensors) -> Tensor
   variants: function

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1410,7 +1410,8 @@ class TestTensorCreation(TestCase):
     def test_meshgrid_unsupported_indexing(self):
         with self.assertRaisesRegex(RuntimeError,
                                     'indexing must be one of "xy" or "ij"'):
-            torch.meshgrid(torch.tensor([1, 2]), indexing='')
+            torch.meshgrid(torch.tensor([1, 2]),
+                           indexing='definitely not any kind of indexing mode')
 
     def test_meshgrid_non_1d_tensor(self):
         with self.assertRaisesRegex(RuntimeError,

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -629,7 +629,7 @@ const std::vector<std::string> functions = {
 
             return torch.index(self, indices), backward
 
-        def meshgrid(tensors: List[Tensor]):
+        def meshgrid(tensors: List[Tensor], *, indexing: str):
             size = len(tensors)
             sizes = [0] * size
             for i in range(size):
@@ -645,8 +645,8 @@ const std::vector<std::string> functions = {
                     else:
                         view_shape[i] = sizes[i]
                         grads_tensors.append((grad_outputs[i]._grad_sum_to_size(view_shape)).reshape([sizes[i]]))
-                return grads_tensors
-            return torch.meshgrid(tensors), backward
+                return grads_tensors, None
+            return torch.meshgrid(tensors, indexing=indexing), backward
 
         def mv(self, vec):
             def backward(grad_output):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2898,8 +2898,8 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 @parse_args('v', 's')
-def meshgrid(g, tensor_list, indexing: Optional[str] = None):
-    if indexing is None:
+def meshgrid(g, tensor_list, indexing: str = 'ij'):
+    if indexing == '':
         indexing = 'ij'
     elif indexing not in {'ij', 'xy'}:
         raise ValueError(f'Unsupported indexing: {indexing}')


### PR DESCRIPTION
Now that the forward compatibility window has passed, we can merge the
overloads into a single signature.

DO NOT MERGE: Wait until two weeks after #62722 has merged.
