### PR TITLE
OperatorEntry: Move assertSignatureIsCorrect out of line

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -381,18 +381,19 @@ std::string OperatorEntry::listAllDispatchKeys() const {
   return str.str();
 }
 
-void OperatorEntry::reportSignatureError(std::string name) const {
-  TORCH_CHECK(false,
-        "\nTried to access or call an operator with a wrong signature.\n",
-        "  operator: ", (schema_.has_value() ? toString(schema_->schema) : toString(name_)), "\n",
-        "    ", (schema_.has_value() ? schema_->debug : "unknown debug info"), "\n",
-        "  correct signature:  ", cpp_signature_->signature.name(), "\n",
-        "    ", cpp_signature_->debug, "\n",
-        "  accessed/called as: ", name, "\n",
-        "This likely happened in a call to OperatorHandle::typed<Return (Args...)>(). ",
-        "Please make sure that the function signature matches the signature in the operator registration call."
+void OperatorEntry::assertSignatureIsCorrect(const CppSignature signature) const {
+  TORCH_CHECK(
+      !cpp_signature_.has_value() || (signature == cpp_signature_->signature),
+      "\nTried to access or call an operator with a wrong signature.\n",
+      "  operator: ", (schema_.has_value() ? toString(schema_->schema) : toString(name_)), "\n",
+      "    ", (schema_.has_value() ? schema_->debug : "unknown debug info"), "\n",
+      "  correct signature:  ", cpp_signature_->signature.name(), "\n",
+      "    ", cpp_signature_->debug, "\n",
+      "  accessed/called as: ", signature.name(), "\n",
+      "This likely happened in a call to OperatorHandle::typed<Return (Args...)>(). ",
+      "Please make sure that the function signature matches the signature in the operator registration call."
   );
-};
+}
 
 void OperatorEntry::reportError(DispatchKey dispatchKey) const {
   // If there is an invariant problem, report it now.

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -150,11 +150,11 @@ public:
 
   // Asserts that the given FuncType is correct for calling this operator in an unboxed way.
   template<class FuncType>
-  void assertSignatureIsCorrect() {
-    if (C10_UNLIKELY(cpp_signature_.has_value() && (CppSignature::make<FuncType>() != cpp_signature_->signature))) {
-      reportSignatureError(CppSignature::make<FuncType>().name());
-    }
+  void assertSignatureIsCorrect() const {
+    assertSignatureIsCorrect(CppSignature::make<FuncType>());
   }
+
+  void assertSignatureIsCorrect(const CppSignature signature) const;
 
   [[noreturn]] void reportError(DispatchKey dispatchKey) const;
 
@@ -236,7 +236,6 @@ private:
   // Whether this operator needs to be observed with RecordFunction
   const bool is_observed_;
 
-  [[noreturn]] void reportSignatureError(std::string name) const;
   const KernelFunction& computeDispatchTableEntry(const c10::Dispatcher& dispatcher, DispatchKey dispatch_key) const;
   std::pair<const AnnotatedKernel&, const char*> computeDispatchTableEntryWithDebug(
     const c10::Dispatcher& dispatcher, DispatchKey dispatch_key

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -261,13 +261,6 @@ struct TORCH_API {name} {{
 STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA({name}, name, "aten::{f.func.name.name}")
 STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA({name}, overload_name, "{f.func.name.overload_name}")
 STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA({name}, schema_str, {cpp_string(str(f.func))})
-
-// aten::{f.func}
-static C10_NOINLINE c10::TypedOperatorHandle<{name}::schema> create_{name}_typed_handle() {{
-  return c10::Dispatcher::singleton()
-      .findSchemaOrThrow({name}::name, {name}::overload_name)
-      .typed<{name}::schema>();
-}}
 """
 
             for is_redispatching_fn in [False, True]:
@@ -283,7 +276,9 @@ static C10_NOINLINE c10::TypedOperatorHandle<{name}::schema> create_{name}_typed
                 defns += f"""
 // aten::{f.func}
 {sig.defn(name=method_name, is_redispatching_fn=is_redispatching_fn)} {{
-    static auto op = create_{name}_typed_handle();
+    static auto op = c10::Dispatcher::singleton()
+        .findSchemaOrThrow({name}::name, {name}::overload_name)
+        .typed<{name}::schema>();
     return op.{dispatcher_call}({dispatcher_exprs_str});
 }}
 """


### PR DESCRIPTION
This resolves the code bloat issue in #63118

When this function is fully inlined it expands to a fair bit of code, primarily because it calls
`c10::demangle` three times and has lots of exception handling for string allocation failures.
Why three? Well it turns out comparing `CppSignature` compares `.name()` as a fallback if the
type-ids don't match. That means the `!=` really needs to be outlined as well for best code size.

I found this function wasn't being inlined in #63118 anyway, so this shouldn't be a performance
regression. This also takes the binary size down further than before #62185,
`assertSignatureIsCorrect` no longer gets instantiated for every unique signature type.
