### PR TITLE
fix tools/nightly.py raises: TypeError: 'type' object is not subscriptable

### DIFF
--- a/tools/nightly.py
+++ b/tools/nightly.py
@@ -324,7 +324,7 @@ def deps_install(deps: List[str], existing_env: bool, env_opts: List[str]) -> No
 
 
 @timed("Installing pytorch nightly binaries")
-def pytorch_install(url: str) -> tempfile.TemporaryDirectory[str]:
+def pytorch_install(url: str) -> tempfile.TemporaryDirectory:
     """"Install pytorch into a temporary directory"""
     pytdir = tempfile.TemporaryDirectory()
     cmd = ["conda", "create", "--yes", "--no-deps", "--prefix", pytdir.name, url]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#64140 fix tools/nightly.py raises: TypeError: 'type' object is not subscriptable**

fix: #64017

cc @ezyang @malfet @rgommers @xuzhao9 @gramster