### PR TITLE
Fixes failure in test_dataloader.py that occurs on jetson boards

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -67,8 +67,11 @@ load_tests = load_tests
 # as well during the execution of this test suite, and it will cause
 # CUDA OOM error on Windows.
 TEST_CUDA = torch.cuda.is_available()
-dev_name = torch.cuda.get_device_name(torch.cuda.current_device()).lower()
-IS_JETSON = 'xavier' in dev_name or 'nano' in dev_name or 'jetson' in dev_name or 'tegra' in dev_name
+if TEST_CUDA:
+    dev_name = torch.cuda.get_device_name(torch.cuda.current_device()).lower()
+    IS_JETSON = 'xavier' in dev_name or 'nano' in dev_name or 'jetson' in dev_name or 'tegra' in dev_name
+else:
+    IS_JETSON = False
 
 if not NO_MULTIPROCESSING_SPAWN:
     # We want to use `spawn` if able because some of our tests check that the
@@ -1335,7 +1338,7 @@ except RuntimeError as e:
         counting_ds_n = 11
         dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
         for ctx in supported_multiprocessing_contexts:
-            # windows doesn't support sharing cuda tensor; ROCm does not yet fully support IPC
+            # windows and jetson devices don't support sharing cuda tensor; ROCm does not yet fully support IPC
             if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS and not IS_JETSON:
                 ds_cls = CUDACountingDataset
             else:

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -67,7 +67,8 @@ load_tests = load_tests
 # as well during the execution of this test suite, and it will cause
 # CUDA OOM error on Windows.
 TEST_CUDA = torch.cuda.is_available()
-
+dev_name = torch.cuda.get_device_name(torch.cuda.current_device()).lower()
+IS_JETSON = 'xavier' in dev_name or 'nano' in dev_name or 'jetson' in dev_name or 'tegra' in dev_name
 
 if not NO_MULTIPROCESSING_SPAWN:
     # We want to use `spawn` if able because some of our tests check that the
@@ -1335,7 +1336,7 @@ except RuntimeError as e:
         dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
         for ctx in supported_multiprocessing_contexts:
             # windows doesn't support sharing cuda tensor; ROCm does not yet fully support IPC
-            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS:
+            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS and not IS_JETSON:
                 ds_cls = CUDACountingDataset
             else:
                 ds_cls = CountingDataset


### PR DESCRIPTION
CUDA IPC is not supported for jetsons

