### PR TITLE
preserve memory format in `cudnn_convolution_add_relu_out`

### DIFF
--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -564,7 +564,7 @@ Tensor cudnn_convolution_add_relu(
       /*layout=*/c10::nullopt,
       /*device=*/kCUDA,
       /*pin_memory=*/c10::nullopt,
-      /*memory_format=*/at::MemoryFormat::Contiguous);
+      /*memory_format=*/input_t.suggest_memory_format());
   if (output_t.numel() == 0) {
     return output_t;
   }


### PR DESCRIPTION
Basically identical to #62482, just for the "add" variant. CC @cpuhrsch 

Will add a test case (e.g., a channels-last conv2d provided by @cpuhrsch once it is fully unbroken).