### PR TITLE
Specify pytorch-dev-infra for CI related files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,7 @@
 # Github Actions
 # This list is for people wanting to be notified every time there's a change
 # related to Github Actions
-/.github/ @seemethere @janeyx99 @zhouzhuojie @driazati
+/.github/ @pytorch/pytorch-dev-infra
 
 # Parametrizations
 /torch/nn/utils/parametriz*.py @lezcano
@@ -54,3 +54,9 @@
 /aten/src/ATen/native/**/*LinearAlgebra* @lezcano @nikitaved @IvanYashchuk
 # tests
 /test/test_linalg.py @lezcano @nikitaved @IvanYashchuk
+
+# run_test.py / testing framework
+/test/run_test.py @pytorch/pytorch-dev-infra
+
+# CI scripts
+/.jenkins/pytorch/ @pytorch/pytorch-dev-infra


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65025

CI scripts are coming under increasing scrutiny and in an attempt to
have more people review CI scripts changes I'm adding pytorch-dev-infra
as automatic reviewers for all changes as they pertain to the following
folders/files:

* .github/
* test/run_test.py
* .jenkins/pytorch/

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

cc @ezyang @seemethere @malfet @lg20987 @pytorch/pytorch-dev-infra

Differential Revision: [D30947202](https://our.internmc.facebook.com/intern/diff/D30947202)