### PR TITLE
Auto-gen the 'mm' Op in the new lazy tensor core.

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -785,8 +785,6 @@ class LazyTensor {
                       const LazyTensor& input, lazy_tensors::int64 dim,
                       bool keepdim);
 
-  static LazyTensor mm(const LazyTensor& input, const LazyTensor& weight);
-
   static LazyTensor mse_loss(const LazyTensor& input, const LazyTensor& target,
                              lazy_tensors::int64 reduction);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -1746,10 +1746,6 @@ void LazyTensor::min_out(LazyTensor& min, LazyTensor& min_indices,
   min.SetIrValue(ir::Value(node, 0));
   min_indices.SetIrValue(ir::Value(node, 1));
 }
-LazyTensor LazyTensor::mm(const LazyTensor& input, const LazyTensor& weight) {
-  return input.CreateFrom(
-      ir::ops::Dot(input.GetIrValue(), weight.GetIrValue()));
-}
 
 LazyTensor LazyTensor::mse_loss(const LazyTensor& input,
                                 const LazyTensor& target,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -1777,11 +1777,15 @@ LazyTensor LazyTensor::mul(const LazyTensor& input, const at::Scalar& other,
 }
 
 LazyTensor LazyTensor::mv(const LazyTensor& input, const LazyTensor& vec) {
+  // TODO(kreeger): Drop |ir::ops::Dot()| once |mv| and |mv_out| have been
+  //                auto-gen'd.
   return input.CreateFrom(ir::ops::Dot(input.GetIrValue(), vec.GetIrValue()));
 }
 
 void LazyTensor::mv_out(LazyTensor& out, const LazyTensor& input,
                         const LazyTensor& vec) {
+  // TODO(kreeger): Drop |ir::ops::Dot()| once |mv| and |mv_out| have been
+  //                auto-gen'd.
   out.SetIrValue(ir::ops::Dot(input.GetIrValue(), vec.GetIrValue()));
 }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -635,20 +635,6 @@ at::Tensor LazyNativeFunctions::max_pool3d(
       self, kernel_size, stride, padding, dilation, ceil_mode);
 }
 
-at::Tensor LazyNativeFunctions::mm(const at::Tensor& self,
-                                   const at::Tensor& mat2) {
-  LTC_FN_COUNTER("lazy::");
-  // lazy::dot doesn't support integer types.
-  if (!at::native::is_floating_point(self) ||
-      !at::native::is_floating_point(mat2)) {
-    return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(mm)>::call(
-        self, mat2);
-  }
-  return bridge::AtenFromLtcTensor(
-      LazyTensor::mm(/*input=*/bridge::GetLtcTensor(self),
-                     /*weight=*/bridge::GetLtcTensor(mat2)));
-}
-
 at::Tensor LazyNativeFunctions::mul(const at::Tensor& self,
                                     const at::Tensor& other) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -5,6 +5,7 @@ full_codegen:
   - addcdiv
   - addcmul
   - cos
+  - mm
 supported:
   - _log_softmax
   - _log_softmax_backward_data
@@ -31,7 +32,6 @@ supported:
   - fill_.Scalar
   - leaky_relu
   - leaky_relu_backward
-  - mm
   - mul.Tensor
   - mul.Scalar
   - native_batch_norm

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -168,7 +168,7 @@ def gen_lazy_nativefunc_definition(f: NativeFunction, backend_index: BackendInde
 
     return [f"""\
 {sig.decl(name=f"{class_method_name}::{schema.aten_name}")} {{
-    LTC_FN_COUNTER("lazy::")
+    LTC_FN_COUNTER("lazy::");
     {lazy_tensor_decls_str}
     {meta_str}
     return bridge::AtenFromLtcTensor(l_{first_tensor.name}.CreateFrom(

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -168,6 +168,7 @@ def gen_lazy_nativefunc_definition(f: NativeFunction, backend_index: BackendInde
 
     return [f"""\
 {sig.decl(name=f"{class_method_name}::{schema.aten_name}")} {{
+    LTC_FN_COUNTER("lazy::")
     {lazy_tensor_decls_str}
     {meta_str}
     return bridge::AtenFromLtcTensor(l_{first_tensor.name}.CreateFrom(


### PR DESCRIPTION
This looks to be a straight-forward Op to port. The existing tooling auto-gens and everything seems to be working.

Are there any existing unit tests I should add/update here? I have a sample test file that I've verified with locally:

```py
from lazy_tensor_core import debug
import torch
import lazy_tensor_core
import lazy_tensor_core.debug.metrics as metrics

lazy_tensor_core._LAZYC._ltc_init_ts_backend()

torch.manual_seed(42)

device = 'lazy'
dtype = torch.float32

x = torch.randn(3, 3, device=device, dtype=dtype)
y = torch.randn(3, 3, device=device, dtype=dtype)

print(torch.mm(x, y))
print(metrics.metrics_report())
```

The diff from running the same code with the legacy op vs. the auto-generated one looks like this:
```diff
▶ diff -u legacy-output.txt new-output.txt
--- legacy-output.txt   2021-09-23 07:10:12.431555000 -0500
+++ new-output.txt      2021-09-23 07:11:00.441555000 -0500
@@ -3,21 +3,21 @@
         [ 0.3243,  2.8696,  2.7954]], device='lazy:0')
 Metric: DeviceLockWait
   TotalSamples: 21
-  Accumulator: 010.400us
-  ValueRate: 251.506us / second
-  Rate: 507.849 / second
-  Percentiles: 1%=000.300us; 5%=000.400us; 10%=000.400us; 20%=000.400us; 50%=000.500us; 80%=000.600us; 90%=000.700us; 95%=000.700us; 99%=000.700us
+  Accumulator: 011.800us
+  ValueRate: 279.624us / second
+  Rate: 497.635 / second
+  Percentiles: 1%=000.400us; 5%=000.400us; 10%=000.400us; 20%=000.500us; 50%=000.500us; 80%=000.600us; 90%=000.700us; 95%=000.900us; 99%=001.000us
 Metric: IrValueTensorToDataHandle
   TotalSamples: 4
-  Accumulator: 016.500us
-  ValueRate: 483.657us / second
-  Rate: 117.25 / second
-  Percentiles: 1%=001.400us; 5%=001.400us; 10%=001.400us; 20%=001.400us; 50%=003.400us; 80%=010.000us; 90%=010.000us; 95%=010.000us; 99%=010.000us
+  Accumulator: 016.200us
+  ValueRate: 472.753us / second
+  Rate: 116.729 / second
+  Percentiles: 1%=001.600us; 5%=001.600us; 10%=001.600us; 20%=001.600us; 50%=003.700us; 80%=009.200us; 90%=009.200us; 95%=009.200us; 99%=009.200us
 Metric: TensorsGraphSize
   TotalSamples: 21
   Accumulator: 81.00
-  ValueRate: 2126.05 / second
-  Rate: 551.197 / second
+  ValueRate: 2078.44 / second
+  Rate: 538.855 / second
   Percentiles: 1%=1.00; 5%=3.00; 10%=3.00; 20%=3.00; 50%=3.00; 80%=5.00; 90%=5.00; 95%=6.00; 99%=9.00
 Counter: CachedCompile
   Value: 1
@@ -57,8 +57,6 @@
   Value: 2
 Counter: lazy::lt
   Value: 1
-Counter: lazy::mm
-  Value: 1
 Counter: lazy::mul
   Value: 1
 Counter: lazy::ne
```
