### PR TITLE
slow_conv2d_forward: avoid calling dispatcher in parallel region

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -422,7 +422,8 @@ std::tuple<Tensor&, Tensor&> slow_conv2d_forward_out_cpu(
   if (bias.defined()) {
     output.copy_(bias.reshape({-1, 1, 1}));
   }
-  TORCH_CHECK(output.is_contiguous());
+  TORCH_CHECK(output.is_contiguous() && finput.is_contiguous(),
+              "slow_conv2d output tensors must be contiguous");
 
   AT_DISPATCH_ALL_TYPES_AND(kBFloat16, input.scalar_type(), "slow_conv2d_cpu", [&]{
     auto input_a = input.accessor<scalar_t, 4>();

--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -5,6 +5,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/div_rtn.h>
+#include <ATen/native/CPUBlas.h>
 #include <ATen/native/Unfold2d.h>
 
 namespace at {
@@ -135,12 +136,13 @@ static Tensor view_weight_2d(const Tensor& weight_) {
   }
 }
 
+template <typename scalar_t>
 static void slow_conv2d_update_output_frame(
-    Tensor& input,
-    Tensor& output,
-    const Tensor& weight,
-    const Tensor& bias,
-    Tensor& finput,
+    TensorAccessor<scalar_t, 3> input,
+    TensorAccessor<scalar_t, 3> output,
+    TensorAccessor<scalar_t, 2> weight,
+    bool has_bias,
+    TensorAccessor<scalar_t, 2> finput,
     int64_t kernel_height,
     int64_t kernel_width,
     int64_t stride_height,
@@ -154,47 +156,50 @@ static void slow_conv2d_update_output_frame(
     int64_t output_height,
     int64_t output_width) {
   // Note: this is a no_group conv2d
-  if ((input.ndimension() == 4) && (kernel_height == 1) && (stride_height == 1) && (pad_height == 0) &&
+  if ((kernel_height == 1) && (stride_height == 1) && (pad_height == 0) &&
       (kernel_width == 1) && (stride_width == 1) && (pad_width == 0)) {
-    auto output2d =
-        output.reshape({n_output_plane, output_height * output_width});
-    auto weight_new =
-        weight.view({n_output_plane, n_input_plane});
-    auto input_new =
-        input.view({n_input_plane, output_height * output_width});
-
-    if (bias.defined()) {
-      output.copy_(bias.unsqueeze(-1).unsqueeze(-1));
-      output2d.addmm_(weight_new, input_new, 1, 1);
-    } else {
-      at::mm_out(output2d, weight_new, input_new);
-    }
-    return;
-  }
-  unfolded2d_copy_stub(
-      kCPU,
-      finput,
-      input,
-      kernel_height,
-      kernel_width,
-      stride_height,
-      stride_width,
-      pad_height,
-      pad_width,
-      n_input_plane,
-      input_height,
-      input_width,
-      output_height,
-      output_width);
-
-  auto output2d =
-      output.reshape({n_output_plane, output_height * output_width});
-  if (bias.defined()) {
-    output.copy_(bias.unsqueeze(-1).unsqueeze(-1));
-    output2d.addmm_(weight, finput, 1, 1);
+    // 1x1 kernel, no need to unfold input and finput is already set
   } else {
-    output2d.addmm_(weight, finput, 0, 1);
+    unfolded2d_copy_stub(
+        kCPU,
+        c10::CppTypeToScalarType<scalar_t>::value,
+        finput.data(),
+        input.data(),
+        kernel_height,
+        kernel_width,
+        stride_height,
+        stride_width,
+        pad_height,
+        pad_width,
+        n_input_plane,
+        input_height,
+        input_width,
+        output_height,
+        output_width);
   }
+
+  const int beta = has_bias ? 1 : 0;
+
+  // Compute out = weight * input
+  // Note gemm expects fortran order, so all 3 matrices are transposed.
+  // Swapping argument order cancels this, since C == AB <=> T(C) == T(B)T(A)
+  const int64_t m = output_height * output_width;
+  const int64_t n = n_output_plane;
+  const int64_t k = n_input_plane * kernel_height * kernel_width;
+
+  const int64_t lda = m;
+  const int64_t ldb = k;
+  const int64_t ldc = m;
+
+  at::native::cpublas::gemm(
+      TransposeType::NoTranspose,
+      TransposeType::NoTranspose,
+      m, n, k,
+      static_cast<scalar_t>(1),
+      finput.data(), lda,
+      weight.data(), ldb,
+      static_cast<scalar_t>(beta),
+      output.data(), ldc);
 }
 
 void slow_conv2d_backward_update_grad_input_frame(
@@ -213,10 +218,12 @@ void slow_conv2d_backward_update_grad_input_frame(
   at::mm_out(fgrad_input, weight, grad_output_2d);
 
   grad_input.zero_();
+  TORCH_INTERNAL_ASSERT(fgrad_input.scalar_type() == grad_input.scalar_type());
   unfolded2d_acc_stub(
       kCPU,
-      fgrad_input,
-      grad_input,
+      grad_input.scalar_type(),
+      fgrad_input.data_ptr(),
+      grad_input.data_ptr(),
       kernel_height,
       kernel_width,
       stride_height,
@@ -410,34 +417,44 @@ std::tuple<Tensor&, Tensor&> slow_conv2d_forward_out_cpu(
                   n_input_plane * kernel_height * kernel_width,
                   output_height * output_width});
   }
-  output.resize_({batch_size, n_output_plane, output_height, output_width});
 
-  at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-    NoGradGuard no_grad;
-    AutoDispatchBelowADInplaceOrView non_variable_type_mode;
-    for (int64_t t = start; t < end; t++) {
-      Tensor input_t = input[t].unsqueeze(0);
-      Tensor output_t = output[t];
-      Tensor finput_t = finput[t];
-      slow_conv2d_update_output_frame(
-          input_t,
-          output_t,
-          weight_2d,
-          bias,
-          finput_t,
-          kernel_height,
-          kernel_width,
-          stride_height,
-          stride_width,
-          pad_height,
-          pad_width,
-          n_input_plane,
-          input_height,
-          input_width,
-          n_output_plane,
-          output_height,
-          output_width);
-    }
+  output.resize_({batch_size, n_output_plane, output_height, output_width});
+  if (bias.defined()) {
+    output.copy_(bias.reshape({-1, 1, 1}));
+  }
+  TORCH_CHECK(output.is_contiguous());
+
+  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, input.scalar_type(), "slow_conv2d_cpu", [&]{
+    auto input_a = input.accessor<scalar_t, 4>();
+    auto output_a = output.accessor<scalar_t, 4>();
+    auto finput_a = finput.accessor<scalar_t, 3>();
+    auto weight_2d_a = weight_2d.accessor<scalar_t, 2>();
+
+    at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
+      for (int64_t t = start; t < end; t++) {
+        auto input_t = input_a[t];
+        auto output_t = output_a[t];
+        auto finput_t = finput_a[t];
+        slow_conv2d_update_output_frame(
+            input_t,
+            output_t,
+            weight_2d_a,
+            bias.defined(),
+            finput_t,
+            kernel_height,
+            kernel_width,
+            stride_height,
+            stride_width,
+            pad_height,
+            pad_width,
+            n_input_plane,
+            input_height,
+            input_width,
+            n_output_plane,
+            output_height,
+            output_width);
+      }
+    });
   });
 
   return std::tuple<Tensor&, Tensor&>(output, finput);

--- a/aten/src/ATen/native/Unfold2d.h
+++ b/aten/src/ATen/native/Unfold2d.h
@@ -5,10 +5,10 @@
 
 namespace at { namespace native {
 
-using unfold2d_fn =
-    void (*)(
-    Tensor& finput,
-    Tensor& input,
+using unfold2d_fn = void (*)(
+    ScalarType dtype,
+    void *finput,
+    void *input,
     int64_t kH,
     int64_t kW,
     int64_t dH,

--- a/aten/src/ATen/native/cpu/Unfold2d.cpp
+++ b/aten/src/ATen/native/cpu/Unfold2d.cpp
@@ -118,8 +118,9 @@ static void unfolded2d_acc(
 /* note: due to write issues, this one cannot be parallelized as well as
  * unfolded2d_copy */
 void unfolded2d_acc_kernel(
-    Tensor& finput,
-    Tensor& input,
+    ScalarType dtype,
+    void *finput_data,
+    void *input_data,
     int64_t kH,
     int64_t kW,
     int64_t dH,
@@ -136,13 +137,10 @@ void unfolded2d_acc_kernel(
   // output_width*dW does not overflow a int64_t
 
   AT_DISPATCH_FLOATING_TYPES_AND(
-      at::ScalarType::BFloat16, input.scalar_type(), "unfolded2d_acc", [&] {
-        scalar_t* finput_data = finput.data_ptr<scalar_t>();
-        scalar_t* input_data = input.data_ptr<scalar_t>();
-
+      at::ScalarType::BFloat16, dtype, "unfolded2d_acc", [&] {
         unfolded2d_acc(
-            finput_data,
-            input_data,
+            static_cast<scalar_t*>(finput_data),
+            static_cast<scalar_t*>(input_data),
             kH,
             kW,
             dH,
@@ -265,8 +263,9 @@ static void unfolded2d_copy(
 }
 
 void unfolded2d_copy_kernel(
-    Tensor& finput,
-    Tensor& input,
+    ScalarType dtype,
+    void *finput_data,
+    void *input_data,
     int64_t kH,
     int64_t kW,
     int64_t dH,
@@ -285,13 +284,10 @@ void unfolded2d_copy_kernel(
   // output_width*dW does not overflow a int64_t
 
   AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::BFloat16, input.scalar_type(), "unfolded2d_copy", [&] {
-        scalar_t* input_data = input.data_ptr<scalar_t>();
-        scalar_t* finput_data = finput.data_ptr<scalar_t>();
-
+      at::ScalarType::BFloat16, dtype, "unfolded2d_copy", [&] {
         unfolded2d_copy(
-            input_data,
-            finput_data,
+            static_cast<scalar_t*>(input_data),
+            static_cast<scalar_t*>(finput_data),
             kH,
             kW,
             dH,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65759
* #65758
* #65757
* #65737
* #65726
* #65725
* __->__ #65724

See gh-56794

Avoid dispatch inside of parallel_for by:
1. Replacing Tensor slicing with TensorAccessor
2. Copy bias into output only once, outside of the parallel region
3. Replaces `addmm`_ with a direct call to gemm.

Technically this also adds a new requirement that the output always be
contiguous, but the out argument version isn't exposed or used
anywhere in the `torch.nn` API. So that should be fine.

Differential Revision: [D31257875](https://our.internmc.facebook.com/intern/diff/D31257875)