### PR TITLE
Add back the owning_module fix

### DIFF
--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -109,6 +109,11 @@ def split_const_subgraphs(
 
     split = split_module(mod_traced, module, mod_partition)
 
+    # Later we are creating get_attr nodes from main module get_attr nodes and we use the
+    # same node.target. If we don't set the owning_module here, we won't be able to find
+    # the targets of get_attr nodes.
+    split.submod_1.graph.owning_module = mod_traced
+
     # The module that a call_module node refers to gets copied to submodules during split.
     # The path to the module also gets inlined, i.e. mod.a.b -> mod_a_b. Here we need to
     # attach inlined modules to `mod_traced` as it's the owning module now.


### PR DESCRIPTION
Summary: This was a legit fix originally introduced in D30905949 (https://github.com/pytorch/pytorch/commit/446d95a7f64cb464d28d27c4c87c48900a9fde79). But we hesitated and removed it for some reason. Putting it back.

Differential Revision: D30996277

