### PR TITLE
[fx2trt] Refresh execution context across save/load for TRTModule.

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -109,6 +109,16 @@ class TRTModule(torch.nn.Module):
         self.output_names = state_dict[prefix + "output_names"]
         self._initialize()
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop('context', None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if self.engine:
+            self.context = self.engine.create_execution_context()
+
     def forward(self, *inputs):
         with torch.autograd.profiler.record_function("TRTModule:Forward"):
             self._check_initialized()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65592

IExecutionContext might not be safe to be serialized, therefore the simplest way to support save/load of TRTModule is to re-populate the execution context upon every load.

Differential Revision: [D31070427](https://our.internmc.facebook.com/intern/diff/D31070427/)