### PR TITLE
Nnapi Delegation: Quick improvements

### DIFF
--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
@@ -31,9 +31,8 @@ class NnapiBackend : public PyTorchBackendInterface {
   c10::impl::GenericDict compile(
       c10::IValue processed,
       c10::impl::GenericDict method_compile_spec) override {
-    auto dict = processed.toGenericDict();
-
     // Wrap procesed in dictionary: {"forward": processed}
+    auto dict = processed.toGenericDict();
     c10::Dict<c10::IValue, c10::IValue> handles(
         c10::StringType::get(), c10::AnyType::get());
     handles.insert("forward", dict);
@@ -105,7 +104,6 @@ class NnapiBackend : public PyTorchBackendInterface {
   // and cannot be passed through the handles dictionary
   std::unique_ptr<torch::nnapi::bind::NnapiCompilation> comp_;
   c10::List<at::Tensor> out_templates_;
-  mobile::Module shape_compute_module_;
 
   // Runs once per model initialization
   // Cannot be moved to compile(), because init() requires actual inputs
@@ -119,9 +117,9 @@ class NnapiBackend : public PyTorchBackendInterface {
     std::stringstream ss;
     auto shape_ptr = dict.at("shape_compute_module").toString();
     ss.str(*shape_ptr);
-    shape_compute_module_ = _load_for_mobile(ss);
+    auto shape_compute_module = _load_for_mobile(ss);
     out_templates_ =
-        shape_compute_module_.run_method("prepare", ser_model, inputs)
+        shape_compute_module.run_method("prepare", ser_model, inputs)
             .toTensorList();
 
     // Create and initialize NnapiComilation object

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -96,6 +96,9 @@ c10::IValue preprocess(
   // transform Python lists to C++ c10::List
   c10::List<at::Tensor> weights(
       py::cast<std::vector<at::Tensor>>(nnapi_processed[2]));
+  for (int i = 0; i < weights.size(); i++) {
+    weights.set(i, weights.get(i).contiguous());
+  }
   c10::List<int64_t> inp_mem_fmts(
       py::cast<std::vector<int64_t>>(nnapi_processed[3]));
   c10::List<int64_t> out_mem_fmts(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63489

Summary:
A few quick improvements to the Android NNAPI Delegate, some of which were discussed here https://github.com/pytorch/pytorch/pull/62272: 
1) `throw std::exception` replaced with `TORCH_CHECK` to reduce runtime
size (nnapi_backend_lib.cpp)
2) weights processing moved from compile to preprocess step, since it can
be done AOT (nnapi_backend_lib.cpp & nnapi_backend_preprocess.cpp)
3) `ser_model_` and `shape_compute_module_` member variables removed, since they are never used after
`init()`, so they are not needed (nnapi_backend_lib.cpp)

Test Plan:
Unit tests: `python test/test_jit.py TestNnapiBackend`
Run SparkAR segmentation with delegated NNAPI as done here D30259033 (can use `jf download GAekdAwsyGKXhggFALN4LnSBTzcubsIXAAAz --file "v303-nnd-mod.ptl"` to get a preprocessed model from these changes)

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D30398880](https://our.internmc.facebook.com/intern/diff/D30398880)