### PR TITLE
[caffe2] [aten] Remove loose (unpaired) #pragma warning ( pop ) in Te…

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -755,12 +755,6 @@ private:
   TensorBase __dispatch_contiguous(c10::MemoryFormat) const;
 };
 
-// For "multiple ... operators specified" warnings, closing brace of class
-// declaration must be included between pragma push & pop
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-
 inline int64_t get_device(const TensorBase& self) {
   return self.get_device();
 }


### PR DESCRIPTION
…nsorBase.h (#64870)

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/64870

Remove loose (unpaired) #pragma warning ( pop ) in TensorBase.h
Issue started with D30728580 (https://github.com/pytorch/pytorch/commit/d701357d921ef167d42c125e65b6f7da6be3ad0f), was fixed with D30846958 (https://github.com/pytorch/pytorch/commit/40098f48a1a37a06a456fd642d908ca522295706), and brought back again with the reversion of D30846958 (https://github.com/pytorch/pytorch/commit/40098f48a1a37a06a456fd642d908ca522295706).

Reviewed By: H-Huang

Differential Revision: D30875977

fbshipit-source-id: bd593feb5a75245470e43ad568ebdd3f1738da7c
