### PR TITLE
[Release-1.9] Stop warning on .names() access in max_pool2d and max_pool2d_backward

### DIFF
--- a/aten/src/ATen/native/DilatedMaxPool2d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool2d.cpp
@@ -66,14 +66,15 @@ bool ceil_mode) {
     outputHeight, outputWidth, memory_format);
 
   /* resize output and indices */
+  DimnameList maybe_names = input.has_names() ? input.names() : DimnameList{};
   if (input.ndimension() == 3) {
-    set_output(0, {nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), input.names());
+    set_output(0, {nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), maybe_names);
     /* indices will contain the locations for each output point */
-    set_output(1, {nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), input.names());
+    set_output(1, {nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), maybe_names);
   } else {
-    set_output(0, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), input.names());
+    set_output(0, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), maybe_names);
     /* indices will contain the locations for each output point */
-    set_output(1, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), input.names());
+    set_output(1, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), maybe_names);
   }
 }
 
@@ -152,7 +153,8 @@ const Tensor& indices) {
     outputHeight_for_shape_check, outputWidth_for_shape_check,
     memory_format);
 
-  set_output(0, input.sizes(), {}, input.options().memory_format(memory_format), input.names());
+  set_output(0, input.sizes(), {}, input.options().memory_format(memory_format),
+             input.has_names() ? input.names() : DimnameList{});
 }
 } // namespace meta
 

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -296,6 +296,15 @@ class TestNamedTensor(TestCase):
             check_tuple_return(F.max_pool2d_with_indices, [named_tensor_2d, [2, 2]], named_tensor_2d.names)
             check_tuple_return(F.max_pool3d_with_indices, [named_tensor_3d, [2, 2, 2]], named_tensor_3d.names)
 
+    def test_max_pooling_without_names_does_not_warn(self):
+        for device in torch.testing.get_all_device_types():
+            tensor_2d = torch.zeros(2, 3, 5, 7, device=device, requires_grad=True)
+            with warnings.catch_warnings(record=True) as warns:
+                warnings.simplefilter("always")
+                result = F.max_pool2d(tensor_2d, [2, 2])
+                result.sum().backward()
+                self.assertEqual(len(warns), 0)
+
     def test_no_save_support(self):
         named_tensor = torch.zeros(2, 3, names=('N', 'C'))
         buf = io.BytesIO()


### PR DESCRIPTION
Summary:
Cherry-pick of  https://github.com/pytorch/pytorch/pull/60059 into release/1.9 branch

Fixes #60053.

The problem is that `.names()` always triggers the named tensor warning.
To not trigger it, one has to guard it with has_names:
`x.has_names() ? x.names() : DimnameList{}`

This is not the first time this has happened; we should probably
make it so that .names() doesn't raise a warning unless it is actually
populated with names. That's a little tricky to implement so I'm leaving
it for the future.

Test Plan:
- New test, also run `python test/test_nn.py -v -k "max_pool"` and
confirm there are no warnings.

Reviewed By: gchanan

Differential Revision: D29152737

Pulled By: zou3519

fbshipit-source-id: 89a2fdbe6a6064a7044b5b75f7d0c58e51e57509

Fixes #{issue number}
