### PR TITLE
[fx] give warning instead of fatal the program when submod not found during adding get_attr

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -561,9 +561,10 @@ class Graph:
         def _get_attr_reference_exists(mod: torch.nn.Module, qualified_name: str) -> bool:
             module_path, _, name = qualified_name.rpartition(".")
 
-            submod: Optional[torch.nn.Module] = mod.get_submodule(module_path)
-
-            if not submod:
+            try:
+                submod: torch.nn.Module = mod.get_submodule(module_path)
+            except AttributeError:
+                warnings.warn(f"Failed to fetch module {module_path}!")
                 return False
 
             if not hasattr(submod, name):


### PR DESCRIPTION
Summary:
Currently when create get_attr node, if the attribute is in a submodule, we'll fist find the submodule. If the submodule isn't in the owning module we throw an exception.

However, if the attribute can't be found, we give a warning but still allow to create the get_attr node. To align with this behavior, we change the reaction when submod not found from fatal to giving a warning.

Test Plan: CI

Differential Revision: D31021535

