### PR TITLE
[Operator] Adding support for Threshold operator

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -1017,6 +1017,14 @@ at::Tensor LazyNativeFunctions::tanh_backward(const at::Tensor& grad_output,
       bridge::GetLtcTensor(grad_output), bridge::GetLtcTensor(output)));
 }
 
+at::Tensor LazyNativeFunctions::threshold(const at::Tensor& self,
+                                          const at::Scalar& threshold,
+                                          const at::Scalar& value) {
+  LTC_FN_COUNTER("lazy::");
+  return bridge::AtenFromLtcTensor(LazyTensor::threshold(
+      bridge::GetLtcTensor(self), threshold.to<double>(), value.to<double>()));
+}
+
 at::Tensor LazyNativeFunctions::threshold_backward(const at::Tensor& grad_output,
     const at::Tensor& self, const at::Scalar& threshold)
 {

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -60,6 +60,7 @@ supported:
   - t
   - t_
   - tanh
+  - threshold
   - threshold_backward
   - transpose.int
   - transpose_


### PR DESCRIPTION
Summary: This patch adds support for Threshold operator.

Test Plan: 
[.../pytorch/lazy_tensor_core] test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestThreshold

cc @alanwaketan @wconstab 

Relevant Issue - https://github.com/pytorch/pytorch/issues/62431