### PR TITLE
[RFC] [PyTorch Edge] Buffet of changes to speed up model loading for on-device use

### DIFF
--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -115,6 +115,8 @@ class TORCH_API Module {
     return debug_table_;
   }
 
+  std::vector<c10::IValue> bvals_;
+
  private:
   c10::intrusive_ptr<c10::ivalue::Object> object_;
   std::unordered_map<std::string, std::string> metadata_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63465
* #63464

Numerous changes to avoid copying `IValue` where possible, and caching the deserialized `vector<IValue>` from the bytecode pkl, deferring its destruction to model unload. See https://fb.workplace.com/groups/pytorch.edge.team/posts/918085275412879/ for more context.

Differential Revision: [D30388268](https://our.internmc.facebook.com/intern/diff/D30388268/)