### PR TITLE
[WIP] No longer initialize a subgroup in post_localSGD_hook

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/post_localSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/post_localSGD_hook.py
@@ -95,5 +95,5 @@ def post_localSGD_hook(
     # From this moment, model averaging should run after the optimizer step,
     # to globally allreduce all the parameters.
     if state.subgroup is None:
-        state.subgroup, _ = dist.new_subgroups()
+        raise ValueError("Subgroup of PostLocalSGDState is not initialized before allreduce.")
     return default._allreduce_fut(state.subgroup, input_tensor)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64537

Since `post_localSGD_hook` is executed as a future, subgroup initialization in it can somehow cause flakiness and eventually allreduce timeout. Now this is not allowed, and it's the caller's responsibility to initialize the subgroup.

Unfortunately, such flakiness cannot be captured by unit test. I can only reproduce this allreduce timeout in a real use after running the training for over 1 hour.

Differential Revision: [D30761463](https://our.internmc.facebook.com/intern/diff/D30761463/)