### PR TITLE
Remove `.data` from benchmarks and tensorboard

### DIFF
--- a/benchmarks/distributed/ddp/compare/python_ddp.py
+++ b/benchmarks/distributed/ddp/compare/python_ddp.py
@@ -1,4 +1,5 @@
 import functools
+import torch
 import torch.distributed as dist
 import torch.nn as nn
 

--- a/benchmarks/distributed/pipeline/pipe.py
+++ b/benchmarks/distributed/pipeline/pipe.py
@@ -35,7 +35,7 @@ class EmbeddingLayer(nn.Embedding):
     def __init__(self, ntoken, ninp, initrange):
         super().__init__(ntoken, ninp)
         self.ninp = ninp
-        self.weight.data.uniform_(-initrange, initrange)
+        nn.init.uniform_(self.weight, -initrange, initrange)
 
     def forward(self, src):
         return super().forward(src) * math.sqrt(self.ninp)
@@ -82,8 +82,8 @@ class TransformerDecoderLayer(nn.TransformerEncoderLayer):
 class LinearLayer(nn.Linear):
     def __init__(self, ninp, ntoken, initrange):
         super().__init__(ninp, ntoken)
-        self.bias.data.zero_()
-        self.weight.data.uniform_(-initrange, initrange)
+        nn.init.zeros_(self.bias)
+        nn.init.uniform_(self.weight, -initrange, initrange)
 
 
 class TransformerLMSequential(nn.Sequential):

--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -92,9 +92,10 @@ def trainbench(name, rnn_creator, nloops=100, warmup=10,
         bwd_end_event.record()
 
         if modeldef.backward is not None:
-            for param in modeldef.params:
-                assert param.grad is not None
-                param.grad.data.zero_()
+            with torch.no_grad():
+                for param in modeldef.params:
+                    assert param.grad is not None
+                    param.grad.zero_()
 
         if device == 'cuda':
             torch.cuda.synchronize()

--- a/benchmarks/fastrnns/profile.py
+++ b/benchmarks/fastrnns/profile.py
@@ -25,8 +25,9 @@ def run_rnn(name, rnn_creator, nloops=5,
 
         # "Update" parameters
         if modeldef.backward is not None:
-            for param in modeldef.params:
-                param.grad.data.zero_()
+            with torch.no_grad():
+                for param in modeldef.params:
+                    param.grad.zero_()
         torch.cuda.synchronize()
 
     assert device == 'cuda'

--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -41,6 +41,7 @@ class TestBenchNetwork:
         if modeldef.backward is not None:
             benchmark(cuda_sync, modeldef.backward, *backward_input, retain_graph=True)
 
-            for param in modeldef.params:
-                assert param.grad is not None
-                param.grad.data.zero_()
+            with torch.no_grad():
+                for param in modeldef.params:
+                    assert param.grad is not None
+                    param.grad.zero_()

--- a/torch/utils/tensorboard/_convert_np.py
+++ b/torch/utils/tensorboard/_convert_np.py
@@ -26,9 +26,7 @@ def make_np(x):
 
 
 def _prepare_pytorch(x):
-    if isinstance(x, torch.autograd.Variable):
-        x = x.data
-    x = x.cpu().numpy()
+    x = x.detach().cpu().numpy()
     return x
 
 

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -518,7 +518,7 @@ def audio(tag, tensor, sample_rate=44100):
     wave_write.setnchannels(1)
     wave_write.setsampwidth(2)
     wave_write.setframerate(sample_rate)
-    wave_write.writeframes(tensor.data)
+    wave_write.writeframes(tensor.detach())
     wave_write.close()
     audio_string = fio.getvalue()
     fio.close()

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -503,13 +503,13 @@ def make_video(tensor, fps):
 
 
 def audio(tag, tensor, sample_rate=44100):
-    tensor = make_np(tensor)
-    tensor = tensor.squeeze()
-    if abs(tensor).max() > 1:
+    array = make_np(tensor)
+    array = array.squeeze()
+    if abs(array).max() > 1:
         print('warning: audio amplitude out of range, auto clipped.')
-        tensor = tensor.clip(-1, 1)
-    assert(tensor.ndim == 1), 'input tensor should be 1 dimensional.'
-    tensor = (tensor * np.iinfo(np.int16).max).astype('<i2')
+        array = array.clip(-1, 1)
+    assert(array.ndim == 1), 'input tensor should be 1 dimensional.'
+    array = (array * np.iinfo(np.int16).max).astype('<i2')
 
     import io
     import wave
@@ -518,13 +518,13 @@ def audio(tag, tensor, sample_rate=44100):
     wave_write.setnchannels(1)
     wave_write.setsampwidth(2)
     wave_write.setframerate(sample_rate)
-    wave_write.writeframes(tensor.detach())
+    wave_write.writeframes(array.data)
     wave_write.close()
     audio_string = fio.getvalue()
     fio.close()
     audio = Summary.Audio(sample_rate=sample_rate,
                           num_channels=1,
-                          length_frames=tensor.shape[-1],
+                          length_frames=array.shape[-1],
                           encoded_audio_string=audio_string,
                           content_type='audio/wav')
     return Summary(value=[Summary.Value(tag=tag, audio=audio)])


### PR DESCRIPTION
Related to #30987 and #33628. Fix the following tasks:

- Remove the use of `.data` in all our internal code:
  - [x] `benchmarks/`
  - [x] `torch/utils/tensorboard/`

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @gcramer23 @albanD @gchanan 