### PR TITLE
Set mkl thread locally

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -49,7 +49,7 @@ void set_num_threads(int nthreads) {
   omp_set_num_threads(nthreads);
 #endif
 #ifdef TH_BLAS_MKL
-  mkl_set_num_threads(nthreads);
+  mkl_set_num_threads_local(nthreads);
 
   // because PyTorch uses OpenMP outside of MKL invocations
   // as well, we want this flag to be false, so that

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -8,6 +8,7 @@
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <string.h>
 #include <sstream>
+#include<thread>
 
 struct NumThreadsGuard {
   int old_num_threads_;
@@ -48,6 +49,19 @@ TEST(TestParallel, NestedParallel) {
     }
   });
 }
+
+#ifdef TH_BLAS_MKL
+TEST(TestParallel, LocalMKLThreadNumber) {
+  auto master_thread_num = mkl_get_max_threads();
+  auto f = [](int nthreads){
+    set_num_threads(nthreads);
+    ASSERT_TRUE(mkl_get_max_threads(), nthreads);
+  };
+  std::thread t(set_local_threads, 1);
+  t.join();
+  ASSERT_EQ(master_thread_num, mkl_get_max_threads());
+}
+#endif
 
 TEST(TestParallel, NestedParallelThreadId) {
   // check that thread id within a nested parallel block is accurate

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -8,7 +8,10 @@
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <string.h>
 #include <sstream>
-#include<thread>
+#ifdef TH_BLAS_MKL
+#include <mkl.h>
+#include <thread>
+#endif
 
 struct NumThreadsGuard {
   int old_num_threads_;
@@ -55,9 +58,8 @@ TEST(TestParallel, LocalMKLThreadNumber) {
   auto master_thread_num = mkl_get_max_threads();
   auto f = [](int nthreads){
     set_num_threads(nthreads);
-    ASSERT_EQ(mkl_get_max_threads(), nthreads);
   };
-  std::thread t(set_local_threads, 1);
+  std::thread t(f, 1);
   t.join();
   ASSERT_EQ(master_thread_num, mkl_get_max_threads());
 }

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -55,7 +55,7 @@ TEST(TestParallel, LocalMKLThreadNumber) {
   auto master_thread_num = mkl_get_max_threads();
   auto f = [](int nthreads){
     set_num_threads(nthreads);
-    ASSERT_TRUE(mkl_get_max_threads(), nthreads);
+    ASSERT_EQ(mkl_get_max_threads(), nthreads);
   };
   std::thread t(set_local_threads, 1);
   t.join();


### PR DESCRIPTION
Fixes #60469

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62891

We want to land this PR before next release, so soliciting the idea from https://github.com/pytorch/pytorch/pull/60471. And, add corresponding test to verify the result.
Quote from @raven38 :
> Instead of `omp_set_num_threads` which changes the number of threads locally, `mkl_set_num_threads` changes the number of threads globally. I think changing the number of threads should only be done locally after a fork.

- Before this PR using this test:
![image](https://user-images.githubusercontent.com/68879799/128542334-1b899be5-2b6e-4c03-8ac0-568fb15470b8.png)
- After this PR the test passed without Error.

Differential Revision: [D30161483](https://our.internmc.facebook.com/intern/diff/D30161483)