### PR TITLE
Added more version comparison operations 

### DIFF
--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -1,4 +1,3 @@
-from functools import total_ordering
 from typing import Iterable, Union
 
 from pkg_resources import packaging  # type: ignore[attr-defined]

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -9,7 +9,6 @@ InvalidVersion = packaging.version.InvalidVersion
 from .version import __version__ as internal_version
 
 
-@total_ordering
 class TorchVersion(str):
     """A string with magic powers to compare to both Version and iterables!
 

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -50,22 +50,6 @@ class TorchVersion(str):
             # version like 'parrot'
             return super().__gt__(cmp)
 
-    def __lt__(self, cmp):
-        try:
-            return Version(self).__lt__(self._convert_to_version(cmp))
-        except InvalidVersion:
-            # Fall back to regular string comparison if dealing with an invalid
-            # version like 'parrot'
-            return super().__lt__(cmp)
-
-    def __eq__(self, cmp):
-        try:
-            return Version(self).__eq__(self._convert_to_version(cmp))
-        except InvalidVersion:
-            # Fall back to regular string comparison if dealing with an invalid
-            # version like 'parrot'
-            return super().__eq__(cmp)
-
     def __ge__(self, cmp):
         try:
             return Version(self).__ge__(self._convert_to_version(cmp))
@@ -73,6 +57,14 @@ class TorchVersion(str):
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
             return super().__ge__(cmp)
+
+    def __lt__(self, cmp):
+        try:
+            return Version(self).__lt__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__lt__(cmp)
 
     def __le__(self, cmp):
         try:
@@ -82,13 +74,13 @@ class TorchVersion(str):
             # version like 'parrot'
             return super().__le__(cmp)
 
-
-    def __ge__(self, cmp):
+    def __eq__(self, cmp):
         try:
-            return Version(self).__ge__(self._convert_to_version(cmp))
+            return Version(self).__eq__(self._convert_to_version(cmp))
         except InvalidVersion:
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
-            return super().__ge__(cmp)
+            return super().__eq__(cmp)
+
 
 __version__ = TorchVersion(internal_version)

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -1,4 +1,3 @@
-from functools import total_ordering
 from typing import Iterable, Union
 
 from pkg_resources import packaging  # type: ignore[attr-defined]
@@ -9,8 +8,7 @@ InvalidVersion = packaging.version.InvalidVersion
 from .version import __version__ as internal_version
 
 
-@total_ordering
-class TorchVersionBase:
+class TorchVersion(str):
     """A string with magic powers to compare to both Version and iterables!
     Prior to 1.10.0 torch.__version__ was stored as a str and so many did
     comparisons against torch.__version__ as if it were a str. In order to not
@@ -52,6 +50,13 @@ class TorchVersionBase:
             # version like 'parrot'
             return super().__gt__(cmp)
 
+    def __lt__(self, cmp):
+        try:
+            return Version(self).__lt__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__lt__(cmp)
 
     def __eq__(self, cmp):
         try:
@@ -61,8 +66,21 @@ class TorchVersionBase:
             # version like 'parrot'
             return super().__eq__(cmp)
 
-class TorchVersion(TorchVersionBase, str):
-    pass
+    def __ge__(self, cmp):
+        try:
+            return Version(self).__ge__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__ge__(cmp)
+
+    def __le__(self, cmp):
+        try:
+            return Version(self).__le__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__le__(cmp)
 
 
     def __ge__(self, cmp):

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -55,7 +55,7 @@ class TorchVersion(str):
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
             return super().__gt__(cmp)
-    
+
     def __lt__(self, cmp):
         try:
             return Version(self).__lt__(self._convert_to_version(cmp))
@@ -63,7 +63,7 @@ class TorchVersion(str):
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
             return super().__lt__(cmp)
-        
+
     def __eq__(self, cmp):
         try:
             return Version(self).__eq__(self._convert_to_version(cmp))
@@ -71,7 +71,7 @@ class TorchVersion(str):
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
             return super().__eq__(cmp)
-    
+
     def __ge__(self, cmp):
         try:
             return Version(self).__ge__(self._convert_to_version(cmp))

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -55,8 +55,15 @@ class TorchVersion(str):
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
             return super().__gt__(cmp)
-
-
+    
+    def __lt__(self, cmp):
+        try:
+            return Version(self).__lt__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__lt__(cmp)
+        
     def __eq__(self, cmp):
         try:
             return Version(self).__eq__(self._convert_to_version(cmp))
@@ -64,6 +71,22 @@ class TorchVersion(str):
             # Fall back to regular string comparison if dealing with an invalid
             # version like 'parrot'
             return super().__eq__(cmp)
+    
+    def __ge__(self, cmp):
+        try:
+            return Version(self).__ge__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__ge__(cmp)
+
+    def __le__(self, cmp):
+        try:
+            return Version(self).__le__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__le__(cmp)
 
 
     def __ge__(self, cmp):

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -1,3 +1,4 @@
+from functools import total_ordering
 from typing import Iterable, Union
 
 from pkg_resources import packaging  # type: ignore[attr-defined]
@@ -8,23 +9,20 @@ InvalidVersion = packaging.version.InvalidVersion
 from .version import __version__ as internal_version
 
 
-class TorchVersion(str):
+@total_ordering
+class TorchVersionBase:
     """A string with magic powers to compare to both Version and iterables!
-
     Prior to 1.10.0 torch.__version__ was stored as a str and so many did
     comparisons against torch.__version__ as if it were a str. In order to not
     break them we have TorchVersion which masquerades as a str while also
     having the ability to compare against both packaging.version.Version as
     well as tuples of values, eg. (1, 2, 1)
-
     Examples:
         Comparing a TorchVersion object to a Version object
             TorchVersion('1.10.0a') > Version('1.10.0a')
-
         Comparing a TorchVersion object to a Tuple object
             TorchVersion('1.10.0a') > (1, 2)    # 1.2
             TorchVersion('1.10.0a') > (1, 2, 1) # 1.2.1
-
         Comparing a TorchVersion object against a string
             TorchVersion('1.10.0a') > '1.2'
             TorchVersion('1.10.0a') > '1.2.1'
@@ -54,13 +52,6 @@ class TorchVersion(str):
             # version like 'parrot'
             return super().__gt__(cmp)
 
-    def __lt__(self, cmp):
-        try:
-            return Version(self).__lt__(self._convert_to_version(cmp))
-        except InvalidVersion:
-            # Fall back to regular string comparison if dealing with an invalid
-            # version like 'parrot'
-            return super().__lt__(cmp)
 
     def __eq__(self, cmp):
         try:
@@ -70,21 +61,8 @@ class TorchVersion(str):
             # version like 'parrot'
             return super().__eq__(cmp)
 
-    def __ge__(self, cmp):
-        try:
-            return Version(self).__ge__(self._convert_to_version(cmp))
-        except InvalidVersion:
-            # Fall back to regular string comparison if dealing with an invalid
-            # version like 'parrot'
-            return super().__ge__(cmp)
-
-    def __le__(self, cmp):
-        try:
-            return Version(self).__le__(self._convert_to_version(cmp))
-        except InvalidVersion:
-            # Fall back to regular string comparison if dealing with an invalid
-            # version like 'parrot'
-            return super().__le__(cmp)
+class TorchVersion(TorchVersionBase, str):
+    pass
 
 
     def __ge__(self, cmp):


### PR DESCRIPTION
Currently the [TorchVersion](https://github.com/pytorch/pytorch/blob/1022443168b5fad55bbd03d087abf574c9d2e9df/torch/torch_version.py#L13) only only supports 'greater than', and 'equal to' operations for comparing torch versions and something like `TorchVersion('1.5.0') < (1,5,1)` or `TorchVersion('1.5.0') >= (1,5)` will throw an error.

I have added 'less than' (`__lt__()`), 'greater than or equal to' (`__ge__()`) and 'less than or equal to' (`__le__()`) operations, so that the TorchVersion object can be useful for wider range of version comparisons.     

cc @seemethere @zsol