### PR TITLE
Make name() part of IMethod interface

### DIFF
--- a/test/cpp/api/imethod.cpp
+++ b/test/cpp/api/imethod.cpp
@@ -18,6 +18,9 @@ TEST(IMethodTest, CallMethod) {
   auto py_model = p.load_pickle("model", "model.pkl");
   torch::deploy::PythonMethodWrapper py_method(py_model, "forward");
 
+  EXPECT_EQ(script_method.name(), "forward");
+  EXPECT_EQ(py_method.name(), "forward");
+
   auto input = torch::ones({10, 20});
   auto output_py = py_method({input});
   auto output_script = script_method({input});

--- a/torch/csrc/api/include/torch/imethod.h
+++ b/torch/csrc/api/include/torch/imethod.h
@@ -28,6 +28,8 @@ class IMethod {
       std::vector<c10::IValue> args,
       const IValueMap& kwargs = IValueMap()) const = 0;
 
+  virtual const std::string& name() const = 0;
+
   // Returns an ordered list of argument names, possible in both
   // script and python methods.  This is a more portable dependency
   // than a ScriptMethod FunctionSchema, which has more information

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -232,6 +232,10 @@ class PythonMethodWrapper : public torch::IMethod {
       std::string method_name)
       : model_(std::move(model)), method_name_(std::move(method_name)) {}
 
+  const std::string& name() const override {
+    return method_name_;
+  }
+
   c10::IValue operator()(
       std::vector<c10::IValue> args,
       const IValueMap& kwargs = IValueMap()) const override {

--- a/torch/csrc/jit/api/method.h
+++ b/torch/csrc/jit/api/method.h
@@ -46,7 +46,7 @@ struct TORCH_API Method : public torch::IMethod {
     return function_->graph();
   }
 
-  const std::string& name() const {
+  const std::string& name() const override {
     return function_->name();
   }
 


### PR DESCRIPTION
Summary: JIT methods already have name() in their interface, and Py methods have names in their implementation.  I'm adding this for a particular case where someone tried to use name() on a JIT method that we're replacing with an IMethod.

Test Plan: add case to imethod API test

Differential Revision: D30559401

