### PR TITLE
Fix triage workflow when the card already exists in project

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -83,8 +83,15 @@ jobs:
             const columnId = filteredColumns[0].id;
 
             // Create a project card for this new issue.
-            await github.projects.createCard({
-              column_id: columnId,
-              content_id: issue.data.id,
-              content_type: "Issue",
-            })
+            try {
+              await github.projects.createCard({
+                column_id: columnId,
+                content_id: issue.data.id,
+                content_type: "Issue",
+              })
+            } catch (err) {
+              if (err.status !== 422) {
+                throw err;
+              }
+              console.log("Unable to create card: already exists");
+            }


### PR DESCRIPTION
Fixes issues like https://github.com/pytorch/pytorch/runs/3336787242

```
RequestError [HttpError]: Validation Failed: {"resource":"ProjectCard","code":"unprocessable","field":"data","message":"Project already has the associated issue"}
Error: Unhandled error: HttpError: Validation Failed: {"resource":"ProjectCard","code":"unprocessable","field":"data","message":"Project already has the associated issue"}
    at /home/runner/work/_actions/actions/github-script/v2/dist/index.js:7531:23
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v2/dist/index.js:7985:56), <anonymous>:63:1)
    at async main (/home/runner/work/_actions/actions/github-script/v2/dist/index.js:8011:20) {
  name: 'HttpError',
  status: 422,

...
```

The card may already exist, thus no need to handle `422` status code. Anything else will re-throw the err.




