### PR TITLE
[Static Runtime] concat_add_mul_replacenan_clip retains axis arg

### DIFF
--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -174,6 +174,13 @@ void compareResults(
 
 } // namespace
 
+std::shared_ptr<Graph> getGraphFromIR(const std::string& ir) {
+    auto graph = std::make_shared<Graph>();
+    std::unordered_map<std::string, Value*> vmap;
+    parseIR(ir, graph.get(), vmap);
+    return graph;
+}
+
 void testStaticRuntime(
     const std::string& source,
     const std::vector<IValue>& args,

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include <torch/csrc/jit/ir/ir.h>
+
 namespace c10 {
 struct IValue;
 }
@@ -25,6 +27,8 @@ void testStaticRuntime(
     const std::vector<c10::IValue>& args2 = {},
     const bool use_allclose = false,
     const bool use_equalnan = false);
+
+std::shared_ptr<Graph> getGraphFromIR(const std::string& ir);
 
 } // namespace test
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -91,7 +91,7 @@ void ConcatAddMulReplaceNaNClip(std::shared_ptr<torch::jit::Graph>& graph) {
         return (%res))IR";
   std::string fused_pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f, %g, %h, %i, %j):
-        %res = fb::concat_add_mul_replacenan_clip(%c, %e, %a, %i, %j)
+        %res = fb::concat_add_mul_replacenan_clip(%c, %e, %a, %i, %j, %b)
         return (%res))IR";
 
   SubgraphRewriter fuse;


### PR DESCRIPTION
Summary: This op previously assumed `axis == 1`, causing graphs that would otherwise be valid to return incorrect results after fusing.

Differential Revision: D31234944

