### PR TITLE
[xplat][pytorch]: Disabling too many logging.

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -30,11 +30,13 @@
   #define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY 256
   #define VMA_RECORDING_ENABLED 1
 
-  #define VMA_DEBUG_LOG(format, ...)  \
-    do {                              \
-      printf(format, ##__VA_ARGS__);  \
-      printf("\n");                   \
-    } while (false)
+  #define VMA_DEBUG_LOG(format, ...)
+  /*
+  #define VMA_DEBUG_LOG(format, ...) do { \
+      printf(format, __VA_ARGS__); \
+      printf("\n"); \
+  } while(false)
+  */
 #endif /* DEBUG */
 
 #ifdef __clang__


### PR DESCRIPTION
Summary:
Disabling too many logging. These are per frame logging
and outputting lots of logs in Skylight command line.

Test Plan:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
cd -
```

Reviewed By: SS-JIA

Differential Revision: D30778852

