### PR TITLE
Fixed a bug of login and string

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -85,7 +85,7 @@ class LoggingTensorHandler(logging.Handler):
         self.log_list.append(f'{fmt_rets} = {record.msg}({fmt_args})')
 
 def log_input(name: str, var: object):
-    logging.getLogger("LoggingTensor").info("input", (name,), {}, (var,))
+    logging.getLogger("LoggingTensor").info(f"input {name} {var}")
 
 @contextlib.contextmanager
 def capture_logs() -> Iterator[List[str]]:


### PR DESCRIPTION
Fixes #62684
changed a login/string issue from:
logging.getLogger("LoggingTensor").info("input {} {}".format(name, var))
to this: 
logging.getLogger("LoggingTensor").info(f"input {name} {var}")
[readme.txt](https://github.com/pytorch/pytorch/files/7043826/readme.txt)
