### PR TITLE
[ROCm] define C10_WARP_SIZE to warpSize HIP constant

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -302,7 +302,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #endif
 
 #ifdef __HIP_PLATFORM_HCC__
-#define C10_WARP_SIZE warpSize  // = 64 or 32 (Defined in hip_runtime.h)
+#define C10_WARP_SIZE warpSize // = 64 or 32 (Defined in hip_runtime.h)
 #else
 #define C10_WARP_SIZE 32
 #endif

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -302,7 +302,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #endif
 
 #ifdef __HIP_PLATFORM_HCC__
-#define C10_WARP_SIZE 64
+#define C10_WARP_SIZE warpSize  // = 64 or 32 (Defined in hip_runtime.h)
 #else
 #define C10_WARP_SIZE 32
 #endif


### PR DESCRIPTION
warpSize is defined as a constexpr in HIP headers.  It is incorrect to assume warpSize 64.  This change fixes the C10_WARP_SIZE definition in torch sources similar to [how it was done in caffe2](https://github.com/pytorch/pytorch/blob/master/caffe2/utils/GpuDefs.cuh#L10-L14).

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport