### PR TITLE
[quant][fx][graphmode] Make FixedQParam ops work for dtypes other than quint8

### DIFF
--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -43,7 +43,6 @@ from .graph_module import (
 
 from .pattern_utils import (
     MatchResult,
-    get_default_output_activation_post_process_map,
 )
 
 from .match_utils import (
@@ -576,10 +575,9 @@ def maybe_insert_output_observer_for_node(
     if should_insert_observer:
         act_post_process_ctr = qconfig.activation
         if activation_is_int8_quantized(qconfig):
-            act_post_process_ctr = \
-                get_default_output_activation_post_process_map().get(
-                    matched_pattern,
-                    act_post_process_ctr)
+            act_post_process_ctr = qhandler.get_activation_ctr(
+                qconfig,
+                matched_pattern)
         observer = act_post_process_ctr()
         new_obs = insert_observer(node, observer, model, modules, graph)
         # set the type, so the next node can read it

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -1446,11 +1446,12 @@ class FixedQParamsOpQuantizeHandler(QuantizeHandler):
 
     # some qhandlers override the activations constructor
     def get_activation_ctr(self, qconfig, pattern) -> Optional[Callable]:
-        if activation_dtype(qconfig) == torch.float16:
-            return qconfig.activation
-        else:
+        act_dtype = activation_dtype(qconfig)
+        if act_dtype == torch.quint8:
             return get_default_output_activation_post_process_map().get(
-                pattern, None)
+                pattern, qconfig.activation)
+        else:
+            return qconfig.activation
 
     def convert(self,
                 node: Node,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65484

Summary:
This PR makes sure we only use FixedQParamFakeQuantize for quint8 dtype and allows user
to use other dtypes for ops like sigmoid, this is useful for producing reference pattern for
these ops that can be used in other backends like TensorRT

Test Plan:
python test/test_quantization.py TestQuantizeFxOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31120377](https://our.internmc.facebook.com/intern/diff/D31120377)