### PR TITLE
[FX] make ASTReriter patch wrapped functions properly

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2275,7 +2275,21 @@ class TestFX(JitTestCase):
         traced = GraphModule(ast_rewriter.root, graph, "gm")
 
         traced.graph.lint()
+        
+    def test_ast_rewriter_wrapped_via_decorator(self):
+        class F(torch.nn.Module):
+            def forward(self, x):
+                return wrapped_via_decorator(x)
 
+        ast_rewriter = RewritingTracer()
+        graph = ast_rewriter.trace(F())
+        traced = GraphModule(ast_rewriter.root, graph, "gm")
+
+        self.assertIn("wrapped_via_decorator", traced.code)
+        self.assertEqual(traced(0), 1)
+        self.assertIs(wrapped_via_decorator, real_wrapped_via_decorator)
+        self.assertFalse(hasattr(wrapped_via_decorator, "__fx_already_patched"))
+        
     def test_submodule_manipulation_API(self):
         class C(torch.nn.Module):
             def __init__(self):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2289,7 +2289,7 @@ class TestFX(JitTestCase):
         self.assertEqual(traced(0), 1)
         self.assertIs(wrapped_via_decorator, real_wrapped_via_decorator)
         self.assertFalse(hasattr(wrapped_via_decorator, "__fx_already_patched"))
-        
+
     def test_submodule_manipulation_API(self):
         class C(torch.nn.Module):
             def __init__(self):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2275,7 +2275,7 @@ class TestFX(JitTestCase):
         traced = GraphModule(ast_rewriter.root, graph, "gm")
 
         traced.graph.lint()
-        
+
     def test_ast_rewriter_wrapped_via_decorator(self):
         class F(torch.nn.Module):
             def forward(self, x):

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -104,7 +104,7 @@ def _rewrite(fn: Union[torch.nn.Module, Callable]) -> Union[torch.nn.Module, Cal
     else:
         # Rewrite this single free function
         return AST_Rewriter().rewrite(cast(FunctionType, fn))
-    
+
 def _copy_func(f, globals=None, module=None):
     """Based on https://stackoverflow.com/a/13503277/2988730 (@unutbu)"""
     if globals is None:

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -2,6 +2,7 @@ import ast
 import inspect
 import textwrap
 import copy
+import functools
 from types import FunctionType
 from typing import cast, Union, Callable, Dict, Optional, Any
 from torch.fx._symbolic_trace import Tracer

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -34,7 +34,7 @@ class AST_Rewriter(ast.NodeTransformer):
 
         # Pull out the compiled fucntion from the newly-created Module
         code = compile(dest_ast, "", "exec")
-        globals_dict = copy.copy(fn.__globals__)
+        globals_dict = fn.__globals__
         keys_before = set(globals_dict.keys())
         exec(code, globals_dict)
         new_keys = list(set(globals_dict.keys()) - keys_before)


### PR DESCRIPTION
reference the same global namespace (instead of copying it) in ASTRewriter to patch wrapped functions properly

Fixes #{62071}
