### PR TITLE
Add const keyword in jit/python/init.cpp

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -467,7 +467,7 @@ void initJITBindings(PyObject* module) {
             ArgumentSpecCreator arg_spec_creator(*graph);
             Stack stack;
             stack.reserve(inputs.size()); // captures?
-            for (auto& obj : inputs) {
+            for (const auto& obj : inputs) {
               stack.push_back(toTypeInferredIValue(obj));
             }
             ArgumentSpec spec = arg_spec_creator.create(with_grad, stack);
@@ -488,7 +488,7 @@ void initJITBindings(PyObject* module) {
           [](std::shared_ptr<Graph>& graph, const py::tuple& inputs) {
             Stack stack;
             stack.reserve(inputs.size()); // captures?
-            for (auto& obj : inputs) {
+            for (const auto& obj : inputs) {
               stack.push_back(toTypeInferredIValue(obj));
             }
             auto g_inputs = graph->inputs();


### PR DESCRIPTION
The missing `const` keywords are appearing as errors in compilation for pypy builds on conda-forge
https://github.com/conda-forge/pytorch-cpu-feedstock/pull/66
