### PR TITLE
[Draft] Experiment with no-init

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -13,6 +13,7 @@
 
 #include <ATen/Tensor.h>
 #include <ATen/cpu/FlushDenormal.h>
+#include <ATen/detail/BackendDispatch.h>
 
 #ifdef USE_FBGEMM
 #include <fbgemm/Fbgemm.h>
@@ -279,4 +280,13 @@ void Context::unsetDefaultMobileCPUAllocator() {
   c10::SetCPUAllocator(prev_allocator_ptr_ , /*priority*/ 100);
   prev_allocator_ptr_ = nullptr;
 }
+
+void Context::suspendBackendDispatch() {
+  detail::suspendBackendDispatch();
+}
+
+void Context::restoreBackendDispatch() {
+  detail::restoreBackendDispatch();
+}
+
 } // namespace at

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -214,6 +214,9 @@ class TORCH_API Context {
   void setDefaultMobileCPUAllocator();
   void unsetDefaultMobileCPUAllocator();
 
+  void suspendBackendDispatch();
+  void restoreBackendDispatch();
+
  private:
   void initCUDAIfNeeded(DeviceType p) {
     if (p == DeviceType::CUDA) {

--- a/aten/src/ATen/detail/BackendDispatch.cpp
+++ b/aten/src/ATen/detail/BackendDispatch.cpp
@@ -1,0 +1,54 @@
+#include <ATen/detail/BackendDispatch.h>
+
+#include <cstdint>
+
+#include <c10/core/DispatchKey.h>
+#include <c10/core/impl/LocalDispatchKeySet.h>
+
+using c10::impl::tls_set_dispatch_key_excluded;
+using c10::impl::tls_set_dispatch_key_included;
+
+namespace at {
+namespace detail {
+namespace {
+
+void excludeBackendDispatchKeys(bool desired_state) {
+  // Add all backend keys except meta to the TLS exclude list. This will force
+  // the dispatcher to suspend all tensor operations.
+  auto end = static_cast<std::uint8_t>(DispatchKey::EndOfBackendKeys);
+  for (std::uint8_t i = 1; i <= end; i++) {
+    auto dk = static_cast<DispatchKey>(i);
+    if (dk == DispatchKey::Meta) {
+      continue;
+    }
+    tls_set_dispatch_key_excluded(dk, desired_state);
+  }
+
+  // In addition to the backend ops, we also have to stop the backend selection
+  // logic; otherwise, some operations such as `empty` can escape the exclusion
+  // list.
+  tls_set_dispatch_key_excluded(DispatchKey::BackendSelect, desired_state);
+}
+
+} // namespace
+
+void suspendBackendDispatch() {
+  excludeBackendDispatchKeys(/*desired_state*/true);
+
+  // Now that we have excluded all backends from the dispatcher, enable meta
+  // dispatch key which effectively diverts all backend ops to meta.
+  tls_set_dispatch_key_included(DispatchKey::Meta, /*desired_state*/true);
+}
+
+void restoreBackendDispatch() {
+  excludeBackendDispatchKeys(/*desired_state*/false);
+
+  tls_set_dispatch_key_included(DispatchKey::Meta, /*desired_state*/false);
+}
+
+bool backendDispatchSuspended() noexcept {
+  return c10::impl::tls_is_dispatch_key_excluded(DispatchKey::BackendSelect);
+}
+
+} // namespace detail
+} // namespace at

--- a/aten/src/ATen/detail/BackendDispatch.h
+++ b/aten/src/ATen/detail/BackendDispatch.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace at {
+namespace detail {
+
+// Suspends all backends in the dispatcher and diverts op requests to the meta
+// dispatch key.
+void suspendBackendDispatch();
+
+// Restores the dispatcher to its original state.
+void restoreBackendDispatch();
+
+bool backendDispatchSuspended() noexcept;
+
+} // namespace detail
+} // namespace at

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -655,6 +655,18 @@ static PyObject * THPModule_are_vmap_fallback_warnings_enabled(PyObject* _unused
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject *THPModule_suspend_backend_dispatch(PyObject *_unused, PyObject *noargs)
+{
+  at::globalContext().suspendBackendDispatch();
+  Py_RETURN_NONE;
+}
+
+static PyObject *THPModule_restore_backend_dispatch(PyObject *_unused, PyObject *noargs)
+{
+  at::globalContext().restoreBackendDispatch();
+  Py_RETURN_NONE;
+}
+
 //NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, modernize-avoid-c-arrays)
 static PyMethodDef TorchMethods[] = {
   {"_initExtension",  THPModule_initExtension,   METH_O,       nullptr},
@@ -699,6 +711,8 @@ static PyMethodDef TorchMethods[] = {
   {"_vmapmode_decrement_nesting", THPModule_vmapmode_decrement_nesting, METH_NOARGS, nullptr},
   {"_debug_only_display_vmap_fallback_warnings", THPModule_set_display_vmap_fallback_warnings_mode, METH_O, nullptr},
   {"_debug_only_are_vmap_fallback_warnings_enabled", THPModule_are_vmap_fallback_warnings_enabled, METH_NOARGS, nullptr},
+  {"_suspend_backend_dispatch", THPModule_suspend_backend_dispatch, METH_NOARGS, nullptr},
+  {"_restore_backend_dispatch", THPModule_restore_backend_dispatch, METH_NOARGS, nullptr},
   {"_to_dlpack",      THPModule_toDLPack,          METH_O,       nullptr},
   {"_from_dlpack",    THPModule_fromDLPack,        METH_O,       nullptr},
   {"set_flush_denormal", THPModule_setFlushDenormal, METH_O,     nullptr},

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -5,5 +5,6 @@ from .convert_parameters import parameters_to_vector, vector_to_parameters
 from .spectral_norm import spectral_norm, remove_spectral_norm
 from .fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
 from .memory_format import convert_conv2d_weight_memory_format
+from .no_init import no_init
 from . import parametrizations
 from .init import skip_init

--- a/torch/nn/utils/no_init.py
+++ b/torch/nn/utils/no_init.py
@@ -1,0 +1,60 @@
+from typing import Type
+
+from ..._C import _suspend_backend_dispatch, _restore_backend_dispatch
+from ..modules import Module
+
+
+def no_init(module_cls: Type[Module], *args, **kwargs) -> Module:
+    """Constructs a module without initializing its parameters and buffers.
+
+    This function is meant to be used if the size of the specified module is big
+    and you want to inspect it without fully instantiating. For instance an
+    automated sharding system can construct a module with ``no_init()``, inspect
+    its architecture, and materialize its layers at a later time.
+
+    Internally ``no_init()`` forces all parameters and buffers of the module and
+    its sub-modules to use a meta device regardless of the requested device
+    type. The returned module can be used for inspection purposes, but has to be
+    materialized by calling its ``materialize()`` method before doing actual
+    work.
+
+    Args:
+        module_cls:
+            The type of the module to construct.
+        args:
+            The positional arguments to pass to the module's constructor.
+        kwargs:
+            The keyword arguments to pass to the module's constructor.
+
+    Returns:
+        A module instance with uninitialized parameters and buffers.
+
+    Example::
+        >>> import torch
+        >>> m = torch.nn.utils.no_init(torch.nn.Linear, 5, 1)
+        >>> m.weight
+        Parameter containing:
+        tensor(..., device='meta', requires_grad=True)
+        >>> n = m.materialize()
+        >>> n.weight
+        Parameter containing:
+        tensor([[-1.4677e+24,  4.5915e-41,  1.4013e-45,  0.0000e+00, -1.4677e+24,
+                  4.5915e-41]], requires_grad=True)
+
+    Note:
+        The ``args`` and ``kwargs`` arguments must be treated as immutable since
+        they will be used a second time during materialization.
+    """
+    _suspend_backend_dispatch()
+
+    try:
+        module = module_cls(*args, **kwargs)
+    finally:
+        _restore_backend_dispatch()
+
+    def materialize() -> Module:
+        return module_cls(*args, **kwargs)
+
+    module.materialize = materialize
+
+    return module


### PR DESCRIPTION
This draft PR contains an experimental implementation of a `no_init()` function that forces all parameters and buffers of a module and its sub-modules to use a meta device regardless of the requested device type. The returned module can be used for inspection purposes, but has to be materialized by calling its `materialize()` method before doing any actual work.

```python
>>> import torch
>>> m = torch.nn.utils.no_init(torch.nn.Linear, 5, 1)
>>> m.weight
Parameter containing:
tensor(..., device='meta', requires_grad=True)
>>> n = m.materialize()
>>> n.weight
Parameter containing:
tensor([[-1.4677e+24,  4.5915e-41,  1.4013e-45,  0.0000e+00, -1.4677e+24,
             4.5915e-41]], requires_grad=True)
```

Note that `no_init()` does not require any code changes on the module side. We ultimately "hijack" all backend dispatch keys and only allow the meta dispatch key to pass through. This forces the `Dispatcher` to divert all op calls to the meta device for the duration of `no_init()`.