### PR TITLE
Introduce the torch.distributed.ops module

### DIFF
--- a/docs/source/distributed.ops.rst
+++ b/docs/source/distributed.ops.rst
@@ -1,0 +1,89 @@
+.. currentmodule:: torch.distributed.ops
+
+Autograd-Aware Collective Functions
+===================================
+
+.. automodule:: torch.distributed.ops
+
+.. warning::
+    The ``torch.distributed.nn.functional`` module which offers a similar set of
+    functions is deprecated and should not be used for future development.
+
+Example
+^^^^^^^
+::
+
+    # Worker 1 ###########################################
+    import torch
+    import torch.distributed as dist
+    import torch.distributed.ops as distops
+
+    dist.init_process_group(
+        backend="gloo", init_method="tcp://localhost:12345", world_size=2, rank=0
+    )
+
+    x = torch.tensor([[2.0, 2.0, 1.0], [1.0, 3.0, 1.0]], requires_grad=True)
+
+    y = x ** 3
+
+    # y:
+    # tensor([[8,  8, 1],
+    #         [1, 27, 1]])
+
+    # Take the product across all ranks.
+    s = distops.prod(y)
+
+    # s:
+    # tensor([[8, 512, 27],
+    #         [8,  27,  1]])
+
+    s.backward(torch.ones([2, 3]))
+
+    # x_grad:
+    # tensor([[24, 1536, 162]
+    #         [48,   54,  6]])
+
+
+
+    # Worker 2 ###########################################
+    import torch
+    import torch.distributed as dist
+    import torch.distributed.ops as distops
+
+    dist.init_process_group(
+        backend="gloo", init_method="tcp://localhost:12345", world_size=2, rank=1
+    )
+
+    x = torch.tensor([[1.0, 4.0, 3.0], [2.0, 1.0, 1.0]], requires_grad=True)
+
+    y = x ** 3
+
+    # y:
+    # tensor([[1, 64, 27],
+    #         [8,  1,  1]])
+
+    # Take the product across all ranks.
+    s = distops.prod(y)
+
+    # s:
+    # tensor([[8, 512, 27],
+    #         [8,  27,  1]])
+
+    s.backward(torch.ones([2, 3]))
+
+    # x_grad:
+    # tensor([[48, 768, 54]
+    #         [24, 162,  6]])
+
+Functions
+^^^^^^^^^^
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    sum
+    sum_on_rank
+    prod
+    minimum
+    minimum
+    copy

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -447,26 +447,6 @@ Note that you can use ``torch.profiler`` (recommended, only available after 1.8.
 
 Please refer to the `profiler documentation <https://pytorch.org/docs/master/profiler.html>`__ for a full overview of profiler features.
 
-Autograd-enabled communication primitives
------------------------------------------
-
-If you want to use collective communication functions supporting autograd
-you can find an implementation of those in the `torch.distributed.nn.*` module.
-
-Functions here are synchronous and will be inserted in the autograd graph, so
-you need to ensure that all the processes that participated in the collective operation
-will do the backward pass for the backward communication to effectively happen and
-don't cause a deadlock.
-
-Please notice that currently the only backend where all the functions are guaranteed to work is ``gloo``.
-.. autofunction:: torch.distributed.nn.broadcast
-.. autofunction:: torch.distributed.nn.gather
-.. autofunction:: torch.distributed.nn.scatter
-.. autofunction:: torch.distributed.nn.reduce
-.. autofunction:: torch.distributed.nn.all_gather
-.. autofunction:: torch.distributed.nn.all_to_all
-.. autofunction:: torch.distributed.nn.all_reduce
-
 Multi-GPU collective functions
 ------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,6 +60,7 @@ Features described in this documentation are classified by release status:
    torch.distributed <distributed>
    torch.distributed.algorithms.join <distributed.algorithms.join>
    torch.distributed.elastic <distributed.elastic>
+   torch.distributed.ops <distributed.ops>
    torch.distributed.optim <distributed.optim>
    torch.distributions <distributions>
    torch.fft <fft>

--- a/test/distributed/test_ops.py
+++ b/test/distributed/test_ops.py
@@ -1,0 +1,273 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.distributed as dist
+import torch.distributed.ops as ops
+
+from functools import partial
+from torch.testing._internal.common_utils import TestCase, run_tests
+from typing import Callable, Tuple
+from unittest.mock import patch
+
+
+class OpsTest(TestCase):
+    def setUp(self) -> None:
+        self._patches = []  # type: ignore[var-annotated]
+
+        def patch_and_mock(fn: str) -> None:
+            p = patch(f"torch.distributed.ops.dist.{fn}")
+
+            mock = p.start()
+            mock.side_effect = getattr(self, f"_mock_{fn}")
+
+            self._patches.append(p)
+
+        patch_and_mock("all_gather")
+        patch_and_mock("all_reduce")
+        patch_and_mock("broadcast")
+        patch_and_mock("get_rank")
+        patch_and_mock("get_world_size")
+        patch_and_mock("reduce")
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+
+    def _setup(self, rank: int, world_size: int, shape: Tuple[int, ...]) -> None:
+        self._rank = rank  # Simulated rank.
+        self._world_size = world_size  # Simulated world size.
+
+        gen = torch.manual_seed(1)
+
+        # Holds the inputs per rank.
+        self._x = [
+            torch.rand(shape, generator=gen, requires_grad=True) * 4.0 for _ in range(world_size)
+        ]
+
+        # Holds the intermediate activations per rank.
+        self._activations = [x ** 3 for x in self._x]
+
+        # Indicates whether we are in the forward or backward pass of the test.
+        self._backprop = False
+
+    def _mock_all_gather(self, outputs, input_, _) -> None:
+        if self._backprop:
+            # We know that the output gradients are identical on all ranks, so
+            # we can simulate the all-gather operation.
+            inputs = [input_] * self._world_size
+        else:
+            inputs = self._activations
+
+        with torch.no_grad():
+            for o, i in zip(outputs, inputs):
+                o.copy_(i)
+
+    def _mock_all_reduce(self, tensor, op, _) -> None:
+        self._mock_reduce_core(tensor, op)
+
+    def _mock_broadcast(self, tensor, src, _) -> None:
+        if self._rank == src:
+            return
+
+        # We know that the output gradients are identical on all ranks, so we
+        # can treat broadcasting as a noop.
+        if not self._backprop:
+            with torch.no_grad():
+                tensor.copy_(self._activations[self._rank])
+
+    def _mock_get_rank(self, _) -> int:
+        return self._rank
+
+    def _mock_get_world_size(self, _) -> int:
+        return self._world_size
+
+    def _mock_reduce(self, tensor, dst, op, _) -> None:
+        if self._rank != dst:
+            return
+
+        self._mock_reduce_core(tensor, op)
+
+    def _mock_reduce_core(self, tensor, op) -> None:
+        if self._backprop:
+            # We know that the output gradients are identical on all ranks, so
+            # we can simulate the reduce operation.
+            inputs = [tensor.detach().clone()] * self._world_size
+        else:
+            inputs = self._activations
+
+        with torch.no_grad():
+            if op == dist.ReduceOp.SUM:
+                tensor.zero_()
+                for i in inputs:
+                    tensor.add_(i)
+            elif op == dist.ReduceOp.PRODUCT:
+                tensor.fill_(1.0)
+                for i in inputs:
+                    tensor.mul_(i)
+            else:
+                raise RuntimeError("Unsupported reduce operation.")
+
+    def _run_test(self, set_state: Callable, op: Callable) -> None:
+        for world_size in range(1, 5):
+            for rank in range(world_size):
+                for shape in [(1,), (2, 3), (4, 4), (6, 4)]:
+                    with self.subTest(rank=rank, world_size=world_size, shape=shape):
+                        self._setup(rank, world_size, shape)
+
+                        set_state()
+
+                        self._run_and_assert_op(op)
+
+    def _set_state_for_copy(self, src_rank: int) -> None:
+        self._expected_output = self._activations[self._rank]
+
+        if self._rank == src_rank:
+            # Simulate as if backprop (e.g. backward()) was run on all ranks.
+            output = self._world_size * self._expected_output
+
+            self._compute_expected_derivatives(output)
+        else:
+            zero_grad = torch.zeros_like(self._expected_output)
+
+            # For all other ranks the gradient is always zero.
+            self._expected_jacobian = self._expected_hessian = (zero_grad,)
+
+    def _set_state_for_sum(self) -> None:
+        self._expected_output = torch.zeros_like(self._activations[0])
+        for a in self._activations:
+            self._expected_output.add_(a)
+
+        # Simulate as if backprop (e.g. backward()) was run on all ranks.
+        output = self._world_size * self._expected_output
+
+        self._compute_expected_derivatives(output)
+
+    def _set_state_for_sum_on_rank(self, dst_rank: int) -> None:
+        output = torch.zeros_like(self._activations[0])
+        for a in self._activations:
+            output.add_(a)
+
+        self._compute_expected_derivatives(output)
+
+        if self._rank == dst_rank:
+            self._expected_output = output
+        else:
+            self._expected_output = torch.zeros_like(self._activations[0])
+
+    def _set_state_for_prod(self) -> None:
+        self._expected_output = torch.ones_like(self._activations[0])
+        for a in self._activations:
+            self._expected_output.mul_(a)
+
+        # Simulate as if backprop (e.g. backward()) was run on all ranks.
+        output = self._world_size * self._expected_output
+
+        self._compute_expected_derivatives(output)
+
+    def _set_state_for_minimum(self) -> None:
+        self._expected_output = self._activations[0]
+        for a in self._activations:
+            self._expected_output = torch.minimum(self._expected_output, a)
+
+        # Simulate as if backprop (e.g. backward()) was run on all ranks.
+        output = self._world_size * self._expected_output
+
+        self._compute_expected_derivatives(output)
+
+    def _set_state_for_maximum(self) -> None:
+        self._expected_output = self._activations[0]
+        for a in self._activations:
+            self._expected_output = torch.maximum(self._expected_output, a)
+
+        # Simulate as if backprop (e.g. backward()) was run on all ranks.
+        output = self._world_size * self._expected_output
+
+        self._compute_expected_derivatives(output)
+
+    def _compute_expected_derivatives(self, output: torch.Tensor) -> None:
+        x = self._x[self._rank]
+
+        o = (output,)
+
+        grad_output = (torch.ones_like(output),)
+
+        # Compute Jacobian.
+        o = torch.autograd.grad(o, x, grad_output, create_graph=True)  # type: ignore[assignment]
+
+        self._expected_jacobian = o
+
+        # Compute Hessian. Note that we need to retain the autograd graph in
+        # order to run backprop a second time for assertion.
+        o = torch.autograd.grad(o, x, grad_output, retain_graph=True)  # type: ignore[assignment]
+
+        self._expected_hessian = o
+
+    def _run_and_assert_op(self, op: Callable) -> None:
+        output = op(self._activations[self._rank])
+
+        self._assert_op(output)
+
+    def _assert_op(self, output: torch.Tensor) -> None:
+        self.assertEqual(output, self._expected_output)
+
+        try:
+            self._backprop = True
+
+            self._assert_derivatives(output)
+        finally:
+            self._backprop = False
+
+    def _assert_derivatives(self, output: torch.Tensor) -> None:
+        x = self._x[self._rank]
+
+        o = (output,)
+
+        grad_output = (torch.ones_like(output),)
+
+        # Assert Jacobian
+        o = torch.autograd.grad(o, x, grad_output, create_graph=True)  # type: ignore[assignment]
+
+        self.assertEqual(o, self._expected_jacobian)
+
+        # Assert Hessian.
+        o = torch.autograd.grad(o, x, grad_output)  # type: ignore[assignment]
+
+        self.assertEqual(o, self._expected_hessian)
+
+    def test_copy(self) -> None:
+        src_rank = 0
+
+        set_state = partial(self._set_state_for_copy, src_rank)
+
+        op = partial(ops.copy, src_rank)
+
+        self._run_test(set_state, op)
+
+    def test_sum(self) -> None:
+        self._run_test(self._set_state_for_sum, ops.sum)
+
+    def test_sum_on_rank(self) -> None:
+        dst_rank = 0
+
+        set_state = partial(self._set_state_for_sum_on_rank, dst_rank)
+
+        op = partial(ops.sum_on_rank, dst_rank)
+
+        self._run_test(set_state, op)
+
+    def test_prod(self) -> None:
+        self._run_test(self._set_state_for_prod, ops.prod)
+
+    def test_minimum(self) -> None:
+        self._run_test(self._set_state_for_minimum, ops.minimum)
+
+    def test_maximum(self) -> None:
+        self._run_test(self._set_state_for_maximum, ops.maximum)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -1,6 +1,7 @@
 import torch
 from torch.autograd import Function
 import torch.distributed as dist
+import warnings
 
 
 def broadcast(tensor, src, group=dist.group.WORLD):
@@ -20,6 +21,11 @@ def broadcast(tensor, src, group=dist.group.WORLD):
         Tensor: Received tensor from the broadcast op.
 
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
     return _Broadcast.apply(src, group, tensor)
 
 
@@ -35,6 +41,11 @@ def gather(tensor, dst=0, group=dist.group.WORLD):
     Returns:
         tuple[Tensor]: List of appropriately-sized tensors with the gathered data.
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
     return _Gather.apply(dst, group, tensor)
 
 
@@ -55,6 +66,11 @@ def scatter(tensors, src=0, group=dist.group.WORLD):
         Tensor: Output tensor from the scatter operation.
 
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
     return _Scatter.apply(src, group, *tensors)
 
 
@@ -76,6 +92,14 @@ def reduce(tensor, dst, op=dist.ReduceOp.SUM, group=dist.group.WORLD):
         Tensor: Output of the collective.
 
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
+    if op != dist.ReduceOp.SUM:
+        raise RuntimeError("`reduce` supports SUM operation only.")
+
     return _Reduce.apply(dst, op, group, tensor)
 
 
@@ -91,6 +115,11 @@ def all_gather(tensor, group=dist.group.WORLD):
         tuple[Tensor]): Output of the collective.
 
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
     return _AllGather.apply(group, tensor)
 
 
@@ -107,6 +136,11 @@ def all_to_all(tensors, group=dist.group.WORLD):
         tuple[Tensor]): Output of the collective.
 
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
     return _AlltoAll.apply(group, *tensors)
 
 
@@ -129,6 +163,14 @@ def all_reduce(tensor, op=dist.ReduceOp.SUM, group=dist.group.WORLD):
         Tensor: Output of the collective
 
     """
+    warnings.warn(
+        "torch.distributed.nn.functional is deprecated, please use "
+        "torch.distributed.ops instead."
+    )
+
+    if op != dist.ReduceOp.SUM:
+        raise RuntimeError("`all_reduce` supports SUM operation only.")
+
     return _AllReduce.apply(op, group, tensor)
 
 

--- a/torch/distributed/ops.py
+++ b/torch/distributed/ops.py
@@ -1,0 +1,304 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+The ``torch.distributed.ops`` module contains a set of autograd-aware collective
+functions.
+
+These functions are synchronous and will be inserted in the autograd graph. You
+need to ensure that all ranks participating in the operation perform a backward
+pass for the backward communication to effectively happen.
+"""
+
+import torch
+import torch.distributed as dist
+
+from torch.autograd import Function
+from typing import Any, Optional, Tuple
+
+
+def sum(input: torch.Tensor, group: Optional[dist.ProcessGroup] = None) -> torch.Tensor:
+    """Computes the element-wise sum across ranks.
+
+    Arguments:
+        input (Tensor):
+            The input of this rank.
+        group (ProcessGroup, optional):
+            The process group to work on. If ``None``, the default process group
+            will be used.
+
+    Returns:
+        The element-wise sum of all inputs.
+    """
+    return _DistributedSum.apply(input, group)
+
+
+class _DistributedSum(Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any, input: torch.Tensor, group: dist.ProcessGroup
+    ) -> torch.Tensor:
+        ctx.group = group
+
+        # We have to clone `input` to prevent in-place writes by `all_reduce`.
+        output = input.clone()
+
+        dist.all_reduce(output, dist.ReduceOp.SUM, ctx.group)
+
+        return output
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        grad_output = sum(grad_output, ctx.group)
+
+        return (grad_output, None)
+
+
+def sum_on_rank(
+    dst: int, input: torch.Tensor, group: Optional[dist.ProcessGroup] = None
+) -> torch.Tensor:
+    """Computes the element-wise sum across ranks and returns it on ``dst``.
+
+    Arguments:
+        dst (int):
+            The destination rank on which to return the result.
+        input (Tensor):
+            The input of this rank.
+        group (ProcessGroup, optional):
+            The process group to work on. If ``None``, the default process group
+            will be used.
+
+    Returns:
+        The element-wise sum of all inputs on ``dst``, and a zero tensor
+        on other ranks.
+    """
+    return _DistributedSumOnRank.apply(dst, input, group)
+
+
+class _DistributedSumOnRank(Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any, dst: int, input: torch.Tensor, group: dist.ProcessGroup
+    ) -> torch.Tensor:
+        ctx.dst = dst
+
+        ctx.group = group
+
+        # We have to clone `input` to prevent in-place writes by `reduce`.
+        if dist.get_rank(ctx.group) == ctx.dst:
+            input = input.clone()
+
+        dist.reduce(input, ctx.dst, dist.ReduceOp.SUM, ctx.group)
+
+        # Since there is no logical output on ranks other than `dst`, we just
+        # return a zero tensor.
+        if dist.get_rank(ctx.group) != ctx.dst:
+            input = torch.zeros_like(input)
+
+        return input
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[None, torch.Tensor, None]:
+        grad_output = copy(ctx.dst, grad_output, ctx.group)
+
+        return (None, grad_output, None)
+
+
+def prod(input: torch.Tensor, group: Optional[dist.ProcessGroup] = None) -> torch.Tensor:
+    """Computes the element-wise product across ranks.
+
+    Arguments:
+        input (Tensor):
+            The input of this rank.
+        group (ProcessGroup, optional):
+            The process group to work on. If ``None``, the default process group
+            will be used.
+
+    Returns:
+        The element-wise (a.k.a. Hadamard) product of all inputs.
+    """
+    return _DistributedProd.apply(input, group)
+
+
+class _DistributedProd(Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any, input: torch.Tensor, group: dist.ProcessGroup
+    ) -> torch.Tensor:
+        ctx.group = group
+
+        # We have to clone `input` to prevent in-place writes by `all_reduce`.
+        output = input.clone()
+
+        dist.all_reduce(output, dist.ReduceOp.PRODUCT, ctx.group)
+
+        # We effectively revert back our contribution to the product and use the
+        # result as the coefficient of our input.
+        ctx.coefficient = output / input
+
+        return output
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, None]:
+        grad_output = sum(grad_output, ctx.group)
+
+        return (grad_output * ctx.coefficient, None)
+
+
+def minimum(input: torch.Tensor, group: Optional[dist.ProcessGroup] = None) -> torch.Tensor:
+    """Computes the element-wise minimum across ranks.
+
+    Arguments:
+        input (Tensor):
+            The input of this rank.
+        group (ProcessGroup, optional):
+            The process group to work on. If ``None``, the default process group
+            will be used.
+
+    Returns:
+        The element-wise minimum of all inputs.
+    """
+    return _DistributedMinMax.apply(input, group, dist.ReduceOp.MIN)
+
+
+def maximum(input: torch.Tensor, group: Optional[dist.ProcessGroup] = None) -> torch.Tensor:
+    """Computes the element-wise maximum across ranks.
+
+    Arguments:
+        input (int):
+            The input of this rank.
+        group (ProcessGroup, optional):
+            The process group to work on. If ``None``, the default process group
+            will be used.
+
+    Returns:
+        The element-wise maximum of all inputs.
+    """
+    return _DistributedMinMax.apply(input, group, dist.ReduceOp.MAX)
+
+
+class _DistributedMinMax(Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any, input: torch.Tensor, group: dist.ProcessGroup, op: dist.ReduceOp
+    ) -> torch.Tensor:
+        ctx.group = group
+
+        group_size = dist.get_world_size(ctx.group)
+
+        # Gather all inputs to compute the minimum or maximum. Note that we need
+        # the individual inputs in the backward pass; therefore, we can't use
+        # `all_reduce` here.
+        inputs = [torch.zeros_like(input) for _ in range(group_size)]
+
+        dist.all_gather(inputs, input, group)
+
+        # Compute the element-wise minimum or maximum of all inputs.
+        output = inputs[0].clone()
+        for i in inputs[1:]:
+            if op == dist.ReduceOp.MIN:
+                output = torch.minimum(output, i)
+            else:
+                output = torch.maximum(output, i)
+
+        rank = dist.get_rank(ctx.group)
+
+        # We save the inputs of other ranks in the context since we need them to
+        # compute the gradients in the backward pass.
+        del inputs[rank]
+
+        ctx.other_inputs = inputs
+
+        ctx.save_for_backward(input, output)
+
+        return output
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, None, None]:
+        input: torch.Tensor
+        output: torch.Tensor
+
+        input, output = ctx.saved_tensors
+
+        grad_output = sum(grad_output, ctx.group)
+
+        # If the inputs of other ranks have the same minima or maxima, we should
+        # scale down the corresponding input gradients.
+        scale = torch.ones_like(grad_output)
+        for i in ctx.other_inputs:
+            scale += torch.where(input == i, 1, 0)
+
+        grad_input = grad_output / scale
+
+        # Zero out all input gradients for which our input is not the minimum or
+        # maximum.
+        grad_input.masked_fill_(input != output, 0)
+
+        return (grad_input, None, None)
+
+
+def copy(src: int, input: torch.Tensor, group: Optional[dist.ProcessGroup] = None) -> torch.Tensor:
+    """Copies ``input`` from the source rank to other ranks.
+
+    Arguments:
+        src (int):
+            The source rank which holds the actual input.
+        input (Tensor):
+            On the source rank ``input`` represents the tensor to be copied to
+            other ranks; on other ranks it is a tensor with the same shape and
+            data type used to save the received data.
+
+    Returns:
+        On the source rank a view of ``input`` with a custom autograd function;
+        on other ranks ``input`` itself.
+
+    Note:
+        This function is differentiable, meaning gradients will flow back from
+        the result of this operation to ``input``.
+
+        Make sure to use the return value of this function instead of ``input``
+        for further autograd operations; otherwise, the gradients will not be
+        calculated correctly.
+    """
+    return _DistributedCopy.apply(src, input, group)
+
+
+class _DistributedCopy(Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any, src: int, input: torch.Tensor, group: dist.ProcessGroup
+    ) -> torch.Tensor:
+        ctx.src = src
+
+        ctx.group = group
+
+        dist.broadcast(input, ctx.src, ctx.group)
+
+        # For ranks other than `src`, the data of `input` will be overwritten
+        # by `broadcast`; therefore, we have to explicitly update the version
+        # counter of `input`'s storage.
+        if dist.get_rank(ctx.group) != ctx.src:
+            ctx.mark_dirty(input)
+
+        # Note that on `src` the autograd engine will internally create a view
+        # of `input`, attach a new `grad_fn` to the view, and return that view
+        # instead of `input` to the caller.
+        return input
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[None, torch.Tensor, None]:
+        grad_output = sum_on_rank(ctx.src, grad_output, ctx.group)
+
+        return (None, grad_output, None)


### PR DESCRIPTION
Fixes #58005

This PR introduces a new `torch.distributed.ops` module that replaces the `torch.distributed.nn.functional` module. Instead of exposing the low-level collective communication primitives such as `all_reduce` or `broadcast`, the new module offers a high-level API that offers functions such as `sum`, `prod`, or `copy`. The main motivation for this change was that exposing CC primitives as autograd-aware functions was an inherently flawed approach. In particular computing the gradients for different CC operations involves more than simply calling the specified CC primitive. By exposing high-level functions we hide away which CC primitives are internally used and avoid giving the users a false sense of what is being executed.
