### PR TITLE
[Static Runtime] Fix bug of creating output aliases in aten::embedding_bag

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -699,7 +699,7 @@ void _embedding_bag_cpu_impl_out(Tensor& output, Tensor& offset2bag,
       // make bag_size output deterministic
       at::native::zero_(bag_size);
     }
-    max_indices = bag_size;
+     max_indices.copy_(bag_size);
   } else { // MODE_MAX
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       weight.scalar_type(), "embedding_bag_cpu_max_out", [&]() {

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -230,9 +230,13 @@ void testStaticRuntime(
       compareResults(expect, actual, use_allclose, use_equalnan);
     } else {
       // run static runtime again to exercise the memory planner
+      // and allocate managed tensors.
       actual = smodule(args, {});
       smodule.runtime().check_for_memory_leak();
-      // second run
+      compareResults(expect, actual, use_allclose, use_equalnan);
+      // third run to use the allocated managed tensors.
+      actual = smodule(args, {});
+      smodule.runtime().check_for_memory_leak();
       compareResults(expect, actual, use_allclose, use_equalnan);
     }
   }


### PR DESCRIPTION
Summary:
This change fixes a bug that Static Runtime's `aten::embedding_bag` out variant implementation creates aliases in its managed output tensors.

Managed output tensors should never be an alias with each other since writing to them can illegally overwrite others' contents unintentionally, and this exact problem was causing the bug at T97393697, causing SR to return wrong return values.

This bug is detected in inline_cvr/remote_ro by a DCHECK, `verify_no_memory_overlap` (introduced by D30211705 (https://github.com/pytorch/pytorch/commit/3fb33b38b9edfb294b32b61e6c6133822e48f215)), but wasn't found so far since our testing didn't include running the model in the debug mode. Fortunately this bug is not hitting production since the aliases outputs are not used in production.

This change fixes the root cause from `_embedding_bag_cpu_impl_out`  by replacing alias creation with copying.

Note that this change also includes a fundamental change in Static Runtime's unit testing: `testStaticRuntime` exercises the given graph 3 times:
 1. profile run
 2. run using the profile to allocate managed tensors
 3. reuse the managed tensors -- newly added

Adding 3 reveals this bug with a new unittest `EmbeddingBagWithManagedOutput`.

Test Plan:
- Confirmed that the crash experienced by `StaticRuntime.EmbeddingBagWithManagedOutput` disappears with this change (crash paste: P459807248).

- Added `StaticRuntime.EmbeddingBagWithManagedOutput` to detect the same problem in the future.

Differential Revision: D31104345

