### PR TITLE
Parallel: Deduplicate parallel functions in different backends

### DIFF
--- a/aten/src/ATen/Parallel-inl.h
+++ b/aten/src/ATen/Parallel-inl.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <c10/util/SmallVector.h>
+
+namespace at {
+
+template <class F>
+inline void parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F& f) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(grain_size >= 0);
+  if (begin >= end) {
+    return;
+  }
+
+#ifdef INTRA_OP_PARALLEL
+  at::internal::lazy_init_num_threads();
+  const auto numiter = end - begin;
+  const bool use_parallel = (
+    numiter > grain_size && numiter > 1 &&
+    !at::in_parallel_region() &&
+    at::get_num_threads() > 1);
+  if (!use_parallel) {
+    internal::ThreadIdGuard tid_guard(0);
+    f(begin, end);
+    return;
+  }
+
+  internal::invoke_parallel(begin, end, grain_size, f);
+#else
+  internal::ThreadIdGuard tid_guard(0);
+  f(begin, end);
+#endif
+}
+
+template <class scalar_t, class F, class SF>
+inline scalar_t parallel_reduce(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const scalar_t ident,
+    const F& f,
+    const SF& sf) {
+  TORCH_CHECK(grain_size >= 0);
+  if (begin >= end) {
+    return ident;
+  }
+
+#ifdef INTRA_OP_PARALLEL
+  at::internal::lazy_init_num_threads();
+  const auto max_threads = at::get_num_threads();
+  const bool use_parallel = (
+      (end - begin) > grain_size &&
+      !at::in_parallel_region() &&
+      max_threads > 1);
+  if (!use_parallel) {
+    internal::ThreadIdGuard tid_guard(0);
+    return f(begin, end, ident);
+  }
+
+  c10::SmallVector<scalar_t, 64> results(max_threads, ident);
+  internal::invoke_parallel(begin, end, grain_size,
+    [&](const int64_t my_begin, const int64_t my_end) {
+      const auto tid = at::get_thread_num();
+      results[tid] = f(my_begin, my_end, ident);
+    }
+  );
+
+  scalar_t result = ident;
+  for (auto partial_result : results) {
+    result = sf(result, partial_result);
+  }
+  return result;
+#else
+  internal::ThreadIdGuard tid_guard(0);
+  return f(begin, end, ident);
+#endif
+}
+
+} // namespace at

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -160,3 +160,5 @@ TORCH_API int intraop_default_num_threads();
 #elif AT_PARALLEL_NATIVE_TBB
 #include <ATen/ParallelNativeTBB.h>
 #endif
+
+#include <ATen/Parallel-inl.h>

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -134,11 +134,11 @@ inline std::tuple<size_t, size_t> calc_num_tasks_and_chunk_size(
   return std::make_tuple(num_tasks, chunk_size);
 }
 
-void _parallel_run(
+void invoke_parallel(
   const int64_t begin,
   const int64_t end,
   const int64_t grain_size,
-  const std::function<void(int64_t, int64_t, size_t)>& f) {
+  const std::function<void(int64_t, int64_t)>& f) {
   at::internal::lazy_init_num_threads();
 
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -162,7 +162,7 @@ void _parallel_run(
       int64_t local_end = std::min(end, (int64_t)(chunk_size + local_start));
       try {
         ParallelRegionGuard guard(task_id);
-        f(local_start, local_end, task_id);
+        f(local_start, local_end);
       } catch (...) {
         if (!state.err_flag.test_and_set()) {
           state.eptr = std::current_exception();

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -121,6 +121,19 @@ struct ParallelRegionGuard {
 
 namespace internal {
 
+inline std::tuple<size_t, size_t> calc_num_tasks_and_chunk_size(
+    int64_t begin, int64_t end, int64_t grain_size) {
+  if ((end - begin) < grain_size) {
+    return std::make_tuple(1, std::max((int64_t)0, end - begin));
+  }
+  // Choose number of tasks based on grain size and number of threads.
+  size_t chunk_size = divup((end - begin), get_num_threads());
+  // Make sure each task is at least grain_size size.
+  chunk_size = std::max((size_t)grain_size, chunk_size);
+  size_t num_tasks = divup((end - begin), chunk_size);
+  return std::make_tuple(num_tasks, chunk_size);
+}
+
 void _parallel_run(
   const int64_t begin,
   const int64_t end,

--- a/aten/src/ATen/ParallelNative.h
+++ b/aten/src/ATen/ParallelNative.h
@@ -13,7 +13,7 @@ TORCH_API void invoke_parallel(
   const int64_t begin,
   const int64_t end,
   const int64_t grain_size,
-  const std::function<void(int64_t, int64_t, size_t)>& f);
+  const std::function<void(int64_t, int64_t)>& f);
 
 } // namespace internal
 

--- a/aten/src/ATen/ParallelNative.h
+++ b/aten/src/ATen/ParallelNative.h
@@ -9,86 +9,12 @@
 namespace at {
 namespace internal {
 
-inline std::tuple<size_t, size_t> calc_num_tasks_and_chunk_size(
-    int64_t begin, int64_t end, int64_t grain_size) {
-  if ((end - begin) < grain_size) {
-    return std::make_tuple(1, std::max((int64_t)0, end - begin));
-  }
-  // Choose number of tasks based on grain size and number of threads.
-  size_t chunk_size = divup((end - begin), get_num_threads());
-  // Make sure each task is at least grain_size size.
-  chunk_size = std::max((size_t)grain_size, chunk_size);
-  size_t num_tasks = divup((end - begin), chunk_size);
-  return std::make_tuple(num_tasks, chunk_size);
-}
-
-TORCH_API void _parallel_run(
+TORCH_API void invoke_parallel(
   const int64_t begin,
   const int64_t end,
   const int64_t grain_size,
   const std::function<void(int64_t, int64_t, size_t)>& f);
 
 } // namespace internal
-
-template <class F>
-inline void parallel_for(
-    const int64_t begin,
-    const int64_t end,
-    const int64_t grain_size,
-    const F& f) {
-  TORCH_CHECK(grain_size >= 0);
-  if (begin >= end) {
-    return;
-  }
-  if ((end - begin) < grain_size || in_parallel_region()) {
-    internal::ThreadIdGuard tid_guard(0);
-    f(begin, end);
-    return;
-  }
-  internal::_parallel_run(
-      begin,
-      end,
-      grain_size,
-      [f](int64_t start, int64_t end, size_t /* unused */) {
-        f(start, end);
-      }
-  );
-}
-
-template <class scalar_t, class F, class SF>
-inline scalar_t parallel_reduce(
-    const int64_t begin,
-    const int64_t end,
-    const int64_t grain_size,
-    const scalar_t ident,
-    const F& f,
-    const SF& sf) {
-  TORCH_CHECK(grain_size >= 0);
-  if (begin >= end) {
-    return ident;
-  }
-  if ((end - begin) < grain_size || in_parallel_region()) {
-    internal::ThreadIdGuard tid_guard(0);
-    return f(begin, end, ident);
-  }
-  size_t num_tasks, chunk_size;
-  std::tie(num_tasks, chunk_size) =
-      internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);
-  std::vector<scalar_t> results(num_tasks);
-  scalar_t* results_data = results.data();
-  internal::_parallel_run(
-      begin,
-      end,
-      grain_size,
-      [f, ident, results_data](int64_t start, int64_t end, size_t task_id) {
-        results_data[task_id] = f(start, end, ident);
-      }
-  );
-  scalar_t result = ident;
-  for (auto partial_result : results) {
-    result = sf(result, partial_result);
-  }
-  return result;
-}
 
 } // namespace at

--- a/aten/src/ATen/ParallelNativeTBB.h
+++ b/aten/src/ATen/ParallelNativeTBB.h
@@ -14,23 +14,14 @@
 #define INTRA_OP_PARALLEL
 
 namespace at {
+namespace internal {
 
-template <class F>
-inline void parallel_for(
+template <typename F>
+inline void invoke_parallel(
     const int64_t begin,
     const int64_t end,
     const int64_t grain_size,
     const F& f) {
-  TORCH_CHECK(grain_size >= 0);
-  at::internal::lazy_init_num_threads();
-  if (begin >= end) {
-    return;
-  }
-  if ((end - begin) < grain_size || get_num_threads() == 1) {
-    internal::ThreadIdGuard tid_guard(0);
-    f(begin, end);
-    return;
-  }
 
   // Choose number of tasks based on grain size and number of threads.
   int64_t chunk_size = divup((end - begin), get_num_threads());
@@ -56,58 +47,6 @@ inline void parallel_for(
   }
 }
 
-template <class scalar_t, class F, class SF>
-inline scalar_t parallel_reduce(
-    const int64_t begin,
-    const int64_t end,
-    const int64_t grain_size,
-    const scalar_t ident,
-    const F& f,
-    const SF& sf) {
-  TORCH_CHECK(grain_size >= 0);
-  at::internal::lazy_init_num_threads();
-  if (begin >= end) {
-    return ident;
-  }
-  if ((end - begin) < grain_size || get_num_threads() == 1) {
-    internal::ThreadIdGuard tid_guard(0);
-    return f(begin, end, ident);
-  }
 
-  // Choose number of tasks based on grain size and number of threads.
-  int64_t chunk_size = divup((end - begin), get_num_threads());
-  // Make sure each task is at least grain_size size.
-  chunk_size = std::max(grain_size, chunk_size);
-
-  scalar_t result;
-  std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
-  std::exception_ptr eptr;
-  result = tbb::parallel_reduce(
-    tbb::blocked_range<int64_t>(begin, end, chunk_size), ident,
-    [&eptr, &err_flag, f]
-        (const tbb::blocked_range<int64_t>& r, scalar_t ident) {
-      try {
-        internal::ThreadIdGuard tid_guard(
-            tbb::this_task_arena::current_thread_index());
-        return f(r.begin(), r.end(), ident);
-      } catch (...) {
-        if (!err_flag.test_and_set()) {
-          eptr = std::current_exception();
-        }
-        return ident;
-      }
-    },
-    sf
-  );
-  if (eptr) {
-    std::rethrow_exception(eptr);
-  }
-  return result;
-}
-
-template<typename F0, typename F1>
-void intraop_invoke(const F0& f0, const F1& f1) {
-  tbb::parallel_invoke(f0, f1);
-}
-
+} // namespace internal
 } // namespace at

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -1,9 +1,8 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <exception>
-
-#include <c10/util/SmallVector.h>
 
 #ifdef _OPENMP
 #define INTRA_OP_PARALLEL
@@ -49,79 +48,5 @@ inline void invoke_parallel(int64_t begin, int64_t end, int64_t grain_size, cons
 }
 } // namespace internal
 #endif // _OPENMP
-
-
-template <class F>
-inline void parallel_for(
-    const int64_t begin,
-    const int64_t end,
-    const int64_t grain_size,
-    const F& f) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(grain_size >= 0);
-  if (begin >= end) {
-    return;
-  }
-
-#ifdef _OPENMP
-  at::internal::lazy_init_num_threads();
-  const auto numiter = end - begin;
-  const bool use_parallel = (
-    numiter > grain_size && numiter > 1 &&
-    omp_get_max_threads() > 1 && !omp_in_parallel());
-  if (!use_parallel) {
-    internal::ThreadIdGuard tid_guard(0);
-    f(begin, end);
-    return;
-  }
-
-  internal::invoke_parallel(begin, end, grain_size, f);
-#else
-  internal::ThreadIdGuard tid_guard(0);
-  f(begin, end);
-#endif
-}
-
-template <class scalar_t, class F, class SF>
-inline scalar_t parallel_reduce(
-    const int64_t begin,
-    const int64_t end,
-    const int64_t grain_size,
-    const scalar_t ident,
-    const F& f,
-    const SF& sf) {
-  TORCH_CHECK(grain_size >= 0);
-  if (begin >= end) {
-    return ident;
-  }
-
-#ifdef _OPENMP
-  at::internal::lazy_init_num_threads();
-  const bool use_parallel = (
-      (end - begin) <= grain_size ||
-      in_parallel_region() ||
-      get_num_threads() == 1);
-  if (!use_parallel) {
-    internal::ThreadIdGuard tid_guard(0);
-    return f(begin, end, ident);
-  }
-
-  c10::SmallVector<scalar_t, 64> results(at::get_num_threads(), ident);
-  internal::invoke_parallel(begin, end, grain_size,
-    [&](const int64_t my_begin, const int64_t my_end) {
-      const auto tid = at::get_thread_num();
-      results[tid] = f(my_begin, my_end, ident);
-    }
-  );
-
-  scalar_t result = ident;
-  for (auto partial_result : results) {
-    result = sf(result, partial_result);
-  }
-  return result;
-#else
-  internal::ThreadIdGuard tid_guard(0);
-  return f(begin, end, ident);
-#endif
-}
 
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65327
* __->__ #65326

parallel_for and parallel_reduce currently share some common code in
all backends, specifically for detecting if it should run in parallel
or not. This moves all the backend-specific code into a single
`internal::invoke_parallel` function and makes the `parallel_`
functions common to all backends.

Differential Revision: [D31124495](https://our.internmc.facebook.com/intern/diff/D31124495)