### PR TITLE
Replace str by repr for DataChunk

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -73,7 +73,7 @@ except ImportError:
     HAS_DILL = False
 skipIfNoDill = skipIf(not HAS_DILL, "no dill")
 
-T_co = TypeVar('T_co', covariant=True)
+T_co = TypeVar("T_co", covariant=True)
 
 
 def create_temp_dir_and_files():
@@ -110,10 +110,9 @@ def create_temp_dir_and_files():
 
 
 class TestDataChunk(TestCase):
-
     def test_as_string(self):
         elements = list(range(10))
-        chunk : DataChunk[int] = DataChunk(elements)
+        chunk: DataChunk[int] = DataChunk(elements)
         self.assertEqual(str(chunk), str(elements))
 
         batch = [elements] * 3
@@ -122,7 +121,6 @@ class TestDataChunk(TestCase):
 
 
 class TestIterableDataPipeBasic(TestCase):
-
     def setUp(self):
         ret = create_temp_dir_and_files()
         self.temp_dir = ret[0][0]

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -114,7 +114,11 @@ class TestDataChunk(TestCase):
     def test_as_string(self):
         elements = list(range(10))
         chunk : DataChunk[int] = DataChunk(elements)
-        self.assertEquals(str(chunk), str(elements))
+        self.assertEqual(str(chunk), str(elements))
+
+        batch = [elements] * 3
+        chunks: List[DataChunk] = [DataChunk(elements)] * 3
+        self.assertEqual(str(chunk), str(elements))
 
 
 class TestIterableDataPipeBasic(TestCase):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -39,7 +39,7 @@ class DataChunk(List[T]):
         res = indent + "[" + ", ".join([str(i) for i in iter(self)]) + "]"
         return res
 
-    def __str__(self):
+    def __repr__(self):
         return self.as_str()
 
     def __iter__(self) -> Iterator[T]:


### PR DESCRIPTION
Fixes #63173

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63185 Refactor BucketBatch
* **#63184 Replace str by repr for DataChunk**

- str will call default __repr__
- Nested data structure needs to be handled by __repr__

Differential Revision: [D30288892](https://our.internmc.facebook.com/intern/diff/D30288892)