### PR TITLE
Decouple forward AD checks from backward AD in OpInfo tests and gradcheck

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4241,6 +4241,65 @@ class TestAutograd(TestCase):
             with self.assertRaisesRegex(RuntimeError, err_msg):
                 gradcheck(bad_fn, (x, y), check_forward_ad=True, fast_mode=fast_mode)
 
+    def test_gradcheck_check_forward_or_backward_only(self):
+        """Depending on settings for check_forward_ad and check_backward_ad, the
+        correct codepaths should be reached (or not reached)
+        """
+        fwd_fail_err_msg = "FAIL FWD"
+        bwd_fail_err_msg = "FAIL BWD"
+
+        class UserFn(Function):
+                @staticmethod
+                def forward(ctx, foo, fwd_bad, bwd_bad):
+                    ctx.fwd_bad = fwd_bad
+                    ctx.bwd_bad = bwd_bad
+                    return foo * 2
+
+                @staticmethod
+                def vjp(ctx, gO):
+                    if ctx.bwd_bad:
+                        raise RuntimeError(bwd_fail_err_msg)
+                    else:
+                        return 2 * gO, None, None
+
+                @staticmethod
+                def jvp(ctx, gI, _1, _2):
+                    if ctx.fwd_bad:
+                        raise RuntimeError(fwd_fail_err_msg)
+                    else:
+                        return 2 * gI
+
+        for fast_mode in (True, False):
+            for check_forward_ad in (True, False):
+                for check_backward_ad in (True, False):
+                    for fwd_bad in (True, False):
+                        for bwd_bad in (True, False):
+                            fwd_should_fail = fwd_bad and check_forward_ad
+                            bwd_should_fail = bwd_bad and check_backward_ad
+
+                            def run():
+                                gradcheck(UserFn.apply, (x, fwd_bad, bwd_bad), check_forward_ad=check_forward_ad,
+                                          check_backward_ad=check_backward_ad, check_undefined_grad=check_backward_ad,
+                                          check_batched_grad=check_backward_ad, fast_mode=fast_mode)
+
+                            x = torch.rand(2, dtype=torch.double, requires_grad=True)
+
+                            if not check_forward_ad and not check_backward_ad:
+                                with self.assertRaisesRegex(AssertionError, "Expected at least one of"):
+                                    run()
+                                continue
+
+                            if not fwd_should_fail and not bwd_should_fail:
+                                run()
+                            else:
+                                # If both fail, backward AD failure "hides" forward AD failure
+                                if fwd_should_fail:
+                                    fail_msg = fwd_fail_err_msg
+                                if bwd_should_fail:
+                                    fail_msg = bwd_fail_err_msg
+                                with self.assertRaisesRegex(RuntimeError, fail_msg):
+                                    run()
+
     def test_version_counter(self):
         x = torch.randn(1, 2)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4249,25 +4249,25 @@ class TestAutograd(TestCase):
         bwd_fail_err_msg = "FAIL BWD"
 
         class UserFn(Function):
-                @staticmethod
-                def forward(ctx, foo, fwd_bad, bwd_bad):
-                    ctx.fwd_bad = fwd_bad
-                    ctx.bwd_bad = bwd_bad
-                    return foo * 2
+            @staticmethod
+            def forward(ctx, foo, fwd_bad, bwd_bad):
+                ctx.fwd_bad = fwd_bad
+                ctx.bwd_bad = bwd_bad
+                return foo * 2
 
-                @staticmethod
-                def vjp(ctx, gO):
-                    if ctx.bwd_bad:
-                        raise RuntimeError(bwd_fail_err_msg)
-                    else:
-                        return 2 * gO, None, None
+            @staticmethod
+            def vjp(ctx, gO):
+                if ctx.bwd_bad:
+                    raise RuntimeError(bwd_fail_err_msg)
+                else:
+                    return 2 * gO, None, None
 
-                @staticmethod
-                def jvp(ctx, gI, _1, _2):
-                    if ctx.fwd_bad:
-                        raise RuntimeError(fwd_fail_err_msg)
-                    else:
-                        return 2 * gI
+            @staticmethod
+            def jvp(ctx, gI, _1, _2):
+                if ctx.fwd_bad:
+                    raise RuntimeError(fwd_fail_err_msg)
+                else:
+                    return 2 * gI
 
         for fast_mode in (True, False):
             for check_forward_ad in (True, False):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -516,7 +516,7 @@ class TestGradients(TestCase):
 
     def _check_helper(self, device, dtype, op, variant, check, *, check_forward_ad=False, check_backward_ad=True,
                       check_undefined_grad=True):
-        # NB: check_backward_ad does not affect graddgradcheck (always True)
+        # NB: check_backward_ad does not affect gradgradcheck (always True)
         if variant is None:
             self.skipTest("Skipped! Variant not implemented.")
         if not op.supports_dtype(dtype, torch.device(device).type):
@@ -560,7 +560,8 @@ class TestGradients(TestCase):
                                           nondet_tol=op.gradcheck_nondet_tol,
                                           fast_mode=op.gradcheck_fast_mode,
                                           check_forward_ad=check_forward_ad,
-                                          check_backward_ad=check_backward_ad))
+                                          check_backward_ad=check_backward_ad,
+                                          check_undefined_grad=check_undefined_grad))
             elif check == 'gradgradcheck':
                 self.assertFalse(check_forward_ad, msg="Cannot run forward AD check for gradgradcheck")
                 self.assertTrue(gradgradcheck(fn, gradcheck_args,
@@ -578,9 +579,10 @@ class TestGradients(TestCase):
             else:
                 self.assertTrue(False, msg="Unknown check requested!")
 
-    def _grad_test_helper(self, device, dtype, op, variant, *, check_forward_ad=False, check_backward_ad=True):
+    def _grad_test_helper(self, device, dtype, op, variant, *, check_forward_ad=False, check_backward_ad=True,
+                          check_undefined_grad=True):
         return self._check_helper(device, dtype, op, variant, 'gradcheck', check_forward_ad=check_forward_ad,
-                                  check_backward_ad=check_backward_ad)
+                                  check_backward_ad=check_backward_ad, check_undefined_grad=check_undefined_grad)
 
     def _gradgrad_test_helper(self, device, dtype, op, variant):
         return self._check_helper(device, dtype, op, variant, 'gradgradcheck')
@@ -646,13 +648,15 @@ class TestGradients(TestCase):
 
     def _forward_grad_helper(self, device, dtype, op, variant):
         if op.supports_forward_ad:
-            self._grad_test_helper(device, dtype, op, variant, check_forward_ad=True, check_backward_ad=False)
+            self._grad_test_helper(device, dtype, op, variant, check_forward_ad=True, check_backward_ad=False,
+                                   check_undefined_grad=False)
         else:
             err_msg = r"Trying to use forward AD with .* that does not support it\."
             hint_msg = ("Running forward AD for an OP that has does not support it did not "
                         "raise any error. If your op supports forward AD, you should set supports_forward_ad=True")
             with self.assertRaisesRegex(NotImplementedError, err_msg, msg=hint_msg):
-                self._grad_test_helper(device, dtype, op, variant, check_forward_ad=True, check_backward_ad=False)
+                self._grad_test_helper(device, dtype, op, variant, check_forward_ad=True, check_backward_ad=False,
+                                       check_undefined_grad=False)
 
     @_gradcheck_ops(op_db)
     def test_forward_mode_AD(self, device, dtype, op):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -515,7 +515,7 @@ class TestGradients(TestCase):
         return _fn
 
     def _check_helper(self, device, dtype, op, variant, check, *, check_forward_ad=False, check_backward_ad=True,
-                      check_undefined_grad=True):
+                      check_undefined_grad=True, check_batched_grad=None):
         # NB: check_backward_ad does not affect gradgradcheck (always True)
         if variant is None:
             self.skipTest("Skipped! Variant not implemented.")
@@ -554,8 +554,10 @@ class TestGradients(TestCase):
             gradcheck_args += sample.args
 
             if check == 'gradcheck':
+                if check_batched_grad is None:
+                    check_batched_grad = op.check_batched_grad
                 self.assertTrue(gradcheck(fn, gradcheck_args,
-                                          check_batched_grad=op.check_batched_grad,
+                                          check_batched_grad=check_batched_grad,
                                           check_grad_dtypes=True,
                                           nondet_tol=op.gradcheck_nondet_tol,
                                           fast_mode=op.gradcheck_fast_mode,
@@ -580,15 +582,16 @@ class TestGradients(TestCase):
                 self.assertTrue(False, msg="Unknown check requested!")
 
     def _grad_test_helper(self, device, dtype, op, variant, *, check_forward_ad=False, check_backward_ad=True,
-                          check_undefined_grad=True):
+                          check_undefined_grad=True, check_batched_grad=None):
         return self._check_helper(device, dtype, op, variant, 'gradcheck', check_forward_ad=check_forward_ad,
-                                  check_backward_ad=check_backward_ad, check_undefined_grad=check_undefined_grad)
+                                  check_backward_ad=check_backward_ad, check_undefined_grad=check_undefined_grad,
+                                  check_batched_grad=check_batched_grad)
 
     def _gradgrad_test_helper(self, device, dtype, op, variant):
         return self._check_helper(device, dtype, op, variant, 'gradgradcheck')
 
     def _skip_helper(self, op, device, dtype):
-        if not op.supports_autograd:
+        if not op.supports_autograd and not op.supports_forward_ad:
             self.skipTest("Skipped! autograd not supported.")
         if not op.supports_complex_autograd(torch.device(device).type) and dtype.is_complex:
             self.skipTest("Skipped! Complex autograd not supported.")
@@ -649,26 +652,24 @@ class TestGradients(TestCase):
     def _forward_grad_helper(self, device, dtype, op, variant):
         if op.supports_forward_ad:
             self._grad_test_helper(device, dtype, op, variant, check_forward_ad=True, check_backward_ad=False,
-                                   check_undefined_grad=False)
+                                   check_undefined_grad=False, check_batched_grad=False)
         else:
             err_msg = r"Trying to use forward AD with .* that does not support it\."
             hint_msg = ("Running forward AD for an OP that has does not support it did not "
                         "raise any error. If your op supports forward AD, you should set supports_forward_ad=True")
             with self.assertRaisesRegex(NotImplementedError, err_msg, msg=hint_msg):
                 self._grad_test_helper(device, dtype, op, variant, check_forward_ad=True, check_backward_ad=False,
-                                       check_undefined_grad=False)
+                                       check_undefined_grad=False, check_batched_grad=False)
 
     @_gradcheck_ops(op_db)
     def test_forward_mode_AD(self, device, dtype, op):
-        if not op.supports_complex_autograd(torch.device(device).type) and dtype.is_complex:
-            self.skipTest("Skipped! Complex autograd not supported.")
+        self._skip_helper(op, device, dtype)
 
         self._forward_grad_helper(device, dtype, op, op.get_op())
 
     @_gradcheck_ops(op_db)
     def test_inplace_forward_mode_AD(self, device, dtype, op):
-        if not op.supports_complex_autograd(torch.device(device).type) and dtype.is_complex:
-            self.skipTest("Skipped! Complex autograd not supported.")
+        self._skip_helper(op, device, dtype)
 
         if not op.inplace_variant or not op.supports_inplace_autograd:
             self.skipTest("Skipped! Operation does not support inplace autograd.")

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1255,7 +1255,12 @@ def gradcheck(
     Returns:
         True if all differences satisfy allclose condition
     """
-    assert check_forward_ad or check_backward_ad
+    assert check_forward_ad or check_backward_ad, \
+        "Expected at least one of check_forward_ad or check_backward_ad to be True"
+    assert not (check_undefined_grad and not check_backward_ad), \
+        "Setting check_undefined_grad=True requires check_backward_ad to be True"
+    assert not (check_batched_grad and not check_backward_ad), \
+        "Setting check_batched_grad=True requires check_backward_ad to be True"
     # This is just a wrapper that handles the raise_exception logic
     args = locals().copy()
     args.pop("raise_exception")

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -926,25 +926,26 @@ def _real_and_imag_input(fn, complex_inp_indices):
 
 
 def _gradcheck_real_imag(gradcheck_fn, func, func_out, tupled_inputs, outputs, eps, rtol,
-                         atol, check_grad_dtypes, check_forward_ad, nondet_tol):
+                         atol, check_grad_dtypes, check_forward_ad, check_backward_ad, nondet_tol):
     complex_out_indices = [i for i, o in enumerate(outputs) if o.is_complex()]
     has_any_complex_output = any(o.is_complex() for o in _as_tuple(func_out))
-    if has_any_complex_output:
-        real_fn, imag_fn = _real_and_imag_output(func)
+    if check_backward_ad:
+        if has_any_complex_output:
+            real_fn, imag_fn = _real_and_imag_output(func)
 
-        imag_func_out = imag_fn(*tupled_inputs)
-        imag_outputs = _differentiable_outputs(imag_func_out)
-        gradcheck_fn(imag_fn, imag_func_out, tupled_inputs, imag_outputs, eps,
-                     rtol, atol, check_grad_dtypes, nondet_tol,
-                     complex_indices=complex_out_indices, test_imag=True)
+            imag_func_out = imag_fn(*tupled_inputs)
+            imag_outputs = _differentiable_outputs(imag_func_out)
+            gradcheck_fn(imag_fn, imag_func_out, tupled_inputs, imag_outputs, eps,
+                         rtol, atol, check_grad_dtypes, nondet_tol,
+                         complex_indices=complex_out_indices, test_imag=True)
 
-        real_func_out = real_fn(*tupled_inputs)
-        real_outputs = _differentiable_outputs(real_func_out)
-        gradcheck_fn(real_fn, real_func_out, tupled_inputs, real_outputs, eps,
-                     rtol, atol, check_grad_dtypes, nondet_tol, complex_indices=complex_out_indices)
-    else:
-        gradcheck_fn(func, func_out, tupled_inputs, outputs, eps,
-                     rtol, atol, check_grad_dtypes, nondet_tol)
+            real_func_out = real_fn(*tupled_inputs)
+            real_outputs = _differentiable_outputs(real_func_out)
+            gradcheck_fn(real_fn, real_func_out, tupled_inputs, real_outputs, eps,
+                         rtol, atol, check_grad_dtypes, nondet_tol, complex_indices=complex_out_indices)
+        else:
+            gradcheck_fn(func, func_out, tupled_inputs, outputs, eps,
+                         rtol, atol, check_grad_dtypes, nondet_tol)
 
     if check_forward_ad:
         complex_inp_indices = [i for i, inp in enumerate(tupled_inputs) if is_tensor_like(inp) and inp.is_complex()]
@@ -1192,6 +1193,7 @@ def gradcheck(
     check_grad_dtypes: bool = False,
     check_batched_grad: bool = False,
     check_forward_ad: bool = False,
+    check_backward_ad: bool = True,
     fast_mode: bool = False,
 ) -> bool:
     r"""Check gradients computed via small finite differences against analytical
@@ -1243,6 +1245,8 @@ def gradcheck(
             batched gradients using prototype vmap support. Defaults to False.
         check_forward_ad (bool, optional): if True, check that the gradients computed with forward
             mode AD match the numerical ones. Defaults to False.
+        check_backward_ad (bool, optional): if False, do not perform any checks that rely on
+            backward mode AD to be implemented. Defaults to True.
         fast_mode (bool, optional): Fast mode for gradcheck and gradgradcheck is currently only
             implemented for R to R functions. If none of the inputs and outputs are complex
             a faster implementation of gradcheck that no longer computes the entire jacobian
@@ -1251,6 +1255,7 @@ def gradcheck(
     Returns:
         True if all differences satisfy allclose condition
     """
+    assert check_forward_ad or check_backward_ad
     # This is just a wrapper that handles the raise_exception logic
     args = locals().copy()
     args.pop("raise_exception")
@@ -1264,7 +1269,7 @@ def gradcheck(
 
 
 def _gradcheck_helper(func, inputs, eps, atol, rtol, check_sparse_nnz, nondet_tol, check_undefined_grad,
-                      check_grad_dtypes, check_batched_grad, check_forward_ad, fast_mode):
+                      check_grad_dtypes, check_batched_grad, check_forward_ad, check_backward_ad, fast_mode):
     tupled_inputs = _as_tuple(inputs)
     _check_inputs(tupled_inputs, check_sparse_nnz)
 
@@ -1274,7 +1279,11 @@ def _gradcheck_helper(func, inputs, eps, atol, rtol, check_sparse_nnz, nondet_to
 
     gradcheck_fn = _fast_gradcheck if fast_mode else _slow_gradcheck
     _gradcheck_real_imag(gradcheck_fn, func, func_out, tupled_inputs, outputs, eps,
-                         rtol, atol, check_grad_dtypes, check_forward_ad=check_forward_ad, nondet_tol=nondet_tol)
+                         rtol, atol, check_grad_dtypes, check_forward_ad=check_forward_ad,
+                         check_backward_ad=check_backward_ad, nondet_tol=nondet_tol)
+    # Short circuit because remaining tests rely on backward AD to be implemented
+    if not check_backward_ad:
+        return True
 
     for i, o in enumerate(outputs):
         if check_batched_grad:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -612,15 +612,22 @@ class OpInfo(object):
         if supports_gradgrad is None:
             supports_gradgrad = supports_autograd
         else:
-            assert not (supports_gradgrad and not supports_autograd)
+            assert not (supports_gradgrad and not supports_autograd), (
+                "supports_gradgrad refines the part of autograd is supported, so it should "
+                "not be set if supports_autograd is False")
         if check_batched_grad is None:
             check_batched_grad = supports_autograd
         else:
-            assert not (check_batched_grad and not supports_autograd)
+            assert not (check_batched_grad and not supports_autograd), (
+                "check_batched_grad refines the part of autograd that will be checked (by gradcheck), so "
+                "it should not be set if supports_autograd is False")
         if check_batched_gradgrad is None:
             check_batched_gradgrad = supports_gradgrad
         else:
-            assert not (check_batched_gradgrad and not supports_gradgrad)
+            assert not (check_batched_gradgrad and not supports_gradgrad), (
+                "check_batched_gradgrad refines the part of autograd that will be checked (by "
+                "gradgradcheck), so it should not be set if either supports_gradgrad or supports_autograd "
+                "is False.")
 
         self.supports_gradgrad = supports_gradgrad
         self.check_batched_grad = check_batched_grad
@@ -630,7 +637,9 @@ class OpInfo(object):
         if supports_inplace_autograd is None:
             supports_inplace_autograd = supports_autograd or supports_forward_ad
         else:
-            assert not (supports_inplace_autograd and not supports_autograd and not supports_forward_ad)
+            assert not (supports_inplace_autograd and not supports_autograd and not supports_forward_ad), (
+                "supports_inplace_autograd refines the part of autograd that is supported, so "
+                "it should not be set if both supports_autograd and supports_forward_ad are False")
         self.supports_inplace_autograd = supports_inplace_autograd
 
         self.supports_sparse = supports_sparse

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -596,19 +596,24 @@ class OpInfo(object):
         else:
             self.autodiff_nonfusible_nodes = autodiff_nonfusible_nodes
 
-        # autograd support
+        # Autograd support
+
+        # Autograd flags that don't depend on backward AD
+        self.supports_forward_ad = supports_forward_ad
+        self.gradcheck_fast_mode = gradcheck_fast_mode
+        self.gradcheck_wrapper = gradcheck_wrapper
+
+        # Autograd flags that depend on backward AD only
         self.supports_autograd = supports_autograd
+        self.supports_gradgrad = supports_autograd and supports_gradgrad
+        self.check_batched_grad = supports_autograd and check_batched_grad
+        self.check_batched_gradgrad = self.supports_gradgrad and check_batched_gradgrad
+        self.gradcheck_nondet_tol = supports_autograd and gradcheck_nondet_tol
+
+        # Autograd flags that depend on both forward AD and backward AD
         self.supports_inplace_autograd = supports_inplace_autograd
         if self.supports_inplace_autograd is None:
-            self.supports_inplace_autograd = supports_autograd
-
-        self.gradcheck_wrapper = gradcheck_wrapper
-        self.supports_gradgrad = supports_gradgrad
-        self.supports_forward_ad = supports_forward_ad
-        self.check_batched_grad = check_batched_grad
-        self.check_batched_gradgrad = check_batched_gradgrad
-        self.gradcheck_nondet_tol = gradcheck_nondet_tol
-        self.gradcheck_fast_mode = gradcheck_fast_mode
+            self.supports_inplace_autograd = supports_autograd or supports_forward_ad
 
         self.supports_sparse = supports_sparse
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -482,7 +482,7 @@ class OpInfo(object):
                  safe_casts_outputs=False,  # whether op allows safe casting when writing to out arguments
 
                  # the following metadata relates to autograd support
-                 supports_autograd=True,  # whether the operation supports gradient computations
+                 supports_autograd=True,  # whether the operation supports backward mode AD
                                           # if true, gradient correctness is tested in test_ops.py
                                           # using the op's sample inputs
                  supports_gradgrad=True,  # whether the op supports second order gradients


### PR DESCRIPTION
Fixes #64999

- Adds a flag to gradcheck `check_backward_ad` that can be used to disable gradcheck for backward ad
  - This is a bit bc-breaking in terms of positional args, but I prefer this ordering
- In OpInfo tests for forward ad:
  - set `check_backward_ad` False
- In test_ops treat `supports_autograd` as if it is `supports_backward_ad` (it basically already is)
  - the only modification needed is to no longer skip forward ad tests if `supports_autograd` is false
  - test_dtype, test_variant_consistency, etc behave correctly as-is
  - In a follow-up PR, we can rename it to actually be `supports_backward_ad`
- Testing
  - https://github.com/pytorch/pytorch/pull/65060