### PR TITLE
[BF16] Add BF16 support to _aminmax and _anminmax_all operators

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
@@ -125,7 +125,7 @@ static void aminmax_kernel_impl(
     Tensor& max_result) {
   at::TensorIterator iter = make_reduction("aminmax_cuda", min_result,
     max_result, self, dim, keepdim, self.scalar_type());
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, self.scalar_type(), "aminmax_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, self.scalar_type(), "aminmax_cuda", [&]() {
     gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinMaxOps<scalar_t, scalar_t, int32_t>{},
@@ -167,7 +167,7 @@ void aminmax_allreduce_kernel_impl(const Tensor& input, Tensor& min_result, Tens
   auto iter = make_reduction("aminmax_cuda", min_result, max_result, input,
                              std::vector<int64_t>{}, false, dtype);
   TORCH_CHECK(iter.numel() > 0, "min_max on a tensor with no elements is not defined.");
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, dtype, "aminmax_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, dtype, "aminmax_all_cuda", [&] {
     _min_max_values_kernel_cuda_impl<scalar_t>(iter);
   });
 }

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -667,7 +667,7 @@ class TestReductions(TestCase):
 
     @onlyOnCPUAndCUDA
     @dtypesIfCPU(torch.float, torch.double)
-    @dtypesIfCUDA(torch.half, torch.float)
+    @dtypesIfCUDA(torch.half, torch.float, torch.bfloat16)
     def test_aminmax(self, device, dtype):
 
         def _amin_wrapper(x, dim=None, keepdims=False):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6647,7 +6647,7 @@ op_db: List[OpInfo] = [
     OpInfo('aminmax',
            ref=lambda x, dim=None, keepdim=False: (np.amin(x, axis=dim, keepdims=keepdim), np.amax(x, axis=dim, keepdims=keepdim)),
            dtypes=all_types_and(torch.bool),
-           dtypesIfCUDA=all_types_and(torch.bool, torch.float16),
+           dtypesIfCUDA=all_types_and(torch.bool, torch.float16, torch.bfloat16),
            decorators=(onlyOnCPUAndCUDA,),
            supports_autograd=False,
            sample_inputs_func=sample_inputs_aminmax,


### PR DESCRIPTION
Summary: Add BF16 support to _aminmax_all and _aminmax operators.

Test Plan:
Added unit test:
https://www.internalfb.com/intern/testinfra/testconsole/testrun/2533274857208373/

Differential Revision: D30073837

