### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -519,6 +519,9 @@ git add index.rst jit.rst
 ...
 ```
 
+ - user-facing documentation should go on https://pytorch.org/docs
+ - developer-facing documentation should go in the wiki https://github.com/pytorch/pytorch/wiki (and possibly linked from contributing.md)
+
 #### Building C++ Documentation
 For C++ documentation (https://pytorch.org/cppdocs), we use
 [Doxygen](http://www.doxygen.nl/) and then convert it to


### PR DESCRIPTION
Guidance on structuring and where to add documentation given its context.

Fixes #62606 

@zou3519 can you please tell anymore (if any) type of documentation and where it should go so I can add it to contributing.md
