### PR TITLE
Add force_on_cpu test to win cuda10.2 on GHA

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -161,6 +161,7 @@ class CIWorkflow:
     enable_backwards_compat_test: YamlShellBool = "''"
     enable_xla_test: YamlShellBool = "''"
     enable_noarch_test: YamlShellBool = "''"
+    enable_force_on_cpu_test: YamlShellBool = "''"
 
     def __post_init__(self) -> None:
         if self.is_libtorch:
@@ -241,6 +242,7 @@ WINDOWS_WORKFLOWS = [
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         on_pull_request=True,
         num_test_shards=2,
+        enable_force_on_cpu_test=1,
         ciflow_config=CIFlowConfig(
             enabled=True,
             trigger_action_only=True,

--- a/.github/scripts/generate_pytorch_test_matrix.py
+++ b/.github/scripts/generate_pytorch_test_matrix.py
@@ -47,10 +47,13 @@ def main() -> None:
         configs['jit_legacy'] = {'num_shards': 1, 'runner': TEST_RUNNER_TYPE}
     if MULTIGPU_RUNNER_TYPE is not None and os.getenv('ENABLE_MULTIGPU_TEST'):
         configs['multigpu'] = {'num_shards': 1, 'runner': MULTIGPU_RUNNER_TYPE}
-    if NOGPU_RUNNER_TYPE is not None and os.getenv('ENABLE_NOGPU_NO_AVX_TEST'):
-        configs['nogpu_NO_AVX'] = {'num_shards': 1, 'runner': NOGPU_RUNNER_TYPE}
-    if NOGPU_RUNNER_TYPE is not None and os.getenv('ENABLE_NOGPU_NO_AVX2_TEST'):
-        configs['nogpu_NO_AVX2'] = {'num_shards': 1, 'runner': NOGPU_RUNNER_TYPE}
+    if NOGPU_RUNNER_TYPE is not None:
+        if os.getenv('ENABLE_NOGPU_NO_AVX_TEST'):
+            configs['nogpu_NO_AVX'] = {'num_shards': 1, 'runner': NOGPU_RUNNER_TYPE}
+        if os.getenv('ENABLE_NOGPU_NO_AVX2_TEST'):
+            configs['nogpu_NO_AVX2'] = {'num_shards': 1, 'runner': NOGPU_RUNNER_TYPE}
+        if os.getenv('ENABLE_FORCE_ON_CPU_TEST'):
+            configs['force_on_cpu'] = {'num_shards': 1, 'runner': NOGPU_RUNNER_TYPE}
     if os.getenv('ENABLE_DISTRIBUTED_TEST'):
         configs['distributed'] = {'num_shards': 1, 'runner': TEST_RUNNER_TYPE}
     if os.getenv('ENABLE_SLOW_TEST'):

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -246,12 +246,6 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
-              # run the full test suite for force_on_cpu test
-              export USE_CUDA=0
-            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             .jenkins/pytorch/win-test.sh
       !{{ common.upload_test_reports(name='windows') }}
       !{{ common.render_test_results() }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -246,11 +246,11 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              # run the full test suite for force_on_cpu test
               export USE_CUDA=0
+            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+              export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh
       !{{ common.upload_test_reports(name='windows') }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -156,6 +156,8 @@ jobs:
       NUM_TEST_SHARDS: !{{ num_test_shards }}
       NUM_TEST_SHARDS_ON_PULL_REQUEST: !{{ num_test_shards_on_pull_request }}
       PR_BODY: ${{ github.event.pull_request.body }}
+      NOGPU_RUNNER_TYPE: windows.4xlarge
+      ENABLE_FORCE_ON_CPU_TEST: !{{ enable_force_on_cpu_test }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -212,10 +214,12 @@ jobs:
           .\.circleci\scripts\vs_install.ps1
 {%- if cuda_version != "cpu" %}
       - name: Install Cuda
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cuda_install.sh
       - name: Install Cudnn
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
@@ -244,6 +248,9 @@ jobs:
             fi
             if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
+            fi
+            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              export USE_CUDA=0
             fi
             .jenkins/pytorch/win-test.sh
       !{{ common.upload_test_reports(name='windows') }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -237,12 +237,6 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
-              # run the full test suite for force_on_cpu test
-              export USE_CUDA=0
-            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -140,6 +140,8 @@ jobs:
       NUM_TEST_SHARDS: 2
       NUM_TEST_SHARDS_ON_PULL_REQUEST: 2
       PR_BODY: ${{ github.event.pull_request.body }}
+      NOGPU_RUNNER_TYPE: windows.4xlarge
+      ENABLE_FORCE_ON_CPU_TEST: ''
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -204,10 +206,12 @@ jobs:
         run: |
           .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cuda_install.sh
       - name: Install Cudnn
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
@@ -235,6 +239,9 @@ jobs:
             fi
             if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
+            fi
+            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              export USE_CUDA=0
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -237,11 +237,11 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              # run the full test suite for force_on_cpu test
               export USE_CUDA=0
+            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+              export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -219,11 +219,11 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              # run the full test suite for force_on_cpu test
               export USE_CUDA=0
+            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+              export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -219,12 +219,6 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
-              # run the full test suite for force_on_cpu test
-              export USE_CUDA=0
-            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -132,6 +132,8 @@ jobs:
       NUM_TEST_SHARDS: 2
       NUM_TEST_SHARDS_ON_PULL_REQUEST: 2
       PR_BODY: ${{ github.event.pull_request.body }}
+      NOGPU_RUNNER_TYPE: windows.4xlarge
+      ENABLE_FORCE_ON_CPU_TEST: ''
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -219,6 +221,9 @@ jobs:
             fi
             if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
+            fi
+            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              export USE_CUDA=0
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
@@ -239,11 +239,11 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              # run the full test suite for force_on_cpu test
               export USE_CUDA=0
+            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+              export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
@@ -142,6 +142,8 @@ jobs:
       NUM_TEST_SHARDS: 2
       NUM_TEST_SHARDS_ON_PULL_REQUEST: 2
       PR_BODY: ${{ github.event.pull_request.body }}
+      NOGPU_RUNNER_TYPE: windows.4xlarge
+      ENABLE_FORCE_ON_CPU_TEST: 1
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -206,10 +208,12 @@ jobs:
         run: |
           .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cuda_install.sh
       - name: Install Cudnn
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
@@ -237,6 +241,9 @@ jobs:
             fi
             if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
+            fi
+            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              export USE_CUDA=0
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
@@ -239,12 +239,6 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
-              # run the full test suite for force_on_cpu test
-              export USE_CUDA=0
-            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -142,6 +142,8 @@ jobs:
       NUM_TEST_SHARDS: 2
       NUM_TEST_SHARDS_ON_PULL_REQUEST: 1
       PR_BODY: ${{ github.event.pull_request.body }}
+      NOGPU_RUNNER_TYPE: windows.4xlarge
+      ENABLE_FORCE_ON_CPU_TEST: ''
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -206,10 +208,12 @@ jobs:
         run: |
           .\.circleci\scripts\vs_install.ps1
       - name: Install Cuda
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cuda_install.sh
       - name: Install Cudnn
+        if: ${{ matrix.config != 'force_on_cpu' }}
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
@@ -237,6 +241,9 @@ jobs:
             fi
             if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
               export RUN_SMOKE_TESTS_ONLY=1
+            fi
+            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              export USE_CUDA=0
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -239,11 +239,11 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+              # run the full test suite for force_on_cpu test
               export USE_CUDA=0
+            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+              export RUN_SMOKE_TESTS_ONLY=1
             fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -239,12 +239,6 @@ jobs:
             if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
               export SHARD_NUMBER=0
             fi
-            if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
-              # run the full test suite for force_on_cpu test
-              export USE_CUDA=0
-            elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
-              export RUN_SMOKE_TESTS_ONLY=1
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -55,6 +55,13 @@ if [[ "${BUILD_ENVIRONMENT}" == *cuda11* ]]; then
   export BUILD_SPLIT_CUDA=ON
 fi
 
+if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
+  # run the full test suite for force_on_cpu test
+  export USE_CUDA=0
+elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+  export RUN_SMOKE_TESTS_ONLY=1
+fi
+
 run_tests() {
     # Run nvidia-smi if available
     for path in '/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe' /c/Windows/System32/nvidia-smi.exe; do

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -921,6 +921,7 @@ class TestCppExtensionJIT(common.TestCase):
 
     @unittest.skipIf(TEST_WITH_ASAN, "ASAN disables the crash handler's signal handler")
     @unittest.skipIf(not has_breakpad(), "Built without breakpad")
+    @unittest.skipIf(os.environ.get("TEST_CONFIG") == "force_on_cpu", "fails on force_on_cpu config, tracked w/ #65253")
     def test_crash_handler(self):
         with tempfile.TemporaryDirectory() as temp_dir, tempfile.NamedTemporaryFile(delete=not sys.platform == "win32") as stderr:
             # Use multiprocessing to spin up a separate process to make catching


### PR DESCRIPTION
Part of migrating from Circle.

Once we get a successful force_on_cpu test, we can move it to trunk only.