### PR TITLE
Fix typo in NNAPI tests

### DIFF
--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -78,7 +78,7 @@ class TestNNAPI(TestCase):
                     # to get a nice message.
                     self.assertEqual(eager_output, nnapi_output, atol=0, rtol=0)
             if expected_memory_format:
-                self.assertTrue(nnapi_out.is_contiguous(memory_format=expected_memory_format))
+                self.assertTrue(nnapi_output.is_contiguous(memory_format=expected_memory_format))
 
     def float_and_quant_and_nhwc(self, inp_float, scale, zero_point):
         torch.manual_seed(29)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63797

Summary:

nnapi memory format test has a typo

Test Plan:

pytest test/test_nnapi.py::TestNNAPI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D30495473](https://our.internmc.facebook.com/intern/diff/D30495473)