### PR TITLE
Define timeout in TestIndividualWorkerQueue

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2314,7 +2314,7 @@ class TestIndividualWorkerQueue(TestCase):
     def _run_ind_worker_queue_test(self, batch_size, num_workers):
         loader = DataLoader(
             self.dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers,
-            worker_init_fn=self.dataset.worker_init_fn
+            timeout=5, worker_init_fn=self.dataset.worker_init_fn
         )
         current_worker_idx = 0
         for i, (worker_ids, sample) in enumerate(loader):


### PR DESCRIPTION
This test occasionally deadlocks while waiting for the child process to report result. 
But as the test is small, entire test should never take more than 1-2 sec, but to be on the safe side set timeout to 5 sec

Somewhat mitigates https://github.com/pytorch/pytorch/issues/65727

