### PR TITLE
[ONNX] Update doc and error message for indexing export (#64290)

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -230,6 +230,7 @@ When indexing into a tensor for reading, the following patterns are not supporte
 
   # Tensor indices that includes negative values.
   data[torch.tensor([[1, 2], [2, -3]]), torch.tensor([-2, 3])]
+  # Workarounds: use positive index values.
 
 Writes / Sets
 ~~~~~~~~~~~~~
@@ -238,12 +239,24 @@ When indexing into a Tensor for writing, the following patterns are not supporte
 
   # Multiple tensor indices if any has rank >= 2
   data[torch.tensor([[1, 2], [2, 3]]), torch.tensor([2, 3])] = new_data
+  # Workarounds: use single tensor index with rank >= 2,
+  #              or multiple consecutive tensor indices with rank == 1.
 
   # Multiple tensor indices that are not consecutive
   data[torch.tensor([2, 3]), :, torch.tensor([1, 2])] = new_data
+  # Workarounds: transpose `data` such that tensor indices are consecutive.
 
   # Tensor indices that includes negative values.
   data[torch.tensor([1, -2]), torch.tensor([-2, 3])] = new_data
+  # Workarounds: use postive index values.
+
+  # Implicit broadcasting required for new_data.
+  data[torch.tensor([[0, 2], [1, 1]]), 1:3] = new_data
+  # Workarounds: expand new_data explicitly.
+  # Example:
+  #   data shape: [3, 4, 5]
+  #   new_data shape: [5]
+  #   expected new_data shape after broadcasting: [2, 2, 2, 5]
 
 Adding support for operators
 ----------------------------

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2307,6 +2307,16 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.zeros([2, 17, 3], dtype=torch.int64)
         self.run_test(IndexPutModel9(), (x,))
 
+        class IndexPutModel10(torch.nn.Module):
+            def forward(self, x, ind, update):
+                x[ind, 1:3] = update.view(1, 1, 1, 5).expand(2, 2, 2, 5)
+                return x
+
+        x = torch.randn(3, 4, 5)
+        ind = torch.tensor([[0, 2], [1, 1]])
+        update = torch.randn(5)
+        self.run_test(IndexPutModel10(), (x, ind, update))
+
     @skipIfUnsupportedMinOpsetVersion(11)
     @disableScriptTest()  # Ellipses followed by tensor indexing not scriptable
     def test_index_put_ellipsis(self):

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
@@ -90,8 +90,9 @@ std::unordered_map<int64_t, ConvertedIndex> MergeSliceAndSelectToIndices(
         dim = dim + rank - dim_offset;
       } else {
         std::cerr
-            << "Error: ONNX Remove Inplace Ops - Cannot export ellipsis indexing for input "
-            << "of unknown rank.";
+            << "Error: Cannot export ellipsis indexing for input "
+            << "of unknown rank. Check https://pytorch.org/docs/stable/onnx.html#indexing"
+            << "for details.";
       }
     }
     dim = dim + dim_offset;
@@ -199,7 +200,8 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
   if (((max_index_dim - min_index_dim + 1) != tensor_ind_count) &&
       tensor_ind_count != 0) {
     AT_ERROR(
-        "Only consecutive 1-d tensor indices are supported in exporting aten::index_put to ONNX.");
+        "Only consecutive 1-d tensor indices are supported in exporting aten::index_put to ONNX.",
+        "Check https://pytorch.org/docs/stable/onnx.html#indexing for details");
   }
 
   size_t tensor_ind_offset = tensor_ind_count == 0 ? 0 : tensor_ind_count - 1;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Added suggested workarounds into indexing section of onnx export documentation.
Update indexing export warning message with link to documentation.

Co-authored-by: BowenBao <bowbao@microsoft.com>