### PR TITLE
minor fixes in c10d for Windows

### DIFF
--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -40,7 +40,7 @@ int flock_(int fd, int op) {
   DWORD low = 1, high = 0;
   OVERLAPPED offset = {0, 0, 0, 0, NULL};
 
-  if (hdl < 0)
+  if ((intptr_t)hdl < 0)
     return -1;
 
   switch (op) {

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -923,8 +923,8 @@ void TCPClient::setTimeout(std::chrono::milliseconds value) {
   }
 
 #ifdef _WIN32
-  struct timeval timeoutTV = {value.count() / 1000,
-                              (value.count() % 1000) * 1000};
+  struct timeval timeoutTV = {static_cast<long>(value.count() / 1000),
+                              static_cast<long>((value.count() % 1000) * 1000)};
 #else
   struct timeval timeoutTV = {.tv_sec = value.count() / 1000,
                               .tv_usec = (value.count() % 1000) * 1000};


### PR DESCRIPTION
Found out by triggering builds against clang on Windows.
