### PR TITLE
[ONNX] Add prim::PythonOp check back in export.cpp

### DIFF
--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -70,35 +70,45 @@ void validateBlock(
       std::string("ONNX export failed: ") + name + \
       "\n\nGraph we tried to export:\n" + b->owningGraph()->toString());
     // Special error messages for certain types of operators
-    if (node->kind() == aten::expand) {
-      if (operator_export_type ==
-          onnx_torch::OperatorExportTypes::ONNX_ATEN_FALLBACK) {
-        WithInsertPoint guard(node);
-        auto* new_node = b->owningGraph()->insertNode(b->owningGraph()->create(
-            Symbol(::c10::onnx::ATen), node->inputs(), node->outputs().size()));
-        for (size_t i = 0; i < node->outputs().size(); ++i) {
-          node->output(i)->replaceAllUsesWith(new_node->output(i));
-        }
-        new_node->s_(Symbol::fromQualString("attr::operator"), "expand");
-      }
-    }
-    if (node->kind() == prim::PackPadded || node->kind() == prim::PadPacked) {
-      if (operator_export_type !=
-          onnx_torch::OperatorExportTypes::ONNX_FALLTHROUGH) {
-        FAIL_EXPORT(
-            "Cannot export individual pack_padded_sequence or pad_packed_sequence; these operations must occur in pairs.\n\nUsage of this operation occurred at:\n" +
-            getNodeStackTraceString(node));
-      }
-    }
-    bool is_aten_enabled = operator_export_type ==
-            onnx_torch::OperatorExportTypes::ONNX_ATEN_FALLBACK ||
-        operator_export_type == onnx_torch::OperatorExportTypes::ONNX_ATEN ||
-        operator_export_type ==
-            onnx_torch::OperatorExportTypes::ONNX_FALLTHROUGH;
-    if (node->kind().is_aten() && !is_aten_enabled && !node->mustBeNone()) {
+    if (node->kind() == prim::PythonOp) {
+      auto py_node = static_cast<PythonOp*>(node);
       FAIL_EXPORT(
-          "Couldn't export operator " + node->kind().toDisplayString() +
-          "\n\nDefined at:\n" + getNodeStackTraceString(node));
+          "Couldn't export Python operator " + py_node->name() +
+          "\n\nDefined at:\n" + getNodeStackTraceString(node))
+    } else {
+      if (node->kind() == aten::expand) {
+        if (operator_export_type ==
+            onnx_torch::OperatorExportTypes::ONNX_ATEN_FALLBACK) {
+          WithInsertPoint guard(node);
+          auto* new_node =
+              b->owningGraph()->insertNode(b->owningGraph()->create(
+                  Symbol(::c10::onnx::ATen),
+                  node->inputs(),
+                  node->outputs().size()));
+          for (size_t i = 0; i < node->outputs().size(); ++i) {
+            node->output(i)->replaceAllUsesWith(new_node->output(i));
+          }
+          new_node->s_(Symbol::fromQualString("attr::operator"), "expand");
+        }
+      }
+      if (node->kind() == prim::PackPadded || node->kind() == prim::PadPacked) {
+        if (operator_export_type !=
+            onnx_torch::OperatorExportTypes::ONNX_FALLTHROUGH) {
+          FAIL_EXPORT(
+              "Cannot export individual pack_padded_sequence or pad_packed_sequence; these operations must occur in pairs.\n\nUsage of this operation occurred at:\n" +
+              getNodeStackTraceString(node));
+        }
+      }
+      bool is_aten_enabled = operator_export_type ==
+              onnx_torch::OperatorExportTypes::ONNX_ATEN_FALLBACK ||
+          operator_export_type == onnx_torch::OperatorExportTypes::ONNX_ATEN ||
+          operator_export_type ==
+              onnx_torch::OperatorExportTypes::ONNX_FALLTHROUGH;
+      if (node->kind().is_aten() && !is_aten_enabled && !node->mustBeNone()) {
+        FAIL_EXPORT(
+            "Couldn't export operator " + node->kind().toDisplayString() +
+            "\n\nDefined at:\n" + getNodeStackTraceString(node));
+      }
     }
 #undef FAIL_EXPORT
   }


### PR DESCRIPTION
The PR https://github.com/pytorch/pytorch/pull/64460 removes the check to pass the test in the middle of developing. Test the check to see if it is needed.
