### PR TITLE
Fix inconsistency between Python and JIT power operation

### DIFF
--- a/test/jit/test_aten_pow.py
+++ b/test/jit/test_aten_pow.py
@@ -1,0 +1,90 @@
+import torch
+from torch.testing._internal.common_utils import TestCase
+
+class TestAtenPow(TestCase):
+    def test_aten_pow_zero_negative_exponent(self):
+        '''
+        1. Testing a = int, b = int
+        '''
+        @torch.jit.script
+        def fn_int_int(a: int, b: int):
+            return a ** b
+        # Existing correct behaviors of aten::pow
+        self.assertEqual(fn_int_int(2, 1), 2 ** 1)
+        self.assertEqual(fn_int_int(2, 0), 2 ** 0)
+        self.assertEqual(fn_int_int(2, -2), 2 ** (-2))
+        self.assertEqual(fn_int_int(-2, 2), (-2) ** 2)
+        self.assertEqual(fn_int_int(-2, 0), (-2) ** 0)
+        self.assertEqual(fn_int_int(-2, -2), (-2) ** (-2))
+        self.assertEqual(fn_int_int(-2, -1), (-2) ** (-1))
+        self.assertEqual(fn_int_int(0, 2), 0 ** 1)
+        self.assertEqual(fn_int_int(0, 0), 0 ** 0)
+        # zero base and negative exponent case that should trigger RunTimeError
+        self.assertRaises(RuntimeError, fn_int_int, 0, -2)
+
+        '''
+        2. Testing a = int, b = float
+        '''
+        @torch.jit.script
+        def fn_int_float(a: int, b: float):
+            return a ** b
+        # Existing correct behaviors of aten::pow
+        self.assertEqual(fn_int_float(2, 2.5), 2 ** 2.5)
+        self.assertEqual(fn_int_float(2, -2.5), 2 ** (-2.5))
+        self.assertEqual(fn_int_float(2, -0.0), 2 ** (-0.0))
+        self.assertEqual(fn_int_float(2, 0.0), 2 ** (0.0))
+        self.assertEqual(fn_int_float(-2, 2.0), (-2) ** 2.0)
+        self.assertEqual(fn_int_float(-2, -2.0), (-2) ** (-2.0))
+        self.assertEqual(fn_int_float(-2, -3.0), (-2) ** (-3.0))
+        self.assertEqual(fn_int_float(-2, -0.0), (-2) ** (-0.0))
+        self.assertEqual(fn_int_float(-2, 0.0), (-2) ** (0.0))
+        self.assertEqual(fn_int_float(0, 2.0), 0 ** 2.0)
+        self.assertEqual(fn_int_float(0, 0.5), 0 ** 0.5)
+        self.assertEqual(fn_int_float(0, 0.0), 0 ** 0.0)
+        self.assertEqual(fn_int_float(0, -0.0), 0 ** (-0.0))
+        # zero base and negative exponent case that should trigger RunTimeError
+        self.assertRaises(RuntimeError, fn_int_float, 0, -2.5)
+
+        '''
+        3. Testing a = float, b = int
+        '''
+        @torch.jit.script
+        def fn_float_int(a: float, b: int):
+            return a ** b
+        # Existing correct behaviors of aten::pow
+        self.assertEqual(fn_float_int(2.5, 2), 2.5 ** 2)
+        self.assertEqual(fn_float_int(2.5, -2), 2.5 ** (-2))
+        self.assertEqual(fn_float_int(2.5, -0), 2.5 ** (-0))
+        self.assertEqual(fn_float_int(2.5, 0), 2.5 ** 0)
+        self.assertEqual(fn_float_int(-2.5, 2), 2.5 ** 2)
+        self.assertEqual(fn_float_int(-2.5, -2), (-2.5) ** (-2))
+        self.assertEqual(fn_float_int(-2.5, -3), (-2.5) ** (-3))
+        self.assertEqual(fn_float_int(-2.5, -0), (-2.5) ** (-0))
+        self.assertEqual(fn_float_int(-2.5, 0), (-2.5) ** 0)
+        self.assertEqual(fn_float_int(0.0, 2), 0 ** 2)
+        self.assertEqual(fn_float_int(0.0, 0), 0 ** 0)
+        self.assertEqual(fn_float_int(0.0, -0), 0 ** (-0))
+        # zero base and negative exponent case that should trigger RunTimeError
+        self.assertRaises(RuntimeError, fn_float_int, 0.0, -2)
+
+        '''
+        4. Testing a = float, b = float
+        '''
+        @torch.jit.script
+        def fn_float_float(a: float, b: float):
+            return a ** b
+        # Existing correct behaviors of aten::pow
+        self.assertEqual(fn_float_float(2.5, 2.0), 2.5 ** 2.0)
+        self.assertEqual(fn_float_float(2.5, -2.0), 2.5 ** (-2.0))
+        self.assertEqual(fn_float_float(2.5, -0.0), 2.5 ** (-0.0))
+        self.assertEqual(fn_float_float(2.5, 0.0), 2.5 ** 0.0)
+        self.assertEqual(fn_float_float(-2.5, 2.0), 2.5 ** 2.0)
+        self.assertEqual(fn_float_float(-2.5, -2.0), (-2.5) ** (-2.0))
+        self.assertEqual(fn_float_float(-2.5, -3.0), (-2.5) ** (-3.0))
+        self.assertEqual(fn_float_float(-2.5, -0.0), (-2.5) ** (-0.0))
+        self.assertEqual(fn_float_float(-2.5, 0.0), (-2.5) ** 0.0)
+        self.assertEqual(fn_float_float(0.0, 2.0), 0.0 ** 2.0)
+        self.assertEqual(fn_float_float(0.0, 0.0), 0.0 ** 0.0)
+        self.assertEqual(fn_float_float(0.0, -0.0), 0.0 ** (-0.0))
+        # zero base and negative exponent case that should trigger RunTimeError
+        self.assertRaises(RuntimeError, fn_float_float, 0.0, -2.0)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -60,6 +60,7 @@ from jit.test_script_profile import TestScriptProfile  # noqa: F401
 from jit.test_convert_activation import TestFunctionalToInplaceActivation, TestInplaceToFunctionalActivation  # noqa: F401
 from jit.test_parametrization import TestParametrization  # noqa: F401
 from jit.test_attr import TestGetDefaultAttr  # noqa: F401
+from jit.test_aten_pow import TestAtenPow  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -79,6 +79,13 @@ c10::List<std::string> splitNoneSeparator(const std::string& string) {
   return splits;
 }
 
+template <typename T, typename U>
+auto powWrapper(T a, U b) {
+  TORCH_CHECK(
+      !(a == 0.0 && b < 0.0), "0.0 cannot be raised to a negative power")
+  return pow(a, b);
+}
+
 RegisterOperators reg(
     {OperatorGenerator(
          TORCH_SELECTIVE_SCHEMA("aten::str(t elem) -> str"),
@@ -893,13 +900,13 @@ RegisterOperators reg(
      // results
      DEFINE_GENERIC_OP_WITH_COMPLEX(
          aten::pow,
-         static_cast<double>(pow(a, b)),
-         static_cast<double>(pow(a, b)),
+         static_cast<double>(powWrapper(a, b)),
+         static_cast<double>(powWrapper(a, b)),
          static_cast<c10::complex<double>>(pow(a, b)),
          float,
          float,
          complex),
-     DEFINE_INT_FLOAT_OP(aten::pow, pow(a, b), float),
+     DEFINE_INT_FLOAT_OP(aten::pow, static_cast<double>(powWrapper(a, b)), float),
      DEFINE_FLOAT_COMPLEX_OP(aten::pow, pow(a, b), complex),
      DEFINE_SCALAR_BINARY_OP_AVOID_COLLISION(
          aten::pow,
@@ -912,7 +919,7 @@ RegisterOperators reg(
            // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
            int64_t a, b;
            pop(stack, a, b);
-           push(stack, pow(a, b));
+           push(stack, static_cast<double>(powWrapper(a, b)));
          },
          aliasAnalysisFromSchema()),
      // min and max are in prim:: because there is a difference between


### PR DESCRIPTION
When base is zero and exponent is negative, python power operation would raise a run time error while JIT would return inf. 
This is due to underlying cmath pow(a, b) function in some compilers would return inf instead of throwing error. Therefore, we are wrapping cmath pow function inside a wrapper and perform an addition check for zero base with negative exponent in the wrapper.

Note: Check that lint failure is not related to files changed in this PR.

Fixes #62556 
