### PR TITLE
Remove confusing SHARD_NUMBER resetting logic

### DIFF
--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -109,6 +109,7 @@ on:
             -e GITHUB_ACTIONS \
             -e IN_CI \
             -e SHARD_NUMBER \
+            -e NUM_TEST_SHARDS \
             -e JOB_BASE_NAME \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -305,9 +305,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -233,9 +233,6 @@ jobs:
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |
-            if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-              export SHARD_NUMBER=0
-            fi
             .jenkins/pytorch/win-test.sh
       !{{ common.upload_test_reports(name='windows') }}
       !{{ common.render_test_results() }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -438,9 +438,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -438,9 +438,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -438,9 +438,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -438,9 +438,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -438,9 +438,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -282,6 +282,7 @@ jobs:
             -e GITHUB_ACTIONS \
             -e IN_CI \
             -e SHARD_NUMBER \
+            -e NUM_TEST_SHARDS \
             -e JOB_BASE_NAME \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e SCCACHE_BUCKET \

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -438,9 +438,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -436,9 +436,6 @@ jobs:
           else
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
-          if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-            export SHARD_NUMBER=0
-          fi
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -224,9 +224,6 @@ jobs:
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |
-            if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-              export SHARD_NUMBER=0
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -206,9 +206,6 @@ jobs:
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |
-            if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-              export SHARD_NUMBER=0
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda10.2-py3.yml
@@ -226,9 +226,6 @@ jobs:
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |
-            if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-              export SHARD_NUMBER=0
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -226,9 +226,6 @@ jobs:
         # Time out the test phase after 3.5 hours
         timeout-minutes: 210
         run: |
-            if [[ $NUM_TEST_SHARDS -ne 2 ]]; then
-              export SHARD_NUMBER=0
-            fi
             .jenkins/pytorch/win-test.sh
       - name: Zip test reports for upload
         if: always()

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -507,7 +507,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *jit_legacy-test || "${JOB_BASE_NAME}" == *jit
 elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   # TODO: run some C++ tests
   echo "no-op at the moment"
-elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 || "${SHARD_NUMBER}" == 1 ]]; then
+elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 || ("${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1) ]]; then
   if [[ "${BUILD_ENVIRONMENT}" == *linux-xenial-cuda11.1*-test1* ]]; then
     test_torch_deploy
   fi
@@ -515,7 +515,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 || "$
   install_torchvision
   test_python_shard1
   test_aten
-elif [[ "${BUILD_ENVIRONMENT}" == *-test2 || "${JOB_BASE_NAME}" == *-test2 || "${SHARD_NUMBER}" == 2 ]]; then
+elif [[ "${BUILD_ENVIRONMENT}" == *-test2 || "${JOB_BASE_NAME}" == *-test2 || ("${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1) ]]; then
   install_torchvision
   test_python_shard2
   test_libtorch

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -80,7 +80,7 @@ run_tests() {
           "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
         fi
     else
-        if [[ "${JOB_BASE_NAME}" == *-test1 || "${SHARD_NUMBER}" == 1 ]]; then
+        if [[ "${JOB_BASE_NAME}" == *-test1 || ("${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1) ]]; then
             "$SCRIPT_HELPERS_DIR"/test_python_first_shard.bat "$DETERMINE_FROM"
 
             if [[ -z ${RUN_SMOKE_TESTS_ONLY} ]]; then
@@ -90,7 +90,7 @@ run_tests() {
               fi
             fi
 
-        elif [[ "${JOB_BASE_NAME}" == *-test2 || "${SHARD_NUMBER}" == 2 ]]; then
+        elif [[ "${JOB_BASE_NAME}" == *-test2 || ("${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1) ]]; then
             "$SCRIPT_HELPERS_DIR"/test_python_second_shard.bat "$DETERMINE_FROM"
 
             if [[ -z ${RUN_SMOKE_TESTS_ONLY} ]]; then


### PR DESCRIPTION
The SHARD_NUMBER reset was to figure out a way to differentiate whether we had just one shard vs multiple. 

We shouldn't reset SHARD_NUMBER but instead should just pass and use NUM_TEST_SHARDS for clarity and ease of scaling up to more shards.

cc @ezyang @seemethere @malfet @pytorch/pytorch-dev-infra