### PR TITLE
[fx] give warning instead of fatal the program when submod not found during adding get_attr (#65225)

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -265,7 +265,7 @@ def _barrier(worker_names):
         )
 
 @_require_initialized
-def _wait_all_workers():
+def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     r"""
     Block until all local and remote RPC processes reach this method and wait
     for all outstanding work to complete. Every RPC process must call this
@@ -274,7 +274,7 @@ def _wait_all_workers():
     framework will work after this method returns.
     """
     try:
-        _all_gather(None, timeout=DEFAULT_SHUTDOWN_TIMEOUT)
+        _all_gather(None, timeout=timeout)
     except RuntimeError as ex:
         logger.error(
             f"Failed to respond to 'Shutdown Proceed' in time, got error {ex}"
@@ -283,7 +283,7 @@ def _wait_all_workers():
 
 
 @_require_initialized
-def shutdown(graceful=True):
+def shutdown(graceful=True, timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     r"""
     Perform a shutdown of the RPC agent, and then destroy the RPC agent. This
     stops the local agent from accepting outstanding requests, and shuts
@@ -333,7 +333,7 @@ def shutdown(graceful=True):
     """
     if graceful:
         try:
-            _wait_all_workers()
+            _wait_all_workers(timeout)
             _delete_all_user_and_unforked_owner_rrefs()
             _get_current_rpc_agent().join(shutdown=True)
         finally:

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1319,6 +1319,34 @@ class RpcTest(RpcAgentTestFixture):
         dist.barrier()
         rpc.shutdown(graceful=False)
 
+    @dist_init(setup_rpc=False)
+    def test_wait_all_workers_timeout(self):
+        initialize_pg(self.file_init_method, self.rank, self.world_size)
+
+        rpc.init_rpc(
+            name=worker_name(self.rank),
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=self.rpc_backend_options,
+        )
+
+        og_func = rpc.api._wait_all_workers                                                
+
+        def wait_all_workers_sleep(timeout):
+            try:
+                rpc.api._all_gather(SlowPickleClass(0.5), timeout=timeout)
+            except RuntimeError as ex:
+                raise ex
+            
+        rpc.api._wait_all_workers = wait_all_workers_sleep 
+        try:
+            with self.assertRaisesRegex(RuntimeError, ''):
+                rpc.shutdown(graceful=True, timeout=0.01)
+        finally:
+                rpc.api._wait_all_workers = og_func
+        dist.barrier()
+
     def test_wait_all_workers_dense(self):
         self._wait_all_workers(heavy_rpc, torch.ones(100, 100))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65395

Summary:

Currently when create get_attr node, if the attribute is in a submodule, we'll fist find the submodule. If the submodule isn't in the owning module we throw an exception.

However, if the attribute can't be found, we give a warning but still allow to create the get_attr node. To align with this behavior, we change the reaction when submod not found from fatal to giving a warning.

Test Plan: CI

Reviewed By: jamesr66a, jfix71

Differential Revision: D31021535

fbshipit-source-id: 4c0b471448c09cc927d0f47b5bf56594f25a8863

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @gcramer23