### PR TITLE
.github: Specify names for all generated jobs

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -71,6 +71,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: !{{ build_environment }}-calculate-docker-image
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout_pytorch("false") }}
@@ -127,6 +128,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: !{{ build_environment }}-build
+    name: !{{ build_environment }}-build
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout_pytorch("recursive") }}
@@ -233,6 +235,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: !{{ build_environment }}-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -256,6 +259,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: !{{ build_environment }}-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout_pytorch("recursive") }}
@@ -390,6 +394,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       DOCS_TYPE: ${{ matrix.docs_type }}
+    name: !{{ build_environment }}-docs-${{ matrix.docs_type }}
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout_pytorch("recursive") }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -84,6 +84,7 @@ jobs:
       JOB_BASE_NAME: !{{ build_environment }}-build
       http_proxy: "!{{ common. squid_proxy }}"
       https_proxy: "!{{ common.squid_proxy }}"
+    name: !{{ build_environment }}-build
     steps:
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: seemethere/add-github-ssh-key@v1
@@ -192,6 +193,7 @@ jobs:
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: [build, generate-test-matrix, !{{ ciflow_config.root_job_name }}]
+    name: !{{ build_environment }}-test-${{ matrix.config }}-shard${{ matrix.shard }}
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: libtorch-linux-xenial-cuda10.2-py3.6-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: libtorch-linux-xenial-cuda10.2-py3.6-gcc7-build
+    name: libtorch-linux-xenial-cuda10.2-py3.6-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: libtorch-linux-xenial-cuda11.3-py3.6-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: libtorch-linux-xenial-cuda11.3-py3.6-gcc7-build
+    name: libtorch-linux-xenial-cuda11.3-py3.6-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-bionic-cuda10.2-py3.9-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-bionic-cuda10.2-py3.9-gcc7-build
+    name: linux-bionic-cuda10.2-py3.9-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: linux-bionic-cuda10.2-py3.9-gcc7-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: linux-bionic-cuda10.2-py3.9-gcc7-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-bionic-py3.6-clang9-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-bionic-py3.6-clang9-build
+    name: linux-bionic-py3.6-clang9-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: linux-bionic-py3.6-clang9-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: linux-bionic-py3.6-clang9-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
+++ b/.github/workflows/generated-linux-bionic-py3.8-gcc9-coverage.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-bionic-py3.8-gcc9-coverage-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-bionic-py3.8-gcc9-coverage-build
+    name: linux-bionic-py3.8-gcc9-coverage-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: linux-bionic-py3.8-gcc9-coverage-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: linux-bionic-py3.8-gcc9-coverage-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-xenial-cuda10.2-py3.6-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-xenial-cuda10.2-py3.6-gcc7-build
+    name: linux-xenial-cuda10.2-py3.6-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: linux-xenial-cuda10.2-py3.6-gcc7-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: linux-xenial-cuda10.2-py3.6-gcc7-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-xenial-cuda11.3-py3.6-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-xenial-cuda11.3-py3.6-gcc7-build
+    name: linux-xenial-cuda11.3-py3.6-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: linux-xenial-cuda11.3-py3.6-gcc7-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: linux-xenial-cuda11.3-py3.6-gcc7-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-xenial-py3.6-gcc5.4-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: linux-xenial-py3.6-gcc5.4-build
+    name: linux-xenial-py3.6-gcc5.4-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: linux-xenial-py3.6-gcc5.4-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: linux-xenial-py3.6-gcc5.4-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash
@@ -528,6 +532,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       DOCS_TYPE: ${{ matrix.docs_type }}
+    name: linux-xenial-py3.6-gcc5.4-docs-${{ matrix.docs_type }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: linux-xenial-py3.6-gcc7-bazel-test-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: parallelnative-linux-xenial-py3.6-gcc5.4-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: parallelnative-linux-xenial-py3.6-gcc5.4-build
+    name: parallelnative-linux-xenial-py3.6-gcc5.4-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: parallelnative-linux-xenial-py3.6-gcc5.4-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: parallelnative-linux-xenial-py3.6-gcc5.4-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-paralleltbb-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-paralleltbb-linux-xenial-py3.6-gcc5.4.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: paralleltbb-linux-xenial-py3.6-gcc5.4-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: paralleltbb-linux-xenial-py3.6-gcc5.4-build
+    name: paralleltbb-linux-xenial-py3.6-gcc5.4-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -304,6 +306,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: paralleltbb-linux-xenial-py3.6-gcc5.4-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -327,6 +330,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: paralleltbb-linux-xenial-py3.6-gcc5.4-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -48,6 +48,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -143,6 +144,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7-build
+    name: periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -48,6 +48,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: periodic-linux-xenial-cuda11.1-py3.6-gcc7-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -143,6 +144,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: periodic-linux-xenial-cuda11.1-py3.6-gcc7-build
+    name: periodic-linux-xenial-cuda11.1-py3.6-gcc7-build
     steps:
       - name: Display EC2 information
         shell: bash
@@ -302,6 +304,7 @@ jobs:
       ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
     container:
       image: python:3.9
+    name: periodic-linux-xenial-cuda11.1-py3.6-gcc7-generate-test-matrix
     steps:
       - name: Install dependencies
         run: pip install typing-extensions==3.10
@@ -325,6 +328,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    name: periodic-linux-xenial-cuda11.1-py3.6-gcc7-test-${{ matrix.config }}-shard${{ matrix.shard }}
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -50,6 +50,7 @@ jobs:
       JOB_BASE_NAME: periodic-win-vs2019-cuda11.1-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
+    name: periodic-win-vs2019-cuda11.1-py3-build
     steps:
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: seemethere/add-github-ssh-key@v1
@@ -169,6 +170,7 @@ jobs:
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: [build, generate-test-matrix, ciflow_should_run]
+    name: periodic-win-vs2019-cuda11.1-py3-test-${{ matrix.config }}-shard${{ matrix.shard }}
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
@@ -50,6 +50,7 @@ jobs:
     timeout-minutes: 90
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    name: puretorch-linux-xenial-py3.6-gcc5.4-calculate-docker-image
     steps:
       - name: Display EC2 information
         shell: bash
@@ -145,6 +146,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.calculate-docker-image.outputs.docker_image }}
       JOB_BASE_NAME: puretorch-linux-xenial-py3.6-gcc5.4-build
+    name: puretorch-linux-xenial-py3.6-gcc5.4-build
     steps:
       - name: Display EC2 information
         shell: bash

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -50,6 +50,7 @@ jobs:
       JOB_BASE_NAME: win-vs2019-cpu-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
+    name: win-vs2019-cpu-py3-build
     steps:
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: seemethere/add-github-ssh-key@v1
@@ -161,6 +162,7 @@ jobs:
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: [build, generate-test-matrix, ciflow_should_run]
+    name: win-vs2019-cpu-py3-test-${{ matrix.config }}-shard${{ matrix.shard }}
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
@@ -52,6 +52,7 @@ jobs:
       JOB_BASE_NAME: win-vs2019-cuda10.2-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
+    name: win-vs2019-cuda10.2-py3-build
     steps:
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: seemethere/add-github-ssh-key@v1
@@ -171,6 +172,7 @@ jobs:
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: [build, generate-test-matrix, ciflow_should_run]
+    name: win-vs2019-cuda10.2-py3-test-${{ matrix.config }}-shard${{ matrix.shard }}
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -52,6 +52,7 @@ jobs:
       JOB_BASE_NAME: win-vs2019-cuda11.3-py3-build
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
+    name: win-vs2019-cuda11.3-py3-build
     steps:
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: seemethere/add-github-ssh-key@v1
@@ -171,6 +172,7 @@ jobs:
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
       CONTINUE_THROUGH_ERROR: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: [build, generate-test-matrix, ciflow_should_run]
+    name: win-vs2019-cuda11.3-py3-test-${{ matrix.config }}-shard${{ matrix.shard }}
     strategy:
       matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
       fail-fast: false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #64940

Generates specific names for all generated jobs so that they can be
easier to distinguish from the job view level

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>