### PR TITLE
[ONNX] Support exporting with Apex O2

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -65,6 +65,24 @@ class TestONNXRuntime_cuda(unittest.TestCase):
         target[target == 1] = -100
         self.run_test(FusionModel(), (input, target))
 
+    @skipIfNoCuda
+    @disableScriptTest()
+    def test_apex_o2(self):
+        class LinearModel(torch.nn.Module):
+            def __init__(self):
+                super(LinearModel, self).__init__()
+                self.linear = torch.nn.Linear(3, 5)
+
+            def forward(self, x):
+                return self.linear(x)
+        try:
+            from apex import amp
+        except:
+            raise unittest.SkipTest("Apex is not available")
+        input = torch.randn(3, 3, device=torch.device("cuda"))
+        model = amp.initialize(LinearModel(), opt_level="O2")
+        self.run_test(model, input)
+
 TestONNXRuntime_cuda.setUp = TestONNXRuntime.setUp
 TestONNXRuntime_cuda.run_test = TestONNXRuntime.run_test
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -77,7 +77,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
                 return self.linear(x)
         try:
             from apex import amp
-        except:
+        except Exception:
             raise unittest.SkipTest("Apex is not available")
         input = torch.randn(3, 3, device=torch.device("cuda"))
         model = amp.initialize(LinearModel(), opt_level="O2")

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -79,7 +79,7 @@ def disable_apex_o2_state_dict_hook(model):
     # Exporter cannot identify them as same tensors.
     # Since this hook is only used by optimizer, it is safe to
     # remove this hook while exporting.
-    tmp_map = {}
+    tmp_map = {}  # type: ignore[var-annotated]
     for module in model.modules():
         for k, v in module._state_dict_hooks.items():
             if type(v).__name__ == 'O2StateDictHook':
@@ -99,7 +99,7 @@ def disable_apex_o2_state_dict_hook(model):
 @contextlib.contextmanager
 def exporter_context(model, mode):
     with select_model_mode_for_export(model, mode) as mode_ctx, \
-        disable_apex_o2_state_dict_hook(model) as apex_ctx:
+            disable_apex_o2_state_dict_hook(model) as apex_ctx:
         yield (mode_ctx, apex_ctx)
 
 def export(model, args, f, export_params=True, verbose=False, training=None,


### PR DESCRIPTION
Apex O2 hook state_dict to return fp16 weights as fp32. Exporter cannot identify them as same tensors.
Since this hook is only used by optimizer, it is safe to remove this hook while exporting.