### PR TITLE
Fix Nnapi backend execute's dangling pointer

### DIFF
--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
@@ -83,8 +83,8 @@ class NnapiBackend : public PyTorchBackendInterface {
       if (fmt == 0) {
         fixed_inputs.push_back(tensorInp.get(i).contiguous());
       } else if (fmt == 1) {
-        c10::IntArrayRef order = {0, 2, 3, 1};
-        fixed_inputs.push_back(tensorInp.get(i).permute(order).contiguous());
+        fixed_inputs.push_back(
+            tensorInp.get(i).permute({0, 2, 3, 1}).contiguous());
       } else {
         throw std::exception();
         std::cerr << "Invalid mem_fmt" << std::endl;
@@ -102,8 +102,7 @@ class NnapiBackend : public PyTorchBackendInterface {
       // 0: NCHW, 1: NHWC
       // TODO: See if it's possible to use those directly.
       if (fmt == 1) {
-        c10::IntArrayRef order = {0, 3, 1, 2};
-        outputs.set(i, outputs.get(i).permute(order));
+        outputs.set(i, outputs.get(i).permute({0, 3, 1, 2}));
       } else if (fmt != 0) {
         throw std::exception();
         std::cerr << "Invalid mem_fmt" << std::endl;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63092

### Summary:
Bug discovered while testing NNAPI Delegate on SparkAR.
Using
```
c10::IntArrayRef order = {0, 2, 3, 1};
fixed_inputs.push_back(tensorInp.get(i).permute(order).contiguous());
```
results in a garbage value for order in `permute()`.
Moving order inside the call to `permute()` fixes this issue. Problem is seemingly related to Issue 4409, but luckily the solution in this case is simple.

Bug wasn't caught earlier, since regular unit tests weren't affected by the dangling pointer, and address sanitizer NNAPI tests are turned off due to there being a different failure (T95764916).

### Test Plan:
Run Unit tests: python test/test_jit.py
Build and run SparkAR on an Android phone at the top of this diff stack (D30173959): buck build --show-output arstudioplayer_arm64_debug -c pt.enable_nnapi=1

Differential Revision: [D30237504](https://our.internmc.facebook.com/intern/diff/D30237504/)