### PR TITLE
Add nn.function.hardtanh in acc_tracer

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -411,6 +411,18 @@ def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
     return node.kwargs["input"]
 
 @register_acc_op_mapping(
+    op_and_target=("call_function", nn.functional.hardtanh),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("min_val", "left"),
+        ("max_val", "right"),
+    ],
+)
+@register_acc_op
+def hardtanh(*, input, left, right):
+    return nn.functional.hardtanh(input, min_val=left, max_val=right)
+
+@register_acc_op_mapping(
     op_and_target=("call_function", nn.functional.hardsigmoid))
 @register_acc_op
 def hardsigmoid(*, input):


### PR DESCRIPTION
Summary: This op is used by mobilenet v2.

Test Plan:
buck test glow/fb/fx/oss_acc_tracer:test_acc_tracer -- test_hardtanh
buck test glow/fb/fx/acc_tracer:test_acc_shape_inference -- hardtanh
buck test glow/fb/fx/oss_acc_tracer:test_acc_tracer -- test_hardtanh

Differential Revision: D31184297

