### PR TITLE
Allow LocalResponseNorm to accept 0 dim batch sizes

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13252,6 +13252,12 @@ class TestNNDeviceType(NNTestCase):
 
             self.assertEqual(x.grad, ref_x.grad)
 
+    @onlyOnCPUAndCUDA
+    def test_LocalResponseNorm_empty(self, device):
+        mod = torch.nn.LocalResponseNorm(2).to(device)
+        inp = torch.ones(0, 5, 24, 24, device=device)
+        self._test_module_empty_input(mod, inp, check_size=False)
+
     @onlyCUDA   # Test if CPU and GPU results match
     def test_ReflectionPad3d_large(self, device):
         shapes = ([2, 1000, 7, 7, 7], [1000, 2, 7, 7, 7])

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2376,6 +2376,10 @@ def local_response_norm(input: Tensor, size: int, alpha: float = 1e-4, beta: flo
                 dim
             )
         )
+
+    if input.numel() == 0:
+        return input
+
     div = input.mul(input).unsqueeze(1)
     if dim == 3:
         div = pad(div, (0, 0, size // 2, (size - 1) // 2))


### PR DESCRIPTION
This issue fixes a part of https://github.com/pytorch/pytorch/issues/12013, which is summarized concretely in  https://github.com/pytorch/pytorch/issues/38115.

This PR allows `LocalResponseNorm` to accept tensors with 0 dimensional batch size.
