### PR TITLE
[TensorExpr] Break circular dependency of shared pointers in MemDependencyChecker.

### DIFF
--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -111,7 +111,7 @@ DependencySet AccessInfo::getIndirectDependencies() {
 DependencySet AccessInfo::getDirectDependents() {
   DependencySet res;
   for (auto& depPair : dependents_) {
-    res.insert(depPair.second);
+    res.insert(depPair.second.lock());
   }
   return res;
 }
@@ -174,7 +174,7 @@ void AccessInfo::print() const {
   if (!dependents_.empty()) {
     std::cout << " - dependents: ";
     for (auto& pair : dependents_) {
-      std::cout << pair.second->id() << " ";
+      std::cout << pair.second.lock()->id() << " ";
     }
   }
 

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -109,8 +109,12 @@ class TORCH_API AccessInfo {
   // Each access that depends on this one.
   // ie. this access is present in the dependencies map of all accesses that are
   // dependent.
-  const std::map<size_t, std::shared_ptr<AccessInfo>>& dependents() const {
-    return dependents_;
+  std::map<size_t, std::shared_ptr<AccessInfo>> dependents() const {
+    std::map<size_t, std::shared_ptr<AccessInfo>> res;
+    for (const auto& kv : dependents_) {
+      res.emplace(kv.first, kv.second.lock());
+    }
+    return res;
   }
 
   // Returns the symbolic expression of the indices of this access.
@@ -156,7 +160,7 @@ class TORCH_API AccessInfo {
 
   // Yes these should be sorted.
   std::map<size_t, std::shared_ptr<AccessInfo>> dependencies_;
-  std::map<size_t, std::shared_ptr<AccessInfo>> dependents_;
+  std::map<size_t, std::weak_ptr<AccessInfo>> dependents_;
 };
 
 using VarBoundMap = std::unordered_map<VarPtr, Bound>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65600

Previously AccessInfo owned two maps: dependencies_ and dependents_,
which represented an edge in dependency graph. These two maps were
holding shared pointers and thus each edge immediately became a cycle,
which resulted in memory leaks. This PR makes one of the ends of these
edges weak pointer thus breaking the loop.

Differential Revision: [D31163441](https://our.internmc.facebook.com/intern/diff/D31163441)