### PR TITLE
make toScalarType() const

### DIFF
--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -480,7 +480,7 @@ class C10_API TypeMeta final {
   /**
    * convert TypeMeta handles to ScalarType enum values
    */
-  inline ScalarType toScalarType() {
+  inline ScalarType toScalarType() const {
     if (C10_LIKELY(isScalarType())) {
       return static_cast<ScalarType>(index_);
     }


### PR DESCRIPTION
So it can be called in a const context.