### PR TITLE
[pruner] refactor `ActivationReconstruction` forward hooks

### DIFF
--- a/torch/ao/sparsity/__init__.py
+++ b/torch/ao/sparsity/__init__.py
@@ -17,8 +17,7 @@ from .sparsifier.utils import FakeSparsity
 
 # Parametrizations
 from .experimental.pruner.parametrization import PruningParametrization
-from .experimental.pruner.parametrization import LinearActivationReconstruction
-from .experimental.pruner.parametrization import Conv2dActivationReconstruction
+from .experimental.pruner.parametrization import ActivationReconstruction
 
 # Pruner
 from .experimental.pruner.base_pruner import BasePruner

--- a/torch/ao/sparsity/experimental/pruner/base_pruner.py
+++ b/torch/ao/sparsity/experimental/pruner/base_pruner.py
@@ -8,7 +8,7 @@ from torch.nn.utils import parametrize
 
 from torch.nn.modules.container import ModuleDict, ModuleList
 
-from .parametrization import PruningParametrization, LinearActivationReconstruction, Conv2dActivationReconstruction
+from .parametrization import PruningParametrization, ActivationReconstruction
 
 SUPPORTED_MODULES = {
     nn.Linear,
@@ -140,13 +140,9 @@ class BasePruner(abc.ABC):
 
             assert isinstance(module.parametrizations, ModuleDict)  # make mypy happy
             assert isinstance(module.parametrizations.weight, ModuleList)
-            if isinstance(module, nn.Linear):
+            if isinstance(module, tuple(SUPPORTED_MODULES)):
                 self.activation_handles.append(module.register_forward_hook(
-                    LinearActivationReconstruction(module.parametrizations.weight[0])
-                ))
-            elif isinstance(module, nn.Conv2d):
-                self.activation_handles.append(module.register_forward_hook(
-                    Conv2dActivationReconstruction(module.parametrizations.weight[0])
+                    ActivationReconstruction(module.parametrizations.weight[0])
                 ))
             else:
                 raise NotImplementedError("This module type is not supported yet.")

--- a/torch/ao/sparsity/experimental/pruner/parametrization.py
+++ b/torch/ao/sparsity/experimental/pruner/parametrization.py
@@ -13,27 +13,25 @@ class PruningParametrization(nn.Module):
         return x[list(valid_outputs)]
 
 
-class LinearActivationReconstruction:
+class ActivationReconstruction:
     def __init__(self, parametrization):
         self.param = parametrization
 
     def __call__(self, module, input, output):
         max_outputs = self.param.original_outputs
         pruned_outputs = self.param.pruned_outputs
-        reconstructed_tensor = torch.zeros((output.shape[0], len(max_outputs)))
         valid_columns = list(max_outputs - pruned_outputs)
-        reconstructed_tensor[:, valid_columns] = output
-        return reconstructed_tensor
 
+        # get size of reconstructed output
+        sizes = list(output.shape)
+        sizes[1] = len(max_outputs)
 
-class Conv2dActivationReconstruction:
-    def __init__(self, parametrization):
-        self.param = parametrization
+        # get valid indices of reconstructed output
+        indices = []
+        for size in output.shape:
+            indices.append(slice(0, size, 1))
+        indices[1] = valid_columns
 
-    def __call__(self, module, input, output):
-        max_outputs = self.param.original_outputs
-        pruned_outputs = self.param.pruned_outputs
-        reconstructed_tensor = torch.zeros((output.shape[0], len(max_outputs), output.shape[2], output.shape[3]))
-        valid_columns = list(max_outputs - pruned_outputs)
-        reconstructed_tensor[:, valid_columns, :, :] = output
+        reconstructed_tensor = torch.zeros(sizes)
+        reconstructed_tensor[indices] = output
         return reconstructed_tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Combined functionality for `ActivationReconstruction` for both Linear and Conv2d in one class. The only difference between the old classes was the size and indexing of the reconstructed tensor -- that logic can be generalized by iterating over the size of `output`.

Differential Revision: [D30282765](https://our.internmc.facebook.com/intern/diff/D30282765/)