### PR TITLE
Back out "D30740897 Add fusion enabled apis"

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -61,8 +61,6 @@ Creating TorchScript Code
     ScriptFunction
     freeze
     optimize_for_inference
-    enable_fusion
-    fusion_enabled
     save
     load
     ignore

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from typing import Iterator
 
 from torch.utils import set_module
-from typing import Optional
 
 # These are imported so users can access them from the `torch.jit` module
 from torch._jit_internal import (
@@ -198,34 +197,6 @@ def _hide_source_ranges() -> Iterator[None]:
     finally:
         torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges)  # type: ignore[attr-defined]
 
-def enable_fusion(enabled: bool, device: Optional[str] = None):
-    """
-    Enables or disables JIT fusion based on the parameter `enabled`.
-
-    If `device` is None, both CPU and GPU fusion will be turned on or off.
-    Otherwise, device must be equal to "cpu" or "cuda", and will turn on or off
-    CPU and GPU fusion respectively.
-    """
-
-    if device is None:
-        torch._C._jit_override_can_fuse_on_cpu(enabled)
-        torch._C._jit_override_can_fuse_on_gpu(enabled)
-    else:
-        assert device in ["cpu", "cuda"], "Device-specific fusion must be equal to 'cpu' or 'cuda' if not None"
-        if device == "cuda":
-            torch._C._jit_override_can_fuse_on_gpu(enabled)
-        else:
-            torch._C._jit_override_can_fuse_on_cpu(enabled)
-
-def fusion_enabled(device: str):
-    """
-    Returns whether JIT fusion is enabled for "cpu" or "cuda"
-    """
-    assert device == "cpu" or device == "cuda"
-    if device == "cpu":
-        return torch._C._jit_can_fuse_on_cpu()
-    else:
-        return torch._C._jit_can_fuse_on_gpu()
 
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")


### PR DESCRIPTION
Summary:
D30740897 (https://github.com/pytorch/pytorch/commit/39aeb3bf63f61664bc6c4a929a80a660365c2a5e) broke caffe2/torch/fb/module_factory/optimizers/tests:test_full_sync_optimizer_needed_coverage (https://fburl.com/test/mb46jxon) and blocked training_platform_unit_tests

{F660271297}

multsect results confirms

```
multisect --config FBCODE_TEST bisect 844424966128796 --workers 16 revisions --begin 09629edc --end fc86b434
D30740897 (https://github.com/pytorch/pytorch/commit/39aeb3bf63f61664bc6c4a929a80a660365c2a5e)

````

{F660271232}

Test Plan:
```
buck test mode/opt //caffe2/torch/fb/module_factory/optimizers/tests:test_full_sync_optimizer_needed_coverage

Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/4785074671474181
    ✓ Pass: caffe2/torch/fb/module_factory/optimizers/tests:test_full_sync_optimizer_needed_coverage - main (3.729)
Summary
  Pass: 1

```

Differential Revision: D30753916

