### PR TITLE
[LTC] Add zero_ TorchScript lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -1020,6 +1020,13 @@ at::Tensor LazyNativeFunctions::view(const at::Tensor& self,
       LazyTensor::view(self_tensor, Helpers::I64List(size)));
 }
 
+at::Tensor& LazyNativeFunctions::zero_(at::Tensor& self) {
+  LTC_FN_COUNTER("lazy::");
+  auto selfTensor = bridge::GetLtcTensor(self);
+  LazyTensor::zero_(selfTensor);
+  return self;
+}
+
 void InitializeAtenBindings() {}
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -2858,6 +2858,17 @@ TEST_F(AtenLtcTsTensorTest, TestEmpty) {
   });
 }
 
+TEST_F(AtenLtcTsTensorTest, TestZeroInPlace) {
+  torch::Tensor input = torch::ones({2, 2}, torch::TensorOptions(torch::kFloat));
+
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor lazyInput = CopyToDevice(input, device);
+    auto& output = torch::zero_(input);
+    auto& lazyOutput = torch::zero_(lazyInput);
+    AllClose(output, lazyOutput);
+  });
+}
+
 TEST_F(AtenLtcTsTensorTest, TestZerosLike) {
   torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
   torch::Tensor b = torch::zeros_like(a);

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -82,6 +82,7 @@ supported:
   - addcmul
   - alias
   - tanh_backward
+  - zero_
 autograd:
   - max_pool2d
   - max_pool3d


### PR DESCRIPTION
Summary:
This patch added zero_ to TorchScript lowering.

Test Plan:
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestZeroInPlace

Fixes #62431.
