### PR TITLE
[rfc] Add periodic auto-formatting job

### DIFF
--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -48,7 +48,8 @@ if __name__ == "__main__":
         }
         if data.get("concurrency", None) != expected:
             print(
-                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}'",
+                f"'concurrency' incorrect or not found in '{filename.relative_to(REPO_ROOT)}',"
+                f" expected '{expected}'",
                 file=sys.stderr,
             )
             errors_found = True

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -2,7 +2,7 @@
 
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, Set, List, Any, Tuple
 
 import jinja2
 import json
@@ -562,7 +562,6 @@ if __name__ == "__main__":
         loader=jinja2.FileSystemLoader(str(GITHUB_DIR.joinpath("templates"))),
         undefined=jinja2.StrictUndefined,
     )
-    from typing import *
     template_and_workflows: List[Tuple[Any, Any]] = [
         (jinja_env.get_template("linux_ci_workflow.yml.j2"), LINUX_WORKFLOWS),
         (jinja_env.get_template("windows_ci_workflow.yml.j2"), WINDOWS_WORKFLOWS),

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -562,11 +562,14 @@ if __name__ == "__main__":
         loader=jinja2.FileSystemLoader(str(GITHUB_DIR.joinpath("templates"))),
         undefined=jinja2.StrictUndefined,
     )
-    template_and_workflows = [
+    from typing import *
+    template_and_workflows: List[Tuple[Any, Any]] = [
         (jinja_env.get_template("linux_ci_workflow.yml.j2"), LINUX_WORKFLOWS),
         (jinja_env.get_template("windows_ci_workflow.yml.j2"), WINDOWS_WORKFLOWS),
         (jinja_env.get_template("bazel_ci_workflow.yml.j2"), BAZEL_WORKFLOWS),
-        (jinja_env.get_template("auto_formatter.yml.j2"), [SimpleWorkflow("periodic-auto-formatter")]),
+        (jinja_env.get_template("auto_formatter.yml.j2"), [
+            SimpleWorkflow("periodic-auto-formatter"),
+        ]),
     ]
     # Delete the existing generated files first, this should align with .gitattributes file description.
     existing_workflows = GITHUB_DIR.glob("workflows/generated-*")

--- a/.github/templates/auto_formatter.yml.j2
+++ b/.github/templates/auto_formatter.yml.j2
@@ -1,0 +1,28 @@
+{% import 'common.yml.j2' as common %}
+
+name: autoformatter
+
+on:
+  schedule:
+    - cron: 0 4 * * SAT
+  workflow_dispatch:
+
+concurrency:
+  group: autoformatter-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    runs-on: ubuntu-18.04
+    steps:
+      !{{ common.checkout_pytorch("false") }}
+      - name: Install Dependencies
+        run: |
+          pip install black==21.9b0
+      - name: Run black
+        run: |
+          black tools/testing/*
+      - name: Push results
+        run: |
+          git status
+          git diff

--- a/.github/templates/auto_formatter.yml.j2
+++ b/.github/templates/auto_formatter.yml.j2
@@ -14,12 +14,12 @@ concurrency:
 
 jobs:
   python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       !{{ common.checkout_pytorch("false") }}
       - name: Install Dependencies
         run: |
-          pip install black==21.9b0
+          pip install black==21.8b0
       - name: Run black
         run: |
           black tools/testing/*

--- a/.github/templates/auto_formatter.yml.j2
+++ b/.github/templates/auto_formatter.yml.j2
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: 0 4 * * SAT
   workflow_dispatch:
+  pull_request:  # TODO: remove this before landing!
 
 concurrency:
   group: autoformatter-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/templates/auto_formatter.yml.j2
+++ b/.github/templates/auto_formatter.yml.j2
@@ -1,5 +1,11 @@
 {% import 'common.yml.j2' as common %}
 
+{%- block name -%}
+# Template is at:    .github/templates/auto_formatter.yml.j2
+# Generation script: .github/scripts/generate_ci_workflows.py
+name: !{{ build_environment }}
+{%- endblock %}
+
 name: autoformatter
 
 on:
@@ -9,7 +15,7 @@ on:
   pull_request:  # TODO: remove this before landing!
 
 concurrency:
-  group: autoformatter-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: periodic-auto-formatter-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/generated-periodic-auto-formatter.yml
+++ b/.github/workflows/generated-periodic-auto-formatter.yml
@@ -1,0 +1,34 @@
+# @generated DO NOT EDIT MANUALLY
+
+
+name: autoformatter
+
+on:
+  schedule:
+    - cron: 0 4 * * SAT
+  workflow_dispatch:
+
+concurrency:
+  group: autoformatter-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout PyTorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
+          submodules: false
+      - name: Install Dependencies
+        run: |
+          pip install black==21.9b0
+      - name: Run black
+        run: |
+          black tools/testing/*
+      - name: Push results
+        run: |
+          git status
+          git diff

--- a/.github/workflows/generated-periodic-auto-formatter.yml
+++ b/.github/workflows/generated-periodic-auto-formatter.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout PyTorch
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
@@ -25,7 +25,7 @@ jobs:
           submodules: false
       - name: Install Dependencies
         run: |
-          pip install black==21.9b0
+          pip install black==21.8b0
       - name: Run black
         run: |
           black tools/testing/*

--- a/.github/workflows/generated-periodic-auto-formatter.yml
+++ b/.github/workflows/generated-periodic-auto-formatter.yml
@@ -1,5 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
-
+# Template is at:    .github/templates/auto_formatter.yml.j2
+# Generation script: .github/scripts/generate_ci_workflows.py
+name: periodic-auto-formatter
 
 name: autoformatter
 
@@ -10,7 +12,7 @@ on:
   pull_request:  # TODO: remove this before landing!
 
 concurrency:
-  group: autoformatter-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: periodic-auto-formatter-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/generated-periodic-auto-formatter.yml
+++ b/.github/workflows/generated-periodic-auto-formatter.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     - cron: 0 4 * * SAT
   workflow_dispatch:
+  pull_request:  # TODO: remove this before landing!
 
 concurrency:
   group: autoformatter-${{ github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#65249**

This adds a job that will run `black` on a set of files every Saturday at 4 AM (randomly picked time where hopefully no one is working). For code owners that want to, they can opt-in and not have to worry about auto-formatting changes creating noise in their actual PRs.

This will muck up the blame a bit (though you can always follow a link back from the autoformatted lines) since [GitHub doesn't support `--ignore-revs`](https://github.com/github/feedback/discussions/5033), but people are commiting unrelated formatting changes anyways that are already muddying the blame so it might not be that big of a deal