### PR TITLE
Add all_paths utility function in order to show why modules are included in dependencies

### DIFF
--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -93,15 +93,15 @@ class TestDiGraph(PackageTestCase):
         g = DiGraph()
         self.assertFalse([1, 2, 3] in g)
 
-    def test_forward_closures(self):
+    def test_forward_closure(self):
         g = DiGraph()
         g.add_edge("1", "2")
         g.add_edge("2", "3")
         g.add_edge("5", "4")
         g.add_edge("4", "3")
-        self.assertTrue(g.forward_transitive_closures("1") ==
+        self.assertTrue(g.forward_transitive_closure("1") ==
                         set(["1", "2", "3"]))
-        self.assertTrue(g.forward_transitive_closures("4") ==
+        self.assertTrue(g.forward_transitive_closure("4") ==
                         set(["4", "3"]))
 
     def test_all_paths(self):
@@ -114,10 +114,12 @@ class TestDiGraph(PackageTestCase):
         g.add_edge("5", "4")
         g.add_edge("4", "3")
 
-        sub_g = g.all_paths("1", "3")
-        expected_edge_set = set([("1", "2"), ("2", "3"), ("1", "7"),
-                                 ("7", "8"), ("8", "3")])
-        self.assertTrue(set(sub_g.edges) == expected_edge_set)
+        result = g.all_paths("1", "3")
+        # to get rid of indeterminism
+        actual_edges = set([i.strip("\n") for i in result.split(";")[2:-1]])
+        expected_edges = set(['"2" -> "3"', '"1" -> "7"', '"7" -> "8"',
+                          '"1" -> "2"', '"8" -> "3"'])
+        self.assertEqual(actual_edges, expected_edges)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -116,10 +116,10 @@ class TestDiGraph(PackageTestCase):
 
         result = g.all_paths("1", "3")
         # to get rid of indeterminism
-        actual_edges = set([i.strip("\n") for i in result.split(";")[2:-1]])
-        expected_edges = set(['"2" -> "3"', '"1" -> "7"', '"7" -> "8"',
-                          '"1" -> "2"', '"8" -> "3"'])
-        self.assertEqual(actual_edges, expected_edges)
+        actual = set([i.strip("\n") for i in result.split(";")[2:-1]])
+        expected = {'"2" -> "3"', '"1" -> "7"', '"7" -> "8"',
+                    '"1" -> "2"', '"8" -> "3"'}
+        self.assertEqual(actual, expected)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -93,6 +93,32 @@ class TestDiGraph(PackageTestCase):
         g = DiGraph()
         self.assertFalse([1, 2, 3] in g)
 
+    def test_forward_closures(self):
+        g = DiGraph()
+        g.add_edge("1", "2")
+        g.add_edge("2", "3")
+        g.add_edge("5", "4")
+        g.add_edge("4", "3")
+        closures_for_1 =
+        self.assertTrue(g.forward_transitive_closures("1") ==
+                        set(["1", "2", "3"]))
+        self.assertTrue(g.forward_transitive_closures("4") ==
+                        set(["4", "3"]))
+
+    def test_all_paths(self):
+        g = DiGraph()
+        g.add_edge("1", "2")
+        g.add_edge("1", "7")
+        g.add_edge("7", "8")
+        g.add_edge("8", "3")
+        g.add_edge("2", "3")
+        g.add_edge("5", "4")
+        g.add_edge("4", "3")
+
+        sub_g = g.all_paths("1", "3")
+        expected_edge_set = set([("1", "2"), ("2", "3"), ("1", "7"),
+                                 ("7", "8"), ("8", "3")])
+        self.assertTrue(set(sub_g.edges) == expected_edge_set)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -99,7 +99,6 @@ class TestDiGraph(PackageTestCase):
         g.add_edge("2", "3")
         g.add_edge("5", "4")
         g.add_edge("4", "3")
-        closures_for_1 =
         self.assertTrue(g.forward_transitive_closures("1") ==
                         set(["1", "2", "3"]))
         self.assertTrue(g.forward_transitive_closures("4") ==

--- a/torch/package/_digraph.py
+++ b/torch/package/_digraph.py
@@ -121,7 +121,7 @@ class DiGraph:
         forward_reachable_from_src = self.forward_transitive_closures(src)
 
         if dst not in forward_reachable_from_src:
-            return result
+            return result_graph
 
         # Second walk the reverse dependencies of dst, adding each node to
         # the output graph iff it is also present in forward_reachable_from_src.

--- a/torch/package/_digraph.py
+++ b/torch/package/_digraph.py
@@ -87,7 +87,7 @@ class DiGraph:
         except TypeError:
             return False
 
-    def forward_transitive_closures(self, src: str) -> Set[str]:
+    def forward_transitive_closure(self, src: str) -> Set[str]:
         """Returns a set of nodes that are reachable from src"""
 
         result = set(src)
@@ -100,7 +100,7 @@ class DiGraph:
                     working_set.append(n)
         return result
 
-    def backward_transitive_closures(self, src: str) -> Set[str]:
+    def backward_transitive_closure(self, src: str) -> Set[str]:
         """Returns a set of nodes that are reachable from src in reverse direction"""
 
         result = set(src)
@@ -118,7 +118,7 @@ class DiGraph:
 
         result_graph = DiGraph()
         # First compute forward transitive closure of src (all things reachable from src).
-        forward_reachable_from_src = self.forward_transitive_closures(src)
+        forward_reachable_from_src = self.forward_transitive_closure(src)
 
         if dst not in forward_reachable_from_src:
             return result_graph
@@ -135,4 +135,19 @@ class DiGraph:
                     # only explore further if its reachable from src
                     working_set.append(n)
 
-        return result_graph
+        return result_graph.to_dot()
+
+    def to_dot(self) -> str:
+        """Returns the dot representation of the graph.
+
+        Returns:
+            A dot representation of the graph.
+        """
+        edges = "\n".join(f'"{f}" -> "{t}";' for f, t in self.edges)
+        return f"""\
+digraph G {{
+rankdir = LR;
+node [shape=box];
+{edges}
+}}
+"""

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -1032,6 +1032,15 @@ node [shape=box];
         else:
             return []
 
+    def all_paths(self, src: str, dst: str) -> DiGraph:
+        """Return a subgraph that has all paths from src to dst.
+
+        Returns:
+            A DiGraph containing all paths from src to dst.
+        """
+        return self.dependency_graph.all_paths(src, dst)
+
+
 
 # even though these are in the standard library, we do not allow them to be
 # automatically externed since they offer a lot of system level access

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -965,14 +965,7 @@ class PackageExporter:
         Returns:
             A string representation of dependencies in package.
         """
-        edges = "\n".join(f'"{f}" -> "{t}";' for f, t in self.dependency_graph.edges)
-        return f"""\
-digraph G {{
-rankdir = LR;
-node [shape=box];
-{edges}
-}}
-"""
+        return self.dependency_graph.to_dot()
 
     def _nodes_with_action_type(
         self, action: Optional[_ModuleProviderAction]
@@ -1032,11 +1025,13 @@ node [shape=box];
         else:
             return []
 
-    def all_paths(self, src: str, dst: str) -> DiGraph:
-        """Return a subgraph that has all paths from src to dst.
+    def all_paths(self, src: str, dst: str) -> str:
+        """Return a dot representation of the subgraph
+           that has all paths from src to dst.
 
         Returns:
-            A DiGraph containing all paths from src to dst.
+            A dot representation containing all paths from src to dst.
+            (https://graphviz.org/doc/info/lang.html)
         """
         return self.dependency_graph.all_paths(src, dst)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65602

This pr allows users of PackageExporter to know why a certain module has been included in the packaged dependencies. It shows all dependencies from `src` to `dst`.

fixes: https://github.com/pytorch/pytorch/issues/65261
Differential Revision: [D31163681](https://our.internmc.facebook.com/intern/diff/D31163681)