### PR TITLE
fix use external data format pr rebase error (#64357)

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -31,10 +31,10 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=True, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=True, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=True,
-           use_external_data_format=False):
+           opset_version=None, _retain_param_name=None, do_constant_folding=True,
+           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=None,
+           use_external_data_format=None):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
@@ -295,8 +295,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             the opset version is set to 1. Only custom opset domain name and version should be
             indicated through this argument.
 
-        enable_onnx_checker (bool, default True): If True the onnx model checker will be run
-            to ensure the exported model is a valid ONNX model.
+        enable_onnx_checker (bool, default True): Deprecated and ignored. Will be removed in next
+            Pytorch release.
         use_external_data_format (bool, default False): [Deprecated and ignored. Will be removed in
             next Pytorch release.]
             If True, then some of the model parameters are stored in external data files and not in

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -79,7 +79,7 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            opset_version=None, _retain_param_name=None, do_constant_folding=True,
            example_outputs=None, strip_doc_string=None, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=True, use_external_data_format=None):
+           enable_onnx_checker=None, use_external_data_format=None):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
@@ -667,8 +667,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             opset_version=None, do_constant_folding=True,
             dynamic_axes=None, keep_initializers_as_inputs=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
-            enable_onnx_checker=True, use_external_data_format=None,
-            onnx_shape_inference=True):
+            use_external_data_format=None, onnx_shape_inference=True):
 
     if isinstance(model, torch.nn.DataParallel):
         raise ValueError("torch.nn.DataParallel is not supported by ONNX "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#64383 fix use external data format pr rebase error (#64357)**
* #64382 [ONNX] Deprecate use_external_data_format param from torch.onnx.export() function. (#62257)
* #64381 Add onnx test for batched_nms (#53175)
* #64380 [ONNX] Deprecated the example_outputs param from torch.onnx.export() function. (#62815)
* #64379 [ONNX] Fix gather squeeze axis in constant folding (#63588)
* #64378 [ONNX] Fix cuda test case (#63597)
* #64377 [ONNX] Fix input sequence for pad op (#60554)
* #64376 Fix empty size constant creation (#63607)
* #64375 [ONNX] Update instance_norm implementation and support training (#60538)
* #64374 [ONNX] Add log10 symbolic (#63418)
* #64373 [ONNX] minor doc improvements and cleanup (#62514)
* #64372 [ONNX] Add supplementary tests and description for custom_opsets param from torch.onnx.export() function. (#62085)
* #64371 [ONNX] Remove strip_doc_string param from torch.onnx.export() function. (#61712)
* #64370 [ONNX] Remove argument _retain_param_name from torch.onnx.export() function. (#61702)
* #64369 [ONNX] Deprecate enable_onnx_checker argument in torch.onnx.export() (#61708)

* Fix use_external_data_format PR rebase error.

Co-authored-by: hwangdeyu <dejack953@outlook.com>