### PR TITLE
empty caching allocator before test_avg_pool2d large subtest

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13944,7 +13944,7 @@ class TestNNDeviceType(NNTestCase):
         helper(4, 8, 8, 8, 3, divisor_override=42)
         helper(4, 8, 8, 8, 7)
         # ROCm 16GB MI25 hits OOM error. Clear caching allocator prior to running large subtest.
-        if 'cuda' in device:
+        if TEST_WITH_ROCM and 'cuda' in device:
             torch.cuda.empty_cache()
         helper(200, 512, 28, 28, 2)
         helper(4, 8, 7, 7, 3, stride=1)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13943,6 +13943,9 @@ class TestNNDeviceType(NNTestCase):
         helper(4, 8, 8, 8, 3, count_include_pad=False, padding=2, stride=2)
         helper(4, 8, 8, 8, 3, divisor_override=42)
         helper(4, 8, 8, 8, 7)
+        # ROCm 16GB MI25 hits OOM error. Clear caching allocator prior to running large subtest.
+        if 'cuda' in device:
+            torch.cuda.empty_cache()
         helper(200, 512, 28, 28, 2)
         helper(4, 8, 7, 7, 3, stride=1)
         helper(4, 8, 7, 7, 3, padding=2, stride=1)


### PR DESCRIPTION
Otherwise, unrecoverable OOM occurs on MI25.  Fixes broken ROCm CI test1.