### PR TITLE
Adds return type annotation for fork_rng function

### DIFF
--- a/torch/random.py
+++ b/torch/random.py
@@ -1,4 +1,5 @@
 import contextlib
+from typing import Generator
 import warnings
 
 from torch._C import default_generator
@@ -65,7 +66,7 @@ _fork_rng_warned_already = False
 
 
 @contextlib.contextmanager
-def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="devices"):
+def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="devices") -> Generator:
     """
     Forks the RNG, so that when you return, the RNG is reset
     to the state that it was previously in.


### PR DESCRIPTION
Fixes #63723

Since it's a generator function the type annotation shall be `Generator`.
![image](https://user-images.githubusercontent.com/47299190/130318830-29ef9529-0daa-463c-90b2-1b11f63ade8a.png)
