### PR TITLE
[ONNX] Update slice process shape to support rank only inference

### DIFF
--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 import numpy as np
-
+from torch.onnx.symbolic_helper import _set_onnx_shape_inference
 
 def expect_tensor(scalar_type, shape=None):
     def verify(actual_type):
@@ -13,8 +13,10 @@ def expect_tensor(scalar_type, shape=None):
     return verify
 
 class TestONNXShapeInference(unittest.TestCase):
-    from torch.onnx.symbolic_helper import _onnx_main_opset
+    from torch.onnx.symbolic_helper import _onnx_main_opset, _set_opset_version
     opset_version = _onnx_main_opset
+    _set_onnx_shape_inference(True)
+    _set_opset_version(opset_version)
 
     def run_test(self, g, n, type_assertion_funcs):
         if not isinstance(type_assertion_funcs, list):
@@ -86,6 +88,18 @@ class TestONNXShapeInference(unittest.TestCase):
         constant_2 = self.insert_tensor_constant(g, torch.tensor([-1, 0, 0]))
         shape = g.op("Reshape", constant, constant_2)
         self.run_test(g, shape.node(), expect_tensor("Float", shape=(8, 16, 5)))
+
+    def test_slice(self):
+        g = self.create_empty_graph()
+        input = g.addInput()
+        input.setType(input.type().with_sizes([None, None]))
+        start_input = g.addInput()
+        start_input.setType(start_input.type().with_sizes([None]))
+        end = self.insert_tensor_constant(g, torch.tensor([3]))
+        axis = self.insert_tensor_constant(g, torch.tensor([0]))
+        step = self.insert_tensor_constant(g, torch.tensor([1]))
+        slice = g.op("Slice", input, start_input, end, axis, step)
+        self.run_test(g, slice.node(), expect_tensor(None, shape=(None, None)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -1,7 +1,9 @@
 import unittest
 import torch
 import numpy as np
-from torch.onnx.symbolic_helper import _set_onnx_shape_inference
+from torch.onnx.symbolic_helper import (_set_onnx_shape_inference,
+                                        _onnx_main_opset,
+                                        _set_opset_version)
 
 def expect_tensor(scalar_type, shape=None):
     def verify(actual_type):
@@ -15,7 +17,6 @@ def expect_tensor(scalar_type, shape=None):
 class TestONNXShapeInference(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        from torch.onnx.symbolic_helper import _onnx_main_opset, _set_opset_version
         self.opset_version = _onnx_main_opset
         _set_onnx_shape_inference(True)
         _set_opset_version(self.opset_version)

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -13,10 +13,12 @@ def expect_tensor(scalar_type, shape=None):
     return verify
 
 class TestONNXShapeInference(unittest.TestCase):
-    from torch.onnx.symbolic_helper import _onnx_main_opset, _set_opset_version
-    opset_version = _onnx_main_opset
-    _set_onnx_shape_inference(True)
-    _set_opset_version(opset_version)
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        from torch.onnx.symbolic_helper import _onnx_main_opset, _set_opset_version
+        self.opset_version = _onnx_main_opset
+        _set_onnx_shape_inference(True)
+        _set_opset_version(self.opset_version)
 
     def run_test(self, g, n, type_assertion_funcs):
         if not isinstance(type_assertion_funcs, list):

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -941,30 +941,29 @@ c10::SymbolicShape ComputeShapeForSlice(
 }
 
 void ProcessSliceNode(Node* n, int opset_version) {
-  if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+  auto valid = true;
+  if (opset_version >= 10) {
+    valid = ConstantValueMap::HasValue(n->input(1)->debugName()) &&
+        ConstantValueMap::HasValue(n->input(2)->debugName());
+    for (const auto input_idx : c10::irange(3, 5)) {
+      if (n->inputs().size() > input_idx) {
+        valid = valid &&
+            ConstantValueMap::HasValue(n->input(input_idx)->debugName());
+      }
+    }
+  }
+  if (!ConstantValueMap::HasShape(n->input(0)->debugName()) || !valid) {
+    if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
+      auto rank =
+          ConstantValueMap::GetRank(n->input(0)->debugName()).value();
+      UpdateRank(n->output(), rank);
+    }
+    return;
+  } else {
     auto shape_size_0 =
         ConstantValueMap::GetShape(n->input(0)->debugName()).value();
     if (shape_size_0.rank().has_value()) {
       auto input0_shape_value = shape_size_0.sizes().value();
-      auto valid = true;
-      if (opset_version >= 10) {
-        valid = ConstantValueMap::HasValue(n->input(1)->debugName()) &&
-            ConstantValueMap::HasValue(n->input(2)->debugName());
-        for (const auto input_idx : c10::irange(3, 5)) {
-          if (n->inputs().size() > input_idx) {
-            valid = valid &&
-                ConstantValueMap::HasValue(n->input(input_idx)->debugName());
-          }
-        }
-      }
-      if (!valid) {
-        if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
-          auto rank =
-              ConstantValueMap::GetRank(n->input(0)->debugName()).value();
-          UpdateRank(n->output(), rank);
-        }
-        return;
-      }
 
       std::vector<int64_t> start_vector;
       std::vector<int64_t> end_vector;

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -942,6 +942,8 @@ c10::SymbolicShape ComputeShapeForSlice(
 
 void ProcessSliceNode(Node* n, int opset_version) {
   auto valid = true;
+  // For opset version <= 9, starts, ends, axes, steps are attributes,
+  // so their values are always valid.
   if (opset_version >= 10) {
     valid = ConstantValueMap::HasValue(n->input(1)->debugName()) &&
         ConstantValueMap::HasValue(n->input(2)->debugName());
@@ -954,8 +956,7 @@ void ProcessSliceNode(Node* n, int opset_version) {
   }
   if (!ConstantValueMap::HasShape(n->input(0)->debugName()) || !valid) {
     if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
-      auto rank =
-          ConstantValueMap::GetRank(n->input(0)->debugName()).value();
+      auto rank = ConstantValueMap::GetRank(n->input(0)->debugName()).value();
       UpdateRank(n->output(), rank);
     }
     return;


### PR DESCRIPTION
Updated logic will be able to infer rank of slice output, when only rank is known for slice input. Enables cases where `ConstantValueMap::HasRank(input)` is `True`, while `ConstantValueMap::HasShape(input)` is `False`.