### PR TITLE
[LTC] Map a graph to a graph executor instance

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/tensor_util.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_lowering_context.h"
-#include "torch/csrc/jit/runtime/graph_executor.h"
 
 namespace lazy_tensors {
 namespace {
@@ -42,12 +41,11 @@ std::vector<ComputationClient::ComputationPtr> TSComputationClient::Compile(
 std::vector<ComputationClient::DataPtr> TSComputationClient::ExecuteComputation(
     const Computation& computation, lazy_tensors::Span<const DataPtr> arguments,
     const std::string& device, const ExecuteComputationOptions& options) {
-  auto graph =
+  torch::jit::GraphExecutor& graph_executor =
       static_cast<
           torch_lazy_tensors::compiler::ts_backend::GenericComputationTS*>(
           computation.computation())
-          ->graph();
-  torch::jit::GraphExecutor interp(graph, "");
+          ->graph_executor();
   std::vector<torch::jit::IValue> stack;
   for (auto argument : arguments) {
     const auto ts_data =
@@ -58,7 +56,7 @@ std::vector<ComputationClient::DataPtr> TSComputationClient::ExecuteComputation(
         ts_data->data_.device().type() == at::kCUDA);
     stack.emplace_back(ts_data->data_);
   }
-  interp.run(stack);
+  graph_executor.run(stack);
   std::vector<ComputationClient::DataPtr> results;
   for (torch::jit::IValue component : stack) {
     at::Tensor result = component.toTensor();


### PR DESCRIPTION
Currently a new graph executor is created every time ExecuteComputation
happens. Instead we should store the graph to executor mapping for
reusing the profiling-executor optimized code.

Roughly this cuts a single relu-op iteration execution time by half.
