### PR TITLE
[LTC] Fix some CI issues

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -51,10 +51,11 @@ function get_exit_code() {
 
 function file_diff_from_base() {
   # The fetch may fail on Docker hosts, this fetch is necessary for GHA
+  # lazy_tensor_staging is a hack to replace master to avoid some CI issues. Don't merge it.
   set +e
-  git fetch origin master --quiet
+  git fetch origin lazy_tensor_staging --quiet
   set -e
-  git diff --name-only "$(git merge-base origin/master HEAD)" > "$1"
+  git diff --name-only "$(git merge-base origin/lazy_tensor_staging HEAD)" > "$1"
 }
 
 function get_bazel() {

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -107,8 +107,9 @@ def plural(n: int) -> str:
 
 
 def get_base_commit(sha1: str) -> str:
+    # lazy_tensor_staging is a hack to replace master to avoid some CI issues. Don't merge it.
     return subprocess.check_output(
-        ["git", "merge-base", sha1, "origin/master"],
+        ["git", "merge-base", sha1, "origin/lazy_tensor_staging"],
         encoding="ascii",
     ).strip()
 


### PR DESCRIPTION
Summary:
file_diff_from_base() has issues while being run on PRs that are not targeting master.
This patch hacks it to work with lazy_tensor_staging branch.
