### PR TITLE
Clean up serialization APIs + docs

### DIFF
--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -149,5 +149,14 @@ TEST(SerializationTest, TestJitStream_CUDA) {
   // Check if both the output tensors are equal
   ASSERT_TRUE(op.equal(c));
 }
+
+
+TEST(SerializationTest, TestSaveApi) {
+  auto input = torch::ones({2, 2});
+  torch::save(torch::IValue(input), std::string("output.pt"));
+  auto data = torch::load(std::string("output.pt")).toTensor();
+  std::cout << data << "\n";
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/api/include/torch/serialize.h
+++ b/torch/csrc/api/include/torch/serialize.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <c10/util/irange.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/serialize/archive.h>
 #include <torch/serialize/tensor.h>
-#include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <utility>
+#include <ATen/core/stack.h>
 
 namespace torch {
 
@@ -37,10 +38,19 @@ namespace torch {
 ///   auto tensor = torch::ones({3, 4});
 ///   torch::save(tensor, "my_tensor.pt");
 /// \endrst
-template <typename Value, typename... SaveToArgs>
+// template <typename Value = std::enable_if<false, long>, typename...
+// SaveToArgs>
+template <
+    typename Value,
+    typename... SaveToArgs,
+    typename std::enable_if<
+        !std::is_same<Value, torch::IValue>::value &&
+            !std::is_same<Value, std::vector<torch::Tensor>&>::value &&
+            !std::is_same<Value, const std::vector<torch::Tensor>&>::value &&
+            !std::is_same<Value, std::vector<torch::Tensor>>::value,
+        Value>::type* = nullptr>
 void save(const Value& value, SaveToArgs&&... args) {
-  serialize::OutputArchive archive(
-      std::make_shared<jit::CompilationUnit>());
+  serialize::OutputArchive archive(std::make_shared<jit::CompilationUnit>());
   archive << value;
   archive.save_to(std::forward<SaveToArgs>(args)...);
 }
@@ -54,28 +64,24 @@ void save(const Value& value, SaveToArgs&&... args) {
 /// \rst
 /// .. code-block:: cpp
 ///
-///   std::vector<torch::Tensor> tensor_vec = { torch::randn({1, 2}), torch::randn({3, 4}) };
-///   torch::save(tensor_vec, "my_tensor_vec.pt");
+///   std::vector<torch::Tensor> tensor_vec = { torch::randn({1, 2}),
+///   torch::randn({3, 4}) }; torch::save(tensor_vec, "my_tensor_vec.pt");
 ///
-///   std::vector<torch::Tensor> tensor_vec = { torch::randn({5, 6}), torch::randn({7, 8}) };
-///   std::ostringstream stream;
+///   std::vector<torch::Tensor> tensor_vec = { torch::randn({5, 6}),
+///   torch::randn({7, 8}) }; std::ostringstream stream;
 ///   // Note that the same stream cannot be used in multiple torch::save(...)
 ///   // invocations, otherwise the header will be corrupted.
 ///   torch::save(tensor_vec, stream);
 /// \endrst
 template <typename... SaveToArgs>
 void save(const std::vector<torch::Tensor>& tensor_vec, SaveToArgs&&... args) {
-  serialize::OutputArchive archive(
-      std::make_shared<jit::CompilationUnit>());
+  serialize::OutputArchive archive(std::make_shared<jit::CompilationUnit>());
   for (const auto i : c10::irange(tensor_vec.size())) {
     auto& value = tensor_vec[i];
     archive.write(c10::to_string(i), value);
   }
   archive.save_to(std::forward<SaveToArgs>(args)...);
 }
-
-TORCH_API std::vector<char> pickle_save(const torch::IValue& ivalue);
-TORCH_API torch::IValue pickle_load(const std::vector<char>& data);
 
 /// Deserializes the given `value`.
 /// There must be an overload of `operator>>` between `serialize::InputArchive`
@@ -103,7 +109,16 @@ TORCH_API torch::IValue pickle_load(const std::vector<char>& data);
 ///   auto tensor = torch::ones({3, 4});
 ///   torch::load(tensor, "my_tensor.pt");
 /// \endrst
-template <typename Value, typename... LoadFromArgs>
+template <
+    typename Value,
+    typename... LoadFromArgs,
+    typename std::enable_if<
+        !std::is_same<Value, std::string>::value &&
+            !std::is_same<Value, const char*>::value &&
+            !std::is_same<Value, std::vector<torch::Tensor>&>::value &&
+            !std::is_same<Value, const std::vector<torch::Tensor>&>::value &&
+            !std::is_same<Value, std::vector<torch::Tensor>>::value,
+        Value>::type* = nullptr>
 void load(Value& value, LoadFromArgs&&... args) {
   serialize::InputArchive archive;
   archive.load_from(std::forward<LoadFromArgs>(args)...);
@@ -143,4 +158,51 @@ void load(std::vector<torch::Tensor>& tensor_vec, LoadFromArgs&&... args) {
     index++;
   }
 }
+
+// These are identical to the save() and load() with the same signature, but are
+// kept around here for backwards compat
+TORCH_API std::vector<char> pickle_save(const torch::IValue& ivalue);
+TORCH_API torch::IValue pickle_load(const std::vector<char>& data);
+
+TORCH_API std::vector<char> save(const torch::IValue& ivalue);
+TORCH_API torch::IValue load(const std::vector<char>& data);
+
+/// Serializes the given `ivalue` to `filename`.
+///
+/// The data saved to `filename` is compatible with `torch.save` in Python, and
+/// can be loaded with `torch.load(filename)`. For backwards compatibility
+/// reasons, the type passed for `ivalue` MUST be of type `torch::IValue` (i.e.
+/// no conversions required).
+///
+/// \rst
+/// .. code-block:: cpp
+///
+///   auto input = torch::ones({2, 2})
+///   torch::save(torch::IValue(input), "my_file.pt")
+///
+/// \endrst
+///
+/// Load in Python:
+///
+/// \rst
+/// .. code-block::
+///
+///   tensor = torch.load("my_file.pt")
+///
+/// \endrst
+///
+/// Load in C++:
+///
+/// \rst
+/// .. code-block:: cpp
+///
+///   auto tensor = torch::load(std::string("my_file.pt")).toTensor();
+///
+/// \endrst
+
+TORCH_API void save(const torch::IValue& ivalue, const std::string& filename);
+
+/// See torch::save
+TORCH_API torch::IValue load(const std::string& filename);
+
 } // namespace torch

--- a/torch/csrc/api/src/serialize.cpp
+++ b/torch/csrc/api/src/serialize.cpp
@@ -3,16 +3,45 @@
 #include <torch/serialize.h>
 
 #include <vector>
+#include <iostream>
+
 
 namespace torch {
 
 std::vector<char> pickle_save(const at::IValue& ivalue) {
-  return jit::pickle_save(ivalue);
+  return save(ivalue);
 }
 
 torch::IValue pickle_load(const std::vector<char>& data) {
+  return load(data);
+}
+
+std::vector<char> save(const torch::IValue& ivalue) {
+  return jit::pickle_save(ivalue);
+}
+
+torch::IValue load(const std::vector<char>& data) {
   return jit::pickle_load(data);
 }
 
+void save(const torch::IValue& ivalue, const std::string& filename) {
+  auto bytes = jit::pickle_save(ivalue);
+  std::ofstream outfile(filename, std::ios::out | std::ios::binary);
+  outfile.write(&bytes[0], bytes.size());
+}
+
+torch::IValue load(const std::string& filename) {
+  std::ifstream input_stream(filename);
+  std::vector<char> input;
+  input.insert(
+      input.begin(),
+      std::istream_iterator<char>(input_stream),
+      std::istream_iterator<char>());
+
+  for (const auto& x : input) {
+    std::cout << "c " << std::hex << int(x) << "\n";
+  }
+  return jit::pickle_load(input);
+}
 
 } // namespace torch

--- a/torch/csrc/jit/serialization/pickle.cpp
+++ b/torch/csrc/jit/serialization/pickle.cpp
@@ -84,6 +84,7 @@ class VectorReader : public caffe2::serialize::ReadAdapterInterface {
 
   size_t read(uint64_t pos, void* buf, size_t n, const char* what)
       const override {
+    std::cout << "Reading chunk " << std::dec << pos << " for " << n << "\n";
     std::copy(
         data_.data() + pos,
         data_.data() + pos + n,


### PR DESCRIPTION
This moves `torch::pickle_save` and `torch::pickle_load` to `torch::save` and `torch::load` respectively. This has been an issue for a while and the confusing name differences between Python and C++ have tripped up many PyTorch users. The `pickle_` methods also never made it into the C++ docs, so there was no way to discover them unless users sifted through old PRs.

Since this is overloading `torch::save` and `torch::load` with new functionality, we need to take extra care (i.e. have a bunch of `std::enable_if`s) to not BC break existing `save` / `load` usages. These use an old mechanism that can probably be done entirely through the pickle API, but we should deprecate it for a release before changing the behavior (which could cause silent changes in how serialization works) before doing this (if we do it at all).

TODO:
* Fix load corruption issue (the file is fine, torch.load works OK, C++ loading is broken)
* Verify that methods are in the docs

Fixes #58720

