### PR TITLE
Fix warnings

### DIFF
--- a/aten/src/ATen/cpu/FlushDenormal.cpp
+++ b/aten/src/ATen/cpu/FlushDenormal.cpp
@@ -4,12 +4,12 @@
 
 namespace at { namespace cpu {
 
+#if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
 static constexpr unsigned int DENORMALS_ZERO = 0x0040;
 static constexpr unsigned int FLUSH_ZERO = 0x8000;
 
 bool set_flush_denormal(bool on) {
   // Compile if we have SSE support (GCC), x86-64 (MSVC), or x86 with SSE (MSVC)
-#if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
   // Denormals-Are-Zero is supported by most SSE2 processors, with the exception
   // of some early Pentium 4 processors. We guard it with a runtime check.
   // Flush-To-Zero (FTZ) only requires SSE.
@@ -24,8 +24,12 @@ bool set_flush_denormal(bool on) {
     _mm_setcsr(csr);
     return true;
   }
-#endif
   return false;
 }
+#else
+bool set_flush_denormal(bool on) {
+  return false;
+}
+#endif
 
 }}  // namespace at::cpu

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -295,8 +295,8 @@ class QLinearPackWeightFp16Legacy final {
  public:
   static Tensor run(at::Tensor weight, c10::optional<Tensor> bias) {
     auto& ctx = at::globalContext();
-    auto options = weight.options();
 #ifdef USE_FBGEMM
+    auto options = weight.options();
     if (ctx.qEngine() == at::QEngine::FBGEMM) {
       auto prepacked =
           PackedLinearWeightFp16::prepack(std::move(weight), std::move(bias));

--- a/caffe2/core/net_dag_utils_test.cc
+++ b/caffe2/core/net_dag_utils_test.cc
@@ -57,8 +57,7 @@ class DagUtilTestContext {
 };
 
 void PrintChains(const dag_utils::ExecutionChains& chains) {
-  // NOLINTNEXTLINE(performance-for-range-copy,clang-diagnostic-range-loop-construct)
-  for (const auto kv : chains) {
+  for (const auto& kv : chains) {
     std::stringstream ss;
     ss << kv.first << ": ";
     for (const auto& v : kv.second) {

--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -216,8 +216,7 @@ void parseShapeInfoMapFromString(
     }
 
     bool valid = true;
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 1; i < size; i++) {
+    for (size_t i = 1; i < size; i++) {
       auto dim = kv[i];
       try {
         shape.add_dims(std::stoi(dim));

--- a/caffe2/opt/shape_info.h
+++ b/caffe2/opt/shape_info.h
@@ -74,7 +74,7 @@ struct TORCH_API ShapeInfo {
 
   void setDimType(int idx, TensorBoundShape_DimType type) {
     CAFFE_ENFORCE(
-        dim_type.size() > idx, dim_type.size(), "vs", dim_type.size());
+        dim_type.size() > static_cast<unsigned>(idx), dim_type.size(), "vs", dim_type.size());
     dim_type[idx] = type;
     dim_type_is_set = true;
   }
@@ -88,7 +88,7 @@ struct TORCH_API ShapeInfo {
   }
 
   TensorBoundShape_DimType getDimType(int idx) const {
-    if (dim_type.size() > idx) {
+    if (dim_type.size() > static_cast<unsigned>(idx)) {
       return dim_type[idx];
     } else {
       return TensorBoundShape_DimType_UNKNOWN;

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -846,8 +846,7 @@ void addObjectMethods(py::module& m) {
              std::map<std::string, py::object> inputs)
               -> std::vector<py::object> {
             caffe2::Predictor::TensorMap tensors_data{};
-            // NOLINTNEXTLINE(clang-diagnostic-range-loop-construct,performance-for-range-copy)
-            for (const auto pair : inputs) {
+            for (const auto& pair : inputs) {
               const auto& name = pair.first;
               const auto& input = pair.second;
 #ifdef USE_NUMPY
@@ -1017,8 +1016,7 @@ void addObjectMethods(py::module& m) {
               -> std::vector<py::object> {
             Predictor::TensorMap tensors_data;
 #ifdef USE_NUMPY
-            // NOLINTNEXTLINE(clang-diagnostic-range-loop-construct,performance-for-range-copy)
-            for (const auto pair : inputs) {
+            for (const auto& pair : inputs) {
               const auto& name = pair.first;
               const auto& input = pair.second;
               CAFFE_ENFORCE(

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -2075,13 +2075,13 @@ TEST(InlinedCallStackTest, BlockAnnotation) {
       for (Block* block : n->blocks()) {
         for (Node* if_node : block->nodes()) {
           if (if_node->kind() == aten::add) {
-            for (const auto e : if_node->callstack().value()->vec()) {
+            for (const auto& e : if_node->callstack().value()->vec()) {
               add_ss << std::get<1>(e);
             }
             add_ss << if_node->sourceRange();
           }
           if (if_node->kind() == aten::mul) {
-            for (const auto e : if_node->callstack().value()->vec()) {
+            for (const auto& e : if_node->callstack().value()->vec()) {
               mul_ss << std::get<1>(e);
             }
             mul_ss << if_node->sourceRange();

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -104,6 +104,10 @@ else()
       -fno-strict-aliasing
       -Wno-write-strings
       -Wno-strict-aliasing)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        list(APPEND TORCH_PYTHON_COMPILE_OPTIONS
+          -Wno-writable-strings)
+    endif()
 endif()
 
 if(USE_CUDA)

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -9,9 +9,9 @@ namespace torch { namespace autograd {
 
 struct PyAnomalyMetadata : public AnomalyMetadata {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,clang-diagnostic-writable-strings)
-  static constexpr char* ANOMALY_TRACE_KEY = "traceback_";
+  static constexpr const char* ANOMALY_TRACE_KEY = "traceback_";
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,clang-diagnostic-writable-strings)
-  static constexpr char* ANOMALY_PARENT_KEY = "parent_";
+  static constexpr const char* ANOMALY_PARENT_KEY = "parent_";
 
   PyAnomalyMetadata() {
     pybind11::gil_scoped_acquire gil;

--- a/torch/csrc/jit/mobile/backport_manager.cpp
+++ b/torch/csrc/jit/mobile/backport_manager.cpp
@@ -439,7 +439,7 @@ bool BackportManager::backport(
     auto input_model_stream_version =
         _get_model_bytecode_version(input_model_stream);
 
-    if (input_model_stream_version != bytecode_version) {
+    if (static_cast<int64_t>(input_model_stream_version) != bytecode_version) {
       TORCH_WARN(
           "The bytecode version of input model stream is supposed to be ",
           bytecode_version,
@@ -456,7 +456,7 @@ bool BackportManager::backport(
     auto output_model_stream_version =
         _get_model_bytecode_version(output_model_stream);
 
-    if (output_model_stream_version != bytecode_version) {
+    if (static_cast<int64_t>(output_model_stream_version) != bytecode_version) {
       TORCH_WARN(
           "The bytecode version of output model stream is supposed to be ",
           bytecode_version,

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -235,8 +235,7 @@ bool matchAtenFuncToUse(
     c10::optional<int> n) {
   Node* node = use.user;
   return node->kind() == Symbol::aten(func_name) &&
-      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      (!n.has_value() || n.value() == use.offset);
+      (!n.has_value() || static_cast<size_t>(n.value()) == use.offset);
 }
 
 bool matchCallFuncToUse(
@@ -246,8 +245,7 @@ bool matchCallFuncToUse(
   Node* node = use.user;
   return node->kind() == prim::CallFunction &&
       getFuncName(node->inputs()[0]) == func_name &&
-      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      (!n.has_value() || n.value() == use.offset);
+      (!n.has_value() || static_cast<size_t>(n.value()) == use.offset);
 }
 
 // Check any use of `v` matches the aten function call
@@ -518,15 +516,13 @@ bool useQuantizable(const Use& use, QuantType quant_type) {
   if (quant_type == QuantType::STATIC) {
     for (const auto& func_input : _observe_inputs_aten_func) {
       if (matchAtenFuncToUse(use, func_input.func_name, c10::nullopt)) {
-        // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-        return use.offset == func_input.arg_index;
+        return use.offset == static_cast<size_t>(func_input.arg_index);
       }
     }
 
     for (const auto& func_input : _observe_inputs_call_func) {
       if (matchCallFuncToUse(use, func_input.func_name, c10::nullopt)) {
-        // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-        return use.offset == func_input.arg_index;
+        return use.offset == static_cast<size_t>(func_input.arg_index);
       }
     }
   }

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -865,8 +865,7 @@ struct PythonPrintImpl {
     auto checkSubvalue = [&hasNonASCII](const IValue& val) {
       if (val.isString()) {
         const auto maxASCII = 0x7fu;
-        for (auto& c : val.toStringRef()) {
-          // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
+        for (auto c : val.toStringRef()) {
           if (c > maxASCII) {
             hasNonASCII = true;
             return true;


### PR DESCRIPTION
Add `-Wno-writable-strings`(which is clang's flavor of `-Wwrite-strings`) to list of warnings ignored while compiling torch_python.
Avoid unnecessary copies in range loop
Fix number of signed-unsigned comparisons

Found while building locally on M1
