### PR TITLE
Fix `sort` kernel for 1D non-contiguous output tensors.

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -150,10 +150,15 @@ void sortKeyValueInplace(const Tensor& key,
       at::cuda::detail::TensorInfo<int64_t, unsigned int> valueInfo =
         at::cuda::detail::getTensorInfo<int64_t, unsigned int>(value);
 
-      keyInfo.reduceDim(dim);
-      int collapseKeyDim = keyInfo.collapseDims(dim);
-      valueInfo.reduceDim(dim);
-      int collapseValueDim = valueInfo.collapseDims(dim);
+      int collapseKeyDim = 0;
+      int collapseValueDim = 0;
+
+      if (keyInfo.dims > 1) {
+        keyInfo.reduceDim(dim);
+        collapseKeyDim = keyInfo.collapseDims(dim);
+        valueInfo.reduceDim(dim);
+        collapseValueDim = valueInfo.collapseDims(dim);
+      }
 
       if (keyInfo.isContiguous()) {
         HANDLE_SORT_CASE(unsigned int, -2);

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -199,6 +199,16 @@ class TestSortAndSelect(TestCase):
     def test_sort_discontiguous_slow(self, device, dtype):
         self._test_sort_discontiguous(device, dtype)
 
+    @dtypes(torch.float32)
+    def test_sort_1d_output_discontiguous(self, device, dtype):
+        tensor = torch.randn(12, device=device, dtype=dtype)
+        values = torch.empty_like(tensor)
+        indices = torch.empty_like(tensor, dtype=torch.long)
+        torch.sort(tensor[:6], out=(values[::2], indices[::2]))
+        values_cont, indices_cont = tensor[:6].sort()
+        self.assertEqual(indices[::2], indices_cont)
+        self.assertEqual(values[::2], values_cont)
+
     # FIXME: remove torch.bool from unsupported types once support is added for cub sort
     @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
     def test_stable_sort_against_numpy(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62942 Fix `topk` kernel for 1D non-contiguous output tensors.
* **#62941 Fix `sort` kernel for 1D non-contiguous output tensors.**

Fixes: #62645

For small 1D tensors, `sort` was calling `TensorInfo::reducedDim` followed by
`TensorInfo::collapseDims`. This combination rewrote the strides to `1`.