### PR TITLE
Pass normalize_to_only_use_kwargs to normalize_function.

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2962,6 +2962,16 @@ class TestFX(JitTestCase):
         self.assertEqual(nf(**val), f(**val))
 
 
+    def test_normalized_arguments(self):
+        class Tracer(torch.fx.Tracer):
+            def is_leaf_module(self, m, module_qualified_name):
+                return False
+
+        mod = torch.nn.Linear(4, 4)
+        net = Tracer().trace(mod)
+        node = list(net.nodes)[3]
+        ret = node.normalized_arguments(mod, normalize_to_only_use_kwargs=True)
+        self.assertEqual(ret.kwargs.keys(), ["input", "weight", "bias"])
 
 
 def run_getitem_target():

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -500,7 +500,7 @@ class Node:
         """
         if self.op == 'call_function':
             assert callable(self.target)
-            return normalize_function(self.target, self.args, self.kwargs, arg_types, kwarg_types)  # type: ignore[arg-type]
+            return normalize_function(self.target, self.args, self.kwargs, arg_types, kwarg_types, normalize_to_only_use_kwargs)  # type: ignore[arg-type]
         elif self.op == 'call_module':
             assert isinstance(self.target, str)
             return normalize_module(root, self.target, self.args, self.kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63810

Summary:

See https://github.com/pytorch/pytorch/issues/62554