### PR TITLE
[nnc] Disable erf and erfc

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -108,8 +108,9 @@ const OperatorSet& supported_eltwise_set() {
       "aten::log2(Tensor self) -> Tensor",
       "aten::log1p(Tensor self) -> Tensor",
       "aten::exp(Tensor self) -> Tensor",
-      "aten::erf(Tensor self) -> Tensor",
-      "aten::erfc(Tensor self) -> Tensor",
+      // TODO: These are currently slower and less accurate than aten when.
+      // "aten::erf(Tensor self) -> Tensor",
+      // "aten::erfc(Tensor self) -> Tensor",
       "aten::fmod.Scalar(Tensor self, Scalar other) -> Tensor",
       "aten::fmod.Tensor(Tensor self, Tensor other) -> Tensor",
       "aten::cos(Tensor self) -> Tensor",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63764
* #63763
* __->__ #63762

These introduce small accuracy differences that cause some internal
tests to fail, and it's not worth fixing the tests right now because they're
slower than the ATen ops anyways.

Differential Revision: [D30484557](https://our.internmc.facebook.com/intern/diff/D30484557/)