### PR TITLE
.github: Make sure to deep clone on windows

### DIFF
--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -80,6 +80,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -183,6 +185,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -147,6 +149,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -130,6 +132,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -140,6 +142,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -139,6 +141,8 @@ jobs:
         with:
           submodules: recursive
           path: pytorch-${{ github.run_id }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62907

Deep clones allow us to use git commands on historical commits so that
we can do things like collect test times correctly

Should fix empty `.pytorch-test-times.json` files that @walterddr was observing

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D30166414](https://our.internmc.facebook.com/intern/diff/D30166414)