### PR TITLE
[LTC] Add _log_softmax TorchScript lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -72,6 +72,13 @@ at::Tensor subtensor(const at::Tensor& tensor, int dim, int groups, int g) {
 
 }  // namespace
 
+at::Tensor LazyNativeFunctions::_log_softmax(const at::Tensor& self, int64_t dim,
+                                         bool /* half_to_float */) {
+  LTC_FN_COUNTER("lazy::");
+  return bridge::AtenFromLtcTensor(
+      LazyTensor::log_softmax(bridge::GetLtcTensor(self), dim, c10::nullopt));
+}
+
 at::Tensor LazyNativeFunctions::_softmax(const at::Tensor& self, int64_t dim,
                                          bool /* half_to_float */) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -19,6 +19,7 @@
 #include "lazy_tensor_core/csrc/ops/index_select.h"
 #include "lazy_tensor_core/csrc/ops/leaky_relu.h"
 #include "lazy_tensor_core/csrc/ops/leaky_relu_backward.h"
+#include "lazy_tensor_core/csrc/ops/log_softmax.h"
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
 #include "lazy_tensor_core/csrc/ops/permute.h"
 #include "lazy_tensor_core/csrc/ops/repeat.h"
@@ -264,6 +265,10 @@ class TSNodeLowering : public NodeLowering {
     if (node->op().op == at::aten::leaky_relu_backward) {
       return LowerLeakyReluBackward(ir::NodeCast<ir::ops::LeakyReluBackward>(
           node, ir::OpKind(at::aten::leaky_relu_backward)));
+    }
+    if (node->op().op == at::aten::log_softmax) {
+      return LowerLogSoftmax(
+          ir::NodeCast<ir::ops::LogSoftmax>(node, ir::OpKind(at::aten::log_softmax)));
     }
     if (node->op().op == at::aten::permute) {
       return LowerPermute(
@@ -667,6 +672,14 @@ class TSNodeLowering : public NodeLowering {
     arguments.emplace_back(loctx()->GetOutputOp(node->operand(1)));
     arguments.push_back(node->negative_slope());
     arguments.push_back(node->self_is_result());
+    return LowerBuiltin(node, arguments);
+  }
+
+  TSOpVector LowerLogSoftmax(const ir::ops::LogSoftmax* node) {
+    std::vector<torch::jit::NamedValue> arguments;
+    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
+    arguments.emplace_back(node->dim());
+    arguments.emplace_back(node->dtype());
     return LowerBuiltin(node, arguments);
   }
 

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -6163,6 +6163,22 @@ TEST_F(AtenLtcTsTensorTest, TestLogSoftmaxCast) {
   });
 }
 
+TEST_F(AtenLtcTsTensorTest, TestLogSoftmaxWrapper) {
+  torch::Tensor input =
+      torch::rand({10, 2, 6, 4}, torch::TensorOptions(torch::kFloat));
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_input = CopyToDevice(input, device);
+    int rank = input.dim();
+    for (int dim = -rank; dim < rank; ++dim) {
+      torch::Tensor output =
+          torch::_log_softmax(input, dim, /*half_to_float=*/false);
+      torch::Tensor xla_output =
+          torch::_log_softmax(xla_input, dim, /*half_to_float=*/false);
+      AllClose(output, xla_output, /*rtol=*/1e-3);
+    }
+  });
+}
+
 TEST_F(AtenLtcTsTensorTest, TestSoftmax) {
   torch::Tensor input =
       torch::rand({10, 2, 6, 4}, torch::TensorOptions(torch::kFloat));

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -1,6 +1,7 @@
 backend: Lazy
 cpp_namespace: torch_lazy_tensors
 supported:
+  - _log_softmax
   - add.Tensor
   - addcdiv
   - addcdiv_


### PR DESCRIPTION
Summary:
This patch added _log_softmax to TorchScript lowering.

Test Plan:
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestLogSoftmax*

Fixes #62431.
