### PR TITLE
CI: Upgrade windows 10.1 jobs to 10.2

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -146,10 +146,10 @@ class VcSpec:
 _VC2019 = VcSpec(2019)
 
 WORKFLOW_DATA = [
-    # VS2019 CUDA-10.1
-    WindowsJob(None, _VC2019, CudaVersion(10, 1), master_only=True),
-    # VS2019 CUDA-10.1 force on cpu
-    WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True, master_only=True),
+    # VS2019 CUDA-10.2
+    WindowsJob(None, _VC2019, CudaVersion(10, 2), master_only=True),
+    # VS2019 CUDA-10.2 force on cpu
+    WindowsJob(1, _VC2019, CudaVersion(10, 2), force_on_cpu=True, master_only=True),
 
     # TODO: This test is disabled due to https://github.com/pytorch/pytorch/issues/59724
     # WindowsJob('_azure_multi_gpu', _VC2019, CudaVersion(11, 1), multi_gpu=True, master_and_nightly=True),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7789,15 +7789,15 @@ workflows:
               only:
                 - postnightly
       - pytorch_windows_build:
-          build_environment: pytorch-win-vs2019-cuda10.1-py3
-          cuda_version: "10.1"
+          build_environment: pytorch-win-vs2019-cuda10.2-py3
+          cuda_version: "10.2"
           filters:
             branches:
               only:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py38_cuda10.1_build
+          name: pytorch_windows_vs2019_py38_cuda10.2_build
           python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
@@ -7805,18 +7805,18 @@ workflows:
           vc_year: "2019"
           vs_version: "16.8.6"
       - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda10.1-py3
-          cuda_version: "10.1"
+          build_environment: pytorch-win-vs2019-cuda10.2-py3
+          cuda_version: "10.2"
           filters:
             branches:
               only:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py38_cuda10.1_on_cpu_test1
+          name: pytorch_windows_vs2019_py38_cuda10.2_on_cpu_test1
           python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py38_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.2_build
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: BuildTools
@@ -9406,9 +9406,9 @@ workflows:
           requires:
             - binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build
       - pytorch_windows_build:
-          build_environment: pytorch-win-vs2019-cuda10.1-py3
-          cuda_version: "10.1"
-          name: pytorch_windows_vs2019_py38_cuda10.1_build
+          build_environment: pytorch-win-vs2019-cuda10.2-py3
+          cuda_version: "10.2"
+          name: pytorch_windows_vs2019_py38_cuda10.2_build
           python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
@@ -9416,12 +9416,12 @@ workflows:
           vc_year: "2019"
           vs_version: "16.8.6"
       - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda10.1-py3
-          cuda_version: "10.1"
-          name: pytorch_windows_vs2019_py38_cuda10.1_on_cpu_test1
+          build_environment: pytorch-win-vs2019-cuda10.2-py3
+          cuda_version: "10.2"
+          name: pytorch_windows_vs2019_py38_cuda10.2_on_cpu_test1
           python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py38_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.2_build
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: BuildTools


### PR DESCRIPTION
This is first 2 steps in the following task:
1. Upgrade 10.1 to 10.2
2. Migrate force_on_cpu job to GHA

Test plan:
https://github.com/pytorch/pytorch/pull/65086
The 10.2 jobs passed:
1. build https://circleci.com/gh/pytorch/pytorch/16036482?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
2. force_on_cpu https://circleci.com/gh/pytorch/pytorch/16038754?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link