### PR TITLE
[ONNX] Use Reciprocal operator instead of Div(1, x).

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -674,10 +674,7 @@ Caffe2Ops Caffe2Backend::CreateReciprocal(
   Caffe2Ops ret;
   auto* c2_op = ret.ops.Add();
 
-  caffe2::Argument exponent;
-  exponent.set_name("exponent");
-  exponent.set_f(-1.0);
-  BuildOperator(c2_op, "Pow", {node.input(0)}, {node.output(0)}, {exponent});
+  BuildOperator(c2_op, "Reciprocal", {node.input(0)}, {node.output(0)}, {});
   return ret;
 }
 

--- a/caffe2/operators/reciprocal_op.cc
+++ b/caffe2/operators/reciprocal_op.cc
@@ -8,7 +8,7 @@ namespace caffe2 {
 REGISTER_CPU_OPERATOR(
     Reciprocal,
     UnaryElementwiseOp<
-        TensorTypes<float>,
+        TensorTypes<float, double>,
         CPUContext,
         ReciprocalFunctor<CPUContext>>);
 
@@ -64,8 +64,8 @@ Y:
 
 </details>
 )DOC")
-.Input(0, "X", "*(type: Tensor`<float>`)* Input data tensor.")
-.Output(0, "Y", "*(type: Tensor`<float>`)* Output tensor.");
+.Input(0, "X", "*(type: Tensor`<float, double>`)* Input data tensor.")
+.Output(0, "Y", "*(type: Tensor`<float, double>`)* Output tensor.");
 
 OPERATOR_SCHEMA(ReciprocalGradient).NumInputs(2).NumOutputs(1).AllowInplace({{1, 0}});
 

--- a/caffe2/operators/reciprocal_op.cu
+++ b/caffe2/operators/reciprocal_op.cu
@@ -47,13 +47,13 @@ bool ReciprocalGradientFunctor<CUDAContext>::Forward(
 REGISTER_CUDA_OPERATOR(
     Reciprocal,
     UnaryElementwiseOp<
-        TensorTypes<float>,
+        TensorTypes<float, double>,
         CUDAContext,
         ReciprocalFunctor<CUDAContext>>);
 REGISTER_CUDA_OPERATOR(
     ReciprocalGradient,
     BinaryElementwiseOp<
-        TensorTypes<float>,
+        TensorTypes<float, double>,
         CUDAContext,
         ReciprocalGradientFunctor<CUDAContext>>);
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -209,7 +209,7 @@ def true_divide(g, self, other):
 
 
 def reciprocal(g, self):
-    return g.op("Div", torch.ones(1), self)
+    return g.op("Reciprocal", self)
 
 
 @parse_args("v", "i")


### PR DESCRIPTION
This is a more readable and perhaps more performant way to export
torch.reciprocal.