### PR TITLE
Add `SourceView` which doesn't own source text as base class of `Source`

### DIFF
--- a/test/cpp/jit/test_class_import.cpp
+++ b/test/cpp/jit/test_class_import.cpp
@@ -9,7 +9,7 @@
 namespace torch {
 namespace jit {
 
-static const auto classSrcs1 = R"JIT(
+static constexpr c10::string_view classSrcs1 = R"JIT(
 class FooNestedTest:
     def __init__(self, y):
         self.y = y
@@ -26,7 +26,7 @@ class FooTest:
         self.x = self.class_attr.y + self.class_attr2.y
 )JIT";
 
-static const auto classSrcs2 = R"JIT(
+static constexpr c10::string_view classSrcs2 = R"JIT(
 class FooTest:
     def __init__(self, x):
       self.dx = x
@@ -134,7 +134,7 @@ TEST(ClassImportTest, ClassDerive) {
   ASSERT_TRUE(newCls2->findMethod(method->name()));
 }
 
-static const auto torchbindSrc = R"JIT(
+static constexpr c10::string_view torchbindSrc = R"JIT(
 class FooBar1234(Module):
   __parameters__ = []
   f : __torch__.torch.classes._TorchScriptTesting._StackString

--- a/test/cpp/jit/test_class_parser.cpp
+++ b/test/cpp/jit/test_class_parser.cpp
@@ -5,7 +5,7 @@
 
 namespace torch {
 namespace jit {
-const auto testSource = R"JIT(
+constexpr c10::string_view testSource = R"JIT(
   class FooTest:
     def __init__(self, x):
       self.x = x

--- a/test/cpp/jit/test_interface.cpp
+++ b/test/cpp/jit/test_interface.cpp
@@ -18,12 +18,12 @@ def one(self, x: Tensor, y: Tensor) -> Tensor:
 def forward(self, x: Tensor) -> Tensor:
     return x
 )JIT"};
-static const auto parentForward = R"JIT(
+static const std::string parentForward = R"JIT(
 def forward(self, x: Tensor) -> Tensor:
     return self.subMod.forward(x)
 )JIT";
 
-static const auto moduleInterfaceSrc = R"JIT(
+static constexpr c10::string_view moduleInterfaceSrc = R"JIT(
 class OneForward(ModuleInterface):
     def one(self, x: Tensor, y: Tensor) -> Tensor:
         pass

--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -13,7 +13,7 @@
 namespace torch {
 namespace jit {
 
-static const auto moduleInterfaceSrc = R"JIT(
+static constexpr c10::string_view moduleInterfaceSrc = R"JIT(
 class OneInterface(ModuleInterface):
     def one(self, x: Tensor, y: Tensor) -> Tensor:
         pass
@@ -27,7 +27,7 @@ def forward(self, x: Tensor) -> Tensor:
     return self.attr + x
 )JIT"};
 
-static const auto parentForward = R"JIT(
+static const std::string parentForward = R"JIT(
 def forward(self, x: Tensor) -> Tensor:
     return self.subMod1.one(x, x) + self.subMod2.one(x, x)
 )JIT";

--- a/torch/csrc/jit/frontend/error_report.h
+++ b/torch/csrc/jit/frontend/error_report.h
@@ -39,7 +39,7 @@ struct TORCH_API ErrorReport : public std::exception {
   friend const ErrorReport& operator<<(const ErrorReport& e, const T& t);
 
   mutable std::stringstream ss;
-  SourceRange context;
+  OwnedSourceRange context;
   mutable std::string the_message;
   std::vector<Call> error_stack;
 };

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -27,7 +27,7 @@ namespace jit {
 namespace {
 struct SchemaParser {
   SchemaParser(const std::string& str)
-      : L(std::make_shared<Source>(str)),
+      : L(std::make_shared<SourceView>(c10::string_view(str))),
         type_parser(L, /*parse_complete_tensor_types*/ false) {}
 
   either<OperatorName, FunctionSchema> parseDeclaration() {

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -46,7 +46,7 @@ Decl mergeTypesFromTypeComment(
 }
 
 struct ParserImpl {
-  explicit ParserImpl(const std::shared_ptr<Source>& source)
+  explicit ParserImpl(const std::shared_ptr<SourceView>& source)
       : L(source), shared(sharedParserData()) {}
 
   Ident parseIdent() {
@@ -801,7 +801,7 @@ struct ParserImpl {
   SharedParserData& shared;
 };
 
-Parser::Parser(const std::shared_ptr<Source>& src)
+Parser::Parser(const std::shared_ptr<SourceView>& src)
     : pImpl(new ParserImpl(src)) {}
 
 Parser::~Parser() = default;

--- a/torch/csrc/jit/frontend/parser.h
+++ b/torch/csrc/jit/frontend/parser.h
@@ -17,7 +17,7 @@ TORCH_API Decl mergeTypesFromTypeComment(
     bool is_method);
 
 struct TORCH_API Parser {
-  explicit Parser(const std::shared_ptr<Source>& src);
+  explicit Parser(const std::shared_ptr<SourceView>& src);
   TreeRef parseFunction(bool is_method);
   TreeRef parseClass();
   Decl parseTypeComment();

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -10,7 +10,7 @@ size_t SourceRangeHasher::operator()(const torch::jit::SourceRange& key) const {
       std::hash<size_t>()(key.start()) ^ std::hash<size_t>()(key.end()));
 }
 
-c10::optional<SourceRange> Source::findSourceRangeThatGenerated(
+c10::optional<SourceRange> SourceView::findSourceRangeThatGenerated(
     const SourceRange& range) {
   if (!gen_ranges_) {
     return c10::nullopt;
@@ -69,11 +69,11 @@ C10_EXPORT void SourceRange::print_with_context(
     bool highlight,
     const std::string& funcname) const {
   // This is an empty SourceRange, used as a sentinel value.
-  if (!source_) {
+  if (!source_view_) {
     return;
   }
 
-  const std::string& str = source_->text();
+  c10::string_view str = source_view_->text();
   if (size() == str.size()) {
     // this is just the entire file, not a subset, so print it out.
     // primarily used to print out python stack traces

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -12,29 +12,29 @@ namespace jit {
 class SourceRangeUnpickler;
 struct SourceRange;
 
-// Source represents a code segment. It keeps track of:
-//  - text : the text of the code segment
+// SourceView represents a code segment. It keeps track of:
+//  - text_view : the view into text of the code segment
 //  - filename (optional) : if present, represents the name of the file from
 //                          which the code segment originated.
 //  - starting_line_no : represents the line in the original file where the
 //                       code segment started.
-struct Source {
-  explicit Source(
-      std::string text,
+struct SourceView {
+  explicit SourceView(
+      c10::string_view text_view,
       std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
-      : text_(std::move(text)),
+      : text_view_(text_view),
         filename_(c10::nullopt),
         starting_line_no_(0),
         gen_ranges_(std::move(gen_ranges)) {
     calc_line_start_offsets();
   }
 
-  Source(
-      std::string text,
+  SourceView(
+      c10::string_view text_view,
       c10::optional<std::string> filename,
       size_t starting_line_no,
       std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
-      : text_(std::move(text)),
+      : text_view_(text_view),
         filename_(std::move(filename)),
         starting_line_no_(starting_line_no),
         gen_ranges_(std::move(gen_ranges)) {
@@ -71,8 +71,8 @@ struct Source {
     }
   }
 
-  const std::string& text() const {
-    return text_;
+  const c10::string_view text() const {
+    return text_view_;
   }
 
   const c10::optional<std::string>& filename() const {
@@ -86,15 +86,18 @@ struct Source {
   c10::optional<SourceRange> findSourceRangeThatGenerated(
       const SourceRange& range);
 
+ protected:
+  c10::string_view text_view_;
+
  private:
   void calc_line_start_offsets() {
     line_starting_offsets_.push_back(0);
     size_t pos = 0;
-    while ((pos = text_.find('\n', pos)) != std::string::npos) {
+    while ((pos = text().find('\n', pos)) != std::string::npos) {
       line_starting_offsets_.push_back(++pos);
     }
   }
-  std::string text_;
+
   c10::optional<std::string> filename_;
   // If filename_ is not present, starting_line_no_ is don't care
   size_t starting_line_no_;
@@ -105,15 +108,67 @@ struct Source {
   std::shared_ptr<SourceRangeUnpickler> gen_ranges_;
 };
 
-// A SourceRange is a view into a Source, that points to a subset of the source,
-// specified by `start` and `end` byte offsets into the source text.
+// Source represents a code segment like SourceView, but the former owns a copy
+// of source text while the latter doesn't.
+struct Source : public SourceView {
+  explicit Source(
+      std::string text,
+      std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
+      : SourceView(text, gen_ranges), text_(std::move(text)) {
+    text_view_ = text_;
+  }
+
+  explicit Source(
+      c10::string_view text_view,
+      std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
+      : SourceView(text_view, gen_ranges),
+        text_(text_view.begin(), text_view.end()) {
+    text_view_ = text_;
+  }
+
+  explicit Source(
+      std::string text,
+      c10::optional<std::string> filename,
+      size_t starting_line_no,
+      std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
+      : SourceView(text, filename, starting_line_no, gen_ranges),
+        text_(std::move(text)) {
+    text_view_ = text_;
+  }
+
+  explicit Source(
+      c10::string_view text_view,
+      c10::optional<std::string> filename,
+      size_t starting_line_no,
+      std::shared_ptr<SourceRangeUnpickler> gen_ranges = nullptr)
+      : SourceView(text_view, filename, starting_line_no, gen_ranges),
+        text_(text_view.begin(), text_view.end()) {
+    text_view_ = text_;
+  }
+
+  // Constructor that deepcopies and owns source text referenced in
+  // `source_view`.
+  explicit Source(const SourceView& source_view) : SourceView(source_view) {
+    text_ = std::string(text_view_.begin(), text_view_.end());
+    text_view_ = text_;
+  }
+
+  std::string text_;
+};
+
+// A SourceRange is a reference to subset of a Source, specified by `start` and
+// `end` byte offsets into the source text.
 struct TORCH_API SourceRange {
-  SourceRange(std::shared_ptr<Source> source_, size_t start_, size_t end_)
-      : source_(std::move(source_)), start_(start_), end_(end_) {}
-  SourceRange() : source_(nullptr), start_(0), end_(0) {}
+  SourceRange(
+      std::shared_ptr<SourceView> source_view_,
+      size_t start_,
+      size_t end_)
+      : source_view_(std::move(source_view_)), start_(start_), end_(end_) {}
+  SourceRange() : source_view_(nullptr), start_(0), end_(0) {}
 
   const std::string text() const {
-    return source_->text().substr(start(), end() - start());
+    auto text_view = source_view_->text().substr(start(), end() - start());
+    return std::string(text_view.begin(), text_view.end());
   }
   size_t size() const {
     return end() - start();
@@ -128,8 +183,8 @@ struct TORCH_API SourceRange {
       bool highlight,
       const std::string& funcname) const;
 
-  const std::shared_ptr<Source>& source() const {
-    return source_;
+  const std::shared_ptr<SourceView>& source() const {
+    return source_view_;
   }
   size_t start() const {
     return start_;
@@ -144,16 +199,16 @@ struct TORCH_API SourceRange {
   }
 
   c10::optional<std::tuple<std::string, size_t, size_t>> file_line_col() const {
-    if (!source_ || !source()->filename()) {
+    if (!source_view_ || !source()->filename()) {
       return c10::nullopt;
     }
 
-    auto lineno = source_->lineno_for_offset(start_);
-    auto col_offset = (int)start_ - (int)source_->offset_for_line(lineno);
+    auto lineno = source_view_->lineno_for_offset(start_);
+    auto col_offset = (int)start_ - (int)source_view_->offset_for_line(lineno);
     // TODO: c10::optional<>::value returns an rvalue ref so can't use it here??
     return std::make_tuple<std::string, size_t, size_t>(
-        source_->filename().value_or(""),
-        source_->lineno_to_source_lineno(lineno),
+        source_view_->filename().value_or(""),
+        source_view_->lineno_to_source_lineno(lineno),
         (size_t)col_offset);
   }
 
@@ -167,16 +222,30 @@ struct TORCH_API SourceRange {
   }
 
   c10::optional<SourceRange> findSourceRangeThatGenerated() const {
-    if (!source_) {
+    if (!source_view_) {
       return c10::nullopt;
     }
-    return source_->findSourceRangeThatGenerated(*this);
+    return source_view_->findSourceRangeThatGenerated(*this);
   }
 
+ protected:
+  std::shared_ptr<SourceView> source_view_;
+
  private:
-  std::shared_ptr<Source> source_;
   size_t start_;
   size_t end_;
+};
+
+// OwnedSourceRange is just like a SourceRange except that it owns a `Source`
+// instead of `SourceView`. Thus OwnedSourceRange owns a copy of source text.
+struct OwnedSourceRange : public SourceRange {
+  OwnedSourceRange(const SourceRange& source_range)
+      : SourceRange(source_range) {
+    const auto& source = source_range.source();
+    if (source) {
+      source_view_ = std::make_shared<Source>(*source);
+    }
+  }
 };
 
 struct TORCH_API SourceRangeHasher {

--- a/torch/csrc/jit/frontend/source_ref.h
+++ b/torch/csrc/jit/frontend/source_ref.h
@@ -21,26 +21,26 @@ namespace jit {
  */
 class TORCH_API SourceRef : public CustomClassHolder {
  public:
-  explicit SourceRef(std::shared_ptr<Source> source)
-      : source_(std::move(source)) {}
+  explicit SourceRef(std::shared_ptr<SourceView> source_view)
+      : source_view_(std::move(source_view)) {}
   bool operator==(const SourceRef& other) const {
-    return source_ == other.source_;
+    return source_view_ == other.source_view_;
   }
-  bool operator<(const Source& other) const {
-    return source_.get() < &other;
+  bool operator<(const SourceView& other) const {
+    return source_view_.get() < &other;
   }
-  friend bool operator<(const Source& other, const SourceRef& self) {
-    return &other < self.source_.get();
+  friend bool operator<(const SourceView& other, const SourceRef& self) {
+    return &other < self.source_view_.get();
   }
   bool operator<(const SourceRef& other) const {
-    return *this < *other.source_.get();
+    return *this < *other.source_view_.get();
   }
-  const Source* operator->() const {
-    return source_.get();
+  const SourceView* operator->() const {
+    return source_view_.get();
   }
 
  private:
-  std::shared_ptr<Source> source_;
+  std::shared_ptr<SourceView> source_view_;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1641,7 +1641,7 @@ size_t Node::blocksFromGraphBlock() {
 }
 
 inline const SourceRange& fakeRange() {
-  static SourceRange range(std::make_shared<Source>(""), 0, 1);
+  static SourceRange range(std::make_shared<Source>(std::string("")), 0, 1);
   return range;
 }
 

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -104,7 +104,9 @@ void initTreeViewBindings(PyObject* module) {
             return SourceRange(self.source_, start, end);
           })
       .def_property_readonly("source", [](const SourceRangeFactory& self) {
-        return self.source_->text();
+        auto text_view = self.source_->text();
+        std::string text(text_view.begin(), text_view.end());
+        return text;
       });
 
   py::class_<TreeView>(m, "TreeView")

--- a/torch/csrc/jit/serialization/import_export_helpers.cpp
+++ b/torch/csrc/jit/serialization/import_export_helpers.cpp
@@ -22,7 +22,7 @@ std::string qualifierToArchivePath(
   return export_prefix + path + "." + kExportSuffix;
 }
 
-std::shared_ptr<Source> findSourceInArchiveFromQualifier(
+std::shared_ptr<SourceView> findSourceInArchiveFromQualifier(
     caffe2::serialize::PyTorchStreamReader& reader,
     const std::string& export_prefix,
     const std::string& qualifier) {

--- a/torch/csrc/jit/serialization/import_export_helpers.h
+++ b/torch/csrc/jit/serialization/import_export_helpers.h
@@ -12,7 +12,7 @@ class PyTorchStreamReader;
 namespace torch {
 namespace jit {
 
-struct Source;
+struct SourceView;
 
 // Convert a class type's qualifier name to the corresponding path the source
 // file it should be written to.
@@ -23,7 +23,7 @@ std::string qualifierToArchivePath(
     const std::string& qualifier,
     const std::string& export_prefix);
 
-std::shared_ptr<Source> findSourceInArchiveFromQualifier(
+std::shared_ptr<SourceView> findSourceInArchiveFromQualifier(
     caffe2::serialize::PyTorchStreamReader& reader,
     const std::string& export_prefix,
     const std::string& qualifier);

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -157,7 +157,7 @@ void SourceImporterImpl::parseSourceIfNeeded(const std::string& qualifier) {
     return;
   }
   loaded_sources_.insert(qualifier);
-  std::shared_ptr<Source> src = source_loader_(qualifier);
+  std::shared_ptr<SourceView> src = source_loader_(qualifier);
 
   // The importer, when looking for classes/functions doesn't know if 'foo'
   // contains definitions or if it is a prefix of 'foo.bar', we only figure it

--- a/torch/csrc/jit/serialization/import_source.h
+++ b/torch/csrc/jit/serialization/import_source.h
@@ -6,6 +6,7 @@
 #include <torch/csrc/jit/frontend/parser.h>
 #include <torch/csrc/jit/frontend/resolver.h>
 #include <torch/csrc/jit/frontend/script_type_parser.h>
+#include <torch/csrc/jit/frontend/source_range.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/serialization/export.h>
 #include <torch/custom_class.h>
@@ -18,7 +19,8 @@
 namespace torch {
 namespace jit {
 
-using SourceLoader = std::function<std::shared_ptr<Source>(const std::string&)>;
+using SourceLoader =
+    std::function<std::shared_ptr<SourceView>(const std::string&)>;
 
 struct SourceImporterImpl : public Resolver,
                             std::enable_shared_from_this<SourceImporterImpl> {

--- a/torch/csrc/jit/serialization/source_range_serialization.cpp
+++ b/torch/csrc/jit/serialization/source_range_serialization.cpp
@@ -17,21 +17,22 @@ class SourceRangeSerializer {
   // Serialize Source as Tuple[str, Optional[str], int, List[int]]
   // This caches serialized sources, since many SourceRanges can
   // refer to the same one.
-  c10::IValue serialize_source(const std::shared_ptr<Source>& s);
+  c10::IValue serialize_source(const std::shared_ptr<SourceView>& s);
 
-  std::unordered_map<std::shared_ptr<Source>, c10::IValue> serialized_sources;
+  std::unordered_map<std::shared_ptr<SourceView>, c10::IValue>
+      serialized_sources;
 };
 
 SourceRange SourceRangeDeserializer::deserialize(const c10::IValue& iv) {
   const auto& tup_elems = iv.toTuple()->elements();
   TORCH_INTERNAL_ASSERT(tup_elems.size() == 3);
-  std::shared_ptr<Source> source_ = deserialize_source(tup_elems[0]);
+  std::shared_ptr<SourceView> source_ = deserialize_source(tup_elems[0]);
   int64_t start_ = tup_elems[1].toInt();
   int64_t end_ = tup_elems[2].toInt();
   return SourceRange(source_, start_, end_);
 }
 
-std::shared_ptr<Source> SourceRangeDeserializer::deserialize_source(
+std::shared_ptr<SourceView> SourceRangeDeserializer::deserialize_source(
     const c10::IValue& iv) {
   auto tup = iv.toTuple();
   auto it = cached_sources.find(tup);
@@ -58,7 +59,7 @@ c10::IValue SourceRangeSerializer::serialize(const SourceRange& sr) {
 }
 
 c10::IValue SourceRangeSerializer::serialize_source(
-    const std::shared_ptr<Source>& s) {
+    const std::shared_ptr<SourceView>& s) {
   if (serialized_sources.count(s)) {
     return serialized_sources.at(s);
   }

--- a/torch/csrc/jit/serialization/source_range_serialization.h
+++ b/torch/csrc/jit/serialization/source_range_serialization.h
@@ -38,10 +38,10 @@ class SourceRangeDeserializer {
   SourceRange deserialize(const c10::IValue& iv);
 
  private:
-  std::shared_ptr<Source> deserialize_source(const c10::IValue& iv);
+  std::shared_ptr<SourceView> deserialize_source(const c10::IValue& iv);
   std::unordered_map<
       c10::intrusive_ptr<c10::ivalue::Tuple>,
-      std::shared_ptr<Source>>
+      std::shared_ptr<SourceView>>
       cached_sources;
 };
 

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -47,6 +47,12 @@ struct Check {
     count_ = count;
   };
 
+  Check(
+      CheckType type,
+      c10::string_view str,
+      c10::optional<size_t> count = c10::nullopt)
+      : Check(type, std::string(str.begin(), str.end()), count) {}
+
   CheckType type_;
   c10::optional<size_t> count_;
   const std::string search_str_;
@@ -116,7 +122,7 @@ size_t assertFind(
 }
 
 size_t assertFind(
-    const std::shared_ptr<Source>& source,
+    const std::shared_ptr<SourceView>& source,
     const std::string& sub,
     size_t start,
     const Check& check) {
@@ -196,7 +202,9 @@ struct FileCheckImpl {
   friend std::ostream& operator<<(std::ostream& out, const FileCheckImpl& fc);
 
  private:
-  bool parseSingleCheck(const std::shared_ptr<Source>& source, size_t* start) {
+  bool parseSingleCheck(
+      const std::shared_ptr<SourceView>& source,
+      size_t* start) {
     const static std::vector<std::pair<CheckType, std::string>> check_pairs = {
         {CHECK, ": "},
         {CHECK_NEXT, "-NEXT: "},
@@ -226,8 +234,9 @@ struct FileCheckImpl {
         }
         size_t end =
             assertFind(SourceRange(source, end_check_string, end_line), ":");
-        count = c10::stoll(
-            source->text().substr(end_check_string, end - end_check_string));
+        auto count_view =
+            source->text().substr(end_check_string, end - end_check_string);
+        count = c10::stoll(std::string(count_view.begin(), count_view.end()));
         end_check_string = end + 2; // add ':' and the space
       }
       auto check = Check(
@@ -244,7 +253,9 @@ struct FileCheckImpl {
     return false;
   }
 
-  size_t findNextStart(const std::shared_ptr<Source>& source, size_t prev_end) {
+  size_t findNextStart(
+      const std::shared_ptr<SourceView>& source,
+      size_t prev_end) {
     size_t start = source->text().find('#', prev_end);
     if (start == std::string::npos) {
       return start;
@@ -267,7 +278,7 @@ struct FileCheckImpl {
     }
   }
 
-  void parseStrings(const std::shared_ptr<Source>& source) {
+  void parseStrings(const std::shared_ptr<SourceView>& source) {
     size_t start = 0;
     start = findNextStart(source, 0);
     while (start != std::string::npos) {
@@ -286,7 +297,7 @@ struct FileCheckImpl {
 
   void doCheckNot(
       const std::vector<Check>& nots,
-      const std::shared_ptr<Source>& source,
+      const std::shared_ptr<SourceView>& source,
       const SourceRange& prev,
       const SourceRange& next) {
     auto start = prev.end(); // inclusive
@@ -303,7 +314,7 @@ struct FileCheckImpl {
   // Checks that source token is highlighted, does not advance search range.
   void doCheckSourceHighlighted(
       const Check& check,
-      const std::shared_ptr<Source>& source,
+      const std::shared_ptr<SourceView>& source,
       size_t start_offset) {
     auto construct_error_and_throw = [&](size_t error_start_pos) {
       SourceRange error_range(
@@ -379,7 +390,7 @@ struct FileCheckImpl {
 
   SourceRange matchDagGroup(
       const std::vector<Check>& group,
-      const std::shared_ptr<Source>& source,
+      const std::shared_ptr<SourceView>& source,
       const SourceRange& prev) {
     size_t group_beg = std::string::npos;
     size_t group_end = 0;
@@ -397,7 +408,7 @@ struct FileCheckImpl {
 
   SourceRange matchGroup(
       const std::vector<Check>& group,
-      const std::shared_ptr<Source>& source,
+      const std::shared_ptr<SourceView>& source,
       const SourceRange& prev) {
     AT_ASSERT(group.size() != 0);
     CheckType type = group[0].type_;
@@ -456,7 +467,7 @@ struct FileCheckImpl {
     return SourceRange(source, start_range, end_range);
   }
 
-  void doChecks(const std::shared_ptr<Source>& source) {
+  void doChecks(const std::shared_ptr<SourceView>& source) {
     SourceRange prev(source, 0, 0);
     for (size_t i = 0; i < groups.size(); i++) {
       const auto& curr_group = groups[i];


### PR DESCRIPTION
This would save the cost copying text from stack to heap in some cases (like
parsing function schema during loading phase of libtorch.so)

