### PR TITLE
[BE] Use `DispatchKeySet` in `check_base_legacy_new`

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -20,6 +20,7 @@
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/TracerMode.h>
 #include <c10/core/Backend.h>
+#include <c10/core/DispatchKeySet.h>
 #include <c10/core/Layout.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
@@ -325,42 +326,30 @@ Tensor legacy_new_from_sequence(
 // TODO: Rewrite this using dispatchKeyToTensorOptions
 void check_base_legacy_new(c10::DispatchKey dispatch_key, at::Layout expected_layout) {
   if (expected_layout == c10::kStrided) {
-    TORCH_CHECK(
-        dispatch_key == c10::DispatchKey::CPU ||
-            dispatch_key == c10::DispatchKey::CUDA ||
-            dispatch_key == c10::DispatchKey::HIP ||
-            dispatch_key == c10::DispatchKey::XLA ||
-            dispatch_key == c10::DispatchKey::Lazy ||
-            dispatch_key == c10::DispatchKey::XPU,
-        "new(): expected DispatchKey: ",
+    constexpr c10::DispatchKeySet expected_key_set({
         c10::DispatchKey::CPU,
-        " or ",
         c10::DispatchKey::CUDA,
-        " or ",
         c10::DispatchKey::HIP,
-        " or ",
         c10::DispatchKey::XLA,
-        " or ",
         c10::DispatchKey::Lazy,
-        " or ",
         c10::DispatchKey::XPU,
+    });
+    TORCH_CHECK(expected_key_set.has(dispatch_key),
+        "new(): expected key in ",
+        expected_key_set,
         " but got: ",
         dispatch_key);
   } else if(expected_layout == c10::kSparse) {
     // NOTE: no sparse XLA or Lazy
-    TORCH_CHECK(
-        dispatch_key == c10::DispatchKey::SparseCPU ||
-            dispatch_key == c10::DispatchKey::SparseCUDA ||
-            dispatch_key == c10::DispatchKey::SparseHIP ||
-            dispatch_key == c10::DispatchKey::SparseXPU,
-        "new(): expected DispatchKey: ",
+    constexpr c10::DispatchKeySet expected_key_set({
         c10::DispatchKey::SparseCPU,
-        " or ",
         c10::DispatchKey::SparseCUDA,
-        " or ",
         c10::DispatchKey::SparseHIP,
-        " or ",
         c10::DispatchKey::SparseXPU,
+    });
+    TORCH_CHECK(expected_key_set.has(dispatch_key),
+        "new(): expected key in ",
+        expected_key_set,
         " but got: ",
         dispatch_key);
   } else {


### PR DESCRIPTION
Refactor:
```
TORCH_CHECK ( key == a ||
              key == b ||
              key == c,
              "expected key to be in ", a, " or ", b , " or ", c,
              " but got ", key);
```
into
```
TORCH_CHECK( key_set.has(key),
            "expected key to be in ", key_set,
            " but got ", key );
```
