### PR TITLE
[static runtime] fuse to+gather+to+lengths_to_offsets

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -11,6 +11,12 @@ at::Tensor& reshape_copy_out(
     const at::Tensor& self,
     const std::vector<int64_t>& proposed_shape,
     bool infer_size = true);
+at::Tensor& to_copy_out(
+    Tensor& out,
+    const Tensor& self,
+    bool non_blocking,
+    bool copy_strides,
+    c10::optional<MemoryFormat> memory_format);
 } // namespace native
 } // namespace at
 


### PR DESCRIPTION
Test Plan:
Before:
`I0826 17:17:54.165174 1064079 PyTorchPredictorBenchLib.cpp:313] PyTorch run finished. Milliseconds per iter: 6.66724. Iters per second: 149.987`

After:
`I0826 17:13:07.464485 1040300 PyTorchPredictorBenchLib.cpp:313] PyTorch run finished. Milliseconds per iter: 6.46362. Iters per second: 154.712`

Profile after: P453143683

Accuracy tested comparing with jit interpreter for no differences under 1e-3 (nnc ops turned on) https://www.internalfb.com/intern/diff/view-version/136824794/

Differential Revision: D30515441

