### PR TITLE
Reduce Pytorch Warnings - Enforce stricter compiler flags + explicit casting

### DIFF
--- a/aten/src/ATen/core/DeprecatedTypeProperties.h
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.h
@@ -97,7 +97,7 @@ class TORCH_API DeprecatedTypeProperties {
   /// Constructs the `TensorOptions` from a type and a `device_index`.
   TensorOptions options(int16_t device_index = -1) const {
     return TensorOptions().dtype(typeMeta())
-                          .device(device_type(), device_index)
+                          .device(device_type(), static_cast<c10::DeviceIndex>(device_index))
                           .layout(layout());
   }
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1040,7 +1040,8 @@ inline const ivalue::Object& IValue::toObjectRef() const {
   }                                                        \
   template <>                                              \
   inline c10::detail::ivalue_to_const_ref_overload_return<T>::type IValue::to<T>() const& { \
-    return this->method_name();            \
+    typedef c10::detail::ivalue_to_const_ref_overload_return<T>::type return_type;          \
+    return static_cast<return_type>(this->method_name());                                   \
   }
 
 DEFINE_TO(at::Tensor, toTensor)

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -588,7 +588,8 @@ inline TensorOptions device(Device device) {
 /// Convenience function that returns a `TensorOptions` object with the
 /// `device` set to CUDA and the `device_index` set to the given one.
 inline TensorOptions device_index(int16_t device_index) {
-  return TensorOptions().device_index(device_index);
+  return TensorOptions().device_index(
+      static_cast<c10::DeviceIndex>(device_index));
 }
 
 /// Convenience function that returns a `TensorOptions` object with the

--- a/caffe2/proto/caffe2_pb.h
+++ b/caffe2/proto/caffe2_pb.h
@@ -115,12 +115,12 @@ inline TORCH_API at::Device OptionToDevice(const caffe2::DeviceOption option) {
   switch (type) {
     case caffe2::PROTO_CPU:
       if (option.has_numa_node_id()) {
-        id = option.numa_node_id();
+        id = static_cast<c10::DeviceIndex>(option.numa_node_id());
       }
       break;
     case caffe2::PROTO_CUDA:
     case caffe2::PROTO_HIP:
-      id = option.device_id();
+      id = static_cast<c10::DeviceIndex>(option.device_id());
       break;
   }
   return at::Device(ProtoToType(type), id);


### PR DESCRIPTION
Summary: From D26624430 added the stricter compilation flags, then addressed the errors induced when building sparsenn_operators

Test Plan:
```
buck build --show-output //caffe2/torch/fb/sparsenn:sparsenn_operators

buck test caffe2/torch/fb/sparsenn:test
```

Differential Revision: D30947652

