### PR TITLE
Convert profiler schedule to a functor for serialization

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -3,6 +3,7 @@ import gc
 import io
 import json
 import os
+import pickle
 import unittest
 
 import torch
@@ -546,6 +547,7 @@ class TestProfiler(TestCase):
             warmup=1,
             active=2,
             repeat=2)
+        self.assertEqual(test_schedule, pickle.loads(pickle.dumps(test_schedule)))
         test_schedule_expected_outputs = [
             ProfilerAction.NONE,
             ProfilerAction.NONE,

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -3,7 +3,6 @@ import gc
 import io
 import json
 import os
-import pickle
 import unittest
 
 import torch


### PR DESCRIPTION
Fixes #64492

Functions generated from factories are not pickleable, but classes are. The one behavior change from this PR is that we no longer enforce kwargs for the ctor. Dataclasses are getting keyword-only support, but only in 3.10. (Which means we won't be able to use it until 3.13 or 3.14...)

Test plan: existing unit tests, plus a line for pickling.
