### PR TITLE
[torch] Set default log level for torch elastic

### DIFF
--- a/torch/distributed/elastic/utils/log_level.py
+++ b/torch/distributed/elastic/utils/log_level.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def get_log_level() -> str:
+    """
+    Return default log level for pytorch.
+    """
+    return "WARNING"

--- a/torch/distributed/elastic/utils/logging.py
+++ b/torch/distributed/elastic/utils/logging.py
@@ -12,6 +12,8 @@ import os
 import warnings
 from typing import Optional
 
+from torch.distributed.elastic.utils.log_level import get_log_level
+
 
 def get_logger(name: Optional[str] = None):
     """
@@ -32,7 +34,7 @@ def get_logger(name: Optional[str] = None):
 
 def _setup_logger(name: Optional[str] = None):
     log = logging.getLogger(name)
-    log.setLevel(os.environ.get("LOGLEVEL", "WARNING"))
+    log.setLevel(os.environ.get("LOGLEVEL", get_log_level()))
     return log
 
 


### PR DESCRIPTION
Summary: The default log level in fb and oss is different: in oss we use WARNING and in fb we use INFO.

Test Plan: unittests, f291441502

Differential Revision: D30296298

