### PR TITLE
Refactor AotCompile to return a pair

### DIFF
--- a/binaries/aot_model_compiler.cc
+++ b/binaries/aot_model_compiler.cc
@@ -112,10 +112,10 @@ c10::IValue preprocess(
   auto sizes = getInputSizesForMethod(method_compile_spec, method_name);
 
   std::string llvm_asm_code;
-  auto func =
-      torch::jit::mobile::nnc::aotCompile(method_name, graph, sizes, &llvm_asm_code);
-  writeOutputLlvmAssembly(llvm_asm_code);
+  auto compiled = torch::jit::mobile::nnc::aotCompile(method_name, graph, sizes);
+  writeOutputLlvmAssembly(compiled.second);
 
+  auto func = std::move(compiled.first);
   func->set_nnc_kernel_id(getNncKernelId(method_name));
 
   torch::jit::mobile::nnc::CompilationUnit cu;

--- a/torch/csrc/jit/mobile/nnc/aot_compiler.h
+++ b/torch/csrc/jit/mobile/nnc/aot_compiler.h
@@ -11,11 +11,10 @@ namespace nnc {
 
 // Performs Ahead Of Time compilation of a given method in a model
 // returning the compiled function and LLVM assembly code
-TORCH_API std::unique_ptr<Function> aotCompile(
+TORCH_API std::pair<std::unique_ptr<Function>, const std::string> aotCompile(
     const std::string& method_name,
     std::shared_ptr<Graph>& subgraph,
-    const std::vector<int64_t>& sizes,
-    std::string* compiled_assembly);
+    const std::vector<int64_t>& sizes);
 
 } // namespace nnc
 } // namespace mobile


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65707

Refactoring aotCompile to return a pair of compiled function and the LLVM assembly instead of updating an incoming string with assembly code

Testing: Gives expected results when compiled and run 
```
(pytorch)  ~/local/pytorch refactor_aot
└─ $ build/bin/aot_model_compiler --model mobilenetv3.pt --model_name=pytorch_dev_mobilenetv3 --model_version=v1 --input_dims="2,2,2"
The compiled model was saved to mobilenetv3.compiled.pt
```

Differential Revision: [D31220452](https://our.internmc.facebook.com/intern/diff/D31220452)