### PR TITLE
 Stop exporting symbols in anonymous namespaces

### DIFF
--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -10,8 +10,8 @@ class TypeMetaTestFoo {};
 class TypeMetaTestBar {};
 } // namespace
 
-CAFFE_KNOWN_TYPE(TypeMetaTestFoo);
-CAFFE_KNOWN_TYPE(TypeMetaTestBar);
+CAFFE_KNOWN_TYPE_NOEXPORT(TypeMetaTestFoo);
+CAFFE_KNOWN_TYPE_NOEXPORT(TypeMetaTestBar);
 
 namespace {
 
@@ -87,8 +87,8 @@ class ClassNoAssignment {
 };
 } // namespace
 
-CAFFE_KNOWN_TYPE(ClassAllowAssignment);
-CAFFE_KNOWN_TYPE(ClassNoAssignment);
+CAFFE_KNOWN_TYPE_NOEXPORT(ClassAllowAssignment);
+CAFFE_KNOWN_TYPE_NOEXPORT(ClassNoAssignment);
 
 namespace {
 

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -610,4 +610,11 @@ inline std::ostream& operator<<(
     return index;                                                    \
   }
 
+#define CAFFE_KNOWN_TYPE_NOEXPORT(T)                                 \
+  template <>                                                        \
+  uint16_t TypeMeta::_typeMetaData<T>() noexcept {                   \
+    static const uint16_t index = addTypeMetaData<T>();              \
+    return index;                                                    \
+  }
+
 } // namespace caffe2

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -610,11 +610,11 @@ inline std::ostream& operator<<(
     return index;                                                    \
   }
 
-#define CAFFE_KNOWN_TYPE_NOEXPORT(T)                                 \
-  template <>                                                        \
-  uint16_t TypeMeta::_typeMetaData<T>() noexcept {                   \
-    static const uint16_t index = addTypeMetaData<T>();              \
-    return index;                                                    \
+#define CAFFE_KNOWN_TYPE_NOEXPORT(T)                    \
+  template <>                                           \
+  uint16_t TypeMeta::_typeMetaData<T>() noexcept {      \
+    static const uint16_t index = addTypeMetaData<T>(); \
+    return index;                                       \
   }
 
 } // namespace caffe2

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -40,9 +40,9 @@ class BlobTestNonDefaultConstructible {
 };
 } // namespace
 
-CAFFE_KNOWN_TYPE(BlobTestFoo);
-CAFFE_KNOWN_TYPE(BlobTestBar);
-CAFFE_KNOWN_TYPE(BlobTestNonDefaultConstructible);
+CAFFE_KNOWN_TYPE_NOEXPORT(BlobTestFoo);
+CAFFE_KNOWN_TYPE_NOEXPORT(BlobTestBar);
+CAFFE_KNOWN_TYPE_NOEXPORT(BlobTestNonDefaultConstructible);
 
 class BlobTestFooSerializer : public BlobSerializerBase {
  public:
@@ -1018,7 +1018,7 @@ class DummyTypeDeserializer : public BlobDeserializerBase {
 };
 } // namespace
 
-CAFFE_KNOWN_TYPE(DummyType);
+CAFFE_KNOWN_TYPE_NOEXPORT(DummyType);
 
 namespace {
 REGISTER_BLOB_SERIALIZER((TypeMeta::Id<DummyType>()), DummyTypeSerializer);

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -1342,6 +1342,12 @@ struct TORCH_API DeviceTypeRegisterer {
   }
 };
 
+#if defined(_MSC_VER)
+#define IMPORT_IF_NOT_MSVC
+#else
+#define IMPORT_IF_NOT_MSVC C10_IMPORT
+#endif
+
 #define CAFFE_REGISTER_DEVICE_TYPE(type, registry_function) \
   namespace {                                               \
   static DeviceTypeRegisterer C10_ANONYMOUS_VARIABLE(       \
@@ -1362,11 +1368,11 @@ C10_DECLARE_REGISTRY(
     Workspace*);
 #define REGISTER_CPU_OPERATOR_CREATOR(key, ...) \
   C10_REGISTER_CREATOR(CPUOperatorRegistry, key, __VA_ARGS__)
-#define REGISTER_CPU_OPERATOR(name, ...)                           \
-  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
-  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CPU##name() { \
-    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                \
-  }                                                                \
+#define REGISTER_CPU_OPERATOR(name, ...)                                   \
+  IMPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
+  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CPU##name() {         \
+    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                        \
+  }                                                                        \
   C10_REGISTER_CLASS(CPUOperatorRegistry, name, __VA_ARGS__)
 #define REGISTER_CPU_OPERATOR_STR(str_name, ...) \
   C10_REGISTER_TYPED_CLASS(CPUOperatorRegistry, str_name, __VA_ARGS__)
@@ -1397,11 +1403,11 @@ C10_DECLARE_REGISTRY(
     Workspace*);
 #define REGISTER_CUDA_OPERATOR_CREATOR(key, ...) \
   C10_REGISTER_CREATOR(CUDAOperatorRegistry, key, __VA_ARGS__)
-#define REGISTER_CUDA_OPERATOR(name, ...)                           \
-  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();   \
-  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CUDA##name() { \
-    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                 \
-  }                                                                 \
+#define REGISTER_CUDA_OPERATOR(name, ...)                                   \
+  IMPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();   \
+  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_CUDA##name() {         \
+    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                         \
+  }                                                                         \
   C10_REGISTER_CLASS(CUDAOperatorRegistry, name, __VA_ARGS__)
 #define REGISTER_CUDA_OPERATOR_STR(str_name, ...) \
   C10_REGISTER_TYPED_CLASS(CUDAOperatorRegistry, str_name, __VA_ARGS__)
@@ -1421,11 +1427,11 @@ C10_DECLARE_REGISTRY(
     Workspace*);
 #define REGISTER_HIP_OPERATOR_CREATOR(key, ...) \
   C10_REGISTER_CREATOR(HIPOperatorRegistry, key, __VA_ARGS__)
-#define REGISTER_HIP_OPERATOR(name, ...)                           \
-  C10_IMPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
-  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_HIP##name() { \
-    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                \
-  }                                                                \
+#define REGISTER_HIP_OPERATOR(name, ...)                                   \
+  IMPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();  \
+  static void CAFFE2_UNUSED CAFFE_ANONYMOUS_VARIABLE_HIP##name() {         \
+    CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name();                        \
+  }                                                                        \
   C10_REGISTER_CLASS(HIPOperatorRegistry, name, __VA_ARGS__)
 #define REGISTER_HIP_OPERATOR_STR(str_name, ...) \
   C10_REGISTER_TYPED_CLASS(HIPOperatorRegistry, str_name, __VA_ARGS__)

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -583,17 +583,23 @@ OpSchema::Cost PointwiseCostInference(
 
 } // namespace caffe2
 
+#if defined(_MSC_VER)
+#define EXPORT_IF_NOT_MSVC
+#else
+#define EXPORT_IF_NOT_MSVC C10_EXPORT
+#endif
+
 #ifndef CAFFE2_NO_OPERATOR_SCHEMA
 
 #define OPERATOR_SCHEMA(name)                                       \
-  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
+  EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
   static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
       &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #else // CAFFE2_NO_OPERATOR_SCHEMA
 
 #define OPERATOR_SCHEMA(name)                                       \
-  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
+  EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
   static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
@@ -602,7 +608,7 @@ OpSchema::Cost PointwiseCostInference(
 #ifdef CAFFE2_NO_GRADIENT_OPS
 
 #define GRADIENT_OPERATOR_SCHEMA(name)                              \
-  C10_EXPORT void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
+  EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
   static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -591,25 +591,25 @@ OpSchema::Cost PointwiseCostInference(
 
 #ifndef CAFFE2_NO_OPERATOR_SCHEMA
 
-#define OPERATOR_SCHEMA(name)                                       \
+#define OPERATOR_SCHEMA(name)                                               \
   EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
-  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
+  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =             \
       &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #else // CAFFE2_NO_OPERATOR_SCHEMA
 
-#define OPERATOR_SCHEMA(name)                                       \
+#define OPERATOR_SCHEMA(name)                                               \
   EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
-  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
+  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =             \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #endif // CAFFE2_NO_OPERATOR_SCHEMA
 
 #ifdef CAFFE2_NO_GRADIENT_OPS
 
-#define GRADIENT_OPERATOR_SCHEMA(name)                              \
+#define GRADIENT_OPERATOR_SCHEMA(name)                                      \
   EXPORT_IF_NOT_MSVC void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
-  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =     \
+  static OpSchema* C10_ANONYMOUS_VARIABLE(name) CAFFE2_UNUSED =             \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
 
 #else

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -469,7 +469,7 @@ C10_EXPORT void GemmStridedBatched<float, CPUContext>(
 namespace {
 
 template <typename T>
-C10_EXPORT void BroadcastImpl(
+void BroadcastImpl(
     const int X_ndim,
     const int* X_dims,
     const int Y_ndim,
@@ -780,7 +780,7 @@ CAFFE2_SPECIALIZED_CPU_ADD_STRIPED_BATCH(float);
 namespace {
 
 template <typename TIn, typename TOut, class BinaryOperator, bool kBroadcast1st>
-C10_EXPORT void RowwiseBinaryOp(
+void RowwiseBinaryOp(
     const int rows,
     const int cols,
     const BinaryOperator& op,
@@ -798,7 +798,7 @@ C10_EXPORT void RowwiseBinaryOp(
 }
 
 template <typename TIn, typename TOut, class BinaryOperator, bool kBroadcast1st>
-C10_EXPORT void ColwiseBinaryOp(
+void ColwiseBinaryOp(
     const int rows,
     const int cols,
     const BinaryOperator& op,
@@ -816,7 +816,7 @@ C10_EXPORT void ColwiseBinaryOp(
 }
 
 template <typename TIn, typename TOut, class BinaryOperator>
-C10_EXPORT void BroadcastBinaryOpImpl(
+void BroadcastBinaryOpImpl(
     const int ndim,
     const int* A_dims,
     const int* B_dims,
@@ -1671,7 +1671,7 @@ CAFFE2_SPECIALIZED_COPY_MATRIX(std::uint16_t)
 namespace {
 
 template <typename T>
-C10_EXPORT void Im2ColZeroPaddingAndNoDilationNCHW(
+void Im2ColZeroPaddingAndNoDilationNCHW(
     const int C,
     const int H,
     const int W,
@@ -1718,7 +1718,7 @@ C10_EXPORT void Im2ColZeroPaddingAndNoDilationNCHW(
 }
 
 template <typename T>
-C10_EXPORT void Col2ImZeroPaddingAndNoDilationNCHW(
+void Col2ImZeroPaddingAndNoDilationNCHW(
     const int C,
     const int H,
     const int W,
@@ -1754,7 +1754,7 @@ C10_EXPORT void Col2ImZeroPaddingAndNoDilationNCHW(
 }
 
 template <typename T>
-C10_EXPORT void Im2ColZeroPaddingAndNoDilationNHWC(
+void Im2ColZeroPaddingAndNoDilationNHWC(
     const int C,
     const int H,
     const int W,
@@ -1779,7 +1779,7 @@ C10_EXPORT void Im2ColZeroPaddingAndNoDilationNHWC(
 }
 
 template <typename T>
-C10_EXPORT void Col2ImZeroPaddingAndNoDilationNHWC(
+void Col2ImZeroPaddingAndNoDilationNHWC(
     const int C,
     const int H,
     const int W,
@@ -1806,7 +1806,7 @@ C10_EXPORT void Col2ImZeroPaddingAndNoDilationNHWC(
 }
 
 template <typename T, bool kCol2Im>
-C10_EXPORT void Im2ColNdNCHWImpl(
+void Im2ColNdNCHWImpl(
     const int N,
     const int img_size,
     const int col_size,


### PR DESCRIPTION
The cases are found out by compiling against clang on Windows.
Those functions will still be exported under this case, which is a waste of space in the symbol table.