### PR TITLE
[LTC] Add threshold_backward TorchScript lowering

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -984,6 +984,14 @@ at::Tensor LazyNativeFunctions::tanh_backward(const at::Tensor& grad_output,
       bridge::GetLtcTensor(grad_output), bridge::GetLtcTensor(output)));
 }
 
+at::Tensor LazyNativeFunctions::threshold_backward(const at::Tensor& grad_output,
+    const at::Tensor& self, const at::Scalar& threshold)
+{
+  LTC_FN_COUNTER("lazy::");
+  return bridge::AtenFromLtcTensor(LazyTensor::threshold_backward(
+      bridge::GetLtcTensor(grad_output), bridge::GetLtcTensor(self), threshold.to<double>()));
+}
+
 at::Tensor LazyNativeFunctions::transpose(const at::Tensor& self, int64_t dim0,
                                           int64_t dim1) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -31,6 +31,7 @@
 #include "lazy_tensor_core/csrc/ops/squeeze.h"
 #include "lazy_tensor_core/csrc/ops/stack.h"
 #include "lazy_tensor_core/csrc/ops/sum.h"
+#include "lazy_tensor_core/csrc/ops/threshold_backward.h"
 #include "lazy_tensor_core/csrc/ops/ts_embedding_dense_backward.h"
 #include "lazy_tensor_core/csrc/ops/ts_log_softmax_backward.h"
 #include "lazy_tensor_core/csrc/ops/ts_native_batch_norm_backward.h"
@@ -310,6 +311,10 @@ class TSNodeLowering : public NodeLowering {
     if (node->op().op == at::aten::sum) {
       return LowerSum(
           ir::NodeCast<ir::ops::Sum>(node, ir::OpKind(at::aten::sum)));
+    }
+    if (node->op().op == at::aten::threshold_backward) {
+      return LowerThresholdBackward(
+          ir::NodeCast<ir::ops::ThresholdBackward>(node, ir::OpKind(at::aten::threshold_backward)));
     }
     if (node->op().op == at::aten::unsqueeze) {
       return LowerUnsqueeze(ir::NodeCast<ir::ops::Unsqueeze>(
@@ -830,6 +835,15 @@ class TSNodeLowering : public NodeLowering {
     std::vector<torch::jit::NamedValue> kwarguments;
     kwarguments.emplace_back("dtype", sum->dtype());
     return LowerBuiltin(sum, arguments, kwarguments);
+  }
+
+  TSOpVector LowerThresholdBackward(const ir::ops::ThresholdBackward* node) {
+    std::vector<torch::jit::NamedValue> arguments;
+    for (auto& operand : node->operands()) {
+      arguments.emplace_back(loctx()->GetOutputOp(operand));
+    }
+    arguments.emplace_back(node->threshold());
+    return LowerBuiltin(node, arguments);
   }
 
   TSOpVector LowerUnselect(const ir::ops::Unselect* node) {

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -5643,6 +5643,21 @@ TEST_F(AtenLtcTsTensorTest, TestThreshold) {
   });
 }
 
+TEST_F(AtenLtcTsTensorTest, TestThresholdBackward) {
+  float threshold = 0.4;
+  float value = 20;
+
+  auto testFunction = [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
+    return torch::threshold(inputs[0], threshold, value);
+  };
+
+  ForEachDevice([&](const torch::Device& device) {
+    TestBackward({torch::rand({2, 1, 4, 6},
+        torch::TensorOptions(torch::kFloat).requires_grad(true))},
+        device, testFunction);
+  });
+}
+
 TEST_F(AtenLtcTsTensorTest, TestThresholdInPlace) {
   torch::Tensor input =
       torch::rand({2, 1, 4, 6}, torch::TensorOptions(torch::kFloat));

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -58,6 +58,7 @@ supported:
   - t
   - t_
   - tanh
+  - threshold_backward
   - transpose.int
   - transpose_
   - unsqueeze


### PR DESCRIPTION
Summary:
This patch added threshold_backward to TorchScript lowering.

Test Plan:
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestThresholdBackward

Fixes #62431.
