### PR TITLE
Add hash and int128 utils for Lazy Tensor Core

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2067,6 +2067,23 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "lazy_tests",
+    size = "small",
+    srcs = glob([
+        "test/cpp/lazy/*.cpp",
+        "test/cpp/lazy/*.h",
+    ]),
+    linkstatic = True,
+    tags = [
+        "exclusive",
+    ],
+    deps = [
+        ":torch",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 # all tests
 test_suite(
     name = "all_tests",

--- a/c10/util/int128.cpp
+++ b/c10/util/int128.cpp
@@ -1,0 +1,184 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <c10/util/Logging.h>
+#include <c10/util/int128.h>
+#include <iomanip>
+#include <ostream> // NOLINT(readability/streams)
+#include <sstream>
+
+namespace c10 {
+
+const uint128_pod kuint128max = {
+    uint64_t{0xFFFFFFFFFFFFFFFFu},
+    uint64_t{0xFFFFFFFFFFFFFFFFu}};
+
+// Returns the 0-based position of the last set bit (i.e., most significant bit)
+// in the given uint64. The argument may not be 0.
+//
+// For example:
+//   Given: 5 (decimal) == 101 (binary)
+//   Returns: 2
+#define STEP(T, n, pos, sh)                   \
+  do {                                        \
+    if ((n) >= (static_cast<T>(1) << (sh))) { \
+      (n) = (n) >> (sh);                      \
+      (pos) |= (sh);                          \
+    }                                         \
+  } while (0)
+static inline int Fls64(uint64_t n) {
+  //   GOOGLE_DCHECK_NE(0, n);
+  int pos = 0;
+  STEP(uint64_t, n, pos, 0x20);
+  uint32_t n32 = n;
+  STEP(uint32_t, n32, pos, 0x10);
+  STEP(uint32_t, n32, pos, 0x08);
+  STEP(uint32_t, n32, pos, 0x04);
+  return pos + ((uint64_t{0x3333333322221100u} >> (n32 << 2)) & 0x3);
+}
+#undef STEP
+
+// Like Fls64() above, but returns the 0-based position of the last set bit
+// (i.e., most significant bit) in the given uint128. The argument may not be 0.
+static inline int Fls128(uint128 n) {
+  if (uint64_t hi = Uint128High64(n)) {
+    return Fls64(hi) + 64;
+  }
+  return Fls64(Uint128Low64(n));
+}
+
+void uint128::DivModImpl(
+    uint128 dividend,
+    uint128 divisor,
+    uint128* quotient_ret,
+    uint128* remainder_ret) {
+  if (divisor == 0) {
+    LOG(FATAL) << "Division or mod by zero: dividend.hi=" << dividend.hi_
+               << ", lo=" << dividend.lo_;
+  } else if (dividend < divisor) {
+    *quotient_ret = 0;
+    *remainder_ret = dividend;
+    return;
+  } else {
+    int dividend_bit_length = Fls128(dividend);
+    int divisor_bit_length = Fls128(divisor);
+    int difference = dividend_bit_length - divisor_bit_length;
+    uint128 quotient = 0;
+    while (difference >= 0) {
+      quotient <<= 1;
+      uint128 shifted_divisor = divisor << difference;
+      if (shifted_divisor <= dividend) {
+        dividend -= shifted_divisor;
+        quotient += 1;
+      }
+      difference -= 1;
+    }
+    // record the final quotient and remainder
+    *quotient_ret = quotient;
+    *remainder_ret = dividend;
+  }
+}
+
+uint128& uint128::operator/=(const uint128& divisor) {
+  uint128 quotient = 0;
+  uint128 remainder = 0;
+  DivModImpl(*this, divisor, &quotient, &remainder);
+  *this = quotient;
+  return *this;
+}
+uint128& uint128::operator%=(const uint128& divisor) {
+  uint128 quotient = 0;
+  uint128 remainder = 0;
+  DivModImpl(*this, divisor, &quotient, &remainder);
+  *this = remainder;
+  return *this;
+}
+
+std::ostream& operator<<(std::ostream& o, const uint128& b) {
+  std::ios_base::fmtflags flags = o.flags();
+
+  // Select a divisor which is the largest power of the base < 2^64.
+  uint128 div;
+  std::streamsize div_base_log;
+  switch (flags & std::ios::basefield) {
+    case std::ios::hex:
+      div = (uint64_t)0x1000000000000000u; // 16^15
+      div_base_log = 15;
+      break;
+    case std::ios::oct:
+      div = (uint64_t)01000000000000000000000u; // 8^21
+      div_base_log = 21;
+      break;
+    default: // std::ios::dec
+      div = (uint64_t)10000000000000000000u; // 10^19
+      div_base_log = 19;
+      break;
+  }
+
+  // Now piece together the uint128 representation from three chunks of
+  // the original value, each less than "div" and therefore representable
+  // as a uint64.
+  std::ostringstream os;
+  std::ios_base::fmtflags copy_mask =
+      std::ios::basefield | std::ios::showbase | std::ios::uppercase;
+  os.setf(flags & copy_mask, copy_mask);
+  uint128 high = b;
+  uint128 low;
+  uint128::DivModImpl(high, div, &high, &low);
+  uint128 mid;
+  uint128::DivModImpl(high, div, &high, &mid);
+  if (high.lo_ != 0) {
+    os << high.lo_;
+    os << std::noshowbase << std::setfill('0') << std::setw(div_base_log);
+    os << mid.lo_;
+    os << std::setw(div_base_log);
+  } else if (mid.lo_ != 0) {
+    os << mid.lo_;
+    os << std::noshowbase << std::setfill('0') << std::setw(div_base_log);
+  }
+  os << low.lo_;
+  std::string rep = os.str();
+
+  // Add the requisite padding.
+  std::streamsize width = o.width(0);
+  if (width > rep.size()) {
+    if ((flags & std::ios::adjustfield) == std::ios::left) {
+      rep.append(width - rep.size(), o.fill());
+    } else {
+      rep.insert(
+          static_cast<std::string::size_type>(0), width - rep.size(), o.fill());
+    }
+  }
+
+  // Stream the final representation in a single "<<" call.
+  return o << rep;
+}
+
+} // namespace c10

--- a/c10/util/int128.h
+++ b/c10/util/int128.h
@@ -1,0 +1,394 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <c10/macros/Export.h>
+#include <iosfwd>
+
+namespace c10 {
+
+struct uint128_pod;
+
+// TODO(xiaofeng): Define GOOGLE_PROTOBUF_HAS_CONSTEXPR when constexpr is
+// available.
+#ifdef GOOGLE_PROTOBUF_HAS_CONSTEXPR
+#define UINT128_CONSTEXPR constexpr
+#else
+#define UINT128_CONSTEXPR
+#endif
+
+class uint128;
+static inline uint128& operator<<=(uint128& self, int amount);
+
+// An unsigned 128-bit integer type. Thread-compatible.
+class TORCH_API uint128 {
+ public:
+  UINT128_CONSTEXPR uint128(); // Sets to 0, but don't trust on this behavior.
+  UINT128_CONSTEXPR uint128(uint64_t top, uint64_t bottom);
+#ifndef SWIG
+  UINT128_CONSTEXPR uint128(int bottom);
+  UINT128_CONSTEXPR uint128(uint32_t bottom); // Top 96 bits = 0
+#endif
+  UINT128_CONSTEXPR uint128(uint64_t bottom); // hi_ = 0
+  UINT128_CONSTEXPR uint128(const uint128_pod& val);
+
+  // Trivial copy constructor, assignment operator and destructor.
+
+  void Initialize(uint64_t top, uint64_t bottom);
+
+  // Arithmetic operators.
+  uint128& operator+=(const uint128& b);
+  uint128& operator-=(const uint128& b);
+  uint128& operator*=(const uint128& b);
+  // Long division/modulo for uint128.
+  uint128& operator/=(const uint128& b);
+  uint128& operator%=(const uint128& b);
+  uint128 operator++(int);
+  uint128 operator--(int);
+  // Make msvc happy with using operator<<= from DivModImpl
+  // which is a static function, and linker complained about missing
+  // static version of this overload
+  friend uint128& operator<<=(uint128&, int);
+  uint128& operator>>=(int);
+  uint128& operator&=(const uint128& b);
+  uint128& operator|=(const uint128& b);
+  uint128& operator^=(const uint128& b);
+  uint128& operator++();
+  uint128& operator--();
+
+  friend uint64_t Uint128Low64(const uint128& v);
+  friend uint64_t Uint128High64(const uint128& v);
+
+  // We add "std::" to avoid including all of port.h.
+  TORCH_API friend std::ostream& operator<<(std::ostream& o, const uint128& b);
+
+ private:
+  static void DivModImpl(
+      uint128 dividend,
+      uint128 divisor,
+      uint128* quotient_ret,
+      uint128* remainder_ret);
+
+  // Little-endian memory order optimizations can benefit from
+  // having lo_ first, hi_ last.
+  // See util/endian/endian.h and Load128/Store128 for storing a uint128.
+  uint64_t lo_;
+  uint64_t hi_;
+
+  // Not implemented, just declared for catching automatic type conversions.
+  uint128(uint8_t);
+  uint128(uint16_t);
+  uint128(float v);
+  uint128(double v);
+};
+
+// This is a POD form of uint128 which can be used for static variables which
+// need to be operated on as uint128.
+struct uint128_pod {
+  // Note: The ordering of fields is different than 'class uint128' but the
+  // same as its 2-arg constructor.  This enables more obvious initialization
+  // of static instances, which is the primary reason for this struct in the
+  // first place.  This does not seem to defeat any optimizations wrt
+  // operations involving this struct.
+  uint64_t hi;
+  uint64_t lo;
+};
+
+TORCH_API extern const uint128_pod kuint128max;
+
+// allow uint128 to be logged
+TORCH_API extern std::ostream& operator<<(std::ostream& o, const uint128& b);
+
+// Methods to access low and high pieces of 128-bit value.
+// Defined externally from uint128 to facilitate conversion
+// to native 128-bit types when compilers support them.
+inline uint64_t Uint128Low64(const uint128& v) {
+  return v.lo_;
+}
+inline uint64_t Uint128High64(const uint128& v) {
+  return v.hi_;
+}
+
+// TODO: perhaps it would be nice to have int128, a signed 128-bit type?
+
+// --------------------------------------------------------------------------
+//                      Implementation details follow
+// --------------------------------------------------------------------------
+inline bool operator==(const uint128& lhs, const uint128& rhs) {
+  return (
+      Uint128Low64(lhs) == Uint128Low64(rhs) &&
+      Uint128High64(lhs) == Uint128High64(rhs));
+}
+inline bool operator!=(const uint128& lhs, const uint128& rhs) {
+  return !(lhs == rhs);
+}
+
+inline UINT128_CONSTEXPR uint128::uint128() : lo_(0), hi_(0) {}
+inline UINT128_CONSTEXPR uint128::uint128(uint64_t top, uint64_t bottom)
+    : lo_(bottom), hi_(top) {}
+inline UINT128_CONSTEXPR uint128::uint128(const uint128_pod& v)
+    : lo_(v.lo), hi_(v.hi) {}
+inline UINT128_CONSTEXPR uint128::uint128(uint64_t bottom)
+    : lo_(bottom), hi_(0) {}
+#ifndef SWIG
+inline UINT128_CONSTEXPR uint128::uint128(uint32_t bottom)
+    : lo_(bottom), hi_(0) {}
+inline UINT128_CONSTEXPR uint128::uint128(int bottom)
+    : lo_(bottom), hi_(static_cast<int64_t>((bottom < 0) ? -1 : 0)) {}
+#endif
+
+#undef UINT128_CONSTEXPR
+
+inline void uint128::Initialize(uint64_t top, uint64_t bottom) {
+  hi_ = top;
+  lo_ = bottom;
+}
+
+// Comparison operators.
+
+#define CMP128(op)                                                  \
+  inline bool operator op(const uint128& lhs, const uint128& rhs) { \
+    return (Uint128High64(lhs) == Uint128High64(rhs))               \
+        ? (Uint128Low64(lhs) op Uint128Low64(rhs))                  \
+        : (Uint128High64(lhs) op Uint128High64(rhs));               \
+  }
+
+CMP128(<)
+CMP128(>)
+CMP128(>=)
+CMP128(<=)
+
+#undef CMP128
+
+// Unary operators
+
+inline uint128 operator-(const uint128& val) {
+  const uint64_t hi_flip = ~Uint128High64(val);
+  const uint64_t lo_flip = ~Uint128Low64(val);
+  const uint64_t lo_add = lo_flip + 1;
+  if (lo_add < lo_flip) {
+    return uint128(hi_flip + 1, lo_add);
+  }
+  return uint128(hi_flip, lo_add);
+}
+
+inline bool operator!(const uint128& val) {
+  return !Uint128High64(val) && !Uint128Low64(val);
+}
+
+// Logical operators.
+
+inline uint128 operator~(const uint128& val) {
+  return uint128(~Uint128High64(val), ~Uint128Low64(val));
+}
+
+#define LOGIC128(op)                                                   \
+  inline uint128 operator op(const uint128& lhs, const uint128& rhs) { \
+    return uint128(                                                    \
+        Uint128High64(lhs) op Uint128High64(rhs),                      \
+        Uint128Low64(lhs) op Uint128Low64(rhs));                       \
+  }
+
+LOGIC128(|)
+LOGIC128(&)
+LOGIC128(^)
+
+#undef LOGIC128
+
+#define LOGICASSIGN128(op)                                     \
+  inline uint128& uint128::operator op(const uint128& other) { \
+    hi_ op other.hi_;                                          \
+    lo_ op other.lo_;                                          \
+    return *this;                                              \
+  }
+
+LOGICASSIGN128(|=)
+LOGICASSIGN128(&=)
+LOGICASSIGN128(^=)
+
+#undef LOGICASSIGN128
+
+// Shift operators.
+
+inline uint128 operator<<(const uint128& val, int amount) {
+  // uint64_t shifts of >= 64 are undefined, so we will need some
+  // special-casing.
+  if (amount < 64) {
+    if (amount == 0) {
+      return val;
+    }
+    uint64_t new_hi =
+        (Uint128High64(val) << amount) | (Uint128Low64(val) >> (64 - amount));
+    uint64_t new_lo = Uint128Low64(val) << amount;
+    return uint128(new_hi, new_lo);
+  } else if (amount < 128) {
+    return uint128(Uint128Low64(val) << (amount - 64), 0);
+  } else {
+    return uint128(0, 0);
+  }
+}
+
+inline uint128 operator>>(const uint128& val, int amount) {
+  // uint64_t shifts of >= 64 are undefined, so we will need some
+  // special-casing.
+  if (amount < 64) {
+    if (amount == 0) {
+      return val;
+    }
+    uint64_t new_hi = Uint128High64(val) >> amount;
+    uint64_t new_lo =
+        (Uint128Low64(val) >> amount) | (Uint128High64(val) << (64 - amount));
+    return uint128(new_hi, new_lo);
+  } else if (amount < 128) {
+    return uint128(0, Uint128High64(val) >> (amount - 64));
+  } else {
+    return uint128(0, 0);
+  }
+}
+
+static inline uint128& operator<<=(uint128& self, int amount) {
+  // uint64_t shifts of >= 64 are undefined, so we will need some
+  // special-casing.
+  if (amount < 64) {
+    if (amount != 0) {
+      self.hi_ = (self.hi_ << amount) | (self.lo_ >> (64 - amount));
+      self.lo_ = self.lo_ << amount;
+    }
+  } else if (amount < 128) {
+    self.hi_ = self.lo_ << (amount - 64);
+    self.lo_ = 0;
+  } else {
+    self.hi_ = 0;
+    self.lo_ = 0;
+  }
+  return self;
+}
+
+inline uint128& uint128::operator>>=(int amount) {
+  // uint64_t shifts of >= 64 are undefined, so we will need some
+  // special-casing.
+  if (amount < 64) {
+    if (amount != 0) {
+      lo_ = (lo_ >> amount) | (hi_ << (64 - amount));
+      hi_ = hi_ >> amount;
+    }
+  } else if (amount < 128) {
+    lo_ = hi_ >> (amount - 64);
+    hi_ = 0;
+  } else {
+    lo_ = 0;
+    hi_ = 0;
+  }
+  return *this;
+}
+
+inline uint128 operator+(const uint128& lhs, const uint128& rhs) {
+  return uint128(lhs) += rhs;
+}
+
+inline uint128 operator-(const uint128& lhs, const uint128& rhs) {
+  return uint128(lhs) -= rhs;
+}
+
+inline uint128 operator*(const uint128& lhs, const uint128& rhs) {
+  return uint128(lhs) *= rhs;
+}
+
+inline uint128 operator/(const uint128& lhs, const uint128& rhs) {
+  return uint128(lhs) /= rhs;
+}
+
+inline uint128 operator%(const uint128& lhs, const uint128& rhs) {
+  return uint128(lhs) %= rhs;
+}
+
+inline uint128& uint128::operator+=(const uint128& b) {
+  hi_ += b.hi_;
+  uint64_t lolo = lo_ + b.lo_;
+  if (lolo < lo_)
+    ++hi_;
+  lo_ = lolo;
+  return *this;
+}
+
+inline uint128& uint128::operator-=(const uint128& b) {
+  hi_ -= b.hi_;
+  if (b.lo_ > lo_)
+    --hi_;
+  lo_ -= b.lo_;
+  return *this;
+}
+
+inline uint128& uint128::operator*=(const uint128& b) {
+  uint64_t a96 = hi_ >> 32;
+  uint64_t a64 = hi_ & 0xffffffffu;
+  uint64_t a32 = lo_ >> 32;
+  uint64_t a00 = lo_ & 0xffffffffu;
+  uint64_t b96 = b.hi_ >> 32;
+  uint64_t b64 = b.hi_ & 0xffffffffu;
+  uint64_t b32 = b.lo_ >> 32;
+  uint64_t b00 = b.lo_ & 0xffffffffu;
+  // multiply [a96 .. a00] x [b96 .. b00]
+  // terms higher than c96 disappear off the high side
+  // terms c96 and c64 are safe to ignore carry bit
+  uint64_t c96 = a96 * b00 + a64 * b32 + a32 * b64 + a00 * b96;
+  uint64_t c64 = a64 * b00 + a32 * b32 + a00 * b64;
+  this->hi_ = (c96 << 32) + c64;
+  this->lo_ = 0;
+  // add terms after this one at a time to capture carry
+  *this += uint128(a32 * b00) << 32;
+  *this += uint128(a00 * b32) << 32;
+  *this += a00 * b00;
+  return *this;
+}
+
+inline uint128 uint128::operator++(int) {
+  uint128 tmp(*this);
+  *this += 1;
+  return tmp;
+}
+
+inline uint128 uint128::operator--(int) {
+  uint128 tmp(*this);
+  *this -= 1;
+  return tmp;
+}
+
+inline uint128& uint128::operator++() {
+  *this += 1;
+  return *this;
+}
+
+inline uint128& uint128::operator--() {
+  *this -= 1;
+  return *this;
+}
+
+} // namespace c10

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1134,6 +1134,9 @@ endif()
         ${TORCH_ROOT}/test/mobile/nnc
         ${CMAKE_BINARY_DIR}/test_mobile_nnc
       )
+
+      add_subdirectory(${TORCH_ROOT}/test/cpp/lazy
+                       ${CMAKE_BINARY_DIR}/test_lazy)
     endif()
   endif()
 

--- a/test/cpp/lazy/CMakeLists.txt
+++ b/test/cpp/lazy/CMakeLists.txt
@@ -1,0 +1,44 @@
+set(LAZY_TEST_ROOT ${TORCH_ROOT}/test/cpp/lazy)
+
+# Build the cpp gtest binary containing the cpp-only tests.
+set(LAZY_TEST_SRCS
+  ${LAZY_TEST_ROOT}/test_misc.cpp
+)
+
+add_executable(test_lazy
+  ${TORCH_ROOT}/test/cpp/common/main.cpp
+  ${LAZY_TEST_SRCS}
+)
+
+# TODO temporary until we can delete the old gtest polyfills.
+target_compile_definitions(test_lazy PRIVATE USE_GTEST)
+
+set(LAZY_TEST_DEPENDENCIES torch gtest)
+
+target_link_libraries(test_lazy PRIVATE ${LAZY_TEST_DEPENDENCIES})
+target_include_directories(test_lazy PRIVATE ${ATen_CPU_INCLUDE})
+
+if(USE_CUDA)
+  target_link_libraries(test_lazy PRIVATE
+    ${CUDA_LIBRARIES}
+    ${CUDA_NVRTC_LIB}
+    ${CUDA_CUDA_LIB}
+    ${TORCH_CUDA_LIBRARIES})
+
+  target_compile_definitions(test_lazy PRIVATE USE_CUDA)
+elseif(USE_ROCM)
+  target_link_libraries(test_lazy PRIVATE
+    ${ROCM_HIPRTC_LIB}
+    ${PYTORCH_HIP_HCC_LIBRARIES}
+    ${TORCH_CUDA_LIBRARIES})
+
+  target_compile_definitions(test_lazy PRIVATE USE_ROCM)
+endif()
+
+if(INSTALL_TEST)
+  install(TARGETS test_lazy DESTINATION bin)
+  # Install PDB files for MSVC builds
+  if(MSVC AND BUILD_SHARED_LIBS)
+    install(FILES $<TARGET_PDB_FILE:test_lazy> DESTINATION bin OPTIONAL)
+  endif()
+endif()

--- a/test/cpp/lazy/test_misc.cpp
+++ b/test/cpp/lazy/test_misc.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "torch/csrc/lazy/core/hash.h"
+#include "c10/util/int128.h"
+
+namespace torch {
+namespace lazy {
+
+template <typename T>
+void test_hash_repeatable_sensitive(T example_a, T example_b) {
+  // repeatable
+  EXPECT_EQ(Hash(example_a), Hash(example_a));
+
+  // sensitive
+  EXPECT_NE(Hash(example_a), Hash(example_b));
+}
+
+TEST(HashTest, Sanity) {
+  // String
+  test_hash_repeatable_sensitive(
+      std::string(
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut at suscipit purus."),
+      std::string(
+          "Lorem Jpsum dolor sit amet, consectetur adipiscing elit. Ut at suscipit purus."));
+
+  // Number types
+  test_hash_repeatable_sensitive(true, false);
+  test_hash_repeatable_sensitive((int8_t)0xfa, (int8_t)0xfb);
+  test_hash_repeatable_sensitive((int16_t)0xface, (int16_t)0xfade);
+  test_hash_repeatable_sensitive((int32_t)0xfaceb000, (int32_t)0xfadeb000);
+  test_hash_repeatable_sensitive((int64_t)0x1faceb000, (int64_t)0x1fadeb000);
+  test_hash_repeatable_sensitive((uint8_t)0xfa, (uint8_t)0xfb);
+  test_hash_repeatable_sensitive((uint16_t)0xface, (uint16_t)0xfade);
+  test_hash_repeatable_sensitive((uint32_t)0xfaceb000, (uint32_t)0xfadeb000);
+  test_hash_repeatable_sensitive((uint64_t)0x1faceb000, (uint64_t)0x1fadeb000);
+
+  // c10 types
+  test_hash_repeatable_sensitive(c10::ScalarType::Bool, c10::ScalarType::Byte);
+  test_hash_repeatable_sensitive(c10::Scalar(1.334), c10::Scalar(1.335));
+  test_hash_repeatable_sensitive(c10::Scalar(true), c10::Scalar(false));
+  test_hash_repeatable_sensitive(c10::Scalar(12345), c10::Scalar(12354));
+
+  // c10::optional
+  test_hash_repeatable_sensitive(
+      c10::optional<std::string>("I have value!"),
+      c10::optional<std::string>(c10::nullopt));
+
+  // Containers
+  test_hash_repeatable_sensitive(
+      std::vector<int32_t>({0, 1, 1, 2, 3, 5, 8}),
+      std::vector<int32_t>({1, 1, 2, 3, 5, 8, 12}));
+
+}
+
+} // namespace lazy
+} // namespace torch

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -348,7 +348,17 @@ core_sources_full = core_sources_full_mobile + [
     "torch/csrc/jit/tensorexpr/external_functions_codegen.cpp",
 ]
 
-libtorch_core_sources = sorted(core_sources_common + core_sources_full + core_trainer_sources + libtorch_profiler_sources)
+lazy_tensor_core_sources = [
+    "torch/csrc/lazy/core/hash.cpp",
+]
+
+libtorch_core_sources = sorted(
+    core_sources_common +
+    core_sources_full +
+    core_trainer_sources +
+    libtorch_profiler_sources +
+    lazy_tensor_core_sources,
+)
 
 # These files are the only ones that are supported on Windows.
 libtorch_distributed_base_sources = [

--- a/torch/csrc/lazy/core/hash.cpp
+++ b/torch/csrc/lazy/core/hash.cpp
@@ -1,0 +1,89 @@
+#include <iomanip>
+#include <sstream>
+
+#include <torch/csrc/lazy/core/hash.h>
+
+namespace torch {
+namespace lazy {
+namespace {
+
+hash_t LoadHash(const uint8_t** data, const uint8_t* top) {
+  std::ptrdiff_t size = top - (*data);
+  if (size >= (int)sizeof(hash_t)) {
+    hash_t v;
+    std::memcpy(&v, *data, sizeof(v));
+    *data += sizeof(hash_t);
+    return v;
+  }
+  union {
+    hash_t h;
+    std::array<uint8_t, sizeof(hash_t)> b;
+#ifdef _MSC_VER
+  // MSVC (or some versions we use) doesn't support C99 union field init
+  // but it initializes the first member of the union.
+  } uval = {0};
+#else
+  } uval = {.h = 0};
+#endif
+  // use memcpy for compatibility with platforms not supporting unaligned access
+  // note: compiled as single `movl` instr on x64.
+  std::memcpy(uval.b.data(), *data, size);
+  *data += size;
+  return uval.h;
+}
+
+} // namespace
+
+hash_t HashBlock(const void* data, size_t n, const hash_t& seed) {
+  const hash_t m = c10::uint128((uint64_t)0xc6a4a7935bd1e995);
+  const int r = 47;
+
+  const uint8_t* u8_data = reinterpret_cast<const uint8_t*>(data);
+  const uint8_t* top = u8_data + n;
+  hash_t h = seed ^ ((uint64_t)n * m);
+  while (u8_data < top) {
+    hash_t k = LoadHash(&u8_data, top);
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h ^= k;
+    h *= m;
+  }
+  h ^= h >> r;
+  h *= m;
+  h ^= h >> r;
+  return h;
+}
+
+hash_t DataHash(const void* data, size_t size) {
+  return HashBlock(data, size, c10::uint128((uint64_t)0xc2b2ae3d27d4eb4f));
+}
+
+size_t StdDataHash(const void* data, size_t size) {
+  return HashReduce(DataHash(data, size));
+}
+
+size_t StdHashCombine(uintmax_t a, uintmax_t b) {
+  return a ^
+         (b * 0x27d4eb2f165667c5 + 0x9e3779b97f4a7c15 + (a << 6) + (a >> 2));
+}
+
+hash_t HashCombine(const hash_t& a, const hash_t& b) {
+  static const hash_t kb = c10::uint128(101, 0x27d4eb2f165667c5);
+  return a ^ (b * kb + (uint64_t)0x9e3779b97f4a7c15 + (a << 6) + (a >> 2));
+}
+
+size_t HashReduce(const hash_t& a) {
+  return StdHashCombine(c10::Uint128Low64(a), c10::Uint128High64(a));
+}
+
+std::string HashToString(const hash_t& a) {
+  std::stringstream ss;
+  ss << std::hex << c10::Uint128High64(a) << std::setfill('0') << std::setw(16)
+     << Uint128Low64(a);
+  return ss.str();
+}
+
+} // namespace lazy
+} // namespace torch

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -1,0 +1,134 @@
+/**
+ * Hash Utils adapted from PyTorch/XLA
+ * https://github.com/pytorch/xla/blob/e0e5f937a0ba8d904f9608137dc8c51ba439df2d/third_party/xla_client/util.h
+ */
+#pragma once
+
+#include <cstring>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <c10/core/Scalar.h>
+#include <c10/core/ScalarType.h>
+#include <c10/util/int128.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+namespace torch {
+namespace lazy {
+
+using size_t = std::size_t;
+using hash_t = c10::uint128;
+
+// Std* functions use 64-bit hash
+size_t TORCH_API StdDataHash(const void* data, size_t size);
+
+size_t TORCH_API StdHashCombine(uintmax_t a, uintmax_t b);
+
+// Other functions are all 128-bit
+hash_t TORCH_API HashBlock(const void* data, size_t n, const hash_t& seed);
+
+hash_t TORCH_API DataHash(const void* data, size_t size);
+
+hash_t TORCH_API HashCombine(const hash_t& a, const hash_t& b);
+
+size_t TORCH_API HashReduce(const hash_t& a);
+
+// Returns a string representation of a hash
+std::string TORCH_API HashToString(const hash_t& a);
+
+struct HashReducer {
+  size_t operator()(const hash_t& value) const {
+    return HashReduce(value);
+  }
+};
+
+static inline hash_t StringHash(const char* data) {
+  return DataHash(data, std::strlen(data));
+}
+
+// Automatic templated implementation for 'arithmetic' types
+template <
+    typename T,
+    typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+hash_t Hash(const T& value) {
+  return DataHash(&value, sizeof(value));
+}
+
+// Specialiazed implementations for proprietary types
+static inline hash_t Hash(const c10::ScalarType& value) {
+  return DataHash(&value, sizeof(value));
+}
+
+static inline hash_t Hash(const c10::Scalar& value) {
+  return DataHash(&value, sizeof(value));
+}
+
+static inline hash_t Hash(const std::string& value) {
+  return DataHash(value.data(), value.size());
+}
+
+// Taken from glibc's implementation of hashing optionals,
+// we want to include a contribution to the hash to distinguish
+// cases where one or another option was null, but we hope it doesn't
+// collide with an actually scalar value.
+static const int64_t kNullOpt = -3333;
+
+// Hashing for c10::optional types contributes to hash
+// for optionals with null value, important to distinguish
+// between <nullopt, non-nullopt> and <non-nullopt, nullopt> cases
+template <typename T>
+hash_t Hash(const c10::optional<T>& value) {
+  if(value.has_value()){
+    return Hash(value.value());
+  } else {
+    return Hash(kNullOpt);
+  }
+}
+
+// Hashing of containers
+// Forward declare to allow hashes of vectors of vectors to work.
+template <typename T>
+hash_t ContainerHash(const T& values);
+
+template <typename T>
+hash_t Hash(const std::vector<T>& values) {
+  return ContainerHash(values);
+}
+
+template <typename T>
+hash_t Hash(const std::set<T>& values) {
+  return ContainerHash(values);
+}
+
+template <typename T, typename S>
+hash_t Hash(const std::pair<T, S>& values) {
+  return HashCombine(Hash(values.first), Hash(values.second));
+}
+
+static inline hash_t Hash(const hash_t& value) {
+  return value;
+}
+
+template <typename T>
+hash_t ContainerHash(const T& values) {
+  hash_t h = c10::uint128((uint64_t)0x85ebca77c2b2ae63);
+  for (auto& value : values) {
+    h = HashCombine(h, Hash(value));
+  }
+  return h;
+}
+
+// Varargs hashing
+template <typename T = void>
+hash_t MHash() {
+  return c10::uint128((uint64_t)0x165667b19e3779f9);
+}
+
+template <typename T, typename... Targs>
+hash_t MHash(T value, Targs... Fargs) {
+  return HashCombine(Hash(value), MHash(Fargs...));
+}
+
+} // namespace lazy
+} // namespace torch


### PR DESCRIPTION
These utils are prerequisites for Lazy Node base class.

- set up new torch/csrc/lazy, test/cpp/lazy dirs
- add source files to build_variables.bzl in new lazy_core_sources var
- create new test_lazy binary

Fixes #65636 
