### PR TITLE
[vulkan] Throw an exception if device does not support Vulkan

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -154,10 +154,10 @@ Context* context() {
       return new Context(adapter);
     }
     catch (const std::exception& e) {
-      TORCH_WARN("Vulkan: Failed to initialize context! Error: ", e.what());
+      TORCH_CHECK(false, "Vulkan: Failed to initialize context! Error: ", e.what());
     }
     catch (...) {
-      TORCH_WARN("Vulkan: Failed to initialize context! Error: Unknown");
+      TORCH_CHECK(false, "Vulkan: Failed to initialize context! Error: Unknown");
     }
 
     return nullptr;


### PR DESCRIPTION
Summary:
If the Vulkan instance cannot be initialized successfully (i.e. no `vkPhysicalDevice` could be found due to missing drivers) then Vulkan ops will not be able to execute. However, currently `api::context()` which is used to access the global Vulkan context simply returns a null pointer if there is a problem initializing the Vulkan instance.

This leads to Segmentation Faults later on because Vulkan ops assume that `api::context()` will not return a `nullptr`. For instance: [this line](https://www.internalfb.com/code/fbsource/xplat/caffe2/aten/src/ATen/native/vulkan/ops/Persistent.cpp?lines=14) will frequently cause a Segmentation Fault when drivers are not present.

Instead of having `api::context()` returning a nullptr when Vulkan cannot be initialized, it should just throw an exception since ops cannot be executed anyway. This results in a more graceful failure as these exceptions can be caught instead of crashing the app with a Seg Fault down the line.

Test Plan:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
cd -
```

On an Omni model portal, I can also remove the vulkan drivers in order to test the functionality when Vulkan is not supported.

Reviewed By: kimishpatel

Differential Revision: D30139891

