### PR TITLE
Add expecttest to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Python dependencies required for development
 astunparse
+expecttest
 future
 numpy
 psutil


### PR DESCRIPTION
This PR closes the developer environment gap left by #60658 by adding [expecttest](https://github.com/ezyang/expecttest) to `requirements.txt`. Thus it provides a solution to one of the short-term problems that #60697 tries to solve, but does not provide a long-term solution to #61375.