### PR TITLE
[Static Runtime] Fix resize_output_check warning coming from prim::VarConcat

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1833,6 +1833,7 @@ REGISTER_OPERATOR_FUNCTOR(
           check_cat_no_zero_dim(inputs);
           dim = legacy_cat_wrap_dim(dim, inputs);
           auto& out_t = p_node->Output(0).toTensor();
+          fastResizeToZero(out_t);
           at::native::_cat_out_cpu(inputs, dim, out_t);
         }
       };


### PR DESCRIPTION
Test Plan: Tested the fix with BR v1 model predictor-replayer setup.

Differential Revision: D30846506

