### PR TITLE
Make DataChunk support list in-place ops

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -110,14 +110,54 @@ def create_temp_dir_and_files():
 
 
 class TestDataChunk(TestCase):
+    def setUp(self):
+        self.elements = list(range(10))
+        random.shuffle(self.elements)
+        self.chunk: DataChunk[int] = DataChunk(self.elements)
+
+    def test_getitem(self):
+        for i in range(10):
+            self.assertEqual(self.elements[i], self.chunk[i])
+
+    def test_iter(self):
+        for ele, dc in zip(self.elements, iter(self.chunk)):
+            self.assertEqual(ele, dc)
+
+    def test_len(self):
+        self.assertEqual(len(self.elements), len(self.chunk))
+
     def test_as_string(self):
+        self.assertEqual(str(self.chunk), str(self.elements))
+
+        batch = [self.elements] * 3
+        chunks: List[DataChunk[int]] = [DataChunk(self.elements)] * 3
+        self.assertEqual(str(batch), str(chunks))
+
+    def test_sort(self):
+        chunk: DataChunk[int] = DataChunk(self.elements)
+        chunk.sort()
+        self.assertTrue(isinstance(chunk, DataChunk))
+        for i, d in enumerate(chunk):
+            self.assertEqual(i, d)
+
+    def test_reverse(self):
+        chunk: DataChunk[int] = DataChunk(self.elements)
+        chunk.reverse()
+        self.assertTrue(isinstance(chunk, DataChunk))
+        for i in range(10):
+            self.assertEqual(chunk[i], self.elements[9-i])
+
+    def test_random_shuffle(self):
         elements = list(range(10))
         chunk: DataChunk[int] = DataChunk(elements)
-        self.assertEqual(str(chunk), str(elements))
 
-        batch = [elements] * 3
-        chunks: List[DataChunk] = [DataChunk(elements)] * 3
-        self.assertEqual(str(chunk), str(elements))
+        rng = random.Random(0)
+        rng.shuffle(chunk)
+
+        rng = random.Random(0)
+        rng.shuffle(elements)
+
+        self.assertEqual(chunk, elements)
 
 
 class TestIterableDataPipeBasic(TestCase):

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -145,7 +145,7 @@ class TestDataChunk(TestCase):
         chunk.reverse()
         self.assertTrue(isinstance(chunk, DataChunk))
         for i in range(10):
-            self.assertEqual(chunk[i], self.elements[9-i])
+            self.assertEqual(chunk[i], self.elements[9 - i])
 
     def test_random_shuffle(self):
         elements = list(range(10))

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -133,14 +133,14 @@ class UnBatchIterDataPipe(IterDataPipe):
             else:
                 raise IndexError(f"unbatch_level {self.unbatch_level} exceeds the depth of the DataPipe")
 
-# TODO(ejguan): https://github.com/pytorch/pytorch/issues/63095
+
 def _in_batch_shuffle_fn(data: DataChunk):
-    d = list(data)
-    random.shuffle(d)
-    return DataChunk(d)
+    random.shuffle(data)
+    return data
+
 
 class BucketBatcherIterDataPipe(IterDataPipe[DataChunk[T_co]]):
-    r""" :class:`BucketBatcherIterDataPipe`.
+    r""":class:`BucketBatcherIterDataPipe`.
 
     Iterable DataPipe to create mini-batches of data from sorted bucket. An outer
     dimension will be added as `batch_size` if `drop_last` is set to `True`,

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -25,25 +25,17 @@ T_co = TypeVar('T_co', covariant=True)
 T = TypeVar('T')
 
 
-class DataChunk(List[T]):
+class DataChunk(list, Generic[T]):
     def __init__(self, items):
+        super().__init__(items)
         self.items = items
-
-    def __getitem__(self, key):
-        return self.items[key]
-
-    def __len__(self):
-        return len(self.items)
 
     def as_str(self, indent=''):
         res = indent + "[" + ", ".join([str(i) for i in iter(self)]) + "]"
         return res
 
-    def __repr__(self):
-        return self.as_str()
-
     def __iter__(self) -> Iterator[T]:
-        for i in self.items:
+        for i in super().__iter__():
             yield i
 
     def raw_iterator(self):


### PR DESCRIPTION
Fixes #63095

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#63422 Make DataChunk support list in-place ops**

Make `DataChunk` delegate to list method. Then it will support in-place operations:
- `sort`
- `reverse`
- `append`
- `extend`
- `random.shuffle`

Differential Revision: [D30379027](https://our.internmc.facebook.com/intern/diff/D30379027)