### PR TITLE
Microbenchmarking matrix mult (einsum, torch.mult, torch.mm)

### DIFF
--- a/benchmarks/operator_benchmark/pt/matrix_mult_test.py
+++ b/benchmarks/operator_benchmark/pt/matrix_mult_test.py
@@ -1,0 +1,119 @@
+import operator_benchmark as op_bench
+import torch
+
+"""
+Microbenchmarks for batch matrix mult with einsum and torch.bmm.
+"""
+
+batch_mm_configs_short = op_bench.config_list(
+    attr_names=["B", "M", "N", "K"],
+    attrs=[
+        [4, 5, 3, 2],
+        [32, 25, 20, 30],
+        [128, 100, 120, 110],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=["short"],
+)
+
+batch_mm_configs_long = op_bench.config_list(
+    attr_names=["B", "M", "N", "K"],
+    attrs=[
+        [128, 256, 128, 256],
+        [512, 1024, 1024, 512],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=["long"],
+)
+
+batch_mm_op_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['einsum_bmm', torch.einsum],
+        ['bmm', torch.bmm],
+    ],
+)
+
+class BatchMatrixMultBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, B, M, N, K, device, op_func):
+        self.inputs = {
+            "input_one": torch.rand(B, M, N, device=device),
+            "input_two": torch.rand(B, N, K, device=device)
+        }
+        self.op_func = op_func
+
+    def forward(self, input_one, input_two):
+        if self.op_func.__name__ == "einsum":
+            return torch.einsum('bij,bjk->bik', input_one, input_two)
+        else:
+            return torch.bmm(input_one, input_two)
+
+
+"""
+Microbenchmarks for element-wise matrix mult with einsum and torch.mul.
+"""
+
+batch_elementwise_configs_short = op_bench.config_list(
+    attr_names=["B", "M", "N"],
+    attrs=[
+        [4, 5, 3],
+        [32, 25, 20],
+        [100, 90, 110],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=["short"],
+)
+
+
+batch_elementwise_configs_long = op_bench.cross_product_configs(
+    B=[128, 512, 1024],
+    M=[128, 512, 1024],
+    N=[128, 512, 1024],
+    device=['cpu', 'cuda'],
+    tags=['long']
+)
+
+batch_elementwise_op_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['einsum_elementwise', torch.einsum],
+        ['mul', torch.mul],
+    ],
+)
+
+class BatchElementWiseBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, B, M, N, device, op_func):
+        self.inputs = {
+            "input_one": torch.rand(B, M, N, device=device),
+            "input_two": torch.rand(B, M, N, device=device)
+        }
+        self.op_func = op_func
+
+    def forward(self, input_one, input_two):
+        if self.op_func.__name__ == "einsum":
+            return torch.einsum('bij,bij->bij', input_one, input_two)
+        else:
+            return torch.mul(input_one, input_two)
+
+
+op_bench.generate_pt_tests_from_op_list(
+    batch_mm_op_list,
+    batch_mm_configs_short + batch_mm_configs_long,
+    BatchMatrixMultBenchmark,
+)
+
+op_bench.generate_pt_tests_from_op_list(
+    batch_elementwise_op_list,
+    batch_elementwise_configs_short + batch_elementwise_configs_long,
+    BatchElementWiseBenchmark,
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Test Plan:
```
> buck run mode/opt caffe2/benchmarks/operator_benchmark/pt:matrix_mult_test

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking PyTorch: einsum_bmm
# Mode: Eager
# Name: einsum_bmm_B4_M5_N3_K2_cpu
# Input: B: 4, M: 5, N: 3, K: 2, device: cpu
Forward Execution Time (us) : 27.970

# Benchmarking PyTorch: einsum_bmm
# Mode: Eager
# Name: einsum_bmm_B32_M25_N20_K30_cpu
# Input: B: 32, M: 25, N: 20, K: 30, device: cpu
Forward Execution Time (us) : 41.830

# Benchmarking PyTorch: einsum_bmm
# Mode: Eager
# Name: einsum_bmm_B128_M100_N120_K110_cpu
# Input: B: 128, M: 100, N: 120, K: 110, device: cpu
Forward Execution Time (us) : 499.114

# Benchmarking PyTorch: bmm
# Mode: Eager
# Name: bmm_B4_M5_N3_K2_cpu
# Input: B: 4, M: 5, N: 3, K: 2, device: cpu
Forward Execution Time (us) : 6.268

# Benchmarking PyTorch: bmm
# Mode: Eager
# Name: bmm_B32_M25_N20_K30_cpu
# Input: B: 32, M: 25, N: 20, K: 30, device: cpu
Forward Execution Time (us) : 12.676

# Benchmarking PyTorch: bmm
# Mode: Eager
# Name: bmm_B128_M100_N120_K110_cpu
# Input: B: 128, M: 100, N: 120, K: 110, device: cpu
Forward Execution Time (us) : 438.219

# Benchmarking PyTorch: einsum_elementwise
# Mode: Eager
# Name: einsum_elementwise_B4_M5_N3_cpu
# Input: B: 4, M: 5, N: 3, device: cpu
Forward Execution Time (us) : 7.657

# Benchmarking PyTorch: einsum_elementwise
# Mode: Eager
# Name: einsum_elementwise_B32_M25_N20_cpu
# Input: B: 32, M: 25, N: 20, device: cpu
Forward Execution Time (us) : 18.523

# Benchmarking PyTorch: einsum_elementwise
# Mode: Eager
# Name: einsum_elementwise_B100_M90_N110_cpu
# Input: B: 100, M: 90, N: 110, device: cpu
Forward Execution Time (us) : 55.103

# Benchmarking PyTorch: mul
# Mode: Eager
# Name: mul_B4_M5_N3_cpu
# Input: B: 4, M: 5, N: 3, device: cpu
Forward Execution Time (us) : 2.501

# Benchmarking PyTorch: mul
# Mode: Eager
# Name: mul_B32_M25_N20_cpu
# Input: B: 32, M: 25, N: 20, device: cpu
Forward Execution Time (us) : 10.589

# Benchmarking PyTorch: mul
# Mode: Eager
# Name: mul_B100_M90_N110_cpu
# Input: B: 100, M: 90, N: 110, device: cpu
Forward Execution Time (us) : 50.102

Differential Revision: D30455179

