### PR TITLE
support using gradients named for outputs in derivatives

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1,3 +1,4 @@
+import dataclasses
 import gc
 import io
 import math
@@ -15,8 +16,11 @@ from collections import OrderedDict
 from itertools import product, permutations
 from operator import mul
 from functools import reduce, partial
-import torch
 
+from tools.autograd import gen_autograd_functions
+from tools.autograd import load_derivatives
+import tools.codegen.model
+import torch
 from torch import nn
 from torch._six import inf, nan
 from torch.autograd.function import once_differentiable
@@ -9499,6 +9503,128 @@ class TestMultithreadAutograd(TestCase):
 
         torch.autograd.gradcheck(fn, [inp_r, inp_c], check_forward_ad=True)
         torch.autograd.gradcheck(fn, [inp_c, inp_r], check_forward_ad=True)
+
+
+class TestCreateDerivative(TestCase):
+
+    def test_named_grads(self):
+        schema = tools.codegen.model.FunctionSchema.parse(
+            'func(Tensor a, Tensor b) -> (Tensor x, Tensor y)')
+        native_function = dataclasses.replace(DEFAULT_NATIVE_FUNCTION,
+                                              func=schema)
+
+        derivative = load_derivatives.create_derivative(
+            native_function,
+            formula='func_backward(grad_x, grad_y)',
+            var_names=(),
+            available_named_gradients=['grad_x', 'grad_y'])
+        self.assertSetEqual(derivative.named_gradients, {'grad_x', 'grad_y'})
+
+    def test_non_differentiable_output(self):
+        specification = 'func(Tensor a, Tensor b) -> (Tensor x, bool y, Tensor z)'
+        schema = tools.codegen.model.FunctionSchema.parse(specification)
+        native_function = dataclasses.replace(DEFAULT_NATIVE_FUNCTION,
+                                              func=schema)
+
+        differentiability_info = load_derivatives.create_differentiability_info(
+            defn={'name': specification,
+                  'a': 'grads[0]',
+                  'b': 'grads[2]',
+                  },
+            functions_by_signature={schema.signature(): [native_function]},
+            functions_by_schema={specification: native_function},
+        )
+
+        self.assertListEqual(differentiability_info.available_named_gradients,
+                             # grad_y is not present because y is a
+                             # bool and thus not differentiable.
+                             ['grad_x', 'grad_z'])
+
+    def test_indexed_grads(self):
+        schema = tools.codegen.model.FunctionSchema.parse(
+            'func(Tensor a, Tensor b) -> (Tensor x, Tensor y)')
+        native_function = dataclasses.replace(DEFAULT_NATIVE_FUNCTION,
+                                              func=schema)
+
+        derivative = load_derivatives.create_derivative(
+            native_function,
+            formula='func_backward(grads[0], grads[1])',
+            var_names=(),
+            available_named_gradients=['grad_x', 'grad_y'])
+        self.assertSetEqual(derivative.named_gradients, set())
+
+    def test_named_grads_and_indexed_grads(self):
+        specification = 'func(Tensor a, Tensor b) -> (Tensor x, Tensor y)'
+        schema = tools.codegen.model.FunctionSchema.parse(specification)
+        native_function = dataclasses.replace(DEFAULT_NATIVE_FUNCTION,
+                                              func=schema)
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    'illegally mixes use of "grad_RETURN_NAME"'):
+            load_derivatives.create_differentiability_info(
+                defn={'name': specification,
+                      # Uh-oh, the derivatives reference gradients by
+                      # name and by index.
+                      'a': 'grad_x',
+                      'b': 'grads[1]',
+                      },
+                functions_by_signature={schema.signature(): [native_function]},
+                functions_by_schema={specification: native_function},
+            )
+
+class TestGenAutogradFunctions(TestCase):
+    def test_non_differentiable_output_invalid_type(self):
+        specification = 'func(Tensor a, Tensor b) -> (Tensor x, bool y, Tensor z)'
+        schema = tools.codegen.model.FunctionSchema.parse(specification)
+        native_function = dataclasses.replace(DEFAULT_NATIVE_FUNCTION,
+                                              func=schema)
+
+        differentiability_info = load_derivatives.create_differentiability_info(
+            defn={'name': specification,
+                  'a': 'grad_x',
+                  'b': 'grad_z',
+                  },
+            functions_by_signature={schema.signature(): [native_function]},
+            functions_by_schema={specification: native_function},
+        )
+        definition = gen_autograd_functions.process_function(
+            differentiability_info,
+            gen_autograd_functions.FUNCTION_DEFINITION)
+        # grad_z should map to grads[1], not grads[2] because output 1
+        # (y) is not differentiable.
+        assert 'grad_z = grads[2]' not in definition
+        assert 'grad_z = grads[1]' in definition
+
+
+    def test_non_differentiable_output_output_differentiability(self):
+        specification = 'func(Tensor a, Tensor b) -> (Tensor x, Tensor y, Tensor z)'
+        schema = tools.codegen.model.FunctionSchema.parse(specification)
+        native_function = dataclasses.replace(DEFAULT_NATIVE_FUNCTION,
+                                              func=schema)
+
+        differentiability_info = load_derivatives.create_differentiability_info(
+            defn={'name': specification,
+                  'a': 'grad_x',
+                  'b': 'grad_z',
+                  'output_differentiability': [True, False, True],
+                  },
+            functions_by_signature={schema.signature(): [native_function]},
+            functions_by_schema={specification: native_function},
+        )
+        definition = gen_autograd_functions.process_function(
+            differentiability_info,
+            gen_autograd_functions.FUNCTION_DEFINITION)
+        # grad_z should map to grads[1], not grads[2] because output 1
+        # (y) is not differentiable.
+        assert 'grad_z = grads[2]' not in definition
+        assert 'grad_z = grads[1]' in definition
+
+
+# Represents the most basic NativeFunction. Use dataclasses.replace()
+# to edit for use.
+DEFAULT_NATIVE_FUNCTION, _ = tools.codegen.model.NativeFunction.from_yaml(
+    {'func': 'func() -> bool'},
+    loc=tools.codegen.model.Location(__file__, 1))
 
 
 # e.g., TestAutogradDeviceTypeCPU and TestAutogradDeviceTypeCUDA

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -17,9 +17,12 @@ from itertools import product, permutations
 from operator import mul
 from functools import reduce, partial
 
+import tools_package  # allows for importing tools below
+
 from tools.autograd import gen_autograd_functions
 from tools.autograd import load_derivatives
 import tools.codegen.model
+
 import torch
 from torch import nn
 from torch._six import inf, nan

--- a/test/tools_package.py
+++ b/test/tools_package.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+import tempfile
+
+
+# The tools/ dir is at the top-level of the pytorch project. We are
+# currently in the test/ subdirectory, so we have to go up two levels
+# to find it.
+TOOLS_DIR = pathlib.Path(__file__).parent.parent / 'tools/'
+assert TOOLS_DIR.is_dir()
+
+
+# We don't want to add TOOLS_DIR to sys.path, otherwise imports will
+# need to look like:
+# import codegen
+#  instead of
+# import tools.codegen
+#
+# We don't want to add TOOLS_DIR.parent to sys.path, otherwise we have
+# given another way to import torch: we would be asking for trouble.
+#
+# Instead, make a temporary directory to add to sys.path. Inside that
+# temporary directory, symlink to tools/.
+
+
+# This will get deleted when the module is destroyed.
+temp_dir = tempfile.TemporaryDirectory()
+(pathlib.Path(temp_dir.name) / 'tools/').symlink_to(TOOLS_DIR)
+
+
+# Note that this is not robust if the module is reloaded. If we want
+# to support that, we'll need a handle to an object that can remove
+# itself from sys.path upon its destruction.
+sys.path.append(temp_dir.name)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -59,6 +59,10 @@
 #     you can refer to the gradients of each outputs using 'grads',
 #     e.g., 'grads[0]', 'grads[1]'.
 #
+#     When a function returns multiple *differentiable* outputs that
+#     are named, you can refer to the gradients of each outputs using
+#     'grad_{name}', e.g., 'grad_x', 'grad_y'.
+#
 #     When a function returns *one* differentiable output (the
 #     first output) and some more nondifferentiable outputs,
 #     you MUST refer to the gradient of the differentiable output with
@@ -66,6 +70,11 @@
 #
 #     Note that the number of differentibale outputs can be modified by the
 #     'output_differentiability' entry (see above).
+#
+#     Across a differentiable function's derivatives set, it is not
+#     permitted to mix the use of "grad", "grads[INDEX]", and
+#     "grad_NAME". You must be consistent for that differentiable
+#     function.
 #
 #   - Any of the input arguments, tensor or non-tensor, including
 #     argument names that only appear in Declarations.yaml, e.g. 'output'.
@@ -1392,7 +1401,7 @@
   result: auto_linear
 
 - name: triangular_solve(Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False) -> (Tensor solution, Tensor cloned_coefficient)
-  self, A: triangular_solve_backward(grads[0], grads[1], self, A, solution, upper, transpose, unitriangular, grad_input_mask)
+  self, A: triangular_solve_backward(grad_solution, grad_cloned_coefficient, self, A, solution, upper, transpose, unitriangular, grad_input_mask)
 
 - name: tril(Tensor self, int diagonal=0) -> Tensor
   self: grad.tril(diagonal)

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -480,6 +480,11 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
 
     if uses_single_grad(info):
         body.append('auto& grad = grads[0];')
+    else:
+        # Generate aliases for gradients named for returned values.
+        body.extend(
+            f'const auto& {name} = grads[{info.available_named_gradients.index(name)}];'
+            for name in info.used_named_gradients)
 
     def emit_derivative(
         derivative: Derivative,

--- a/tools/codegen/api/autograd.py
+++ b/tools/codegen/api/autograd.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import re
-from typing import Optional, Sequence, List, Tuple, Match
+from typing import Optional, Sequence, Set, List, Tuple, Match
 
 from tools.codegen.api import cpp
 from tools.codegen.api.types import Binding, NamedCType
@@ -43,6 +43,9 @@ class Derivative:
 
     # Saved outputs that are referenced by the formula.
     saved_outputs: Tuple[SavedAttribute, ...]
+
+    # Gradients that are referenced by name in the formula.
+    named_gradients: Set[str]
 
 # Represents a forward formula that calculates forward derivatives
 # for one tensor.
@@ -114,6 +117,14 @@ class DifferentiabilityInfo:
 
     # The union of 'saved_outputs' of all 'derivatives'.
     all_saved_outputs: Sequence[SavedAttribute]
+
+    # All named gradients that are available for use, in the same
+    # order as in the grads vector.
+    available_named_gradients: Sequence[str]
+
+    # The named gradients that are used in any of the derivatives.
+    # Invariant: all(name in available_named_gradients for name in used_named_gradients)
+    used_named_gradients: Set[str]
 
     # The function's input arguments for which it calculates derivatives.
     # It's the union of 'var_names' of all 'derivatives', sorted by the


### PR DESCRIPTION
Fixes #62196

Testing:
This is currently only manually tested by modifying `triangular_solve` and running its `OpInfo` test.

There is scope for some unit tests:
1) ensure we identify `grad_X` and codegen the aliases appropriately
2) test the forbidden cases (e.g. mixing grad, grads and grad_X)

And also, we probably want to have an end to end test that ensures that a derivative written autograds correctly.

To be discussed:
1) If a function has named outputs, should `grads[1]` still be permitted?

I think no, eventually. But maybe not addressed in this PR. I could address them all since there's not that many though...

2) If a function has named outputs, but only one is differentiable, should we allow identifying it `grad`?

I think yes.

3) It probably makes sense to not allow mixing of `grad`, `grads[1]` and `grad_{output_name}`. We already disallow mixing of `grad` and `grads`.

I suspect this is broken with this change. We already have code that sanity checks the uses of `grads` vs `grad`. It probably needs to be adjusted to account for these gradient identifiers as well.

4) We may want to forbid outputs named "input_mask" to avoid conflict with `grad_input_mask`.

5) I have concerns about second derivatives, where we have inputs and outputs named `grad_X`. We'll want to ensure that there are no name conflicts between inputs, outputs, `grad_{output_name}`. Does `grad_grad_blah` improve readability?