### PR TITLE
Fix render_test_results if condition on always()

### DIFF
--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -169,7 +169,7 @@ on:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
+    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
     needs: [build-and-test, !{{ ciflow_config.root_job_name }}]
     runs-on: linux.2xlarge
     steps:

--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -169,8 +169,8 @@ on:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
     needs: [build-and-test, !{{ ciflow_config.root_job_name }}]
+    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
     runs-on: linux.2xlarge
     steps:
       - name: Log in to ECR

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -439,8 +439,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, !{{ ciflow_config.root_job_name }}]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -440,7 +440,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, !{{ ciflow_config.root_job_name }}]
+    needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -439,8 +439,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -259,11 +259,11 @@ jobs:
   # doesn't create the best experience
   render_test_results:
 {%- if only_build_on_pull_request %}
-    if:  ${{ github.event_name == 'push' && always() }}
+    if:  ${{ github.event_name == 'push' && (needs.test.result == 'success' || needs.test.result == 'failure') }}
 {%- else %}
-    if: always()
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
 {%- endif %}
-    needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
+    needs: [test, !{{ ciflow_config.root_job_name }}]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -258,12 +258,12 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
+    needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
 {%- if only_build_on_pull_request %}
     if:  ${{ github.event_name == 'push' && (needs.test.result == 'success' || needs.test.result == 'failure') }}
 {%- else %}
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
 {%- endif %}
-    needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -263,7 +263,7 @@ jobs:
 {%- else %}
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
 {%- endif %}
-    needs: [test, !{{ ciflow_config.root_job_name }}]
+    needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
@@ -396,8 +396,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
@@ -397,7 +397,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ]
+    needs: [generate-test-matrix, test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
@@ -396,8 +396,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -405,8 +405,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -405,8 +405,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -406,7 +406,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ciflow_should_run]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -405,8 +405,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -405,8 +405,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -406,7 +406,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ciflow_should_run]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -396,8 +396,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -397,7 +397,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ]
+    needs: [generate-test-matrix, test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -396,8 +396,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -396,8 +396,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -397,7 +397,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ]
+    needs: [generate-test-matrix, test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -396,8 +396,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -257,8 +257,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
     needs: [build-and-test, ciflow_should_run]
+    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
     runs-on: linux.2xlarge
     steps:
       - name: Log in to ECR

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -257,7 +257,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
+    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
     needs: [build-and-test, ciflow_should_run]
     runs-on: linux.2xlarge
     steps:

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -404,7 +404,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ciflow_should_run]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -403,8 +403,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -403,8 +403,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
@@ -220,8 +220,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
@@ -220,8 +220,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ciflow_should_run]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
@@ -221,7 +221,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ciflow_should_run]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -195,8 +195,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -196,7 +196,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ]
+    needs: [generate-test-matrix, test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -195,8 +195,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
@@ -213,8 +213,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
@@ -214,7 +214,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ]
+    needs: [generate-test-matrix, test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
@@ -213,8 +213,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
@@ -212,8 +212,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
@@ -213,7 +213,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
-    needs: [test, ]
+    needs: [generate-test-matrix, test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
@@ -212,8 +212,8 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    if: always()
-    needs: [generate-test-matrix, test, ]
+    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    needs: [test, ]
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #62997

Fixes #62979, changed the condition to listen on the previous'
job's result to be either 'success' or 'failure'.

Notice that 'skipped' will also skip this job, which is what
we want.

Differential Revision: [D30202598](https://our.internmc.facebook.com/intern/diff/D30202598)