### PR TITLE
[QPL] improve qpl logging for run method

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -186,8 +186,7 @@ void Method::run(Stack& stack) const {
       owner_->getMetadata();
 
   if (observer) {
-    observer->onEnterRunMethod(
-        copied_metadata, instance_key, function_->name());
+    observer->onEnterRunMethod(instance_key);
   }
 
   auto debug_info = std::make_shared<MobileDebugInfo>();
@@ -210,6 +209,8 @@ void Method::run(Stack& stack) const {
 #endif
 
     observer->onFailRunMethod(
+        copied_metadata,
+        function_->name(),
         instance_key,
         error_message.empty() ? "Unknown exception" : error_message.c_str());
   });
@@ -218,7 +219,8 @@ void Method::run(Stack& stack) const {
     stack.insert(stack.begin(), owner_->_ivalue()); // self
     function_->run(stack);
     if (observer) {
-      observer->onExitRunMethod(instance_key);
+      observer->onExitRunMethod(
+          copied_metadata, function_->name(), instance_key);
     }
     failure_guard.release();
     // This exception must be caught first as it derived from c10::Error

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -67,12 +67,16 @@ class MobileModuleObserver {
  public:
   virtual ~MobileModuleObserver() = default;
 
-  virtual void onEnterRunMethod(
+  virtual void onEnterRunMethod(const int32_t) {}
+  virtual void onExitRunMethod(
       const std::unordered_map<std::string, std::string>&,
+      const std::string&,
+      const int32_t) {}
+  virtual void onFailRunMethod(
+      const std::unordered_map<std::string, std::string>&,
+      const std::string&,
       const int32_t,
-      const std::string&) {}
-  virtual void onExitRunMethod(const int32_t) {}
-  virtual void onFailRunMethod(const int32_t, const char*) {}
+      const char*) {}
   virtual void onEnterLoadModel(const int32_t) {}
   virtual void onExitLoadModel(
       const int32_t,


### PR DESCRIPTION
Summary: This diff moved run method metadata logging from marker start to marker end. This should improve perf because we can skip metadata logging is mark is not sampled.

Test Plan: To be tested.

Differential Revision: D31105548

