### PR TITLE
[fx2trt] Add dequantize support

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1106,3 +1106,35 @@ def acc_ops_permute(network, target, args, kwargs, name):
     layer.second_transpose = tuple(permutation)
     layer.name = name
     return layer.get_output(0)
+
+@tensorrt_converter(acc_ops.quantize_per_tensor)
+def acc_ops_quantize_per_tensor(network, target, args, kwargs, name):
+    input_val = kwargs["input"]
+
+    if not isinstance(input_val, trt.tensorrt.ITensor):
+        raise RuntimeError(f"{name} received input {input_val} that is not part "
+                           "of the TensorRT region!")
+
+    q_scale = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "q_scale")
+    q_zero_point = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "q_zero_point")
+    dtype = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "dtype")
+    if dtype not in (torch.quint8, torch.qint8, torch.qint32):
+        raise RuntimeError("Only support (torch.quint8, torch.qint8, torch.qint32) "
+                           f"quantized type in quantize_per_tensor, get {dtype}.")
+
+    if q_zero_point != 0:
+        raise RuntimeError(f"Only support zero_point == 0, get {q_zero_point}")
+
+    # temporarily set q_scale to 1 to make sure the q_scale is different
+    # for quantize and dequantize to avoid the error
+    # TODO: follow up with nvidia TensorRT team to repro and fix the problem
+    q_scale = 1
+    scale_layer = network.add_constant((1,), trt.Weights(np.ascontiguousarray([float(q_scale)], dtype=np.float32)))
+    scale_layer.name = input_val.name + ".quant.scale"
+    scale = scale_layer.get_output(0)
+    assert trt.__version__ > "8.0", "Explicit quantize op is only supported in "
+    "TensorRT 8.0 or above, current TensorRT version:" + trt.__version__
+    layer = network.add_quantize(input=input_val, scale=scale)
+    layer.axis = 0
+    layer.name = input_val.name + ".quant"
+    return layer.get_output(0)

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -462,10 +462,12 @@ def quantize_per_tensor(*, input, acc_out_ty=None):
     )
 
 
-@register_acc_op_mapping(op_and_target=("call_function", torch.dequantize))
-@register_acc_op_mapping(op_and_target=("call_method", "dequantize"))
 @register_acc_op
-def dequantize(*, input):
+def dequantize(*, input, input_tensor_meta):
+    """ `input_tensor_meta` contains extra argument of quantization
+    parameters, e.g. scale/zero_point and will be using for
+    lowring dequantize op to TensorRT
+    """
     return torch.dequantize(input)
 
 
@@ -1174,3 +1176,27 @@ def packed_quantized_convrelu2d_mapper(
         )
         relu_node.meta = node.meta
         return relu_node
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.dequantize),
+    arg_replacement_tuples=[
+        ("input", "input")
+    ]
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "dequantize"),
+    arg_replacement_tuples=[
+        ("input", "input")
+    ]
+)
+def custom_dequantize_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
+    assert "tensor_meta" in node.kwargs["input"].meta
+    new_kwargs = {"input": node.kwargs["input"], "input_tensor_meta": node.kwargs["input"].meta["tensor_meta"]}
+    # `input_tensor_meta` contains quantization parameters that can be used to lower
+    # acc_ops.dequantize to TensorRT ops
+    with node.graph.inserting_before(node):
+        new_node = node.graph.create_node(
+            "call_function", dequantize, kwargs=new_kwargs, name=node.name
+        )
+        new_node.meta = node.meta
+        return new_node

--- a/torch/fx/experimental/graph_manipulation.py
+++ b/torch/fx/experimental/graph_manipulation.py
@@ -412,7 +412,7 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
         def get_arg_info(arg: Argument) -> Any:
             if isinstance(arg, torch.fx.Node):
                 return {"is_node": True, "name": str(arg)}
-            elif isinstance(arg, torch.dtype):
+            elif isinstance(arg, (torch.dtype, torch.memory_format, torch.qscheme)):
                 return str(arg)
             else:
                 return arg


### PR DESCRIPTION
Summary: Only available after TensorRT 8.0

Test Plan: buck run mode/opt caffe2/torch/fb/fx2trt:test_dequantize

Reviewed By: 842974287

Differential Revision: D30296863

