### PR TITLE
Adding handler to collective quantization API

### DIFF
--- a/torch/distributed/algorithms/quantization/quantization.py
+++ b/torch/distributed/algorithms/quantization/quantization.py
@@ -3,7 +3,6 @@ import torch
 import torch.distributed as dist
 
 from enum import Enum
-from typing import Callable, Any
 
 TORCH_HALF_MIN = torch.finfo(torch.float16).min
 TORCH_HALF_MAX = torch.finfo(torch.float16).max

--- a/torch/distributed/algorithms/quantization/quantization.py
+++ b/torch/distributed/algorithms/quantization/quantization.py
@@ -159,9 +159,9 @@ def auto_quantize(func, qtype, quant_loss=None):
         in_splits = kwargs.get('in_splits', None)
 
 
-        if ((func == dist.all_to_all_single) or (func == dist.all_to_all) or (func == dist.all_gather)):
+        try:
             dispatch[func](qtype, *args, **kwargs)
-        else:
+        except KeyError:
             raise RuntimeError(
                 f"The collective op {func} is not supported yet"
             )

--- a/torch/distributed/algorithms/quantization/quantization.py
+++ b/torch/distributed/algorithms/quantization/quantization.py
@@ -2,9 +2,8 @@ import functools
 import torch
 import torch.distributed as dist
 
-
 from enum import Enum
-
+from typing import Callable, Any
 
 TORCH_HALF_MIN = torch.finfo(torch.float16).min
 TORCH_HALF_MAX = torch.finfo(torch.float16).max
@@ -85,6 +84,52 @@ def _dequantize_tensor_list(tensor_list, qtype, quant_loss=None):
     dequantized_tensor_list = [_dequantize_tensor(t, qtype) for t in tensor_list]
     return dequantized_tensor_list
 
+def _quantized_a2a_single_handler(*args, **kwargs):
+    group = kwargs.get('group', None)
+    async_op = kwargs.get('async_op', False)
+    qtype = args[0]
+    tensors = args[1]
+    input_tensor = args[2]
+    out_splits = kwargs.get('out_splits', None)
+    in_splits = kwargs.get('in_splits', None)
+    quant_loss = kwargs.get('quant_loss', None)
+    input_tensors = _quantize_tensor(input_tensor, qtype)
+    out_tensors = _quantize_tensor(tensors, qtype)
+    dist.all_to_all_single(out_tensors, input_tensors, out_splits, in_splits, group=group)
+    for i, t in enumerate(_dequantize_tensor(out_tensors, qtype, quant_loss=quant_loss)):
+        tensors[i] = t
+
+def _quantized_a2a_handler(*args, **kwargs):
+    group = kwargs.get('group', None)
+    async_op = kwargs.get('async_op', False)
+    quant_loss = kwargs.get('quant_loss', None)
+    qtype = args[0]
+    tensors = args[1]
+    input_tensor = args[2]
+    input_tensors = _quantize_tensor_list(input_tensor, qtype)
+    out_tensors = _quantize_tensor_list(tensors, qtype)
+    dist.all_to_all(out_tensors, input_tensors, group=group, async_op=async_op)
+    for i, t in enumerate(_dequantize_tensor_list(out_tensors, qtype, quant_loss=quant_loss)):
+        tensors[i] = t
+
+def _quantized_all_gather_handler(*args, **kwargs):
+    group = kwargs.get('group', None)
+    async_op = kwargs.get('async_op', False)
+    quant_loss = kwargs.get('quant_loss', None)
+    qtype = args[0]
+    tensors = args[1]
+    input_tensor = args[2]
+    input_tensors = _quantize_tensor(input_tensor, qtype)
+    out_tensors = _quantize_tensor_list(tensors, qtype)
+    dist.all_gather(out_tensors, input_tensors, group=group, async_op=async_op)
+    for i, t in enumerate(_dequantize_tensor_list(out_tensors, qtype, quant_loss=quant_loss)):
+        tensors[i] = t
+
+dispatch = {
+    dist.all_to_all_single: _quantized_a2a_single_handler,
+    dist.all_to_all: _quantized_a2a_handler,
+    dist.all_gather: _quantized_all_gather_handler,
+}
 
 def auto_quantize(func, qtype, quant_loss=None):
     """
@@ -109,32 +154,14 @@ def auto_quantize(func, qtype, quant_loss=None):
             raise RuntimeError(
                 'The async_op=True mode is not supported yet.'
             )
-        if (func == dist.all_gather):
-            tensors = args[0]
-            input_tensors = _quantize_tensor(args[1], qtype)
-            out_tensors = _quantize_tensor_list(tensors, qtype)
-            dist.all_gather(out_tensors, input_tensors, group=group, async_op=async_op)
-            for i, t in enumerate(_dequantize_tensor_list(out_tensors, qtype, quant_loss=quant_loss)):
-                tensors[i] = t
+        tensors = args[0]
+        input_tensor = args[1]
+        out_splits = kwargs.get('out_splits', None)
+        in_splits = kwargs.get('in_splits', None)
 
-        elif (func == dist.all_to_all):
-            tensors = args[0]
-            input_tensors = _quantize_tensor_list(args[1], qtype)
-            out_tensors = _quantize_tensor_list(tensors, qtype)
-            dist.all_to_all(out_tensors, input_tensors, group=group, async_op=async_op)
-            for i, t in enumerate(_dequantize_tensor_list(out_tensors, qtype, quant_loss=quant_loss)):
-                tensors[i] = t
 
-        elif (func == dist.all_to_all_single):
-            tensors = args[0]
-            out_splits = kwargs.get('out_splits', None)
-            in_splits = kwargs.get('in_splits', None)
-            # Quantizing the input/output tensor
-            input_tensors = _quantize_tensor(args[1], qtype)
-            out_tensors = _quantize_tensor(tensors, qtype)
-            dist.all_to_all_single(out_tensors, input_tensors, out_splits, in_splits, group=group)
-            for i, t in enumerate(_dequantize_tensor(out_tensors, qtype, quant_loss=quant_loss)):
-                tensors[i] = t
+        if ((func == dist.all_to_all_single) or (func == dist.all_to_all) or (func == dist.all_gather)):
+            dispatch[func](qtype, *args, **kwargs)
         else:
             raise RuntimeError(
                 f"The collective op {func} is not supported yet"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64573

Making the collective quantization API more flexible. This diff adds a handler that maps to each collective.

Differential Revision: [D30744267](https://our.internmc.facebook.com/intern/diff/D30744267/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @cbalioglu @gcramer23