### PR TITLE
Fix torch.istft length mismatch and window runtime error

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -926,7 +926,9 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> ho
   window_envelop = window_envelop.slice(2, start, end, 1);
 
   // Apply window normalization on non-tiny indices
-  y = at::where(window_envelop.abs().to(kDouble) > 1e-11, y / window_envelop, y);
+  window_envelop = at::where(
+    window_envelop.abs() > 1e-11, window_envelop, at::ones({}, window_envelop.options()));
+  y = y / window_envelop;
   y = y.squeeze(1);  // size: (channel, expected_output_signal_len)
   if (input_dim == 3) {
     y = y.squeeze(0);

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -925,11 +925,8 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> ho
   y = y.slice(2, start, end, 1);
   window_envelop = window_envelop.slice(2, start, end, 1);
 
-  // Apply window normalization on non-zero indices
-  window_envelop = window_envelop.repeat({y.size(0), y.size(1), 1});
-  auto index = at::indexing::TensorIndex(window_envelop.abs().to(kDouble) > 1e-11);
-  y.index_put_({index,}, y.index(index) / window_envelop.index(index));
-
+  // Apply window normalization on non-tiny indices
+  y = at::where(window_envelop.abs().to(kDouble) > 1e-11, y / window_envelop, y);
   y = y.squeeze(1);  // size: (channel, expected_output_signal_len)
   if (input_dim == 3) {
     y = y.squeeze(0);

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -938,7 +938,7 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> ho
   // zero padding if the given lengthOpt is longer than expected
   if(end > expected_output_signal_len) {
     TORCH_WARN_ONCE(
-      "The length of signal is shorter than the length parameter. Pad zeros to the tail. "
+      "The length of signal is shorter than the length parameter. Result is being padded with zeros in the tail. "
       "Please check your center and hop_length settings."
     );
     y = at::constant_pad_nd(y, {0, end - expected_output_signal_len}, 0);

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -920,7 +920,7 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> ho
 
   // We need to trim the front padding away if centered
   const auto start = center ? n_fft / 2 : 0;
-  const auto end = lengthOpt.has_value()? start + lengthOpt.value() : - n_fft / 2;
+  const auto end = lengthOpt.has_value() ? start + lengthOpt.value() : (center ? - n_fft / 2 : -1);
 
   y = y.slice(2, start, end, 1);
   window_envelop = window_envelop.slice(2, start, end, 1);

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1125,7 +1125,7 @@ class TestFFT(TestCase):
                 for i in range(num_trials):
                     original = torch.randn(*sizes, dtype=dtype, device=device)
                     stft = torch.stft(original, return_complex=True, **stft_kwargs)
-                    inversed = torch.istft(stft, length=original.size(1), **istft_kwargs)
+                    inversed = torch.istft(stft, **istft_kwargs)
 
                     # trim the original for case when constructed signal is shorter than original
                     original = original[..., :inversed.size(-1)]
@@ -1203,10 +1203,6 @@ class TestFFT(TestCase):
         self.assertRaises(
             RuntimeError, torch.istft, stft, n_fft=4,
             hop_length=20, win_length=1, window=torch.ones(1))
-        # A window of zeros does not meet NOLA
-        invalid_window = torch.zeros(4, device=device)
-        self.assertRaises(
-            RuntimeError, torch.istft, stft, n_fft=4, win_length=4, window=invalid_window)
         # Input cannot be empty
         self.assertRaises(RuntimeError, torch.istft, torch.zeros((3, 0, 2)), 2)
         self.assertRaises(RuntimeError, torch.istft, torch.zeros((0, 3, 2)), 2)

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1188,37 +1188,39 @@ class TestFFT(TestCase):
         def _test_istft_is_inverse_of_stft_with_padding(stft_kwargs):
             # generates a random sound signal for each tril and then does the stft/istft
             # operation to check whether we can reconstruct signal
-            data_sizes = [(2, 20), (3, 15), (4, 10)]
             num_trials = 100
+            sizes = stft_kwargs['size']
+            del stft_kwargs['size']
             istft_kwargs = stft_kwargs.copy()
             del istft_kwargs['pad_mode']
-            for sizes in data_sizes:
-                for i in range(num_trials):
-                    original = torch.randn(*sizes, dtype=dtype, device=device)
-                    stft = torch.stft(original, return_complex=True, **stft_kwargs)
+            for i in range(num_trials):
+                original = torch.randn(*sizes, dtype=dtype, device=device)
+                stft = torch.stft(original, return_complex=True, **stft_kwargs)
+                with self.assertWarnsOnceRegex(UserWarning, "The length of signal is shorter than the length parameter."):
                     inversed = torch.istft(stft, length=original.size(-1), **istft_kwargs)
-                    n_frames = stft.size(-1)
-                    if stft_kwargs["center"] is True:
-                        len_expected = stft_kwargs["n_fft"] // 2 + stft_kwargs["hop_length"] * (n_frames - 1)
-                    else:
-                        len_expected = stft_kwargs["n_fft"] + stft_kwargs["hop_length"] * (n_frames - 1)
-                    # trim the original for case when constructed signal is shorter than original
-                    padding = inversed[..., len_expected:]
-                    inversed = inversed[..., :len_expected]
-                    original = original[..., :len_expected]
-                    # test the padding points of the inversed signal are all zeros
-                    zeros = torch.zeros_like(padding, device=padding.device)
-                    self.assertEqual(
-                        padding, zeros, msg='istft padding values against zeros',
-                        atol=7e-6, rtol=0, exact_dtype=True)
-                    self.assertEqual(
-                        inversed, original, msg='istft comparison against original',
-                        atol=7e-6, rtol=0, exact_dtype=True)
+                n_frames = stft.size(-1)
+                if stft_kwargs["center"] is True:
+                    len_expected = stft_kwargs["n_fft"] // 2 + stft_kwargs["hop_length"] * (n_frames - 1)
+                else:
+                    len_expected = stft_kwargs["n_fft"] + stft_kwargs["hop_length"] * (n_frames - 1)
+                # trim the original for case when constructed signal is shorter than original
+                padding = inversed[..., len_expected:]
+                inversed = inversed[..., :len_expected]
+                original = original[..., :len_expected]
+                # test the padding points of the inversed signal are all zeros
+                zeros = torch.zeros_like(padding, device=padding.device)
+                self.assertEqual(
+                    padding, zeros, msg='istft padding values against zeros',
+                    atol=7e-6, rtol=0, exact_dtype=True)
+                self.assertEqual(
+                    inversed, original, msg='istft comparison against original',
+                    atol=7e-6, rtol=0, exact_dtype=True)
 
         patterns = [
             # hamming_window, not centered, not normalized, not onesided
             # window same size as n_fft
             {
+                'size': [2, 20],
                 'n_fft': 3,
                 'hop_length': 2,
                 'win_length': 3,
@@ -1228,25 +1230,14 @@ class TestFFT(TestCase):
                 'normalized': False,
                 'onesided': False,
             },
-            # hamming_window, not centered, not normalized, onesided
-            # window same size as n_fft
-            {
-                'n_fft': 5,
-                'hop_length': 2,
-                'win_length': 5,
-                'window': torch.hamming_window(5, dtype=dtype, device=device),
-                'center': False,
-                'pad_mode': 'constant',
-                'normalized': False,
-                'onesided': True,
-            },
             # hamming_window, centered, not normalized, onesided, long hop_length
             # window same size as n_fft
             {
-                'n_fft': 10,
-                'hop_length': 9,
-                'win_length': 10,
-                'window': torch.hamming_window(10, dtype=dtype, device=device),
+                'size': [2, 500],
+                'n_fft': 256,
+                'hop_length': 254,
+                'win_length': 256,
+                'window': torch.hamming_window(256, dtype=dtype, device=device),
                 'center': True,
                 'pad_mode': 'constant',
                 'normalized': False,

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1264,6 +1264,10 @@ class TestFFT(TestCase):
         self.assertRaises(
             RuntimeError, torch.istft, stft, n_fft=4,
             hop_length=20, win_length=1, window=torch.ones(1))
+        # A window of zeros does not meet NOLA
+        invalid_window = torch.zeros(4, device=device)
+        self.assertRaises(
+            RuntimeError, torch.istft, stft, n_fft=4, win_length=4, window=invalid_window)
         # Input cannot be empty
         self.assertRaises(RuntimeError, torch.istft, torch.zeros((3, 0, 2)), 2)
         self.assertRaises(RuntimeError, torch.istft, torch.zeros((0, 3, 2)), 2)

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -569,7 +569,8 @@ def istft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
 
     Since :func:`~torch.stft` discards elements at the end of the signal if they do not fit in a frame,
     ``istft`` may return a shorter signal than the original signal (can occur if :attr:`center` is False
-    since the signal isn't padded).
+    since the signal isn't padded). If `length` is given in the arguments and is longer than expected,
+    ``istft`` will pad zeros to the end of the returned signal.
 
     If :attr:`center` is ``True``, then there will be padding e.g. ``'constant'``, ``'reflect'``, etc.
     Left padding can be trimmed off exactly because they can be calculated but right padding cannot be


### PR DESCRIPTION
The PR fixes two issues:
- See #62747 and https://github.com/pytorch/audio/issues/1409. The length mismatch when the given ``length`` parameter is longer than expected. Add padding logic in consistent with librosa. 
- See #62323. The current implementations checks if the min value of window_envelop.abs() is greater than zero.  In librosa they normalize the signal on non-zero values by indexing. Like 
```
approx_nonzero_indices = ifft_window_sum > util.tiny(ifft_window_sum)
y[approx_nonzero_indices] /= ifft_window_sum[approx_nonzero_indices]
``` 