### PR TITLE
Eagerly populate python_error::what() when TORCH_SHOW_CPP_STACKTRACES=1

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -253,5 +253,3 @@ python_error::python_error() : type(nullptr), value(nullptr), traceback(nullptr)
     restore();
   }
 }
-
-

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -243,6 +243,15 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
   }
 }
 
-
-
 } // namespace torch
+
+python_error::python_error() : type(nullptr), value(nullptr), traceback(nullptr),
+    message("unknown Python error (for more information, try rerunning with TORCH_SHOW_CPP_STACKTRACES=1)") {
+  if (torch::get_cpp_stacktraces_enabled()) {
+    // Eagerly populate message
+    persist();
+    restore();
+  }
+}
+
+

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -131,7 +131,7 @@ extern PyObject *THPException_FatalError;
 // Throwing this exception means that the python error flags have been already
 // set and control should be immediately returned to the interpreter.
 struct python_error : public std::exception {
-  python_error() : type(nullptr), value(nullptr), traceback(nullptr) {}
+  python_error();
 
   python_error(const python_error& other)
       : type(other.type),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65376

Let's suppose there's a bug in PyTorch and python_error gets thrown
and never gets caught.  Typically, you'll get a very useless error
message like this:

```
terminate called after throwing an instance of 'python_error'
  what():
  Aborted (core dumped)
```

Now, you'll get:

```
what():  unknown Python error (for more information, try rerunning with TORCH_SHOW_CPP_STACKTRACES=1)
```

and with TORCH_SHOW_CPP_STACKTRACES=1 you'll get:

```
what():  error message from Python object
```

If we're OK with making Python exceptions go even slower, we could
eagerly populate unconditionally.  I'm also not so happy we don't get
a Python backtrace or the Python error name, that's worth improving
(this is a minimal diff to get the discussion going.)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D31067632](https://our.internmc.facebook.com/intern/diff/D31067632)