### PR TITLE
Add docstring for saved tensors default hooks

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -241,3 +241,19 @@ Anomaly detection
 .. autoclass:: detect_anomaly
 
 .. autoclass:: set_detect_anomaly
+
+
+Saved tensors default hooks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some operations need intermediary results to be saved during the forward pass
+in order to execute the backward pass.
+You can define how these saved tensors should be packed / unpacked using hooks.
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    graph.set_saved_tensors_default_hooks
+    graph.reset_saved_tensors_default_hooks
+    graph.save_on_cpu

--- a/torch/autograd/saved_variable_default_hooks.py
+++ b/torch/autograd/saved_variable_default_hooks.py
@@ -1,14 +1,88 @@
 import torch
-from typing import Any
+from typing import Callable, Any
 
-def set_saved_tensors_default_hooks(pack_hook, unpack_hook):
+def set_saved_tensors_default_hooks(pack_hook: Callable[[torch.Tensor], Any], unpack_hook: Callable[[Any], torch.Tensor]):
+    """Sets a pair of pack / unpack hooks for saved tensors.
+
+    Use these hooks to define how intermediary results of an operation
+    should be packed before saving, and unpacked on retrieval.
+
+    When default hooks are set, the ``pack_hook`` function will be called
+    everytime an operation saves a tensor for backward (this includes
+    intermediary results saved using
+    :func:`~torch.autograd.function._ContextMethodMixin.save_for_backward` but
+    also those recorded by a PyTorch-defined operation). The output of
+    ``pack_hook`` is then stored in the computation graph instead of the
+    original tensor.
+
+    The ``unpack_hook`` is called when the saved tensor needs to be accessed,
+    namely when executing :func:`torch.Tensor.backward()` or
+    :func:`torch.autograd.grad()`. It takes as argument the *packed* object
+    returned by ``pack_hook`` and should return a tensor which has the same
+    content as the original tensor (passed as input to the corresponding
+    ``pack_hook``).
+
+    The hooks should have the following signatures:
+
+        pack_hook(tensor: Tensor) -> Any
+
+        unpack_hook(Any) -> Tensor
+
+    where the return value of ``pack_hook`` is a valid input to ``unpack_hook``.
+
+    In general, you want ``unpack_hook(pack_hook(t))`` to be equal to ``t`` in terms
+    of value, size and dtype.
+
+    Example::
+
+        >>> def pack_hook(x):
+        ...     print("Packing", x)
+        ...     return x
+        >>>
+        >>> def unpack_hook(x):
+        ...     print("Unpacking", x)
+        ...     return x
+        >>>
+        >>> a = torch.ones(5, requires_grad=True)
+        >>> b = torch.ones(5, requires_grad=True) * 2
+        >>> torch.autograd.graph.set_saved_tensors_default_hooks(pack_hook, unpack_hook)
+        >>> y = a * b
+        Packing tensor([1., 1., 1., 1., 1.])
+        Packing tensor([2., 2., 2., 2., 2.])
+        >>> torch.autograd.graph.reset_saved_tensors_default_hooks()
+        >>> y.sum().backward()
+        Unpacking tensor([1., 1., 1., 1., 1.])
+        Unpacking tensor([2., 2., 2., 2., 2.])
+
+    .. warning ::
+        Performing an inplace operation on the input to either hooks may lead
+        to undefined behavior.
+
+    .. warning ::
+        Only one pair of hooks is allowed at a time. To register a different
+        pair of hooks, call :func:`~torch.autograd.graph.reset_saved_tensors_default_hooks()`
+        first.
+
+    """
     torch._C._autograd._register_default_hooks(pack_hook, unpack_hook)
 
 def reset_saved_tensors_default_hooks():
+    """Removes the current pair of default pack / unpack hooks for saved tensors.
+
+    Intermediary values that are saved after this function is called won't be
+    packed / unpacked with the default hooks previously defined.
+
+    This does not affect previously saved tensors: intermediary values that
+    were saved before this function is called are still stored in their *packed* form
+    and will be unpacked using the corresponding ``unpack_hook``.
+
+    Also see :func:`~torch.autograd.graph.set_saved_tensors_default_hooks()`.
+    """
     torch._C._autograd._reset_default_hooks()
 
-class save_on_cpu(object):
-    """"Context-manager under which tensors saved by the forward pass will be
+
+class save_on_cpu():
+    """Context-manager under which tensors saved by the forward pass will be
     stored on cpu, then retrieved for backward.
 
     When performing operations within this context manager, intermediary
@@ -45,7 +119,6 @@ class save_on_cpu(object):
         >>> # the content of prod_1 and c only live on CPU
         >>> y.sum().backward()  # all CPU tensors are moved back to GPU, for backward
         >>> # all intermediary tensors are released (deleted) after the call to backward
-
 
     """
     def __init__(self, pin_memory=False):


### PR DESCRIPTION
Closed in favor of #62361

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62924
* #62923
* __->__ #62922

Adds documentation for the saved tensors default hooks introduced in #61834