### PR TITLE
[docs] Mention `vsplit`, `hsplit` and `tensor_split` in Tensor views doc

### DIFF
--- a/docs/source/tensor_view.rst
+++ b/docs/source/tensor_view.rst
@@ -71,6 +71,9 @@ For reference, here’s a full list of view ops in PyTorch:
 - :meth:`~torch.Tensor.view_as`
 - :meth:`~torch.Tensor.unbind`
 - :meth:`~torch.Tensor.split`
+- :meth:`~torch.Tensor.hsplit`
+- :meth:`~torch.Tensor.vsplit`
+- :meth:`~torch.Tensor.tensor_split`
 - :meth:`~torch.Tensor.split_with_sizes`
 - :meth:`~torch.Tensor.swapaxes`
 - :meth:`~torch.Tensor.swapdims`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63191

**Summary**
This commit adds `vsplit`, `hsplit` and `tensor_split` to the list of
view ops on the Tensor Views documentation page.

**Test Plan**
Continuous integration.

*Before*
<img width="195" alt="Captura de Pantalla 2021-08-12 a la(s) 2 55 07 p  m" src="https://user-images.githubusercontent.com/4392003/129275921-c1cfdf6c-9f1f-45f3-98b6-1de7a0f0cc84.png">

*After*
<img width="197" alt="Captura de Pantalla 2021-08-12 a la(s) 2 55 15 p  m" src="https://user-images.githubusercontent.com/4392003/129275936-de4afde7-0143-4e1d-b38f-c86256f4896c.png">

**Fixes**
This commit fixes #62727.

Differential Revision: [D30293181](https://our.internmc.facebook.com/intern/diff/D30293181)