### PR TITLE
[testing][wip] Use fastcov instead of lcov

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -41,6 +41,7 @@ if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
   export PYTORCH_COLLECT_COVERAGE=1
   export COVERAGE_RCFILE="$PWD/.coveragerc" # coverage config file needed for plug-ins and settings to work
   pip install -e tools/coverage_plugins_package # allows coverage to run with JitPlugin for JIT coverage
+  pip install fastcov==1.13  # lcov compatible implementation that is way faster than lcov
 fi
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
@@ -547,6 +548,6 @@ if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
   popd
   pushd build
   echo "Generating lcov coverage report for C++ sources"
-  time lcov --capture --directory . --output-file coverage.info
+  time fastcov --lcov --search-directory . --compiler-directory build --output coverage.info --dump-statistic
   popd
 fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -548,6 +548,6 @@ if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
   popd
   pushd build
   echo "Generating lcov coverage report for C++ sources"
-  time fastcov --lcov --search-directory . --compiler-directory build --output coverage.info --dump-statistic
+  time fastcov --lcov --search-directory . --compiler-directory . --output coverage.info --dump-statistic
   popd
 fi


### PR DESCRIPTION
In offline testing it's about 50x faster than lcov which seems good (on a c5.metal with 96 cores, the ec2 runners will have less speedup but still good), but we need to verify that the results are equivalent