### PR TITLE
Add batched model to torchdeploy examples

### DIFF
--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -32,14 +32,14 @@ class TORCH_API IMethod {
   // script and python methods.  This is a more portable dependency
   // than a ScriptMethod FunctionSchema, which has more information
   // than can be generally expected from a python method.
-  const std::vector<std::string>& getArgumentNames();
+  const std::vector<std::string>& getArgumentNames() const;
 
  protected:
   virtual void setArgumentNames(std::vector<std::string>& argumentNames) const = 0;
 
  private:
-  bool isArgumentNamesInitialized_ { false };
-  std::vector<std::string> argumentNames_;
+  mutable bool isArgumentNamesInitialized_ { false };
+  mutable std::vector<std::string> argumentNames_;
 };
 
 } // namespace torch

--- a/torch/csrc/api/src/imethod.cpp
+++ b/torch/csrc/api/src/imethod.cpp
@@ -2,7 +2,7 @@
 
 namespace torch {
 
-const std::vector<std::string>& IMethod::getArgumentNames()
+const std::vector<std::string>& IMethod::getArgumentNames() const
 {
   if (isArgumentNamesInitialized_) {
     return argumentNames_;

--- a/torch/csrc/deploy/example/examples.py
+++ b/torch/csrc/deploy/example/examples.py
@@ -1,4 +1,9 @@
+from typing import Tuple, List, Dict
+
 import torch
+import torch.nn as nn
+from torch import Tensor
+
 
 class Simple(torch.nn.Module):
     def __init__(self, N, M):
@@ -9,19 +14,22 @@ class Simple(torch.nn.Module):
         output = self.weight + input
         return output
 
-import torch.nn as nn
 
 def load_library():
     torch.ops.load_library("my_so.so")
+
 
 def conv1x1(in_planes, out_planes, stride=1):
     """1x1 convolution"""
     return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
 
+
 def conv3x3(in_planes, out_planes, stride=1):
     """3x3 convolution with padding"""
-    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
-                     padding=1, bias=False)
+    return nn.Conv2d(
+        in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False
+    )
+
 
 class BasicBlock(nn.Module):
     expansion = 1
@@ -54,12 +62,12 @@ class BasicBlock(nn.Module):
 
         return out
 
+
 class ResNet(nn.Module):
     def __init__(self, block, layers, num_classes=1000):
         super(ResNet, self).__init__()
         self.inplanes = 64
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3,
-                               bias=False)
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
         self.bn1 = nn.BatchNorm2d(64)
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
@@ -72,7 +80,7 @@ class ResNet(nn.Module):
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
-                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
             elif isinstance(m, nn.BatchNorm2d):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)
@@ -110,8 +118,28 @@ class ResNet(nn.Module):
 
         return x
 
+
 def resnet18():
     return ResNet(BasicBlock, [2, 2, 2, 2])
+
+
+class BatchedModel(nn.Module):
+    def forward(self, input1: Tensor, input2: Tensor) -> Tuple[Tensor, Tensor]:
+        return (input1 * -1, input2 * -1)
+
+    def make_prediction(
+        self, input: List[Tuple[Tensor, Tensor]]
+    ) -> List[Tuple[Tensor, Tensor]]:
+        return [self.forward(i[0], i[1]) for i in input]
+
+    def make_batch(
+        self, mega_batch: List[Tuple[Tensor, Tensor, int]], goals: Dict[str, str]
+    ) -> List[List[Tuple[Tensor, Tensor, int]]]:
+        max_bs = int(goals["max_bs"])
+        return [
+            mega_batch[start_idx : start_idx + max_bs]
+            for start_idx in range(0, len(mega_batch), max_bs)
+        ]
 
 
 class MultiReturn(torch.nn.Module):

--- a/torch/csrc/deploy/example/generate_examples.py
+++ b/torch/csrc/deploy/example/generate_examples.py
@@ -9,9 +9,9 @@ from torch.package import PackageExporter
 from torch.fx import symbolic_trace
 
 try:
-    from .examples import Simple, resnet18, MultiReturn, multi_return_metadata, load_library
+    from .examples import Simple, resnet18, MultiReturn, multi_return_metadata, load_library, BatchedModel
 except ImportError:
-    from examples import Simple, resnet18, MultiReturn, multi_return_metadata, load_library
+    from examples import Simple, resnet18, MultiReturn, multi_return_metadata, load_library, BatchedModel
 
 try:
     from .fx.examples import SimpleWithLeaf
@@ -29,17 +29,20 @@ def generate_fx_example():
     model_jit = torch.jit.script(model)
     model_jit.save(str(p / (name + "_jit")))
 
-def save(name, model, model_jit, eg, featurestore_meta=None):
+def save(name, model, model_jit=None, eg=None, featurestore_meta=None):
     with PackageExporter(str(p / name)) as e:
         e.mock("iopath.**")
         e.intern("**")
         e.save_pickle("model", "model.pkl", model)
-        e.save_pickle("model", "example.pkl", eg)
+        if eg:
+            e.save_pickle("model", "example.pkl", eg)
         if featurestore_meta:
             # TODO(whc) can this name come from buck somehow,
             # so it's consistent with predictor_config_constants::METADATA_FILE_NAME()?
             e.save_text("extra_files", "metadata.json", featurestore_meta)
-    model_jit.save(str(p / (name + "_jit")))
+
+    if model_jit:
+        model_jit.save(str(p / (name + "_jit")))
 
 
 parser = argparse.ArgumentParser(description="Generate Examples")
@@ -65,6 +68,10 @@ if __name__ == "__main__":
 
     multi_return = MultiReturn()
     save("multi_return", multi_return, torch.jit.script(multi_return), (torch.rand(10, 20),), multi_return_metadata)
+
+    # used for torch deploy/package tests in predictor
+    batched_model = BatchedModel()
+    save("batched_model", batched_model)
 
     with PackageExporter(str(p / "load_library")) as e:
         e.mock("iopath.**")


### PR DESCRIPTION
Summary: Used for upcoming diff that adds support for batching to torchdeploy

Test Plan: Models are used by later diffs, but generation script is verified by CI now and locally.

Differential Revision: D30135938

