### PR TITLE
[debugging only] Why is there an extra TensorImpl created in dispatcher

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -45,7 +45,11 @@ public:
   int64_t dense_dim() const { return dense_dim_; }
   bool coalesced() const { return coalesced_; }
   Tensor indices() const { return indices_; }
-  Tensor values() const { return values_; }
+  Tensor values() const {
+    std::cout << "values(): " << values_.unsafeGetTensorImpl() << std::endl;
+
+    return values_;
+  }
 
   IntArrayRef strides() const override;
   int64_t stride(int64_t d) const override;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5089,6 +5089,11 @@
   device_check: NoCheck
   device_guard: False
 
+- func: my_test_sparse_op(Tensor self) -> ()
+  variants: function
+  dispatch:
+    CPU: my_test_sparse_op
+
 # This method doesn't do any check but only directly sets the flag. So it can be
 # a bit unsafe. Similar to _indices and _values, this is useful for implementing
 # custom sparse operations in Python/C++ extension.

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -17,6 +17,15 @@ namespace native {
 
 using namespace at::sparse;
 
+void my_test_sparse_op(const Tensor& self) {
+  at::Tensor indices = at::tensor({0, 1, 2}, at::TensorOptions().dtype(at::kLong)).reshape({1, 3});
+  at::Tensor values = at::tensor({3, 3, 3});
+  auto s = at::sparse_coo_tensor(indices, values);
+
+  std::cout << "my_test_sparse_op" << std::endl;
+  auto s_values = s._values();
+  std::cout << "my_test_sparse_op: " << s_values.unsafeGetTensorImpl() << std::endl;
+}
 /******************************************************************************
  * access methods
  ******************************************************************************/
@@ -46,7 +55,10 @@ Tensor _indices_sparse(const SparseTensor& self) {
 }
 
 Tensor _values_sparse(const SparseTensor& self) {
-  return get_sparse_impl(self)->values();
+  std::cout << "_values_sparse" << std::endl;
+  auto s_values = get_sparse_impl(self)->values();
+  std::cout << "_values_sparse: " << s_values.unsafeGetTensorImpl() << std::endl;
+  return s_values;
 }
 
 Tensor& _coalesced_sparse_(SparseTensor& self, bool coalesced) {


### PR DESCRIPTION
Fixes #{issue number}
 - When we call into `my_test_sparse_op` registered in native_functions.yaml

```
(...) 
KernelFunction::call: 0x55bc645e9e60
KernelFunction::call: 0x55bc645e9e60
KernelFunction::call: 0x55bc645e9e60
KernelFunction::call: 0x55bc645e9e60
my_test_sparse_op       <-----------calling into the op
 KernelFunction::call (unboxed)
_values_sparse
values(): 0x55bc645e9f50    <---- the actual TensorImpl
_values_sparse: 0x55bc645e9f50  <---- going back up the callstack
KernelFunction::call: 0x55bc645e9f50 <--- call into this KernelFunction ONCE
my_test_sparse_op: 0x55bc645e9f50

```

- When we call into `my_test_sparse_op` registered using cpp_extension

<details>

<summary>
Code
</summary>

```
#include <torch/extension.h>

using namespace torch;
using namespace aten;
using namespace torch::autograd;

void boxedFunction(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
  std::cout << "boxed" << std::endl;
  {
    at::AutoDispatchBelowAutograd guard;
    op.redispatchBoxed(dispatch_keys & c10::after_autograd_keyset, stack);
  }
}

template<class... Inputs>
inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
  return {std::forward<Inputs>(inputs)...};
}

// Simple case: tensor inputs and outputs
torch::Tensor my_test_op(const torch::Tensor& self, const torch::Tensor& other) {
  torch::Tensor indices = torch::tensor({0, 1, 2}).reshape({1, 3});
  torch::Tensor values = torch::tensor({3, 3, 3});
  auto s = at::sparse_coo_tensor(indices, values);

  std::cout << "my_test_sparse_op" << std::endl;
  auto s_values = s._values();
  std::cout << "my_test_sparse_op: " << s_values.unsafeGetTensorImpl() << std::endl;

  return self + other;
}

Tensor my_test_op_dispatched(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_op", "")
    .typed<torch::Tensor (const at::Tensor&, const at::Tensor&)>();
  return op.call(self, other);
}

void my_test_op_dispatch_boxed(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_op", "");
  auto stack = makeStack(self, other);
  op.callBoxed(&stack);
}

TORCH_LIBRARY(my_ops, m) {
  m.def("my_test_op(Tensor self, Tensor other) -> Tensor ");
}

TORCH_LIBRARY_IMPL(my_ops, CPU, m) {
  m.impl("my_test_op", TORCH_FN(my_test_op));
}

#ifdef _USE_BOXED
TORCH_LIBRARY_IMPL(my_ops, Autograd, m) {
  m.impl("my_test_op", torch::CppFunction::makeFromBoxedFunction<&boxedFunction>());
}
#endif

int main() {
  torch::Tensor a = torch::tensor({0, 1, 2});
  torch::Tensor b = torch::tensor({3, 3, 3});
  my_test_op_dispatched(a, b);
}
```

</details>

```
KernelFunction::call: 0x564a5c580940
KernelFunction::call: 0x564a5c585540
KernelFunction::call: 0x564a5c585540
KernelFunction::call: 0x564a5c585540
KernelFunction::call: 0x564a5c585540
my_test_sparse_op
 KernelFunction::call (unboxed)
 KernelFunction::call (unboxed)
_values_sparse
values(): 0x564a5c584170
_values_sparse: 0x564a5c584170
KernelFunction::call: 0x564a5c584170  <---- call into kernelfunction TWICE
KernelFunction::call: 0x564a5c574bc0  <----- the second time we call into it TensorImpl has changed! what happened here ^^^
my_test_sparse_op: 0x564a5c574bc0
 KernelFunction::call (unboxed)
KernelFunction::call: 0x564a5c580940

```