### PR TITLE
replace C10_WARP_SIZE with warpSize

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -15,8 +15,6 @@
 #include <thrust/execution_policy.h>
 #include <thrust/unique.h>
 
-#include <c10/macros/Macros.h>
-
 namespace at {
 namespace native {
 
@@ -264,7 +262,7 @@ Tensor embedding_backward_cuda_kernel(
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
-    const int stride_warped = ceil_div(stride, C10_WARP_SIZE)*C10_WARP_SIZE;
+    const int stride_warped = ceil_div(stride, warpSize)*warpSize;
     const int block = std::min(stride_warped, MAX_BLOCK_SIZE);
     const int grid = ceil_div(num_of_partial_segments*stride_warped, block);
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -9,7 +9,7 @@
 
 #include <thrust/tuple.h>
 
-#define NUM_THREADS (C10_WARP_SIZE * 2)
+#define NUM_THREADS (warpSize * 2)
 #define THREAD_WORK_SIZE 4
 #define BLOCK_WORK_SIZE (THREAD_WORK_SIZE * num_threads)
 

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -327,8 +327,8 @@ void multinomial_with_replacement_kernel_impl(
     int maxThreads = props->maxThreadsPerBlock;
     int maxShared = props->sharedMemPerBlock;
 
-    int requiredWarps = at::cuda::ATenCeilDiv(numCategories, C10_WARP_SIZE);
-    int requiredThreads = std::min(maxThreads, requiredWarps * C10_WARP_SIZE);
+    int requiredWarps = at::cuda::ATenCeilDiv(numCategories, warpSize);
+    int requiredThreads = std::min(maxThreads, requiredWarps * warpSize);
     int requiredShared = requiredThreads * sizeof(accscalar_t);
 
     if (n_sample == 1 && maxShared >= requiredShared) {

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -12,7 +12,7 @@
 
 namespace {
 
-constexpr int num_threads = C10_WARP_SIZE * 2;
+constexpr int num_threads = warpSize * 2;
 constexpr int thread_work_size = 1;
 constexpr int block_work_size = thread_work_size * num_threads;
 

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -5,7 +5,6 @@
 #include <ATen/WrapDimUtils.h>
 #include <THC/THCTensorMathReduce.cuh>
 #include <THC/THCThrustAllocator.cuh>
-#include <c10/macros/Macros.h>
 
 #include <ATen/AccumulateType.h>
 #include <ATen/cuda/NumericLimits.cuh>
@@ -155,7 +154,7 @@ inline dim3 SoftMax_getBlockSize(int ILP, uint64_t dim_size) {
 
   while (block_size < (max_block_size)) block_size *= 2;
   // Launch at least a single warp - the kernel assumes that.
-  block_size = std::max(block_size, static_cast<uint64_t>(C10_WARP_SIZE));
+  block_size = std::max(block_size, static_cast<uint64_t>(warpSize));
   return dim3(block_size);
 }
 
@@ -351,13 +350,13 @@ blockReduce(AccumT* smem, AccumT val,
   AccumT warpVal = defaultVal;
 
   // First warp will perform per-warp reductions for the remaining warps
-  uint32_t mask = (((uint64_t)1) << (blockDim.x / C10_WARP_SIZE)) - 1;
-  if (threadIdx.x < C10_WARP_SIZE) {
-    int lane = threadIdx.x % C10_WARP_SIZE;
-    if (lane < blockDim.x / C10_WARP_SIZE) {
+  uint32_t mask = (((uint64_t)1) << (blockDim.x / warpSize)) - 1;
+  if (threadIdx.x < warpSize) {
+    int lane = threadIdx.x % warpSize;
+    if (lane < blockDim.x / warpSize) {
 #pragma unroll
-      for (int i = 0; i < C10_WARP_SIZE; ++i) {
-        warpVal = r(warpVal, smem[lane * C10_WARP_SIZE + i]);
+      for (int i = 0; i < warpSize; ++i) {
+        warpVal = r(warpVal, smem[lane * warpSize + i]);
       }
 #ifndef __HIP_PLATFORM_HCC__
       __syncwarp(mask);
@@ -372,7 +371,7 @@ blockReduce(AccumT* smem, AccumT val,
   AccumT blockVal = defaultVal;
 
   if (threadIdx.x == 0) {
-    for (int i = 0; i < blockDim.x / C10_WARP_SIZE; ++i) {
+    for (int i = 0; i < blockDim.x / warpSize; ++i) {
       blockVal = r(blockVal, smem[i]);
     }
     smem[0] = blockVal;

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -6,8 +6,6 @@
 #include <ATen/native/cuda/SortingRadixSelect.cuh>
 #include <ATen/native/cuda/SortUtils.cuh>
 
-#include <c10/macros/Macros.h>
-
 using namespace at::native;
 
 namespace at {
@@ -254,7 +252,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
     dim3 grid;                                                            \
     TORCH_INTERNAL_ASSERT(getGridFromTiles(inputSlices, grid), "Too many slices to sort"); \
                                                                           \
-    dim3 block(std::min(at::cuda::ATenCeilDiv(sliceSize, (int64_t) C10_WARP_SIZE)*(int64_t) C10_WARP_SIZE, (int64_t) 1024)); \
+    dim3 block(std::min(at::cuda::ATenCeilDiv(sliceSize, (int64_t) warpSize)*(int64_t) warpSize, (int64_t) 1024)); \
                                                                           \
     /* This is used as a template parameter to calculate indices. */      \
     /* We only specialize it if all collapsed dim sizes are the */        \

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -37,7 +37,7 @@ __global__ void RowwiseMomentsCUDAKernel(
 
   __shared__
       typename std::aligned_storage<sizeof(WelfordType), alignof(WelfordType)>::
-          type val_shared[C10_WARP_SIZE];
+          type val_shared[warpSize];
   WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
 
   const int64_t i = blockIdx.x;
@@ -95,8 +95,8 @@ __global__ void ComputeInternalGradientsCUDAKernel(
     acc_type<T, true>* ds,
     acc_type<T, true>* db) {
   using T_ACC = acc_type<T, true>;
-  __shared__ T_ACC ds_shared[C10_WARP_SIZE];
-  __shared__ T_ACC db_shared[C10_WARP_SIZE];
+  __shared__ T_ACC ds_shared[warpSize];
+  __shared__ T_ACC db_shared[warpSize];
   const int64_t i = blockIdx.x;
   T_ACC sum1 = 0;
   T_ACC sum2 = 0;

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -2,7 +2,6 @@
 
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
-#include <c10/macros/Macros.h>
 
 namespace at { namespace native {
 
@@ -297,7 +296,7 @@ __global__ void indexSparseIntersectionKernel(
 // }
 
 template <typename Dtype, typename Acctype>
-C10_LAUNCH_BOUNDS_1(C10_WARP_SIZE*4)
+C10_LAUNCH_BOUNDS_1(warpSize*4)
 __global__ void coalesceValuesKernel(
   int64_t *segment_offsets, int64_t *value_indices,
   Dtype *values, Dtype *newValues,
@@ -325,7 +324,7 @@ __global__ void coalesceValuesKernel(
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++)
       {
-        int featureDim = startFeature + ii * C10_WARP_SIZE;
+        int featureDim = startFeature + ii * warpSize;
         if (featureDim < stride)
         {
           tmp[ii] += static_cast<Acctype>(values[valueRow + featureDim]);
@@ -335,7 +334,7 @@ __global__ void coalesceValuesKernel(
     #pragma unroll
     for (int ii = 0; ii < SZ; ii++)
     {
-      int featureDim = startFeature + ii * C10_WARP_SIZE;
+      int featureDim = startFeature + ii * warpSize;
       if (featureDim < stride)
       {
         newValues[newValueRow + featureDim] = static_cast<Dtype>(tmp[ii]);

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -6,7 +6,6 @@
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/NativeFunctions.h>
 #include <ATen/SparseTensorUtils.h>
-#include <c10/macros/Macros.h>
 #include <c10/util/accumulate.h>
 #include <THC/THCThrustAllocator.cuh>
 
@@ -22,7 +21,6 @@
 #include <thrust/unique.h>
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/binary_search.h>
-#include <c10/macros/Macros.h>
 
 namespace at { namespace native {
 
@@ -130,8 +128,8 @@ SparseTensor _coalesce_sparse_cuda(const SparseTensor& self) {
     const int SZ = 4;
     values = values.contiguous();
     int64_t stride = c10::multiply_integers(values.sizes().slice(1));
-    dim3 grid(THCCeilDiv(newNnz, (int64_t) SZ), THCCeilDiv(stride, (int64_t) C10_WARP_SIZE*SZ));
-    dim3 block(C10_WARP_SIZE, SZ);
+    dim3 grid(THCCeilDiv(newNnz, (int64_t) SZ), THCCeilDiv(stride, (int64_t) warpSize*SZ));
+    dim3 block(warpSize, SZ);
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16, values.scalar_type(), "coalesce_sparse_cuda", [&] {
         using cuda_accscalar_t = acc_type<scalar_t, /* is_cuda */ true>;

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -301,12 +301,6 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #define C10_HIP_HOST_DEVICE
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
-#define C10_WARP_SIZE 64
-#else
-#define C10_WARP_SIZE 32
-#endif
-
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 #define __func__ __FUNCTION__
 #endif


### PR DESCRIPTION
`warpSize` and `C10_WARP_SIZE` were inconsistently used within ATen.  Since `warpSize` is defined by both CUDA and ROCm builds, use `warpSize` instead of hard-coded `C10_WARP_SIZE` to pick up any future changes to `warpSize` that would be platform or arch specific.