### PR TITLE
Make IMethod cache mutable so getArgument works on const IMethod

### DIFF
--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -32,14 +32,14 @@ class TORCH_API IMethod {
   // script and python methods.  This is a more portable dependency
   // than a ScriptMethod FunctionSchema, which has more information
   // than can be generally expected from a python method.
-  const std::vector<std::string>& getArgumentNames();
+  const std::vector<std::string>& getArgumentNames() const;
 
  protected:
   virtual void setArgumentNames(std::vector<std::string>& argumentNames) const = 0;
 
  private:
-  bool isArgumentNamesInitialized_ { false };
-  std::vector<std::string> argumentNames_;
+  mutable bool isArgumentNamesInitialized_ { false };
+  mutable std::vector<std::string> argumentNames_;
 };
 
 } // namespace torch

--- a/torch/csrc/api/src/imethod.cpp
+++ b/torch/csrc/api/src/imethod.cpp
@@ -2,7 +2,7 @@
 
 namespace torch {
 
-const std::vector<std::string>& IMethod::getArgumentNames()
+const std::vector<std::string>& IMethod::getArgumentNames() const
 {
   if (isArgumentNamesInitialized_) {
     return argumentNames_;


### PR DESCRIPTION
Test Plan: existing unit tests

Reviewed By: alanwaketan

Differential Revision: D30135939

