### PR TITLE
Fix builder pinning

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -62,8 +62,8 @@ popd
 
 # Clone the Builder master repo
 retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
-git checkout release/1.9
 pushd "$BUILDER_ROOT"
+git checkout release/1.9
 echo "Using builder from "
 git --no-pager log --max-count 1
 popd


### PR DESCRIPTION
`git checkout release/1.9` should be done after work dir is changed to
`BUILDER_ROOT`
