### PR TITLE
Fix torch.any documentation

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -644,9 +644,6 @@ add_docstr(torch.any,
            r"""
 any(input) -> Tensor
 
-Args:
-    {input}
-
 Tests if any element in :attr:`input` evaluates to `True`.
 
 .. note:: This function matches the behaviour of NumPy in returning


### PR DESCRIPTION
Currently, the description of torch.any would be parsed like

```
param input
the input tensor.
```

However, it should be

```
Tests if any element in input evaluates to True.
```