### PR TITLE
Bugfix for fuse qconfig comparison

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -314,8 +314,7 @@ class TestFuseFx(QuantizationTestCase):
 
             self.checkGraphModuleNodes(quantized, expected_node_list=node_list)
 
-
-    def test_fuse_example_with_factory_kwargs_bug(self):
+    def test_problematic_fuse_example(self):
         class LinearRelu(nn.Sequential):
             def __init__(self):
                 super().__init__(
@@ -335,7 +334,7 @@ class TestFuseFx(QuantizationTestCase):
                 return x
 
         model = M().eval()
-
+        # these qconfigs somehow fail equality where default_qconfig does not
         qconfig_dict = {
             "": None,
             "object_type": [

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -314,6 +314,39 @@ class TestFuseFx(QuantizationTestCase):
 
             self.checkGraphModuleNodes(quantized, expected_node_list=node_list)
 
+
+    def test_fuse_example_with_factory_kwargs_bug(self):
+        class LinearRelu(nn.Sequential):
+            def __init__(self):
+                super().__init__(
+                    nn.Linear(5, 5),
+                    nn.ReLU(),
+                )
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin_relu = LinearRelu()
+                self.linear = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.lin_relu(x)
+                x = self.linear(x)
+                return x
+
+        model = M().eval()
+
+        qconfig_dict = {
+            "": None,
+            "object_type": [
+                (torch.nn.Linear, get_default_qconfig('fbgemm')),
+                (torch.nn.ReLU, get_default_qconfig('fbgemm')),
+            ],
+        }
+        m = prepare_fx(model, qconfig_dict)
+
+        self.checkGraphModuleNodes(m, expected_node=ns.call_module(torch.nn.intrinsic.modules.fused.LinearReLU))
+
     def test_fuse_custom_config_dict_validity(self):
         r"""
         Verifies that if a user passes an invalid key or makes a typo when

--- a/torch/quantization/fx/prepare.py
+++ b/torch/quantization/fx/prepare.py
@@ -15,7 +15,7 @@ from torch.fx.graph import (
 )
 from torch.fx.node import Argument
 
-from ..qconfig import QConfigAny
+from ..qconfig import QConfigAny, qconfig_function_equality
 from .qconfig_utils import (
     convert_dict_to_ordered_dict,
     generate_qconfig_map,
@@ -194,7 +194,7 @@ def update_qconfig_for_fusion(
                     # Raise an error if the modules in the fused module have
                     # different qconfigs specified in the qconfig_dict
                     for op in ops:
-                        if object_type_dict.get(op, None) != fused_qconfig:
+                        if not qconfig_function_equality(object_type_dict.get(op, None), fused_qconfig):
                             raise LookupError("During fusion, we need to specify the same " +
                                               f"qconfigs for both modules in {module_type}.")
 

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -219,7 +219,7 @@ def qconfig_function_equality(q1: QConfigAny, q2: QConfigAny):
         return same and p1.keywords == p2.keywords
 
     if q1 is None or q2 is None:
-        return q1==q2
+        return q1 == q2
     else:
         assert q1 is not None and q2 is not None
         return compare_partial(q1.activation.p, q2.activation.p) and compare_partial(q1.weight.p, q2.weight.p)

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -222,4 +222,7 @@ def qconfig_function_equality(q1: QConfigAny, q2: QConfigAny):
         return q1 == q2
     else:
         assert q1 is not None and q2 is not None
-        return compare_partial(q1.activation.p, q2.activation.p) and compare_partial(q1.weight.p, q2.weight.p)
+        try:
+            return compare_partial(q1.activation.p, q2.activation.p) and compare_partial(q1.weight.p, q2.weight.p)
+        except AttributeError:
+            return q1 == q2

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -212,8 +212,14 @@ def add_module_to_qconfig_obs_ctr(
 
 
 def qconfig_function_equality(q1: QConfigAny, q2: QConfigAny):
-    try:
+    # functools.partial has no __eq__ operator defined so '==' defaults to 'is'
+    def compare_partial(p1, p2):
+        same = p1.func == p2.func
+        same = same and p1.args == p2.args
+        return same and p1.keywords == p2.keywords
+
+    if q1 is None or q2 is None:
+        return q1==q2
+    else:
         assert q1 is not None and q2 is not None
-        return (q1.activation.p.func == q2.activation.p.func) and (q1.weight.p.func == q2.weight.p.func)
-    except:
-        return q1 == q2
+        return compare_partial(q1.activation.p, q2.activation.p) and compare_partial(q1.weight.p, q2.weight.p)

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -209,3 +209,11 @@ def add_module_to_qconfig_obs_ctr(
         return QConfig(activation, weight)
     else:
         return QConfigDynamic(activation, weight)
+
+
+def qconfig_function_equality(q1: QConfigAny, q2: QConfigAny):
+    try:
+        assert q1 is not None and q2 is not None
+        return (q1.activation.p.func == q2.activation.p.func) and (q1.weight.p.func == q2.weight.p.func)
+    except:
+        return q1 == q2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63513
* __->__ #63384

Summary: In some cases the changes to qconfig on module would cause the
fusions to fail. This bugfix solves that problem by adding a
qconfig_function_comparison that compares the functions within the
qconfig rather than the modules the qconfigs are on. The comparison
looks at the partial object within QConfig.activation/weight.p and
compares args, keywords and func. This is necessary to do mannually
because partial doesn't have __eq__ implemented and so == reverts to is.

Test Plan: python test/test_quantization.py
TestFuseFx.test_problematic_fuse_example

Reviewers: supriyar

Subscribers:

Tasks:

Tags:

Differential Revision: [D30386264](https://our.internmc.facebook.com/intern/diff/D30386264)