### PR TITLE
[Pytorch Edge] Trace Custom Classes

### DIFF
--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -81,6 +81,20 @@ constexpr bool op_allowlist_check(string_view op_name) {
 #endif
 }
 
+// Returns true iff the given custom class name is on the allowlist
+// and should be registered
+constexpr bool custom_class_allowlist_check(string_view custom_class_name) {
+#if !defined(TORCH_CUSTOM_CLASS_ALLOWLIST)
+  // If the TORCH_CUSTOM_CLASS_ALLOWLIST parameter is not defined,
+  // all custom classes are to be registered
+  return true;
+#else
+  return op_allowlist_contains(
+    C10_STRINGIZE(TORCH_CUSTOM_CLASS_ALLOWLIST),
+    custom_class_name);
+#endif
+}
+
 // Returns true iff the given schema string is on the allowlist
 // and should be registered
 constexpr bool schema_allowlist_check(string_view schema) {
@@ -90,6 +104,7 @@ constexpr bool schema_allowlist_check(string_view schema) {
   return op_allowlist_check(schema.substr(0, schema.find("(")));
 #endif
 }
+
 
 // schema_allowlist_check() implicitly depends on a macro, TORCH_OPERATOR_WHITELIST.
 // Add this API to pass arbitrary allowlist.

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -27,6 +27,8 @@ enum class C10_API_ENUM RecordScope : uint8_t {
   TORCHSCRIPT_FUNCTION,
   // Kernel Function dtype Tag
   KERNEL_FUNCTION_DTYPE,
+  // Torchbind custom class,
+  CUSTOM_CLASS,
   // Kernel Function dtype Tag
   LITE_INTERPRETER,
   // User defined scope (e.g. with record_function())

--- a/tools/lite_interpreter/gen_selected_mobile_ops_header.py
+++ b/tools/lite_interpreter/gen_selected_mobile_ops_header.py
@@ -76,10 +76,13 @@ def write_selected_mobile_ops(
         selective_builder: SelectiveBuilder,
 ) -> None:
     root_ops = extract_root_operators(selective_builder)
+    custom_classes = selective_builder.custom_classes
     with open(output_file_path, "wb") as out_file:
         body_parts = [selected_mobile_ops_preamble]
         if not selective_builder.include_all_operators:
             body_parts.append("#define TORCH_OPERATOR_WHITELIST " + (";".join(sorted(root_ops))) + ";\n\n")
+            if selective_builder.include_all_kernel_dtypes is False:
+                body_parts.append("#define TORCH_CUSTOM_CLASS_ALLOWLIST " + (";".join(sorted(custom_classes))) + ";\n\n")
 
         body_parts.append(get_selected_kernel_dtypes_code(selective_builder))
         header_contents = "".join(body_parts)

--- a/torch/csrc/jit/mobile/import.h
+++ b/torch/csrc/jit/mobile/import.h
@@ -17,6 +17,28 @@ constexpr const char* kArchiveNameBytecode = "bytecode";
 constexpr const char* kArchiveNameConstants = "constants";
 constexpr const char* kArchiveNameVersion = "version";
 
+namespace detail {
+/**
+ * In the Facebook internal build (using BUCK), this macro is enabled by
+ * passing in -c pt.enable_record_kernel_dtype=1 when building the tracer
+ * binary.
+ */
+#if defined ENABLE_RECORD_KERNEL_FUNCTION_DTYPE
+TORCH_API void record_custom_class(std::string name);
+
+/**
+ * Record an instance of a custom class being loaded
+ * grab portion of string after final '.' from qualified name
+ * as this seemingly aligns with how users name their custom classes
+ */
+#define RECORD_CUSTOM_CLASS(NAME) \
+  auto name = std::string(NAME);  \
+  detail::record_custom_class(name.substr(name.find_last_of(".") + 1));
+#else
+#define RECORD_CUSTOM_CLASS(NAME)
+#endif
+} // namespace detail
+
 // The family of methods below load a serialized Mobile Module
 // into a mobile::Module object.
 TORCH_API mobile::Module _load_for_mobile(


### PR DESCRIPTION
Summary: Trace when a custom class is used so that the follow up diff can make them selective.

Test Plan:
Look at model output yamls.

Example selected_mobile_ops.h
  #pragma once
  /**
   * Generated by gen_selected_mobile_ops_header.py
   */

  #define TORCH_OPERATOR_WHITELIST aten::__getitem__.t;aten::__is__;aten::__isnot__;aten::_set_item.str;aten::contiguous;aten::dequantize.self;aten::embedding;aten::gelu;aten::len.t;aten::max.dim;aten::ne.int;aten::permute;aten::quantize_per_tensor;aten::relu;aten::size;aten::softmax.int;prim::RaiseException;prim::TupleIndex;prim::TupleUnpack;prim::Uninitialized;prim::unchecked_cast;quantized::add;quantized::cat;quantized::conv1d;quantized::linear;quantized::linear_relu;quantized::mul.Scalar;

  #define TORCH_CUSTOM_CLASS_ALLOWLIST Conv2dPackedParamsBase;LinearPackedParamsBase;

  #pragma once
  #include <c10/core/ScalarType.h>
  #include <c10/util/string_view.h>
  #include <c10/macros/Macros.h>

  namespace at {
  inline constexpr bool should_include_kernel_dtype(
    const char *kernel_tag_str,
    at::ScalarType scalar_type
  ) {
    c10::string_view kernel_tag_sv C10_UNUSED = c10::string_view(kernel_tag_str);
    if (kernel_tag_sv.compare("GeluKernelImpl") == 0) {
      return scalar_type == at::ScalarType::Float;
    } else if (kernel_tag_sv.compare("_local_scalar_dense_cpu") == 0) {
      return scalar_type == at::ScalarType::Long || scalar_type == at::ScalarType::Float || scalar_type == at::ScalarType::Double;
    } else if (kernel_tag_sv.compare("cat_serial_kernel") == 0) {
  continues on...

Differential Revision: D31154791

