### PR TITLE
[Release-1.9] Remove Caffe2 thread-pool leak warning (#60318)

### DIFF
--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -87,7 +87,6 @@ PThreadPool* pthreadpool() {
       auto num_threads = leaked->get_thread_count();
       // NOLINTNEXTLINE(modernize-make-unique)
       threadpool.reset(new PThreadPool(num_threads));
-      TORCH_WARN("Leaking Caffe2 thread-pool after fork.");
     }
   }
   return threadpool.get();


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/57273.

Some users reported that they dislike the Caffe2 thread-pool leak warning, as it floods their logs, and have requested disabling it, or have asked for a way to filter it.

It seems caffe2 pthreadpool already exists because of some dependency in the binary distribution, so `torch.set_num_threads()` invocation isn't required to reproduce the issue (as is otherwise the case when building from the master branch).

https://github.com/pytorch/pytorch/issues/60171's test script does have a `set_num_threads` invocation & hence that's why I was able to reproduce the issue after building from the master branch's source code.

cc malfet & ejguan, who have the authority to make a decision.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/60318

Reviewed By: albanD

Differential Revision: D29265771

Pulled By: ezyang

fbshipit-source-id: 26f678af2fec45ef8f7e1d39a57559790eb9e94b

Fixes #{issue number}
