### PR TITLE
[profiling executor] Fix segfault during compilation of fallback graph

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -756,6 +756,7 @@ Function* createFallbackPathFunction(
 
 void ProfilingGraphExecutorImpl::replaceFallbackGraphWithFallbackFunction(
     Block* b) {
+  GraphOptimizerEnabledGuard g(false);
   Stack s;
   for (auto it = b->nodes().begin(); it != b->nodes().end();) {
     if (it->kind() == prim::FallbackGraph) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63776
* __->__ #63827
* #63775

I'm not entirely sure I understand what's happening here, but using ASAN I tracked down a segfault to a wild address read with this stacktrace:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==1956957==ERROR: AddressSanitizer: SEGV on unknown address 0x195e001ddc5d (pc 0x7fe8146099bf bp 0x7ffe897e54d0 sp 0x6290000d5460 T0)
==1956957==The signal is caused by a READ memory access.
    #0 0x7fe8146099be in gsignal (/lib64/libpthread.so.0+0x129be)
    #1 0x7fe814609b1f  (/lib64/libpthread.so.0+0x12b1f)
    #2 0x7fe7abe90a27 in c10::IValue::isTensor() const ../aten/src/ATen/core/ivalue.h:367
    #3 0x7fe7b84eaad0 in torch::jit::ArgumentSpec::addTensor(c10::IValue const&, bool) ../torch/csrc/jit/runtime/argument_spec.h:86
    #4 0x7fe7b84e37a8 in torch::jit::ArgumentSpecCreator::create(bool, std::vector<c10::IValue, std::allocator<c10::IValue> > const&) const ../torch/csrc/jit/runtime/argument_spec.cpp:153
    #5 0x7fe7b85346b0 in torch::jit::GraphExecutorImpl::getOrCompile(std::vector<c10::IValue, std::allocator<c10::IValue> > const&) ../torch/csrc/jit/runtime/graph_executor.cpp:629
    #6 0x7fe7b8533b63 in torch::jit::GraphExecutorImpl::getPlanFor(std::vector<c10::IValue, std::allocator<c10::IValue> >&, unsigned long) (/home/bertrand/local/miniconda3/envs/pytorch3/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so+0x2150db63)
    #7 0x7fe7b8521517 in torch::jit::GraphExecutor::getPlanFor(std::vector<c10::IValue, std::allocator<c10::IValue> >&, unsigned long) ../torch/csrc/jit/runtime/graph_executor.cpp:781
    #8 0x7fe7b85cd4c6 in torch::jit::ProfilingGraphExecutorImpl::replaceFallbackGraphWithFallbackFunction(torch::jit::Block*) ../torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp:768
    #9 0x7fe7b85cd8e7 in torch::jit::ProfilingGraphExecutorImpl::replaceFallbackGraphWithFallbackFunction(torch::jit::Block*) ../torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp:779
    #10 0x7fe7b85ca5ee in torch::jit::ProfilingGraphExecutorImpl::getOptimizedPlanFor(std::vector<c10::IValue, std::allocator<c10::IValue> >&, unsigned long) ../torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp:686
    #11 0x7fe7b85cb1fa in torch::jit::ProfilingGraphExecutorImpl::getPlanFor(std::vector<c10::IValue, std::allocator<c10::IValue> >&, unsigned long) ../torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp:704
    #12 0x7fe7b8521517 in torch::jit::GraphExecutor::getPlanFor(std::vector<c10::IValue, std::allocator<c10::IValue> >&, unsigned long) ../torch/csrc/jit/runtime/graph_executor.cpp:781
```

What seems suspicious in here is that the `ArgumentSpecCreator` is trying to
read the stack for some purpose (I don't really understand what an arg spec
is), but when we're building a fallback graph in
`replaceFallbackGraphWithFallbackFunction`, we create a dummy empty `Stack s;`,
which suggests that we don't have any data to feed to the arg spec.

Futhering my sense that something fishy is going on here, `GraphExecutorImpl`
selects between `getOrCompile` (which takes a `Stack`) and
`getOrCompileFallback` (which does *not* take a stack, and also has "fallback"
in the name).  So I'm surmising that we should be disabling the graph optimizer
when generating a fallback function here.

Finally, when I run my repro (which takes forever, because it's sensitive to
the contents of memory in a user-managed stack), it succeeds with this diff and
fails without.

Hopefully someone who knows this code well can chime in with whether I'm on the
right track.

Differential Revision: [D30504489](https://our.internmc.facebook.com/intern/diff/D30504489/)