### PR TITLE
Implement ProcessGroupNCCL’s allgather_coalesced API

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1067,12 +1067,26 @@ Arguments:
               py::arg("input_tensor"),
               py::call_guard<py::gil_scoped_release>())
 
-          .def(
+           .def(
               "allgather_coalesced",
               &::c10d::ProcessGroup::allgather_coalesced,
               py::arg("output_lists"),
               py::arg("input_list"),
               py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "allgather_coalesced",
+              [](::c10d::ProcessGroup& pg,
+                 std::vector<std::vector<at::Tensor>>& output,
+                 std::vector<at::Tensor>& input) {
+//                std::vector<std::vector<at::Tensor>> outputs = {output};
+//                std::vector<at::Tensor> inputs = {input};
+                return pg.allgather_coalesced(
+                    output, input, ::c10d::AllgatherOptions());
+              },
+              py::arg("output_lists"),
+              py::arg("input_list"),
               py::call_guard<py::gil_scoped_release>())
 
           .def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62918
* #61437
* #61436

allgather_coalesced needs to be implemented on top of NCCL’s allgather API.
The csrc implementation should be done in ProcessGroupNCCL.cpp, and the tests should be put in test_c10d_nccl.py.

Differential Revision: [D30167797](https://our.internmc.facebook.com/intern/diff/D30167797/)