### PR TITLE
Update link to tutorial on defining NN modules

### DIFF
--- a/docs/source/notes/modules.rst
+++ b/docs/source/notes/modules.rst
@@ -285,7 +285,7 @@ In the next section, we give a full example of training a neural network.
 For more information, check out:
 
 * Library of PyTorch-provided modules: `torch.nn <https://pytorch.org/docs/stable/nn.html>`_
-* Defining neural net modules: https://pytorch.org/tutorials/beginner/examples_nn/two_layer_net_module.html
+* Defining neural net modules: https://pytorch.org/tutorials/beginner/examples_nn/polynomial_module.html
 
 .. _Neural Network Training with Modules:
 


### PR DESCRIPTION
Fixes #65527. Please, see my comment in the issue: https://github.com/pytorch/pytorch/issues/65527#issuecomment-925863193. The file was renamed in https://github.com/pytorch/tutorials/commit/ce58d5904c04c4be10561447e41a153f573a3f93#diff-e5ef486bd89eb38de15752211d9437953681b8caa8f44d7c86bb820d13151df2, but the link in this repository was not updated.

It doesn't change the fact that the old link is still working, but I guess this has to be fixed in [pytorch/tutorials](https://github.com/pytorch/tutorials) instead of here.
