### PR TITLE
rename namespace f4d to velox

### DIFF
--- a/aten/src/ATen/native/ReduceAllOps.cpp
+++ b/aten/src/ATen/native/ReduceAllOps.cpp
@@ -30,4 +30,4 @@ std::tuple<Tensor, Tensor> _aminmax_all(const Tensor &self) {
   return at::aminmax(self);
 }
 
-}} // namesapce at::native
+}} // namespace at::native

--- a/aten/src/ATen/native/RowwisePrune.cpp
+++ b/aten/src/ATen/native/RowwisePrune.cpp
@@ -103,4 +103,4 @@ std::tuple<Tensor, Tensor> _rowwise_prune(const Tensor& weights,
                                         compressed_indices_dtype);
 }
 
-}} // namesapce at::native
+}} // namespace at::native


### PR DESCRIPTION
Summary: Moving all namespace definitions, declarations and  references from 'f4d' to 'velox'

Test Plan:
```
buck build //f4d/...
buck test //f4d/...
```
Also monitor the signals from sandcaslte

Reviewed By: pedroerp

Differential Revision: D30140136

