### PR TITLE
[oss][pytorch] Add quint2x4 dtype

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -57,6 +57,7 @@ DLDataType getDLDataType(const Tensor& t) {
     case ScalarType::QUInt8:
     case ScalarType::QInt32:
     case ScalarType::QUInt4x2:
+    case ScalarType::QUInt2x4:
       TORCH_CHECK(false, "QUInt/QInt types are not supported by dlpack");
       break;
     case ScalarType::Undefined:

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -528,6 +528,8 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
           NAME, at::kQInt32, at::qint32, int, CHAR_BIT * sizeof(int), INT_MIN, INT_MAX, __VA_ARGS__) \
       AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                                      \
           NAME, at::kQUInt4x2, at::quint4x2, uint8_t, 4, 0, 15, __VA_ARGS__)                   \
+      AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                                      \
+          NAME, at::kQUInt2x4, at::quint2x4, uint8_t, 2, 0, 3, __VA_ARGS__)                   \
       default:                                                                                 \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                        \
     }                                                                                          \

--- a/aten/src/ATen/native/quantized/affine_quantizer.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer.cpp
@@ -122,7 +122,7 @@ Tensor& quantize_tensor_per_tensor_affine(
 
   // Temporary solution to pack the tensor if dtype is torch.quint4x2
   // Can move this into the fbgemm::Quantize op.
-  if (qtensor.scalar_type() == at::ScalarType::QUInt4x2) {
+  if (qtensor.scalar_type() == at::ScalarType::QUInt4x2 || qtensor.scalar_type() == at::ScalarType::QUInt2x4) {
     quantize_tensor_per_tensor_affine_sub_byte_stub(
         rtensor.device().type(), rtensor, qtensor, scale, zero_point);
   } else {
@@ -227,7 +227,7 @@ Tensor& dequantize_tensor_per_tensor_affine(
     checkZeroPoint<underlying_t>(fn_name, zero_point);
   });
 
-  if (qtensor.scalar_type() == at::ScalarType::QUInt4x2) {
+  if (qtensor.scalar_type() == at::ScalarType::QUInt4x2 || qtensor.scalar_type() == at::ScalarType::QUInt2x4) {
     dequantize_tensor_per_tensor_affine_sub_byte_stub(
         qtensor.device().type(), qtensor, rtensor, scale, zero_point);
   } else {

--- a/aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/ceil_div.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/DispatchStub.h>
@@ -14,8 +15,8 @@ Tensor int_repr_quantized_cpu(const Tensor& self) {
   Tensor dst;
   // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(self.scalar_type(), "int_repr", [&]() {
-    if (bit_width == 4) {
-      int64_t out_size = std::ceil(self.numel() * 0.5);
+    if (bit_width == 4 || bit_width == 2) {
+      int64_t out_size = at::ceil_div(self.numel() * bit_width, (int64_t)8);
       dst = at::empty(
           {out_size},
           self.options().dtype(UNDERLYING_TYPE),

--- a/aten/src/TH/CMakeLists.txt
+++ b/aten/src/TH/CMakeLists.txt
@@ -52,6 +52,7 @@ install(FILES
   THGenerateIntTypes.h
   THGenerateQUInt8Type.h
   THGenerateQUInt4x2Type.h
+  THGenerateQUInt2x4Type.h
   THGenerateQInt8Type.h
   THGenerateQInt32Type.h
   THGenerateQTypes.h

--- a/aten/src/TH/THGenerateQTypes.h
+++ b/aten/src/TH/THGenerateQTypes.h
@@ -11,6 +11,7 @@
 #include <TH/THGenerateQInt8Type.h>
 #include <TH/THGenerateQInt32Type.h>
 #include <TH/THGenerateQUInt4x2Type.h>
+#include <TH/THGenerateQUInt2x4Type.h>
 
 #ifdef THQLocalGenerateManyTypes
 #undef THQLocalGenerateManyTypes

--- a/aten/src/TH/THGenerateQUInt2x4Type.h
+++ b/aten/src/TH/THGenerateQUInt2x4Type.h
@@ -1,0 +1,24 @@
+#ifndef TH_GENERIC_FILE
+#error "You must define TH_GENERIC_FILE before including THGenerateQUInt2x4Type.h"
+#endif
+
+#define quantized_t c10::quint2x4
+#define scalar_t uint8_t
+#define Real QUInt2x4
+#define RealUnderlying Byte
+#define THQUANTIZED
+#define THQUINT8
+#define TH_REAL_IS_BYTE
+#line 1 TH_GENERIC_FILE
+#include TH_GENERIC_FILE
+#undef scalar_t
+#undef quantized_t
+#undef Real
+#undef RealUnderlying
+#undef TH_REAL_IS_BYTE
+#undef THQUINT8
+#undef THQUANTIZED
+
+#ifndef THGenerateManyTypes
+#undef TH_GENERIC_FILE
+#endif

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -39,6 +39,7 @@
 #define THQInt8Storage THStorage
 #define THQInt32Storage THStorage
 #define THQUInt4x2Storage THStorage
+#define THQUInt2x4Storage THStorage
 #define THComplexFloatStorage THStorage
 #define THComplexDoubleStorage THStorage
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -7,6 +7,7 @@
 #include <c10/util/complex.h>
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>
+#include <c10/util/quint2x4.h>
 #include <c10/util/quint4x2.h>
 #include <c10/util/quint8.h>
 
@@ -42,7 +43,8 @@ namespace c10 {
   _(c10::quint8, QUInt8) /* 13 */                        \
   _(c10::qint32, QInt32) /* 14 */                        \
   _(at::BFloat16, BFloat16) /* 15 */                     \
-  _(c10::quint4x2, QUInt4x2) /* 16 */
+  _(c10::quint4x2, QUInt4x2) /* 16 */                    \
+  _(c10::quint2x4, QUInt2x4) /* 17 */
 
 // If you want to support ComplexHalf for real, add ComplexHalf
 // into this macro (and change the name).  But beware: convert()
@@ -179,7 +181,8 @@ AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CppTypeToScalarType)
   _(c10::qint8, QInt8)          \
   _(c10::quint8, QUInt8)        \
   _(c10::qint32, QInt32)        \
-  _(c10::quint4x2, QUInt4x2)
+  _(c10::quint4x2, QUInt4x2)    \
+  _(c10::quint2x4, QUInt2x4)
 
 #define AT_FORALL_COMPLEX_TYPES(_)     \
   _(c10::complex<float>, ComplexFloat) \
@@ -248,7 +251,8 @@ static inline bool isComplexType(ScalarType t) {
 static inline bool isQIntType(ScalarType t) {
   // Don't forget to extend this when adding new QInt types
   return t == ScalarType::QInt8 || t == ScalarType::QUInt8 ||
-      t == ScalarType::QInt32 || t == ScalarType::QUInt4x2;
+      t == ScalarType::QInt32 || t == ScalarType::QUInt4x2 ||
+      t == ScalarType::QUInt2x4;
 }
 
 static inline ScalarType toQIntType(ScalarType t) {
@@ -273,6 +277,8 @@ static inline ScalarType toUnderlying(ScalarType t) {
     case ScalarType::QInt32:
       return ScalarType::Int;
     case ScalarType::QUInt4x2:
+      return ScalarType::Byte;
+    case ScalarType::QUInt2x4:
       return ScalarType::Byte;
     default:
       return t;

--- a/c10/util/quint2x4.h
+++ b/c10/util/quint2x4.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <cstdint>
+
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+
+/**
+ * quint2x4 is for un-signed 2 bit quantized Tensors that are packed to byte
+ * boundary.
+ */
+struct alignas(1) quint2x4 {
+  using underlying = uint8_t;
+  uint8_t val_;
+  quint2x4() = default;
+  C10_HOST_DEVICE explicit quint2x4(uint8_t val) : val_(val) {}
+};
+
+} // namespace c10

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -172,6 +172,7 @@ class TestPublicBindings(unittest.TestCase):
             "QInt8StorageBase",
             "qscheme",
             "QUInt4x2StorageBase",
+            "QUInt2x4StorageBase",
             "QUInt8StorageBase",
             "read_vitals",
             "REMOVE_DROPOUT",

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -555,7 +555,7 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
     dt = ('Double', 'Float', 'Long', 'Int',
           'Short', 'Char', 'Byte', 'Bool',
           'Half', 'BFloat16', 'ComplexDouble',
-          'ComplexFloat', 'QUInt8', 'QInt8', 'QInt32', 'QUInt4x2')
+          'ComplexFloat', 'QUInt8', 'QInt8', 'QInt32', 'QUInt4x2', 'QUInt2x4')
     for c in dt:
         legacy_storage_base_hints.append('class {}StorageBase(object): ...'.format(c))
     for c in dt:
@@ -576,7 +576,7 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
                          ['float32', 'float', 'float64', 'double', 'float16', 'bfloat16', 'half',
                           'uint8', 'int8', 'int16', 'short', 'int32', 'int', 'int64', 'long',
                           'complex32', 'complex64', 'cfloat', 'complex128', 'cdouble',
-                          'quint8', 'qint8', 'qint32', 'bool', 'quint4x2']]
+                          'quint8', 'qint8', 'qint32', 'bool', 'quint4x2', 'quint2x4']]
 
     # Generate __all__ directive
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -609,11 +609,16 @@ class QUInt4x2Storage(TypedStorage):
     def dtype(self):
         return torch.quint4x2
 
+class QUInt2x4Storage(TypedStorage):
+    @classproperty
+    def dtype(self):
+        return torch.quint2x4
+
 _storage_classes = {
     UntypedStorage, DoubleStorage, FloatStorage, LongStorage, IntStorage,
     ShortStorage, CharStorage, ByteStorage, HalfStorage, BoolStorage,
     QUInt8Storage, QInt8Storage, QInt32Storage, BFloat16Storage,
-    ComplexFloatStorage, ComplexDoubleStorage, QUInt4x2Storage
+    ComplexFloatStorage, ComplexDoubleStorage, QUInt4x2Storage, QUInt2x4Storage,
 }
 
 # The _tensor_classes set is initialized by the call to _C._initialize_tensor_type_bindings()

--- a/torch/csrc/Storage.h
+++ b/torch/csrc/Storage.h
@@ -37,6 +37,8 @@
     PyObject_IsInstance(obj, THPComplexFloatStorageClass)
 #define THPQUInt4x2Storage_Check(obj) \
     PyObject_IsInstance(obj, THPQUInt8StorageClass)
+#define THPQUInt2x4Storage_Check(obj) \
+    PyObject_IsInstance(obj, THPQUInt8StorageClass)
 
 #define THPDoubleStorage_CData(obj)         (obj)->cdata
 #define THPFloatStorage_CData(obj)          (obj)->cdata
@@ -54,6 +56,7 @@
 #define THPComplexDoubleStorage_CData(obj)  (obj)->cdata
 #define THPComplexFloatStorage_CData(obj)   (obj)->cdata
 #define THPQUInt4x2Storage_CData(obj)       (obj)->cdata
+#define THPQUInt2x4Storage_CData(obj)       (obj)->cdata
 
 #define THPStorageType TH_CONCAT_3(THP,Real,StorageType)
 #define THPStorageBaseStr TH_CONCAT_STRING_2(Real,StorageBase)

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -118,6 +118,9 @@
 #define THPQUInt4x2Utils_checkReal(object)      THPUtils_checkReal_INT(object)
 #define THPQUInt4x2Utils_unpackReal(object)     (int)THPUtils_unpackReal_INT(object)
 #define THPQUInt4x2Utils_newReal(value)         THPUtils_newReal_INT(value)
+#define THPQUInt2x4Utils_checkReal(object)      THPUtils_checkReal_INT(object)
+#define THPQUInt2x4Utils_unpackReal(object)     (int)THPUtils_unpackReal_INT(object)
+#define THPQUInt2x4Utils_newReal(value)         THPUtils_newReal_INT(value)
 
 
 #define THPUtils_assert(cond, ...) THPUtils_assertRet(nullptr, cond, __VA_ARGS__)

--- a/torch/csrc/utils/tensor_dtypes.cpp
+++ b/torch/csrc/utils/tensor_dtypes.cpp
@@ -51,6 +51,8 @@ std::pair<std::string, std::string> getDtypeNames(
       return std::make_pair("bfloat16", "");
     case at::ScalarType::QUInt4x2:
       return std::make_pair("quint4x2", "");
+    case at::ScalarType::QUInt2x4:
+      return std::make_pair("quint2x4", "");
     default:
       throw std::runtime_error("Unimplemented scalar type");
   }

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -203,6 +203,7 @@ def _dtype_to_storage_type_map():
         torch.qint32: 'QInt32Storage',
         torch.quint8: 'QUInt8Storage',
         torch.quint4x2: 'QUInt4x2Storage',
+        torch.quint2x4: 'QUInt2x4Storage',
     }
 
 @lru_cache(maxsize=None)
@@ -286,10 +287,11 @@ class TypedStorage:
                 self._storage = eval(self.__module__).UntypedStorage(int(args[0]) * self.element_size())
 
             elif len(args) == 1 and isinstance(args[0], collections.abc.Sequence):
-                if self.dtype in [torch.quint8, torch.quint4x2, torch.qint32, torch.qint8]:
+                if self.dtype in [torch.quint8, torch.quint4x2, torch.quint2x4, torch.qint32, torch.qint8]:
                     interpret_dtypes = {
                         torch.quint8: torch.uint8,
                         torch.quint4x2: torch.uint8,
+                        torch.quint2x4: torch.uint8,
                         torch.qint32: torch.int32,
                         torch.qint8: torch.int8
                     }
@@ -359,10 +361,11 @@ class TypedStorage:
     def __setitem__(self, idx, value):
         if not isinstance(idx, (int, slice)):
             raise RuntimeError(f"can't index a {type(self)} with {type(idx)}")
-        if self.dtype in [torch.quint8, torch.quint4x2, torch.qint32, torch.qint8]:
+        if self.dtype in [torch.quint8, torch.quint4x2, torch.quint2x4, torch.qint32, torch.qint8]:
             interpret_dtypes = {
                 torch.quint8: torch.uint8,
                 torch.quint4x2: torch.uint8,
+                torch.quint2x4: torch.uint8,
                 torch.qint32: torch.int32,
                 torch.qint8: torch.int8
             }
@@ -385,10 +388,11 @@ class TypedStorage:
         elif not isinstance(idx, int):
             raise RuntimeError(f"can't index a {type(self)} with {type(idx)}")
 
-        if self.dtype in [torch.quint8, torch.quint4x2, torch.qint32, torch.qint8]:
+        if self.dtype in [torch.quint8, torch.quint4x2, torch.quint2x4, torch.qint32, torch.qint8]:
             interpret_dtypes = {
                 torch.quint8: torch.uint8,
                 torch.quint4x2: torch.uint8,
+                torch.quint2x4: torch.uint8,
                 torch.qint32: torch.int32,
                 torch.qint8: torch.int8
             }


### PR DESCRIPTION
Summary:
Introduce 2bit qtensor. The new dtype added for this is c10::quint2x4

The underlying storage for this is still uint8_t, so we pack 4 2-bit values in a byte while quantizing it.

Kernels that use this dtype should be aware of the packing format. (4 2-bit values in one byte)

Test Plan: `buck test mode/dev-asan caffe2/test/:quantization -- test_qtensor`

Differential Revision: D31148141

