### PR TITLE
[quant] handle empty input in fused_moving_avg_obs_fake_quant op

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
@@ -220,6 +220,9 @@ at::Tensor fused_moving_avg_obs_fake_quant(
     const int64_t ch_axis,
     bool per_row_fake_quant,
     bool symmetric_quant) {
+  if (self.numel() == 0) {
+    return self.clone();
+  }
   const auto res = at::_fused_moving_avg_obs_fq_helper(
       self,
       observer_on,

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1039,6 +1039,26 @@ class TestFusedObsFakeQuant(TestCase):
             self.assertEqual(in_running_max_ref, in_running_max_op)
             torch.testing.assert_allclose(out, x_in)
 
+        # Test empty input works
+        x = torch.empty(0, 5, device=device)
+        out = pt_op(
+            x,
+            torch.tensor(1, device=device),
+            torch.tensor(1, device=device),
+            in_running_min_op,
+            in_running_max_op,
+            scale,
+            zero_point,
+            avg_const,
+            0,
+            255,
+            0,
+            False,
+            symmetric_quant,
+        )
+        output_shape = (0, 5)
+        self.assertEqual(out.shape, output_shape)
+
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            symmetric_quant=st.booleans())
     @settings(deadline=None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64829

Summary:
If an empty input is passed in, the aminmax operator fails with a runtime error like
```
RuntimeError: aminmax(): cannot compute aminmax over an empty dimension as the operation has no identity.
```

To avoid this during training we just return the input if we find it to be empty

Test Plan:
python test/test_quantization.py TestFusedObsFakeQuant

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D30870879](https://our.internmc.facebook.com/intern/diff/D30870879)