### PR TITLE
Remove orphan from cuDNN persistent note

### DIFF
--- a/docs/source/cudnn_persistent_rnn.rst
+++ b/docs/source/cudnn_persistent_rnn.rst
@@ -1,6 +1,3 @@
-:orphan:
-
-
 .. note::
 
     If the following conditions are satisfied:


### PR DESCRIPTION
Fixes #60009.

As the document is properly [included](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/rnn.py#L799), and [`:orphan:` doesn't need to be used in included documents](https://github.com/sphinx-doc/sphinx/issues/6787#issuecomment-549256840), and no warning is emitted in my local build when removing it, I think it can be removed.

The artifact reported in #60009 can be seen in 3 pages: [torch.nn.RNN](https://pytorch.org/docs/stable/generated/torch.nn.RNN.html#torch.nn.RNN), [torch.nn.LSTM](https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html#torch.nn.LSTM), and [torch.nn.GRU](https://pytorch.org/docs/stable/generated/torch.nn.GRU.html#torch.nn.GRU).

cc @ezyang @suo 