### PR TITLE
Add nn.function.hardsigmoid in acc_tracer

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -411,6 +411,12 @@ def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
     return node.kwargs["input"]
 
 @register_acc_op_mapping(
+    op_and_target=("call_function", nn.functional.hardsigmoid))
+@register_acc_op
+def hardsigmoid(*, input):
+    return nn.functional.hardsigmoid(input)
+
+@register_acc_op_mapping(
     op_and_target=("call_function", torch.ops.quantized.add),
     arg_replacement_tuples=[
         ("qa", "input"),


### PR DESCRIPTION
Summary:
hardsigmoid is used by mobile net v3 oss model.
This diff added hardsigmoid support in acc_tracer

Test Plan:
buck test glow/fb/fx/acc_tracer:test_acc_shape_inference
buck test glow/fb/fx/oss_acc_tracer:test_acc_tracer -- test_hardsigmoid

Reviewed By: jfix71

Differential Revision: D30950304

