### PR TITLE
Use src size for memcpy in order to avoid fortify complaints

### DIFF
--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -103,7 +103,7 @@ template <typename To, typename From>
 To raw_bitcast(const From& src) {
   TORCH_CHECK(sizeof(To) == sizeof(From), "Invalid bitcast invocation");
   To storage;
-  std::memcpy(&storage, &src, sizeof(From));
+  std::memcpy(&storage, &src, sizeof(To));
   return reinterpret_cast<To&>(storage);
 }
 


### PR DESCRIPTION
Summary: When compiling against the Android SDK with `--D_FORTIFY_SOURCE=2`, the compiler will complain that the `dst` size is a larger size than the `src` size due to the function templating using two differently sized objects. There is a `TORCH_CHECK` to ensure we don't go through with these `memcpy`'s, but in the interest of making the compiler happy, lets switch the `memcpy` to take `sizeof(src)`.

Test Plan: CI

Differential Revision: D30992678

