### PR TITLE
[iOS] Zero out NSError to avoid heap corruptions for the OSS builds

### DIFF
--- a/aten/src/ATen/native/metal/MetalContext.mm
+++ b/aten/src/ATen/native/metal/MetalContext.mm
@@ -77,7 +77,7 @@ using namespace at::native::metal;
   }
   id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
   TORCH_CHECK(func, "Failed to load the Metal Shader function: ", kernel);
-  NSError* errors;
+  NSError* errors = nil;
   state = [_device newComputePipelineStateWithFunction:func error:&errors];
   TORCH_CHECK(state, errors.localizedDescription.UTF8String);
   _pipelineCache[kernel] = state;
@@ -122,7 +122,7 @@ using namespace at::native::metal;
       floatArgIndex++;
     }
   }
-  NSError* errors;
+  NSError* errors = nil;
   id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]
                                         constantValues:constantValues
                                                  error:&errors];

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -38,7 +38,7 @@ static inline c10::ScalarType scalarType(TensorType type) {
 
 static id parse(NSString* jsonStr) {
   NSData* data = [jsonStr dataUsingEncoding:NSUTF8StringEncoding];
-  NSError* error;
+  NSError* error = nil;
   id result = [NSJSONSerialization JSONObjectWithData:data
                                               options:0
                                                 error:&error];

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
@@ -68,7 +68,7 @@
   _modelPath = [self _save:modelSpecs
                 identifier:[NSString stringWithCString:identifier.c_str()
                                               encoding:NSUTF8StringEncoding]];
-  NSError* error;
+  NSError* error = nil;
   NSURL* compiledModelPath = nil;
   if (@available(iOS 11.0, macOS 10.13, *)) {
     compiledModelPath =
@@ -113,12 +113,11 @@
 
 - (id<MLFeatureProvider>)forwardWithInputs:
     (const std::vector<PTMCoreMLFeatureSpecs>&)inputs {
-  NSError* error;
+  NSError* error = nil;
   PTMCoreMLFeatureProvider* inputFeature = [[PTMCoreMLFeatureProvider alloc]
       initWithFeatureSpecs:inputs
              CoreMLVersion:self.coreMLVersion];
   if (inputFeature == nil) {
-    NSLog(@"inputFeature is not initialized.");
     return nil;
   }
   if (@available(iOS 11.0, macOS 10.13, *)) {
@@ -136,14 +135,14 @@
 
     return outputFeature;
   } else {
-    TORCH_CHECK("Core ML is available on iOS 11.0 and above");
+    TORCH_CHECK(false, "Core ML is available on iOS 11.0 and above");
     return nil;
   }
 }
 
 - (BOOL)cleanup {
   NSFileManager* fileManager = [NSFileManager defaultManager];
-  NSError* error;
+  NSError* error = nil;
   if (![fileManager fileExistsAtPath:_modelPath]) {
     [fileManager removeItemAtPath:_modelPath error:&error];
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65076
* #65315
* __->__ #65355

I've been seeing heap corruptions in the CMake builds due to the NSError* not being initialized with `nil`.  However, I haven't see this issue for the BUCK builds.

Differential Revision: [D31048010](https://our.internmc.facebook.com/intern/diff/D31048010/)