### PR TITLE
[ONNX] Fix inplace fill_ dtype export mismatch (#64233)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9476,6 +9476,15 @@ class TestONNXRuntime(unittest.TestCase):
         filled_value = 7
         self.run_test(FillModule(), (x, filled_value))
 
+        class FillScalarModule(torch.nn.Module):
+            def forward(self, x):
+                res = x + 2
+                res.fill_(2.5)
+                return res, x
+
+        x = torch.ones(2, 3, 4, dtype=torch.long)
+        self.run_test(FillScalarModule(), x)
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_index_add_normal(self):
         class M(torch.nn.Module):

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -35,6 +35,10 @@ Node* MutationRemover::createSpecialMappedOp(Node* n) {
           "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)")) {
     new_node =
         graph_->insert(aten::full_like, {inputs.at(0), inputs.at(1)})->node();
+    new_node->copyMetadata(n);
+    new_node->output()->setType(n->output()->type());
+    new_node = graph_->insert(aten::type_as, {new_node->output(), inputs.at(0)})
+                   ->node();
   } else if (n->matches("aten::zero_(Tensor(a!) self) -> Tensor(a!)")) {
     new_node = graph_->insert(aten::zeros_like, {n->inputs().at(0)})->node();
   } else if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Append `type_as` after convert `fill_` to `full_like` without dtype argument.

BowenBao <bowbao@microsoft.com>