### PR TITLE
[PyTorch] Extract parseOperator() into a standalone source file

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -542,6 +542,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
        ${TORCH_SRC_DIR}/csrc/jit/mobile/module.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/observer.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/parse_bytecode.cpp
+       ${TORCH_SRC_DIR}/csrc/jit/mobile/parse_operators.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/train/export_data.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/train/optim/sgd.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/train/random.cpp

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/mobile/model_compatibility.h>
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/csrc/jit/mobile/parse_bytecode.h>
+#include <torch/csrc/jit/mobile/parse_operators.h>
 #include <torch/csrc/jit/mobile/runtime_compatibility.h>
 #include <torch/csrc/jit/serialization/export.h>
 #include <torch/csrc/jit/serialization/import.h>
@@ -954,6 +955,57 @@ TEST(RunTimeTest, ParseBytecode) {
   auto output1 = inputs1[0].toList();
   ASSERT_EQ(output1[0], 2);
   ASSERT_EQ(output1[1], 1);
+}
+
+TEST(RunTimeTest, ParseOperator) {
+  // A simple example to show a simple bytecode that can be used independent of
+  // PyTorch TorchScript serialization (unpickler, etc) and operator library.
+  // It has one operator and we should be able to register it. The original
+  // PyTorch program:
+
+  // class Add(torch.nn.Module):
+  //     def __init__(self):
+  //         super(Add, self).__init__()
+
+  //     def forward(self, a, b):
+  //         return a + b
+
+  // 1. Prepare for the bytecode. In reality it can be from a customized
+  // deserializer.
+  std::vector<IValue> instructions{
+      to_tuple({"STOREN", 1, 3}),
+      to_tuple({"DROPR", 1, 0}),
+      to_tuple({"MOVE", 2, 0}),
+      to_tuple({"MOVE", 3, 0}),
+      to_tuple({"OP", 0, 0}),
+      to_tuple({"RET", 0, 0}),
+  };
+  std::vector<IValue> operators{
+      to_tuple({"aten::add", "Tensor", 2}),
+  };
+  std::vector<IValue> constants{
+      to_tuple({1}),
+  };
+  int64_t model_version = caffe2::serialize::kProducedBytecodeVersion;
+  // 2. Parse the function
+  std::string function_name("test_function");
+  auto function = std::unique_ptr<mobile::Function>(
+      new mobile::Function(c10::QualifiedName(function_name)));
+  std::vector<IValue> debug_handles_m_tuple;
+  parseInstructions(
+      function_name, instructions, debug_handles_m_tuple, function.get());
+  parseOperators(operators, model_version, 1, function.get());
+  const size_t rsize = 5;
+  parseRegisterSize(rsize, function.get());
+
+  // 3. Prepare for inputs and run the function
+  // Note that the first input is reserved for Module object.
+  // Since this is a function test and Module object is not required,
+  // a dummy IValue (0) is added here.
+  std::vector<IValue> inputs{0, at::tensor(1), at::tensor(2)};
+  function->run(inputs);
+  auto output = inputs[0];
+  ASSERT_EQ(output, at::tensor(3));
 }
 
 namespace {

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -436,6 +436,7 @@ torch_mobile_core = [
     "torch/csrc/jit/mobile/module.cpp",
     "torch/csrc/jit/mobile/observer.cpp",
     "torch/csrc/jit/mobile/parse_bytecode.cpp",
+    "torch/csrc/jit/mobile/parse_operators.cpp",
     "torch/csrc/jit/runtime/register_prim_ops.cpp",
     "torch/csrc/jit/runtime/register_special_ops.cpp",
 ]
@@ -477,6 +478,7 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/jit/mobile/module.cpp",
     "torch/csrc/jit/mobile/observer.cpp",
     "torch/csrc/jit/mobile/parse_bytecode.cpp",
+    "torch/csrc/jit/mobile/parse_operators.cpp",
     "torch/csrc/jit/mobile/train/export_data.cpp",
     "torch/csrc/jit/mobile/train/optim/sgd.cpp",
     "torch/csrc/jit/mobile/train/random.cpp",

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/parse_bytecode.h>
+#include <torch/csrc/jit/mobile/parse_operators.h>
 
 #include <ATen/core/ivalue.h>
 #include <c10/util/ScopeExit.h>
@@ -181,19 +182,6 @@ bool isTensorInBytecodeArchive(
 }
 
 namespace {
-void print_unsupported_ops_and_throw(
-    const std::unordered_set<std::string>& unsupported_ops) {
-  std::string error_message("{");
-  for (const auto& op_name : unsupported_ops) {
-    error_message += op_name + ", ";
-  }
-  error_message += "}";
-  TORCH_CHECK(
-      false,
-      "Following ops cannot be found. ",
-      "Check fburl.com/missing_ops for the fix.",
-      error_message);
-}
 
 // The deserializer class which loads the bytecode package from bc files.
 class BytecodeDeserializer final {
@@ -236,42 +224,6 @@ BytecodeDeserializer::BytecodeDeserializer(
     : compilation_unit_(std::make_shared<CompilationUnit>()),
       reader_(std::move(reader)),
       module_load_options_(module_load_options) {}
-
-/**
- * Loads operators by looking them up in the Dispatcher and returns
- * the set of operator names (with overload) that are not supported
- * by the current runtime.
- */
-std::unordered_set<std::string> load_and_find_unsupported_operator_names(
-    const std::vector<IValue>& ops_list,
-    mobile::Function* function,
-    int64_t model_version) {
-  std::unordered_set<std::string> unsupported_op_names;
-  // ops_list is the list of operator names that were read in from
-  // bytecode.plk for the method that is currently being processed.
-  for (const auto& op : ops_list) {
-    auto op_item = op.toTuple()->elements();
-    TORCH_CHECK(
-        op_item.size() >= 2,
-        "There should be either two parts (name and overload name), ",
-        "or three parts (name, overload name and number of specified args) ",
-        "for an operator");
-    c10::optional<int> num_args;
-    if (op_item.size() > 2) {
-      num_args = op_item[2].toInt();
-    }
-    auto op_found = function->append_operator(
-        op_item[0].toString()->string(),
-        op_item[1].toString()->string(),
-        num_args,
-        model_version);
-    if (!op_found) {
-      unsupported_op_names.emplace(operator_str(
-          op_item[0].toString()->string(), op_item[1].toString()->string()));
-    }
-  }
-  return unsupported_op_names;
-}
 
 TypePtr BytecodeDeserializer::resolveTypeName(const c10::QualifiedName& qn) {
   return resolveTypeNameMobile(qn, compilation_unit_);
@@ -334,20 +286,6 @@ void BytecodeDeserializer::parseFunctionSchema(
         false /*is_varargs*/,
         false /*is_varret*/);
     function->setSchema(std::move(schema));
-  }
-}
-
-void parseOperators(
-    const std::vector<IValue>& ops_list,
-    const int64_t& model_version,
-    const uint64_t& module_load_options,
-    mobile::Function* function) {
-  std::unordered_set<std::string> unsupported_op_names =
-      load_and_find_unsupported_operator_names(
-          ops_list, function, model_version);
-  if ((module_load_options & MobileModuleLoadOptions::OPERATOR_CHECK) &&
-      !unsupported_op_names.empty()) {
-    print_unsupported_ops_and_throw(unsupported_op_names);
   }
 }
 

--- a/torch/csrc/jit/mobile/import.h
+++ b/torch/csrc/jit/mobile/import.h
@@ -17,13 +17,6 @@ constexpr const char* kArchiveNameBytecode = "bytecode";
 constexpr const char* kArchiveNameConstants = "constants";
 constexpr const char* kArchiveNameVersion = "version";
 
-enum MobileModuleLoadOptions {
-  OPERATOR_CHECK = 1,
-};
-
-const uint64_t _default_mobile_module_load_options =
-    MobileModuleLoadOptions::OPERATOR_CHECK;
-
 // The family of methods below load a serialized Mobile Module
 // into a mobile::Module object.
 TORCH_API mobile::Module _load_for_mobile(

--- a/torch/csrc/jit/mobile/parse_operators.cpp
+++ b/torch/csrc/jit/mobile/parse_operators.cpp
@@ -1,0 +1,84 @@
+#include <ATen/core/ivalue.h>
+#include <torch/csrc/jit/mobile/parse_operators.h>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+std::string operator_str(
+    const std::string& name,
+    const std::string& overloadname) {
+  std::string result = name;
+  if (!overloadname.empty()) {
+    result += "." + overloadname;
+  }
+  return result;
+}
+
+/**
+ * Loads operators by looking them up in the Dispatcher and returns
+ * the set of operator names (with overload) that are not supported
+ * by the current runtime.
+ */
+std::unordered_set<std::string> load_and_find_unsupported_operator_names(
+    const std::vector<IValue>& ops_list,
+    mobile::Function* function,
+    int64_t model_version) {
+  std::unordered_set<std::string> unsupported_op_names;
+  // ops_list is the list of operator names that were read in from
+  // bytecode.plk for the method that is currently being processed.
+  for (const auto& op : ops_list) {
+    auto op_item = op.toTuple()->elements();
+    TORCH_CHECK(
+        op_item.size() >= 2,
+        "There should be either two parts (name and overload name), ",
+        "or three parts (name, overload name and number of specified args) ",
+        "for an operator");
+    c10::optional<int> num_args;
+    if (op_item.size() > 2) {
+      num_args = op_item[2].toInt();
+    }
+    auto op_found = function->append_operator(
+        op_item[0].toString()->string(),
+        op_item[1].toString()->string(),
+        num_args,
+        model_version);
+    if (!op_found) {
+      unsupported_op_names.emplace(operator_str(
+          op_item[0].toString()->string(), op_item[1].toString()->string()));
+    }
+  }
+  return unsupported_op_names;
+}
+
+void print_unsupported_ops_and_throw(
+    const std::unordered_set<std::string>& unsupported_ops) {
+  std::string error_message("{");
+  for (const auto& op_name : unsupported_ops) {
+    error_message += op_name + ", ";
+  }
+  error_message += "}";
+  TORCH_CHECK(
+      false,
+      "Following ops cannot be found. ",
+      "Check fburl.com/missing_ops for the fix.",
+      error_message);
+}
+
+void parseOperators(
+    const std::vector<IValue>& ops_list,
+    const int64_t& model_version,
+    const uint64_t& module_load_options,
+    mobile::Function* function) {
+  std::unordered_set<std::string> unsupported_op_names =
+      load_and_find_unsupported_operator_names(
+          ops_list, function, model_version);
+  if ((module_load_options & MobileModuleLoadOptions::OPERATOR_CHECK) &&
+      !unsupported_op_names.empty()) {
+    print_unsupported_ops_and_throw(unsupported_op_names);
+  }
+}
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/parse_operators.h
+++ b/torch/csrc/jit/mobile/parse_operators.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <torch/csrc/jit/mobile/function.h>
+
+namespace torch {
+namespace jit {
+using c10::IValue;
+
+enum MobileModuleLoadOptions {
+  OPERATOR_CHECK = 1,
+};
+
+const uint64_t _default_mobile_module_load_options =
+    MobileModuleLoadOptions::OPERATOR_CHECK;
+
+namespace mobile {
+
+TORCH_API void parseOperators(
+    const std::vector<IValue>& ops_list,
+    const int64_t& model_version,
+    const uint64_t& module_load_options,
+    mobile::Function* function);
+} // namespace mobile
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Summary: This is following up this PR: https://github.com/pytorch/pytorch/pull/61862. The purpose is to modularize operator parsing so that it can be used as needed without pulling the whole `import.cpp` into build.

Test Plan: Added a unit test in `test_lite_predictor.cpp` called `ParseOperators`, similar to `ParseBytecode`.

Differential Revision: D31006555

