### PR TITLE
[iOS][GPU] Consolidate array and non-array kernel for upsampling_nearest2d

### DIFF
--- a/aten/src/ATen/native/metal/MetalShaders.h
+++ b/aten/src/ATen/native/metal/MetalShaders.h
@@ -466,8 +466,12 @@ kernel void reflection_pad2d(texture2d_array<half, access::read> in_arr[[texture
   }
 }
 
-kernel void resize_nearest(texture2d_array<half, access::sample> in[[texture(0)]],
-                           texture2d_array<half, access::write> out[[texture(1)]],
+constant bool resize_is_arr = (ushort_arg_4 > 1 || ushort_arg_5 > 4);
+constant bool resize_is_tex = !resize_is_arr;
+kernel void resize_nearest(texture2d_array<half, access::sample> in_arr[[texture(0), function_constant(resize_is_arr)]],
+                           texture2d<half, access::sample> in_tex[[texture(0), function_constant(resize_is_tex)]],
+                           texture2d_array<half, access::write> out_arr[[texture(1), function_constant(resize_is_arr)]],
+                           texture2d<half, access::write> out_tex[[texture(1), function_constant(resize_is_tex)]],
                            ushort3 gid[[thread_position_in_grid]]) {
     const ushort oH = ushort_arg_0;
     const ushort oW = ushort_arg_1;
@@ -479,24 +483,13 @@ kernel void resize_nearest(texture2d_array<half, access::sample> in[[texture(0)]
     constexpr sampler s(coord::pixel, address::clamp_to_edge, filter::nearest);
     const int in_y = (int)(gid.y / height_scale);
     const int in_x = (int)(gid.x / width_scale);
-    out.write(in.sample(s, float2(in_x, in_y), gid.z), gid.xy, gid.z);
+    if(resize_is_arr) {
+        out_arr.write(in_arr.sample(s, float2(in_x, in_y), gid.z), gid.xy, gid.z);
+    } else {
+        out_tex.write(in_tex.sample(s, float2(in_x, in_y)), gid.xy);
+    }
 }
 
-kernel void resize_nearest_nonarray(texture2d<half, access::sample> in[[texture(0)]],
-                                    texture2d<half, access::write> out[[texture(1)]],
-                                    ushort2 gid[[thread_position_in_grid]]) {
-    const ushort oH = ushort_arg_0;
-    const ushort oW = ushort_arg_1;
-    if (gid.x >= oW || gid.y >= oH) {
-        return;
-    }
-    const float height_scale = float(ushort_arg_2) / 10000;
-    const float width_scale = float(ushort_arg_3) / 10000;
-    constexpr sampler s(coord::pixel, address::clamp_to_edge, filter::nearest);
-    const int in_y = (int)(gid.y / height_scale);
-    const int in_x = (int)(gid.x / width_scale);
-    out.write(in.sample(s, float2(in_x, in_y)), gid.xy);
-}
 
 constant bool reshape_out_is_arr = (ushort_arg_3 > 1 || ushort_arg_2 > 4);
 constant bool reshape_out_is_tex = !reshape_out_is_arr;

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
@@ -42,6 +42,7 @@ bool test_sigmoid();
 bool test_hardsigmoid();
 bool test_hardswish();
 bool test_upsampling_nearest2d_vec();
+bool test_upsampling_nearest2d_vec2();
 bool test_adaptive_avg_pool2d();
 bool test_hardtanh_();
 bool test_reshape();

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -740,6 +740,24 @@ bool test_upsampling_nearest2d_vec() {
   });
 }
 
+bool test_upsampling_nearest2d_vec2() {
+  __block std::vector<int64_t> size{1, 3, 24, 24};
+  return TEST(size, __PRETTY_FUNCTION__, ^bool {
+    auto X1 = at::rand(size, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+    auto Y1 = at::upsample_nearest2d(
+        X1,
+        c10::optional<at::IntArrayRef>({}),
+        c10::optional<at::ArrayRef<double>>({2, 2}));
+    auto X2 = X1.metal();
+    auto Y2 = at::upsample_nearest2d(
+                  X2,
+                  c10::optional<at::IntArrayRef>({}),
+                  c10::optional<at::ArrayRef<double>>({2, 2}))
+                  .cpu();
+    return almostEqual(Y1, Y2);
+  });
+}
+
 bool test_adaptive_avg_pool2d() {
   __block std::vector<int64_t> size{1, 48, 24, 24};
   return TEST(size, __PRETTY_FUNCTION__, ^bool {

--- a/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.mm
@@ -70,6 +70,7 @@
   REG_TEST("test_hardsigmoid", test_hardsigmoid);
   REG_TEST("test_hardswish", test_hardswish);
   REG_TEST("test_upsampling_nearest2d_vec", test_upsampling_nearest2d_vec);
+  REG_TEST("test_upsampling_nearest2d_vec2", test_upsampling_nearest2d_vec2);
   REG_TEST("test_adaptive_avg_pool2d", test_adaptive_avg_pool2d);
   REG_TEST("test_hardtanh_", test_hardtanh_);
   REG_TEST("test_reshape", test_reshape);

--- a/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
+++ b/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
@@ -1,8 +1,8 @@
 #import <ATen/native/metal/MetalCommandBuffer.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalTensorUtils.h>
-#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -41,7 +41,7 @@ Tensor upsample_nearest2d_vec(
       output_width);
   std::vector<int64_t> outputSizes{
       nbatch, channels, output_height, output_width};
-  if(input.numel() == 0){
+  if (input.numel() == 0) {
     return makeTensor({outputSizes}, input.options());
   }
   MPSImage* X = imageFromTensor(input);
@@ -60,17 +60,16 @@ Tensor upsample_nearest2d_vec(
   } else {
     NSUInteger sh = scale_h.value() * 10000;
     NSUInteger sw = scale_w.value() * 10000;
-    id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
-        specializedPipelineState:mpscnn::kernelFor(
-                                     Y,
-                                     "resize_nearest",
-                                     "resize_nearest_nonarray")
-                       Constants:@[
-                         @(output_height),
-                         @(output_width),
-                         @(sh),
-                         @(sw)
-                       ]];
+    id<MTLComputePipelineState> state =
+        [[MetalContext sharedInstance] specializedPipelineState:"resize_nearest"
+                                                      Constants:@[
+                                                        @(output_height),
+                                                        @(output_width),
+                                                        @(sh),
+                                                        @(sw),
+                                                        @(nbatch),
+                                                        @(channels),
+                                                      ]];
     id<MTLComputeCommandEncoder> encoder =
         [commandBuffer.buffer computeCommandEncoder];
     [encoder setComputePipelineState:state];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63062
* __->__ #63061

Cleanup the redundant shader code for the upsampling nearest kernel.

Differential Revision: [D30236905](https://our.internmc.facebook.com/intern/diff/D30236905/)