### PR TITLE
Use `detach` after `clone` when deepcopying IValue Tensors

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -799,7 +799,7 @@ IValue IValue::deepcopy(
   IValue copy;
   switch(tag) {
     case IValue::Tag::Tensor:
-      copy = IValue(toTensor().clone());
+      copy = IValue(toTensor().clone().detach());
       break;
     case IValue::Tag::Tuple: {
       std::vector<IValue> copied_tuple;

--- a/test/jit/test_copy.py
+++ b/test/jit/test_copy.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import copy
+
+import torch
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestCopy(JitTestCase):
+    """
+    Tests for copying behavior of TorchScript modules
+    """
+    def test_copy_parameter(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.linear_relu_stack = torch.nn.Linear(2, 4)
+
+            def forward(self, x):
+                return x
+
+        m = torch.jit.script(Model())
+        copied_m = copy.deepcopy(m)
+
+        for (p, copied_p) in zip(m.parameters(), copied_m.parameters()):
+            self.assertEqual(p.is_leaf, copied_p.is_leaf)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -62,6 +62,7 @@ from jit.test_parametrization import TestParametrization  # noqa: F401
 from jit.test_attr import TestGetDefaultAttr  # noqa: F401
 from jit.test_aten_pow import TestAtenPow  # noqa: F401
 from jit.test_optimize_for_mobile_preserve_debug_info import TestOptimizeForMobilePreserveDebugInfo  # noqa: F401
+from jit.test_copy import TestCopy  # noqa: F401
 
 # Torch
 from torch import Tensor


### PR DESCRIPTION
Previously `torch.clone` is used to copy IValue Tensors, this has the
unintended effect of creating a gradient link between old and new
tensors. This is not desired effect for deepcopy. Using `detach` after
 `clone` would avoid this problem.

