### PR TITLE
Allow CPU self.min_val to be moved to GPU

### DIFF
--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -141,6 +141,11 @@ class FakeQuantize(FakeQuantizeBase):
             self.zero_point.copy_(_zero_point)
 
         if self.fake_quant_enabled[0] == 1:
+            # Make sure computation are done on the same device.
+            # In this case, moving self variables to X.device allows
+            # models to run fast under a distributed GPU setup.
+            self.scale = self.scale.to(device=X.device)
+            self.zero_point = self.zero_point.to(device=X.device)
             if self.is_per_channel:
                 X = torch.fake_quantize_per_channel_affine(
                     X, self.scale, self.zero_point,
@@ -231,6 +236,11 @@ class FixedQParamsFakeQuantize(FakeQuantizeBase):
 
     def forward(self, X):
         if self.fake_quant_enabled[0] == 1:
+            # Make sure computation are done on the same device.
+            # In this case, moving self variables to X.device allows
+            # models to run fast under a distributed GPU setup.
+            self.scale = self.scale.to(device=X.device)
+            self.zero_point = self.zero_point.to(device=X.device)
             X = torch.fake_quantize_per_tensor_affine(X, self.scale,
                                                       self.zero_point, self.quant_min,
                                                       self.quant_max)


### PR DESCRIPTION
Summary: Right after seeding a fake quantization model, we noticed that self.min_val and self.max_val are loaded from seed model into current model on CPU. During run time, errors showed up because the self.min_val and self.max_val of fake quantization is right now assumed to be initialized on GPU during first run-step.

Differential Revision: D30767803

