### PR TITLE
make target det list export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.xml
 **/.pytorch_specified_test_cases.csv
 **/.pytorch-disabled-tests.json
 **/.pytorch-slow-tests.json
+**/.pytorch-target-det-list.json
 **/.pytorch-test-times.json
 */*.pyc
 */*.so*

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -22,6 +22,7 @@ try:
     sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
     from tools.testing.test_selections import (
         export_S3_test_times,
+        export_target_det_list,
         get_shard_based_on_S3,
         get_slow_tests_based_on_S3,
         get_specified_test_cases,
@@ -341,6 +342,8 @@ TARGET_DET_LIST = [
     'distributed/pipeline/sync/test_transparency',
     'distributed/pipeline/sync/test_worker',
 ]
+
+TARGET_DET_FILE = '.pytorch-target-det-list.json'
 
 # the JSON file to store the S3 test stats
 TEST_TIMES_FILE = '.pytorch-test-times.json'
@@ -712,6 +715,13 @@ def parse_args():
         help='dumps test times from previous S3 stats into a file, format JSON',
     )
     parser.add_argument(
+        '--export-target-det-list',
+        nargs='?',
+        type=str,
+        const=TARGET_DET_FILE,
+        help='dumps test times from previous S3 stats into a file, format JSON',
+    )
+    parser.add_argument(
         '--shard',
         nargs=2,
         type=int,
@@ -1050,6 +1060,13 @@ def main():
             if determine_target(TARGET_DET_LIST + slow_tests, test, touched_files, options)
         ]
         sys.path.remove('test')
+
+        # TODO: move this to tools/test_selections.py
+        target_det_filename = options.export_target_det_list
+        if target_det_filename:
+            print(f'Determine target list and report to {target_det_filename}.')
+            export_target_det_list(selected_tests, target_det_filename)
+            return
 
     if IS_IN_CI:
         selected_tests = get_reordered_tests(selected_tests, ENABLE_PR_HISTORY_REORDERING)

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -290,6 +290,17 @@ def export_S3_test_times(test_times_filename: Optional[str] = None) -> Dict[str,
     return test_times
 
 
+# TODO refactor this and unify with tools.stats.export_*
+def export_target_det_list(selected_test: List[Any], target_det_filename: str) -> None:
+    if target_det_filename is not None:
+        print(f'Exporting target determination result to {target_det_filename}.')
+        if os.path.exists(target_det_filename):
+            print(f'Overwriting existent file: {target_det_filename}')
+        with open(target_det_filename, 'w+') as file:
+            json.dump(selected_test, file, indent='    ', separators=(',', ': '))
+            file.write('\n')
+
+
 def get_test_case_configs(dirpath: str) -> None:
     get_slow_tests(dirpath=dirpath)
     get_disabled_tests(dirpath=dirpath)


### PR DESCRIPTION
Add functionality to export target det list.

Currently it outputs a list of test files that TD decided to run. What extra information do we want to export?
- [ ] file type? 
- [ ] ALL test files that ran through TD and a flag true/false? (b/c some files are not even going through TD, it might be good to log everything)
- [ ] ALL test files dependencies that triggered TD to decide to run (e.g. which traceback changed files triggered the decision of running a test)

