### PR TITLE
[DO NOT MERGE] disable CUDA/HIP caching allocator for all tests

### DIFF
--- a/.jenkins/caffe2/common.sh
+++ b/.jenkins/caffe2/common.sh
@@ -6,6 +6,10 @@ TEST_DIR="$ROOT_DIR/test"
 gtest_reports_dir="${TEST_DIR}/test-reports/cpp"
 pytest_reports_dir="${TEST_DIR}/test-reports/python"
 
+# Let's see what happens when we disable the caching allocator.
+export PYTORCH_NO_CUDA_MEMORY_CACHING=1
+export PYTORCH_NO_HIP_MEMORY_CACHING=1
+
 # Figure out which Python to use
 PYTHON="$(which python)"
 if [[ "${BUILD_ENVIRONMENT}" =~ py((2|3)\.?[0-9]?\.?[0-9]?) ]]; then

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -8,6 +8,10 @@ set -ex
 # Save the SCRIPT_DIR absolute path in case later we chdir (as occurs in the gpu perf test)
 SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
 
+# Let's see what happens when we disable the caching allocator.
+export PYTORCH_NO_CUDA_MEMORY_CACHING=1
+export PYTORCH_NO_HIP_MEMORY_CACHING=1
+
 # Required environment variables:
 #   $BUILD_ENVIRONMENT (should be set by your Docker image)
 


### PR DESCRIPTION
Let's see what happens when we disable the caching allocator.

We've seen some ROCm unit test failures when not using the caching allocator and got curious if CUDA behaved similar.