### PR TITLE
upstreaming fairscale fsdp to PyTorch

### DIFF
--- a/test/distributed/fsdp/test_flatten_params_wrapper.py
+++ b/test/distributed/fsdp/test_flatten_params_wrapper.py
@@ -1,0 +1,302 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+""" Test FlattenParamsWrapper on CPU and GPU (FP32 & FP16 on GPU). """
+
+from collections import OrderedDict
+import unittest
+
+import torch
+
+from torch.distributed._fsdp.flatten_params_wrapper import FlattenParamsWrapper
+from torch.testing._internal.common_fsdp import objects_are_equal
+
+
+class TestFlattenParams(unittest.TestCase):
+    """ Base test class and used for CPU case. """
+
+    def _get_module_init_fns(self):
+        return [
+            self._get_basic_linear_module,
+            self._get_shared_params_transformer,
+        ]
+
+    def _get_empty_module(self, seed=0):
+        torch.manual_seed(seed)  # keep everything deterministic
+
+        class Test(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        module = Test()
+
+        def get_input(device, dtype):
+            torch.manual_seed(1)  # keep everything deterministic
+            return torch.rand(1).to(device=device, dtype=dtype)
+
+        module.get_input = get_input
+        return module
+
+    def _get_transformer(self, seed=0):
+        torch.manual_seed(seed)  # keep everything deterministic
+        module = torch.nn.Transformer(
+            d_model=32, num_encoder_layers=2, num_decoder_layers=2, dim_feedforward=128, dropout=0.1,
+        )
+        module.register_buffer("dummy_buffer", torch.tensor(1.0))
+
+        def get_input(device, dtype):
+            torch.manual_seed(1)  # keep everything deterministic
+            src = torch.rand(20, 8, 32).to(device=device, dtype=dtype)  # T x B x C
+            tgt = torch.rand(10, 8, 32).to(device=device, dtype=dtype)  # T x B x C
+            return (src, tgt)
+
+        module.get_input = get_input
+        return module
+
+    def _get_shared_params_transformer(self, seed=0):
+        module = self._get_transformer(seed=seed)
+        # share the FFNs
+        for enc_layer, dec_layer in zip(module.encoder.layers, module.decoder.layers):
+            dec_layer.linear1.weight = enc_layer.linear1.weight
+            dec_layer.linear2.weight = enc_layer.linear2.weight
+        return module
+
+    def _get_basic_linear_module(self, seed=0):
+        module = torch.nn.Sequential(
+            torch.nn.Sequential(torch.nn.Linear(4, 8), torch.nn.Linear(8, 8)),
+            torch.nn.Sequential(torch.nn.Linear(8, 16)),
+            torch.nn.Linear(16, 4),
+        )
+
+        def get_input(device, dtype):
+            torch.manual_seed(1)  # keep everything deterministic
+            return (torch.rand(8, 4).to(device=device, dtype=dtype),)
+
+        module.get_input = get_input
+        return module
+
+    def _get_output(self, module):
+        device = next(module.parameters()).device
+        dtype = next(module.parameters()).dtype
+        input = module.get_input(device, dtype)
+        return module(*input)
+
+    def _get_pnorm_after_step(self, module):
+        optim = torch.optim.SGD(module.parameters(), lr=0.01)
+        loss = self._get_output(module).sum()
+        loss.backward()
+        optim.step()
+        return torch.norm(torch.stack([p.detach().norm() for p in module.parameters()]))
+
+    def _test_num_params(self, module):
+        ref_num_params = sum(p.numel() for p in module.parameters())
+
+        flat_module = FlattenParamsWrapper(module)
+        flat_num_params = sum(p.numel() for p in flat_module.parameters())
+
+        assert ref_num_params == flat_num_params
+        assert flat_num_params == flat_module.flat_param.numel()
+
+    def _test_output(self, module):
+        ref_output = self._get_output(module)
+
+        flat_module = FlattenParamsWrapper(module)
+        flat_output = self._get_output(flat_module)
+        assert objects_are_equal(ref_output, flat_output)
+
+    def test_partial_flattening(self):
+        module = self._get_transformer()
+        num_params = sum(p.numel() for p in module.parameters())
+
+        params_to_flatten = list(module.encoder.layers[1].parameters()) + list(module.decoder.layers[0].parameters())
+        num_params_to_flatten = sum(p.numel() for p in params_to_flatten)
+
+        module = FlattenParamsWrapper(module, param_list=params_to_flatten)
+        assert module.flat_param.numel() == num_params_to_flatten
+        assert sum(p.numel() for p in module.parameters()) == num_params
+
+        # flattened parameters are removed
+        assert len(list(module.encoder.layers[1].parameters())) == 0
+        assert len(list(module.decoder.layers[0].parameters())) == 0
+
+        # non-flattened parameters remain
+        assert len(list(module.encoder.layers[0].parameters())) > 0
+        assert len(list(module.decoder.layers[1].parameters())) > 0
+
+        # test that changing the module dtype works properly
+        orig_dtype = params_to_flatten[0].dtype
+        new_dtype = torch.float32 if orig_dtype == torch.float16 else torch.float16
+        assert module.flat_param.dtype == orig_dtype
+        assert all(p.dtype == orig_dtype for p in module.encoder.layers[0].parameters())
+        module = module.to(dtype=new_dtype)
+        assert module.flat_param.dtype == new_dtype
+        assert all(p.dtype == new_dtype for p in module.encoder.layers[0].parameters())
+
+    def test_two_flattening_group(self):
+        module = self._get_transformer()
+        num_params = sum(p.numel() for p in module.parameters())
+
+        params_to_flatten1 = list(module.encoder.layers[1].parameters()) + list(module.decoder.layers[0].parameters())
+        params_to_flatten2 = list(module.encoder.layers[0].parameters()) + list(module.decoder.layers[1].parameters())
+        num_params_to_flatten1 = sum(p.numel() for p in params_to_flatten1)
+        num_params_to_flatten2 = sum(p.numel() for p in params_to_flatten2)
+
+        module = FlattenParamsWrapper(module, param_list=[params_to_flatten1, params_to_flatten2])
+        assert module.flat_params[0].numel() == num_params_to_flatten1
+        assert module.flat_params[1].numel() == num_params_to_flatten2
+        assert sum(p.numel() for p in module.parameters()) == num_params
+
+    def test_flatten_nothing(self):
+        module = self._get_transformer()
+        ref_out = self._get_output(module)
+        ref_state_dict = module.state_dict()
+        for k, v in ref_state_dict.items():
+            ref_state_dict[k] = v.clone()
+        module = FlattenParamsWrapper(module, param_list=[[]])
+        fpw_state_dict = module.state_dict()
+        assert ref_state_dict.keys() == fpw_state_dict.keys()
+        for k, v in ref_state_dict.items():
+            torch.testing.assert_allclose(v, fpw_state_dict[k])
+        fpw_out = self._get_output(module)
+        torch.testing.assert_allclose(ref_out, fpw_out)
+
+    def test_empty_module(self):
+        module = self._get_empty_module()
+        in_data = torch.rand(1)
+        ref_out = module(in_data)
+        module = FlattenParamsWrapper(module)
+        assert len(list(module.parameters())) == 0
+        assert len(module.state_dict()) == 0
+        fpw_out = module(in_data)
+        torch.testing.assert_allclose(ref_out, fpw_out)
+
+    def test_num_params(self):
+        module = self._get_transformer()
+        self._test_num_params(module)
+
+    def test_shared_params_num_params(self):
+        module = self._get_shared_params_transformer()
+        self._test_num_params(module)
+
+    def test_output(self):
+        module = self._get_transformer()
+        self._test_output(module)
+
+    def test_shared_params_output(self):
+        module = self._get_shared_params_transformer()
+        self._test_output(module)
+
+    def test_shared_params_pnorm_after_step(self):
+        # incorrect parameter sharing is likely to cause problems after an
+        # optimization step
+        module = self._get_shared_params_transformer()
+        ref_pnorm_after_step = self._get_pnorm_after_step(module)
+
+        module = self._get_shared_params_transformer()  # recreate
+        flat_module = FlattenParamsWrapper(module)
+        flat_pnorm_after_step = self._get_pnorm_after_step(flat_module)
+
+        torch.testing.assert_allclose(ref_pnorm_after_step, flat_pnorm_after_step)
+
+    def test_state_dict_equality(self):
+        """Test that unflattened state dict matches original (unwrapped) one."""
+        modules_to_test = [init_fn() for init_fn in self._get_module_init_fns()]
+        for module in modules_to_test:
+            ref_state_dict = module.state_dict()
+
+            flat_module = FlattenParamsWrapper(module)
+            flat_state_dict = flat_module.state_dict()
+
+            assert (
+                ref_state_dict.keys() == flat_state_dict.keys()
+            ), f"{ref_state_dict.keys()} != {flat_state_dict.keys()}"
+            assert objects_are_equal(ref_state_dict, flat_state_dict), f"{ref_state_dict} != {flat_state_dict}"
+
+    def test_load_state_dict(self):
+        """Test that original (unwrapped) state_dict can be loaded in wrapped module."""
+        for module_init_fn in self._get_module_init_fns():
+            module = module_init_fn()
+            ref_state_dict = module.state_dict()
+            ref_output = self._get_output(module)
+
+            module = module_init_fn(seed=1234)
+            flat_module = FlattenParamsWrapper(module)
+
+            # This should work without the unflatten_params context manager
+            flat_module.load_state_dict(ref_state_dict)
+            flat_output = self._get_output(flat_module)
+            assert objects_are_equal(ref_output, flat_output)
+
+            # And it should work with the context manager too
+            with flat_module.unflatten_params():
+                flat_module.load_state_dict(ref_state_dict)
+            flat_output = self._get_output(flat_module)
+            assert objects_are_equal(ref_output, flat_output)
+
+    def test_flat_state_dict(self):
+        """Test that flat state dict can be reloaded and produces the same results."""
+        for module_init_fn in self._get_module_init_fns():
+            flat_module = FlattenParamsWrapper(module_init_fn())
+            ref_output = self._get_output(flat_module)
+
+            flat_state_dict = flat_module.flat_state_dict()
+
+            new_module = FlattenParamsWrapper(module_init_fn(seed=1234))
+            new_module.load_state_dict(flat_state_dict)
+            new_output = self._get_output(new_module)
+
+            assert objects_are_equal(ref_output, new_output)
+
+    def test_unflatten_params(self):
+        for module_init_fn in self._get_module_init_fns():
+            module = FlattenParamsWrapper(module_init_fn())
+            buffers = {k.replace("_fpw_module.", "") for k, _ in module.named_buffers()}
+
+            def clone_state_dict():
+                return OrderedDict((k, v.clone()) for k, v in module.state_dict().items())
+
+            ref_flat_param = module.flat_param.clone()
+            with module.unflatten_params():
+                ref_state_dict = clone_state_dict()
+            assert not torch.all(ref_flat_param == 0)
+
+            # confirm that unflatten_params reflects values from new_flat_param
+            new_flat_param = torch.full_like(module.flat_param, fill_value=42.0)
+            with module.unflatten_params(flat_params=[new_flat_param]):
+                new_state_dict = clone_state_dict()
+                assert new_state_dict.keys() == ref_state_dict.keys()
+                for k, v in new_state_dict.items():
+                    if k in buffers:  # buffers are not changed
+                        torch.testing.assert_allclose(v, ref_state_dict[k])
+                    else:  # params reflect new_flat_param value
+                        torch.testing.assert_allclose(v, torch.ones_like(v) * 42.0)
+
+            # after context manager exits, we go back to previous (reference) state
+            torch.testing.assert_allclose(module.flat_param, ref_flat_param)
+            with module.unflatten_params():
+                ref_state_dict2 = clone_state_dict()
+                assert objects_are_equal(ref_state_dict, ref_state_dict2)
+
+            # if we load the new_state_dict, then the flat param should match new_flat_param
+            module.load_state_dict(new_state_dict)
+            torch.testing.assert_allclose(module.flat_param, new_flat_param)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "test requires a GPU")
+class TestFlattenParamsCUDA(TestFlattenParams):
+    def _get_transformer(self, seed=0):
+        module = super()._get_transformer(seed=seed)
+        return module.cuda()
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "test requires a GPU")
+class TestFlattenParamsCUDAHalf(TestFlattenParams):
+    def _get_transformer(self, seed=0):
+        module = super()._get_transformer(seed=seed)
+        return module.cuda().half()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/fsdp/test_fsdp.py
+++ b/test/distributed/fsdp/test_fsdp.py
@@ -1,0 +1,515 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+from math import inf
+import pickle
+from typing import Dict
+import unittest
+from unittest import mock
+
+import torch
+from torch import nn
+import torch.distributed
+
+from torch.distributed._fsdp import FullyShardedDataParallel
+from torch.testing._internal.common_fsdp import (
+    DeviceAndTypeCheckModule,
+    DummyProcessGroup,
+    get_cycles_per_ms,
+    objects_are_equal,
+    TransformerWithSharedParams,
+    NestedWrappedModule,
+    CONFIG_OPTIONS,
+    DistributedTest,
+    spawn_and_init,
+    MixtureOfExperts,
+)
+
+# How to use remote-pdb: https://gist.github.com/sshleifer/9d43351957179c13606e015b072927d4
+# All helper functions called by spawn must be either @classmethod, @staticmethod
+
+class TestMixedPrecision(DistributedTest):
+    def test_all_fp32(self):
+        self._spawn_test_case(
+            {"mixed_precision": False},
+            False,  # autocast enabled
+            torch.float32,  # expected_input_dtype
+            torch.float32,  # expected_param_dtype
+            torch.float32,  # expected_loss_dtype
+            torch.float32,  # expected_reduce_dtype
+        )
+
+    def test_mixed_precision(self):
+        self._spawn_test_case(
+            {"mixed_precision": True},
+            False,  # autocast enabled
+            torch.float16,  # expected_input_dtype
+            torch.float16,  # expected_param_dtype
+            torch.float16,  # expected_loss_dtype
+            torch.float16,  # expected_reduce_dtype
+        )
+
+    def test_mixed_precision_autocast(self):
+        """If autocast enabled, loss should be fp32."""
+        self._spawn_test_case(
+            {"mixed_precision": True},
+            True,  # autocast enabled
+            torch.float16,  # expected_input_dtype
+            torch.float16,  # expected_param_dtype
+            torch.float32,  # expected_loss_dtype
+            torch.float16,  # expected_reduce_dtype
+        )
+
+    def test_mixed_precision_autocast_buffer_type_fp32(self):
+        """If autocast enabled, loss should be fp32."""
+        self._spawn_test_case(
+            {"mixed_precision": True, "buffer_dtype": torch.float32},
+            True,  # autocast enabled
+            torch.float16,  # expected_input_dtype
+            torch.float16,  # expected_param_dtype
+            torch.float32,  # expected_loss_dtype
+            torch.float16,  # expected_reduce_dtype
+            expected_buffer_type=torch.float32,
+        )
+
+    def test_mixed_precision_autocast_fp32_compute(self):
+        self._spawn_test_case(
+            {"mixed_precision": True, "compute_dtype": torch.float32},
+            True,  # autocast enabled
+            torch.float16,  # expected_input_dtype
+            torch.float32,  # expected_param_dtype
+            torch.float32,  # expected_loss_dtype
+            torch.float32,  # expected_reduce_dtype
+            expected_buffer_type=torch.float32,
+        )
+
+    def test_fp32_reduce_scatter(self):
+        self._spawn_test_case(
+            {"mixed_precision": True, "fp32_reduce_scatter": True},
+            False,  # autocast enabled
+            torch.float16,  # expected_input_dtype
+            torch.float16,  # expected_param_dtype
+            torch.float16,  # expected_loss_dtype
+            torch.float32,  # expected_reduce_dtype
+            expected_buffer_type=torch.float16,
+        )
+
+    def test_fp32_reduce_scatter_autocast(self):
+        self._spawn_test_case(
+            {"mixed_precision": True, "fp32_reduce_scatter": True},
+            True,  # autocast enabled
+            torch.float16,  # expected_input_dtype
+            torch.float16,  # expected_param_dtype
+            torch.float32,  # expected_loss_dtype
+            torch.float32,  # expected_reduce_dtype
+        )
+
+    def _spawn_test_case(
+        self,
+        cfg,
+        autocast_enabled,
+        in_dtype,
+        p_dtype,
+        loss_dtype,
+        reduce_dtype,
+        expected_buffer_type=None,
+        world_size=2,
+    ):
+        """Call test_dtypes inside of torch.multiprocessing.spawn"""
+        fn = functools.partial(
+            self._test_dtypes,
+            cfg,
+            autocast_enabled,
+            in_dtype,
+            p_dtype,
+            loss_dtype,
+            reduce_dtype,
+            expected_buffer_type=expected_buffer_type,
+        )
+        spawn_and_init(fn, world_sizes=[world_size])
+
+    @staticmethod
+    def _test_dtypes(
+        cfg: Dict, autocast, in_dtype, p_dtype, loss_dtype, reduce_dtype, rank, group, expected_buffer_type=None
+    ):
+        # Patch torch.distributed.reduce_scatter to check the dtype of the reduction
+        orig_reduce_scatter = torch.distributed.reduce_scatter
+
+        model: nn.Module = DeviceAndTypeCheckModule(
+            expected_input_dtype=in_dtype,
+            expected_param_dtype=p_dtype,
+            expected_loss_dtype=loss_dtype,
+            expected_buffer_dtype=expected_buffer_type,
+        )
+
+        def _reduce_scatter(output, input_list, **kwargs):
+            for tensor in input_list:
+                model._check("reduce_scatter.dtype", tensor.dtype, expected=reduce_dtype)
+            return orig_reduce_scatter(output, input_list, **kwargs)
+
+        with mock.patch("torch.distributed.reduce_scatter", new=_reduce_scatter):
+            model = FullyShardedDataParallel(model, group, **cfg).cuda()
+            device = next(model.parameters()).device
+            x = torch.rand(2, 5).to(device)
+            with torch.cuda.amp.autocast(enabled=autocast):
+                loss = model(x)
+            loss.backward()
+
+
+class TestComparisonToPyTorchDDP(DistributedTest):
+    """
+    Compare losses and parameter values after several updates when using
+    PyTorch DDP vs. FullyShardedDataParallel.
+    """
+
+    def test_nested_wrapped_model(self):
+        for config in CONFIG_OPTIONS:
+            test_fn = functools.partial(self._test_identical_outputs, NestedWrappedModule, config)
+            spawn_and_init(test_fn)
+
+    def test_nested_all_wrapped_model(self):
+        for config in CONFIG_OPTIONS:
+            model_fn = functools.partial(NestedWrappedModule, wrap_everything=True)
+            test_fn = functools.partial(self._test_identical_outputs, model_fn, config)
+            spawn_and_init(test_fn)
+
+    # def test_nested_all_wrapped_model_checkpoint(self):
+    #    for config in CONFIG_OPTIONS:
+    #        model_fn = functools.partial(NestedWrappedModule, wrap_everything=True, checkpoint=True)
+    #        test_fn = functools.partial(self._test_identical_outputs, model_fn, config)
+    #        spawn_and_init(test_fn)
+
+    def test_transformer_parameterized(self):
+        # Test every combination of these options:
+        for config in CONFIG_OPTIONS:
+            spawn_and_init(functools.partial(self._test_identical_outputs, TransformerWithSharedParams, config))
+
+    def test_cpu_offload_and_cpu_grads(self):
+        # We don't test the False condition because that requires the optimizer to internally do
+        # the device transfer and PyTorch optimizers don't support this.
+        config = {"mixed_precision": True, "cpu_offload": True, "move_grads_to_cpu": True}
+        test_fn = functools.partial(
+            self._test_identical_outputs, TransformerWithSharedParams, config, use_cuda=False, lr=0.01
+        )
+        spawn_and_init(test_fn)
+
+    def test_cpu_offload_and_cuda_grads_breaks(self):
+        # If grads are on gpu, but model and optimizer are on cpu, backward breaks.
+        config = {"mixed_precision": True, "cpu_offload": True, "move_grads_to_cpu": False}
+        with self.assertRaises(Exception):  # RuntimeError inside spawn
+            test_fn = functools.partial(
+                self._test_identical_outputs, TransformerWithSharedParams, config, use_cuda=False
+            )
+            spawn_and_init(test_fn)
+
+    def test_delayed_optim_step(self):
+        # We use a model with a long CUDA delay right before the optimizer step.
+        # This tests our streams logic, and that we don't start the FP32 -> FP16
+        # transfer until after the optimization step completes.
+        config = {"mixed_precision": True}
+        model_fn = functools.partial(NestedWrappedModuleWithDelay, delay_after_loss_ms=250)
+        test_fn = functools.partial(self._test_identical_outputs, model_fn, config)
+        spawn_and_init(test_fn)
+
+    def test_delayed_reduce_scatter(self):
+        # We insert a delay in the torch.distributed.reduce_scatter op, so that
+        # the post_backward_stream takes much longer than the backward pass.
+        # This tests that we properly block at the end of the backward pass for
+        # the reductions to finish.
+        config = {"mixed_precision": True}
+        model_fn = functools.partial(NestedWrappedModuleWithDelay, delay_before_reduction_ms=250)
+        test_fn = functools.partial(self._test_identical_outputs, model_fn, config)
+        spawn_and_init(test_fn)
+
+    # @parameterized.expand([[{"checkpoint_act": False}], [{"checkpoint_act": True}]], name_func=rename_test)
+    def test_mixture_of_experts(self):
+        fsdp_config = {"mixed_precision": True}
+        test_fn = functools.partial(
+            self._test_identical_outputs,
+            functools.partial(MixtureOfExperts),
+            fsdp_config,
+            # MixtureOfExperts implements custom reduce logic, so the reference
+            # behavior should use that logic instead of PyTorch DDP.
+            ref_ddp_fn=self._dummy_ddp_fn,
+            norm_type=None,
+        )
+        spawn_and_init(test_fn)
+
+    # @parameterized.expand([[{"checkpoint_act": False}], [{"checkpoint_act": True}]], name_func=rename_test)
+    def test_mixture_of_experts_with_delay_before_free(self):
+        fsdp_config = {"mixed_precision": True}
+        test_fn = functools.partial(
+            self._test_identical_outputs,
+            functools.partial(MixtureOfExperts, delay_before_free_ms=250),
+            fsdp_config,
+            # MixtureOfExperts implements custom reduce logic, so the reference
+            # behavior should use that logic instead of PyTorch DDP.
+            ref_ddp_fn=self._dummy_ddp_fn,
+            norm_type=None,
+        )
+        spawn_and_init(test_fn)
+
+    def test_mixture_of_experts_grad_clip_breaks(self):
+        config = {"mixed_precision": True}
+        test_fn = functools.partial(
+            self._test_identical_outputs, MixtureOfExperts, config, ref_ddp_fn=self._dummy_ddp_fn, norm_type=2,
+        )
+        with self.assertRaises(Exception):
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _dummy_ddp_fn(cls, model, group):
+        return DummyDDP(model)
+
+    def test_clip_norm_transformer(self):
+        config = {"mixed_precision": True}
+        for norm_type in [1, inf]:
+            test_fn = functools.partial(
+                self._test_identical_outputs, TransformerWithSharedParams, config, norm_type=norm_type,
+            )
+        spawn_and_init(test_fn)
+
+
+class TestParamInit(DistributedTest):
+    def test_param_change_after_init(self):
+        test_fn = functools.partial(self._test_param_change_after_init, config={"mixed_precision": True})
+        spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_param_change_after_init(cls, rank, group, config):
+        # Establish reference behavior.
+        model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        model.eval()  # no dropout for this test
+        input = model.module.get_input(torch.device("cuda"))
+        ref_output = model(*input)
+
+        # Change the weights in place.
+        model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        model.eval()  # no dropout for this test
+        first_param = next(model.parameters())
+        nn.init.normal_(first_param.data)
+        new_output = model(*input)
+
+        assert not objects_are_equal(ref_output, new_output), "new_output did not reflect change to param after init"
+
+
+class TestSerialization(DistributedTest):
+    def test_pickle(self):
+        """Ensure that wrapped modules can be pickled/unpickled."""
+        for mixed_precision, cpu_offload in [(False, False), (True, False), (True, True)]:
+            config = {"mixed_precision": mixed_precision, "cpu_offload": cpu_offload}
+            test_fn = functools.partial(self._test_pickle, config=config)
+            spawn_and_init(test_fn, world_sizes=[2])
+
+    def test_multiprocessing(self):
+        """Ensure that wrapped modules can be sent via multiprocessing."""
+        for mixed_precision, cpu_offload in [(False, False), (True, False), (True, True)]:
+            config = {"mixed_precision": mixed_precision, "cpu_offload": cpu_offload}
+            test_fn = functools.partial(self._test_multiprocessing, config=config)
+            spawn_and_init(test_fn, world_sizes=[2])
+
+    @classmethod
+    def _test_pickle(cls, rank, group, config):
+        model = cls._get_model(group, config)
+        model = pickle.loads(pickle.dumps(model))
+        if not config["cpu_offload"]:
+            model = model.cuda()
+        cls._one_step(model, group)
+
+    @classmethod
+    def _test_multiprocessing(cls, rank, group, config):
+        mp = torch.multiprocessing.Pool(1)
+        dummy_group = DummyProcessGroup(rank=group.rank(), size=group.size())
+        model = mp.apply(cls._get_model, (dummy_group, config))
+        if not config["cpu_offload"]:
+            model = model.cuda()
+        cls._one_step(model, group)
+
+    @classmethod
+    def _get_model(cls, group, config):
+        with torch.no_grad():  # required for multiprocessing
+            model = NestedWrappedModule(group, wrapper_config=config)
+            return FullyShardedDataParallel(model, group, **config)
+
+    @classmethod
+    def _one_step(cls, model, group):
+        # reset the process group (required after unpickling)
+        for m in model.modules():
+            if isinstance(m, FullyShardedDataParallel):
+                m.process_group = group
+        optim = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+        input = model.module.get_input(torch.device("cuda"))
+        output = model(*input)
+        loss = model.module.get_loss(input, output)
+        model.module.run_backward(loss)
+        optim.step()
+
+
+class TestHooks(DistributedTest):
+    # Feel free to modify these tests as the implementation changes.
+    # They aspire to make sure that backward hooks are registered and used
+
+    def test_output_backward_hooks(self):
+        for cuda_first in [True, False]:
+            fn = functools.partial(self._test_output_backward_hooks, cuda_first=cuda_first)
+            spawn_and_init(fn)
+
+    def test_backward_hooks_after_save(self):
+        fn = functools.partial(self._test_backward_hooks_after_save, cuda_first=False)
+        spawn_and_init(fn)
+
+    @classmethod
+    def _test_backward_hooks_after_save(cls, rank, group, cuda_first=False):
+        model = cls.get_wrapped_model(group, cuda_first=cuda_first)
+        cls._train_for_several_steps(model, 2, model.mixed_precision)
+        state_1 = model.local_state_dict()
+        model.load_local_state_dict(state_1)
+        cls._test_output_backward_hooks(rank, group, cuda_first=cuda_first, model=model)
+
+    @classmethod
+    def _test_output_backward_hooks(cls, rank, group, cuda_first=False, model=None):
+        if model is None:
+            model = cls.get_wrapped_model(group, cuda_first=cuda_first)
+        optim = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+        optim.zero_grad()
+        # Inputs always cuda regardless of move_grads_cpu, or model.device
+        input = model.module.get_input(torch.device("cuda"))
+        output = model(*input)
+        assert len(output._backward_hooks) == 1  # this is pre-bwd hook
+        loss = model.module.get_loss(input, output).cuda()
+        loss.backward()
+        assert len(output._backward_hooks) == 1  # It doesn't get removed
+        optim.step()
+        assert len(output._backward_hooks) == 1
+
+    def test_register_functions_called(self):
+        for cuda_first in [True, False]:
+            fn = functools.partial(self._test_register_functions_called, cuda_first=cuda_first)
+            spawn_and_init(fn)
+
+    @classmethod
+    def _test_register_functions_called(cls, rank, group, cuda_first=False):
+        """Tests that _register_{pre|post}_backward_hooks called during forward."""
+        model = cls.get_wrapped_model(group, cuda_first=cuda_first)
+        input = model.module.get_input(torch.device("cuda"))
+        model._register_post_backward_hooks = mock.MagicMock(return_value=None)
+        model._register_pre_backward_hooks = mock.MagicMock(return_value=None)
+        assert not model._register_post_backward_hooks.called
+        assert not model._register_pre_backward_hooks.called
+        model(*input)
+        assert model._register_post_backward_hooks.called
+        assert model._register_pre_backward_hooks.called
+
+
+class TestNoGrad(DistributedTest):
+    def test_transformer_parameterized(self):
+        for config in CONFIG_OPTIONS:
+            test_fn = functools.partial(self._test_transformer, config=config)
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_transformer(cls, rank, group, config):
+        autocast = config["mixed_precision"]
+
+        # Train model for a step
+        model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        cls._train_for_several_steps(model, 1, autocast)
+
+        model.eval()  # no dropout for this test
+
+        # Eval in standard mode (i.e., without no_grad)
+        input = model.module.get_input(torch.device("cuda"))
+        ref_output = model(*input)
+
+        # Eval with no_grad and compare
+        with torch.no_grad():
+            no_grad_output = model(*input)
+
+        assert objects_are_equal(ref_output, no_grad_output, raise_exception=True)
+
+
+class TestModuleProperties(DistributedTest):
+    def test_named_parameters(self):
+        for config in [{"flatten_parameters": False}, {"flatten_parameters": True}]:
+            test_fn = functools.partial(self._test_named_params, config=config)
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_named_params(cls, rank, group, config):
+        # Get the named parameters before wrapping.
+        before_wrap_model = TransformerWithSharedParams(group)
+        before_wrap_params = before_wrap_model.named_parameters()
+
+        # Train the model for 1 step.
+        model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        cls._train_for_several_steps(model, 1, autocast=False)
+
+        # Get the named parameters after wrapping to compare.
+        after_wrap_params = model.named_parameters()
+
+        if not config["flatten_parameters"]:
+            for before_nm, after_nm in zip(before_wrap_params, after_wrap_params):
+                assert before_nm[0] == after_nm[0]
+        else:
+            named_params_flat = list(p for p in after_wrap_params)[0][0]
+            assert "flat_param_0" in named_params_flat
+
+        # Compare name and size under the `summon_full_params` context.
+        with model.summon_full_params():
+            after_wrap_params = model.named_parameters()
+
+            for before_nm, after_nm_original in zip(before_wrap_params, after_wrap_params):
+                assert before_nm[0] == after_nm_original[0]
+                torch.testing.assert_allclose(before_nm[1].shape, after_nm_original[1].cpu().shape)
+
+
+class DummyDDP(nn.Module):
+    def __init__(self, module):
+        super().__init__()
+        self.module = module
+
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)
+
+
+class ModuleWithDelay(nn.Module):
+    def __init__(self, module, delay_after_loss_ms=0, delay_before_reduction_ms=0):
+        super().__init__()
+        self.delay_after_loss_ms = delay_after_loss_ms
+        self.delay_before_reduction_ms = delay_before_reduction_ms
+        self.module = module
+
+    def get_input(self, device):
+        return self.module.get_input(device)
+
+    def forward(self, x):
+        return self.module(x)
+
+    def get_loss(self, input, output):
+        loss = self.module.get_loss(input, output)
+        if self.delay_after_loss_ms > 0:
+            torch.cuda._sleep(int(self.delay_after_loss_ms * get_cycles_per_ms()))
+        return loss
+
+    def run_backward(self, loss):
+        orig_reduce_scatter = torch.distributed.reduce_scatter
+
+        def _delayed_reduce_scatter(*args, **kwargs):
+            if self.delay_before_reduction_ms > 0:
+                torch.cuda._sleep(int(self.delay_before_reduction_ms * get_cycles_per_ms()))
+            return orig_reduce_scatter(*args, **kwargs)
+
+        with mock.patch("torch.distributed.reduce_scatter", _delayed_reduce_scatter):
+            self.module.run_backward(loss)
+
+
+class NestedWrappedModuleWithDelay(ModuleWithDelay):
+    def __init__(self, group, wrapper_config, **kwargs):
+        super().__init__(NestedWrappedModule(group, wrapper_config), **kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/fsdp/test_fsdp_apply.py
+++ b/test/distributed/fsdp/test_fsdp_apply.py
@@ -1,0 +1,63 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import unittest
+
+import torch.nn as nn
+
+from torch.testing._internal.common_fsdp import (
+    CONFIG_OPTIONS,
+    DistributedTest,
+    NestedWrappedModule,
+    TransformerWithSharedParams,
+    spawn_and_init,
+)
+
+
+class TestApply(DistributedTest):
+    def test_transformer_weight_init(self):
+        for config in CONFIG_OPTIONS:
+            model_init_fn = functools.partial(model_init_and_apply_custom_weight_init, TransformerWithSharedParams)
+            test_fn = functools.partial(self._test_identical_outputs, model_init_fn, config, lr=0.01)
+            spawn_and_init(test_fn)
+
+    def test_nested_wrapped_weight_init(self):
+        for config in CONFIG_OPTIONS:
+            model_init_fn = functools.partial(model_init_and_apply_custom_weight_init, NestedWrappedModule)
+            test_fn = functools.partial(self._test_identical_outputs, model_init_fn, config, lr=0.01)
+            spawn_and_init(test_fn)
+
+
+def model_init_and_apply_custom_weight_init(model_init_fn, *args, **kwargs):
+    model = model_init_fn(*args, **kwargs)
+    model.apply(init_bert_params_)
+    return model
+
+
+def init_bert_params_(module):
+    """
+    Initialize the weights specific to the BERT Model.
+    """
+
+    def normal_(data):
+        # with FSDP, module params will be on CUDA, so we cast them back to CPU
+        # so that the RNG is consistent with and without FSDP
+        data.copy_(data.cpu().normal_(mean=0.0, std=0.02))
+
+    if isinstance(module, nn.Linear):
+        normal_(module.weight.data)
+        if module.bias is not None:
+            module.bias.data.zero_()
+    if isinstance(module, nn.Embedding):
+        normal_(module.weight.data)
+        if module.padding_idx is not None:
+            module.weight.data[module.padding_idx].zero_()
+    if isinstance(module, nn.MultiheadAttention):
+        normal_(module.in_proj_weight.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/fsdp/test_fsdp_freezing_weights.py
+++ b/test/distributed/fsdp/test_fsdp_freezing_weights.py
@@ -1,0 +1,269 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP with some params frozen. """
+
+
+from enum import Enum
+from itertools import product
+import tempfile
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+import torch.optim as optim
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.testing._internal.common_fsdp import dist_init, objects_are_equal, rmf, teardown
+
+
+class FreezeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.trunk = nn.Sequential(
+            nn.Conv2d(3, 64, kernel_size=3),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+            nn.Flatten(),
+        )
+        self.head = nn.Linear(64, 10)
+
+        self.trunk = FSDP(self.trunk)
+
+    def forward(self, x):
+        return self.head(self.trunk(x))
+
+
+def _freeze_distributed_worker(
+    gpu_id, world_size, tempfile_name, unused,
+):
+    torch.cuda.set_device(gpu_id)
+
+    rank = gpu_id
+    result = dist_init(rank, world_size, tempfile_name, unused)
+    assert result, "Dist init failed"
+
+    torch.manual_seed(0)
+    torch.backends.cudnn.deterministic = True
+    batch = torch.randn(size=(2, 3, 224, 224)).cuda()
+
+    # The use case for this test is where the weights in the submodule
+    # are not frozen but the leftover weights or those contained by the
+    # root module are frozen. Refer to issue #758 for a real world example.
+    model = FreezeModel()
+    model = model.cuda()
+
+    for param in model.head.parameters():
+        param.requires_grad = False
+
+    model = FSDP(model)
+
+    if gpu_id == 0:
+        print(model)
+
+    target = torch.tensor([0, 1], dtype=torch.long).cuda()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+
+    for iteration in range(3):
+        out = model(batch)
+        fake_loss = criterion(out, target)
+        print("Loss", iteration, ":", fake_loss.item())
+        optimizer.zero_grad()
+        fake_loss.backward()
+        optimizer.step()
+
+    teardown()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+def test_submodule_freezing_weights(temp_files):
+    world_size = 2
+    mp.spawn(
+        _freeze_distributed_worker, (world_size, temp_files[0], temp_files[1]), nprocs=world_size,
+    )
+
+
+class Model(nn.Module):
+    def __init__(self, with_fsdp, freeze_after_wrap_fsdp):
+        super().__init__()
+        self.trunk = nn.Sequential(
+            nn.Conv2d(3, 64, kernel_size=3),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+            nn.Flatten(),
+        )
+        self.head = nn.Linear(64, 10)
+        if with_fsdp and freeze_after_wrap_fsdp:
+            self.fsdp_wrap()
+
+    def fsdp_wrap(self):
+        self.trunk = FSDP(self.trunk)
+        self.head = FSDP(self.head)
+
+    def forward(self, x):
+        return self.head(self.trunk(x))
+
+
+class NestedTrunkModel(nn.Module):
+    def __init__(self, with_fsdp, freeze_after_wrap_fsdp):
+        super().__init__()
+        self.trunk = nn.Sequential(
+            self._create_block(3, 64, with_fsdp, freeze_after_wrap_fsdp),
+            self._create_block(64, 64, with_fsdp, freeze_after_wrap_fsdp),
+        )
+        self.head = nn.Sequential(nn.AdaptiveAvgPool2d(output_size=(1, 1)), nn.Flatten(), nn.Linear(64, 10),)
+        if with_fsdp and freeze_after_wrap_fsdp:
+            self.fsdp_wrap()
+
+    def fsdp_wrap(self):
+        for name, child in self.trunk.named_children():
+            wrapped_child = FSDP(child)
+            setattr(self.trunk, name, wrapped_child)
+        self.trunk = FSDP(self.trunk)
+        self.head = FSDP(self.head)
+
+    def forward(self, x):
+        return self.head(self.trunk(x))
+
+    def _create_block(self, in_channels, out_channels, with_fsdp, freeze_after_wrap_fsdp):
+        block = nn.Sequential(nn.Conv2d(in_channels, out_channels, kernel_size=3), nn.ReLU(inplace=True),)
+        return block
+
+
+def _create_model(with_fsdp, with_nested_trunk, freeze_after_wrap_fsdp):
+    if with_nested_trunk:
+        model = NestedTrunkModel(with_fsdp, freeze_after_wrap_fsdp)
+    else:
+        model = Model(with_fsdp, freeze_after_wrap_fsdp)
+    return model
+
+
+class FreezingMethod(str, Enum):
+    GradToNone = "grad_to_none"
+    RequiresGrad = "requires_grad"
+
+
+def _distributed_worker(
+    gpu_id,
+    world_size,
+    with_fsdp,
+    with_nested_trunk,
+    freezing_method,
+    freeze_after_wrap_fsdp,
+    tempfile_name,
+    unused,
+    rank_0_output,
+    expected_state,
+):
+    torch.cuda.set_device(gpu_id)
+
+    rank = gpu_id
+    result = dist_init(rank, world_size, tempfile_name, unused)
+    assert result, "Dist init failed"
+
+    torch.manual_seed(0)
+    torch.backends.cudnn.deterministic = True
+    batch = torch.randn(size=(2, 3, 224, 224)).cuda()
+
+    model = _create_model(with_fsdp, with_nested_trunk, freeze_after_wrap_fsdp)
+    model = model.cuda()
+
+    # freezing the trunk using requires_grad.
+    if freezing_method == FreezingMethod.RequiresGrad:
+        for param in model.trunk.parameters():
+            param.requires_grad = False
+
+    if with_fsdp:
+        if not freeze_after_wrap_fsdp:
+            model.fsdp_wrap()
+        model = FSDP(model)
+    else:
+        model = DistributedDataParallel(model, device_ids=[gpu_id])
+
+    if gpu_id == 0:
+        print(model)
+
+    target = torch.tensor([0, 1], dtype=torch.long).cuda()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+
+    for iteration in range(3):
+        out = model(batch)
+        fake_loss = criterion(out, target)
+        print("Loss", iteration, ":", fake_loss.item())
+        optimizer.zero_grad()
+        fake_loss.backward()
+        if freezing_method == FreezingMethod.GradToNone:
+            for param in model.trunk.parameters():
+                param.grad = None
+        optimizer.step()
+
+    if with_fsdp:
+        fsdp_state = model.state_dict()
+        # Move tensors to CPU to compare numerics.
+        for k, v in fsdp_state.items():
+            fsdp_state[k] = v.cpu()
+        assert objects_are_equal(expected_state, fsdp_state, raise_exception=True)
+    elif rank == 0:
+        state_after = model.module.cpu().state_dict()
+        torch.save(state_after, rank_0_output)
+
+    teardown()
+
+
+# A fixture to get tempfiles and ensure they are cleaned up.
+@pytest.fixture()
+def temp_files():
+    num = 15  # 1 DDP and 4 FSDP cases each needs 3 files.
+    files = [tempfile.mkstemp()[1] for _ in range(num)]
+
+    yield tuple(files)
+
+    # temp files could have been removed, so we use rmf.
+    for name in files:
+        rmf(name)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+@pytest.mark.parametrize("nested_trunk", ["nested_trunk", "simple_trunk"])
+def test_freezing_weights(temp_files, nested_trunk):
+    with_nested_trunk = nested_trunk == "nested_trunk"
+
+    world_size = 2
+    # DDP
+    with_fsdp = False
+    freezing_method = FreezingMethod.RequiresGrad
+    mp.spawn(
+        _distributed_worker,
+        (world_size, with_fsdp, with_nested_trunk, freezing_method, True) + temp_files[0:3] + (None,),
+        nprocs=world_size,
+    )
+    # FSDP, case 1 and 2.
+    with_fsdp = True
+    expected_state = torch.load(temp_files[2])
+    temp_file_idx = 3
+    for freezing_method, freeze_after_wrap_fsdp in product(
+        [FreezingMethod.RequiresGrad, FreezingMethod.GradToNone], [True, False]
+    ):
+        print(f"Testing FSDP with freezing method {freezing_method}")
+        mp.spawn(
+            _distributed_worker,
+            (world_size, with_fsdp, with_nested_trunk, freezing_method, freeze_after_wrap_fsdp)
+            + temp_files[temp_file_idx : temp_file_idx + 3]
+            + (expected_state,),
+            nprocs=world_size,
+        )
+        temp_file_idx += 3

--- a/test/distributed/fsdp/test_fsdp_input.py
+++ b/test/distributed/fsdp/test_fsdp_input.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP with different input types. """
+
+import tempfile
+
+import pytest
+import torch
+from torch.nn import Linear, Module
+from torch.optim import SGD
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed._fsdp.fully_sharded_data_parallel import TrainingState
+from torch.testing._internal.common_fsdp import dist_init, rmf, teardown
+
+
+# A fixture to get tempfiles and ensure they are cleaned up.
+@pytest.fixture()
+def temp_files():
+    num = 2  # dist_init needs 2 files
+    files = [tempfile.mkstemp()[1] for _ in range(num)]
+
+    yield tuple(files)
+
+    # temp files could have been removed, so we use rmf.
+    for name in files:
+        rmf(name)
+
+
+# We only test on GPU since mix-precision only works on GPU.
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 1, reason="CUDA required"
+)
+@pytest.mark.parametrize(
+    "fsdp_config", [{}, {"mixed_precision": True}],
+)
+@pytest.mark.parametrize("input_cls", [dict, list])
+def test_input_type(temp_files, fsdp_config, input_cls):
+    """Test FSDP with input being a list or a dict, only single GPU."""
+    result = dist_init(rank=0, world_size=1, filename=temp_files[0], filename_rpc=temp_files[1])
+    assert result, "Dist init failed"
+
+    assert isinstance(fsdp_config, dict), str(fsdp_config)
+
+    class Model(Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = Linear(4, 4)
+
+        def forward(self, input):
+            if isinstance(input, list):
+                input = input[0]
+            else:
+                assert isinstance(input, dict), input
+                input = input["in"]
+            return self.layer(input)
+
+    model = FSDP(Model(), **fsdp_config).cuda()
+    optim = SGD(model.parameters(), lr=0.1)
+
+    for _ in range(5):
+        in_data = torch.rand(64, 4).cuda()
+        in_data.requires_grad = True
+        if input_cls is list:
+            in_data = [in_data]
+        else:
+            assert input_cls is dict
+            in_data = {"in": in_data}
+
+        out = model(in_data)
+        out.sum().backward()
+        optim.step()
+        optim.zero_grad()
+
+    model.assert_state(TrainingState.IDLE)
+
+    teardown()

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -1,0 +1,449 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP with GPU memory usage. """
+
+import contextlib
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+import torch.optim as optim
+
+from torch.utils.checkpoint import checkpoint
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed._fsdp.utils import get_process_group_cached
+from torch.testing._internal.common_fsdp import (
+    dist_init,
+    dump_all_tensors,
+    teardown,
+    temp_files_ctx,
+)
+
+
+def to_fsdp(module, fsdp_config):
+    return FSDP(module, process_group=get_process_group_cached(), **fsdp_config)
+
+
+def get_cur_mem(rank, result, prefix):
+    """Collect memory allocated values in a result dict in MB"""
+    result[prefix] = round(torch.cuda.memory_allocated() / 1024 / 1024)
+
+
+class Model(nn.Module):
+    def __init__(self, hidden_dim, with_checkpoint=False, with_fsdp=False):
+        super().__init__()
+        # TODO (Min): for both fast and memory efficient conv kernels, we should be using
+        #     AMP/fp16 + channel_last input format. Otherwise, cudnn internally does conversion
+        #     to channel_last when it is fp16 weights. Leave this knowledge here and perhaps
+        #     future test can cover it.
+        batch_norm_fsdp_config = {
+            "mixed_precision": False,  # Keep the weights in FP32.
+            "flatten_parameters": False,  # Do not flatten.
+            # Reshard==False is good for performance. When FSDP(checkpoint(FSDP(bn))) is used, this
+            # **must** be False because BN's FSDP wrapper's pre-backward callback isn't called
+            # within the checkpoint's outer backward when multiple forward passes are used.
+            "reshard_after_forward": False,
+            # No bucketing or small bucketing should be enough for BNs.
+            "bucket_cap_mb": 0,
+            # Setting this for SyncBatchNorm. This may have a performance impact. If
+            # SyncBatchNorm is used, this can be enabled by passing in the `fsdp_config` argument.
+            "force_input_to_fp32": False,
+        }
+        if with_fsdp:
+            self.stem = nn.Sequential(
+                nn.Conv2d(3, 64, kernel_size=3),
+                to_fsdp(nn.BatchNorm2d(64), batch_norm_fsdp_config),
+                nn.ReLU(inplace=True)
+            )
+        else:
+            self.stem = nn.Sequential(
+                nn.Conv2d(3, 64, kernel_size=3),
+                nn.BatchNorm2d(64),
+                nn.ReLU(inplace=True)
+            )
+        if with_fsdp:
+            self.blocks = nn.Sequential(
+                nn.Conv2d(64, hidden_dim, kernel_size=5, padding=2),
+                to_fsdp(nn.BatchNorm2d(hidden_dim), batch_norm_fsdp_config),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(hidden_dim, hidden_dim, kernel_size=5, padding=2),
+                to_fsdp(nn.BatchNorm2d(hidden_dim), batch_norm_fsdp_config),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(hidden_dim, hidden_dim, kernel_size=5, padding=2),
+                to_fsdp(nn.BatchNorm2d(hidden_dim), batch_norm_fsdp_config),
+                nn.ReLU(inplace=True),
+                nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+                nn.Flatten(),
+            )
+        else:
+            self.blocks = nn.Sequential(
+                nn.Conv2d(64, hidden_dim, kernel_size=5, padding=2),
+                nn.BatchNorm2d(hidden_dim),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(hidden_dim, hidden_dim, kernel_size=5, padding=2),
+                nn.BatchNorm2d(hidden_dim),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(hidden_dim, hidden_dim, kernel_size=5, padding=2),
+                nn.BatchNorm2d(hidden_dim),
+                nn.ReLU(inplace=True),
+                nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+                nn.Flatten(),
+            )
+
+        self.head = nn.Linear(hidden_dim, 10)
+        self.with_checkpoint = with_checkpoint
+
+    def forward(self, x):
+        if self.with_checkpoint:
+            return self.head(checkpoint(self.blocks, self.stem(x)))
+        else:
+            return self.head(self.blocks(self.stem(x)))
+
+
+def create_model(with_fsdp, with_checkpoint, model_hidden_dim, fsdp_config):
+    model = Model(model_hidden_dim, with_checkpoint, with_fsdp)
+    if with_fsdp:
+        model.stem = to_fsdp(model.stem, fsdp_config)
+        model.blocks = to_fsdp(model.blocks, fsdp_config)
+        model.head = to_fsdp(model.head, fsdp_config)
+    return model
+
+
+def _distributed_worker(
+    gpu_id, world_size, with_fsdp, with_checkpoint, filename, filename_rpc, expected, model_hidden_dim, fsdp_config
+):
+    torch.cuda.set_device(gpu_id)
+
+    rank = gpu_id
+    result = dist_init(rank, world_size, filename, filename_rpc)
+    assert result, "Dist init failed"
+
+    torch.manual_seed(0)
+    torch.backends.cudnn.deterministic = True
+
+    # Note that FSDP auto-cast the input in AMP mode. So we don't need to call half() here.
+    batch = torch.randn(size=(2, 3, 224, 224)).cuda()
+
+    model = create_model(with_fsdp, with_checkpoint, model_hidden_dim, fsdp_config)
+    model = model.cuda()
+    if with_fsdp:
+        model = to_fsdp(model, fsdp_config)
+    else:
+        model = DistributedDataParallel(model, device_ids=[gpu_id], bucket_cap_mb=500)
+
+    # We enable momentum so that after the first iteration, the optimizer state is added
+    # to the total memory used.
+    criterion = nn.MSELoss()
+    optimizer = optim.SGD(model.parameters(), lr=1e-4, momentum=0.9)
+
+    # Set AMP context if needed.
+    context = contextlib.suppress()
+    if "mixed_precision" in fsdp_config and fsdp_config["mixed_precision"]:
+        context = torch.cuda.amp.autocast(enabled=True)
+
+    # We have observed that sometimes after 3rd iteration, 4th one can fail (not on this
+    # test but on much bigger scale tests). We run 4 iterations here just in case it happens.
+    iterations = 4
+
+    results = {}  # results of memory stats
+    for iteration in range(iterations):
+        get_cur_mem(gpu_id, results, f"iter {iteration}: start")
+
+        with context:
+            out = model(batch)
+            get_cur_mem(gpu_id, results, f"iter {iteration}: after fwd")
+
+            out = sum(o.sum() for o in out[0])
+            fake_loss = criterion(out, torch.tensor(0.0).cuda())
+            get_cur_mem(gpu_id, results, f"iter {iteration}: after loss")
+
+        fake_loss.backward()
+        get_cur_mem(gpu_id, results, f"iter {iteration}: after bwd")
+
+        optimizer.step()
+        get_cur_mem(gpu_id, results, f"iter {iteration}: after step")
+
+        # It is important to use `set_to_none` below, not optimizer.zero_grad() to reclaim memory.
+        model.zero_grad(set_to_none=True)
+        get_cur_mem(gpu_id, results, f"iter {iteration}: done")
+
+    dump_all_tensors(gpu_id)
+    print(results)
+
+    def cmp(results, expected):
+        ret = ""
+        assert results.keys() == expected.keys(), f"{list(results.keys())} vs. {list(expected.keys())}"
+        for k, v in results.items():
+            exp = expected[k]
+            if abs(exp - v) > 1:  # allow 1MB rounding differences
+                ret += f"{k}: got {v}, expected {exp}\n"
+        return ret
+
+    output = cmp(results, expected)
+    assert not output, output
+
+    teardown()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+@pytest.mark.parametrize("ckpt", ["no_ckpt", "ckpt"])
+@pytest.mark.parametrize("fsdp", ["ddp", "fsdp", "fsdp_amp_default", "fsdp_amp_compute_dtype32"])
+def test_fsdp_memory(fsdp, ckpt):
+    expected = {
+        ("ddp", "no_ckpt"): {
+            "iter 0: start": 9,
+            "iter 0: after fwd": 346,
+            "iter 0: after loss": 346,
+            "iter 0: after bwd": 14,
+            "iter 0: after step": 17,
+            "iter 0: done": 13,
+            "iter 1: start": 13,
+            "iter 1: after fwd": 350,
+            "iter 1: after loss": 350,
+            "iter 1: after bwd": 17,
+            "iter 1: after step": 17,
+            "iter 1: done": 13,
+            "iter 2: start": 13,
+            "iter 2: after fwd": 350,
+            "iter 2: after loss": 350,
+            "iter 2: after bwd": 17,
+            "iter 2: after step": 17,
+            "iter 2: done": 13,
+            "iter 3: start": 13,
+            "iter 3: after fwd": 350,
+            "iter 3: after loss": 350,
+            "iter 3: after bwd": 17,
+            "iter 3: after step": 17,
+            "iter 3: done": 13,
+        },
+        ("fsdp", "no_ckpt"): {
+            "iter 0: start": 3,
+            "iter 0: after fwd": 340,
+            "iter 0: after loss": 340,
+            "iter 0: after bwd": 16,
+            "iter 0: after step": 18,
+            "iter 0: done": 5,
+            "iter 1: start": 5,
+            "iter 1: after fwd": 342,
+            "iter 1: after loss": 342,
+            "iter 1: after bwd": 18,
+            "iter 1: after step": 18,
+            "iter 1: done": 5,
+            "iter 2: start": 5,
+            "iter 2: after fwd": 342,
+            "iter 2: after loss": 342,
+            "iter 2: after bwd": 18,
+            "iter 2: after step": 18,
+            "iter 2: done": 5,
+            "iter 3: start": 5,
+            "iter 3: after fwd": 342,
+            "iter 3: after loss": 342,
+            "iter 3: after bwd": 18,
+            "iter 3: after step": 18,
+            "iter 3: done": 5,
+        },
+        ("fsdp_amp_default", "no_ckpt"): {
+            "iter 0: start": 28,
+            "iter 0: after fwd": 630,
+            "iter 0: after loss": 630,
+            "iter 0: after bwd": 67,
+            "iter 0: after step": 93,
+            "iter 0: done": 54,
+            "iter 1: start": 54,
+            "iter 1: after fwd": 657,
+            "iter 1: after loss": 657,
+            "iter 1: after bwd": 93,
+            "iter 1: after step": 93,
+            "iter 1: done": 54,
+            "iter 2: start": 54,
+            "iter 2: after fwd": 657,
+            "iter 2: after loss": 657,
+            "iter 2: after bwd": 93,
+            "iter 2: after step": 93,
+            "iter 2: done": 54,
+            "iter 3: start": 54,
+            "iter 3: after fwd": 657,
+            "iter 3: after loss": 657,
+            "iter 3: after bwd": 93,
+            "iter 3: after step": 93,
+            "iter 3: done": 54,
+        },
+        ("fsdp_amp_compute_dtype32", "no_ckpt"): {
+            "iter 0: start": 28,
+            "iter 0: after fwd": 657,
+            "iter 0: after loss": 657,
+            "iter 0: after bwd": 67,
+            "iter 0: after step": 93,
+            "iter 0: done": 54,
+            "iter 1: start": 54,
+            "iter 1: after fwd": 684,
+            "iter 1: after loss": 684,
+            "iter 1: after bwd": 93,
+            "iter 1: after step": 93,
+            "iter 1: done": 54,
+            "iter 2: start": 54,
+            "iter 2: after fwd": 684,
+            "iter 2: after loss": 684,
+            "iter 2: after bwd": 93,
+            "iter 2: after step": 93,
+            "iter 2: done": 54,
+            "iter 3: start": 54,
+            "iter 3: after fwd": 684,
+            "iter 3: after loss": 684,
+            "iter 3: after bwd": 93,
+            "iter 3: after step": 93,
+            "iter 3: done": 54,
+        },
+        ("ddp", "ckpt"): {
+            "iter 0: start": 9,
+            "iter 0: after fwd": 57,
+            "iter 0: after loss": 57,
+            "iter 0: after bwd": 14,
+            "iter 0: after step": 17,
+            "iter 0: done": 13,
+            "iter 1: start": 13,
+            "iter 1: after fwd": 61,
+            "iter 1: after loss": 61,
+            "iter 1: after bwd": 17,
+            "iter 1: after step": 17,
+            "iter 1: done": 13,
+            "iter 2: start": 13,
+            "iter 2: after fwd": 61,
+            "iter 2: after loss": 61,
+            "iter 2: after bwd": 17,
+            "iter 2: after step": 17,
+            "iter 2: done": 13,
+            "iter 3: start": 13,
+            "iter 3: after fwd": 61,
+            "iter 3: after loss": 61,
+            "iter 3: after bwd": 17,
+            "iter 3: after step": 17,
+            "iter 3: done": 13,
+        },
+        ("fsdp", "ckpt"): {
+            "iter 0: start": 3,
+            "iter 0: after fwd": 51,
+            "iter 0: after loss": 51,
+            "iter 0: after bwd": 16,
+            "iter 0: after step": 18,
+            "iter 0: done": 5,
+            "iter 1: start": 5,
+            "iter 1: after fwd": 53,
+            "iter 1: after loss": 53,
+            "iter 1: after bwd": 18,
+            "iter 1: after step": 18,
+            "iter 1: done": 5,
+            "iter 2: start": 5,
+            "iter 2: after fwd": 53,
+            "iter 2: after loss": 53,
+            "iter 2: after bwd": 18,
+            "iter 2: after step": 18,
+            "iter 2: done": 5,
+            "iter 3: start": 5,
+            "iter 3: after fwd": 53,
+            "iter 3: after loss": 53,
+            "iter 3: after bwd": 18,
+            "iter 3: after step": 18,
+            "iter 3: done": 5,
+        },
+        ("fsdp_amp_default", "ckpt"): {
+            "iter 0: start": 28,
+            "iter 0: after fwd": 52,
+            "iter 0: after loss": 52,
+            "iter 0: after bwd": 67,
+            "iter 0: after step": 93,
+            "iter 0: done": 54,
+            "iter 1: start": 54,
+            "iter 1: after fwd": 79,
+            "iter 1: after loss": 79,
+            "iter 1: after bwd": 93,
+            "iter 1: after step": 93,
+            "iter 1: done": 54,
+            "iter 2: start": 54,
+            "iter 2: after fwd": 79,
+            "iter 2: after loss": 79,
+            "iter 2: after bwd": 93,
+            "iter 2: after step": 93,
+            "iter 2: done": 54,
+            "iter 3: start": 54,
+            "iter 3: after fwd": 79,
+            "iter 3: after loss": 79,
+            "iter 3: after bwd": 93,
+            "iter 3: after step": 93,
+            "iter 3: done": 54,
+        },
+        ("fsdp_amp_compute_dtype32", "ckpt"): {
+            "iter 0: start": 28,
+            "iter 0: after fwd": 52,
+            "iter 0: after loss": 52,
+            "iter 0: after bwd": 67,
+            "iter 0: after step": 93,
+            "iter 0: done": 54,
+            "iter 1: start": 54,
+            "iter 1: after fwd": 79,
+            "iter 1: after loss": 79,
+            "iter 1: after bwd": 93,
+            "iter 1: after step": 93,
+            "iter 1: done": 54,
+            "iter 2: start": 54,
+            "iter 2: after fwd": 79,
+            "iter 2: after loss": 79,
+            "iter 2: after bwd": 93,
+            "iter 2: after step": 93,
+            "iter 2: done": 54,
+            "iter 3: start": 54,
+            "iter 3: after fwd": 79,
+            "iter 3: after loss": 79,
+            "iter 3: after bwd": 93,
+            "iter 3: after step": 93,
+            "iter 3: done": 54,
+        },
+    }[(fsdp, ckpt)]
+
+    # Compute the FSDP config.
+    fsdp_config = {}
+
+    # Set mixed precision.
+    if "amp" in fsdp:
+        fsdp_config["mixed_precision"] = True
+
+    # When compute_dtype is FP32, make sure we use clear_autocast_cache.
+    # Setting fp32_reduce_scatter and verbose for more code coverage.
+    if "compute_dtype32" in fsdp:
+        fsdp_config["compute_dtype"] = torch.float32
+        fsdp_config["fp32_reduce_scatter"] = True
+        fsdp_config["clear_autocast_cache"] = True
+        fsdp_config["verbose"] = True
+
+    # Using bigger hidden dimension for AMP to increase the model size
+    # so that bug in handling params will show up but we don't do that
+    # in the base case to keep the test fast.
+    #   - hidden_dim 128: model size ~4MB
+    #   - hidden_dim 512: model size ~55MB
+    #   - hidden_dim 1024: model size ~200MB (seems to be too big for CI tests though)
+    model_hidden_dim = 128
+    if "amp" in fsdp:
+        model_hidden_dim = 512
+
+    # Get the fsdp and checkpoint flags.
+    with_fsdp = "fsdp" in fsdp
+    with_ckpt = ckpt == "ckpt"
+
+    world_size = 2
+    with temp_files_ctx(num=2) as temp_files:
+        mp.spawn(
+            _distributed_worker,
+            (world_size, with_fsdp, with_ckpt, temp_files[0], temp_files[1], expected, model_hidden_dim, fsdp_config),
+            nprocs=world_size,
+        )

--- a/test/distributed/fsdp/test_fsdp_multiple_forward.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_forward.py
@@ -1,0 +1,78 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP with different multiple forward of the same module. """
+
+import tempfile
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from torch.nn import Linear, Module
+from torch.optim import SGD
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed._fsdp.fully_sharded_data_parallel import TrainingState
+from torch.testing._internal.common_fsdp import dist_init, teardown
+
+
+def _test_func(rank, world_size, fsdp_config, tempfile_name, unused):
+    result = dist_init(rank, world_size, tempfile_name, unused)
+    assert result, "Dist init failed"
+
+    assert isinstance(fsdp_config, dict), str(fsdp_config)
+
+    class Model(Module):
+        def __init__(self):
+            super().__init__()
+            self.inner = FSDP(Linear(4, 4), **fsdp_config)
+            self.outer = Linear(4, 5)
+
+        def forward(self, x):
+            # Forward twice.
+            i = self.inner(x)
+            j = self.inner(x)
+            return self.outer(i + j)
+
+    model = FSDP(Model(), **fsdp_config).cuda()
+    optim = SGD(model.parameters(), lr=0.1)
+
+    for _ in range(3):
+        in_data = torch.rand(64, 4).cuda()
+        in_data.requires_grad = True
+        out = model(in_data)
+        out.sum().backward()
+        optim.step()
+        optim.zero_grad()
+
+    model.assert_state(TrainingState.IDLE)
+    teardown()
+
+
+# We use strings for precision and flatten instead of bool to
+# make the pytest output more readable.
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+@pytest.mark.parametrize("precision", ["full", "mixed"])
+@pytest.mark.parametrize("flatten", ["flatten", "no_flatten"])
+def test1(precision, flatten):
+    temp_file_name = tempfile.mkstemp()[1]
+    unused = tempfile.mkstemp()[1]
+
+    fsdp_config = {}
+    fsdp_config["mixed_precision"] = precision == "mixed"
+    fsdp_config["flatten_parameters"] = flatten == "flatten"
+
+    # Some bugs only show up when we are in world_size > 1 due to sharding changing
+    # the tensor dimensions.
+    world_size = 2
+    mp.spawn(
+        _test_func, args=(world_size, fsdp_config, temp_file_name, unused), nprocs=world_size, join=True,
+    )

--- a/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
@@ -1,0 +1,87 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP with nested wrapping multiple times. """
+
+import tempfile
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from torch.nn import Linear, Module, Sequential
+from torch.optim import SGD
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed._fsdp.fully_sharded_data_parallel import TrainingState
+from torch.testing._internal.common_fsdp import dist_init, teardown
+
+
+def _test_func(rank, world_size, fsdp_config, tempfile_name, unused):
+    result = dist_init(rank, world_size, tempfile_name, unused)
+    assert result, "Dist init failed"
+
+    assert isinstance(fsdp_config, dict), str(fsdp_config)
+
+    class InnerModel(Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = Sequential(FSDP(Linear(5, 5), **fsdp_config),)
+
+        def forward(self, x):
+            return self.layers(x)
+
+    inner_model = InnerModel()
+    model = FSDP(inner_model, **fsdp_config).cuda()
+    optim = SGD(model.parameters(), lr=0.1)
+
+    for i in range(3):
+        input = torch.rand((1, 5), dtype=torch.float).cuda()
+        input.requires_grad = True
+        output = model(input)
+        output.sum().backward()
+        optim.step()
+        optim.zero_grad()
+    input = torch.rand((1, 5), dtype=torch.float).cuda()
+    output = model(input)
+
+    model.assert_state(TrainingState.IDLE)
+
+    # second time to rewrap the inner model
+    rewrapped_model = FSDP(inner_model, **fsdp_config).cuda()
+    rewrapped_output = rewrapped_model(input)
+
+    assert torch.allclose(output, rewrapped_output)
+    teardown()
+
+
+# We use strings for precision and flatten instead of bool to
+# make the pytest output more readable.
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 1, reason="CUDA required"
+)
+@pytest.mark.parametrize("world_size", [1, 2])
+@pytest.mark.parametrize("precision", ["full", "mixed"])
+@pytest.mark.parametrize("flatten", ["flatten", "no_flatten"])
+def test(world_size, precision, flatten):
+    """
+    This test simulates wrapping the module after training to run inference.
+    This is required in cases where later in a session, the model is wrapped again in FSDP but
+    contains nested FSDP wrappers within the module.
+    """
+    temp_file_name = tempfile.mkstemp()[1]
+    unused = tempfile.mkstemp()[1]
+
+    fsdp_config = {
+        "mixed_precision": precision == "mixed",
+        "flatten_parameters": flatten == "flatten",
+    }
+
+    mp.spawn(
+        _test_func, args=(world_size, fsdp_config, temp_file_name, unused), nprocs=world_size, join=True,
+    )

--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -1,0 +1,257 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP and ensure expected overlapping between all_gather and forward. """
+
+from statistics import mean
+import time
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch.cuda import Event
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.testing._internal.common_fsdp import (
+    dist_init,
+    get_cycles_per_ms,
+    teardown,
+    temp_files_ctx
+)
+
+
+class Layer(nn.Module):
+    def __init__(self, compute_cycles, has_params: bool):
+        super().__init__()
+        self.sleep_cycles = compute_cycles
+        self.optional_param = None
+        if has_params:
+            self.optional_param = nn.Parameter(torch.rand(1))
+
+    def forward(self, x):
+        # Get 2 events.
+        self.e1 = Event(enable_timing=True)
+        self.e2 = Event(enable_timing=True)
+
+        # Record the fake forward compute time.
+        self.e1.record()
+        if self.sleep_cycles > 0:
+            torch.cuda._sleep(self.sleep_cycles)
+        if self.optional_param is not None:
+            x = x + self.optional_param  # force the param to be part of the graph
+        self.e2.record()
+        return x
+
+    def get_time(self):
+        # return the recorded duration.
+        return self.e1.elapsed_time(self.e2)
+
+
+def _create_model(fsdp_config, compute_cycles, has_params: bool):
+    model = FSDP(
+        nn.Sequential(
+            FSDP(Layer(compute_cycles, has_params), **fsdp_config),
+            FSDP(Layer(compute_cycles, has_params), **fsdp_config),
+            FSDP(Layer(compute_cycles, has_params), **fsdp_config),
+            FSDP(Layer(compute_cycles, has_params), **fsdp_config),
+        ),
+        **fsdp_config
+    ).cuda()
+    return model
+
+
+class Min10:
+    def __init__(self):
+        self.data = []
+
+    def add(self, new_data):
+        if len(self.data) < 10:
+            self.data.append(new_data)
+        else:
+            self.data = sorted(self.data)
+            if new_data < self.data[-1]:
+                self.data[-1] = new_data
+
+    def avg(self):
+        return mean(self.data)
+
+
+def _distributed_worker(
+    gpu_id, world_size, fsdp_config, tempfile, tempfile_rpc,
+):
+    torch.cuda.set_device(gpu_id)
+
+    rank = gpu_id
+    result = dist_init(rank, world_size, tempfile, tempfile_rpc)
+    assert result, "Dist init failed"
+
+    # Save the original torch.distributed.all_gather function since we will
+    # patch it to include an artificial delay.
+    orig_all_gather = torch.distributed.all_gather
+    orig_all_gather_base = (
+        torch.distributed._all_gather_base if hasattr(torch.distributed, "_all_gather_base") else None
+    )
+
+    def run(compute_cycles, all_gather_cycles):
+        has_params = all_gather_cycles > 0
+        model = _create_model(fsdp_config, compute_cycles, has_params)
+
+        # Get the input and sets the input's requires_grad to True because
+        # we have a fake compute in the forward pass.
+        batch = torch.rand(1).cuda()
+        batch.requires_grad = True
+
+        # We run 20 iterations but only collect timing data from the minimal 10
+        # data points because nondeterministic system events can disturb the timing.
+        cpu_iter = Min10()
+        cpu_wait = Min10()
+        gpu_compute = Min10()
+        gpu_total = Min10()
+        for _ in range(20):
+            # Get two events for measuring the overall time.
+            e1 = Event(enable_timing=True)
+            e2 = Event(enable_timing=True)
+
+            cpu_start = time.process_time()
+
+            all_gather_called = False
+            all_gather_base_called = False
+
+            def _delayed_all_gather(*args, **kwargs):
+                nonlocal all_gather_called
+                all_gather_called = True
+                torch.cuda._sleep(all_gather_cycles)
+                return orig_all_gather(*args, **kwargs)
+
+            def _delayed_all_gather_base(*args, **kwargs):
+                nonlocal all_gather_base_called
+                all_gather_base_called = True
+                torch.cuda._sleep(all_gather_cycles)
+                assert orig_all_gather_base
+                return orig_all_gather_base(*args, **kwargs)
+
+            method_string_all_gather_base = "torch.distributed._all_gather_base"
+            if hasattr(torch.distributed, "_all_gather_base") is False:
+                # no such method, to make mock_all_gather_base 0 invocation, use an impossible name
+                method_string_all_gather_base = "math.nan"
+                pass
+            # forward pass
+            #
+            # Even though both e1 & e2 are on the compute stream, since
+            # compute depends on all_gather, e2-e1 includes all_gather time.
+            e1.record()
+            with patch("torch.distributed.all_gather", _delayed_all_gather):
+                with patch(method_string_all_gather_base, _delayed_all_gather_base):
+                    out = model(batch)
+                    if has_params and world_size > 1:
+                        assert all_gather_called or all_gather_base_called
+                    else:
+                        assert not all_gather_called and not all_gather_base_called
+            e2.record()
+
+            # backward pass
+            out.backward()
+            model.zero_grad(set_to_none=True)
+
+            cpu_iter_time = time.process_time() - cpu_start
+
+            # wait for gpu
+            out.item()
+            cpu_wait_for_gpu_time = time.process_time() - cpu_start - cpu_iter_time
+
+            # get sum of the compute time
+            times = []
+            for mod in model.modules():
+                if not isinstance(mod, Layer):
+                    continue
+                times.append(mod.get_time())
+
+            # get gpu compute + all_gather time
+            overall_gpu_time = e1.elapsed_time(e2)
+
+            cpu_iter.add(cpu_iter_time)
+            cpu_wait.add(cpu_wait_for_gpu_time)
+            gpu_compute.add(sum(times))
+            gpu_total.add(overall_gpu_time)
+
+        del model
+        return {
+            "cpu_iter": cpu_iter.avg(),
+            "cpu_wait": cpu_wait.avg(),
+            "gpu_compute": gpu_compute.avg(),
+            "gpu_total": gpu_total.avg(),
+        }
+
+    sleep_cycles = int(100 * get_cycles_per_ms())
+
+    e1 = run(0, 0)  # no compute, no all-gather
+    e2 = run(0, sleep_cycles)  # no compute, only all-gather
+    e3 = run(sleep_cycles, 0)  # only compute, no all-gather
+    e4 = run(sleep_cycles, sleep_cycles)  # both compute and all-gather
+    debug_string = f"\nrank{rank}:\n  e1: {e1}\n  e2: {e2}\n  e3: {e3}\n  e4: {e4}"
+    print(debug_string)
+
+    # Check the cpu/gpu timing. CPU should run ahead of GPU. Therefore, cpu-gpu
+    # wait should be long, except when there is no real work on GPU.
+    #
+    # If the assertions fail below, we likely have a cpu-gpu wait in the forward/backward pass.
+    short = [e1["cpu_iter"], e2["cpu_iter"], e3["cpu_iter"], e4["cpu_iter"], e1["cpu_wait"]]
+    long = [e3["cpu_wait"], e4["cpu_wait"]]
+    if world_size == 1:
+        short.append(e2["cpu_wait"])  # all gather should not be happening.
+    else:
+        long.append(e2["cpu_wait"])  # all gather should happen and prolong the cpu-gpu wait.
+    for s in short:
+        for l in long:
+            # 10X longer is a safe margin, since the GPU work timing is around 100X more
+            # of that of the CPU.
+            assert s * 10 < l, f"{s} * 10 < {l} in " + debug_string
+
+    # Check the GPU timing.
+    short = [e1["gpu_compute"], e1["gpu_total"], e2["gpu_compute"]]
+    long = [e3["gpu_compute"], e3["gpu_total"], e4["gpu_compute"], e4["gpu_total"]]
+    if world_size == 1:
+        short.append(e2["gpu_total"])  # all gather should not be happening.
+    else:
+        long.append(e2["gpu_total"])  # all gather should happen and prolong the cpu-gpu wait.
+    for s in short:
+        for l in long:
+            # 10X longer is a safe margin, since the time is around 100X longer
+            # when there is work on GPU vs. no work.
+            assert s * 10 < l, f"{s} * 10 < {l} in " + debug_string
+
+    # Check the GPU overlapping when there is all-gather.
+    if world_size > 1:
+        compute_only = e3["gpu_compute"]
+        all_gather_only = e2["gpu_total"]
+        both = e4["gpu_total"]
+        assert compute_only + all_gather_only > 1.1 * both, (
+            f"{compute_only} + {all_gather_only} > 1.1 * {both} in " + debug_string
+        )
+
+    teardown()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+@pytest.mark.parametrize("world_size", [1, 2])
+@pytest.mark.parametrize("flatten", ["flatten", "no_flatten"])
+@pytest.mark.parametrize("mixed", ["mixed", "full"])
+def test_forward_overlap(world_size, flatten, mixed):
+    fsdp_config = {
+        "flatten_parameters": flatten == "flatten",
+        "mixed_precision": mixed == "mixed",
+    }
+    with temp_files_ctx(2) as temp_files:
+        mp.spawn(
+            _distributed_worker, (world_size, fsdp_config, temp_files[0], temp_files[1]), nprocs=world_size,
+        )

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -1,0 +1,267 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import unittest
+import pytest
+
+import torch
+from torch import nn
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.testing._internal.common_fsdp import (
+    dist_init,
+    objects_are_equal,
+    teardown,
+    temp_files_ctx,
+    CONFIG_OPTIONS,
+    DistributedTest,
+    NestedWrappedModule,
+    TransformerWithSharedParams,
+    spawn_and_init,
+)
+
+
+class TestLocalStateDict(DistributedTest):
+    def test_load_local_state_dict(self):
+        for flatten_params, mixed_precision in [[True, True], [False, False]]:
+            test_fn = functools.partial(
+                self._load_local_and_train, {"flatten_parameters": flatten_params, "mixed_precision": mixed_precision}
+            )
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _load_local_and_train(cls, config, rank, group, d_model=16, d_vocab=23):
+        """Check that local_state_dict can be saved and loaded for a given worker, and that training updates it"""
+        model = cls.get_wrapped_model(
+            group, cuda_first=False, config=config, d_vocab=d_vocab, d_model=d_model, add_bn=False
+        )  # Set bn=True here to show that BN doesn't get updated
+        state_1 = model.local_state_dict()
+        state_before_training = {k: v.cpu().clone() for k, v in state_1.items()}
+        assert len(state_1) > 0
+        model.load_local_state_dict(state_1)
+        weight_key = "flat_param_0" if model.flatten_parameters else "embed_tokens.weight"
+
+        state_1_weight = state_1[weight_key]
+        assert state_1_weight.dtype == torch.float32, f"got dtype {state_1_weight.dtype} expected torch.float32"
+        if not model.flatten_parameters:
+            # The weight will be sharded since we access module.state_dict directly
+            state_1_module_weight = model.module.state_dict()[weight_key]
+            torch.testing.assert_allclose(state_1_weight, state_1_module_weight)
+            torch.testing.assert_allclose(state_1_weight, model.module.embed_tokens.weight)
+        cls._train_for_several_steps(model, 1, model.mixed_precision)
+
+        state_2 = model.local_state_dict()
+        state_after_training = {k: v.cpu().clone() for k, v in state_2.items()}
+        model.load_local_state_dict(state_2)
+
+        assert state_1.keys() == state_2.keys()
+
+        # Assert that parameters were updated since before training
+        unchanged = []
+        unwrapped_model = model.module.module
+        buffers = {name for name, _ in unwrapped_model.named_buffers()}
+        for k in state_1:
+            if (state_before_training[k] == state_after_training[k]).all() and (k not in buffers):
+                unchanged.append(k)
+        if unchanged:
+            raise AssertionError(f"params {unchanged} not changed after training")
+
+
+class TestSaveLoadStateDict(DistributedTest):
+    def test_calling_state_dict_twice_mixed_precision(self):
+        for mixed_precision in [False, True]:
+            test_fn = functools.partial(
+                self._test_calling_state_dict_twice, {"flatten_parameters": False, "mixed_precision": mixed_precision}
+            )
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_calling_state_dict_twice(cls, config, rank, group, **model_kwargs):
+        ddp_model = cls.get_wrapped_model(group, cuda_first=False, config=config, **model_kwargs)
+        autocast = ddp_model.mixed_precision
+        cls._train_for_several_steps(ddp_model, 1, autocast)
+        ddp_model.state_dict()
+        ddp_model.state_dict()  # second call
+
+    def test_state_dict_after_forward(self):
+        for config in CONFIG_OPTIONS:
+            test_fn = functools.partial(self._test_module_state_dict, config)
+            spawn_and_init(test_fn)
+
+    def test_state_dict_before_forward(self):
+        for mixed_precision in [False, True]:
+            test_fn = functools.partial(
+                self._test_state_dict_before_forward, {"flatten_parameters": False, "mixed_precision": mixed_precision}
+            )
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_state_dict_before_forward(cls, config, rank, group):
+        ddp_model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        sd = ddp_model.state_dict()
+        for param_name in ("embed_tokens.weight", "vocab_bias"):
+            wt = sd[param_name]
+            assert wt.dtype == torch.float32, f"got dtype {wt.dtype} for {param_name}, expected torch.float32"
+        cls._train_for_several_steps(ddp_model, 1, ddp_model.mixed_precision)
+
+    @classmethod
+    def _test_module_state_dict(cls, config, rank, group):
+        ddp_model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        autocast = ddp_model.mixed_precision
+        cls._train_for_several_steps(ddp_model, 2, autocast)
+        state_1 = ddp_model.state_dict()
+        # You must make a new FSDP instance to use module.load_state_dict
+        unwrapped_model = TransformerWithSharedParams(group)
+        unwrapped_model.load_state_dict(state_1)
+        new_ddp_model = FSDP(unwrapped_model, group, **config).cuda()
+        cls._train_for_several_steps(new_ddp_model, 2, autocast)
+        try:
+            ddp_model.load_state_dict(new_ddp_model.state_dict())
+            AssertionError("ddp_model.load_state_dict(new_ddp_model.state_dict()) succeeded")
+        except Exception:
+            pass
+
+    def test_nested_wrapped_model(self):
+        for config in CONFIG_OPTIONS:
+            test_fn = functools.partial(self._test_nested_wrapped_model, config=config)
+            spawn_and_init(test_fn)
+
+    def test_nested_wrapped_model_local_state_dict(self):
+        for config in CONFIG_OPTIONS:
+            test_fn = functools.partial(self._test_nested_wrapped_model_local_state_dict, config=config)
+            spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_nested_wrapped_model(cls, rank, group, config=None):
+        # Get reference state dict without any nested FSDP instances.
+        model = NestedWrappedModule(group, None).cuda()
+        model = nn.parallel.DistributedDataParallel(model, device_ids=[rank], output_device=rank, process_group=group)
+        cls._train_for_several_steps(model, 2, autocast=config["mixed_precision"])
+        ref_state_dict = {k: v.clone() for k, v in model.module.state_dict().items()}
+
+        # Create a nested FSDP-wrapped instance.
+        if config["mixed_precision"]:
+            config["compute_dtype"] = torch.float32
+        model = NestedWrappedModule(group, config)
+        model = FSDP(model, group, **config).cuda()
+        cls._train_for_several_steps(model, 2, autocast=config["mixed_precision"])
+
+        # Round-trip state dict save/load/save.
+        state_dict = {k: v.clone() for k, v in model.state_dict().items()}
+        model.load_state_dict(state_dict)
+        state_dict = model.state_dict()
+
+        assert ref_state_dict.keys() == state_dict.keys(), f"{ref_state_dict.keys()} != {state_dict.keys()}"
+        for key in ref_state_dict.keys():
+            assert objects_are_equal(
+                ref_state_dict[key], state_dict[key], raise_exception=False
+            ), f"{key}, {ref_state_dict[key]} != {state_dict[key]}"
+
+    @classmethod
+    def _test_nested_wrapped_model_local_state_dict(cls, rank, group, config=None, local=None):
+        # Create a nested FSDP-wrapped instance.
+        model = NestedWrappedModule(group, config)
+        model = FSDP(model, group, **config).cuda()
+        cls._train_for_several_steps(model, 2, autocast=config["mixed_precision"])
+
+        # Round trip state dict save/load/save.
+        ref_state_dict = {k: v.clone() for k, v in model.local_state_dict().items()}
+        model.load_local_state_dict(ref_state_dict)
+        state_dict = model.local_state_dict()
+
+        assert ref_state_dict.keys() == state_dict.keys(), f"{ref_state_dict.keys()} != {state_dict.keys()}"
+        for key in ref_state_dict.keys():
+            assert objects_are_equal(
+                ref_state_dict[key], state_dict[key], raise_exception=False
+            ), f"{key}, {ref_state_dict[key]} != {state_dict[key]}"
+
+
+class TestStateDictDeviceDtype(DistributedTest):
+    def test_state_dict_device(self):
+        for mixed_precision, cpu_offload in [[False, False], [True, False], [True, True]]:
+            test_fn = functools.partial(
+                self._test_state_dict_device, {"cpu_offload": cpu_offload, "mixed_precision": mixed_precision}
+            )
+            spawn_and_init(test_fn)
+
+    def test_state_dict_device_cuda(self):
+        for mixed_precision, cpu_offload in [[False, False], [True, False], [True, True]]:
+            test_fn = functools.partial(
+                self._test_state_dict_device,
+                {"cpu_offload": cpu_offload, "mixed_precision": mixed_precision, "state_dict_device": torch.device("cuda")},
+            )
+            spawn_and_init(test_fn)
+
+    def test_state_dict_device_cpu(self):
+        for mixed_precision, cpu_offload in [[False, False], [True, False], [True, True]]:
+            test_fn = functools.partial(
+                self._test_state_dict_device,
+                {"cpu_offload": cpu_offload, "mixed_precision": mixed_precision, "state_dict_device": torch.device("cpu")},
+            )
+            spawn_and_init(test_fn)
+
+    def test_state_dict_device_pure_fp16(self):
+        test_fn = functools.partial(
+            self._test_state_dict_device,
+            {"cpu_offload": False, "mixed_precision": False, "compute_dtype": torch.float16},
+            # pure_fp16 is similar to the --memory-efficient-fp16 option in fairseq
+            pure_fp16=True,
+        )
+        spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_state_dict_device(cls, config, rank, group, pure_fp16=False, **model_kwargs):
+        model = TransformerWithSharedParams(group, **model_kwargs)
+        if pure_fp16:
+            assert not config["mixed_precision"]
+            model = model.half()
+        fsdp_model = FSDP(model, group, **config)
+        if not config["cpu_offload"]:
+            fsdp_model = fsdp_model.cuda()
+        autocast = fsdp_model.mixed_precision or pure_fp16
+        cls._train_for_several_steps(fsdp_model, 1, autocast)
+
+        sd = fsdp_model.state_dict()
+
+        sd_device = config.get("state_dict_device")
+        for k, v in sd.items():
+            if config["cpu_offload"] or (sd_device is not None and sd_device.type == "cpu"):
+                assert v.device.type == "cpu", v.device.type
+            else:
+                assert v.device.type == "cuda", v.device.type
+
+        expected_dtype = torch.float16 if pure_fp16 else torch.float32
+        for k, v in sd.items():
+            if not torch.is_floating_point(v):
+                continue
+            assert v.dtype == expected_dtype, f"{v.dtype} != {expected_dtype}"
+
+
+@pytest.mark.skipif(torch.cuda.is_available(), reason="Testing only on CPUs to save time")
+def test_local_state_dict_calls_state_dict_recursion():
+    """Testing the case of infinite recursive when FSDP is subclassed"""
+
+    class TestModule(FSDP):
+        def __init__(self):
+            super().__init__(module=nn.Linear(100, 100))
+
+        def state_dict(self, *args, **kwargs):
+            return self.local_state_dict(*args, **kwargs)
+
+    rank = 0
+    world_size = 1
+    with temp_files_ctx(2) as temp_files:
+        result = dist_init(rank, world_size, temp_files[0], temp_files[1])
+        assert result, "Dist init failed"
+
+        m = TestModule()
+        d = m.state_dict()
+
+        teardown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import gc
+import unittest
+
+import torch
+
+from torch.testing._internal.common_fsdp import CONFIG_OPTIONS, DistributedTest, spawn_and_init
+
+
+def get_cuda_mem():
+    torch.cuda.synchronize()
+    gc.collect()
+    return torch.cuda.memory_allocated()
+
+
+class TestMemory(DistributedTest):
+    def test_memory(self):
+        for config in CONFIG_OPTIONS:
+            spawn_and_init(functools.partial(self._test_memory, config))
+
+    def test_memory_volatile(self):
+        for config in CONFIG_OPTIONS:
+            spawn_and_init(functools.partial(self._test_memory, config, volatile=True))
+
+    @classmethod
+    def _test_memory(cls, config, rank, group, volatile=False):
+        model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+        cls._train_for_several_steps(model, 1, autocast=model.mixed_precision)
+
+        mems = [get_cuda_mem()]
+
+        with model.summon_full_params(volatile=volatile):
+            mems.append(get_cuda_mem())
+            assert mems[1] >= mems[0]
+
+            state_dict = model.state_dict()
+            mems.append(get_cuda_mem())
+            assert mems[2] >= mems[1]
+
+        mems.append(get_cuda_mem())
+        assert mems[3] <= mems[2]
+
+        del state_dict
+        mems.append(get_cuda_mem())
+        # Any value other than `==` indicates a memory leak. If mems[4] >
+        # mems[0], that indicates we're not cleaning up params properly in
+        # summon_full_params. If mems[4] < mems[0], that indicates there's a
+        # memory leak in _train_for_several_steps.
+        assert mems[4] == mems[0], f"memory leak detected, {mems[4]} != {mems[0]}"
+
+
+class TestPersistence(DistributedTest):
+    def test_non_volatile(self):
+        for config in CONFIG_OPTIONS:
+            spawn_and_init(functools.partial(self._test_persistence, config))
+
+    @classmethod
+    def _test_persistence(cls, config, rank, group, volatile=False):
+        model = cls.get_wrapped_model(group, cuda_first=False, config=config)
+
+        with model.summon_full_params(volatile=False):
+            model.module.embed_tokens.weight.data.fill_(42)
+        with model.summon_full_params():
+            # non-volatile changes are persisted
+            assert torch.all(model.module.embed_tokens.weight.data == 42.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/fsdp/test_fsdp_uneven.py
+++ b/test/distributed/fsdp/test_fsdp_uneven.py
@@ -1,0 +1,136 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test FSDP with uneven parameter shards. """
+
+import tempfile
+
+import pytest
+import torch
+from torch import Tensor
+import torch.multiprocessing as mp
+from torch.nn import Linear, Sequential
+from torch.optim import SGD
+
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed._fsdp.fully_sharded_data_parallel import TrainingState
+from torch.testing._internal.common_fsdp import dist_init, teardown
+
+
+def _test_func(rank, world_size, model, fsdp_config, tempfile_name, unused, test_case):
+    result = dist_init(rank, world_size, tempfile_name, unused)
+    assert result, "Dist init failed"
+
+    my_lr = 0.1
+
+    device = torch.device("cuda")
+    if fsdp_config.get("mixed_precision", False):
+        dtype = torch.float16
+        fsdp_config["fp32_reduce_scatter"] = True
+    else:
+        dtype = torch.float32
+
+    if test_case["assert_ref_out"]:
+        with torch.no_grad():
+            # Compute one iteration local output.
+            fp32_weight = model.weight.T.clone().to(device)
+            weight = fp32_weight.to(dtype)
+            v = torch.Tensor(test_case["inputs"][0][rank]).to(device, dtype)
+            ref_forward_output_my_rank = torch.matmul(v, weight)
+            # Compute one iteration global weight update.
+            v = torch.Tensor(test_case["inputs"][0][:world_size]).to(device, dtype)
+            grad = v.float().sum(0).repeat(weight.shape[0], 1).div(world_size)
+            ref_weight_out = fp32_weight - grad.T * my_lr
+            assert ref_weight_out.dtype == torch.float32
+    model.to(device)  # not dtype, since FSDP will manage mixed precision internally
+    assert isinstance(fsdp_config, dict), str(fsdp_config)
+    model = FSDP(model, **fsdp_config)
+    optim = SGD(model.parameters(), lr=my_lr)
+    inputs = test_case["inputs"]
+    assert len(inputs) == 1 or not test_case["assert_ref_out"]
+    assert len(inputs[0]) >= world_size
+    for in_data in inputs:
+        in_data = Tensor(in_data[rank]).to(device, dtype)
+        out = model(in_data)
+        out.float().sum().backward()
+        optim.step()
+        optim.zero_grad()
+        if test_case["assert_ref_out"]:
+            with model.summon_full_params():
+                weight_out = model.module.weight.data.T.clone()
+            # make sure we can do more fwd/bwd
+            loss = model(in_data)
+            loss.sum().backward()
+
+    if test_case["assert_ref_out"]:
+        torch.testing.assert_allclose(ref_forward_output_my_rank, out)
+        torch.testing.assert_allclose(ref_weight_out, weight_out)
+
+    model.assert_state(TrainingState.IDLE)
+    teardown()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+@pytest.mark.parametrize("test_case", [{"inputs": [torch.rand(8, 3)], "assert_ref_out": True}])
+@pytest.mark.parametrize(
+    "fsdp_config", [{}, {"flatten_parameters": False}, {"mixed_precision": True}],
+)
+@pytest.mark.parametrize("world_size", list(range(2, 9)))
+def test_one_iteration(world_size, test_case, fsdp_config):
+    """Test FSDP with uneven divide of parameter shards."""
+    if world_size > torch.cuda.device_count():
+        pytest.skip("Not enough GPUs.")
+
+    temp_file_name = tempfile.mkstemp()[1]
+    unused = tempfile.mkstemp()[1]
+
+    # TODO (Min): we may want to extend this to a simple 2 layer model so that it covers
+    #             more cases in FSDP. Also, assert_ref_out can be extended to multiple
+    #             iterations. This could be a good bootcamp task. I should file a github
+    #             issue once we merge.
+    model = Linear(3, 3, bias=False)
+    mp.spawn(
+        _test_func,
+        args=(world_size, model, fsdp_config, temp_file_name, unused, test_case),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
+)
+@pytest.mark.parametrize("test_case", [{"inputs": [torch.rand(8, 3), torch.rand(8, 3)], "assert_ref_out": False}])
+@pytest.mark.parametrize("fsdp_config", [{}, {"flatten_parameters": False}])
+@pytest.mark.parametrize("world_size", list(range(2, 9)))
+def test_smaller_than_world_size(world_size, test_case, fsdp_config):
+    """Test FSDP with uneven divide of parameter shards."""
+    if world_size > torch.cuda.device_count():
+        pytest.skip("Not enough GPUs.")
+
+    temp_file_name = tempfile.mkstemp()[1]
+    unused = tempfile.mkstemp()[1]
+
+    model = Sequential(
+        Linear(3, 3, bias=False),
+        Linear(3, 4, bias=False),
+        Linear(4, 5, bias=False),
+        Linear(5, 4, bias=False),
+        Linear(4, 3, bias=False),
+        Linear(3, 1, bias=False),
+        Linear(1, 1, bias=False),  # param here is smaller than world_size if unflattened.
+    )
+    mp.spawn(
+        _test_func,
+        args=(world_size, model, fsdp_config, temp_file_name, unused, test_case),
+        nprocs=world_size,
+        join=True,
+    )

--- a/test/distributed/fsdp/test_reduce_scatter_bucketer.py
+++ b/test/distributed/fsdp/test_reduce_scatter_bucketer.py
@@ -1,0 +1,94 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import itertools
+import sys
+import unittest
+from unittest import mock
+
+import torch
+from torch.distributed._fsdp.reduce_scatter_bucketer import ReduceScatterBucketer
+from torch.testing._internal.common_fsdp import spawn_and_init, teardown
+
+
+CONFIG_OPTIONS = [
+    dict(zip(["bucket_cap_mb", "shard_size"], config)) for config in itertools.product([0, 0.25], [1, 262144])
+]
+
+class TestReduceScatterBucketer(unittest.TestCase):
+    # TODO(sshleifer): check if possible to reuse `DistributedTest, spawn_and_init`.
+    def setUp(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available, skipping test")
+        if sys.platform == "win32":
+            raise unittest.SkipTest("NCCL doesn't support Windows, skipping test")
+        if torch.cuda.device_count() < 2:
+            raise unittest.SkipTest("distributed tests require 2+ GPUs, skipping")
+
+    def tearDown(self):
+        teardown()
+
+    def test_reduce_scatter(self):
+        for config in CONFIG_OPTIONS:
+            spawn_and_init(functools.partial(self._test_reduce_scatter, **config))
+
+    @staticmethod
+    def _test_reduce_scatter(rank, group, bucket_cap_mb=None, shard_size=None):
+        bucketer = ReduceScatterBucketer(bucket_cap_mb=bucket_cap_mb)
+        world_size = group.size()
+
+        tensors = [torch.ones(shard_size).cuda() for _ in range(world_size)]
+        tensors[rank].fill_(0)
+
+        input_bytes = shard_size * world_size * 4
+        bucket_bytes = bucket_cap_mb * 1024 * 1024
+
+        callback = mock.MagicMock()
+        bucketer.reduce_scatter_async(tensors, group, callback_fn=callback)
+
+        if bucket_cap_mb > 0 and input_bytes < bucket_bytes:
+            assert callback.call_count == 0
+            bucketer.flush()
+        assert callback.call_count == 1
+
+        result = callback.call_args[0][0]  # get first positional arg
+        assert torch.is_tensor(result), result
+        assert torch.all(result == (world_size - 1))
+
+    def test_out_of_order_reduction(self):
+        spawn_and_init(self._test_out_of_order_reduction)
+
+    @staticmethod
+    def _test_out_of_order_reduction(rank, group):
+        bucketer = ReduceScatterBucketer(bucket_cap_mb=0.25)
+        world_size = group.size()
+
+        small_tensors = [torch.ones(1).cuda() for _ in range(world_size)]
+        big_tensors = [torch.ones(262144).cuda() for _ in range(world_size)]
+        more_small_tensors = [torch.ones(2).cuda() for _ in range(world_size)]
+
+        callback1 = mock.MagicMock()
+        callback2 = mock.MagicMock()
+        callback3 = mock.MagicMock()
+
+        bucketer.reduce_scatter_async(small_tensors, group, callback_fn=callback1)
+        assert callback1.call_count == 0
+        bucketer.reduce_scatter_async(big_tensors, group, callback_fn=callback2)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        bucketer.reduce_scatter_async(more_small_tensors, group, callback_fn=callback3)
+        assert callback1.call_count == 0
+        assert callback2.call_count == 1
+        assert callback3.call_count == 0
+
+        bucketer.flush()
+        assert callback1.call_count == 1
+        assert callback2.call_count == 1
+        assert callback3.call_count == 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -1,0 +1,82 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+""" Test utility functions from torch/distributed/fsdp/utils.py. """
+
+import pytest
+
+import torch
+
+from torch.distributed._fsdp.utils import (
+    replace_by_prefix_,
+    apply_to_tensors,
+    chunk_and_pad
+)
+
+from collections import OrderedDict
+import random
+
+
+def test_replace_by_prefix():
+    state_dict = {"layer.a": torch.tensor(1), "abc.layer.def": torch.tensor(2), "layer.b": torch.tensor(3)}
+    replace_by_prefix_(state_dict, "layer.", "module.layer.")
+    assert state_dict == {
+        "module.layer.a": torch.tensor(1),
+        "abc.layer.def": torch.tensor(2),
+        "module.layer.b": torch.tensor(3),
+    }
+
+
+@pytest.mark.parametrize("devices", [["cpu"], ["cuda"], ["cpu", "cuda"]])
+def test_apply_to_tensors(devices):
+    """Test apply_to_tensors for both cpu & gpu"""
+    if "cuda" in devices and not torch.cuda.is_available() or torch.cuda.device_count() < 1:
+        pytest.skip("Skipped due to lack of GPU")
+    expected = 0
+
+    def get_a_tensor():
+        """Return a random tensor on random device."""
+        dev = random.choice(devices)
+        shape = random.choice(((1), (2, 3), (4, 5, 6), (7, 8, 9, 10)))
+        t = torch.rand(shape).to(dev)
+        nonlocal expected
+        expected += t.numel()
+        return t
+
+    # create a mixed bag of data.
+    data = [1, "str"]
+    data.append({"key1": get_a_tensor(), "key2": {1: get_a_tensor()}, "key3": 3})
+    data.insert(0, set(["x", get_a_tensor(), get_a_tensor()]))
+    data.append(([1], get_a_tensor(), (1), [get_a_tensor()], set((1, 2))))
+    od = OrderedDict()
+    od["k"] = "value"
+    data.append(od)
+
+    total = 0
+
+    def fn(t):
+        nonlocal total
+        total += t.numel()
+        return t
+
+    new_data = apply_to_tensors(fn, data)
+    assert total == expected, f"{total} vs. {expected}"
+    for i, v in enumerate(data):
+        assert type(new_data[i]) == type(v), f"expected type {type(v)} got {type(new_data[i])}"
+
+
+@pytest.mark.parametrize("num_chunks", list(num_chunks for num_chunks in range(1, 33)))
+def test_chunk_and_pad(num_chunks):
+    max_tensor_size = 256
+    tensor = torch.zeros(max_tensor_size)
+    for tensor_size in range(1, max_tensor_size + 1):
+        tensor_i = tensor[:tensor_size]
+        chunks = chunk_and_pad(tensor_i, num_chunks)
+        assert len(chunks) == num_chunks
+        assert all(len(chunks[0]) == len(chunk) for chunk in chunks)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -165,6 +165,20 @@ USE_PYTEST_LIST = [
     "test_typing",
     "distributed/elastic/events/lib_test",
     "distributed/elastic/agent/server/test/api_test",
+    "distributed/fsdp/test_utils",
+    "distributed/fsdp/test_reduce_scatter_bucketer",
+    "distributed/fsdp/test_fsdp_uneven",
+    "distributed/fsdp/test_fsdp",
+    "distributed/fsdp/test_fsdp_summon_full_params",
+    "distributed/fsdp/test_fsdp_state_dict",
+    "distributed/fsdp/test_fsdp_overlap",
+    "distributed/fsdp/test_fsdp_multiple_wrapping",
+    "distributed/fsdp/test_fsdp_multiple_forward",
+    "distributed/fsdp/test_fsdp_memory",
+    "distributed/fsdp/test_fsdp_input",
+    "distributed/fsdp/test_fsdp_freezing_weights",
+    "distributed/fsdp/test_fsdp_apply",
+    "distributed/fsdp/test_flatten_params_wrapper",
 ]
 
 WINDOWS_BLOCKLIST = [
@@ -197,6 +211,20 @@ WINDOWS_BLOCKLIST = [
     "distributed/elastic/agent/server/test/api_test",
     "distributed/elastic/multiprocessing/api_test",
     "distributed/_sharded_tensor/test_sharded_tensor",
+    "distributed/fsdp/test_utils",
+    "distributed/fsdp/test_reduce_scatter_bucketer",
+    "distributed/fsdp/test_fsdp_uneven",
+    "distributed/fsdp/test_fsdp",
+    "distributed/fsdp/test_fsdp_summon_full_params",
+    "distributed/fsdp/test_fsdp_state_dict",
+    "distributed/fsdp/test_fsdp_overlap",
+    "distributed/fsdp/test_fsdp_multiple_wrapping",
+    "distributed/fsdp/test_fsdp_multiple_forward",
+    "distributed/fsdp/test_fsdp_memory",
+    "distributed/fsdp/test_fsdp_input",
+    "distributed/fsdp/test_fsdp_freezing_weights",
+    "distributed/fsdp/test_fsdp_apply",
+    "distributed/fsdp/test_flatten_params_wrapper",
 ]
 
 ROCM_BLOCKLIST = [
@@ -210,6 +238,20 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_type_hints",
     "test_openmp",
+    "distributed/fsdp/test_utils.py",
+    "distributed/fsdp/test_reduce_scatter_bucketer.py",
+    "distributed/fsdp/test_fsdp_uneven.py",
+    "distributed/fsdp/test_fsdp.py",
+    "distributed/fsdp/test_fsdp_summon_full_params.py",
+    "distributed/fsdp/test_fsdp_state_dict.py",
+    "distributed/fsdp/test_fsdp_overlap.py",
+    "distributed/fsdp/test_fsdp_multiple_wrapping.py",
+    "distributed/fsdp/test_fsdp_multiple_forward.py",
+    "distributed/fsdp/test_fsdp_memory.py",
+    "distributed/fsdp/test_fsdp_input.py",
+    "distributed/fsdp/test_fsdp_freezing_weights.py",
+    "distributed/fsdp/test_fsdp_apply.py",
+    "distributed/fsdp/test_flatten_params_wrapper.py",
 ]
 
 RUN_PARALLEL_BLOCKLIST = [

--- a/torch/distributed/_fsdp/__init__.py
+++ b/torch/distributed/_fsdp/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+from .fully_sharded_data_parallel import FullyShardedDataParallel
+
+__all__: List[str] = []

--- a/torch/distributed/_fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/_fsdp/flatten_params_wrapper.py
@@ -1,0 +1,482 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright (c) Tongzhou Wang
+# Licensed under the MIT License.
+
+from contextlib import contextmanager
+from itertools import chain
+import typing
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
+
+import torch
+from torch import Tensor
+import torch.nn as nn
+
+from .utils import replace_by_prefix_
+
+if TYPE_CHECKING:
+    from collections import OrderedDict  # noqa: F401
+
+
+class FlatParameter(nn.Parameter):
+    """ A parameter that is initialized from a list of parameters and can be
+        turned into a list of views as needed.
+    """
+
+    def __new__(cls, params: Sequence[nn.Parameter], requires_grad: bool = True) -> "FlatParameter":
+        """ Make an object using the parent's __new__ function. """
+
+        # A empty of non-list input doesn't make sense.
+        if not isinstance(params, (list, tuple)) or len(params) == 0:
+            raise ValueError("An non-empty list or tuple argument is needed")
+
+        # Normally, all items are Parameters. But during pickling, we will have a single
+        # Tensor as the input and later in __init__, the correct _param_numels and _param_shapes
+        # are set.
+        if not all(isinstance(p, (nn.Parameter, Tensor)) for p in params):
+            raise ValueError("List items need to be Parameter types")
+
+        # Flattening involves (1) making a tensor flat (i.e. single dimensional) and (2) making a module
+        # hierarchy flat (using a single tensor to replace a tree of tensors). Therefore,
+        # adding back nesting and hierarchy is counter-productive. If nesting is encountered
+        # in the future, the reasonable thing to do is likely for the top level FlatParameter to
+        # absorb the nested one and keep the result flat, free from hierarchy.
+        if any(isinstance(p, FlatParameter) for p in params):
+            raise ValueError("Nesting FlatParameter is not supported")
+
+        data = torch.cat([p.detach().reshape(-1) if isinstance(p, nn.Parameter) else p.reshape(-1) for p in params], 0)
+        return super(FlatParameter, cls).__new__(cls, data, requires_grad=requires_grad)  # type: ignore[call-arg]
+
+    def __init__(self, params: Sequence[nn.Parameter], requires_grad: bool = True):
+        """ Initialize the _param_numels and _param_shapes lists. """
+        self._param_numels = [p.numel() for p in params]
+        assert self.numel() <= sum(
+            self._param_numels
+        ), f"Something wrong with __new__ method, {self.numel()} vs. {sum(self._param_numels)}"
+        self._param_shapes = [p.size() for p in params]
+
+        # These are set by FPW class below, not by this class itself.
+        self._param_infos: List[Tuple[str, nn.Module, str]] = []
+        self._shared_param_infos: List[Tuple[str, str, nn.Module, str, nn.Module, str]] = []
+
+    def get_param_views(self, external_data: Optional[Tensor] = None) -> Iterator[Tensor]:
+        """ Return a generator of views that map to the original parameters. """
+        # Note, self.data could be sharded, so its numel is <= to the sum.
+        assert self.data.numel() <= sum(
+            self._param_numels
+        ), f"Incorrect internal state {self.data.numel()} vs. {sum(self._param_numels)}"
+        data = external_data if external_data is not None else self
+        if data.numel() != sum(self._param_numels):
+            raise ValueError(
+                f"Incorrect numel of supplied data: got {data.numel()} but expected {sum(self._param_numels)}"
+            )
+        return (t.view(s) for (t, s) in zip(data.split(self._param_numels), self._param_shapes))
+
+    def metadata(self) -> Tuple[List[str], List[torch.Size], List[int]]:
+        """Return tuple of (names, shapes, numels) metadata for this flat parameter."""
+        names = [".".join([m, n]) if m else n for (m, _, n) in self._param_infos]
+        return names, self._param_shapes, self._param_numels
+
+    def __setstate__(self, state: Tuple[Any, Any, Any, Any]) -> None:
+        """ Use by pickle to set the internal states. """
+        (self._param_numels, self._param_shapes, self._param_infos, self._shared_param_infos) = state
+        assert self.numel() <= sum(
+            self._param_numels
+        ), f"Incorrect pickling {self.numel()} vs. {sum(self._param_numels)}"
+
+    def __reduce_ex__(self, proto: int) -> Tuple[Any, Any, Any]:
+        """ Support pickling between ranks. """
+        return (
+            FlatParameter,  # Callable
+            # Args to the callable above
+            ([self.data], self.requires_grad),
+            # Args to __setstate__
+            (self._param_numels, self._param_shapes, self._param_infos, self._shared_param_infos),
+        )
+
+
+# Static types.
+ParamGroups = Optional[Union[List[List[nn.Parameter]], List[nn.Parameter]]]
+
+
+class FlattenParamsWrapper(nn.Module):
+    """
+    A wrapper for transparently flattening a Module's parameters.
+    Compared to the original implementation [1], this version:
+    - removes tracing
+    - supports shared parameters
+    - handles state_dict/load_state_dict transparently
+    - is renamed to FlattenParamsWrapper
+    - refactored to use the FlatParameter class
+    - extended to support flattening multiple groups of params (useful
+      when different groups of params need different hyperparameters, like
+      learning rate or weight decay)
+    [1] https://github.com/SsnL/PyTorch-Reparam-Module
+    Args:
+        module (nn.Module):
+            The module to wrap.
+        param_list (Optional[List[List[nn.Parameter]]]):
+            Only flatten parameters appearing in the given groups.
+            If the param_list is an empty list, then no parameters will get flattened.
+            Note, if a single param is in one of the list, it still get flattened and the
+            original param is removed and replaced with the flatten one.
+            Default: None, flatten all parameters (if any)
+        flat_param_names (Optional[List[str]]):
+            originally, give each flat_param a unique name. Note a "flat_param_"
+            prefix will be added to those names.
+    """
+
+    def __init__(self, module: nn.Module, param_list: ParamGroups = None, flat_param_names: Optional[List[str]] = None):
+        super().__init__()
+        self._fpw_module = module
+        self.is_flattened = False
+
+        # Handle param_list being None.
+        if param_list is None:
+            param_list = list(module.parameters())
+
+        # Be backward compatible and turn a single param list into a list of
+        # a single list.
+        if len(param_list) > 0 and isinstance(param_list[0], nn.Parameter):
+            param_list = [cast(List[nn.Parameter], param_list)]
+
+        # Since the parameters will be deleted, let's record the number original
+        # parameters managed by this class. This and get_param_views function
+        # below are used by fsdp_optim_utils.py to save/restore optimizer state,
+        # which mirrors the flatten parameters here.
+        self.num_params_managed = 0
+
+        self._param_sets = []
+        overall_param_set: Set[nn.Parameter] = set()
+        for p_list in param_list:
+            # Remove any duplicates from the list.
+            p_set: Set[nn.Parameter] = set(cast(List[nn.Parameter], p_list))
+
+            self.num_params_managed += len(p_set)
+            overall_param_set = overall_param_set.union(p_set)
+
+            # Convert from list of Parameters to set of (Module, name) tuples,
+            # which will survive in case the parameter instances are reset.
+            # Also, a shared param will correctly appear under multiple modules
+            # as they should.
+            new_p_set_with_names = set()
+            for m in self.modules():
+                for n, p in m.named_parameters(recurse=False):
+                    if p in p_set:
+                        new_p_set_with_names.add((m, n))
+            if new_p_set_with_names:
+                self._param_sets.append(new_p_set_with_names)
+
+        if len(overall_param_set) != self.num_params_managed:
+            # Each p_list above could have shared params. However, you can't
+            # have shared params cross different p_list. That means part of
+            # the flattened parameter must be shared, which is impossible to
+            # support.
+            raise ValueError(f"Incorrect param groups {len(overall_param_set)} vs {self.num_param_managed}")
+
+        self.flat_params: List[FlatParameter] = []
+
+        # Prepare flat param names.
+        if flat_param_names is None:
+            flat_param_names = [f"{i}" for i, _ in enumerate(self._param_sets)]
+        if len(flat_param_names) != len(self._param_sets):
+            raise ValueError("Names and number of param lists must be equal")
+        if len(flat_param_names) != len(set(flat_param_names)):
+            raise ValueError("Each flat param must be given a unique name")
+        self.flat_param_names = [f"flat_param_{n}" for n in flat_param_names]
+
+        # Init all flat_params.
+        for new_p_set in self._param_sets:
+            params, param_infos, shared_param_infos = self._init_flatten_params(new_p_set)
+            flat_param = FlatParameter(params, params[0].requires_grad)
+            flat_param._param_infos = param_infos
+            flat_param._shared_param_infos = shared_param_infos
+            self.flat_params.append(flat_param)
+
+        self._flatten_params(self.flat_params)
+
+        # Register hook to be called after state_dict() to remove the
+        # "_fpw_module." prefix and before load_state_dict() to add it back.
+        self._register_state_dict_hook(_post_state_dict_hook)
+        self._register_load_state_dict_pre_hook(_pre_load_state_dict_hook)
+
+        # Flag to indicate whether state_dict() should automatically unflatten
+        # params. This defaults to True, but may be set to False if the user
+        # explicitly requests a flat state dict via flat_state_dict().
+        self._auto_unflatten_state_dict = True
+
+    @property
+    def module(self) -> Any:
+        """ Support fpw.module in case we are immitating DDP, which has .module
+            property to the underlying module.
+        """
+        return self._fpw_module
+
+    @property
+    def flat_param(self) -> nn.Parameter:
+        """ We used to support only a single flat_param. This allows us to
+            be backward compatible.
+        """
+        assert len(self.flat_params) == 1, "Incorrect access to flat_param"
+        return self.flat_params[0]
+
+    def _init_flatten_params(
+        self, p_set: Set[Tuple[nn.Module, str]]
+    ) -> Tuple[
+        List[nn.Parameter], List[Tuple[str, nn.Module, str]], List[Tuple[str, str, nn.Module, str, nn.Module, str]]
+    ]:
+        """ Build metadata for need-to-be-flatten parameters and returns a list
+            contains the need-to-be-flatten parameters.
+            This also returns param_infos and shared_param_infos, which
+            will be attached to the flat parameter object.
+        Args:
+            p_set (set):
+                A set of (module, param_name) for a set of params that needed
+                to be flattened. There could be shared params in this set.
+        """
+        param_infos = []
+        shared_param_memo: Dict[nn.Parameter, Tuple[str, nn.Module, str]] = {}
+        shared_param_infos = []
+        params = []
+        for module_name, m in self.named_modules():
+            for n, p in m.named_parameters(recurse=False):
+                if p is not None and (m, n) in p_set:
+                    if p in shared_param_memo:
+                        mname, shared_m, shared_n = shared_param_memo[p]
+                        shared_param_infos.append((module_name, mname, m, n, shared_m, shared_n))
+                    else:
+                        shared_param_memo[p] = (module_name, m, n)
+                        param_infos.append((module_name, m, n))
+                        params.append(p)
+        del shared_param_memo
+
+        assert len(set(p.dtype for p in params)) == 1, "expects all parameters to have same dtype"
+        assert len(set(p.requires_grad for p in params)) == 1, "expects all parameters to have same requires_grad"
+        assert len(params) == len(set(params)), "params list should not have dups"
+        return params, param_infos, shared_param_infos
+
+    @property
+    def _param_infos(self) -> Iterator[Tuple[str, nn.Module, str]]:
+        return chain(*[p._param_infos for p in self.flat_params])
+
+    @property
+    def _shared_param_infos(self) -> Iterator[Tuple[str, str, nn.Module, str, nn.Module, str]]:
+        return chain(*[p._shared_param_infos for p in self.flat_params])
+
+    def _flatten_params(self, flat_params: List[FlatParameter]) -> None:
+        """ Flatten the managed parameters and replaced the original
+            attributes with views to the flat params.
+        """
+        assert not self.is_flattened
+        self.is_flattened = True
+
+        # register the flatten ones and save it to self.
+        assert len(self.flat_param_names) == len(flat_params), f"{len(self.flat_param_names)} vs. {len(flat_params)}"
+        for n, flat_param in zip(self.flat_param_names, flat_params):
+            self.register_parameter(n, flat_param)
+        self.flat_params = flat_params
+
+        # deregister the names as parameters
+        for _, m, n in self._param_infos:
+            delattr(m, n)
+        for _, _, m, n, _, _ in self._shared_param_infos:
+            delattr(m, n)
+
+        # register the views as plain attributes
+        self._unflatten_params_as_views()
+
+    def _unflatten_params(self, external_data: Optional[List[Optional[Tensor]]] = None) -> None:
+        """ Undo flattening and create separate parameters from the already flattened
+            self.flat_param or a user supplied external data.
+        """
+        assert self.is_flattened or external_data is not None
+        self.is_flattened = False
+
+        ps = self.get_param_views(external_data)
+        for (_, m, n), p in zip(self._param_infos, ps):
+            if hasattr(m, n):
+                delattr(m, n)
+            m.register_parameter(n, nn.Parameter(p))
+        for (_, _, m, n, shared_m, shared_n) in self._shared_param_infos:
+            if hasattr(m, n):
+                delattr(m, n)
+            m.register_parameter(n, getattr(shared_m, shared_n))
+
+        for n in self.flat_param_names:
+            # This ensures the flat params are removed from the module.
+            delattr(self, n)
+        self.flat_params = []
+
+    def _unflatten_params_as_views(self) -> None:
+        """ Unlike ``_unflatten_params``, this function unflatten into views and keep
+            self.flat_param unchanged.
+        """
+        assert self.is_flattened
+        ps = self.get_param_views()
+        for (_, m, n), p in zip(self._param_infos, ps):
+            setattr(m, n, p)  # This will set as plain attr
+        for (_, _, m, n, shared_m, shared_n) in self._shared_param_infos:
+            setattr(m, n, getattr(shared_m, shared_n))
+
+    @contextmanager
+    def unflatten_params(self, flat_params: Optional[List[Tensor]] = None) -> Generator:
+        """
+        Unflatten params. If the current instance is already unflattened, then
+        it will remain unflattened after the context manager exits.
+        Args:
+            flat_params (List[Tensor], Optional):
+                flat params to use for unflattening.
+                If provided, the current instance must be in a flattened state
+                at the start of the context manager. The provided Tensor must be
+                appropriately sized and will only be used within the context
+                manager. After the context manager exits, we will revert to
+                using ``self.flat_params``
+                Default: None.
+        """
+        assert (
+            flat_params is None or self.is_flattened
+        ), "Unflattening with external flat_param requires current instance to be flattened"
+
+        orig_flattened = self.is_flattened
+        if orig_flattened:
+            orig_flat_params = self.flat_params
+            self._unflatten_params(cast(Optional[List[Optional[Tensor]]], flat_params))
+
+        # Put yield in a try...finally in case the caller catches the exception and handles
+        # it. In that case, we need to properly handle the undoing of state here.
+        try:
+            yield
+        finally:
+            if orig_flattened:
+                self._flatten_params(orig_flat_params)
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward missing attributes to wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.module, name)  # fallback to wrapped module
+
+    def __getitem__(self, key: int) -> Any:
+        """Forward indexing calls in case the module is a nn.Sequential."""
+        return self.module.__getitem__(key)
+
+    @typing.overload  # type: ignore[override]
+    def state_dict(
+        self, destination: Mapping[str, Tensor], prefix: str = ..., keep_vars: bool = ...
+    ) -> Mapping[str, Tensor]:
+        ...
+
+    @typing.overload
+    def state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> "OrderedDict[str, Tensor]":
+        ...
+
+    # Since we have overloads above, we can use Any here.
+    def state_dict(self, *args: Any, **kwargs: Any) -> Any:
+        """Return the wrapped module's state_dict."""
+        if self.is_flattened and self._auto_unflatten_state_dict:
+            # Returns the original version.
+            with self.unflatten_params():
+                return super().state_dict(*args, **kwargs)
+        else:
+            # Returns flattened version.
+            return super().state_dict(*args, **kwargs)
+
+    def flat_state_dict(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Return the flattened state_dict."""
+        assert self.is_flattened
+        with self._no_auto_unflatten_state_dict():
+            return self.state_dict(*args, **kwargs)
+
+    @contextmanager
+    def _no_auto_unflatten_state_dict(self) -> Generator:
+        backup = self._auto_unflatten_state_dict
+        self._auto_unflatten_state_dict = False
+        # Put yield in a try...finally in case the caller catches the exception and handles
+        # it. In that case, we need to properly handle the undoing of state.
+        try:
+            yield
+        finally:
+            self._auto_unflatten_state_dict = backup
+
+    def load_state_dict(
+        self, state_dict: Union[Dict[str, Tensor], "OrderedDict[str, Tensor]"], strict: bool = True
+    ) -> NamedTuple:
+        """
+        Load a state dict. If necessary, ``unflatten_params`` will be called to
+        match the input state_dict.
+        """
+        # unflatten the module automatically if the state_dict is non-flat
+        if self.is_flattened and "flat_param_0" not in state_dict:
+            # This object is flatten but state_dict is not. So we unflatten and load.
+            with self.unflatten_params():
+                return super().load_state_dict(state_dict, strict)  # type: ignore[arg-type]
+        else:
+            # Otherwise, load it as is but make older state dict compatible.
+            if "flat_param" in state_dict:
+                state_dict["flat_param_0"] = state_dict["flat_param"]
+                del state_dict["flat_param"]
+            return super().load_state_dict(state_dict, strict)  # type: ignore[arg-type]
+
+    def forward(self, *inputs: Any, **kwinputs: Any) -> Any:
+        self._unflatten_params_as_views()
+        return self.module(*inputs, **kwinputs)
+
+    def get_param_views(self, external_data_list: Optional[List[Optional[Tensor]]] = None) -> Iterator[Tensor]:
+        """ Used to get a generator over all views from a list of external data list. """
+        params = self.flat_params
+        if external_data_list is None:
+            external_data_list = [None] * len(params)
+        assert len(external_data_list) == len(
+            params
+        ), f"Incorrect external data list: {len(external_data_list)} vs. {len(params)}"
+
+        gens = []
+        for p, data in zip(params, external_data_list):
+            gens.append(p.get_param_views(data))
+
+        return chain(*gens)
+
+    def metadata(self, flat_param_idx: int) -> Tuple[List[str], List[torch.Size], List[int]]:
+        """Return metadata for a flat param given its index in the flat_params list."""
+        return self.flat_params[flat_param_idx].metadata()
+
+
+def _post_state_dict_hook(
+    module: nn.Module, state_dict: "OrderedDict[str, Tensor]", prefix: str, *args: Any
+) -> "OrderedDict[str, Tensor]":
+    # Move everything from .fpw_module up one level.
+    replace_by_prefix_(state_dict, prefix + "_fpw_module.", prefix)
+    return state_dict
+
+
+def _pre_load_state_dict_hook(
+    state_dict: Union[Dict[str, Tensor], "OrderedDict[str, Tensor]"], prefix: str, *args: Any
+) -> None:
+    # Push everything down to ._fpw_module level.
+    replace_by_prefix_(state_dict, prefix, prefix + "_fpw_module.")
+    # The flat_param_* keys actually needs to move one level up.
+    flat_param_key = prefix + "_fpw_module.flat_param"
+    for k in list(state_dict.keys()):
+        if k.startswith(flat_param_key):
+            last_part = k.split(".")[-1]
+            assert last_part.startswith("flat_param_"), last_part
+            replace_by_prefix_(state_dict, k, prefix + last_part)

--- a/torch/distributed/_fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/_fsdp/fully_sharded_data_parallel.py
@@ -1,0 +1,1737 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import copy
+from enum import Enum, auto
+import functools
+import logging
+from math import inf
+import time
+import traceback
+import typing
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
+
+import torch
+from torch.autograd import Variable
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parameter import Parameter
+
+from .flatten_params_wrapper import FlattenParamsWrapper
+from .utils import (
+    apply_to_tensors,
+    replace_by_prefix_,
+    calc_grad_norm_,
+    chunk_and_pad,
+    enable_pytorch_sync_bn,
+    get_process_group_cached,
+    validate_process_group,
+)
+from .reduce_scatter_bucketer import ReduceScatterBucketer
+
+if TYPE_CHECKING:
+    from collections import OrderedDict  # noqa: F401
+
+
+class TrainingState(Enum):
+    """
+    Simple enum to indicate what state FSDP is in. Used for asserting
+    to make sure APIs are called in the correct state.
+    ..note::
+        BACKWARD_PRE and BACKWARD_POST states are used to ensure we
+        receives backward hooks in the correct order. It is used to catch
+        unexpected order of hooks being called (likely due to our
+        hook registration logic or autograd engine logic changes).
+    TODO (Min): It would be nice to capture the stepping state as well.
+        Maybe we can use the model.zero_grad() call, but not sure if it
+        is called if optim.zero_grad() is used instead.
+        It would be nice to have clear state transition be explicit like:
+        zero_grad -> fwd -> bwd -> optionally accum grad by repeating
+        fwd/bwd -> stepping -> loop back to zero_grad
+    """
+
+    IDLE = auto()
+    FORWARD = auto()
+    BACKWARD_PRE = auto()
+    BACKWARD_POST = auto()
+    SUMMON_FULL_PARAMS = auto()
+
+
+class FullyShardedDataParallel(nn.Module):
+    """
+    A wrapper for sharding Module parameters across data parallel workers. This
+    is inspired by `Xu et al.`_ as well as the ZeRO Stage 3 from DeepSpeed_.
+    FullyShardedDataParallel is commonly shorten to FSDP.
+    .. _`Xu et al.`: https://arxiv.org/abs/2004.13336
+    .. _DeepSpeed: https://www.deepspeed.ai/
+    Usage::
+        import torch
+        from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
+        torch.cuda.set_device(device_id)
+        sharded_module = FSDP(my_module)
+        optim = torch.optim.Adam(sharded_module.parameters(), lr=0.0001)
+        x = sharded_module(x, y=3, z=torch.Tensor([1]))
+        loss = x.sum()
+        loss.backward()
+        optim.step()
+    It is also possible to shard individual layers separately and have an outer
+    wrapper handle any leftover parameters. This can be helpful to further
+    reduce GPU memory usage, reduce system memory usage when initializing large
+    models and to improve training speed by overlapping the all-gather step
+    across the forward pass. For example::
+        import torch
+        from fairscale.nn.auto_wrap import enable_wrap, auto_wrap, wrap
+        from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
+        fsdp_params = dict(wrapper_cls=FSDP, mixed_precision=True, flatten_parameters=True)
+        with enable_wrap(**fsdp_params):
+            # Wraps layer in FSDP by default if within context
+            self.l1 = wrap(torch.nn.Linear(5, 5))
+            assert isinstance(self.l1, FSDP)
+            # Separately Wraps children modules with more than 1e8 params
+            large_tfmr = torch.nn.Transformer(d_model=2048, encoder_layers=12, decoder_layers=12)
+            self.l2 = auto_wrap(large_tfmr, min_num_params=1e8)
+            assert isinstance(self.l2, FSDP)
+    .. warning::
+        The optimizer must be initialized *after* the module has been wrapped,
+        since FSDP will shard parameters in-place and this will break any
+        previously initialized optimizers.
+    .. warning::
+        If you wrap every parameter inside a nested FSDP and leaving the outer
+        FSDP empty without any parameter, checkpointing activation may trigger
+        an assert on the backward pass. The solution is to leave some parameters
+        to the outer FSDP.
+    .. warning::
+        If activation checkpointing is used with FSDP, it is strongly encouraged
+        to use ``checkpoint_wrapper`` function from FairScale instead of the
+        ``checkpoint`` function from PyTorch.
+    Args:
+        module (nn.Module):
+            module to be wrapped with FSDP.
+        process_group (Optional):
+            process group for sharding
+        reshard_after_forward (bool, Optional):
+            if ``True``, reshard parameters after the forward pass. This saves
+            memory but slows training. This is only relevant when resharding
+            individual layers.
+        mixed_precision (bool, Optional):
+            if ``True``, inputs, activations and gradients will be kept in FP16;
+            computation and communication will occur in FP16; and a (sharded)
+            master copy of the model weights will be maintained in FP32.
+        fp32_reduce_scatter (bool, Optional):
+            if ``True``, then reduce-scatter gradients in FP32. This is only
+            relevant when *``mixed_precision``* is ``True``.
+        flatten_parameters (bool, Optional):
+            if ``True``, flatten parameters into a single contiguous tensor,
+            which improves training speed.
+        move_params_to_cpu (bool, Optional):
+            if ``True``, offload FP32 params to CPU. This is only relevant when
+            *``mixed_precision``* is ``True``.
+        compute_dtype (torch.dtype, Optional):
+            dtype for full parameters for computation. This defaults to
+            ``torch.float32`` unless *``mixed_precision``* is set, in which case
+            it defaults to ``torch.float16``.
+        buffer_dtype (torch.dtype, Optional):
+            dtype for buffers for computation. This defaults to ``compute_dtype``.
+        move_grads_to_cpu (bool, Optional):
+            move gradient shard to CPU after reduction. This is useful when
+            combined with CPU-based optimizers. It defaults to the value of
+            *``cpu_offload``*.
+        bucket_cap_mb (int, Optional):
+            FSDP will bucket parameters so that gradient reduction can
+            be more efficient for small parameters.
+            ``bucket_cap_mb`` controls the bucket size in MegaBytes (MB). Buckets
+            are sub-divided based on world_size, so the max shard size is roughly
+            ``bucket_cap_mb / world_size``. There is one bucketer (with potentially
+            multiple ``bucket_cap_mb`` sized buffers shared by all FSDP instances.
+            Large gradient tensors are directly reduced without using the buffers.
+            The buffers are there to reduce communication overhead for small tensors.
+            Overlapping with computation happens due to use of a different CUDA stream
+            than the computation CUDA stream. The total memory overhead per buffer is around
+            ``bucket_cap_mb / world_size * (world_size + 1)``.
+            The buffers are allocated during the backward pass and freed at the end
+            of the backward pass to save more memory for other phases of the
+            training process.
+            Note, the memory vs. speed tradeoff of bucket size is very different
+            from that of the DDP engine. In DDP, the buffer size ``1MB + n*cap_mb``,
+            until n is big enough to cover the entire model size. The order
+            of which buffer is ready there is more rigid and DDP requires all
+            gradients to be computed in the backward. In FSDP, the buffer size
+            does not change with model size (it changes based on number of
+            <dtype, device, process_group> tuples) and gradient ready order matters
+            little since FSDP has a final flush call that ensures everything is reduced
+            and not all gradients need to be upfront known. Overlapping with compute is
+            done differently too.
+            Values <= 0 disable bucketing.
+            Default: 25.
+        compute_device (torch.device, Optional):
+            device for computation. If not given and module params are on a CUDA
+            device, the param's device will be used. If not given and module
+            params are on CPU, then the current CUDA device (as indicated by
+            ``torch.cuda.current_device()`` will be used.
+        no_broadcast_optim_state: (bool, Optional)
+            do not broadcast this modules optimizer state when ``gather_full_optim_state_dict`` is called.
+            If you set this true, you are expected to overwrite the relevant state entries of the returned optimizer state dict
+            with the proper state at each rank. This is useful for situations, like Mixture Of Experts,
+            where all but a few parameters can fit on one node.
+            Default: False
+        state_dict_device (torch.device, Optional):
+            device for parameters returned by :func:`state_dict`. If not given,
+            this will default to ``compute_dtype``. Note that only the device
+            type will be respected (e.g., "cuda:0" and "cuda:1" are the same).
+        clear_autocast_cache (bool):
+            When using mixed precision training with `torch.amp.autocast`, if the model weights
+            are in FP32, autocast maintains a cache for downcasted weights. The cache can cause
+            GPU OOM during the forward pass. Setting this flag to true will help clearing this
+            cache as inner FSDP instances finish part of the forward pass to save GPU memory.
+            Default: False
+        force_input_to_fp32 (bool):
+            Set to ``True`` to force input floating point tensors to be FP32 (if they are FP16)
+            when the FSDP instance is in full precision mode. This helps avoid issues of running
+            SyncBatchNorm with AMP and checkpoint_wrapper.
+            Default: False
+        verbose (bool):
+            Set this to ``True`` to turn on verbose output for model's string representation.
+            Default: False
+        cpu_offload (bool, Optional):
+            if ``True``, offload FP32 params to CPU. This is only relevant when
+            *``mixed_precision``* is ``True``. Note: This arg will be deprecated in favor of
+            *``move_params_to_cpu``* in an upcoming release.
+    """
+
+    def __init__(
+        self,
+        module: nn.Module,
+        process_group: Optional[ProcessGroup] = None,
+        reshard_after_forward: bool = True,
+        mixed_precision: bool = False,
+        fp32_reduce_scatter: bool = False,
+        flatten_parameters: bool = True,
+        move_params_to_cpu: bool = False,
+        compute_dtype: Optional[torch.dtype] = None,
+        buffer_dtype: Optional[torch.dtype] = None,
+        move_grads_to_cpu: Optional[bool] = None,
+        bucket_cap_mb: int = 25,
+        compute_device: Optional[torch.device] = None,
+        no_broadcast_optim_state: Optional[bool] = False,
+        state_dict_device: Optional[torch.device] = None,
+        clear_autocast_cache: bool = False,
+        force_input_to_fp32: bool = False,
+        verbose: bool = False,
+        cpu_offload: bool = False,
+    ):
+        init_start = time.time()
+        super().__init__()
+        self.process_group = process_group or get_process_group_cached()
+        self.rank = self.process_group.rank()
+        self.world_size = self.process_group.size()
+        self.reshard_after_forward = reshard_after_forward
+        self.mixed_precision = mixed_precision
+        self.fp32_reduce_scatter = fp32_reduce_scatter
+        self.flatten_parameters = flatten_parameters
+        self.move_params_to_cpu = move_params_to_cpu or cpu_offload
+        self.compute_dtype = compute_dtype or (torch.float16 if mixed_precision else torch.float32)
+        self.buffer_dtype = buffer_dtype or self.compute_dtype
+        self.move_grads_to_cpu = self.move_params_to_cpu if move_grads_to_cpu is None else move_grads_to_cpu
+        self.bucket_cap_mb = bucket_cap_mb
+        self.compute_device = compute_device or _get_default_cuda_device(module)
+        self.uncollected_opt_state: Dict[int, Dict] = {}
+        self.no_broadcast_optim_state = no_broadcast_optim_state
+        self.state_dict_device = state_dict_device or self.compute_device
+        self.clear_autocast_cache = clear_autocast_cache
+        self.force_input_to_fp32 = force_input_to_fp32
+        self.verbose = verbose
+
+        self.gradient_predivide_factor: float = self._get_gradient_predivide_factor(self.world_size)
+        self.gradient_postdivide_factor: float = self.world_size / self.gradient_predivide_factor
+
+        self.numel_padded_per_param: List[int] = []
+        self._tstart = time.time()
+
+        if self.fp32_reduce_scatter and not self.mixed_precision:
+            raise ValueError("fp32_reduce_scatter requires mixed_precision=True")
+        if self.move_params_to_cpu and not self.mixed_precision:
+            raise ValueError("cpu_offload requires mixed_precision=True")
+
+        # skip validation if the process group was created above
+        if process_group:
+            validate_process_group(self.compute_device, self.process_group)
+
+        # enable pytorch sync_bn just in case model contains sync_bn layers.
+        enable_pytorch_sync_bn(module)
+
+        # Only handle params which are not already sharded. This enables
+        # sharding individual layers of a Module, with an outer wrapper to
+        # shard any leftover parameters.
+        param_names = []
+        params = []
+        for param_name, param in module.named_parameters():
+            if not hasattr(param, "_is_sharded"):
+                param_names.append(param_name)
+                params.append(param)
+
+        self._has_params = len(params) > 0
+
+        # For now, it is either all flatten or none flatten. This will be extended to
+        # multiple flatten groups in my next PR.
+        to_be_flatten_params: List[List[Parameter]] = [[]]
+        non_flatten_params = params
+        param_name_groups = [[n] for n in param_names]
+        if self.flatten_parameters:
+            to_be_flatten_params = [params]
+            non_flatten_params = []
+            param_name_groups = [param_names]
+        del param_names
+
+        self._fsdp_wrapped_module: nn.Module = FlattenParamsWrapper(module, param_list=to_be_flatten_params)
+        del module  # free original module in case it helps garbage collection
+
+        # Now, in this FSDP wrapper class, we keep a list of to-be-flatten and not-to-be-flatten
+        # params for doing sharding, gradient hooks, etc. Note, the ordering of the
+        # list matters: flatten params are always in the front.
+        #
+        # The self._num_flatten_params and self._param_name_groups are computed
+        # and kept here to support summon_full_params and shard-to-full weight
+        # consolidation.
+        self.params = cast(List[Parameter], self._fsdp_wrapped_module.flat_params) + non_flatten_params
+        self._num_flatten_params = len(self._fsdp_wrapped_module.flat_params)
+        self._param_name_groups = param_name_groups
+
+        # Shard module parameters in place
+        self._shard_parameters_()
+
+        # Make sure all parameters are sharded.
+        for n, p in self.named_parameters():
+            assert hasattr(p, "_is_sharded"), f"found unsharded parameter: {n} ; {p.size()}"
+
+        self._reset_lazy_init()
+
+        # Flag to indicate if we require gradient reduction in the backward
+        # pass. This will be False when inside the no_sync context manager.
+        self._require_backward_grad_sync: bool = True
+
+        # Enum to indicate if we're in the forward/backward pass, idle, etc.
+        self.training_state = TrainingState.IDLE
+
+        # Flag to indicate if the full params are gathered.
+        self.has_full_params: bool = False
+
+        # Register hook after state_dict() to remove the "_fsdp_wrapped_module."
+        # prefix and before load_state_dict() to add it back.
+        self._register_state_dict_hook(_post_state_dict_hook)
+        self._register_load_state_dict_pre_hook(_pre_load_state_dict_hook)
+
+        # Flag to indicate whether state_dict() should automatically summon the
+        # full params. This defaults to True, but may be set to False if the
+        # user explicitly requests the local state dict via local_state_dict().
+        self._return_full_state_dict = True
+        init_end = time.time()
+
+        logging.debug(
+            f"FSDP.__init__(done): total_init_time: {(init_end - init_start): .4f} \
+            num_params: {(sum(p.numel() for p in self.params))}"
+        )
+
+        # Flag to guard multiple pre-backward hook being executed per iteration.
+        # This is reset at the end of the backward pass.
+        self._pre_backward_hook_has_run = False
+
+    def _get_gradient_predivide_factor(self, world_size: int) -> float:
+        factor: int = 1
+        while world_size % factor == 0 and world_size / factor > factor:
+            factor *= 2
+        return float(factor)
+
+    def set_gradient_divide_factors(self, pre: float, post: float, recursive: bool) -> None:
+        """Allowing user to override the pre and post divide factors.
+        Args:
+            pre (float): divide factor before the reduction.
+            post (float): divide factor after the reduction.
+            recursive (bool): recursively set it for all child FSDP instances or not.
+        """
+        self.assert_state(TrainingState.IDLE)
+        if recursive:
+            for module in self.modules():
+                if isinstance(module, FullyShardedDataParallel) and module != self:
+                    module.set_gradient_divide_factors(pre, post, False)
+        self.gradient_predivide_factor = pre
+        self.gradient_postdivide_factor = post
+
+    @property
+    def module(self) -> FlattenParamsWrapper:
+        """ make model.module accessible, just like DDP. """
+        assert isinstance(self._fsdp_wrapped_module, FlattenParamsWrapper)
+        return self._fsdp_wrapped_module
+
+    def apply(self, fn: Callable[[nn.Module], None]) -> "FullyShardedDataParallel":
+        """
+        Applies ``fn`` recursively to every submodule (as returned by
+        ``.children()``) as well as self. Typical use includes initializing the
+        parameters of a model.
+        Compared to ``torch.nn.Module.apply``, this version additionally gathers
+        the full parameters before applying ``fn``. It should not be called from
+        within another ``summon_full_params`` context.
+        Args:
+            fn (nn.Module): function to be applied to each submodule
+        Returns:
+            Module: self
+        """
+        is_uninitialized = self._is_root is None
+        self.assert_state(TrainingState.IDLE)
+        with self.summon_full_params(recurse=False):
+            return_value = super().apply(fn)
+        # summon_full_params will call _lazy_init, which sets _is_root. However,
+        # apply() may be called directly on children instances to do weight
+        # init, so we should reset the _is_root flag in this case.
+        if is_uninitialized and self._is_root:
+            for module in self.modules():
+                if isinstance(module, FullyShardedDataParallel):
+                    module._reset_lazy_init()
+        return return_value
+
+    def _cast_buffers(
+        self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None, memo: Optional[Set] = None
+    ) -> None:
+        """Move all buffers to the given *device* and *dtype*.
+        If *device* or *dtype* are not given, then they will default to
+        ``self.compute_device`` and ``self.buffer_dtype``, respectively. In the
+        case of nested FSDP instances, we will respect the child instance's
+        ``compute_device`` and ``buffer_dtype`` configuration.
+        Args:
+            device (torch.device, Optional):
+                device to cast buffers to (defaults to compute_device)
+            dtype (torch.dtype, Optional):
+                dtype to cast buffers to (defaults to buffer_dtype)
+            memo (Set, Optional):
+                set of modules that have already been processed
+        """
+        if memo is None:
+            memo = set()
+        for module in self.modules():
+            if module is not self and isinstance(module, FullyShardedDataParallel):
+                # Allow any child FSDP instances to handle their own buffers.
+                module._cast_buffers(device=device, dtype=dtype, memo=memo)
+            elif module not in memo:
+                memo.add(module)
+                for name, buf in module.named_buffers(recurse=False):
+                    if buf is None:
+                        continue
+                    buf = buf.to(device=device or self.compute_device)
+                    if torch.is_floating_point(buf):
+                        buf = buf.to(dtype=dtype or self.buffer_dtype)
+                    setattr(module, name, buf)
+
+    @property
+    def params_with_grad(self) -> List[Parameter]:
+        """[p for p in self.parameters() if p.grad is not None]"""
+        return [p for p in self.parameters() if p.grad is not None]
+
+    @torch.no_grad()
+    def clip_grad_norm_(
+        self,
+        max_norm: Union[float, int],
+        norm_type: Union[float, int] = 2.0,
+        # filter_params_fn: Callable[[Any], Any] = None,
+    ) -> torch.Tensor:
+        """
+        Clip all gradients at this point in time. The norm is computed over all
+        gradients together, as if they were concatenated into a single vector.
+        Gradients are modified in-place.
+        Args:
+            max_norm (float or int): max norm of the gradients
+            norm_type (float or int): type of the used p-norm. Can be ``'inf'``
+                for infinity norm.
+        Returns:
+            Total norm of the parameters (viewed as a single vector).
+        .. note:: This is analogous to `torch.nn.utils.clip_grad_norm_` but
+            handles the partitioning and multiple devices per rank under the
+            hood. The default torch util is not applicable here, because each
+            rank only has a partial view of all the grads in the model, so
+            calling it in the OSS context would lead to different scaling being
+            applied per subset of model parameters.
+        .. warning:: This needs to be called on all ranks, since synchronization
+            primitives will be used.
+        """
+        # We don't call torch.cuda.synchronize() here, since clipping can be
+        # inside the train loop and we probably don't want to force a GPU-CPU sync.
+        # _lazy_init should be sufficient, since it will force the other streams
+        # to sync with the default stream (via _wait_for_previous_optim_step).
+        self._lazy_init()
+        assert self._is_root, "clip_grad_norm should only be called on the root (parent) instance"
+        self.assert_state(TrainingState.IDLE)
+
+        max_norm = float(max_norm)
+        norm_type = float(norm_type)
+        params_with_grad = self.params_with_grad
+        if not self.children_share_process_group:
+            raise NotImplementedError(
+                "clip_grad_norm requires that all params share one process group. "
+                "Please use clip_grad_by_value_ if multiple process groups are used."
+            )
+        # Computes the max norm for this shard's gradients and sync's across workers
+        local_norm = calc_grad_norm_(params_with_grad, norm_type).cuda()
+        if norm_type == inf:
+            total_norm = local_norm
+            dist.all_reduce(total_norm, op=torch.distributed.ReduceOp.MAX, group=self.process_group)
+        else:
+            total_norm = local_norm ** norm_type
+            dist.all_reduce(total_norm, group=self.process_group)
+            total_norm = total_norm ** (1.0 / norm_type)
+
+        if self.move_grads_to_cpu:
+            total_norm = total_norm.cpu()
+
+        # Now multiply each grad by (max_norm/total_norm), same as torch 1.7 https://tinyurl.com/3wtxhhqq)
+        clip_coef = torch.tensor(max_norm, dtype=total_norm.dtype, device=total_norm.device) / (total_norm + 1e-6)
+        if clip_coef < 1:
+            # multiply by clip_coef
+            for p in params_with_grad:
+                assert p.grad is not None
+                p.grad.detach().mul_(clip_coef.to(p.grad.device))
+
+        return total_norm
+
+    @torch.no_grad()
+    def _shard_parameters_(self) -> None:
+        """
+        At initialization we wrap a module with full parameters and shard the
+        parameters in-place. Sharding is implemented by viewing each parameter
+        as a 1D Tensor and retaining only a single slice, where the slice size
+        is determined by the number of data parallel workers.
+        Wrapping modules with many small parameters (or with a very large data
+        parallel world size) will result in many small parameter shards and slow
+        performance. In this case it's better to set *``flatten_parameters``* to
+        ``True``, so that all of the small parameters in the module are combined
+        into a single contiguous Tensor and sharded once.
+        After this initial sharding is complete, the user can initialize a
+        ``torch.optim.Optimizer`` in the usual way, i.e.::
+        .. code-block:: python
+            optim = torch.optim.Adam(sharded_module.parameters(), lr=0.0001)
+        The optimizer will see only a single slice of parameters and will thus
+        allocate less memory for optimizer state, avoiding redundancy across
+        data parallel workers.
+        """
+        self.numel_padded_per_param = []
+        for p in self.params:
+            assert not hasattr(p, "_is_sharded")
+            assert p.is_floating_point()
+            if self.mixed_precision:
+                assert p.dtype == torch.float32
+
+            # If world_size is 1, then we all-reduce grads instead of sharding.
+            p._is_sharded = self.world_size > 1  # type: ignore[attr-defined]
+            p._orig_size = p.data.size()  # type: ignore[attr-defined]
+
+            if not p._is_sharded:  # type: ignore[attr-defined]
+                self.numel_padded_per_param.append(0)
+                continue
+            p._is_sharded = True  # type: ignore[attr-defined]
+
+            # Replace p.data with the relevant shard.
+            orig_data = p.data
+            p.data, num_padded = self._get_shard(p.data)
+            self.numel_padded_per_param.append(num_padded)
+            free_storage_(orig_data)
+        assert len(self.numel_padded_per_param) == len(self.params)
+
+    def _get_shard(self, tensor: torch.Tensor) -> Tuple[torch.Tensor, int]:
+        """Return the local shard of a full tensor."""
+        # Shard using torch.chunk to match all-gather/reduce-scatter.
+        chunks = list(torch.flatten(tensor).chunk(self.world_size))
+        while len(chunks) < self.world_size:
+            chunks.append(chunks[0].new_empty(0))
+
+        # Determine number of padding elements.
+        num_to_pad = chunks[0].numel() - chunks[self.rank].numel()
+        assert num_to_pad >= 0, num_to_pad
+
+        shard = chunks[self.rank].clone()
+        if num_to_pad > 0:
+            shard = F.pad(shard, [0, num_to_pad])
+        return shard, num_to_pad
+
+    def extra_repr(self) -> str:
+        repr = (
+            f"world_size={self.world_size}, "
+            f"flatten_parameters={self.flatten_parameters}, "
+            f"mixed_precision={self.mixed_precision}, "
+        )
+        if self.verbose:
+            repr = (
+                f"rank={self.rank}, " + repr + f"reshard_after_forward={self.reshard_after_forward}, "
+                f"compute_dtype={self.compute_dtype}, "
+                f"buffer_dtype={self.buffer_dtype}, "
+                f"fp32_reduce_scatter={self.fp32_reduce_scatter}, "
+                f"compute_device={self.compute_device}"
+                f"cpu_offload={self.move_params_to_cpu}, "
+                f"move_grads_to_cpu={self.move_grads_to_cpu}, "
+                f"bucket_cap_mb={self.bucket_cap_mb}, "
+                f"clear_autocast_cache={self.clear_autocast_cache}"
+                f"force_input_to_fp32={self.force_input_to_fp32}"
+            )
+        return repr
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward missing attributes to wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.module, name)
+
+    def __getstate__(self) -> Dict[str, str]:
+        """Serialize the state of the current FSDP instance.
+        Some properties are not serializable (e.g., process groups, streams), so
+        we remove them and try to reconstruct them in :func:`__setstate__`.
+        """
+        state = copy.copy(self.__dict__)
+        state["is_sharded"] = [p._is_sharded for p in self.params]  # type: ignore[attr-defined]
+        state["orig_sizes"] = [p._orig_size for p in self.params]  # type: ignore[attr-defined]
+        if state["process_group"] is not None:
+            state["process_group"] = "MISSING"  # process_group isn't pickleable
+        self._reset_lazy_init()
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Intercept state setting and perform needed changes on params."""
+        super().__setstate__(state)
+
+        def fixup(p: Parameter, is_sharded: bool, size: torch.Size) -> Parameter:
+            assert isinstance(p, Parameter)
+            p.data = p.data.clone()  # move tensors out of shared memory
+            p._is_sharded = is_sharded  # type: ignore[attr-defined]
+            p._orig_size = size  # type: ignore[attr-defined]
+            return p
+
+        self.params = [
+            fixup(p, is_sharded, size) for p, is_sharded, size in zip(self.params, self.is_sharded, self.orig_sizes)
+        ]
+        del self.is_sharded
+        del self.orig_sizes
+        self._reset_lazy_init()
+
+    def named_parameters(self, *args: Any, **kwargs: Any) -> Iterator[Tuple[str, Parameter]]:
+        """Returns an iterator over the module parameters, yielding both the name of the
+        parameter as well as the parameter.
+        With FSDP, the `named_parameters` function implemented in `nn.Module` will not
+        be able to return the name and param when we use flattened parameters unless
+        we call this function under a `summon_full_params` context.
+        If you want the full param to be returned, you should call this function
+        under a `summon_full_params` context when using flattened or original params.
+        """
+        named_param = super().named_parameters(*args, **kwargs)
+        for name, param in named_param:
+            if (
+                hasattr(self, "flatten_parameters")
+                and self.flatten_parameters
+                and hasattr(self, "training_state")
+                and self.training_state != TrainingState.SUMMON_FULL_PARAMS
+            ):
+                yield name, param
+            else:
+                yield _clean_path(name), param
+
+    def __getitem__(self, key: int) -> Any:
+        """Forward indexing calls in case the module is a nn.Sequential."""
+        return self.module.__getitem__(key)
+
+    @typing.overload  # type: ignore[override]
+    def state_dict(
+        self, destination: Mapping[str, torch.Tensor], prefix: str = ..., keep_vars: bool = ...
+    ) -> Mapping[str, torch.Tensor]:
+        ...
+
+    @typing.overload
+    def state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> "OrderedDict[str, torch.Tensor]":
+        ...
+
+    # Since we have overloads above, we can use Any here.
+    def state_dict(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Returns the whole (unsharded) state of the module. Parameters are not
+        sharded, so the resulting state_dict can be loaded directly by the
+        wrapped Module without any sharding-specific logic. Returned tensors
+        will be full precision (e.g., FP32).
+        .. warning:: This needs to be called on all ranks, since synchronization
+            primitives will be used.
+        """
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        self._lazy_init()
+
+        def maybe_cast_buffers(dtype: Optional[torch.dtype] = None) -> None:
+            if self.mixed_precision:
+                self._cast_buffers(dtype=dtype)
+
+        if self._return_full_state_dict:
+            if self.training_state != TrainingState.SUMMON_FULL_PARAMS:
+                with self.summon_full_params(recurse=False, volatile=True):
+                    maybe_cast_buffers(torch.float32)
+                    state_dict = super().state_dict(*args, **kwargs)
+            else:
+                maybe_cast_buffers(torch.float32)
+                state_dict = super().state_dict(*args, **kwargs)
+        else:
+            maybe_cast_buffers(torch.float32)
+            state_dict = self.module.flat_state_dict(*args, **kwargs)
+
+        if self.move_params_to_cpu:
+            for k in state_dict.keys():
+                state_dict[k] = state_dict[k].cpu()
+
+        # In case we are in mixed precision, restore buffers back to buffer_dtype.
+        maybe_cast_buffers()
+        return state_dict
+
+    @typing.overload
+    def local_state_dict(
+        self, destination: Mapping[str, torch.Tensor], prefix: str = ..., keep_vars: bool = ...
+    ) -> Mapping[str, torch.Tensor]:
+        ...
+
+    @typing.overload
+    def local_state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> "OrderedDict[str, torch.Tensor]":
+        ...
+
+    # Since we have overloads above, we can use Any here.
+    def local_state_dict(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Returns the local (sharded) state of the module. Parameters are sharded,
+        so the resulting state_dict can only be loaded after the Module has been
+        wrapped with FSDP.
+        """
+        with contextlib.ExitStack() as stack:
+            # Tell any nested FSDP instances not to auto summon full params.
+            for module in self.modules():  # includes self
+                if isinstance(module, FullyShardedDataParallel):
+                    stack.enter_context(module._no_return_full_state_dict())
+            # We need to specially call FSDP's state_dict function in case
+            # self.state_dict is a function from a child class of FSDP.
+            return FullyShardedDataParallel.state_dict(self, *args, **kwargs)
+
+    @contextlib.contextmanager
+    def _no_return_full_state_dict(self) -> Generator:
+        backup = self._return_full_state_dict
+        self._return_full_state_dict = False
+        try:
+            yield
+        finally:
+            self._return_full_state_dict = backup
+
+    def _load_state_dict(
+        self, state_dict: Union[Dict[str, torch.Tensor], "OrderedDict[str, torch.Tensor]"], strict: bool = True
+    ) -> NamedTuple:
+        """
+        Load a whole (unsharded) state_dict.
+        .. warning:: This needs to be called on all ranks, since synchronization
+            primitives will be used.
+        """
+        if self._return_full_state_dict:
+            with self.summon_full_params():
+                return self.module.load_state_dict(state_dict, strict)
+        else:
+            torch.cuda.synchronize()
+            self._lazy_init()
+            return self.module.load_state_dict(state_dict, strict)
+
+    def load_state_dict(
+        self, state_dict: Union[Dict[str, torch.Tensor], "OrderedDict[str, torch.Tensor]"], strict: bool = True
+    ) -> NamedTuple:
+        return self._load_state_dict(state_dict, strict)
+
+    def load_local_state_dict(
+        self, state_dict: Union[Dict[str, torch.Tensor], "OrderedDict[str, torch.Tensor]"], strict: bool = True
+    ) -> NamedTuple:
+        """Load a local (sharded) state_dict."""
+        with contextlib.ExitStack() as stack:
+            # Tell any nested FSDP instances not to auto summon full params.
+            for module in self.modules():  # includes self
+                if isinstance(module, FullyShardedDataParallel):
+                    stack.enter_context(module._no_return_full_state_dict())
+            output = self._load_state_dict(state_dict, strict)
+        return output
+
+
+    @contextlib.contextmanager
+    def summon_full_params(self, recurse: bool = True, volatile: bool = False) -> Generator:
+        """
+        A context manager to expose full params for the current FSDP instance.
+        Can be useful *after* forward/backward for a model to get the params for
+        additional processing or checking. Parameters will be gathered in full
+        precision (e.g., FP32).
+        .. note:: This can be used on inner FSDPs.
+        .. note:: This can *not* be used within a forward or backward pass. Nor
+            can forward and backward be started from within this context.
+        .. note:: The full parameters will be freed after the context manager
+            exits; it is up to the caller to clone them if needed.
+        .. note:: The full parameters can be modified, but only the portion
+            corresponding to the local param shard will persist after the
+            context manager exits (unless ``volatile=True``, in which case there
+            are no guarantees about persistence).
+        Args:
+            recurse (bool, Optional): recursively summon all params for nested
+                FSDP instances (default: True)
+            volatile (bool, Optional): if ``True``, modifications to params are
+                not guaranteed to persist after the context manager exists;
+                enabling this can be slightly more efficient (default: False)
+        """
+        if recurse:
+            with contextlib.ExitStack() as stack:
+                # Summon all params for any nested FSDP instances.
+                for module in self.modules():
+                    if isinstance(module, FullyShardedDataParallel):
+                        stack.enter_context(module.summon_full_params(recurse=False, volatile=volatile))
+                # Yield to the caller, with full params in all nested instances.
+                yield
+            # Exiting from the ExitStack will re-shard params.
+            return
+        else:
+            torch.cuda.synchronize()
+            self._lazy_init()
+            self.assert_state(TrainingState.IDLE)
+            # Set the state so that we assert when trying to go into
+            # forward/backward.
+            self.training_state = TrainingState.SUMMON_FULL_PARAMS
+            full_tensors = self._rebuild_full_params(force_full_precision=True)
+            assert full_tensors is not None
+            with contextlib.ExitStack() as stack:
+                if self.module.is_flattened:
+                    # Update flattened views to point to fully-sized tensors. We
+                    # use self.params instead of full_tensors since the
+                    # latter may contain padding.
+                    stack.enter_context(
+                        self.module.unflatten_params(
+                            flat_params=[p.data for p in self.params[: self._num_flatten_params]]
+                        )
+                    )
+                try:
+                    yield
+                finally:
+                    stack.close()
+                    assert len(full_tensors) == len(self.params)
+                    for p, (full_tensor, safe_to_free) in zip(self.params, full_tensors):
+                        if not volatile:
+                            # Copy any changes made to the full params back into
+                            # the corresponding local shards.
+                            local_shard, _ = self._get_shard(full_tensor)
+                            p._fp32_shard.copy_(local_shard.view_as(p._fp32_shard))  # type: ignore[attr-defined]
+                        if safe_to_free:
+                            free_storage_(full_tensor)
+                    self.has_full_params = False
+                    self._use_fp32_param_shard()
+                    self.training_state = TrainingState.IDLE
+
+    def _reset_lazy_init(self) -> None:
+        """Reset instance so :func:`_lazy_init` will run on the next forward."""
+        self._is_root: Optional[bool] = None
+        self._streams: Dict[str, torch.cuda.Stream] = {}
+        self._reducer: Optional[ReduceScatterBucketer] = None
+        for p in self.params:
+            if hasattr(p, "_fp32_shard"):
+                # reset _init_param_attributes
+                del p._fp32_shard  # type: ignore[attr-defined]
+
+    def _lazy_init(self) -> None:
+        """Initialization steps that should happen lazily, typically right
+        before the first forward pass.
+        """
+        # Initialize param attributes lazily, in case the param's dtype or
+        # device changes after __init__.
+        for p in self.params:
+            self._init_param_attributes(p)
+
+        # Initialize _is_root and setup streams. These steps would ideally
+        # happen in __init__, but _is_root can only be determined after the
+        # entire model hierarchy is setup, thus we run it lazily.
+        if self._is_root is None:
+            self._set_is_root()
+            self._setup_streams()
+
+        if self._is_root:
+            # Buffers stay on GPU, and don't get sharded. Since _cast_buffers
+            # applies recursively, we only call this from the root instance.
+            self._cast_buffers()
+
+            # Don't free the full params for the outer-most (root) instance,
+            # since those params will be needed immediately after for the
+            # backward pass.
+            self.reshard_after_forward = False
+
+            # Due to the use of streams, we need to make sure the previous
+            # ``optim.step()`` is done before we all-gather parameters.
+            self._wait_for_previous_optim_step()
+
+    @torch.no_grad()
+    def _init_param_attributes(self, p: Parameter) -> None:
+        """
+        We manage several attributes on each Parameter instance. The first two
+        are set by :func:`_shard_parameters_`:
+            ``_is_sharded``: ``True`` if the Parameter is sharded or ``False``
+                if the Parameter is intentionally not sharded (in which case we
+                will all-reduce grads for this param).
+            ``_orig_size``: the size of the original Parameter (before sharding)
+        The remaining attributes are set here:
+            ``_fp32_shard``: a single shard of the parameters in full precision
+                (typically FP32, but this is dependent on the dtype of the model
+                as it's passed in by the user). This can be on CPU or GPU
+                depending on the value of *``cpu_offload``*.
+            ``_fp16_shard``: if *``mixed_precision``* is ``True``, this will be
+                a single shard of the parameters in FP16, used for all-gather.
+            ``_full_param_padded``: the full weight (padded to be evenly
+                divisible by ``world_size``), used for computation in the
+                forward and backward pass. This will be resized in place and
+                only materialized (via all-gather) as needed.
+        """
+        assert hasattr(p, "_is_sharded") and hasattr(p, "_orig_size")
+        if hasattr(p, "_fp32_shard"):
+            return
+
+        # A single shard of the parameters in full precision.
+        p._fp32_shard = p.data  # type: ignore[attr-defined]
+
+        if self.mixed_precision:
+            assert p._fp32_shard.dtype == torch.float32  # type: ignore[attr-defined]
+
+            if self.move_params_to_cpu:
+                assert p._fp32_shard.device == torch.device("cpu")  # type: ignore[attr-defined]
+                # If we plan to keep the FP32 parameters on CPU, then pinning
+                # memory allows us to later use non-blocking transfers when moving
+                # the FP32 param shard to compute_device.
+                p._fp32_shard = p._fp32_shard.pin_memory()  # type: ignore[attr-defined]
+                p.data = p._fp32_shard  # type: ignore[attr-defined]
+
+            # In mixed precision mode, we maintain a reduced precision
+            # (typically FP16) parameter shard on compute_device for performing
+            # the computation in the forward/backward pass. We resize the
+            # storage to size 0 at init (here) and re-materialize (by copying
+            # from _fp32_shard) as needed.
+            p._fp16_shard = torch.zeros_like(  # type: ignore[attr-defined]
+                p._fp32_shard,  # type: ignore[attr-defined]
+                device=self.compute_device,
+                dtype=self.compute_dtype
+            )
+            free_storage_(p._fp16_shard)  # type: ignore[attr-defined]
+        else:
+            # use _fp32_shard
+            p._fp16_shard = None  # type: ignore[attr-defined]
+
+        # We also maintain a full-sized parameter of type self.compute_dtype
+        # (FP16 for mixed_precision or FP32 otherwise). We resize the
+        # storage to size 0 at init (here) and only materialize as needed. The
+        # storage may contain padding elements so that it is evenly divisible by
+        # world_size, although these padding elements will be removed before the
+        # relevant computation.
+        if p._is_sharded:  # type: ignore[attr-defined]
+            p._full_param_padded = torch.zeros(  # type: ignore[attr-defined]
+                p.data.numel() * self.world_size, device=self.compute_device, dtype=self.compute_dtype
+            )
+            free_storage_(p._full_param_padded)  # type: ignore[attr-defined]
+
+        if self.move_grads_to_cpu:
+            # We can optionally move the grad shard to CPU during the backward
+            # pass. In this case, it's important to pre-allocate the CPU grad
+            # shard in pinned memory so that we can do a non-blocking transfer.
+            p._cpu_grad = torch.zeros_like(p.data, device="cpu").pin_memory()  # type: ignore[attr-defined]
+
+    def _set_is_root(self) -> None:
+        """If ``True``, implies that no other :class:`FullyShardedDataParallel`
+        instance wraps this one. Called once by :func:`_lazy_init`.
+        Also sets self.children_share_process_group = True if all child
+        instances share the same process group. If some child instances use a
+        different process group, self.clip_grad_norm_ will raise an error.
+        """
+        if self._is_root is not None:
+            return
+        # No FSDP instance wraps this, else _is_root would be set to False.
+        self._is_root = True
+        # If final backward callback is never been queued, state should be IDLE.
+        # If final backward callback is queued, the callback should be finished
+        # and the state was reset to be IDLE.
+        # This should be asserted at the beginning of forward pass in the root instance only.
+        # For children instances, if they are checkpointed, state will not be reset to
+        # IDLE after each inner forward/backward.
+        self.assert_state(TrainingState.IDLE)
+        # Check if the root instance is being checkpointed. It doesn't make sense to
+        # checkpoint the root instance since it won't save GPU memory.
+        assert (
+            getattr(self, "_checkpoint_fwd_counter", 0) == 0
+        ), "Is the root FSDP module wrapping an activation checkpointed module? If so, please remove that."
+        # As the root, we now set all children instances to False and
+        # give them a closure to try to queue a wait_for_post_backward.
+        self.children_share_process_group = True
+        for n, m in self.named_modules():
+            # `n != ""` excludes self.
+            if n != "" and isinstance(m, FullyShardedDataParallel):
+                # We relax the assert for non-root instance, when the nested inialized module is wrapped
+                # again in FSDP later, for example after training to run inference.
+                assert m._is_root is None or not m._is_root
+                if m._is_root is None:
+                    m._is_root = False
+                if m.process_group != self.process_group:
+                    self.children_share_process_group = False
+
+                # if child instance in its own (smaller) world, that was probably an attempt to avoid OOM.
+                # Therefore gathering this child's optim state will probably cause OOM, so we won't do it.
+                m.no_broadcast_optim_state = m.no_broadcast_optim_state or (
+                    (m.world_size == 1) and (m.world_size < self.world_size) and (m.process_group != self.process_group)
+                )
+
+    def _setup_streams(self) -> None:
+        """Create streams to overlap data transfer and computation."""
+        if len(self._streams) > 0 or not self._is_root:
+            return
+
+        if torch.cuda.is_available():
+            # Stream to move main FP32 params (may be on CPU) to FP16 for forward.
+            self._streams["fp32_to_fp16"] = torch.cuda.Stream()
+            # Stream for all-gathering parameters.
+            self._streams["all_gather"] = torch.cuda.Stream()
+            # Stream for overlapping grad reduction with the backward pass.
+            self._streams["post_backward"] = torch.cuda.Stream()
+
+        # Helper for bucketing reduce-scatter ops. This is also shared with
+        # children instances to improve bucket utilization.
+        self._reducer = ReduceScatterBucketer(self.bucket_cap_mb)
+        # We share streams with all children instances, which allows them to
+        # overlap transfers across the forward pass without synchronizing with
+        # the default stream.
+        for n, m in self.named_modules():
+            if n != "" and isinstance(m, FullyShardedDataParallel):
+                m._streams = self._streams
+                m._reducer = self._reducer
+
+    def _wait_for_previous_optim_step(self) -> None:
+        """
+        The outer-most :class:`FullyShardedDataParallel` instance (i.e., the root
+        instance) needs to synchronize with the default stream to ensure the
+        previous optimizer step is done.
+        """
+        if not torch.cuda.is_available():
+            return
+        if self.mixed_precision:
+            self._streams["fp32_to_fp16"].wait_stream(torch.cuda.current_stream())
+        else:
+            self._streams["all_gather"].wait_stream(torch.cuda.current_stream())
+
+    def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        self._lazy_init()
+
+        # Start of a forward pass.
+        self.training_state = TrainingState.FORWARD
+
+        # For root and mixed precision, we convert the input to FP16 (no_grad is needed for
+        # the conversion).
+        if self._is_root and self.mixed_precision:
+            args, kwargs = cast_floats_to_right_precision(True, True, *args, **kwargs)
+
+        # If enabled, convert the input to FP32 if we are in full precision.
+        # no_grad is not used because the input might be for a non-root instance,
+        # which mean autograd needs to go through the conversion.
+        if self.force_input_to_fp32 and not self.mixed_precision:
+            args, kwargs = cast_floats_to_right_precision(False, False, *args, **kwargs)
+
+        # All-gather full parameters. This will also transfer FP32 parameters to
+        # ``self.compute_dtype`` (e.g., FP16 if *mixed_precision* is ``True``).
+        self._rebuild_full_params()
+
+        # Register backward hooks to reshard params and reduce-scatter grads.
+        # These need to be re-registered every forward pass.
+        self._register_post_backward_hooks()
+
+        outputs = self.module(*args, **kwargs)
+
+        if self.reshard_after_forward:
+            self._free_full_params()
+            if self.mixed_precision:
+                self._free_fp16_param_shard()
+
+        # Switch to main FP32 param shard. We maintain this invariant throughout
+        # the code, i.e., ``p.data == p._fp32_shard`` after each function. This
+        # also ensures that after the first forward, the optimizer state will be
+        # initialized with the correct dtype and (sharded) size, since optimizer
+        # state is typically initialized lazily in ``optim.step()``.
+        self._use_fp32_param_shard()
+
+        # Register pre-backward hooks to all-gather the params for the backward
+        # pass (if output's grad was needed). This won't register anything if
+        # we are in eval mode.
+        #
+        # Some model does forward pass multiple times, we need to register the
+        # pre-backward hook on every output since the last output's hook has to
+        # fire first to setup for backward. However, we use ``self._pre_backward_hook_has_run``
+        # to prevent repeated overhead from multiple hook callbacks.
+        outputs = self._register_pre_backward_hooks(outputs)
+
+        # Done with a forward pass.
+        self.training_state = TrainingState.IDLE
+
+        # Only need to clear cache during forward. During backward, the cache is not used.
+        # TODO (Min): Future PyTorch versions may provide a way to completely disable this
+        #     cache. Update this when that's available.
+        if self.clear_autocast_cache:
+            torch.clear_autocast_cache()
+
+        return outputs
+
+    def _register_pre_backward_hooks(self, outputs: Any) -> Any:
+        """Register pre-backward hook to run before the wrapped module's
+        backward. Hooks should be attached to all outputs from the forward.
+        Returns:
+            outputs: new outputs with hooks registered if they requires gradient.
+        """
+        if not torch.is_grad_enabled():
+            return outputs  # don't register hooks if grad isn't enabled
+
+        if self._is_root:
+            # This actually means that only root instance has
+            # _post_backward_callback_queued defined. Accidentally accessing this field
+            # will assert on all other instances, giving us a nice bug checker.
+            self._post_backward_callback_queued = False
+
+        def _pre_backward_hook(*unused: Any) -> None:
+            # try to queue final backward callback only once for root, so
+            # that final backward callback is attached to the outer most
+            # backward graph task and called after all the backward
+            # calls are completed.
+            if self._is_root:
+                self._queue_wait_for_post_backward()
+
+            # All-gather full parameters or switching to the full params.
+            #
+            # This needs to be done on every pre_backward hook, even within the same
+            # iteration (i.e. for checkpointed, multiple forward pass modules). This is
+            # because after the forward pass (i.e. in checkpoint inner graph), we always
+            # switch to fp32_shard in the ``forward`` function.
+            #
+            # Note, both ``self._rebuild_full_params`` and ``self._use_full_params`` are
+            # idempotent.  So in case they are called unnecessarily, they don't incur much
+            # overhead.
+            if self.reshard_after_forward:
+                self._rebuild_full_params()
+            else:
+                self._use_full_params()
+
+            # Only run the ``self._prep_grads_for_backward`` once per iteration (i.e. in case
+            # it is multiple outputs or multiple forward passes).
+            if self._pre_backward_hook_has_run:
+                return  # only run once (from multiple outputs or multiple forward passes)
+            self._pre_backward_hook_has_run = True
+
+            # Start of a backward pass for the first time in an iteration.
+            self.assert_state([TrainingState.IDLE, TrainingState.BACKWARD_PRE])
+            self.training_state = TrainingState.BACKWARD_PRE
+
+            # Prepare p.grad so that it is in the right shape, device, accumulated values, etc.
+            self._prep_grads_for_backward()
+
+        def _register_hook(t: torch.Tensor) -> torch.Tensor:
+            if t.requires_grad:
+                t.register_hook(_pre_backward_hook)
+            return t
+
+        # Attach hooks to Tensor outputs.
+        outputs = apply_to_tensors(_register_hook, outputs)
+
+        return outputs
+
+    def _register_post_backward_hooks(self) -> None:
+        """
+        Register backward hooks to reshard params and reduce-scatter grads.
+        This is called during forward pass. The goal is to attach a hook
+        on each of the parameter's gradient generating function (``grad_acc``
+        below) so that the hook is called *after* all gradients for that
+        param are computed.
+        Goals:
+        1. We want the hook to fire once and only once *after* all gradients
+        are accumulated for a param.
+        2. If it fires more than once, we end up incorrectly shard the grad
+        multiple times. (could lead to dimension too small)
+        3. If it fires once but too early or doesn't fire, we leave gradients
+        unsharded. (could lead to dimension too large)
+        Due to multiple-pass forward, this function can be called on
+        the same parameter multiple times in a single forward pass. If we register
+        the hook multiple time, we end up getting called multiple times. We
+        could try to get a new hook every time and delete the previous one
+        registered. However, due to *unknown reason* (I have debugged it for
+        a long time!), in mixed precision mode, we get two different ``grad_acc``
+        objects below during different calls of this function (in the same
+        forward pass). If we keep the last one, the hook end up firing too
+        early. In full precision mode, we luckily get the *same* ``grad_acc``
+        object, so deleting and re-registering still ensured the hook fire
+        once after all gradients are generated.
+        Empirically, keep the first hook register per forward pass seems to
+        work the best. We do need to remove the hook at the end of the
+        backward pass. Otherwise, the next forward pass will not register
+        a new hook, which is needed for a new forward pass.
+        """
+        if not torch.is_grad_enabled():
+            return  # don't register grad hooks if grad isn't enabled
+        for p in self.params:
+            if p.requires_grad:
+                if hasattr(p, "_shard_bwd_hook"):
+                    continue
+                # Register a hook on the first call, empirically, autograd
+                # fires it at the end for this param, which makes sense.
+                p_tmp = p.expand_as(p)  # Get a grad_fn on p_tmp.
+                assert p_tmp.grad_fn is not None
+                grad_acc = p_tmp.grad_fn.next_functions[0][0]  # Gets its GradAccumulation object.
+                handle = grad_acc.register_hook(functools.partial(self._post_backward_hook, p))
+                p._shard_bwd_hook = (grad_acc, handle)  # type: ignore[attr-defined]
+
+    @torch.no_grad()
+    def _post_backward_hook(self, param: Parameter, *unused: Any) -> None:
+        """
+        At the start of :func:`_post_backward_hook`, ``param.grad`` contains the
+        full gradient for the local batch. The reduce-scatter op will replace
+        ``param.grad`` with a single shard of the summed gradient across all
+        GPUs. This shard will align with the current GPU rank. For example::
+            before reduce_scatter:
+                param.grad (GPU #0): [1, 2, 3, 4]
+                param.grad (GPU #1): [5, 6, 7, 8]
+            after reduce_scatter:
+                param.grad (GPU #0): [6, 8]    # 1+5, 2+6
+                param.grad (GPU #1): [10, 12]  # 3+7, 4+8
+        The local GPU's ``optim.step`` is responsible for updating a single
+        shard of params, also corresponding to the current GPU's rank. This
+        alignment is created by :func:`_shard_parameters_`, which ensures that
+        the local optimizer only sees the relevant parameter shard.
+        """
+        # First hook callback will see PRE state. If we have multiple params,
+        # then subsequent hook callbacks will see POST state. When checkpoint
+        # fwd counter is used, IDLE is also possible since the pre-backward hook
+        # is not triggered (see ``auto_wrap_bn`` below, we have to use
+        # FSDP(checkpoint(conv, FSDP(bn), ...)), with reshard_after_forward=False).
+        if hasattr(self, "_checkpoint_fwd_counter"):
+            self.assert_state([TrainingState.BACKWARD_PRE, TrainingState.BACKWARD_POST, TrainingState.IDLE])
+        else:
+            self.assert_state([TrainingState.BACKWARD_PRE, TrainingState.BACKWARD_POST])
+        self.training_state = TrainingState.BACKWARD_POST
+        if param.grad is None:
+            return
+
+        if param.grad.requires_grad:
+            raise RuntimeError("FSDP only works with gradients that don't require gradients")
+
+        # If this is a checkpointed module, we check if the following
+        # counter reaches 0. If not, it is not the final backward call
+        # for this module yet. Therefore, we early return in that case.
+        if hasattr(self._fsdp_wrapped_module, "_checkpoint_fwd_counter"):
+            if self._fsdp_wrapped_module._checkpoint_fwd_counter != 0:
+                return
+
+        if self._require_backward_grad_sync or self.reshard_after_forward:
+            # Free full params. As a special case, we don't free the full params
+            # when in a ``no_sync`` context (as inversely indicated by
+            # ``self._require_backward_grad_sync``), since the params will not
+            # get updated before the next forward. This saves networking
+            # bandwidth but uses more GPU memory.
+            self._free_full_params([param])
+
+        if self.mixed_precision:
+            # This is a no-op if reshard_after_forward is True, since we already
+            # free the param shard when rebuilding the full params in the
+            # pre_backward_hook.
+            self._free_fp16_param_shard([param])
+
+        # Switch to FP32 shard after backward.
+        self._use_fp32_param_shard([param])
+
+        if not self._require_backward_grad_sync:
+            return
+
+        # Wait for all work in the current stream to finish, then start the
+        # reductions in post_backward stream.
+        self._streams["post_backward"].wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._streams["post_backward"]):
+            orig_grad_data = param.grad.data
+
+            if self.mixed_precision and self.fp32_reduce_scatter:
+                # Cast grad to FP32.
+                param.grad.data = param.grad.data.to(param.dtype)
+
+            if self.gradient_predivide_factor > 1:
+                # Average grad by world_size for consistency with PyTorch DDP.
+                param.grad.data.div_(self.gradient_predivide_factor)
+
+            callback_fn = functools.partial(self._post_reduction_hook, param)
+            if param._is_sharded:  # type: ignore[attr-defined]
+                assert param._is_sharded  # type: ignore[attr-defined]
+                assert self._reducer is not None
+                grad_chunks = chunk_and_pad(param.grad.data, self.world_size)
+                self._reducer.reduce_scatter_async(grad_chunks, group=self.process_group, callback_fn=callback_fn)
+            else:
+                # Currently the only way for _is_sharded to be False is if
+                # world_size == 1. This could be relaxed in the future, in which
+                # case grads should be all-reduced here.
+                assert self.world_size == 1
+                callback_fn(param.grad.data)
+
+            # After _post_backward_hook returns, orig_grad_data will eventually
+            # go out of scope, at which point it could otherwise be freed for
+            # further reuse by the main stream while the div/reduce_scatter/copy
+            # are underway in the post_backward stream. See:
+            # github.com/NVIDIA/apex/blob/master/apex/parallel/distributed.py
+            orig_grad_data.record_stream(self._streams["post_backward"])
+
+    def _post_reduction_hook(self, param: Parameter, reduced_grad: torch.Tensor) -> None:
+        """Hook to call on each param after the reduce-scatter."""
+        assert torch.cuda.current_stream() == self._streams["post_backward"]
+        assert param.grad is not None
+        self.assert_state(TrainingState.BACKWARD_POST)
+        param.grad.data = reduced_grad
+        if self.gradient_postdivide_factor > 1:
+            # Average grad by world_size for consistency with PyTorch DDP.
+            param.grad.data.div_(self.gradient_postdivide_factor)
+        # Cast grad to param's dtype (typically FP32). Note: we do this
+        # before the move_grads_to_cpu step so that this entire hook remains
+        # non-blocking. The downside is a bit more D2H transfer in that case.
+        if self.mixed_precision:
+            orig_param_grad_data = param.grad.data
+            param.grad.data = param.grad.data.to(dtype=param.data.dtype)
+            # Don't let this memory get reused until after the transfer.
+            orig_param_grad_data.record_stream(torch.cuda.current_stream())  # type: ignore[arg-type]
+        if hasattr(param, "_saved_grad_shard") and param._saved_grad_shard is not None:  # type: ignore[attr-defined]
+            assert (
+                param._saved_grad_shard.shape == param.grad.shape  # type: ignore[attr-defined]
+            ), f"{param._saved_grad_shard.shape} vs {param.grad.shape}"  # type: ignore[attr-defined]
+            param.grad.data += param._saved_grad_shard  # type: ignore[attr-defined]
+            delattr(param, "_saved_grad_shard")
+        # Optionally move gradients to CPU, typically used if one is running
+        # the optimizer on the CPU.
+        if self.move_grads_to_cpu:
+            param._cpu_grad.copy_(param.grad.data, non_blocking=True)  # type: ignore[attr-defined]
+            # Don't let this memory get reused until after the transfer.
+            param.grad.data.record_stream(torch.cuda.current_stream())  # type: ignore[arg-type]
+            param.grad.data = param._cpu_grad  # type: ignore[attr-defined]
+
+    def _queue_wait_for_post_backward(self) -> None:
+        """Try to queue a `wait_for_post_backward` callback.
+        Only called on root and only queue one callback at the beginning of
+        outer most backward.
+        """
+        assert self._is_root
+        if not self._post_backward_callback_queued:
+            self.assert_state([TrainingState.IDLE])
+            self._post_backward_callback_queued = True
+            Variable._execution_engine.queue_callback(self._wait_for_post_backward)
+
+    @torch.no_grad()
+    def _wait_for_post_backward(self) -> None:
+        """Wait for post-backward to finish. Only called on root instance."""
+        assert self._is_root
+        # Check if the root module has params and if any of them has
+        # the `requires_grad` field set. If `requires_grad=False` for
+        # all the params, the post_backward hook will not fire and the
+        # state will remain in `TrainingState.BACKWARD_PRE`.
+        if any([p.requires_grad for p in self.params]):
+            self.assert_state(TrainingState.BACKWARD_POST)
+        else:
+            self.assert_state(TrainingState.BACKWARD_PRE)
+
+        if self._require_backward_grad_sync:
+            # Flush any unreduced buckets in the post_backward stream.
+            with torch.cuda.stream(self._streams["post_backward"]):
+                assert self._reducer is not None
+                self._reducer.flush()
+            torch.cuda.current_stream().wait_stream(self._streams["post_backward"])
+            if self.move_grads_to_cpu:
+                # Wait for the non-blocking GPU -> CPU grad transfers to finish.
+                torch.cuda.current_stream().synchronize()
+
+        # A backward pass is done, clean up below.
+
+        # Free reducer buffers.
+        if self._reducer is not None:
+            self._reducer.teardown()
+
+        def _remove_shard_bwd_hook(fsdp_module: FullyShardedDataParallel) -> None:
+            """Helper used below on all fsdp modules."""
+            for p in fsdp_module.params:
+                if p.requires_grad:
+                    if hasattr(p, "_shard_bwd_hook"):
+                        assert len(p._shard_bwd_hook) == 2, len(p._shard_bwd_hook)  # type: ignore[attr-defined]
+                        p._shard_bwd_hook[1].remove()  # type: ignore[attr-defined]
+                        delattr(p, "_shard_bwd_hook")
+
+        # Update root and nested FSDP's hooks and flags.
+        for m in self.modules():  # includes self
+            if isinstance(m, FullyShardedDataParallel):
+                _remove_shard_bwd_hook(m)
+                m._pre_backward_hook_has_run = False
+                if any(p.requires_grad for p in m.parameters()):
+                    # Check if the module has params and if any of them has
+                    # the `requires_grad` field set. If `requires_grad=False` for
+                    # all the params, the post_backward hook will not fire and the
+                    # state will remain in `TrainingState.BACKWARD_PRE`.
+                    if any([p.requires_grad for p in m.params]):
+                        m.assert_state(TrainingState.BACKWARD_POST)
+                    else:
+                        m.assert_state(TrainingState.BACKWARD_PRE)
+                else:
+                    # When `m` and its children has no params or has params but
+                    # none with `requires_grad==True`, there are two cases:
+                    # 1. output tensors are `requires_grad==True`. In this case,
+                    # pre-backward hook is still registered, so it is in BACKWARD_PRE state.
+                    # 2. output tensors are `requires_grad==False`. In this case,
+                    # pre-backward hook is not registered, so it is in IDLE state.
+                    m.assert_state([TrainingState.BACKWARD_PRE, TrainingState.IDLE])
+                m.training_state = TrainingState.IDLE
+
+                if m._is_root:
+                    # reset this flag for cases like "one forward pass + multiple backward passes"
+                    self._post_backward_callback_queued = False
+
+    @torch.no_grad()
+    def _rebuild_full_params(self, force_full_precision: bool = False) -> Optional[List[Tuple[torch.Tensor, bool]]]:
+        """
+        Gather all shards of params.
+
+        Note, this is idempotent if full params are already gathered. Callers
+        assume the idempotency. So please keep it that way.
+
+        Args:
+            force_full_precision (bool, Optional): by default params will be gathered
+                in ``compute_dtype`` (e.g., FP16), unless *force_full_precision* is
+                ``True``, in which case they will be gathered in full precision
+                (e.g., FP32), possibly in fresh storage. The parameter that's being
+                rebuilt will end up in full precision as well.
+        Returns:
+            A list of tuples, where the first element is the full-sized param
+            and the second element is a bool indicating if it's safe for the
+            caller to free the full-sized param. This will be ``None`` if
+            ``force_full_precision=False`` and the full params are already gathered.
+        """
+        output_tensors: List[Tuple[torch.Tensor, bool]] = []
+
+        def update_p_data(custom_output_tensor: Optional[torch.Tensor] = None) -> None:
+            """
+            Helper function to update p.data pointer.
+            Args:
+                custom_output_tensor (torch.Tensor, Optional): if not None, this
+                tensor contains the data we just gathered.
+            """
+            if custom_output_tensor is not None:
+                assert p._is_sharded  # type: ignore[attr-defined]
+                p.data = custom_output_tensor
+                output_tensors.append((p.data, True))
+            elif not p._is_sharded:  # type: ignore[attr-defined]
+                if self.mixed_precision and not force_full_precision:
+                    assert p._fp16_shard is not None  # type: ignore[attr-defined]
+                    p.data = p._fp16_shard  # type: ignore[attr-defined]
+                    output_tensors.append((p.data, True))
+                else:
+                    # Here p.data == p._fp32_shard, so it's not safe to free.
+                    output_tensors.append((p.data, False))
+            else:
+                p.data = p._full_param_padded  # type: ignore[attr-defined]
+                output_tensors.append((p.data, True))
+            # Trim any padding and reshape to match original size.
+            p.data = p.data[: p._orig_size.numel()].view(p._orig_size)  # type: ignore[attr-defined]
+
+        # Early exit if we already have full params and don't need full precision.
+        if self.has_full_params and not force_full_precision:
+            for p in self.params:
+                update_p_data()
+            return output_tensors
+
+        self.has_full_params = True
+
+        with torch.cuda.stream(self._streams["all_gather"]):
+            if self.mixed_precision and not force_full_precision:
+                self._cast_fp32_param_shards_to_fp16()
+
+            for p in self.params:
+                # e.g., when world_size == 1
+                if not p._is_sharded:  # type: ignore[attr-defined]
+                    update_p_data()
+                else:
+                    # If self.move_params_to_cpu and force_full_precision, we need to cast
+                    # the FP32 CPU param to CUDA for the all-gather.
+                    p_data = p.data.to(p._full_param_padded.device, non_blocking=True)  # type: ignore[attr-defined]
+
+                    p_size = p._full_param_padded.size()  # type: ignore[attr-defined]
+                    assert p_size.numel() % self.world_size == 0
+                    if self.mixed_precision and force_full_precision:
+                        # Allocate fresh tensor in full precision since we are in
+                        # mixed precision and full precision rebuild is asked.
+                        output_tensor = p_data.new_zeros(p_size)
+                    else:
+                        if p._full_param_padded.storage().size() != p_size.numel():  # type: ignore[attr-defined]
+                            # Allocate based on full size from all shards.
+                            alloc_storage_(p._full_param_padded, size=p_size)  # type: ignore[attr-defined]
+                        output_tensor = p._full_param_padded  # type: ignore[attr-defined]
+
+                    # Fill output_tensor with (p.data for each shard in self.world_size)
+                    if hasattr(dist, "_all_gather_base"):
+                        # New version of PyTorch has all_gather_base, which is faster than chunk and then all_gather.
+                        dist._all_gather_base(output_tensor, p_data, group=self.process_group)
+                    else:
+                        chunks = list(output_tensor.chunk(self.world_size))
+                        dist.all_gather(chunks, p_data, group=self.process_group)
+
+                    # Set p.data = output_tensor (with padding trimmed)
+                    update_p_data(output_tensor)
+
+                    if self.mixed_precision and not force_full_precision:
+                        self._free_fp16_param_shard([p])
+        torch.cuda.current_stream().wait_stream(self._streams["all_gather"])
+        return output_tensors
+
+    @torch.no_grad()
+    def _use_full_params(self) -> None:
+        """
+        Switch p.data pointers to use the full params.
+        Note: this assumes full params are already gathered.
+
+        Note: this might be called after full_params is already in used. So please
+              make sure it is idempotent in that case.
+        """
+        assert self.has_full_params
+        for p in self.params:
+            if not p._is_sharded:  # type: ignore[attr-defined]
+                if self.mixed_precision:
+                    assert p._fp16_shard is not None  # type: ignore[attr-defined]
+                    assert p._fp16_shard.storage().size() != 0  # type: ignore[attr-defined]
+                    p.data = p._fp16_shard  # type: ignore[attr-defined]
+            else:
+                assert p._full_param_padded.storage().size() != 0  # type: ignore[attr-defined]
+                p.data = p._full_param_padded[: p._orig_size.numel()].view(p._orig_size)  # type: ignore[attr-defined]
+
+    @torch.no_grad()
+    def _prep_grads_for_backward(self) -> None:
+        """
+        Make sure p.grad is correctly prepared for the backward with
+        right shape, device, accumulated values, etc.
+        """
+        for p in self.params:
+            if p.grad is not None:
+                if p.grad.device != p.data.device:
+                    p.grad = None
+                elif p.grad.size() == p._orig_size:  # type: ignore[attr-defined]
+                    # This is gradient accumulation with no_sync context.
+                    pass
+                elif p.grad.size() == p._fp32_shard.shape:  # type: ignore[attr-defined]
+                    # This is gradient accumulation without no_sync context.
+                    # We save the grad shard and set p.grad to None for this backward pass.
+                    # We will accumulate after this pass's grad is generated and reduced and
+                    # sharded.
+                    p._saved_grad_shard = p.grad.data  # type: ignore[attr-defined]
+                    p.grad = None
+                else:
+                    raise AssertionError(f"unexpected grad shape: {p.grad.size()}")
+
+    @torch.no_grad()
+    def _free_full_params(self, params: Optional[List[Parameter]] = None) -> None:
+        """Free up storage for full parameters."""
+        if params is None:
+            params = self.params
+        self.has_full_params = False
+        current_stream = torch.cuda.current_stream()
+        for p in params:
+            # e.g., world_size == 1
+            if not p._is_sharded:  # type: ignore[attr-defined]
+                if self.mixed_precision:
+                    self._free_fp16_param_shard([p])
+                continue
+            # Don't let PyTorch reuse this memory until all work in the current
+            # stream is complete.
+            p._full_param_padded.record_stream(current_stream)  # type: ignore[attr-defined]
+            # There may be external references to the Tensor Storage that we
+            # can't modify, such as references that are created by
+            # ctx.save_for_backward in the forward pass. Thus when we
+            # unshard parameters, we should reuse the original Tensor
+            # Storage object and unshard it in-place. For now, just resize
+            # the Storage to 0 to save memory.
+            free_storage_(p._full_param_padded)  # type: ignore[attr-defined]
+
+
+    @torch.no_grad()
+    def _use_fp32_param_shard(self, params: Optional[List[Parameter]] = None) -> None:
+        """Use FP32 shard for a list of params."""
+        if params is None:
+            params = self.params
+        for p in params:
+            p.data = p._fp32_shard  # type: ignore[attr-defined]
+
+    @torch.no_grad()
+    def _cast_fp32_param_shards_to_fp16(self, params: Optional[List[Parameter]] = None) -> None:
+        """Cast FP32 param shard to FP16 for a list of params."""
+        if params is None:
+            params = self.params
+        with torch.cuda.stream(self._streams["fp32_to_fp16"]):
+            for p in params:
+                assert p._fp16_shard is not None  # type: ignore[attr-defined]
+                alloc_storage_(p._fp16_shard, size=p._fp32_shard.size())  # type: ignore[attr-defined]
+                p._fp16_shard.copy_(  # type: ignore[attr-defined]
+                    # If cpu_offload is True, this will be non-blocking because
+                    # _fp32_shard is pinned, otherwise it's a no-op.
+                    p._fp32_shard.to(p._fp16_shard.device, non_blocking=True)  # type: ignore[attr-defined]
+                )
+                p.data = p._fp16_shard  # type: ignore[attr-defined]
+        torch.cuda.current_stream().wait_stream(self._streams["fp32_to_fp16"])
+
+    @torch.no_grad()
+    def _free_fp16_param_shard(self, params: Optional[List[Parameter]] = None) -> None:
+        """Free storage for FP16 shards for a list of params."""
+        if params is None:
+            params = self.params
+        current_stream = torch.cuda.current_stream()
+        for p in params:
+            if p._fp16_shard is not None:  # type: ignore[attr-defined]
+                # _fp16_shard is allocated in "fp32_to_fp16" stream, so we can't
+                # free it until the work in the current stream completes.
+                p._fp16_shard.record_stream(current_stream)  # type: ignore[attr-defined]
+                free_storage_(p._fp16_shard)  # type: ignore[attr-defined]
+
+    def assert_state(self, state: Union[TrainingState, List[TrainingState]]) -> None:
+        """Assert we are in the given state."""
+        # Since assert can be turned off and this error checking
+        # is really important, we use explicit error checking
+        # and raise a ValueError if needed.
+        if isinstance(state, TrainingState):
+            state = [state]
+        if self.training_state not in state:
+            msg = f"expected to be in states {state} but current state " f"is {self.training_state}"
+            # In case we are failing in the context of autograd hook, asserting
+            # may not generate useful msg. So, let's print it to be sure.
+            if self.rank == 0:
+                print(f"Asserting FSDP instance is: {self}")
+                print(f"ERROR: {msg}")
+                traceback.print_stack()
+            raise ValueError(msg)
+
+
+    @property
+    def _fsdp_instances(self) -> List[nn.Module]:
+        """Returns all fsdp modules in self.modules() including self."""
+        return [m for m in self.modules() if isinstance(m, FullyShardedDataParallel)]
+
+
+    def _print_r0(self, msg: str, restart: bool = False) -> None:
+        """Debugging utility to print memory usage stats nicely on rank 0"""
+        if restart:
+            self._tstart = time.time()
+        if self.rank == 0:
+            gb_denom = 1024 ** 3
+            logging.info(
+                f"{msg} cur={torch.cuda.memory_allocated()/gb_denom: .4f} GB, \
+                max={torch.cuda.max_memory_allocated()/gb_denom: .4f} GB, t={time.time()-self._tstart: .1f}"
+            )
+
+    # Note: This property will be deprecated in an upcoming release in favor of `move_params_to_cpu`.
+    @property
+    def cpu_offload(self) -> bool:
+        return self.move_params_to_cpu
+
+
+def _get_default_cuda_device(module: nn.Module) -> torch.device:
+    """Try to infer CUDA device from module parameters."""
+    try:
+        compute_device = next(module.parameters()).device
+        if compute_device.type == "cuda":
+            return compute_device
+    except StopIteration:
+        pass
+    # Fall back to current CUDA device
+    return torch.device("cuda")
+
+
+def cast_floats_to_right_precision(to_fp16: bool, no_grad: bool, *args: Any, **kwargs: Any) -> Tuple[Any, Any]:
+    """
+    Cast floating point Tensors in *args or **kwargs to FP16 or FP32 if they are not.
+    We also retain the requires_grad flag so that casting doesn't affect the autograd graph.
+    """
+
+    def fn_fp16(x: torch.Tensor) -> torch.Tensor:
+        if x.dtype is torch.float32:
+            y = x.half()
+            if x.is_leaf:
+                y.requires_grad = x.requires_grad
+            return y
+        return x
+
+    def fn_fp32(x: torch.Tensor) -> torch.Tensor:
+        if x.dtype is torch.float16:
+            y = x.float()
+            if x.is_leaf:
+                y.requires_grad = x.requires_grad
+            return y
+        return x
+
+    fn = fn_fp16 if to_fp16 else fn_fp32
+    context = torch.no_grad() if no_grad else contextlib.suppress()
+    with context:  # type: ignore[attr-defined]
+        return apply_to_tensors(fn, args), apply_to_tensors(fn, kwargs)
+
+
+def free_storage_(data: torch.Tensor) -> None:
+    """Free underlying storage of a Tensor."""
+    if data.storage().size() > 0:
+        # Since we're modifying the Tensor's Storage directly, make sure the Tensor
+        # is the sole occupant of the Storage.
+        assert data.storage_offset() == 0
+        data.storage().resize_(0)  # type: ignore[attr-defined]
+
+
+@torch.no_grad()
+def alloc_storage_(data: torch.Tensor, size: torch.Size) -> None:
+    """Allocate storage for a tensor."""
+    if data.storage().size() == size.numel():  # no need to reallocate
+        return
+    assert data.storage().size() == 0
+    data.storage().resize_(size.numel())  # type: ignore[attr-defined]
+
+
+def _post_state_dict_hook(
+    module: FullyShardedDataParallel, state_dict: "OrderedDict[str, torch.Tensor]", prefix: str, *args: Any
+) -> "OrderedDict[str, torch.Tensor]":
+    # Assuming we are in a ``summon_full_params()`` context, we need to clone
+    # each tensor so that it does not get freed (in-place) when the context
+    # exits. At the same time, this hook can be called multiple times
+    # recursively, so we need to make sure that we only clone each tensor at
+    # most once. Thus we add an attribute on the tensor called "_has_been_cloned"
+    # which keeps track of tensors that are no longer at risk of being freed.
+    for key in state_dict.keys():
+        if not key.startswith(prefix) or getattr(state_dict[key], "_has_been_cloned", False):
+            continue
+        if state_dict[key].device.type != module.state_dict_device.type:
+            state_dict[key] = state_dict[key].to(device=module.state_dict_device)
+            state_dict[key]._has_been_cloned = True  # type: ignore[attr-defined]
+        elif module.training_state == TrainingState.SUMMON_FULL_PARAMS:
+            # We copy the state_dict since full param will be freed after we
+            # exit the ``summon_full_params()`` context.
+            state_dict[key] = state_dict[key].clone()
+            state_dict[key]._has_been_cloned = True  # type: ignore[attr-defined]
+
+    # Remove "_fsdp_wrapped_module." prefix
+    replace_by_prefix_(state_dict, prefix + "_fsdp_wrapped_module.", prefix)
+    return state_dict
+
+
+def _pre_load_state_dict_hook(
+    state_dict: Union[Dict[str, torch.Tensor], "OrderedDict[str, torch.Tensor]"], prefix: str, *args: Any
+) -> None:
+    replace_by_prefix_(state_dict, prefix, prefix + "_fsdp_wrapped_module.")
+
+
+def _clean_path(path: str) -> str:
+    """ Remove FSDP related wrapper modules from a given state dict key str path. """
+    return ".".join([split for split in path.split(".") if split not in {"_fsdp_wrapped_module", "_fpw_module"}])

--- a/torch/distributed/_fsdp/reduce_scatter_bucketer.py
+++ b/torch/distributed/_fsdp/reduce_scatter_bucketer.py
@@ -1,0 +1,186 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+from torch import Tensor
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+
+class Bucket:
+    def __init__(self, data: Tensor, group: ProcessGroup):
+        self.data = data
+        self.group = group
+        self.offset = 0
+        self.callbacks: List[Callable] = []
+        self.output_shard = torch.zeros_like(data[0])
+
+    def flush(self) -> None:
+        """Flush content of the bucket."""
+        if self.offset == 0:
+            assert len(self.callbacks) == 0
+            return
+        # reduce-scatter bucket
+        if hasattr(dist, "_reduce_scatter_base"):
+            dist._reduce_scatter_base(
+                self.output_shard[: self.offset], self.data[:, : self.offset].contiguous(), group=self.group
+            )
+        else:
+            dist.reduce_scatter(
+                self.output_shard[: self.offset], list(self.data[:, : self.offset].unbind(0)), group=self.group
+            )
+        # execute post-reduction callbacks
+        for callback_fn in self.callbacks:
+            callback_fn()
+        # reuse input bucket but allocate a fresh output shard
+        self.data[:, : self.offset].zero_()
+        self.offset = 0
+        self.callbacks.clear()
+        self.output_shard = torch.zeros_like(self.data[0])
+
+    def setup(self) -> None:
+        """Setup the buffers if they are not allocated.
+        Using ``setup`` and ``teardown``, we can ensure that the bucket
+        buffers are only allocated during the backward pass, hence saving more
+        memory to other parts of the training process, such as the forward pass
+        for activation memory.
+        """
+        for tensor in [self.data, self.output_shard]:
+            if tensor.storage().size() == 0:
+                tensor.storage().resize_(tensor.size().numel())  # type: ignore[attr-defined]
+
+    def teardown(self) -> None:
+        """Tear down the bucket by freeing the memory"""
+        assert self.offset == 0 and self.callbacks == [], "Incorrect call of teardown"
+        for tensor in [self.data, self.output_shard]:
+            tensor.storage().resize_(0)  # type: ignore[attr-defined]
+
+
+class ReduceScatterBucketer:
+    """
+    Helper for bucketing multiple reduce-scatter operations on small tensors
+    into larger reduce-scatter ops to improve communication efficiency.
+    Usage::
+        bucketer = ReduceScatterBucketer()
+        bucketer.reduce_scatter_async(
+            small_tensors, callback_fn=lambda result: print("small")
+        )
+        bucketer.reduce_scatter_async(
+            big_tensors, callback_fn=lambda result: print("big")
+        )
+        bucketer.reduce_scatter_async(
+            more_small_tensors, callback_fn=lambda result: print("small2")
+        )
+        bucketer.flush()  # callbacks only guaranteed to be called after flush()
+        # Example output (note that it is out of order, due to bucketing):
+        # big
+        # small
+        # small2
+    Args:
+        bucket_cap_mb (int, Optional): bucket size for communicating. Buckets
+            are sub-divided based on world_size. Values <= 0 disable bucketing.
+    """
+
+    def __init__(self, bucket_cap_mb: int = 25):
+        self.bucket_cap_mb = bucket_cap_mb
+        self.buckets: Dict[Tuple[torch.dtype, torch.device, ProcessGroup], Bucket] = {}
+
+    @torch.no_grad()
+    def reduce_scatter_async(
+        self, input_list: List[Tensor], group: ProcessGroup, callback_fn: Optional[Callable] = None,
+    ) -> None:
+        """
+        Reduce-scatter a list of tensors asynchronously, so smaller reductions
+        can be bucketed together. The given callback (``callback_fn``) will be
+        called with the reduced result at some later time. Call ``flush()`` to
+        force all queued ops and callbacks to be executed.
+        Note that large inputs will be reduced immediately, and this function
+        may also flush the relevant bucket to make room for ``input_list``.
+        Args:
+            input_list (List[Tensor]): list of tensors to reduce-scatter. List
+                should contain ``group.size()`` tensors and each tensor should
+                have identical shape, dtype and device.
+            group (ProcessGroup): process group for reduction
+            callback_fn (Callable, Optional): callback function to call after
+                the reduction executes. Function will be called with a single
+                argument corresponding to the reduced result.
+        """
+        world_size = group.size()
+
+        assert (
+            len(input_list) == world_size
+        ), f"reduce_scatter received {len(input_list)} inputs, expected group.size() ({world_size})"
+
+        first_input = input_list[0]
+        first_input_size = first_input.numel()
+
+        bucket_shard_size = self._get_shard_size(first_input.element_size(), world_size)
+        if first_input_size > bucket_shard_size:
+            # TODO: investigate how to avoid using torch.cat (because it seems to be slow for CPU tensors)
+            # input is too big to fit in the bucket, reduce-scatter directly
+            output = torch.zeros_like(input_list[0])
+            if hasattr(dist, "_reduce_scatter_base"):
+                input_flattened = torch.cat(input_list)
+                dist._reduce_scatter_base(output, input_flattened, group=group)
+            else:
+                # fallback
+                dist.reduce_scatter(output, input_list, group=group)
+            if callback_fn is not None:
+                callback_fn(output)
+            return
+
+        bucket = self._get_bucket(first_input, group)
+        if first_input_size > bucket.data.size(1) - bucket.offset:
+            # not enough space remaining in bucket, flush it now
+            bucket.flush()
+
+        # copy data from input_list into bucket
+        stacked_input = torch.stack(input_list).view(world_size, first_input_size)
+        offset = bucket.offset
+        bucket.data[:, offset : offset + first_input_size].copy_(stacked_input)
+        bucket.offset += first_input_size
+
+        # callback will be given the reduced result
+        if callback_fn is not None:
+            result_view = bucket.output_shard[offset : offset + first_input_size].view_as(first_input)
+            bucket.callbacks.append(functools.partial(callback_fn, result_view))
+
+    @torch.no_grad()
+    def flush(self) -> None:
+        """Reduce-scatter any partial buckets."""
+        for bucket in self.buckets.values():
+            bucket.flush()
+
+    @torch.no_grad()
+    def teardown(self) -> None:
+        """Free buffers from all buckets."""
+        for bucket in self.buckets.values():
+            bucket.teardown()
+
+    @functools.lru_cache()
+    def _get_shard_size(self, element_size: int, num_shards: int) -> int:
+        if self.bucket_cap_mb <= 0:  # Values <= 0 disable bucketing.
+            return 0
+        MB = 1024 * 1024
+        bucket_size = self.bucket_cap_mb * MB / element_size
+        return int(bucket_size // num_shards)
+
+    def _get_bucket(self, tensor: Tensor, group: ProcessGroup) -> Bucket:
+        # TODO (Min): the `group` used here in the key is the object hash, not the content
+        #     hash. That means if FSDP instances are initialized with different process groups,
+        #     even when the group members are in fact the same, we end up creating different
+        #     buckets here.
+        key = (tensor.dtype, tensor.device, group)
+        if key not in self.buckets:
+            # buckets are divided into world_size pieces, bucket.data shaped (world_size, shard_size)
+            world_size = group.size()
+            shard_size = self._get_shard_size(tensor.element_size(), world_size)
+            data = tensor.new_zeros((world_size, shard_size))
+            self.buckets[key] = Bucket(data, group)
+        self.buckets[key].setup()
+        return self.buckets[key]

--- a/torch/distributed/_fsdp/utils.py
+++ b/torch/distributed/_fsdp/utils.py
@@ -1,0 +1,219 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Useful functions for manipulating state_dicts."""
+
+from typing import Dict, List, Tuple, Union, Any, Callable, Set, Optional, Sequence
+from collections import OrderedDict  # noqa: F401
+from collections import abc
+
+import torch
+from torch import Tensor
+from torch.nn.utils.rnn import PackedSequence
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+import torch.nn.functional as F
+
+from math import inf
+
+
+"""Useful functions to deal with tensor types with other python container types."""
+
+
+def apply_to_tensors(fn: Callable, container: Union[torch.Tensor, Dict, List, Tuple, Set]) -> Any:
+    """Recursively apply to all tensor in different kinds of container types."""
+
+    def _apply(x: Union[torch.Tensor, Dict, List, Tuple, Set]) -> Any:
+        if torch.is_tensor(x):
+            return fn(x)
+        elif isinstance(x, OrderedDict):
+            od = OrderedDict()
+            for key, value in x.items():
+                od[key] = _apply(value)
+            return od
+        elif isinstance(x, PackedSequence):
+            _apply(x.data)
+            return x
+        elif isinstance(x, dict):
+            return {key: _apply(value) for key, value in x.items()}
+        elif isinstance(x, list):
+            return [_apply(x) for x in x]
+        elif isinstance(x, tuple):
+            return tuple(_apply(x) for x in x)
+        elif isinstance(x, set):
+            return {_apply(x) for x in x}
+        else:
+            return x
+
+    return _apply(container)
+
+
+def replace_by_prefix_(
+    state_dict: Union[Dict[str, Tensor], "OrderedDict[str, Tensor]"], old_prefix: str, new_prefix: str
+) -> None:
+    """
+    Replace all keys that match a given old_prefix with a new_prefix (in-place).
+    Usage::
+        state_dict = {"layer.xyz": torch.tensor(1)}
+        replace_by_prefix_(state_dict, "layer.", "module.layer.")
+        assert state_dict == {"module.layer.xyz": torch.tensor(1)}
+    """
+    if old_prefix == new_prefix:
+        raise ValueError("old_prefix and new_prefix must be distinct")
+    for key in list(state_dict.keys()):
+        if not key.startswith(old_prefix):
+            continue
+        new_key = new_prefix + key[len(old_prefix) :]
+        state_dict[new_key] = state_dict[key]
+        del state_dict[key]
+
+
+# Credits:  classy_vision/generic/distributed_util.py
+def recursive_copy_to_device(value: Any, non_blocking: bool, device: torch.device) -> Any:
+    """
+    Recursively searches lists, tuples, dicts and copies tensors to device if
+    possible. Non-tensor values are passed as-is in the result.
+    NOTE:  These are all copies, so if there are two objects that reference
+    the same object, then after this call, there will be two different objects
+    referenced on the device.
+    """
+
+    if isinstance(value, torch.Tensor):
+        return value.to(device, non_blocking=non_blocking)
+
+    if isinstance(value, (list, tuple)):
+        values = []
+        for val in value:
+            values.append(recursive_copy_to_device(val, non_blocking=non_blocking, device=device))
+
+        return values if isinstance(value, list) else tuple(values)
+
+    if isinstance(value, abc.Mapping):
+        device_val: Dict[str, Any] = {}
+        for key, val in value.items():
+            device_val[key] = recursive_copy_to_device(val, non_blocking=non_blocking, device=device)
+
+        return device_val
+
+    return value
+
+
+def calc_grad_norm_(parameters: List[torch.nn.Parameter], p: float) -> torch.Tensor:
+    r"""Calculate gradient norm of an iterable of parameters.
+    Returns:
+        Total norm of the parameters (viewed as a single vector).
+    """
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    parameters = list(filter(lambda par: par.grad is not None, parameters))
+
+    if len(parameters) == 0:
+        return torch.tensor(0.0)
+    p = float(p)
+    if p == inf:
+        local_norm = max(par.grad.detach().abs().max() for par in parameters)
+    else:
+        # Compute the norm in full precision no matter what
+        local_norm = torch.norm(
+            torch.stack([torch.norm(par.grad.detach(), p, dtype=torch.float32) for par in parameters]), p).to(
+                dtype=parameters[0].dtype)
+    return local_norm
+
+
+def chunk_and_pad(tensor: torch.Tensor, num_chunks: int) -> List[torch.Tensor]:
+    """Chunk a given Tensor into num_chunks parts and add any necessary padding."""
+    chunks = list(torch.flatten(tensor).chunk(num_chunks))
+    # torch.chunk may return fewer than num_chunks chunks, pad accordingly.
+    num_pad_for_partial_chunk = chunks[0].numel() - chunks[-1].numel()
+    if num_pad_for_partial_chunk > 0:
+        chunks[-1] = F.pad(chunks[-1], [0, num_pad_for_partial_chunk])
+    if len(chunks) < num_chunks:
+        chunks.extend([torch.zeros_like(chunks[0]) for _ in range(num_chunks - len(chunks))])
+    return chunks
+
+
+def validate_process_group(device: torch.device, process_group: ProcessGroup) -> None:
+    """Do a quick test in case user called FSDP without calling torch.cuda.set_device()
+       correctly. This can easily happen in cpu_offload case where the model resides on
+       the CPU.
+    """
+    if not hasattr(process_group, "allgather"):
+        # Likely a dummy pg for unit test, skip checking.
+        return
+
+    world_size = process_group.size()
+    if "cuda" in str(device):
+        input_tensor = torch.ones(1).to(device)
+        output = list(torch.zeros(world_size).to(device).chunk(world_size))
+        dist.all_gather(output, input_tensor, group=process_group)
+        assert torch.cat(output).sum() == float(world_size), (
+            f"found {torch.cat(output).sum()} devices in process group but "
+            f"world_size={world_size}. Check torch.cuda.set_device is called properly"
+        )
+
+
+def enable_pytorch_sync_bn(module: torch.nn.Module) -> None:
+    """Call _specify_ddp_gpu_num for all pytorch SyncBN layers so that it
+       is happily running even without DDP. E.g. this is used by FSDP.
+    """
+    for layer in module.modules():
+        if isinstance(layer, torch.nn.modules.SyncBatchNorm) and hasattr(layer, "_specify_ddp_gpu_num"):
+            # Number "1" below meant to be the number of GPUs for each DDP worker.
+            # (i.e. "device_ids" in DDP. As far as I see, the value is not actually
+            # used, but this call needs to be made to avoid an exception.
+            # This function is removed from pytorch since 1.9.
+            layer._specify_ddp_gpu_num(1)  # type: ignore[operator]
+
+
+def get_process_group_cached(ranks: Optional[Sequence[int]] = None) -> ProcessGroup:
+    """
+    Singleton PyTorch distributed group cache. Inspired by the code from fairseq.
+    Just like torch.distributed.new_group, this method needs to be called on all ranks
+    at the same time when a new group is created. This is true for all ranks irrespective
+    of their group membership status.
+    For FSDP, it is important to use the same group between outer and inner FSDP instances,
+    otherwise, inner FSDP instances will not share the gradient reduction bucket buffer with
+    the root instance. This will result in increased GPU memory utilization.
+    Each separate process group also uses separate NCCL library instances, which will have
+    a significant effect on GPU memory use if too many process groups are created and used.
+    Setting NCCL_BUFFSIZE=102400 env variable is a useful technique to check if the NCCL
+    memory is causing GPU OOM. Note, the NCCL buffers are not allocated
+    through the PyTorch caching allocator, therefore, you may see GPU OOM even when
+    torch.cuda.reserved_memory() is still way below the total amount of GPU memory.
+    Extra process groups can also reduce training speed (observed on VISSL models).
+    Args:
+        ranks (Optional[List[int]]):
+            Ranks requested in the target group. None for all ranks.
+            Default: None
+    Returns:
+        (ProcessGroup):
+            Return the requested process group. Throws RuntimeError if torch.distributed module is not yet initialized.
+    """
+    if not dist.is_initialized():
+        raise RuntimeError("torch.distributed is not yet initialized but process group is requested.")
+
+    # Init the cache if needed.
+    if not hasattr(get_process_group_cached, "_global_group_cache"):
+        get_process_group_cached._global_group_cache = {}  # type: ignore[attr-defined]
+        # Populate with default process group.
+        cache = get_process_group_cached._global_group_cache  # type: ignore[attr-defined]
+        assert dist.group.WORLD is not None
+        default_pg = dist.group.WORLD
+        if type(default_pg) == object:
+            # For PyTorch 1.6 and 1.7, dist.group.WORLD is an object, not a world process group, like that in 1.8 and 1.9.
+            default_pg = dist.new_group()
+        cache[None] = default_pg
+        cache[frozenset(list(range(dist.get_world_size())))] = default_pg
+
+    # Lookup and fill the cache if needed.
+    cache = get_process_group_cached._global_group_cache  # type: ignore[attr-defined]
+    if ranks is not None:
+        # take care of ordering and duplicates in the ranks list. use tuple so that ranks
+        # can be used as a cache index.
+        ranks = tuple(sorted(list(set(ranks))))
+    if ranks not in cache:
+        cache[ranks] = dist.new_group(ranks=ranks)
+
+    return cache[ranks]

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1,0 +1,576 @@
+import logging
+import os
+import tempfile
+import functools
+from statistics import mean
+import itertools
+import sys
+import unittest
+from unittest import mock
+import gc
+import contextlib
+import subprocess
+
+import torch
+import torch.nn as nn
+from torch.distributed import rpc
+import torch.multiprocessing as mp
+from torch import Tensor
+
+from torch.distributed._fsdp import FullyShardedDataParallel
+from torch.distributed._fsdp.fully_sharded_data_parallel import TrainingState
+
+from typing import Callable, List, Any, Optional, Union, Generator, Dict, Tuple
+
+keys = ["reshard_after_forward", "mixed_precision", "flatten_parameters"]
+CONFIG_OPTIONS = [dict(zip(keys, config)) for config in itertools.product([True, False], repeat=len(keys))]
+
+class DummyProcessGroup:
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+class DeviceAndTypeCheckModule(nn.Module):
+    """A simple module for checking Tensor devices and dtypes."""
+
+    def __init__(
+        self,
+        expected_input_dtype: Optional[torch.dtype] = None,
+        expected_input_device: Optional[torch.device] = None,
+        expected_param_dtype: Optional[torch.dtype] = None,
+        expected_param_device: Optional[torch.device] = None,
+        expected_loss_dtype: Optional[torch.dtype] = None,
+        expected_loss_device: Optional[torch.device] = None,
+        expected_buffer_dtype: Optional[torch.device] = None,
+    ):
+        super().__init__()
+        self.expected_input_dtype = expected_input_dtype
+        self.expected_input_device = expected_input_device
+        self.expected_param_dtype = expected_param_dtype
+        self.expected_param_device = expected_param_device
+        self.expected_loss_dtype = expected_loss_dtype
+        self.expected_loss_device = expected_loss_device
+        self.expected_buffer_dtype = expected_buffer_dtype
+
+        self.linear = nn.Linear(5, 5)
+        self.register_buffer("buffer", torch.rand((5,)))
+
+    def _check(
+        self,
+        key: str,
+        x: Union[torch.device, torch.dtype],
+        expected: Union[Optional[torch.device], Optional[torch.dtype]],
+    ) -> None:
+        assert expected in {None, x}, f"{key} ({x}) != expected ({expected})"
+
+    def forward(self, *input: Tensor, **kwargs: Any) -> Tensor:
+        x = input[0]
+        self._check("input.dtype", x.dtype, self.expected_input_dtype)
+        self._check("input.device", x.device, self.expected_input_device)
+
+        param = self.linear.weight
+        self._check("param.dtype", param.dtype, self.expected_param_dtype)
+        self._check("param.device", param.device, self.expected_param_device)
+        self._check("buffer.dtype", self.buffer.dtype, self.expected_buffer_dtype)  # type: ignore[arg-type]
+        x = x + self.buffer
+        loss = (self.linear(x) + self.buffer).sum()
+        self._check("loss.dtype", loss.dtype, self.expected_loss_dtype)
+        self._check("loss.device", loss.device, self.expected_loss_device)
+
+        return loss
+
+
+@functools.lru_cache()
+def get_cycles_per_ms() -> float:
+    """Measure and return approximate number of cycles per millisecond for torch.cuda._sleep
+    Copied from: github.com/pytorch/pytorch/blob/master/test/test_cuda.py
+    """
+
+    def measure() -> float:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        torch.cuda._sleep(1000000)
+        end.record()
+        end.synchronize()
+        cycles_per_ms = 1000000 / start.elapsed_time(end)
+        return cycles_per_ms
+
+    # Get 10 values and remove the 2 max and 2 min and return the avg.
+    # This is to avoid system disturbance that skew the results, e.g.
+    # the very first cuda call likely does a bunch of init, which takes
+    # much longer than subsequent calls.
+    #
+    # Tested on both Tesla V100, Quadro GP100, Titan RTX, RTX 3090 GPUs
+    # and seems to return stable values. Therefore, we enable caching
+    # using lru_cache decorator above.
+    num = 10
+    vals = []
+    for _ in range(num):
+        vals.append(measure())
+    vals = sorted(vals)
+    return mean(vals[2 : num - 2])
+
+
+def dist_init(rank: int, world_size: int, filename: str, filename_rpc: str = "") -> bool:
+    """
+    Initialize torch distributed, based on a temporary file shared across ranks, which makes it possible for unrelated
+    tests to be run concurrently.
+    Return false if not enough GPUs present in the system.
+    .. warning: This limits the usecase to all ranks being on the same node
+    """
+    print(f"dist init r={rank}, world={world_size}")
+
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["RANK"] = str(rank)
+    url = "file://" + filename
+
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    if backend == "nccl" and torch.cuda.device_count() < world_size:
+        logging.warning("Requested world size cannot be reached on this machine, not enough GPUs")
+        return False
+
+    torch.distributed.init_process_group(backend=backend, rank=rank, world_size=world_size, init_method=url)
+
+    if torch.cuda.is_available() and torch.cuda.device_count():
+        torch.cuda.set_device(rank % torch.cuda.device_count())
+
+    return True
+
+
+def teardown() -> None:
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
+
+
+def get_world_sizes() -> List[int]:
+    limit = torch.cuda.device_count()
+    return [x for x in [1, 2, 4, 8] if x <= limit]
+
+
+def rmf(filename: str) -> None:
+    """Remove a file like rm -f."""
+    try:
+        os.remove(filename)
+    except FileNotFoundError:
+        pass
+
+
+def spawn_for_all_world_sizes(test_func: Callable, world_sizes: List[int] = get_world_sizes(), args: Any = None) -> None:
+    if args is None:
+        args = []
+    for world_size in world_sizes:
+        _, filename = tempfile.mkstemp()
+        _, filename_rpc = tempfile.mkstemp()
+
+        try:
+            # (lefaudeux) Let mp handle the process joining, join=False and handling context has
+            # been unstable in the past.
+            mp.spawn(test_func, args=(world_size, filename, filename_rpc, *args), nprocs=world_size, join=True)
+        finally:
+            rmf(filename)
+            rmf(filename_rpc)
+
+
+def objects_are_equal(a: Any, b: Any, raise_exception: bool = False, dict_key: Optional[str] = None) -> bool:
+    """
+    Test that two objects are equal. Tensors are compared to ensure matching
+    size, dtype, device and values.
+    """
+    if type(a) is not type(b):
+        if raise_exception:
+            raise ValueError(f"type mismatch {type(a)} vs. {type(b)}")
+        return False
+    if isinstance(a, dict):
+        if set(a.keys()) != set(b.keys()):
+            if raise_exception:
+                raise ValueError(f"keys mismatch {a.keys()} vs. {b.keys()}")
+            return False
+        for k in a.keys():
+            if not objects_are_equal(a[k], b[k], raise_exception, k):
+                return False
+        return True
+    elif isinstance(a, (list, tuple, set)):
+        if len(a) != len(b):
+            if raise_exception:
+                raise ValueError(f"length mismatch {len(a)} vs. {len(b)}")
+            return False
+        return all(objects_are_equal(x, y, raise_exception) for x, y in zip(a, b))
+    elif torch.is_tensor(a):
+        try:
+            # assert_allclose doesn't strictly test shape, dtype and device
+            shape_dtype_device_match = a.size() == b.size() and a.dtype == b.dtype and a.device == b.device
+            if not shape_dtype_device_match:
+                if raise_exception:
+                    msg = f"sizes: {a.size()} vs. {b.size()}, "
+                    msg += f"types: {a.dtype} vs. {b.dtype}, "
+                    msg += f"device: {a.device} vs. {b.device}"
+                    raise AssertionError(msg)
+                else:
+                    return False
+            # assert_allclose.
+            torch.testing.assert_allclose(a, b)
+            return True
+        except (AssertionError, RuntimeError) as e:
+            if raise_exception:
+                if dict_key and isinstance(e, AssertionError):
+                    # Add dict key to the assertion error.
+                    msg = e.args[0]
+                    new_msg = f"For dict key '{dict_key}': {msg}"
+                    raise AssertionError(new_msg) from None
+                else:
+                    raise e
+            else:
+                return False
+    else:
+        return a == b
+
+
+def dump_all_tensors(rank: int) -> None:
+    """Useful tool for debugging memory issues from the python side."""
+    if rank != 0:
+        return
+    for obj in gc.get_objects():
+        try:
+            ttype = str(type(obj))
+            if torch.is_tensor(obj) or (hasattr(obj, "data") and torch.is_tensor(obj.data)):
+                print(ttype, obj.shape, obj.dtype, obj.device, obj.storage().size())
+        except Exception:
+            pass
+    print(torch.cuda.memory_summary())
+
+
+@contextlib.contextmanager
+def temp_files_ctx(num: int) -> Generator:
+    """ A context to get tempfiles and ensure they are cleaned up. """
+    files = [tempfile.mkstemp()[1] for _ in range(num)]
+
+    try:
+        yield tuple(files)
+    finally:
+        # temp files could have been removed, so we use rmf.
+        for name in files:
+            rmf(name)
+
+
+def init_and_run(fn, args, rank, world_size, filename, filename_rpc):
+    dist_init(rank, world_size, filename, filename_rpc)
+    group = torch.distributed.new_group()
+    fn(rank, group, *args)
+
+
+def spawn_and_init(fn, args=None, **spawn_kwargs):
+    if args is None:
+        args = ()
+
+    run_fn = functools.partial(init_and_run, fn, args)
+    spawn_for_all_world_sizes(run_fn, **spawn_kwargs)
+
+
+@contextlib.contextmanager
+def in_temporary_directory() -> Generator:
+    """
+    Context manager to create a temporary direction and remove
+    it at the end of the context
+    """
+    old_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        try:
+            yield temp_dir
+        finally:
+            os.chdir(old_cwd)
+
+
+class TransformerWithSharedParams(nn.Module):
+    def __init__(self, group, *unused_args, d_vocab=23, d_model=16, add_bn=True, **unused_kwargs):
+        super().__init__()
+        self.rank = group.rank()
+        self.world_size = group.size()
+        torch.manual_seed(0)  # keep everything deterministic
+        assert d_vocab >= 12  # we use torch.arange(12) as input
+        self.embed_tokens = nn.Embedding(d_vocab, d_model)
+        self.transformer = nn.Transformer(
+            d_model=d_model, num_encoder_layers=2, num_decoder_layers=2, dim_feedforward=8, dropout=0.1,
+        )
+        self.output_proj = nn.Linear(d_model, d_vocab)
+
+        # share the embedding and output projection weights
+        self.output_proj.weight = self.embed_tokens.weight
+        self.register_buffer("vocab_bias", self.embed_tokens.weight.new_ones((d_model,)))
+        self.register_buffer("long_buffer", torch.zeros_like(self.vocab_bias, dtype=torch.long))  # type: ignore[arg-type]
+
+        self.bs = 2
+        self.bn = torch.nn.BatchNorm1d(self.bs) if add_bn else torch.nn.Identity()
+
+    def get_input(self, device):
+        torch.manual_seed(1 + self.rank)  # keep everything deterministic
+        src = torch.arange(12, device=device).view(6, self.bs)  # T x B
+        tgt = torch.arange(self.bs * 4, device=device).view(4, self.bs)  # T x B
+        return (src, tgt)
+
+    def forward(self, src_ids, tgt_ids):
+        src = self.embed_tokens(src_ids)
+        src = src + self.vocab_bias + self.long_buffer.type_as(src)  # type: ignore[operator]
+        tgt = self.embed_tokens(tgt_ids)
+        tgt = self.bn(tgt)
+        x = self.transformer(src, tgt)
+        return self.output_proj(x)
+
+    def get_loss(self, input, output):
+        _, tgt = input
+        return nn.functional.cross_entropy(output.view(-1, output.size(-1)), tgt.view(-1), reduction="sum")
+
+    def run_backward(self, loss):
+        loss.backward()
+
+
+class NestedWrappedModule(nn.Module):
+    # def __init__(self, group, wrapper_config, wrap_everything=False, checkpoint=False):
+    def __init__(self, group, wrapper_config, wrap_everything=False):
+        super().__init__()
+        self.rank = group.rank()
+        self.world_size = group.size()
+        self.wrapper_config = wrapper_config
+
+        def _maybe_wrap(layer):
+            if wrapper_config is not None:
+                return FullyShardedDataParallel(layer, group, **wrapper_config)
+            return layer
+
+        torch.manual_seed(0)  # keep everything deterministic
+        self.module = nn.Sequential(
+            nn.Linear(8, 4),
+            _maybe_wrap(nn.Sequential(_maybe_wrap(nn.Linear(4, 16)), nn.Linear(16, 16),)),
+            _maybe_wrap(nn.Linear(16, 4)),
+            nn.Linear(4, 8),
+        )
+
+        # Wrap all modules triggers a corner case where root FSDP doesn't have any params.
+        # Test it with checkpoint_wrapper as well to validate final backward callback
+        # is queued correctly when root FSDP does not have any params and every layer is
+        # wrapped as FSDP(checkpoint(module)).
+        if wrap_everything:
+            # if checkpoint:
+            #    self.module = nn.Sequential(
+            #        _maybe_wrap(checkpoint_wrapper(nn.Linear(8, 4))),
+            #        _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 16))),
+            #        _maybe_wrap(checkpoint_wrapper(nn.Linear(16, 4))),
+            #        _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 8))),
+            #    )
+            # else:
+            self.module = nn.Sequential(
+                _maybe_wrap(nn.Linear(8, 4)),
+                _maybe_wrap(nn.Linear(4, 16)),
+                _maybe_wrap(nn.Linear(16, 4)),
+                _maybe_wrap(nn.Linear(4, 8)),
+            )
+
+    def get_input(self, device):
+        torch.manual_seed(1 + self.rank)  # keep everything deterministic
+        return (torch.rand(4, 8, device=device),)
+
+    def forward(self, x):
+        return self.module(x)
+
+    def get_loss(self, input, output):
+        loss = output.sum()
+        return loss
+
+    def run_backward(self, loss):
+        loss.backward()
+
+
+class MixtureOfExperts(NestedWrappedModule):
+    # def __init__(self, group, wrapper_config, checkpoint_act=False, delay_before_free_ms=0):
+    def __init__(self, group, wrapper_config, delay_before_free_ms=0):
+        super().__init__(group, wrapper_config)
+        self.group = group
+        self.delay_before_free_ms = delay_before_free_ms
+
+        # "expert" params are different on each rank
+        torch.manual_seed(42 + group.rank())
+        d_expert = 23
+        d_shared = 12
+        d_input = 8
+        expert = nn.Linear(d_expert, d_shared)
+
+        self.num_expert_params = sum([p.numel() for p in expert.parameters()])
+        for p in expert.parameters():
+            p.expert = True  # type: ignore[attr-defined]
+
+        # everything else is shared
+        torch.manual_seed(0)
+
+        shared = nn.Linear(d_shared, d_expert)
+
+        # if checkpoint_act:
+        #    expert = checkpoint_wrapper(expert)
+        #    shared = checkpoint_wrapper(shared)
+
+        if wrapper_config is not None:
+            # we create a process group of size 1 for the expert params
+            expert_group = torch.distributed.new_group([group.rank()])  # world size 1 means no shard
+            expert = FullyShardedDataParallel(expert, expert_group, **wrapper_config)  # type: ignore[assignment]
+
+            shared = FullyShardedDataParallel(shared, group, **wrapper_config)  # type: ignore[assignment]
+
+        self.module = nn.Sequential(nn.Linear(d_input, d_shared), shared, expert, nn.Linear(d_shared, d_input))
+
+    def forward(self, x):
+        if self.delay_before_free_ms > 0:
+            expert = self.module[2]
+            if isinstance(expert, FullyShardedDataParallel):
+                orig_free_full_params = self.module[2]._free_full_params
+
+                def _free_full_params_with_delay(*args):
+                    torch.cuda._sleep(int(self.delay_before_free_ms * get_cycles_per_ms()))
+                    return orig_free_full_params(*args)
+
+                assert hasattr(expert, "_free_full_params")
+                with mock.patch.object(expert, "_free_full_params", _free_full_params_with_delay):
+                    return self.module(x)
+
+        return self.module(x)
+
+    def run_backward(self, loss):
+        loss.backward()
+
+        # manually reduce gradients if not wrapped in FullyShardedDataParallel
+        if self.wrapper_config is None:
+            with torch.no_grad():
+                for p in self.parameters():
+                    if hasattr(p, "expert"):
+                        continue  # these params don't need grad reduction
+                    p.grad.data.div_(self.world_size)
+                    torch.distributed.all_reduce(p.grad.data, group=self.group)
+
+
+# How to use remote-pdb: https://gist.github.com/sshleifer/9d43351957179c13606e015b072927d4
+# All helper functions called by spawn must be either @classmethod, @staticmethod
+class DistributedTest(unittest.TestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available, skipping test")
+        if sys.platform == "win32":
+            raise unittest.SkipTest("NCCL doesn't support Windows, skipping test")
+        if torch.cuda.device_count() < 2:
+            raise unittest.SkipTest("distributed tests require 2+ GPUs, skipping")
+
+    def tearDown(self):
+        teardown()
+
+    @staticmethod
+    def _train_for_several_steps(model, num_steps, autocast, lr=0.01, norm_type=None):
+        model_device = next(model.parameters()).device
+        # use SGD with momentum instead of Adam, since Adam is scale invariant
+        # and this makes it bad for tests
+        optim = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9)
+        for _ in range(num_steps):
+            optim.zero_grad()
+            with torch.cuda.amp.autocast(enabled=autocast):
+                # Inputs always cuda regardless of move_grads_cpu, or model.device
+                input = model.module.get_input(torch.device("cuda"))
+                output = model(*input)
+                loss = model.module.get_loss(input, output).to(model_device)
+            assert loss.dtype == torch.float32
+            model.module.run_backward(loss)
+            if norm_type is not None:
+                clip_norm = 0.3
+                if isinstance(model, FullyShardedDataParallel):
+                    model.clip_grad_norm_(clip_norm, norm_type)
+                else:
+                    torch.nn.utils.clip_grad_norm_(model.parameters(), clip_norm, norm_type)
+            optim.step()
+        if isinstance(model, FullyShardedDataParallel):
+            model.assert_state(TrainingState.IDLE)
+        return loss.detach()
+
+    @staticmethod
+    def get_wrapped_model(group, cuda_first=False, config=None, **model_kwargs) -> FullyShardedDataParallel:
+        if config is None:
+            config = {}
+        if cuda_first:
+            model = FullyShardedDataParallel(TransformerWithSharedParams(group, **model_kwargs).cuda(), group, **config)
+        else:
+            model = FullyShardedDataParallel(TransformerWithSharedParams(group, **model_kwargs), group, **config).cuda()
+        return model
+
+    @classmethod
+    def _test_identical_outputs(
+        cls, model_init_fn, config, rank, group, num_steps=2, use_cuda=True, lr=0.01, ref_ddp_fn=None, norm_type=2,
+    ):
+        if config.get("mixed_precision", False):
+            autocast = True
+            # Force the compute dtype to be torch.float32 so that we get
+            # identical results as PyTorch DDP when using autocast. Note that
+            # this will cause the all-gather to happen in FP32, which is slower
+            # than necessary in most cases.
+            config["compute_dtype"] = torch.float32
+        else:
+            autocast = False
+
+        # Establish reference behavior with PyTorch DDP (+ optionally autocast).
+        model = model_init_fn(group=group, wrapper_config=None).cuda()
+        if ref_ddp_fn is None:
+            model = nn.parallel.DistributedDataParallel(
+                model, device_ids=[rank], output_device=rank, process_group=group
+            )
+        else:
+            model = ref_ddp_fn(model, group)
+        ref_loss = cls._train_for_several_steps(model, num_steps, autocast, lr=lr, norm_type=norm_type)
+        ref_state_dict = model.module.state_dict()
+        if config.get("cpu_offload", False):
+            ref_loss = ref_loss.cpu()
+            for k in ref_state_dict.keys():
+                ref_state_dict[k] = ref_state_dict[k].cpu()
+
+        # Confirm we get the same behavior using FullyShardedDataParallel.
+        model = FullyShardedDataParallel(model_init_fn(group=group, wrapper_config=config), group, **config)
+        if use_cuda:
+            model = model.cuda()
+        else:
+            assert next(model.parameters()).device == torch.device("cpu")
+        shard_loss = cls._train_for_several_steps(model, num_steps, autocast, lr=lr, norm_type=norm_type)
+        shard_state_dict = model.state_dict()
+
+        try:
+            torch.testing.assert_allclose(ref_loss, shard_loss)
+            assert objects_are_equal(ref_state_dict, shard_state_dict, raise_exception=True)
+        except (AssertionError, RuntimeError) as e:
+            raise Exception(f"FullyShardedDataParallel didn't match PyTorch DDP using config: {config}\n\n {e}")
+
+
+def state_dict_norm(state: Dict[str, torch.Tensor]) -> torch.Tensor:
+    """Compute the norm from a state_dict for simple comparison."""
+    norm = torch.zeros(1)
+    for v in state.values():
+        if not v.is_floating_point():
+            v = v.float()
+        norm += v.norm()
+    return norm
+
+
+def torch_cuda_version(compiled: bool = False) -> Tuple[int, ...]:
+    if compiled:
+        numbering = torch.version.cuda.split(".")[:2]  # type: ignore[attr-defined]
+    else:
+        def get_smi_ver() -> str:  # type: ignore[return]
+            """Get CUDA version from nvidia-smi"""
+            for line in subprocess.check_output("nvidia-smi".split()).decode("utf-8").split("\n"):
+                if "CUDA Version" in line:
+                    res = line.split()[8]
+                    assert res.startswith("10.") or res.startswith("11."), res
+                    return res
+            AssertionError("can not get cuda version")
+
+        _smi_ver = get_smi_ver()
+        numbering = _smi_ver.split(".")[:2]
+    return tuple(int(n) for n in numbering)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65107

upstreaming fairscale fsdp implementations and tests to PyTorch. be noted that checkpoint_wrapper is not imported from fairscale, so the checkpoint_wrapper related tests are skipped. we will mostly adopt the new version of checkpoint implementation that can simply FSDP impelementation for multiple checkpoint use cases, the new version is still being developed https://github.com/pytorch/pytorch/pull/62964

Differential Revision: [D30521673](https://our.internmc.facebook.com/intern/diff/D30521673/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D30521673/)!