### PR TITLE
[FX] Fix _replicate_for_data_parallel on GraphModule

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2296,6 +2296,21 @@ class TestFX(JitTestCase):
                             r"Call using an FX-traced Module, line .* of the "
                             r"traced Module's generated forward function:")
 
+    def test_graph_module_replicate_for_dp(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return torch.relu(x)
+
+        gm = torch.fx.symbolic_trace(Foo())
+
+        x = torch.randn(5, 3)
+        out = gm(x)
+
+        replica = gm._replicate_for_data_parallel()
+        out_replica = replica(x)
+
+        torch.testing.assert_allclose(out_replica, out)
+
     def test_ast_rewriter_rewrites_assert(self):
         class M(torch.nn.Module):
             def forward(self, x: torch.Tensor, y: int, z: int):

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -656,6 +656,11 @@ class {module_name}(torch.nn.Module):
         orig_str = super().__str__()
         return '\n'.join([orig_str, self._code])
 
+    def _replicate_for_data_parallel(self):
+        new_gm = self.__copy__()
+        new_gm._is_replica = True
+        return new_gm
+
 # workarounds for issues in __torch_function__
 
 # WAR for __torch_function__ not handling tensor lists,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63821

Previously, `Module._replicate_for_data_parallel` would call `__new__` on a `GraphModule`, which compelled the creation of a new `GraphModuleImpl` class that inherited from the existing `GraphModuleImpl` class. There are two possible solutions to this:

1) Define `GraphModule.__new__` in such a way that it strips out existing `GraphModuleImpl` classes in the inheritance hierarchy. However, this does not work with `_replicate_for_data_parallel`, since that function copies over the instance's dict but not the class's dict, and thus does not carry forward the `forward` method. This makes the `__new__`ed module uncallable
2) The solution in this PR, where I've defined `GraphModule._replicate_for_data_parallel`. This does a shallow copy on the `GraphModule`, sets `_is_replica = True`, and returns that. Someone should let me know if these are the correct semantics for this method.

Differential Revision: [D30502115](https://our.internmc.facebook.com/intern/diff/D30502115)