### PR TITLE
[FX] TorchVision tests are now passing

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3302,8 +3302,6 @@ class TestVisionTracing(JitTestCase):
         "retinanet_resnet50_fpn": PROXY_ITERATED,
     }
     UNSCRIPTABLE_MODELS = {
-        "googlenet": INCONSISTENT_TYPE,
-        "inception_v3": INCONSISTENT_TYPE,
     }
 
     output_transform = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63888
* __->__ #63887

Running `test/test_fx.py` with master torchvision brings up false-negative for these models. It may be the case that fixes were landed in torchvision. Let's see what happens with these tests in CI. If they pass, maybe we can land

Differential Revision: [D30523132](https://our.internmc.facebook.com/intern/diff/D30523132)