### PR TITLE
[ONNX] Deprecated the example_outputs param from torch.onnx.export() function. (#62815)

### DIFF
--- a/test/jit/test_export_modes.py
+++ b/test/jit/test_export_modes.py
@@ -64,7 +64,7 @@ class TestExportModes(JitTestCase):
             return (a, a)
         f = io.BytesIO()
         x = torch.ones(3)
-        torch.onnx._export(foo, (x,), f, example_outputs=(x, x))
+        torch.onnx._export(foo, (x,), f)
 
     @skipIfNoLapack
     def test_aten_fallback(self):

--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -49,20 +49,17 @@ class TestONNXExport(JitTestCase):
 
         tm = TraceMe()
         tm = torch.jit.trace(tm, torch.rand(3, 4))
-        example_outputs = (tm(torch.rand(3, 4)),)
         f = io.BytesIO()
-        torch.onnx._export(tm, (torch.rand(3, 4),), f, example_outputs=example_outputs)
+        torch.onnx._export(tm, (torch.rand(3, 4),), f)
 
     def test_export_tensoroption_to(self):
         def foo(x):
             return x[0].clone().detach().cpu() + x
 
         traced = torch.jit.trace(foo, (torch.rand([2])))
-        example_outputs = traced(torch.rand([2]))
 
         f = io.BytesIO()
-        torch.onnx._export_to_pretty_string(traced, (torch.rand([2]),), f,
-                                            example_outputs=example_outputs)
+        torch.onnx._export_to_pretty_string(traced, (torch.rand([2]),), f)
 
     def test_onnx_export_script_module(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -75,10 +72,8 @@ class TestONNXExport(JitTestCase):
                 return x + x
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3))
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
 
     @suppress_warnings
     def test_onnx_export_func_with_warnings(self):
@@ -93,11 +88,9 @@ class TestONNXExport(JitTestCase):
             def forward(self, x):
                 return func_with_warning(x)
 
-        outputs = WarningTest()(torch.randn(42))
         # no exception
         torch.onnx.export_to_pretty_string(
-            WarningTest(), torch.randn(42), None, verbose=False,
-            example_outputs=outputs)
+            WarningTest(), torch.randn(42), None, verbose=False)
 
     def test_onnx_export_script_python_fail(self):
         class PythonModule(torch.jit.ScriptModule):
@@ -119,11 +112,9 @@ class TestONNXExport(JitTestCase):
                 return y + y
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3))
         f = io.BytesIO()
         with self.assertRaisesRegex(RuntimeError, "Couldn't export Python"):
-            torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False,
-                               example_outputs=outputs)
+            torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
 
     def test_onnx_export_script_inline_trace(self):
         class ModuleToInline(torch.nn.Module):
@@ -144,10 +135,8 @@ class TestONNXExport(JitTestCase):
                 return y + y
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3))
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
 
     def test_onnx_export_script_inline_script(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -169,10 +158,8 @@ class TestONNXExport(JitTestCase):
                 return y + y
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3))
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
 
     def test_onnx_export_script_module_loop(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -189,10 +176,8 @@ class TestONNXExport(JitTestCase):
                 return x
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3))
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
 
     @suppress_warnings
     def test_onnx_export_script_truediv(self):
@@ -206,11 +191,9 @@ class TestONNXExport(JitTestCase):
                 return x + z
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3))
 
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3, dtype=torch.float),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.zeros(1, 2, 3, dtype=torch.float),), None, verbose=False)
 
     def test_onnx_export_script_non_alpha_add_sub(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -223,10 +206,8 @@ class TestONNXExport(JitTestCase):
                 return bs - 1
 
         mte = ModuleToExport()
-        outputs = torch.LongTensor([mte(torch.rand(3, 4))])
         torch.onnx.export_to_pretty_string(
-            mte, (torch.rand(3, 4),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.rand(3, 4),), None, verbose=False)
 
     def test_onnx_export_script_module_if(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -240,10 +221,8 @@ class TestONNXExport(JitTestCase):
                 return x
 
         mte = ModuleToExport()
-        outputs = mte(torch.zeros(1, 2, 3, dtype=torch.long))
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False,
-            example_outputs=outputs)
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
 
     def test_onnx_export_script_inline_params(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -272,8 +251,7 @@ class TestONNXExport(JitTestCase):
         reference = torch.mm(torch.mm(torch.zeros(2, 3), torch.ones(3, 3)), torch.ones(3, 4))
         self.assertEqual(result, reference)
         torch.onnx.export_to_pretty_string(
-            mte, (torch.ones(2, 3),), None, verbose=False,
-            example_outputs=result)
+            mte, (torch.ones(2, 3),), None, verbose=False)
 
     def test_onnx_export_speculate(self):
 
@@ -305,18 +283,16 @@ class TestONNXExport(JitTestCase):
             return x.t()
 
         f1 = Foo(transpose)
-        outputs_f1 = f1(torch.ones(1, 10, dtype=torch.float))
         f2 = Foo(linear)
-        outputs_f2 = f2(torch.ones(1, 10, dtype=torch.float))
 
         torch.onnx.export_to_pretty_string(
             f1,
             (torch.ones(1, 10, dtype=torch.float), ),
-            None, verbose=False, example_outputs=outputs_f1)
+            None, verbose=False)
         torch.onnx.export_to_pretty_string(
             f2,
             (torch.ones(1, 10, dtype=torch.float), ),
-            None, verbose=False, example_outputs=outputs_f2)
+            None, verbose=False)
 
     def test_onnx_export_shape_reshape(self):
         class Foo(torch.nn.Module):
@@ -328,10 +304,8 @@ class TestONNXExport(JitTestCase):
                 return reshaped
 
         foo = torch.jit.trace(Foo(), torch.zeros(1, 2, 3))
-        outputs = foo(torch.zeros(1, 2, 3))
         f = io.BytesIO()
-        torch.onnx.export_to_pretty_string(foo, (torch.zeros(1, 2, 3)), f,
-                                           example_outputs=outputs)
+        torch.onnx.export_to_pretty_string(foo, (torch.zeros(1, 2, 3)), f)
 
     def test_listconstruct_erasure(self):
         class FooMod(torch.nn.Module):
@@ -360,11 +334,10 @@ class TestONNXExport(JitTestCase):
         mod = DynamicSliceExportMod()
 
         input = torch.rand(3, 4, 5)
-        example_outs = mod(input)
 
         f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
-            DynamicSliceExportMod(), (input,), f, example_outputs=example_outs, opset_version=10)
+            DynamicSliceExportMod(), (input,), f, opset_version=10)
 
     def test_export_dict(self):
         class DictModule(torch.nn.Module):
@@ -380,4 +353,4 @@ class TestONNXExport(JitTestCase):
 
         with self.assertRaisesRegex(RuntimeError, r"DictConstruct.+is not supported."):
             torch.onnx.export_to_pretty_string(
-                torch.jit.script(mod), (x_in,), f, example_outputs=(mod(x_in),))
+                torch.jit.script(mod), (x_in,), f)

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -19,7 +19,7 @@ def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
 
             outputs = model(inputs)
             script_model = torch.jit.script(model)
-            run_model_test(self, script_model, False, example_outputs=outputs,
+            run_model_test(self, script_model, False,
                            input=inputs, rtol=rtol, atol=atol)
 
 

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -40,14 +40,13 @@ def check_onnx_opset_operator(model, ops, opset_version=_export_onnx_opset_versi
                     assert attributes[j][attribute_field] == getattr(graph.node[i].attribute[j], attribute_field)
 
 
-def check_onnx_opsets_operator(module, x, ops, opset_versions, training=torch.onnx.TrainingMode.EVAL, example_outputs=None,
+def check_onnx_opsets_operator(module, x, ops, opset_versions, training=torch.onnx.TrainingMode.EVAL,
                                input_names=None, dynamic_axes=None):
     for opset_version in opset_versions:
         f = io.BytesIO()
         torch.onnx.export(module, x, f,
                           opset_version=opset_version,
                           training=training,
-                          example_outputs=example_outputs,
                           input_names=input_names,
                           dynamic_axes=dynamic_axes)
         model = onnx.load(io.BytesIO(f.getvalue()))
@@ -91,10 +90,8 @@ class TestONNXOpset(TestCase):
         x = torch.arange(1., 6., requires_grad=True)
         k = torch.tensor(3)
         module = MyModuleDynamic()
-        example_output = module(x, k)
         check_onnx_opsets_operator(module, [x, k], ops,
-                                   opset_versions=[10],
-                                   example_outputs=example_output)
+                                   opset_versions=[10])
 
     def test_maxpool(self):
         module = torch.nn.MaxPool1d(2, stride=1)
@@ -191,7 +188,6 @@ class TestONNXOpset(TestCase):
 
         module = DynamicSliceModel()
         x = torch.rand(1, 2)
-        example_output = module(x)
         ops_10 = [{"op_name" : "Shape"},
                   {"op_name" : "Constant"},
                   {"op_name" : "Gather",
@@ -202,7 +198,7 @@ class TestONNXOpset(TestCase):
                   {"op_name" : "Slice",
                    "attributes" : []}]
         ops = {10 : ops_10}
-        check_onnx_opsets_operator(module, x, ops, opset_versions=[10], example_outputs=example_output,
+        check_onnx_opsets_operator(module, x, ops, opset_versions=[10],
                                    input_names=['x'], dynamic_axes={"x": [0, 1]})
 
         ops_10 = [{"op_name" : "Constant"},
@@ -212,7 +208,7 @@ class TestONNXOpset(TestCase):
                   {"op_name" : "Slice",
                    "attributes" : []}]
         ops = {10 : ops_10}
-        check_onnx_opsets_operator(module, x, ops, opset_versions=[10], example_outputs=example_output)
+        check_onnx_opsets_operator(module, x, ops, opset_versions=[10])
 
     def test_flip(self):
         class MyModule(Module):

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -278,12 +278,11 @@ class TestOperators(TestCase):
     def test_conv_variable_length(self):
         x = torch.ones(5, 3, 6, 6, requires_grad=True)
         model = torch.nn.Conv2d(3, 2, 3)
-        y = model(x)
 
         dynamic_axes = {"input_1": [0, 2, 3], "output_1": {0: "output_1_variable_dim_0", 1: "output_1_variable_dim_1"}}
         model_proto_name = "conv2d.onnx"
         torch.onnx.export(model, x, model_proto_name, verbose=True, input_names=["input_1"], output_names=["output_1"],
-                          example_outputs=y, dynamic_axes=dynamic_axes)
+                          dynamic_axes=dynamic_axes)
 
         import onnx
         onnx_model = onnx.load(model_proto_name)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -134,7 +134,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         return cuda_model, cuda_input
 
     def run_debug_test(self, model, train, batch_size, state_dict=None,
-                       input=None, use_gpu=True, example_outputs=None,
+                       input=None, use_gpu=True,
                        operator_export_type=torch.onnx.OperatorExportTypes.ONNX):
         """
         # TODO: remove this from the final release version
@@ -153,7 +153,6 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
             model, input = self.convert_cuda(model, input)
 
         onnxir, torch_out = do_export(model, input, export_params=self.embed_params, verbose=False,
-                                      example_outputs=example_outputs,
                                       do_constant_folding=False,
                                       opset_version=self.opset_version,
                                       keep_initializers_as_inputs=True,
@@ -168,7 +167,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     def run_actual_test(self, model, train, batch_size, state_dict=None,
                         input=None, use_gpu=True, rtol=0.001, atol=1e-7,
-                        example_outputs=None, do_constant_folding=True,
+                        do_constant_folding=True,
                         operator_export_type=torch.onnx.OperatorExportTypes.ONNX,
                         input_names=None, dynamic_axes=None,
                         remained_onnx_input_idx=None):
@@ -191,7 +190,6 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         # Verify the model runs the same in Caffe2
         verify.verify(model, input, c2, rtol=rtol, atol=atol,
-                      example_outputs=example_outputs,
                       do_constant_folding=do_constant_folding,
                       opset_version=self.opset_version,
                       keep_initializers_as_inputs=True,
@@ -202,7 +200,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     def run_model_test(self, model, train, batch_size, state_dict=None,
                        input=None, use_gpu=True, rtol=0.001, atol=1e-7,
-                       example_outputs=None, do_constant_folding=True,
+                       do_constant_folding=True,
                        operator_export_type=torch.onnx.OperatorExportTypes.ONNX,
                        input_names=None, dynamic_axes=None,
                        remained_onnx_input_idx=None):
@@ -214,7 +212,6 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         if self.embed_params:
             self.run_actual_test(model, train, batch_size, state_dict, input,
                                  use_gpu=use_gpu_, rtol=rtol, atol=atol,
-                                 example_outputs=example_outputs,
                                  do_constant_folding=do_constant_folding,
                                  operator_export_type=operator_export_type,
                                  input_names=input_names,
@@ -222,8 +219,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                                  remained_onnx_input_idx=remained_onnx_input_idx)
         else:
             self.run_debug_test(model, train, batch_size, state_dict, input,
-                                use_gpu=use_gpu_, example_outputs=example_outputs,
-                                operator_export_type=operator_export_type)
+                                use_gpu=use_gpu_, operator_export_type=operator_export_type)
 
     def test_linear(self):
         class MyModel(torch.nn.Module):
@@ -1401,9 +1397,8 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return x[1:x.size(0)]
         module = DynamicSliceModel()
         x = torch.rand(1, 2)
-        example_output = module(x)
         self.run_model_test(DynamicSliceModel(), train=False, input=(x,),
-                            batch_size=BATCH_SIZE, use_gpu=False, example_outputs=example_output)
+                            batch_size=BATCH_SIZE, use_gpu=False)
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_dynamic_slice_to_the_end(self):
@@ -1472,7 +1467,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         y = torch.ones(2, 3, 4) * 2
         self.run_model_test(Arithmetic(),
                             train=False, input=(), batch_size=BATCH_SIZE,
-                            use_gpu=False, example_outputs=(x + 3, y * (x + 3)))
+                            use_gpu=False)
 
     def test_tensor_factories(self):
         class TensorFactory(torch.nn.Module):
@@ -1493,11 +1488,9 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            use_gpu=False, example_outputs=(torch.ones(x.size()),),
-                            input_names=['x'], dynamic_axes={'x': [0, 1, 2]})
+                            use_gpu=False, input_names=['x'], dynamic_axes={'x': [0, 1, 2]})
         self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            use_gpu=False, example_outputs=(torch.ones(x.size()),),
-                            remained_onnx_input_idx=[])
+                            use_gpu=False, remained_onnx_input_idx=[])
 
     def test_tensor_like_factories_script(self):
         class TensorFactory(torch.jit.ScriptModule):
@@ -1509,12 +1502,10 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            use_gpu=False, example_outputs=(torch.ones(x.size()),),
-                            input_names=['x'], dynamic_axes={'x': [0, 1, 2]})
+                            use_gpu=False, input_names=['x'], dynamic_axes={'x': [0, 1, 2]})
         remained_onnx_input_idx = None if self.opset_version < 9 else []
         self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            use_gpu=False, example_outputs=(torch.ones(x.size()),),
-                            remained_onnx_input_idx=remained_onnx_input_idx)
+                            use_gpu=False, remained_onnx_input_idx=remained_onnx_input_idx)
 
     def test_full(self):
         class FullModel(torch.nn.Module):
@@ -1532,8 +1523,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return torch.full((4, 5), x, dtype=torch.long)
 
         x = torch.tensor(12)
-        self.run_model_test(FullClass(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            use_gpu=False, example_outputs=FullClass()(x))
+        self.run_model_test(FullClass(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
     def test_clamp(self):
         class ClampModel(torch.nn.Module):
@@ -2021,8 +2011,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return a
 
         x = (torch.randn(3, 4), torch.randn(4, 3))
-        self.run_model_test(TupleModel(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            example_outputs=(x,))
+        self.run_model_test(TupleModel(), train=False, input=(x,), batch_size=BATCH_SIZE)
 
     def test_nested_tuple_input_output(self):
         class NestedTupleModel(torch.jit.ScriptModule):
@@ -2032,8 +2021,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         x = torch.randn(4, 5)
         y = (torch.randn(4, 5), (torch.randn(4, 5), torch.randn(4, 5)))
-        self.run_model_test(NestedTupleModel(), train=False, input=(x, y), batch_size=BATCH_SIZE,
-                            example_outputs=x + y[0] + y[1][0] + y[1][1])
+        self.run_model_test(NestedTupleModel(), train=False, input=(x, y), batch_size=BATCH_SIZE)
 
     def test_topk(self):
         class TopKModel(torch.nn.Module):
@@ -2050,7 +2038,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return torch.topk(input, 3, dim=0)
 
         x = torch.randn(4, 3, requires_grad=True)
-        self.run_model_test(TopKModel(), train=False, input=(x,), batch_size=BATCH_SIZE, example_outputs=torch.topk(x, 3, dim=0))
+        self.run_model_test(TopKModel(), train=False, input=(x,), batch_size=BATCH_SIZE)
 
     def test_floor(self):
         class FloorModel(torch.nn.Module):
@@ -2086,9 +2074,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return torch.arange(a.size(0), dtype=torch.float).view(-1, 1) + a
 
         x = torch.randn(3, 4, requires_grad=True)
-        outputs = ArangeScript()(x)
-        self.run_model_test(ArangeScript(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(ArangeScript(), train=False, input=(x,), batch_size=BATCH_SIZE)
 
         class ArangeModel(torch.nn.Module):
             def forward(self, a):
@@ -2104,9 +2090,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return torch.arange(2, a.size(0) + 2, dtype=torch.float).view(-1, 1) + a
 
         x = torch.randn(3, 4, requires_grad=True)
-        outputs = ArangeScript()(x)
-        self.run_model_test(ArangeScript(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(ArangeScript(), train=False, input=(x,), batch_size=BATCH_SIZE)
 
         class ArangeModel(torch.nn.Module):
             def forward(self, a):
@@ -2122,9 +2106,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return torch.arange(2, a.size(0) * a.size(1) + 2, a.size(1), dtype=torch.float).view(-1, 1) + a
 
         x = torch.randn(3, 4, requires_grad=True)
-        outputs = ArangeScript()(x)
-        self.run_model_test(ArangeScript(), train=False, input=(x,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(ArangeScript(), train=False, input=(x,), batch_size=BATCH_SIZE)
 
         class ArangeModel(torch.nn.Module):
             def forward(self, a):
@@ -2249,9 +2231,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = WhileModel()
         inputs = torch.zeros(1, 2, 3, dtype=torch.long)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,)
 
     def test_while_cond(self):
         class WhileModel(torch.jit.ScriptModule):
@@ -2266,9 +2246,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         model = WhileModel()
         x = torch.zeros(1, 2, 3, dtype=torch.long)
         a = torch.tensor([0], dtype=torch.long)
-        outputs = model(x, a)
-        self.run_model_test(model, train=False, input=(x, a), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(x, a), batch_size=BATCH_SIZE)
 
     @unittest.skip("Disabled due to onnx optimizer deprecation")
     def test_loop(self):
@@ -2281,9 +2259,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = LoopModel()
         inputs = torch.zeros(1, 2, 3, dtype=torch.long)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE)
 
     @unittest.skip("Disabled due to onnx optimizer deprecation")
     def test_dynamic_loop(self):
@@ -2296,9 +2272,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = LoopModel()
         inputs = torch.zeros(1, 2, 3, dtype=torch.long)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE)
 
     @unittest.skip("Disabled due to onnx optimizer deprecation")
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -2317,9 +2291,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = NestedLoopsModel()
         inputs = torch.zeros(1, 2, 3, dtype=torch.long)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,)
 
     def test_select(self):
         class SelectModel(torch.nn.Module):
@@ -2337,9 +2309,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = StandardDeviation()
         inputs = torch.randn(2, 3, 4)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE)
 
     def test_std_along_dims(self):
         class StandardDeviationAlongDims(torch.nn.Module):
@@ -2348,9 +2318,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = StandardDeviationAlongDims()
         inputs = torch.randn(2, 3, 4)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE)
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_masked_fill(self):
@@ -2379,9 +2347,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         y = torch.zeros(4, requires_grad=True)
         z = torch.ones(5, requires_grad=True)
         model = MeshgridModel()
-        outputs = model(x, y, z)
-        self.run_model_test(model, train=False, input=(x, y, z), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(x, y, z), batch_size=BATCH_SIZE)
 
     def test_remainder(self):
         class RemainderModel(torch.nn.Module):
@@ -2391,9 +2357,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         x = torch.randn(4, 2, 3)
         y = torch.randn(1, 2, 1)
         model = RemainderModel()
-        outputs = model(x, y)
-        self.run_model_test(model, train=False, input=(x, y), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(x, y), batch_size=BATCH_SIZE)
 
     def test_remainder_scalar(self):
         class RemainderModel(torch.nn.Module):
@@ -2402,9 +2366,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         inputs = torch.randint(10, (2, 3))
         model = RemainderModel()
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,)
 
     def test_baddbmm(self):
         class MyModule(torch.nn.Module):
@@ -2423,9 +2385,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         model = GeluModel()
         inputs = torch.randn(2, 4, 5, 6, requires_grad=True)
-        outputs = model(inputs)
-        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE,
-                            example_outputs=(outputs,))
+        self.run_model_test(model, train=False, input=(inputs,), batch_size=BATCH_SIZE)
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_index_fill(self):

--- a/test/onnx/test_pytorch_onnx_caffe2_quantized.py
+++ b/test/onnx/test_pytorch_onnx_caffe2_quantized.py
@@ -28,7 +28,7 @@ class TestQuantizedOps(unittest.TestCase):
         output = q_model(*pt_inputs)
 
         f = io.BytesIO()
-        torch.onnx.export(q_model, pt_inputs, f, input_names=input_names, example_outputs=output,
+        torch.onnx.export(q_model, pt_inputs, f, input_names=input_names,
                           operator_export_type=torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK)
         f.seek(0)
         onnx_model = onnx.load(f)
@@ -84,8 +84,6 @@ class TestQuantizedOps(unittest.TestCase):
         self.generic_unary_test(torch.nn.ReLU())
 
     def export_to_onnx(self, model, input, input_names):
-        outputs = model(input)
-
         traced = torch.jit.trace(model, input)
         buf = io.BytesIO()
         torch.jit.save(traced, buf)
@@ -93,7 +91,7 @@ class TestQuantizedOps(unittest.TestCase):
 
         model = torch.jit.load(buf)
         f = io.BytesIO()
-        torch.onnx.export(model, input, f, input_names=input_names, example_outputs=outputs,
+        torch.onnx.export(model, input, f, input_names=input_names,
                           operator_export_type=torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK)
         f.seek(0)
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -73,9 +73,9 @@ def to_numpy(elem):
         return RuntimeError("Input has unknown type.")
 
 
-def convert_to_onnx(model, input=None, opset_version=9, example_outputs=None,
-                    do_constant_folding=True, keep_initializers_as_inputs=True,
-                    dynamic_axes=None, input_names=None, output_names=None,
+def convert_to_onnx(model, input=None, opset_version=9, do_constant_folding=True,
+                    keep_initializers_as_inputs=True, dynamic_axes=None,
+                    input_names=None, output_names=None,
                     fixed_batch_size=False, training=None,
                     onnx_shape_inference=True):
     # export the model to ONNX
@@ -83,7 +83,6 @@ def convert_to_onnx(model, input=None, opset_version=9, example_outputs=None,
     input_copy = copy.deepcopy(input)
     torch.onnx._export(model, input_copy, f,
                        opset_version=opset_version,
-                       example_outputs=example_outputs,
                        do_constant_folding=do_constant_folding,
                        keep_initializers_as_inputs=keep_initializers_as_inputs,
                        dynamic_axes=dynamic_axes,
@@ -159,7 +158,7 @@ def run_model_test(self, model, batch_size=2, state_dict=None,
             input = input + ({},)
 
         ort_sess = convert_to_onnx(model, input=input, opset_version=self.opset_version,
-                                   example_outputs=output, do_constant_folding=do_constant_folding,
+                                   do_constant_folding=do_constant_folding,
                                    keep_initializers_as_inputs=self.keep_initializers_as_inputs,
                                    dynamic_axes=dynamic_axes, input_names=input_names,
                                    output_names=output_names, fixed_batch_size=fixed_batch_size, training=training,
@@ -321,8 +320,8 @@ class TestONNXRuntime(unittest.TestCase):
         _run_test(model, tracing_remained_onnx_input_idx)
 
     def run_model_test_with_external_data(self, model, input, rtol=0.001, atol=1e-7,
-                                          example_outputs=None, do_constant_folding=True,
-                                          dynamic_axes=None, input_names=None, output_names=None,
+                                          do_constant_folding=True, dynamic_axes=None,
+                                          input_names=None, output_names=None,
                                           ort_optim_on=True, training=None):
         import os
         import tempfile
@@ -347,7 +346,6 @@ class TestONNXRuntime(unittest.TestCase):
                 input_copy = copy.deepcopy(input)
                 torch.onnx.export(model, input_copy, model_file_name,
                                   opset_version=self.opset_version,
-                                  example_outputs=output,
                                   verbose=False,
                                   do_constant_folding=do_constant_folding,
                                   keep_initializers_as_inputs=self.keep_initializers_as_inputs,
@@ -7963,7 +7961,6 @@ class TestONNXRuntime(unittest.TestCase):
         script_model = torch.jit.script(model)
         output = model(x)
         ort_sess = convert_to_onnx(script_model, input=(x,), opset_version=self.opset_version,
-                                   example_outputs=output,
                                    training=torch.onnx.TrainingMode.TRAINING)
         ort_outs = run_ort(ort_sess, input=(x,))
         assert not torch.all(torch.eq(x, torch.from_numpy(ort_outs[0])))
@@ -8007,7 +8004,6 @@ class TestONNXRuntime(unittest.TestCase):
         y = model(input)
         output = y.cpu().numpy()
         ort_sess = convert_to_onnx(script_model, input=(x,), opset_version=self.opset_version,
-                                   example_outputs=y,
                                    training=torch.onnx.TrainingMode.TRAINING)
         ort_outs = run_ort(ort_sess, input=(x,))
         ort_mask = np.where(ort_outs[0] != 0, 1, 0)
@@ -8092,11 +8088,9 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.jit.script(MyModule())
         box_regression = torch.randn([4, 4])
         proposal = [torch.randn(2, 4), torch.randn(2, 4)]
-        outputs = model(box_regression, proposal)
 
         with self.assertRaises(RuntimeError) as cm:
-            convert_to_onnx(model, input=(box_regression, proposal),
-                            example_outputs=outputs)
+            convert_to_onnx(model, input=(box_regression, proposal))
 
     def test_initializer_sequence(self):
         class MyModule(torch.nn.Module):
@@ -8165,10 +8159,9 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.ones(2, 3, dtype=torch.float)
         y = torch.tensor(5, dtype=torch.long)
-        example_output = (test_model(x, y),)
         f = io.BytesIO()
 
-        torch.onnx.export(test_model, (x, y), f, example_outputs=example_output, do_constant_folding=False)
+        torch.onnx.export(test_model, (x, y), f, do_constant_folding=False)
         loaded_model = onnx.load_from_string(f.getvalue())
 
         actual_list = [p.name for p in loaded_model.graph.initializer]

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -32,7 +32,6 @@ class TestUtilityFuns(TestCase):
 
     def _model_to_graph(self, model, input,
                         do_constant_folding=True,
-                        example_outputs=None,
                         training=TrainingMode.EVAL,
                         operator_export_type=OperatorExportTypes.ONNX,
                         input_names=None,
@@ -49,7 +48,6 @@ class TestUtilityFuns(TestCase):
                                                               _disable_torch_constant_prop=True,
                                                               operator_export_type=operator_export_type,
                                                               training=training,
-                                                              example_outputs=example_outputs,
                                                               input_names=input_names,
                                                               dynamic_axes=dynamic_axes)
         _set_onnx_shape_inference(True)
@@ -115,11 +113,11 @@ class TestUtilityFuns(TestCase):
         example_output = model(input_t)
 
         with self.assertRaises(RuntimeError):
-            torch.onnx.export(model,
-                              (input_t, ),
-                              "test.onnx",
-                              opset_version=self.opset_version,
-                              example_outputs=[example_output])
+            torch.onnx._export(model,
+                               (input_t,),
+                               "test.onnx",
+                               opset_version=self.opset_version,
+                               example_outputs=[example_output])
 
     def test_constant_fold_transpose(self):
         class TransposeModule(torch.nn.Module):
@@ -757,9 +755,8 @@ class TestUtilityFuns(TestCase):
         q_model = torch.quantization.convert(q_model, inplace=False)
 
         q_model.eval()
-        output = q_model(*pt_inputs)
 
-        graph, _, __ = self._model_to_graph(q_model, pt_inputs, example_outputs=output,
+        graph, _, __ = self._model_to_graph(q_model, pt_inputs,
                                             operator_export_type=OperatorExportTypes.ONNX_FALLTHROUGH,
                                             input_names=['pt_inputs'],
                                             dynamic_axes={'pt_inputs': [0, 1, 2, 3]})
@@ -786,9 +783,8 @@ class TestUtilityFuns(TestCase):
 
         x = torch.tensor([2])
         model = PrimModule()
-        output = model(x)
         model.eval()
-        graph, _, __ = self._model_to_graph(model, (x,), example_outputs=output,
+        graph, _, __ = self._model_to_graph(model, (x,),
                                             operator_export_type=OperatorExportTypes.ONNX_FALLTHROUGH,
                                             input_names=['x'], dynamic_axes={'x': [0]})
         iter = graph.nodes()
@@ -851,10 +847,9 @@ class TestUtilityFuns(TestCase):
 
         model = torch.jit.script(MyModule())
         x = torch.randn(10, 3, 128, 128)
-        example_outputs = model(x)
         _set_opset_version(self.opset_version)
         _set_operator_export_type(OperatorExportTypes.ONNX)
-        graph, _, __ = self._model_to_graph(model, (x,), do_constant_folding=True, example_outputs=example_outputs,
+        graph, _, __ = self._model_to_graph(model, (x,), do_constant_folding=True,
                                             operator_export_type=OperatorExportTypes.ONNX,
                                             training=torch.onnx.TrainingMode.TRAINING,
                                             input_names=['x'], dynamic_axes={'x': [0, 1, 2, 3]})

--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -1215,8 +1215,6 @@ class TestQuantizeONNXExport(JitTestCase):
         input_names = ["x"]
 
         def export_to_onnx(model, input, input_names):
-            outputs = model(input)
-
             traced = torch.jit.trace(model, input)
             buf = io.BytesIO()
             torch.jit.save(traced, buf)
@@ -1224,7 +1222,7 @@ class TestQuantizeONNXExport(JitTestCase):
 
             model = torch.jit.load(buf)
             f = io.BytesIO()
-            torch.onnx.export(model, input, f, input_names=input_names, example_outputs=outputs,
+            torch.onnx.export(model, input, f, input_names=input_names,
                               operator_export_type=torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK)
         onnx_model = export_to_onnx(model, data, input_names)
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -197,6 +197,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             Since this optimization adjusts model initializers, it will be disabled if
             export_params = False or keep_initializers_as_inputs = True.
         example_outputs (T or a tuple of T, where T is Tensor or convertible to Tensor, default None):
+            [Deprecated and ignored. Will be removed in next PyTorch release],
             Must be provided when exporting a ScriptModule or ScriptFunction, ignored otherwise.
             Used to determine the type and shape of the outputs without tracing the execution of
             the model. A single object is treated as equivalent to a tuple of one element.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

* `example_outputs` used to determine the type and shape of the outputs without tracing the execution of the model. And it must be provided when exporting a ScriptModule or ScriptFunction when using export() function.

* Since we can work out `example_outputs` in internal function instead of being provided by user, so we deprecated this argument in the export() function to increase user experience of calling this function.

Co-authored-by: hwangdeyu <dejack953@outlook.com>