### PR TITLE
LLVM-12 fix for shm_mutex

### DIFF
--- a/caffe2/contrib/shm_mutex/shm_mutex.h
+++ b/caffe2/contrib/shm_mutex/shm_mutex.h
@@ -331,7 +331,7 @@ struct shm_traits<ShmTicketMutex<T>> {
   using header_t = T;
 };
 
-using TicketStruct = struct : ShmBaseHeader {
+struct TicketStruct : ShmBaseHeader {
   std::atomic<unsigned> ticket;
   std::atomic<unsigned> now;
 };


### PR DESCRIPTION
Summary:
Fixes
```
stderr: In file included from caffe2/caffe2/contrib/shm_mutex/shm_mutex.cc:1:
caffe2/caffe2/contrib/shm_mutex/shm_mutex.h:334:28: error: anonymous non-C-compatible type given name for linkage purposes by alias declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]
using TicketStruct = struct : ShmBaseHeader {
                           ^
                            TicketStruct
caffe2/caffe2/contrib/shm_mutex/shm_mutex.h:334:31: note: type is not C-compatible due to this base class
using TicketStruct = struct : ShmBaseHeader {
                              ^~~~~~~~~~~~~
caffe2/caffe2/contrib/shm_mutex/shm_mutex.h:334:7: note: type is given name 'TicketStruct' for linkage purposes by this alias declaration
using TicketStruct = struct : ShmBaseHeader {
      ^
1 error generated.
Cannot execute a rule out of process. On RE worker. Thread: Thread[main,5,main]
Command failed with exit code 1.
```

Test Plan: Sandcastle

Differential Revision: D31248938

