### PR TITLE
[LTC] Lower convolution_overrideable to _convolution

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_backward_overrideable.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_backward_overrideable.cpp
@@ -30,6 +30,19 @@ ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
       [&]() { return compiler::NodeLowering::Get()->Infer(this); });
 }
 
+ConvolutionBackwardOverrideable::ConvolutionBackwardOverrideable(
+    const Value& grad_output, const Value& input, const Value& weight,
+    std::vector<lazy_tensors::int64> stride,
+    std::vector<lazy_tensors::int64> padding,
+    std::vector<lazy_tensors::int64> dilation, bool transposed,
+    std::vector<lazy_tensors::int64> output_padding, lazy_tensors::int64 groups,
+    std::array<bool, 3> output_mask)
+    : ConvolutionBackwardOverrideable(grad_output, input, weight, stride,
+                                      padding, dilation, transposed,
+                                      output_padding, groups) {
+  output_mask_ = std::move(output_mask);
+}
+
 NodePtr ConvolutionBackwardOverrideable::Clone(OpList operands) const {
   return MakeNode<ConvolutionBackwardOverrideable>(
       operands.at(0), operands.at(1), operands.at(2), stride_, padding_,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_backward_overrideable.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_backward_overrideable.h
@@ -18,6 +18,14 @@ class ConvolutionBackwardOverrideable : public Node {
       std::vector<lazy_tensors::int64> output_padding,
       lazy_tensors::int64 groups);
 
+  ConvolutionBackwardOverrideable(
+      const Value& grad_output, const Value& input, const Value& weight,
+      std::vector<lazy_tensors::int64> stride,
+      std::vector<lazy_tensors::int64> padding,
+      std::vector<lazy_tensors::int64> dilation, bool transposed,
+      std::vector<lazy_tensors::int64> output_padding,
+      lazy_tensors::int64 groups, std::array<bool, 3> output_mask);
+
   NodePtr Clone(OpList operands) const override;
 
   std::string ToString() const override;
@@ -36,6 +44,8 @@ class ConvolutionBackwardOverrideable : public Node {
 
   lazy_tensors::int64 groups() const { return groups_; }
 
+  std::array<bool, 3> output_mask() const { return output_mask_; }
+
  private:
   std::vector<lazy_tensors::int64> stride_;
   std::vector<lazy_tensors::int64> padding_;
@@ -43,6 +53,7 @@ class ConvolutionBackwardOverrideable : public Node {
   std::vector<lazy_tensors::int64> output_padding_;
   bool transposed_;
   lazy_tensors::int64 groups_;
+  std::array<bool, 3> output_mask_;
 };
 
 }  // namespace ops

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -442,7 +442,7 @@ class LazyTensor {
       std::vector<lazy_tensors::int64> padding,
       std::vector<lazy_tensors::int64> dilation, bool transposed,
       std::vector<lazy_tensors::int64> output_padding,
-      lazy_tensors::int64 groups);
+      lazy_tensors::int64 groups, std::array<bool, 3> output_mask);
 
   static LazyTensor convolution_overrideable(
       const LazyTensor& input, const LazyTensor& weight,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -980,12 +980,12 @@ LazyTensor::convolution_backward_overrideable(
     const LazyTensor& weight, std::vector<lazy_tensors::int64> stride,
     std::vector<lazy_tensors::int64> padding,
     std::vector<lazy_tensors::int64> dilation, bool transposed,
-    std::vector<lazy_tensors::int64> output_padding,
-    lazy_tensors::int64 groups) {
+    std::vector<lazy_tensors::int64> output_padding, lazy_tensors::int64 groups,
+    std::array<bool, 3> output_mask) {
   ir::NodePtr node = ir::MakeNode<ir::ops::ConvolutionBackwardOverrideable>(
       out_backprop.GetIrValue(), input.GetIrValue(), weight.GetIrValue(),
       std::move(stride), std::move(padding), std::move(dilation), transposed,
-      std::move(output_padding), groups);
+      std::move(output_padding), groups, std::move(output_mask));
   LazyTensor grad_input = out_backprop.CreateFrom(ir::Value(node, 0));
   LazyTensor grad_weight = out_backprop.CreateFrom(ir::Value(node, 1));
   LazyTensor grad_bias = out_backprop.CreateFrom(ir::Value(node, 2));

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -270,7 +270,8 @@ LazyNativeFunctions::convolution_backward_overrideable(
     int64_t groups, std::array<bool, 3> output_mask) {
   // Lower to cudnn_convolution_backward when possbile
   if (at::globalContext().userEnabledCuDNN() &&
-      lazy_tensors::sys_util::GetEnvBool("LTC_TS_CUDA", true)) {
+      lazy_tensors::compiler::TSComputationClient::HardwareDeviceType() ==
+          at::kCUDA) {
     LTC_FN_COUNTER("lazy::");
     auto result = LazyTensor::convolution_backward_overrideable(
         bridge::GetLtcTensor(grad_output), bridge::GetLtcTensor(input),

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -704,8 +704,10 @@ class TSNodeLowering : public NodeLowering {
 
     // TODO: Clean up after convolution unification is done.
     auto& ctx = at::globalContext();
-    LTC_CHECK(ctx.userEnabledCuDNN() &&
-              lazy_tensors::sys_util::GetEnvBool("LTC_TS_CUDA", true));
+    LTC_CHECK(
+        ctx.userEnabledCuDNN() &&
+        lazy_tensors::compiler::TSComputationClient::HardwareDeviceType() ==
+            at::kCUDA);
 
     // See cudnn_convolution_backward/cudnn_convolution_transpose_backward in
     // native_functions.yaml


### PR DESCRIPTION
Currently convolution_overrideable is implemented as a special fallback
due to the implementation limitations of convolution in Eager, which
brings two problems, 1) graph fragementation 2) fallback convolution
kernel may not be using the most efficient version for that device.
This PR fixes the forward convolution by lowering it to _convolution,
and it is verified to work for CPU and CUDA.