### PR TITLE
Enable test_api IMethodTest in OSS

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -263,6 +263,7 @@ test_libtorch() {
     python test/cpp/jit/tests_setup.py shutdown
     # Wait for background download to finish
     wait
+    python torch/csrc/deploy/example/generate_examples.py # test_api now includes IMethodTest that relies on it.
     OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" build/bin/test_api --gtest_output=xml:$TEST_REPORTS_DIR/test_api.xml
     build/bin/test_tensorexpr --gtest_output=xml:$TEST_REPORTS_DIR/test_tensorexpr.xml
     build/bin/test_mobile_nnc --gtest_output=xml:$TEST_REPORTS_DIR/test_mobile_nnc.xml

--- a/test/cpp/api/imethod.cpp
+++ b/test/cpp/api/imethod.cpp
@@ -17,6 +17,8 @@ const char* path(const char* envname, const char* path) {
   return env ? env : path;
 }
 
+// Run `python torch/csrc/deploy/example/generate_examples.py` before running the following tests.
+// TODO(jwtan): Figure out a way to automate the above step for development. (CI has it already.)
 TEST(IMethodTest, CallMethod) {
   auto scriptModel = torch::jit::load(path("SIMPLE_JIT", simpleJit));
   auto scriptMethod = scriptModel.get_method("forward");

--- a/torch/csrc/deploy/CMakeLists.txt
+++ b/torch/csrc/deploy/CMakeLists.txt
@@ -46,10 +46,3 @@ target_include_directories(test_deploy_lib BEFORE PRIVATE ${PYTHON_INC_DIR})
 add_executable(deploy_benchmark ${DEPLOY_DIR}/example/benchmark.cpp)
 target_include_directories(deploy_benchmark PRIVATE ${PYTORCH_ROOT}/torch)
 target_link_libraries(deploy_benchmark PUBLIC torch_deploy)
-
-add_custom_target(deploy_generated_examples ALL
-  COMMAND python torch/csrc/deploy/example/generate_examples.py
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMENT "Generating torch::deploy examples"
-  VERBATIM
-)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63303
* #62950

Summary:
Tries running `python torch/csrc/deploy/example/generate_examples.py`
before test_api.

Differential Revision: [D30334816](https://our.internmc.facebook.com/intern/diff/D30334816)