### PR TITLE
Move some distributed C++ GTest unit tests from test.sh to Python wrapper

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -317,9 +317,6 @@ test_distributed() {
     # test reporting process (in print_test_stats.py) to function as expected.
     TEST_REPORTS_DIR=test/test-reports/cpp-distributed/test_distributed
     mkdir -p $TEST_REPORTS_DIR
-    "$TORCH_BIN_DIR"/FileStoreTest --gtest_output=xml:$TEST_REPORTS_DIR/FileStoreTest.xml
-    "$TORCH_BIN_DIR"/HashStoreTest --gtest_output=xml:$TEST_REPORTS_DIR/HashStoreTest.xml
-    "$TORCH_BIN_DIR"/TCPStoreTest --gtest_output=xml:$TEST_REPORTS_DIR/TCPStoreTest.xml
 
     MPIEXEC=$(command -v mpiexec)
     # TODO: this is disabled on GitHub Actions until this issue is resolved


### PR DESCRIPTION
Summary:
This is the beginning of transitioning away from test.sh: https://github.com/pytorch/pytorch/issues/64067

Moved execution of FileStoreTest, HashStoreTest, TCPStoreTest from test.sh to run_test.py. Since these are compiled tests, the logic of test.sh was just migrated and the tests are run through subprocess.

Test Plan:
```
python3 test/run_test.py --include cpp/c10d/FileStoreTest cpp/c10d/HashStoreTest cpp/c10d/TCPStoreTest
```

Wait for CI

Differential Revision: D30662844

