### PR TITLE
[fx const fold] fix a case when some inputs are unused

### DIFF
--- a/test/fx/test_fx_const_fold.py
+++ b/test/fx/test_fx_const_fold.py
@@ -435,3 +435,22 @@ class TestConstFold(unittest.TestCase):
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
         self.assertTrue(torch.equal(fold_result, base_result))
+
+    def test_const_fold_unused_placeholder(self):
+        class ConstFoldTestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.const = torch.nn.Parameter(torch.randn(2, 3))
+
+            def forward(self, x, y, z):
+                a = self.const + self.const
+                return y + a
+
+        mod = ConstFoldTestModule()
+        gm_folded = const_fold.split_const_subgraphs(mod)
+
+        # Now run both folded and non-folded to check results equal.
+        in_x = torch.randn(2, 3)
+        fold_result = gm_folded(in_x, in_x, in_x)
+        base_result = mod(in_x, in_x, in_x)
+        self.assertTrue(torch.equal(fold_result, base_result))


### PR DESCRIPTION
Summary: If there're unused inputs, they won't appear in `submod_1`. We need to add all the unused inputs so that the model after const fold has the same inputs as the original model.

Differential Revision: D31021217

