### PR TITLE
Optimize reduction configs, avoid invalid configuration arguments we have for the…

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -5,7 +5,6 @@
 #include <ATen/native/LinearAlgebra.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/Reduce.cuh>
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/ReduceOps.h>
 

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -2,7 +2,6 @@
 #include <ATen/native/ReduceOps.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/Reduce.cuh>
 #include <ATen/native/cuda/Resize.cuh>
 #include <ATen/native/cuda/Normalization.cuh>
 #include <c10/cuda/CUDAMathCompat.h>


### PR DESCRIPTION
… reduce kernels

Previously, when reduction included fastest dimension, and that dimension was small, and number of outputs was also small, it resulted in a very small threadblock (e.g. (1,2)). This led to bad performance, and, as tensor became bigger, could trigger launching too many blocks and "invalid configuration argument".

Fixes #48573

It also greatly improves performance of the cases similar to #48573 reproducer that were passing before:
```
import torch
dummy = torch.randn(1, 512, 1024, 4, device='cuda:0')*1000
inp = dummy[..., :3]
out=torch.mean(inp)
```
before this PR on V100  - 2 ms, after this PR - 22 us
