### PR TITLE
enable increment build for build_libtorch

### DIFF
--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -14,10 +14,10 @@ from tools.setup_helpers.cmake import CMake
 if __name__ == '__main__':
     # Placeholder for future interface. For now just gives a nice -h.
     parser = argparse.ArgumentParser(description='Build libtorch')
-    parser.add_argument('--cmake', action="store_true", help='rerun cmake')
-    parser.add_argument('--cmake_only', action="store_true",
+    parser.add_argument('--rerun-cmake', action="store_true", help='rerun cmake')
+    parser.add_argument('--cmake-only', action="store_true",
                         help='Stop once cmake terminates. Leave users a chance to adjust build options')
     options = parser.parse_args()
 
     build_caffe2(version=None, cmake_python_library=None, build_python=False,
-                 rerun_cmake=options.cmake, cmake_only=options.cmake_only, cmake=CMake())
+                 rerun_cmake=options.rerun_cmake, cmake_only=options.cmake_only, cmake=CMake())

--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -15,7 +15,8 @@ if __name__ == '__main__':
     # Placeholder for future interface. For now just gives a nice -h.
     parser = argparse.ArgumentParser(description='Build libtorch')
     parser.add_argument('--cmake', action="store_true", help='rerun cmake')
-    parser.add_argument('--cmake_only', action="store_true", help='Stop once cmake terminates. Leave users a chance to adjust build options')
+    parser.add_argument('--cmake_only', action="store_true",
+                        help='Stop once cmake terminates. Leave users a chance to adjust build options')
     options = parser.parse_args()
 
     build_caffe2(version=None, cmake_python_library=None, build_python=False,

--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -14,7 +14,9 @@ from tools.setup_helpers.cmake import CMake
 if __name__ == '__main__':
     # Placeholder for future interface. For now just gives a nice -h.
     parser = argparse.ArgumentParser(description='Build libtorch')
+    parser.add_argument('--cmake', action="store_true", help='rerun cmake')
+    parser.add_argument('--cmake_only', action="store_true", help='Stop once cmake terminates. Leave users a chance to adjust build options')
     options = parser.parse_args()
 
     build_caffe2(version=None, cmake_python_library=None, build_python=False,
-                 rerun_cmake=True, cmake_only=False, cmake=CMake())
+                 rerun_cmake=options.cmake, cmake_only=options.cmake_only, cmake=CMake())


### PR DESCRIPTION
Since issue #59859 is resolved.

rerun_cmake in build_libtorch should not be hardcoded.
build_libtorch is necessary to generate debug version libtorch.