### PR TITLE
Simplify the logic of running ci workflow codegen

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -115,25 +115,6 @@ class CIWorkflow:
         if self.is_libtorch:
             self.exclude_test = True
 
-        # The following code allows for scheduled jobs to be debuggable by
-        # adding the label 'ciflow/scheduled' and assigning + unassigning pytorchbot,
-        # without overwriting the workflow's own ciflow_config, if already enabled.
-        if self.is_scheduled:
-            if self.ciflow_config.enabled:
-                self.ciflow_config.labels.add('ciflow/scheduled')
-            else:
-                self.ciflow_config = CIFlowConfig(
-                    enabled=True,
-                    labels={'ciflow/scheduled'}
-                )
-
-        # CIFlow requires on_pull_request to be set in order to be enabled.
-        # If on_pull_request wasn't previously specified, we set trigger_action_only
-        # to True as we want to avoid unintentional pull_request event triggers
-        if self.ciflow_config.enabled:
-            self.ciflow_config.trigger_action_only = self.ciflow_config.trigger_action_only or not self.on_pull_request
-            self.on_pull_request = True
-
         if not self.on_pull_request:
             self.only_build_on_pull_request = False
 
@@ -156,11 +137,10 @@ class CIWorkflow:
             assert self.test_runner_type in WINDOWS_RUNNERS, err_message
 
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
-        output_file_path = GITHUB_DIR / f"workflows/generated-{workflow.build_environment}.yml"
+        output_file_path = GITHUB_DIR / f"workflows/generated-{self.build_environment}.yml"
         with open(output_file_path, "w") as output_file:
-            GENERATED = "generated"
-            output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
-            output_file.write(workflow_template.render(asdict(workflow)))
+            output_file.writelines([f"# @generated DO NOT EDIT MANUALLY\n"])
+            output_file.write(workflow_template.render(asdict(self)))
             output_file.write("\n")
         print(output_file_path)
 
@@ -197,6 +177,12 @@ WINDOWS_WORKFLOWS = [
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         num_test_shards=2,
         is_scheduled="45 0,4,8,12,16,20 * * *",
+        on_pull_request=True,
+        ciflow_config = CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels={'ciflow/scheduled'}
+        ),
     ),
 ]
 
@@ -299,6 +285,12 @@ LINUX_WORKFLOWS = [
         test_runner_type=LINUX_CUDA_TEST_RUNNER,
         num_test_shards=2,
         is_scheduled="45 0,4,8,12,16,20 * * *",
+        on_pull_request=True,
+        ciflow_config = CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels={'ciflow/scheduled'}
+        ),
     ),
     CIWorkflow(
         arch="linux",
@@ -307,6 +299,12 @@ LINUX_WORKFLOWS = [
         test_runner_type=LINUX_CUDA_TEST_RUNNER,
         is_libtorch=True,
         is_scheduled="45 0,4,8,12,16,20 * * *",
+        on_pull_request=True,
+        ciflow_config = CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels={'ciflow/scheduled'},
+        ),
     ),
     # CIWorkflow(
     #     arch="linux",
@@ -404,7 +402,6 @@ BAZEL_WORKFLOWS = [
         on_pull_request=True,
         ciflow_config=CIFlowConfig(
             enabled=True,
-            trigger_action_only=True,
             labels=set(['ciflow/default']),
         ),
     ),

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -139,7 +139,7 @@ class CIWorkflow:
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
         output_file_path = GITHUB_DIR / f"workflows/generated-{self.build_environment}.yml"
         with open(output_file_path, "w") as output_file:
-            output_file.writelines([f"# @generated DO NOT EDIT MANUALLY\n"])
+            output_file.writelines(["# @generated DO NOT EDIT MANUALLY\n"])
             output_file.write(workflow_template.render(asdict(self)))
             output_file.write("\n")
         print(output_file_path)
@@ -178,7 +178,7 @@ WINDOWS_WORKFLOWS = [
         num_test_shards=2,
         is_scheduled="45 0,4,8,12,16,20 * * *",
         on_pull_request=True,
-        ciflow_config = CIFlowConfig(
+        ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
             labels={'ciflow/scheduled'}
@@ -286,7 +286,7 @@ LINUX_WORKFLOWS = [
         num_test_shards=2,
         is_scheduled="45 0,4,8,12,16,20 * * *",
         on_pull_request=True,
-        ciflow_config = CIFlowConfig(
+        ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
             labels={'ciflow/scheduled'}
@@ -300,7 +300,7 @@ LINUX_WORKFLOWS = [
         is_libtorch=True,
         is_scheduled="45 0,4,8,12,16,20 * * *",
         on_pull_request=True,
-        ciflow_config = CIFlowConfig(
+        ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
             labels={'ciflow/scheduled'},

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -139,7 +139,8 @@ class CIWorkflow:
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
         output_file_path = GITHUB_DIR / f"workflows/generated-{self.build_environment}.yml"
         with open(output_file_path, "w") as output_file:
-            output_file.writelines(["# @generated DO NOT EDIT MANUALLY\n"])
+            GENERATED = "generated"  # Note that please keep the variable GENERATED otherwise phabricator will hide the whole file
+            output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
             output_file.write(workflow_template.render(asdict(self)))
             output_file.write("\n")
         print(output_file_path)

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -5,7 +5,7 @@ name: linux-xenial-py3.6-gcc7-bazel-test
 
 on:
   pull_request:
-    types: [unassigned]
+    types: [opened, synchronize, reopened, unassigned]
   push:
     branches:
       - master


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62853


wanted to simplify the logic in the `__post_int__`, and delegate the settings back to individual workflows, this gives us more flexibility in changing individual workflows, as well as reducing the complexity of understanding the mutation conditions.

Differential Revision: [D30149190](https://our.internmc.facebook.com/intern/diff/D30149190)