### PR TITLE
Disable target determination for now

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -95,6 +95,7 @@ TESTS = discover_tests(
     blocklisted_tests=[
         'test_bundled_images',
         'test_cpp_extensions_aot',
+        'test_determination',
         'test_gen_backend_stubs',
         'test_jit_fuser',
         'test_jit_simple',

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -38,10 +38,11 @@ try:
         get_reordered_tests,
         get_test_case_configs,
     )
-    from tools.testing.modulefinder_determinator import (
-        should_run_test,
-        TARGET_DET_LIST,
-    )
+    # NS: Disable target determination
+    # from tools.testing.modulefinder_determinator import (
+    #     should_run_test,
+    #     TARGET_DET_LIST,
+    # )
 
     HAVE_TEST_SELECTION_TOOLS = True
 except ImportError:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -32,7 +32,8 @@ try:
     from tools.testing.test_selections import (
         export_S3_test_times,
         get_shard_based_on_S3,
-        get_slow_tests_based_on_S3,
+        # NS: Disable target determination
+        # get_slow_tests_based_on_S3,
         get_specified_test_cases,
         get_reordered_tests,
         get_test_case_configs,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -953,30 +953,31 @@ def main():
     if options.coverage and not PYTORCH_COLLECT_COVERAGE:
         shell(["coverage", "erase"])
 
-    if options.determine_from is not None and os.path.exists(options.determine_from):
-        slow_tests = get_slow_tests_based_on_S3(
-            TESTS, TARGET_DET_LIST, SLOW_TEST_THRESHOLD
-        )
-        print_to_stderr(
-            "Added the following tests to target_det tests as calculated based on S3:"
-        )
-        print_to_stderr(slow_tests)
-        with open(options.determine_from, "r") as fh:
-            touched_files = [
-                os.path.normpath(name.strip())
-                for name in fh.read().split("\n")
-                if len(name.strip()) > 0
-            ]
-        # HACK: Ensure the 'test' paths can be traversed by Modulefinder
-        sys.path.append(test_directory)
-        selected_tests = [
-            test
-            for test in selected_tests
-            if should_run_test(
-                TARGET_DET_LIST + slow_tests, test, touched_files, options
-            )
-        ]
-        sys.path.remove(test_directory)
+    # NS: Disable target determination until it can be made more reliable
+    # if options.determine_from is not None and os.path.exists(options.determine_from):
+    #     slow_tests = get_slow_tests_based_on_S3(
+    #         TESTS, TARGET_DET_LIST, SLOW_TEST_THRESHOLD
+    #     )
+    #     print_to_stderr(
+    #         "Added the following tests to target_det tests as calculated based on S3:"
+    #     )
+    #     print_to_stderr(slow_tests)
+    #     with open(options.determine_from, "r") as fh:
+    #         touched_files = [
+    #             os.path.normpath(name.strip())
+    #             for name in fh.read().split("\n")
+    #             if len(name.strip()) > 0
+    #         ]
+    #     # HACK: Ensure the 'test' paths can be traversed by Modulefinder
+    #     sys.path.append(test_directory)
+    #     selected_tests = [
+    #         test
+    #         for test in selected_tests
+    #         if should_run_test(
+    #             TARGET_DET_LIST + slow_tests, test, touched_files, options
+    #         )
+    #     ]
+    #     sys.path.remove(test_directory)
 
     if IS_IN_CI:
         selected_tests = get_reordered_tests(


### PR DESCRIPTION
There were several reports of target determinator incorrectly skipping
tests, most recent one is https://github.com/pytorch/pytorch/issues/64902

Let's disable it until it could be further stabilized
