### PR TITLE
test_cudnn_convolution_relu skipCUDAIfRocm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16678,6 +16678,7 @@ class TestNNDeviceType(NNTestCase):
                 self.assertEqual(output, output_ng, rtol=1e-2, atol=1e-5)
 
     @onlyCUDA
+    @skipCUDAIfRocm
     @skipCUDAIfNoCudnn
     @dtypes(torch.float, torch.double, torch.float16)
     def test_cudnn_convolution_relu(self, device, dtype):


### PR DESCRIPTION
Summary: skip rocm test for test_cudnn_convolution_relu

Test Plan: This skips a test

Reviewed By: ngimel

Differential Revision: D30233620

