### PR TITLE
Fixing clang_tidy install script import error.

### DIFF
--- a/tools/linter/install/clang_tidy.py
+++ b/tools/linter/install/clang_tidy.py
@@ -1,5 +1,5 @@
 import os
-from tools.linter.install.download_bin import download, PYTORCH_ROOT, HASH_PATH
+from download_bin import download, PYTORCH_ROOT, HASH_PATH
 
 PLATFORM_TO_URL = {
     "Linux": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-tidy",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63368

I was getting the following error when installing clang_tidy locally

(base) jclow@jclow-mbp pytorch % python3 tools/linter/install/clang_tidy.py
Traceback (most recent call last):
  File "tools/linter/install/clang_tidy.py", line 2, in <module>
    from tools.linter.install.download_bin import download, PYTORCH_ROOT, HASH_PATH
ModuleNotFoundError: No module named 'tools'

Through using a same folder file import, we can avoid the mess that is Pytorch absolute path import.