### PR TITLE
Opinfo: embedding, add shape analysis

### DIFF
--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -254,6 +254,14 @@ const std::string shape_compute_functions =
               result_size.append(self[i])
           return result_size
 
+        def embedding(weight: List[int], indices: List[int], padding_idx:int = -1, scale_grad_by_freq:bool=False, sparse: bool=False):
+          assert len(weight) == 2
+          if len(indices) == 1:
+            return index_select(weight, 0, indices)
+          size = _copy(indices)
+          size.append(weight[1])
+          return size
+
         def max_int():
           return 9223372036854775807
 
@@ -486,6 +494,14 @@ const std::string shape_compute_functions =
               assert seen_dims[i] != seen_dims[j]
           return newSizes
 
+        def embedding(weight: List[int], indices: List[int], padding_idx:int = -1, scale_grad_by_freq:bool=False, sparse: bool=False):
+          assert len(weight) == 2
+          if len(indices) == 1:
+            return index_select(weight, 0, indices)
+          size = _copy(indices)
+          size.append(weight[1])
+          return size
+
         def flatten(input: List[int], start_dim: int, end_dim: int):
           start_dim = maybe_wrap_dim(start_dim, len(input))
           end_dim = maybe_wrap_dim(end_dim, len(input))
@@ -555,6 +571,7 @@ static const OperatorMap<std::string>& get_schema_to_function_graph() {
       {"aten::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, "
        "float eps=1e-05, bool cudnn_enable=True) -> Tensor", "unary_five_unused_inputs"},
       {"aten::softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor", "unary_two_unused_inputs"},
+      {"aten::embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor", "embedding"},
       {"aten::mm(Tensor self, Tensor mat2) -> Tensor", "mm"},
       {"aten::dot(Tensor self, Tensor tensor) -> Tensor", "dot"},
       {"aten::mv(Tensor self, Tensor vec) -> Tensor", "mv"},
@@ -573,6 +590,7 @@ static const OperatorMap<std::string>& get_schema_to_function_graph() {
       {"aten::expand_as(Tensor(a) self, Tensor other) -> Tensor(a)", "expand"},
       {"aten::expand(Tensor(a) self, int[] size, *, bool implicit=False) -> Tensor(a)", "expand_one_unused"},
       {"aten::mean.dim(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", "mean_dim"},
+      {"aten::embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor", "embedding"},
       {"aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor", "addmm"},
   };
   // clang-format on

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2302,6 +2302,40 @@ def sample_inputs_max_pool2d(op_info, device, dtype, requires_grad, **kwargs):
 
     return list(generator())
 
+def sample_inputs_embedding(op_info, device, dtype, requires_grad, **kwargs):
+
+    def make_arg(shape, low=None, high=None):
+        return make_tensor(shape, device=device, dtype=dtype,
+                           low=low, high=high,
+                           requires_grad=requires_grad)
+
+    nn_inps = (
+        (make_arg((40,), 0, 9), torch.nn.Embedding(20, embedding_dim=64, max_norm=1.0)),
+        (make_arg((2, 4), 0, 9), torch.nn.Embedding(10, 20, sparse=True)),
+        (make_arg(()), torch.nn.Embedding(0, 0, sparse=True)),
+        (make_arg((2, 4), 0, 9), torch.nn.Embedding(10, 0, sparse=True)),
+        (make_arg((4,), 0, 21), torch.nn.Embedding(22, 5, max_norm=1.0)),
+        (make_arg((2,), 0, 5), torch.nn.Embedding.from_pretrained(torch.arange(6.).view(2, 3), max_norm=2.,
+                                                                  norm_type=.5, scale_grad_by_freq=False, sparse=True)),
+    )
+
+    def generator():
+        for inp, module in nn_inps:
+            module = module.to(device)
+            kwargs = {
+                "weight": module.weight,
+                "padding_idx": module.padding_idx,
+                "max_norm": module.max_norm,
+                "norm_type": module.norm_type,
+                "scale_grad_by_freq": module.scale_grad_by_freq,
+                "sparse": module.sparse,
+            }
+
+            yield SampleInput(inp, kwargs=kwargs)
+
+    return list(generator())
+
+
 def sample_inputs_normalize(self, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, low=-1, high=1, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -7117,6 +7151,14 @@ op_db: List[OpInfo] = [
            dtypesIfCPU=floating_types_and(torch.int64),
            dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_max_pool2d),
+    OpInfo('nn.functional.embedding',
+           aten_name='embedding',
+           supports_autograd=True,
+           supports_out=False,
+           assert_jit_shape_analysis=True,
+           dtypesIfCPU=_dispatch_dtypes((torch.int64, torch.int32)),
+           dtypesIfCUDA=_dispatch_dtypes((torch.int64, torch.int32)),
+           sample_inputs_func=sample_inputs_embedding),
     UnaryUfuncInfo(
         'nn.functional.logsigmoid',
         aten_name="log_sigmoid",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#63959 Opinfo: embedding, add shape analysis**
* #63530 Add Maxpool to shape analysis / Opinfo
* #63516 Add view with negative dim
* #63615 Generalize expand logic
* #63407 Add permute, arange
* #63365 Add support for slice, selec twith int, index_select
* #63099 Add squeeze, unsqueeze, transpose shape functins
* #63050 Add batch of unary functions

