### PR TITLE
add distributed/_sharded_tensor/test_sharded_tensor to ROCM_BLOCKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -245,6 +245,7 @@ ROCM_BLOCKLIST = [
     'distributed/rpc/test_faulty_agent',
     'distributed/rpc/test_tensorpipe_agent',
     'distributed/rpc/cuda/test_tensorpipe_agent',
+    'distributed/_sharded_tensor/test_sharded_tensor',
     'test_determination',
     'test_multiprocessing',
     'test_jit_legacy',


### PR DESCRIPTION
Fixes current ROCm CI test2 brokenness until tensorpipe is fully supported by ROCm.
