### PR TITLE
Update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,8 @@ commands:
           name: (Optional) Merge target branch
           no_output_timeout: "10m"
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && "$CIRCLE_BRANCH" != "nightly" ]]; then
-              PR_NUM=$(basename $CIRCLE_PULL_REQUEST)
+            if [[ -n "$CIRCLE_PR_NUMBER" && "$CIRCLE_BRANCH" != "nightly" ]]; then
+              PR_NUM=$CIRCLE_PR_NUMBER
               CIRCLE_PR_BASE_BRANCH=$(curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUM | jq -r '.base.ref')
               if [[ "${BUILD_ENVIRONMENT}" == *"xla"* || "${BUILD_ENVIRONMENT}" == *"gcc5"* ]] ; then
                 set -x

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -70,7 +70,7 @@ add_to_env_file IN_CI 1
 add_to_env_file CI_MASTER "${CI_MASTER:-}"
 add_to_env_file COMMIT_SOURCE "${CIRCLE_BRANCH:-}"
 add_to_env_file BUILD_ENVIRONMENT "${BUILD_ENVIRONMENT}"
-add_to_env_file CIRCLE_PULL_REQUEST "${CIRCLE_PULL_REQUEST}"
+add_to_env_file CIRCLE_PR_NUMBER "${CIRCLE_PR_NUMBER}"
 
 
 if [[ "${BUILD_ENVIRONMENT}" == *-build ]]; then

--- a/.circleci/verbatim-sources/commands.yml
+++ b/.circleci/verbatim-sources/commands.yml
@@ -103,8 +103,8 @@ commands:
           name: (Optional) Merge target branch
           no_output_timeout: "10m"
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && "$CIRCLE_BRANCH" != "nightly" ]]; then
-              PR_NUM=$(basename $CIRCLE_PULL_REQUEST)
+            if [[ -n "$CIRCLE_PR_NUMBER" && "$CIRCLE_BRANCH" != "nightly" ]]; then
+              PR_NUM=$CIRCLE_PR_NUMBER
               CIRCLE_PR_BASE_BRANCH=$(curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUM | jq -r '.base.ref')
               if [[ "${BUILD_ENVIRONMENT}" == *"xla"* || "${BUILD_ENVIRONMENT}" == *"gcc5"* ]] ; then
                 set -x

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -51,11 +51,11 @@ test_python_all() {
   export GLOO_SOCKET_IFNAME=lo0
   echo "Ninja version: $(ninja --version)"
 
-  # Try to pull value from CIRCLE_PULL_REQUEST first then GITHUB_HEAD_REF second
-  # CIRCLE_PULL_REQUEST comes from CircleCI
+  # Try to pull value from CIRCLE_PR_NUMBER first then GITHUB_HEAD_REF second
+  # CIRCLE_PR_NUMBER comes from CircleCI
   # NOTE: file_diff_from_base is currently bugged for GHA due to an issue finding a merge base for ghstack PRs
   #       see https://github.com/pytorch/pytorch/issues/60111
-  IN_PULL_REQUEST=${CIRCLE_PULL_REQUEST:-${GITHUB_HEAD_REF:-}}
+  IN_PULL_REQUEST=${CIRCLE_PR_NUMBER:-${GITHUB_HEAD_REF:-}}
   if [ -n "$IN_PULL_REQUEST" ]; then
     DETERMINE_FROM=$(mktemp)
     file_diff_from_base "$DETERMINE_FROM"

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -42,10 +42,10 @@ fi
 
 export SCRIPT_HELPERS_DIR=$SCRIPT_PARENT_DIR/win-test-helpers
 
-# Try to pull value from CIRCLE_PULL_REQUEST
+# Try to pull value from CIRCLE_PR_NUMBER
 # NOTE: file_diff_from_base is currently bugged for GHA due to an issue finding a merge base for ghstack PRs
 #       see https://github.com/pytorch/pytorch/issues/60111
-IN_PULL_REQUEST=${CIRCLE_PULL_REQUEST:-}
+IN_PULL_REQUEST=${CIRCLE_PR_NUMBER:-}
 if [ -n "$IN_PULL_REQUEST" ]; then
   DETERMINE_FROM="${TMP_DIR}/determine_from"
   file_diff_from_base "$DETERMINE_FROM"


### PR DESCRIPTION
`CIRCLE_PULL_REQUEST` is not defined even for master jobs, as one can
see in https://app.circleci.com/pipelines/github/pytorch/pytorch/378881/workflows/b2bc9600-e60b-49d0-9ff2-df3b65939a61/jobs/15966607
Use `CIRCLE_PR_NUMBER` instead, which is only defined in pull requests,
according to https://circleci.com/docs/2.0/env-vars/
> CIRCLE_PR_NUMBER	Integer	The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
