### PR TITLE
Fix lop1p lowering bug

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -529,7 +529,7 @@ def relu(*, input, inplace=False):
 )
 def torch_log1p_mapper(node: torch.fx.Node, _: torch.nn.Module) -> torch.fx.Node:
     with node.graph.inserting_before(node):
-        add_kwargs = {"input": node.kwargs["input"], "other": 1}
+        add_kwargs = {"input": node.kwargs["input"], "other": 1.0}
         add_node = node.graph.call_function(add, kwargs=add_kwargs)
         add_node.meta = node.meta.copy()
         log_kwargs = {"input": add_node}


### PR DESCRIPTION
Summary:
`1` will introduce a int tensor instead of float tensor, which doesn't work well with downstream operators (elementwise). Error would be like
```
[TensorRT] WARNING: IElementWiseLayer with inputs (Unnamed Layer* 1) [Unary]_output and (Unnamed Layer* 2) [Constant]_output: first input has type Float but second input has type Int32.
```
Changing the constant to be float type fixes this.

Reviewed By: 842974287

Differential Revision: D30796959

