### PR TITLE
try sub-module device reassignment

### DIFF
--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -149,6 +149,10 @@ struct TORCH_API Module : public Object {
     _ivalue()->setAttr(name, module._ivalue());
   }
 
+  Module get_submodule(const std::string& name) {
+    return _ivalue()->getAttr(name).toModule();
+  }
+
   void apply(const std::function<void(Module&)>& fn);
 
   buffer_list buffers(bool recurse = true) const;


### PR DESCRIPTION
Test Plan:
`CUDA_VISIBLE_DEVICES=0,1,2,3 buck run mode/opt -c fbcode.nvcc_arch=v100,a100 scripts/pls331/bench:model_read_copy_update -c fbcode.split-dwarf=true 2>&1`

output before and after m.to(device):
{F647498149}

{P443500993}

Differential Revision: D30360633

