### PR TITLE
Tensor docs

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -323,43 +323,29 @@ def set_default_tensor_type(t):
 
 
 def set_default_dtype(d):
-    r"""
+    r"""Sets the default floating point dtype to :attr:`d`.
+    This dtype is:
 
-    Sets the default floating point dtype to :attr:`d`. Supports torch.float32
-    and torch.float64 as inputs. Other dtypes may be accepted without complaint
-    but are not supported and are unlikely to work as expected.
+    1. The inferred dtype for python floats in :func:`torch.tensor`.
+    2. Used to infer dtype for python complex numbers. The default complex dtype is set to
+       ``torch.complex128`` if default floating point dtype is ``torch.float64``,
+       otherwise it's set to ``torch.complex64``
 
-    When PyTorch is initialized its default floating point dtype is torch.float32,
-    and the intent of set_default_dtype(torch.float64) is to facilitate NumPy-like
-    type inference. The default floating point dtype is used to:
-
-    1. Infer the dtype of Python floats. This affect tensor constructors like
-       :func:`torch.tensor` and type promotion between bool and integer tensors
-       and Python floats.
-    2. Implicitly determine the default complex dtype. When the default floating point
-       type is float32 the default complex dtype is complex64, and when the default
-       floating point type is float64 the default complex type is complex128.
+    The default floating point dtype is initially ``torch.float32``.
 
     Args:
-        d (:class:`torch.dtype`): the floating point dtype to make the default.
-                                  Either torch.float32 or torch.float64.
+        d (:class:`torch.dtype`): the floating point dtype to make the default
 
     Example:
         >>> # initial default for floating point is torch.float32
-        >>> # Python floats are interpreted as float32
         >>> torch.tensor([1.2, 3]).dtype
         torch.float32
         >>> # initial default for floating point is torch.complex64
-        >>> # Complex Python numbers are interpreted as complex64
         >>> torch.tensor([1.2, 3j]).dtype
         torch.complex64
-
         >>> torch.set_default_dtype(torch.float64)
-
-        >>> # Python floats are now interpreted as float64
         >>> torch.tensor([1.2, 3]).dtype    # a new floating point tensor
         torch.float64
-        >>> # Complex Python numbers are now interpreted as complex128
         >>> torch.tensor([1.2, 3j]).dtype   # a new complex tensor
         torch.complex128
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -323,29 +323,43 @@ def set_default_tensor_type(t):
 
 
 def set_default_dtype(d):
-    r"""Sets the default floating point dtype to :attr:`d`.
-    This dtype is:
+    r"""
 
-    1. The inferred dtype for python floats in :func:`torch.tensor`.
-    2. Used to infer dtype for python complex numbers. The default complex dtype is set to
-       ``torch.complex128`` if default floating point dtype is ``torch.float64``,
-       otherwise it's set to ``torch.complex64``
+    Sets the default floating point dtype to :attr:`d`. Supports torch.float32
+    and torch.float64 as inputs. Other dtypes may be accepted without complaint
+    but are not supported and are unlikely to work as expected.
 
-    The default floating point dtype is initially ``torch.float32``.
+    When PyTorch is initialized its default floating point dtype is torch.float32,
+    and the intent of set_default_dtype(torch.float64) is to facilitate NumPy-like
+    type inference. The default floating point dtype is used to:
+
+    1. Infer the dtype of Python floats. This affect tensor constructors like
+       :func:`torch.tensor` and type promotion between bool and integer tensors
+       and Python floats.
+    2. Implicitly determine the default complex dtype. When the default floating point
+       type is float32 the default complex dtype is complex64, and when the default
+       floating point type is float64 the default complex type is complex128.
 
     Args:
-        d (:class:`torch.dtype`): the floating point dtype to make the default
+        d (:class:`torch.dtype`): the floating point dtype to make the default.
+                                  Either torch.float32 or torch.float64.
 
     Example:
         >>> # initial default for floating point is torch.float32
+        >>> # Python floats are interpreted as float32
         >>> torch.tensor([1.2, 3]).dtype
         torch.float32
         >>> # initial default for floating point is torch.complex64
+        >>> # Complex Python numbers are interpreted as complex64
         >>> torch.tensor([1.2, 3j]).dtype
         torch.complex64
+
         >>> torch.set_default_dtype(torch.float64)
+
+        >>> # Python floats are now interpreted as float64
         >>> torch.tensor([1.2, 3]).dtype    # a new floating point tensor
         torch.float64
+        >>> # Complex Python numbers are now interpreted as complex128
         >>> torch.tensor([1.2, 3j]).dtype   # a new complex tensor
         torch.complex128
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -792,15 +792,29 @@ add_docstr(torch.as_tensor,
            r"""
 as_tensor(data, dtype=None, device=None) -> Tensor
 
-Convert the data into a `torch.Tensor`. If the data is already a `Tensor` with the same `dtype` and `device`,
-no copy will be performed, otherwise a new `Tensor` will be returned with computational graph retained if data
-`Tensor` has ``requires_grad=True``. Similarly, if the data is an ``ndarray`` of the corresponding `dtype` and
-the `device` is the cpu, no copy will be performed.
+Converts :attr:`data` into a tensor, sharing data and preserving autograd
+history if possible.
+
+If data is already a tensor with the same
+:attr:`dtype` and :attr:`device` then data itself is returned, but if data is a
+tensor with a different dtype or device then it's copied as if using
+`data.to(dtype=dtype, device=device)`.
+
+If data is a NumPy array (an ndarray) with the same dtype and device then a
+tensor is constructed using :func:`torch.from_numpy`.
+
+.. seealso::
+
+    :func:`torch.tensor` never shares its data and creates a new "leaf tensor."
+
 
 Args:
     {data}
     {dtype}
-    {device}
+    device - the device of the constructed tensor. If None and data is a tensor
+        then the device of data is used. If None and data is not a tensor then
+        the result tensor is constructed on the CPU.
+
 
 Example::
 
@@ -7995,29 +8009,34 @@ add_docstr(torch.tensor,
            r"""
 tensor(data, *, dtype=None, device=None, requires_grad=False, pin_memory=False) -> Tensor
 
-Constructs a tensor with :attr:`data`.
+Constructs a tensor with no autograd history (a "leaf tensor") by copying :attr:`data`.
 
 .. warning::
 
-    :func:`torch.tensor` always copies :attr:`data`. If you have a Tensor
-    ``data`` and want to avoid a copy, use :func:`torch.Tensor.requires_grad_`
-    or :func:`torch.Tensor.detach`.
-    If you have a NumPy ``ndarray`` and want to avoid a copy, use
-    :func:`torch.as_tensor`.
+    When working with tensors prefer using :func:`torch.Tensor.clone`,
+    :func:`torch.Tensor.detach`, and :func:`torch.Tensor.requires_grad_` for
+    readability. Letting `t` be a tensor, ``torch.tensor(t)`` is equivalent to
+    ``t.clone().detach()``, and ``torch.tensor(t, requires_grad=True)``
+    is equivalent to ``t.clone().detach().requires_grad_(True)``.
 
-.. warning::
+    To change whether a tensor requires grad without copying it use just
+    :func:`torch.Tensor.requires_grad_` or :func:`torch.Tensor.detach` without
+    cloning the tensor.
 
-    When data is a tensor `x`, :func:`torch.tensor` reads out 'the data' from whatever it is passed,
-    and constructs a leaf variable. Therefore ``torch.tensor(x)`` is equivalent to ``x.clone().detach()``
-    and ``torch.tensor(x, requires_grad=True)`` is equivalent to ``x.clone().detach().requires_grad_(True)``.
-    The equivalents using ``clone()`` and ``detach()`` are recommended.
+
+.. seealso::
+
+    :func:`torch.as_tensor` preserves autograd history and avoids copies where possible.
+    :func:`torch.from_numpy` creates a tensor that shares storage with a NumPy array.
 
 Args:
     {data}
 
 Keyword args:
     {dtype}
-    {device}
+    device - the device of the constructed tensor. If None and data is a tensor
+        then the device of data is used. If None and data is not a tensor then
+        the result tensor is constructed on the CPU.
     {requires_grad}
     {pin_memory}
 
@@ -8034,10 +8053,10 @@ Example::
 
     >>> torch.tensor([[0.11111, 0.222222, 0.3333333]],
     ...              dtype=torch.float64,
-    ...              device=torch.device('cuda:0'))  # creates a torch.cuda.DoubleTensor
+    ...              device=torch.device('cuda:0'))  # creates a double tensor on a CUDA device
     tensor([[ 0.1111,  0.2222,  0.3333]], dtype=torch.float64, device='cuda:0')
 
-    >>> torch.tensor(3.14159)  # Create a scalar (zero-dimensional tensor)
+    >>> torch.tensor(3.14159)  # Create a zero-dimensional (scalar) tensor
     tensor(3.1416)
 
     >>> torch.tensor([])  # Create an empty tensor (of size (0,))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -792,7 +792,7 @@ add_docstr(torch.as_tensor,
            r"""
 as_tensor(data, dtype=None, device=None) -> Tensor
 
-Converts dataa into a tensor, sharing data and preserving autograd
+Converts data into a tensor, sharing data and preserving autograd
 history if possible.
 
 If data is already a tensor with the requeseted dtype and device

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -811,7 +811,7 @@ tensor is constructed using :func:`torch.from_numpy`.
 Args:
     {data}
     {dtype}
-    device - the device of the constructed tensor. If None and data is a tensor
+    device (:class:`torch.device`, optional): the device of the constructed tensor. If None and data is a tensor
         then the device of data is used. If None and data is not a tensor then
         the result tensor is constructed on the CPU.
 
@@ -8029,7 +8029,7 @@ Args:
 
 Keyword args:
     {dtype}
-    device - the device of the constructed tensor. If None and data is a tensor
+    device (:class:`torch.device`, optional): the device of the constructed tensor. If None and data is a tensor
         then the device of data is used. If None and data is not a tensor then
         the result tensor is constructed on the CPU.
     {requires_grad}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -792,11 +792,11 @@ add_docstr(torch.as_tensor,
            r"""
 as_tensor(data, dtype=None, device=None) -> Tensor
 
-Converts :attr:`data` into a tensor, sharing data and preserving autograd
+Converts dataa into a tensor, sharing data and preserving autograd
 history if possible.
 
-If data is already a tensor with the same
-:attr:`dtype` and :attr:`device` then data itself is returned, but if data is a
+If data is already a tensor with the requeseted dtype and device
+then data itself is returned, but if data is a
 tensor with a different dtype or device then it's copied as if using
 `data.to(dtype=dtype, device=device)`.
 
@@ -805,7 +805,7 @@ tensor is constructed using :func:`torch.from_numpy`.
 
 .. seealso::
 
-    :func:`torch.tensor` never shares its data and creates a new "leaf tensor."
+    :func:`torch.tensor` never shares its data and creates a new "leaf tensor" (see :doc:`/notes/autograd`).
 
 
 Args:
@@ -8009,7 +8009,7 @@ add_docstr(torch.tensor,
            r"""
 tensor(data, *, dtype=None, device=None, requires_grad=False, pin_memory=False) -> Tensor
 
-Constructs a tensor with no autograd history (a "leaf tensor") by copying :attr:`data`.
+Constructs a tensor with no autograd history (also known as a "leaf tensor", see :doc:`/notes/autograd`) by copying :attr:`data`.
 
 .. warning::
 
@@ -8018,11 +8018,6 @@ Constructs a tensor with no autograd history (a "leaf tensor") by copying :attr:
     readability. Letting `t` be a tensor, ``torch.tensor(t)`` is equivalent to
     ``t.clone().detach()``, and ``torch.tensor(t, requires_grad=True)``
     is equivalent to ``t.clone().detach().requires_grad_(True)``.
-
-    To change whether a tensor requires grad without copying it use just
-    :func:`torch.Tensor.requires_grad_` or :func:`torch.Tensor.detach` without
-    cloning the tensor.
-
 
 .. seealso::
 


### PR DESCRIPTION
Fixes #62146.

Modernizes and clarifies the documentation of torch.tensor and torch.as_tensor, highlighting the distinction in their copying behavior and preservation of autograd history. 