### PR TITLE
[nnc] Disable automatic fma fusion

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -91,7 +91,11 @@ static llvm::orc::JITTargetMachineBuilder makeTargetMachineBuilder(
   auto JTMB = triple ? makeJTMBFromTriple(*triple, cpu, attrs)
                      : makeJTMBFromHost(cpu, attrs);
   JTMB.setCodeGenOptLevel(llvm::CodeGenOpt::Default);
-  JTMB.getOptions().AllowFPOpFusion = llvm::FPOpFusion::Fast;
+  // TODO: This is disabled because it changes numerical precision (for the
+  // better, but that still causes test failures).  We need to either fix the
+  // tests or introduce an explicit FMA intrinsic.
+
+  // JTMB.getOptions().AllowFPOpFusion = llvm::FPOpFusion::Fast;
   return JTMB;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63764
* __->__ #63763
* #63762

This makes me sad, but some internal tests fail due to the *increased*
precision of fma versus mul+add.  For now, I don't think this matters much,
because fma and mul+add are both b/w bound and that means the extra flops don't
really help you.  But in the longer term (i.e. generating matmuls) we will need
to introduce an explicit fma.

Differential Revision: [D30484556](https://our.internmc.facebook.com/intern/diff/D30484556/)