### PR TITLE
Provide function interface for `remove_duplicate_output_args`

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -15,6 +15,9 @@ def torch_dtype_to_trt(dtype):
         return trt.int8
     elif dtype == torch.int32:
         return trt.int32
+    elif dtype == torch.int64:
+        # TRT does not support int64
+        return trt.int32
     elif dtype == torch.float16:
         return trt.float16
     elif dtype == torch.float32:

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -7,6 +7,9 @@ import torch.fx
 from torch.fx.node import _get_qualified_name
 
 
+TRTInterpreterResult = Tuple[Any, Sequence[str], Sequence[str]]
+
+
 # Borrowed from torch2trt
 def torch_dtype_to_trt(dtype):
     if trt.__version__ >= "7.0" and dtype == torch.bool:
@@ -336,7 +339,7 @@ class TRTInterpreter(torch.fx.Interpreter):
         fp16_mode=True,
         int8_mode=False,
         strict_type_constraints=True,
-    ):
+    ) -> TRTInterpreterResult:
         # TODO hack, should check contents of args and remove fp16_mode probably
         self.fp16_mode = fp16_mode
 

--- a/torch/fx/experimental/fx2trt/passes/remove_duplicate_output_args.py
+++ b/torch/fx/experimental/fx2trt/passes/remove_duplicate_output_args.py
@@ -10,6 +10,15 @@ import dataclasses as dc
 _LOGGER = logging.getLogger(__name__)
 
 
+RemoveDuplicateOutputArgsFunc = t.Callable[
+    [
+        fx.GraphModule,
+        t.Collection[str],
+    ],
+    t.Mapping[str, "RemoveDuplicateResult"]
+]
+
+
 def remove_duplicate_output_args(
     top_level: fx.GraphModule,
     target_subnets: t.Collection[str]

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -771,7 +771,7 @@ class Graph:
         return op
 
     @compatibility(is_backward_compatible=True)
-    def python_code(self, root_module: str) -> PythonCode:
+    def python_code(self, root_module: str, pdb: bool = False) -> PythonCode:
         """
         Turn this ``Graph`` into valid Python code.
 
@@ -830,9 +830,9 @@ class Graph:
                     node._repr_fn = orig_repr_fns[node]
 
         with override_node_repr(self):
-            return self._python_code(root_module, namespace)
+            return self._python_code(root_module, namespace, pdb)
 
-    def _python_code(self, root_module: str, namespace: _Namespace) -> PythonCode:
+    def _python_code(self, root_module: str, namespace: _Namespace, pdb:bool = False) -> PythonCode:
         free_vars: List[str] = []
         body: List[str] = []
         globals_: Dict[str, Any] = {}
@@ -1008,6 +1008,8 @@ class Graph:
         else:
             wrap_stmts = ''
 
+        if pdb:
+            body.insert(0, "import pdb; pdb.set_trace()\n")
         # If the original function didn't have self as its first argument, we
         # would have added it.
         if len(orig_args) == 0 or orig_args[0] != 'self':

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -550,7 +550,7 @@ class {module_name}(torch.nn.Module):
         return self._code
 
     @compatibility(is_backward_compatible=True)
-    def recompile(self) -> PythonCode:
+    def recompile(self, pdb:bool = False) -> PythonCode:
         """
         Recompile this GraphModule from its ``graph`` attribute. This should be
         called after editing the contained ``graph``, otherwise the generated
@@ -559,7 +559,7 @@ class {module_name}(torch.nn.Module):
         if self._graph._pytree_info is not None:
             self._in_spec = self._graph._pytree_info.in_spec
             self._out_spec = self._graph._pytree_info.out_spec
-        python_code = self._graph.python_code(root_module='self')
+        python_code = self._graph.python_code(root_module='self', pdb=pdb)
         self._code = python_code.src
 
         cls = type(self)


### PR DESCRIPTION
Summary: So that its implementation can be abstracted and replaced

Test Plan: Run linter, CI

Reviewed By: 842974287

Differential Revision: D30966916

