### PR TITLE
Fix subclass refcount

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -23,6 +23,7 @@ def no_dispatch() -> Iterator[None]:
 # 3. Enter dispatcher, wind your way through Autograd
 # 4. Hit Python dispatch key, call __torch_dispatch__
 
+WRAPPER_DEVICE = "meta"
 # TODO: TensorBase should work
 class LoggingTensor(torch.Tensor):
     elem: torch.Tensor
@@ -34,7 +35,7 @@ class LoggingTensor(torch.Tensor):
         # The wrapping tensor (LoggingTensor) is just a meta tensor, so it
         # doesn't hold any memory (meta tensor is generally the preferred type
         # of tensor you want to make a subclass from)...
-        r = torch.Tensor._make_subclass(cls, elem.to('meta'), elem.requires_grad)
+        r = torch.Tensor._make_subclass(cls, elem.to(WRAPPER_DEVICE), elem.requires_grad)
         # ...the real tensor is held as an element on the tensor.
         r.elem = elem
         return r
@@ -334,6 +335,34 @@ $3 = input('grad_output')
 $4 = torch._ops.aten.mul($3, tensor(2))
 $5 = torch._ops.aten.mul($4, $0)
 $6 = torch._ops.aten.add_($1, $5)''')
+
+    def test_subclass_creation(self):
+        # Make sure these statements runs without error
+        # In particular checking that when internal detach returns
+        # subclasses, these are cleanly overwritten.
+        class Foo(torch.Tensor):
+            pass
+        a = torch.Tensor._make_subclass(Foo, LoggingTensor(torch.rand(2)))
+        b = LoggingTensor(torch.rand(2)).as_subclass(Foo)
+
+        # And in case where we don't know if the user wants this subclass
+        # overwritten, raise a nice error.
+        # The standard LoggingTensor will fail because it is not on the right device
+        with self.assertRaisesRegex(TypeError, "expected.*device=cpu.*device=meta"):
+            Foo(LoggingTensor(torch.rand(2)))
+
+        # And if we put it on the right device, we still get a nice error
+        try:
+            global WRAPPER_DEVICE
+            prev_device = WRAPPER_DEVICE
+            WRAPPER_DEVICE = "cpu"
+
+            err_msg = "Creating a new Tensor subclass Foo.*python object of type LoggingTensor"
+            with self.assertRaisesRegex(RuntimeError, err_msg):
+                Foo(LoggingTensor(torch.rand(2)))
+
+        finally:
+            WRAPPER_DEVICE = prev_device
 
 
 if __name__ == '__main__':

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -516,6 +516,15 @@ class AbstractTestCases:
             # declared with requires_grad.
             self.assertTrue(t.grad is not None)
 
+            # Make sure invalid subclasses raise nice errors
+            class BadSubTensor():
+                member_var = object()
+
+            err_msg = "Creating a Tensor subclass from a class that does not inherit from Tensor"
+            with self.assertRaisesRegex(RuntimeError, err_msg):
+                s0 = t0.as_subclass(BadSubTensor)
+
+
         def test_type(self):
             x = torch.randn(3, 3).double()
             self.assertEqual(x.type('torch.FloatTensor').dtype, torch.float32)


### PR DESCRIPTION
Note that this is not a solution for https://github.com/pytorch/pytorch/issues/64548 which should be addressed as well.

This PR adds two main checks:
- When creating Tensor pyobjects, we ensure that the type is a subtype of THPVariable (otherwise our pointer casts do very weird stuff).
- Ensures that we only set the Tensor's pyobj if it is not already set (otherwise we leak the THPVariable). Fix call sites where the user explicitly asked for the pyobject to be changed to properly clear it before setting it again.