### PR TITLE
.circleci: Skip cuda / cudnn install if existing

### DIFF
--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -35,14 +35,14 @@ else
 
     curl --retry 3 -kLO $cuda_installer_link
     7z x ${cuda_installer_name}.exe -o${cuda_installer_name}
-    mkdir cuda_install_logs
-    trap 'rm -rf ${cuda_installer_name} ${cuda_installer_name}.exe cuda_install_logs' EXIT
+    cuda_install_logs=$(mktemp -d)
+    trap 'rm -rf ${cuda_installer_name} ${cuda_installer_name}.exe ${cuda_install_logs}' EXIT
 
     (
         # subshell for +e
         set +e
         pushd "${cuda_installer_name}"
-        ./setup.exe -s "${cuda_install_packages}" -loglevel:6 -log:"$(pwd -W)/cuda_install_logs"
+        ./setup.exe -s "${cuda_install_packages}" -loglevel:6 -log:"${cuda_install_logs}"
     )
 
     if [[ ! -f "/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA_VERSION}/bin/nvcc.exe" ]]; then

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -67,6 +67,3 @@ else
     cp -r NvToolsExt/* "C:/Program Files/NVIDIA Corporation/NvToolsExt/"
     export NVTOOLSEXT_PATH="C:\\Program Files\\NVIDIA Corporation\\NvToolsExt\\"
 fi
-
-# Always copy vc integration to set env variables
-cp -r ${msbuild_project_dir}/* "C:/Program Files (x86)/Microsoft Visual Studio/2019/${VC_PRODUCT}/MSBuild/Microsoft/VC/v160/BuildCustomizations/"

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eux -o pipefail
 
-cuda_major_version=${CUDA_VERSION%.*}
-
 case ${CUDA_VERSION} in
     10.1)
         cuda_installer_name="cuda_10.1.243_426.00_win10"
@@ -38,12 +36,12 @@ else
     curl --retry 3 -kLO $cuda_installer_link
     7z x ${cuda_installer_name}.exe -o${cuda_installer_name}
     mkdir cuda_install_logs
-    trap 'rm -rf $cuda_installer_link $cuda_installer_name cuda_install_logs' EXIT
+    trap 'rm -rf ${cuda_installer_name} ${cuda_installer_name}.exe cuda_install_logs' EXIT
 
     (
         # subshell for +e
         set +e
-        pushd ${cuda_installer_name}
+        pushd "${cuda_installer_name}"
         ./setup.exe -s "${cuda_install_packages}" -loglevel:6 -log:"$(pwd -W)/cuda_install_logs"
     )
 

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
 set -eux -o pipefail
 
-cuda_major_version=${CUDA_VERSION%.*}
-
 case ${CUDA_VERSION} in
     10.1)
         cuda_installer_name="cuda_10.1.243_426.00_win10"
-        msbuild_project_dir="CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
         cuda_install_packages="nvcc_10.1 cuobjdump_10.1 nvprune_10.1 cupti_10.1 cublas_10.1 cublas_dev_10.1 cudart_10.1 cufft_10.1 cufft_dev_10.1 curand_10.1 curand_dev_10.1 cusolver_10.1 cusolver_dev_10.1 cusparse_10.1 cusparse_dev_10.1 nvgraph_10.1 nvgraph_dev_10.1 npp_10.1 npp_dev_10.1 nvrtc_10.1 nvrtc_dev_10.1 nvml_dev_10.1"
         ;;
     10.2)
         cuda_installer_name="cuda_10.2.89_441.22_win10"
-        msbuild_project_dir="CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
         cuda_install_packages="nvcc_10.2 cuobjdump_10.2 nvprune_10.2 cupti_10.2 cublas_10.2 cublas_dev_10.2 cudart_10.2 cufft_10.2 cufft_dev_10.2 curand_10.2 curand_dev_10.2 cusolver_10.2 cusolver_dev_10.2 cusparse_10.2 cusparse_dev_10.2 nvgraph_10.2 nvgraph_dev_10.2 npp_10.2 npp_dev_10.2 nvrtc_10.2 nvrtc_dev_10.2 nvml_dev_10.2"
         ;;
     11.1)
         cuda_installer_name="cuda_11.1.0_456.43_win10"
-        msbuild_project_dir="visual_studio_integration/CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
         cuda_install_packages="nvcc_11.1 cuobjdump_11.1 nvprune_11.1 nvprof_11.1 cupti_11.1 cublas_11.1 cublas_dev_11.1 cudart_11.1 cufft_11.1 cufft_dev_11.1 curand_11.1 curand_dev_11.1 cusolver_11.1 cusolver_dev_11.1 cusparse_11.1 cusparse_dev_11.1 npp_11.1 npp_dev_11.1 nvrtc_11.1 nvrtc_dev_11.1 nvml_dev_11.1"
         ;;
     11.3)
         cuda_installer_name="cuda_11.3.0_465.89_win10"
-        msbuild_project_dir="visual_studio_integration/CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
         cuda_install_packages="thrust_11.3 nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
         ;;
     *)
@@ -70,4 +64,3 @@ else
     cp -r NvToolsExt/* "C:/Program Files/NVIDIA Corporation/NvToolsExt/"
     export NVTOOLSEXT_PATH="C:\\Program Files\\NVIDIA Corporation\\NvToolsExt\\"
 fi
-

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -37,13 +37,14 @@ else
 
     curl --retry 3 -kLO $cuda_installer_link
     7z x ${cuda_installer_name}.exe -o${cuda_installer_name}
-    cd ${cuda_installer_name}
     mkdir cuda_install_logs
+    trap 'rm -rf $cuda_installer_link $cuda_installer_name cuda_install_logs' EXIT
 
     (
         # subshell for +e
         set +e
-        ./setup.exe -s ${cuda_install_packages} -loglevel:6 -log:"$(pwd -W)/cuda_install_logs"
+        pushd ${cuda_installer_name}
+        ./setup.exe -s "${cuda_install_packages}" -loglevel:6 -log:"$(pwd -W)/cuda_install_logs"
     )
 
     if [[ ! -f "/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA_VERSION}/bin/nvcc.exe" ]]; then
@@ -52,10 +53,6 @@ else
         7z a "c:\\w\\build-results\\cuda_install_logs.7z" cuda_install_logs
         exit 1
     fi
-
-    cd ..
-    rm -rf ./${cuda_installer_name}
-    rm -f ./${cuda_installer_name}.exe
 fi
 
 if [[ -f "/c/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64/nvToolsExt64_1.dll" ]]; then

--- a/.circleci/scripts/windows_cudnn_install.sh
+++ b/.circleci/scripts/windows_cudnn_install.sh
@@ -29,11 +29,15 @@ cudnn_installer_name="cudnn_installer.zip"
 cudnn_installer_link="https://ossci-windows.s3.amazonaws.com/cudnn-${CUDA_VERSION}-windows${windows_version_qualifier}-x64-${archive_version}.zip"
 cudnn_install_folder="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA_VERSION}/"
 
-curl --retry 3 -o "${cudnn_installer_name}" "$cudnn_installer_link"
-7z x "${cudnn_installer_name}" -ocudnn
-# shellcheck recommends to use '${var:?}/*' to avoid potentially expanding to '/*'
-# Remove all of the directories before attempting to copy files
-rm -rf "${cudnn_install_folder:?}/*"
-cp -rf cudnn/cuda/* "${cudnn_install_folder}"
-rm -rf cudnn
-rm -f "${cudnn_installer_name}.zip"
+if [[ -f "${cudnn_install_folder}/include/cudnn.h" ]]; then
+    echo "Existing cudnn installation found, skipping install..."
+else
+    curl --retry 3 -o "${cudnn_installer_name}" "$cudnn_installer_link"
+    7z x "${cudnn_installer_name}" -ocudnn
+    # shellcheck recommends to use '${var:?}/*' to avoid potentially expanding to '/*'
+    # Remove all of the directories before attempting to copy files
+    rm -rf "${cudnn_install_folder:?}/*"
+    cp -rf cudnn/cuda/* "${cudnn_install_folder}"
+    rm -rf cudnn
+    rm -f "${cudnn_installer_name}.zip"
+fi

--- a/.circleci/scripts/windows_cudnn_install.sh
+++ b/.circleci/scripts/windows_cudnn_install.sh
@@ -34,7 +34,7 @@ if [[ -f "${cudnn_install_folder}/include/cudnn.h" ]]; then
 else
     curl --retry 3 -o "${cudnn_installer_name}" "$cudnn_installer_link"
     7z x "${cudnn_installer_name}" -ocudnn
-    # shellcheck recommends to use '${var:?}/*' to avoid potentially expanding to '/*'
+    # Use '${var:?}/*' to avoid potentially expanding to '/*'
     # Remove all of the directories before attempting to copy files
     rm -rf "${cudnn_install_folder:?}/*"
     cp -rf cudnn/cuda/* "${cudnn_install_folder}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64825

Rewrites this script to only install the CUDA tools if they are not already
pre-installed

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D30869803](https://our.internmc.facebook.com/intern/diff/D30869803)

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @ezyang @seemethere @malfet @lg20987 @pytorch/pytorch-dev-infra