### PR TITLE
Use RDS for build size tracking

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -74,6 +74,23 @@ jobs:
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout_pytorch("false") }}
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -164,6 +181,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -173,7 +191,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -74,23 +74,6 @@ jobs:
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout_pytorch("false") }}
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -174,11 +174,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -223,6 +223,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-          pip3 install requests==2.26
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -223,6 +240,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +250,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -233,11 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -92,23 +92,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -92,6 +92,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -223,6 +223,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-          pip3 install requests==2.26
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-paralleltbb-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-paralleltbb-linux-xenial-py3.6-gcc5.4.yml
@@ -223,6 +223,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-          pip3 install requests==2.26
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -231,11 +231,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -90,6 +90,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -221,6 +238,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -230,7 +248,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -90,23 +90,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -231,11 +231,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-<<<<<<< HEAD
-          pip3 install requests==2.26
-=======
-          pip3 install requests boto3==1.16.34
->>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -90,6 +90,23 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
+      - name: CHECK THE STUFF
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
+          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install -r requirements.txt
+          pip3 install requests boto3==1.16.34
+          python3 tools/stats/scribe.py
+          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |
@@ -221,6 +238,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -230,7 +248,11 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+<<<<<<< HEAD
           pip3 install requests==2.26
+=======
+          pip3 install requests boto3==1.16.34
+>>>>>>> 2853327bbe8 ([wip] Check RDS proxy)
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -90,23 +90,6 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: false
-      - name: CHECK THE STUFF
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          IS_GHA: 1
-          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
-          CIRCLE_TAG: ${{ steps.parse-ref.outputs.tag }}
-          CIRCLE_WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
-        run: |
-          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-          export COMMIT_TIME
-          pip3 install -r requirements.txt
-          pip3 install requests boto3==1.16.34
-          python3 tools/stats/scribe.py
-          exit 1
       - name: Calculate docker image tag
         id: calculate-tag
         run: |

--- a/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
@@ -223,6 +223,7 @@ jobs:
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
+          IS_GHA: 1
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -232,7 +233,7 @@ jobs:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
-          pip3 install requests==2.26
+          pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
       - name: Chown workspace
         run: |

--- a/tools/stats/scribe.py
+++ b/tools/stats/scribe.py
@@ -76,7 +76,7 @@ def register_rds_schema(table_name: str, schema: Dict[str, str]) -> None:
     }
 
     event = [
-        {"create_table": {"table_name": table_name, "fields": {**schema, **base},}}
+        {"create_table": {"table_name": table_name, "fields": {**schema, **base}}}
     ]
 
     invoke_rds(event)
@@ -114,7 +114,7 @@ def rds_saved_query(query_names: Union[str, List[str]]) -> Any:
 
     events = []
     for name in query_names:
-        events.append({"read": {"saved_query_name": name,}})
+        events.append({"read": {"saved_query_name": name}})
 
     return invoke_rds(events)
 
@@ -137,7 +137,7 @@ def rds_write(
     events = []
     for values in values_list:
         events.append(
-            {"write": {"table_name": table_name, "values": {**values, **base},}}
+            {"write": {"table_name": table_name, "values": {**values, **base}}}
         )
 
     print("Wrote stats for", table_name)

--- a/tools/stats/scribe.py
+++ b/tools/stats/scribe.py
@@ -8,7 +8,7 @@ from typing import Dict, Any, List, Union
 _lambda_client = None
 
 
-def sprint(*args):
+def sprint(*args: Any) -> None:
     print("[scribe]", *args)
 
 
@@ -76,12 +76,7 @@ def register_rds_schema(table_name: str, schema: Dict[str, str]) -> None:
     }
 
     event = [
-        {
-            "create_table": {
-                "table_name": table_name,
-                "fields": {**schema, **base},
-            }
-        }
+        {"create_table": {"table_name": table_name, "fields": {**schema, **base},}}
     ]
 
     invoke_rds(event)
@@ -119,13 +114,7 @@ def rds_saved_query(query_names: Union[str, List[str]]) -> Any:
 
     events = []
     for name in query_names:
-        events.append(
-            {
-                "read": {
-                    "saved_query_name": name,
-                }
-            }
-        )
+        events.append({"read": {"saved_query_name": name,}})
 
     return invoke_rds(events)
 
@@ -148,19 +137,8 @@ def rds_write(
     events = []
     for values in values_list:
         events.append(
-            {
-                "write": {
-                    "table_name": table_name,
-                    "values": {**values, **base},
-                }
-            }
+            {"write": {"table_name": table_name, "values": {**values, **base},}}
         )
 
     print("Wrote stats for", table_name)
     invoke_rds(events)
-
-
-if __name__ == "__main__":
-    # Test read
-    print(rds_saved_query(["sample"]))
-    print(rds_query([{"table_name": "workflow_run", "fields": ["name"], "limit": 10}]))

--- a/tools/stats/scribe.py
+++ b/tools/stats/scribe.py
@@ -25,7 +25,7 @@ def aws_lambda() -> Any:
 
 def invoke_lambda(name: str, payload: Any) -> Any:
     res = aws_lambda().invoke(
-        FunctionName="gh-ci-scribe-proxy", Payload=json.dumps(payload).encode()
+        FunctionName=name, Payload=json.dumps(payload).encode()
     )
     payload = str(res["Payload"].read().decode())
     if res.get("FunctionError"):

--- a/tools/stats/scribe.py
+++ b/tools/stats/scribe.py
@@ -8,6 +8,10 @@ from typing import Dict, Any, List, Union
 _lambda_client = None
 
 
+def sprint(*args):
+    print("[scribe]", *args)
+
+
 def aws_lambda() -> Any:
     global _lambda_client
     # lazy import so that we don't need to introduce extra dependencies
@@ -17,6 +21,16 @@ def aws_lambda() -> Any:
         _lambda_client = boto3.client("lambda")
 
     return _lambda_client
+
+
+def invoke_lambda(name: str, payload: Any) -> Any:
+    res = aws_lambda().invoke(
+        FunctionName="gh-ci-scribe-proxy", Payload=json.dumps(payload).encode()
+    )
+    payload = str(res["Payload"].read().decode())
+    if res.get("FunctionError"):
+        raise Exception(payload)
+    return payload
 
 
 def send_to_scribe(logs: str) -> str:
@@ -31,23 +45,16 @@ def send_to_scribe(logs: str) -> str:
 
 
 def _send_to_scribe_via_boto3(logs: str) -> str:
-
-    print("Scribe access token not provided, sending report via boto3...")
+    sprint("Scribe access token not provided, sending report via boto3...")
     event = {"base64_bz2_logs": base64.b64encode(bz2.compress(logs.encode())).decode()}
-    res = aws_lambda().invoke(
-        FunctionName="gh-ci-scribe-proxy", Payload=json.dumps(event).encode()
-    )
-    payload = str(res["Payload"].read().decode())
-    if res.get("FunctionError"):
-        raise Exception(payload)
-    return payload
+    return str(invoke_lambda("gh-ci-scribe-proxy", event))
 
 
 def _send_to_scribe_via_http(access_token: str, logs: str) -> str:
     # lazy import so that we don't need to introduce extra dependencies
     import requests  # type: ignore[import]
 
-    print("Scribe access token provided, sending report via http...")
+    sprint("Scribe access token provided, sending report via http...")
     r = requests.post(
         "https://graph.facebook.com/scribe_logs",
         data={"access_token": access_token, "logs": logs},
@@ -56,18 +63,11 @@ def _send_to_scribe_via_http(access_token: str, logs: str) -> str:
     return str(r.text)
 
 
-def _rds_invoke(events: List[Dict[str, Any]]) -> Any:
-    res = aws_lambda().invoke(
-        FunctionName="rds-proxy", Payload=json.dumps(events).encode()
-    )
-    payload = str(res["Payload"].read().decode())
-    if res.get("FunctionError"):
-        raise Exception(payload)
-
-    return json.loads(payload)
+def invoke_rds(events: List[Dict[str, Any]]) -> Any:
+    return invoke_lambda("rds-proxy", events)
 
 
-def register_rds_table(table_name: str, schema: Dict[str, str]) -> None:
+def register_rds_schema(table_name: str, schema: Dict[str, str]) -> None:
     base = {
         "pr": "string",
         "ref": "string",
@@ -84,7 +84,7 @@ def register_rds_table(table_name: str, schema: Dict[str, str]) -> None:
         }
     ]
 
-    _rds_invoke(event)
+    invoke_rds(event)
 
 
 def schema_from_sample(data: Dict[str, Any]) -> Dict[str, str]:
@@ -110,7 +110,7 @@ def rds_query(queries: Union[Query, List[Query]]) -> Any:
     for query in queries:
         events.append({"read": {**query}})
 
-    return _rds_invoke(events)
+    return invoke_rds(events)
 
 
 def rds_saved_query(query_names: Union[str, List[str]]) -> Any:
@@ -127,15 +127,22 @@ def rds_saved_query(query_names: Union[str, List[str]]) -> Any:
             }
         )
 
-    return _rds_invoke(events)
+    return invoke_rds(events)
 
 
-def rds_write(table_name: str, values_list: List[Dict[str, Any]]) -> None:
+def rds_write(
+    table_name: str, values_list: List[Dict[str, Any]], only_on_master: bool = True
+) -> None:
+    sprint("Writing for ", os.getenv("CIRCLE_PR_NUMBER"))
+    if not only_on_master and os.getenv("CIRCLE_PR_NUMBER"):
+        sprint("Skipping RDS write on PR")
+        return
+
     base = {
-        "pr": os.environ.get("CIRCLE_PR_NUMBER"),
-        "ref": os.environ.get("CIRCLE_SHA1"),
-        "branch": os.environ.get("CIRCLE_BRANCH"),
-        "workflow_id": os.environ.get("CIRCLE_WORKFLOW_ID"),
+        "pr": os.getenv("CIRCLE_PR_NUMBER"),
+        "ref": os.getenv("CIRCLE_SHA1"),
+        "branch": os.getenv("CIRCLE_BRANCH"),
+        "workflow_id": os.getenv("CIRCLE_WORKFLOW_ID"),
     }
 
     events = []
@@ -149,7 +156,8 @@ def rds_write(table_name: str, values_list: List[Dict[str, Any]]) -> None:
             }
         )
 
-    _rds_invoke(events)
+    print("Wrote stats for", table_name)
+    invoke_rds(events)
 
 
 if __name__ == "__main__":

--- a/tools/stats/scribe.py
+++ b/tools/stats/scribe.py
@@ -2,6 +2,21 @@ import base64
 import bz2
 import os
 import json
+from typing import Dict, Any, List, Union
+
+
+_lambda_client = None
+
+
+def aws_lambda() -> Any:
+    global _lambda_client
+    # lazy import so that we don't need to introduce extra dependencies
+    import boto3  # type: ignore[import]
+
+    if _lambda_client is None:
+        _lambda_client = boto3.client("lambda")
+
+    return _lambda_client
 
 
 def send_to_scribe(logs: str) -> str:
@@ -16,15 +31,14 @@ def send_to_scribe(logs: str) -> str:
 
 
 def _send_to_scribe_via_boto3(logs: str) -> str:
-    # lazy import so that we don't need to introduce extra dependencies
-    import boto3  # type: ignore[import]
 
     print("Scribe access token not provided, sending report via boto3...")
     event = {"base64_bz2_logs": base64.b64encode(bz2.compress(logs.encode())).decode()}
-    client = boto3.client("lambda")
-    res = client.invoke(FunctionName='gh-ci-scribe-proxy', Payload=json.dumps(event).encode())
-    payload = str(res['Payload'].read().decode())
-    if res.get('FunctionError'):
+    res = aws_lambda().invoke(
+        FunctionName="gh-ci-scribe-proxy", Payload=json.dumps(event).encode()
+    )
+    payload = str(res["Payload"].read().decode())
+    if res.get("FunctionError"):
         raise Exception(payload)
     return payload
 
@@ -40,3 +54,105 @@ def _send_to_scribe_via_http(access_token: str, logs: str) -> str:
     )
     r.raise_for_status()
     return str(r.text)
+
+
+def _rds_invoke(events: List[Dict[str, Any]]) -> Any:
+    res = aws_lambda().invoke(
+        FunctionName="rds-proxy", Payload=json.dumps(events).encode()
+    )
+    payload = str(res["Payload"].read().decode())
+    if res.get("FunctionError"):
+        raise Exception(payload)
+
+    return json.loads(payload)
+
+
+def register_rds_table(table_name: str, schema: Dict[str, str]) -> None:
+    base = {
+        "pr": "string",
+        "ref": "string",
+        "branch": "string",
+        "workflow_id": "string",
+    }
+
+    event = [
+        {
+            "create_table": {
+                "table_name": table_name,
+                "fields": {**schema, **base},
+            }
+        }
+    ]
+
+    _rds_invoke(event)
+
+
+def schema_from_sample(data: Dict[str, Any]) -> Dict[str, str]:
+    schema = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            schema[key] = "string"
+        elif isinstance(value, int):
+            schema[key] = "int"
+        else:
+            raise RuntimeError(f"Unsupported value type: {key}: {value}")
+    return schema
+
+
+Query = Dict[str, Any]
+
+
+def rds_query(queries: Union[Query, List[Query]]) -> Any:
+    if not isinstance(queries, list):
+        queries = [queries]
+
+    events = []
+    for query in queries:
+        events.append({"read": {**query}})
+
+    return _rds_invoke(events)
+
+
+def rds_saved_query(query_names: Union[str, List[str]]) -> Any:
+    if not isinstance(query_names, list):
+        query_names = [query_names]
+
+    events = []
+    for name in query_names:
+        events.append(
+            {
+                "read": {
+                    "saved_query_name": name,
+                }
+            }
+        )
+
+    return _rds_invoke(events)
+
+
+def rds_write(table_name: str, values_list: List[Dict[str, Any]]) -> None:
+    base = {
+        "pr": os.environ.get("CIRCLE_PR_NUMBER"),
+        "ref": os.environ.get("CIRCLE_SHA1"),
+        "branch": os.environ.get("CIRCLE_BRANCH"),
+        "workflow_id": os.environ.get("CIRCLE_WORKFLOW_ID"),
+    }
+
+    events = []
+    for values in values_list:
+        events.append(
+            {
+                "write": {
+                    "table_name": table_name,
+                    "values": {**values, **base},
+                }
+            }
+        )
+
+    _rds_invoke(events)
+
+
+if __name__ == "__main__":
+    # Test read
+    print(rds_saved_query(["sample"]))
+    print(rds_query([{"table_name": "workflow_run", "fields": ["name"], "limit": 10}]))

--- a/tools/stats/upload_binary_size_to_scuba.py
+++ b/tools/stats/upload_binary_size_to_scuba.py
@@ -147,15 +147,16 @@ if __name__ == "__main__":
     if len(sys.argv) == 2:
         file_dir = sys.argv[1]
 
-    sample_lib = {
-        "library": "abcd",
-        "size": 1234,
-    }
-    sample_data = {
-        **base_data(),
-        **sample_lib,
-    }
-    register_rds_schema("binary_size", schema_from_sample(sample_data))
+    if os.getenv("IS_GHA", "0") == "1":
+        sample_lib = {
+            "library": "abcd",
+            "size": 1234,
+        }
+        sample_data = {
+            **base_data(),
+            **sample_lib,
+        }
+        register_rds_schema("binary_size", schema_from_sample(sample_data))
 
     if "-android" in os.environ.get("BUILD_ENVIRONMENT", ""):
         report_android_sizes(file_dir)

--- a/tools/stats/upload_binary_size_to_scuba.py
+++ b/tools/stats/upload_binary_size_to_scuba.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Generator, List
 from tools.stats.scribe import (
     send_to_scribe,
     rds_write,
-    register_rds_table,
+    register_rds_schema,
     schema_from_sample,
 )
 
@@ -155,7 +155,7 @@ if __name__ == "__main__":
         **base_data(),
         **sample_lib,
     }
-    register_rds_table("binary_size", schema_from_sample(sample_data))
+    register_rds_schema("binary_size", schema_from_sample(sample_data))
 
     if "-android" in os.environ.get("BUILD_ENVIRONMENT", ""):
         report_android_sizes(file_dir)


### PR DESCRIPTION
This adds 2 utilities: `register_rds_table` and `rds_write`. `register_rds_table` needs to be called once with the schema for the data that `rds_write` will write. These go to a lambda called `rds-proxy`, which will write to/read from the DB as necessary. This data can then be arbitrarily queried via `rds-proxy` (for use in CI) or on metrics.pytorch.org (for analysis).

It also hooks these up for build size tracking (which previously was not working on GHA)