### PR TITLE
[JIT] Make output of prim::TupleConstruct alias only with its inputs

### DIFF
--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -1330,6 +1330,55 @@ TEST(AliasRegistrationTest, AliasMoveAtenListOp) {
       vmap["y"]->node(), vmap["9"]->node()));
 }
 
+TEST(
+    AliasRegistrationTest,
+    AliasMoveForTupleConstructWithSingleUseAsGraphOutput) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  auto graph_string = R"IR(
+  graph():
+    %x : Tensor = prim::MakeTestTensor()
+    %y : Tensor = prim::MakeTestTensor()
+    %z : (Tensor) = prim::TupleConstruct(%x, %y)
+    return (%z))IR";
+
+  torch::jit::parseIR(graph_string, graph.get(), vmap);
+  AliasDb aliasDb(graph);
+
+  EXPECT_TRUE(!aliasDb.mayAlias(vmap["x"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["z"], vmap["x"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["z"], vmap["y"]));
+}
+
+TEST(AliasRegistrationTest, WildcardAliasForTupleConstructWithUses) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  auto graph_string = R"IR(
+  graph():
+    %x : Tensor = prim::MakeTestTensor()
+    %y : Tensor = prim::MakeTestTensor()
+    %z : Tensor = prim::MakeTestTensor()
+    %0 : int = prim::Constant[value=0]()
+    %a : (Tensor) = prim::TupleConstruct(%x, %y)
+    %b : (Tensor) = prim::TupleConstruct(%z)
+    %c : Tensor = prim::TupleIndex(%a, %0)
+    %d : Tensor = prim::TupleIndex(%b, %0)
+    return (%c, %d))IR";
+
+  torch::jit::parseIR(graph_string, graph.get(), vmap);
+  AliasDb aliasDb(graph);
+
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["x"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["x"], vmap["z"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["z"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["a"], vmap["x"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["a"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["a"], vmap["z"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["x"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["y"]));
+  EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["z"]));
+}
+
 TEST(AliasRegistrationTest, PureWithAnnotationsShouldError2) {
   auto registry = torch::RegisterOperators().op(
       "foo::rand12(Tensor(a) arg1) -> Tensor(b)",

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -234,6 +234,7 @@ class AliasDb {
   c10::optional<AliasTypeSet> mapTypeToAliasTypeSetPtr(
       const TypePtr& type) const;
   bool functionalNonEscapingListUse(const Use& use) const;
+  bool functionalNonEscapingTupleUse(const Use& use) const;
 
   std::shared_ptr<Graph> graph_;
 


### PR DESCRIPTION
Summary:
This change makes the output of `prim::TupleConstruct` alias only with its inputs *when* the created tuple is directly returned from the graph.

The same treatment could be made to any tuples newly constructed by `prim::TupleConstruct` if they do not let their elements escape. However, this change only focuses on only one simplest, but frequently used usecase: tuples constructed only to be returned from a graph. This usecase turns out to be very often used.

Test Plan:
Added
- `AliasMoveForTupleConstructWithSingleUseAsGraphOutput`
- `WildcardAliasForTupleConstructWithUses`

to cover the newly added code.

Differential Revision: D30437737

