### PR TITLE
DO NOT MERGE until after 1.10 is cut: change `torch.meshgrid` indexing default to "xy"

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5420,7 +5420,7 @@
   device_check: NoCheck
   device_guard: False
 
-- func: meshgrid(Tensor[] tensors, *, str indexing='ij') -> Tensor[]
+- func: meshgrid(Tensor[] tensors, *, str indexing='xy') -> Tensor[]
 
 - func: cartesian_prod(Tensor[] tensors) -> Tensor
   variants: function

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -331,10 +331,10 @@ def einsum(*args):
 if TYPE_CHECKING:
     # The JIT doesn't understand Union, so only add type annotation for mypy
     def meshgrid(*tensors: Union[Tensor, List[Tensor]],
-                 indexing: Optional[str] = None) -> Tuple[Tensor, ...]:
+                 indexing: str = 'xy') -> Tuple[Tensor, ...]:
         return _meshgrid(*tensors, indexing=indexing)
 else:
-    def meshgrid(*tensors, indexing: Optional[str] = None) -> Tuple[Tensor, ...]:
+    def meshgrid(*tensors, indexing: str = 'xy') -> Tuple[Tensor, ...]:
         r"""Creates grids of coordinates specified by the 1D inputs in `attr`:tensors.
 
         This is helpful when you want to visualize data over some
@@ -430,24 +430,7 @@ else:
         return _meshgrid(*tensors, indexing=indexing)
 
 
-def _meshgrid(*tensors, indexing: Optional[str]):
-    if indexing is None:
-        # The underlying native function requires the "indexing"
-        # argument, but torch.meshgrid() does not require it at the
-        # moment. We check for this case here.
-        #
-        # We do it this way because the end-state for the function
-        # will have `str indexing='xy'`, not `str? indexing=None` as
-        # the parameter and thus it makes sense for this intermediate
-        # state to take the same parameter type to avoid having to
-        # juggle a forward-compatibility breaking change in the
-        # future.
-        raise RuntimeError('torch.meshgrid: the "indexing" parameter is '
-                           'required. The default value was \"ij\", so pass '
-                           'indexing=\'ij\' to keep the existing behavior. In '
-                           'a future release of PyTorch the default will '
-                           'become "xy".')
-
+def _meshgrid(*tensors, indexing: str):
     if has_torch_function(tensors):
         return handle_torch_function(meshgrid, tensors, *tensors, indexing=indexing)
     if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2898,7 +2898,7 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 @parse_args('v', 's')
-def meshgrid(g, tensor_list, indexing: str):
+def meshgrid(g, tensor_list, indexing: str = 'xy'):
     if indexing not in {'ij', 'xy'}:
         raise ValueError(f'Unsupported indexing: {indexing}')
     if indexing == 'xy':

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4652,12 +4652,14 @@ def sample_inputs_meshgrid(op_info: OpInfo, device: torch.device, dtype: torch.d
     ]
 
     sample_inputs = []
-    for shapes, indexing in itertools.product(test_cases, {'xy', 'ij'}):
+    for shapes, indexing in itertools.product(test_cases, {None, 'xy', 'ij'}):
         input, args = make_inputs(
             [make_tensor(shape, device, dtype, requires_grad=requires_grad)
              for shape in shapes])
-        sample_inputs.append(SampleInput(input=input, args=args,
-                                         kwargs=dict(indexing=indexing)))
+        # Verify the default is the same if indexing is not
+        # specified.
+        kwargs = {'indexing': indexing} if indexing is not None else {}
+        sample_inputs.append(SampleInput(input=input, args=args, kwargs=kwargs))
     return sample_inputs
 
 


### PR DESCRIPTION
Fixes #50276

DO NOT MERGE until a release contains #62749