### PR TITLE
[Static Runtime] Group graph nodes into input aliases & output aliases

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 
@@ -16,41 +18,42 @@ StaticModule makeStaticModuleFromScript(const std::string& script) {
 } // namespace
 
 /**
- * Test that StaticModule correctly initializes the set of always alive values
- * containing: 1) Inputs/Outputs 2) Constants 3) Aliases of (1) and (2)
+ * Test that StaticModule::value_group groups values of the graph into
+ * 1) Inputs/Constants and their aliases 2) Outputs and their aliases.
  */
-TEST(StaticModule, ExternalValues) {
-  const std::string src = R"JIT(
-        def forward(self, a, b):
-            a_alias = a.view(a.size())
-            inputs_list = [a, b]
-            return a_alias + b + 1, inputs_list
-    )JIT";
-  auto sm = makeStaticModuleFromScript(src);
+TEST(StaticModule, ValueGroup) {
+  const std::string src = R"IR(
+    graph(%input0 : Tensor, %input1 : Tensor):
+      # Constants.
+      %0 : int = prim::Constant[value=1]()
+      # Internal values.
+      %1 : Tensor = aten::add(%input0, %input1, %0)
+      # This includes aliases of output.
+      %2 : Tensor = aten::add(%input0, %1, %0)
+      # This includes output.
+      %3 : (Tensor) = prim::TupleConstruct(%2)
+      return (%3)
+    )IR";
+  auto input_graph = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(src, input_graph.get());
+  torch::jit::StaticModule sm(input_graph);
+  const Graph& graph = sm.graph();
+  std::vector<const Node*> nodes(graph.nodes().begin(), graph.nodes().end());
+  const auto& value_group = sm.value_group();
 
-  const auto& external_values = sm.external_values();
-  const auto& graph = sm.graph();
-
-  auto value_is_always_alive = [&external_values](const Value* v) {
-    return external_values.find(v) != external_values.end();
-  };
-
-  for (const Value* v : graph.inputs()) {
-    EXPECT_TRUE(value_is_always_alive(v));
+  std::vector<const Value*> expected_input_aliases{graph.inputs()[0], graph.inputs()[1], nodes[0]->output()};
+  for (auto* value : expected_input_aliases) {
+    EXPECT_TRUE(value_group.isInputAlias(value));
   }
-  for (const Value* v : graph.outputs()) {
-    EXPECT_TRUE(value_is_always_alive(v));
-  }
 
-  for (const Node* n : graph.nodes()) {
-    if (n->kind() == prim::Constant ||
-        // In the graph above, a view on an input is created.
-        n->kind() == aten::view ||
-        // We also create a list of the inputs.
-        n->kind() == prim::ListConstruct) {
-      EXPECT_TRUE(value_is_always_alive(n->output()));
-    }
+  std::vector<const Value*> expected_output_aliases{graph.outputs()[0], nodes[2]->output()};
+  for (auto* value : expected_output_aliases) {
+    EXPECT_TRUE(value_group.isOutputAlias(value));
   }
+  EXPECT_FALSE(value_group.isAlwaysAlive(nodes[1]->output()));
+  EXPECT_TRUE(value_group.isAlwaysAlive(graph.inputs()[0]));
+  EXPECT_TRUE(value_group.isAlwaysAlive(graph.inputs()[1]));
+  EXPECT_TRUE(value_group.isAlwaysAlive(graph.outputs()[0]));
 }
 
 TEST(StaticModule, IsOptimizableContainerType_NonOptimizableInputs) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -142,42 +142,6 @@ bool mayContainAlias(
   return db.mayContainAlias(as, bs);
 }
 
-// Get set of all inputs/outputs/constants (always alive) and their aliases
-FastSet<const Value*> GetAlwaysAliveValues(
-    const std::shared_ptr<torch::jit::Graph>& graph,
-    AliasDb& db) {
-  // a set of Values whose live-range exceed current inference
-  FastSet<const Value*> always_alive;
-
-  // mark inputs, constants, outputs as always_alive
-  for (const auto* input : graph->inputs()) {
-    always_alive.insert(input);
-  }
-  for (const auto* output : graph->outputs()) {
-    always_alive.insert(output);
-  }
-  for (const auto* node : graph->nodes()) {
-    if (node->kind() == prim::Constant) {
-      for (const auto* output : node->outputs()) {
-        always_alive.insert(output);
-      }
-    }
-  }
-
-  // insert aliases of always live Values
-  for (const auto* node : graph->nodes()) {
-    // constants are already in the always_alive set
-    if (node->kind() != prim::Constant) {
-      for (const auto* v : node->outputs()) {
-        if (mayContainAlias(db, {v}, always_alive)) {
-          always_alive.insert(v);
-        }
-      }
-    }
-  }
-  return always_alive;
-}
-
 //  Map each value to all values that are alive at the same time.
 using LivenessMap = FastMap<const Value*, FastSet<const Value*>>;
 
@@ -185,7 +149,7 @@ using LivenessMap = FastMap<const Value*, FastSet<const Value*>>;
 //  while keeping track of the live values.
 LivenessMap GetLivenessMap(
     const std::shared_ptr<torch::jit::Graph>& graph,
-    const FastSet<const Value*>& always_alive,
+    const ValueGroup& value_group,
     AliasDb& db) {
   // map a Value to a set of Values that overlap live-ranges with the Value's
   FastMap<const Value*, FastSet<const Value*>> liveness_map;
@@ -282,7 +246,7 @@ LivenessMap GetLivenessMap(
 
   for (const auto* node : graph->nodes()) {
     for (const auto* v : node->outputs()) {
-      if (always_alive.count(v) == 0) {
+      if (!value_group.isAlwaysAlive(v)) {
         add_live_value_fn(v);
       }
     }
@@ -295,7 +259,7 @@ LivenessMap GetLivenessMap(
   }
 
   for (const auto& v : live_values_use_chain) {
-    TORCH_CHECK(always_alive.count(v.first));
+    TORCH_CHECK(value_group.isAlwaysAlive(v.first));
   }
 
   for (const auto* node : graph->nodes()) {
@@ -425,7 +389,7 @@ GetMemoryPlanningCandidates(
 // and debug.
 FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
     const LivenessMap& alive_during,
-    const FastSet<const Value*>& always_alive,
+    const ValueGroup& value_group,
     const std::pair<std::vector<const Value*>, std::vector<const Value*>>&
         optimizable,
     AliasDb& db) {
@@ -469,7 +433,7 @@ FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
       same_storage_values[v] = {v};
     }
     // skip always alive values (alias inputs/outputs/weights)
-    if (always_alive.count(v)) {
+    if (value_group.isAlwaysAlive(v)) {
       continue;
     }
     for (const auto& p : same_storage_values) {
@@ -486,16 +450,14 @@ FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
   // to preserve determinism
   std::vector<const Value*> seen;
 
-  auto compute_liveset_fn =
-      [&always_alive, &alive_during, &same_storage_values](
-          FastSet<const Value*>& live, const Value* v) {
-        for (const auto* sv : same_storage_values.at(v)) {
-          const auto& l = alive_during.count(sv) ? alive_during.at(sv)
-                                                 : FastSet<const Value*>{};
-          live.insert(l.begin(), l.end());
-        }
-        live.insert(always_alive.begin(), always_alive.end());
-      };
+  auto compute_liveset_fn = [&alive_during, &same_storage_values](
+                                FastSet<const Value*>& live, const Value* v) {
+    for (const auto* sv : same_storage_values.at(v)) {
+      const auto& l = alive_during.count(sv) ? alive_during.at(sv)
+                                             : FastSet<const Value*>{};
+      live.insert(l.begin(), l.end());
+    }
+  };
 
   // check if same_storage_values[s] intersects with live
   auto intersect_fn = [&same_storage_values](
@@ -511,7 +473,7 @@ FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
   };
 
   for (const auto* v : optimizable_values) {
-    if (always_alive.count(v)) {
+    if (value_group.isAlwaysAlive(v)) {
       continue;
     }
     // get values that are live during the lifetime of v
@@ -520,7 +482,7 @@ FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
     for (const auto* s : seen) {
       // if live(same_storage_values[v]) and same_storage_values[s]
       // do not overlap, then s and v can share the same storage
-      if (!intersect_fn(live, s)) {
+      if (!intersect_fn(live, s) && !value_group.isAlwaysAlive(s)) {
         share_storage_fn(v, s);
         // since s is added to same_storage_values[v], live needs
         // to be recomputed, so bail out here
@@ -573,6 +535,52 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
 }
 
 } // namespace
+
+void ValueGroup::init(
+    const std::shared_ptr<torch::jit::Graph>& graph,
+    AliasDb& db) {
+  input_or_constant_aliases_.clear();
+  output_aliases_.clear();
+  // Build `input_or_constant_aliases` as we look through nodes forwardly from
+  // the graph's inputs and add aliases of the inputs being created by the
+  // nodes.
+  input_or_constant_aliases_.insert(
+      graph->inputs().begin(), graph->inputs().end());
+  for (const auto* node : graph->nodes()) {
+    if (node->kind() == prim::Constant) {
+      for (const auto* output : node->outputs()) {
+        input_or_constant_aliases_.insert(output);
+      }
+    }
+  }
+  for (const auto* node : graph->nodes()) {
+    if (node->kind() == prim::Constant) {
+      // Constants are already in `input_or_constant_aliases`.
+      continue;
+    }
+    for (const auto* v : node->outputs()) {
+      if (mayContainAlias(db, {v}, input_or_constant_aliases_)) {
+        input_or_constant_aliases_.insert(v);
+      }
+    }
+  }
+
+  // Build `output_aliases` as we look through nodes reversely so that we can
+  // start from the output values, and follow the flows backwardly from there.
+  output_aliases_.insert(graph->outputs().begin(), graph->outputs().end());
+  for (const auto* node : graph->nodes().reverse()) {
+    if (node->kind() == prim::Constant) {
+      // Constants cannot create any aliases.
+      continue;
+    }
+    for (const auto* v : node->outputs()) {
+      if (mayContainAlias(db, {v}, output_aliases_) &&
+          !mayContainAlias(db, {v}, input_or_constant_aliases_)) {
+        output_aliases_.insert(v);
+      }
+    }
+  }
+}
 
 StaticModule::StaticModule(
     std::shared_ptr<torch::jit::Graph> g,
@@ -690,14 +698,15 @@ StaticModule::StaticModule(
   }
 
   // Prepare for memory planning
-  AliasDb alias_db(graph_);
-  external_values_ = GetAlwaysAliveValues(graph_, alias_db);
+  AliasDb alias_db(
+      graph_, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
+  value_group_.init(graph_, alias_db);
 
   if (opts_.optimize_memory) {
-    auto lm = GetLivenessMap(graph_, external_values_, alias_db);
+    auto lm = GetLivenessMap(graph_, value_group_, alias_db);
     auto values = GetMemoryPlanningCandidates(graph_, node_has_out_variant);
     value_to_same_storage_values_ =
-        GenerateSameStorageValues(lm, external_values_, values, alias_db);
+        GenerateSameStorageValues(lm, value_group_, values, alias_db);
   }
 }
 
@@ -873,7 +882,7 @@ c10::IValue StaticRuntime::operator()(
       planner_ = std::make_unique<MemoryPlanner>(
           this,
           static_module_.values_share_same_storage(),
-          static_module_.external_values(),
+          static_module_.value_group(),
           static_module_.opts().enable_out_variant,
           static_module_.opts().optimize_graph_output_memory);
     }
@@ -1102,7 +1111,7 @@ void StaticRuntime::display_nodes(
       planner_ = std::make_unique<MemoryPlanner>(
           this,
           static_module_.values_share_same_storage(),
-          static_module_.external_values(),
+          static_module_.value_group(),
           static_module_.opts().enable_out_variant,
           static_module_.opts().optimize_graph_output_memory);
     }
@@ -1171,7 +1180,7 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
         planner_ = std::make_unique<MemoryPlanner>(
             this,
             static_module_.values_share_same_storage(),
-            static_module_.external_values(),
+            static_module_.value_group(),
             static_module_.opts().enable_out_variant,
             static_module_.opts().optimize_graph_output_memory);
       }

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -51,7 +51,7 @@ MemoryPlanner::MemoryPlanner(
     StaticRuntime* runtime,
     const FastMap<const Value*, std::vector<const Value*>>&
         value_to_same_storage_values,
-    const FastSet<const Value*>& external_values,
+    const ValueGroup& value_group,
     bool enable_out_variant,
     bool manage_graph_output_memory) {
   // collect register indices of outputs of ops with out variant
@@ -62,7 +62,7 @@ MemoryPlanner::MemoryPlanner(
       if (pnode.has_out_variant()) {
         for (const auto i : c10::irange(pnode.outputs().size())) {
           const Value* out_v = pnode.node()->outputs()[i];
-          if (external_values.count(out_v)) {
+          if (value_group.isAlwaysAlive(out_v)) {
             continue;
           }
           // Types are stored in the underlying TorchScript IR

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -36,7 +36,7 @@ class MemoryPlanner {
   explicit MemoryPlanner(
       StaticRuntime* runtime,
       const FastMap<const Value*, std::vector<const Value*>>&,
-      const FastSet<const Value*>& external_values,
+      const ValueGroup& value_group,
       bool enable_out_variant,
       bool manage_graph_output_memory);
   // disable copying and moving


### PR DESCRIPTION
Summary:
This change retrofits `GetAlwaysAliveValues` into `ValueGroup` to group the values used by a graph into three groups as follows:

- input_aliases:  values that are either inputs or contain aliases of inputs or constants.
- output_aliases: values that are either outputs or contain aliases of outputs and are not in input_aliases.
- Values that dont't show up in input_aliases and output_aliases are internally created consumed within the graph.

`output_aliases` is the only new group introduced by this change, and a following diff will use this to preallocate output Tensors to accelerate Static Runtime's performance.

Test Plan: Added `ValueGroup.Init` to cover the updated code path. Note that there was no test for `GetAlwaysAliveValues` before.

Differential Revision: D30940955

