### PR TITLE
DO NOT MERGE until after 1.10 is cut: require that clients provide `indexing` to torch.meshgrid

### DIFF
--- a/aten/src/ATen/native/Itertools.cpp
+++ b/aten/src/ATen/native/Itertools.cpp
@@ -11,7 +11,8 @@ Tensor _triu_mask(int64_t n, int64_t dims, bool diagonal, TensorOptions opt) {
   // get a mask that has value 1 whose indices satisfies i < j < k < ...
   // or i <= j <= k <= ... (depending on diagonal)
   Tensor range = at::arange(n, opt.dtype(kLong));
-  std::vector<Tensor> index_grids = at::meshgrid(std::vector<Tensor>(dims, range));
+  std::vector<Tensor> index_grids = at::meshgrid(std::vector<Tensor>(dims, range),
+                                                 /*indexing=*/"ij");
   Tensor mask = at::full(index_grids[0].sizes(), true, opt.dtype(kBool));
   if(diagonal) {
     for(int64_t i = 0; i < dims - 1; i++) {
@@ -37,7 +38,7 @@ Tensor cartesian_prod(TensorList tensors) {
   if (tensors.size() == 1) {
     return tensors[0];
   }
-  std::vector<Tensor> grids = at::meshgrid(tensors);
+  std::vector<Tensor> grids = at::meshgrid(tensors, /*indexing=*/"ij");
   for(Tensor &t : grids) {
     t = t.flatten();
   }
@@ -48,7 +49,8 @@ Tensor combinations(const Tensor& self, int64_t r, bool with_replacement) {
   TORCH_CHECK(self.dim() == 1, "Expect a 1D vector, but got shape ", self.sizes());
   TORCH_CHECK(r > 0, "Expect a positive number, but got ", r);
   int64_t num_elements = self.numel();
-  std::vector<Tensor> grids = at::meshgrid(std::vector<Tensor>(r, self));
+  std::vector<Tensor> grids = at::meshgrid(std::vector<Tensor>(r, self),
+                                           /*indexing=*/"ij");
   Tensor mask = _triu_mask(num_elements, r, with_replacement, self.options());
   for(Tensor &t : grids) {
     t = t.masked_select(mask);

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -848,7 +848,8 @@ class TestOperators(TestCase):
         x = torch.ones(3, requires_grad=True)
         y = torch.zeros(4, requires_grad=True)
         z = torch.ones(5, requires_grad=True)
-        self.assertONNX(lambda x, y, z: torch.meshgrid(x, y, z), (x, y, z))
+        self.assertONNX(lambda x, y, z: torch.meshgrid(x, y, z, indexing='ij'),
+                        (x, y, z))
 
     def test_topk(self):
         x = torch.arange(1., 6., requires_grad=True)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -2373,7 +2373,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_meshgrid(self):
         class MeshgridModel(torch.nn.Module):
             def forward(self, x, y, z):
-                return torch.meshgrid(x, y, z)
+                return torch.meshgrid(x, y, z, indexing='ij')
 
         x = torch.ones(3, requires_grad=True)
         y = torch.zeros(4, requires_grad=True)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6025,7 +6025,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_meshgrid(self):
         class Meshgrid(torch.nn.Module):
             def forward(self, x, y, z):
-                output1, output2, output3 = torch.meshgrid(x, y, z)
+                output1, output2, output3 = torch.meshgrid(x, y, z, indexing='ij')
                 return output1, output2, output3
 
         x = torch.randn(3, requires_grad=True)
@@ -6037,7 +6037,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_meshgrid_scalar(self):
         class Meshgrid(torch.nn.Module):
             def forward(self, x, y, z):
-                output1, output2, output3 = torch.meshgrid(x, y, z)
+                output1, output2, output3 = torch.meshgrid(x, y, z, indexing='ij')
                 return output1, output2, output3
 
         x = torch.ones(3, requires_grad=True)

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1,7 +1,6 @@
 from typing import (
     Tuple, Optional, Union, Any, Sequence, TYPE_CHECKING
 )
-import warnings
 
 import torch
 import torch.nn.functional as F
@@ -443,9 +442,11 @@ def _meshgrid(*tensors, indexing: Optional[str]):
         # state to take the same parameter type to avoid having to
         # juggle a forward-compatibility breaking change in the
         # future.
-        warnings.warn('torch.meshgrid: in an upcoming release, it will be '
-                      'required to pass the indexing argument.')
-        indexing = 'ij'
+        raise RuntimeError('torch.meshgrid: the "indexing" parameter is '
+                           'required. The default value was \"ij\", so pass '
+                           'indexing=\'ij\' to keep the existing behavior. In '
+                           'a future release of PyTorch the default will '
+                           'become "xy".')
 
     if has_torch_function(tensors):
         return handle_torch_function(meshgrid, tensors, *tensors, indexing=indexing)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2898,10 +2898,8 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 @parse_args('v', 's')
-def meshgrid(g, tensor_list, indexing: str = 'ij'):
-    if indexing == '':
-        indexing = 'ij'
-    elif indexing not in {'ij', 'xy'}:
+def meshgrid(g, tensor_list, indexing: str):
+    if indexing not in {'ij', 'xy'}:
         raise ValueError(f'Unsupported indexing: {indexing}')
     if indexing == 'xy':
         tensor_list[0], tensor_list[1] = tensor_list[1], tensor_list[0]


### PR DESCRIPTION
DO NOT MERGE until after a release contains #62722.
