### PR TITLE
add acc_ops.max, acc_ops.maximum, consolidate acc_ops.min and acc_ops.minimum

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -355,52 +355,6 @@ def matmul(*, input, other):
     return torch.matmul(**locals())
 
 
-@register_custom_acc_mapper_fn(
-    op_and_target=("call_function", torch.min),
-    arg_replacement_tuples=[
-        ("input", "input"),
-        ("other", "other", this_arg_is_optional),
-        ("dim", "dim", this_arg_is_optional),
-        ("keepdim", "keepdim", this_arg_is_optional),
-    ],
-)
-def custom_torch_min_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
-    """
-    Add custom mapping for torch.min because torch.min has three input types, where each yields a different output type:
-        1. torch.min(input); Output: tensor wih the minimum number
-        2. torch.min(input, other); Output: tensor with coordinate-wise min value
-        3[Not Supported] torch.min(input, dim, keepdim); Output:(min_values，and min_indices)
-    """
-    with node.graph.inserting_before(node):
-        # If dim is in kwargs, assert "Not Supported"
-        assert "dim" not in node.kwargs, "Currently not support dim in torch.min"
-
-        if "other" in node.kwargs and node.kwargs["other"] is not None:
-            # If kwargs[other] is a valid tensor, call min_two_tensors_input,
-            op_func = min_two_tensors_input
-        else:
-            # Otherwise, call min_single_tensor_input
-            op_func = min_single_tensor_input
-
-        new_node = node.graph.create_node(
-            "call_function",
-            op_func,
-            kwargs=node.kwargs,
-            name=node.name,
-        )
-        new_node.meta = node.meta
-        return new_node
-
-
-@register_acc_op
-def min_single_tensor_input(*, input):
-    return torch.min(input)
-
-
-@register_acc_op
-def min_two_tensors_input(*, input, other):
-    return torch.min(input, other)
-
 
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.ops.quantized.add),
@@ -571,6 +525,112 @@ def sum(*, input, dim=None, keepdim=False, dtype=None):
         return torch.sum(**locals())
     else:
         return input.sum(dtype=dtype)
+
+
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "max"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.max),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "min"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.min),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+def add_maximum_minimum_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    # there are effectively three versions of torch.max / torch.min
+    # full reduce: torch.max(input) -> Tensor
+    # dimensional reduce: torch.max(input, dim, keepdim=False, *, out=None) -> (Tensor, LongTensor)
+    # elementwise: torch.max(input, other, *, out=None) -> Tensor
+
+    # the mapper function is remapping for both min and max situations
+    # this helper function makes the choices available clearer and provides an easier way
+    # to lookup the right function
+    def target_map(op, target):
+        if (op, target) in (("call_method", "max"), ("call_function", torch.max)):
+            return dict(full_reduce=max_full_reduce,
+                        dim_reduce=max_dim_reduce,
+                        elementwise=maximum)
+        elif (op, target) in (("call_method", "min"), ("call_function", torch.min)):
+            return dict(full_reduce=min_full_reduce,
+                        dim_reduce=min_dim_reduce,
+                        elementwise=minimum)
+
+    with node.graph.inserting_before(node):
+        new_targets = target_map(node.op, node.target)
+        max_kwargs = dict()
+        max_kwargs['input'] = node.kwargs['input']
+        if ("dim_or_other" not in node.kwargs) or (node.kwargs['dim_or_other'] is None):
+            nt = new_targets["full_reduce"]
+            max_node = node.graph.call_function(nt, kwargs=max_kwargs)
+        elif isinstance(node.kwargs['dim_or_other'], int):
+            nt = new_targets["dim_reduce"]
+            dim = node.kwargs["dim_or_other"]
+            max_kwargs['dim'] = dim
+            max_kwargs['keepdim'] = node.kwargs.get('keepdim', False)
+            max_node = node.graph.call_function(nt, kwargs=max_kwargs)
+        else:
+            other = node.kwargs["dim_or_other"]
+            assert isinstance(other, torch.fx.Node)
+            # Lowering path for when provided "other", where we do elem-wise max
+            nt = new_targets["elementwise"]
+            max_kwargs['other'] = other
+            max_node = node.graph.call_function(nt, kwargs=max_kwargs)
+        max_node.meta = node.meta.copy()
+        return max_node
+
+
+@register_acc_op
+def max_full_reduce(*, input):
+    return torch.max(**locals())
+
+@register_acc_op
+def max_dim_reduce(*, input, dim=None, keepdim=False):
+    return torch.max(**locals())
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.maximum))
+@register_acc_op_mapping(op_and_target=("call_method", "maximum"))
+@register_acc_op
+def maximum(*, input, other):
+    return torch.maximum(**locals())
+
+@register_acc_op
+def min_full_reduce(*, input):
+    return torch.min(input)
+
+@register_acc_op
+def min_dim_reduce(*, input, dim=None, keepdim=False):
+    return torch.min(input, dim=dim, keepdim=keepdim)
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.minimum))
+@register_acc_op_mapping(op_and_target=("call_method", "minimum"))
+@register_acc_op
+def minimum(*, input, other):
+    return torch.minimum(**locals())
 
 
 @register_acc_op_mapping(op_and_target=("call_function", torch.sigmoid))


### PR DESCRIPTION
Summary:
This diff adds acc_ops.max and acc_ops.maximum support.
It further consolidates the logic for acc_ops.min and acc_ops.minimum to match the logic for max.

torch.max has three behaviors:
```1. max(input)
2. max(input, dim, keepdim=False, *, out=None)
3. max(input, other, *, out=None)
```

Likewise, torch.min has three identical behaviors.

I've chosen to implement each as an acc_op, then map to the appropriate one.

the third max function is effectively torch.maximum, so I've implemented it as that.

Reviewed By: yinghai, jfix71

Differential Revision: D30551464

