### PR TITLE
Raise TypeError on assigned grad with wrong type

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8377,6 +8377,10 @@ class TestAutogradDeviceType(TestCase):
     def test_grad_assignment(self, devices):
         x = torch.randn(5, 5, device=devices[0])
 
+        # Tests that the wrong type raises
+        with self.assertRaisesRegex(TypeError, "expected to be a Tensor or None"):
+            x.grad = 0
+
         # Tests that the wrong shape raises
         with self.assertRaises(RuntimeError):
             x.grad = torch.randn(2, 2, device=devices[0])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8062,7 +8062,7 @@ class TestTorch(AbstractTestCases._TestTorchMixin):
         self.assertEqual(y.grad.foo, 2)
 
     def test_subclass_preserved(self):
-        class MyTensor(torch._C._TensorBase):
+        class MyTensor(torch.Tensor):
             pass
 
         x = MyTensor(torch.empty(2))

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -476,6 +476,8 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
     return 0;
   }
 
+  TORCH_CHECK_TYPE(THPVariable_Check(py_grad),
+      "assigned grad expected to be a Tensor or None but got grad of type", THPUtils_typename(py_grad));
   THPUtils_assertRet(-1, self != (THPVariable*)py_grad,
       "can't assign Variable as its own grad");
 


### PR DESCRIPTION
Fixes #64813

Raises a TypeError when assigned value to a grad is not a Tensor or
None.

Adds tests.

BC-breaking note:
Setting the `.grad` field with a non-None and non-Tensor object used to return a `RuntimeError` but it now properly returns a `TypeError`.
If your code was catching this error, you should simply update it to catch the new error type.

cc @ezyang @gchanan