### PR TITLE
Fix missing import in torch.optim.swa_utils

### DIFF
--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -3,6 +3,7 @@ import math
 from torch.nn import Module
 from copy import deepcopy
 from torch.optim.lr_scheduler import _LRScheduler
+import warnings
 
 
 class AveragedModel(Module):


### PR DESCRIPTION
Missing `import warnings`.