### PR TITLE
Fix some memory bugs in onnx passes

### DIFF
--- a/torch/csrc/jit/passes/onnx/list_model_parameters.cpp
+++ b/torch/csrc/jit/passes/onnx/list_model_parameters.cpp
@@ -143,6 +143,8 @@ std::vector<IValue> getParamAttributes(
           auto attrVal = tryInsertConstant(*graph, attr);
           n->output()->replaceAllUsesWith(*attrVal);
           n->destroy();
+          // Don't scan blocks below.
+          continue;
         }
       }
     }

--- a/torch/csrc/jit/passes/onnx/list_model_parameters.cpp
+++ b/torch/csrc/jit/passes/onnx/list_model_parameters.cpp
@@ -76,6 +76,7 @@ std::vector<IValue> getParamAttributes(
   WithInsertPoint guard(m);
 
   std::vector<IValue> parameterIValues = {};
+  std::unordered_set<Node*> nodesToDestroy;
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
     Node* n = *it;
     it++; // node n can be destroyed
@@ -142,9 +143,7 @@ std::vector<IValue> getParamAttributes(
           // This attr is constant for ONNX.
           auto attrVal = tryInsertConstant(*graph, attr);
           n->output()->replaceAllUsesWith(*attrVal);
-          n->destroy();
-          // Don't scan blocks below.
-          continue;
+          nodesToDestroy.emplace(n);
         }
       }
     }
@@ -157,6 +156,9 @@ std::vector<IValue> getParamAttributes(
           std::begin(nextParameterIValues),
           std::end(nextParameterIValues));
     }
+  }
+  for (auto n : nodesToDestroy) {
+    n->destroy();
   }
   return parameterIValues;
 }

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/common.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/common.cpp
@@ -4,8 +4,8 @@ namespace torch {
 namespace jit {
 
 bool IndexingPatternFinder::IsSameSource(const Node* n, const Node* m) {
-  const auto& source_n = n->sourceRange().source();
-  const auto& source_m = m->sourceRange().source();
+  const auto source_n = n->sourceRange().source();
+  const auto source_m = m->sourceRange().source();
   return (
       (source_n->text() == source_m->text()) &&
       (source_n->starting_line_no() == source_m->starting_line_no()));

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -317,6 +317,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
   }
 
   for (auto input : b->inputs()) {
+  restart:
     for (auto use : input->uses()) {
       Node* node = use.user;
       if (!mr.inplaceOpVariant(node)) {
@@ -335,6 +336,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
         TORCH_INTERNAL_ASSERT(nullptr != newNode);
         node->replaceInput(index, newNode->output());
         input->replaceAllUsesAfterNodeWith(node, newNode->output());
+        goto restart;
       }
     }
   }

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -325,7 +325,8 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
         if (!mr.inplaceOpVariant(node)) {
           continue;
         }
-        auto it = std::find(node->inputs().begin(), node->inputs().end(), input);
+        auto it =
+            std::find(node->inputs().begin(), node->inputs().end(), input);
         if (it != node->inputs().end()) {
           int index = std::distance(node->inputs().begin(), it);
           std::cerr << "Warning: ONNX Preprocess - Removing mutation from node "
@@ -334,7 +335,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
                     << std::endl;
 
           Node* newNode =
-            addDummyClone(b->owningGraph(), input, false, b->return_node());
+              addDummyClone(b->owningGraph(), input, false, b->return_node());
           TORCH_INTERNAL_ASSERT(nullptr != newNode);
           node->replaceInput(index, newNode->output());
           input->replaceAllUsesAfterNodeWith(node, newNode->output());


### PR DESCRIPTION
Running onnx tests with ASAN uncovers several memory errors.  These two are caused by: (1) iterating the uses list of a node after mutation, and (2) accessing the `blocks` attribute of a possibly deleted node.

To reproduce (this is on a CentOS 7 box):
```
DEBUG=1 CFLAGS="-fsanitize=address" CXXFLAGS="-fsanitize=address" USE_LLVM=$(realpath ../llvm-project/install) CMAKE_PREFIX_PATH=$CONDA_PREFIX python setup.py install
LD_PRELOAD=$(realpath /lib64/libasan.so.5) numactl -C3 pytest -v --cov --cov-report xml:test/coverage.xml --cov-append onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset11 -s
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63754

Differential Revision: [D30493939](https://our.internmc.facebook.com/intern/diff/D30493939)

cc @gmagogsfm