### PR TITLE
Add dropout shape inference as no-op in acc_tracer

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -362,6 +362,14 @@ def square_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
 def matmul(*, input, other):
     return torch.matmul(**locals())
 
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", nn.functional.dropout),
+    arg_replacement_tuples=[("input", "input")])
+def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
+    """
+    Remove dropout node and directly map its input to output.
+    """
+    return node.kwargs["input"]
 
 
 @register_acc_op_mapping(


### PR DESCRIPTION
Summary: Register dropout as no-op in acc_tracer & Add shape inference for no-op

Test Plan:
buck test glow/fb/fx/acc_tracer:test_acc_shape_inference --- test_unary_15_dropout_no_op
buck test glow/fb/fx/oss_acc_tracer:test_acc_tracer -- test_dropout

Reviewed By: jfix71

Differential Revision: D30880679

