### PR TITLE
Provide function interface for `remove_duplicate_output_args` (#65124)

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -15,6 +15,9 @@ def torch_dtype_to_trt(dtype):
         return trt.int8
     elif dtype == torch.int32:
         return trt.int32
+    elif dtype == torch.int64:
+        # TRT does not support int64
+        return trt.int32
     elif dtype == torch.float16:
         return trt.float16
     elif dtype == torch.float32:

--- a/torch/fx/experimental/fx2trt/passes/remove_duplicate_output_args.py
+++ b/torch/fx/experimental/fx2trt/passes/remove_duplicate_output_args.py
@@ -10,6 +10,15 @@ import dataclasses as dc
 _LOGGER = logging.getLogger(__name__)
 
 
+RemoveDuplicateOutputArgsFunc = t.Callable[
+    [
+        fx.GraphModule,
+        t.Collection[str],
+    ],
+    t.Mapping[str, "RemoveDuplicateResult"]
+]
+
+
 def remove_duplicate_output_args(
     top_level: fx.GraphModule,
     target_subnets: t.Collection[str]


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/65124

So that its implementation can be abstracted and replaced

Test Plan: Run linter, CI

Reviewed By: 842974287

Differential Revision: D30966916

