### PR TITLE
Remove incorrect stride assert in Reduce.cuh

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -936,8 +936,6 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
 
   if (!can_use_32bit_indexing) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      // Dim 0 is always the reduced dimension
-      AT_ASSERT(sub_iter.strides(0)[0] == 0);
       int64_t sub_iter_base_idx = sub_iter.view_offsets()[0];
 
       gpu_reduce_kernel<scalar_t, out_scalar_t, vt0>(sub_iter, ops, ident,


### PR DESCRIPTION
Fixes #37583

Per discussion with @ngimel, the condition asserted here may not always hold after TensorIterator's dimension coalescing and reordering. However, the reduction output should still be correct when `sub_iter.strides(0)[0]` is non-zero.

I've verified correctness empirically by:
1. Lowering the threshold ([configured here](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/TensorIterator.cpp#L1127)) at which iterators are split into sub-iterators, making it easier to trigger.
2. Generating many tensors with random dimensions and randint elements which produce a non-zero `sub_iter.strides(0)[0]` in the CUDA kernel.
3. Verifying that the reduction `t.sum(dim=0)` produces the same results for those tensors on CPU and on CUDA.