### PR TITLE
Fix RPC Python User Function Error Handling

### DIFF
--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -155,7 +155,8 @@ c10::intrusive_ptr<JitFuture> toPyJitFuture(
             } catch (py::error_already_set& e) {
               py::gil_scoped_acquire acquire;
               // py::error_already_set requires GIL to destruct, take special care.
-              child->setErrorIfNeeded(std::make_exception_ptr(std::runtime_error(e.what())));
+              child->setErrorIfNeeded(
+                  std::make_exception_ptr(std::runtime_error(e.what())));
               e.restore();
               PyErr_Clear();
               return;

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -3224,7 +3224,7 @@ class RpcTest(RpcAgentTestFixture):
             # Ensure that we have the attribute on this module. Otherwise, the test could fail due to a caller-side pickling error.
             self.assertTrue(hasattr(this_module, "foo_add"))
             with self.assertRaisesRegex(
-                AttributeError, "RPC pickler does not serialize"
+                RuntimeError, "RPC pickler does not serialize"
             ):
                 rpc.rpc_sync(callee_worker, foo_add, args=())
 

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1039,6 +1039,21 @@ class RpcTest(RpcAgentTestFixture):
             )
             self.assertEqual(ret, torch.ones(n, n) * 2)
 
+    @dist_init
+    def test_future_wait_twice(self):
+        dst = worker_name((self.rank + 1) % self.world_size)
+        x = torch.ones(2, 2)
+        futs = []
+        for i in range(20):
+            futs.append(rpc.rpc_async(dst, raise_func))
+
+        with self.assertRaisesRegex(RuntimeError, "Expected error"):
+            torch.futures.wait_all(futs)
+
+        for fut in futs:
+            with self.assertRaisesRegex(RuntimeError, "Expected error"):
+                fut.wait()
+
     def _run_uneven_workload(self, num_repeat=30):
         # worker0 drives and waits for worker1 and worker2
         # throughout the test.

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1046,11 +1046,11 @@ class RpcTest(RpcAgentTestFixture):
         for i in range(20):
             futs.append(rpc.rpc_async(dst, raise_func))
 
-        with self.assertRaisesRegex(RuntimeError, "Expected error"):
+        with self.assertRaisesRegex(ValueError, "Expected error"):
             torch.futures.wait_all(futs)
 
         for fut in futs:
-            with self.assertRaisesRegex(RuntimeError, "Expected error"):
+            with self.assertRaisesRegex(ValueError, "Expected error"):
                 fut.wait()
 
     def _run_uneven_workload(self, num_repeat=30):

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1042,7 +1042,6 @@ class RpcTest(RpcAgentTestFixture):
     @dist_init
     def test_future_wait_twice(self):
         dst = worker_name((self.rank + 1) % self.world_size)
-        x = torch.ones(2, 2)
         futs = []
         for i in range(20):
             futs.append(rpc.rpc_async(dst, raise_func))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#63406 Fix RPC Python User Function Error Handling**

The `RemoteException` will be thrown on the caller side when converting
the response message to IValue. Since it is a Python error, the error
message needs to be extracted explicitly and clear the `PyErr`.

Differential Revision: [D30372741](https://our.internmc.facebook.com/intern/diff/D30372741)