### PR TITLE
[docs] Remove .data from some docs

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -282,9 +282,9 @@ This is how a ``Linear`` module can be implemented::
                 self.register_parameter('bias', None)
 
             # Not a very smart way to initialize weights
-            self.weight.data.uniform_(-0.1, 0.1)
+            nn.init.uniform_(self.weight, -0.1, 0.1)
             if self.bias is not None:
-                self.bias.data.uniform_(-0.1, 0.1)
+                nn.init.uniform_(self.bias, -0.1, 0.1)
 
         def forward(self, input):
             # See the autograd section for explanation of what happens here.

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -58,7 +58,7 @@ def plot_function(function, **args):
     xrange = torch.arange(-7.0, 7.0, 0.01)  # We need to go beyond 6 for ReLU6
     pylab.plot(
         xrange.numpy(),
-        function(torch.autograd.Variable(xrange)).data.numpy(),
+        function(xrange).detach().numpy(),
         **args
     )
 


### PR DESCRIPTION
Related to #30987 and #33628. Fix the following task:

- Remove the use of `.data` in all our internal code:
  - [x] `docs/source/scripts/build_activation_images.py` and `docs/source/notes/extending.rst`

In `docs/source/scripts/build_activation_images.py`, I used `nn.init` because the snippet already assumes `nn` is available (the class inherits from `nn.Module`).

cc @albanD 
