### PR TITLE
[LTC] Enable CI for building and testing

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -324,8 +324,8 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; 
 fi
 
 # Test Lazy Tensor Core. Don't merge to master.
-# No particular reasons why this environment, just restrict lazy tensor to one to limit potential breakages.
-if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.1* ]]; then
+# Restrict lazy tensor to cuda environment to limit potential breakages for the feature branch.
+if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   pushd lazy_tensor_core/
   ./scripts/apply_patches.sh
   python setup.py install

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -158,6 +158,15 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   python tools/amd_build/build_amd.py
   python setup.py install
 
+  # No particular reasons why this environment, just restrict lazy tensor to one to limit potential breakages.
+  if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.1* ]]; then
+    pushd
+    cd lazy_tensor_core/
+    ./scripts/apply_patches.sh
+    python setup.py install
+    popd
+  fi
+
   # remove sccache wrappers post-build; runtime compilation of MIOpen kernels does not yet fully support them
   sudo rm -f /opt/cache/bin/cc
   sudo rm -f /opt/cache/bin/c++

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -323,7 +323,7 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; 
   python test/run_test.py --export-past-test-times
 fi
 
-# Test Lazy Tensor Core
+# Test Lazy Tensor Core. Don't merge to master.
 # No particular reasons why this environment, just restrict lazy tensor to one to limit potential breakages.
 if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.1* ]]; then
   pushd lazy_tensor_core/

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -324,8 +324,8 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; 
 fi
 
 # Test Lazy Tensor Core. Don't merge to master.
-# Restrict lazy tensor to cuda environment to limit potential breakages for the feature branch.
-if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
+# Restrict lazy tensor to cuda environments to limit potential breakages for the feature branch.
+if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.1* ]]; then
   pushd lazy_tensor_core/
   ./scripts/apply_patches.sh
   python setup.py install

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -481,6 +481,11 @@ test_torch_deploy() {
   assert_git_not_dirty
 }
 
+test_lazy_tensor_core() {
+  lazy_tensor_core/test/cpp/build/test_ptltc
+  assert_git_not_dirty
+}
+
 if ! [[ "${BUILD_ENVIRONMENT}" == *libtorch* || "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then
   (cd test && python -c "import torch; print(torch.__config__.show())")
   (cd test && python -c "import torch; print(torch.__config__.parallel_info())")
@@ -500,6 +505,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
 elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 || "${SHARD_NUMBER}" == 1 ]]; then
   if [[ "${BUILD_ENVIRONMENT}" == *linux-xenial-cuda11.1*-test1* ]]; then
     test_torch_deploy
+    test_lazy_tensor_core
   fi
   test_without_numpy
   install_torchvision

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -3,7 +3,6 @@
 #include <ATen/core/Reduction.h>
 #include <torch/csrc/jit/frontend/sugared_value.h>
 #include <torch/jit.h>
-// #include <torch/torch.h>
 
 #include "lazy_tensor_core/csrc/compiler/node_lowering.h"
 #include "lazy_tensor_core/csrc/data_ops.h"

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -3,7 +3,7 @@
 #include <ATen/core/Reduction.h>
 #include <torch/csrc/jit/frontend/sugared_value.h>
 #include <torch/jit.h>
-#include <torch/torch.h>
+// #include <torch/torch.h>
 
 #include "lazy_tensor_core/csrc/compiler/node_lowering.h"
 #include "lazy_tensor_core/csrc/data_ops.h"


### PR DESCRIPTION
Summary:
This patch enables PyTorch CI for builiding and testing LazyTensorCore.

The initial attempt is to build LTC for linux-xenial-cuda11.1 environments and run test_ptltc C++ unit tests in the test1 bots.

Test Plan:
PyTorch CI \*linux-xenial-cuda11.1\*-test1\*.

Fixes #63610.
