### PR TITLE
[Release-1.9.1] Remove use_env from torch.distributed.run, clarify bc around that parameter in comment. (#59409)

### DIFF
--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -445,19 +445,6 @@ def get_args_parser() -> ArgumentParser:
 
 def parse_args(args):
     parser = get_args_parser()
-
-    #
-    # Legacy arguments.
-    #
-
-    parser.add_argument(
-        "--use_env",
-        default=True,
-        action="store_true",
-        help="Use environment variable to pass local rank. If set to True (default), the script "
-        "will NOT pass --local_rank as argument, and will instead set LOCAL_RANK.",
-    )
-
     return parser.parse_args(args)
 
 
@@ -512,6 +499,19 @@ def get_rdzv_endpoint(args):
     return args.rdzv_endpoint
 
 
+def get_use_env(args) -> bool:
+    """
+    Retrieves ``use_env`` from the args.
+    ``use_env`` is a legacy argument, if ``use_env`` is False, the
+    ``--node_rank`` argument will be transferred to all worker processes.
+    ``use_env`` is only used by the ``torch.distributed.launch`` and will
+    be deprecated in future releases.
+    """
+    if not hasattr(args, "use_env"):
+        return True
+    return args.use_env
+
+
 def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str]]:
     # If ``args`` not passed, defaults to ``sys.argv[:1]``
     min_nodes, max_nodes = parse_min_max_nnodes(args.nnodes)
@@ -559,6 +559,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
     with_python = not args.no_python
     cmd: Union[Callable, str]
     cmd_args = []
+    use_env = get_use_env(args)
     if args.run_path:
         cmd = run_script_path
         cmd_args.append(args.training_script)
@@ -570,7 +571,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
                 cmd_args.append("-m")
             cmd_args.append(args.training_script)
         else:
-            if not args.use_env:
+            if not use_env:
                 raise ValueError(
                     "When using the '--no_python' flag,"
                     " you must also set the '--use_env' flag."
@@ -581,7 +582,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
                     " and the '--module' flag at the same time."
                 )
             cmd = args.training_script
-    if not args.use_env:
+    if not use_env:
         log.warning(
             "--use_env is deprecated and will be removed in future releases.\n"
             " Please read local_rank from `os.environ('LOCAL_RANK')` instead."


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/59409

Remove use_env from torch.distributed.run, and clarify bc around that parameter in comment.

Test Plan: n/a

Reviewed By: cbalioglu

Differential Revision: D28876485

fbshipit-source-id: 5f10365968d204985ce517b83c392c688995d76e
