### PR TITLE
Use trsm for triangular_solve in CPU

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.h
+++ b/aten/src/ATen/native/BatchLinearAlgebra.h
@@ -37,7 +37,7 @@ template <class scalar_t, class value_t = scalar_t>
 void lapackSyevd(char jobz, char uplo, int n, scalar_t* a, int lda, value_t* w, scalar_t* work, int lwork, value_t* rwork, int lrwork, int* iwork, int liwork, int* info);
 
 template <class scalar_t>
-void lapackTriangularSolve(char uplo, char trans, char diag, int n, int nrhs, scalar_t* a, int lda, scalar_t* b, int ldb, int* info);
+void lapackTriangularSolve(char side, char uplo, char trans, char diag, int n, int nrhs, scalar_t* a, int lda, scalar_t* b, int ldb);
 
 template <class scalar_t>
 void lapackGels(char trans, int m, int n, int nrhs,
@@ -210,11 +210,10 @@ DECLARE_DISPATCH(lstsq_fn, lstsq_stub);
 
 using triangular_solve_fn = void (*)(
     Tensor& /*A*/,
-    Tensor& /*b*/,
-    Tensor& /*infos*/,
+    Tensor& /*B*/,
+    bool /*left*/,
     bool /*upper*/,
-    bool /*transpose*/,
-    bool /*conjugate_transpose*/,
+    char /*transpose*/,
     bool /*unitriangular*/);
 DECLARE_DISPATCH(triangular_solve_fn, triangular_solve_stub);
 

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -78,7 +78,7 @@ char to_blas(TransposeType trans) {
   switch (trans) {
   case Transpose: return 't';
   case NoTranspose: return 'n';
-  // case ConjTranspose: return 'c';
+  case ConjTranspose: return 'c';
   }
   TORCH_INTERNAL_ASSERT(false, "Invalid transpose type");
 }
@@ -89,7 +89,7 @@ fbgemm::matrix_op_t to_fbgemm(TransposeType trans) {
   switch (trans) {
   case Transpose: return fbgemm::matrix_op_t::Transpose;
   case NoTranspose: return fbgemm::matrix_op_t::NoTranspose;
-  // case ConjTranspose: return fbgemm::matrix_op_t::Transpose;
+  case ConjTranspose: TORCH_INTERNAL_ASSERT(false, "ConjTranspose type is not supported in fbgemm");
   }
   TORCH_INTERNAL_ASSERT(false, "Invalid transpose type");
 }

--- a/aten/src/ATen/native/CPUBlas.h
+++ b/aten/src/ATen/native/CPUBlas.h
@@ -12,7 +12,7 @@ namespace cpublas {
 enum TransposeType {
   Transpose,
   NoTranspose,
-  // ConjTranspose, -- Not implemented
+  ConjTranspose,
 };
 
 namespace internal {

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -97,7 +97,7 @@ void magmaCholeskyBatched(
 
 template<class scalar_t>
 void magmaTriangularSolveBatched(
-    magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     scalar_t** dA_array, magma_int_t ldda, scalar_t** dB_array, magma_int_t lddb, magma_int_t batchsize,
     const MAGMAQueue& magma_queue);
 
@@ -667,29 +667,29 @@ void magmaCholeskyBatched<c10::complex<float>>(
 
 template<>
 void magmaTriangularSolveBatched<double>(
-    magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     double** dA_array, magma_int_t ldda, double** dB_array, magma_int_t lddb, magma_int_t batchsize,
     const MAGMAQueue& magma_queue) {
-  magmablas_dtrsm_batched(MagmaLeft, uplo, trans, diag, m, n, 1, dA_array, ldda, dB_array, lddb, batchsize, magma_queue.get_queue());
+  magmablas_dtrsm_batched(side, uplo, trans, diag, m, n, 1, dA_array, ldda, dB_array, lddb, batchsize, magma_queue.get_queue());
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaTriangularSolveBatched<float>(
-    magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     float** dA_array, magma_int_t ldda, float** dB_array, magma_int_t lddb, magma_int_t batchsize,
     const MAGMAQueue& magma_queue) {
-  magmablas_strsm_batched(MagmaLeft, uplo, trans, diag, m, n, 1, dA_array, ldda, dB_array, lddb, batchsize, magma_queue.get_queue());
+  magmablas_strsm_batched(side, uplo, trans, diag, m, n, 1, dA_array, ldda, dB_array, lddb, batchsize, magma_queue.get_queue());
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaTriangularSolveBatched<c10::complex<double>>(
-    magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     c10::complex<double>** dA_array, magma_int_t ldda, c10::complex<double>** dB_array, magma_int_t lddb, magma_int_t batchsize,
     const MAGMAQueue& magma_queue) {
   magmaDoubleComplex alpha({1, 0});
-  magmablas_ztrsm_batched(MagmaLeft, uplo, trans, diag, m, n, alpha,
+  magmablas_ztrsm_batched(side, uplo, trans, diag, m, n, alpha,
     reinterpret_cast<magmaDoubleComplex**>(dA_array), ldda,
     reinterpret_cast<magmaDoubleComplex**>(dB_array), lddb, batchsize, magma_queue.get_queue());
   AT_CUDA_CHECK(cudaGetLastError());
@@ -697,11 +697,11 @@ void magmaTriangularSolveBatched<c10::complex<double>>(
 
 template<>
 void magmaTriangularSolveBatched<c10::complex<float>>(
-    magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     c10::complex<float>** dA_array, magma_int_t ldda, c10::complex<float>** dB_array, magma_int_t lddb, magma_int_t batchsize,
     const MAGMAQueue& magma_queue) {
   magmaFloatComplex alpha({1, 0});
-  magmablas_ctrsm_batched(MagmaLeft, uplo, trans, diag, m, n, alpha,
+  magmablas_ctrsm_batched(side, uplo, trans, diag, m, n, alpha,
     reinterpret_cast<magmaFloatComplex**>(dA_array), ldda,
     reinterpret_cast<magmaFloatComplex**>(dB_array), lddb, batchsize, magma_queue.get_queue());
   AT_CUDA_CHECK(cudaGetLastError());
@@ -1224,8 +1224,19 @@ void checkMagmaInternalError(magma_int_t info, const std::string& magma_function
       ", when calling ", magma_function_name);
 }
 
+magma_trans_t _get_magma_trans(char trans) {
+  switch (trans) {
+    case 'N':
+      return MagmaNoTrans;
+    case 'T':
+      return MagmaTrans;
+    case 'C':
+      return MagmaConjTrans;
+    default:
+      return MagmaNoTrans;
+  }
+}
 } // anonymous namespace
-
 #endif // USE_MAGMA
 
 #define ALLOCATE_ARRAY(name, type, size) \
@@ -1950,27 +1961,27 @@ REGISTER_DISPATCH(lu_stub, &apply_lu);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangular_solve ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename scalar_t>
-static void apply_triangular_solve_batched(Tensor& A, Tensor& b, bool upper, bool transpose, bool conjugate_transpose, bool unitriangular) {
+static void apply_triangular_solve_batched_magma(Tensor& A, Tensor& b, bool left, bool upper, char transpose, bool unitriangular) {
 #ifndef USE_MAGMA
 AT_ERROR("triangular_solve: MAGMA library not found in "
          "compilation. Please rebuild with MAGMA.");
 #else
   magma_uplo_t uplo = upper ? MagmaUpper : MagmaLower;
-  magma_trans_t trans = transpose ? MagmaTrans : MagmaNoTrans;
-  trans = conjugate_transpose ? MagmaConjTrans : trans;
+  magma_trans_t trans = _get_magma_trans(transpose);
   magma_diag_t diag = unitriangular ? MagmaUnit : MagmaNonUnit;
+  magma_side_t side = left ? MagmaLeft : MagmaRight;
 
   auto A_data = A.data_ptr<scalar_t>();
   auto b_data = b.data_ptr<scalar_t>();
-  magma_int_t m = magma_int_cast(A.size(-2), "A.size(-2)");
-  magma_int_t n = magma_int_cast(A.size(-1), "A.size(-1)");
-  magma_int_t nrhs = magma_int_cast(b.size(-1), "b.size(-1)");
+  magma_int_t m = magma_int_cast(b.size(-2), "m");
+  magma_int_t n = magma_int_cast(b.size(-1), "n");
   // magma returns early if m <= 0 || n <= 0 for magmaTriangularSolveBatched
   // magmaTriangularSolve is calling cuBLAS and it prints
   // ** On entry to DTRSM  parameter number 9 had an illegal value
   // so let's use proper lda parameter here
-  magma_int_t lda = std::max<magma_int_t>(1, m);
-  magma_int_t batch_size = magma_int_cast(batchCount(A), "batchCount");
+  magma_int_t lda = std::max<magma_int_t>(1, left ? m : n);
+  magma_int_t ldb = std::max<magma_int_t>(1, m);
+  magma_int_t batch_size = magma_int_cast(batchCount(A), "batch_size");
 
   auto A_mat_stride = matrixStride(A);
   auto b_mat_stride = matrixStride(b);
@@ -1990,7 +2001,7 @@ AT_ERROR("triangular_solve: MAGMA library not found in "
   MAGMAQueue magma_queue(b.get_device());
 
   constexpr int64_t batch_limit = 65535;
-  // Compute as many batches of 65535 possible
+  // Compute as many batches of 65535 as possible
   // The number of "mini"-batches are floor(batch_size / batch_limit)
   // and these cover floor(batch_size / batch_limit) * batch_limit matrix solves
   int64_t mini_batches = batch_size / batch_limit;
@@ -2000,40 +2011,39 @@ AT_ERROR("triangular_solve: MAGMA library not found in "
     scalar_t** b_array_cur = &b_array[mini_idx];
 
     magmaTriangularSolveBatched<scalar_t>(
-        uplo, trans, diag, n, nrhs, A_array_cur,
-        lda, b_array_cur, lda, batch_limit, magma_queue);
+        side, uplo, trans, diag, m, n, A_array_cur,
+        lda, b_array_cur, ldb, batch_limit, magma_queue);
   }
 
   // Compute whatever is left = batch_size - floor(batch_size / batch_limit) * batch_limit
   // which concisely is equal to batch_size % batch_limit
   if (batch_size % batch_limit != 0) {
     magmaTriangularSolveBatched<scalar_t>(
-        uplo, trans, diag, n, nrhs, &A_array[mini_idx],
+        side, uplo, trans, diag, m, n, &A_array[mini_idx],
         lda, &b_array[mini_idx], lda, batch_size % batch_limit, magma_queue);
   }
 #endif
 }
 
-void triangular_solve_batched_magma(Tensor& A, Tensor& B, Tensor& infos, bool upper, bool transpose, bool conjugate_transpose, bool unitriangular) {
-  (void)infos; // unused
+void triangular_solve_batched_magma(Tensor& A, Tensor& B, bool left, bool upper, char transpose, bool unitriangular) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(A.scalar_type(), "triangular_solve_cuda", [&]{
-    apply_triangular_solve_batched<scalar_t>(A, B, upper, transpose, conjugate_transpose, unitriangular);
+    apply_triangular_solve_batched_magma<scalar_t>(A, B, left, upper, transpose, unitriangular);
   });
 }
 
-void triangular_solve_kernel(Tensor& A, Tensor& B, Tensor& infos, bool upper, bool transpose, bool conjugate_transpose, bool unitriangular) {
+void triangular_solve_kernel(Tensor& A, Tensor& B, bool left, bool upper, char transpose, bool unitriangular) {
   // For batches smaller than 8 and matrix sizes larger than 64x64 cuBLAS forloop is faster than batched version
   if (batchCount(A) <= 8 && A.size(-1) >= 64) {
-    triangular_solve_cublas(A, B, infos, upper, transpose, conjugate_transpose, unitriangular);
+    triangular_solve_cublas(A, B, left, upper, transpose, unitriangular);
   } else {
 #ifndef USE_MAGMA
-    triangular_solve_batched_cublas(A, B, infos, upper, transpose, conjugate_transpose, unitriangular);
+    triangular_solve_batched_cublas(A, B, left, upper, transpose, unitriangular);
 #else
     // cuBLAS batched is faster than MAGMA batched up until 512x512, after that MAGMA is faster
     if (A.size(-1) <= 512) {
-      triangular_solve_batched_cublas(A, B, infos, upper, transpose, conjugate_transpose, unitriangular);
+      triangular_solve_batched_cublas(A, B, left, upper, transpose, unitriangular);
     } else {
-      triangular_solve_batched_magma(A, B, infos, upper, transpose, conjugate_transpose, unitriangular);
+      triangular_solve_batched_magma(A, B, left, upper, transpose, unitriangular);
     }
 #endif // USE_MAGMA
   }
@@ -2725,21 +2735,6 @@ std::tuple<Tensor, Tensor, Tensor> _svd_helper_cuda(const Tensor& self, bool som
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ lu_solve ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#ifdef USE_MAGMA
-magma_trans_t _get_magma_trans(char trans) {
-  switch (trans) {
-    case 'N':
-      return MagmaNoTrans;
-    case 'T':
-      return MagmaTrans;
-    case 'C':
-      return MagmaConjTrans;
-    default:
-      return MagmaNoTrans;
-  }
-}
-#endif
-
 /*
   Solves the matrix equation A X = B
   X and B are n-by-nrhs matrices, A is represented using the LU factorization.
@@ -2882,20 +2877,6 @@ static void lu_solve_looped_magma(const Tensor& b, const Tensor& lu, const Tenso
   });
 }
 
-#if defined(USE_CUSOLVER) || defined(CUDART_VERSION)
-cublasOperation_t _get_cublas_trans(char trans) {
-  switch (trans) {
-    case 'N':
-      return CUBLAS_OP_N;
-    case 'T':
-      return CUBLAS_OP_T;
-    case 'C':
-      return CUBLAS_OP_C;
-    default:
-      return CUBLAS_OP_N;
-  }
-}
-#endif
 
 static void lu_solve_trans_dispatch(const Tensor& b, const Tensor& lu, const Tensor& pivots, char trans) {
   auto batch_size = batchCount(lu);
@@ -2905,7 +2886,7 @@ static void lu_solve_trans_dispatch(const Tensor& b, const Tensor& lu, const Ten
   // heuristics determined from tests dicussed in https://github.com/pytorch/pytorch/pull/59148
 #ifdef USE_CUSOLVER
   if ((batch_size == 1 && m > 512) || (batch_size <= 8 && over_magma_dim_limit)) {
-    lu_solve_looped_cusolver(b, lu, pivots, _get_cublas_trans(trans));
+    lu_solve_looped_cusolver(b, lu, pivots, trans);
   }
 #else
   if (batch_size == 1) {
@@ -2914,7 +2895,7 @@ static void lu_solve_trans_dispatch(const Tensor& b, const Tensor& lu, const Ten
 #endif // ifdef USE_CUSOLVER
 #ifdef CUDART_VERSION
   else if ((batch_size > 2 && m <= 128) || (batch_size > 8 && over_magma_dim_limit)) {
-    lu_solve_batched_cublas(b, lu, pivots, _get_cublas_trans(trans));
+    lu_solve_batched_cublas(b, lu, pivots, trans);
   }
 #endif // ifdef CUDART_VERSION
   else {
@@ -2976,7 +2957,7 @@ void gels_magma(const Tensor& a, Tensor& b, Tensor& infos) {
   });
 }
 
-void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& infos) {
+void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/) {
   // The steps for using the QR decomposition for solving least squares problems
   // are outlined here https://en.wikipedia.org/wiki/QR_decomposition#Using_for_solution_to_linear_inverse_problems
   auto m = A.size(-2);
@@ -3014,14 +2995,13 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& infos) {
 
     // Step 3: solve R X = B
     bool upper = true;
-    bool transpose = false;
-    bool conjugate_transpose = false;
+    char transpose = 'N';
     bool unitriangular = false;
     triangular_solve_kernel(
         const_cast<Tensor&>(A_broadcasted),
         const_cast<Tensor&>(B),
-        const_cast<Tensor&>(infos),
-        upper, transpose, conjugate_transpose, unitriangular);
+        /*left=*/true,
+        upper, transpose, unitriangular);
   } else { // underdetermined case
     Tensor Ah = cloneBatchedColumnMajor(A.conj().transpose(-2, -1));
 
@@ -3038,14 +3018,13 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& infos) {
 
     // Step 2: R^H Z = B
     bool upper = true;
-    bool transpose = true;
-    bool conjugate_transpose = true;
+    char transpose = 'T';
     bool unitriangular = false;
     triangular_solve_kernel(
         const_cast<Tensor&>(Ah_broadcasted),
         const_cast<Tensor&>(B),
-        const_cast<Tensor&>(infos),
-        upper, transpose, conjugate_transpose, unitriangular);
+        /*left=*/true,
+        upper, transpose, unitriangular);
 
     // B matrix has the size max(m, n) x nrhs
     // triangular_solve_kernel writes its output into the first m rows of B leaving the rest untouched

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.h
@@ -36,10 +36,10 @@ namespace at {
 namespace native {
 
 void geqrf_batched_cublas(const Tensor& input, const Tensor& tau);
-void triangular_solve_cublas(Tensor& A, Tensor& B, Tensor& infos, bool upper, bool transpose, bool conjugate_transpose, bool unitriangular);
-void triangular_solve_batched_cublas(Tensor& A, Tensor& B, Tensor& infos, bool upper, bool transpose, bool conjugate_transpose, bool unitriangular);
+void triangular_solve_cublas(Tensor& A, Tensor& B, bool left, bool upper, char transpose, bool unitriangular);
+void triangular_solve_batched_cublas(Tensor& A, Tensor& B, bool left, bool upper, char transpose, bool unitriangular);
 void gels_batched_cublas(const Tensor& a, Tensor& b, Tensor& infos);
-void lu_solve_batched_cublas(const Tensor& b, const Tensor& lu, const Tensor& pivots, cublasOperation_t trans);
+void lu_solve_batched_cublas(const Tensor& b, const Tensor& lu, const Tensor& pivots, char transpose);
 
 #ifdef USE_CUSOLVER
 
@@ -60,7 +60,7 @@ void ormqr_cusolver(const Tensor& input, const Tensor& tau, const Tensor& other,
 Tensor& orgqr_helper_cusolver(Tensor& result, const Tensor& tau);
 
 void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors, const Tensor& infos, bool upper, bool compute_eigenvectors);
-void lu_solve_looped_cusolver(const Tensor& b, const Tensor& lu, const Tensor& pivots, cublasOperation_t trans);
+void lu_solve_looped_cusolver(const Tensor& b, const Tensor& lu, const Tensor& pivots, char transpose);
 
 void lu_looped_cusolver(const Tensor& self, const Tensor& pivots, const Tensor& infos, bool get_pivots);
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4905,17 +4905,6 @@ class TestLinalg(TestCase):
             run_test((4, 4), (2, 1, 3, 4, 2), device, upper, transpose, unitriangular)  # broadcasting A
             run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), device, upper, transpose, unitriangular)  # broadcasting A & b
 
-    @onlyCPU
-    @skipCPUIfNoLapack
-    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
-    def test_triangular_solve_singular(self, device, dtype):
-        b = torch.rand(3, 1, dtype=dtype, device=device)
-        A = torch.eye(3, 3, dtype=dtype, device=device)
-        A[-1, -1] = 0  # Now A is singular
-        err_str = r"triangular_solve: U\(3,3\) is zero, singular U\."
-        with self.assertRaisesRegex(RuntimeError, err_str):
-            torch.triangular_solve(b, A)
-
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63562
* __->__ #63561

This PR also exposes the `side` argument of this function which is used
in the second PR of this stack to optimise the number copies one needs to make
when preparing the arguments to be sent to the backends.

The docs are fixed in the next PR of this stack.

Fixes https://github.com/pytorch/pytorch/issues/56326

The current implementation called trtrs for CPU and trsm for CUDA.
See
https://github.com/pytorch/pytorch/issues/56326#issuecomment-825496115
for a discussion of the differences between these two functions and why
we prefer trsm vs trtrs on CUDA.

On top of that, this is the first of a stack of PRs that aim to
improve the performance of triangular_solve. trsm has an extra parameter
(`side`), which allows to ellide the copy of the triangular matrix.