### PR TITLE
[Pipe] Add a `WithDevice` wrapper to specify device execution for a module.

### DIFF
--- a/test/distributed/pipeline/sync/test_pipe.py
+++ b/test/distributed/pipeline/sync/test_pipe.py
@@ -804,16 +804,16 @@ def test_with_device_wrapper(setup_rpc):
 
     model = nn.Sequential(fc1, fc2, WithDevice(dropout, 'cuda:1'))
     model = Pipe(model, chunks=8)
-    model(torch.rand(16, 16).cuda(0))
+    assert torch.device('cuda:1') == model(torch.rand(16, 16).cuda(0)).local_value().device
     assert [torch.device('cuda:0'), torch.device('cuda:1')] == model.devices
 
     model = nn.Sequential(fc1, WithDevice(dropout, 'cuda:1'))
     model = Pipe(model, chunks=8)
-    model(torch.rand(16, 16).cuda(0))
+    assert torch.device('cuda:1') == model(torch.rand(16, 16).cuda(0)).local_value().device
     assert [torch.device('cuda:0'), torch.device('cuda:1')] == model.devices
 
     model = nn.Sequential(fc1, WithDevice(fc2, 'cuda:0'))
     model = Pipe(model, chunks=8)
-    model(torch.rand(16, 16).cuda(0))
+    assert torch.device('cuda:0') == model(torch.rand(16, 16).cuda(0)).local_value().device
     assert [torch.device('cuda:0')] == model.devices
     assert torch.device('cuda:0') == fc2.weight.device

--- a/test/distributed/pipeline/sync/test_pipe.py
+++ b/test/distributed/pipeline/sync/test_pipe.py
@@ -14,8 +14,7 @@ import torch
 from torch import nn
 from torch import Tensor
 
-from torch.distributed.pipeline.sync import NoChunk
-from torch.distributed.pipeline.sync import Pipe
+from torch.distributed.pipeline.sync import Pipe, NoChunk, WithDevice
 from torch.distributed.pipeline.sync.pipe import PipeSequential
 
 skip_if_no_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda required")
@@ -795,3 +794,26 @@ def test_inputs_wrong_device(setup_rpc):
     model = Pipe(nn.Sequential(Module1().cuda(0), Module1().cuda(1)), chunks=2)
     with pytest.raises(ValueError, match='All inputs should be on the same device as the first partition'):
         model(a, b)
+
+@skip_if_no_cuda
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need atleast two GPUs")
+def test_with_device_wrapper(setup_rpc):
+    fc1 = nn.Linear(16, 8).cuda(0)
+    fc2 = nn.Linear(8, 4).cuda(1)
+    dropout = nn.Dropout()
+
+    model = nn.Sequential(fc1, fc2, WithDevice(dropout, 'cuda:1'))
+    model = Pipe(model, chunks=8)
+    model(torch.rand(16, 16).cuda(0))
+    assert [torch.device('cuda:0'), torch.device('cuda:1')] == model.devices
+
+    model = nn.Sequential(fc1, WithDevice(dropout, 'cuda:1'))
+    model = Pipe(model, chunks=8)
+    model(torch.rand(16, 16).cuda(0))
+    assert [torch.device('cuda:0'), torch.device('cuda:1')] == model.devices
+
+    model = nn.Sequential(fc1, WithDevice(fc2, 'cuda:0'))
+    model = Pipe(model, chunks=8)
+    model(torch.rand(16, 16).cuda(0))
+    assert [torch.device('cuda:0')] == model.devices
+    assert torch.device('cuda:0') == fc2.weight.device

--- a/torch/distributed/pipeline/sync/__init__.py
+++ b/torch/distributed/pipeline/sync/__init__.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 """A Pipe implementation in PyTorch."""
 from .checkpoint import is_checkpointing, is_recomputing
-from .pipe import Pipe
+from .pipe import Pipe, WithDevice
 from .microbatch import NoChunk
 
 __all__ = ["Pipe", "is_checkpointing", "is_recomputing"]

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -135,7 +135,7 @@ class PipeSequential(nn.Sequential):
 
 class WithDevice(nn.Module):
     """
-    Wraps an nn.Module which is part of nn.Sequential passed into :class:`Pipe`
+    Wraps an ``nn.Module`` which is part of ``nn.Sequential`` passed into :class:`Pipe`
     that overrides the device for that module. In cases where :class:`Pipe`
     can't implicitly determine the device for the module and places it on CPU,
     this wrapper can be used to override the implicit behavior and explicitly


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65190

As described in https://github.com/pytorch/pytorch/issues/65093, there
could be modules which don't have any parameters/buffers. In this case, Pipe
determines that the module should be executed on CPU. However this might result
in unnecessary GPU to CPU transfers whereas the user expected the module to be
executed on the GPU itself by keeping its inputs and outputs on GPU.

For this use case, we introduce a `WithDevice` wrapper which can be used to
override which device a particular module should be executed on as part of the
pipeline.

#Closes: https://github.com/pytorch/pytorch/issues/65093

Differential Revision: [D31010027](https://our.internmc.facebook.com/intern/diff/D31010027/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @gcramer23