### PR TITLE
[jit][edge] Implement torch::jit::Function with an Executor for mobile funciton.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -550,6 +550,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
 
   if(NOT INTERN_DISABLE_MOBILE_INTERP)
     set(MOBILE_SRCS
+       ${TORCH_SRC_DIR}/csrc/jit/mobile/executor.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/function.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/import.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/import_data.cpp

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -436,6 +436,7 @@ torch_mobile_core = [
     # This should not be needed eventually.
     # TODO: Remove this dependency
     "torch/csrc/jit/backends/backend_debug_info.cpp",
+    "torch/csrc/jit/mobile/executor.cpp",
     "torch/csrc/jit/mobile/function.cpp",
     "torch/csrc/jit/mobile/import.cpp",
     "torch/csrc/jit/mobile/interpreter.cpp",
@@ -477,6 +478,7 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     # To be included for eager symbolication in lite interpreter
     # when it is built in libtorch
     "torch/csrc/jit/mobile/debug_info.cpp",
+    "torch/csrc/jit/mobile/executor.cpp",
     "torch/csrc/jit/mobile/function.cpp",
     "torch/csrc/jit/mobile/import.cpp",
     "torch/csrc/jit/mobile/import_data.cpp",

--- a/torch/csrc/jit/mobile/executor.cpp
+++ b/torch/csrc/jit/mobile/executor.cpp
@@ -1,0 +1,15 @@
+#include <torch/csrc/jit/mobile/executor.h>
+#include "c10/util/Exception.h"
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+const EdgeExecutionPlan& toEdgeExecutionPlan(const ExecutionPlan& plan) {
+  TORCH_INTERNAL_ASSERT(plan.isEdgeExecutionPlan());
+  return static_cast<const EdgeExecutionPlan&>(plan);
+}
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/executor.h
+++ b/torch/csrc/jit/mobile/executor.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <torch/csrc/jit/runtime/graph_executor.h>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+struct Code;
+
+class EdgeExecutionPlan : public torch::jit::ExecutionPlan {
+ public:
+  EdgeExecutionPlan(const Code& code) : ExecutionPlan(), code_(code) {}
+
+  bool isEdgeExecutionPlan() const override {
+    return true;
+  }
+
+  const Code& getCode() const {
+    return code_;
+  }
+
+ private:
+  const Code& code_;
+};
+
+const EdgeExecutionPlan& toEdgeExecutionPlan(const ExecutionPlan& plan);
+
+class EdgeExecutor : public torch::jit::Executor {
+ public:
+  EdgeExecutor(const Code& code) : plan_(code) {}
+  const ExecutionPlan& getPlanFor(Stack& inputs, size_t remaining_bailout_depth)
+      override {
+    TORCH_INTERNAL_ASSERT(remaining_bailout_depth == 0);
+    return plan_;
+  }
+
+  GraphExecutorState getDebugState() override {
+    TORCH_INTERNAL_ASSERT(
+        false, "getDebugState not supported for EdgeExecutor.");
+  }
+  void debugFlushCompilationCache() override {}
+
+ private:
+  EdgeExecutionPlan plan_;
+};
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/function.cpp
+++ b/torch/csrc/jit/mobile/function.cpp
@@ -11,8 +11,11 @@ namespace jit {
 
 char const* toString(OpCode op);
 namespace mobile {
+
 Function::Function(c10::QualifiedName name)
-    : name_(std::move(name)), code_(std::make_shared<Code>()) {}
+    : name_(std::move(name)),
+      code_(std::make_shared<Code>()),
+      executor_(*code_) {}
 
 const c10::QualifiedName& Function::qualname() const {
   return name_;
@@ -145,27 +148,61 @@ int64_t Function::get_debug_handle(size_t pc) const {
   return code_->instructions_with_handles_[pc].debug_handle;
 }
 
-void Function::setSchema(c10::FunctionSchema schema) {
+torch::jit::Function& Function::setSchema(c10::FunctionSchema schema) {
   schema_ = std::move(schema);
+  return *this;
 }
 
-const at::optional<c10::FunctionSchema>& Function::getSchema() const {
-  return schema_;
+bool Function::hasSchema() const {
+  return schema_.has_value();
 }
 
-bool Function::run(Stack& stack) const {
-  const auto& schema = getSchema();
-  if (schema) { // if we have a schema then resolve optional args if any
-    schema->checkAndNormalizeInputs(
+const c10::FunctionSchema& Function::getSchema() const {
+  return *schema_;
+}
+
+void Function::run(Stack& stack) {
+  if (hasSchema()) { // if we have a schema then resolve optional args if any
+    getSchema().checkAndNormalizeInputs(
         stack, std::unordered_map<std::string, IValue>{} /*kwargs*/);
   }
   InterpreterState interp_state(code_);
-  return interp_state.run(stack);
+  interp_state.run(stack);
 }
 
-c10::IValue Function::operator()(Stack& stack) const {
+void Function::run(Stack&& stack) {
+  run(stack);
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> Function::runAsync(
+    Stack& stack,
+    TaskLauncher taskLauncher) {
+  TORCH_INTERNAL_ASSERT(
+      false, "runAsync() is not supported for torch::jit::mobile::Function.");
+}
+
+at::IValue Function::operator()(Stack stack, const Kwargs& kwargs) {
+  TORCH_INTERNAL_ASSERT(kwargs.empty());
   run(stack);
   return stack.front();
+}
+
+Executor& Function::get_executor() {
+  return executor_;
+}
+
+size_t Function::num_inputs() const {
+  return schema_->arguments().size();
+}
+
+void Function::check_single_output() {
+  TORCH_CHECK(schema_->returns().size() == 1);
+}
+
+std::string Function::pretty_print_schema() const {
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "pretty_print_schema() is not supported for torch::jit::mobile::Function.");
 }
 
 const std::shared_ptr<Code> Function::get_code() const {

--- a/torch/csrc/jit/runtime/executor.h
+++ b/torch/csrc/jit/runtime/executor.h
@@ -20,6 +20,10 @@ struct ExecutionPlan {
     return static_cast<bool>(graph);
   }
 
+  virtual bool isEdgeExecutionPlan() const {
+    return false;
+  }
+
   Code code;
   std::shared_ptr<Graph> graph;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65260 [jit][edge] Support INTERFACE_CALL to ClassType at runtime.
* #65259 [jit][edge] Load interface methods to corresponding ClassTypes.
* **#65765 [jit][edge] Implement torch::jit::Function with an Executor for mobile funciton.**
* #65764 [jit] Abstract GraphExecutor as Executor interface.
* #65763 [jit] Clean up unneeded methods from Function interface.
* #65762 [jit] Remove graph() call from abstract Function interface.
* #65258 [jit][edge] Export maybe-used interface methods from modules.
* #65257 [jit] Factor findAllNodes into one place.

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31244049](https://our.internmc.facebook.com/intern/diff/D31244049)