### PR TITLE
[sparsity] Remove the pack_param from the sparsifier state_dict

### DIFF
--- a/torch/ao/sparsity/sparsifier/base_sparsifier.py
+++ b/torch/ao/sparsity/sparsifier/base_sparsifier.py
@@ -92,28 +92,6 @@ class BaseSparsifier(abc.ABC):
         format_string += ')'
         return format_string
 
-    def _pack_state(self):
-        state: Dict[str, Dict] = defaultdict(dict)
-        for g in self.module_groups:
-            parametrization = g['module'].parametrizations['weight']
-            # original_weight = parametrization.original
-            key = g['fqn']
-            mask = None
-            # Find the mask in the FakeSparsity.
-            found = False
-            for p in parametrization:
-                if isinstance(p, FakeSparsity):
-                    parametrization = p
-                    found = True
-                    break
-            if found:
-                mask = parametrization.mask
-            state[key]['mask'] = mask
-            # Get all the tensors inside the module_group
-            state[key].update(
-                {key: value for key, value in self.state[key].items()})
-        return state
-
     def state_dict(self):
         r"""Returns the state of the optimizer as a :class:`dict`.
 
@@ -128,7 +106,7 @@ class BaseSparsifier(abc.ABC):
         ]
 
         return {
-            'state': self._pack_state(),
+            'state': self.state,
             'module_groups': module_groups,
         }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

That was the original design, that we decided to simplify by removing the packing in the sparsifier.
The state of the sparsifier is saved directly, and the old behavior accidentally bled through to the current version.
This change removes the `_pack_params` method, and changes the state_dict to include the state directly.
We don't have to change the load_state_dict, as it will work with either the old or the new format.