### PR TITLE
delegate to the proper comparison operator

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -923,7 +923,7 @@ constexpr bool operator==(const optional<T>& x, const optional<T>& y) {
 
 template <class T>
 constexpr bool operator!=(const optional<T>& x, const optional<T>& y) {
-  return !(x == y);
+  return x ? *x != y : bool(y);
 }
 
 template <class T>
@@ -933,17 +933,17 @@ constexpr bool operator<(const optional<T>& x, const optional<T>& y) {
 
 template <class T>
 constexpr bool operator>(const optional<T>& x, const optional<T>& y) {
-  return (y < x);
+  return x && *x > y;
 }
 
 template <class T>
 constexpr bool operator<=(const optional<T>& x, const optional<T>& y) {
-  return !(y < x);
+  return x ? *x <= y : !y;
 }
 
 template <class T>
 constexpr bool operator>=(const optional<T>& x, const optional<T>& y) {
-  return !(x < y);
+  return x ? *x >= y : !y;
 }
 
 // 20.5.9, Comparison with nullopt


### PR DESCRIPTION
For example, call T::operator!= rather than !(x == y).

Fixes #62566
