### PR TITLE
Remove outdated comment in hub.py

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -431,8 +431,6 @@ def download_url_to_file(url, dst, hash_prefix=None, progress=True):
 
     """
     file_size = None
-    # We use a different API for python2 since urllib(2) doesn't recognize the CA
-    # certificates in older Python
     req = Request(url, headers={"User-Agent": "torch.hub"})
     u = urlopen(req)
     meta = u.info()


### PR DESCRIPTION
This PR removes an outdated comment about Python2 that was orginally introduced in https://github.com/pytorch/pytorch/pull/25083/files. The code has changed since then, but the comment wasn't removed.


cc @nairbv @NicolasHug