### PR TITLE
[fx2trt] Add acc op and converter for torch.pow

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -764,6 +764,11 @@ def acc_ops_mul(network, target, args, kwargs, name):
         network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.PROD, name
     )
 
+@tensorrt_converter(acc_ops.pow)
+def acc_ops_pow(network, target, args, kwargs, name):
+    return add_binary_elementwise_layer(
+        network, kwargs["input"], kwargs["exponent"], trt.ElementWiseOperation.POW, name
+    )
 
 @tensorrt_converter(acc_ops.min_two_tensors_input)
 def acc_ops_min_two_tensors_input(network, target, args, kwargs, name):

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -496,6 +496,12 @@ def div(*, input, other):
     return input / other
 
 
+@register_acc_op_mapping(op_and_target=("call_function", torch.pow))
+@register_acc_op
+def pow(*, input, exponent):
+    return torch.pow(input, exponent)
+
+
 @register_acc_op_mapping(op_and_target=("call_function", nn.functional.relu))
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.relu),


### PR DESCRIPTION
Summary: att

Test Plan: buck run mode/opt caffe2/torch/fb/fx2trt:test_binary_ops

Differential Revision: D30492488

