### PR TITLE
[ONNX] Fix duplicated output same name case

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -981,6 +981,8 @@ class TestUtilityFuns(TestCase):
         assert graph.graph.node[0].op_type == "Gemm"
         assert graph.graph.node[1].op_type == "Identity"
         assert graph.graph.node[2].op_type == "Identity"
+        assert graph.graph.node[3].op_type == "Gemm"
+        assert graph.graph.node[4].op_type == "Identity"
 
 # opset 10 tests
 TestUtilityFuns_opset10 = type(str("TestUtilityFuns_opset10"),

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -943,9 +943,10 @@ class TestUtilityFuns(TestCase):
                 super(DuplicatedOutputNet, self).__init__()
                 self.fc1 = torch.nn.Linear(input_size, num_classes)
 
-            def forward(self, input1):
-                out = self.fc1(input1)
-                return out, out, out
+            def forward(self, input0, input1):
+                out1 = self.fc1(input0)
+                out2 = self.fc1(input1)
+                return out1, out1, out2, out1, out2
 
         N, D_in, H, D_out = 64, 784, 500, 10
         pt_model = DuplicatedOutputNet(D_in, D_out)
@@ -954,27 +955,29 @@ class TestUtilityFuns(TestCase):
         x = torch.randn(N, D_in)
         dynamic_axes = {
             'input0': {0: 'input0_dim0', 1: 'input0_dim1'},
+            'input1': {0: 'input1_dim0', 1: 'input1_dim1'},
             'output-0': {0: 'output-0_dim0', 1: 'output-0_dim1'},
             'output-1': {0: 'output-1_dim0', 1: 'output-1_dim1'},
-            'output-2': {0: 'output-2_dim0', 1: 'output-2_dim1'}}
+            'output-2': {0: 'output-2_dim0', 1: 'output-2_dim1'},
+            'output-3': {0: 'output-3_dim0', 1: 'output-3_dim1'},
+            'output-4': {0: 'output-4_dim0', 1: 'output-4_dim1'}}
 
         torch.onnx.export(pt_model,
-                          x,
+                          (x, x),
                           f,
-                          input_names=['input0'],
-                          output_names=['output-0', 'output-1', 'output-2'],
-                          opset_version=12,
+                          input_names=['input0', 'input1'],
+                          output_names=['output-0', 'output-1', 'output-2', 'output-3', 'output-4'],
                           do_constant_folding=False,
                           training=torch.onnx.TrainingMode.TRAINING,
                           dynamic_axes=dynamic_axes,
                           verbose=True,
-                          export_params=False,
                           keep_initializers_as_inputs=True)
 
         graph = onnx.load(io.BytesIO(f.getvalue()))
-        assert graph.graph.output[0].name == "output-0"
-        assert graph.graph.output[1].name == "output-1"
-        assert graph.graph.output[2].name == "output-2"
+        assert graph.graph.input[0].name == "input0"
+        assert graph.graph.input[1].name == "input1"
+        for i in range(5):
+            assert graph.graph.output[i].name == "output-" + str(i)
         assert graph.graph.node[0].op_type == "Gemm"
         assert graph.graph.node[1].op_type == "Identity"
         assert graph.graph.node[2].op_type == "Identity"

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -790,9 +790,8 @@ def _set_input_and_output_names(graph, input_names, output_names):
                 identity_node.output().setType(node.type())
                 graph.return_node().replaceInput(i, identity_node.output())
                 node = identity_node.output()
-            else:
-                node_set.add(node)
 
+            node_set.add(node)
             if node.debugName() != name:
                 node.setDebugName(name)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -779,19 +779,20 @@ def _set_input_and_output_names(graph, input_names, output_names):
                 "number of %s names provided (%d) exceeded number of %ss (%d)"
                 % (descriptor, len(name_list), descriptor, len(node_list)))
 
-        # Mark if the node DebugName is set before.
-        node_set = set()
+        # Mark if the output node DebugName is set before.
+        output_node_set = set()
         for i, (name, node) in enumerate(zip(name_list, node_list)):
-            if node in node_set:
-                # Duplicated node, insert onnx::Identity to avoid the same DebugName.
-                identity_node = graph.create("onnx::Identity")
-                identity_node.insertAfter(node.node())
-                identity_node.addInput(node)
-                identity_node.output().setType(node.type())
-                graph.return_node().replaceInput(i, identity_node.output())
-                node = identity_node.output()
+            # Duplicated output node, insert onnx::Identity to avoid setting the same DebugName after setDebugName().
+            if descriptor == "output":
+                if node in output_node_set:
+                    identity_node = graph.create("onnx::Identity")
+                    identity_node.insertAfter(node.node())
+                    identity_node.addInput(node)
+                    identity_node.output().setType(node.type())
+                    graph.return_node().replaceInput(i, identity_node.output())
+                    node = identity_node.output()
+                output_node_set.add(node)
 
-            node_set.add(node)
             if node.debugName() != name:
                 node.setDebugName(name)
 


### PR DESCRIPTION
The model will get the same output name when there are the duplicated outputs nodes specified different name by `dynamic_axes`. 

Just as the exmaple, the example names of the output `[output-2, output-2, output-2]` is not consistent with the names `[output-0, output-1, output-2]` given to the exporter.
>dynamic_axes = {
    'input0': {0: 'input0_dim0', 1: 'input0_dim1'},
    'output-0': {0: 'output-0_dim0', 1: 'output-0_dim1'},
    'output-1': {0: 'output-1_dim0', 1: 'output-1_dim1'},
    'output-2': {0: 'output-2_dim0', 1: 'output-2_dim1'}}
return out, out, out

![image](https://user-images.githubusercontent.com/10047193/131365080-011a2c94-f489-46fb-925e-1e01478fc479.png)

This PR fixs it by adding the `onnx::Identity` in duplicated output.
![image](https://user-images.githubusercontent.com/10047193/131363890-d1ff1626-4a94-4df5-8e69-4880aa2028fe.png)

