### PR TITLE
Allow arbitrary objects in state_dicts

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5499,6 +5499,27 @@ class TestNN(NNTestCase):
         self.assertEqual(m2.bar, m.bar)
         self.assertEqual(m2.sub.foo, m.sub.foo)
 
+    def test_extra_state_non_dict(self):
+
+        class MyModule(torch.nn.Module):
+            def __init__(self, foo):
+                super().__init__()
+                self.foo = foo
+
+            def get_extra_state(self):
+                return self.foo
+
+            def set_extra_state(self, state):
+                self.foo = state
+
+        # Test various types of extra state.
+        for state in ('something', 5, MyModule(3)):
+            m = MyModule(state)
+            m2 = MyModule('something else')
+            m2.load_state_dict(m.state_dict())
+            self.assertEqual(m.state_dict(), m2.state_dict())
+            self.assertEqual(m.foo, m2.foo)
+
     def test_extra_state_missing_set_extra_state(self):
 
         class MyModule(torch.nn.Module):

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -912,6 +912,8 @@ if _enabled:
         "_tracing_name",
         "eval",
         "train",
+        "get_extra_state",
+        "set_extra_state"
     }
 
     def _make_fail(name):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -531,9 +531,32 @@ class Module:
         return buffer
 
     def get_extra_state(self) -> Dict[str, Any]:
+        """
+        Returns any extra state to include in the module's state_dict.
+        Implement this and a corresponding :func:`set_extra_state` for your module
+        if you need to store extra state. This function is called when building the
+        module's `state_dict()`.
+
+        Note that extra state should be pickleable to ensure working serialization
+        of the module. We only provide provide backwards compatibility guarantees
+        for serializing Tensors; other objects may break backwards compatibility if
+        their serialized pickle form changes.
+
+        Returns:
+            dict or OrderedDict: Any extra state to store in the module's state_dict
+        """
         raise NotImplementedError()
 
     def set_extra_state(self, state: Dict[str, Any]):
+        """
+        This function is called from :func:`load_state_dict` to handle any extra state
+        found within the `state_dict`. Implement this function and a corresponding
+        :func:`get_extra_state` for your module if you need to store extra state within its
+        `state_dict`.
+
+        Args:
+            state (dict): Extra state from the `state_dict`
+        """
         raise NotImplementedError()
 
     def _apply(self, fn):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1228,6 +1228,12 @@ class Module:
         for name, buf in self._buffers.items():
             if buf is not None and name not in self._non_persistent_buffers_set:
                 destination[prefix + name] = buf if keep_vars else buf.detach()
+        extra_state = self.get_extra_state()
+        if extra_state:
+            EXTRA_STATE_KEY = prefix + '_extra_state'
+            destination[EXTRA_STATE_KEY] = OrderedDict()
+            for name, obj in extra_state.items():
+                destination[EXTRA_STATE_KEY][name] = obj
 
     # The user can pass an optional arbitrary mappable object to `state_dict`, in which case `state_dict` returns
     # back that same object. But if they pass nothing, an `OrederedDict` is created and returned.
@@ -1365,9 +1371,13 @@ class Module:
             elif strict:
                 missing_keys.append(key)
 
+        EXTRA_STATE_KEY = prefix + '_extra_state'
+        if EXTRA_STATE_KEY in state_dict:
+            self.set_extra_state(state_dict[EXTRA_STATE_KEY])
+
         if strict:
             for key in state_dict.keys():
-                if key.startswith(prefix):
+                if key.startswith(prefix) and key != EXTRA_STATE_KEY:
                     input_name = key[len(prefix):]
                     input_name = input_name.split('.', 1)[0]  # get the name of param/buffer/child
                     if input_name not in self._modules and input_name not in local_state:
@@ -1751,6 +1761,12 @@ class Module:
         strings are acceptable.
         """
         return ''
+
+    def get_extra_state(self):
+        return {}
+
+    def set_extra_state(self, state):
+        pass
 
     def __repr__(self):
         # We treat the extra repr like the sub-module, one item per line


### PR DESCRIPTION
Fixes #62094

Introduces functionality for adding arbitrary objects to module state_dicts. To take advantage of this, the following functions can be defined on a module:
* `get_extra_state(self) -> dict` - Returns a dict defining any extra state this module wants to save
* `set_extra_state(self, state)` - Subsumes the given state within the module

In the details, a sub-dictionary is stored in the state_dict under the key `_extra_state` for each module that requires extra state.