### PR TITLE
Fix `topk` kernel for 1D non-contiguous output tensors.

### DIFF
--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -234,9 +234,14 @@ TORCH_IMPL_FUNC(topk_out_cuda)
     topKInfo.sizes[dim] = 1;                                              \
     indicesInfo.sizes[dim] = 1;                                           \
     /* Collapse all other dims */                                         \
-    int collapseInputDim = inputInfo.collapseDims(dim);                   \
-    int collapseTopKDim = topKInfo.collapseDims(dim);                     \
-    int collapseIndicesDim = indicesInfo.collapseDims(dim);               \
+    int collapseInputDim = 0;                                             \
+    int collapseTopKDim = 0;                                              \
+    int collapseIndicesDim = 0;                                           \
+    if (input.dim() > 1) {                                                \
+      int collapseInputDim = inputInfo.collapseDims(dim);                 \
+      int collapseTopKDim = topKInfo.collapseDims(dim);                   \
+      int collapseIndicesDim = indicesInfo.collapseDims(dim);             \
+    }                                                                     \
     int64_t inputSlices = 1;                                              \
     for (int i = 0; i < inputInfo.dims; ++i) {                            \
       inputSlices *= inputInfo.sizes[i];                                  \

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -238,9 +238,9 @@ TORCH_IMPL_FUNC(topk_out_cuda)
     int collapseTopKDim = 0;                                              \
     int collapseIndicesDim = 0;                                           \
     if (input.dim() > 1) {                                                \
-      int collapseInputDim = inputInfo.collapseDims(dim);                 \
-      int collapseTopKDim = topKInfo.collapseDims(dim);                   \
-      int collapseIndicesDim = indicesInfo.collapseDims(dim);             \
+      collapseInputDim = inputInfo.collapseDims(dim);                     \
+      collapseTopKDim = topKInfo.collapseDims(dim);                       \
+      collapseIndicesDim = indicesInfo.collapseDims(dim);                 \
     }                                                                     \
     int64_t inputSlices = 1;                                              \
     for (int i = 0; i < inputInfo.dims; ++i) {                            \

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -209,6 +209,16 @@ class TestSortAndSelect(TestCase):
         self.assertEqual(indices[::2], indices_cont)
         self.assertEqual(values[::2], values_cont)
 
+    @dtypes(torch.float32)
+    def test_topk_1d_output_discontiguous(self, device, dtype):
+        tensor = torch.randn(12, device=device, dtype=dtype)
+        values = torch.empty_like(tensor)
+        indices = torch.empty_like(tensor, dtype=torch.long)
+        torch.topk(tensor, 6, sorted=True, out=(values[::2], indices[::2]))
+        values_cont, indices_cont = tensor.topk(6, sorted=True)
+        self.assertEqual(indices[::2], indices_cont)
+        self.assertEqual(values[::2], values_cont)
+
     # FIXME: remove torch.bool from unsupported types once support is added for cub sort
     @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
     def test_stable_sort_against_numpy(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#62942 Fix `topk` kernel for 1D non-contiguous output tensors.**
* #62941 Fix `sort` kernel for 1D non-contiguous output tensors.

Fixes: #62940

Apparently, `topk` had the same problems as `sort`: ignoring the strides of 1D tensors.