### PR TITLE
feed model merge net lower benchmark

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -401,6 +401,9 @@ def matmul(*, input, other):
 @register_custom_acc_mapper_fn(
     op_and_target=("call_function", nn.functional.dropout),
     arg_replacement_tuples=[("input", "input")])
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "detach"),
+    arg_replacement_tuples=[("input", "input")])
 def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
     """
     Remove dropout node and directly map its input to output.
@@ -497,6 +500,7 @@ def sub(*, input, other):
 
 @register_acc_op_mapping(op_and_target=("call_function", torch.mul))
 @register_acc_op_mapping(op_and_target=("call_function", operator.mul))
+@register_acc_op_mapping(op_and_target=("call_method", "mul"))
 @register_acc_op
 def mul(*, input, other):
     return input * other
@@ -716,6 +720,7 @@ def cosh(*, input):
 
 
 @register_acc_op_mapping(op_and_target=("call_function", torch.tanh))
+@register_acc_op_mapping(op_and_target=("call_method", "tanh"))
 @register_acc_op
 def tanh(*, input):
     return torch.tanh(**locals())


### PR DESCRIPTION
Summary:
Run benchmark for model  blue_reels_vdd_10s_v1_esuhm_combined, model split is from D30466245.
This model will use linalg_norm op and requires a batch_size change, which is not supported by current linalg_norm plugin(will throw error). So I disabled the plugin, and this makes the lower run number a bit slower than expected.

Test Plan:
run command:
buck run mode/opt -c python.package_style=inplace hpc/new/models/feed/benchmark:feed_lower_benchmark

example output:
Eager, BS: 2048, TFLOP/s: 253.25, Time per iter: 4.49ms, QPS: 456289.25
TensorRT, BS: 2048, TFLOP/s: 162.30, Time per iter: 7.00ms, QPS: 292426.58

Differential Revision: D31010288

