### PR TITLE
[JIT] Optimize aten::append

### DIFF
--- a/torch/csrc/jit/passes/peephole_list_idioms.h
+++ b/torch/csrc/jit/passes/peephole_list_idioms.h
@@ -51,6 +51,21 @@ namespace jit {
 //
 // This is only applied to lists that are not modified.
 //
+// 5. ListConstruct + append
+// Given a function like this:
+//     def foo():
+//         li = [1, 2]
+//         li.append(3)
+//         return li
+// This pass produces:
+//     def foo():
+//         li = [1, 2, 3]
+//         return li
+//
+// This optimization is only applied to append ops that immediately
+// follow the ListConstruct with no users of the list before them.
+// They must also exist in the same owning block as the ListConstuct op.
+//
 // Currently this is invoked as part of PeepholeOptimize
 // return true if graph is modified.
 // If `refine_list_len` is true will attempt to refine the len of lists through


### PR DESCRIPTION
Summary:
Add a pass that transforms sequences like this:
```
li = []
li.append(1)
li.append(2)
```
into this:
```
li = [1, 2]
```

The following algorithm is used to make this optimization safe:

* Create a collection of `aten::append` nodes to optimize.
* For each user node `user` of a `prim::ListConstruct` node,
    * If `user` is not an `aten::append` node, break. The purpose of this check is to prevent breaking correctness in the following scenario:
    ```
    li = []
    x = len(li) # x should be 0, not 1
    li.append(1)
    ```

    * If `user` is not in the same block as the `ListConstruct` node, break. The purpose of this check is to prevent breaking correctness in the presence of control flow.
    ```
    li = []
    if x:
        li.append(1)
    ```
    * Else, add `user` to the collection.

* Use the collection to make a new `ListConstruct` node. Place it after the final `aten::append` node.

Test Plan: New unit tests: `buck test //caffe2/test:jit -- TestPeephole`

Differential Revision: D30387213

