### PR TITLE
Fix gha render-test-result mixed failure passthrough

### DIFF
--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -170,7 +170,7 @@ on:
   # doesn't create the best experience
   render_test_results:
     needs: [build-and-test, !{{ ciflow_config.root_job_name }}]
-    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
+    if: ${{ needs.build-and-test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     steps:
       - name: Log in to ECR

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -444,7 +444,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -263,9 +263,9 @@ jobs:
   render_test_results:
     needs: [generate-test-matrix, test, !{{ ciflow_config.root_job_name }}]
 {%- if only_build_on_pull_request %}
-    if:  ${{ github.event_name == 'push' && (needs.test.result == 'success' || needs.test.result == 'failure') }}
+    if: ${{ github.event_name == 'push' && (needs.test.result != 'skipped' || failure()) }}
 {%- else %}
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
 {%- endif %}
     runs-on: linux.2xlarge
     strategy:

--- a/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7.yml
@@ -401,7 +401,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -410,7 +410,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ciflow_should_run]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -410,7 +410,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ciflow_should_run]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7.yml
@@ -401,7 +401,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -401,7 +401,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -258,7 +258,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [build-and-test, ciflow_should_run]
-    if: ${{ needs.build-and-test.result == 'success' || needs.build-and-test.result == 'failure' }}
+    if: ${{ needs.build-and-test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     steps:
       - name: Log in to ECR

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-cudnn8-py3.6-gcc7.yml
@@ -408,7 +408,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ciflow_should_run]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11-cudnn8-py3.yml
@@ -224,7 +224,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ciflow_should_run]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -199,7 +199,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10-cudnn7-py3.yml
@@ -217,7 +217,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}

--- a/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11-cudnn8-py3.yml
@@ -216,7 +216,7 @@ jobs:
   # doesn't create the best experience
   render_test_results:
     needs: [generate-test-matrix, test, ]
-    if: ${{ needs.test.result == 'success' || needs.test.result == 'failure' }}
+    if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.render-matrix) }}


### PR DESCRIPTION
To fix something like https://github.com/pytorch/pytorch/actions/runs/1114555082


![image](https://user-images.githubusercontent.com/658840/128956528-86997457-5e18-4ae1-83cc-aa7d0ca03c0e.png)

Not sure why `needs.test.result` doesn't capture the `failure` case before, so changed it to `needs.test.result != 'skipped' || failure()`