### PR TITLE
[simple][torchelastic] Improve warning message

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -175,16 +175,17 @@ def launch(args):
 
 
 def main(args=None):
-    warnings.warn(
-        "The module torch.distributed.launch is deprecated\n"
-        "and will be removed in future. Use torchrun.\n"
-        "Note that --use_env is set by default in torchrun.\n"
-        "If your script expects `--local_rank` argument to be set, please\n"
-        "change it to read from `os.environ['LOCAL_RANK']` instead. See \n"
-        "https://pytorch.org/docs/stable/distributed.html#launch-utility for \n"
-        "further instructions\n",
-        FutureWarning,
-    )
+    msg: str = """
+        The module torch.distributed.launch is deprecated
+        and will be removed in future. Use torchrun.
+        Note that --use_env is set by default in torchrun.
+        If your script expects `--local_rank` argument to be set, please
+        change it to read from `os.environ['LOCAL_RANK']` instead. See
+        https://pytorch.org/docs/stable/distributed.html#launch-utility for
+        further instructions,
+    """
+
+    warnings.warn(msg, FutureWarning)
     args = parse_args(args)
     launch(args)
 


### PR DESCRIPTION
Summary: Improve warn message printed when executing `torch.distributed.launch`

Test Plan:
Previous message:

    /home/ubuntu/anaconda3/envs/aivanou-dev/lib/python3.8/site-packages/torch/distributed/launch.py:178: FutureWarning: The module torch.distributed.launch is deprecated
    and will be removed in future. Use torchrun.
    Note that --use_env is set by default in torchrun.
    If your script expects `--local_rank` argument to be set, please
    change it to read from `os.environ['LOCAL_RANK']` instead. See
    https://pytorch.org/docs/stable/distributed.html#launch-utility for
    further instructions

  warnings.warn(

New message:

    /home/ubuntu/anaconda3/envs/aivanou-dev/lib/python3.8/site-packages/torch/distributed/launch.py:188: FutureWarning:
        The module torch.distributed.launch is deprecated
        and will be removed in future. Use torchrun.
        Note that --use_env is set by default in torchrun.
        If your script expects `--local_rank` argument to be set, please
        change it to read from `os.environ['LOCAL_RANK']` instead. See
        https://pytorch.org/docs/stable/distributed.html#launch-utility for
        further instructions,

  warnings.warn(msg, FutureWarning)

Differential Revision: D30845772



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @cbalioglu @gcramer23