### PR TITLE
Cruise perf fixes for ScatterGather kernel when compiled with clang-cuda

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -69,9 +69,9 @@ void gpu_index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
     return;
   }
 
-  auto sizes = at::detail::Array<int64_t, 25>(0);
-  auto strides = at::detail::Array<int64_t, 25>(0);
-  auto index_ptrs = at::detail::Array<char*, 25>(nullptr);
+  auto sizes = at::detail::Array<int64_t, MAX_DIMS>(0);
+  auto strides = at::detail::Array<int64_t, MAX_DIMS>(0);
+  auto index_ptrs = at::detail::Array<char*, MAX_DIMS>(nullptr);
   for (int i = 0; i < num_indices; i++) {
     sizes[i] = index_size[i];
     strides[i] = index_stride[i];

--- a/aten/src/THC/THCTensorScatterGather.cu
+++ b/aten/src/THC/THCTensorScatterGather.cu
@@ -11,7 +11,7 @@
 // This version uses a static number of dimensions.
 template <typename IndexType, typename Real, int Dims>
 struct IndexToScatterGatherOffsets {
-  static __device__ void compute(
+  static inline __device__ void compute(
       IndexType linearId, const int dim,
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t1, IndexType* t1Offset,
@@ -28,7 +28,7 @@ struct IndexToScatterGatherOffsets {
     }
   }
 
-  static __device__ void compute(
+  static inline __device__ void compute(
       IndexType linearId, const int dim,
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
@@ -47,7 +47,7 @@ struct IndexToScatterGatherOffsets {
 // Same as above but using a dynamic number of dimensions.
 template <typename IndexType, typename Real>
 struct IndexToScatterGatherOffsets<IndexType, Real, -1> {
-  static __device__ void compute(
+  static inline __device__ void compute(
       IndexType linearId, const int dim,
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t1, IndexType* t1Offset,
@@ -63,7 +63,7 @@ struct IndexToScatterGatherOffsets<IndexType, Real, -1> {
     }
   }
 
-  static __device__ void compute(
+  static inline __device__ void compute(
       IndexType linearId, const int dim,
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {


### PR DESCRIPTION
Fixes #63000

Namely, make aggressive inlining for ScatterGather kernels to improve it's performance when compiled with clang-cuda.
Also include misc cosmetic to re-use `MAX_DIMS` in IndexKernel.