### PR TITLE
[FX] Check type of target for Node (#63490)

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1280,6 +1280,12 @@ class TestFX(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, 'was used before it has been defined'):
             graph.lint()
 
+    def test_wrong_target_type(self):
+        graph : torch.fx.Graph = torch.fx.Graph()
+        with self.assertRaises(AssertionError):
+            n = torch.fx.Node(graph=graph, name='foo', op='call_function', target='foo',
+                  args=(), kwargs={})
+
     def test_example_shape_prop(self):
         class TestCase(torch.nn.Module):
             def __init__(self):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1066,8 +1066,11 @@ def forward({', '.join(orig_args)}){maybe_return_annotation[0]}:
         # Check targets are legit
         if self.owning_module:
             for node in self.nodes:
-                if node.op in ['get_attr', 'call_module']:
+                if node.op == 'call_function':
+                    assert isinstance(node.target, Callable)
+                else:
                     assert isinstance(node.target, str)
+                if node.op in ['get_attr', 'call_module']:
                     target_atoms = node.target.split('.')
                     m_itr = self.owning_module
                     for i, atom in enumerate(target_atoms):

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -119,7 +119,9 @@ class Node:
         self.name = name  # unique name of value being created
         assert op in ['placeholder', 'call_method', 'call_module', 'call_function', 'get_attr', 'output', 'root']
         self.op = op  # the kind of operation = placeholder|call_method|call_module|call_function|get_attr
-        if op in ['call_method', 'call_module']:
+        if op == 'call_function':
+            assert isinstance(target, Callable)
+        else:
             assert isinstance(target, str)
         self.target = target  # for method/module/function, the name of the method/module/function/attr
         # being invoked, e.g add, layer1, or torch.add


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64027

Summary:
Check data type of target on Node construction and lint.
Add test_wrong_target_type to test/test_fx.py.

Test Plan:
pytest test/test_fx.py

Reviewers:

Subscribers:

Tasks:

Tags: