### PR TITLE
Allow broadcasting along non-reduction dimension for cosine similarity

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -235,9 +235,12 @@ Tensor _pdist_backward(const Tensor& grad, const Tensor& self, const double p, c
 }
 
 Tensor cosine_similarity(const Tensor& x1, const Tensor& x2, int64_t dim, double eps) {
-  TORCH_CHECK(x1.sizes() == x2.sizes(), "cosine_similarity requires both inputs to have the same sizes, but x1 has ",
-              x1.sizes(), " and x2 has ", x2.sizes())
+  TORCH_CHECK(x1.ndimension() == x2.ndimension(), "cosine_similarity requires both inputs to have the same number of dimensions, but x1 has ",
+              x1.ndimension(), " and x2 has ", x2.ndimension());
+  TORCH_CHECK(x1.ndimension() == 0 || x1.size(dim) == x2.size(dim), "cosine_similarity requires both inputs to have the same size at dimension ", dim, "but x1 has ",
+  x1.size(dim), " and x2 has ", x2.size(dim));
   auto commonDtype = at::result_type(x1, x2);
+  TORCH_CHECK(at::isFloatingType(commonDtype), "expected common dtype to be floating point, yet common dtype is ", commonDtype);
   Tensor x1_ = x1.to(commonDtype);
   Tensor x2_ = x2.to(commonDtype);
   // Follow scipy impl to improve numerical precision

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9366,6 +9366,11 @@ class TestNN(NNTestCase):
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=0), (input1, input2)))
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=-1), (input1, input2)))
 
+        # Check broadcasting
+        input1 = torch.randn(2, 1, 3, requires_grad=True)
+        input2 = torch.randn(1, 2, 3, requires_grad=True)
+        self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=-1), (input1, input2)))
+
         # Check cosine_similarity input/output shapes
         input_size = (1, 3, 2, 1)
         expected_size = (1, 2, 1)
@@ -9391,6 +9396,7 @@ class TestNN(NNTestCase):
         input2 = torch.randn(2, 1, 3)
         with self.assertRaises(RuntimeError):
             F.cosine_similarity(input1, input2)
+
 
         # Check type promotion, issue #61454
         input = torch.tensor(12.)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4254,14 +4254,15 @@ Supports :ref:`type promotion <type-promotion-doc>`.
 
 Args:
     x1 (Tensor): First input.
-    x2 (Tensor): Second input (of size matching x1).
+    x2 (Tensor): Second input (with the same number of dimensions as x1, matching x1 size at dimension `dim`, and broadcastable with x1
+        at other dimensions).
     dim (int, optional): Dimension of vectors. Default: 1
     eps (float, optional): Small value to avoid division by zero.
         Default: 1e-8
 
 Shape:
     - Input: :math:`(\ast_1, D, \ast_2)` where D is at position `dim`.
-    - Output: :math:`(\ast_1, \ast_2)` where 1 is at position `dim`.
+    - Output: :math:`(\ast_1, \ast_2)`
 
 Example::
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4254,8 +4254,8 @@ Supports :ref:`type promotion <type-promotion-doc>`.
 
 Args:
     x1 (Tensor): First input.
-    x2 (Tensor): Second input (with the same number of dimensions as x1, matching x1 size at dimension `dim`, and broadcastable with x1
-        at other dimensions).
+    x2 (Tensor): Second input (with the same number of dimensions as x1, matching x1 size at dimension `dim`,
+        and broadcastable with x1 at other dimensions).
     dim (int, optional): Dimension of vectors. Default: 1
     eps (float, optional): Small value to avoid division by zero.
         Default: 1e-8

--- a/torch/nn/modules/distance.py
+++ b/torch/nn/modules/distance.py
@@ -55,7 +55,7 @@ class CosineSimilarity(Module):
     Shape:
         - Input1: :math:`(\ast_1, D, \ast_2)` where D is at position `dim`
         - Input2: :math:`(\ast_1, D, \ast_2)`, same number of dimensions as x1, matching x1 size at dimension `dim`,
-              and broadcastable with x1 at other dimensions).
+              and broadcastable with x1 at other dimensions.
         - Output: :math:`(\ast_1, \ast_2)`
     Examples::
         >>> input1 = torch.randn(100, 128)

--- a/torch/nn/modules/distance.py
+++ b/torch/nn/modules/distance.py
@@ -54,8 +54,8 @@ class CosineSimilarity(Module):
             Default: 1e-8
     Shape:
         - Input1: :math:`(\ast_1, D, \ast_2)` where D is at position `dim`
-        - Input2: :math:`(\ast_1, D, \ast_2)`, same number of dimensions as x1, matching x1 size at dimension `dim`, and broadcastable with x1
-              at other dimensions).
+        - Input2: :math:`(\ast_1, D, \ast_2)`, same number of dimensions as x1, matching x1 size at dimension `dim`,
+              and broadcastable with x1 at other dimensions).
         - Output: :math:`(\ast_1, \ast_2)`
     Examples::
         >>> input1 = torch.randn(100, 128)

--- a/torch/nn/modules/distance.py
+++ b/torch/nn/modules/distance.py
@@ -43,7 +43,7 @@ class PairwiseDistance(Module):
 
 
 class CosineSimilarity(Module):
-    r"""Returns cosine similarity between :math:`x_1` and :math:`x_2`, computed along dim.
+    r"""Returns cosine similarity between :math:`x_1` and :math:`x_2`, computed along `dim`.
 
     .. math ::
         \text{similarity} = \dfrac{x_1 \cdot x_2}{\max(\Vert x_1 \Vert _2 \cdot \Vert x_2 \Vert _2, \epsilon)}.
@@ -54,7 +54,8 @@ class CosineSimilarity(Module):
             Default: 1e-8
     Shape:
         - Input1: :math:`(\ast_1, D, \ast_2)` where D is at position `dim`
-        - Input2: :math:`(\ast_1, D, \ast_2)`, same shape as the Input1
+        - Input2: :math:`(\ast_1, D, \ast_2)`, same number of dimensions as x1, matching x1 size at dimension `dim`, and broadcastable with x1
+              at other dimensions).
         - Output: :math:`(\ast_1, \ast_2)`
     Examples::
         >>> input1 = torch.randn(100, 128)


### PR DESCRIPTION
Checks introduced by #58559 are too strict and disable correctly working cases that people were relying on. 
