### PR TITLE
[nnc] Fix dtype promotion involving scalars

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -135,7 +135,7 @@ const OperatorSet& supported_eltwise_set() {
       "aten::threshold(Tensor self, Scalar threshold, Scalar value) -> Tensor",
       // "aten::masked_fill.Scalar(Tensor self, Tensor mask, Scalar value) -> Tensor",
       // "aten::masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor", TODO: requires 0-dim Tensor
-      "aten::remainder.Scalar(Tensor self, Scalar other) -> Tensor",
+      // "aten::remainder.Scalar(Tensor self, Scalar other) -> Tensor",
       "aten::remainder.Tensor(Tensor self, Tensor other) -> Tensor",
       "aten::sigmoid(Tensor self) -> Tensor",
       "aten::relu(Tensor self) -> Tensor",

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -472,7 +472,7 @@ void promoteInputs(std::vector<ExprHandle>& inputs, const int typeConstraints) {
       if (isIntegralType(highType, false) && isFloatingType(inputType)) {
         highType = c10::get_default_dtype_as_scalartype();
       } else if (highType == c10::kBool) {
-	highType = inputType;
+        highType = inputType;
       }
     } else {
       highType = promoteTypes(highType, inputType);

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -4,7 +4,6 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorGeometry.h>
-#include <ATen/native/TypeProperties.h>
 #include <c10/util/irange.h>
 #include <c10/util/string_utils.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -471,10 +470,12 @@ void promoteInputs(std::vector<ExprHandle>& inputs, const int typeConstraints) {
     auto inputType = input.dtype().scalar_type();
     if (isScalar(input)) {
       if (isIntegralType(highType, false) && isFloatingType(inputType)) {
-        highType = c10::typeMetaToScalarType(c10::get_default_dtype());
+        highType = c10::get_default_dtype_as_scalartype();
+      } else if (highType == c10::kBool) {
+	highType = inputType;
       }
     } else {
-      highType = promoteTypes(highType, input.dtype().scalar_type());
+      highType = promoteTypes(highType, inputType);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/4315

Type promotion involving tensors and scalars in PyTorch is super complicated, but for the fuser's purpose we can reduce it to a fairly simple procedure.  Basically, scalars will perform int->fp promotion, but not fp->higher precision fp (https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc).  Actually detecting a scalar in the tensor expression is a bit dicey, but I think the predicate I came up with is the right one.

As a bonus, remainder() is just kind of broken in some subtle way (which I think was swept under the covers by performing it in higher precision).  So I'm disabling it for the time being.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64002

Differential Revision: [D30566979](https://our.internmc.facebook.com/intern/diff/D30566979)