### PR TITLE
[docs] fix torch.histc's min/max arg types

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4234,8 +4234,8 @@ Elements lower than min and higher than max are ignored.
 Args:
     {input}
     bins (int): number of histogram bins
-    min (int): lower end of the range (inclusive)
-    max (int): upper end of the range (inclusive)
+    min (Scalar): lower end of the range (inclusive)
+    max (Scalar): upper end of the range (inclusive)
 
 Keyword args:
     {out}


### PR DESCRIPTION
Fixes #31475. `torch.histc` accepts Scalar min/max. The docs erroneously specified their types as int.

cc @brianjo @mruberry