### PR TITLE
Add more ciflow labels for more workflows

### DIFF
--- a/.github/generated-ciflow-ruleset.json
+++ b/.github/generated-ciflow-ruleset.json
@@ -1,11 +1,69 @@
 {
   "label_rules": {
+    "ciflow/all": [
+      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
+      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-bionic-py3.8-gcc9-coverage",
+      "linux-xenial-cuda10.2-py3.6-gcc7",
+      "linux-xenial-cuda11.1-py3.6-gcc7",
+      "linux-xenial-py3.6-gcc5.4",
+      "linux-xenial-py3.6-gcc7-bazel-test",
+      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
+      "periodic-linux-xenial-cuda11.3-py3.6-gcc7",
+      "periodic-win-vs2019-cuda11.3-py3",
+      "win-vs2019-cpu-py3",
+      "win-vs2019-cuda10.1-py3",
+      "win-vs2019-cuda11.1-py3"
+    ],
+    "ciflow/bazel": [
+      "linux-xenial-py3.6-gcc7-bazel-test"
+    ],
+    "ciflow/coverage": [
+      "linux-bionic-py3.8-gcc9-coverage"
+    ],
+    "ciflow/cpu": [
+      "linux-bionic-py3.8-gcc9-coverage",
+      "linux-xenial-py3.6-gcc5.4",
+      "linux-xenial-py3.6-gcc7-bazel-test",
+      "win-vs2019-cpu-py3"
+    ],
+    "ciflow/cuda": [
+      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
+      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-xenial-cuda10.2-py3.6-gcc7",
+      "linux-xenial-cuda11.1-py3.6-gcc7",
+      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
+      "periodic-linux-xenial-cuda11.3-py3.6-gcc7",
+      "periodic-win-vs2019-cuda11.3-py3",
+      "win-vs2019-cuda10.1-py3",
+      "win-vs2019-cuda11.1-py3"
+    ],
     "ciflow/default": [
       "linux-bionic-py3.8-gcc9-coverage",
+      "linux-xenial-cuda11.1-py3.6-gcc7",
       "linux-xenial-py3.6-gcc5.4",
       "linux-xenial-py3.6-gcc7-bazel-test",
       "win-vs2019-cpu-py3",
       "win-vs2019-cuda10.1-py3"
+    ],
+    "ciflow/libtorch": [
+      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
+      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
+      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7"
+    ],
+    "ciflow/linux": [
+      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
+      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-bionic-py3.8-gcc9-coverage",
+      "linux-xenial-cuda10.2-py3.6-gcc7",
+      "linux-xenial-cuda11.1-py3.6-gcc7",
+      "linux-xenial-py3.6-gcc5.4",
+      "linux-xenial-py3.6-gcc7-bazel-test",
+      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
+      "periodic-linux-xenial-cuda11.3-py3.6-gcc7"
     ],
     "ciflow/scheduled": [
       "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
@@ -13,7 +71,14 @@
       "periodic-win-vs2019-cuda11.3-py3"
     ],
     "ciflow/slow": [
+      "linux-bionic-cuda10.2-py3.9-gcc7",
       "linux-xenial-cuda10.2-py3.6-gcc7"
+    ],
+    "ciflow/win": [
+      "periodic-win-vs2019-cuda11.3-py3",
+      "win-vs2019-cpu-py3",
+      "win-vs2019-cuda10.1-py3",
+      "win-vs2019-cuda11.1-py3"
     ]
   },
   "version": "v1"

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -29,24 +29,16 @@ LINUX_RUNNERS = {
     LINUX_CUDA_TEST_RUNNER,
 }
 
+CUDA_RUNNERS = {
+    WINDOWS_CUDA_TEST_RUNNER,
+    LINUX_CUDA_TEST_RUNNER,
+}
+CPU_RUNNERS = {
+    WINDOWS_CPU_TEST_RUNNER,
+    LINUX_CPU_TEST_RUNNER,
+}
 
-# TODO: ------------- Remove the comment once fully rollout -------------------
-#       Rollout Strategy:
-#       1. Manual Phase
-#          step 1. Add 'ciflow/default' label to the PR
-#          step 2. Once there's an [unassigned] event from PR, it should rerun
-#          step 3. Remove 'ciflow/default' label
-#          step 4. Trigger the [unassigned] event again, it should not rerun
-#       2. Probot Phase 1 (manual on 1 workflow)
-#          step 1. Probot automatically add labels based on the context
-#          step 2. Manually let probot trigger [unassigned] event
-#       3. Probot Phase 2 (auto on 1 workflows)
-#          step 1. Modify the workflows so that they only listen on [unassigned] events
-#          step 2. Probot automatically adds labels automatically based on the context
-#          step 3. Probot automatically triggers [unassigned] event
-#       4. Probot Phase 3 (auto on many workflows)
-#          step 1. Enable it for all workflows
-#       -----------------------------------------------------------------------
+
 @dataclass
 class CIFlowConfig:
     enabled: bool = False
@@ -67,11 +59,11 @@ class CIFlowConfig:
         # Once fully rollout, we can have strict constraints
         # e.g. ADD      env.GITHUB_ACTOR == '{self.trigger_actor}
         #      REMOVE   github.event.action !='{self.trigger_action}'
-        label_conditions = [f"github.event.action == '{self.trigger_action}'"] + \
-            [f"contains(github.event.pull_request.labels.*.name, '{label}')" for label in self.labels]
+        label_conditions = [
+            f"contains(github.event.pull_request.labels.*.name, '{label}')" for label in sorted(self.labels)]
         self.root_job_condition = f"(github.event_name != 'pull_request') || " \
             f"(github.event.action !='{self.trigger_action}') || " \
-            f"({' && '.join(label_conditions)})"
+            f"({' || '.join(label_conditions)})"
 
     def reset_root_job(self) -> None:
         self.root_job_name = ''
@@ -156,6 +148,9 @@ class CIWorkflow:
             else:
                 self.num_test_shards_on_pull_request = self.num_test_shards
 
+        # Add ciflow/all to labels
+        self.ciflow_config.labels.add('ciflow/all')
+
         self.assert_valid()
 
     def assert_valid(self) -> None:
@@ -164,6 +159,20 @@ class CIWorkflow:
             assert self.test_runner_type in LINUX_RUNNERS, err_message
         if self.arch == 'windows':
             assert self.test_runner_type in WINDOWS_RUNNERS, err_message
+
+        if self.ciflow_config.enabled:
+            # make sure if ciflow/default is set, we then need to set trigger_action_only to False
+            assert self.ciflow_config.trigger_action_only != ('ciflow/default' in self.ciflow_config.labels)
+            assert self.on_pull_request
+            assert 'ciflow/all' in self.ciflow_config.labels
+            if self.arch == 'linux':
+                assert 'ciflow/linux' in self.ciflow_config.labels
+            if self.arch == 'windows':
+                assert 'ciflow/win' in self.ciflow_config.labels
+            if self.test_runner_type in CUDA_RUNNERS:
+                assert 'ciflow/cuda' in self.ciflow_config.labels
+            if self.test_runner_type in CPU_RUNNERS:
+                assert 'ciflow/cpu' in self.ciflow_config.labels
 
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
         output_file_path = GITHUB_DIR / f"workflows/generated-{self.build_environment}.yml"
@@ -183,6 +192,10 @@ WINDOWS_WORKFLOWS = [
         test_runner_type=WINDOWS_CPU_TEST_RUNNER,
         on_pull_request=True,
         num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            labels={'ciflow/default', 'ciflow/cpu', 'ciflow/win'}
+        ),
     ),
     CIWorkflow(
         arch="windows",
@@ -192,6 +205,10 @@ WINDOWS_WORKFLOWS = [
         on_pull_request=True,
         only_run_smoke_tests_on_pull_request=True,
         num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            labels={'ciflow/default', 'ciflow/cuda', 'ciflow/win'}
+        ),
     ),
     CIWorkflow(
         arch="windows",
@@ -199,6 +216,12 @@ WINDOWS_WORKFLOWS = [
         cuda_version="11.1",
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         num_test_shards=2,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels={'ciflow/cuda', 'ciflow/win'}
+        ),
     ),
     CIWorkflow(
         arch="windows",
@@ -211,7 +234,7 @@ WINDOWS_WORKFLOWS = [
         ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
-            labels={'ciflow/scheduled'}
+            labels={'ciflow/scheduled', 'ciflow/win', 'ciflow/cuda'}
         ),
     ),
 ]
@@ -225,6 +248,10 @@ LINUX_WORKFLOWS = [
         on_pull_request=True,
         enable_doc_jobs=True,
         num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            labels={'ciflow/default', 'ciflow/linux', 'ciflow/cpu'}
+        ),
     ),
     # CIWorkflow(
     #     arch="linux",
@@ -268,6 +295,12 @@ LINUX_WORKFLOWS = [
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7",
         test_runner_type=LINUX_CUDA_TEST_RUNNER,
         num_test_shards=2,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels={'ciflow/slow', 'ciflow/linux', 'ciflow/cuda'}
+        ),
     ),
     CIWorkflow(
         arch="linux",
@@ -284,7 +317,7 @@ LINUX_WORKFLOWS = [
         ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
-            labels=set(['ciflow/slow']),
+            labels=set(['ciflow/slow', 'ciflow/linux', 'ciflow/cuda']),
         ),
     ),
     CIWorkflow(
@@ -293,6 +326,12 @@ LINUX_WORKFLOWS = [
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7",
         test_runner_type=LINUX_CUDA_TEST_RUNNER,
         is_libtorch=True,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels=set(['ciflow/libtorch', 'ciflow/linux', 'ciflow/cuda']),
+        ),
     ),
     CIWorkflow(
         arch="linux",
@@ -300,6 +339,11 @@ LINUX_WORKFLOWS = [
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
         test_runner_type=LINUX_CUDA_TEST_RUNNER,
         num_test_shards=2,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            labels=set(['ciflow/default', 'ciflow/linux', 'ciflow/cuda']),
+        ),
     ),
     CIWorkflow(
         arch="linux",
@@ -307,6 +351,12 @@ LINUX_WORKFLOWS = [
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
         test_runner_type=LINUX_CUDA_TEST_RUNNER,
         is_libtorch=True,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            enabled=True,
+            trigger_action_only=True,
+            labels=set(['ciflow/libtorch', 'ciflow/linux', 'ciflow/cuda']),
+        ),
     ),
     CIWorkflow(
         arch="linux",
@@ -319,7 +369,7 @@ LINUX_WORKFLOWS = [
         ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
-            labels={'ciflow/scheduled'}
+            labels={'ciflow/scheduled', 'ciflow/linux', 'ciflow/cuda'}
         ),
     ),
     CIWorkflow(
@@ -333,7 +383,7 @@ LINUX_WORKFLOWS = [
         ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,
-            labels={'ciflow/scheduled'},
+            labels={'ciflow/scheduled', 'ciflow/linux', 'ciflow/libtorch', 'ciflow/cuda'},
         ),
     ),
     # CIWorkflow(
@@ -364,7 +414,7 @@ LINUX_WORKFLOWS = [
         num_test_shards=2,
         ciflow_config=CIFlowConfig(
             enabled=True,
-            labels=set(['ciflow/default']),
+            labels={'ciflow/default', 'ciflow/coverage', 'ciflow/linux', 'ciflow/cpu'},
         ),
     ),
     # CIWorkflow(
@@ -433,7 +483,7 @@ BAZEL_WORKFLOWS = [
         on_pull_request=True,
         ciflow_config=CIFlowConfig(
             enabled=True,
-            labels=set(['ciflow/default']),
+            labels={'ciflow/default', 'ciflow/bazel', 'ciflow/cpu', 'ciflow/linux'},
         ),
     ),
 ]

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -4,7 +4,8 @@
 name: libtorch-linux-xenial-cuda10.2-py3.6-gcc7
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
+  pull_request:
+    types: [unassigned]
   push:
     branches:
       - master
@@ -28,9 +29,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/libtorch') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   calculate-docker-image:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
+    needs: [ciflow_should_run]
     env:
       DOCKER_BUILDKIT: 1
     timeout-minutes: 90
@@ -104,7 +112,7 @@ jobs:
 
   build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, ]
+    needs: [calculate-docker-image, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: libtorch-linux-xenial-cuda10.2-py3.6-gcc7-build

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -4,7 +4,8 @@
 name: libtorch-linux-xenial-cuda11.1-py3.6-gcc7
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
+  pull_request:
+    types: [unassigned]
   push:
     branches:
       - master
@@ -28,9 +29,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/libtorch') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   calculate-docker-image:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
+    needs: [ciflow_should_run]
     env:
       DOCKER_BUILDKIT: 1
     timeout-minutes: 90
@@ -104,7 +112,7 @@ jobs:
 
   build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, ]
+    needs: [calculate-docker-image, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: libtorch-linux-xenial-cuda11.1-py3.6-gcc7-build

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -4,7 +4,8 @@
 name: linux-bionic-cuda10.2-py3.9-gcc7
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
+  pull_request:
+    types: [unassigned]
   push:
     branches:
       - master
@@ -28,9 +29,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux') || contains(github.event.pull_request.labels.*.name, 'ciflow/slow')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   calculate-docker-image:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
+    needs: [ciflow_should_run]
     env:
       DOCKER_BUILDKIT: 1
     timeout-minutes: 90
@@ -104,7 +112,7 @@ jobs:
 
   build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, ]
+    needs: [calculate-docker-image, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-bionic-cuda10.2-py3.9-gcc7-build
@@ -215,6 +223,7 @@ jobs:
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
+    needs: [ciflow_should_run]
     env:
       TEST_RUNNER_TYPE: linux.8xlarge.nvidia.gpu
       ENABLE_JIT_LEGACY_TEST: ''
@@ -242,7 +251,7 @@ jobs:
         run: .github/scripts/generate_pytorch_test_matrix.py
 
   test:
-    needs: [calculate-docker-image, build, generate-test-matrix, ]
+    needs: [calculate-docker-image, build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -400,7 +409,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ciflow_should_run:
     runs-on: ubuntu-18.04
-    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/default')) }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/coverage') || contains(github.event.pull_request.labels.*.name, 'ciflow/cpu') || contains(github.event.pull_request.labels.*.name, 'ciflow/default') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux')) }}
     steps:
       - name: noop
         run: echo running ciflow_should_run

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ciflow_should_run:
     runs-on: ubuntu-18.04
-    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/slow')) }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux') || contains(github.event.pull_request.labels.*.name, 'ciflow/slow')) }}
     steps:
       - name: noop
         run: echo running ciflow_should_run

--- a/.github/workflows/generated-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -4,7 +4,8 @@
 name: linux-xenial-cuda11.1-py3.6-gcc7
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
+  pull_request:
+    types: [opened, synchronize, reopened, unassigned]
   push:
     branches:
       - master
@@ -28,9 +29,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/default') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   calculate-docker-image:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
+    needs: [ciflow_should_run]
     env:
       DOCKER_BUILDKIT: 1
     timeout-minutes: 90
@@ -104,7 +112,7 @@ jobs:
 
   build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, ]
+    needs: [calculate-docker-image, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-xenial-cuda11.1-py3.6-gcc7-build
@@ -215,6 +223,7 @@ jobs:
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
+    needs: [ciflow_should_run]
     env:
       TEST_RUNNER_TYPE: linux.8xlarge.nvidia.gpu
       ENABLE_JIT_LEGACY_TEST: ''
@@ -242,7 +251,7 @@ jobs:
         run: .github/scripts/generate_pytorch_test_matrix.py
 
   test:
-    needs: [calculate-docker-image, build, generate-test-matrix, ]
+    needs: [calculate-docker-image, build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -400,7 +409,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -5,6 +5,7 @@ name: linux-xenial-py3.6-gcc5.4
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unassigned]
   push:
     branches:
       - master
@@ -28,9 +29,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cpu') || contains(github.event.pull_request.labels.*.name, 'ciflow/default') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   calculate-docker-image:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
+    needs: [ciflow_should_run]
     env:
       DOCKER_BUILDKIT: 1
     timeout-minutes: 90
@@ -104,7 +112,7 @@ jobs:
 
   build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, ]
+    needs: [calculate-docker-image, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-xenial-py3.6-gcc5.4-build
@@ -215,6 +223,7 @@ jobs:
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
+    needs: [ciflow_should_run]
     env:
       TEST_RUNNER_TYPE: linux.2xlarge
       ENABLE_JIT_LEGACY_TEST: ''
@@ -242,7 +251,7 @@ jobs:
         run: .github/scripts/generate_pytorch_test_matrix.py
 
   test:
-    needs: [calculate-docker-image, build, generate-test-matrix, ]
+    needs: [calculate-docker-image, build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -400,7 +409,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:
@@ -460,7 +469,7 @@ jobs:
 
   pytorch_python_doc_build:
     runs-on: linux.2xlarge
-    needs: [calculate-docker-image, build, ]
+    needs: [calculate-docker-image, build, ciflow_should_run]
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
     steps:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ciflow_should_run:
     runs-on: ubuntu-18.04
-    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/default')) }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/bazel') || contains(github.event.pull_request.labels.*.name, 'ciflow/cpu') || contains(github.event.pull_request.labels.*.name, 'ciflow/default') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux')) }}
     steps:
       - name: noop
         run: echo running ciflow_should_run

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   ciflow_should_run:
     runs-on: ubuntu-18.04
-    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/scheduled')) }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/libtorch') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux') || contains(github.event.pull_request.labels.*.name, 'ciflow/scheduled')) }}
     steps:
       - name: noop
         run: echo running ciflow_should_run

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   ciflow_should_run:
     runs-on: ubuntu-18.04
-    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/scheduled')) }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/linux') || contains(github.event.pull_request.labels.*.name, 'ciflow/scheduled')) }}
     steps:
       - name: noop
         run: echo running ciflow_should_run

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.3-py3.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   ciflow_should_run:
     runs-on: ubuntu-18.04
-    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (github.event.action == 'unassigned' && contains(github.event.pull_request.labels.*.name, 'ciflow/scheduled')) }}
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/scheduled') || contains(github.event.pull_request.labels.*.name, 'ciflow/win')) }}
     steps:
       - name: noop
         run: echo running ciflow_should_run

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -5,6 +5,7 @@ name: win-vs2019-cpu-py3
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unassigned]
   push:
     branches:
       - master
@@ -31,12 +32,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cpu') || contains(github.event.pull_request.labels.*.name, 'ciflow/default') || contains(github.event.pull_request.labels.*.name, 'ciflow/win')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     defaults:
       run:
         working-directory: pytorch-${{ github.run_id }}
+    needs: [ciflow_should_run]
     env:
       JOB_BASE_NAME: win-vs2019-cpu-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
@@ -90,6 +98,7 @@ jobs:
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
+    needs: [ciflow_should_run]
     runs-on: ubuntu-18.04
     env:
       TEST_RUNNER_TYPE: windows.4xlarge
@@ -121,7 +130,7 @@ jobs:
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       RUN_SMOKE_TESTS_ONLY_ON_PR: False
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
-    needs: [build, generate-test-matrix, ]
+    needs: [build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -198,7 +207,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:

--- a/.github/workflows/generated-win-vs2019-cuda10.1-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.1-py3.yml
@@ -5,6 +5,7 @@ name: win-vs2019-cuda10.1-py3
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unassigned]
   push:
     branches:
       - master
@@ -33,12 +34,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/default') || contains(github.event.pull_request.labels.*.name, 'ciflow/win')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     defaults:
       run:
         working-directory: pytorch-${{ github.run_id }}
+    needs: [ciflow_should_run]
     env:
       JOB_BASE_NAME: win-vs2019-cuda10.1-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
@@ -100,6 +108,7 @@ jobs:
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
+    needs: [ciflow_should_run]
     runs-on: ubuntu-18.04
     env:
       TEST_RUNNER_TYPE: windows.8xlarge.nvidia.gpu
@@ -131,7 +140,7 @@ jobs:
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       RUN_SMOKE_TESTS_ONLY_ON_PR: True
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
-    needs: [build, generate-test-matrix, ]
+    needs: [build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -216,7 +225,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:

--- a/.github/workflows/generated-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.1-py3.yml
@@ -4,6 +4,8 @@
 name: win-vs2019-cuda11.1-py3
 
 on:
+  pull_request:
+    types: [unassigned]
   push:
     branches:
       - master
@@ -32,12 +34,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ciflow_should_run:
+    runs-on: ubuntu-18.04
+    if: ${{ (github.event_name != 'pull_request') || (github.event.action !='unassigned') || (contains(github.event.pull_request.labels.*.name, 'ciflow/cuda') || contains(github.event.pull_request.labels.*.name, 'ciflow/win')) }}
+    steps:
+      - name: noop
+        run: echo running ciflow_should_run
   build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     defaults:
       run:
         working-directory: pytorch-${{ github.run_id }}
+    needs: [ciflow_should_run]
     env:
       JOB_BASE_NAME: win-vs2019-cuda11.1-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
@@ -99,6 +108,7 @@ jobs:
 
   generate-test-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
+    needs: [ciflow_should_run]
     runs-on: ubuntu-18.04
     env:
       TEST_RUNNER_TYPE: windows.8xlarge.nvidia.gpu
@@ -130,7 +140,7 @@ jobs:
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       RUN_SMOKE_TESTS_ONLY_ON_PR: False
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
-    needs: [build, generate-test-matrix, ]
+    needs: [build, generate-test-matrix, ciflow_should_run]
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false
@@ -215,7 +225,7 @@ jobs:
   # logs (like test); we can always move it back to the other one, but it
   # doesn't create the best experience
   render_test_results:
-    needs: [generate-test-matrix, test, ]
+    needs: [generate-test-matrix, test, ciflow_should_run]
     if: ${{ needs.test.result != 'skipped' || failure() }}
     runs-on: linux.2xlarge
     strategy:


### PR DESCRIPTION
- Add more ciflow labels and enable it for more workflows.
- Only the 'ciflow/default' workflows are run by default on pull_request time
- Other labels can be manually triggered by (adding the labels + unassign @pytorchbot), OR wait for pytorchbot's comment opt-in rollout
- The label design is a logical operator `OR`, i.e. adding ('ciflow/cuda' + 'ciflow/win') will trigger the union of them. (design feedback is needed here)


Typical default workflows for normal PRs.


<details>
<summary>Generated label rules</summary>

![image](https://user-images.githubusercontent.com/658840/129779905-eb5e56dd-a696-4040-9eb6-71ecb6487dc1.png)



```
{
  "label_rules": {
    "ciflow/all": [
      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
      "linux-bionic-cuda10.2-py3.9-gcc7",
      "linux-bionic-py3.8-gcc9-coverage",
      "linux-xenial-cuda10.2-py3.6-gcc7",
      "linux-xenial-cuda11.1-py3.6-gcc7",
      "linux-xenial-py3.6-gcc5.4",
      "linux-xenial-py3.6-gcc7-bazel-test",
      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-win-vs2019-cuda11.3-py3",
      "win-vs2019-cpu-py3",
      "win-vs2019-cuda10.1-py3",
      "win-vs2019-cuda11.1-py3"
    ],
    "ciflow/bazel": [
      "linux-xenial-py3.6-gcc7-bazel-test"
    ],
    "ciflow/coverage": [
      "linux-bionic-py3.8-gcc9-coverage"
    ],
    "ciflow/cpu": [
      "linux-bionic-py3.8-gcc9-coverage",
      "linux-xenial-py3.6-gcc5.4",
      "linux-xenial-py3.6-gcc7-bazel-test",
      "win-vs2019-cpu-py3"
    ],
    "ciflow/cuda": [
      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
      "linux-bionic-cuda10.2-py3.9-gcc7",
      "linux-xenial-cuda10.2-py3.6-gcc7",
      "linux-xenial-cuda11.1-py3.6-gcc7",
      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-win-vs2019-cuda11.3-py3",
      "win-vs2019-cuda10.1-py3",
      "win-vs2019-cuda11.1-py3"
    ],
    "ciflow/default": [
      "linux-bionic-py3.8-gcc9-coverage",
      "linux-xenial-cuda11.1-py3.6-gcc7",
      "linux-xenial-py3.6-gcc5.4",
      "linux-xenial-py3.6-gcc7-bazel-test",
      "win-vs2019-cpu-py3",
      "win-vs2019-cuda10.1-py3"
    ],
    "ciflow/libtorch": [
      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7"
    ],
    "ciflow/linux": [
      "libtorch-linux-xenial-cuda10.2-py3.6-gcc7",
      "libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
      "linux-bionic-cuda10.2-py3.9-gcc7",
      "linux-bionic-py3.8-gcc9-coverage",
      "linux-xenial-cuda10.2-py3.6-gcc7",
      "linux-xenial-cuda11.1-py3.6-gcc7",
      "linux-xenial-py3.6-gcc5.4",
      "linux-xenial-py3.6-gcc7-bazel-test",
      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-linux-xenial-cuda11.3-py3.6-gcc7"
    ],
    "ciflow/scheduled": [
      "periodic-libtorch-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-linux-xenial-cuda11.3-py3.6-gcc7",
      "periodic-win-vs2019-cuda11.3-py3"
    ],
    "ciflow/slow": [
      "linux-bionic-cuda10.2-py3.9-gcc7",
      "linux-xenial-cuda10.2-py3.6-gcc7"
    ],
    "ciflow/win": [
      "periodic-win-vs2019-cuda11.3-py3",
      "win-vs2019-cpu-py3",
      "win-vs2019-cuda10.1-py3",
      "win-vs2019-cuda11.1-py3"
    ]
  },
  "version": "v1"
}
```
</details>