### PR TITLE
[Pytorch] Fix callstack pointer serialization bug

### DIFF
--- a/torch/csrc/jit/mobile/debug_info.cpp
+++ b/torch/csrc/jit/mobile/debug_info.cpp
@@ -49,11 +49,7 @@ std::pair<std::vector<StackEntry>, std::string> getStackTraceWithModuleHierarchy
       // Now add source range info to stack
       entries.emplace_back(
           StackEntry{prev_function_name, callstack_ptr->source_range()});
-      if (callstack_ptr->function()) {
-        prev_function_name = callstack_ptr->function()->name();
-      } else {
-        prev_function_name = callstack_ptr->function_name();
-      }
+      prev_function_name = callstack_ptr->function_name();
       // Function name appended here
       // It is renamed to prev_function_name because for StackEntry
       // it will be appended in the next iteration. This is the format

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -47,15 +47,11 @@ c10::IValue InlinedCallStackSerializer::serialize(
   } else {
     elements.emplace_back(c10::IValue());
   }
-  if (cs_ptr->function()) {
-    elements.emplace_back(cs_ptr->function()->name());
+  auto fn_name = cs_ptr->function_name();
+  if (!fn_name.empty()) {
+    elements.emplace_back(fn_name);
   } else {
-    auto fn_name = cs_ptr->function_name();
-    if (!fn_name.empty()) {
-      elements.emplace_back(fn_name);
-    } else {
-      elements.emplace_back("FunctionName_UNKNOWN");
-    }
+    elements.emplace_back("FunctionName_UNKNOWN");
   }
   c10::IValue serialized_cs = c10::ivalue::Tuple::create(elements);
   serialized_inlined_callstack_[cs_ptr] = serialized_cs;


### PR DESCRIPTION
Summary:
We serialize function name associated with InlinedCallStackPtr. This is derived
via querying Function* stored in InlinedCallStack. However this is a raw
pointer that is not gauranteed to be valid when we serialization happens. On
the other hand we also store function name separately when constructing
InlinedCallStack anyways. So this change just uniformly relies on function_name
instead of Function*

Test Plan: Internal build's asan failure + CI

Differential Revision: D30427029

