### PR TITLE
[Static Runtime] Implement aten::append

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -681,3 +681,17 @@ const auto three_tuple_unpack_script = R"JIT(
       a, b, c = tup
       return (a, b, c)
 )JIT";
+
+const auto append_int_script = R"JIT(
+  def forward(self, a: int):
+      lst = [1, 2, 3]
+      lst.append(a)
+      return lst
+)JIT";
+
+const auto append_tensor_script = R"JIT(
+  def forward(self, a: Tensor):
+      lst = []
+      lst.append(a)
+      return lst
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1138,3 +1138,15 @@ TEST(StaticRuntime, InvidualOps_TupleUnpack) {
   testStaticRuntime(three_tuple_unpack_script, {three_tup});
   testStaticRuntime(three_tuple_unpack_script, {three_tup}, {three_tup_large});
 }
+
+TEST(StaticRuntime, IndividualOps_Append) {
+  std::vector<IValue> args_int{1};
+
+  testStaticRuntime(append_int_script, args_int);
+
+  std::vector<IValue> args_tensor{at::randn({1})};
+  std::vector<IValue> args_tensor_large{at::randn({2, 2})};
+
+  testStaticRuntime(append_tensor_script, args_tensor);
+  testStaticRuntime(append_tensor_script, args_tensor, args_tensor_large);
+}

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -159,6 +159,16 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
     });
 
 REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    aten::append,
+    aten_append,
+    [](Node* n) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        auto list = p_node->Input(0).toList();
+        list.push_back(p_node->Input(1));
+      };
+    });
+
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
     prim::GetAttr,
     prim_GetAttr,
     [](Node* n) -> SROperator {


### PR DESCRIPTION
Summary: Add a native implementation for `aten::append`, the list append op.

Test Plan: New unit test: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- Append`

Reviewed By: hlu1

Differential Revision: D30326461

