### PR TITLE
[FX] Add torch.ops.profiler._record_function_{enter,exit} as stateful ops for DCE

### DIFF
--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -24,7 +24,9 @@ Argument = Optional[Union[
     BaseArgumentTypes
 ]]
 
-_side_effectful_functions: Set[Callable] = {torch._assert}
+_side_effectful_functions: Set[Callable] = {
+    torch._assert, torch.ops.profiler._record_function_enter,
+    torch.ops.profiler._record_function_exit}
 
 # this is fixed on master, WAR for 1.5
 def _find_module_of_method(orig_method: Callable[..., Any]) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65180

To be used in conjunction with a facility that allows profiling ranges to be recorded, such as with https://github.com/pytorch/examples/blob/master/fx/profiling_tracer.py

Differential Revision: [D31007115](https://our.internmc.facebook.com/intern/diff/D31007115)