### PR TITLE
Change internal rep of methods from vector to map for faster lookup

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1913,7 +1913,7 @@ struct TORCH_API ClassType : public NamedType {
     return ss.str();
   }
 
-  const std::vector<torch::jit::Function*>& methods() const;
+  const std::vector<torch::jit::Function*> methods() const;
 
   TypePtr findAttribute(const std::string& name) const {
     size_t pos = 0;
@@ -2246,7 +2246,7 @@ struct TORCH_API ClassType : public NamedType {
   std::vector<TypePtr> attributeTypes_;
 
   // List of methods associated with this class.
-  std::vector<torch::jit::Function*> methods_;
+  std::unordered_map<std::string, torch::jit::Function*> methods_;
   std::vector<torch::jit::Function*> staticmethods_;
 
   // List of hooks to be run before/after forward.

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1422,7 +1422,13 @@ struct PythonPrintImpl {
       }
 
       // TODO fields
-      for (auto& method : classType->methods()) {
+      auto methods = classType->methods();
+      // sort to make sure the order is preserved
+      std::sort(
+          methods.begin(), methods.end(), [](const auto& lhs, const auto& rhs) {
+            return lhs->name() < rhs->name();
+          });
+      for (auto& method : methods) {
         printFunction(*method);
       }
       std::set<std::string> already_printed;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63284

Summary: Classtype internally stores methods as vector which is inefficient when we try to add/remove method. This is now changed to map so that add/remove can be done in O(1). 

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: