### PR TITLE
[Static Runtime] Implement jump instruction

### DIFF
--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -56,10 +56,7 @@ class ModuleStaticRuntimeTestContext : public StaticRuntimeTestContext {
 class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
  public:
   explicit GraphStaticRuntimeContext(const std::string& source_ir) {
-    graph_ = std::make_shared<Graph>();
-    std::unordered_map<std::string, Value*> vmap;
-    parseIR(source_ir, graph_.get(), vmap);
-
+    graph_ = getGraphFromIR(source_ir);
     graph_exec_ = GraphExecutor(graph_, "");
   }
 
@@ -173,6 +170,13 @@ void compareResults(
 }
 
 } // namespace
+
+std::shared_ptr<Graph> getGraphFromIR(const std::string& ir) {
+    auto graph = std::make_shared<Graph>();
+    std::unordered_map<std::string, Value*> vmap;
+    parseIR(ir, graph.get(), vmap);
+    return graph;
+}
 
 void testStaticRuntime(
     const std::string& source,

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <torch/csrc/jit/ir/ir.h>
 
 namespace c10 {
 struct IValue;
@@ -25,6 +26,8 @@ void testStaticRuntime(
     const std::vector<c10::IValue>& args2 = {},
     const bool use_allclose = false,
     const bool use_equalnan = false);
+
+std::shared_ptr<Graph> getGraphFromIR(const std::string& ir);
 
 } // namespace test
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -331,6 +331,8 @@ class TORCH_API StaticRuntime {
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_API ProcessedNode {
  public:
+  static constexpr size_t NO_JUMP_TARGET = std::numeric_limits<size_t>::max();
+
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ProcessedNode() = default;
   ProcessedNode(
@@ -384,6 +386,14 @@ class TORCH_API ProcessedNode {
     return op_name_;
   }
 
+  void set_jump_target(size_t loc) {
+    jump_target_ = loc;
+  }
+
+  size_t get_jump_target() const {
+    return jump_target_;
+  }
+
  private:
   void run_impl();
 
@@ -394,6 +404,7 @@ class TORCH_API ProcessedNode {
   std::vector<const IValue*> inputs_; // unowned
   std::vector<IValue> outputs_;
   const char* op_name_;
+  size_t jump_target_ = NO_JUMP_TARGET;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -471,5 +471,41 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         }
       };
     });
+
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    static_runtime::JumpIf,
+    static_runtime_JumpIf,
+    [](Node*) -> SROperator {
+      return [](ProcessedNode* pnode) {
+        if (pnode->Input(0).toBool()) {
+          pnode->set_jump_target(pnode->Input(1).toInt());
+        } else {
+          pnode->set_jump_target(ProcessedNode::NO_JUMP_TARGET);
+        }
+      };
+    });
+
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    static_runtime::JumpIfNot,
+    static_runtime_JumpIfNot,
+    [](Node*) -> SROperator {
+      return [](ProcessedNode* pnode) {
+        if (!pnode->Input(0).toBool()) {
+          pnode->set_jump_target(pnode->Input(1).toInt());
+        } else {
+          pnode->set_jump_target(ProcessedNode::NO_JUMP_TARGET);
+        }
+      };
+    });
+
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    static_runtime::Jump,
+    static_runtime_Jump,
+    [](Node*) -> SROperator {
+      return [](ProcessedNode* pnode) {
+        pnode->set_jump_target(pnode->Input(0).toInt());
+      };
+    });
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -25,6 +25,8 @@ TORCH_API bool HasInplaceOp(
 
 TORCH_API bool forwardHasOp(const Module& module, const char* op_name);
 
+TORCH_API bool hasJumpOps(std::shared_ptr<Graph>& graph);
+
 TORCH_API void FuseSignLog1P(std::shared_ptr<Graph>& graph);
 
 TORCH_API void UseVariadicTupleUnpack(const std::shared_ptr<Graph>& graph);


### PR DESCRIPTION
Summary:
Add the following ops to SR:

* `static_runtime::JumpIf{Not}(%condition : bool, %target : int) -> ()`
* `static_runtime::Jump(%target: int) -> ()`

Jump ops are needed for implementing control flow. The mechanism for jumping works like this:

* In the execution loop, we keep track of an instruction pointer `ip`.
* Each `ProcessedNode` now keeps track of a `jump_target` that ops may write to. The target defaults to -1.
* After executing each node, if `jump_target != -1`, set `ip = jump_target`. Else, set `ip = ip + 1`.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- ControlFlow`

Differential Revision: D31110834

