### PR TITLE
Make UseVariadicOp take list_idx parameter

### DIFF
--- a/torch/csrc/jit/passes/variadic_ops.h
+++ b/torch/csrc/jit/passes/variadic_ops.h
@@ -19,5 +19,17 @@ TORCH_API bool UseVariadicStack(const std::shared_ptr<Graph>& graph);
 TORCH_API bool RemoveListMutationAndUseVariadicStack(
     const std::shared_ptr<Graph>& graph);
 
+TORCH_API bool UseVariadicOp(
+    const std::shared_ptr<Graph>& graph,
+    NodeKind op,
+    NodeKind variadic_op,
+    size_t list_idx = 0);
+
+TORCH_API bool RemoveListMutationAndUseVariadicOp(
+    const std::shared_ptr<Graph>& graph,
+    NodeKind op,
+    NodeKind variadic_op,
+    size_t list_idx = 0);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Previously, this function only worked for variadic op substitutions of the form `op(list, args) -> variadic_op(list_1, ..., list_n, args)`. This change allows for transformations of the form `op(args_0, list, args_1) -> variadic_op(args_0, list_1, ..., list_n, args_1)`.

Test Plan:
`buck test caffe2/test/cpp/jit:jit -- Stack Concat`

(tests exercising `list_idx != 0` will be added further up in this diff stack)

Differential Revision: D30529729



cc @gmagogsfm