### PR TITLE
Use the correct overloaded name to skip boxed autograd not implemented kernel registration

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -411,9 +411,9 @@ def gen_variable_type_func(
         if fn.info is None and not get_base_name(f) in RESET_GRAD_ACCUMULATOR \
                 and not get_base_name(f) in DONT_REQUIRE_DERIVATIVE \
                 and len(gen_differentiable_outputs(fn)) > 0 \
-                and not get_base_name(f) in DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE \
-                and not get_base_name(f) in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT \
-                and not get_base_name(f) in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
+                and not cpp.name(f.func) in DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE \
+                and not type_wrapper_name(f) in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT \
+                and not type_wrapper_name(f) in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
             # NOTE: [ Registering AutogradNotImplemented boxed kernel ]
             #
             # When there is no derivatives.yaml entry, we register a generic boxed


### PR DESCRIPTION
Some internal use_count tests are failing for `dequantize_self` because we only compare the skip list with the base name `dequantize` when we should be comparing with the full name including the overload