### PR TITLE
TST Adds pickle testing for ModuleInfo

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -112,7 +112,7 @@ class TestModule(TestCase):
 
     @modules(module_db)
     def test_pickle(self, device, dtype, module_info):
-        """Test that module can be pickled and unpickled"""
+        # Test that module can be pickled and unpickled.
         module_cls = module_info.module_cls
         module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
                                                        requires_grad=False)
@@ -132,6 +132,7 @@ class TestModule(TestCase):
                 args, kwargs = module_input.forward_input.args, module_input.forward_input.kwargs
                 output = m(*args, **kwargs)
 
+                # === Check unpickled module gives the same output. ===
                 with tempfile.TemporaryFile() as f:
                     torch.save(m, f)
                     f.seek(0)

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_modules import module_db, modules
@@ -107,6 +109,35 @@ class TestModule(TestCase):
                         self.assertEqual(
                             buffer.dtype, dtype,
                             f'Buffer {name} is of dtype {buffer.dtype} instead of the expected dtype {dtype}')
+
+    @modules(module_db)
+    def test_pickle(self, device, dtype, module_info):
+        """Test that module can be pickled and unpickled"""
+        module_cls = module_info.module_cls
+        module_inputs = module_info.module_inputs_func(module_info, device=device, dtype=dtype,
+                                                       requires_grad=False)
+        for module_input in module_inputs:
+            if module_input.forward_input is None:
+                continue
+
+            args, kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
+
+            with freeze_rng_state():
+                # === Instantiate the module. ===
+                args, kwargs = module_input.constructor_input.args, module_input.constructor_input.kwargs
+                m = module_cls(*args, **kwargs)
+                m.to(device).to(dtype)
+
+                # === Do forward pass. ===
+                args, kwargs = module_input.forward_input.args, module_input.forward_input.kwargs
+                output = m(*args, **kwargs)
+
+                with tempfile.TemporaryFile() as f:
+                    torch.save(m, f)
+                    f.seek(0)
+                    m_copy = torch.load(f)
+                    output_from_copy = m_copy(*args, **kwargs)
+                    self.assertEqual(output, output_from_copy)
 
 
 instantiate_device_type_tests(TestModule, globals())


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/61935

This PR adds `test_pickle` to `test_modules`.

cc @albanD @mruberry @jbschlosser