### PR TITLE
[LTC] Add _log_softmax_backward_data TorchScript lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
@@ -11,6 +11,7 @@
 #include "lazy_tensor_core/csrc/ops/permute.h"
 #include "lazy_tensor_core/csrc/ops/softmax_backward.h"
 #include "lazy_tensor_core/csrc/ops/sum.h"
+#include "lazy_tensor_core/csrc/ops/ts_log_softmax_backward.h"
 #include "lazy_tensor_core/csrc/ops/ts_softmax_backward.h"
 #include "lazy_tensor_core/csrc/tensor_util.h"
 #include "lazy_tensor_core/csrc/torch_util.h"
@@ -140,6 +141,14 @@ NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
   return MakeNode<LogSoftmaxBackward>(
       grad_output, output,
       Helpers::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()));
+}
+
+NodePtr TSLogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
+                               lazy_tensors::int64 dim, const Value& self) {
+  return MakeNode<TSLogSoftmaxBackward>(
+      grad_output, output,
+      Helpers::GetCanonicalDimensionIndex(dim, grad_output.shape().rank()),
+      self);
 }
 
 NodePtr SoftmaxBackwardOp(const Value& grad_output, const Value& output,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
@@ -135,6 +135,9 @@ NodePtr SigmoidBackward(const Value& grad_output, const Value& output);
 NodePtr LogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
                              lazy_tensors::int64 dim);
 
+NodePtr TSLogSoftmaxBackwardOp(const Value& grad_output, const Value& output,
+                               lazy_tensors::int64 dim, const Value& self);
+
 NodePtr SoftmaxBackwardOp(const Value& grad_output, const Value& output,
                           lazy_tensors::int64 dim);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_log_softmax_backward.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_log_softmax_backward.cpp
@@ -1,0 +1,30 @@
+#include "lazy_tensor_core/csrc/ops/ts_log_softmax_backward.h"
+
+#include "lazy_tensors/computation_client/debug_macros.h"
+#include "lazy_tensors/computation_client/util.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+TSLogSoftmaxBackward::TSLogSoftmaxBackward(const Value& grad_output,
+    const Value& output, lazy_tensors::int64 dim, const Value& self)
+    : Node(ir::OpKind(at::aten::_log_softmax_backward_data),
+          {grad_output, output, self}, grad_output.shape(),
+          /*num_outputs=*/1, lazy_tensors::util::MHash(dim)),
+      dim_(dim) {}
+
+NodePtr TSLogSoftmaxBackward::Clone(OpList operands) const {
+  return MakeNode<TSLogSoftmaxBackward>(operands.at(0), operands.at(1), dim_,
+    operands.at(2));
+}
+
+std::string TSLogSoftmaxBackward::ToString() const {
+  std::stringstream ss;
+  ss << Node::ToString() << ", dim=" << dim_;
+  return ss.str();
+}
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_log_softmax_backward.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_log_softmax_backward.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "lazy_tensor_core/csrc/ir.h"
+
+namespace torch_lazy_tensors {
+namespace ir {
+namespace ops {
+
+class TSLogSoftmaxBackward : public Node {
+ public:
+  TSLogSoftmaxBackward(const Value& grad_output, const Value& output,
+      lazy_tensors::int64 dim, const Value& self);
+
+  NodePtr Clone(OpList operands) const override;
+
+  std::string ToString() const override;
+
+  lazy_tensors::int64 dim() const { return dim_; }
+
+ private:
+  // The dimension along which the result is computed.
+  lazy_tensors::int64 dim_;
+};
+
+}  // namespace ops
+}  // namespace ir
+}  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -715,6 +715,11 @@ class LazyTensor {
                                          const LazyTensor& output,
                                          lazy_tensors::int64 dim);
 
+  static LazyTensor ts_log_softmax_backward(const LazyTensor& grad_output,
+                                            const LazyTensor& output,
+                                            lazy_tensors::int64 dim,
+                                            const LazyTensor& self);
+
   static LazyTensor log1p(const LazyTensor& input);
   static void log1p_(LazyTensor& input);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -1591,6 +1591,14 @@ LazyTensor LazyTensor::log_softmax_backward(const LazyTensor& grad_output,
       grad_output.GetIrValue(), output.GetIrValue(), dim));
 }
 
+LazyTensor LazyTensor::ts_log_softmax_backward(const LazyTensor& grad_output,
+                                               const LazyTensor& output,
+                                               lazy_tensors::int64 dim,
+                                               const LazyTensor& self) {
+  return grad_output.CreateFrom(ir::ops::TSLogSoftmaxBackwardOp(
+      grad_output.GetIrValue(), output.GetIrValue(), dim, self.GetIrValue()));
+}
+
 LazyTensor LazyTensor::log1p(const LazyTensor& input) {
   return input.CreateFrom(ir::ops::Log1p(input.GetIrValue()));
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -79,6 +79,15 @@ at::Tensor LazyNativeFunctions::_log_softmax(const at::Tensor& self, int64_t dim
       LazyTensor::log_softmax(bridge::GetLtcTensor(self), dim, c10::nullopt));
 }
 
+at::Tensor LazyNativeFunctions::_log_softmax_backward_data(
+    const at::Tensor& grad_output, const at::Tensor& output, int64_t dim,
+    const at::Tensor& self) {
+  LTC_FN_COUNTER("lazy::");
+  return bridge::AtenFromLtcTensor(LazyTensor::ts_log_softmax_backward(
+      bridge::GetLtcTensor(grad_output), bridge::GetLtcTensor(output), dim,
+      bridge::GetLtcTensor(self)));
+}
+
 at::Tensor LazyNativeFunctions::_softmax(const at::Tensor& self, int64_t dim,
                                          bool /* half_to_float */) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -30,6 +30,7 @@
 #include "lazy_tensor_core/csrc/ops/stack.h"
 #include "lazy_tensor_core/csrc/ops/sum.h"
 #include "lazy_tensor_core/csrc/ops/ts_embedding_dense_backward.h"
+#include "lazy_tensor_core/csrc/ops/ts_log_softmax_backward.h"
 #include "lazy_tensor_core/csrc/ops/ts_native_batch_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/ts_native_batch_norm_forward.h"
 #include "lazy_tensor_core/csrc/ops/ts_softmax_backward.h"
@@ -269,6 +270,10 @@ class TSNodeLowering : public NodeLowering {
     if (node->op().op == at::aten::log_softmax) {
       return LowerLogSoftmax(
           ir::NodeCast<ir::ops::LogSoftmax>(node, ir::OpKind(at::aten::log_softmax)));
+    }
+    if (node->op().op == at::aten::_log_softmax_backward_data) {
+      return LowerLogSoftmaxBackward(ir::NodeCast<ir::ops::TSLogSoftmaxBackward>(
+          node, ir::OpKind(at::aten::_log_softmax_backward_data)));
     }
     if (node->op().op == at::aten::permute) {
       return LowerPermute(
@@ -680,6 +685,15 @@ class TSNodeLowering : public NodeLowering {
     arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
     arguments.emplace_back(node->dim());
     arguments.emplace_back(node->dtype());
+    return LowerBuiltin(node, arguments);
+  }
+
+  TSOpVector LowerLogSoftmaxBackward(const ir::ops::TSLogSoftmaxBackward* node) {
+    std::vector<torch::jit::NamedValue> arguments;
+    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
+    arguments.emplace_back(loctx()->GetOutputOp(node->operand(1)));
+    arguments.emplace_back(node->dim());
+    arguments.emplace_back(loctx()->GetOutputOp(node->operand(2)));
     return LowerBuiltin(node, arguments);
   }
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -2,6 +2,7 @@ backend: Lazy
 cpp_namespace: torch_lazy_tensors
 supported:
   - _log_softmax
+  - _log_softmax_backward_data
   - add.Tensor
   - addcdiv
   - addcdiv_


### PR DESCRIPTION
Summary:
This patch added _log_softmax_backward_data to TorchScript lowering.

Test Plan:
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestLogSoftmaxBackward

Fixes #62431.