### PR TITLE
[DataPipe] Make TarArchiveReader and ZipArchiveReader accepts FileSream with attempt to close and additional warning

### DIFF
--- a/torch/utils/data/datapipes/iter/tararchivereader.py
+++ b/torch/utils/data/datapipes/iter/tararchivereader.py
@@ -10,11 +10,11 @@ import warnings
 class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
     r""" :class:`TarArchiveReaderIterDataPipe`.
 
-    Iterable datapipe to extract tar binary streams from input iterable which contains tuples of
-    pathname and tar binary stream, yields pathname and extracted binary stream in a tuple.
+    Iterable datapipe to extract tar binary streams from input iterable which contains tuples of pathnames and
+    tar binary stream. This yields a tuple of pathname and extracted binary stream.
 
     Args:
-        datapipe: Iterable datapipe that provides pathname and tar binary stream in tuples
+        datapipe: Iterable datapipe that provides tuples of pathname and tar binary stream
         mode: File mode used by `tarfile.open` to read file object.
             Mode has to be a string of the form 'filemode[:compression]'
         length: a nominal length of the datapipe
@@ -22,7 +22,7 @@ class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
     Note:
         The opened file handles will be closed automatically if the default DecoderDataPipe
         is attached. Otherwise, user should be responsible to close file handles explicitly
-        or let Python's GC close them periodly.
+        or let Python's GC close them periodically.
     """
     def __init__(
         self,
@@ -36,8 +36,6 @@ class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         self.length: int = length
 
     def __iter__(self) -> Iterator[Tuple[str, BufferedIOBase]]:
-        if not isinstance(self.datapipe, Iterable):
-            raise TypeError("datapipe must be Iterable type but got {}".format(type(self.datapipe)))
         for data in self.datapipe:
             validate_pathname_binary_tuple(data)
             pathname, data_stream = data
@@ -52,15 +50,13 @@ class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
                         warnings.warn("failed to extract file {} from source tarfile {}".format(tarinfo.name, pathname))
                         raise tarfile.ExtractError
                     inner_pathname = os.path.normpath(os.path.join(pathname, tarinfo.name))
-                    # Add a reference of the source tarfile into extracted_fobj, so the source
-                    # tarfile handle won't be released until all the extracted file objs are destroyed.
-                    extracted_fobj.source_ref = tar  # type: ignore[attr-defined]
-                    # typing.cast is used here to silence mypy's type checker
-                    yield (inner_pathname, cast(BufferedIOBase, extracted_fobj))
+                    yield (inner_pathname, extracted_fobj)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(
                     "Unable to extract files from corrupted tarfile stream {} due to: {}, abort!".format(pathname, e))
                 raise e
+            finally:
+                data_stream.close()
 
     def __len__(self):
         if self.length == -1:

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -54,7 +54,6 @@ def get_file_binaries_from_pathnames(pathnames: Iterable, mode: str):
                             .format(type(pathname)))
         yield (pathname, open(pathname, mode))
 
-
 def validate_pathname_binary_tuple(data):
     if not isinstance(data, tuple):
         raise TypeError("pathname binary data should be tuple type, but got {}".format(type(data)))


### PR DESCRIPTION
ghstack is not working for the second commit so I'm manually creating this PR for now. Please only look at changes related to the second commit in this PR (there is a PR for the first commit).

This PR removes TarArchiveReader's dependency on FileLoader DataPipe, by allowing it to use a IterDataPipe of path names as input rather than a tuple of path name and a stream.

It also adds additional tests to ensure that the DataPipe is functioning properly when it is read multiple times or reset half way through reading.

The whole stack fixes #64281 - issues related to unclosed buffer stream.

Stack:
* __->__ #64788
* #64786

cc @VitalyFedyunin @ejguan