### PR TITLE
[PyTorch] Remove unused dump() methods in vec headers

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -237,12 +237,6 @@ public:
       std::memcpy(ptr, tmp_values, count * sizeof(int32_t));
     }
   }
-  void dump() const {
-      for (size_t i = 0; i < size(); ++i) {
-          std::cout << (int)((value_type*)&values)[i] << " ";
-      }
-      std::cout << std::endl;
-  }
   const int32_t& operator[](int idx) const  = delete;
   int32_t& operator[](int idx)  = delete;
   Vectorized<int32_t> abs() const {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -309,12 +309,6 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
       return _mm256_add_epi32(rounded, zero_point_v);
     }
 
-    void dump() const {
-        for (size_t i = 0; i < 8; ++i) {
-          std::cout << ((int32_t*)&vals)[i] << " ";
-        }
-        std::cout << std::endl;
-    }
  private:
     // Load from memory constructor
     Vectorized(const void* ptr) {
@@ -537,12 +531,6 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
       return RequantizeAvx2<value_type>(inp, multiplier_v, zero_point_v);
     }
 
-    void dump() const {
-        for (size_t i = 0; i < size(); ++i) {
-            std::cout << (int)((value_type*)&vals)[i] << " ";
-        }
-        std::cout << std::endl;
-    }
  private:
     // Load from memory constructor
     Vectorized(const void* ptr) {
@@ -702,12 +690,6 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
       return RequantizeAvx2<value_type>(inp, multiplier_v, zero_point_v);
     }
 
-    void dump() const {
-        for (size_t i = 0; i < size(); ++i) {
-            std::cout << (int)((value_type*)&vals)[i] << " ";
-        }
-        std::cout << std::endl;
-    }
  private:
 
     // Load from memory constructor
@@ -790,13 +772,6 @@ struct VectorizedQuantizedConverter {
           tmp_vals[7]);
     }
     return rv;
-  }
-
-  void dump() const {
-      for (int i = 0; i < size(); ++i) {
-          std::cout << vals[i] << " ";
-      }
-      std::cout << std::endl;
   }
 
  protected:

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint32_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint32_vsx.h
@@ -196,18 +196,6 @@ struct Vectorized<c10::qint32> {
     return {veci0, veci1};
   }
 
-  void dump() const {
-    std::cout << _vec0[0] << " ";
-    std::cout << _vec0[1] << " ";
-    std::cout << _vec0[2] << " ";
-    std::cout << _vec0[3] << " ";
-    std::cout << _vec1[0] << " ";
-    std::cout << _vec1[1] << " ";
-    std::cout << _vec1[2] << " ";
-    std::cout << _vec1[3] << " ";
-    std::cout << std::endl;
-  }
-
   DEFINE_MEMBER_OP(operator==, c10::qint32, vec_cmpeq)
   DEFINE_MEMBER_OP(operator!=, c10::qint32, vec_cmpne)
   DEFINE_MEMBER_OP(operator<, c10::qint32, vec_cmplt)

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint8_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_qint8_vsx.h
@@ -361,15 +361,6 @@ struct Vectorized<c10::qint8> {
     return {vec0, vec1};
   }
 
-  void dump() const {
-    value_type vals[size()];
-    store((void*)vals);
-    for (int i = 0; i < size(); ++i) {
-      std::cout << (int)(vals[i]) << " ";
-    }
-    std::cout << std::endl;
-  }
-
   DEFINE_MEMBER_OP(operator==, c10::qint8, vec_cmpeq)
   DEFINE_MEMBER_OP(operator!=, c10::qint8, vec_cmpne)
   DEFINE_MEMBER_OP(operator<, c10::qint8, vec_cmplt)

--- a/aten/src/ATen/cpu/vec/vec512/vec512_int.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_int.h
@@ -270,12 +270,6 @@ public:
       std::memcpy(ptr, tmp_values, count * sizeof(int32_t));
     }
   }
-  void dump() const {
-      for (size_t i = 0; i < size(); ++i) {
-          std::cout << (int)((value_type*)&values)[i] << " ";
-      }
-      std::cout << std::endl;
-  }
   const int32_t& operator[](int idx) const  = delete;
   int32_t& operator[](int idx)  = delete;
   Vectorized<int32_t> abs() const {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -321,12 +321,6 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
       return _mm512_add_epi32(rounded, zero_point_v);
     }
 
-    void dump() const {
-        for (size_t i = 0; i < 16; ++i) {
-          std::cout << ((int32_t*)&vals)[i] << " ";
-        }
-        std::cout << std::endl;
-    }
  private:
     // Load from memory constructor
     Vectorized(const void* ptr) {
@@ -549,12 +543,6 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
       return RequantizeAvx512<value_type>(inp, multiplier_v, zero_point_v);
     }
 
-    void dump() const {
-        for (size_t i = 0; i < size(); ++i) {
-            std::cout << (int)((value_type*)&vals)[i] << " ";
-        }
-        std::cout << std::endl;
-    }
  private:
     // Load from memory constructor
     Vectorized(const void* ptr) {
@@ -714,12 +702,6 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
       return RequantizeAvx512<value_type>(inp, multiplier_v, zero_point_v);
     }
 
-    void dump() const {
-        for (size_t i = 0; i < size(); ++i) {
-            std::cout << (int)((value_type*)&vals)[i] << " ";
-        }
-        std::cout << std::endl;
-    }
  private:
 
     // Load from memory constructor
@@ -804,13 +786,6 @@ struct VectorizedQuantizedConverter {
           tmp_vals[15]);
     }
     return rv;
-  }
-
-  void dump() const {
-      for (int i = 0; i < size(); ++i) {
-          std::cout << vals[i] << " ";
-      }
-      std::cout << std::endl;
   }
 
  protected:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61500
* __->__ #63533

These methods don't seem to be used, and they use std::cout, which incurs a small code size overhead on platforms using libstdc++ due to std::__ioinit (see #61500). Seems like we can just delete them?

Differential Revision: [D30412269](https://our.internmc.facebook.com/intern/diff/D30412269/)