### PR TITLE
[quant] adding memoryless observers for embeddingbag QAT work

### DIFF
--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -370,12 +370,12 @@ class TestObserver(QuantizationTestCase):
             x = obs(x)
 
     def _test_memoryless(self, obs_class):
-        obs=obs_class(memoryless = True)
-        x = torch.randn((3,3))
+        obs = obs_class(memoryless=True)
+        x = torch.randn((3, 3))
         obs(x)
         params = obs.calculate_qparams()
         for _ in range(20):
-            obs(torch.randn((3,3)))
+            obs(torch.randn((3, 3)))
             self.assertNotEqual(params, obs.calculate_qparams())
             obs(x)
             self.assertEqual(params, obs.calculate_qparams())
@@ -383,11 +383,17 @@ class TestObserver(QuantizationTestCase):
     def test_memoryless_minmaxobserver(self):
         self._test_memoryless(MinMaxObserver)
 
-    def test_memoryless_per_channel_minmaxobserver(self):
+    def test_memoryless_perchannelminmaxobserver(self):
         self._test_memoryless(PerChannelMinMaxObserver)
 
-    def test_memoryless_per_channel_histogramobserver(self):
+    def test_memoryless_histogramobserver(self):
         self._test_memoryless(HistogramObserver)
+
+    def test_memoryless_movingaverageminmaxobserver(self):
+        self._test_memoryless(MovingAverageMinMaxObserver)
+
+    def test_memoryless_movingaverageperchannelminmaxobserver(self):
+        self._test_memoryless(MovingAveragePerChannelMinMaxObserver)
 
 
 

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -396,7 +396,6 @@ class TestObserver(QuantizationTestCase):
         self._test_memoryless(MovingAveragePerChannelMinMaxObserver)
 
 
-
 # HistogramObserver that works like it does on master
 class _ReferenceHistogramObserver(HistogramObserver):
     def __init__(self, *args, **kwargs):

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -386,16 +386,6 @@ class TestObserver(QuantizationTestCase):
     def test_memoryless_perchannelminmaxobserver(self):
         self._test_memoryless(PerChannelMinMaxObserver)
 
-    def test_memoryless_histogramobserver(self):
-        self._test_memoryless(HistogramObserver)
-
-    def test_memoryless_movingaverageminmaxobserver(self):
-        self._test_memoryless(MovingAverageMinMaxObserver)
-
-    def test_memoryless_movingaverageperchannelminmaxobserver(self):
-        self._test_memoryless(MovingAveragePerChannelMinMaxObserver)
-
-
 # HistogramObserver that works like it does on master
 class _ReferenceHistogramObserver(HistogramObserver):
     def __init__(self, *args, **kwargs):

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -369,6 +369,27 @@ class TestObserver(QuantizationTestCase):
             # verify no crash
             x = obs(x)
 
+    def _test_memoryless(self, obs_class):
+        obs=obs_class(memoryless = True)
+        x = torch.randn((3,3))
+        obs(x)
+        params = obs.calculate_qparams()
+        for _ in range(20):
+            obs(torch.randn((3,3)))
+            self.assertNotEqual(params, obs.calculate_qparams())
+            obs(x)
+            self.assertEqual(params, obs.calculate_qparams())
+
+    def test_memoryless_minmaxobserver(self):
+        self._test_memoryless(MinMaxObserver)
+
+    def test_memoryless_per_channel_minmaxobserver(self):
+        self._test_memoryless(PerChannelMinMaxObserver)
+
+    def test_memoryless_per_channel_histogramobserver(self):
+        self._test_memoryless(HistogramObserver)
+
+
 
 # HistogramObserver that works like it does on master
 class _ReferenceHistogramObserver(HistogramObserver):

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -375,7 +375,7 @@ class TestObserver(QuantizationTestCase):
         obs(x)
         params = obs.calculate_qparams()
         for _ in range(20):
-            obs(torch.randn((3, 3)))
+            obs(10*torch.randn((3, 3)))
             self.assertNotEqual(params, obs.calculate_qparams())
             obs(x)
             self.assertEqual(params, obs.calculate_qparams())

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -375,7 +375,7 @@ class TestObserver(QuantizationTestCase):
         obs(x)
         params = obs.calculate_qparams()
         for _ in range(20):
-            obs(10*torch.randn((3, 3)))
+            obs(10 * torch.randn((3, 3)))
             self.assertNotEqual(params, obs.calculate_qparams())
             obs(x)
             self.assertEqual(params, obs.calculate_qparams())

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -521,7 +521,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
-            memoryless = memoryless,
+            memoryless=memoryless,
             quant_min=quant_min,
             quant_max=quant_max,
             **kwargs
@@ -851,6 +851,7 @@ class HistogramObserver(_ObserverBase):
             reduce_range=reduce_range,
             factory_kwargs=factory_kwargs,
         )
+        self.memoryless = memoryless
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.bins = bins
         self.register_buffer("histogram", torch.zeros(self.bins, **factory_kwargs))

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -397,10 +397,10 @@ class MinMaxObserver(_ObserverBase):
         dtype=torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
-        memoryless=False,
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
+        memoryless=False,
     ) -> None:
 
         # For x86 quantized kernels, we need to ensure that the vpmaddubsw
@@ -511,9 +511,9 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         dtype=torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
-        memoryless=False,
         quant_min=None,
         quant_max=None,
+        memoryless=False,
         **kwargs
     ) -> None:
         self.averaging_constant = averaging_constant
@@ -521,9 +521,9 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
-            memoryless=memoryless,
             quant_min=quant_min,
             quant_max=quant_max,
+            memoryless=memoryless,
             **kwargs
         )
 
@@ -579,10 +579,10 @@ class PerChannelMinMaxObserver(_ObserverBase):
         dtype=torch.quint8,
         qscheme=torch.per_channel_affine,
         reduce_range=False,
-        memoryless=False,
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
+        memoryless=False,
     ) -> None:
         super(PerChannelMinMaxObserver, self).__init__(
             dtype=dtype,
@@ -762,9 +762,9 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         dtype=torch.quint8,
         qscheme=torch.per_channel_affine,
         reduce_range=False,
-        memoryless=False,
         quant_min=None,
         quant_max=None,
+        memoryless=False,
         **kwargs
     ) -> None:
         super(MovingAveragePerChannelMinMaxObserver, self).__init__(
@@ -772,9 +772,9 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
-            memoryless=memoryless,
             quant_min=quant_min,
             quant_max=quant_max,
+            memoryless=memoryless,
             **kwargs
         )
         self.averaging_constant = averaging_constant
@@ -841,8 +841,8 @@ class HistogramObserver(_ObserverBase):
         dtype: torch.dtype = torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
-        memoryless=False,
         factory_kwargs=None,
+        memoryless=False,
     ) -> None:
         # bins: The number of bins used for histogram calculation.
         super(HistogramObserver, self).__init__(

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -397,6 +397,7 @@ class MinMaxObserver(_ObserverBase):
         dtype=torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
+        memoryless=False,
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
@@ -416,6 +417,7 @@ class MinMaxObserver(_ObserverBase):
             quant_max=quant_max,
             factory_kwargs=factory_kwargs,
         )
+        self.memoryless = memoryless
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs))
         self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs))
@@ -433,6 +435,8 @@ class MinMaxObserver(_ObserverBase):
         r"""Records the running minimum and maximum of ``x``."""
         if x_orig.numel() == 0:
             return x_orig
+        elif self.memoryless:
+            self.reset_min_max_vals()
         x = x_orig.detach()  # avoid keeping autograd tape
         x = x.to(self.min_val.dtype)
         min_val_cur, max_val_cur = torch._aminmax(x)
@@ -454,8 +458,8 @@ class MinMaxObserver(_ObserverBase):
     @torch.jit.export
     def reset_min_max_vals(self):
         """Resets the min/max values."""
-        self.min_val = torch.tensor(float("inf"))
-        self.max_val = torch.tensor(float("-inf"))
+        self.min_val.copy_(torch.tensor(float("inf")))
+        self.max_val.copy_(torch.tensor(float("-inf")))
 
 class MovingAverageMinMaxObserver(MinMaxObserver):
     r"""Observer module for computing the quantization parameters based on the
@@ -507,6 +511,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         dtype=torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
+        memoryless=False,
         quant_min=None,
         quant_max=None,
         **kwargs
@@ -516,6 +521,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
+            memoryless = memoryless,
             quant_min=quant_min,
             quant_max=quant_max,
             **kwargs
@@ -528,7 +534,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         x = x.to(self.min_val.dtype)
         min_val = self.min_val
         max_val = self.max_val
-        if min_val == float("inf") and max_val == float("-inf"):
+        if (min_val == float("inf") and max_val == float("-inf")) or self.memoryless:
             min_val, max_val = torch._aminmax(x)
         else:
             min_val_cur, max_val_cur = torch._aminmax(x)
@@ -573,6 +579,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
         dtype=torch.quint8,
         qscheme=torch.per_channel_affine,
         reduce_range=False,
+        memoryless=False,
         quant_min=None,
         quant_max=None,
         factory_kwargs=None,
@@ -585,6 +592,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
             quant_max=quant_max,
             factory_kwargs=factory_kwargs,
         )
+        self.memoryless = memoryless
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.ch_axis = ch_axis
         self.register_buffer("min_val", torch.tensor([], **factory_kwargs))
@@ -617,7 +625,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
         # are done in place and types need to match for comparisons
         y = y.to(self.min_val.dtype)
         y = torch.flatten(y, start_dim=1)
-        if min_val.numel() == 0 or max_val.numel() == 0:
+        if min_val.numel() == 0 or max_val.numel() == 0 or self.memoryless:
             min_val, max_val = torch._aminmax(y, 1)
         else:
             min_val_cur, max_val_cur = torch._aminmax(y, 1)
@@ -754,6 +762,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         dtype=torch.quint8,
         qscheme=torch.per_channel_affine,
         reduce_range=False,
+        memoryless=False,
         quant_min=None,
         quant_max=None,
         **kwargs
@@ -763,6 +772,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
+            memoryless=memoryless,
             quant_min=quant_min,
             quant_max=quant_max,
             **kwargs
@@ -783,7 +793,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         new_axis_list[0] = self.ch_axis
         y = x.permute(new_axis_list)
         y = torch.flatten(y, start_dim=1)
-        if min_val.numel() == 0 or max_val.numel() == 0:
+        if min_val.numel() == 0 or max_val.numel() == 0 or self.memoryless:
             min_val, max_val = torch._aminmax(y, 1)
         else:
             min_val_cur, max_val_cur = torch._aminmax(y, 1)
@@ -831,6 +841,7 @@ class HistogramObserver(_ObserverBase):
         dtype: torch.dtype = torch.quint8,
         qscheme=torch.per_tensor_affine,
         reduce_range=False,
+        memoryless=False,
         factory_kwargs=None,
     ) -> None:
         # bins: The number of bins used for histogram calculation.
@@ -1047,7 +1058,7 @@ class HistogramObserver(_ObserverBase):
         max_val = self.max_val
         same_values = min_val.item() == max_val.item()
         is_uninitialized = min_val == float("inf") and max_val == float("-inf")
-        if is_uninitialized or same_values:
+        if is_uninitialized or same_values or self.memoryless:
             min_val, max_val = torch._aminmax(x)
             self.min_val.resize_(min_val.shape)
             self.min_val.copy_(min_val)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65443
* __->__ #65699

Summary: 
related to: https://github.com/pytorch/pytorch/pull/65443#discussion_r715132425

The QAT and PAT (pruning aware training) support for embedding bags needs a memoryless observer to work properly. This is necessitated by the changing pruned/non-pruned weights during training which can significantly change the quantization parameters.

This PR adds a memoryless flag to the simpler observer classes (not moving average since those explicitly have memory)

In addition to the above, I altered the reset_min_max_vals
function for MinMaxObserver so that it would preserve the device of the
existing self.min_val and self.max_val which was not preserved
previously compared to how it is initialized (using factory_kwargs)

Test Plan:

python test/test_quantization.py TestObserver

(added test_memoryless_minmaxobserver, test_memoryless_per_channel_minmaxobserver, test_memoryless_histogramobserver)

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31209773](https://our.internmc.facebook.com/intern/diff/D31209773)