### PR TITLE
[fx2trt] re-enable profiler and some miscs for TRTModule

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -42,31 +42,52 @@ def torch_dtype_from_trt(dtype):
 
 
 class TRTModule(torch.nn.Module):
-    def __init__(
-        self, engine=None, input_names=None, output_names=None, fp16_output=False
-    ):
+    def __init__(self, engine=None, input_names=None, output_names=None):
         super(TRTModule, self).__init__()
         self._register_state_dict_hook(TRTModule._on_state_dict)
         self.engine = engine
-        if self.engine is not None:
-            self.context = self.engine.create_execution_context()
         self.input_names = input_names
         self.output_names = output_names
+        self.initialized = False
 
-        # Indicate output is in fp16
-        self.fp16_output = fp16_output
+        if engine:
+            self._initialize()
 
-        # Indices of outputs into the CUDA engine bindings, in the order as they are
-        # in the fx graph's `output` node.
-        self.output_indices_in_order: Sequence[int] = [
+    def _initialize(self):
+        self.initialized = True
+        self.context = self.engine.create_execution_context()
+
+        # Indices of inputs/outputs in the trt engine bindings, in the order
+        # as they are in the original PyTorch model.
+        self.input_binding_indices_in_order: Sequence[int] = [
+            self.engine.get_binding_index(name) for name in self.input_names
+        ]
+        self.output_binding_indices_in_order: Sequence[int] = [
             self.engine.get_binding_index(name) for name in self.output_names
         ]
 
+        self.input_dtypes: Sequence[torch.dtype] = [
+            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
+            for idx in self.input_binding_indices_in_order
+        ]
+        self.input_shapes: Sequence[Sequence[int]] = [
+            tuple(self.engine.get_binding_shape(idx))
+            for idx in self.input_binding_indices_in_order
+        ]
+        self.output_dtypes: Sequence[torch.dtype] = [
+            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
+            for idx in self.output_binding_indices_in_order
+        ]
+
+    def _check_initialized(self):
+        if not self.initialized:
+            raise RuntimeError("TRTModule is not initialized.")
+
     def _on_state_dict(self, state_dict, prefix, local_metadata):
+        self._check_initialized()
         state_dict[prefix + "engine"] = bytearray(self.engine.serialize())
         state_dict[prefix + "input_names"] = self.input_names
         state_dict[prefix + "output_names"] = self.output_names
-        state_dict[prefix + "fp16_output"] = self.fp16_output
 
     def _load_from_state_dict(
         self,
@@ -82,41 +103,64 @@ class TRTModule(torch.nn.Module):
 
         with trt.Logger() as logger, trt.Runtime(logger) as runtime:
             self.engine = runtime.deserialize_cuda_engine(engine_bytes)
-            self.context = self.engine.create_execution_context()
 
         self.input_names = state_dict[prefix + "input_names"]
         self.output_names = state_dict[prefix + "output_names"]
+        self._initialize()
 
     def forward(self, *inputs):
         with torch.autograd.profiler.record_function("TRTModule:Forward"):
+            self._check_initialized()
+
             with torch.autograd.profiler.record_function("TRTModule:ProcessInputs"):
                 assert len(inputs) == len(
                     self.input_names
                 ), f"Wrong number of inputs, expect {len(self.input_names)} get {len(inputs)}."
+
+                # This is only used when the trt engine is using implicit batch dim.
                 batch_size = inputs[0].shape[0]
                 contiguous_inputs: List[torch.Tensor] = [i.contiguous() for i in inputs]
-                bindings: List[Any] = [None] * (len(self.input_names) + len(self.output_names))
+                bindings: List[Any] = [None] * (
+                    len(self.input_names) + len(self.output_names)
+                )
 
                 for i, input_name in enumerate(self.input_names):
-                    assert inputs[i].is_cuda, f"{i}th input is not on cuda device."
-                    idx = self.engine.get_binding_index(input_name)
+                    assert inputs[
+                        i
+                    ].is_cuda, f"{i}th input({input_name}) is not on cuda device."
+                    assert (
+                        inputs[i].dtype == self.input_dtypes[i]
+                    ), f"Dtype mismatch for {i}th input({input_name}). Expect {self.input_dtypes[i]}, got {inputs[i].dtype}."
+
+                    idx = self.input_binding_indices_in_order[i]
                     bindings[idx] = contiguous_inputs[i].data_ptr()
 
                     if not self.engine.has_implicit_batch_dimension:
-                        self.context.set_binding_shape(idx, tuple(contiguous_inputs[i].shape))
+                        self.context.set_binding_shape(
+                            idx, tuple(contiguous_inputs[i].shape)
+                        )
+                    else:
+                        assert (
+                            inputs[i].size()[1:] == self.input_shapes[i]
+                        ), f"Shape mismatch for {i}th input({input_name}). " \
+                           f"Expect {self.input_shapes[i]}, got {inputs[i].size()[1:]}."
 
             with torch.autograd.profiler.record_function("TRTModule:ProcessOutputs"):
                 # create output tensors
                 outputs: List[torch.Tensor] = []
-                for idx in self.output_indices_in_order:
-                    dtype = torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
-
+                for i, idx in enumerate(self.output_binding_indices_in_order):
                     if self.engine.has_implicit_batch_dimension:
-                        shape = (batch_size,) + tuple(self.engine.get_binding_shape(idx))
+                        shape = (batch_size,) + tuple(
+                            self.engine.get_binding_shape(idx)
+                        )
                     else:
                         shape = tuple(self.context.get_binding_shape(idx))
 
-                    output = torch.empty(size=shape, dtype=dtype, device="cuda")
+                    output = torch.empty(  # type: ignore[call-overload]
+                        size=shape,
+                        dtype=self.output_dtypes[i],
+                        device=torch.cuda.current_device(),
+                    )
                     outputs.append(output)
                     bindings[idx] = output.data_ptr()
 
@@ -136,10 +180,12 @@ class TRTModule(torch.nn.Module):
             return tuple(outputs)
 
     def enable_profiling(self):
-        raise RuntimeError(
-            "Profiling is not supported right now because it requires calling"
-            " execute() instead of execute_async()."
-        )
+        """
+        Enable TensorRT profiling. After calling this function, TensorRT will report
+        time spent on each layer in stdout for each forward run.
+        """
+        self._check_initialized()
+
         if not self.context.profiler:
             self.context.profiler = trt.Profiler()
 
@@ -212,9 +258,7 @@ def create_inputs_from_specs(input_specs):
         elif not has_batch_dim:
             shape = (1,) + tuple(shape)
 
-        inputs.append(
-            torch.randn(shape).to(dtype=dtype, device=device)
-        )
+        inputs.append(torch.randn(shape).to(dtype=dtype, device=device))
 
     return inputs
 
@@ -249,8 +293,10 @@ class TRTInterpreter(torch.fx.Interpreter):
 
         missing_ops = self.validate_conversion()
         if missing_ops:
-            warnings.warn("Interpretation will fail due to missing operations \n"
-                          + "\n".join(f"{i}" for i in missing_ops))
+            warnings.warn(
+                "Interpretation will fail due to missing operations \n"
+                + "\n".join(f"{i}" for i in missing_ops)
+            )
 
         self.optimization_profiles: Optional[List] = None
         self.input_specs = input_specs
@@ -403,7 +449,9 @@ class TRTInterpreter(torch.fx.Interpreter):
         converter = CONVERTERS.get(submod_type)
 
         if not converter:
-            raise RuntimeError(f'Conversion of module of type {submod_type} not currently supported!')
+            raise RuntimeError(
+                f"Conversion of module of type {submod_type} not currently supported!"
+            )
 
         return converter(self.network, submod, args, kwargs, self._cur_node_name)
 


### PR DESCRIPTION
Summary:
Previously disabled attaching trt profiler to exec context in TRTModule because https://fburl.com/mc33n880 states that `enqueue()` doesn't support profiling. Seems to be a lie though. Re-enable attaching profiler in this diff.

Also added a bunch of checks for dtype and shape, and fixed saving state_dict and loading back.

Test Plan: buck run mode/opt -c python.package_style=inplace -j 40 deeplearning/trt/fx2trt:acc2trt_test

Differential Revision: D30962757

