### PR TITLE
[PyTorch][easy] Fix c10::optional::operator= exception specification

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -658,7 +658,9 @@ class optional : private OptionalBase<T> {
 
   optional& operator=(const optional& rhs) = default;
 
-  optional& operator=(optional&& rhs) = default;
+  optional& operator=(optional&& rhs) noexcept(
+      std::is_nothrow_move_assignable<T>::value&&
+          std::is_nothrow_move_constructible<T>::value) = default;
 
   template <class U = T>
   auto operator=(U&& v) -> typename std::enable_if<


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #64691
* #64824
* __->__ #65547
* #64823
* #64839

It's supposed to be conditionally noexcept like this; see
https://en.cppreference.com/w/cpp/utility/optional/operator%3D

Differential Revision: [D31146447](https://our.internmc.facebook.com/intern/diff/D31146447/)