### PR TITLE
[PyTorch] Compare Type pointers before calling operator== in EqualNode

### DIFF
--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -246,7 +246,9 @@ bool EqualNode::operator()(const Node* lhs, const Node* rhs) const {
   if (lhs_outputs.size() != rhs_outputs.size())
     return false;
   for (const auto i : c10::irange(lhs_outputs.size())) {
-    if (*lhs_outputs[i]->type() != *rhs_outputs[i]->type())
+    const auto& lt = lhs_outputs[i]->type();
+    const auto& rt = rhs_outputs[i]->type();
+    if (!(lt == rt || *lt == *rt))
       return false;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65352

This can be a big win if it saves the virtual call to operator== and the cost is tiny.

Differential Revision: [D30974969](https://our.internmc.facebook.com/intern/diff/D30974969/)