### PR TITLE
Fix type annotation in tools/nightly.py

### DIFF
--- a/tools/nightly.py
+++ b/tools/nightly.py
@@ -324,7 +324,7 @@ def deps_install(deps: List[str], existing_env: bool, env_opts: List[str]) -> No
 
 
 @timed("Installing pytorch nightly binaries")
-def pytorch_install(url: str) -> tempfile.TemporaryDirectory[str]:
+def pytorch_install(url: str) -> "tempfile.TemporaryDirectory[str]":
     """"Install pytorch into a temporary directory"""
     pytdir = tempfile.TemporaryDirectory()
     cmd = ["conda", "create", "--yes", "--no-deps", "--prefix", pytdir.name, url]


### PR DESCRIPTION
`tempfile.TemporaryDirectory` is a generic only in python-3.9 and above

Workaround by wrapping type annotation in quotes

Fixes https://github.com/pytorch/pytorch/issues/64017
