### PR TITLE
Added PandasDataframeWrapper

### DIFF
--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -1,0 +1,43 @@
+try:
+    import pandas  # type: ignore[import]
+    # pandas used only for prototyping, will be shortly replaced with TorchArrow
+    WITH_PANDAS = True
+except ImportError:
+    WITH_PANDAS = False
+
+
+class PandasWrapper():
+    @classmethod
+    def concat(cls, buffer):
+        if not WITH_PANDAS:
+            Exception('DataFrames prototype requires pandas to function')
+        return pandas.concat(buffer)
+
+    @classmethod
+    def get_len(cls, df):
+        if not WITH_PANDAS:
+            Exception('DataFrames prototype requires pandas to function')
+        return len(df.index)
+
+
+default_wrapper = PandasWrapper
+
+# When you build own implementation just override it with dataframe_wrapper.set_df_wrapper(new_wrapper_class)
+
+
+def get_df_wrapper():
+    return default_wrapper
+
+
+def set_df_wrapper(wrapper):
+    default_wrapper = wrapper
+
+
+def concat(buffer):
+    wrapper = get_df_wrapper()
+    wrapper.concat(buffer)
+
+
+def get_len(df):
+    wrapper = get_df_wrapper()
+    wrapper.conget_len(df)

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -29,10 +29,22 @@ class PandasWrapper:
         return isinstance(data, pandas.core.series.Series)
 
     @classmethod
+    def enumerate(cls, data):
+        if not WITH_PANDAS:
+            Exception("DataFrames prototype requires pandas to function")
+        return enumerate(data)
+
+    @classmethod
     def concat(cls, buffer, **kwargs):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
         return pandas.concat(buffer, **kwargs)
+
+    @classmethod
+    def get_item(cls, data, idx):
+        if not WITH_PANDAS:
+            Exception("DataFrames prototype requires pandas to function")
+        return data[idx:idx + 1]
 
     @classmethod
     def get_len(cls, df):
@@ -71,6 +83,16 @@ def is_series_object(data):
 def concat(buffer):
     wrapper = get_df_wrapper()
     wrapper.concat(buffer)
+
+
+def enumerate(data):
+    wrapper = get_df_wrapper()
+    wrapper.enumerate(data)
+
+
+def get_item(data, idx):
+    wrapper = get_df_wrapper()
+    wrapper.get_item(data, idx)
 
 
 def get_len(df):

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -11,44 +11,44 @@ class PandasWrapper:
     @classmethod
     def create_dataframe(cls, data, columns):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")
         return pandas.DataFrame(data, columns=columns)
 
     @classmethod
     def is_dataframe(cls, data):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
+            return False
         return isinstance(data, pandas.core.frame.DataFrame)
 
     @classmethod
     def is_column(cls, data):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
+            return False
         return isinstance(data, pandas.core.series.Series)
 
     @classmethod
     def iterate(cls, data):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")
         for d in data:
             yield d
 
     @classmethod
     def concat(cls, buffer):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")
         return pandas.concat(buffer)
 
     @classmethod
     def get_item(cls, data, idx):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
-        return data[idx:idx + 1]
+            raise Exception("DataFrames prototype requires pandas to function")
+        return data[idx : idx + 1]
 
     @classmethod
     def get_len(cls, df):
         if not WITH_PANDAS:
-            Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")
         return len(df.index)
 
 

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -9,10 +9,10 @@ except ImportError:
 
 class PandasWrapper:
     @classmethod
-    def create_dataframe(cls, data):
+    def create_dataframe(cls, data, columns):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
-        return pandas.DataFrame(data)
+        return pandas.DataFrame(data, columns=columns)
 
     @classmethod
     def is_dataframe(cls, data):
@@ -64,9 +64,9 @@ def set_df_wrapper(wrapper):
     default_wrapper = wrapper
 
 
-def create_dataframe(data):
+def create_dataframe(data, columns=None):
     wrapper = get_df_wrapper()
-    wrapper.create_dataframe(data)
+    wrapper.create_dataframe(data, columns)
 
 
 def is_dataframe(data):

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -1,5 +1,3 @@
-import torcharrow as ta
-
 try:
     import pandas  # type: ignore[import]
 
@@ -11,10 +9,10 @@ except ImportError:
 
 class PandasWrapper:
     @classmethod
-    def create_dataframe(cls, data, **kwargs):
+    def create_dataframe(cls, data):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
-        return pandas.DataFrame(data, **kwargs)
+        return pandas.DataFrame(data)
 
     @classmethod
     def is_dataframe_object(cls, data):
@@ -29,16 +27,17 @@ class PandasWrapper:
         return isinstance(data, pandas.core.series.Series)
 
     @classmethod
-    def enumerate(cls, data):
+    def iterate(cls, data):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
-        return enumerate(data)
+        for d in data:
+            yield d
 
     @classmethod
-    def concat(cls, buffer, **kwargs):
+    def concat(cls, buffer):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
-        return pandas.concat(buffer, **kwargs)
+        return pandas.concat(buffer)
 
     @classmethod
     def get_item(cls, data, idx):
@@ -65,17 +64,17 @@ def set_df_wrapper(wrapper):
     default_wrapper = wrapper
 
 
-def create_dataframe(data, **kwargs):
+def create_dataframe(data):
     wrapper = get_df_wrapper()
-    wrapper.create_dataframe(data, **kwargs)
+    wrapper.create_dataframe(data)
 
 
-def is_dataframe_object(data):
+def is_dataframe(data):
     wrapper = get_df_wrapper()
     wrapper.is_dataframe_object()
 
 
-def is_series_object(data):
+def is_column(data):
     wrapper = get_df_wrapper()
     wrapper.is_series_object()
 
@@ -85,9 +84,9 @@ def concat(buffer):
     wrapper.concat(buffer)
 
 
-def enumerate(data):
+def iterate(data):
     wrapper = get_df_wrapper()
-    wrapper.enumerate(data)
+    wrapper.iterate(data)
 
 
 def get_item(data, idx):

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -15,13 +15,13 @@ class PandasWrapper:
         return pandas.DataFrame(data)
 
     @classmethod
-    def is_dataframe_object(cls, data):
+    def is_dataframe(cls, data):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
         return isinstance(data, pandas.core.frame.DataFrame)
 
     @classmethod
-    def is_series_object(cls, data):
+    def is_column(cls, data):
         if not WITH_PANDAS:
             Exception("DataFrames prototype requires pandas to function")
         return isinstance(data, pandas.core.series.Series)
@@ -71,12 +71,12 @@ def create_dataframe(data):
 
 def is_dataframe(data):
     wrapper = get_df_wrapper()
-    wrapper.is_dataframe_object()
+    wrapper.is_dataframe()
 
 
 def is_column(data):
     wrapper = get_df_wrapper()
-    wrapper.is_series_object()
+    wrapper.is_column()
 
 
 def concat(buffer):

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -1,28 +1,48 @@
+import torcharrow as ta
+
 try:
     import pandas  # type: ignore[import]
+
     # pandas used only for prototyping, will be shortly replaced with TorchArrow
     WITH_PANDAS = True
 except ImportError:
     WITH_PANDAS = False
 
 
-class PandasWrapper():
+class PandasWrapper:
     @classmethod
-    def concat(cls, buffer):
+    def create_dataframe(cls, data, **kwargs):
         if not WITH_PANDAS:
-            Exception('DataFrames prototype requires pandas to function')
-        return pandas.concat(buffer)
+            Exception("DataFrames prototype requires pandas to function")
+        return pandas.DataFrame(data, **kwargs)
+
+    @classmethod
+    def is_dataframe_object(cls, data):
+        if not WITH_PANDAS:
+            Exception("DataFrames prototype requires pandas to function")
+        return isinstance(data, pandas.core.frame.DataFrame)
+
+    @classmethod
+    def is_series_object(cls, data):
+        if not WITH_PANDAS:
+            Exception("DataFrames prototype requires pandas to function")
+        return isinstance(data, pandas.core.series.Series)
+
+    @classmethod
+    def concat(cls, buffer, **kwargs):
+        if not WITH_PANDAS:
+            Exception("DataFrames prototype requires pandas to function")
+        return pandas.concat(buffer, **kwargs)
 
     @classmethod
     def get_len(cls, df):
         if not WITH_PANDAS:
-            Exception('DataFrames prototype requires pandas to function')
+            Exception("DataFrames prototype requires pandas to function")
         return len(df.index)
 
 
-default_wrapper = PandasWrapper
-
 # When you build own implementation just override it with dataframe_wrapper.set_df_wrapper(new_wrapper_class)
+default_wrapper = PandasWrapper
 
 
 def get_df_wrapper():
@@ -33,6 +53,21 @@ def set_df_wrapper(wrapper):
     default_wrapper = wrapper
 
 
+def create_dataframe(data, **kwargs):
+    wrapper = get_df_wrapper()
+    wrapper.create_dataframe(data, **kwargs)
+
+
+def is_dataframe_object(data):
+    wrapper = get_df_wrapper()
+    wrapper.is_dataframe_object()
+
+
+def is_series_object(data):
+    wrapper = get_df_wrapper()
+    wrapper.is_series_object()
+
+
 def concat(buffer):
     wrapper = get_df_wrapper()
     wrapper.concat(buffer)
@@ -40,4 +75,4 @@ def concat(buffer):
 
 def get_len(df):
     wrapper = get_df_wrapper()
-    wrapper.conget_len(df)
+    wrapper.get_len(df)

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -71,12 +71,12 @@ def create_dataframe(data, columns=None):
 
 def is_dataframe(data):
     wrapper = get_df_wrapper()
-    wrapper.is_dataframe()
+    wrapper.is_dataframe(data)
 
 
 def is_column(data):
     wrapper = get_df_wrapper()
-    wrapper.is_column()
+    wrapper.is_column(data)
 
 
 def concat(buffer):

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -56,18 +56,18 @@ class ShuffleDataFramesPipe(DFIterDataPipe):
         all_buffer = []
         for df in self.source_datapipe:
             if size is None:
-                size = dataframe_wrapper.get_len(df)
-            for i in range(dataframe_wrapper.get_len(df)):
-                all_buffer.append(dataframe_wrapper.get_item(df, index=i))
+                size = df_wrapper.get_len(df)
+            for i in range(df_wrapper.get_len(df)):
+                all_buffer.append(df_wrapper.get_item(df, index=i))
         random.shuffle(all_buffer)
         buffer = []
         for df in all_buffer:
             buffer.append(df)
             if len(buffer) == size:
-                yield dataframe_wrapper.concat(buffer)
+                yield df_wrapper.concat(buffer)
                 buffer = []
         if len(buffer):
-            yield dataframe_wrapper.concat(buffer)
+            yield df_wrapper.concat(buffer)
 
 
 @functional_datapipe('_dataframes_filter', enable_df_api_tracing=True)

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -6,14 +6,6 @@ from torch.utils.data import (
     functional_datapipe,
 )
 
-try:
-    import pandas  # type: ignore[import]
-    # pandas used only for prototyping, will be shortly replaced with TorchArrow
-    WITH_PANDAS = True
-except ImportError:
-    WITH_PANDAS = False
-
-
 @functional_datapipe('_dataframes_as_tuples')
 class DataFramesAsTuplesPipe(IterDataPipe):
     def __init__(self, source_datapipe):
@@ -41,44 +33,40 @@ class ConcatDataFramesPipe(DFIterDataPipe):
     def __init__(self, source_datapipe, batch=3):
         self.source_datapipe = source_datapipe
         self.batch = batch
-        if not WITH_PANDAS:
-            Exception('DataFrames prototype requires pandas to function')
 
     def __iter__(self):
         buffer = []
         for df in self.source_datapipe:
             buffer.append(df)
             if len(buffer) == self.batch:
-                yield pandas.concat(buffer)
+                yield dataframe_wrapper.concat(buffer)
                 buffer = []
         if len(buffer):
-            yield pandas.concat(buffer)
+            yield dataframe_wrapper.concat(buffer)
 
 
 @functional_datapipe('_dataframes_shuffle', enable_df_api_tracing=True)
 class ShuffleDataFramesPipe(DFIterDataPipe):
     def __init__(self, source_datapipe):
         self.source_datapipe = source_datapipe
-        if not WITH_PANDAS:
-            Exception('DataFrames prototype requires pandas to function')
 
     def __iter__(self):
         size = None
         all_buffer = []
         for df in self.source_datapipe:
             if size is None:
-                size = len(df.index)
-            for i in range(len(df.index)):
-                all_buffer.append(df[i:i + 1])
+                size = dataframe_wrapper.get_len(df)
+            for i in range(dataframe_wrapper.get_len(df)):
+                all_buffer.append(dataframe_wrapper.get_item(df, index=i))
         random.shuffle(all_buffer)
         buffer = []
         for df in all_buffer:
             buffer.append(df)
             if len(buffer) == size:
-                yield pandas.concat(buffer)
+                yield dataframe_wrapper.concat(buffer)
                 buffer = []
         if len(buffer):
-            yield pandas.concat(buffer)
+            yield dataframe_wrapper.concat(buffer)
 
 
 @functional_datapipe('_dataframes_filter', enable_df_api_tracing=True)

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -58,7 +58,7 @@ class ShuffleDataFramesPipe(DFIterDataPipe):
             if size is None:
                 size = df_wrapper.get_len(df)
             for i in range(df_wrapper.get_len(df)):
-                all_buffer.append(df_wrapper.get_item(df, index=i))
+                all_buffer.append(df_wrapper.get_item(df, i))
         random.shuffle(all_buffer)
         buffer = []
         for df in all_buffer:

--- a/torch/utils/data/datapipes/dataframe/datapipes.py
+++ b/torch/utils/data/datapipes/dataframe/datapipes.py
@@ -5,6 +5,7 @@ from torch.utils.data import (
     IterDataPipe,
     functional_datapipe,
 )
+from torch.utils.data.datapipes.dataframe import dataframe_wrapper as df_wrapper
 
 @functional_datapipe('_dataframes_as_tuples')
 class DataFramesAsTuplesPipe(IterDataPipe):
@@ -39,10 +40,10 @@ class ConcatDataFramesPipe(DFIterDataPipe):
         for df in self.source_datapipe:
             buffer.append(df)
             if len(buffer) == self.batch:
-                yield dataframe_wrapper.concat(buffer)
+                yield df_wrapper.concat(buffer)
                 buffer = []
         if len(buffer):
-            yield dataframe_wrapper.concat(buffer)
+            yield df_wrapper.concat(buffer)
 
 
 @functional_datapipe('_dataframes_shuffle', enable_df_api_tracing=True)
@@ -74,8 +75,6 @@ class FilterDataFramesPipe(DFIterDataPipe):
     def __init__(self, source_datapipe, filter_fn):
         self.source_datapipe = source_datapipe
         self.filter_fn = filter_fn
-        if not WITH_PANDAS:
-            Exception('DataFrames prototype requires pandas to function')
 
     def __iter__(self):
         size = None
@@ -93,10 +92,10 @@ class FilterDataFramesPipe(DFIterDataPipe):
             if res:
                 buffer.append(df)
                 if len(buffer) == size:
-                    yield pandas.concat(buffer)
+                    yield df_wrapper.concat(buffer)
                     buffer = []
         if len(buffer):
-            yield pandas.concat(buffer)
+            yield df_wrapper.concat(buffer)
 
 
 @functional_datapipe('_to_dataframes_pipe', enable_df_api_tracing=True)
@@ -105,8 +104,6 @@ class ExampleAggregateAsDataFrames(DFIterDataPipe):
         self.source_datapipe = source_datapipe
         self.columns = columns
         self.dataframe_size = dataframe_size
-        if not WITH_PANDAS:
-            Exception('DataFrames prototype requires pandas to function')
 
     def _as_list(self, item):
         try:
@@ -119,7 +116,7 @@ class ExampleAggregateAsDataFrames(DFIterDataPipe):
         for item in self.source_datapipe:
             aggregate.append(self._as_list(item))
             if len(aggregate) == self.dataframe_size:
-                yield pandas.DataFrame(aggregate, columns=self.columns)
+                yield df_wrapper.create_dataframe(aggregate, columns=self.columns)
                 aggregate = []
         if len(aggregate) > 0:
-            yield pandas.DataFrame(aggregate, columns=self.columns)
+            yield df_wrapper.create_dataframe(aggregate, columns=self.columns)

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -97,9 +97,9 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
         if df_wrapper.is_series_object(condition):
             # We are operatring on DataFrames filter here
             result = []
-            for idx, mask in enumerate(condition):
+            for idx, mask in df_wrapper.enumerate(condition):
                 if mask:
-                    result.append(data[idx:idx + 1])
+                    result.append(df_wrapper.get_item(data, idx))
             if len(result):
                 return df_wrapper.concat(result)
             else:

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -94,7 +94,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
     def _returnIfTrue(self, data):
         condition = self.filter_fn(data, *self.args, **self.kwargs)
 
-        if df_wrapper.is_series_object(condition):
+        if df_wrapper.is_column(condition):
             # We are operatring on DataFrames filter here
             result = []
             for idx, mask in enumerate(df_wrapper.iterate(condition)):
@@ -111,7 +111,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
             return data
 
     def _isNonEmpty(self, data):
-        if df_wrapper.is_dataframe_object(data):
+        if df_wrapper.is_dataframe(data):
             return True
         r = data is not None and \
             not (isinstance(data, list) and len(data) == 0 and self.drop_empty_batches)

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -97,7 +97,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
         if df_wrapper.is_series_object(condition):
             # We are operatring on DataFrames filter here
             result = []
-            for idx, mask in df_wrapper.enumerate(condition):
+            for idx, mask in enumerate(df_wrapper.iterate(condition)):
                 if mask:
                     result.append(df_wrapper.get_item(data, idx))
             if len(result):
@@ -112,7 +112,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
 
     def _isNonEmpty(self, data):
         if df_wrapper.is_dataframe_object(data):
-                return True
+            return True
         r = data is not None and \
             not (isinstance(data, list) and len(data) == 0 and self.drop_empty_batches)
         return r

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -2,13 +2,7 @@ import warnings
 from typing import Callable, Dict, Iterator, Optional, Tuple, TypeVar
 
 from torch.utils.data import DataChunk, IterDataPipe, functional_datapipe
-
-try:
-    import pandas  # type: ignore[import]
-    # pandas used only for prototyping, will be shortly replaced with TorchArrow
-    WITH_PANDAS = True
-except ImportError:
-    WITH_PANDAS = False
+from torch.utils.data.datapipes.dataframe import dataframe_wrapper as df_wrapper
 
 T_co = TypeVar('T_co', covariant=True)
 
@@ -99,17 +93,17 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
 
     def _returnIfTrue(self, data):
         condition = self.filter_fn(data, *self.args, **self.kwargs)
-        if WITH_PANDAS:
-            if isinstance(condition, pandas.core.series.Series):
-                # We are operatring on DataFrames filter here
-                result = []
-                for idx, mask in enumerate(condition):
-                    if mask:
-                        result.append(data[idx:idx + 1])
-                if len(result):
-                    return pandas.concat(result)
-                else:
-                    return None
+
+        if df_wrapper.is_series_object(condition):
+            # We are operatring on DataFrames filter here
+            result = []
+            for idx, mask in enumerate(condition):
+                if mask:
+                    result.append(data[idx:idx + 1])
+            if len(result):
+                return df_wrapper.concat(result)
+            else:
+                return None
 
         if not isinstance(condition, bool):
             raise ValueError("Boolean output is required for `filter_fn` of FilterIterDataPipe, got", type(condition))
@@ -117,8 +111,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
             return data
 
     def _isNonEmpty(self, data):
-        if WITH_PANDAS:
-            if isinstance(data, pandas.core.frame.DataFrame):
+        if df_wrapper.is_dataframe_object(data):
                 return True
         r = data is not None and \
             not (isinstance(data, list) and len(data) == 0 and self.drop_empty_batches)


### PR DESCRIPTION
## Summary
- Added `PandasDataframeWrapper` around `pandas` functions to easily drop-and-replace`torcharrow` for Facebook internal use cases
- Updated relevant datapipe/dataframe usesites to use the new `PandasDataframeWrapper` instead of calling `pandas` functions directly
