### PR TITLE
Repro for python_mode bug

### DIFF
--- a/test/test_repro.py
+++ b/test/test_repro.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn as nn
+import asyncio
+import functools
+import re
+import sys
+import textwrap
+import traceback
+import types
+import unittest.mock
+import warnings
+from asyncio.events import AbstractEventLoop
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, List, Optional, Set, Tuple, TypeVar
+
+import testslide
+
+"""
+Repro instructions:
+1. `pip install testslide`
+2. `cd test` and `testslide test_repro.py`
+"""
+
+# NB: the internal code comment on async_test might be suspicious.
+# (see https://fburl.com/diffusion/ebwww689).
+# Maybe the bug happens as a result of a user error?
+def async_test(func):
+    if not asyncio.iscoroutinefunction(func):
+        raise TypeError("Only 'async def' is supported, please fix your call site")
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kws: Any) -> None:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(func(*args, **kws))
+
+    return wrapper
+
+class TestBlah(testslide.TestCase):
+    # async_test is required for this repro
+    @async_test
+    async def test_one_frame(self):
+        # net doesn't even get used! But somehow it is required for the repro
+        net = nn.Linear(2, 1)
+
+        def foo():
+            # Create a nn.Parameter, then del it. This makes it so that
+            # we flip the ownership bit on the Tensor.
+            x = torch.nn.Parameter(torch.randn(3))
+            y = x * x
+            return y
+
+        y = foo()

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -64,6 +64,17 @@ void concrete_decref_fn(const c10::impl::PyInterpreter* self, PyObject* pyobj) {
     return;
 
   pybind11::gil_scoped_acquire gil;
+
+  // Uncommenting out the following line makes the error go away.
+  // The implication that a Python error was set BEFORE PyObject_IsInstance
+  // was called, so there is bug somewhere before this function
+  // (concrete_decref_fn) gets called.
+  // PyErr_PrintEx(0);
+
+  // The following assert fails
+  auto is_tensor = PyObject_IsInstance(pyobj, THPVariableClass);
+  TORCH_INTERNAL_ASSERT(is_tensor == 0 || is_tensor == 1);
+
   if (Py_REFCNT(pyobj) > 1) {
     // It's still alive!  This can happen if a weak ref resurrected
     // the PyObject without flipping ownership.  At this point it is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#65068 Repro for python_mode bug**

To run the repro:
1. `pip install testslide` (some testing library)
2. `cd test` and `testslide test_repro.py`