### PR TITLE
[ROCm] hipFree() may not not synchronize non-blocking streams

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1170,6 +1170,10 @@ class DeviceCachingAllocator {
   }
 
   void release_block(Block* block) {
+#ifdef __HIP_PLATFORM_HCC__
+    // HIP runtime does not synchronize non-blocking streams during free
+    C10_CUDA_CHECK(cudaStreamSynchronize(block->stream));
+#endif
     C10_CUDA_CHECK(cudaFree((void*)block->ptr));
     total_allocated_memory -= block->size;
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1456,7 +1456,7 @@ class THCUncachedAllocator {
   // allocated streams by device pointer
   std::unordered_map<void*, cudaStream_t> allocated_streams;
 
-  void add_allocated_stream(void *ptr, cudaStream_t stream) {
+  void add_allocated_stream(void* ptr, cudaStream_t stream) {
     std::lock_guard<std::mutex> lock(mutex);
     allocated_streams[ptr] = stream;
   }
@@ -1464,7 +1464,8 @@ class THCUncachedAllocator {
   cudaStream_t get_allocated_stream(void* ptr) {
     std::lock_guard<std::mutex> lock(mutex);
     auto it = allocated_streams.find(ptr);
-    TORCH_INTERNAL_ASSERT(it != allocated_streams.end(), "allocation stream not found");
+    TORCH_INTERNAL_ASSERT(
+        it != allocated_streams.end(), "allocation stream not found");
     cudaStream_t stream = it->second;
     allocated_streams.erase(it);
     return stream;


### PR DESCRIPTION
hipFree() may not synchronize non-blocking streams.  When disabling the caching allocator, it will result in memory access faults for tests that create and destroy many intermediate tensors because the memory is recovered before the kernels run.  Here we introduce a safer uncached allocator to use when disabling the caching allocator.  Further, the caching allocator will synchronize the stream associated with the cached block before calling hipFree().