### PR TITLE
[static runtime][easy] ProcessedNode::outputs() should return const ref

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -283,7 +283,7 @@ class TORCH_API StaticRuntime {
     return *outputs_[i];
   }
 
-  const std::vector<IValue*> outputs() const {
+  const std::vector<IValue*>& outputs() const {
     return outputs_;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65363

Looks like a typo on the return type here. Not sure if this was actually causing any problems, but it's easy to fix.

Differential Revision: [D31063171](https://our.internmc.facebook.com/intern/diff/D31063171/)