### PR TITLE
Support bool input tensors for argmax and other functions

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -381,7 +381,7 @@ static void max_values_kernel_impl(TensorIterator& iter) {
 }
 
 static void argmax_kernel_impl(TensorIterator &iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(1), "argmax_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, iter.dtype(1), "argmax_cpu", [&] {
     binary_kernel_reduce(
       iter,
       ArgMaxOps<scalar_t>{},
@@ -390,7 +390,7 @@ static void argmax_kernel_impl(TensorIterator &iter) {
 }
 
 static void argmin_kernel_impl(TensorIterator &iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(1), "argmin_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, iter.dtype(1), "argmin_cpu", [&] {
     binary_kernel_reduce(
       iter,
       ArgMinOps<scalar_t>{},

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -168,12 +168,7 @@ static void topk_kernel(
         return topk_impl_loop<scalar_t, float>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
             k, sizes[dim], largest, sorted, data, strides, n);
-      } else if (self.scalar_type() == ScalarType::Bool) {
-        return topk_impl_loop<scalar_t, bool>(
-            mode_values_stride, mode_indices_stride, tmp_values_stride,
-            k, sizes[dim], largest, sorted, data, strides, n);
-      }
-        else {
+      } else {
         return topk_impl_loop<scalar_t, scalar_t>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
             k, sizes[dim], largest, sorted, data, strides, n);

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -162,13 +162,18 @@ static void topk_kernel(
   auto mode_indices_stride = indices.strides()[dim];
   auto tmp_values_stride = self.strides()[dim];
 
-  AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "topk_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(ScalarType::BFloat16, ScalarType::Bool, self.scalar_type(), "topk_cpu", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
       if (self.scalar_type() == ScalarType::BFloat16) {
         return topk_impl_loop<scalar_t, float>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
             k, sizes[dim], largest, sorted, data, strides, n);
-      } else {
+      } else if (self.scalar_type() == ScalarType::Bool) {
+        return topk_impl_loop<scalar_t, bool>(
+            mode_values_stride, mode_indices_stride, tmp_values_stride,
+            k, sizes[dim], largest, sorted, data, strides, n);
+      }
+        else {
         return topk_impl_loop<scalar_t, scalar_t>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
             k, sizes[dim], largest, sorted, data, strides, n);

--- a/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
@@ -76,6 +76,8 @@ void argmax_kernel_cuda(TensorIterator& iter) {
     argmax_kernel_cuda_impl<at::Half, float>(iter);
   } else if (iter.dtype(1) == kBFloat16) {
     argmax_kernel_cuda_impl<at::BFloat16, float>(iter);
+  } else if (iter.dtype(1) == kBool) {
+    argmax_kernel_cuda_impl<at::kBool, float>(iter);
   } else {
     AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmax_cuda", [&]() {
       argmax_kernel_cuda_impl<scalar_t>(iter);
@@ -90,6 +92,8 @@ void argmin_kernel_cuda(TensorIterator& iter) {
     argmin_kernel_cuda_impl<at::Half, float>(iter);
   } else if (iter.dtype(1) == kBFloat16) {
     argmin_kernel_cuda_impl<at::BFloat16, float>(iter);
+  } else if (iter.dtype(1) == kBool) {
+    argmin_kernel_cuda_impl<at::kBool, float>(iter);
   } else {
     AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmin_cuda", [&]() {
       argmin_kernel_cuda_impl<scalar_t>(iter);

--- a/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
@@ -76,10 +76,8 @@ void argmax_kernel_cuda(TensorIterator& iter) {
     argmax_kernel_cuda_impl<at::Half, float>(iter);
   } else if (iter.dtype(1) == kBFloat16) {
     argmax_kernel_cuda_impl<at::BFloat16, float>(iter);
-  } else if (iter.dtype(1) == kBool) {
-    argmax_kernel_cuda_impl<at::kBool, float>(iter);
   } else {
-    AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmax_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kBool, iter.dtype(1), "argmax_cuda", [&]() {
       argmax_kernel_cuda_impl<scalar_t>(iter);
     });
   }
@@ -92,10 +90,8 @@ void argmin_kernel_cuda(TensorIterator& iter) {
     argmin_kernel_cuda_impl<at::Half, float>(iter);
   } else if (iter.dtype(1) == kBFloat16) {
     argmin_kernel_cuda_impl<at::BFloat16, float>(iter);
-  } else if (iter.dtype(1) == kBool) {
-    argmin_kernel_cuda_impl<at::kBool, float>(iter);
   } else {
-    AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmin_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kBool, iter.dtype(1), "argmin_cuda", [&]() {
       argmin_kernel_cuda_impl<scalar_t>(iter);
     });
   }

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -307,9 +307,6 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
     "The dimension being sorted can not have more than INT_MAX elements.");
 
   const auto self_dtype = self.dtype();
-  // FIXME: remove this check once cub sort supports bool
-  TORCH_CHECK(self_dtype != ScalarType::Bool,
-    "Sort currently does not support bool dtype on CUDA.");
   TORCH_CHECK(self_dtype != ScalarType::ComplexFloat && self_dtype != ScalarType::ComplexDouble,
     "Sort currently does not support complex dtypes on CUDA.");
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -208,7 +208,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
   }
 
 #define RUN_T(INDEX_T)                                                  \
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "topk_out_cuda", [&] { \
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::BFloat16, at::ScalarType::Bool, input.scalar_type(), "topk_out_cuda", [&] { \
     at::cuda::detail::TensorInfo<scalar_t, INDEX_T> inputInfo =           \
       at::cuda::detail::getTensorInfo<scalar_t, INDEX_T>(input);          \
     at::cuda::detail::TensorInfo<scalar_t, INDEX_T> topKInfo =            \

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1504,7 +1504,7 @@ class TestReductions(TestCase):
             np_fn = partial(np.nansum, dtype=np_out_dtype)
             self.compare_with_numpy(torch_fn, np_fn, x, device=None, dtype=None)
 
-    @dtypes(*(get_all_int_dtypes() + get_all_fp_dtypes(include_bfloat16=False)))
+    @dtypes(*(torch.testing.get_all_dtypes(include_bfloat16=False, include_complex=False)))
     def test_argminmax_multiple(self, device, dtype):
         # Case: All Ones
         t = torch.ones(3, 3, device=device, dtype=dtype)
@@ -1525,7 +1525,7 @@ class TestReductions(TestCase):
                     # Generate Input.
                     x = _generate_input(shape, dtype, device, with_extremal)
 
-                    if dtype == torch.half:
+                    if dtype == torch.half or dtype == torch.bool:
                         max_val = torch.max(x.to(torch.float))
                         min_val = torch.min(x.to(torch.float))
                     else:
@@ -1818,7 +1818,7 @@ class TestReductions(TestCase):
         with self.assertRaisesRegex(RuntimeError, rmsg):
             torch.min(x, dim=0, out=(illegal_values, illegal_indices))
 
-    @dtypes(*get_all_dtypes(include_bool=False, include_complex=False))
+    @dtypes(*torch.testing.get_all_dtypes(include_complex=False))
     def test_dim_arg_reduction_scalar(self, device, dtype):
         example = 4.0
 

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -130,12 +130,7 @@ class TestSortAndSelect(TestCase):
             self.assertIsOrdered('descending', x, res2val, res2ind,
                                  'random with NaNs')
 
-<<<<<<< HEAD
-    # FIXME: remove torch.bool from unsupported types once support is added for cub sort
-    @dtypes(*set(get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
-=======
     @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.complex64, torch.complex128})
->>>>>>> 351ebc3fa1 (Lift restriction of bool inputs in cuda)
     def test_stable_sort(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return
@@ -229,12 +224,7 @@ class TestSortAndSelect(TestCase):
             self.assertEqual(indices, indices_cont)
             self.assertEqual(values, values_cont)
 
-<<<<<<< HEAD
-    # FIXME: remove torch.bool from unsupported types once support is added for cub sort
-    @dtypes(*set(get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
-=======
     @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.complex64, torch.complex128})
->>>>>>> 351ebc3fa1 (Lift restriction of bool inputs in cuda)
     def test_stable_sort_against_numpy(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return
@@ -299,7 +289,7 @@ class TestSortAndSelect(TestCase):
             idx_numpy = np.argsort(sample_numpy, axis=dim, kind='stable')
             self.assertEqual(idx_torch, idx_numpy)
 
-    @dtypes(*(get_all_int_dtypes() + get_all_fp_dtypes()))
+    @dtypes(*(torch.testing.get_all_dtypes(include_complex=False)))
     def test_msort(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return
@@ -686,18 +676,10 @@ class TestSortAndSelect(TestCase):
         self.assertEqual(ind, expected_ind, atol=0, rtol=0)
 
     @onlyOnCPUAndCUDA
-<<<<<<< HEAD
-    @dtypesIfCUDA(*(get_all_dtypes(include_complex=False,
-                                   include_bool=False,
-                                   include_half=False,
-                                   include_bfloat16=True)))
-    @dtypes(*(get_all_dtypes(include_complex=False, include_bool=False, include_half=False, include_bfloat16=False)))
-=======
     @dtypesIfCUDA(*(torch.testing.get_all_dtypes(include_complex=False,
                                                  include_half=False,
                                                  include_bfloat16=True)))
     @dtypes(*(torch.testing.get_all_dtypes(include_complex=False, include_half=False, include_bfloat16=False)))
->>>>>>> 351ebc3fa1 (Lift restriction of bool inputs in cuda)
     def test_topk_zero(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -130,8 +130,12 @@ class TestSortAndSelect(TestCase):
             self.assertIsOrdered('descending', x, res2val, res2ind,
                                  'random with NaNs')
 
+<<<<<<< HEAD
     # FIXME: remove torch.bool from unsupported types once support is added for cub sort
     @dtypes(*set(get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
+=======
+    @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.complex64, torch.complex128})
+>>>>>>> 351ebc3fa1 (Lift restriction of bool inputs in cuda)
     def test_stable_sort(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return
@@ -225,8 +229,12 @@ class TestSortAndSelect(TestCase):
             self.assertEqual(indices, indices_cont)
             self.assertEqual(values, values_cont)
 
+<<<<<<< HEAD
     # FIXME: remove torch.bool from unsupported types once support is added for cub sort
     @dtypes(*set(get_all_dtypes()) - {torch.bool, torch.complex64, torch.complex128})
+=======
+    @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.complex64, torch.complex128})
+>>>>>>> 351ebc3fa1 (Lift restriction of bool inputs in cuda)
     def test_stable_sort_against_numpy(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return
@@ -608,10 +616,12 @@ class TestSortAndSelect(TestCase):
         self.assertEqual(top1, top2)
         self.assertEqual(idx1, idx2)
 
-    def _test_topk_dtype(self, device, dtype, integral, size):
+    def _test_topk_dtype(self, device, dtype, integral, boolean, size):
         if integral:
             a = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max,
                               size=(size,), dtype=dtype, device=device)
+        elif boolean:
+            a = torch.randn(size=(size,), device=device).to(dtype)
         else:
             a = torch.randn(size=(size,), dtype=dtype, device=device)
 
@@ -625,7 +635,7 @@ class TestSortAndSelect(TestCase):
         small = 10
         large = 4096
         for curr_size in (small, large):
-            self._test_topk_dtype(device, dtype, True, curr_size)
+            self._test_topk_dtype(device, dtype, True, False, curr_size)
 
     @onlyCUDA
     @dtypes(torch.bfloat16)
@@ -635,7 +645,15 @@ class TestSortAndSelect(TestCase):
         small = 10
         large = 8192
         for curr_size in (small, large):
-            self._test_topk_dtype(device, dtype, False, curr_size)
+            self._test_topk_dtype(device, dtype, False, False, curr_size)
+
+    @dtypes(torch.bool)
+    def test_topk_bool(self, device, dtype):
+
+        small = 10
+        large = 8192
+        for curr_size in (small, large):
+            self._test_topk_dtype(device, dtype, False, True, curr_size)
 
     @dtypesIfCUDA(*get_all_fp_dtypes())
     @dtypes(torch.float, torch.double, torch.bfloat16)
@@ -668,11 +686,18 @@ class TestSortAndSelect(TestCase):
         self.assertEqual(ind, expected_ind, atol=0, rtol=0)
 
     @onlyOnCPUAndCUDA
+<<<<<<< HEAD
     @dtypesIfCUDA(*(get_all_dtypes(include_complex=False,
                                    include_bool=False,
                                    include_half=False,
                                    include_bfloat16=True)))
     @dtypes(*(get_all_dtypes(include_complex=False, include_bool=False, include_half=False, include_bfloat16=False)))
+=======
+    @dtypesIfCUDA(*(torch.testing.get_all_dtypes(include_complex=False,
+                                                 include_half=False,
+                                                 include_bfloat16=True)))
+    @dtypes(*(torch.testing.get_all_dtypes(include_complex=False, include_half=False, include_bfloat16=False)))
+>>>>>>> 351ebc3fa1 (Lift restriction of bool inputs in cuda)
     def test_topk_zero(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -7,7 +7,7 @@ from itertools import permutations, product
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import (
-    all_types, all_types_and, floating_types_and, get_all_dtypes, get_all_int_dtypes, get_all_fp_dtypes,
+    all_types, all_types_and, floating_types_and, get_all_dtypes, get_all_fp_dtypes,
 )
 from torch.testing._internal.common_utils import \
     (TEST_WITH_ROCM, TestCase, run_tests, slowTest)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7927,8 +7927,8 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_nextafter),
     OpInfo('topk',
            dtypes=all_types(),
-           dtypesIfCPU=all_types_and(torch.bfloat16),
-           dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16),
+           dtypesIfCPU=all_types_and(torch.bfloat16, torch.bool),
+           dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16, torch.bool),
            sample_inputs_func=sample_inputs_topk,
            skips=(
                # Topk is not raising a warning when the out is resized
@@ -9750,7 +9750,7 @@ op_db: List[OpInfo] = [
         supports_multiple_dims=False,
         supports_autograd=False,
         result_dtype=torch.int64,
-        dtypes=all_types_and(torch.float16, torch.bfloat16),
+        dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
         ref=reference_reduction_numpy(np.argmax, supports_keepdims=False),
         skips=(
             # FIXME: keepdim parameter is ignored when dim=None
@@ -9763,7 +9763,7 @@ op_db: List[OpInfo] = [
         supports_multiple_dims=False,
         supports_autograd=False,
         result_dtype=torch.int64,
-        dtypes=all_types_and(torch.float16, torch.bfloat16),
+        dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
         ref=reference_reduction_numpy(np.argmin, supports_keepdims=False),
         skips=(
             # FIXME: keepdim parameter is ignored when dim=None

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9120,8 +9120,8 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_unfold),
     OpInfo('msort',
            dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16),
-           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
-           dtypesIfROCM=all_types_and(torch.float16),
+           dtypesIfCUDA=all_types_and(torch.bool, torch.float16, torch.bfloat16),
+           dtypesIfROCM=all_types_and(torch.bool, torch.float16),
            check_batched_gradgrad=False,
            skips=(
                #  msort does not correctly warn when resizing out= inputs.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9016,8 +9016,7 @@ op_db: List[OpInfo] = [
            )),
     OpInfo('sort',
            dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16),
-           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
-           dtypesIfROCM=all_types_and(torch.float16),
+           dtypesIfROCM=all_types_and(torch.bool, torch.float16),
            sample_inputs_func=sample_inputs_sort,
            skips=(
                # sort does not correctly warn when resizing out= inputs


### PR DESCRIPTION
Fixes #35529
This PR aims to remove the restrictions on Boolean input tensors for the following operators:
`torch.sort` / `torch.msort` / `torch.argsort` / `torch.argmax` / `torch.argmin` / `torch.topk`

cc @ngimel