### PR TITLE
add deepcopy support to subclasses

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -11,6 +11,7 @@ import copy
 import pickle
 import shutil
 import pathlib
+from copy import deepcopy
 
 from torch._utils_internal import get_file_path_2
 from torch._utils import _rebuild_tensor
@@ -697,45 +698,6 @@ class TestOldSerialization(TestCase, SerializationMixin):
             return super(TestOldSerialization, self).run(*args, **kwargs)
 
 
-class TestWrapperSubclass(torch.Tensor):
-    elem: torch.Tensor
-    __slots__ = ['elem', 'other']
-
-    @staticmethod
-    def __new__(cls, elem, *args, **kwargs):
-        # The wrapping tensor (TestSubclass) is just a meta tensor, so it
-        # doesn't hold any memory (meta tensor is generally the preferred type
-        # of tensor you want to make a subclass from)...
-        r = torch.Tensor._make_subclass(cls, elem.to('meta'), elem.requires_grad)
-        # ...the real tensor is held as an element on the tensor.
-        r.elem = elem
-        return r
-
-
-class TestGetStateSubclass(torch.Tensor):
-    elem: torch.Tensor
-    __slots__ = ['elem']
-
-    @staticmethod
-    def __new__(cls, elem, *args, **kwargs):
-        # The wrapping tensor (TestSubclass) is just a meta tensor, so it
-        # doesn't hold any memory (meta tensor is generally the preferred type
-        # of tensor you want to make a subclass from)...
-        r = torch.Tensor._make_subclass(cls, elem.to('meta'), elem.requires_grad)
-        # ...the real tensor is held as an element on the tensor.
-        r.elem = elem
-        return r
-
-    def __getstate__(self):
-        return ("foo", getattr(self, "elem", None), self.__dict__)
-
-    def __setstate__(self, state):
-        marker, self.elem, self.__dict__ = state
-        if not marker == "foo":
-            raise RuntimeError("Invalid state for TestGetStateSubclass")
-        self.reloaded = True
-
-
 class TestSerialization(TestCase, SerializationMixin):
     def test_serialization_zipfile(self):
         data = self._test_serialization_data()
@@ -790,6 +752,52 @@ class TestSerialization(TestCase, SerializationMixin):
 
         self.assertEqual(state.weight.size(), big_model.weight.size())
 
+
+    def run(self, *args, **kwargs):
+        with serialization_method(use_zip=True):
+            return super(TestSerialization, self).run(*args, **kwargs)
+
+
+class TestWrapperSubclass(torch.Tensor):
+    elem: torch.Tensor
+    __slots__ = ['elem', 'other']
+
+    @staticmethod
+    def __new__(cls, elem, *args, **kwargs):
+        # The wrapping tensor (TestSubclass) is just a meta tensor, so it
+        # doesn't hold any memory (meta tensor is generally the preferred type
+        # of tensor you want to make a subclass from)...
+        r = torch.Tensor._make_subclass(cls, elem.to('meta'), elem.requires_grad)
+        # ...the real tensor is held as an element on the tensor.
+        r.elem = elem
+        return r
+
+
+class TestGetStateSubclass(torch.Tensor):
+    elem: torch.Tensor
+    __slots__ = ['elem']
+
+    @staticmethod
+    def __new__(cls, elem, *args, **kwargs):
+        # The wrapping tensor (TestSubclass) is just a meta tensor, so it
+        # doesn't hold any memory (meta tensor is generally the preferred type
+        # of tensor you want to make a subclass from)...
+        r = torch.Tensor._make_subclass(cls, elem.to('meta'), elem.requires_grad)
+        # ...the real tensor is held as an element on the tensor.
+        r.elem = elem
+        return r
+
+    def __getstate__(self):
+        return ("foo", getattr(self, "elem", None), self.__dict__)
+
+    def __setstate__(self, state):
+        marker, self.elem, self.__dict__ = state
+        if not marker == "foo":
+            raise RuntimeError("Invalid state for TestGetStateSubclass")
+        self.reloaded = True
+
+
+class TestSubclassSerialization(TestCase):
     def test_tensor_subclass_wrapper_serialization(self):
         wrapped_tensor = torch.rand(2)
         my_tensor = TestWrapperSubclass(wrapped_tensor)
@@ -825,10 +833,20 @@ class TestSerialization(TestCase, SerializationMixin):
         self.assertEqual(new_tensor.foo, foo_val)
         self.assertTrue(new_tensor.reloaded)
 
+    def test_tensor_subclass_deepcopy(self):
+        wrapped_tensor = torch.rand(2)
+        my_tensor = TestWrapperSubclass(wrapped_tensor)
 
-    def run(self, *args, **kwargs):
-        with serialization_method(use_zip=True):
-            return super(TestSerialization, self).run(*args, **kwargs)
+        foo_val = "bar"
+        my_tensor.foo = foo_val
+        self.assertEqual(my_tensor.foo, foo_val)
+
+        new_tensor = deepcopy(my_tensor)
+
+        self.assertIsInstance(new_tensor, TestWrapperSubclass)
+        self.assertEqual(new_tensor.elem, my_tensor.elem)
+        self.assertEqual(new_tensor.foo, foo_val)
+
 
 instantiate_device_type_tests(TestBothSerialization, globals())
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3034,6 +3034,10 @@ class TestTorchDeviceType(TestCase):
         for i in range(a.numel()):
             self.assertEqual(w[1][1][i], q[1][1][i] - 1)
 
+        # Check that deepcopy preserves attributes
+        a.foo = 3
+        self.assertEqual(deepcopy(a).foo, 3)
+
     @dtypes(torch.float32, torch.complex64)
     def test_deepcopy_scalar(self, device, dtype):
         from copy import deepcopy

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -128,7 +128,7 @@ class Tensor(torch._C._TensorBase):
                 new_tensor.grad = self.grad.__deepcopy__(memo)
 
             if not type(self) is Tensor:
-                new_tensor = new_tensor.as_subclass(type(self))
+                new_tensor = new_tensor.as_subclass(type(self))  # type: ignore[arg-type]
 
                 # Plain Tensors don't have slots
                 slots_to_save = copyreg._slotnames(self.__class__)  # type: ignore[attr-defined]

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -5,6 +5,7 @@ from numbers import Number
 from typing import Any, Dict, Optional, Tuple, Union
 import warnings
 import copyreg
+from copy import deepcopy
 
 import torch
 import torch._C as _C
@@ -125,6 +126,18 @@ class Tensor(torch._C._TensorBase):
                     new_tensor.requires_grad = self.requires_grad
             if self.grad is not None:
                 new_tensor.grad = self.grad.__deepcopy__(memo)
+
+            if not type(self) is Tensor:
+                new_tensor = new_tensor.as_subclass(type(self))
+
+                # Plain Tensors don't have slots
+                slots_to_save = copyreg._slotnames(self.__class__)  # type: ignore[attr-defined]
+                for slot in slots_to_save:
+                    if hasattr(self, slot):
+                        setattr(new_tensor, slot, deepcopy(getattr(self, slot), memo))
+
+            new_tensor.__dict__ = deepcopy(self.__dict__, memo)
+
             memo[id(self)] = new_tensor
             return new_tensor
 


### PR DESCRIPTION
Happy to get any feedback on how to make this code cleaner!

This:
- Fix Tensor attribute deepcopy BC-breaking?
- Add a test for Tensor attribute deepcopy
- Fix subclass deepcopy
- Moves the subclass serialization tests into their own class not to interfere with other serialization test logic
- Add a test for subclass deepcopy


cc @ezyang @gchanan