### PR TITLE
[vulkan] Add _reshape_alias

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -154,10 +154,10 @@ Context* context() {
       return new Context(adapter);
     }
     catch (const std::exception& e) {
-      TORCH_WARN("Vulkan: Failed to initialize context! Error: ", e.what());
+      TORCH_CHECK(false, "Vulkan: Failed to initialize context! Error: ", e.what());
     }
     catch (...) {
-      TORCH_WARN("Vulkan: Failed to initialize context! Error: Unknown");
+      TORCH_CHECK(false, "Vulkan: Failed to initialize context! Error: Unknown");
     }
 
     return nullptr;

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -42,10 +42,18 @@ Tensor view(
   return convert(v_output);
 }
 
+Tensor _reshape_alias(
+    const Tensor& self_arg,
+    const IntArrayRef shape,
+    const IntArrayRef strides) {
+  return view(self_arg, shape);
+}
+
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::view"), TORCH_FN(view));
+  m.impl(TORCH_SELECTIVE_NAME("aten::_reshape_alias"), TORCH_FN(_reshape_alias));
 }
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
D29792126 (https://github.com/pytorch/pytorch/commit/adb73d3dcffdbcdcb7344413d7e27c8633db030a) changed the behaviour of `reshape()` such that it calls `_reshape_alias()` instead of `view()` in order to avoid duplicating some work such as computing strides.

Vulkan has not yet implemented `_reshape_alias()` so `reshape()` would fail with

```
C++ exception with description "Could not run 'aten::_reshape_alias' with arguments from the 'Vulkan' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions.
```

For Vulkan there is no concept of strides so it's fine to just have `_reshape_alias()` point to `view()`.

Test Plan:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
cd -
```

Reviewed By: kimishpatel

Differential Revision: D30054706

