### PR TITLE
Use higher timeout for TSAN tests.

### DIFF
--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import logging
 import threading
 import warnings
@@ -175,6 +176,9 @@ if is_available():
             rpc_backend_options.init_method, rank=rank, world_size=world_size
         )
         store, _, _ = next(rendezvous_iterator)
+
+        # Use same timeout as RPC.
+        store.set_timeout(timedelta(seconds=rpc_backend_options.rpc_timeout))
 
         # Use a PrefixStore to distinguish multiple invocations.
         with _init_counter_lock:

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -312,7 +312,7 @@ def _tensorpipe_init_backend_handler(store, name, rank, world_size, rpc_backend_
     # this, it's easy to hit timeout in rpc.shutdown() if there is no other RPC
     # on that process before rpc.shutdown(), as the agent initialization can
     # take longer than 5s.
-    api._all_gather(None, timeout=rpc_constants.DEFAULT_RPC_TIMEOUT_SEC)
+    api._all_gather(None, timeout=rpc_backend_options.rpc_timeout)
     # Need a barrier here to make sure no peers leave before the rank0 finishes
     # _all_gather
     group.barrier().wait()

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -23,6 +23,7 @@ import torch.distributed as c10d
 from torch.testing._internal.common_utils import (
     TestCase,
     TEST_WITH_ROCM,
+    TEST_WITH_TSAN,
     FILE_SCHEMA,
     find_free_port,
     retry_on_connect_failures,
@@ -289,7 +290,11 @@ def create_tcp_store(
         )
 
 
-TIMEOUT_DEFAULT = 100
+if TEST_WITH_TSAN:
+    # TSAN runs much slower.
+    TIMEOUT_DEFAULT = 500
+else:
+    TIMEOUT_DEFAULT = 100
 TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
 
 

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -7,7 +7,7 @@ from typing import Tuple
 import torch.distributed as dist
 import torch.distributed.rpc as rpc
 from torch.distributed.rpc import _rref_context_get_debug_info
-from torch.testing._internal.common_utils import FILE_SCHEMA
+from torch.testing._internal.common_utils import FILE_SCHEMA, TEST_WITH_TSAN
 
 
 if not dist.is_available():
@@ -61,13 +61,19 @@ def dist_init(
         self.worker_id = self.rank
         self.setup_fault_injection(faulty_messages, messages_to_delay)
 
+        rpc_backend_options = self.rpc_backend_options
         if setup_rpc:
+            if TEST_WITH_TSAN:
+                # TSAN runs much slower.
+                rpc_backend_options.rpc_timeout = rpc.constants.DEFAULT_RPC_TIMEOUT_SEC * 5
+                rpc.constants.DEFAULT_SHUTDOWN_TIMEOUT = 60
+
             rpc.init_rpc(
                 name="worker%d" % self.rank,
                 backend=self.rpc_backend,
                 rank=self.rank,
                 world_size=self.world_size,
-                rpc_backend_options=self.rpc_backend_options,
+                rpc_backend_options=rpc_backend_options,
             )
 
         return_value = old_test_method(self, *arg, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65391

TSAN tests are much slower than the usual dev/opt mode, about 5-10x
slower.

As a result, for TSAN build mode we use a much higher timeout for distributed
tests.

Differential Revision: [D31076575](https://our.internmc.facebook.com/intern/diff/D31076575/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @gcramer23