### PR TITLE
run_test.py: add option to run only core tests

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -275,8 +275,10 @@ RUN_PARALLEL_BLOCKLIST = [
 
 WINDOWS_COVERAGE_BLOCKLIST = []
 
-# A subset of our TEST list encompassing the tests for "core" functionality
+# A subset of our TEST list that validates PyTorch's ops, modules, and autograd function as expected
 CORE_TEST_LIST = [
+    "test_autograd",
+    "test_modules",
     "test_nn",
     "test_ops",
     "test_torch"
@@ -708,7 +710,8 @@ def parse_args():
         "-core",
         "--core",
         action="store_true",
-        help="Only run core tests, defined by CORE_TEST_LIST."
+        help="Only run core tests, or tests that validate PyTorch's ops, modules,"
+        "and autograd. They are defined by CORE_TEST_LIST."
     )
     parser.add_argument(
         "-pt",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -275,6 +275,12 @@ RUN_PARALLEL_BLOCKLIST = [
 
 WINDOWS_COVERAGE_BLOCKLIST = []
 
+# A subset of our TEST list encompassing the tests for "core" functionality
+CORE_TEST_LIST = [
+    "test_nn",
+    "test_ops",
+    "test_torch"
+]
 
 # These tests are slow enough that it's worth calculating whether the patch
 # touched any related files first. This list was manually generated, but for every
@@ -699,6 +705,12 @@ def parse_args():
         help="run all distributed tests",
     )
     parser.add_argument(
+        "-core",
+        "--core",
+        action="store_true",
+        help="Only run core tests, defined by CORE_TEST_LIST."
+    )
+    parser.add_argument(
         "-pt",
         "--pytest",
         action="store_true",
@@ -897,6 +909,12 @@ def get_selected_tests(options):
     if options.distributed_tests:
         selected_tests = list(
             filter(lambda test_name: test_name in DISTRIBUTED_TESTS, selected_tests)
+        )
+
+    # Filter to only run core tests when --core option is specified
+    if options.core:
+        selected_tests = list(
+            filter(lambda test_name: test_name in CORE_TEST_LIST, selected_tests)
         )
 
     # process reordering


### PR DESCRIPTION
This is in response to a feature request from some folks in the core team to have a local command that would only run relevant "core" tests. The idea is to have a local smoke test option for developers to run locally before making a PR in order to verify their changes did not break core functionality. These smoke tests are not targeted to be short but rather relevant.

This PR enables that by allowing developers to run `python test/run_test.py --core` or `python test/run_test.py -core` in order to run the CORE_TEST_LIST, which is currently test_nn.py, test_torch.py, and test_ops.py.

I am not the best person to judge what should be considered "core", so please comment which tests should be included and/or excluded from the CORE_TEST_LIST! 

Test plan:
```
(pytorch) janeyx@janeyx-mbp test % python run_test.py --core -v
Selected tests: test_nn, test_ops, test_torch
Running test_nn ... [2021-08-25 14:48:28.865078]
Executing ['/Users/janeyx/miniconda3/envs/pytorch/bin/python', 'test_nn.py', '-v'] ... [2021-08-25 14:48:28.865123]
test_to (__main__.PackedSequenceTest) ... ok
test_to_memory_format (__main__.PackedSequenceTest) ... ok
```
