### PR TITLE
fix sort and topk with discontiguous out

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -150,10 +150,14 @@ void sortKeyValueInplace(const Tensor& key,
       at::cuda::detail::TensorInfo<int64_t, unsigned int> valueInfo =
         at::cuda::detail::getTensorInfo<int64_t, unsigned int>(value);
 
-      keyInfo.reduceDim(dim);
+      auto strideKey = keyInfo.strides[dim];
+      keyInfo.sizes[dim] = 1;
       int collapseKeyDim = keyInfo.collapseDims(dim);
-      valueInfo.reduceDim(dim);
+      keyInfo.strides[collapseKeyDim] = strideKey;
+      auto strideValue = valueInfo.strides[dim];
+      valueInfo.sizes[dim]=1;
       int collapseValueDim = valueInfo.collapseDims(dim);
+      valueInfo.strides[collapseValueDim] = strideValue;
 
       if (keyInfo.isContiguous()) {
         HANDLE_SORT_CASE(unsigned int, -2);
@@ -174,10 +178,14 @@ void sortKeyValueInplace(const Tensor& key,
       at::cuda::detail::TensorInfo<int64_t, uint64_t> valueInfo =
         at::cuda::detail::getTensorInfo<int64_t, uint64_t>(value);
 
-      keyInfo.reduceDim(dim);
+      auto strideKey = keyInfo.strides[dim];
+      keyInfo.sizes[dim] = 1;
       int collapseKeyDim = keyInfo.collapseDims(dim);
-      valueInfo.reduceDim(dim);
+      keyInfo.strides[collapseKeyDim] = strideKey;
+      auto strideValue = valueInfo.strides[dim];
+      valueInfo.sizes[dim]=1;
       int collapseValueDim = valueInfo.collapseDims(dim);
+      valueInfo.strides[collapseValueDim] = strideValue;
 
       // int64_t case is rare, just instantiate the generic version
       HANDLE_SORT_CASE(uint64_t, -1);

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -233,10 +233,16 @@ TORCH_IMPL_FUNC(topk_out_cuda)
     inputInfo.sizes[dim] = 1;                                             \
     topKInfo.sizes[dim] = 1;                                              \
     indicesInfo.sizes[dim] = 1;                                           \
+    /* stash the stride of dim because it can be accidentally collapsed */ \
+    auto strideTopK = topKInfo.strides[dim];                              \
+    auto strideIndices = indicesInfo.strides[dim];                        \
     /* Collapse all other dims */                                         \
     int collapseInputDim = inputInfo.collapseDims(dim);                   \
     int collapseTopKDim = topKInfo.collapseDims(dim);                     \
     int collapseIndicesDim = indicesInfo.collapseDims(dim);               \
+    /* restore stride in case it was collapsed */                         \
+    topKInfo.strides[collapseTopKDim] = strideTopK;                       \
+    indicesInfo.strides[collapseIndicesDim] = strideIndices;              \
     int64_t inputSlices = 1;                                              \
     for (int i = 0; i < inputInfo.dims; ++i) {                            \
       inputSlices *= inputInfo.sizes[i];                                  \

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -203,7 +203,7 @@ class TestSortAndSelect(TestCase):
     def test_sort_1d_output_discontiguous(self, device, dtype):
         tensor = torch.randn(12, device=device, dtype=dtype)[:6]
         values = torch.empty_like(tensor)[::2]
-        indices = torch.empty(18, device="cuda", dtype=torch.long)[::3]
+        indices = torch.empty(18, device=device, dtype=torch.long)[::3]
         torch.sort(tensor, out=(values, indices))
         values_cont, indices_cont = tensor.sort()
         self.assertEqual(indices, indices_cont)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -199,6 +199,29 @@ class TestSortAndSelect(TestCase):
     def test_sort_discontiguous_slow(self, device, dtype):
         self._test_sort_discontiguous(device, dtype)
 
+    @dtypes(torch.float32)
+    def test_sort_1d_output_discontiguous(self, device, dtype):
+        tensor = torch.randn(12, device=device, dtype=dtype)[:6]
+        values = torch.empty_like(tensor)[::2]
+        indices = torch.empty(18, device="cuda", dtype=torch.long)[::3]
+        torch.sort(tensor, out=(values, indices))
+        values_cont, indices_cont = tensor.sort()
+        self.assertEqual(indices, indices_cont)
+        self.assertEqual(values, values_cont)
+
+    @dtypes(torch.float32)
+    def test_topk_1d_output_discontiguous(self, device, dtype):
+        tensor = torch.randn(12, device=device, dtype=dtype)
+        values = torch.empty_like(tensor)[::2]
+        indices = torch.empty(18, device=device, dtype=torch.long)[::3]
+        for sorted in (True, False):
+            # outputs of `sorted=False` test are not guaranteed to be the same,
+            # but with current implementation they are
+            torch.topk(tensor, 6, sorted=sorted, out=(values, indices))
+            values_cont, indices_cont = tensor.topk(6, sorted=sorted)
+            self.assertEqual(indices, indices_cont)
+            self.assertEqual(values, values_cont)
+
     # FIXME: remove torch.bool from unsupported types once support is added for cub sort
     @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
     def test_stable_sort_against_numpy(self, device, dtype):


### PR DESCRIPTION
Fixes #62645 and #62940. The root cause of those bugs is in the bad interaction between `collapseDims` and setting the size of sorting/topK dimension to 1. If all other dimensions happen to be 1, `collapseDims` thinks that that `1` dimension is collapsible (even though it was specifically marked to be preserved) and loses its stride information. If dimension was really of size 1, the stride information would be unimportant, but since in reality that dimension is not 1 and was set to 1 for convenience, the loss of stride information results in incorrect outputs. 
