### PR TITLE
[ONNX] exporter changes for torch hub models

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -382,12 +382,14 @@ namespace c10 {
   _(onnx, Gather)                    \
   _(onnx, Gemm)                      \
   _(onnx, LSTM)                      \
+  _(onnx, MatMul)                    \
   _(onnx, Mul)                       \
   _(onnx, Pow)                       \
   _(onnx, RNN)                       \
   _(onnx, Shape)                     \
   _(onnx, Size)                      \
   _(onnx, Slice)                     \
+  _(onnx, Softmax)                   \
   _(onnx, Squeeze)                   \
   _(onnx, Sub)                       \
   _(onnx, Transpose)                 \
@@ -423,7 +425,9 @@ namespace c10 {
   _(onnx, ReduceL2)                  \
   _(onnx, Conv)                      \
   _(onnx, BatchNormalization)        \
+  _(onnx, ReduceMean)                \
   _(onnx, ReduceProd)                \
+  _(onnx, Relu)                      \
   _(onnx, Neg)                       \
   _(onnx, NonZero)                   \
   _(onnx, Range)                     \

--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -413,11 +413,12 @@ symbolic function should use the ``name`` kwarg which gets set to the name of th
 the ``prim`` namespace, so for this use case, there's a back door: register the
 symbolic for ``"::prim_PythonOp"``.
 
-Please also consider adding shape inference logic when you regiester a custom symbolic function
-via setType API. This can help the exporter to obtain correct shape inference.
-An example of setType is test_aten_embedding_2 in test_operators.py.
-Although it is not required to add shape inference logic,
-the exporter emits a warning message if it is not added.
+Custom symbolic functions should add type and shape information by calling ``setType(...)``
+on Value objects before returning them (implemented in C++ by
+``torch::jit::Value::setType``). This is not required, but it can help the exporter's
+shape and type inference for down-stream nodes. For a non-trivial example of ``setType``, see
+``test_aten_embedding_2`` in
+`test_operators.py <https://github.com/pytorch/pytorch/blob/master/test/onnx/test_operators.py>`_.
 
 The example below shows how you can access ``requires_grad`` via the ``Node`` object::
 

--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -413,12 +413,11 @@ symbolic function should use the ``name`` kwarg which gets set to the name of th
 the ``prim`` namespace, so for this use case, there's a back door: register the
 symbolic for ``"::prim_PythonOp"``.
 
-Custom symbolic functions should add type and shape information by calling ``setType(...)``
-on Value objects before returning them (implemented in C++ by
-``torch::jit::Value::setType``). This is not required, but it can help the exporter's
-shape and type inference for down-stream nodes. For a non-trivial example of ``setType``, see
-``test_aten_embedding_2`` in
-`test_operators.py <https://github.com/pytorch/pytorch/blob/master/test/onnx/test_operators.py>`_.
+Please also consider adding shape inference logic when you regiester a custom symbolic function
+via setType API. This can help the exporter to obtain correct shape inference.
+An example of setType is test_aten_embedding_2 in test_operators.py.
+Although it is not required to add shape inference logic,
+the exporter emits a warning message if it is not added.
 
 The example below shows how you can access ``requires_grad`` via the ``Node`` object::
 

--- a/test/onnx/expect/TestOperators.test_at_op.expect
+++ b/test/onnx/expect/TestOperators.test_at_op.expect
@@ -38,10 +38,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ATen1_dim_0"
+            dim_value: 3
           }
           dim {
-            dim_param: "ATen1_dim_1"
+            dim_value: 4
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
@@ -3,111 +3,25 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "emb.weight"
-    input: "input"
     output: "3"
-    name: "ATenOp_0"
-    op_type: "ATenOp"
-    attribute {
-      name: "custom_attributes_json"
-      s: "{\"padding_idx\":-1,\"scale_grad_by_freq\":false,\"sparse\":false}"
-      type: STRING
-    }
-    attribute {
-      name: "name"
-      s: "aten::embedding"
-      type: STRING
-    }
-    domain: "com.microsoft"
-  }
-  node {
-    input: "3"
-    input: "1"
-    output: "4"
-    name: "Add_1"
-    op_type: "Add"
-  }
-  node {
-    input: "4"
-    output: "5"
-    name: "Shape_2"
-    op_type: "Shape"
-  }
-  node {
-    output: "6"
-    name: "Constant_3"
+    name: "Constant_0"
     op_type: "Constant"
     attribute {
       name: "value"
       t {
-        data_type: 7
-        raw_data: "\000\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "5"
-    input: "6"
-    output: "7"
-    name: "Gather_4"
-    op_type: "Gather"
-    attribute {
-      name: "axis"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    input: "7"
-    output: "8"
-    name: "Unsqueeze_5"
-    op_type: "Unsqueeze"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-  }
-  node {
-    input: "8"
-    output: "9"
-    name: "Concat_6"
-    op_type: "Concat"
-    attribute {
-      name: "axis"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    input: "9"
-    output: "10"
-    name: "ConstantOfShape_7"
-    op_type: "ConstantOfShape"
-    attribute {
-      name: "value"
-      t {
-        dims: 1
+        dims: 32
         data_type: 1
-        raw_data: "\000\000\200?"
+        raw_data: "\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?"
       }
       type: TENSOR
     }
   }
   name: "torch-jit-export"
-  initializer {
-    dims: 4
-    dims: 8
-    data_type: 1
-    name: "emb.weight"
-    raw_data: "\264\314\344\275\017A\376\276\313\374&>J\266a\277s\306\\=\212\032+?\211[t\275\344[\357\276Dk\\\276OKb?\234\'B\277A\334\274\2767N\257\276\320s\263\277\371+\244>:\314\202\277K\200L??\001\275\275\236u4\2774\032\315\277\214\004\224>Z\320\372>\267B\305\276\346G6\277N\265.\276\343\316\272\277t\364a>\201)|>p\223\251\277Qm2?\346\275)\277\354\235\233?"
-  }
-  input {
-    name: "input"
+  output {
+    name: "3"
     type {
       tensor_type {
-        elem_type: 7
+        elem_type: 1
         shape {
           dim {
             dim_value: 32
@@ -116,40 +30,7 @@ graph {
       }
     }
   }
-  input {
-    name: "1"
-    type {
-      tensor_type {
-        elem_type: 1
-        shape {
-          dim {
-            dim_value: 1
-          }
-          dim {
-            dim_value: 8
-          }
-        }
-      }
-    }
-  }
-  output {
-    name: "10"
-    type {
-      tensor_type {
-        elem_type: 1
-        shape {
-          dim {
-            dim_param: "ConstantOfShape10_dim_0"
-          }
-        }
-      }
-    }
-  }
 }
 opset_import {
   version: 12
-}
-opset_import {
-  domain: "com.microsoft"
-  version: 1
 }

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_add.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_add.expect
@@ -1,0 +1,64 @@
+ir_version: 7
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "input_1"
+    input: "input_2"
+    output: "2"
+    name: "Add_0"
+    op_type: "Add"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "input_1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "input_1_dim_1"
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "input_2_dim_1"
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "Add2_dim_1"
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 12
+}

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_matmul.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_matmul.expect
@@ -1,0 +1,73 @@
+ir_version: 7
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "input_1"
+    input: "input_2"
+    output: "2"
+    name: "MatMul_0"
+    op_type: "MatMul"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "input_1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "input_1_dim_1"
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "input_2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_param: "input_2_dim_2"
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "input_1_dim_1"
+          }
+          dim {
+            dim_param: "input_2_dim_2"
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 12
+}

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_reduce_mean.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_reduce_mean.expect
@@ -3,60 +3,52 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "0"
+    input: "input"
     output: "1"
-    name: "Shape_0"
-    op_type: "Shape"
-  }
-  node {
-    input: "1"
-    output: "2"
-    name: "ConstantFill_1"
-    op_type: "ConstantFill"
+    name: "ReduceMean_0"
+    op_type: "ReduceMean"
     attribute {
-      name: "dtype"
-      i: 1
-      type: INT
+      name: "axes"
+      ints: 1
+      type: INTS
     }
     attribute {
-      name: "input_as_shape"
-      i: 1
+      name: "keepdims"
+      i: 0
       type: INT
-    }
-    attribute {
-      name: "value"
-      f: 0
-      type: FLOAT
     }
   }
   name: "torch-jit-export"
   input {
-    name: "0"
+    name: "input"
     type {
       tensor_type {
         elem_type: 1
         shape {
           dim {
-            dim_value: 5
+            dim_value: 2
           }
           dim {
-            dim_value: 8
+            dim_param: "input_dim_1"
+          }
+          dim {
+            dim_param: "input_dim_2"
           }
         }
       }
     }
   }
   output {
-    name: "2"
+    name: "1"
     type {
       tensor_type {
         elem_type: 1
         shape {
           dim {
-            dim_value: 5
+            dim_value: 2
           }
           dim {
-            dim_value: 8
+            dim_param: "input_dim_2"
           }
         }
       }
@@ -64,5 +56,5 @@ graph {
   }
 }
 opset_import {
-  version: 7
+  version: 12
 }

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_unchange.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_unchange.expect
@@ -3,60 +3,68 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "0"
+    input: "input"
     output: "1"
-    name: "Shape_0"
-    op_type: "Shape"
+    name: "Transpose_0"
+    op_type: "Transpose"
+    attribute {
+      name: "perm"
+      ints: 1
+      ints: 0
+      type: INTS
+    }
   }
   node {
     input: "1"
     output: "2"
-    name: "ConstantFill_1"
-    op_type: "ConstantFill"
+    name: "Softmax_1"
+    op_type: "Softmax"
     attribute {
-      name: "dtype"
+      name: "axis"
       i: 1
       type: INT
     }
+  }
+  node {
+    input: "2"
+    output: "3"
+    name: "Transpose_2"
+    op_type: "Transpose"
     attribute {
-      name: "input_as_shape"
-      i: 1
-      type: INT
-    }
-    attribute {
-      name: "value"
-      f: 0
-      type: FLOAT
+      name: "perm"
+      ints: 1
+      ints: 0
+      type: INTS
     }
   }
   name: "torch-jit-export"
   input {
-    name: "0"
+    name: "input"
     type {
       tensor_type {
         elem_type: 1
         shape {
           dim {
-            dim_value: 5
+            dim_value: 2
           }
           dim {
-            dim_value: 8
+            dim_param: "input_dim_1"
           }
         }
       }
     }
   }
   output {
-    name: "2"
+    name: "3"
     type {
       tensor_type {
         elem_type: 1
         shape {
           dim {
-            dim_value: 5
+            dim_value: 2
           }
           dim {
-            dim_value: 8
+            dim_param: "input_dim_1"
           }
         }
       }
@@ -64,5 +72,5 @@ graph {
   }
 }
 opset_import {
-  version: 7
+  version: 12
 }

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -94,10 +94,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ATen3_dim_0"
+            dim_value: 1
           }
           dim {
-            dim_param: "ATen3_dim_1"
+            dim_value: 8
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
+++ b/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
@@ -106,16 +106,16 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ATen3_dim_0"
+            dim_value: 20
           }
           dim {
-            dim_param: "ATen3_dim_1"
+            dim_value: 5
           }
           dim {
-            dim_param: "ATen3_dim_2"
+            dim_value: 10
           }
           dim {
-            dim_param: "ATen3_dim_3"
+            dim_value: 10
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
+++ b/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
@@ -1,0 +1,44 @@
+ir_version: 7
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    output: "7"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        dims: 2
+        dims: 3
+        data_type: 1
+        raw_data: "\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?\000\000\200?"
+      }
+      type: TENSOR
+    }
+  }
+  name: "torch-jit-export"
+  output {
+    name: "7"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 12
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -1,5 +1,6 @@
 
-from test_pytorch_common import TestCase, run_tests, flatten, skipIfNoLapack
+from test_pytorch_common import TestCase, run_tests, flatten, skipIfNoLapack, \
+    BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 
 import torch
 import torch.onnx
@@ -892,23 +893,69 @@ class TestOperators(TestCase):
         y = torch.empty(3, 2, 1, dtype=torch.long).random_(5)
         self.assertONNX(torch.nn.CrossEntropyLoss(), (x, y), opset_version=12)
 
+    def test_lstm_none_sequence_lens(self):
+        """Test symbolic shape inference for LSTM when the input sequence_lens = None."""
+        input = torch.randn(RNN_SEQUENCE_LENGTH, BATCH_SIZE, RNN_INPUT_SIZE)
+        h0 = torch.randn(1, BATCH_SIZE, RNN_HIDDEN_SIZE)
+        c0 = torch.randn(1, BATCH_SIZE, RNN_HIDDEN_SIZE)
+
+        class LSTMModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.rnn = torch.nn.LSTM(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False)
+
+            def forward(self, x, h0, c0):
+                a, b = self.rnn(x, (h0, c0))
+                return torch.ones(b[0].shape)
+
+        self.assertONNX(LSTMModel(),
+                        (input, h0, c0), input_names=["x", "y"],
+                        dynamic_axes={"x" : {0: 'batch'}}, opset_version=12)
+
+    def test_dynamic_axes_add(self):
+        m1 = torch.randn(2, 3, requires_grad=True)
+        m2 = torch.randn(2, 1, requires_grad=True)
+        self.assertONNX(lambda x, y: torch.add(x, y), (m1, m2), input_names=["input_1", "input_2"],
+                        dynamic_axes={"input_1": {1: "dim_1"}, "input_2": {1: "dim_2"}},
+                        opset_version=12)
+
+    def test_dynamic_axes_matmul(self):
+        m1 = torch.randn(2, 2, 4, requires_grad=True)
+        m2 = torch.randn(2, 4, 3, requires_grad=True)
+        self.assertONNX(lambda x, y: torch.matmul(x, y), (m1, m2), input_names=["input_1", "input_2"],
+                        dynamic_axes={"input_1": {1: "dim_0"}, "input_2": {2: "dim_1"}},
+                        opset_version=12)
+
+    def test_dynamic_axes_reduce_mean(self):
+        m1 = torch.randn(2, 3, 4, requires_grad=True)
+        self.assertONNX(lambda x: torch.mean(x, dim=1), (m1), input_names=["input"],
+                        dynamic_axes={"input": {1: "dim_1", 2: "dim_2"}},
+                        opset_version=12)
+
+    def test_dynamic_axes_unchange(self):
+        """Test ProcessUnchangeNode in symbolic shape inference."""
+        m1 = torch.randn(2, 3, requires_grad=True)
+        self.assertONNX(lambda x: torch.softmax(x, dim=0), (m1,), input_names=["input"],
+                        dynamic_axes={"input": {1: "dim_1"}},
+                        opset_version=12)
+
     def test_aten_embedding_1(self):
         _onnx_opset_version = 12
 
-        @parse_args('v', 'v', 'i', 'b', 'b')
+        @parse_args("v", "v", "i", "b", "b")
         def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
             custom_attributes_json = (
-                '{'
+                "{"
                 f'"padding_idx":{str(padding_idx)},'
                 f'"scale_grad_by_freq":{str(scale_grad_by_freq).lower()},'
                 f'"sparse":{str(sparse).lower()}'
-                '}'
+                "}"
             )
-            output = g.op("com.microsoft::ATenOp", weight, indices, name_s='aten::embedding',
+            output = g.op("com.microsoft::ATenOp", weight, indices, name_s="aten::embedding",
                           custom_attributes_json_s=custom_attributes_json)
             return output
 
-        register_custom_op_symbolic('::embedding', embedding, _onnx_opset_version)
+        register_custom_op_symbolic("::embedding", embedding, _onnx_opset_version)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -925,32 +972,32 @@ class TestOperators(TestCase):
         y = torch.randn(1, 8)
         self.assertONNX(model, (x, y), opset_version=_onnx_opset_version)
 
-        unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
+        unregister_custom_op_symbolic("::embedding", _onnx_opset_version)
 
     # This is test_aten_embedding_1 with shape inference on custom symbolic aten::embedding.
     def test_aten_embedding_2(self):
         _onnx_opset_version = 12
 
-        @parse_args('v', 'v', 'i', 'b', 'b')
+        @parse_args("v", "v", "i", "b", "b")
         def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
             custom_attributes_json = (
-                '{'
+                "{"
                 f'"padding_idx":{str(padding_idx)},'
                 f'"scale_grad_by_freq":{str(scale_grad_by_freq).lower()},'
                 f'"sparse":{str(sparse).lower()}'
-                '}'
+                "}"
             )
-            output = g.op("com.microsoft::ATenOp", weight, indices, name_s='aten::embedding',
+            output = g.op("com.microsoft::ATenOp", weight, indices, name_s="aten::embedding",
                           custom_attributes_json_s=custom_attributes_json)
 
             # do shape inference and set it via setType
             indices_shape = _get_tensor_sizes(indices)
-            if indices_shape is not None and hasattr(weight.type(), 'with_sizes'):
+            if indices_shape is not None and hasattr(weight.type(), "with_sizes"):
                 output_type = weight.type().with_sizes(indices_shape + [_get_tensor_dim_size(weight, 1)])
                 output.setType(output_type)
             return output
 
-        register_custom_op_symbolic('::embedding', embedding, _onnx_opset_version)
+        register_custom_op_symbolic("::embedding", embedding, _onnx_opset_version)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -965,10 +1012,10 @@ class TestOperators(TestCase):
         model = Model()
         x = torch.ones(32, dtype=torch.long)
         y = torch.randn(1, 8)
-        self.assertONNX(model, (x, y), opset_version=_onnx_opset_version, input_names=['input_1', 'input_2'],
-                        dynamic_axes={"input_1": {0: "dim_0"}, 'input_2': {0: "dim_1", 1: "dim_2"}})
+        self.assertONNX(model, (x, y), opset_version=_onnx_opset_version, input_names=["input_1", "input_2"],
+                        dynamic_axes={"input_1": {0: "dim_0"}, "input_2": {0: "dim_1", 1: "dim_2"}})
 
-        unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
+        unregister_custom_op_symbolic("::embedding", _onnx_opset_version)
 
 if __name__ == "__main__":
     no_onnx_dep_flag = "--no-onnx"

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -895,20 +895,20 @@ class TestOperators(TestCase):
     def test_aten_embedding_1(self):
         _onnx_opset_version = 12
 
-        @parse_args("v", "v", "i", "b", "b")
+        @parse_args('v', 'v', 'i', 'b', 'b')
         def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
             custom_attributes_json = (
-                "{"
+                '{'
                 f'"padding_idx":{str(padding_idx)},'
                 f'"scale_grad_by_freq":{str(scale_grad_by_freq).lower()},'
                 f'"sparse":{str(sparse).lower()}'
-                "}"
+                '}'
             )
-            output = g.op("com.microsoft::ATenOp", weight, indices, name_s="aten::embedding",
+            output = g.op("com.microsoft::ATenOp", weight, indices, name_s='aten::embedding',
                           custom_attributes_json_s=custom_attributes_json)
             return output
 
-        register_custom_op_symbolic("::embedding", embedding, _onnx_opset_version)
+        register_custom_op_symbolic('::embedding', embedding, _onnx_opset_version)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -925,32 +925,32 @@ class TestOperators(TestCase):
         y = torch.randn(1, 8)
         self.assertONNX(model, (x, y), opset_version=_onnx_opset_version)
 
-        unregister_custom_op_symbolic("::embedding", _onnx_opset_version)
+        unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
 
     # This is test_aten_embedding_1 with shape inference on custom symbolic aten::embedding.
     def test_aten_embedding_2(self):
         _onnx_opset_version = 12
 
-        @parse_args("v", "v", "i", "b", "b")
+        @parse_args('v', 'v', 'i', 'b', 'b')
         def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
             custom_attributes_json = (
-                "{"
+                '{'
                 f'"padding_idx":{str(padding_idx)},'
                 f'"scale_grad_by_freq":{str(scale_grad_by_freq).lower()},'
                 f'"sparse":{str(sparse).lower()}'
-                "}"
+                '}'
             )
-            output = g.op("com.microsoft::ATenOp", weight, indices, name_s="aten::embedding",
+            output = g.op("com.microsoft::ATenOp", weight, indices, name_s='aten::embedding',
                           custom_attributes_json_s=custom_attributes_json)
 
             # do shape inference and set it via setType
             indices_shape = _get_tensor_sizes(indices)
-            if indices_shape is not None and hasattr(weight.type(), "with_sizes"):
+            if indices_shape is not None and hasattr(weight.type(), 'with_sizes'):
                 output_type = weight.type().with_sizes(indices_shape + [_get_tensor_dim_size(weight, 1)])
                 output.setType(output_type)
             return output
 
-        register_custom_op_symbolic("::embedding", embedding, _onnx_opset_version)
+        register_custom_op_symbolic('::embedding', embedding, _onnx_opset_version)
 
         class Model(torch.nn.Module):
             def __init__(self):
@@ -965,10 +965,10 @@ class TestOperators(TestCase):
         model = Model()
         x = torch.ones(32, dtype=torch.long)
         y = torch.randn(1, 8)
-        self.assertONNX(model, (x, y), opset_version=_onnx_opset_version, input_names=["input_1", "input_2"],
-                        dynamic_axes={"input_1": {0: "dim_0"}, "input_2": {0: "dim_1", 1: "dim_2"}})
+        self.assertONNX(model, (x, y), opset_version=_onnx_opset_version, input_names=['input_1', 'input_2'],
+                        dynamic_axes={"input_1": {0: "dim_0"}, 'input_2': {0: "dim_1", 1: "dim_2"}})
 
-        unregister_custom_op_symbolic("::embedding", _onnx_opset_version)
+        unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
 
 if __name__ == "__main__":
     no_onnx_dep_flag = "--no-onnx"

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -39,7 +39,6 @@ from torch.nn.utils.rnn import PackedSequence
 from torch.onnx import register_custom_op_symbolic, unregister_custom_op_symbolic
 from torch.onnx.utils import ONNXCheckerError
 
-
 def to_numpy(elem):
     if isinstance(elem, torch.Tensor):
         if elem.requires_grad:

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -40,16 +40,6 @@ from torch.onnx import register_custom_op_symbolic, unregister_custom_op_symboli
 from torch.onnx.utils import ONNXCheckerError
 
 
-def flatten_tuples(elem):
-    tup = []
-    for t in elem:
-        if isinstance(t, (tuple)):
-            tup += flatten_tuples(t)
-        else:
-            tup += [t]
-    return tup
-
-
 def to_numpy(elem):
     if isinstance(elem, torch.Tensor):
         if elem.requires_grad:
@@ -9795,19 +9785,6 @@ class TestONNXRuntime(unittest.TestCase):
         self.assertTrue(f.getvalue(), "ONNX graph was not exported.")
         loaded_model = onnx.load_from_string(f.getvalue())
 
-
-    def test_tuple_output_from_if_with_raised_exception(self):
-        class M(torch.nn.Module):
-            def __init__(self):
-                super(M, self).__init__()
-
-            def forward(self, t: Tensor) -> Tuple[Tensor, Tensor]:
-                if float(t) < 0:
-                    raise Exception("Negative input")
-                else:
-                    return torch.zeros(5), torch.zeros(5)
-        x = torch.zeros(1)
-        self.run_test(torch.jit.script(M()), (x,))
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -293,10 +293,10 @@ void NodeToONNX(
           ONNXShapeTypeInference(const_node, empty_params_dict, opset_version);
           env[old] = const_node->output();
         } else {
-          auto input_reliable = AreInputsReliableOrStatic(outputs[i]->node());
+          // ConstantValueMap has been set in shape inference,
+          // set_constant_value_map = false here to avoid redundancy.
           MergeInferredTypeAndSetMap(
-              outputs[i], old->type(), outputs[i]->type());
-          UpdateReliable(outputs[i], input_reliable);
+              outputs[i], old->type(), outputs[i]->type(), false);
 
           // Copy over source location and scope information to all nodes
           // created by the symbolic

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -489,6 +489,12 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
   } else if (node->kind() == onnx::Equal) {
     updated_val = at::eq(inputTensorValues[0], inputTensorValues[1]);
     return c10::optional<at::Tensor>(updated_val);
+  } else if (node->kind() == onnx::Greater) {
+    updated_val = at::greater(inputTensorValues[0], inputTensorValues[1]);
+    return c10::optional<at::Tensor>(updated_val);
+  } else if (node->kind() == onnx::Less) {
+    updated_val = at::less(inputTensorValues[0], inputTensorValues[1]);
+    return c10::optional<at::Tensor>(updated_val);
   } else if (node->kind() == onnx::Neg) {
     updated_val = at::neg(inputTensorValues[0]);
     return c10::optional<at::Tensor>(updated_val);

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -361,7 +361,7 @@ void ONNXMergeIfBlockOutputShapes(Node* node) {
          const ::c10::SymbolicShape& b) -> ::c10::SymbolicShape {
     std::vector<::c10::ShapeSymbol> dims;
     if (a.rank() && b.rank() && a.rank() == b.rank()) {
-      for (const auto j : c10::irange(a.rank().value())) {
+      for (size_t j = 0; j < a.rank().value(); ++j) {
         if (a[j] == b[j]) {
           dims.emplace_back(a[j]);
         } else {
@@ -464,12 +464,12 @@ std::vector<Value*> FixupONNXControlflowNode(Node* n, int opset_version) {
 void FixupONNXControlflowNodeOutputs(Node* n) {
   switch (n->kind()) {
     case ::c10::onnx::Loop: {
-      auto loop_carried_output_size = n->blocks().at(0)->inputs().size() - 2;
-      for (auto i : c10::irange(n->outputs().size())) {
-        auto type = n->blocks().at(0)->outputs().at(i + 1)->type();
+      for (size_t i = 0; i < n->outputs().size(); ++i) {
+        auto loop_carried_output_size = n->blocks().at(0)->inputs().size() - 2;
         if (i < loop_carried_output_size) {
-          n->output(i)->setType(type);
+          n->output(i)->setType(n->blocks().at(0)->outputs().at(i + 1)->type());
         } else {
+          auto type = n->blocks().at(0)->outputs().at(i + 1)->type();
           if (auto t_type = type->cast<TensorType>()) {
             auto sizes = t_type->symbolic_sizes().sizes();
             if (sizes.has_value()) {

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -361,7 +361,7 @@ void ONNXMergeIfBlockOutputShapes(Node* node) {
          const ::c10::SymbolicShape& b) -> ::c10::SymbolicShape {
     std::vector<::c10::ShapeSymbol> dims;
     if (a.rank() && b.rank() && a.rank() == b.rank()) {
-      for (size_t j = 0; j < a.rank().value(); ++j) {
+      for (const auto j : c10::irange(a.rank().value())) {
         if (a[j] == b[j]) {
           dims.emplace_back(a[j]);
         } else {
@@ -464,12 +464,12 @@ std::vector<Value*> FixupONNXControlflowNode(Node* n, int opset_version) {
 void FixupONNXControlflowNodeOutputs(Node* n) {
   switch (n->kind()) {
     case ::c10::onnx::Loop: {
-      for (size_t i = 0; i < n->outputs().size(); ++i) {
-        auto loop_carried_output_size = n->blocks().at(0)->inputs().size() - 2;
+      auto loop_carried_output_size = n->blocks().at(0)->inputs().size() - 2;
+      for (auto i : c10::irange(n->outputs().size())) {
+        auto type = n->blocks().at(0)->outputs().at(i + 1)->type();
         if (i < loop_carried_output_size) {
-          n->output(i)->setType(n->blocks().at(0)->outputs().at(i + 1)->type());
+          n->output(i)->setType(type);
         } else {
-          auto type = n->blocks().at(0)->outputs().at(i + 1)->type();
           if (auto t_type = type->cast<TensorType>()) {
             auto sizes = t_type->symbolic_sizes().sizes();
             if (sizes.has_value()) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -84,13 +84,16 @@ std::pair<TypePtr, bool> MergeInferredType(
 void MergeInferredTypeAndSetMap(
     Value* dest_v,
     TypePtr existing_type,
-    TypePtr inferred_type) {
+    TypePtr inferred_type,
+    bool set_constant_value_map) {
   TypePtr mergedType;
   bool inferred;
   std::tie(mergedType, inferred) =
       MergeInferredType(existing_type, inferred_type);
   dest_v->setType(mergedType);
-  ConstantValueMap::SetUseInferredType(dest_v->debugName(), inferred);
+  if (set_constant_value_map) {
+    ConstantValueMap::SetUseInferredType(dest_v->debugName(), inferred);
+  }
 }
 
 namespace {
@@ -141,6 +144,7 @@ TensorTypePtr TorchTensorTypeFromONNX(
           // Assign a new Symbol, no need to keep track
           // of it because there won't be duplicates.
           sym = c10::ShapeSymbol::newSymbol();
+          symbol_map[sym.value()] = "";
         }
         sizes.emplace_back(sym.value());
       }
@@ -197,8 +201,6 @@ void UpdateTorchValueByOnnxValueInfo(
       MergeInferredTypeAndSetMap(v, v->type(), torch_list_type);
     }
   }
-
-  return true;
 }
 
 bool IsValidONNXControlflowNode(const Node* n) {
@@ -618,6 +620,16 @@ void UpdateShape(Value* value, const ::c10::SymbolicShape& shape) {
   }
 }
 
+void UpdateShapeConstantValueMap(
+    const Value* value,
+    const ::c10::SymbolicShape& shape) {
+  ConstantValueMap::SetShape(value->debugName(), shape);
+  if (shape.rank().has_value()) {
+    auto rank = shape.rank().value();
+    ConstantValueMap::SetRank(value->debugName(), rank);
+  }
+}
+
 c10::optional<std::vector<int64_t>> GetValueFromListConstructNode(
     Node* lc_node) {
   auto rank = lc_node->inputs().size();
@@ -640,6 +652,198 @@ c10::optional<std::vector<int64_t>> GetValueFromListConstructNode(
       : c10::nullopt;
 }
 
+void ProcessBroadCastNode(Node* n) {
+  TORCH_INTERNAL_ASSERT(n->inputs().size() == 2);
+  if (ConstantValueMap::HasShape(n->input(0)->debugName()) &&
+      ConstantValueMap::HasShape(n->input(1)->debugName())) {
+    auto input_shape_0 = ConstantValueMap::GetShape(n->input(0)->debugName());
+    auto input_shape_value_0 = input_shape_0.value().sizes();
+    auto input_shape_1 = ConstantValueMap::GetShape(n->input(1)->debugName());
+    auto input_shape_value_1 = input_shape_1.value().sizes();
+    size_t rank_0 = input_shape_value_0.value().size();
+    size_t rank_1 = input_shape_value_1.value().size();
+    size_t rank_max = std::max(rank_0, rank_1);
+    size_t rank_min = std::min(rank_0, rank_1);
+    std::vector<::c10::ShapeSymbol> final_shape;
+    final_shape.reserve(rank_max);
+    for (auto idx = 0; idx < rank_max; idx++) {
+      final_shape.emplace_back(::c10::ShapeSymbol::newSymbol());
+    }
+    for (auto idx = 0; idx < rank_min; idx++) {
+      auto is_static_0 =
+          input_shape_value_0.value()[rank_0 - 1 - idx].is_static();
+      auto is_static_1 =
+          input_shape_value_1.value()[rank_1 - 1 - idx].is_static();
+      if (is_static_0 && is_static_1) {
+        auto static_0_sz =
+            input_shape_value_0.value()[rank_0 - 1 - idx].static_size();
+        auto static_1_sz =
+            input_shape_value_1.value()[rank_1 - 1 - idx].static_size();
+        final_shape[rank_max - 1 - idx] = ::c10::ShapeSymbol::fromStaticSize(
+            std::max(static_0_sz, static_1_sz));
+      }
+    }
+
+    if (rank_0 < rank_1) {
+      for (auto idx = rank_min; idx < rank_max; idx++) {
+        auto shape_idx = rank_max - 1 - idx;
+        final_shape[shape_idx] = input_shape_value_1.value()[shape_idx];
+      }
+    } else {
+      for (auto idx = rank_min; idx < rank_max; idx++) {
+        auto shape_idx = rank_max - 1 - idx;
+        final_shape[shape_idx] = input_shape_value_0.value()[shape_idx];
+      }
+    }
+
+    UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
+  }
+}
+
+void ProcessConcatNode(Node* n) {
+  int axis = n->i(attr::axis);
+  if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
+    auto rank = ConstantValueMap::GetRank(n->input(0)->debugName()).value();
+    size_t axis_adjust = 0;
+    if (axis >= 0) {
+      axis_adjust = static_cast<size_t>(axis);
+    } else {
+      axis_adjust = static_cast<size_t>(axis + static_cast<int>(rank));
+    }
+    std::vector<::c10::ShapeSymbol> final_shape;
+    final_shape.reserve(rank);
+    for (auto idx = 0; idx < rank; idx++) {
+      if (idx == axis_adjust) {
+        auto flag = true;
+        int64_t size_total = 0;
+        for (auto input_idx = 0; input_idx < n->inputs().size(); input_idx++) {
+          if (ConstantValueMap::HasShape(n->input(input_idx)->debugName())) {
+            auto input_shape =
+                ConstantValueMap::GetShape(n->input(input_idx)->debugName());
+            auto input_shape_value = input_shape.value().sizes();
+            auto shape_symbol = input_shape_value.value()[idx];
+            if (shape_symbol.is_static()) {
+              size_total += shape_symbol.static_size();
+            } else {
+              flag = false;
+              break;
+            }
+          }
+        }
+        if (flag) {
+          final_shape.emplace_back(
+              ::c10::ShapeSymbol::fromStaticSize(size_total));
+        } else {
+          final_shape.emplace_back(::c10::ShapeSymbol::newSymbol());
+        }
+      } else {
+        auto flag = false;
+        for (auto input_idx = 0; input_idx < n->inputs().size(); input_idx++) {
+          if (ConstantValueMap::HasShape(n->input(input_idx)->debugName())) {
+            auto input_shape =
+                ConstantValueMap::GetShape(n->input(input_idx)->debugName());
+            auto input_shape_value = input_shape.value().sizes();
+            auto shape_symbol = input_shape_value.value()[idx];
+            if (shape_symbol.is_static()) {
+              final_shape.emplace_back(::c10::ShapeSymbol::fromStaticSize(
+                  shape_symbol.static_size()));
+              flag = true;
+              break;
+            }
+          }
+        }
+        if (!flag) {
+          final_shape.emplace_back(::c10::ShapeSymbol::newSymbol());
+        }
+      }
+    }
+    UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
+  }
+}
+
+void ProcessMatMulNode(Node* n) {
+  if (ConstantValueMap::HasShape(n->input(0)->debugName()) &&
+      ConstantValueMap::HasShape(n->input(1)->debugName())) {
+    auto input_shape_0 =
+        ConstantValueMap::GetShape(n->input(0)->debugName()).value();
+    auto input_shape_value_0 = input_shape_0.sizes().value();
+    auto input_shape_1 =
+        ConstantValueMap::GetShape(n->input(1)->debugName()).value();
+    auto input_shape_value_1 = input_shape_1.sizes().value();
+    size_t rank_0 = input_shape_value_0.size();
+    size_t rank_1 = input_shape_value_1.size();
+    auto is_rank_0_1 = false;
+    if (rank_0 == 1) {
+      input_shape_value_0.insert(
+          input_shape_value_0.begin(), ::c10::ShapeSymbol::fromStaticSize(1));
+      rank_0 = 2;
+      is_rank_0_1 = true;
+    }
+    auto is_rank_1_1 = false;
+    if (rank_1 == 1) {
+      input_shape_value_1.emplace_back(::c10::ShapeSymbol::fromStaticSize(1));
+      rank_1 = 2;
+      is_rank_1_1 = true;
+    }
+    size_t rank = std::max(rank_0, rank_1);
+    std::vector<::c10::ShapeSymbol> final_shape;
+    final_shape.reserve(rank);
+    if (rank_0 >= rank_1) {
+      for (auto idx = 0; idx < rank_0 - 2; idx++) {
+        final_shape.emplace_back(input_shape_value_0[idx]);
+      }
+    } else {
+      for (auto idx = 0; idx < rank_1 - 2; idx++) {
+        final_shape.emplace_back(input_shape_value_1[idx]);
+      }
+    }
+    final_shape.emplace_back(input_shape_value_0[rank_0 - 2]);
+    final_shape.emplace_back(input_shape_value_1[rank_1 - 1]);
+    if (is_rank_0_1) {
+      final_shape.erase(final_shape.begin());
+    }
+    if (is_rank_1_1) {
+      final_shape.pop_back();
+    }
+    UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
+  }
+}
+
+void ProcessReduceNode(Node* n) {
+  if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+    auto input_shape_0 = ConstantValueMap::GetShape(n->input(0)->debugName());
+    auto input_shape_value_0 = input_shape_0.value().sizes();
+    size_t rank_0 = input_shape_value_0.value().size();
+    std::vector<::c10::ShapeSymbol> final_shape;
+    if (!n->hasAttributeS("axes")) {
+      UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
+      return;
+    }
+    final_shape.reserve(rank_0);
+    std::vector<int64_t> axes_vector = n->is(attr::axes);
+    for (auto idx = 0; idx < axes_vector.size(); idx++) {
+      if (axes_vector[idx] < 0) {
+        axes_vector[idx] += rank_0;
+      }
+    }
+    int64_t keepdims = 0;
+    if (n->hasAttributeS("keepdims")) {
+      keepdims = n->i(attr::keepdims);
+    }
+    for (auto idx = 0; idx < rank_0; idx++) {
+      auto it = std::find(axes_vector.begin(), axes_vector.end(), idx);
+      if (it != axes_vector.end()) {
+        if (keepdims != 0) {
+          final_shape.emplace_back(::c10::ShapeSymbol::fromStaticSize(1));
+        }
+      } else {
+        final_shape.emplace_back(input_shape_value_0.value()[idx]);
+      }
+    }
+    UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
+  }
+}
+
 void ProcessReshapeNode(Node* n, int opset_version) {
   if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
     auto shape_temp =
@@ -647,9 +851,13 @@ void ProcessReshapeNode(Node* n, int opset_version) {
     auto shape_vector_0 =
         ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
             n->input(0)->debugName());
+    std::vector<int64_t> shape_vector_0_value(0);
     if (shape_vector_0.has_value()) {
+      shape_vector_0_value = shape_vector_0.value();
+    }
+    if (shape_vector_0.has_value() || shape_temp.size() > 0) {
       auto final_shape = ComputeShapeFromReshape(
-          n, shape_vector_0.value(), shape_temp, opset_version);
+          n, shape_vector_0_value, shape_temp, opset_version);
       UpdateShapeFromVector(n->output(), final_shape);
       return;
     }
@@ -808,6 +1016,14 @@ void ProcessSliceNode(Node* n, int opset_version) {
   }
 }
 
+void ProcessUnchangeNode(Node* n) {
+  if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+    auto shape_size_0 =
+        ConstantValueMap::GetShape(n->input(0)->debugName()).value();
+    UpdateShape(n->output(), shape_size_0);
+  }
+}
+
 void ProcessTimeSeriesNode(Node* n) {
   auto input0_shape = ConstantValueMap::GetShape(n->input(0)->debugName());
   auto input1_shape = ConstantValueMap::GetShape(n->input(1)->debugName());
@@ -892,6 +1108,20 @@ void ComputeConstant(Node* n, int opset_version) {
   }
 
   switch (n->kind()) {
+    case ::c10::onnx::Add:
+    case ::c10::onnx::Div:
+    case ::c10::onnx::Equal:
+    case ::c10::onnx::Greater:
+    case ::c10::onnx::GreaterOrEqual:
+    case ::c10::onnx::Less:
+    case ::c10::onnx::LessOrEqual:
+    case ::c10::onnx::Mod:
+    case ::c10::onnx::Mul:
+    case ::c10::onnx::Pow:
+    case ::c10::onnx::Sub: {
+      ProcessBroadCastNode(n);
+      break;
+    }
     case ::c10::onnx::Shape: {
       auto input_shape =
           ConstantValueMap::GetShapeInto1DInt64Vector(n->input()->debugName());
@@ -907,6 +1137,10 @@ void ComputeConstant(Node* n, int opset_version) {
         at::Tensor f_copy = at::empty({shape_value_size}, options);
         f_copy.copy_(f);
         ConstantValueMap::SetValue(n->output()->debugName(), f_copy);
+        std::vector<::c10::ShapeSymbol> final_shape_vector(
+            1, c10::ShapeSymbol::fromStaticSize(shape_value_size));
+        ::c10::SymbolicShape final_shape(final_shape_vector);
+        UpdateShape(n->output(), final_shape);
       }
       break;
     }
@@ -968,6 +1202,10 @@ void ComputeConstant(Node* n, int opset_version) {
           }
         }
       }
+      break;
+    }
+    case ::c10::onnx::Concat: {
+      ProcessConcatNode(n);
       break;
     }
     case ::c10::onnx::ConstantOfShape: {
@@ -1047,6 +1285,15 @@ void ComputeConstant(Node* n, int opset_version) {
       }
       break;
     }
+    case ::c10::onnx::MatMul: {
+      ProcessMatMulNode(n);
+      break;
+    }
+    case ::c10::onnx::ReduceMean:
+    case ::c10::onnx::ReduceProd: {
+      ProcessReduceNode(n);
+      break;
+    }
     case ::c10::onnx::RNN:
     case ::c10::onnx::LSTM:
     case ::c10::onnx::GRU: {
@@ -1081,6 +1328,12 @@ void ComputeConstant(Node* n, int opset_version) {
     }
     case ::c10::onnx::Slice: {
       ProcessSliceNode(n, opset_version);
+      break;
+    }
+    case ::c10::onnx::Cast:
+    case ::c10::onnx::Relu:
+    case ::c10::onnx::Softmax: {
+      ProcessUnchangeNode(n);
       break;
     }
     case ::c10::onnx::Tile: {
@@ -1130,7 +1383,20 @@ bool IsListConstructIntType(const Value* v) {
 
 bool AllGraphInputsStatic(const Graph* g) {
   for (auto n : g->inputs()) {
-    if (!n->isCompleteTensor()) {
+    if (TensorTypePtr input_type = n->type()->cast<TensorType>()) {
+      if (input_type->dim()) {
+        auto shape = input_type->symbolic_sizes();
+        if (!ConstantValueMap::HasShape(n->debugName())) {
+          UpdateShapeConstantValueMap(n, shape);
+        }
+      }
+    }
+  }
+  for (auto n : g->inputs()) {
+    // Some inputs can be non-Tensor type, e.g.,
+    // __torch__.torch.classes.quantized.LinearPackedParamsBase
+    // so we only need check Tensor type here.
+    if (n->type()->cast<TensorType>() && !n->isCompleteTensor()) {
       return false;
     }
   }
@@ -1432,10 +1698,29 @@ void ONNXShapeTypeInference(
 
 } // namespace
 
+// For some operators, there are some inputs not related to shape inference.
+// For example, LSTM input 4 (sequence_lens) is optional,
+// and the shape inference can be done through other required inputs.
+// When we compute reliable, we don't need this input be reliable.
+static std::unordered_map<std::string, std::unordered_set<int64_t>>
+    non_required_shape_inference_idx_map = {{"onnx::LSTM", {4}}};
+
 std::pair<bool, bool> AreInputsReliableOrStatic(Node* n) {
   auto reliable = true;
   auto complete = true;
-  for (auto input : n->inputs()) {
+  auto input_size = n->inputs().size();
+  std::unordered_set<int64_t> non_required_idx = {};
+  if (non_required_shape_inference_idx_map.find(n->kind().toDisplayString()) !=
+      non_required_shape_inference_idx_map.end()) {
+    non_required_idx =
+        non_required_shape_inference_idx_map[n->kind().toDisplayString()];
+  }
+  for (auto idx = 0; idx < input_size; idx++) {
+    if (!non_required_idx.empty() &&
+        non_required_idx.find(idx) != non_required_idx.end()) {
+      continue;
+    }
+    auto input = n->inputs()[idx];
     reliable &=
         ConstantValueMap::GetTypeReliable(input->debugName()).value_or(false);
     if (auto pt = input->type()->cast<TensorType>()) {
@@ -1453,6 +1738,7 @@ static std::unordered_set<std::string> nodeTypeReliableForTracer = {
     "prim::ListConstruct",
     "onnx::Cast",
     "onnx::Constant",
+    "onnx::Relu",
     "com.microsoft::Gelu"};
 
 void UpdateReliable(
@@ -1564,8 +1850,9 @@ void ONNXShapeTypeInference(
         // NOLINTNEXTLINE(modernize-use-nullptr)
         if ((strstr(ex.what(), shape_err) == NULL) &&
             // NOLINTNEXTLINE(modernize-use-nullptr)
-            (strstr(ex.what(), type_err) == NULL))
+            (strstr(ex.what(), type_err) == NULL)) {
           throw;
+        }
       }
       GRAPH_DEBUG(
           "ONNX graph after shape inference: ", prettyPrint(*model_proto));
@@ -1573,7 +1860,6 @@ void ONNXShapeTypeInference(
   }
 
   SpecialPostProcess(n);
-
   if (IsValidONNXNode(n)) {
     ProcessConstantValueMap(n, opset_version);
     if (n->kind() != prim::ListConstruct) {
@@ -1585,6 +1871,26 @@ void ONNXShapeTypeInference(
     }
   }
   UpdateReliable(n);
+
+  // For the node type that does nott have ComputeConstant logic, it may have
+  // reliable shape but its shape is not in ConstantValueMap. So we need this
+  // logic to update ConstantValueMap.
+  for (auto node_output : n->outputs()) {
+    if (ConstantValueMap::HasTypeReliable(node_output->debugName())) {
+      auto reliable =
+          ConstantValueMap::GetTypeReliable(node_output->debugName())
+              .value_or(false);
+      if (reliable && !ConstantValueMap::HasShape(node_output->debugName())) {
+        // TODO: ListType case
+        if (auto output_tensor_type = node_output->type()->cast<TensorType>()) {
+          if (output_tensor_type->dim()) {
+            auto symbolic_sizes = output_tensor_type->symbolic_sizes();
+            UpdateShapeConstantValueMap(node_output, symbolic_sizes);
+          }
+        }
+      }
+    }
+  }
 
   GRAPH_DEBUG(
       "Torch graph after shape inference:", n->owningGraph()->toString());

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.h
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.h
@@ -10,7 +10,8 @@ namespace jit {
 void MergeInferredTypeAndSetMap(
     Value* dest_v,
     TypePtr existing_type,
-    TypePtr inferred_type);
+    TypePtr inferred_type,
+    bool set_constant_value_map = true);
 
 // Update graph input types with dynamic axes info.
 // Axes that are marked as dynamic will be assigned as dynamic ShapeSymbol.

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -35,10 +35,14 @@ Node* MutationRemover::createSpecialMappedOp(Node* n) {
           "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)")) {
     new_node =
         graph_->insert(aten::full_like, {inputs.at(0), inputs.at(1)})->node();
-    new_node->copyMetadata(n);
-    new_node->output()->setType(n->output()->type());
-    new_node = graph_->insert(aten::type_as, {new_node->output(), inputs.at(0)})
-                   ->node();
+    // aten::empty type can be undefined.
+    if (inputs.at(0)->node()->kind() != aten::empty) {
+      new_node->copyMetadata(n);
+      new_node->output()->setType(n->output()->type());
+      new_node =
+          graph_->insert(aten::type_as, {new_node->output(), inputs.at(0)})
+              ->node();
+    }
   } else if (n->matches("aten::zero_(Tensor(a!) self) -> Tensor(a!)")) {
     new_node = graph_->insert(aten::zeros_like, {n->inputs().at(0)})->node();
   } else if (

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -31,10 +31,10 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=True, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=True,
-           use_external_data_format=False):
+           opset_version=None, _retain_param_name=None, do_constant_folding=True,
+           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=None,
+           use_external_data_format=None):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -31,10 +31,10 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=None,
-           use_external_data_format=None):
+           opset_version=None, _retain_param_name=True, do_constant_folding=True,
+           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=True,
+           use_external_data_format=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -439,11 +439,11 @@ def unbind(g, self, dim=0, _outputs=None):
 
 # Generate paddings in ONNX order based on pad in pytorch.
 # Args:
-#     dim: the dimension of the tensor.
+#     input: the input tensor.
 #     pad: the paddings in pytorch.
 #          The order is dim_n_begin, dim_n_end, dim_n-1_begin, dim_n-1_end, ..., dim_m_begin, dim_m_end,
 #          where m is in range [0, n].
-def _prepare_onnx_paddings(g, dim, pad):
+def _prepare_onnx_paddings(g, input, pad):
     if not sym_help._is_packed_list(pad) and sym_help._is_list(pad) and sym_help._is_scalar_list(pad):
         pad = g.op("ConcatFromSequence", pad, axis_i=0, new_axis_i=1)
     # The desired order of paddings is
@@ -452,7 +452,12 @@ def _prepare_onnx_paddings(g, dim, pad):
     # Assume zero-dimensions in the beginning, pad the "pad" sequence with zeros in the beginning
     pad_len = torch.onnx.symbolic_opset9.size(g, pad, g.op("Constant", value_t=torch.tensor([0])))
     # Set extension = [0] * (dim * 2 - len(pad))
-    extension = g.op("Sub", g.op("Mul", g.op("Constant", value_t=torch.tensor(dim, dtype=torch.int64)),
+    rank = sym_help._get_tensor_rank(input)
+    if rank is None:
+        rank = g.op("Size", g.op("Shape", input))
+    else:
+        rank = g.op("Constant", value_t=torch.tensor(rank, dtype=torch.int64))
+    extension = g.op("Sub", g.op("Mul", rank,
                      g.op("Constant", value_t=torch.tensor(2, dtype=torch.int64))), pad_len)
     # Concat pad with extension: paddings = [dim_n_begin, dim_n_end, dim_n-1_begin, dim_n-1_end, 0, 0, ... ]
     # Currently ONNX only supports int64 type for Pad
@@ -473,19 +478,19 @@ def constant_pad_nd(g, input, padding, value=None):
     mode = "constant"
     value = sym_help._maybe_get_scalar(value)
     value = sym_help._if_scalar_type_as(g, value, input)
-    pad = _prepare_onnx_paddings(g, sym_help._get_tensor_rank(input), padding)
+    pad = _prepare_onnx_paddings(g, input, padding)
     return g.op("Pad", input, pad, value, mode_s=mode)
 
 
 def reflection_pad(g, input, padding):
     mode = "reflect"
-    paddings = _prepare_onnx_paddings(g, sym_help._get_tensor_rank(input), padding)
+    paddings = _prepare_onnx_paddings(g, input, padding)
     return g.op("Pad", input, paddings, mode_s=mode)
 
 
 def replication_pad(g, input, padding):
     mode = "edge"
-    paddings = _prepare_onnx_paddings(g, sym_help._get_tensor_rank(input), padding)
+    paddings = _prepare_onnx_paddings(g, input, padding)
     return g.op("Pad", input, paddings, mode_s=mode)
 
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -76,19 +76,33 @@ def select_model_mode_for_export(model, mode):
 
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=True, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
+           opset_version=None, _retain_param_name=None, do_constant_folding=True,
+           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=None, use_external_data_format=False):
+           enable_onnx_checker=None, use_external_data_format=None):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
+
     if enable_onnx_checker is not None:
-        warnings.warn("`enable_onnx_checker' is deprecated and ignored. It will be removed in"
-                      "the next PyTorch release. To proceed despite ONNX checker failures, you"
-                      "can catch torch.onnx.ONNXCheckerError.")
+        warnings.warn("'enable_onnx_checker' is deprecated and ignored. It will be removed in "
+                      "the next PyTorch release. To proceed despite ONNX checker failures, "
+                      "catch torch.onnx.ONNXCheckerError.")
+    if _retain_param_name is not None:
+        warnings.warn("'_retain_param_name' is deprecated and ignored. "
+                      "It will be removed in the next PyTorch release.")
+    if strip_doc_string is not None:
+        warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
+                      "next PyTorch release. It's combined with `verbose' argument now. ")
+    if example_outputs is not None:
+        warnings.warn("`example_outputs' is deprecated and ignored. Will be removed in "
+                      "next PyTorch release.")
+    if use_external_data_format is not None:
+        warnings.warn("`use_external_data_format' is deprecated and ignored. Will be removed in next "
+                      "PyTorch release. The code will work as it is False if models are not larger than 2GB, "
+                      "Otherwise set to False because of size limits imposed by Protocol Buffers.")
 
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
@@ -204,8 +218,6 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
 
     torch._C._jit_pass_onnx_scalar_type_analysis(graph, True, _export_onnx_opset_version)
     torch._C._jit_pass_lint(graph)
-
-    torch._C._jit_pass_onnx_fold_if(graph)
 
     torch._C._jit_pass_onnx_peephole(graph, _export_onnx_opset_version, fixed_batch_size)
     torch._C._jit_pass_lint(graph)
@@ -549,9 +561,14 @@ def _model_to_graph(model, args, verbose=False,
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                            google_printer=False, opset_version=None, _retain_param_name=True,
+                            google_printer=False, opset_version=None, _retain_param_name=None,
                             keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
                             do_constant_folding=True, dynamic_axes=None):
+    if f is not None:
+        warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
+    if _retain_param_name is not None:
+        warnings.warn("'_retain_param_name' is deprecated and ignored. "
+                      "It will be removed in the next PyTorch release.")
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, google_printer,
@@ -587,8 +604,8 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
         args = _decide_input_format(model, args)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type,
-                                                        example_outputs, _retain_param_name,
-                                                        val_do_constant_folding, fixed_batch_size=fixed_batch_size,
+                                                        example_outputs, val_do_constant_folding,
+                                                        fixed_batch_size=fixed_batch_size,
                                                         training=training, dynamic_axes=dynamic_axes,
                                                         export_params=export_params,
                                                         keep_initializers_as_inputs=val_keep_init_as_ip)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -566,11 +566,12 @@ def export_to_pretty_string(model, args, f, export_params=True, verbose=False, t
                             google_printer=False, opset_version=None, _retain_param_name=None,
                             keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
                             do_constant_folding=True, dynamic_axes=None):
-    if f is not None:
-        warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
-    if _retain_param_name is not None:
-        warnings.warn("'_retain_param_name' is deprecated and ignored. "
-                      "It will be removed in the next PyTorch release.")
+    if aten:
+        assert operator_export_type is None
+        assert aten
+        operator_export_type = OperatorExportTypes.ONNX_ATEN
+    elif operator_export_type is None:
+        operator_export_type = OperatorExportTypes.ONNX
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, google_printer,
@@ -606,11 +607,9 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
         args = _decide_input_format(model, args)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type,
-                                                        example_outputs, val_do_constant_folding,
-                                                        fixed_batch_size=fixed_batch_size,
-                                                        training=training, dynamic_axes=dynamic_axes,
-                                                        export_params=export_params,
-                                                        keep_initializers_as_inputs=val_keep_init_as_ip)
+                                                        example_outputs, _retain_param_name,
+                                                        val_do_constant_folding, fixed_batch_size=fixed_batch_size,
+                                                        training=training, dynamic_axes=dynamic_axes)
 
         return graph._pretty_print_onnx(params_dict, opset_version, False,
                                         operator_export_type, google_printer,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -603,7 +603,9 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
                                                         output_names, operator_export_type,
                                                         example_outputs, _retain_param_name,
                                                         val_do_constant_folding, fixed_batch_size=fixed_batch_size,
-                                                        training=training, dynamic_axes=dynamic_axes)
+                                                        training=training, dynamic_axes=dynamic_axes,
+                                                        export_params=export_params,
+                                                        keep_initializers_as_inputs=val_keep_init_as_ip)
 
         return graph._pretty_print_onnx(params_dict, opset_version, False,
                                         operator_export_type, google_printer,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -79,30 +79,16 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            opset_version=None, _retain_param_name=True, do_constant_folding=True,
            example_outputs=None, strip_doc_string=True, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_external_data_format=False):
+           enable_onnx_checker=None, use_external_data_format=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
-
     if enable_onnx_checker is not None:
-        warnings.warn("'enable_onnx_checker' is deprecated and ignored. It will be removed in "
-                      "the next PyTorch release. To proceed despite ONNX checker failures, "
-                      "catch torch.onnx.ONNXCheckerError.")
-    if _retain_param_name is not None:
-        warnings.warn("'_retain_param_name' is deprecated and ignored. "
-                      "It will be removed in the next PyTorch release.")
-    if strip_doc_string is not None:
-        warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release. It's combined with `verbose' argument now. ")
-    if example_outputs is not None:
-        warnings.warn("`example_outputs' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release.")
-    if use_external_data_format is not None:
-        warnings.warn("`use_external_data_format' is deprecated and ignored. Will be removed in next "
-                      "PyTorch release. The code will work as it is False if models are not larger than 2GB, "
-                      "Otherwise set to False because of size limits imposed by Protocol Buffers.")
+        warnings.warn("`enable_onnx_checker' is deprecated and ignored. It will be removed in"
+                      "the next PyTorch release. To proceed despite ONNX checker failures, you"
+                      "can catch torch.onnx.ONNXCheckerError.")
 
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -76,10 +76,10 @@ def select_model_mode_for_export(model, mode):
 
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
+           opset_version=None, _retain_param_name=True, do_constant_folding=True,
+           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=None, use_external_data_format=None):
+           enable_onnx_checker=True, use_external_data_format=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
@@ -563,15 +563,9 @@ def _model_to_graph(model, args, verbose=False,
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                            google_printer=False, opset_version=None, _retain_param_name=None,
+                            google_printer=False, opset_version=None, _retain_param_name=True,
                             keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
                             do_constant_folding=True, dynamic_axes=None):
-    if aten:
-        assert operator_export_type is None
-        assert aten
-        operator_export_type = OperatorExportTypes.ONNX_ATEN
-    elif operator_export_type is None:
-        operator_export_type = OperatorExportTypes.ONNX
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, google_printer,


### PR DESCRIPTION
When exporting several torch hub models, we find the following issues:
(1) LSTM optional input not related to shape inference, we need relax `AllGraphInputsStatic` condition。
Added unit test: `test/onnx/test_operators.py::TestOperators::test_lstm_none_sequence_lens`
(2) Check graph input `isCompleteTensor`, we only consider when it is Tensor type.
(3) When `prim::Uninitialized` happen and we don't know the input rank for `reflectionPad`, we need calculate it. 
-- I did a local test by doing `rank = g.op('Size', g.op('Shape', input))` all the time, and it looks good to me.
(4) Added several symbolic shape inference to have proper shape inference propagation, several unit tests in `test_operators` cover this.
(5) Deprecate `_jit_pass_onnx_fold_if`.

