### PR TITLE
MaxUnpooling: parallel_for not always backed by OMP

### DIFF
--- a/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
@@ -5,6 +5,8 @@
 #include <ATen/native/Pool.h>
 #include <ATen/native/cpu/utils.h>
 
+#include <c10/util/Optional.h>
+
 namespace at { namespace native {
 
 namespace {
@@ -50,8 +52,7 @@ void cpu_max_unpool(
   int64_t input_image_size = numel / channels;
   int64_t output_image_size = output.numel() / channels;
 
-  bool has_error = false;
-  int64_t error_index = 0;
+  std::atomic<c10::optional<int64_t>> optional_error_index;
 
   // parallel on dim N, C, D, H, W: [channels, input_image_size]
   at::parallel_for(0, numel, 0, [&](int64_t begin, int64_t end) {
@@ -64,11 +65,7 @@ void cpu_max_unpool(
 
       int64_t maxp = indices_data[i];
       if (maxp < 0 || maxp >= output_image_size) {
-        #pragma omp critical
-        {
-          has_error = true;
-          error_index = maxp;
-        }
+        optional_error_index = maxp;
       } else {
         output_ptr[maxp] = input_data[i];
       }
@@ -78,14 +75,14 @@ void cpu_max_unpool(
     }
   });
 
-  if (has_error) {
+  if (auto error_index = optional_error_index.load()) {
     if (is_3d) {
-      AT_ERROR("Found an invalid max index: ", error_index,
+      AT_ERROR("Found an invalid max index: ", error_index.value(),
           " (output volumes are of size ", output_depth,
           "x", output_height, "x", output_width);
       (void)error_index;
     } else {
-      AT_ERROR("Found an invalid max index: ", error_index,
+      AT_ERROR("Found an invalid max index: ", error_index.value(),
           " (output volumes are of size ", output_height,
           "x", output_width);
       (void)error_index;
@@ -120,8 +117,7 @@ void cpu_max_unpool_channels_last(
   int64_t input_image_size = input_height * input_width;
   int64_t output_image_size = output_height * output_width;
 
-  bool has_error = false;
-  int64_t error_index = 0;
+  std::atomic<c10::optional<int64_t>> optional_error_index;
 
   // parallel on dim N, H, W
   at::parallel_for(0, nbatch * input_image_size, 0, [&](int64_t begin, int64_t end) {
@@ -138,11 +134,7 @@ void cpu_max_unpool_channels_last(
       for (int64_t c = 0; c < channels; c++) {
         int64_t maxp = indices_ptr[c];
         if (maxp < 0 || maxp >= output_image_size) {
-          #pragma omp critical
-          {
-            has_error = true;
-            error_index = maxp;
-          }
+          optional_error_index = maxp;
         } else {
           output_ptr[maxp * channels + c] = input_ptr[c];
         }
@@ -153,8 +145,8 @@ void cpu_max_unpool_channels_last(
     }
   });
 
-  if (has_error) {
-    AT_ERROR("Found an invalid max index: ", error_index,
+  if (auto error_index = optional_error_index.load()) {
+    AT_ERROR("Found an invalid max index: ", error_index.value(),
         " (output volumes are of size ", output_height,
         "x", output_width);
     (void)error_index;
@@ -198,8 +190,7 @@ void cpu_max_unpool_backward(
   int64_t input_image_size = numel / channels;
   int64_t output_image_size = grad_output.numel() / channels;
 
-  bool has_error = false;
-  int64_t error_index = 0;
+  std::atomic<c10::optional<int64_t>> optional_error_index;
 
   // parallel on dim N, C, D, H, W
   at::parallel_for(0, numel, 0, [&](int64_t begin, int64_t end) {
@@ -212,11 +203,7 @@ void cpu_max_unpool_backward(
 
       int64_t maxp = indices_data[i];
       if (maxp < 0 || maxp >= output_image_size) {
-        #pragma omp critical
-        {
-          has_error = true;
-          error_index = maxp;
-        }
+          optional_error_index = maxp;
       } else {
         grad_input_data[i] = grad_output_ptr[maxp];
       }
@@ -226,15 +213,15 @@ void cpu_max_unpool_backward(
     }
   });
 
-  if (has_error) {
+  if (auto error_index = optional_error_index.load()) {
     if (is_3d) {
-      AT_ERROR("invalid max index ", error_index,
+      AT_ERROR("invalid max index ", error_index.value(),
           ", odepth= ", output_depth,
           ", owidth= ", output_width,
           ", oheight= ", output_height);
       (void)error_index;
     } else {
-      AT_ERROR("invalid max index ", error_index,
+      AT_ERROR("invalid max index ", error_index.value(),
           ", owidth= ", output_width,
           ", oheight= ", output_height);
       (void)error_index;
@@ -269,8 +256,7 @@ void cpu_max_unpool_backward_channels_last(
   int64_t input_image_size = input_height * input_width;
   int64_t output_image_size = output_height * output_width;
 
-  bool has_error = false;
-  int64_t error_index = 0;
+  std::atomic<c10::optional<int64_t>> optional_error_index;
 
   // parallel on dim N, H, W
   at::parallel_for(0, nbatch * input_image_size, 0, [&](int64_t begin, int64_t end) {
@@ -286,11 +272,7 @@ void cpu_max_unpool_backward_channels_last(
       for (int64_t c = 0; c < channels; c++) {
         int64_t maxp = indices_ptr[c];
         if (maxp < 0 || maxp >= output_image_size) {
-          #pragma omp critical
-          {
-            has_error = true;
-            error_index = maxp;
-          }
+          optional_error_index = maxp;
         } else {
           grad_input_ptr[c] = grad_output_ptr[maxp * channels + c];
         }
@@ -301,8 +283,8 @@ void cpu_max_unpool_backward_channels_last(
     }
   });
 
-  if (has_error) {
-    AT_ERROR("invalid max index ", error_index,
+  if (auto error_index = optional_error_index.load()) {
+    AT_ERROR("invalid max index ", error_index.value(),
         ", owidth= ", output_width,
         ", oheight= ", output_height);
     (void)error_index;


### PR DESCRIPTION
Use `atomic_optional` instead of `#pragma omp critical` inside max_unpooling kernels

Using any OpenMP pragma in `at::parallel_for` body is wrong, as it can
be implemented using native treading algorithms such as ptrheads

`c10::optional` sounds like a much better approach to pair of
`has_error` and `error_index` variables, but unfortunately wrapping `c10::optional` in `std::atomic` for some reason to requires 16-bit atomic primitives, which is not part of compiler runtime for older Linux systems 

It also fixes ICE reported in https://github.com/pytorch/pytorch/issues/65578

