### PR TITLE
Mark functions in backend header as inline to suppress warning

### DIFF
--- a/torch/csrc/jit/backends/backend.h
+++ b/torch/csrc/jit/backends/backend.h
@@ -9,7 +9,7 @@ namespace torch {
 namespace jit {
 namespace {
 // NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
-c10::FunctionSchema getIsAvailableSchema() {
+inline c10::FunctionSchema getIsAvailableSchema() {
   c10::Argument self("self", c10::AnyType::get());
   c10::Argument available("available", c10::BoolType::get());
   c10::FunctionSchema preprocessor_schema(
@@ -23,7 +23,7 @@ c10::FunctionSchema getIsAvailableSchema() {
 constexpr static auto kBackendsNamespace = "__backends__";
 
 // NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
-c10::FunctionSchema getCompileSchema() {
+inline c10::FunctionSchema getCompileSchema() {
   c10::Argument self("self", c10::AnyType::get());
   c10::Argument mod("processed", c10::AnyType::get());
   auto any_dict_ty =
@@ -40,7 +40,7 @@ c10::FunctionSchema getCompileSchema() {
 }
 
 // NOLINTNEXTLINE(clang-diagnostic-unneeded-internal-declaration)
-c10::FunctionSchema getExecuteSchema() {
+inline c10::FunctionSchema getExecuteSchema() {
   auto any_list_ty = c10::ListType::create(c10::AnyType::get());
   c10::Argument self("self", c10::AnyType::get());
   c10::Argument handle("handle", c10::AnyType::get());


### PR DESCRIPTION
Differential Revision: D30593104

