### PR TITLE
Display workflow name in EC2, Build and Test jobs

### DIFF
--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -90,7 +90,7 @@ on:
           export COMMIT_TIME
           pip3 install requests==2.26
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
-      - name: Test
+      - name: Test ${{ github.workflow }}
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -19,7 +19,7 @@ concurrency:
 {%- endmacro -%}
 
 {%- macro display_ec2_information() -%}
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -65,7 +65,7 @@ jobs:
         run: |
           !{{ common.pull_docker("${DOCKER_IMAGE}") }}
       !{{ common.parse_ref() }}
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -224,7 +224,7 @@ jobs:
         run: |
           sudo df -H
       !{{ common.parse_ref() }}
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -97,7 +97,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
 {%- endif %}
       !{{ common.parse_ref() }}
-      - name: Build
+      - name: Build ${{ github.workflow }}
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
@@ -202,7 +202,7 @@ jobs:
         name: Setup Python3
         with:
           python-version: '3.x'
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }}, ${{ matrix.runner }})
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -303,7 +303,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -387,7 +387,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -303,7 +303,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -387,7 +387,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -303,7 +303,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -387,7 +387,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -303,7 +303,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -387,7 +387,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -303,7 +303,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -387,7 +387,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -529,7 +529,7 @@ jobs:
       DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
       DOCS_TYPE: ${{ matrix.docs_type }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -61,7 +61,7 @@ jobs:
       JOB_BASE_NAME: linux-xenial-py3.6-gcc7-bazel-test-build-and-test
       NUM_TEST_SHARDS: 1
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -223,7 +223,7 @@ jobs:
           export COMMIT_TIME
           pip3 install requests==2.26
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
-      - name: Test
+      - name: Test ${{ github.workflow }}
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -303,7 +303,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -387,7 +387,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -59,7 +59,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -163,7 +163,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -59,7 +59,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -163,7 +163,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |
@@ -301,7 +301,7 @@ jobs:
       NUM_TEST_SHARDS: ${{ matrix.num_shards }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -385,7 +385,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }},  ${{ matrix.runner }})
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -72,7 +72,7 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: recursive
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -100,7 +100,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -228,7 +228,7 @@ jobs:
         name: Setup Python3
         with:
           python-version: '3.x'
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }}, ${{ matrix.runner }})
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/

--- a/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -165,7 +165,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         env:
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
         run: |

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -72,7 +72,7 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: recursive
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -92,7 +92,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
@@ -169,7 +169,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -210,7 +210,7 @@ jobs:
         name: Setup Python3
         with:
           python-version: '3.x'
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }}, ${{ matrix.runner }})
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/

--- a/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
@@ -74,7 +74,7 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: recursive
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -102,7 +102,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -230,7 +230,7 @@ jobs:
         name: Setup Python3
         with:
           python-version: '3.x'
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }}, ${{ matrix.runner }})
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -74,7 +74,7 @@ jobs:
           # deep clone, to allow use of git merge-base
           fetch-depth: 0
           submodules: recursive
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -102,7 +102,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Build
+      - name: Build ${{ github.workflow }}
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Display EC2 information
+      - name: Display EC2 information for ${{ github.workflow }}
         shell: bash
         run: |
           set -euo pipefail
@@ -230,7 +230,7 @@ jobs:
         name: Setup Python3
         with:
           python-version: '3.x'
-      - name: Test
+      - name: Test ${{ github.workflow }} / test (${{ matrix.config }}, ${{ matrix.shard }}, ${{ matrix.num_shards }}, ${{ matrix.runner }})
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/


### PR DESCRIPTION
This makes runner logs much more traceable.
For example for https://github.com/pytorch/pytorch/runs/3750103720 highlighted failed step has all the info needed to identify it:
![image](https://user-images.githubusercontent.com/2453524/135493080-5caae21e-2e2d-45bf-b2e6-fcda3d6cd69e.png)
