### PR TITLE
[ONNX] Fix remainder export (#64230)

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -376,6 +376,15 @@ def _topk_helper(g, input, k, dim, largest=True, sorted=False, out=None):
         return g.op("TopK", input, k, axis_i=dim, largest_i=largest, sorted_i=sorted, outputs=2)
 
 
+def _lt_helper(g, input, other):
+    if _export_onnx_opset_version <= 8:
+        from torch.onnx.symbolic_opset8 import lt as _lt8
+        return _lt8(g, input, other)
+    else:
+        from torch.onnx.symbolic_opset9 import lt as _lt9
+        return _lt9(g, input, other)
+
+
 def _interpolate_warning(interpolate_mode):
     onnx_op = "onnx:Resize" if _export_onnx_opset_version >= 10 else "onnx:Upsample"
     warnings.warn("You are trying to export the model with " + onnx_op + " for ONNX opset version "

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -394,6 +394,13 @@ def round(g, self):
     return g.op("Round", self)
 
 
+def remainder(g, input, other):
+    if sym_help._is_fp(input) or sym_help._is_fp(other):
+        from torch.onnx.symbolic_opset9 import remainder as _remainder_9
+        return _remainder_9(g, input, other)
+    return g.op("Mod", input, other, fmod_i=0)
+
+
 @parse_args("v", "v", "i", "i")
 def split(g, self, split_size_or_sizes, dim, _outputs=None):
     if not sym_help._is_split_static(split_size_or_sizes, _outputs):

--- a/torch/onnx/symbolic_opset7.py
+++ b/torch/onnx/symbolic_opset7.py
@@ -1,5 +1,4 @@
-from torch.onnx.symbolic_helper import _block_list_in_opset, parse_args
-import torch.onnx.symbolic_helper as sym_help
+from torch.onnx.symbolic_helper import _block_list_in_opset
 
 import torch.onnx.symbolic_opset9 as sym_opset9
 
@@ -42,29 +41,6 @@ def min(g, self, dim_or_y=None, keepdim=None):
                       "This might cause the onnx model to be incorrect, if inputs to min operators "
                       "have different shapes")
     return sym_opset9.min(g, self, dim_or_y, keepdim)
-
-
-def div(g, self, other, *args):
-    if len(args) == 0:
-        return sym_opset9.true_divide(g, self, other)
-    else:
-        return _div_rounding_mode(g, self, other, *args)
-
-
-@parse_args("v", "v", "s")
-def _div_rounding_mode(g, self, other, rounding_mode):
-    if rounding_mode == "floor":
-        return _floor_divide(g, self, other)
-    else:
-        return sym_opset9._div_rounding_mode(g, self, other, rounding_mode)
-
-
-def _floor_divide(g, self, other):
-    if sym_help._is_fp(self) or sym_help._is_fp(other):
-        out = sym_opset9.true_divide(g, self, other)
-        return g.op("Floor", out)
-    else:
-        raise RuntimeError("Integer floor division requires ONNX opset 9 or greater")
 
 
 for block_listed_op in block_listed_operators:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -5,7 +5,6 @@ import torch.onnx.symbolic_opset9 as sym_opset9
 
 from torch.onnx.symbolic_helper import parse_args, _unimplemented, _block_list_in_opset, _try_get_scalar_type
 from torch.onnx.symbolic_opset9 import _cast_Float  # type: ignore[attr-defined]
-from torch.onnx.symbolic_opset7 import div  # noqa: F401
 
 import warnings
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

* Fix remainder export for edge case when input is negative. New export relies on true_divide export.
* Simplified true_divide export. Cleaned up redundant code which is handled by scalar type analysis pass. Removed dependency on `onnx::Where`, thus supports opset 7 & 8.

Fixes #60179

Co-authored-by: BowenBao <bowbao@microsoft.com>