### PR TITLE
[Static Runtime] Add first iter metric

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -880,14 +880,14 @@ c10::IValue StaticRuntime::operator()(
 
 namespace {
 
-std::string generate_node_time_json(const std::string& kind, float millis) {
+std::string generate_latency_json(const std::string& label, double millis) {
 #ifdef FBCODE_CAFFE2
   folly::dynamic json = folly::dynamic::object();
-  json["type"] = kind;
+  json["type"] = label;
   json["metric"] = "latency";
   json["unit"] = "ms";
   json["value"] = millis;
-  return folly::toJson(json);
+  return "PyTorchObserver " + folly::toJson(json);
 #else
   return "";
 #endif
@@ -941,8 +941,12 @@ void StaticRuntime::benchmark(
     }
 
     if (generate_ai_pep_output) {
-      LOG(INFO) << "PyTorchObserver " << generate_node_time_json(kind, ms);
+      LOG(INFO) << generate_latency_json(kind, ms);
     }
+  }
+  if (generate_ai_pep_output) {
+    LOG(INFO) << generate_latency_json(
+        "static_runtime_first_iter", results.first_iter_time);
   }
   std::cout << std::setw(15) << results.total_time << " ms. in Total"
             << std::endl;
@@ -954,6 +958,8 @@ void StaticRuntime::benchmark(
             << " ms" << std::endl;
   std::cout << "Outputs deallocation time: " << results.output_dealloc_time
             << " ms" << std::endl;
+  std::cout << "First iter time: " << results.first_iter_time << " ms"
+            << std::endl;
 
   if (planner_) {
     std::cout << "Total memory managed: " << planner_->total_managed()
@@ -1084,7 +1090,7 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
     const int main_runs) {
-  TORCH_CHECK(warmup_runs >= 0 && main_runs >= 1);
+  TORCH_CHECK(warmup_runs >= 1 && main_runs >= 1);
 
   // See comment on above use of InferenceMode for
   // explanation.
@@ -1100,8 +1106,15 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
 
   results.setup_time = timer.MilliSeconds();
 
+  // The first iteration profiles each node's output Tensors' sizes and
+  // initializes the memory planner with the profile information. Folllowing
+  // iterations just use the already established memory planning.
+  timer.Start();
+  operator()(args, kwargs);
+  results.first_iter_time = timer.MilliSeconds();
+
   // warmup runs
-  for (const auto i : c10::irange(warmup_runs)) {
+  for (const auto i : c10::irange(warmup_runs - 1)) {
     (void)i; // Suppress unused variable warning
     operator()(args, kwargs);
   }

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -248,6 +248,7 @@ class TORCH_API StaticRuntime {
     float memory_alloc_time{0.0};
     float memory_dealloc_time{0.0};
     float output_dealloc_time{0.0};
+    float first_iter_time{0.0};
     float total_time{0.0};
     size_t out_nodes_count{0};
     size_t total_nodes_count{0};

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -25,6 +25,8 @@ void initStaticModuleBindings(PyObject* module) {
       .def_readonly(
           "output_dealloc_time",
           &StaticRuntime::IndividualMetrics::output_dealloc_time)
+      .def_readonly(
+          "first_iter_time", &StaticRuntime::IndividualMetrics::first_iter_time)
       .def_readonly("total_time", &StaticRuntime::IndividualMetrics::total_time)
       .def_readonly(
           "out_nodes_count", &StaticRuntime::IndividualMetrics::out_nodes_count)


### PR DESCRIPTION
Summary: The first iteration is special since it initializes the memory planner. This change logs and reports first iteration time during benchmarking. It also generates a FAI-PEP output when `generate_ai_pep_output` is set.

Test Plan:
Run any benchmark, and observe:
```
I0902 15:19:32.528977 2492358 impl.cpp:948] PyTorchObserver {"value":6.415958881378174,"unit":"ms","metric":"latency","type":"static_runtime_first_iter"}
...
First iter time: 6.41596 ms
```

Note that this metric is likely to have significantly more noise than the others since we don't have as many data points.

Differential Revision: D30740619

