### PR TITLE
Make torch._C.ScriptModule scriptable

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8200,6 +8200,28 @@ dedent """
         # c is used, then unused should be ordered by alphabetical
         FileCheck().check(r"%c : int, %a : int, %b : int").run(loop_unused.graph)
 
+    def test_script_module_conversion(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super(Foo, self).__init__()
+
+            def forward(self):
+                return 2
+
+        scripted_foo = torch.jit.script(Foo())
+        cpp_module = scripted_foo._c
+
+        class Bar(torch.nn.Module):
+            def __init__(self, m):
+                super(Bar, self).__init__()
+                self.m = m
+
+            def forward(self):
+                return self.m()
+
+        bar = Bar(cpp_module)
+        self.checkModule(bar, ())
+
     def test_filecheck(self):
         def test_check():
             file = "232"

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1232,6 +1232,25 @@ void initJitScriptBindings(PyObject* module) {
                 py::cast<Module>(other)._ivalue().get();
           })
       .def(
+          "__call__",
+          [](const Module& self, py::args args, py::kwargs kwargs) {
+            HANDLE_TH_ERRORS
+            Method method = self.get_method("forward");
+            return invokeScriptMethodFromPython(
+                method,
+                // NOLINTNEXTLINE(performance-move-const-arg)
+                std::move(args),
+                // NOLINTNEXTLINE(performance-move-const-arg)
+                std::move(kwargs));
+            // return invokeScriptMethodFromPython(
+            //     method,
+            //     // NOLINTNEXTLINE(performance-move-const-arg)
+            //     tuple_slice(std::move(args), 1),
+            //     // NOLINTNEXTLINE(performance-move-const-arg)
+            //     std::move(kwargs));
+            END_HANDLE_TH_ERRORS_PYBIND
+          })
+      .def(
           "__deepcopy__",
           [](const Module& self, const py::dict& memo) {
             return Module(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64696

This PR makes torch._C.ScriptModule scriptable by wrapping it in RecursiveScriptModule when we are scripting the top level model. By doing so, we can skip over re-scripting torch._C.ScriptModule. 
Differential Revision: [D30817088](https://our.internmc.facebook.com/intern/diff/D30817088)