### PR TITLE
[LTC] Add nll_loss_backward TorchScript lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -760,6 +760,21 @@ at::Tensor LazyNativeFunctions::ne(const at::Tensor& self,
       LazyTensor::ne(bridge::GetLtcTensor(self), bridge::GetLtcTensor(other)));
 }
 
+at::Tensor LazyNativeFunctions::nll_loss_backward(const at::Tensor& grad_output,
+    const at::Tensor& self, const at::Tensor& target,
+    const c10::optional<at::Tensor>& weight, int64_t reduction,
+    int64_t ignore_index, const at::Tensor& total_weight)
+{
+  LTC_FN_COUNTER("lazy::");
+
+  auto selfTensor = bridge::GetLtcTensor(self);
+  return bridge::AtenFromLtcTensor(
+      LazyTensor::nll_loss_backward(bridge::GetLtcTensor(grad_output), selfTensor,
+          bridge::GetLtcTensor(target), bridge::GetOrCreateLtcTensor(weight,
+              selfTensor.GetDevice()),
+          reduction, ignore_index, bridge::GetLtcTensor(total_weight)));
+}
+
 // We need to explicitly override max pooling operators and just call the
 // fallback for them because we've customized the autograd function for them
 // (backward needs saved indices from forward).

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -32,6 +32,7 @@ supported:
   - mul.Scalar
   - native_batch_norm
   - native_batch_norm_backward
+  - nll_loss_backward
   - gelu
   - gelu_backward
   - max_pool2d_with_indices


### PR DESCRIPTION
Summary:
This patch added nll_loss_backward to TorchScript lowering.

Test Plan:
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestNllLossBackward

Fixes #62431.
