### PR TITLE
cat_shape_check: Fixes dimension in the error message for CUDA cat shape check and removes unnecessary offending index information

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -108,8 +108,7 @@ static inline void check_cat_shape_except_dim(const Tensor & first, const Tensor
     int64_t first_dim_size = first.sizes()[dim];
     int64_t second_dim_size = second.sizes()[dim];
     TORCH_CHECK(first_dim_size == second_dim_size, "torch.cat(): Sizes of tensors must match except in dimension ",
-                dimension, ". Got ", first_dim_size, " and ", second_dim_size, " in dimension ", dim,
-                " (The offending index is ", index, ")");
+                dimension, ". Got ", first_dim_size, " and ", second_dim_size, " in dimension ", dim, ".");
   }
 }
 

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -183,13 +183,11 @@ void check_shape_except_dim(const Tensor &first, const Tensor &second,
     if (dim == dimension) {
       continue;
     }
-    int64_t first_dim_size = at::native::size(first, dim);
-    int64_t second_dim_size = at::native::size(second, dim);
+    int64_t first_dim_size = first.sizes()[dim];
+    int64_t second_dim_size = second.sizes()[dim];
     TORCH_CHECK(first_dim_size == second_dim_size,
-        "Sizes of tensors must match except in dimension ", dim, ". Got ",
-        static_cast<long long>(first_dim_size), " and ",
-        static_cast<long long>(second_dim_size), " (The offending index is ",
-        index, ")");
+        "Sizes of tensors must match except in dimension ", dimension, ". Got ",
+        first_dim_size, " and ", second_dim_size, " in dimension ", dim, ".");
   }
 }
 


### PR DESCRIPTION
Fixes: #64207

Thank you, @SsnL for the bug report with reproducing script.