### PR TITLE
Pass through allow-list from prepare_qat into propagate_qconfig_ to allow custom mapping and custom QAT module

### DIFF
--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -64,7 +64,6 @@ def _propagate_qconfig_helper(module, qconfig_dict, allow_list=None,
         _propagate_qconfig_helper(child, qconfig_dict, allow_list,
                                   qconfig_with_device_check, module_prefix)
 
-# TODO(jerryzh): expose allow_list
 def propagate_qconfig_(module, qconfig_dict=None, allow_list=None):
     r"""Propagate qconfig through the module hierarchy and assign `qconfig`
     attribute on each leaf module
@@ -75,6 +74,7 @@ def propagate_qconfig_(module, qconfig_dict=None, allow_list=None):
             quantization configuration, qconfig applies to all submodules of a
             given module unless qconfig for the submodules are specified (when
             the submodule already has qconfig attribute)
+        allow_list: a set that lists out allowable modules to be propagated with qconfig
 
     Return:
         None, module is modified inplace with qconfig attached
@@ -394,7 +394,7 @@ def quantize_dynamic(model, qconfig_spec=None, dtype=torch.qint8,
     convert(model, mapping, inplace=True)
     return model
 
-def prepare_qat(model, mapping=None, inplace=False):
+def prepare_qat(model, mapping=None, inplace=False, allow_list=None):
     r"""
     Prepares a copy of the model for quantization calibration or
     quantization-aware training and converts it to quantized version.
@@ -408,6 +408,7 @@ def prepare_qat(model, mapping=None, inplace=False):
                  replaced.
         inplace: carry out model transformations in-place, the original module
                  is mutated
+        allow_list: a set that lists out allowable modules to be propagated with qconfig
     """
     torch._C._log_api_usage_once("quantization_api.quantize.prepare_qat")
     if mapping is None:
@@ -416,7 +417,7 @@ def prepare_qat(model, mapping=None, inplace=False):
     if not inplace:
         model = copy.deepcopy(model)
 
-    propagate_qconfig_(model, qconfig_dict=None)
+    propagate_qconfig_(model, qconfig_dict=None, allow_list=allow_list)
     convert(model, mapping=mapping, inplace=True, remove_qconfig=False)
     prepare(model, observer_non_leaf_module_list=set(mapping.values()), inplace=True)
     return model


### PR DESCRIPTION
Summary:
Pytorch Quantization: allow prepare_qat to include custom module by passing allow_list into the prepare_qat.

When we are implementing custom module and custom mapping for Quantization Aware Training (QAT), we need to add the custom module to the mappings and to the allow_list during prepare_qat. The allow_list needs to be surfaced to the  propagate_qconfig_.

Test Plan: relying on general unit test

Differential Revision: D30982060

