### PR TITLE
Make empty* and *_like factory functions respect tensor subclasses

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1777,6 +1777,8 @@
     MkldnnCPU: empty_mkldnn
     SparseCPU, SparseCUDA: empty_sparse
 
+# We do not make new_empty a composite that calls into new_empty_strided, as the strided version
+# is significantly more difficult to implement by different backends
 - func: new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   variants: method
   dispatch:
@@ -1784,6 +1786,8 @@
 
 - func: new_empty_strided(Tensor self, int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   variants: method
+  dispatch:
+    CompositeExplicitAutograd: new_empty_strided
 
 - func: new_full(Tensor self, int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   variants: method
@@ -1831,6 +1835,8 @@
 - func: empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   device_check: NoCheck
   device_guard: False
+  dispatch:
+    CompositeExplicitAutograd: empty_like
 
 - func: empty_strided(int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -384,6 +384,21 @@ $6 = torch._ops.aten.add_($1, $5)''')
 
         self.assertEqual(type(MyTensor(2).new_ones(3)), MyTensor)
 
+    def test_like(self) -> None:
+        class MyTensor(torch.Tensor):
+            __torch_function__ = torch._C._disabled_torch_function_impl
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                return MyTensor(3)
+
+        for f in ["empty", "ones", "rand", "randn", "zeros"]:
+            f_name = f + "_like"
+            self.assertEqual(type(getattr(torch, f_name)(MyTensor(2))), MyTensor)
+
+        self.assertEqual(type(torch.full_like(MyTensor(2), 1.)), MyTensor)
+        self.assertEqual(type(torch.randint_like(MyTensor(2), high=3)), MyTensor)
+
     def test_enable_python_mode_error(self) -> None:
         with self.assertRaisesRegex(ValueError, "__torch_dispatch__"):
             with enable_python_mode(torch.Tensor):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2319,5 +2319,14 @@
 - name: _pin_memory(Tensor self, Device? device=None) -> Tensor
   self: grad
 
+# Empty factory functions have explicit non-differentiability so that they propagate the class
+# when used with a Tensor subclass together with __torch_dispatch__.
+# All the other factory functions are composite and call into one of these.
 - name: new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  output_differentiability: [False]
+
+- name: new_empty_strided(Tensor self, int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  output_differentiability: [False]
+
+- name: empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
   output_differentiability: [False]

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2323,10 +2323,13 @@
 # when used with a Tensor subclass together with __torch_dispatch__.
 # All the other factory functions are composite and call into one of these.
 - name: new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  self: non_differentiable
   output_differentiability: [False]
 
 - name: new_empty_strided(Tensor self, int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  self: non_differentiable
   output_differentiability: [False]
 
 - name: empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+  self: non_differentiable
   output_differentiability: [False]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/65243


cc @albanD