### PR TITLE
[LTC] Add nll_loss_forward TorchScript lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss_forward.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss_forward.cpp
@@ -1,4 +1,4 @@
-#include "lazy_tensor_core/csrc/ops/nll_loss.h"
+#include "lazy_tensor_core/csrc/ops/nll_loss_forward.h"
 
 #include "lazy_tensor_core/csrc/compiler/node_lowering.h"
 #include "lazy_tensors/computation_client/util.h"
@@ -8,13 +8,13 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-NllLoss::NllLoss(const Value& logits, const Value& labels,
+NllLossForward::NllLossForward(const Value& logits, const Value& labels,
                  const c10::optional<Value>& weight, ReductionMode reduction,
                  int ignore_index)
-    : Node(ir::OpKind(at::aten::nll_loss),
+    : Node(ir::OpKind(at::aten::nll_loss_forward),
            lazy_tensors::util::GetValuesVector<Value>({logits, labels},
                                                       {&weight}),
-           /*num_outputs=*/1,
+           /*num_outputs=*/2,
            lazy_tensors::util::MHash(
                lazy_tensors::util::GetEnumValue(reduction), ignore_index)),
       reduction_(reduction),
@@ -23,16 +23,16 @@ NllLoss::NllLoss(const Value& logits, const Value& labels,
       [&]() { return compiler::NodeLowering::Get()->Infer(this); });
 }
 
-NodePtr NllLoss::Clone(OpList operands) const {
+NodePtr NllLossForward::Clone(OpList operands) const {
   c10::optional<Value> weight;
   if (operands.size() > 2) {
     weight = operands.at(2);
   }
-  return MakeNode<NllLoss>(operands.at(0), operands.at(1), weight, reduction_,
-                           ignore_index_);
+  return MakeNode<NllLossForward>(operands.at(0), operands.at(1), weight,
+      reduction_, ignore_index_);
 }
 
-std::string NllLoss::ToString() const {
+std::string NllLossForward::ToString() const {
   std::stringstream ss;
   ss << Node::ToString()
      << ", reduction=" << lazy_tensors::util::GetEnumValue(reduction_)

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss_forward.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss_forward.h
@@ -9,9 +9,9 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-class NllLoss : public Node {
+class NllLossForward : public Node {
  public:
-  NllLoss(const Value& logits, const Value& labels,
+  NllLossForward(const Value& logits, const Value& labels,
           const c10::optional<Value>& weight, ReductionMode reduction,
           int ignore_index);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -860,9 +860,9 @@ class LazyTensor {
 
   static LazyTensor neg(const LazyTensor& input);
 
-  static LazyTensor nll_loss(const LazyTensor& input, const LazyTensor& target,
-                             const LazyTensor& weight,
-                             lazy_tensors::int64 reduction, int ignore_index);
+  static std::tuple<LazyTensor, LazyTensor>
+  nll_loss_forward(const LazyTensor& input, const LazyTensor& target,
+      const LazyTensor& weight, lazy_tensors::int64 reduction, int ignore_index);
 
   static LazyTensor nll_loss2d(const LazyTensor& input,
                                const LazyTensor& target,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -74,10 +74,10 @@
 #include "lazy_tensor_core/csrc/ops/mse_loss_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_backward.h"
 #include "lazy_tensor_core/csrc/ops/native_batch_norm_forward.h"
-#include "lazy_tensor_core/csrc/ops/nll_loss.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss2d_backward.h"
 #include "lazy_tensor_core/csrc/ops/nll_loss_backward.h"
+#include "lazy_tensor_core/csrc/ops/nll_loss_forward.h"
 #include "lazy_tensor_core/csrc/ops/nms.h"
 #include "lazy_tensor_core/csrc/ops/nonzero.h"
 #include "lazy_tensor_core/csrc/ops/normal.h"
@@ -1967,14 +1967,14 @@ LazyTensor LazyTensor::neg(const LazyTensor& input) {
   return input.CreateFrom(ir::ops::Neg(input.GetIrValue()));
 }
 
-LazyTensor LazyTensor::nll_loss(const LazyTensor& input,
-                                const LazyTensor& target,
-                                const LazyTensor& weight,
-                                lazy_tensors::int64 reduction,
-                                int ignore_index) {
-  return input.CreateFrom(ir::MakeNode<ir::ops::NllLoss>(
-      input.GetIrValue(), target.GetIrValue(), GetOptionalIrValue(weight),
-      GetReductionMode(reduction), ignore_index));
+std::tuple<LazyTensor, LazyTensor>
+LazyTensor::nll_loss_forward(const LazyTensor& input, const LazyTensor& target,
+    const LazyTensor& weight, lazy_tensors::int64 reduction, int ignore_index) {
+  auto node = ir::MakeNode<ir::ops::NllLossForward>(input.GetIrValue(),
+      target.GetIrValue(), GetOptionalIrValue(weight),
+      GetReductionMode(reduction), ignore_index);
+  return std::make_tuple(input.CreateFrom(ir::Value(node, 0)),
+      input.CreateFrom(ir::Value(node, 1)));
 }
 
 LazyTensor LazyTensor::nll_loss2d(const LazyTensor& input,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -775,6 +775,24 @@ at::Tensor LazyNativeFunctions::nll_loss_backward(const at::Tensor& grad_output,
           reduction, ignore_index, bridge::GetLtcTensor(total_weight)));
 }
 
+std::tuple<at::Tensor,at::Tensor>
+LazyNativeFunctions::nll_loss_forward(const at::Tensor& self,
+    const at::Tensor& target, const c10::optional<at::Tensor>& weight,
+    int64_t reduction, int64_t ignore_index)
+{
+  LTC_FN_COUNTER("lazy::");
+
+  auto selfTensor = bridge::GetLtcTensor(self);
+  auto lazyOutputs = LazyTensor::nll_loss_forward(
+      selfTensor, bridge::GetLtcTensor(target),
+      bridge::GetOrCreateLtcTensor(weight, selfTensor.GetDevice()),
+      reduction, ignore_index);
+
+  return std::make_tuple(
+      bridge::AtenFromLtcTensor(std::get<0>(lazyOutputs)),
+      bridge::AtenFromLtcTensor(std::get<1>(lazyOutputs)));
+}
+
 // We need to explicitly override max pooling operators and just call the
 // fallback for them because we've customized the autograd function for them
 // (backward needs saved indices from forward).

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -33,6 +33,7 @@ supported:
   - native_batch_norm
   - native_batch_norm_backward
   - nll_loss_backward
+  - nll_loss_forward
   - gelu
   - gelu_backward
   - max_pool2d_with_indices


### PR DESCRIPTION
Summary:
This patch added nll_loss_forward to TorchScript lowering.

Test Plan:
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestNllLoss

Fixes #62431.
