### PR TITLE
[Static Runtime] Manage output tensors

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -79,7 +79,7 @@ struct TORCH_API StaticModuleOptions {
   // to batch allocate tensor storage for output tensors of the
   // graph, where storage is deallocated outside static runtime
   // (enable_out_variant must be true)
-  bool optimize_graph_output_memory{false};
+  bool manage_output_tensors{false};
 };
 
 /// The static runime supports two execution modes.
@@ -176,6 +176,11 @@ class TORCH_API StaticModule {
   }
 
   const StaticModuleOptions& opts() const;
+
+  const ValueGroup& valueGroup() const {
+    return value_group_;
+  }
+
   size_t num_inputs() const;
   size_t num_outputs() const;
 
@@ -337,6 +342,14 @@ class TORCH_API StaticRuntime {
   bool is_optimizable_container_type(Node* n) const {
     return static_module_.is_optimizable_container_type(n);
   }
+
+  // Deallocate managed output tensors. This should be called only when all the
+  // references to the output from Static Runtime are gone.
+  void deallocateOutputTensors();
+
+  bool checkOutputTensorMemoryLeaks();
+
+  bool isManagedOutputTensor(const IValue& ivalue);
 
  private:
   // helper method for copying input args/kwargs into inputs_

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -47,33 +47,66 @@ static void assign_storage_to_managed_tensors(
   }
 }
 
+static bool setIncludes(const FastSet<const Value*>& set, const Value* v) {
+  return set.find(v) != set.end();
+}
+
+static void assignStorageToOutputTensors(
+    StaticRuntime* runtime,
+    const FastSet<const Value*>& managed_output_tensor_values,
+    std::vector<std::pair<size_t, at::Tensor*>>* managed_output_tensors) {
+  for (auto& pnode : runtime->nodes()) {
+    for (const auto i : c10::irange(pnode.outputs().size())) {
+      auto& ival = pnode.Output(i);
+      const auto* val = pnode.node()->outputs()[i];
+      if (!setIncludes(managed_output_tensor_values, val)) {
+        continue;
+      }
+      TORCH_CHECK(ival.isTensor());
+      at::Tensor* tensor = &ival.toTensor();
+      managed_output_tensors->emplace_back(0, tensor);
+    }
+  }
+}
+
 MemoryPlanner::MemoryPlanner(
     StaticRuntime* runtime,
     const FastMap<const Value*, std::vector<const Value*>>&
         value_to_same_storage_values,
     const ValueGroup& value_group,
     bool enable_out_variant,
-    bool manage_graph_output_memory) {
+    bool manage_output_tensors) {
   // collect register indices of outputs of ops with out variant
   FastSet<const Value*> managed_tensor_values;
   FastSet<const Value*> leaked_values;
+  // Never manage graph outputs so that we can do std::move(output_ivalue).
+  // This does not affect performance if the graph returns a collection object.
+  FastSet<const Value*> graph_output_values(
+      runtime->graph().outputs().begin(), runtime->graph().outputs().end());
   if (enable_out_variant) {
     for (ProcessedNode& pnode : runtime->nodes()) {
-      if (pnode.has_out_variant()) {
-        for (const auto i : c10::irange(pnode.outputs().size())) {
-          const Value* out_v = pnode.node()->outputs()[i];
-          if (value_group.isAlwaysAlive(out_v)) {
-            continue;
-          }
-          // Types are stored in the underlying TorchScript IR
-          const auto& type = out_v->type();
-          if (type->castRaw<TensorType>()) {
-            managed_tensor_values.insert(out_v);
-          } else if (runtime->is_optimizable_container_type(pnode.node())) {
-            // We "leak" certain container types because their allocations
-            // take a long time
-            leaked_values.insert(out_v);
-          }
+      if (!pnode.has_out_variant()) {
+        continue;
+      }
+      for (const auto i : c10::irange(pnode.outputs().size())) {
+        const Value* out_v = pnode.node()->outputs()[i];
+        // Types are stored in the underlying TorchScript IR
+        bool is_tensor_type = out_v->type()->castRaw<TensorType>();
+        if (manage_output_tensors && is_tensor_type &&
+            !setIncludes(graph_output_values, out_v) &&
+            value_group.isOutputAlias(out_v)) {
+          managed_output_tensor_values_.insert(out_v);
+          continue;
+        }
+        if (value_group.isAlwaysAlive(out_v)) {
+          continue;
+        }
+        if (is_tensor_type) {
+          managed_tensor_values.insert(out_v);
+        } else if (runtime->is_optimizable_container_type(pnode.node())) {
+          // We "leak" certain container types because their allocations
+          // take a long time
+          leaked_values.insert(out_v);
         }
       }
     }
@@ -85,7 +118,9 @@ MemoryPlanner::MemoryPlanner(
     for (const auto i : c10::irange(pnode.outputs().size())) {
       // Types are stored in the underlying TorchScript IR
       const Value* out_v = pnode.node()->outputs()[i];
-      if (managed_tensor_values.count(out_v) || leaked_values.count(out_v)) {
+      if (setIncludes(managed_tensor_values, out_v) ||
+          setIncludes(managed_output_tensor_values_, out_v) ||
+          setIncludes(leaked_values, out_v)) {
         continue;
       }
       IValue& out = pnode.Output(i);
@@ -116,6 +151,11 @@ MemoryPlanner::MemoryPlanner(
         managed_tensors_);
   }
 
+  if (enable_out_variant && manage_output_tensors) {
+    ::torch::jit::assignStorageToOutputTensors(
+        runtime, managed_output_tensor_values_, &managed_output_tensors_);
+  }
+
   num_managed_tensors_ = 0;
   for (const auto& ms : managed_tensors_) {
     num_managed_tensors_ += ms.second.size();
@@ -134,7 +174,7 @@ at::DataPtr MemoryPlanner::allocate_buffer(size_t size) {
   return allocator->allocate(size);
 }
 
-void MemoryPlanner::allocate() {
+void MemoryPlanner::allocateManagedTensors() {
   if (managed_bytes_ == 0) {
     return;
   }
@@ -166,9 +206,42 @@ void MemoryPlanner::allocate() {
   DCHECK_EQ(offset, managed_bytes_);
 }
 
+void MemoryPlanner::allocateOutputTensors() {
+  if (output_buffer_bytes_ == 0) {
+    return;
+  }
+  TORCH_CHECK(
+      !output_buffer_,
+      "Previously allocated output_buffer_ was not deallocated properly.");
+  output_buffer_ = allocate_buffer(output_buffer_bytes_);
+
+  size_t offset = 0;
+  uint8_t* start = static_cast<uint8_t*>(output_buffer_.get());
+
+  for (const auto& ms : managed_output_tensors_) {
+    auto tensor_size = ms.first;
+    auto* tensor = ms.second;
+    if (tensor_size == 0) {
+      continue;
+    }
+    DCHECK_LE(offset + tensor_size, output_buffer_bytes_);
+    void* src = static_cast<void*>(start + offset);
+    tensor->storage().set_data_ptr_noswap(
+        at::DataPtr(src, src, nullptr, tensor->device()));
+    tensor->storage().set_nbytes(tensor_size);
+    offset += tensor_size;
+  }
+  DCHECK_EQ(offset, output_buffer_bytes_);
+}
+
+void MemoryPlanner::allocate() {
+  // TODO: Improve this once D31357486 is landed.
+  allocateManagedTensors();
+  allocateOutputTensors();
+}
+
 void MemoryPlanner::deallocate() {
   managed_bytes_ = 0;
-
   // free memory used by outputs of ops in out variants
   // but keep the TensorImpl and StorageImpl around
   for (auto& ms : managed_tensors_) {
@@ -195,6 +268,22 @@ void MemoryPlanner::deallocate() {
     *iv = IValue();
   }
   buffer_ = {};
+}
+
+void MemoryPlanner::deallocateOutputTensors() {
+  size_t output_buffer_bytes = 0;
+  for (auto& ms : managed_output_tensors_) {
+    auto* tensor = ms.second;
+    size_t current_size =
+        compute_aligned_tensor_size(tensor->storage().nbytes());
+    tensor->storage().unsafeGetStorageImpl()->reset();
+    if (current_size > ms.first) {
+      ms.first = current_size;
+    }
+    output_buffer_bytes += ms.first;
+  }
+  output_buffer_bytes_ = output_buffer_bytes;
+  output_buffer_ = {};
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -38,7 +38,7 @@ class MemoryPlanner {
       const FastMap<const Value*, std::vector<const Value*>>&,
       const ValueGroup& value_group,
       bool enable_out_variant,
-      bool manage_graph_output_memory);
+      bool manage_output_tensors);
   // disable copying and moving
   MemoryPlanner(const MemoryPlanner&) = delete;
   MemoryPlanner& operator=(const MemoryPlanner&) = delete;
@@ -47,9 +47,14 @@ class MemoryPlanner {
 
   void allocate();
   void deallocate();
+  void deallocateOutputTensors();
 
   size_t total_num_managed_tensors() const {
     return num_managed_tensors_;
+  }
+
+  size_t total_num_managed_output_tensors() const {
+    return managed_output_tensors_.size();
   }
 
   size_t total_num_unmanaged() const {
@@ -62,6 +67,35 @@ class MemoryPlanner {
 
   size_t total_reused_tensors() const {
     return reused_tensors_;
+  }
+
+  size_t numOutputBufferBytes() const {
+    return output_buffer_bytes_;
+  }
+
+  bool isManagedOutputTensorValue(const Value* value) const {
+    return managed_output_tensor_values_.find(value) !=
+        managed_output_tensor_values_.end();
+  }
+
+  // Check if `ivalue` is contained as a managed tensor. Only used in DCHECK().
+  bool isManagedOutputTensor(const IValue& ivalue) const {
+    if (!output_buffer_ || // output buffer got already deallocated.
+        output_buffer_bytes_ == 0 || // memory planning is not yet initialized.
+        !ivalue.isTensor() // a non-tensor is never managed
+    ) {
+      return false;
+    }
+    const auto& tensor = ivalue.toTensor();
+    if (!tensor.has_storage() || !tensor.storage().data_ptr()) {
+      return false;
+    }
+    // TODO: Improve this once D31357486 is landed.
+    uint8_t* tensor_ptr =
+        static_cast<uint8_t*>(tensor.storage().data_ptr().get());
+    uint8_t* buffer_start = static_cast<uint8_t*>(output_buffer_.get());
+    uint8_t* buffer_end = buffer_start + output_buffer_bytes_;
+    return buffer_start <= tensor_ptr && tensor_ptr < buffer_end;
   }
 
  private:
@@ -77,13 +111,15 @@ class MemoryPlanner {
   size_t managed_bytes_{0};
   size_t reused_tensors_{0};
 
-  // since output tensors are alive after one inference, their storage
-  // is managed differently (e.g., deallocation happens at client side)
-  // std::vector<std::pair<size_t, std::vector<at::Tensor*>>>
-  //     managed_output_storage_;
-  // size_t managed_output_bytes_{0};
-  // size_t reused_output_tensors_{0};
-  // at::DataPtr output_buffer_; // allocated each time we call Run()
+  // Since output tensors are alive after one inference, their storage
+  // is managed differently (e.g., deallocation happens on the client side).
+  FastSet<const Value*> managed_output_tensor_values_{};
+  std::vector<std::pair<size_t, at::Tensor*>> managed_output_tensors_{};
+  at::DataPtr output_buffer_;
+  size_t output_buffer_bytes_{0};
+
+  void allocateManagedTensors();
+  void allocateOutputTensors();
 
   static size_t compute_aligned_tensor_size(size_t nbytes);
   static at::DataPtr allocate_buffer(size_t size);


### PR DESCRIPTION
Summary:
This change enables `StaticRuntime` to manage output tensors (returned from a graph) as follows:

- At the creation of `StaticModule`, it gathers a set of candidates for output tensors (& their aliases) for managing. This is done by `ValueGroup` introduced by the previous diff.
- At the end of the 1st iteration, `MemoryPlanner` creates a set of output  `at::Tensor*` to manage. This set consists of tensors objects from the aforementioned candidates, excluding the direct output value of the graph to simplify ivalue ownership passing (`std::move(ivalue)` to return from SR). Note that this exclusion has no perf implication for  inline_cvr & ctr_mobilefeed since they only return a container object (e.g., tuple).
-  The 2nd+ iterations preallocates a slab memory and all identified output tensors during the 1st iteration. Note that these preallocated tensors are *NOT* deallocated when returned from SR. The client receives the output tensors, and completes using them, and is responsible to call `StaticRuntime::deallocateOutputTensors()` to deallocate them. This mandates that SR cannot be reentered until `deallocateOutputTensors` is called by the client.
- In case of a buggy client missing a call to `StaticRuntime::deallocateOutputTensors()`, SR throws an exception when reentered instead of leaking memory.
- Nit: I plan to use camlcase for function names, and so all newly introduced functions use camlcase despite inconsistencies with snakecase. We can gradually fix the inconsistencies.

This change will be followed by another one to enable `manage_output_tensors` from `PyTorchScriptPredictor`, starting with `ptvsc2_prediction_bench` as a testbed.

Test Plan:
- Added `StaticRuntime.ManageOutputTensors*` to cover the newly added code paths.

- Enhanced `testStaticRuntime` to exercise each unittest test case with `manage_output_tensors` on. Confirmed that SR actually managed output tensors successfully for a few existing testcases (e.g., StaticRuntime.EmbeddingBag`).

Differential Revision: D31049221

