### PR TITLE
Add linalg.triangular_solve

### DIFF
--- a/aten/src/ATen/ConjugateFallback.cpp
+++ b/aten/src/ATen/ConjugateFallback.cpp
@@ -23,6 +23,11 @@ void conjugateFallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_ke
   object.fallback_impl(op, dispatch_keys, stack);
 }
 
+void conjugateFallbackToHandleOnlyMutableInputs(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
+  ConjFallback object;
+  object.linalg_fallback(op, dispatch_keys, stack);
+}
+
 TORCH_LIBRARY_IMPL(_, Conjugate, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&conjugateFallback>());
 }
@@ -45,6 +50,8 @@ TORCH_LIBRARY_IMPL(aten, Conjugate, m) {
   m.impl("empty.out", torch::CppFunction::makeFallthrough());
   m.impl("empty_strided", torch::CppFunction::makeFallthrough());
   m.impl("full_like", torch::CppFunction::makeFallthrough());
+  m.impl("solve_triangular", torch::CppFunction::makeFallthrough());
+  m.impl("solve_triangular.out", torch::CppFunction::makeFromBoxedFunction<&conjugateFallbackToHandleOnlyMutableInputs>());
   m.impl("stride.int", torch::CppFunction::makeFallthrough());
   m.impl("stride.Dimname", torch::CppFunction::makeFallthrough());
   m.impl("size.int", torch::CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3808,4 +3808,236 @@ Tensor _det_lu_based_helper_backward_helper(
   }
 }
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ solve_triangular ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+namespace {
+void checkSameDtype(const Tensor& t1,
+                    const Tensor& t2,
+                    const char* const f_name,
+                    const char* const t1_name,
+                    const char* const t2_name) {
+  TORCH_CHECK(t1.scalar_type() == t2.scalar_type(),
+              f_name, ": Expected ", t1_name, " and ", t2_name, " to have the same dtype. ",
+              "Got ", t1_name, ".dtype = ", t1.scalar_type(),
+              " and ", t2_name, ".dtype = ", t2.scalar_type());
+}
+
+void checkIsMatrix(const Tensor& t,
+                   const char* const f_name,
+                   const char* const t_name) {
+  TORCH_CHECK(t.dim() >= 2, f_name, ": Expected ", t_name,
+                            " to be a tensor of at least 2 dimensions.");
+}
+
+void checkIsSquareMatrix(const Tensor& t,
+                         const char* const f_name,
+                         const char* const t_name) {
+  checkIsMatrix(t, f_name, t_name);
+  TORCH_CHECK(t.size(-1) == t.size(-2),
+              f_name, ": Expected ", t_name,
+              " to be a square matrix or batch of square matrices. "
+              "Got matrices of size (", t.size(-2), ", ", t.size(-1), ").");
+}
+
+void checkInputsSolver(const Tensor& A,
+                       const Tensor& B,
+                       const Tensor& out,
+                       const bool left,
+                       const char* const f_name) {
+  checkSameDtype(A, B, f_name, "A", "B");
+  checkSameDtype(A, out, f_name, "A", "out");
+  checkIsSquareMatrix(A, f_name, "A");
+  checkIsMatrix(B, f_name, "B");
+  TORCH_CHECK(A.size(-1) == B.size(left ? -2 : -1),
+              f_name, ": Incompatible shapes for the equation ", left ? "AX = B" : "XA = B",
+              ". Each matrix in A is of shape (", A.size(-2), ", ", A.size(-1),
+              "), but each matrix in B is of shape (", B.size(-2), ", ", B.size(-1), ")");
+}
+
+bool is_fortran_compatible_column_major_order(const Tensor& t) {
+  const auto t_strides = t.strides();
+  const auto ndim = t.dim();
+  const auto rows = t.sizes()[ndim - 2];
+  return (t_strides[ndim - 2] == 1) && (t_strides[ndim - 1] >= std::max<int64_t>(1, rows));
+}
+
+bool is_fortran_compatible_row_major_order(const Tensor& t) {
+  const auto t_strides = t.strides();
+  const auto ndim = t.dim();
+  const auto cols = t.sizes()[ndim - 1];
+  return (t_strides[ndim - 1] == 1) && (t_strides[ndim - 2] >= std::max<int64_t>(1, cols));
+}
+
+bool is_fortran_ready(const Tensor& t) {
+  return t.is_non_overlapping_and_dense() ||
+         is_fortran_compatible_row_major_order(t) ||
+         is_fortran_compatible_column_major_order(t);
+}
+
+char trans_char(const bool contig, const bool conj) {
+    return conj ? 'C' : contig ? 'N' : 'T';
+}
+} // end of anonymous namespace
+
+/*
+Solves the matrix equation AX = B for A triangular.
+'upper' controls the portion of input matrix to consider in computations,
+'unitriangular' if true then we assume diag(A) to be ones
+'left' If true solves AX = B, if false solves XA = B
+'out' The tensor with the result. If A == out, A will be modified in place
+*/
+Tensor& linalg_triangular_solve_out(
+    const Tensor& A,
+    const Tensor& B,
+    bool left,
+    bool upper,
+    bool unitriangular,
+    Tensor& out) {
+  checkInputsSolver(A, B, out, left, "solve_triangular");
+  Tensor A_broad, B_broad;
+  std::tie(B_broad, A_broad) = _linalg_broadcast_batch_dims(B, A, "solve_triangular", /*check_errors*/ false);
+
+  // We'll write F-contig / F-transpose for FORTRAN contiguous / FORTRAN transpose etc
+  // At this point, A, B have been broadcasted but may or may not be F-ready
+
+  // The following algorithm minimises copies and allocations. In pseudocode:
+  // if out is wrong size:
+  //   resize_output(out)
+  // # Invariant: out is the right size
+  // Tensor out_f; # Tensor that we will pass to FORTRAN
+  // if out is F-ready:
+  //   out_f = out;
+  // else:
+  //   Allocate out_f F-ready
+  // if B != out_f:
+  //   copy B into out_f
+  // # Invariant: out_f F-ready and has B copied into it
+  // if out_f is F-transposed:
+  //   transpose equation
+  // if out_f is conj:
+  //   conjugate equation
+  // # Invariant: out_f is not conjugated and F-contig
+  // Tensor A_f; # Tensor that will be sent to FORTRAN
+  // if A is F-ready:
+  //   if A is conj and A is not transposed:
+  //     # We need to clone A in this case. See [Cloning A]
+  //     clone A F-contig into A_f
+  //   else:
+  //     A_f = A;
+  // else:
+  //   clone A F-contig into A_f
+  // # Invariant: out_f is F-contig and A_f is F-ready
+  // # We pass FORTRAN the flags indicating if A_f is transposed and or conjugated
+  //
+  // # Here we undo the conjugations / transposes on out_f if needed
+  //
+  // if out_f not same out:
+  //   copy out_f into out
+  // return out
+  //
+  // Note: [Cloning A] If we are careful when allocating B when it needs to be allocated at the
+  // beginning of the algorithm, it is possible to always elide the copy of A here.
+  // Via this trick, the algorithm will copy at most one of A or B (never both) whenever A
+  // and B are F-ready (which happens almost always in practice).
+  // In most practical situations, this function copy at most one tensor.
+  // When called as f(A, B, out=B) in most practical cases it'll perform no copies.
+  //
+  // Note: The logic for the negative bit is the same as that for the conjugate bit
+
+  const bool avoid_copy_A = is_fortran_ready(A_broad) && A_broad.stride(-2) == 1 && A_broad.is_conj();
+  if (avoid_copy_A){
+    // See Note: [Cloning A]
+    at::native::resize_output(out, B_broad.sizes());
+  }
+  else {
+    // poorman's reimplementation of resize_output with result F-contig
+    if (resize_output_check(out, B_broad.sizes())) {
+      out.resize_(B_broad.transpose(-2, -1).sizes(), MemoryFormat::Contiguous);
+      out.transpose_(-2, -1);  // make 'out' have Fortran contiguous memory layout
+    }
+  }
+  // Invariant: out has the right size, so we'll be able to copy into it later on
+
+  Tensor out_f;
+  // We use C10_LIKELY mostly for documentation as it helps following what's the most likely path
+  if C10_LIKELY (is_fortran_ready(out)) {
+    out_f = out;
+    if C10_LIKELY (!out.is_same(B_broad)) {
+      out_f.copy_(B_broad);
+    }
+  } else{
+    if (avoid_copy_A){
+      // See Note: [Cloning A]
+      out_f = B_broad.clone(at::MemoryFormat::Contiguous);
+    }
+    else {
+      out_f = cloneBatchedColumnMajor(B_broad);
+    }
+  }
+  // Invariant: out_f F-ready and has B copied into it
+
+  // out_f is F-transposed
+  bool transpose_A = false;
+  bool transpose_out_f = false;
+  if (out_f.stride(-1) == 1) {
+    left = !left;
+    transpose_A = true;
+    transpose_out_f = true;
+    out_f.transpose_(-2 ,-1);
+  }
+
+  // No need to conjugate anything if out_f is conj as AX = conj(B) <=> conj(A)conj(X) = B
+  // and X = B after the algortihm. We just anotate that A is conjugated later on
+  // The solution will be written into out_f, so it'll be conjugated already
+
+  Tensor A_f;
+  bool A_is_conj = A_broad.is_conj() != out_f.is_conj();
+  bool A_is_neg = A_broad.is_neg() != out_f.is_neg();
+  bool A_is_f_contig = (A_broad.stride(-1) == 1) == transpose_A;
+  if C10_LIKELY (is_fortran_ready(A_broad) && !((A_is_conj && !A_is_f_contig) || A_is_neg)) {
+    A_f = A_broad;
+  } else {
+    // We choose C-contig rather than F-contig because it has better memory access in solvers
+    // We resolve the conj as well
+    A_f = A_broad.clone(at::MemoryFormat::Contiguous);
+    A_is_f_contig = transpose_A;
+    A_is_conj = false;
+    A_is_neg = false;
+  }
+  // Invariant: out_f is F-contig and A_f is F-ready
+
+  // If we pass the matrix physically F-transposed, we need to change the parity of upper
+  if (A_f.stride(-1) == 1) {
+    upper = !upper;
+  }
+
+  const char transpose = trans_char(A_is_f_contig, A_is_conj);
+
+  triangular_solve_stub(
+    A_f.device().type(), A_f, out_f,
+    /*left=*/left,
+    /*upper=*/upper,
+    /*transpose*/transpose,
+    /*unitriangular=*/unitriangular);
+
+  if (transpose_out_f) {
+    out_f.transpose_(-2, -1);
+  }
+
+  if (!out_f.is_same(out)) {
+    out.copy_(out_f);
+  }
+  return out;
+}
+
+Tensor linalg_triangular_solve(
+    const Tensor& A,
+    const Tensor& B,
+    bool left,
+    bool upper,
+    bool unitriangular) {
+  Tensor out = at::empty({0}, A.options());
+  linalg_triangular_solve_out(A, B, left, upper, unitriangular, out);
+  return out;
+}
+
 }}  // namespace at::native

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -279,8 +279,10 @@ static inline void checkAllSameDim(TensorList tensors, int64_t dim) {
   }
 }
 
-static inline std::tuple<Tensor,Tensor> _linalg_broadcast_batch_dims(const Tensor& arg1, const Tensor& arg2, const char* name) {
-  linearSolveCheckInputs(arg1, arg2, name);
+static inline std::tuple<Tensor,Tensor> _linalg_broadcast_batch_dims(const Tensor& arg1, const Tensor& arg2, const char* name, const bool check_errors=true) {
+  if (check_errors) {
+    linearSolveCheckInputs(arg1, arg2, name);
+  }
 
   // broadcast the batch dimensions of arg1 and arg2.
   IntArrayRef arg1_batch_sizes(arg1.sizes().data(), arg1.ndimension() - 2);
@@ -293,8 +295,8 @@ static inline std::tuple<Tensor,Tensor> _linalg_broadcast_batch_dims(const Tenso
   std::vector<int64_t> arg2_expand_size({expand_batch_portion});
   arg2_expand_size.insert(arg2_expand_size.end(), { arg2.size(-2), arg2.size(-1) });
 
-  Tensor arg1_broadcasted  = arg1.expand(arg1_expand_size);
-  Tensor arg2_broadcasted = arg2.expand(arg2_expand_size);
+  auto arg1_broadcasted  = arg1_expand_size == arg1.sizes() ? arg1 : arg1.expand(arg1_expand_size);
+  auto arg2_broadcasted  = arg2_expand_size == arg2.sizes() ? arg2 : arg2.expand(arg2_expand_size);
   return std::make_tuple(arg1_broadcasted, arg2_broadcasted);
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6675,6 +6675,17 @@
   dispatch:
     CPU, CUDA: triangular_solve
 
+- func: linalg_triangular_solve.out(Tensor self, Tensor B, *, bool left=True, bool upper=True, bool unitriangular=False, Tensor(a!) out) -> Tensor(a!)
+  python_module: linalg
+  dispatch:
+    CPU, CUDA: linalg_triangular_solve_out
+
+- func: linalg_triangular_solve(Tensor self, Tensor B, *, bool left=True, bool upper=True, bool unitriangular=False) -> Tensor
+  python_module: linalg
+  variants: method, function
+  dispatch:
+    CPU, CUDA: linalg_triangular_solve
+
 - func: symeig.e(Tensor self, bool eigenvectors=False, bool upper=True, *, Tensor(a!) e, Tensor(b!) V) -> (Tensor(a!) eigenvalues, Tensor(b!) eigenvectors)
   dispatch:
     CompositeExplicitAutograd: symeig_out

--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -49,6 +49,7 @@ Solvers
 
     solve
     lstsq
+    triangular_solve
 
 Inverses
 --------

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1394,6 +1394,10 @@
 - name: triangular_solve(Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False) -> (Tensor solution, Tensor cloned_coefficient)
   self, A: triangular_solve_backward(grads[0], grads[1], self, A, solution, upper, transpose, unitriangular, grad_input_mask)
 
+- name: linalg_triangular_solve(Tensor self, Tensor B, *, bool left=True, bool upper=True, bool unitriangular=False) -> Tensor
+  self, B: linalg_triangular_solve_backward(grad, self, result, left, upper, unitriangular, grad_input_mask)
+  result: linalg_triangular_solve_forward(self_t, B_t, self_p, result, left, upper, unitriangular)
+
 - name: tril(Tensor self, int diagonal=0) -> Tensor
   self: grad.tril(diagonal)
   result: auto_linear

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -90,7 +90,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'dot', 'vdot', 'cholesky', 'triangular_solve', 'mm', '_unsafe_view', 'mv', 'outer',
     'bmm', 'diagonal', 'alias', 'atan', 'log', 'log10', 'log1p', 'log2', 'reciprocal',
     'tan', 'pow', 'rsqrt', 'tanh', 'tanh_backward', 'asinh', 'acosh', 'atanh', 'take', 'fill_',
-    'exp', 'nonzero', 'mean', 'inverse', 'solve', 'linalg_cholesky', 'addcmul', 'addcdiv',
+    'exp', 'nonzero', 'mean', 'inverse', 'solve', 'linalg_triangular_solve', 'linalg_cholesky', 'addcmul', 'addcdiv',
     'matrix_exp', 'linalg_eigh', 'cholesky_solve', 'linalg_qr', '_svd_helper', '_fft_c2c', '_fft_r2c',
     'linalg_solve', 'sqrt', 'stack', 'gather', 'index_select', 'index_add_', 'linalg_inv', 'linalg_inv_ex',
     'l1_loss_backward', 'baddbmm', 'addbmm', 'addmm', 'addmv', 'addr', 'linalg_householder_product',

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9727,11 +9727,11 @@ add_docstr(torch.triangular_solve,
            r"""
 triangular_solve(b, A, upper=True, transpose=False, unitriangular=False) -> (Tensor, Tensor)
 
-Solves a system of equations with a triangular coefficient matrix :math:`A`
+Solves a system of equations with a square upper or lower triangular invertible matrix :math:`A`
 and multiple right-hand sides :math:`b`.
 
-In particular, solves :math:`AX = b` and assumes :math:`A` is upper-triangular
-with the default keyword arguments.
+In symbols, it solves :math:`AX = b` and assumes :math:`A` is square upper-triangular
+(or lower-triangular if :attr:`upper`\ `= False`) and does not have zeros on the diagonal.
 
 `torch.triangular_solve(b, A)` can take in 2D inputs `b, A` or inputs that are
 batches of 2D matrices. If the inputs are batches, then returns
@@ -9748,10 +9748,8 @@ Args:
                 :math:`*` is zero of more batch dimensions
     A (Tensor): the input triangular coefficient matrix of size :math:`(*, m, m)`
                 where :math:`*` is zero or more batch dimensions
-    upper (bool, optional): whether to solve the upper-triangular system
-        of equations (default) or the lower-triangular system of equations. Default: ``True``.
-    transpose (bool, optional): whether :math:`A` should be transposed before
-        being sent into the solver. Default: ``False``.
+    upper (bool, optional): whether :math:`A` is upper or lower triangular. Default: ``True``.
+    transpose (bool, optional): whether to transpose :math:`A` before solving the system. Default: ``False``.
     unitriangular (bool, optional): whether :math:`A` is unit triangular.
         If True, the diagonal elements of :math:`A` are assumed to be
         1 and not referenced from :math:`A`. Default: ``False``.

--- a/torch/csrc/api/include/torch/linalg.h
+++ b/torch/csrc/api/include/torch/linalg.h
@@ -160,6 +160,14 @@ inline Tensor& solve_out(Tensor& result, const Tensor& input, const Tensor& othe
   return torch::linalg_solve_out(result, input, other);
 }
 
+inline Tensor triangular_solve(const Tensor& input, const Tensor& other, bool left, bool upper, bool unitriangular) {
+  return torch::linalg_triangular_solve(input, other, left, upper, unitriangular);
+}
+
+inline Tensor& triangular_solve_out(Tensor& result, const Tensor& input, const Tensor& other, bool left, bool upper, bool unitriangular) {
+  return torch::linalg_triangular_solve_out(result, input, other, left, upper, unitriangular);
+}
+
 inline std::tuple<Tensor, Tensor, Tensor> svd(const Tensor& input, bool full_matrices) {
   return torch::linalg_svd(input, full_matrices);
 }
@@ -424,6 +432,18 @@ inline Tensor solve(const Tensor& input, const Tensor& other) {
 
 inline Tensor& solve_out(Tensor& result, const Tensor& input, const Tensor& other) {
   return detail::solve_out(result, input, other);
+}
+
+/// Computes a solution of a linear system AX = B for input = A and other = B whenever A is square
+/// upper or lower triangular and does not have zeros in the diagonal
+///
+/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.triangular_solve
+inline Tensor triangular_solve(const Tensor& input, const Tensor& other, bool left, bool upper, bool unitriangular) {
+  return detail::triangular_solve(input, other, left, upper, unitriangular);
+}
+
+inline Tensor& triangular_solve_out(Tensor& result, const Tensor& input, const Tensor& other, bool left, bool upper, bool unitriangular) {
+  return detail::triangular_solve_out(result, input, other, left, upper, unitriangular);
 }
 
 /// Computes the singular values and singular vectors

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -164,6 +164,22 @@ std::tuple<Tensor, Tensor> triangular_solve_backward(
     const Tensor & b, const Tensor & a, const Tensor & x,
     const bool upper, const bool transpose, const bool unitriangular,
     std::array<bool, 2> output_mask);
+Tensor linalg_triangular_solve_forward(
+    const Tensor& A_t,
+    const Tensor& B_t,
+    const Tensor& A,
+    const Tensor& X,
+    const bool left,
+    const bool upper,
+    const bool unitriangular);
+std::tuple<Tensor, Tensor> linalg_triangular_solve_backward(
+    const Tensor& grad,
+    const Tensor& A,
+    const Tensor& X,
+    const bool left,
+    const bool upper,
+    const bool unitriangular,
+    std::array<bool, 2> output_mask);
 std::tuple<Tensor, Tensor, Tensor> _trilinear_backward(const Tensor& grad_out, const Tensor& i1, const Tensor& i2, const Tensor& i3,
                                                        IntArrayRef expand1, IntArrayRef expand2, IntArrayRef expand3,
                                                        IntArrayRef sumdim, std::array<bool, 3> grad_mask);

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1733,7 +1733,7 @@ Computes the solution of a square system of linear equations with a unique solut
 
 Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
 this function computes the solution :math:`X \in \mathbb{K}^{n \times k}` of the **linear system** associated to
-:math:`A \in \mathbb{K}^{n \times n}, B \in \mathbb{K}^{m \times k}`, which is defined as
+:math:`A \in \mathbb{K}^{n \times n}, B \in \mathbb{K}^{n \times k}`, which is defined as
 
 .. math:: AX = B
 
@@ -1757,9 +1757,18 @@ Letting `*` be zero or more batch dimensions,
     This function computes `X = \ `:attr:`A`\ `.inverse() @ \ `:attr:`B` in a faster and
     more numerically stable way than performing the computations separately.
 
+.. note::
+    It is possible to compute the solution of the system :math:`XA = B` by passing the inputs
+    :attr:`A` and :attr:`B` transposed and transposing the output returned by this function.
+
 """ + fr"""
 .. note:: {common_notes["sync_note"]}
 """ + r"""
+
+.. seealso::
+
+        :func:`torch.linalg.triangular_solve` computes the solution of a triangular system of linear
+        equations with a unique solution.
 
 Args:
     A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
@@ -1806,6 +1815,82 @@ Examples::
 .. _invertible:
     https://en.wikipedia.org/wiki/Invertible_matrix#The_invertible_matrix_theorem
 """)
+
+triangular_solve = _add_docstr(_linalg.linalg_triangular_solve, r"""
+linalg.triangular_solve(A, B, *, left=True, upper=True, unitriangular=False, out=None) -> Tensor
+
+Computes the solution of a triangular system of linear equations with a unique solution.
+
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+this function computes the solution :math:`X \in \mathbb{K}^{n \times k}` of the **linear system**
+associated to the upper triangular matrix :math:`A \in \mathbb{K}^{n \times n}` without zeros on the diagonal
+(that is, it is `invertible`_) and the rectangular matrix , :math:`B \in \mathbb{K}^{n \times k}`,
+which is defined as
+
+.. math:: AX = B
+
+If :attr:`upper`\ `= False`, :math:`A` will be assumed to be lower triangular without zeros on the diagonal.
+
+If :attr:`left`\ `= False`, the returned matrix :math:`X \in \mathbb{K}^{n \times k}` will solve the system
+
+.. math::
+
+    XA = B\mathrlap{\qquad A \in \mathbb{K}^{k \times k}, B \in \mathbb{K}^{n \times k}.}
+
+If :attr:`upper`\ `= True` (resp. `False`) just the upper (resp. lower) triangular half of :attr:`A`
+will accessed. The opposite half will be considered to be full of zeros and will not be accessed.
+
+If :attr:`unitriangular`\ `= True`, the diagonal of :attr:`A` is assumed to be ones and will not be accessed.
+
+If the diagonal of :attr:`A` contains zeros or elements that are very close to zero and
+:attr:`unitriangular`\ `= False` (default) or if the input matrix is badly conditioned,
+the result may contain `NaN`s.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if the inputs are batches of matrices then
+the output has the same batch dimensions.
+
+.. seealso::
+
+        :func:`torch.linalg.solve` computes the solution of a general square system of linear
+        equations with a unique solution.
+
+Args:
+    A (Tensor): tensor of shape `(*, n, n)` (or `(*, k, k)` if :attr:`left`\ `= True`)
+                where `*` is zero or more batch dimensions.
+    B (Tensor): right-hand side tensor of shape `(*, n, k)`.
+
+Keyword args:
+    left (bool optional): whether to solve the system :math:`AX=B` or :math:`XA = B`. Default: `True`.
+    upper (bool optional): whether :attr:`A` is an upper or lower triangular matrix. Default: `True`.
+    unitriangular (bool, optional): if `True`, the diagonal elements of :attr:`A` are assumed to be
+                                    all equal to `1`. Default: `False`.
+    out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
+
+Examples::
+
+    >>> A = torch.randn(3, 3).triu_()
+    >>> b = torch.randn(3, 4)
+    >>> X = torch.linalg.triangular_solve(A, B)
+    >>> torch.allclose(A @ X, B)
+    True
+
+    >>> A = torch.randn(2, 3, 3).tril_()
+    >>> B = torch.randn(2, 3, 4)
+    >>> X = torch.linalg.triangular_solve(A, B, upper=False)
+    >>> torch.allclose(A @ X, B)
+    True
+
+    >>> A = torch.randn(2, 4, 4).tril_()
+    >>> B = torch.randn(2, 3, 4)
+    >>> X = torch.linalg.triangular_solve(A, B, left=False)
+    >>> torch.allclose(X @ A, B)
+    True
+
+.. _invertible:
+    https://en.wikipedia.org/wiki/Invertible_matrix#The_invertible_matrix_theorem
+""")
+
 
 tensorinv = _add_docstr(_linalg.linalg_tensorinv, r"""
 linalg.tensorinv(A, ind=2, *, out=None) -> Tensor

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -953,6 +953,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.trapz: lambda y, x=None, dim=-1: -1,
         torch.trapezoid: lambda y, x=None, dim=-1: -1,
         torch.triangular_solve: lambda input, A, upper=True, transpose=False, unitriangular=False: -1,
+        torch.linalg.triangular_solve: lambda input, B, left=True, upper=True, unitriangular=False: -1,
         torch.tril: lambda input, diagonal=0, out=None: -1,
         torch.triplet_margin_loss: (lambda anchor, positive, negative, margin=1.0, p=2, eps=1e-06, swap=False,
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63564
* #63563

This PR adds the first solver with structure to `linalg`. This solver
has an API compatible with that of `linalg.solve` preparing these for a
possible future merge of the APIs. The new API:
- Just returns the solution, rather than the solution and a copy of `A`
- Removes the confusing `transpose` argument and replaces it by a
correct handling of conj and strides within the call
- Adds a `left=True` kwarg. This can be achieved via transposes of the
inputs and the result, but it's exposed for convenience.

This PR also implements a dataflow that minimises the number of copies
needed before calling LAPACK / MAGMA / cuBLAS and takes advantage of the
conjugate and neg bits.

This algorithm is implemented for `triangular_solve` (which, for this, is
the most complex of all the solvers due to the `upper` parameters).
Once more solvers are added, we will factor out this calling algorithm,
so that all of them can take advantage of it.

Given the complexity of this algorithm, we implement some thorough
testing. We also added tests for all the backends, which was not done
before.

We also add forward AD support for `triangular_solve` and improve the
docs of `linalg.triangular_solve`. We also fix a few issues with those of
`torch.triangular_solve`.

Fixes https://github.com/pytorch/pytorch/issues/54258
Fixes https://github.com/pytorch/pytorch/issues/56327