### PR TITLE
[JIT] constant object compilation  unit ref fix

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -969,10 +969,10 @@ WeakOrStrongTypePtr::WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr
 
 WeakTypePtr WeakOrStrongTypePtr::asWeakTypePtr() const {
   if (!holds_strong_ref()) {
-    std::weak_ptr<torch::jit::CompilationUnit> weak_cu = c10::get<std::weak_ptr<torch::jit::CompilationUnit>>(cu_);
-    return WeakTypePtr(weak_cu, type_);
+    return WeakTypePtr(cu_.getWeakRefOrThrow(), type_);
   } else {
-    std::weak_ptr<torch::jit::CompilationUnit> weak_cu = c10::get<std::shared_ptr<torch::jit::CompilationUnit>>(cu_);
+    std::weak_ptr<torch::jit::CompilationUnit> weak_cu =
+        cu_.getStrongRefOrThrow();
     return WeakTypePtr(weak_cu, type_);
   }
 }

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -951,22 +951,6 @@ WeakTypePtr::WeakTypePtr(
   type_ = type;
 }
 
-WeakOrStrongTypePtr::WeakOrStrongTypePtr(WeakTypePtr weak) {
-  cu_ = WeakOrStrongCompilationUnit(weak.cu_);
-  type_ = weak.type_;
-}
-
-
-WeakOrStrongTypePtr::WeakOrStrongTypePtr(StrongTypePtr strong) {
-  cu_ = WeakOrStrongCompilationUnit(strong.cu_);
-  type_ = strong.type_;
-}
-
-WeakOrStrongTypePtr::WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr type) {
-  cu_ = WeakOrStrongCompilationUnit(cu);
-  type_ = type;
-}
-
 WeakTypePtr WeakOrStrongTypePtr::asWeakTypePtr() const {
   if (!holds_strong_ref()) {
     return WeakTypePtr(cu_.getWeakRefOrThrow(), type_);

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -9,8 +9,6 @@
 #include <c10/util/hash.h>
 #include <cmath>
 #include <iostream>
-#include "c10/util/Exception.h"
-#include "jit/api/compilation_unit.h"
 
 namespace c10 {
 bool _fastEqualsForContainer(const IValue& lhs, const IValue& rhs) {

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -9,6 +9,8 @@
 #include <c10/util/hash.h>
 #include <cmath>
 #include <iostream>
+#include "c10/util/Exception.h"
+#include "jit/api/compilation_unit.h"
 
 namespace c10 {
 bool _fastEqualsForContainer(const IValue& lhs, const IValue& rhs) {
@@ -890,8 +892,17 @@ void ivalue::Object::resizeObject(size_t slot) {
   slots_.resize(type()->numAttributes());
 }
 
+
 c10::intrusive_ptr<ivalue::Object> ivalue::Object::copy() const {
-  auto object = ivalue::Object::create(c10::StrongTypePtr(type_.cu_, type()), type()->numAttributes());
+  auto object = ivalue::Object::create(type_, type()->numAttributes());
+  for (const auto i : c10::irange(slots_.size())) {
+    object->setSlot(i, slots_[i]);
+  }
+  return object;
+}
+
+c10::intrusive_ptr<ivalue::Object> ivalue::Object::copy_to_weak_compilation_ref() const {
+  auto object = ivalue::Object::create(type_.asWeakTypePtr(), type()->numAttributes());
   for (const auto i : c10::irange(slots_.size())) {
     object->setSlot(i, slots_[i]);
   }
@@ -904,7 +915,8 @@ c10::intrusive_ptr<ivalue::Object> ivalue::Object::deepcopy() const {
 }
 
 c10::intrusive_ptr<ivalue::Object> ivalue::Object::deepcopy(IValue::HashAliasedIValueMap& memo) const {
-  auto object = ivalue::Object::create(c10::StrongTypePtr(type_.cu_, type()), type()->numAttributes());
+  auto cu = type_.cu_;
+  auto object = ivalue::Object::create(WeakOrStrongTypePtr(type_.cu_, type_.type_), type()->numAttributes());
   for (const auto i : c10::irange(slots_.size())) {
     if (slots_[i].type() == c10::CapsuleType::get()) {
       // If we've gotten here, it means that we have *not* copied this
@@ -932,6 +944,43 @@ StrongTypePtr::StrongTypePtr(
   type_ = type;
   TORCH_INTERNAL_ASSERT(type_);
 }
+
+WeakTypePtr::WeakTypePtr(
+    std::weak_ptr<torch::jit::CompilationUnit> cu,
+    TypePtr type) {
+  cu_ = std::move(cu);
+  type_ = type;
+}
+
+WeakOrStrongTypePtr::WeakOrStrongTypePtr(WeakTypePtr weak) {
+  cu_ = WeakOrStrongCompilationUnit(weak.cu_);
+  type_ = weak.type_;
+  is_strong_ = false;
+}
+
+
+WeakOrStrongTypePtr::WeakOrStrongTypePtr(StrongTypePtr strong) {
+  cu_ = WeakOrStrongCompilationUnit(strong.cu_);
+  type_ = strong.type_;
+  is_strong_ = true;
+}
+
+WeakOrStrongTypePtr::WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr type) {
+  cu_ = WeakOrStrongCompilationUnit(cu);
+  type_ = type;
+  is_strong_ = cu.index() == 0;
+}
+
+WeakTypePtr WeakOrStrongTypePtr::asWeakTypePtr() const {
+  if (!is_strong_) {
+    std::weak_ptr<torch::jit::CompilationUnit> weak_cu = c10::get<std::weak_ptr<torch::jit::CompilationUnit>>(cu_);
+    return WeakTypePtr(weak_cu, type_);
+  } else {
+    std::weak_ptr<torch::jit::CompilationUnit> weak_cu = c10::get<std::shared_ptr<torch::jit::CompilationUnit>>(cu_);
+    return WeakTypePtr(weak_cu, type_);
+  }
+}
+
 
 ska::flat_hash_map<std::type_index, c10::ClassTypePtr>& getCustomClassTypeMap() {
     static ska::flat_hash_map<std::type_index, c10::ClassTypePtr> tmap;

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -8,7 +8,6 @@
 #include <c10/util/variant.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <typeindex>
-#include "c10/util/Exception.h"
 
 namespace torch {
 class TORCH_API CustomClassHolder : public c10::intrusive_ptr_target {};

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1164,13 +1164,13 @@ struct TORCH_API WeakTypePtr {
 
 // internal build errors with std::variant :/
 struct WeakOrStrongCompilationUnit {
-  WeakOrStrongCompilationUnit(
+  explicit WeakOrStrongCompilationUnit(
       std::shared_ptr<torch::jit::CompilationUnit> shared_cu) {
     strong_ptr_ = shared_cu;
     weak_ptr_ = c10::nullopt;
   }
 
-  WeakOrStrongCompilationUnit(
+  explicit WeakOrStrongCompilationUnit(
       std::weak_ptr<torch::jit::CompilationUnit> weak_cu) {
     strong_ptr_ = c10::nullopt;
     weak_ptr_ = weak_cu;
@@ -1197,9 +1197,18 @@ struct WeakOrStrongCompilationUnit {
 // An Object will hold a non-owning Compilation Unit reference if it is a
 // Constant in the graph and a Owning reference otherwise
 struct TORCH_API WeakOrStrongTypePtr {
-  explicit WeakOrStrongTypePtr(WeakTypePtr weak);
-  explicit WeakOrStrongTypePtr(StrongTypePtr strong);
-  WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr type);
+  explicit WeakOrStrongTypePtr(WeakTypePtr weak)
+      : cu_(WeakOrStrongCompilationUnit(weak.cu_)) {
+    type_ = weak.type_;
+  }
+  explicit WeakOrStrongTypePtr(StrongTypePtr strong)
+      : cu_(WeakOrStrongCompilationUnit(strong.cu_)) {
+    type_ = strong.type_;
+  }
+  explicit WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr type)
+      : cu_(cu) {
+    type_ = type;
+  }
   WeakTypePtr asWeakTypePtr() const;
 
   WeakOrStrongCompilationUnit cu_;

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -7,6 +7,7 @@
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <typeindex>
+#include <c10/util/variant.h>
 
 namespace torch {
 class TORCH_API CustomClassHolder : public c10::intrusive_ptr_target {};
@@ -1146,6 +1147,30 @@ struct TORCH_API StrongTypePtr {
   std::shared_ptr<torch::jit::CompilationUnit> cu_;
   std::shared_ptr<Type> type_;
 };
+
+struct TORCH_API WeakTypePtr {
+  WeakTypePtr(
+      std::weak_ptr<torch::jit::CompilationUnit> cu,
+      std::shared_ptr<Type> type);
+
+  std::weak_ptr<torch::jit::CompilationUnit> cu_;
+  std::shared_ptr<Type> type_;
+};
+
+
+using WeakOrStrongCompilationUnit = c10::variant<std::shared_ptr<torch::jit::CompilationUnit>, std::weak_ptr<torch::jit::CompilationUnit>>;
+
+struct TORCH_API WeakOrStrongTypePtr {
+  WeakOrStrongTypePtr(WeakTypePtr weak);
+  WeakOrStrongTypePtr(StrongTypePtr strong);
+  WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr type);
+  WeakTypePtr asWeakTypePtr() const;
+
+  WeakOrStrongCompilationUnit cu_;
+  TypePtr type_;
+  bool is_strong_;
+};
+
 
 TORCH_API ska::flat_hash_map<std::type_index, c10::ClassTypePtr>&
 getCustomClassTypeMap();

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1177,7 +1177,7 @@ struct WeakOrStrongCompilationUnit {
   }
 
   std::shared_ptr<torch::jit::CompilationUnit> getStrongRefOrThrow() const {
-    TORCH_INTERNAL_ASSERT(weak_ptr_ != c10::nullopt);
+    TORCH_INTERNAL_ASSERT(strong_ptr_ != c10::nullopt);
     return *strong_ptr_;
   }
 
@@ -1214,7 +1214,7 @@ struct TORCH_API WeakOrStrongTypePtr {
   WeakOrStrongCompilationUnit cu_;
   TypePtr type_;
   bool holds_strong_ref() const {
-    return cu_.holdingStrongRef() == 0;
+    return cu_.holdingStrongRef();
   }
 };
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -5,7 +5,6 @@
 #include <ATen/core/ivalue_to.h>
 #include <c10/util/C++17.h>
 #include <c10/util/intrusive_ptr.h>
-#include <c10/util/variant.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <typeindex>
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1163,35 +1163,35 @@ struct TORCH_API WeakTypePtr {
 };
 
 // internal build errors with std::variant :/
-struct WeakOrStrongCompilationUnit
-    : public std::pair<
-          c10::optional<std::shared_ptr<torch::jit::CompilationUnit>>,
-          c10::optional<std::weak_ptr<torch::jit::CompilationUnit>>> {
-  using pair::pair;
+struct WeakOrStrongCompilationUnit {
   WeakOrStrongCompilationUnit(
       std::shared_ptr<torch::jit::CompilationUnit> shared_cu) {
-    this->first = shared_cu;
-    this->second = c10::nullopt;
+    strong_ptr_ = shared_cu;
+    weak_ptr_ = c10::nullopt;
   }
+
   WeakOrStrongCompilationUnit(
       std::weak_ptr<torch::jit::CompilationUnit> weak_cu) {
-    this->first = c10::nullopt;
-    this->second = weak_cu;
+    strong_ptr_ = c10::nullopt;
+    weak_ptr_ = weak_cu;
   }
 
   std::shared_ptr<torch::jit::CompilationUnit> getStrongRefOrThrow() const {
-    TORCH_INTERNAL_ASSERT(this->first != c10::nullopt);
-    return *this->first;
+    TORCH_INTERNAL_ASSERT(weak_ptr_ != c10::nullopt);
+    return *strong_ptr_;
   }
 
   std::weak_ptr<torch::jit::CompilationUnit> getWeakRefOrThrow() const {
-    TORCH_INTERNAL_ASSERT(this->second != c10::nullopt);
-    return *this->second;
+    TORCH_INTERNAL_ASSERT(weak_ptr_ != c10::nullopt);
+    return *weak_ptr_;
   }
 
   bool holdingStrongRef() const {
-    return this->first != c10::nullopt;
+    return strong_ptr_ != c10::nullopt;
   }
+
+  c10::optional<std::shared_ptr<torch::jit::CompilationUnit>> strong_ptr_;
+  c10::optional<std::weak_ptr<torch::jit::CompilationUnit>> weak_ptr_;
 };
 
 // An Object will hold a non-owning Compilation Unit reference if it is a

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1148,6 +1148,11 @@ struct TORCH_API StrongTypePtr {
   std::shared_ptr<Type> type_;
 };
 
+// [Constant Object Weak CompilationUnit Reference]
+// A non owning pointer to a type. When a class get inserted as a constant
+// into a graph, if we used a strong pointer we would have a circular reference
+// from Object -> CompilationUnit and CompilationUnit -> Graph (which owns the
+// Constant Object)
 struct TORCH_API WeakTypePtr {
   WeakTypePtr(
       std::weak_ptr<torch::jit::CompilationUnit> cu,
@@ -1160,6 +1165,8 @@ struct TORCH_API WeakTypePtr {
 
 using WeakOrStrongCompilationUnit = c10::variant<std::shared_ptr<torch::jit::CompilationUnit>, std::weak_ptr<torch::jit::CompilationUnit>>;
 
+// An Object will hold a non-owning Compilation Unit reference if it is a
+// Constant in the graph and a Owning reference otherwise
 struct TORCH_API WeakOrStrongTypePtr {
   WeakOrStrongTypePtr(WeakTypePtr weak);
   WeakOrStrongTypePtr(StrongTypePtr strong);

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1168,14 +1168,16 @@ using WeakOrStrongCompilationUnit = c10::variant<std::shared_ptr<torch::jit::Com
 // An Object will hold a non-owning Compilation Unit reference if it is a
 // Constant in the graph and a Owning reference otherwise
 struct TORCH_API WeakOrStrongTypePtr {
-  WeakOrStrongTypePtr(WeakTypePtr weak);
-  WeakOrStrongTypePtr(StrongTypePtr strong);
+  explicit WeakOrStrongTypePtr(WeakTypePtr weak);
+  explicit WeakOrStrongTypePtr(StrongTypePtr strong);
   WeakOrStrongTypePtr(WeakOrStrongCompilationUnit cu, TypePtr type);
   WeakTypePtr asWeakTypePtr() const;
 
   WeakOrStrongCompilationUnit cu_;
   TypePtr type_;
-  bool is_strong_;
+  bool holds_strong_ref() const {
+    return cu_.index() == 0;
+  }
 };
 
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -957,9 +957,9 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
 
   std::shared_ptr<torch::jit::CompilationUnit> compilation_unit() {
     if (type_.holds_strong_ref()) {
-      return c10::get<std::shared_ptr<torch::jit::CompilationUnit>>(type_.cu_);
+      return type_.cu_.getStrongRefOrThrow();
     } else {
-      auto weak_ptr = c10::get<std::weak_ptr<torch::jit::CompilationUnit>>(type_.cu_);
+      auto weak_ptr = type_.cu_.getWeakRefOrThrow();
       return std::shared_ptr<torch::jit::CompilationUnit>(weak_ptr);
     }
   }

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -949,6 +949,10 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
 
   c10::intrusive_ptr<Object> copy_to_weak_compilation_ref() const;
 
+  void unasfe_make_weak_compilation_ref() {
+    type_ = type_.asWeakTypePtr();
+  }
+
   c10::intrusive_ptr<Object> copy() const;
 
   c10::intrusive_ptr<Object> deepcopy() const;

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -123,12 +123,11 @@ c10::optional<Value*> tryInsertConstant(
       n->destroy();
       return c10::nullopt;
     };
-  } else if ((val.isGenericDict() && insertableIValue(val)) || (val.isEnum())) {
-    n->ival_(attr::value, val);
-    n->output()->setType(val.type());
-    // TODO: add object to insertableIValue
-    // see [Constant Object Weak CompilationUnit Reference]
-  } else if ((val.isObject() && !val.toObjectRef().type()->is_module()) && val.toObjectRef().is_weak_compilation_ref()) {
+    // TODO: bail on inserting object with owning compilation unit reference
+    // see: [Constant Object Weak CompilationUnit Reference]
+  } else if (
+      (val.isGenericDict() && insertableIValue(val)) || (val.isEnum()) ||
+      (val.isObject() && !val.toObjectRef().type()->is_module())) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());
   } else {

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -123,9 +123,11 @@ c10::optional<Value*> tryInsertConstant(
       n->destroy();
       return c10::nullopt;
     };
-  } else if (
-      (val.isGenericDict() && insertableIValue(val)) || (val.isEnum()) ||
-      (val.isObject() && !val.toObjectRef().type()->is_module())) {
+  } else if ((val.isGenericDict() && insertableIValue(val)) || (val.isEnum())) {
+    n->ival_(attr::value, val);
+    n->output()->setType(val.type());
+  // TODO: add object to insertableIValue
+  } else if ((val.isObject() && !val.toObjectRef().type()->is_module()) && val.toObjectRef().is_weak_compilation_ref()) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());
   } else {

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -126,7 +126,8 @@ c10::optional<Value*> tryInsertConstant(
   } else if ((val.isGenericDict() && insertableIValue(val)) || (val.isEnum())) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());
-  // TODO: add object to insertableIValue
+    // TODO: add object to insertableIValue
+    // see [Constant Object Weak CompilationUnit Reference]
   } else if ((val.isObject() && !val.toObjectRef().type()->is_module()) && val.toObjectRef().is_weak_compilation_ref()) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -108,6 +108,7 @@ c10::optional<std::vector<IValue>> runNodeIfInputsAreConstant(
       if (!db) {
         continue;
       }
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       Node* n_non_const = const_cast<Node*>(n);
       if (db->mayContainAlias(
               n_non_const->inputs(), {n_non_const->outputs()})) {

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -100,6 +100,7 @@ c10::optional<std::vector<IValue>> runNodeIfInputsAreConstant(
         return c10::nullopt;
       }
     }
+    // see [Constant Object Weak CompilationUnit Reference]
     if (v.isCustomClass()) {
       if (v.toObject()->is_weak_compilation_ref()) {
         continue;

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -114,7 +114,7 @@ c10::optional<std::vector<IValue>> runNodeIfInputsAreConstant(
         continue;
       }
       auto obj = v.toObject();
-      obj->unasfe_make_weak_compilation_ref();
+      obj->unsafe_make_weak_compilation_ref();
     }
     if (v.isObject()) {
       if (!v.toObject()->is_weak_compilation_ref()) {

--- a/torch/csrc/jit/passes/constant_propagation.h
+++ b/torch/csrc/jit/passes/constant_propagation.h
@@ -25,7 +25,8 @@ TORCH_API bool ConstantPropagationImmutableTypes(std::shared_ptr<Graph>& graph);
 // specified, nodes that output user defined classes are not run.
 TORCH_API c10::optional<Stack> runNodeIfInputsAreConstant(
     const Node* node,
-    bool ignore_custom_classes = false);
+    bool ignore_custom_classes = false,
+    AliasDb* db = nullptr);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -467,6 +467,15 @@ class AttributePropagator {
             } else {
               attr = overrideGradient(attr);
             }
+            if (attr.isObject()) {
+              if (object_memo_.count(attr.toObject())) {
+                attr = object_memo_[attr.toObject()];
+              } else {
+                auto weak_class_obj = attr.toObject()->copy_to_weak_compilation_ref();
+                object_memo_[attr.toObject()] = weak_class_obj;
+                attr = weak_class_obj;
+              }
+            }
             if (auto attrVal = tryInsertConstant(*graph, attr)) {
               paramConst = *attrVal;
             } else {
@@ -758,6 +767,11 @@ class AttributePropagator {
 
   // Contains the attributes names (e.g. {"self", "subModule", "a"}
   std::deque<std::string> names_;
+
+  // constants in the graph cannot hold a reference to
+  //
+  std::unordered_map<c10::intrusive_ptr<at::ivalue::Object>, c10::intrusive_ptr<at::ivalue::Object>> object_memo_;
+
 }; // class AttributePropagator
 } // namespace
 

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -768,8 +768,7 @@ class AttributePropagator {
   // Contains the attributes names (e.g. {"self", "subModule", "a"}
   std::deque<std::string> names_;
 
-  // constants in the graph cannot hold a reference to
-  //
+  // see [Constant Object Weak CompilationUnit Reference]
   std::unordered_map<c10::intrusive_ptr<at::ivalue::Object>, c10::intrusive_ptr<at::ivalue::Object>> object_memo_;
 
 }; // class AttributePropagator

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -2,7 +2,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/irange.h>
-#include "ATen/core/ivalue.h"
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/irange.h>
+#include "ATen/core/ivalue.h"
 
 namespace torch {
 namespace jit {
@@ -320,11 +321,17 @@ void dictConstruct(Stack& stack, const at::DictType& type, size_t num_inputs) {
   push(stack, std::move(vals));
 }
 
-void createObject(Stack& stack, const at::ClassTypePtr& type) {
-  auto userObj = c10::ivalue::Object::create(
-      c10::StrongTypePtr(type->compilation_unit(), type),
-      type->numAttributes());
-  push(stack, std::move(userObj));
+void createObject(Stack& stack, const at::ClassTypePtr& type, bool as_weak_ref) {
+  if (as_weak_ref) {
+    c10::WeakTypePtr weak(type->compilation_unit(), type);
+    auto userObj = c10::ivalue::Object::create(weak, type->numAttributes());
+    push(stack, std::move(userObj));
+  } else {
+    auto userObj = c10::ivalue::Object::create(
+        c10::StrongTypePtr(type->compilation_unit(), type),
+        type->numAttributes());
+    push(stack, std::move(userObj));
+  }
 }
 
 void isinstance(Stack& stack, at::ArrayRef<at::TypePtr> types) {

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/irange.h>
+#include "ATen/core/ivalue.h"
 
 namespace torch {
 namespace jit {
@@ -323,7 +324,8 @@ void dictConstruct(Stack& stack, const at::DictType& type, size_t num_inputs) {
 void createObject(Stack& stack, const at::ClassTypePtr& type, bool as_weak_ref) {
   if (as_weak_ref) {
     c10::WeakTypePtr weak(type->compilation_unit(), type);
-    auto userObj = c10::ivalue::Object::create(weak, type->numAttributes());
+    auto userObj = c10::ivalue::Object::create(
+        c10::WeakOrStrongTypePtr(weak), type->numAttributes());
     push(stack, std::move(userObj));
   } else {
     auto userObj = c10::ivalue::Object::create(

--- a/torch/csrc/jit/runtime/vararg_functions.h
+++ b/torch/csrc/jit/runtime/vararg_functions.h
@@ -32,7 +32,7 @@ void listConstruct(
 
 void dictConstruct(Stack& stack, const at::DictType& type, size_t num_inputs);
 
-void createObject(Stack& stack, const at::ClassTypePtr& type);
+void createObject(Stack& stack, const at::ClassTypePtr& type, bool as_weak_ref=false);
 
 void isinstance(Stack& stack, at::ArrayRef<at::TypePtr> types);
 

--- a/torch/csrc/jit/runtime/vararg_functions.h
+++ b/torch/csrc/jit/runtime/vararg_functions.h
@@ -32,6 +32,8 @@ void listConstruct(
 
 void dictConstruct(Stack& stack, const at::DictType& type, size_t num_inputs);
 
+// as weak_ref will create a Object with a non-owning CompilationUnit reference,
+// for use as a constant in the Graph to avoid a reference cycle
 void createObject(Stack& stack, const at::ClassTypePtr& type, bool as_weak_ref=false);
 
 void isinstance(Stack& stack, at::ArrayRef<at::TypePtr> types);


### PR DESCRIPTION
// A non owning pointer to a type. When a class get inserted as a constant
// into a graph, if we used a strong pointer we would have a circular reference
// from Object -> CompilationUnit and CompilationUnit -> Graph (which owns the
// Constant Object)
