### PR TITLE
Avoid storage access with tensor deepcopy for HPU tensors

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -91,7 +91,7 @@ class Tensor(torch._C._TensorBase):
             # does accurate alias tracking; however, the code below
             # doesn't work because of
             # https://github.com/pytorch/pytorch/issues/47442
-            if self.is_sparse or self.device.type in ['xla', 'mlc', 'ort', 'meta']:
+            if self.is_sparse or self.device.type in ['xla', 'mlc', 'ort', 'meta', 'hpu']:
                 new_tensor = self.clone()
             else:
                 new_storage = self.storage().__deepcopy__(memo)


### PR DESCRIPTION
Add is_hpu() methods for Aten tensor and device
