### PR TITLE
[PyTorch Edge] Revert copying of opname in Function::append_operator

### DIFF
--- a/torch/csrc/jit/mobile/function.cpp
+++ b/torch/csrc/jit/mobile/function.cpp
@@ -38,7 +38,7 @@ bool Function::append_operator(
                                 are removed */
   // Keep the original opname in code_
   code_->op_names_.emplace_back(name, overload_name);
-  auto opname = code_->op_names_.back();
+  const auto& opname = code_->op_names_.back();
 
   const auto& opname_c10 = opname;
   std::function<void(Stack&)> fn;


### PR DESCRIPTION
Summary:
Based on discussion here:
https://www.internalfb.com/diff/D30615710 (https://github.com/pytorch/pytorch/commit/3727baea6f181f35ed83772abb960ba264d50f12)?dst_version_fbid=182906743925901&transaction_fbid=2132434103575494

Test Plan: Phabricator Tests

Differential Revision: D31004499

