### PR TITLE
[Release-1.9.1]: Fix elastic launch doc (#62378)

### DIFF
--- a/docs/source/elastic/train_script.rst
+++ b/docs/source/elastic/train_script.rst
@@ -18,7 +18,7 @@ working with ``torch.distributed.run`` with these differences:
    ``save_checkpoint(path)`` logic in your script. When any number of
    workers fail we restart all the workers with the same program
    arguments so you will lose progress up to the most recent checkpoint
-   (see `elastic launch <distributed.html>`_).
+   (see `elastic launch <run.html>`_).
 
 4. ``use_env`` flag has been removed. If you were parsing local rank by parsing
    the ``--local_rank`` option, you need to get the local rank from the


### PR DESCRIPTION
Summary:
The documentation link should be https://pytorch.org/docs/stable/elastic/run.html

Pull Request resolved: https://github.com/pytorch/pytorch/pull/62378

Reviewed By: aivanou

Differential Revision: D30002830

Pulled By: kiukchung

fbshipit-source-id: 34b434acaa10222561df43f6397a2420eef02015

Fixes #{issue number}
