### PR TITLE
[jit] Abstract GraphExecutor as Executor interface.

### DIFF
--- a/aten/src/ATen/core/builtin_function.h
+++ b/aten/src/ATen/core/builtin_function.h
@@ -64,8 +64,12 @@ struct BuiltinOpFunction : public Function {
     // nop
   }
 
-  GraphExecutor& get_executor() override {
-    TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had a GraphExecutor requested "
+  bool hasExecutor() const override {
+    return false;
+  }
+
+  Executor& get_executor() override {
+    TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had an Executor requested "
       "from it. This probably indicates that the JIT calling context needs a "
       "special case on torch::jit::tryToGraphFunction()");
   }

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -16,7 +16,7 @@ namespace torch {
 namespace jit {
 
 struct Graph;
-struct GraphExecutor;
+class Executor;
 
 using Stack = std::vector<at::IValue>;
 using Kwargs = std::unordered_map<std::string, at::IValue>;
@@ -58,7 +58,11 @@ struct TORCH_API Function {
   // if this isn't yet defined, run its method_creator function
   virtual void ensure_defined() = 0;
 
-  virtual GraphExecutor& get_executor() = 0;
+  virtual bool hasExecutor() const {
+    return true;
+  }
+
+  virtual Executor& get_executor() = 0;
 
   virtual const c10::FunctionSchema& getSchema() const = 0;
 

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -56,7 +56,7 @@ void placeholderCreator(GraphFunction&) {
 }
 
 void GraphFunction::run(Stack& stack) {
-  get_executor().run(stack);
+  get_graph_executor().run(stack);
 }
 
 void GraphFunction::run(Stack&& stack) {
@@ -66,7 +66,7 @@ void GraphFunction::run(Stack&& stack) {
 c10::intrusive_ptr<c10::ivalue::Future> GraphFunction::runAsync(
     Stack& stack,
     TaskLauncher taskLauncher) {
-  return get_executor().runAsync(stack, std::move(taskLauncher));
+  return get_graph_executor().runAsync(stack, std::move(taskLauncher));
 }
 
 IValue GraphFunction::operator()(

--- a/torch/csrc/jit/api/method.h
+++ b/torch/csrc/jit/api/method.h
@@ -54,7 +54,7 @@ struct TORCH_API Method : public torch::IMethod {
     return function_->num_inputs();
   }
 
-  GraphExecutor& get_executor() {
+  Executor& get_executor() {
     return function_->get_executor();
   }
 

--- a/torch/csrc/jit/runtime/executor.h
+++ b/torch/csrc/jit/runtime/executor.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/runtime/argument_spec.h>
+#include <torch/csrc/jit/runtime/interpreter.h>
+
+namespace torch {
+namespace jit {
+
+struct ExecutionPlan {
+  ExecutionPlan() = default;
+  ExecutionPlan(
+      std::shared_ptr<Graph> graph,
+      std::string function_name,
+      size_t remaining_bailout_depth = 0)
+      : code(graph, std::move(function_name), remaining_bailout_depth),
+        graph(std::move(graph)) {}
+
+  operator bool() const {
+    return static_cast<bool>(graph);
+  }
+
+  Code code;
+  std::shared_ptr<Graph> graph;
+};
+
+// Notice that those structs don't manage lifetime of their members.
+// They is only valid only right after you call getDebugState() and should never
+// be used again once another GraphExecutor function is called.
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct GraphExecutorState {
+  const Graph* graph = nullptr;
+  ExecutionPlan fallback; // XXX: members of this field are optional
+  std::unordered_map<ArgumentSpec, ExecutionPlan> execution_plans;
+};
+
+class TORCH_API Executor {
+ public:
+  virtual const ExecutionPlan& getPlanFor(
+      Stack& inputs,
+      size_t remaining_bailout_depth) = 0;
+  virtual GraphExecutorState getDebugState() = 0;
+  virtual void debugFlushCompilationCache() = 0;
+
+  virtual ~Executor() = default;
+};
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -781,10 +781,6 @@ const ExecutionPlan& GraphExecutor::getPlanFor(
   return pImpl->getPlanFor(inputs, remaining_bailout_depth);
 }
 
-std::shared_ptr<Graph> GraphExecutor::graph() const {
-  return pImpl->graph;
-}
-
 GraphExecutorState GraphExecutor::getDebugState() {
   return pImpl->getDebugState();
 }

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -135,7 +135,8 @@ void setstateTuple(
       return;
     }
     if (auto f = tryToGraphFunction(setstate)) {
-      exportFunction(exportSet, ModuleMethod{module, *f, std::move(qn)}, toplevel);
+      exportFunction(
+          exportSet, ModuleMethod{module, *f, std::move(qn)}, toplevel);
     }
   } else {
     for (size_t i = 0, n = type->numAttributes(); i < n; ++i) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65260 [jit][edge] Support INTERFACE_CALL to ClassType at runtime.
* #65259 [jit][edge] Load interface methods to corresponding ClassTypes.
* #65765 [jit][edge] Implement torch::jit::Function with an Executor for mobile funciton.
* **#65764 [jit] Abstract GraphExecutor as Executor interface.**
* #65763 [jit] Clean up unneeded methods from Function interface.
* #65762 [jit] Remove graph() call from abstract Function interface.
* #65258 [jit][edge] Export maybe-used interface methods from modules.
* #65257 [jit] Factor findAllNodes into one place.

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31244047](https://our.internmc.facebook.com/intern/diff/D31244047)