### PR TITLE
[Static Runtime] Implement and enable variadic tuple unpack

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -855,3 +855,20 @@ const auto getitem_mutable_input_dict_script = R"JIT(
       c = a + b
       return c.clone()
 )JIT";
+
+const auto var_tuple_unpack_script = R"JIT(
+  def forward(self, input_0: Tuple[Tensor, Tensor], input_1: Tuple[int, int]):
+      a, b = input_0
+      c, d = input_1
+      res = a * c + b * d
+      return res.clone()
+)JIT";
+
+const auto var_tuple_unpack_not_applied_script = R"JIT(
+  def forward(self, input_0: Tuple[Tensor, Tensor], input_1: Tuple[int, int]):
+      a, b = input_0
+      x = a + b
+      c, d = input_1
+      res = a * c + b * d + x
+      return res.clone()
+)JIT";

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -85,6 +85,7 @@ void OptimizeGraph(
 #endif
   ConstantPropagation(graph);
   RemoveImmutableInputDictLookups(graph);
+  UseVariadicTupleUnpack(graph);
 }
 
 // remove unused input 0 from graph

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -457,5 +457,19 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       };
     });
 
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    static_runtime::VarTupleUnpack,
+    static_runtime_VarTupleUnpack,
+    [](Node*) -> SROperator {
+      return [](ProcessedNode* pnode) {
+        size_t output_idx = 0;
+        for (const auto& tuple : pnode->inputs()) {
+          for (auto& elem : tuple->toTuple()->elements()) {
+            pnode->Output(output_idx) = elem;
+            ++output_idx;
+          }
+        }
+      };
+    });
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -25,5 +25,7 @@ TORCH_API bool HasInplaceOp(
 
 TORCH_API void FuseSignLog1P(std::shared_ptr<Graph>& graph);
 
+TORCH_API void UseVariadicTupleUnpack(const std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
Add a new op `static_runtime::VarTupleUnpack` and a graph pass transforming graph sequences from:
```
%0, %1 = prim::TupleUnpack(%a)
%2, %3 = prim::TupleUnpack(%b)
```
into:
```
%0, %1, %2, %3 = static_runtime::VarTupleUnpack(%a, %b)
```

The pass is only applied to contiguous blocks of `TupleUnpack` nodes. This is the most straightforward way to guarantee correctness, and it is sufficient for the models we care about.

Test Plan: New unit tests: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- VarTupleUnpack`

Differential Revision: D30872109

