### PR TITLE
[TensorExpr] Delete dtype_ field from Let - it should use its var's dtype.

### DIFF
--- a/torch/csrc/jit/tensorexpr/cpp_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cpp_codegen.cpp
@@ -336,10 +336,10 @@ void CppPrinter::visit(ExternalCallPtr v) {
 }
 
 void CppPrinter::visit(LetPtr v) {
-  if (v->dtype().lanes() == 1) {
+  if (v->var()->dtype().lanes() == 1) {
     emitIndent();
-    os() << v->dtype().ToCppString() << " " << *v->var() << " = " << *v->value()
-         << ";" << std::endl;
+    os() << v->var()->dtype().ToCppString() << " " << *v->var() << " = "
+         << *v->value() << ";" << std::endl;
   } else {
     vector_vars_[v->var()] = v->value();
   }

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -508,7 +508,7 @@ void CudaPrinter::visit(BlockPtr v) {
 
 void CudaPrinter::visit(LetPtr v) {
   emitIndent();
-  os() << dtypeToCppString(v->dtype());
+  os() << dtypeToCppString(v->var()->dtype());
   os() << " " << *v->var() << " = ";
   v->value()->accept(this);
   os() << ";" << std::endl;

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -125,7 +125,7 @@ class HalfRewriter : public IRMutator {
     if (isHalf(v->var()->dtype().scalar_type())) {
       VarPtr load_new_var = alloc<Var>(v->var()->name_hint(), kFloat);
       ExprPtr new_value = alloc<Cast>(
-          v->value()->dtype().cloneWithScalarType(ScalarType::Float),
+          v->var()->dtype().cloneWithScalarType(ScalarType::Float),
           v->value()->accept_mutator(this));
       var_map[v->var()] = load_new_var;
 

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -122,10 +122,10 @@ class HalfRewriter : public IRMutator {
   }
 
   StmtPtr mutate(LetPtr v) override {
-    if (isHalf(v->dtype().scalar_type())) {
+    if (isHalf(v->value()->dtype().scalar_type())) {
       VarPtr load_new_var = alloc<Var>(v->var()->name_hint(), kFloat);
       ExprPtr new_value = alloc<Cast>(
-          v->dtype().cloneWithScalarType(ScalarType::Float),
+          v->value()->dtype().cloneWithScalarType(ScalarType::Float),
           v->value()->accept_mutator(this));
       var_map[v->var()] = load_new_var;
 

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -122,7 +122,7 @@ class HalfRewriter : public IRMutator {
   }
 
   StmtPtr mutate(LetPtr v) override {
-    if (isHalf(v->value()->dtype().scalar_type())) {
+    if (isHalf(v->var()->dtype().scalar_type())) {
       VarPtr load_new_var = alloc<Var>(v->var()->name_hint(), kFloat);
       ExprPtr new_value = alloc<Cast>(
           v->value()->dtype().cloneWithScalarType(ScalarType::Float),

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -450,7 +450,7 @@ void IRPrinter::visit(FreePtr v) {
 }
 
 void IRPrinter::visit(LetPtr v) {
-  os() << dtypeToCppString(v->dtype()) << " " << *v->var();
+  os() << dtypeToCppString(v->var()->dtype()) << " " << *v->var();
   os() << " = " << *v->value();
   os() << ";" << std::endl;
 }

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -419,11 +419,7 @@ class TORCH_API Let : public StmtNode<Let> {
     return alloc<Let>(var.node(), val.node());
   }
 
-  Let(VarPtr var, ExprPtr val) : dtype_(var->dtype()), var_(var), val_(val) {}
-
-  Dtype dtype() const {
-    return dtype_;
-  }
+  Let(VarPtr var, ExprPtr val) : var_(var), val_(val) {}
 
   VarPtr var() const {
     return var_;
@@ -442,7 +438,6 @@ class TORCH_API Let : public StmtNode<Let> {
   }
 
  private:
-  Dtype dtype_;
   VarPtr var_;
   ExprPtr val_;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65634

Differential Revision: [D31182697](https://our.internmc.facebook.com/intern/diff/D31182697)