### PR TITLE
Add low level torch.profiler.kineto_profile base class

### DIFF
--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -11,6 +11,9 @@ Overview
 API Reference
 -------------
 
+.. autoclass:: torch.profiler.profiler
+  :members:
+
 .. autoclass:: torch.profiler.profile
   :members:
 

--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -11,7 +11,7 @@ Overview
 API Reference
 -------------
 
-.. autoclass:: torch.profiler.kineto_profiler
+.. autoclass:: torch.profiler.kineto_profile
   :members:
 
 .. autoclass:: torch.profiler.profile

--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -11,7 +11,7 @@ Overview
 API Reference
 -------------
 
-.. autoclass:: torch.profiler.profiler
+.. autoclass:: torch.profiler.kineto_profiler
   :members:
 
 .. autoclass:: torch.profiler.profile

--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -11,7 +11,7 @@ Overview
 API Reference
 -------------
 
-.. autoclass:: torch.profiler.kineto_profile
+.. autoclass:: torch.profiler._KinetoProfile
   :members:
 
 .. autoclass:: torch.profiler.profile

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -178,16 +178,13 @@ class profile(object):
             self.with_modules)
 
     def __enter__(self):
-        self.start()
-        return self
-
-    def start(self):
         if not self.enabled:
             return
         if self.entered:
             raise RuntimeError("Profiler context manager is not reentrant")
         self._prepare_trace()
         self._start_trace()
+        return self
 
     def _prepare_trace(self):
         self.entered = True
@@ -198,10 +195,6 @@ class profile(object):
         _enable_profiler(self.config(), self.kineto_activities)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.stop()
-        return False
-
-    def stop(self):
         if not self.enabled:
             return
         if self.use_cuda:
@@ -214,6 +207,7 @@ class profile(object):
             profile_memory=self.profile_memory,
             with_flops=self.with_flops)
         self.function_events._build_tree()
+        return False
 
     def __repr__(self):
         if self.function_events is None:

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -178,13 +178,16 @@ class profile(object):
             self.with_modules)
 
     def __enter__(self):
+        self.start()
+        return self
+
+    def start(self):
         if not self.enabled:
             return
         if self.entered:
             raise RuntimeError("Profiler context manager is not reentrant")
         self._prepare_trace()
         self._start_trace()
-        return self
 
     def _prepare_trace(self):
         self.entered = True
@@ -195,6 +198,10 @@ class profile(object):
         _enable_profiler(self.config(), self.kineto_activities)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        return False
+
+    def stop(self):
         if not self.enabled:
             return
         if self.use_cuda:
@@ -207,7 +214,6 @@ class profile(object):
             profile_memory=self.profile_memory,
             with_flops=self.with_flops)
         self.function_events._build_tree()
-        return False
 
     def __repr__(self):
         if self.function_events is None:

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -8,7 +8,7 @@ examine their input shapes and stack traces, study device kernel activity and vi
 
 '''
 
-from .profiler import profile, kineto_profile, \
+from .profiler import profile, _KinetoProfile, \
     schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
 from torch.autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -8,6 +8,7 @@ examine their input shapes and stack traces, study device kernel activity and vi
 
 '''
 
-from .profiler import profile, kineto_profiler, schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
+from .profiler import profile, kineto_profiler, \
+    schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
 from torch.autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -8,6 +8,6 @@ examine their input shapes and stack traces, study device kernel activity and vi
 
 '''
 
-from .profiler import profile, schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
+from .profiler import profile, profiler, schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
 from torch.autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -8,7 +8,7 @@ examine their input shapes and stack traces, study device kernel activity and vi
 
 '''
 
-from .profiler import profile, kineto_profiler, \
+from .profiler import profile, kineto_profile, \
     schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
 from torch.autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -8,6 +8,6 @@ examine their input shapes and stack traces, study device kernel activity and vi
 
 '''
 
-from .profiler import profile, profiler, schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
+from .profiler import profile, kineto_profiler, schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
 from torch.autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -70,7 +70,6 @@ class kineto_profiler(object):
         self.with_stack = with_stack
         self.with_modules = with_modules
         self.profiler: Optional[prof.profile] = None
-        self.step_rec_fn: Optional[prof.record_function] = None
 
     def prepare_trace(self):
         self.profiler = prof.profile(
@@ -424,7 +423,11 @@ class profile(kineto_profiler):
             (ProfilerAction.RECORD, ProfilerAction.RECORD_AND_SAVE): [],
             (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.NONE): [self.stop_trace, self._trace_ready],
             (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.WARMUP): [self.stop_trace, self._trace_ready, self.prepare_trace],
-            (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.RECORD): [],
+            (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.RECORD): [
+                self.stop_trace,
+                self._trace_ready,
+                self.prepare_trace,
+                self.start_trace],
             (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.RECORD_AND_SAVE): [
                 self.stop_trace,
                 self._trace_ready,

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -44,7 +44,8 @@ class profiler(object):
             Note that this support exist, at the moment, only for TorchScript models
             and not eager mode models.
     """
-    def __init__(self,
+    def __init__(
+            self,
             *,
             activities: Optional[Iterable[ProfilerActivity]] = None,
             record_shapes: bool = False,

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -43,6 +43,12 @@ class profiler(object):
             then aten::add's module hierarchy is A.B
             Note that this support exist, at the moment, only for TorchScript models
             and not eager mode models.
+
+    .. note::
+        Enabling shape and stack tracing results in additional overhead.
+        When record_shapes=True is specified, profiler will temporarily hold references to the tensors;
+        that may further prevent certain optimizations that depend on the reference count and introduce
+        extra tensor copies.
     """
     def __init__(
             self,
@@ -210,7 +216,6 @@ def schedule(*, wait: int, warmup: int, active: int, repeat: int = 0, skip_first
     if warmup == 0:
         warn("Profiler won't be using warmup, this can skew profiler results")
     return schedule_fn
-
 
 def _default_schedule_fn(_: int) -> ProfilerAction:
     """

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -401,7 +401,7 @@ class profile(profiler):
         self.current_action = self.schedule(self.step_num)
         self.step_rec_fn: Optional[prof.record_function] = None
 
-        self.action_map:Dict[Tuple[ProfilerAction, Optional[ProfilerAction]], List[Any]] = {
+        self.action_map: Dict[Tuple[ProfilerAction, Optional[ProfilerAction]], List[Any]] = {
             # key is (prev_action, current_action), value is action list corresponding to the state pair.
             (ProfilerAction.NONE, ProfilerAction.NONE): [],
             (ProfilerAction.NONE, ProfilerAction.WARMUP): [self.prepare_trace],
@@ -415,7 +415,7 @@ class profile(profiler):
             (ProfilerAction.WARMUP, ProfilerAction.RECORD): [self.start_trace],
             (ProfilerAction.WARMUP, ProfilerAction.RECORD_AND_SAVE): [self.start_trace],
             (ProfilerAction.RECORD, ProfilerAction.NONE): [
-                partial(warn,"Incorrect schedule: RECORD followed by NONE"),
+                partial(warn, "Incorrect schedule: RECORD followed by NONE"),
                 self.stop_trace],
             (ProfilerAction.RECORD, ProfilerAction.WARMUP): [
                 partial(warn, "Incorrect schedule: RECORD followed by WARMUP"),

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -9,172 +9,9 @@ from warnings import warn
 
 import torch
 import torch.autograd.profiler as prof
+from torch.autograd.profiler import profile as kineto_profile
 from torch.autograd import kineto_available, ProfilerActivity
 
-
-def supported_activities():
-    """
-    Returns a set of supported profiler tracing activities.
-
-    Note: profiler uses CUPTI library to trace on-device CUDA kernels.
-    In case when CUDA is enabled but CUPTI is not available, passing
-    ``ProfilerActivity.CUDA`` to profiler results in using the legacy CUDA
-    profiling code (same as in the legacy ``torch.autograd.profiler``).
-    This, in turn, results in including CUDA time in the profiler table output,
-    but not in the JSON trace.
-    """
-    return torch.autograd._supported_activities()
-
-
-class kineto_profiler(object):
-    """Low-level profiler wrap the autograd profile
-
-    Args:
-        activities (iterable): list of activity groups (CPU, CUDA) to use in profiling, supported values:
-            ``torch.profiler.ProfilerActivity.CPU``, ``torch.profiler.ProfilerActivity.CUDA``.
-            Default value: ProfilerActivity.CPU and (when available) ProfilerActivity.CUDA.
-        record_shapes (bool): save information about operator's input shapes.
-        profile_memory (bool): track tensor memory allocation/deallocation.
-        with_stack (bool): record source information (file and line number) for the ops.
-        with_flops (bool): use formula to estimate the FLOPS of specific operators
-            (matrix multiplication and 2D convolution).
-        with_modules (bool): record module hierarchy (including function names)
-            corresponding to the callstack of the op. e.g. If module A's forward call's
-            module B's forward which contains an aten::add op,
-            then aten::add's module hierarchy is A.B
-            Note that this support exist, at the moment, only for TorchScript models
-            and not eager mode models.
-
-    .. note::
-        Enabling shape and stack tracing results in additional overhead.
-        When record_shapes=True is specified, profiler will temporarily hold references to the tensors;
-        that may further prevent certain optimizations that depend on the reference count and introduce
-        extra tensor copies.
-    """
-    def __init__(
-            self,
-            *,
-            activities: Optional[Iterable[ProfilerActivity]] = None,
-            record_shapes: bool = False,
-            profile_memory: bool = False,
-            with_stack: bool = False,
-            with_flops: bool = False,
-            with_modules: bool = False):
-        if activities:
-            self.activities = set(activities)
-        else:
-            self.activities = supported_activities()
-        self.record_shapes = record_shapes
-        self.with_flops = with_flops
-        self.profile_memory = profile_memory
-        self.with_stack = with_stack
-        self.with_modules = with_modules
-        self.profiler: Optional[prof.profile] = None
-
-    def prepare_trace(self):
-        self.profiler = prof.profile(
-            use_cuda=(ProfilerActivity.CUDA in self.activities),
-            use_cpu=(ProfilerActivity.CPU in self.activities),
-            record_shapes=self.record_shapes,
-            with_flops=self.with_flops,
-            profile_memory=self.profile_memory,
-            with_stack=self.with_stack,
-            with_modules=self.with_modules,
-            use_kineto=True,
-        )
-        self.profiler._prepare_trace()
-
-    def start_trace(self):
-        assert self.profiler is not None
-        self.profiler._start_trace()
-
-        if kineto_available():
-            dist_info = self._get_distributed_info()
-            if dist_info:
-                self.add_metadata_json("distributedInfo", json.dumps(dist_info))
-
-    def stop_trace(self):
-        assert self.profiler is not None
-        self.profiler.__exit__(None, None, None)
-
-    def export_chrome_trace(self, path: str):
-        """
-        Exports the collected trace in Chrome JSON format.
-        """
-        assert self.profiler
-        if path.endswith('.gz'):
-            fp = tempfile.NamedTemporaryFile('w+t', suffix='.json', delete=False)
-            fp.close()
-            retvalue = self.profiler.export_chrome_trace(fp.name)
-            with open(fp.name) as fin:
-                with gzip.open(path, 'wt') as fout:
-                    fout.writelines(fin)
-            os.remove(fp.name)
-            return retvalue
-        else:
-            return self.profiler.export_chrome_trace(path)
-
-    def export_stacks(self, path: str, metric: str = "self_cpu_time_total"):
-        """Save stack traces in a file in a format suitable for visualization.
-
-        Args:
-            path (str): save stacks file to this location;
-            metric (str): metric to use: "self_cpu_time_total" or "self_cuda_time_total"
-
-        .. note::
-            Example of using FlameGraph tool:
-
-            - git clone https://github.com/brendangregg/FlameGraph
-            - cd FlameGraph
-            - ./flamegraph.pl --title "CPU time" --countname "us." profiler.stacks > perf_viz.svg
-        """
-        assert self.profiler
-        return self.profiler.export_stacks(path, metric)
-
-    def key_averages(self, group_by_input_shape: bool = False, group_by_stack_n: int = 0):
-        """Averages events, grouping them by operator name and (optionally) input shapes and
-        stack.
-
-        .. note::
-            To use shape/stack functionality make sure to set record_shapes/with_stack
-            when creating profiler context manager.
-        """
-        assert self.profiler
-        return self.profiler.key_averages(group_by_input_shape, group_by_stack_n)
-
-    def events(self):
-        """
-        Returns the list of unaggregated profiler events,
-        to be used in the trace callback or after the profiling is finished
-        """
-        assert self.profiler
-        return self.profiler.function_events
-
-    def add_metadata(self, key: str, value: str):
-        """
-        Adds a user defined metadata with a string key and a string value
-        into the trace file
-        """
-        wrapped_value = "\"" + value.replace('"', '\\"') + "\""
-        torch.autograd._add_metadata_json(key, wrapped_value)
-
-    def add_metadata_json(self, key: str, value: str):
-        """
-        Adds a user defined metadata with a string key and a valid json value
-        into the trace file
-        """
-        torch.autograd._add_metadata_json(key, value)
-
-    def _get_distributed_info(self):
-        import torch.distributed as dist
-        if not dist.is_available() or not dist.is_initialized():
-            return None
-
-        return {
-            "backend": dist.get_backend(),
-            "rank": dist.get_rank(),
-            "world_size": dist.get_world_size()
-        }
 
 class ProfilerAction(Enum):
     """
@@ -217,6 +54,7 @@ def schedule(*, wait: int, warmup: int, active: int, repeat: int = 0, skip_first
         warn("Profiler won't be using warmup, this can skew profiler results")
     return schedule_fn
 
+
 def _default_schedule_fn(_: int) -> ProfilerAction:
     """
     Default profiler behavior - immediately starts recording the events,
@@ -250,8 +88,21 @@ def tensorboard_trace_handler(dir_name: str, worker_name: Optional[str] = None, 
         prof.export_chrome_trace(os.path.join(dir_name, file_name))
     return handler_fn
 
+def supported_activities():
+    """
+    Returns a set of supported profiler tracing activities.
 
-class profile(kineto_profiler):
+    Note: profiler uses CUPTI library to trace on-device CUDA kernels.
+    In case when CUDA is enabled but CUPTI is not available, passing
+    ``ProfilerActivity.CUDA`` to profiler results in using the legacy CUDA
+    profiling code (same as in the legacy ``torch.autograd.profiler``).
+    This, in turn, results in including CUDA time in the profiler table output,
+    but not in the JSON trace.
+    """
+    return torch.autograd._supported_activities()
+
+
+class profile(kineto_profile):
     """Profiler context manager.
 
     Args:
@@ -370,23 +221,31 @@ class profile(kineto_profiler):
             with_modules: bool = False,
             # deprecated:
             use_cuda: Optional[bool] = None):
-        super().__init__(
-            activities=activities,
-            record_shapes=record_shapes,
-            profile_memory=profile_memory,
-            with_stack=with_stack,
-            with_flops=with_flops,
-            with_modules=with_modules
-        )
+
+        if activities:
+            activities = set(activities)
+        else:
+            activities = supported_activities()
 
         if use_cuda is not None:
             warn("use_cuda is deprecated, use activities argument instead")
             if use_cuda:
-                self.activities.add(ProfilerActivity.CUDA)
+                activities.add(ProfilerActivity.CUDA)
             elif ProfilerActivity.CUDA in self.activities:
-                self.activities.remove(ProfilerActivity.CUDA)
+                activities.remove(ProfilerActivity.CUDA)
 
-        assert len(self.activities) > 0, "No valid profiler activities found"
+        assert len(activities) > 0, "No valid profiler activities found"
+
+        super().__init__(
+            use_cuda=(ProfilerActivity.CUDA in activities),
+            use_cpu=(ProfilerActivity.CPU in activities),
+            record_shapes=record_shapes,
+            with_flops=with_flops,
+            profile_memory=profile_memory,
+            with_stack=with_stack,
+            with_modules=with_modules,
+            use_kineto=True
+        )
 
         if schedule:
             self.schedule = schedule
@@ -403,40 +262,40 @@ class profile(kineto_profiler):
         self.action_map: Dict[Tuple[ProfilerAction, Optional[ProfilerAction]], List[Any]] = {
             # key is (prev_action, current_action), value is action list corresponding to the state pair.
             (ProfilerAction.NONE, ProfilerAction.NONE): [],
-            (ProfilerAction.NONE, ProfilerAction.WARMUP): [self.prepare_trace],
-            (ProfilerAction.NONE, ProfilerAction.RECORD): [self.prepare_trace, self.start_trace],
-            (ProfilerAction.NONE, ProfilerAction.RECORD_AND_SAVE): [self.prepare_trace, self.start_trace],
+            (ProfilerAction.NONE, ProfilerAction.WARMUP): [self._prepare_trace],
+            (ProfilerAction.NONE, ProfilerAction.RECORD): [self._prepare_trace, self._start_trace],
+            (ProfilerAction.NONE, ProfilerAction.RECORD_AND_SAVE): [self._prepare_trace, self._start_trace],
             (ProfilerAction.WARMUP, ProfilerAction.NONE): [
                 partial(warn, "Incorrect schedule: WARMUP followed by NONE"),
-                self.start_trace,
-                self.stop_trace],
+                self._start_trace,
+                super().stop],
             (ProfilerAction.WARMUP, ProfilerAction.WARMUP): [],
-            (ProfilerAction.WARMUP, ProfilerAction.RECORD): [self.start_trace],
-            (ProfilerAction.WARMUP, ProfilerAction.RECORD_AND_SAVE): [self.start_trace],
+            (ProfilerAction.WARMUP, ProfilerAction.RECORD): [self._start_trace],
+            (ProfilerAction.WARMUP, ProfilerAction.RECORD_AND_SAVE): [self._start_trace],
             (ProfilerAction.RECORD, ProfilerAction.NONE): [
                 partial(warn, "Incorrect schedule: RECORD followed by NONE"),
-                self.stop_trace],
+                super().stop],
             (ProfilerAction.RECORD, ProfilerAction.WARMUP): [
                 partial(warn, "Incorrect schedule: RECORD followed by WARMUP"),
-                self.stop_trace],
+                super().stop],
             (ProfilerAction.RECORD, ProfilerAction.RECORD): [],
             (ProfilerAction.RECORD, ProfilerAction.RECORD_AND_SAVE): [],
-            (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.NONE): [self.stop_trace, self._trace_ready],
-            (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.WARMUP): [self.stop_trace, self._trace_ready, self.prepare_trace],
+            (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.NONE): [super().stop, self._trace_ready],
+            (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.WARMUP): [super().stop, self._trace_ready, self._prepare_trace],
             (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.RECORD): [
-                self.stop_trace,
+                super().stop,
                 self._trace_ready,
-                self.prepare_trace,
-                self.start_trace],
+                self._prepare_trace,
+                self._start_trace],
             (ProfilerAction.RECORD_AND_SAVE, ProfilerAction.RECORD_AND_SAVE): [
-                self.stop_trace,
+                super().stop,
                 self._trace_ready,
-                self.prepare_trace,
-                self.start_trace],
+                self._prepare_trace,
+                self._start_trace],
             # used for exit action
-            (ProfilerAction.WARMUP, None): [self.start_trace, self.stop_trace],
-            (ProfilerAction.RECORD, None): [self.stop_trace, self._trace_ready],
-            (ProfilerAction.RECORD_AND_SAVE, None): [self.stop_trace, self._trace_ready]
+            (ProfilerAction.WARMUP, None): [self._start_trace, super().stop],
+            (ProfilerAction.RECORD, None): [super().stop, self._trace_ready],
+            (ProfilerAction.RECORD_AND_SAVE, None): [super().stop, self._trace_ready]
         }
 
     def __enter__(self):
@@ -457,6 +316,14 @@ class profile(kineto_profiler):
             self.step_rec_fn.__exit__(None, None, None)
         self._transit_action(self.current_action, None)
 
+    def _start_trace(self):
+        super()._start_trace()
+
+        if kineto_available():
+            dist_info = self._get_distributed_info()
+            if dist_info:
+                self.add_metadata_json("distributedInfo", json.dumps(dist_info))
+
     def step(self):
         """
         Signals the profiler that the next profiling step has started.
@@ -472,6 +339,55 @@ class profile(kineto_profiler):
         if self.record_steps:
             self.step_rec_fn = prof.record_function("ProfilerStep#" + str(self.step_num))
             self.step_rec_fn.__enter__()
+
+    def export_chrome_trace(self, path: str):
+        """
+        Exports the collected trace in Chrome JSON format.
+        """
+        if path.endswith('.gz'):
+            fp = tempfile.NamedTemporaryFile('w+t', suffix='.json', delete=False)
+            fp.close()
+            retvalue = super().export_chrome_trace(fp.name)
+            with open(fp.name) as fin:
+                with gzip.open(path, 'wt') as fout:
+                    fout.writelines(fin)
+            os.remove(fp.name)
+            return retvalue
+        else:
+            return super().export_chrome_trace(path)
+
+    def events(self):
+        """
+        Returns the list of unaggregated profiler events,
+        to be used in the trace callback or after the profiling is finished
+        """
+        return self.function_events
+
+    def add_metadata(self, key: str, value: str):
+        """
+        Adds a user defined metadata with a string key and a string value
+        into the trace file
+        """
+        wrapped_value = "\"" + value.replace('"', '\\"') + "\""
+        torch.autograd._add_metadata_json(key, wrapped_value)
+
+    def add_metadata_json(self, key: str, value: str):
+        """
+        Adds a user defined metadata with a string key and a valid json value
+        into the trace file
+        """
+        torch.autograd._add_metadata_json(key, value)
+
+    def _get_distributed_info(self):
+        import torch.distributed as dist
+        if not dist.is_available() or not dist.is_initialized():
+            return None
+
+        return {
+            "backend": dist.get_backend(),
+            "rank": dist.get_rank(),
+            "world_size": dist.get_world_size()
+        }
 
     def _trace_ready(self):
         if self.on_trace_ready:

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -62,7 +62,7 @@ class _KinetoProfile(object):
             with_stack: bool = False,
             with_flops: bool = False,
             with_modules: bool = False):
-        self.activities = set(activities) or supported_activities()
+        self.activities = set(activities) if activities else supported_activities()
         self.record_shapes = record_shapes
         self.with_flops = with_flops
         self.profile_memory = profile_memory
@@ -379,7 +379,7 @@ class profile(_KinetoProfile):
             # deprecated:
             use_cuda: Optional[bool] = None):
 
-        activities_set = set(activities) or supported_activities()
+        activities_set = set(activities) if activities else supported_activities()
         if use_cuda is not None:
             warn("use_cuda is deprecated, use activities argument instead")
             if use_cuda:

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -26,7 +26,7 @@ def supported_activities():
     return torch.autograd._supported_activities()
 
 
-class profiler(object):
+class kineto_profiler(object):
     """Low-level profiler wrap the autograd profile
 
     Args:
@@ -252,7 +252,7 @@ def tensorboard_trace_handler(dir_name: str, worker_name: Optional[str] = None, 
     return handler_fn
 
 
-class profile(profiler):
+class profile(kineto_profiler):
     """Profiler context manager.
 
     Args:

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -223,22 +223,22 @@ class profile(kineto_profile):
             use_cuda: Optional[bool] = None):
 
         if activities:
-            activities = set(activities)
+            activities_set = set(activities)
         else:
-            activities = supported_activities()
+            activities_set = supported_activities()
 
         if use_cuda is not None:
             warn("use_cuda is deprecated, use activities argument instead")
             if use_cuda:
-                activities.add(ProfilerActivity.CUDA)
-            elif ProfilerActivity.CUDA in self.activities:
-                activities.remove(ProfilerActivity.CUDA)
+                activities_set.add(ProfilerActivity.CUDA)
+            elif ProfilerActivity.CUDA in activities_set:
+                activities_set.remove(ProfilerActivity.CUDA)
 
-        assert len(activities) > 0, "No valid profiler activities found"
+        assert len(activities_set) > 0, "No valid profiler activities found"
 
         super().__init__(
-            use_cuda=(ProfilerActivity.CUDA in activities),
-            use_cpu=(ProfilerActivity.CPU in activities),
+            use_cuda=(ProfilerActivity.CUDA in activities_set),
+            use_cpu=(ProfilerActivity.CPU in activities_set),
             record_shapes=record_shapes,
             with_flops=with_flops,
             profile_memory=profile_memory,


### PR DESCRIPTION
Refactor torch.profiler.profile by separate it into one low level class and one high level wrapper.

The PR include the following change:
1. separate class torch.profiler.profile into two separated class: kineto_profiler and torch.profiler.profile. 
2. The former class has the low-level functionality exposed in C++ level like: prepare_profiler, start_profiler, stop_profiler. 
3. The original logics in torch.profiler.profile including export_chrome_trace, export_stacks, key_averages, events, add_metadata are all moved into kineto_profiler since they are all exposed by the torch.autograd.profiler.
4. The new torch.profiler.profile is fully back-compatible with original class since it inherit from torch.profiler.kineto_profiler. Its only responsibility in new implementation is the maintenance of the finite state machine of ProfilerAction. 

With the refactoring, the responsibility boundary is clear and the new logic is simple to understand.