### PR TITLE
[EASY] Update the clang-tidy error message

### DIFF
--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -183,7 +183,8 @@ def main() -> None:
             f"Could not find '{options.clang_tidy_exe}'\n"
             + "We provide a custom build of clang-tidy that has additional checks.\n"
             + "You can install it by running:\n"
-            + "$ python3 tools/linter/install/clang_tidy.py"
+            + "$ python3 -m tools.linter.install.clang_tidy \n"
+            + "from the pytorch folder"
         )
         raise RuntimeError(msg)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63370

As shown by this CI run, the actual thing that is incorrect is the prompt.
https://github.com/pytorch/pytorch/actions/runs/1137298261

The CI runs the below command instead of the original command. 
The original command errors out when importing another file on line 1.
Trying to fix the code to work with the original command causes the CI to error out.

We should actually ask the user to run
`python3 -m tools.linter.install.clang_tidy`

Differential Revision: [D30530216](https://our.internmc.facebook.com/intern/diff/D30530216)