### PR TITLE
Silent rm error for sccache log file

### DIFF
--- a/.jenkins/caffe2/common.sh
+++ b/.jenkins/caffe2/common.sh
@@ -18,7 +18,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
     if which sccache > /dev/null; then
         # Save sccache logs to file
         sccache --stop-server || true
-        rm ~/sccache_error.log || true
+        rm -f ~/sccache_error.log || true
         SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
 
         # Report sccache stats for easier debugging

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -74,7 +74,7 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
   if which sccache > /dev/null; then
     # Save sccache logs to file
     sccache --stop-server > /dev/null  2>&1 || true
-    rm ~/sccache_error.log || true
+    rm -f ~/sccache_error.log || true
     if [[ -n "${SKIP_SCCACHE_INITIALIZATION:-}" ]]; then
       # sccache --start-server seems to hang forever on self hosted runners for GHA
       # so let's just go ahead and skip the --start-server altogether since it seems


### PR DESCRIPTION
Sample reporting from dr.ci

![image](https://user-images.githubusercontent.com/658840/131724645-75afa04f-7554-4674-8e7c-cf139c84d994.png)


The `rm` command is not actually running into problems, just need to silent the console output.
