### PR TITLE
make layout check optional in torch.testing.assert_close()

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -772,6 +772,15 @@ class TestAssertClose(TestCase):
                 with self.assertRaisesRegex(AssertionError, "layout"):
                     fn()
 
+    def test_mismatching_layout_no_check(self):
+        strided = torch.randn((2, 2))
+        sparse_coo = strided.to_sparse()
+        sparse_csr = strided.to_sparse_csr()
+
+        for actual, expected in itertools.combinations((strided, sparse_coo, sparse_csr), 2):
+            for fn in assert_close_with_inputs(actual, expected):
+                fn(check_layout=False)
+
     def test_mismatching_dtype(self):
         actual = torch.empty((), dtype=torch.float)
         expected = actual.clone().to(torch.int)

--- a/torch/testing/_asserts.py
+++ b/torch/testing/_asserts.py
@@ -261,12 +261,12 @@ def _check_attributes_equal(
 def _equalize_attributes(actual: Tensor, expected: Tensor) -> Tuple[Tensor, Tensor]:
     """Equalizes some attributes of two tensors for value comparison.
 
-    If :attr:`actual` and :attr:`expected`
-    - are not on the same :attr:`~torch.Tensor.device`, they are moved CPU memory,
-    - do not have the same ``dtype``, they are promoted  to a common ``dtype`` (according to
-        :func:`torch.promote_types`)
-    - do not have the same ``layout``, they are converted to strided tensors, and
-    - both are sparse COO tensors, but only one is coalesced, they are coalesced.
+    If :attr:`actual` and :attr:`expected` are ...
+    - ... not on the same :attr:`~torch.Tensor.device`, they are moved CPU memory.
+    - ... not of the same ``dtype``, they are promoted  to a common ``dtype`` (according to
+        :func:`torch.promote_types`).
+    - ... not of the same ``layout``, they are converted to strided tensors.
+    - ... both sparse COO tensors but only one is coalesced, the other one is coalesced.
 
     Args:
         actual (Tensor): Actual tensor.


### PR DESCRIPTION
In case the inputs have a different layout, `assert_close(..., check_layout=False)` converts them to strided before comparison. This is helpful if you just want to compare the values of sparse COO / CSR tensor against a strided reference.

This keeps BC, since the default `check_layout=True` was the old, hard-coded behavior.