### PR TITLE
[FX] Fix GraphModule deepcopy to use deepcopied graph

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -586,7 +586,7 @@ class {module_name}(torch.nn.Module):
     def __deepcopy__(self, memo):
         fake_mod = torch.nn.Module()
         fake_mod.__dict__ = copy.deepcopy(self.__dict__)
-        return GraphModule(fake_mod, self.graph)
+        return GraphModule(fake_mod, fake_mod.__dict__['_graph'])
 
     def __copy__(self):
         return GraphModule(self, self.graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63090

Previously `GraphModule.__deepcopy__` was passing through the original `Graph` instance and not deep copying it. This fixes that.

Differential Revision: [D30252471](https://our.internmc.facebook.com/intern/diff/D30252471)