### PR TITLE
[Static Runtime] Mark StaticModule and StaticRuntime with C10_DISABLE_COPY_AND_ASSIGN

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -90,13 +90,14 @@ static void BM_deep_wide_static(benchmark::State& state) {
   }
 }
 
-torch::jit::StaticRuntime getStaticRuntime() {
+std::shared_ptr<torch::jit::StaticModule> getStaticModule() {
   static auto smod = std::make_shared<torch::jit::StaticModule>(getDeepAndWideSciptModel());
-  return torch::jit::StaticRuntime(*smod);
+  return smod;
 }
 
 static void BM_deep_wide_static_threaded(benchmark::State& state) {
-   auto sr = getStaticRuntime();
+  auto sm = getStaticModule();
+  torch::jit::StaticRuntime sr(*sm);
 
   const int batch_size = 1; // state.range(0);
   auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -106,6 +106,8 @@ class TORCH_API StaticModule {
       bool is_frozen = false,
       const StaticModuleOptions& opts = StaticModuleOptions());
 
+  C10_DISABLE_COPY_AND_ASSIGN(StaticModule);
+
   typedef enum {
     CONSTANT_VALUE = -2, // VALUE nodes defined by prim::Constant
     INPUT_VALUE = -1, // VALUE nodes representing graph inputs
@@ -216,6 +218,8 @@ class TORCH_API StaticModule {
 class TORCH_API StaticRuntime {
  public:
   explicit StaticRuntime(const StaticModule& sm);
+
+  C10_DISABLE_COPY_AND_ASSIGN(StaticRuntime);
 
   std::vector<at::Tensor> operator()(const std::vector<at::Tensor>& inps);
 


### PR DESCRIPTION
Summary: `StaticModule` and `StaticRuntime` are heavy with a large buffer and other dynamically allocated data which is not meant to be copied around. So this change marks them with C10_DISABLE_COPY_AND_ASSIGN to prevent implicit copying.

Test Plan: - Confirmed that `buck run //caffe2/benchmarks/static_runtime:deep_wide_pt_benchmark` succeeded.

Differential Revision: D30984672

