### PR TITLE
Add __module__ to torch.dtype.__dict__

### DIFF
--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -126,6 +126,22 @@ PyTypeObject THPDtypeType = {
 
 void THPDtype_init(PyObject *module)
 {
+  // Set a __dict__ with `__module__` = `torch`. This means
+  // `__module__` value will be inherited by instances, which will
+  // prevent Pickle from having to search all of sys.modules in order
+  // to find the module when pickling a dtype.
+  //
+  // See https://github.com/pytorch/pytorch/issues/65077
+  AT_ASSERT(THPDtypeType.tp_dict == nullptr);
+  auto dict = THPObjectPtr(PyDict_New());
+  if (!dict) throw python_error();
+  auto torch = THPUtils_packString("torch");
+  if (!torch) throw python_error();
+  if (PyDict_SetItemString(dict, "__module__", torch) < 0 ) {
+      throw python_error();
+  }
+  THPDtypeType.tp_dict = dict.release();
+
   if (PyType_Ready(&THPDtypeType) < 0) {
     throw python_error();
   }

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -127,12 +127,16 @@ PyTypeObject THPDtypeType = {
 void THPDtype_init(PyObject *module)
 {
   // Set a __dict__ with `__module__` = `torch`. This means
-  // `__module__` value will be inherited by instances, which will
-  // prevent Pickle from having to search all of sys.modules in order
-  // to find the module when pickling a dtype.
+  // `__module__` value will be inherited by instances
+  // (i.e. `torch.float32.__module__ == "torch"`). This will prevent
+  // Pickle from having to search all of sys.modules in order to find
+  // the module when pickling a dtype instance.
+  //
+  // We have to do this in C++ because extension types are not mutable
+  // from Python code.
   //
   // See https://github.com/pytorch/pytorch/issues/65077
-  AT_ASSERT(THPDtypeType.tp_dict == nullptr);
+  TORCH_INTERNAL_ASSERT(THPDtypeType.tp_dict == nullptr);
   auto dict = THPObjectPtr(PyDict_New());
   if (!dict) throw python_error();
   auto torch = THPUtils_packString("torch");


### PR DESCRIPTION
torch.dtype.__reduce__ returns a string, which causes Pickle to look
up the object by module and name. In order to find the right module,
Pickle looks for __module__ on the object; if it doesn't find that, it
falls back to searching sys.modules.

Previously, torch.dtype instances did not have a `__module__`
attribute, so pickling dtypes would fall back to a search of
sys.module.

Instances of normal Python objects have a `__module__` attribute
because normal Python classes have a `__module__` key in their
`__dict__`. Imitate that by populating one in `torch.dtype`.

We set the field in `tp_dict` before calling `PyType_Ready` (instead
of afterwards) because of the doc warning against mutating a type's
dictionary once initialized:
https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_dict

fixes #65077

---

I didn't add any tests because I didn't see any obvious places with similar tests for pickling or dtype objects. Let me know if I missed the right place, or should start one.