### PR TITLE
[DDP] Add host-side time to CUDATimer

### DIFF
--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -192,6 +192,17 @@ void Logger::set_construction_data_and_log(
   at::LogPyTorchDDPUsage(*ddp_logging_data_);
 }
 
+void Logger::set_event_time(
+    int64_t& event_time,
+    Timer& timer,
+    Timer::Event event) {
+  auto timestamp = timer.getTimestamp(event);
+  if (timestamp != c10::nullopt) {
+    // TODO: should we set this as human-readable time instead of unixtime?
+    event_time = *timestamp;
+  }
+}
+
 void Logger::calculate_avg_time(
     int64_t& avg_time,
     int64_t& time_duration,
@@ -213,6 +224,11 @@ void Logger::reset_performance_stats() {
   ddp_logging_data_->ints_map["backward_comm_time"] = 0;
   ddp_logging_data_->ints_map["backward_compute_time"] = 0;
   ddp_logging_data_->ints_map["backward_compute_comm_overlap_time"] = 0;
+  ddp_logging_data_->ints_map["forward_compute_time_start"] = 0;
+  ddp_logging_data_->ints_map["backward_compute_time_start"] = 0;
+  ddp_logging_data_->ints_map["backward_comm_time_start"] = 0;
+  ddp_logging_data_->ints_map["backward_compute_time_end"] = 0;
+  ddp_logging_data_->ints_map["backward_comm_time_end"] = 0;
 }
 
 void Logger::set_runtime_stats_and_log() {
@@ -300,6 +316,32 @@ void Logger::set_runtime_stats_and_log() {
       *reducer_->timer_,
       Timer::Event::kBackwardCommStart,
       Timer::Event::kBackwardComputeEnd);
+
+  set_event_time(
+    ddp_logging_data_->ints_map["forward_compute_time_start"],
+    *reducer_->timer_,
+    Timer::Event::kForwardStart
+  );
+  set_event_time(
+    ddp_logging_data_->ints_map["backward_compute_time_start"],
+    *reducer_->timer_,
+    Timer::Event::kBackwardComputeStart
+  );
+  set_event_time(
+    ddp_logging_data_->ints_map["backward_comm_time_start"],
+    *reducer_->timer_,
+    Timer::Event::kBackwardCommStart
+  );
+  set_event_time(
+    ddp_logging_data_->ints_map["backward_compute_time_end"],
+    *reducer_->timer_,
+    Timer::Event::kBackwardComputeEnd
+  );
+  set_event_time(
+    ddp_logging_data_->ints_map["backward_comm_time_end"],
+    *reducer_->timer_,
+    Timer::Event::kBackwardCommEnd
+  );
 
   // Log runtime stats to stderr if TORCH_DISTRIBUTED_DEBUG=DETAIL is enabled.
   if (parseDistDebugLevel() == DistributedDebugLevel::DETAIL) {

--- a/torch/csrc/distributed/c10d/logger.hpp
+++ b/torch/csrc/distributed/c10d/logger.hpp
@@ -57,6 +57,13 @@ class TORCH_API Logger {
       Timer& timer,
       Timer::Event start_event,
       Timer::Event end_event);
+
+  // Set the absolute time of the event that has been recorded in reducer.
+  void set_event_time(
+    int64_t& event_time,
+    Timer& timer,
+    Timer::Event event
+  );
   // Set stats that can be collected only during
   // training loop. It is called at the beginning of forward call
   // to record the run time stats of sampled iterations that previouly ran.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -23,9 +23,6 @@
 namespace c10d {
 namespace {
 
-inline int64_t current_time_in_nanos() {
-  return torch::autograd::profiler::getTime();
-}
 
 constexpr int kUnsetDivFactor = -1;
 
@@ -50,41 +47,8 @@ C10_DEFINE_TYPED_REGISTRY( // NOLINT
 namespace {
 
 class CpuTimer : public Timer {
- private:
-  // The timestamp of forward call start time in each iteration.
-  int64_t forward_start_time = -1;
-  // The timestamp of backward computation start and end time in each
-  // iteration.
-  int64_t backward_compute_start_time = -1;
-  int64_t backward_compute_end_time = -1;
-  // The timestamp of first communication call start time in each iteration.
-  int64_t backward_comm_start_time = -1;
-  // The timestamp of last communication call end time in each iteration.
-  int64_t backward_comm_end_time = -1;
-
-  int64_t& getTime(Event event) {
-    switch (event) {
-      case Event::kForwardStart:
-        return forward_start_time;
-      case Event::kBackwardComputeStart:
-        return backward_compute_start_time;
-      case Event::kBackwardComputeEnd:
-        return backward_compute_end_time;
-      case Event::kBackwardCommStart:
-        return backward_comm_start_time;
-      case Event::kBackwardCommEnd:
-        return backward_comm_end_time;
-      default:
-        TORCH_INTERNAL_ASSERT(false);
-    }
-  }
-
  public:
   explicit CpuTimer(c10::Device /* unused */) {}
-
-  void record(Event event) override {
-    getTime(event) = current_time_in_nanos();
-  }
 
   c10::optional<int64_t> measureDifference(Event start, Event end) override {
     int64_t start_time = getTime(start);

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -27,11 +27,27 @@ constexpr int kDefaultFirstBucketBytes = int(1024 * 1024);
 constexpr int kDefaultBucketBytesCap = int(25 * 1024 * 1024);
 // Collect runtime stats once for every kDDPRuntimeLoggingSampleRate iterations.
 constexpr int kDDPRuntimeLoggingSampleRate = 100;
+constexpr int kUnsetTime = -1;
+
+inline int64_t current_time_in_nanos() {
+  return torch::autograd::profiler::getTime();
+}
 
 // Forward declaration
 class Logger;
 
 class TORCH_API Timer {
+  private:
+    // The timestamp of forward call start time in each iteration.
+    int64_t forward_start_time = kUnsetTime;
+    // The timestamp of backward computation start and end time in each
+    // iteration.
+    int64_t backward_compute_start_time = kUnsetTime;
+    int64_t backward_compute_end_time = kUnsetTime;
+    // The timestamp of first communication call start time in each iteration.
+    int64_t backward_comm_start_time = kUnsetTime;
+    // The timestamp of last communication call end time in each iteration.
+  int64_t backward_comm_end_time = kUnsetTime;
  public:
   enum class Event {
     kForwardStart,
@@ -41,14 +57,45 @@ class TORCH_API Timer {
     kBackwardCommEnd,
   };
 
-  // Record the current event, i.e., mark it as having occurred now.
-  virtual void record(Event event) = 0;
+  // Record the current event, i.e., mark it as having occurred now. Default
+  // CPU implementation.
+  virtual void record(Event event) {
+    getTime(event) = current_time_in_nanos();
+  }
 
   // Return the difference between when two events occurred, in nanoseconds.
   // Or nullopt if one of them hasn't been recorded.
   virtual c10::optional<int64_t> measureDifference(Event start, Event end) = 0;
 
   virtual ~Timer() = default;
+
+  // Return host-side timestamp, or nullopt if it has not yet been recorded.
+  c10::optional<int64_t> getTimestamp(Event event) {
+    auto time = getTime(event);
+    if (time == kUnsetTime) {
+      return c10::nullopt;
+    } else {
+      return time;
+    }
+  }
+
+  // Return host-side time member variable corresponding to the given event.
+  int64_t& getTime(Event event) {
+    switch (event) {
+      case Event::kForwardStart:
+        return forward_start_time;
+      case Event::kBackwardComputeStart:
+        return backward_compute_start_time;
+      case Event::kBackwardComputeEnd:
+        return backward_compute_end_time;
+      case Event::kBackwardCommStart:
+        return backward_comm_start_time;
+      case Event::kBackwardCommEnd:
+        return backward_comm_end_time;
+      default:
+        TORCH_INTERNAL_ASSERT(false);
+    }
+  }
 };
 
 // Local accumulator type for a single bucket.

--- a/torch/csrc/distributed/c10d/reducer_cuda.cpp
+++ b/torch/csrc/distributed/c10d/reducer_cuda.cpp
@@ -43,6 +43,8 @@ class CudaTimer : public Timer {
   explicit CudaTimer(c10::Device dev) : device(dev) {}
 
   void record(Event event) override {
+    // Parent class sets the host-side time
+    Timer::record(event);
     c10::DeviceGuard g(device);
     getEvent(event).record();
   }

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5012,6 +5012,17 @@ class DistributedTest:
                 ddp_logging_data.get("avg_backward_comm_time"),
                 ddp_logging_data.get("avg_backward_compute_comm_overlap_time"),
             )
+            # Test host-side times are roughly in the order that we expect
+            fwd_host_side_time = ddp_logging_data.get("forward_compute_time_start")
+            bwd_comp_start_host_side_time = ddp_logging_data.get("backward_compute_time_start")
+            bwd_comp_end_host_side_time = ddp_logging_data.get("backward_compute_time_end")
+            bwd_comm_start_host_side_time = ddp_logging_data.get("backward_comm_time_start")
+            bwd_comm_end_host_side_time = ddp_logging_data.get("backward_comm_time_end")
+            self.assertGreaterEqual(bwd_comm_end_host_side_time, bwd_comm_start_host_side_time)
+            self.assertGreaterEqual(bwd_comm_start_host_side_time, bwd_comp_start_host_side_time)
+            self.assertGreaterEqual(bwd_comp_end_host_side_time, bwd_comp_start_host_side_time)
+            self.assertGreaterEqual(bwd_comp_start_host_side_time, fwd_host_side_time)
+
             # test larger net with mixed data types, verify multiple bucket sizes
             model = LargeNet()
             model.float()
@@ -5063,6 +5074,17 @@ class DistributedTest:
                 ddp_logging_data.get("avg_backward_comm_time"),
                 ddp_logging_data.get("avg_backward_compute_comm_overlap_time"),
             )
+            # Test host-side times are roughly in the order that we expect
+            fwd_host_side_time = ddp_logging_data.get("forward_compute_time_start")
+            bwd_comp_start_host_side_time = ddp_logging_data.get("backward_compute_time_start")
+            bwd_comp_end_host_side_time = ddp_logging_data.get("backward_compute_time_end")
+            bwd_comm_start_host_side_time = ddp_logging_data.get("backward_comm_time_start")
+            bwd_comm_end_host_side_time = ddp_logging_data.get("backward_comm_time_end")
+            self.assertGreaterEqual(bwd_comm_end_host_side_time, bwd_comm_start_host_side_time)
+            self.assertGreaterEqual(bwd_comm_start_host_side_time, bwd_comp_start_host_side_time)
+            self.assertGreaterEqual(bwd_comp_end_host_side_time, bwd_comp_start_host_side_time)
+            self.assertGreaterEqual(bwd_comp_start_host_side_time, fwd_host_side_time)
+
 
         @sandcastle_skip_if(BACKEND == "nccl", "nccl does not support DDP on CPU models")
         def test_static_graph_api_cpu(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62770
* #62751
* #62748

Adding timing of forward, backward comp, backward comm, etc will help
detect desynchronization issues.

Differential Revision: [D30115585](https://our.internmc.facebook.com/intern/diff/D30115585/)