### PR TITLE
[PyTorch] Add Library::fallback overload for CppFunction

### DIFF
--- a/torch/library.h
+++ b/torch/library.h
@@ -684,6 +684,10 @@ public:
     return _fallback(std::move(f));
   }
 
+  Library& fallback(CppFunction f) & {
+    return _fallback(std::move(f));
+  }
+
   template <class CurClass>
   inline torch::class_<CurClass> class_(const std::string& className);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63712
* __->__ #63697
* #63688

When the argument is a CppFunction (as it is when called as `m.fallback(CppFunction::makeFallthrough())`) there's no need to copy it.

Differential Revision: [D30463296](https://our.internmc.facebook.com/intern/diff/D30463296/)