### PR TITLE
[docs][ao] Add missing documentation for torch.quantized_batch_norm

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -352,6 +352,7 @@ Pointwise Ops
     polygamma
     positive
     pow
+    quantized_batch_norm
     rad2deg
     real
     reciprocal

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11250,6 +11250,7 @@ Returns:
 
 Example::
 
+    >>> qx = torch.quantize_per_tensor(torch.rand(2, 2, 2, 2), 1.5, 3, torch.quint8)
     >>> torch.quantized_batch_norm(qx, torch.ones(2), torch.zeros(2), torch.rand(2), torch.rand(2), 0.00001, 0.2, 2)
     tensor([[[[-0.2000, -0.2000],
           [ 1.6000, -0.2000]],

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11237,10 +11237,10 @@ Applies batch normalization on a 4D (NCHW) quantized tensor.
 
 Arguments:
     input (Tensor): quantized tensor
-    weight (Tensor): tensor that corresponds to the gamma, size C
-    bias (Tensor):  tensor that corresponds to the beta, size C
-    mean (Tensor): mean value in batch normalization, size C
-    var (Tensor): variance value, size C
+    weight (Tensor): float tensor that corresponds to the gamma, size C
+    bias (Tensor):  float tensor that corresponds to the beta, size C
+    mean (Tensor): float mean value in batch normalization, size C
+    var (Tensor): float tensor for variance, size C
     eps (float): a value added to the denominator for numerical stability.
     output_scale (float): output quantized tensor scale
     output_zero_point (int): output quantized tensor zero_point

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11224,6 +11224,49 @@ Example::
             [100, 200]], dtype=torch.uint8)
 """)
 
+
+add_docstr(torch.quantized_batch_norm,
+           r"""
+quantized_batch_norm(input, weight=None, bias=None, mean, var, eps, output_scale, output_zero_point) -> Tensor
+
+Applies batch normalization on a 4D (NCHW) quantized tensor.
+
+.. math::
+
+        y = \frac{x - \mathrm{E}[x]}{\sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+Arguments:
+    input (Tensor): quantized tensor
+    weight (Tensor): tensor that corresponds to the gamma, size C
+    bias (Tensor):  tensor that corresponds to the beta, size C
+    mean (Tensor): mean value in batch normalization, size C
+    var (Tensor): variance value, size C
+    eps (float): a value added to the denominator for numerical stability.
+    output_scale (float): output quantized tensor scale
+    output_zero_point (int): output quantized tensor zero_point
+
+Returns:
+    Tensor: A quantized tensor with batch normalization applied.
+
+Example::
+
+    >>> torch.quantized_batch_norm(qx, torch.ones(2), torch.zeros(2), torch.rand(2), torch.rand(2), 0.00001, 0.2, 2)
+    tensor([[[[-0.2000, -0.2000],
+          [ 1.6000, -0.2000]],
+
+         [[-0.4000, -0.4000],
+          [-0.4000,  0.6000]]],
+
+
+        [[[-0.2000, -0.2000],
+          [-0.2000, -0.2000]],
+
+         [[ 0.6000, -0.4000],
+          [ 0.6000, -0.4000]]]], size=(2, 2, 2, 2), dtype=torch.quint8,
+       quantization_scheme=torch.per_tensor_affine, scale=0.2, zero_point=2)
+""")
+
+
 add_docstr(torch.Generator,
            r"""
 Generator(device='cpu') -> Generator


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63263
* #63258
* #63242
* __->__ #63240

Summary:
Op is exposed via torch.quantized_batch_norm to the end user without any existing documentation

Test Plan:
CI
Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D30316431](https://our.internmc.facebook.com/intern/diff/D30316431)