### PR TITLE
[SR] Disable NNC temporarily

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -460,6 +460,11 @@ namespace {
 // contains FP divide, which is single-ported.
 static constexpr int kVectorWidth = 16;
 
+// disable NNC temporarily until a code cache is implemented
+#ifdef TORCH_ENABLE_LLVM
+#undef TORCH_ENABLE_LLVM
+#endif
+
 #ifdef TORCH_ENABLE_LLVM
 
 struct TEWrapper {


### PR DESCRIPTION
Summary: Disable NNC temporarily until a code cache is implemented to reduce the compilation time.

Reviewed By: ajyu

Differential Revision: D30080326

