### PR TITLE
Fix port allocation race condition for elastic test

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -84,6 +84,7 @@ class DistributedUtilTest(unittest.TestCase):
 
     def test_create_store_timeout_on_server(self):
         with self.assertRaises(TimeoutError):
+            # use any available port (port 0) since timeout is expected
             create_c10d_store(
                 is_server=True,
                 server_addr=socket.gethostname(),
@@ -94,6 +95,7 @@ class DistributedUtilTest(unittest.TestCase):
 
     def test_create_store_timeout_on_worker(self):
         with self.assertRaises(TimeoutError):
+            # use any available port (port 0) since timeout is expected
             create_c10d_store(
                 is_server=False,
                 server_addr=socket.gethostname(),

--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -84,22 +84,20 @@ class DistributedUtilTest(unittest.TestCase):
 
     def test_create_store_timeout_on_server(self):
         with self.assertRaises(TimeoutError):
-            port = get_free_port()
             create_c10d_store(
                 is_server=True,
                 server_addr=socket.gethostname(),
-                server_port=port,
+                server_port=0,
                 world_size=2,
                 timeout=1,
             )
 
     def test_create_store_timeout_on_worker(self):
         with self.assertRaises(TimeoutError):
-            port = get_free_port()
             create_c10d_store(
                 is_server=False,
                 server_addr=socket.gethostname(),
-                server_port=port,
+                server_port=0,
                 world_size=2,
                 timeout=1,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#65149 Fix port allocation race condition for elastic test**

Fixes #64789

There is a race condition between when the free port is acquired to when it is used to create the store in which it may have been used. Since this test only tests that timeout is triggered for tcpstore, we can bind to any port on tcpstore creation.

This only affects the test on the server (since that is where the port is used), but I changed both tests for clarity

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @cbalioglu @gcramer23

Differential Revision: [D30993166](https://our.internmc.facebook.com/intern/diff/D30993166)