### PR TITLE
[Static Runtime] Add perf metrics for number of managed tensors & unmanaged values

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -966,6 +966,10 @@ void StaticRuntime::benchmark(
             << std::endl;
 
   if (planner_) {
+    std::cout << "Total number of managed tensors: "
+              << planner_->total_num_managed_tensors() << std::endl;
+    std::cout << "Total number of unmanaged values: "
+              << planner_->total_num_unmanaged() << std::endl;
     std::cout << "Total memory managed: " << planner_->total_managed()
               << " bytes" << std::endl;
     if (static_module_.opts().optimize_memory) {

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -115,6 +115,11 @@ MemoryPlanner::MemoryPlanner(
         value_to_same_storage_values,
         managed_tensors_);
   }
+
+  num_managed_tensors_ = 0;
+  for (const auto& ms : managed_tensors_) {
+    num_managed_tensors_ += ms.second.size();
+  }
 }
 
 // Don't change the size if it is already aligned, otherwise increase the size

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -48,9 +48,18 @@ class MemoryPlanner {
   void allocate();
   void deallocate();
 
+  size_t total_num_managed_tensors() const {
+    return num_managed_tensors_;
+  }
+
+  size_t total_num_unmanaged() const {
+    return unmanaged_ivalues_.size();
+  }
+
   size_t total_managed() const {
     return managed_bytes_;
   }
+
   size_t total_reused_tensors() const {
     return reused_tensors_;
   }
@@ -64,6 +73,7 @@ class MemoryPlanner {
   // Thus, if memonger is disabled, all vectors are of size 1.
   std::vector<std::pair<size_t, std::vector<at::Tensor*>>> managed_tensors_;
   at::DataPtr buffer_; // allocated each time we call Run()
+  size_t num_managed_tensors_{0};
   size_t managed_bytes_{0};
   size_t reused_tensors_{0};
 


### PR DESCRIPTION
Summary: This change lets Static Runtime print out number of managed tensors & unmanaged values as performance metrics during profile runs.

Test Plan:
Confirmed that a profile run prints out the added metric values:
```
...
Total number of managed tensors: 1250
Total number of external values: 2981
...
```

Differential Revision: D30926617

