### PR TITLE
[android][vulkan] Fix model loading for Vulkan backend

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
@@ -121,7 +121,7 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     }
     deviceType_ = deviceJniCodeToDeviceType(device);
     module_ = torch::jit::load(
-        std::move(modelPath->toStdString()), deviceType_, extra_files);
+        std::move(modelPath->toStdString()), c10::nullopt, extra_files);
     if (has_extra) {
       static auto putMethod =
           facebook::jni::JMap<facebook::jni::JString, facebook::jni::JString>::

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
@@ -83,9 +83,9 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     }
     deviceType_ = deviceJniCodeToDeviceType(device);
     module_ = torch::jit::_load_for_mobile(
-        std::move(modelPath->toStdString()), deviceType_, extra_files);
+        std::move(modelPath->toStdString()), c10::nullopt, extra_files);
     torch::jit::_load_extra_only_for_mobile(
-        std::move(modelPath->toStdString()), deviceType_, extra_files);
+        std::move(modelPath->toStdString()), c10::nullopt, extra_files);
     if (has_extra) {
       static auto putMethod =
           facebook::jni::JMap<facebook::jni::JString, facebook::jni::JString>::


### PR DESCRIPTION
Fix for:
https://github.com/pytorch/pytorch/issues/62040
https://github.com/pytorch/pytorch/issues/61709



Loading module for Vulkan backend fails using java/android api.

Caused by: com.facebook.jni.CppException: supported devices include CPU and CUDA, however got VULKAN
Exception raised from readInstruction at /usr/local/pytorch_android_example/third_party/pytorch/torch/csrc/jit/serialization/unpickler.cpp:451 (most recent call first):

Unpickler allows only CPU and XPU devices to convert loaded constant tensor. 
Prepacked tensors in vulkan model are CPU which will be converted to Vulkan device during unpacking.


Test:
```
BUILD_LITE_INTERPRETER=0 sh ./scripts/build_pytorch_android.sh arm64-v8a
BUILD_LITE_INTERPRETER=0 gradle -p android test_app:installMnetVulkanLocalBaseDebug -PABI_FILTERS=arm64-v8a
```
test_app inferences vulkan model



Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63402

Differential Revision: [D30370692](https://our.internmc.facebook.com/intern/diff/D30370692)