### PR TITLE
remove deadcode from pickler.h

### DIFF
--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -192,7 +192,6 @@ class TORCH_API Pickler {
       const std::string& class_name);
   // raw string data is appended directly to the byte stream
   void pushBytes(const std::string& string);
-  void pushTensorData(const at::Tensor& tensor);
 
   // Add a BINPUT op and return the memoization id used
   size_t pushNextBinPut();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #63829

Function definition is not used.

cc @gmagogsfm

Differential Revision: [D30645050](https://our.internmc.facebook.com/intern/diff/D30645050)