### PR TITLE
[docs] Remove `input` parameter from `Tensor.flatten` docs

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1513,9 +1513,9 @@ See :func:`torch.frexp`
 
 add_docstr_all('flatten',
                r"""
-flatten(input, start_dim=0, end_dim=-1) -> Tensor
+flatten(start_dim=0, end_dim=-1) -> Tensor
 
-see :func:`torch.flatten`
+See :func:`torch.flatten`
 """)
 
 add_docstr_all('gather',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63180

**Summary**
This commit removes the `input` parameter from the signature for
`Tensor.flatten` shown in its documentation. This parameter is accepted
by `torch.flatten` but not `Tensor.flatten` (since the input is the
`Tensor` on which `flatten` is invoked).

**Test Plan**
Continuous integration.

**Fixes**
This commit fixes #57478.

Differential Revision: [D30293156](https://our.internmc.facebook.com/intern/diff/D30293156)