### PR TITLE
[Structured Kernels] Port `cross` to structured kernels

### DIFF
--- a/aten/src/ATen/native/Cross.cpp
+++ b/aten/src/ATen/native/Cross.cpp
@@ -7,22 +7,23 @@
 namespace at {
 namespace meta {
 
-DEFINE_DISPATCH(cross_stub);
-
 TORCH_META_FUNC(cross)
 (const Tensor & input, const Tensor & other, const c10::optional<int64_t> dimension) {
   const Tensor& out = maybe_get_output(0);
-  
-  auto device_res = out.device().type();
-  TORCH_CHECK(device_res == kCPU || device_res == kCUDA, "cross only supports CPU and CUDA devices, out got: ", device_res);
+
   auto device1 = input.device().type();
-  TORCH_CHECK(device1 == kCPU || device1 == kCUDA, "cross only supports CPU and CUDA devices, input got: ", device1);
   auto device2 = other.device().type();
-  TORCH_CHECK(device2 == kCPU || device2 == kCUDA, "cross only supports CPU and CUDA devices, other got: ", device2);
-  TORCH_CHECK(device_res == device1, "out and input must have the same device type. out: ", device_res, " input: ", device1);
+
+  if (out.defined()) {
+    auto device_res = out.device().type();
+    TORCH_CHECK(device_res == device1, "out and input must have the same device type. out: ", device_res, " input: ", device1);
+    TORCH_CHECK(!out.is_cuda() || out.get_device() == input.get_device(),
+                "device of out (", input.get_device(), ") must match device of input (", other.get_device(), ")");
+  }
+
   TORCH_CHECK(device1 == device2, "input and other must have the same device type. input: ", device1, " other: ", device2);
-  TORCH_CHECK(!out.is_cuda() || out.get_device() == input.get_device(), "device of out (", input.get_device(), ") must match device of input (", other.get_device(), ")");
-  TORCH_CHECK(!input.is_cuda() || input.get_device() == other.get_device(), "device of input (", input.get_device(), ") must match device of other (", other.get_device(), ")");
+  TORCH_CHECK(!input.is_cuda() || input.get_device() == other.get_device(),
+              "device of input (", input.get_device(), ") must match device of other (", other.get_device(), ")");
   TORCH_CHECK(input.dim() == other.dim(), "inconsistent tensors dimensions input: ", input.dim(), " other: ", other.dim());
   TORCH_CHECK(input.sizes() == other.sizes(), "inconsistent tensors sizes input: ", input.sizes(), " other: ", other.sizes());
 
@@ -41,12 +42,18 @@ TORCH_META_FUNC(cross)
   }
 
   set_output(input.sizes(), input.options());
-
-  return out;
 }
 
-TORCH_IMPL_FUNC(gather_out)
+} // namespace at::meta
+
+namespace native {
+
+DEFINE_DISPATCH(cross_stub);
+
+TORCH_IMPL_FUNC(cross_out)
 (const Tensor & input, const Tensor & other, const c10::optional<int64_t> dimension, const Tensor & out) {
+  auto device1 = input.device().type();
+
   int64_t dim = -1;
   if(!dimension.has_value()) {
     for(int64_t i = 0; i < input.dim(); i++) {
@@ -60,7 +67,6 @@ TORCH_IMPL_FUNC(gather_out)
   }
 
   cross_stub(device1, out, input, other, dim);
-  return out;
 }
 
-}} // namespace at::meta
+}} // at::native

--- a/aten/src/ATen/native/Cross.h
+++ b/aten/src/ATen/native/Cross.h
@@ -5,7 +5,7 @@
 
 namespace at { namespace native {
 
-using cross_fn = void(*)(Tensor&, const Tensor&, const Tensor&, const int64_t d);
+using cross_fn = void(*)(const Tensor&, const Tensor&, const Tensor&, const int64_t d);
 
 DECLARE_DISPATCH(cross_fn, cross_stub);
 

--- a/aten/src/ATen/native/cpu/CrossKernel.cpp
+++ b/aten/src/ATen/native/cpu/CrossKernel.cpp
@@ -11,7 +11,7 @@
 namespace at { namespace native { namespace {
 
 template<typename scalar_t>
-static void apply_cross(Tensor& result, const Tensor& a, const Tensor& b, const int64_t dim) {
+static void apply_cross(const Tensor& result, const Tensor& a, const Tensor& b, const int64_t dim) {
   int64_t total = a.numel() / 3;
   int64_t a_stride = a.stride(dim);
   int64_t b_stride = b.stride(dim);
@@ -64,7 +64,7 @@ static void apply_cross(Tensor& result, const Tensor& a, const Tensor& b, const 
   });
 }
 
-static void cross_kernel_impl(Tensor& result, const Tensor& a, const Tensor& b, const int64_t dim) {
+static void cross_kernel_impl(const Tensor& result, const Tensor& a, const Tensor& b, const int64_t dim) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(result.scalar_type(), "cross", [&]() {
     apply_cross<scalar_t>(result, a, b, dim);
   });

--- a/aten/src/ATen/native/cuda/CrossKernel.cu
+++ b/aten/src/ATen/native/cuda/CrossKernel.cu
@@ -59,7 +59,7 @@ void launch_cross_kernel(const TensorIteratorBase& iter, int64_t ostride,
   });
 }
 
-void cross_impl(Tensor& result, const Tensor& x1, const Tensor& x2, int64_t dim) {
+void cross_impl(const Tensor& result, const Tensor& x1, const Tensor& x2, int64_t dim) {
   const int64_t ostride = result.stride(dim);
   const int64_t x1stride = x1.stride(dim);
   const int64_t x2stride = x2.stride(dim);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6145,13 +6145,13 @@
   device_guard: False
 
 - func: cross.out(Tensor self, Tensor other, int? dim=None, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
     CPU, CUDA: cross_out
 
 - func: cross(Tensor self, Tensor other, int? dim=None) -> Tensor
   variants: method, function
-  dispatch:
-    CPU, CUDA: cross
+  structured_delegate: cross.out
 
 - func: triu.out(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5819,12 +5819,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and_complex(),
            dtypesIfCUDA=all_types_and_complex_and(torch.half),
            sample_inputs_func=sample_inputs_cross,
-           supports_forward_ad=True,
-           skips=(
-               # AssertionError: UserWarning not triggered :
-               # Resized a non-empty tensor but did not warn about it.
-               SkipInfo('TestCommon', 'test_out'),
-           )),
+           supports_forward_ad=True,),
     OpInfo('cumsum',
            dtypesIfCPU=all_types_and_complex(),
            dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16),


### PR DESCRIPTION
This PR ports `cross` to structured kernels. Please see https://github.com/pytorch/pytorch/issues/55070 for the tracker issue.

**Notes:**

* Earlier `input.device().type()` was used to get the output tensor device type, which I believe was incorrect. This has been corrected in this PR.
* Out skip has been removed in this PR, an outcome of porting to structured kernels.
* We had checks to ensure an error is raised if a device except CUDA and CPU is passed, these checks have been removed now. Since we now support `meta` as well.

cc: @ysiraichi @ezyang 