### PR TITLE
[JIT] greedy by size memory planning strategy

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -216,6 +216,8 @@ core_sources_full_mobile = [
     "torch/csrc/jit/passes/lower_tuples.cpp",
     "torch/csrc/jit/passes/memory_planning.cpp",
     "torch/csrc/jit/passes/memory_planning/linear_scan.cpp",
+    "torch/csrc/jit/passes/memory_planning/greedy_by_size.cpp",
+    "torch/csrc/jit/passes/memory_planning/greedy_util.cpp",
     "torch/csrc/jit/passes/normalize_ops.cpp",
     "torch/csrc/jit/passes/peephole_list_idioms.cpp",
     "torch/csrc/jit/passes/value_refinement_utils.cpp",

--- a/torch/csrc/jit/passes/memory_planning.cpp
+++ b/torch/csrc/jit/passes/memory_planning.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/passes/memory_planning.h>
+#include <torch/csrc/jit/passes/memory_planning/greedy_by_size.h>
 #include <torch/csrc/jit/passes/memory_planning/linear_scan.h>
 
 #include <jit/tensorexpr/kernel.h>
@@ -246,6 +247,10 @@ void planMemory(std::shared_ptr<Graph>& graph, Strategy strat) {
       allocations = linearScanHeuristic(managed_live_ranges);
       break;
     };
+    case Strategy::GREEDY_BY_SIZE: {
+      allocations = greedyBySize(managed_live_ranges);
+      break;
+    }
     default:
       return;
   }

--- a/torch/csrc/jit/passes/memory_planning/greedy_by_size.cpp
+++ b/torch/csrc/jit/passes/memory_planning/greedy_by_size.cpp
@@ -1,0 +1,36 @@
+#include <torch/csrc/jit/passes/memory_planning/greedy_by_size.h>
+#include <torch/csrc/jit/passes/memory_planning/greedy_util.h>
+
+namespace torch {
+namespace jit {
+
+std::unordered_map<LiveRange, Region, live_range_hash> greedyBySize(
+    std::unordered_map<LiveRange, uint64_t, live_range_hash>
+        managed_live_ranges) {
+  // sort tensor usage records in non-increasing order of size
+  auto cmp = [&managed_live_ranges](LiveRange& lvr1, LiveRange& lvr2) {
+    return managed_live_ranges[lvr1] >= managed_live_ranges[lvr2];
+  };
+  std::vector<LiveRange> sorted_size_live_ranges;
+  std::sort(
+      sorted_size_live_ranges.begin(), sorted_size_live_ranges.end(), cmp);
+
+  std::multiset<std::pair<LiveRange, Region>, _region_offset_cmp>
+      ordered_allocations;
+
+  for (auto& lvr : sorted_size_live_ranges) {
+    auto t_size =
+        MemoryPlanner::compute_aligned_tensor_size(managed_live_ranges[lvr]);
+    auto best_offset =
+        findOffset(lvr, t_size, managed_live_ranges, ordered_allocations);
+    ordered_allocations.insert(
+        std::make_pair(lvr, Region{best_offset, t_size}));
+  }
+  std::unordered_map<LiveRange, Region, live_range_hash> allocations;
+  for (auto& item : ordered_allocations) {
+    allocations[item.first] = item.second;
+  }
+  return allocations;
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/memory_planning/greedy_by_size.h
+++ b/torch/csrc/jit/passes/memory_planning/greedy_by_size.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <torch/csrc/jit/passes/memory_planning.h>
+
+namespace torch {
+namespace jit {
+
+std::unordered_map<LiveRange, Region, live_range_hash> greedyBySize(
+    std::unordered_map<LiveRange, uint64_t, live_range_hash>
+        managed_live_ranges);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/memory_planning/greedy_util.cpp
+++ b/torch/csrc/jit/passes/memory_planning/greedy_util.cpp
@@ -1,0 +1,42 @@
+#include <torch/csrc/jit/passes/memory_planning/greedy_by_size.h>
+#include <torch/csrc/jit/passes/memory_planning/greedy_util.h>
+
+namespace torch {
+namespace jit {
+
+uint64_t findOffset(
+    LiveRange live_range,
+    uint64_t t_size,
+    std::unordered_map<LiveRange, uint64_t, live_range_hash>
+        managed_live_ranges,
+    std::multiset<std::pair<LiveRange, Region>, _region_offset_cmp>
+        ordered_allocations) {
+  uint64_t prev_offset = 0;
+  uint64_t smallest_gap = std::numeric_limits<uint64_t>::max();
+  c10::optional<uint64_t> best_offset = c10::nullopt;
+
+  for (const auto& item : ordered_allocations) {
+    auto offset = item.second.offset;
+    auto alloced_lvr = item.first;
+
+    auto latest_begin = std::max(live_range.begin, alloced_lvr.begin);
+    auto earliest_end = std::min(live_range.end, alloced_lvr.end);
+    if (latest_begin <= earliest_end) {
+      auto gap = offset - prev_offset;
+      if (gap >= t_size && gap < smallest_gap) {
+        smallest_gap = gap;
+        best_offset = c10::optional<uint64_t>(prev_offset);
+      }
+      auto alloced_t_size = MemoryPlanner::compute_aligned_tensor_size(
+          managed_live_ranges[alloced_lvr]);
+      prev_offset = std::max(prev_offset, offset + alloced_t_size);
+    }
+  }
+  if (!best_offset.has_value()) {
+    best_offset = c10::optional<uint64_t>(prev_offset);
+  }
+  return best_offset.value();
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/memory_planning/greedy_util.h
+++ b/torch/csrc/jit/passes/memory_planning/greedy_util.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <torch/csrc/jit/passes/memory_planning.h>
+
+namespace torch {
+namespace jit {
+
+struct _region_offset_cmp {
+  inline bool operator()(
+      const std::pair<LiveRange, Region>& v1,
+      const std::pair<LiveRange, Region>& v2) const {
+    return region_offset_cmp()(v1.second, v2.second);
+  }
+};
+
+uint64_t findOffset(
+    LiveRange live_range,
+    uint64_t t_size,
+    std::unordered_map<LiveRange, uint64_t, live_range_hash>
+        managed_live_ranges,
+    std::multiset<std::pair<LiveRange, Region>, _region_offset_cmp>
+        ordered_allocations);
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63873
* #63872
* #63539
* __->__ #63538
* #63537
* #63835
* #62174
* #62995

Greedy by size (a heuristic that allocates largest tensors first) based on [this paper]( https://arxiv.org/pdf/2001.03288.pdf). It's factored the way it is for the purposes of making subsequent strategies simpler to implement.