### PR TITLE
sync c10d NCCL version parsing with formatting

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -20,19 +20,18 @@ std::string getNcclVersion() {
     } else {
       // this condition is meant to mirror what is done in upstream NCCL
       // e.g., 2.8.0 -> 2800, 2.9.0 -> 20900
+      int ncclMajor, ncclMinor, ncclPatch;
       if (version >= 2900) {
-        auto ncclMajor = version / 10000;
-        auto ncclMinor = (version % 10000) / 100;
-        auto ncclPatch = version % (ncclMajor * 10000 + ncclMinor * 100);
-        versionString = std::to_string(ncclMajor) + "." +
-          std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
+        ncclMajor = version / 10000;
+        ncclMinor = (version % 10000) / 100;
+        ncclPatch = version % (ncclMajor * 10000 + ncclMinor * 100);
       } else {
-        auto ncclMajor = version / 1000;
-        auto ncclMinor = (version % 1000) / 100;
-        auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
-        versionString = std::to_string(ncclMajor) + "." +
-          std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
+        ncclMajor = version / 1000;
+        ncclMinor = (version % 1000) / 100;
+        ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
       }
+      versionString = std::to_string(ncclMajor) + "." +
+        std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
     }
   });
 

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -21,9 +21,9 @@ std::string getNcclVersion() {
       // this condition is meant to mirror what is done in upstream NCCL
       // e.g., 2.8.0 -> 2800, 2.9.0 -> 20900
       if (version >= 2900) {
-        ncclMajor = version / 10000;
-        ncclMinor = (version % 10000) / 100;
-        ncclPatch = version % (ncclMajor * 10000 + ncclMinor * 100);
+        auto ncclMajor = version / 10000;
+        auto ncclMinor = (version % 10000) / 100;
+        auto ncclPatch = version % (ncclMajor * 10000 + ncclMinor * 100);
         versionString = std::to_string(ncclMajor) + "." +
           std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
       } else {

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -21,6 +21,15 @@ std::string getNcclVersion() {
       auto ncclMajor = version / 1000;
       auto ncclMinor = (version % 1000) / 100;
       auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
+      // this condition is meant to mirror what is done in upstream NCCL
+      // e.g., 2.8.0 -> 2800, 2.9.0 -> 20900
+      // note that ncclMajor isn't expected to be 3 with the new format,
+      // but will be 30 until it is parsed correctly; 3 is used for clarity
+      if (ncclMajor >= 3 || (ncclMajor >= 2 && ncclMinor >= 9)) {
+        ncclMajor = version / 10000;
+        ncclMinor = (version % 10000) / 100;
+        ncclPatch = version % (ncclMajor * 10000 + ncclMinor * 100);
+      }
       versionString = std::to_string(ncclMajor) + "." +
           std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
     }

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -19,7 +19,7 @@ std::string getNcclVersion() {
       versionString = "Unknown NCCL version";
     } else {
       // this condition is meant to mirror what is done in upstream NCCL
-      // e.g., 2.8.0 -> 2800, 2.9.0 -> 20900
+      // e.g., 2.8.99 -> 2899, 2.9.0 -> 20900
       int ncclMajor, ncclMinor, ncclPatch;
       if (version >= 2900) {
         ncclMajor = version / 10000;

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -18,20 +18,21 @@ std::string getNcclVersion() {
     if (status != ncclSuccess || version < 100) {
       versionString = "Unknown NCCL version";
     } else {
-      auto ncclMajor = version / 1000;
-      auto ncclMinor = (version % 1000) / 100;
-      auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
       // this condition is meant to mirror what is done in upstream NCCL
       // e.g., 2.8.0 -> 2800, 2.9.0 -> 20900
-      // note that ncclMajor isn't expected to be 3 with the new format,
-      // but will be 30 until it is parsed correctly; 3 is used for clarity
-      if (ncclMajor >= 3 || (ncclMajor >= 2 && ncclMinor >= 9)) {
+      if (version >= 2900) {
         ncclMajor = version / 10000;
         ncclMinor = (version % 10000) / 100;
         ncclPatch = version % (ncclMajor * 10000 + ncclMinor * 100);
-      }
-      versionString = std::to_string(ncclMajor) + "." +
+        versionString = std::to_string(ncclMajor) + "." +
           std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
+      } else {
+        auto ncclMajor = version / 1000;
+        auto ncclMinor = (version % 1000) / 100;
+        auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
+        versionString = std::to_string(ncclMajor) + "." +
+          std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
+      }
     }
   });
 


### PR DESCRIPTION
related to #62295
NCCL broke compatibility with previous version format reporting in 2.9.x, and as we use the NCCL function here rather than the compile-time macros (as related to #62916), this function needs to match the new version format:
https://github.com/NVIDIA/nccl/blob/7e515921295adaab72adf56ea71a0fafb0ecb5f3/src/nccl.h.in#L22

Note that the new format doesn't actually support major versions >= 3 in upstream, but we anticipate that this format change will also be applied to those versions and account for that in this PR.

CC @ptrblck

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang