### PR TITLE
[Core] Update Exception.h

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -301,7 +301,8 @@ C10_API std::string GetExceptionString(const std::exception& e);
         __func__,                                                   \
         __FILE__,                                                   \
         static_cast<uint32_t>(__LINE__),                            \
-        #cond "INTERNAL ASSERT FAILED at" C10_STRINGIZE(__FILE__)); \
+        #cond                                                       \
+        " INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE__));     \
   }
 #else
 // It would be nice if we could build a combined string literal out of
@@ -316,8 +317,8 @@ C10_API std::string GetExceptionString(const std::exception& e);
         __FILE__,                                                               \
         static_cast<uint32_t>(__LINE__),                                        \
         #cond                                                                   \
-        "INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE__) ":" C10_STRINGIZE( \
-            __LINE__) ", please report a bug to PyTorch. ",                     \
+        " INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE__) ":"               \
+        C10_STRINGIZE(__LINE__) ", please report a bug to PyTorch. ",           \
         c10::str(__VA_ARGS__));                                                 \
   }
 #endif


### PR DESCRIPTION
Just a small thing that's a little annoying; currently `TORCH_INTERNAL_ASSERT` generates messages like this:

```
unknown file: Failure
C++ exception with description "g_outputs.count(out) > 0INTERNAL ASSERT FAILED at "../torch/csrc/jit/passes/memory_planning.cpp":481, please report a bug to PyTorch. 22
Exception raised from getManagedLiveRangesFromMemEvents at ../torch/csrc/jit/passes/memory_planning.cpp:481 (most recent call first):
```

i.e. with no space between the `#cond` checked and `INTERNAL ASSERT FAILED...`

Re the `STRIP_ERROR_MESSAGES` branch: I'm not sure whether the differences are intentional or accidental? I.e. we don't pass `__FILE__` and `__VA_ARGS__` to `torchCheckFail` whereas we do to `torchInternalAssertFail`. I can reconcile the two in this PR if it's simply an omission.
