### PR TITLE
[TensorExpr] Remove more 'const' from IRVisitor methods for *Imm types.

### DIFF
--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -394,9 +394,9 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     }
   }
 
-#define IMM_VISIT(Type, Name)                         \
-  TORCH_API void visit(const Name##Imm* v) override { \
-    value_ = Value(v->value());                       \
+#define IMM_VISIT(Type, Name)                   \
+  TORCH_API void visit(Name##Imm* v) override { \
+    value_ = Value(v->value());                 \
   }
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_VISIT);
 #undef IMM_VISIT

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -32,7 +32,7 @@ class HalfChecker : public IRVisitor {
     IRVisitor::visit(v);
   }
 
-  void visit(const HalfImm* v) override {
+  void visit(HalfImm* v) override {
     hasHalf_ = true;
   }
 

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -83,7 +83,7 @@ class TORCH_API HashProvider : public IRVisitor {
 
 // NOLINTNEXTLINE
 #define IMM_VISIT(Type, Name)                    \
-  void visit(const Name##Imm* v) override {      \
+  void visit(Name##Imm* v) override {            \
     CACHE_GUARD();                               \
     putHash(v, hash_combine(#Name, v->value())); \
   }

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -224,6 +224,16 @@ std::vector<VarHandle> VarVectorToVarHandleVector(const std::vector<Var*>& v) {
   return result;
 }
 
+bool immediateIsNegative(Expr* e) {
+#define TYPE_CASE(Type, Name)                         \
+  if (Name##Imm* imm = dynamic_cast<Name##Imm*>(e)) { \
+    return imm->value() < 0;                          \
+  }
+  AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+#undef TYPE_CASE
+  return false;
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -319,9 +319,9 @@ Expr* getImmediateByType(Dtype dtype, T initialVal) {
 
 template <typename T>
 T immediateAs(Expr* e) {
-#define TYPE_CASE(Type, Name)                                     \
-  if (const Name##Imm* imm = dynamic_cast<const Name##Imm*>(e)) { \
-    return imm->value();                                          \
+#define TYPE_CASE(Type, Name)                         \
+  if (Name##Imm* imm = dynamic_cast<Name##Imm*>(e)) { \
+    return imm->value();                              \
   }
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
 #undef TYPE_CASE
@@ -336,9 +336,9 @@ T immediateAs(ExprHandle e) {
 
 template <typename T>
 bool immediateEquals(Expr* e, T val) {
-#define TYPE_CASE(Type, Name)                                     \
-  if (const Name##Imm* imm = dynamic_cast<const Name##Imm*>(e)) { \
-    return imm->value() == val;                                   \
+#define TYPE_CASE(Type, Name)                         \
+  if (Name##Imm* imm = dynamic_cast<Name##Imm*>(e)) { \
+    return imm->value() == val;                       \
   }
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
 #undef TYPE_CASE
@@ -346,16 +346,7 @@ bool immediateEquals(Expr* e, T val) {
   return false;
 }
 
-template <typename T>
-bool immediateIsNegative(const T* e) {
-#define TYPE_CASE(Type, Name)                                     \
-  if (const Name##Imm* imm = dynamic_cast<const Name##Imm*>(e)) { \
-    return imm->value() < 0;                                      \
-  }
-  AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
-#undef TYPE_CASE
-  return false;
-}
+TORCH_API bool immediateIsNegative(Expr* e);
 
 // Represents a ramp vector node:
 //     [base, base + 1 * stride, ... , base + (lanes - 1) * stride]

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -212,9 +212,9 @@ static void formatImm(std::ostream& os, T v) {
 }
 
 // NOLINTNEXTLINE
-#define IMM_PRINT_VISIT(Type, Name)           \
-  void IRPrinter::visit(const Name##Imm* v) { \
-    formatImm(os(), v->value());              \
+#define IMM_PRINT_VISIT(Type, Name)     \
+  void IRPrinter::visit(Name##Imm* v) { \
+    formatImm(os(), v->value());        \
   }
 AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_PRINT_VISIT);
 #undef IMM_PRINT_VISIT

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -32,7 +32,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(Lshift* v) override;
   void visit(Rshift* v) override;
   void visit(CompareSelect* v) override;
-#define IMM_PRINT_VISIT(Type, Name) void visit(const Name##Imm* v) override;
+#define IMM_PRINT_VISIT(Type, Name) void visit(Name##Imm* v) override;
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_PRINT_VISIT);
 #undef IMM_PRINT_VISIT
   void visit(Cast* v) override;

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -74,7 +74,7 @@ void IRVisitor::visit(CompareSelect* v) {
 
 // NOLINTNEXTLINE
 #define IMM_VISIT(Type, Name) \
-  void IRVisitor::visit(const Name##Imm* v) {}
+  void IRVisitor::visit(Name##Imm* v) {}
 AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_VISIT);
 #undef IMM_VISIT
 

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -68,7 +68,7 @@ class TORCH_API IRVisitor {
   virtual void visit(Rshift* v);
   virtual void visit(CompareSelect* v);
 
-#define IMM_PRINT_VISIT(Type, Name) virtual void visit(const Name##Imm* v);
+#define IMM_PRINT_VISIT(Type, Name) virtual void visit(Name##Imm* v);
 
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_PRINT_VISIT)
 #undef IMM_PRINT_VISIT

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -230,7 +230,7 @@ class LLVMCodeGenImpl : public IRVisitor {
   void visit(Rshift* v) override;
   void visit(CompareSelect* v) override;
 
-#define IMM_VISIT_DECLARE(_1, Name) void visit(const Name##Imm* v) override;
+#define IMM_VISIT_DECLARE(_1, Name) void visit(Name##Imm* v) override;
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_VISIT_DECLARE);
 #undef IMM_VISIT_DECLARE
 
@@ -884,17 +884,17 @@ getFromType(llvm::Type* type, T value) {
 }
 
 #define IMM_VISIT_DECLARE(Type, Name)                  \
-  void LLVMCodeGenImpl::visit(const Name##Imm* v) {    \
+  void LLVMCodeGenImpl::visit(Name##Imm* v) {          \
     value_ = getFromType<Type>(Name##Ty_, v->value()); \
   }
 AT_FORALL_SCALAR_TYPES(IMM_VISIT_DECLARE);
 #undef IMM_VISIT_DECLARE
 
-void LLVMCodeGenImpl::visit(const HalfImm* v) {
+void LLVMCodeGenImpl::visit(HalfImm* v) {
   value_ = llvm::ConstantFP::get(HalfTy_, v->value());
 }
 
-void LLVMCodeGenImpl::visit(const BoolImm* v) {
+void LLVMCodeGenImpl::visit(BoolImm* v) {
   value_ = llvm::ConstantInt::get(BoolTy_, v->value());
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62932

Differential Revision: [D30172961](https://our.internmc.facebook.com/intern/diff/D30172961)