### PR TITLE
fix copy.deepcopy on LinearPackedParams

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -154,15 +154,10 @@ class TestStaticQuantizedModule(QuantizationTestCase):
                          linear_unpack(loaded_qlinear._packed_params._packed_params))
         self.assertEqual(qlinear.scale, loaded_qlinear.scale)
         self.assertEqual(qlinear.zero_point, loaded_qlinear.zero_point)
-        self.checkScriptable(loaded_qlinear, [[X_q]], check_save_load=True)
-
-        # make sure loaded_qlinear has the same dir as qlinear
-        # since scripting the module will add __overloads__ to __dict__,
-        # we filter this item from the check.
-        dir_qlinear_modified = [x for x in dir(qlinear) if x != '__overloads__']
-        dir_loaded_qlinear_modified = [x for x in dir(loaded_qlinear) if x != '__overloads__']
-        self.assertTrue(dir_qlinear_modified == dir_loaded_qlinear_modified)
-
+        # scripting will add __overloads__ to __dict__, which is why we script a copy
+        # to be able to do the check in the next line
+        self.checkScriptable(copy.deepcopy(loaded_qlinear), [[X_q]], check_save_load=True)
+        self.assertTrue(dir(qlinear) == dir(loaded_qlinear))
         self.assertEqual(qlinear._weight_bias(), loaded_qlinear._weight_bias())
         self.assertEqual(qlinear._weight_bias(), torch.ops.quantized.linear_unpack(qlinear._packed_params._packed_params))
         Z_q2 = loaded_qlinear(X_q)

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -94,6 +94,16 @@ class LinearPackedParams(torch.nn.Module):
         self.set_weight_bias(state[0], state[1])
         self.training = state[2]
 
+    def __deepcopy__(self, memo):
+        new_instance = type(self).__new__(type(self))
+        torch.nn.Module.__init__(new_instance)
+        state = self.__getstate__()
+        new_instance.__setstate__(state)
+        return new_instance
+
+    def __copy__(self):
+        return self.__deepcopy__({})
+
     def __repr__(self):
         return self._weight_bias().__repr__()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #61877
* __->__ #64367

Summary:

This is the same thing as https://github.com/pytorch/pytorch/pull/56154
but for quantized linear. It fixes the behavior of `copy.deepcopy` on
these modules. Before this PR, copied instances of `LinearPackedParams`
were not properly initialized, and inspecting them raised errors of
missing `_modules`. After this PR, inspecting and using the copies
works.

Test Plan:

```
python test/test_quantization.py TestStaticQuantizedModule.test_linear_api
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D30702667](https://our.internmc.facebook.com/intern/diff/D30702667)