### PR TITLE
Reverts cat and stack warning when out= is not the expected shape

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -197,7 +197,7 @@ Tensor & _cat_out_cpu(TensorList tensors, int64_t dim, Tensor& result) {
   // for understanding why at::native::resize_output is not called directly.
   // if (at::native::resize_output_check(result, result_size)) {
   // TODO: restore the above, see https://github.com/pytorch/pytorch/issues/64709
-  
+
   if (result.sizes() != result_size) {
     result.resize_(result_size, first_tensor_mem_format);
   }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -195,7 +195,10 @@ Tensor & _cat_out_cpu(TensorList tensors, int64_t dim, Tensor& result) {
   // raise a warning while resizing if output has one or more elements
   // See https://github.com/pytorch/pytorch/pull/62560#discussion_r687363362
   // for understanding why at::native::resize_output is not called directly.
-  if (at::native::resize_output_check(result, result_size)) {
+  // if (at::native::resize_output_check(result, result_size)) {
+  // TODO: restore the above, see https://github.com/pytorch/pytorch/issues/64709
+  
+  if (result.sizes() != result_size) {
     result.resize_(result_size, first_tensor_mem_format);
   }
 
@@ -1517,7 +1520,13 @@ bool inline maybe_native_stack(Tensor& result, TensorList tensors, int64_t dim) 
 
     // skip resizing if size of result is same as expected
     // raise a warning while resizing if output has one or more elements
-    at::native::resize_output(result, result_sizes);
+    // at::native::resize_output(result, result_sizes);
+    // TODO: restore the above, see https://github.com/pytorch/pytorch/issues/64709
+
+    if (result.sizes() != result_sizes) {
+      result.resize_(result_sizes);
+    }
+
     stack_serial_stub(kCPU, result, tensors, dim);
     return true;
   }

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -534,7 +534,7 @@ Tensor& cat_out_cuda(TensorList inputs, int64_t dimension, Tensor& out) {
   // for understanding why at::native::resize_output is not called directly.
   // if (at::native::resize_output_check(out, size)) {
   // TODO: restore the above, see https://github.com/pytorch/pytorch/issues/64709
-  
+
   if (out.sizes() != size) {
     out.resize_(size, memory_format);
   }

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -532,7 +532,10 @@ Tensor& cat_out_cuda(TensorList inputs, int64_t dimension, Tensor& out) {
   // raise a warning while resizing if output has one or more elements
   // See https://github.com/pytorch/pytorch/pull/62560#discussion_r687363362
   // for understanding why at::native::resize_output is not called directly.
-  if (at::native::resize_output_check(out, size)) {
+  // if (at::native::resize_output_check(out, size)) {
+  // TODO: restore the above, see https://github.com/pytorch/pytorch/issues/64709
+  
+  if (out.sizes() != size) {
     out.resize_(size, memory_format);
   }
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8741,8 +8741,8 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
            supports_forward_ad=True,
            skips=(
-             # TODO: see https://github.com/pytorch/pytorch/issues/64709
-             SkipInfo('TestCommon', 'test_out'),
+               # TODO: see https://github.com/pytorch/pytorch/issues/64709
+               SkipInfo('TestCommon', 'test_out'),
            )),
     OpInfo('unfold',
            op=lambda x, *args: x.unfold(*args),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8682,7 +8682,7 @@ op_db: List[OpInfo] = [
     OpInfo('stack',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_stack,
-           assert_autodiffed=True
+           assert_autodiffed=True,
            skips=(
                # TODO: see https://github.com/pytorch/pytorch/issues/64709
                SkipInfo('TestCommon', 'test_out'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8685,7 +8685,7 @@ op_db: List[OpInfo] = [
            assert_autodiffed=True
            skips=(
                # TODO: see https://github.com/pytorch/pytorch/issues/64709
-               SkipInfo('TestCommon', 'test_out'), 
+               SkipInfo('TestCommon', 'test_out'),
            )),
     OpInfo('hstack',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
@@ -8693,7 +8693,7 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            skips=(
                # TODO: see https://github.com/pytorch/pytorch/issues/64709
-               SkipInfo('TestCommon', 'test_out'), 
+               SkipInfo('TestCommon', 'test_out'),
            )),
     OpInfo('hypot',
            dtypes=floating_types(),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8711,6 +8711,8 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            assert_autodiffed=True,
            skips=(
+               # TODO: see https://github.com/pytorch/pytorch/issues/64709
+               SkipInfo('TestCommon', 'test_out'),
                # RuntimeError: Arguments for call not valid.
                #               Expected a value of type 'List[Tensor]' for argument
                #               'tensors' but instead found type 'Tensor (inferred)'.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8682,11 +8682,19 @@ op_db: List[OpInfo] = [
     OpInfo('stack',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_stack,
-           assert_autodiffed=True),
+           assert_autodiffed=True
+           skips=(
+               # TODO: see https://github.com/pytorch/pytorch/issues/64709
+               SkipInfo('TestCommon', 'test_out'), 
+           )),
     OpInfo('hstack',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
-           supports_forward_ad=True),
+           supports_forward_ad=True,
+           skips=(
+               # TODO: see https://github.com/pytorch/pytorch/issues/64709
+               SkipInfo('TestCommon', 'test_out'), 
+           )),
     OpInfo('hypot',
            dtypes=floating_types(),
            dtypesIfCPU=floating_types_and(torch.bfloat16),
@@ -8723,13 +8731,19 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
            supports_forward_ad=True,
            skips=(
+               # TODO: see https://github.com/pytorch/pytorch/issues/64709
+               SkipInfo('TestCommon', 'test_out'),
                # RuntimeError: _fn() Expected a value of type
                #   'Tensor (inferred)' for argument 't0' but instead found type 'tuple'.
                SkipInfo('TestJit', 'test_jit_alias_remapping'),)),
     OpInfo('dstack',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
-           supports_forward_ad=True),
+           supports_forward_ad=True,
+           skips=(
+             # TODO: see https://github.com/pytorch/pytorch/issues/64709
+             SkipInfo('TestCommon', 'test_out'),
+           )),
     OpInfo('unfold',
            op=lambda x, *args: x.unfold(*args),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),


### PR DESCRIPTION
These warnings are being thrown too aggressively at the moment. See https://github.com/pytorch/pytorch/issues/64709 for a follow-up to reenable them once internal call sites are reviewed.