### PR TITLE
[quant] Making isPlaceholderObserver work post migration

### DIFF
--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -227,7 +227,8 @@ c10::optional<std::string> findObserverName(Value* v) {
 bool isPlaceholderObserver(Value* observer) {
   if (getModuleName(observer).has_value()) {
     auto name = getModuleName(observer).value();
-    if (name == "__torch__.torch.quantization.observer.PlaceholderObserver") {
+    // if PlaceholderObserver is (anywhere) in name
+    if (name.find("PlaceholderObserver") != std::string::npos) {
       return true;
     }
   }

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -1272,16 +1272,16 @@ def _is_activation_post_process(module):
     return (
         isinstance(module, torch.quantization.ObserverBase)
         or isinstance(module, torch.quantization.FakeQuantize)
-        or _is_observer_script_module(module, "torch.quantization.observer")
+        or _is_observer_script_module(module, "quantization.observer")
     )
 
 
 def _is_per_channel_script_obs_instance(module):
     if isinstance(module, torch.jit.RecursiveScriptModule):
         return _is_observer_script_module(
-            module, "torch.quantization.observer.PerChannelMinMaxObserver"
+            module, "quantization.observer.PerChannelMinMaxObserver"
         ) or _is_observer_script_module(
-            module, "torch.quantization.observer.MovingAveragePerChannelMinMaxObserver"
+            module, "quantization.observer.MovingAveragePerChannelMinMaxObserver"
         )
     return False
 


### PR DESCRIPTION
Summary:
this would have cause errors when PlaceholderObserver was moved to ao.

see: D30391189

Test Plan: buck test mode/opt //caffe2/test:quantization -- --exact 'caffe2/test:quantization - test_dynamic_quant_multi_uses (quantization.jit.test_quantize_jit.TestQuantizeDynamicJitPasses)'

Differential Revision: D30432008

