### PR TITLE
Back out "nn.functional.linear OpInfo"

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2648,30 +2648,6 @@ def sample_inputs_hardswish(self, device, dtype, requires_grad):
                requires_grad=requires_grad, low=-5, high=5)) for _ in range(1, N)]
     return tensors
 
-def sample_inputs_linear(self, device, dtype, requires_grad):
-    features_options = [[3, 4], [128, 128]]
-    batch_options: List[List[int]] = [
-        [],  # no batch
-        [0],
-        [64],
-        [5, 7],
-    ]
-    create_tensor = partial(make_tensor, device=device, dtype=dtype,
-                            requires_grad=requires_grad, low=-2, high=2)
-
-    sample_inputs = []
-    for has_bias, (in_feat, out_feat), batch_shape in \
-            itertools.product([True, False], features_options, batch_options):
-        input_tensor = create_tensor(batch_shape + [in_feat])
-        weight = create_tensor([out_feat, in_feat])
-        if not has_bias:
-            sample_inputs.append(SampleInput(input_tensor, args=(weight,)))
-            continue
-
-        bias = create_tensor([out_feat])
-        sample_inputs.append(SampleInput(input_tensor, args=(weight, bias)))
-    return sample_inputs
-
 def sample_inputs_interpolate(mode, self, device, dtype, requires_grad):
     N, C = 2, 3
     D = 4
@@ -7545,17 +7521,6 @@ op_db: List[OpInfo] = [
            dtypesIfCPU=floating_types_and(torch.int64),
            dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_avgpool2d),
-    OpInfo('nn.functional.linear',
-           aten_name='linear',
-           supports_autograd=True,
-           sample_inputs_func=sample_inputs_linear,
-           dtypesIfCPU=all_types_and_complex_and(torch.half, torch.bfloat16),
-           dtypesIfROCM=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-           dtypesIfCUDA=floating_and_complex_types_and(torch.float16, *[torch.bfloat16] if CUDA11OrLater else []),
-           backward_dtypesIfCUDA=floating_and_complex_types_and(torch.float16,
-                                                                *[torch.bfloat16] if CUDA11OrLater else []),
-           supports_forward_ad=True,
-           supports_out=False),
     UnaryUfuncInfo(
         'nn.functional.logsigmoid',
         aten_name="log_sigmoid",


### PR DESCRIPTION
Summary: Original commit changeset: ca41dbd98176

Differential Revision: D30758201

Reverting because the OpInfo is causing periodic_pytorch_xenial_cuda10_2_cudnn7_gcc7_old_gradcheck_test1 to fail. Relevant log snippet:

```
Sep 04 19:10:44   test_fn_gradgrad_nn_functional_linear_cuda_complex128 (__main__.TestGradientsCUDA) ... ERROR (50.428s)
Sep 04 19:11:16   test_fn_gradgrad_nn_functional_linear_cuda_float64 (__main__.TestGradientsCUDA) ... ERROR (31.645s)
``` 

cc @zou3519 