### PR TITLE
Improve IMethod::getArgumentNames to deal with empty argument names list

### DIFF
--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -38,6 +38,7 @@ class IMethod {
   virtual void setArgumentNames(std::vector<std::string>& argumentNames) const = 0;
 
  private:
+  bool isArgumentNamesInitialized_ { false };
   std::vector<std::string> argumentNames_;
 };
 

--- a/torch/csrc/api/src/imethod.cpp
+++ b/torch/csrc/api/src/imethod.cpp
@@ -4,11 +4,11 @@ namespace torch {
 
 const std::vector<std::string>& IMethod::getArgumentNames()
 {
-  // TODO(jwtan): Deal with empty parameter list.
-  if (!argumentNames_.empty()) {
+  if (isArgumentNamesInitialized_) {
     return argumentNames_;
   }
 
+  isArgumentNamesInitialized_ = true;
   setArgumentNames(argumentNames_);
   return argumentNames_;
 }

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -279,7 +279,6 @@ InferredType tryToInferContainerType(py::handle input);
 
 // Try to infer the type of a Python object
 // The type cannot be inferred if:
-//   input is a None
 //   input is an empty container (list, dict)
 //   input is an list with element types that cannot be unified
 //   input is an dict with key or value types that cannot be unified


### PR DESCRIPTION
Summary: This diff improved IMethod::getArgumentNames to deal with empty argument names list.

Test Plan:
buck test mode/dev caffe2/caffe2/fb/predictor:pytorch_predictor_test -- PyTorchDeployPredictor.GetEmptyArgumentNamesValidationMode
buck test mode/dev caffe2/caffe2/fb/predictor:pytorch_predictor_test -- PyTorchDeployPredictor.GetEmptyArgumentNamesRealMode

Reviewed By: wconstab

Differential Revision: D30038175

