### PR TITLE
Update torch.distributed.run OMP_NUM_THREADS message to log.warning

### DIFF
--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -595,7 +595,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
     nproc_per_node = determine_local_world_size(args.nproc_per_node)
     if "OMP_NUM_THREADS" not in os.environ and nproc_per_node > 1:
         omp_num_threads = 1
-        print(
+        log.warning(
             f"*****************************************\n"
             f"Setting OMP_NUM_THREADS environment variable for each process to be "
             f"{omp_num_threads} in default, to avoid your system being overloaded, "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#63953 Update torch.distributed.run OMP_NUM_THREADS message to log.warning**

Closes #61138

Test:
`python -m torch.distributed.run --nproc_per_node 2 test.py`
Still outputs message

`LOGLEVEL=ERROR python -m torch.distributed.run --nproc_per_node 2 test.py`
Does not output message anymore

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @agolynski @SciPioneer @H-Huang @mrzzd @cbalioglu @gcramer23

Differential Revision: [D30542997](https://our.internmc.facebook.com/intern/diff/D30542997)