### PR TITLE
Back out "Eagerly populate python_error::what() when TORCH_SHOW_CPP_STACKTRACES=1"

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -244,12 +244,3 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
 }
 
 } // namespace torch
-
-python_error::python_error() : type(nullptr), value(nullptr), traceback(nullptr),
-    message("unknown Python error (for more information, try rerunning with TORCH_SHOW_CPP_STACKTRACES=1)") {
-  if (torch::get_cpp_stacktraces_enabled()) {
-    // Eagerly populate message
-    persist();
-    restore();
-  }
-}

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -131,7 +131,7 @@ extern PyObject *THPException_FatalError;
 // Throwing this exception means that the python error flags have been already
 // set and control should be immediately returned to the interpreter.
 struct python_error : public std::exception {
-  python_error();
+  python_error() : type(nullptr), value(nullptr), traceback(nullptr) {}
 
   python_error(const python_error& other)
       : type(other.type),


### PR DESCRIPTION
Summary: Original commit changeset: 9cfda47cafb3

Test Plan: unland

Reviewed By: ezyang

Differential Revision: D31116643

