### PR TITLE
[PyTorch] Don't inline KernelFunction constructor

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -5,6 +5,12 @@
 
 namespace c10 {
 
+KernelFunction::KernelFunction(std::unique_ptr<OperatorKernel> functor, InternalBoxedKernelFunction* boxed_kernel_func, void* unboxed_kernel_func)
+: functor_(std::move(functor))
+, boxed_kernel_func_(boxed_kernel_func)
+, unboxed_kernel_func_(unboxed_kernel_func)
+{}
+
 // This a "fake" kernel which doesn't actually do anything.  Instead, it is a
 // distinguished kernel which is special cased by the dispatch table to
 // be handled specially.  Its semantics is that it redispatches to the

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -11,12 +11,6 @@ inline KernelFunction::KernelFunction()
 , unboxed_kernel_func_(nullptr)
 {}
 
-inline KernelFunction::KernelFunction(std::unique_ptr<OperatorKernel> functor, InternalBoxedKernelFunction* boxed_kernel_func, void* unboxed_kernel_func)
-: functor_(std::move(functor))
-, boxed_kernel_func_(boxed_kernel_func)
-, unboxed_kernel_func_(unboxed_kernel_func)
-{}
-
 template<KernelFunction::BoxedKernelFunction* func>
 inline void KernelFunction::make_boxed_function(OperatorKernel*, const OperatorHandle& opHandle, DispatchKeySet, Stack* stack) {
     // Note that we're dropping the DispatchKeySet argument.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63712
* #63697
* #63688

These are created in TORCH_LIBRARY_IMPL and friends (where performance doesn't matter), and inlining likely increases code size.

Differential Revision: [D30463865](https://our.internmc.facebook.com/intern/diff/D30463865/)