### PR TITLE
[Static Runtime] Add pass to split fast_gather

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -548,7 +548,7 @@ PrepareForStaticModule(
 StaticModule::StaticModule(
     std::shared_ptr<torch::jit::Graph> g,
     const StaticModuleOptions& opts)
-    : StaticModule(PrepareForStaticModule(g, opts), opts) {}
+    : StaticModule(PrepareForStaticModule(g->copy(), opts), opts) {}
 
 StaticModule::StaticModule(
     const torch::jit::Module& m,


### PR DESCRIPTION
Summary: This pass turns calls to `fast_gather` into `aten::to` + `fast_gather_no_cast`, as described in D30458345.

Differential Revision: D30463270

