### PR TITLE
[PyTorch] Define C10_MOBILE when building c10 target itself

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -376,12 +376,16 @@ __host__ __device__
 
 #if defined(__ANDROID__)
 #define C10_ANDROID 1
-#define C10_MOBILE 1
+#ifndef C10_MOBILE
+#error "building for Android but forgot to define C10_MOBILE!"
+#endif
 #elif (                   \
     defined(__APPLE__) && \
     (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE))
 #define C10_IOS 1
-#define C10_MOBILE 1
+#ifndef C10_MOBILE
+#error "building for iOS but forgot to define C10_MOBILE!"
+#endif
 #endif // ANDROID / IOS
 
 // Portable determination of whether type T is trivially copyable.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #64753
* __->__ #64779

See updated code comment for explanation.

Differential Revision: [D30849739](https://our.internmc.facebook.com/intern/diff/D30849739/)