### PR TITLE
[ONNX] Support torch.isfinite export

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6176,10 +6176,10 @@ class TestONNXRuntime(unittest.TestCase):
     def test_log10(self):
         class Log10(torch.nn.Module):
             def forward(self, input):
-                return torch.log1p(input)
+                return torch.log10(input)
+
         x = torch.rand(2, 3, 4)
-        model = Log10()
-        self.run_test(model, x)
+        self.run_test(Log10(), x)
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_round(self):
@@ -7012,7 +7012,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2, float("inf")], [2, float("nan"), float("inf")]])
         self.run_test(M(), (x, ))
 
-    @skipIfUnsupportedMinOpsetVersion(10)  # ONNX IsInf op is added in opset 10.
+    @skipIfUnsupportedMinOpsetVersion(10)
     def test_isfinite(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6172,6 +6172,15 @@ class TestONNXRuntime(unittest.TestCase):
         model = Log1p()
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_log10(self):
+        class Log10(torch.nn.Module):
+            def forward(self, input):
+                return torch.log1p(input)
+        x = torch.rand(2, 3, 4)
+        model = Log10()
+        self.run_test(model, x)
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_round(self):
         class Round(torch.nn.Module):
@@ -7001,6 +7010,15 @@ class TestONNXRuntime(unittest.TestCase):
                 return x.isinf()
 
         x = torch.tensor([[1, 2, float("inf")], [2, float("nan"), float("inf")]])
+        self.run_test(M(), (x, ))
+
+    @skipIfUnsupportedMinOpsetVersion(10)  # ONNX IsInf op is added in opset 10.
+    def test_isfinite(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x.isfinite()
+
+        x = torch.tensor([[1, 2, float("inf")], [2, float("nan"), -float("inf")]])
         self.run_test(M(), (x, ))
 
     @skipIfUnsupportedMinOpsetVersion(9)  # ONNX IsNaN op is added in opset 9.

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6172,15 +6172,6 @@ class TestONNXRuntime(unittest.TestCase):
         model = Log1p()
         self.run_test(model, x)
 
-    @skipIfUnsupportedMinOpsetVersion(9)
-    def test_log10(self):
-        class Log10(torch.nn.Module):
-            def forward(self, input):
-                return torch.log10(input)
-
-        x = torch.rand(2, 3, 4)
-        self.run_test(Log10(), x)
-
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_round(self):
         class Round(torch.nn.Module):

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -307,6 +307,14 @@ def fake_quantize_per_tensor_affine(g, inputs, scale, zero_point, quant_min=-128
     zero_point = torch.tensor(zero_point, dtype=zero_point_dtype)  # ONNX requires zero_point to be tensor
     return g.op("DequantizeLinear", g.op("QuantizeLinear", inputs, scale, zero_point), scale, zero_point)
 
+
 def isinf(g, input):
     from torch.onnx.symbolic_opset9 import _cast_Double  # type: ignore[attr-defined]
     return g.op("IsInf", _cast_Double(g, input, False))
+
+
+def isfinite(g, input):
+    from torch.onnx.symbolic_opset9 import isnan, __or_, __not_
+    inf_node = isinf(g, input)
+    nan_node = isnan(g, input)
+    return __not_(g, __or_(g, inf_node, nan_node))

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -314,7 +314,7 @@ def isinf(g, input):
 
 
 def isfinite(g, input):
-    from torch.onnx.symbolic_opset9 import isnan, __or_, __not_
+    from torch.onnx.symbolic_opset9 import isnan, __not_, __or_
     inf_node = isinf(g, input)
     nan_node = isnan(g, input)
     return __not_(g, __or_(g, inf_node, nan_node))

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1540,7 +1540,7 @@ def log1p(g, self):
 
 
 def log10(g, self):
-    return div(g, log(g, self), sym_help._if_scalar_type_as(g, torch.ones(1) * 10, self))
+    return div(g, log(g, self), log(g, sym_help._if_scalar_type_as(g, torch.ones(1) * 10, self)))
 
 
 def pow(g, self, exponent):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1539,6 +1539,10 @@ def log1p(g, self):
     return log(g, add(g, sym_help._if_scalar_type_as(g, torch.ones(1), self), self))
 
 
+def log10(g, self):
+    return div(g, log(g, self), sym_help._if_scalar_type_as(g, torch.log(10), self))
+
+
 def pow(g, self, exponent):
     f_dtype = self_dtype = self.type().scalarType()
     if not sym_help._is_fp(self):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1540,7 +1540,7 @@ def log1p(g, self):
 
 
 def log10(g, self):
-    return div(g, log(g, self), sym_help._if_scalar_type_as(g, torch.log(10), self))
+    return div(g, log(g, self), sym_help._if_scalar_type_as(g, torch.ones(1) * 10, self))
 
 
 def pow(g, self, exponent):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1539,10 +1539,6 @@ def log1p(g, self):
     return log(g, add(g, sym_help._if_scalar_type_as(g, torch.ones(1), self), self))
 
 
-def log10(g, self):
-    return div(g, log(g, self), log(g, sym_help._if_scalar_type_as(g, torch.ones(1) * 10, self)))
-
-
 def pow(g, self, exponent):
     f_dtype = self_dtype = self.type().scalarType()
     if not sym_help._is_fp(self):


### PR DESCRIPTION
Summary:
Pull Request resolved:  #64754

1. onnx::IsInf is introduced in opset 10, onnx:isnan is introduced in opset 9 -> isfinite = not(or(isinf,isnan)) -> opset 10

Test Plan: Imported from OSS