### PR TITLE
Disable autograd fallback tests on Windows

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -969,6 +969,8 @@ void assertBasicChecks(F op) {
 
 } // namespace
 
+#if !defined(_MSC_VER)
+
 TEST(TestAutogradNotImplementedFallback, RetSingleNonTensor) {
   REGISTER_TEST_OP("ret_single_non_tensor", "_test::ret_single_non_tensor(Tensor self, Tensor other) -> int", ret_single_non_tensor);
   auto opHandle = c10::Dispatcher::singleton().findSchemaOrThrow("_test::ret_single_non_tensor", "");
@@ -1124,6 +1126,8 @@ TEST(TestAutogradNotImplementedFallback, TensorlistOp) {
 
   ASSERT_TRUE(at::allclose(op(a, vec), tensorlist_op(a, vec)));
 }
+
+#endif
 
 
 // TODO add these tests if needed

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -969,6 +969,9 @@ void assertBasicChecks(F op) {
 
 } // namespace
 
+// These tests trigger an MSVC bug in the internal arvr build
+// Reproduce with: buck build @arvr/mode/win/opt //xplat/caffe2:autograd_libtorch_test_ovrsource
+// It is probably caused by the lambda, see https://github.com/pytorch/pytorch/issues/48763
 #if !defined(_MSC_VER)
 
 TEST(TestAutogradNotImplementedFallback, RetSingleNonTensor) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65147

I think they trigger an MSVC bug per https://github.com/pytorch/pytorch/issues/48763

Differential Revision: [D30992685](https://our.internmc.facebook.com/intern/diff/D30992685/)