### PR TITLE
Adding IterableAsDataPipe IterDataPipe

### DIFF
--- a/torch/utils/data/datapipes/iter/__init__.py
+++ b/torch/utils/data/datapipes/iter/__init__.py
@@ -43,6 +43,9 @@ from torch.utils.data.datapipes.iter.selecting import (
 from torch.utils.data.datapipes.iter.tobytes import (
     ToBytesIterDataPipe as ToBytes,
 )
+from torch.utils.data.datapipes.iter.utils import (
+    IterableAsDataPipeIterDataPipe as IterableAsDataPipe,
+)
 
 __all__ = ['Batch',
            'BucketBatcher',
@@ -51,6 +54,7 @@ __all__ = ['Batch',
            'Filter',
            'GroupByKey',
            'HttpReader',
+           'IterableAsDataPipe',
            'ListDirFiles',
            'LoadFilesFromDisk',
            'Map',

--- a/torch/utils/data/datapipes/iter/utils.py
+++ b/torch/utils/data/datapipes/iter/utils.py
@@ -1,0 +1,10 @@
+from torch.utils.data import IterDataPipe
+
+
+class IterableAsDataPipeIterDataPipe(IterDataPipe):
+    def __init__(self, iterable):
+        self.iterable = iterable
+
+    def __iter__(self):
+        for data in self.iterable:
+            yield data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63523 Adding DataLoader2 class as future replacement of DataLoader
* **#63522 Adding IterableAsDataPipe IterDataPipe**
Supports sharding and batching on loader level
* **#63522 Adding IterableAsDataPipe IterDataPipe
usefull for tests and simple cases**

usefull for tests and simple cases

Differential Revision: [D30426528](https://our.internmc.facebook.com/intern/diff/D30426528)