### PR TITLE
[Pytorch Edge] Move RuntimeCompatibilityInfo Factory Method

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -751,7 +751,7 @@ TEST(LiteInterpreterTest, GetRuntimeOpsAndInfo) {
 
 TEST(LiteInterpreterTest, isCompatibleSuccess) {
   // test trivial success case
-  auto runtime_info = get_runtime_compatibility_info();
+  auto runtime_info = RuntimeCompatibilityInfo::get();
   std::unordered_map<std::string, OperatorInfo> model_ops;
   model_ops["aten::add.Scalar"] = OperatorInfo{2};
 

--- a/torch/csrc/jit/mobile/runtime_compatibility.cpp
+++ b/torch/csrc/jit/mobile/runtime_compatibility.cpp
@@ -47,7 +47,7 @@ std::unordered_map<std::string, OperatorInfo> _get_runtime_ops_and_info() {
   return result;
 }
 
-RuntimeCompatibilityInfo get_runtime_compatibility_info() {
+RuntimeCompatibilityInfo RuntimeCompatibilityInfo::get() {
   return RuntimeCompatibilityInfo{
       _get_runtime_bytecode_version(), _get_runtime_ops_and_info()};
 }

--- a/torch/csrc/jit/mobile/runtime_compatibility.h
+++ b/torch/csrc/jit/mobile/runtime_compatibility.h
@@ -18,14 +18,15 @@ struct OperatorInfo {
 struct RuntimeCompatibilityInfo {
   uint64_t bytecode_version;
   std::unordered_map<std::string, OperatorInfo> operator_info;
+
+  // Factory Method
+  static TORCH_API RuntimeCompatibilityInfo get();
 };
 
 TORCH_API uint64_t _get_runtime_bytecode_version();
 
 TORCH_API std::unordered_map<std::string, OperatorInfo>
 _get_runtime_ops_and_info();
-
-TORCH_API RuntimeCompatibilityInfo get_runtime_compatibility_info();
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Realized I forgot to move the Runtime half of these functions be within the struct.

Test Plan: ci

Differential Revision: D30205521

