### PR TITLE
[ONNX] Add shape inference for squeeze nodes

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1387,6 +1387,19 @@ class TestONNXRuntime(unittest.TestCase):
         x_noop = torch.randn(2, 2, 3)
         self.squeeze_model_tests(1, x_squeeze, x_noop)
 
+    def test_squeeze_dynamic_without_dim(self):
+        class Squeeze(torch.nn.Module):
+            def forward(self, input):
+                output = input.view(-1)
+                return output.squeeze()
+
+        inputs = torch.rand(2, 3)
+        another_inputs = torch.rand(4, 5)
+        self.run_test(Squeeze(), (inputs, ),
+                      input_names=["x"],
+                      dynamic_axes={"x" : {0: "0", 1: "1"}},
+                      test_with_inputs=[another_inputs])
+
     def test_squeeze_neg_without_no_op(self):
         x = torch.randn(2, 1, 4)
         self.squeeze_model_tests(-2, x, None)

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1356,11 +1356,7 @@ void ComputeConstant(Node* n, int opset_version) {
                 .sizes();
         if (input0_shape_size.has_value()) {
           auto input0_shape_value = input0_shape_size.value();
-          // For opset_versions > 13, for n->inputs().size() > 1,
-          // the shape inference is handled via onnx shape inference
-          // For opset_versions < 13, we ensure the attribute axes is not
-          // present as in cases with axes attr present, the shape inference is
-          // handled via onnx shape inference
+          // Other cases are handled via onnx shape inference
           if ((opset_version >= 13 && n->inputs().size() == 1) ||
               (opset_version < 13 && !n->hasAttributeS("axes"))) {
             auto final_shape = ComputeShapeFromSqueeze(input0_shape_value);


### PR DESCRIPTION
- Current exporter only supports shape propagation for squeeze nodes when dim argument is provided
- Add shape inference logic for squeeze node, when dim is not present
