### PR TITLE
Benchmark inplace or view fallback templated or boxed

### DIFF
--- a/aten/src/ATen/native/TestOps.cpp
+++ b/aten/src/ATen/native/TestOps.cpp
@@ -27,6 +27,19 @@ Tensor _test_optional_intlist(
   return output;
 }
 
+Tensor my_test_normal_op(const Tensor& self, const Tensor& other) {
+  return self + other;
+}
+
+Tensor my_test_view_op(const Tensor& self) {
+  return self;
+}
+
+Tensor& my_test_inplace_op(Tensor& self, const Tensor& other) {
+  return self.add_(other);
+}
+
+
 /// If addends is nullopt, return values.
 /// Else, return a new tensor containing the elementwise sums.
 Tensor _test_optional_floatlist(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3801,6 +3801,36 @@
   dispatch:
     CPU, CUDA: sinh_out
 
+- func: my_test_normal_op(Tensor self, Tensor other) -> Tensor
+  variants: function
+  dispatch:
+    CPU: my_test_normal_op
+
+- func: my_test_view_op(Tensor(a) self) -> Tensor(a)
+  variants: function
+  dispatch:
+    CPU: my_test_view_op
+
+- func: my_test_inplace_op_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  variants: function
+  dispatch:
+    CPU: my_test_inplace_op
+
+- func: my_test_normal_op_boxed(Tensor self, Tensor other) -> Tensor
+  variants: function
+  dispatch:
+    CPU: my_test_normal_op
+
+- func: my_test_view_op_boxed(Tensor(a) self) -> Tensor(a)
+  variants: function
+  dispatch:
+    CPU: my_test_view_op
+
+- func: my_test_inplace_op_boxed_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  variants: function
+  dispatch:
+    CPU: my_test_inplace_op
+
 # Returns a copy of this `Variable` that is detached from its autograd graph.
 # This method is OK to call if the `Variable` is a view.
 #

--- a/tools/autograd/gen_inplace_or_view_type.py
+++ b/tools/autograd/gen_inplace_or_view_type.py
@@ -47,6 +47,8 @@ VIEW_FUNCTIONS = {
     'unfold': 'self',
     'unsqueeze': 'self',
     'flatten': 'self',
+    'my_test_view_op_boxed': 'self',
+    'my_test_view_op': 'self',
     'view': 'self',
     'unbind': 'self',
     '_indices': 'self',
@@ -122,6 +124,10 @@ WRAPPER_REGISTRATION = CodeTemplate("""\
 m.impl("${unqual_operator_name_with_overload}",
        TORCH_FN(${class_type}::${type_wrapper_name})
 );
+""")
+
+INPLACE_OR_VIEW_NOT_IMPLEMENTED_REGISTRATION = CodeTemplate("""\
+m.impl("${unqual_operator_name_with_overload}", torch::autograd::ADInplaceOrViewFallback());
 """)
 
 AUTOGRAD_NOT_IMPLEMENTED_REGISTRATION = CodeTemplate("""\
@@ -404,6 +410,11 @@ def inplace_or_view_method_registration(fn: NativeFunctionWithDifferentiabilityI
     f = fn.func
     if get_view_info(fn) is None and (not modifies_arguments(f) or is_foreach_op(str(f.func.name))):
         return None
+    # Ideally we won't need to rely on a hardcoded list of views
+    if get_base_name(f) in ["my_test_normal_op_boxed", "my_test_view_op_boxed", "my_test_inplace_op_boxed"]:
+        return INPLACE_OR_VIEW_NOT_IMPLEMENTED_REGISTRATION.substitute(
+            unqual_operator_name_with_overload=f.func.name,
+        )
     return WRAPPER_REGISTRATION.substitute(
         unqual_operator_name_with_overload=f.func.name,
         type_wrapper_name=type_wrapper_name(f),

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -413,7 +413,9 @@ def gen_variable_type_func(
                 and len(gen_differentiable_outputs(fn)) > 0 \
                 and not get_base_name(f) in DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE \
                 and not get_base_name(f) in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT \
-                and not get_base_name(f) in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
+                and not get_base_name(f) in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT \
+                and get_base_name(f) not in ["my_test_normal_op", "my_test_view_op", "my_test_inplace_op", "my_test_normal_op_boxed", "my_test_view_op_boxed", "my_test_inplace_op_boxed"]:
+                # Still use codegen dispatch for these - for testing purposes
             # NOTE: [ Registering AutogradNotImplemented boxed kernel ]
             #
             # When there is no derivatives.yaml entry, we register a generic boxed

--- a/tools/autograd/templates/ADInplaceOrViewType.cpp
+++ b/tools/autograd/templates/ADInplaceOrViewType.cpp
@@ -1,6 +1,7 @@
 #include "torch/csrc/autograd/VariableTypeUtils.h"
 
 #include <torch/library.h>
+#include <torch/csrc/autograd/autograd_not_implemented_fallback.h>
 
 
 #include <ATen/RedispatchFunctions.h>

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -182,12 +182,13 @@ void autogradNotImplementedFallbackImpl(const c10::OperatorHandle& op, c10::Disp
   }
 }
 
+
+
 torch::CppFunction autogradNotImplementedFallback() {
   return torch::CppFunction::makeFromBoxedFunction<&autogradNotImplementedFallbackImpl>();
 }
 
 // Unfortunately we have to do this lookup...
-static const std::vector<std::string> NEEDS_METADATA_CHANGE = {"aten::view_as_complex", "aten::view_as_real", "aten::_conj", "aten::_neg_view"};
 
 // [WIP] What about in-place views
 void ADInplaceOrViewFallbackImpl(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
@@ -233,10 +234,10 @@ void ADInplaceOrViewFallbackImpl(const c10::OperatorHandle& op, c10::DispatchKey
     }
   }
   TORCH_INTERNAL_ASSERT((aliased_input_idx == -1 && aliased_output_idx == -1) ||
-    (aliased_input_idx != -1 && aliased_output_idx != -1))
+    (aliased_input_idx == 0 && aliased_output_idx == 0))
   const bool is_view = aliased_input_idx != -1;
   const bool need_view_func = is_view
-                         && (std::find(NEEDS_METADATA_CHANGE.begin(), NEEDS_METADATA_CHANGE.end(), op_name) != NEEDS_METADATA_CHANGE.end()
+                         && (std::find(detail::NEEDS_METADATA_CHANGE.begin(), detail::NEEDS_METADATA_CHANGE.end(), op_name) != detail::NEEDS_METADATA_CHANGE.end()
                              || !aliased_input.unsafeGetTensorImpl()->support_as_strided());
   std::function<at::Tensor(const at::Tensor&)> view_func = nullptr;
   std::vector<c10::IValue> stack_args_copy;

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -138,7 +138,7 @@ void autogradNotImplementedFallbackImpl(const c10::OperatorHandle& op, c10::Disp
   } else {
     // If neither in-place nor view
     at::AutoDispatchBelowADInplaceOrView guard;
-    op.redispatchBoxed(dispatch_keys & c10::after_autograd_keyset, stack);
+    op.redispatchBoxed(dispatch_keys & c10::after_ADInplaceOrView_keyset, stack);
   }
   #ifndef NDEBUG
   _foreach_tensor([&](size_t idx_tensor, size_t _, const at::Tensor& t) {
@@ -184,6 +184,130 @@ void autogradNotImplementedFallbackImpl(const c10::OperatorHandle& op, c10::Disp
 
 torch::CppFunction autogradNotImplementedFallback() {
   return torch::CppFunction::makeFromBoxedFunction<&autogradNotImplementedFallbackImpl>();
+}
+
+// Unfortunately we have to do this lookup...
+static const std::vector<std::string> NEEDS_METADATA_CHANGE = {"aten::view_as_complex", "aten::view_as_real", "aten::_conj", "aten::_neg_view"};
+
+// [WIP] What about in-place views
+void ADInplaceOrViewFallbackImpl(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
+  const auto& schema = op.schema();
+  const auto& op_name = schema.operator_name().name;
+  const auto& arguments = schema.arguments();
+  const auto& returns = schema.returns();
+  const auto num_arguments = arguments.size();
+  const auto num_returns = returns.size();
+  const auto stack_start = stack->size() - num_arguments;
+  bool any_is_inplace = false;
+
+  std::vector<size_t> tensors_to_increment_version_on_stack;
+  at::Tensor aliased_input;
+
+  int64_t aliased_output_idx = -1;
+  for (const auto i : c10::irange(num_returns)) {
+    const auto& alias_info = returns[i].alias_info();
+    if (alias_info.has_value() && !alias_info->isWrite()) {
+      // TODO: use torch check instead of AT_ASSERT
+      AT_ASSERT(aliased_output_idx == -1, "Expected a single output to be aliased, but observed at least 2 outputs with alias info");
+      aliased_output_idx = i;
+    }
+  }
+
+  int64_t aliased_input_idx = -1;
+  for (const auto i : c10::irange(num_arguments)) {
+    const auto& alias_info = arguments[i].alias_info();
+    if (alias_info.has_value()) {
+      if (!alias_info->isWrite()) {
+        aliased_input_idx = i;
+        // TODO: use torch check instead of AT_ASSERT
+        AT_ASSERT(!aliased_input.defined(), "Expected a single input to be aliased, but observed at least 2 input with alias info");
+        const c10::IValue& aliased_input_iv = (*stack)[stack_start + i]; // get a reference to an ivalue on the stack
+        // TODO: use torch check instead of AT_ASSERT
+        AT_ASSERT(aliased_input_iv.isTensor());
+        // copy assignment
+        aliased_input = aliased_input_iv.toTensor();
+      } else {
+        tensors_to_increment_version_on_stack.push_back(i);
+        any_is_inplace = true;
+      }
+    }
+  }
+  TORCH_INTERNAL_ASSERT((aliased_input_idx == -1 && aliased_output_idx == -1) ||
+    (aliased_input_idx != -1 && aliased_output_idx != -1))
+  const bool is_view = aliased_input_idx != -1;
+  const bool need_view_func = is_view
+                         && (std::find(NEEDS_METADATA_CHANGE.begin(), NEEDS_METADATA_CHANGE.end(), op_name) != NEEDS_METADATA_CHANGE.end()
+                             || !aliased_input.unsafeGetTensorImpl()->support_as_strided());
+  std::function<at::Tensor(const at::Tensor&)> view_func = nullptr;
+  std::vector<c10::IValue> stack_args_copy;
+  if (any_is_inplace || need_view_func) {
+    stack_args_copy = std::vector<c10::IValue>(stack->begin() + stack_start, stack->end());
+  }
+
+  if (need_view_func) {
+    // TODO: simplifications here, if we can assume the view is always the first return, and that
+    // there will only be a single return
+    view_func = [=](const at::Tensor& t) {
+      // We have to make another copy because the same lambda can be used twice! e.g., double backward
+      std::vector<c10::IValue> stack_args_copy_copy(stack_args_copy);
+      stack_args_copy_copy.at(stack_args_copy_copy.size() - num_arguments + aliased_input_idx) = t;
+      op.callBoxed(&stack_args_copy_copy);
+      return stack_args_copy_copy[stack_args_copy_copy.size() - num_returns + aliased_output_idx].toTensor();
+    };
+  }
+
+  {
+    at::AutoDispatchBelowADInplaceOrView guard;
+    op.redispatchBoxed(dispatch_keys & c10::after_ADInplaceOrView_keyset, stack);
+  }
+
+  if (any_is_inplace) {
+    for (const auto i : c10::irange(tensors_to_increment_version_on_stack.size())) {
+      increment_version(stack_args_copy[tensors_to_increment_version_on_stack[i]].toTensor());
+    }
+  }
+
+  if (is_view) {
+    const c10::IValue& aliased_output_iv = (*stack)[stack->size() - num_returns + aliased_output_idx];
+    if (aliased_output_iv.isTensorList()) {
+      auto aliased_output = aliased_output_iv.toTensorVector();
+      // Only allow rebasing of the history if we return a single Tensor
+      // If view was created in a no grad or inference mode block, raise an error
+      // See NOTE [ View + Inplace detection ] for more details about this logic
+      auto result = as_view(
+        /* base=*/aliased_input,
+        /* output=*/aliased_output,
+        /* is_bw_differentiable=*/true,
+        /* is_fw_differentiable=*/true,
+        /* creation_meta=*/InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::MULTI_OUTPUT_NODE : CreationMeta::NO_GRAD_MODE));
+        // ^ pass in creation meta unecessarily even if not isDifferentiableType
+      stack->at(stack->size() - num_returns + aliased_output_idx) = result;
+    } else {
+      AT_ASSERT(aliased_output_iv.isTensor());
+      const at::Tensor& aliased_output = aliased_output_iv.toTensor();
+      if (isDifferentiableType(aliased_output.scalar_type())) {
+        auto result = as_view(
+          /* base=*/aliased_input,
+          /* output=*/aliased_output,
+          /* is_bw_differentiable=*/true,
+          /* is_fw_differentiable=*/true,
+          /* view_func=*/view_func,
+          /* creation_meta=*/InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::DEFAULT : CreationMeta::NO_GRAD_MODE));
+        stack->at(stack->size() - num_returns + aliased_output_idx) = result;
+      } else {
+        auto result = as_view(
+        /* base=*/aliased_input,
+        /* output=*/aliased_output,
+        /* is_bw_differentiable=*/false,
+        /* is_fw_differentiable=*/false);
+        stack->at(stack->size() - num_returns + aliased_output_idx) = result;
+      }
+    }
+  }
+}
+
+torch::CppFunction ADInplaceOrViewFallback() {
+  return torch::CppFunction::makeFromBoxedFunction<&ADInplaceOrViewFallbackImpl>();
 }
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.h
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.h
@@ -9,7 +9,6 @@
 namespace torch {
 namespace autograd {
 
-
 namespace detail {
 
 template <typename F>
@@ -81,13 +80,154 @@ void for_each_output_tensor(std::tuple<Args...>& tup, F fn) {
   for_each_tuple(tup,  ForEachTensor<F>(fn), std::index_sequence_for<Args...>());
 }
 
+// Why are there all these overloads? and why are there placeholders internal asserts?
+template<typename ReturnT, typename... Args>
+ReturnT call_with_new_first_arg(ReturnT(*op)(Args...), const at::Tensor& new_t, const at::Tensor& old_t, Args&&... args) {
+  return op(new_t, std::forward<Args>(args)...);
 }
+
+template<typename ReturnT, typename... Args>
+ReturnT call_with_new_first_arg(ReturnT(*op)(Args...), const at::Tensor& new_t, Args&&... args) {
+  // Placeholder
+  TORCH_INTERNAL_ASSERT(false, "Expect first argument to be a tensor when need_view_func=true");
+  return op(std::forward<Args>(args)...);
+}
+
+template<typename... Ts>
+at::Tensor get_first_return(std::tuple<at::Tensor, Ts...>& tup) {
+  return std::get<0>(tup);
+}
+
+template<typename... Ts>
+at::Tensor get_first_return(std::tuple<Ts...>& tup) {
+  TORCH_INTERNAL_ASSERT(false, "Expect first return to be a single tensor when need_view_func=true");
+  return at::Tensor();
+}
+
+// We don't need this anymore
+inline bool isFwGradDefined(const c10::optional<at::Tensor>& t) {
+  return t.has_value() && t->defined() && t->_fw_grad(/*level */ 0).defined();
+}
+
+inline at::Tensor get_first_return(const at::Tensor& t) {
+  return t;
+}
+
+// Will this be ambiguous?
+template<typename T>
+at::Tensor get_first_return(const T& t) {
+  TORCH_INTERNAL_ASSERT(false, "Expect first return to be a single tensor when need_view_func=true");
+  return at::Tensor();
+}
+
+template<typename T>
+struct TD;
+
+template<typename T>
+T call_as_view(T&& t, const at::Tensor* aliased_input, std::function<at::Tensor(const at::Tensor&)> view_func) {
+  // Placeholder because compiler doesn't realize that non-view won't reach here
+  TORCH_INTERNAL_ASSERT(false);
+  return std::forward<T>(t);
+}
+
+template<typename... Args>
+variable_list call_as_view(variable_list&& output, const at::Tensor* aliased_input, std::function<at::Tensor(const at::Tensor&)> view_func) {
+  TORCH_INTERNAL_ASSERT(view_func == nullptr);
+  return as_view(
+    /* base=*/*aliased_input,
+    /* output=*/output,
+    /* is_bw_differentiable=*/true,
+    /* is_fw_differentiable=*/true,
+    /* creation_meta=*/InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::MULTI_OUTPUT_NODE : CreationMeta::NO_GRAD_MODE));
+    // ^ pass in creation meta unecessarily even if not isDifferentiableType
+}
+
+template<typename... Args>
+std::tuple<variable_list, Args...> call_as_view(std::tuple<variable_list, Args...> outputs, const at::Tensor* aliased_input, std::function<at::Tensor(const at::Tensor&)> view_func) {
+  TORCH_INTERNAL_ASSERT(view_func == nullptr);
+  auto result = as_view(
+    /* base=*/*aliased_input,
+    /* output=*/std::get<0>(outputs),
+    /* is_bw_differentiable=*/true,
+    /* is_fw_differentiable=*/true,
+    /* creation_meta=*/InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::MULTI_OUTPUT_NODE : CreationMeta::NO_GRAD_MODE));
+    // ^ pass in creation meta unecessarily even if not isDifferentiableType
+  std::get<0>(outputs) = result;
+  return outputs;
+}
+
+template<typename... Args>
+std::tuple<at::Tensor, Args...> call_as_view(std::tuple<at::Tensor, Args...> outputs, const at::Tensor* aliased_input, std::function<at::Tensor(const at::Tensor&)> view_func) {
+  if (isDifferentiableType(std::get<0>(outputs).scalar_type())) {
+    auto result = as_view(
+      /* base=*/*aliased_input,
+      /* output=*/std::get<0>(outputs),
+      /* is_bw_differentiable=*/true,
+      /* is_fw_differentiable=*/true,
+      /* view_func=*/view_func,
+      /* creation_meta=*/InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::DEFAULT : CreationMeta::NO_GRAD_MODE));
+    std::get<0>(outputs) = result;
+    return outputs;
+  } else {
+    auto result = as_view(
+      /* base=*/*aliased_input,
+      /* output=*/std::get<0>(outputs),
+      /* is_bw_differentiable=*/false,
+      /* is_fw_differentiable=*/false);
+    std::get<0>(outputs) = result;
+    return outputs;
+  }
+}
+
+inline at::Tensor call_as_view(at::Tensor&& output, const at::Tensor* aliased_input, std::function<at::Tensor(const at::Tensor&)> view_func) {
+  // Factor this out
+  if (isDifferentiableType(output.scalar_type())) {
+      return as_view(
+        /* base=*/*aliased_input,
+        /* output=*/output,
+        /* is_bw_differentiable=*/true,
+        /* is_fw_differentiable=*/true,
+        /* view_func=*/view_func,
+        /* creation_meta=*/InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::DEFAULT : CreationMeta::NO_GRAD_MODE));
+  } else {
+    return as_view(
+    /* base=*/*aliased_input,
+    /* output=*/output,
+    /* is_bw_differentiable=*/false,
+    /* is_fw_differentiable=*/false);
+  }
+}
+
+template<typename T>
+struct remove_reference_if_rvalue_reference {
+  using type = std::conditional_t<
+                std::is_rvalue_reference<T>::value,
+                std::remove_reference_t<T>,
+                T>;
+};
+
+static const std::vector<std::string> NEEDS_METADATA_CHANGE = {"aten::view_as_complex", "aten::view_as_real", "aten::_conj", "aten::_neg_view"};
+
+// template<typename ReturnT>
+// typename detail::remove_reference_if_rvalue_reference<ReturnT>::type
+// post_process(ReturnT&& ret, const std::vector<const at::Tensor*>& tensors_to_increment_version, const at::Tensor* aliased_input, std::function<at::Tensor(const at::Tensor&)> view_func, bool is_view_) {
+//   for (const auto i : c10::irange(tensors_to_increment_version.size())) {
+//     increment_version(*tensors_to_increment_version[i]);
+//   }
+//   if (is_view_) {
+//     return detail::call_as_view(std::forward<ReturnT>(ret), aliased_input, view_func);
+//   } else {
+//     return std::forward<ReturnT>(ret);
+//   }
+// };
+
+} // namespace detail
 
 template<typename ReturnT, typename... Args>
 struct ADInplaceOrViewFallback2Impl {
 public:
-  ADInplaceOrViewFallback2Impl(ReturnT(*op)(Args&&...), std::string schema_string)
-   : op_(op), schema_(torch::jit::parseSchema(schema_string)) {
+  ADInplaceOrViewFallback2Impl(ReturnT(*op)(Args...), std::string fqname, std::string schema_string)
+   : op_(op), fqname_(fqname), schema_(torch::jit::parseSchema(schema_string)) {
     // Precompute whether the operator is in-place or view or neither
     // This allows us to short circuit quickly when it is neither
     const auto& op_name = schema_.operator_name().name;
@@ -95,6 +235,8 @@ public:
     const auto& returns = schema_.returns();
     const auto num_arguments = arguments.size();
     const auto num_returns = returns.size();
+    int aliased_input_idx = -1;
+    int aliased_output_idx = -1;
 
     for (int idx_arg = 0; idx_arg < num_arguments; idx_arg++) {
       const auto& alias_info = arguments[idx_arg].alias_info();
@@ -104,26 +246,30 @@ public:
         if (alias_info->isWrite()) {
           any_is_inplace_ = true;
         } else {
-          AT_ASSERT(aliased_input_idx_ == -1, "Expected a single input to be aliased, but observed at least 2 input with alias info");
-          aliased_input_idx_ = idx_arg;
+          AT_ASSERT(aliased_input_idx == -1, "Expected a single input to be aliased, but observed at least 2 input with alias info");
+          aliased_input_idx = idx_arg;
         }
       }
     }
-
     for (int idx_ret = 0; idx_ret < num_returns; idx_ret++) {
       const auto& alias_info = returns[idx_ret].alias_info();
       if (alias_info.has_value()) {
         if (!alias_info->isWrite()) {
-          AT_ASSERT(aliased_output_idx_ == -1, "Expected a single output to be aliased, but observed at least 2 outputs with alias info");
-          aliased_output_idx_ = idx_ret;
+          AT_ASSERT(aliased_output_idx == -1, "Expected a single output to be aliased, but observed at least 2 outputs with alias info");
+          aliased_output_idx = idx_ret;
         }
       }
     }
+    TORCH_INTERNAL_ASSERT((aliased_input_idx == -1 && aliased_output_idx == -1) ||
+      (aliased_input_idx == 0 && aliased_output_idx == 0))
+
+    is_view_ = aliased_input_idx != -1;
+    needs_metadata_change_ = std::find(
+      detail::NEEDS_METADATA_CHANGE.begin(), detail::NEEDS_METADATA_CHANGE.end(), op_name) != detail::NEEDS_METADATA_CHANGE.end();
   };
 
   ReturnT operator() (Args&&... args) {
-    if (aliased_input_idx_ == -1 && !any_is_inplace_) {
-      // Fallthrough if neither in-place nor view
+    if (!is_view_ && !any_is_inplace_) {
       at::AutoDispatchBelowADInplaceOrView guard;
       return op_(std::forward<Args>(args)...);
     }
@@ -135,7 +281,6 @@ public:
 
     std::vector<const at::Tensor*> tensors_to_increment_version;
     const at::Tensor* aliased_input = nullptr;
-    const at::Tensor* aliased_output = nullptr;
 
     detail::for_each_input_tensor([&](size_t idx_tensor, size_t idx_arg, const at::Tensor& t) {
       const auto& alias_info = arguments[idx_arg].alias_info();
@@ -143,61 +288,87 @@ public:
         if (alias_info->isWrite()) {
           tensors_to_increment_version.push_back(&t);
         } else {
-          AT_ASSERT(aliased_output == nullptr, "Expected a single output to be aliased, but observed at least 2 outputs with alias info");
-          aliased_output = &t;
+          AT_ASSERT(aliased_input == nullptr, "Expected a single input to be aliased, but observed at least 2 outputs with alias info");
+          aliased_input = &t;
         }
       }
-    }, args...);
+    }, std::forward<Args>(args)...);
 
-    ReturnT outputs;
-    {
-      at::AutoDispatchBelowADInplaceOrView guard;
-      // Do we need to forward here?
-      // Is there a case where we'd want the args to be moved from?
-      // another issue with the templated version that we cannot redispatch? we can only call directly back into
-      // the user should be expected to call the dispatcher? or... can we?
-      outputs = std::move(op_(args...));
-    }
+    std::function<at::Tensor(const at::Tensor&)> view_func = nullptr;
+    // For this to compile, we should extract it out its creation, just like the others
+    // if (is_view_ && (needs_metadata_change_  && !aliased_input->unsafeGetTensorImpl()->support_as_strided())) {
+    //   view_func = [=](const at::Tensor& t) {
+    //     return detail::get_first_return(detail::call_with_new_first_arg(op_, t, std::forward<Args>(args)...));
+    //   };
+    // }
 
-    detail::for_each_output_tensor(outputs, [&](size_t idx_tensor, size_t idx_arg, const at::Tensor& t) {
-      const auto& alias_info = arguments[idx_arg].alias_info();
-      if (alias_info.has_value() && !alias_info->isWrite()) {
-        AT_ASSERT(aliased_input == nullptr, "Expected a single input to be aliased, but observed at least 2 inputs with alias info");
-        aliased_input = &t;
+    // We need to call into a separate function because sometimes we return references and
+    // sometimes we return by value, and the code needs to work for both cases.
+    // Having a templated function that takes a univeral reference is useful for handling this.
+    // There might be a simpler way though
+    auto post_process = [&](auto&& ret) -> typename detail::remove_reference_if_rvalue_reference<decltype(ret)>::type {
+      for (const auto i : c10::irange(tensors_to_increment_version.size())) {
+        increment_version(*tensors_to_increment_version[i]);
       }
-    });
+      if (is_view_) {
+        return detail::call_as_view(std::forward<decltype(ret)>(ret), aliased_input, view_func);
+      } else {
+        return std::forward<decltype(ret)>(ret);
+      }
+    };
+    // We should do the redispatch ourselves (this code doesn't quite work yet...)
+    // User needs to pass in ns::op_name now; there might be a way to extract that from the scheam though
+    // auto operatorHandle = c10::Dispatcher::singleton()
+    //   .findSchemaOrThrow(fqname_.c_str(), "")
+    //   .typed<decltype(op_)>();
+    // at::AutoDispatchBelowADInplaceOrView guard;
 
-    for (const auto i : c10::irange(tensors_to_increment_version.size())) {
-      increment_version(*tensors_to_increment_version[i]);
-    }
+    // This lambda doesn't seem to have overhead
+    // return detail::post_process(operatorHandle.call(std::forward<Args>(args)...), tensors_to_increment_version, aliased_input, view_func, is_view_);
+    return post_process(op_(std::forward<Args>(args)...));
+  }
+private:
+  ReturnT(*op_)(Args...);
+  std::string fqname_;
+  c10::FunctionSchema schema_;
+  bool any_is_inplace_ = false;
+  bool is_view_ = false;
+  bool needs_metadata_change_ = false;
+};
 
-    // Make a base-view relationship
-    if (aliased_output != nullptr) {
-      auto result = as_view(
-        /* base=*/*aliased_input,
-        /* output=*/*aliased_output,
-        /* is_bw_differentiable=*/ true,
-        /* is_fw_differentiable=*/ true,
-        /* view_func=*/ nullptr, // What are the consequences of not providing this?
-        /* creation_meta=*/ InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::DEFAULT : CreationMeta::NO_GRAD_MODE));
-    }
-    // We need to replace the first
-    return outputs;
+// Bringing this back, so we can measure performance of
+// boxed autograd + boxed InplaceOrView vs templated autograd + templated InplaceOrView
+template<typename ReturnT, typename... Args>
+struct AutogradNotImplementedFallback2Impl {
+public:
+  AutogradNotImplementedFallback2Impl(ReturnT(*op)(Args&&...), std::string fqname, std::string schema_string)
+   : op_(op), fqname_(fqname), schema_(torch::jit::parseSchema(schema_string)) {};
+  ReturnT operator() (Args&&... args) {
+    // We should really have a conditional here, and dispatch past InplaceOrView if neither view nor inplace
+    // but for the purposes of testing perf of InplaceOrView, we keep this here.
+    // We should also be "redispatching"
+    at::AutoDispatchBelowAutograd guard;
+    auto operatorHandle = c10::Dispatcher::singleton()
+      .findSchemaOrThrow(fqname_.c_str(), "")
+      .typed<decltype(op_)>();
+    return operatorHandle.call(std::forward<Args>(args)...);
   }
 private:
   ReturnT(*op_)(Args&&...);
+  std::string fqname_;
   c10::FunctionSchema schema_;
-  bool any_is_inplace_ = false;
-  int aliased_input_idx_ = -1;
-  int aliased_output_idx_ = -1;
 };
-
 
 // We should instead do computation
 
 template<typename ReturnT, typename... Args>
-ADInplaceOrViewFallback2Impl<ReturnT, Args...> ADInplaceOrViewFallback2(ReturnT(*op)(Args&&...), std::string schema_str) {
-  return ADInplaceOrViewFallback2Impl<ReturnT, Args...>(op, schema_str);
+ADInplaceOrViewFallback2Impl<ReturnT, Args...> ADInplaceOrViewFallback2(ReturnT(*op)(Args...), std::string fqname, std::string schema_str) {
+  return ADInplaceOrViewFallback2Impl<ReturnT, Args...>(op, fqname, schema_str);
+}
+
+template<typename ReturnT, typename... Args>
+AutogradNotImplementedFallback2Impl<ReturnT, Args...> autogradNotImplementedFallback2(ReturnT(*op)(Args...), std::string fqname, std::string schema_str) {
+  return AutogradNotImplementedFallback2Impl<ReturnT, Args...>(op, fqname, schema_str);
 }
 
 TORCH_API torch::CppFunction autogradNotImplementedFallback();
@@ -212,13 +383,12 @@ TORCH_API torch::CppFunction ADInplaceOrViewFallback();
     m.impl(op, ADInplaceOrViewFallback());                       \
   }
 
-
-#define REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK2(ns, op, schema_str)     \
+#define REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK2(ns, op, fqname, schema_str, fn)     \
   TORCH_LIBRARY_IMPL(ns, Autograd, m) {                                     \
-    m.impl(op, AutogradNotImplementedFallback());                            \
+    m.impl(op, autogradNotImplementedFallback());                            \
   }                                                                         \
   TORCH_LIBRARY_IMPL(ns, ADInplaceOrView, m) {                              \
-    m.impl(op, autogradInplaceOrViewFallback2());                            \
+    m.impl(op, ADInplaceOrViewFallback2(fn, fqname, schema_str));                            \
   }
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.h
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.h
@@ -2,10 +2,223 @@
 
 #include <ATen/ATen.h>
 #include <torch/library.h>
+#include <torch/csrc/autograd/VariableTypeUtils.h>
+#include <torch/csrc/autograd/FunctionsManual.h>
+#include <torch/csrc/jit/frontend/function_schema_parser.h>
 
 namespace torch {
 namespace autograd {
 
+
+namespace detail {
+
+template <typename F>
+struct ForEachTensor : IterArgs<ForEachTensor<F>> {
+  F fn_;
+  mutable size_t idx_arg_ = 0;
+  mutable size_t idx_tensor_ = 0;
+  ForEachTensor(F fn) : fn_(fn) {}
+  void operator()(const variable_list& tensors) const {
+    for (const auto& t : tensors) {
+      fn_(idx_arg_, idx_tensor_, t);
+      idx_tensor_++;
+    }
+    idx_arg_++;
+  }
+  void operator()(const at::TensorList& tensors) const {
+    for (const auto& t : tensors) {
+      fn_(idx_tensor_, idx_arg_ , t);
+      idx_tensor_++;
+    }
+    idx_arg_++;
+  }
+  void operator()(const c10::optional<at::Tensor>& x) const {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (x.has_value() && x.value().defined()) {
+      fn_(idx_tensor_, idx_arg_, x.value());
+      idx_tensor_++;
+    }
+    idx_arg_++;
+  }
+  void operator()(const at::Tensor& x) const {
+    fn_(idx_tensor_, idx_arg_, x);
+    idx_tensor_++;
+    idx_arg_++;
+  }
+  template <typename T>
+  void operator()(const T& x) const {
+    // no op
+  }
+};
+
+template <typename F, typename... Args>
+inline void for_each_input_tensor(F fn, Args&&... args) {
+  ForEachTensor<F>(fn).apply(std::forward<Args>(args)...);
+}
+
+
+template <class Mapper, class... Args, size_t... Indices>
+void for_each_tuple(
+    std::tuple<Args...>& tuple,
+    const Mapper& mapper,
+    std::index_sequence<Indices...>) {
+  // We need a context where the parameter pack can be expanded
+  auto l = { (mapper(std::forward<Args>(std::get<Indices>(tuple))), 0)...};
+}
+
+template<typename F>
+void for_each_output_tensor(at::Tensor& t, F fn) {
+  fn(0, 0, t);
+}
+
+template<typename T, typename F>
+void for_each_output_tensor(T& not_tup, F fn) {
+  (ForEachTensor<F>(fn))(not_tup);
+}
+
+template<class... Args, typename F>
+void for_each_output_tensor(std::tuple<Args...>& tup, F fn) {
+  for_each_tuple(tup,  ForEachTensor<F>(fn), std::index_sequence_for<Args...>());
+}
+
+}
+
+template<typename ReturnT, typename... Args>
+struct ADInplaceOrViewFallback2Impl {
+public:
+  ADInplaceOrViewFallback2Impl(ReturnT(*op)(Args&&...), std::string schema_string)
+   : op_(op), schema_(torch::jit::parseSchema(schema_string)) {
+    // Precompute whether the operator is in-place or view or neither
+    // This allows us to short circuit quickly when it is neither
+    const auto& op_name = schema_.operator_name().name;
+    const auto& arguments = schema_.arguments();
+    const auto& returns = schema_.returns();
+    const auto num_arguments = arguments.size();
+    const auto num_returns = returns.size();
+
+    for (int idx_arg = 0; idx_arg < num_arguments; idx_arg++) {
+      const auto& alias_info = arguments[idx_arg].alias_info();
+      if (alias_info.has_value()) {
+        // Assume that if any of the alias info for input is write, then the same
+        // input must be returned as-is as output (maybe parseSchema already checks this?)
+        if (alias_info->isWrite()) {
+          any_is_inplace_ = true;
+        } else {
+          AT_ASSERT(aliased_input_idx_ == -1, "Expected a single input to be aliased, but observed at least 2 input with alias info");
+          aliased_input_idx_ = idx_arg;
+        }
+      }
+    }
+
+    for (int idx_ret = 0; idx_ret < num_returns; idx_ret++) {
+      const auto& alias_info = returns[idx_ret].alias_info();
+      if (alias_info.has_value()) {
+        if (!alias_info->isWrite()) {
+          AT_ASSERT(aliased_output_idx_ == -1, "Expected a single output to be aliased, but observed at least 2 outputs with alias info");
+          aliased_output_idx_ = idx_ret;
+        }
+      }
+    }
+  };
+
+  ReturnT operator() (Args&&... args) {
+    if (aliased_input_idx_ == -1 && !any_is_inplace_) {
+      // Fallthrough if neither in-place nor view
+      at::AutoDispatchBelowADInplaceOrView guard;
+      return op_(std::forward<Args>(args)...);
+    }
+    const auto& op_name = schema_.operator_name().name;
+    const auto& arguments = schema_.arguments();
+    const auto& returns = schema_.returns();
+    const auto num_arguments = arguments.size();
+    const auto num_returns = returns.size();
+
+    std::vector<const at::Tensor*> tensors_to_increment_version;
+    const at::Tensor* aliased_input = nullptr;
+    const at::Tensor* aliased_output = nullptr;
+
+    detail::for_each_input_tensor([&](size_t idx_tensor, size_t idx_arg, const at::Tensor& t) {
+      const auto& alias_info = arguments[idx_arg].alias_info();
+      if (alias_info.has_value()) {
+        if (alias_info->isWrite()) {
+          tensors_to_increment_version.push_back(&t);
+        } else {
+          AT_ASSERT(aliased_output == nullptr, "Expected a single output to be aliased, but observed at least 2 outputs with alias info");
+          aliased_output = &t;
+        }
+      }
+    }, args...);
+
+    ReturnT outputs;
+    {
+      at::AutoDispatchBelowADInplaceOrView guard;
+      // Do we need to forward here?
+      // Is there a case where we'd want the args to be moved from?
+      // another issue with the templated version that we cannot redispatch? we can only call directly back into
+      // the user should be expected to call the dispatcher? or... can we?
+      outputs = std::move(op_(args...));
+    }
+
+    detail::for_each_output_tensor(outputs, [&](size_t idx_tensor, size_t idx_arg, const at::Tensor& t) {
+      const auto& alias_info = arguments[idx_arg].alias_info();
+      if (alias_info.has_value() && !alias_info->isWrite()) {
+        AT_ASSERT(aliased_input == nullptr, "Expected a single input to be aliased, but observed at least 2 inputs with alias info");
+        aliased_input = &t;
+      }
+    });
+
+    for (const auto i : c10::irange(tensors_to_increment_version.size())) {
+      increment_version(*tensors_to_increment_version[i]);
+    }
+
+    // Make a base-view relationship
+    if (aliased_output != nullptr) {
+      auto result = as_view(
+        /* base=*/*aliased_input,
+        /* output=*/*aliased_output,
+        /* is_bw_differentiable=*/ true,
+        /* is_fw_differentiable=*/ true,
+        /* view_func=*/ nullptr, // What are the consequences of not providing this?
+        /* creation_meta=*/ InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::DEFAULT : CreationMeta::NO_GRAD_MODE));
+    }
+    // We need to replace the first
+    return outputs;
+  }
+private:
+  ReturnT(*op_)(Args&&...);
+  c10::FunctionSchema schema_;
+  bool any_is_inplace_ = false;
+  int aliased_input_idx_ = -1;
+  int aliased_output_idx_ = -1;
+};
+
+
+// We should instead do computation
+
+template<typename ReturnT, typename... Args>
+ADInplaceOrViewFallback2Impl<ReturnT, Args...> ADInplaceOrViewFallback2(ReturnT(*op)(Args&&...), std::string schema_str) {
+  return ADInplaceOrViewFallback2Impl<ReturnT, Args...>(op, schema_str);
+}
+
 TORCH_API torch::CppFunction autogradNotImplementedFallback();
+
+TORCH_API torch::CppFunction ADInplaceOrViewFallback();
+
+#define REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK(ns, op)      \
+  TORCH_LIBRARY_IMPL(ns, Autograd, m) {                         \
+    m.impl(op, autogradNotImplementedFallback());                \
+  }                                                             \
+  TORCH_LIBRARY_IMPL(ns, ADInplaceOrView, m) {                  \
+    m.impl(op, ADInplaceOrViewFallback());                       \
+  }
+
+
+#define REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK2(ns, op, schema_str)     \
+  TORCH_LIBRARY_IMPL(ns, Autograd, m) {                                     \
+    m.impl(op, AutogradNotImplementedFallback());                            \
+  }                                                                         \
+  TORCH_LIBRARY_IMPL(ns, ADInplaceOrView, m) {                              \
+    m.impl(op, autogradInplaceOrViewFallback2());                            \
+  }
 
 }} // namespace torch::autograd


### PR DESCRIPTION
This PR implements both templated and boxed version:

Benchmarks comparing templated and boxed versions in its current state.
We test for baseline (addition out-of-place), view op (just alias), in-place (addition in-place)
In the measurements below always register boxed Autograd kernel, but for...
 - boxed => boxed kernel for ADInplaceOrView
 - templated => templated kernel for ADInplaceOrView
 - codegen => copy-pasted codegened kernel for ADInplaceOrview
 - fallthrough => don't register ADInplaceOrView
 - we expect templated to be faster than boxed in all cases because
   - we can precompute values on construction
   - no need to incur reference count bumps from copying the stack in the in-place case
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
baseline                                 731 ns          731 ns       942423
boxed                                   1561 ns         1561 ns       448876
templated                               1568 ns         1568 ns       447501
baseline_view                           18.3 ns         18.3 ns     37993160
boxed_view                              1031 ns         1031 ns       687561
templated_view                           994 ns          994 ns       705317
codegen_view                             983 ns          983 ns       704384
fallthrough_view                         595 ns          595 ns      1178183
baseline_inplace                         352 ns          352 ns      1945817
boxed_inplace                           1339 ns         1339 ns       525608
templated_inplace                       1247 ns         1247 ns       548316
codegen_inplace                         1217 ns         1217 ns       548446
fallthrough_inplace                     1499 ns         1499 ns       527335 <---- if fallthrough_inplace is run directly after codegen_inplace, it is slow
fallthrough_inplace_a_second_time       1143 ns         1142 ns       627750 <---- same test again is faster!
```
 - As shown above, there is some weird interactions that depend on the orderings of the timings, but running the test a second time may correct the measurement...
<details>
<summary>
Code
</summary>

```c++
#include <torch/extension.h>
#include <torch/csrc/autograd/autograd_not_implemented_fallback.h>
#include <benchmark/benchmark.h>

using namespace torch;
using namespace aten;
using namespace torch::autograd;

torch::Tensor my_test_op(const torch::Tensor& self, const torch::Tensor& other) {
  return self + other;
}

torch::Tensor my_test_view_op2(const torch::Tensor& self) {
  return self;
}

const torch::Tensor& my_test_inplace_op(const torch::Tensor& self, const torch::Tensor& other) {
  return self.add_(other);
}

// We want to isolate the time it takes to go through Autograd kernel for in-place op and
// fallthrough the InplaceOrView kernel
const torch::Tensor&  my_test_inplace_op_for_fallthrough(const torch::Tensor& self, const torch::Tensor& other ) {
  return self.add_(other);
}

// Registering this inplace op fallthrough shouldn't really impact perf
// const torch::Tensor&  my_test_inplace_op_fallthrough(const torch::Tensor& self, const torch::Tensor& other ) {
//   at::AutoDispatchBelowADInplaceOrView guard;
//   return my_test_inplace_op_for_fallthrough(self, other);
// }

// torch/include/ATen/RedispatchFunctions.h
// aten::alias(Tensor(a) self) -> Tensor(a)
// at::Tensor alias_redispatch(c10::DispatchKeySet dispatchKeySet, const at::Tensor & self) {
//     return at::_ops::alias::redispatch(dispatchKeySet, self);
// }

// Codegened ADInplaceOrView kernel
at::Tensor aliasInplaceOrViewCodegened(c10::DispatchKeySet ks, const at::Tensor & self) {
  auto _tmp = ([&]() {
    at::AutoDispatchBelowADInplaceOrView guard;
    return my_test_view_op2(self); // Lets just not do any redispatch
    // return alias_redispatch(ks & c10::after_ADInplaceOrView_keyset, self);
  })();
  std::function<at::Tensor(const at::Tensor&)> func=nullptr;
  if (false || !self.unsafeGetTensorImpl()->support_as_strided()) {
    func = [=](const at::Tensor& input_base) {
      return at::alias(input_base);
    };
  }
  auto result = as_view(/* base */ self, /* output */ _tmp, /* is_bw_differentiable */ true, /* is_fw_differentiable */ true, /* view_func */ func, /* creation_meta */ InferenceMode::is_enabled() ? CreationMeta::INFERENCE_MODE : (at::GradMode::is_enabled() ? CreationMeta::DEFAULT : CreationMeta::NO_GRAD_MODE));
  return result;
}

const at::Tensor & addInplaceCodegened(c10::DispatchKeySet ks, const at::Tensor & self, const at::Tensor & other) {
  {
    at::AutoDispatchBelowADInplaceOrView guard;
    my_test_inplace_op(self, other);
  }
  increment_version(self);
  return self;
}

Tensor dispatch_to_baseline(const Tensor& self, const Tensor& other) {
  at::AutoDispatchBelowADInplaceOrView guard;
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_op_baseline", "")
    .typed<decltype(my_test_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_boxed(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_op_boxed", "")
    .typed<decltype(my_test_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_templated(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_op_templated", "")
    .typed<decltype(my_test_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_baseline_view(const Tensor& self) {
  at::AutoDispatchBelowADInplaceOrView guard;
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_view_op2_baseline", "")
    .typed<decltype(my_test_view_op2)>();
  return op.call(self);
}

Tensor dispatch_to_boxed_view(const Tensor& self) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_view_op2_boxed", "")
    .typed<decltype(my_test_view_op2)>();
  return op.call(self);
}

Tensor dispatch_to_templated_view(const Tensor& self) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_view_op2_templated", "")
    .typed<decltype(my_test_view_op2)>();
  return op.call(self);
}

Tensor dispatch_to_codegen_view(const Tensor& self) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_view_op2_codegen", "")
    .typed<decltype(my_test_view_op2)>();
  return op.call(self);
}

Tensor dispatch_to_fallthrough_view(const Tensor& self) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_view_op2_fallthrough", "")
    .typed<decltype(my_test_view_op2)>();
  return op.call(self);
}

Tensor dispatch_to_baseline_inplace(const Tensor& self, const Tensor& other) {
  at::AutoDispatchBelowADInplaceOrView guard;
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_inplace_op_baseline", "")
    .typed<decltype(my_test_inplace_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_boxed_inplace(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_inplace_op_boxed", "")
    .typed<decltype(my_test_inplace_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_templated_inplace(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_inplace_op_templated", "")
    .typed<decltype(my_test_inplace_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_codegen_inplace(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_inplace_op_codegen", "")
    .typed<decltype(my_test_inplace_op)>();
  return op.call(self, other);
}

Tensor dispatch_to_fallthrough_inplace(const Tensor& self, const Tensor& other) {
  static auto op = torch::Dispatcher::singleton()
    .findSchemaOrThrow("my_ops::my_test_inplace_op_fallthrough", "")
    .typed<decltype(my_test_inplace_op_for_fallthrough)>();
  return op.call(self, other);
}

TORCH_LIBRARY(my_ops, m) {
  m.def("my_test_op_baseline(Tensor self, Tensor other) -> Tensor ");
  m.def("my_test_op_boxed(Tensor self, Tensor other) -> Tensor ");
  m.def("my_test_op_templated(Tensor self, Tensor other) -> Tensor ");
  m.def("my_test_view_op2_baseline(Tensor(a) self) -> Tensor(a) ");
  m.def("my_test_view_op2_boxed(Tensor(a) self) -> Tensor(a) ");
  m.def("my_test_view_op2_templated(Tensor(a) self) -> Tensor(a) ");
  m.def("my_test_view_op2_codegen(Tensor(a) self) -> Tensor(a) ");
  m.def("my_test_view_op2_fallthrough(Tensor(a) self) -> Tensor(a) ");
  m.def("my_test_inplace_op_baseline(Tensor(a!) self, Tensor other) -> Tensor(a!) ");
  m.def("my_test_inplace_op_boxed(Tensor(a!) self, Tensor other) -> Tensor(a!) ");
  m.def("my_test_inplace_op_templated(Tensor(a!) self, Tensor other) -> Tensor(a!) ");
  m.def("my_test_inplace_op_codegen(Tensor(a!) self, Tensor other) -> Tensor(a!) ");
  m.def("my_test_inplace_op_fallthrough(Tensor(a!) self, Tensor other) -> Tensor(a!) ");
}

TORCH_LIBRARY_IMPL(my_ops, CPU, m) {
  m.impl("my_test_op_baseline", TORCH_FN(my_test_op));
  m.impl("my_test_op_boxed", TORCH_FN(my_test_op));
  m.impl("my_test_op_templated", TORCH_FN(my_test_op));
  m.impl("my_test_view_op2_baseline", TORCH_FN(my_test_view_op2));
  m.impl("my_test_view_op2_boxed", TORCH_FN(my_test_view_op2));
  m.impl("my_test_view_op2_templated", TORCH_FN(my_test_view_op2));
  m.impl("my_test_view_op2_codegen", TORCH_FN(my_test_view_op2));
  m.impl("my_test_view_op2_fallthrough", TORCH_FN(my_test_view_op2));
  m.impl("my_test_inplace_op_baseline", TORCH_FN(my_test_inplace_op));
  m.impl("my_test_inplace_op_boxed", TORCH_FN(my_test_inplace_op));
  m.impl("my_test_inplace_op_templated", TORCH_FN(my_test_inplace_op));
  m.impl("my_test_inplace_op_codegen", TORCH_FN(my_test_inplace_op));
  m.impl("my_test_inplace_op_fallthrough", TORCH_FN(my_test_inplace_op_for_fallthrough));
}

/**
 * Register Autograd and ADInplaceOrView kernels
 * We always register boxed Autograd kernel, but for...
 *  - boxed => boxed kernel for ADInplaceOrView
 *  - templated => templated kernel for ADInplaceOrView
 *  - codegen => copy-pasted codegened kernel for ADInplaceOrview
 *  - fallthrough => don't register ADInplaceOrView
 */
REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK(my_ops, "my_test_op_boxed");
REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK2(my_ops, "my_test_op_templated", "my_ops::my_test_op_templated", "my_test_op_templated(Tensor self, Tensor other) -> Tensor ", my_test_op);
REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK(my_ops, "my_test_view_op2_boxed");
REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK2(my_ops, "my_test_view_op2_templated", "my_ops::my_test_view_op2_templated", "my_test_view_op2_templated(Tensor(a) self) -> Tensor(a)", my_test_view_op2);
REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK(my_ops, "my_test_inplace_op_boxed");
REGISTER_AUTOGRAD_NOT_IMPLEMENTED_FALLBACK2(my_ops, "my_test_inplace_op_templated", "my_ops::my_test_inplace_op_templated", "my_test_inplace_op_templated(Tensor(a!) self, Tensor other) -> Tensor(a!)", my_test_inplace_op);

TORCH_LIBRARY_IMPL(my_ops, Autograd, m) {
  m.impl("my_test_view_op2_codegen", autogradNotImplementedFallback());
}
// copy-pasted codegened InplaceOrView kernel, but instead of redispatching, call directly into the function
// this could make a difference?
TORCH_LIBRARY_IMPL(my_ops, ADInplaceOrView, m) {
  m.impl("my_test_view_op2_codegen", TORCH_FN(aliasInplaceOrViewCodegened));
}

// Only register Autograd kernel for this one
TORCH_LIBRARY_IMPL(my_ops, Autograd, m) {
  m.impl("my_test_view_op2_fallthrough", autogradNotImplementedFallback());
}

TORCH_LIBRARY_IMPL(my_ops, Autograd, m) {
  m.impl("my_test_inplace_op_codegen", autogradNotImplementedFallback());
}
// copy-pasted codegened InplaceOrView kernel, but instead of redispatching, call directly into the function
// this could make a difference?
TORCH_LIBRARY_IMPL(my_ops, ADInplaceOrView, m) {
  m.impl("my_test_inplace_op_codegen", TORCH_FN(addInplaceCodegened));
}

// Only register Autograd kernel for this one
TORCH_LIBRARY_IMPL(my_ops, Autograd, m) {
  m.impl("my_test_inplace_op_fallthrough", autogradNotImplementedFallback());
}

// TORCH_LIBRARY_IMPL(my_ops, ADInplaceOrView, m) {
//   m.impl("my_test_inplace_op_fallthrough", TORCH_FN(my_test_inplace_op_fallthrough));
// }

static void baseline(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_baseline(a, b);
  }
}
BENCHMARK(baseline);

static void boxed(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_boxed(a, b);
  }
}
BENCHMARK(boxed);

static void templated(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_templated(a, b);
  }
}
BENCHMARK(templated);

static void baseline_view(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  for (auto _ : state) {
    dispatch_to_baseline_view(a);
  }
}
BENCHMARK(baseline_view);

static void boxed_view(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  for (auto _ : state) {
    dispatch_to_boxed_view(a);
  }
}
BENCHMARK(boxed_view);

static void templated_view(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  for (auto _ : state) {
    dispatch_to_templated_view(a);
  }
}
BENCHMARK(templated_view);

static void codegen_view(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  for (auto _ : state) {
    dispatch_to_codegen_view(a);
  }
}
BENCHMARK(codegen_view);

static void fallthrough_view(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true);
  for (auto _ : state) {
    dispatch_to_fallthrough_view(a);
  }
}
BENCHMARK(fallthrough_view);

static void baseline_inplace(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true).clone();
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_baseline_inplace(a, b);
  }
}
BENCHMARK(baseline_inplace);

static void boxed_inplace(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true).clone();
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_boxed_inplace(a, b);
  }
}
BENCHMARK(boxed_inplace);

static void templated_inplace(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true).clone();
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_templated_inplace(a, b);
  }
}
BENCHMARK(templated_inplace);

static void codegen_inplace(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true).clone();
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_codegen_inplace(a, b);
  }
}
BENCHMARK(codegen_inplace);

static void fallthrough_inplace(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true).clone();
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_fallthrough_inplace(a, b);
  }
}
BENCHMARK(fallthrough_inplace);

static void fallthrough_inplace_a_second_time(benchmark::State& state) {
  torch::Tensor a = torch::ones({1, 2, 3}).set_requires_grad(true).clone();
  torch::Tensor b = torch::ones({1, 2, 3}).set_requires_grad(false);
  for (auto _ : state) {
    dispatch_to_fallthrough_inplace(a, b);
  }
}
BENCHMARK(fallthrough_inplace_a_second_time);


BENCHMARK_MAIN();

```
EDIT: updated benchmark and code to include the kernel copy-pasted from codegened code

</details>