### PR TITLE
[fix] TestMultiThreadAutograd: propagate exception from child thread to main thread

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9314,7 +9314,7 @@ class TestMultithreadAutograd(TestCase):
         for p in threads:
             p.join()
 
-    def test_simple_backward_fail(self):
+    def test_multithreaded_exception_propagation(self):
         # Test whether exception in child thread
         # are propagated to main thread.
         def fn():

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9295,7 +9295,7 @@ class TestMultithreadAutograd(TestCase):
             def run(self):
                 self.exception = None
                 try:
-                    self.ret = self._target(*self._args, **self._kwargs)
+                    self.ret = super(PropagatingThread, self).run()
                 except Exception as e:
                     self.exception = e
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9281,16 +9281,47 @@ class TestAutogradInferenceMode(TestCase):
         run_test(lambda x: x.add_(2))
         run_test(lambda x: x.transpose_(0, 1))
 
+
 class TestMultithreadAutograd(TestCase):
     def _run_py_multithread_fn(self, fn, args=(), num_threads=10, kwargs=None):
+
+        class PropagatingThread(threading.Thread):
+            '''Helper class to propagate exception from child
+            thread to main thread on join.
+
+            Reference: https://stackoverflow.com/a/31614591/5602957
+            '''
+
+            def run(self):
+                self.exception = None
+                try:
+                    self.ret = self._target(*self._args, **self._kwargs)
+                except Exception as e:
+                    self.exception = e
+
+            def join(self, timeout=None):
+                super(PropagatingThread, self).join(timeout)
+                if self.exception:
+                    raise self.exception from self.exception
+                return self.ret
+
         threads = []
         for _ in range(num_threads):
-            p = threading.Thread(target=fn, args=(args))
+            p = PropagatingThread(target=fn, args=args)
             p.start()
             threads.append(p)
 
         for p in threads:
             p.join()
+
+    def test_simple_backward_fail(self):
+        # Test whether exception in child thread
+        # are propagated to main thread.
+        def fn():
+            self.assertTrue(False)
+
+        with self.assertRaises(AssertionError):
+            self._run_py_multithread_fn(fn)
 
     def test_simple_backward(self):
         # simple multithreaded backward that create threads in the beginning of training


### PR DESCRIPTION
Fixes #62895 