### PR TITLE
[Reland] Replacing the p.data acccess in utils with tensor.set_ . Passes both test_post_localSGD_optimizer_pari and test_periodic_model_averager tests

### DIFF
--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -29,5 +29,6 @@ def average_parameters(
 
     offset = 0
     for p in params_it2:
-        p.data = flat_params[offset : offset + p.numel()].view_as(p)
+        with torch.no_grad():
+            p.set_(flat_params[offset : offset + p.numel()].view_as(p).type_as(p))
         offset += p.numel()

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -30,5 +30,5 @@ def average_parameters(
     offset = 0
     for p in params_it2:
         with torch.no_grad():
-            p.set_(flat_params[offset : offset + p.numel()].view_as(p).type_as(p))
+            p.set_(flat_params[offset : offset + p.numel()].view_as(p).type_as(p))  # type: ignore[call-overload]
         offset += p.numel()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #63905
* __->__ #63895

When updating the model parameter, updating `parameter.data` is no longer recommended, because this `data` field will be deprecated in the future.

The replacement is `tensor.set_`.

Differential Revision: [D30526178](https://our.internmc.facebook.com/intern/diff/D30526178/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @agolynski @SciPioneer @H-Huang @mrzzd @cbalioglu @gcramer23