### PR TITLE
Add __ge__ to TorchVersion

### DIFF
--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -65,4 +65,13 @@ class TorchVersion(str):
             # version like 'parrot'
             return super().__eq__(cmp)
 
+
+    def __ge__(self, cmp):
+        try:
+            return Version(self).__ge__(self._convert_to_version(cmp))
+        except InvalidVersion:
+            # Fall back to regular string comparison if dealing with an invalid
+            # version like 'parrot'
+            return super().__ge__(cmp)
+
 __version__ = TorchVersion(internal_version)


### PR DESCRIPTION
This PR adds greater equal comparison so that not the base class's (str) comparison method is used.
This is necessary for a correct comparison with a version string.

Previously the following was the case:
```py
>>> torch.__version__
'1.10.0.dev20210830+cpu'
>>> torch.__version__>"1.9"
True
>>> torch.__version__>="1.9"
False  # Wrong output since the base class (str) was used for __ge__ comparison
```
