### PR TITLE
Adds JOB_BASE_NAME to steps of CircleCI mac workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1368,7 +1368,6 @@ jobs:
   pytorch_macos_10_15_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.15-py3-arm64-build
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.3.0"
     steps:
@@ -1381,6 +1380,7 @@ jobs:
             set -e
             export IN_CI=1
             export CROSS_COMPILE_ARM64=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
@@ -1406,12 +1406,10 @@ jobs:
   pytorch_macos_10_13_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-build
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
       - checkout
-      - run: echo "JOB_BASE_NAME is $JOB_BASE_NAME"
       - run_brew_for_macos_build
       - run:
           name: Build
@@ -1419,6 +1417,7 @@ jobs:
           command: |
             set -e
             export IN_CI=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
@@ -1442,7 +1441,6 @@ jobs:
   pytorch_macos_10_13_py3_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -1456,6 +1454,7 @@ jobs:
           command: |
             set -e
             export IN_CI=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             chmod a+x .jenkins/pytorch/macos-test.sh
             unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
@@ -1466,6 +1465,9 @@ jobs:
             set -ex
             source /Users/distiller/workspace/miniconda3/bin/activate
             pip install boto3
+
+            export IN_CI=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             # Using the same IAM user to write stats to our OSS bucket
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4}
@@ -1478,7 +1480,6 @@ jobs:
   pytorch_macos_10_13_py3_lite_interpreter_build_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -1493,6 +1494,7 @@ jobs:
             set -e
             export IN_CI=1
             export BUILD_LITE_INTERPRETER=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
             chmod a+x ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
             unbuffer ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh 2>&1 | ts
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1411,6 +1411,7 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
+      - run: echo "JOB_BASE_NAME is $JOB_BASE_NAME"
       - run_brew_for_macos_build
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1368,6 +1368,7 @@ jobs:
   pytorch_macos_10_15_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.15-py3-arm64-build
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.3.0"
     steps:
@@ -1405,6 +1406,7 @@ jobs:
   pytorch_macos_10_13_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-build
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -1439,6 +1441,7 @@ jobs:
   pytorch_macos_10_13_py3_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -1474,6 +1477,7 @@ jobs:
   pytorch_macos_10_13_py3_lite_interpreter_build_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -114,6 +114,7 @@
   pytorch_macos_10_15_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.15-py3-arm64-build
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.3.0"
     steps:
@@ -151,6 +152,7 @@
   pytorch_macos_10_13_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-build
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -185,6 +187,7 @@
   pytorch_macos_10_13_py3_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -220,6 +223,7 @@
   pytorch_macos_10_13_py3_lite_interpreter_build_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
+      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -114,7 +114,6 @@
   pytorch_macos_10_15_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.15-py3-arm64-build
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.3.0"
     steps:
@@ -127,6 +126,7 @@
             set -e
             export IN_CI=1
             export CROSS_COMPILE_ARM64=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
@@ -152,12 +152,10 @@
   pytorch_macos_10_13_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-build
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
       - checkout
-      - run: echo "JOB_BASE_NAME is $JOB_BASE_NAME"
       - run_brew_for_macos_build
       - run:
           name: Build
@@ -165,6 +163,7 @@
           command: |
             set -e
             export IN_CI=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
@@ -188,7 +187,6 @@
   pytorch_macos_10_13_py3_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -202,6 +200,7 @@
           command: |
             set -e
             export IN_CI=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             chmod a+x .jenkins/pytorch/macos-test.sh
             unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
@@ -212,6 +211,9 @@
             set -ex
             source /Users/distiller/workspace/miniconda3/bin/activate
             pip install boto3
+
+            export IN_CI=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
 
             # Using the same IAM user to write stats to our OSS bucket
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4}
@@ -224,7 +226,6 @@
   pytorch_macos_10_13_py3_lite_interpreter_build_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
-      JOB_BASE_NAME: $CIRCLE_JOB
     macos:
       xcode: "12.0"
     steps:
@@ -239,6 +240,7 @@
             set -e
             export IN_CI=1
             export BUILD_LITE_INTERPRETER=1
+            export JOB_BASE_NAME=$CIRCLE_JOB
             chmod a+x ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
             unbuffer ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh 2>&1 | ts
       - store_test_results:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -157,6 +157,7 @@
       xcode: "12.0"
     steps:
       - checkout
+      - run: echo "JOB_BASE_NAME is $JOB_BASE_NAME"
       - run_brew_for_macos_build
       - run:
           name: Build

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -781,7 +781,7 @@ def assemble_s3_object(
 
 
 def send_report_to_s3(head_report: Version2Report) -> None:
-    job = os.environ.get('JOB_BASE_NAME')
+    job = os.getenv('JOB_BASE_NAME', os.environ.get('CIRCLE_JOB'))
     sha1 = os.environ.get('CIRCLE_SHA1')
     branch = os.environ.get('CIRCLE_BRANCH', '')
     now = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
Upon noticing that we had a job entry named "None" in our S3 stats, I set out to find which test reporting had a JOB_BASE_NAME that wasn't set. 

It turns out all non Windows and Linux workflows did not have JOB_BASE_NAME but instead used CIRCLE_JOB. This remedies the current issue by explicitly setting JOB_BASE_NAME in Mac workflows, but doesn't touch anything else as those other jobs (like android) do not report test stats.

This also adds back the CIRCLE_JOB dependency in print_test_stats to be backwards compatible, but the goal is to move off of CIRCLE_JOB dependency to a more CI-platform-agnostic naming of variables.

![image](https://user-images.githubusercontent.com/31798555/128551988-d392de4a-449a-4525-aabe-f6484dcb0046.png)
And now we have the macos instead of None!