### PR TITLE
[ONNX] Allow registration of custom symbolics for prim namespace

### DIFF
--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -119,7 +119,7 @@ class TestCustomAutogradFunction(unittest.TestCase):
                 return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
 
         from torch.onnx import register_custom_op_symbolic
-        register_custom_op_symbolic("::prim_PythonOp", symbolic_pythonop, 1)
+        register_custom_op_symbolic("prim::PythonOp", symbolic_pythonop, 1)
 
         x = torch.randn(2, 3, 4, requires_grad=True)
         model = MyModule()

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -394,7 +394,7 @@ void NodeToONNX(
 
     py::object opset_version = onnx_symbolic.attr("_export_onnx_opset_version");
     py::object is_registered_op = onnx_registry.attr("is_registered_op")(
-        "prim_PythonOp", "", opset_version);
+        "PythonOp", "prim", opset_version);
     if (!py::hasattr(pyobj, "symbolic") &&
         (!PyObject_IsTrue(is_registered_op.ptr()))) {
       // Simply clone the node, unless either

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -36,8 +36,12 @@ def register_ops_helper(domain, version, iter_version):
             op = ("any", op[1])
         if op[0] == "_all":
             op = ("all", op[1])
-        if isfunction(op[1]) and not is_registered_op(op[0], domain, version):
-            register_op(op[0], op[1], domain, version)
+        domain_register = domain
+        if op[0].startswith("prim_"):
+            op = (op[0][5:], op[1])
+            domain_register = "prim"
+        if isfunction(op[1]) and not is_registered_op(op[0], domain_register, version):
+            register_op(op[0], op[1], domain_register, version)
 
 
 def register_ops_in_version(domain, version):


### PR DESCRIPTION
Currently in order to register a custom symbolic for a torch.autograd.Function, one has to register it under the name "::prim_PythonOp". This is a work-around the fact that register_custom_op_symbolic doesn't allow registration for ops in the prim namespace. We should just allow registration in the prim namespace and get rid of the ::prim_ workaround.
