### PR TITLE
[DDP] log gradient ready order and bucket indices

### DIFF
--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/StringUtil.h>
 #include <c10d/Utils.hpp>
 #include <c10d/logger.hpp>
 #include <fmt/format.h>
@@ -85,6 +86,16 @@ void Logger::set_parameter_stats() {
     unique_dtypes.insert(std::string(t.dtype().name()));
   }
   ddp_logging_data_->strs_map["dtypes"] = c10::Join(", ", unique_dtypes);
+}
+
+std::vector<std::vector<size_t>> Logger::get_per_bucket_variable_indices() {
+  std::vector<std::vector<size_t>> per_bucket_variable_indices;
+  per_bucket_variable_indices.reserve(reducer_->buckets_.size());
+  for (const auto& bucket : reducer_->buckets_) {
+    const auto& indices = bucket.variable_indices;
+    per_bucket_variable_indices.push_back(indices);
+  }
+  return per_bucket_variable_indices;
 }
 
 std::vector<int> Logger::get_bucket_sizes() {
@@ -237,6 +248,23 @@ void Logger::set_runtime_stats_and_log() {
     ddp_logging_data_->strs_map["rebuilt_bucket_size_limits"] =
         c10::Join(", ", get_bucket_size_limits());
   }
+  // Log gradient ready order
+  if (!reducer_->grad_ready_order_indices_.empty()) {
+    // Note that the indices are for the previous iteration as
+    // this function is called in forward pass, and we last computed gradient
+    // ready order in the last backward pass.
+    ddp_logging_data_->strs_map["prev_iteration_grad_ready_order_indices"] =
+        c10::Join(", ", reducer_->grad_ready_order_indices_);
+  }
+  // Log per-bucket variable indices
+  std::vector<std::string> per_bucket_variable_indices;
+  auto indices = get_per_bucket_variable_indices();
+  per_bucket_variable_indices.reserve(indices.size());
+  for (const auto& bucket_indices : indices) {
+    per_bucket_variable_indices.push_back(c10::Join(" ", bucket_indices));
+  }
+  ddp_logging_data_->strs_map["per_bucket_variable_indices"] =
+      c10::Join(", ", per_bucket_variable_indices);
 
   reset_performance_stats();
 

--- a/torch/csrc/distributed/c10d/logger.hpp
+++ b/torch/csrc/distributed/c10d/logger.hpp
@@ -39,6 +39,8 @@ class TORCH_API Logger {
   std::vector<int> get_bucket_sizes();
   // Get bucket size limits specified during DDP construction.
   std::vector<int> get_bucket_size_limits();
+  // Get variable indices for each bucket.
+  std::vector<std::vector<size_t>> get_per_bucket_variable_indices();
   // Set comm. hook, if used
   void set_comm_hook(const std::string& hook);
   // Set running with uneven input detection (model.join() context manager)

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -604,6 +604,8 @@ void Reducer::autograd_hook(size_t index) {
     return;
   }
 
+  grad_ready_order_indices_.push_back(index);
+
   // See Note [Skip allreducing local_used_maps_dev]
   if (dynamic_graph_find_unused() || static_graph_first_iteration()) {
     // Since it gets here, this param has been used for this iteration. We want
@@ -1313,6 +1315,8 @@ void Reducer::prepare_for_backward(
 
   // Reset accounting.
   expect_autograd_hooks_ = true;
+  // Clear gradient ready order as it can be different in the next iteration.
+  grad_ready_order_indices_.clear();
 
   reset_bucket_counting();
 

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -524,6 +524,9 @@ class TORCH_API Reducer {
   // Mapping of variable index to fully qualified name of model to notify users
   // about errors when certain parameters do not get gradient.
   std::unordered_map<size_t, std::string> param_names_;
+  // Variable indices stored sequentially in order of when the gradient is ready
+  // for the current backwards pass.
+  std::vector<int> grad_ready_order_indices_;
   // Bytes capacity of first bucket, can be configured by user
   int64_t first_bucket_bytes_cap_;
   // Per iteration set of parameter indices that have been marked ready.

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4992,6 +4992,11 @@ class DistributedTest:
             self.assertEqual(
                 ddp_logging_data.get("rebuilt_bucket_sizes"), str(param_size)
             )
+            grad_ready_order = ddp_logging_data.get("prev_iteration_grad_ready_order_indices")
+            expected_order = list(reversed([str(x) for x in range(3)]))
+            self.assertEqual(grad_ready_order, ", ".join(expected_order))
+            bucket_indices = ddp_logging_data.get("per_bucket_variable_indices")
+            self.assertEqual(bucket_indices, " ".join(expected_order))
             # It is hard to test accurate latency, but it can test whether the latency is
             # a valid value and in the expected range.
             self.assertGreaterEqual(ddp_logging_data.get("avg_forward_compute_time"), 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62770
* __->__ #62751
* #62748

This will help us determine whether gradient ready order and bucket
indices are aligned amongst all the ranks. This should always be true for rank
0 as we determine rebuilt bucket order by the gradient ready order on rank 0,
but would be interested to see this on different workloads for other ranks

Differential Revision: [D30111833](https://our.internmc.facebook.com/intern/diff/D30111833/)