### PR TITLE
[fx2trt] add unsqueeze converter

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -197,7 +197,9 @@ def create_inputs_from_specs(input_specs):
         elif not has_batch_dim:
             shape = (1,) + tuple(shape)
 
-        inputs.append(torch.empty(shape, dtype=dtype, device=device))
+        inputs.append(
+            torch.randn(shape).to(dtype=dtype, device=device)
+        )
 
     return inputs
 


### PR DESCRIPTION
Summary:
Added converter for acc_ops.unsqueeze. Needed for ig model.

DIdn't add support for input that has more than one dynamic dim. This is not needed right now and I feel it would be a rare case.

Test Plan: unit test

Reviewed By: yinghai

Differential Revision: D30138293

