### PR TITLE
Torch.eq converter and acc_op

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1510,3 +1510,9 @@ def acc_ops_dequantize(network, target, args, kwargs, name):
     layer.name = input_val.name + ".dequant"
     layer.axis = 0
     return layer.get_output(0)
+
+@tensorrt_converter(acc_ops.eq)
+def acc_ops_eq(network, target, args, kwargs, name):
+    return add_binary_elementwise_layer(
+        network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.EQUAL, name
+    )

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -1477,3 +1477,8 @@ def packed_quantized_convrelu2d_mapper(
         )
         relu_node.meta = node.meta
         return relu_node
+@register_acc_op_mapping(op_and_target=("call_function", torch.eq))
+@register_acc_op_mapping(op_and_target=("call_method", "eq"))
+@register_acc_op
+def eq(*, input, other):
+    return torch.eq(input, other)


### PR DESCRIPTION
Summary: Added fx2trt support for torch.eq and updated unit test.

Test Plan: Added unit test in test_binary_ops.py.

Differential Revision: D31193727

