### PR TITLE
Moving getattr_from_fqn to torch.quantization.utils

### DIFF
--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -7,7 +7,7 @@ toq = torch.ops.quantized
 from torch.fx import GraphModule
 from torch.fx.graph import Graph, Node
 
-from .utils import getattr_from_fqn
+from torch.quantization.utils import getattr_from_fqn
 from .ns_types import NSSubgraph, NSNodeTargetType
 from .mappings import (
     get_base_name_to_sets_of_related_ops,

--- a/torch/quantization/ns/pattern_utils.py
+++ b/torch/quantization/ns/pattern_utils.py
@@ -6,7 +6,7 @@ toq = torch.ops.quantized
 from torch.fx import GraphModule
 from torch.fx.graph import Node
 
-from .utils import getattr_from_fqn
+from torch.quantization.utils import getattr_from_fqn
 from .ns_types import NSNodeTargetType
 from torch.quantization.fx.pattern_utils import get_default_quant_patterns
 from torch.quantization import (

--- a/torch/quantization/utils.py
+++ b/torch/quantization/utils.py
@@ -5,7 +5,7 @@ import warnings
 
 import torch
 from .quant_type import QuantType, quant_type_to_str
-from typing import Tuple
+from typing import Tuple, Any
 
 def get_combined_dict(default_dict, additional_dict):
     d = default_dict.copy()
@@ -20,6 +20,16 @@ def is_per_channel(qscheme):
     return qscheme in [torch.per_channel_affine,
                        torch.per_channel_affine_float_qparams,
                        torch.per_channel_symmetric]
+
+def getattr_from_fqn(gm: Any, fqn: str) -> Any:
+    """
+    Given a gm and a fqn such as "foo.bar.baz", returns gm.foo.bar.baz.
+    """
+    fqn_parts = fqn.split(".")
+    cur_val = gm
+    for part in fqn_parts:
+        cur_val = getattr(cur_val, part)
+    return cur_val
 
 def get_qparam_dict(observer_or_fake_quant):
     qscheme = observer_or_fake_quant.qscheme if hasattr(observer_or_fake_quant, "qscheme") else None


### PR DESCRIPTION
Summary: moving this function because the functionality would be useful outside of ns

Test Plan: buck test //caffe2/test:quantization_fx mode/dev-nosan --keep-going --config client.id=nuclide --show-full-output -- suite

Differential Revision: D30260735

