### PR TITLE
XNNPack Input Pointer Caching Comment

### DIFF
--- a/aten/src/ATen/native/xnnpack/Convolution.cpp
+++ b/aten/src/ATen/native/xnnpack/Convolution.cpp
@@ -325,6 +325,17 @@ Tensor run(
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   xnn_status setup_status;
 
+  /*
+   * Input Pointer Caching:
+   * Previously, we cached the input/output pointers and dimension parameters
+   * so that if the same pointers and parameters are used, this setup could be
+   * skipped.
+   * However, XNNPack has integrated offsets with its indirection buffer, so the
+   * buffer does not need to be recalculated even if activation tensor pointer
+   * changes as long as tensor dimensions are the same. Thus, the aforementioned
+   * manual caching is not needed here.
+   */
+
   if (context.transposed_) {
     setup_status = xnn_setup_deconvolution2d_nhwc_f32(
       context.op.get(),                                      // operator


### PR DESCRIPTION
Summary: Added a comment to explain why we no longer need to manually cache pointers/parameters for convolution, as removed in D29777605 (https://github.com/pytorch/pytorch/commit/f5c6c3947e4618d30ebd68a414f1cfcda27bdcd4)

Test Plan: Sandcastle tests (no code changed)

Reviewed By: kimishpatel

Differential Revision: D30113489

