### PR TITLE
Update cuda amp to also check xla device

### DIFF
--- a/torch/autocast_mode.py
+++ b/torch/autocast_mode.py
@@ -135,7 +135,7 @@ class autocast(object):
             self.fast_dtype = torch.get_autocast_cpu_dtype()
         else:
             raise RuntimeError('User specified autocast device_type must be \'cuda\' or \'cpu\'')
-        if not torch.cuda.is_available() and self.device == 'cuda':
+        if torch.cuda.amp.common.amp_definitely_not_available() and self.device == 'cuda':
             warnings.warn('User provided device_type of \'cuda\', but CUDA is not available. Disabling')
             enabled = False
         for key, value in kwargs.items():


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/3086. Pytorch/XLA:GPU also use cuda amp. I verified the pt/xla `test_autocast` with this fix and all test passed.