### PR TITLE
[DataPipe] removing filter's inheritance from map

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1033,7 +1033,7 @@ class TestFunctionalIterDataPipe(TestCase):
         for data, exp in zip(filter_dp, range(5, 10)):
             self.assertEqual(data, exp)
 
-        with self.assertRaisesRegex(TypeError, r"instance doesn't have valid length$"):
+        with self.assertRaisesRegex(TypeError, r"has no len"):
             len(filter_dp)
 
         def _non_bool_fn(data):

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -1,13 +1,29 @@
+import warnings
 from torch.utils.data import IterDataPipe, functional_datapipe, DataChunk
 from typing import Callable, TypeVar, Iterator, Optional, Tuple, Dict
 
-from .callable import MapperIterDataPipe
-
 T_co = TypeVar('T_co', covariant=True)
 
+try:
+    import dill
+
+    # XXX: By default, dill writes the Pickler dispatch table to inject its
+    # own logic there. This globally affects the behavior of the standard library
+    # pickler for any user who transitively depends on this module!
+    # Undo this extension to avoid altering the behavior of the pickler globally.
+    dill.extend(use_dill=False)
+    DILL_AVAILABLE = True
+except ImportError:
+    DILL_AVAILABLE = False
+
+# Default function to return each item directly
+# In order to keep datapipe picklable, eliminates the usage
+# of python lambda function
+def default_filter_fn(data):
+    return True
 
 @functional_datapipe('filter')
-class FilterIterDataPipe(MapperIterDataPipe):
+class FilterIterDataPipe(IterDataPipe[T_co]):
     r""" :class:`FilterIterDataPipe`.
 
     Iterable DataPipe to filter elements from datapipe according to filter_fn.
@@ -22,18 +38,31 @@ class FilterIterDataPipe(MapperIterDataPipe):
             This also accepts -1 as input to apply filtering to the lowest nesting level.
             It currently doesn't support argument < -1.
     """
+    datapipe: IterDataPipe
+    filter_fn: Callable
     drop_empty_batches: bool
 
     def __init__(self,
-                 datapipe: IterDataPipe[T_co],
-                 filter_fn: Callable[..., bool],
+                 datapipe: IterDataPipe,
+                 filter_fn: Callable = default_filter_fn,
                  fn_args: Optional[Tuple] = None,
                  fn_kwargs: Optional[Dict] = None,
                  drop_empty_batches: bool = True,
                  nesting_level: int = 0,
                  ) -> None:
+        super().__init__()
+        self.datapipe = datapipe
+        # Partial object has no attribute '__name__', but can be pickled
+        if hasattr(filter_fn, '__name__') and filter_fn.__name__ == '<lambda>' and not DILL_AVAILABLE:
+            warnings.warn("Lambda function is not supported for pickle, please use "
+                          "regular python function or functools.partial instead.")
+        self.filter_fn = filter_fn  # type: ignore[assignment]
+        self.args = () if fn_args is None else fn_args
+        self.kwargs = {} if fn_kwargs is None else fn_kwargs
+        if nesting_level < -1:
+            raise ValueError("nesting_level must be -1 or >= 0")
+        self.nesting_level = nesting_level
         self.drop_empty_batches = drop_empty_batches
-        super().__init__(datapipe, fn=filter_fn, fn_args=fn_args, fn_kwargs=fn_kwargs, nesting_level=nesting_level)
 
     def __iter__(self) -> Iterator[T_co]:
         res: bool
@@ -66,7 +95,7 @@ class FilterIterDataPipe(MapperIterDataPipe):
                 return self._returnIfTrue(data)
 
     def _returnIfTrue(self, data):
-        condition = self.fn(data, *self.args, **self.kwargs)
+        condition = self.filter_fn(data, *self.args, **self.kwargs)
         if not isinstance(condition, bool):
             raise ValueError("Boolean output is required for `filter_fn` of FilterIterDataPipe")
         if condition:
@@ -77,5 +106,17 @@ class FilterIterDataPipe(MapperIterDataPipe):
             not (isinstance(data, list) and len(data) == 0 and self.drop_empty_batches)
         return r
 
-    def __len__(self):
-        raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
+    def __getstate__(self):
+        if DILL_AVAILABLE:
+            dill_function = dill.dumps(self.filter_fn)
+        else:
+            dill_function = self.filter_fn
+        state = (self.datapipe, dill_function, self.args, self.kwargs, self.drop_empty_batches, self.nesting_level)
+        return state
+
+    def __setstate__(self, state):
+        (self.datapipe, dill_function, self.args, self.kwargs, self.drop_empty_batches, self.nesting_level) = state
+        if DILL_AVAILABLE:
+            self.filter_fn = dill.loads(dill_function)  # type: ignore[assignment]
+        else:
+            self.filter_fn = dill_function  # type: ignore[assignment]

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -16,11 +16,6 @@ try:
 except ImportError:
     DILL_AVAILABLE = False
 
-# Default function to return each item directly
-# In order to keep datapipe picklable, eliminates the usage
-# of python lambda function
-def default_filter_fn(data):
-    return True
 
 @functional_datapipe('filter')
 class FilterIterDataPipe(IterDataPipe[T_co]):
@@ -44,7 +39,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
 
     def __init__(self,
                  datapipe: IterDataPipe,
-                 filter_fn: Callable = default_filter_fn,
+                 filter_fn: Callable,
                  fn_args: Optional[Tuple] = None,
                  fn_kwargs: Optional[Dict] = None,
                  drop_empty_batches: bool = True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64404
* #64398

This PR remove `filter`'s inheritance from `map`. This allows `filter` to not have a `__len__` function and that behavior is what we would like.

cc @VitalyFedyunin @ejguan

Differential Revision: [D30713120](https://our.internmc.facebook.com/intern/diff/D30713120)