### PR TITLE
Catch exception when registering a fallback

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -47,7 +47,11 @@ void ltc_eager_fallback(const c10::OperatorHandle& op,
 }
 
 TORCH_LIBRARY_IMPL(_, Lazy, m) {
-  m.fallback(torch::CppFunction::makeFromBoxedFunction<&ltc_eager_fallback>());
+  try {
+    m.fallback(
+        torch::CppFunction::makeFromBoxedFunction<&ltc_eager_fallback>());
+  } catch (...) {
+  }
 }
 
 }  // namespace torch_lazy_tensors


### PR DESCRIPTION
This is more of a question, not sure what the right approach is here. If we have two plugins for the `Lazy` key: TorchScript and XLA, both could register a fallback. Is there a way we could defer this registration and bundle it with the rest of the plugin initialization, like we do in `compiler::InitTorchScriptBackend()` for lowering and execution of graphs?