### PR TITLE
[caffe2/aten] Remove loose #pragma warning ( pop ) in TensorBase.h

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -755,12 +755,6 @@ private:
   TensorBase __dispatch_contiguous(c10::MemoryFormat) const;
 };
 
-// For "multiple ... operators specified" warnings, closing brace of class
-// declaration must be included between pragma push & pop
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-
 inline int64_t get_device(const TensorBase& self) {
   return self.get_device();
 }


### PR DESCRIPTION
Summary: Remove loose `#pragma warning ( pop )` in TensorBase.h.

Reviewed By: ezyang

Differential Revision: D30846958

