### PR TITLE
Refactored `copy_` to use dispatcher for handling named tensors

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1241,6 +1241,7 @@
     MkldnnCPU: copy_mkldnn_
     SparseCPU, SparseCUDA, SparseHIP, SparseXPU: copy_sparse_wrapper_
     CompositeExplicitAutograd: copy_
+    Named: named_copy_
 
 - func: _copy_from(Tensor self, Tensor dst, bool non_blocking=False) -> Tensor
   dispatch: {}

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -512,19 +512,14 @@ SparseTensor& copy_sparse_wrapper_(
     bool non_blocking) {
   // TODO: Once copy_ is fully migrated to use dispatcher, handle named
   // inference using dispatcher instead of doing it everywhere
-  auto maybe_outnames = namedinference::compute_broadcast_outnames(self, src);
-  {
-    NoNamesGuard guard;
-    if (!self.is_sparse() || !src.is_sparse()) {
-      AT_ERROR(
-          "copy_() between dense and sparse Tensors is not implemented! Found self type = ",
-          self.toString(),
-          " and src type = ",
-          src.toString());
-    }
-    at::copy_sparse_to_sparse_(self, src, non_blocking);
+  if (!self.is_sparse() || !src.is_sparse()) {
+    AT_ERROR(
+        "copy_() between dense and sparse Tensors is not implemented! Found self type = ",
+        self.toString(),
+        " and src type = ",
+        src.toString());
   }
-  namedinference::propagate_names_if_nonempty(self, maybe_outnames);
+  at::copy_sparse_to_sparse_(self, src, non_blocking);
   return self;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65778
* #65777

Description:
- All the backends other than mkldnn in the original flow go through
  name propagation. Therefore, deduping named tensor handling.