### PR TITLE
[easy] add an `inplace` argument to MutableNetProto.to_net() and core.Net() constructor

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -1469,12 +1469,15 @@ class Net(object):
         Net._net_names_used |= set([name])
         return name
 
-    def __init__(self, name_or_proto):
+    def __init__(self, name_or_proto, inplace=False):
         """
         Create a Net.
         Args:
-            name_or_proto:  If a NetDef is provided, clone it. Otherwise,
+            name_or_proto:  If a NetDef is provided, clone it (or take ownership,
+                            depending on the value of `inplace`). Otherwise,
                             create an empty net with the given name.
+            inplace: If a NetDef is provided, take ownership when `inplace` is True;
+                     otherwise, clone it.
         """
         self._input_record = None
         self._output_record = None
@@ -1487,10 +1490,13 @@ class Net(object):
         self._attr_dict = defaultdict(list)
         if type(name_or_proto) is caffe2_pb2.NetDef:
             proto = name_or_proto
-            # We rae initializing a network by a NetDef. In this case, we will
+            # We are initializing a network by a NetDef. In this case, we will
             # initialize our network with the given netdef.
-            self._net = caffe2_pb2.NetDef()
-            self._net.CopyFrom(proto)
+            if inplace:
+                self._net = proto
+            else:
+                self._net = caffe2_pb2.NetDef()
+                self._net.CopyFrom(proto)
 
             existing_outputs = [list(op.output) for op in self._net.op]
 


### PR DESCRIPTION
Summary: The caffe2 core.Net constructor can accept a caffe2_pb2.NetDef proto, but it always creates a copy. This is wasteful when we can prove that the proto being passed to it will not be used anywhere else. So we add an "inplace" argument to the `core.Net` constructor that allows clients to give away ownership of the passed proto without copying. We default this argument to `False`, ensuring that behavior does not change unless explicitly requested.

Test Plan: Let CI run.

Differential Revision: D29976510

