### PR TITLE
[Release-1.9.1] Fix CI failures

### DIFF
--- a/.circleci/docker/common/install_breakpad.sh
+++ b/.circleci/docker/common/install_breakpad.sh
@@ -2,14 +2,8 @@
 
 set -ex
 
-git clone https://github.com/driazati/breakpad.git
+git clone https://github.com/malfet/breakpad.git -b pytorch/release-1.9
 pushd breakpad
-
-# breakpad has no actual releases, so this is pinned to the top commit from
-# main when this was forked (including the one patch commit). This uses a fork
-# of the breakpad mainline that automatically daisy-chains out to any previously
-# installed signal handlers (instead of overwriting them).
-git checkout 5485e473ed46d065e05489e50dfc59d90dfd7e22
 
 git clone https://chromium.googlesource.com/linux-syscall-support src/third_party/lss
 pushd src/third_party/lss

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -61,6 +61,10 @@ RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
 RUN rm install_vision.sh
 ENV INSTALLED_VISION ${VISION}
 
+ADD ./common/install_openssl.sh install_openssl.sh
+ENV OPENSSL_ROOT_DIR /opt/openssl
+RUN bash ./install_openssl.sh
+
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH
@@ -92,10 +96,6 @@ ENV TORCH_NVCC_FLAGS "-Xfatbin -compress-all"
 
 # Install LLVM dev version (Defined in the pytorch/builder github repository)
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
-
-ADD ./common/install_openssl.sh install_openssl.sh
-ENV OPENSSL_ROOT_DIR /opt/openssl
-RUN bash ./install_openssl.sh
 
 USER jenkins
 CMD ["bash"]

--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -113,6 +113,10 @@ ADD ./common/install_ninja.sh install_ninja.sh
 RUN if [ -n "${NINJA_VERSION}" ]; then bash ./install_ninja.sh; fi
 RUN rm install_ninja.sh
 
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh
+ENV OPENSSL_ROOT_DIR /opt/openssl
+
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH
@@ -129,10 +133,6 @@ ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}
 
 # Install LLVM dev version (Defined in the pytorch/builder github repository)
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
-
-ADD ./common/install_openssl.sh install_openssl.sh
-RUN bash ./install_openssl.sh
-ENV OPENSSL_ROOT_DIR /opt/openssl
 
 USER jenkins
 CMD ["bash"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Python dependencies required for development
 astunparse
 future
-numpy
+numpy<1.21
 psutil
 pyyaml
 requests


### PR DESCRIPTION
Pin numpy version to 1.20 to avoid mypy failures
Re-fork https://github.com/google/breakpad to be able to access now deleted commit https://github.com/driazati/breakpad/commit/5485e473ed46d065e05489e50dfc59d90dfd7e22 (which github had now yet pruned at the time of this PR)

For the record, 1.9 was build with breakpad integration forked at  https://github.com/google/breakpad/commit/f7428bc397fd1e5bd6162a592ebc988d6d585eb3 plus following patch:
```
diff --git a/src/client/linux/handler/exception_handler.cc b/src/client/linux/handler/exception_handler.cc
index ca353c40..6d1fbfd5 100644
--- a/src/client/linux/handler/exception_handler.cc
+++ b/src/client/linux/handler/exception_handler.cc
@@ -381,7 +381,7 @@ void ExceptionHandler::SignalHandler(int sig, siginfo_t* info, void* uc) {
   // successfully, restore the default handler. Otherwise, restore the
   // previously installed handler. Then, when the signal is retriggered, it will
   // be delivered to the appropriate handler.
-  if (handled) {
+  if (false && handled) {
     InstallDefaultHandler(sig);
   } else {
     RestoreHandlersLocked();
```

Last but not the least: build OpenSSL before sccache, otherwise sccache "accelerated" build inside container times out 