### PR TITLE
Separating quantization test from distributed_test

### DIFF
--- a/test/distributed/algorithms/quantization/quantization_test.py
+++ b/test/distributed/algorithms/quantization/quantization_test.py
@@ -1,0 +1,108 @@
+import torch
+import os
+import torch.cuda
+import torch.distributed as dist
+import torch.distributed.algorithms.quantization.quantization as quant
+from torch.distributed.algorithms.quantization.quantization import DQuantType
+from torch.testing._internal.common_distributed import (
+    requires_gloo,
+    skip_if_lt_x_gpu,
+    requires_nccl,
+)
+from torch.testing._internal.distributed.distributed_test import (
+    DistributedTest, TestDistBackend
+)
+
+def _build_tensor(size, value=None, dtype=torch.float, device_id=None):
+    if value is None:
+        value = size
+    if device_id is None:
+        return torch.empty(size, size, size, dtype=dtype).fill_(value)
+    else:
+        return torch.empty(size, size, size, dtype=dtype).fill_(value).cuda(device_id)
+class DistQuantizationTests(TestDistBackend, DistributedTest._DistTestBase):
+    def setUp(self):
+        super().setUp()
+        self._fork_processes()
+        torch.backends.cudnn.flags(allow_tf32=False).__enter__()
+
+    @requires_gloo()
+    def test_all_gather_fp16(self):
+        group, group_id, rank = self._init_global_test()
+        self._test_all_gather(group, group_id, rank, dtype=torch.float32, qtype=DQuantType.FP16)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(int(os.environ["WORLD_SIZE"]))
+    def test_all_to_all_fp16(self):
+        group, group_id, rank = self._init_global_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_helper(
+            group,
+            group_id,
+            rank,
+            cuda=True,
+            rank_to_GPU=rank_to_GPU,
+            dtype=torch.float32,
+            qtype=DQuantType.FP16)
+
+    def _test_all_gather(
+            self, group, group_id, rank, cuda=False, rank_to_GPU=None, dtype=torch.float, qtype=None):
+        for dest in group:
+            tensor = _build_tensor(dest + 1, rank, dtype=dtype)
+            tensors = [_build_tensor(dest + 1, -1, dtype=dtype) for i in group]
+            expected_tensors = [_build_tensor(dest + 1, i, dtype=dtype) for i in group]
+            if (qtype is not None):
+                allgather = quant.auto_quantize(dist.all_gather, qtype, quant_loss=None)
+            else:
+                allgather = dist.all_gather
+            if cuda:
+                tensor = tensor.cuda(rank_to_GPU[rank][0])
+                tensors = [t.cuda(rank_to_GPU[rank][0]) for t in tensors]
+            if tensors[0].dtype == torch.complex64:
+                tensor_shapes = [torch.view_as_real(tensors[0]).shape]
+            else:
+                tensor_shapes = [tensors[0].shape]
+            allgather(tensors, tensor, group=group_id, async_op=False)
+
+            for t1, t2 in zip(tensors, expected_tensors):
+                self.assertEqual(t1, t2)
+
+        self._barrier()
+
+    def _test_all_to_all(
+        self,
+        group,
+        group_id,
+        rank,
+        cuda=False,
+        rank_to_GPU=None,
+        dtype=torch.float,
+        qtype=None
+    ):
+        if group_id is not None:
+            size = len(group)
+            in_splits = [i + 1 for i in group]
+            in_tensors = [
+                torch.ones([in_splits[i], size], dtype=dtype) * rank
+                for i, _ in enumerate(group)
+            ]
+            out_tensors = [
+                torch.ones([(rank + 1), size], dtype=dtype) for _ in group
+            ]
+            expected_tensors = [
+                torch.ones([rank + 1, size], dtype=dtype) * i for i in group
+            ]
+            if cuda:
+                in_tensors = [t.cuda(rank_to_GPU[rank][0]) for t in in_tensors]
+                expected_tensors = [
+                    t.cuda(rank_to_GPU[rank][0]) for t in expected_tensors
+                ]
+                out_tensors = [t.cuda(rank_to_GPU[rank][0]) for t in out_tensors]
+            if(qtype is not None):
+                quantize_alltoall = quant.auto_quantize(dist.all_to_all, qtype, quant_loss=None)
+                quantize_alltoall(out_tensors, in_tensors, group=group_id)
+            else:
+                dist.all_to_all(out_tensors, in_tensors, group=group_id)
+            for t1, t2 in zip(out_tensors, expected_tensors):
+                self.assertEqual(t1, t2)
+        self._barrier()

--- a/torch/distributed/algorithms/quantization/quantization.py
+++ b/torch/distributed/algorithms/quantization/quantization.py
@@ -86,16 +86,13 @@ def auto_quantize(func, qtype, quant_loss=None):
     """
     This is a prototype API that automatically quantize the input tensors, choose the precision types, and
     pass other necessary arguments and then dequantizes the output.
-
     Currently it only supports:
         . FP16 quantization method
         . all_gather, all_to_all collective ops
-
     Args:
         func (callable): A function representing collective operations.
         qtype (QuantType): Quantization method
         quant_loss (float, optional): This can be used to improve accuracy in the dequantization.
-
     Returns:
         (callable): the same collective as func but enables automatic quantization/dequantization.
     """

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -19,7 +19,6 @@ import torch.distributed.algorithms.ddp_comm_hooks.post_localSGD_hook as post_lo
 import torch.distributed.algorithms.ddp_comm_hooks.powerSGD_hook as powerSGD
 import torch.distributed.algorithms.model_averaging.averagers as averagers
 import torch.distributed.algorithms.model_averaging.utils as model_averaging_utils
-import torch.distributed.algorithms.quantization as quant
 import torch.nn as nn
 import torch.nn.functional as F
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
@@ -29,7 +28,6 @@ from torch.distributed.algorithms.ddp_comm_hooks import default_hooks as default
 from torch.distributed.algorithms.ddp_comm_hooks import (
     quantization as quantization_hooks,
 )
-from torch.distributed.algorithms.quantization import DQuantType
 from torch.distributed.distributed_c10d import (
     get_world_size,
     _get_default_group,
@@ -2765,15 +2763,12 @@ class DistributedTest:
 
         # ALL GATHER
         def _test_all_gather_helper(
-            self, group, group_id, rank, cuda=False, rank_to_GPU=None, dtype=torch.float, qtype=None
+            self, group, group_id, rank, cuda=False, rank_to_GPU=None, dtype=torch.float
         ):
             for dest in group:
                 tensor = _build_tensor(dest + 1, rank, dtype=dtype)
                 tensors = [_build_tensor(dest + 1, -1, dtype=dtype) for i in group]
-                if qtype is not None:
-                    allgather = quant.auto_quantize(dist.all_gather, qtype, quant_loss=None)
-                else:
-                    allgather = dist.all_gather
+                allgather = dist.all_gather
                 if cuda:
                     tensor = tensor.cuda(rank_to_GPU[rank][0])
                     tensors = [t.cuda(rank_to_GPU[rank][0]) for t in tensors]
@@ -2838,12 +2833,6 @@ class DistributedTest:
         def test_all_gather_full_group(self):
             group, group_id, rank = self._init_full_group_test()
             self._test_all_gather_helper(group, group_id, rank)
-
-        @sandcastle_skip_if(BACKEND == "nccl", "Nccl does not support CPU tensors")
-        @sandcastle_skip_if(BACKEND == "mpi", "all_gather_quantized does not support MPI")
-        def test_all_gather_quantized(self):
-            group, group_id, rank = self._init_global_test()
-            self._test_all_gather_helper(group, group_id, rank, dtype=torch.float32, qtype=DQuantType.FP16)
 
         def _run_all_gather_coalesced_and_verify(
             self, output_tensor_lists, input_tensors, expected_tensors, group_id
@@ -3047,7 +3036,6 @@ class DistributedTest:
             cuda=False,
             rank_to_GPU=None,
             dtype=torch.float,
-            qtype=None
         ):
             if group_id is not None:
                 size = len(group)
@@ -3068,11 +3056,7 @@ class DistributedTest:
                         t.cuda(rank_to_GPU[rank][0]) for t in expected_tensors
                     ]
                     out_tensors = [t.cuda(rank_to_GPU[rank][0]) for t in out_tensors]
-                if(qtype is not None):
-                    quantize_alltoall = quant.auto_quantize(dist.all_to_all, qtype, quant_loss=None)
-                    quantize_alltoall(out_tensors, in_tensors, group=group_id)
-                else:
-                    dist.all_to_all(out_tensors, in_tensors, group=group_id)
+                dist.all_to_all(out_tensors, in_tensors, group=group_id)
                 for t1, t2 in zip(out_tensors, expected_tensors):
                     self.assertEqual(t1, t2)
             self._barrier()
@@ -3154,20 +3138,6 @@ class DistributedTest:
         def test_all_to_all(self):
             group, group_id, rank = self._init_global_test()
             self._test_all_to_all_helper(group, group_id, rank)
-
-        @sandcastle_skip_if(BACKEND != "nccl", "Only NCCL supports all_to_all")
-        @skip_if_rocm
-        def test_all_to_all_quantized(self):
-            group, group_id, rank = self._init_global_test()
-            rank_to_GPU = self._init_multigpu_helper()
-            self._test_all_to_all_helper(
-                group,
-                group_id,
-                rank,
-                cuda=True,
-                rank_to_GPU=rank_to_GPU,
-                dtype=torch.float32,
-                qtype=DQuantType.FP16)
 
         @sandcastle_skip_if(BACKEND != "nccl", "Only NCCL supports CUDA all_to_all")
         @skip_if_rocm


### PR DESCRIPTION
Summary: Dedicating separate tests for different quantization methods. Currently supporting FP16 method.

Test Plan: uck test mode/dev //caffe2/test/distributed/algorithms/quantization:quantization_gloo_fork -- name_of_the_test

Differential Revision: D30142580



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @cbalioglu @gcramer23