### PR TITLE
[BF16] Add a missing thread local specifier to autocast_gpu_dtype

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -59,7 +59,7 @@ thread_local int nesting = 0;
 thread_local at::ScalarType autocast_cpu_dtype = at::kBFloat16;
 
 // autocast_gpu_dtype is the lower_precision_fp used by AutocastGPU.
-at::ScalarType autocast_gpu_dtype = at::kHalf;
+thread_local at::ScalarType autocast_gpu_dtype = at::kHalf;
 }
 
 void clear_cache() {


### PR DESCRIPTION
Summary:
Fix a missing thread local specifier introduced by recent PR

https://github.com/pytorch/pytorch/pull/61002

Test Plan: Unit Tests

Differential Revision: D30376154

