### PR TITLE
[JIT] Fix compilation unit reference link in constant object upon load

### DIFF
--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -123,11 +123,13 @@ c10::optional<Value*> tryInsertConstant(
       n->destroy();
       return c10::nullopt;
     };
-    // TODO: bail on inserting object with owning compilation unit reference
     // see: [Constant Object Weak CompilationUnit Reference]
   } else if (
-      (val.isGenericDict() && insertableIValue(val)) || (val.isEnum()) ||
-      (val.isObject() && !val.toObjectRef().type()->is_module())) {
+      (val.isObject() && !val.toObjectRef().type()->is_module()) &&
+      val.toObject()->is_weak_compilation_ref()) {
+    n->ival_(attr::value, val);
+    n->output()->setType(val.type());
+  } else if ((val.isGenericDict() && insertableIValue(val)) || (val.isEnum())) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());
   } else {

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -123,12 +123,16 @@ c10::optional<Value*> tryInsertConstant(
       n->destroy();
       return c10::nullopt;
     };
+  } else if (val.isObject()) {
+    const auto& ref = val.toObjectRef();
     // see: [Constant Object Weak CompilationUnit Reference]
-  } else if (
-      (val.isObject() && !val.toObjectRef().type()->is_module()) &&
-      val.toObject()->is_weak_compilation_ref()) {
-    n->ival_(attr::value, val);
-    n->output()->setType(val.type());
+    if (ref.type()->is_module() && ref.is_weak_compilation_ref()) {
+      n->ival_(attr::value, val);
+      n->output()->setType(val.type());
+    } else {
+      n->destroy();
+      return c10::nullopt;
+    }
   } else if ((val.isGenericDict() && insertableIValue(val)) || (val.isEnum())) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -126,7 +126,7 @@ c10::optional<Value*> tryInsertConstant(
   } else if (val.isObject()) {
     const auto& ref = val.toObjectRef();
     // see: [Constant Object Weak CompilationUnit Reference]
-    if (ref.type()->is_module() && ref.is_weak_compilation_ref()) {
+    if (!ref.type()->is_module() && ref.is_weak_compilation_ref()) {
       n->ival_(attr::value, val);
       n->output()->setType(val.type());
     } else {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -526,6 +526,11 @@ void initJITBindings(PyObject* module) {
           py::arg("graph"))
       .def("_jit_pass_erase_shape_information", EraseShapeInformation)
       .def(
+          "_jit_object_is_non_holding",
+          [](Node& n) {
+            return toIValue(n.output())->toObject()->is_weak_compilation_ref();
+          })
+      .def(
           "_jit_erase_non_input_shape_information",
           [](std::shared_ptr<Graph>& g) {
             std::vector<TypePtr> input_types;

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -78,7 +78,19 @@ struct ConstantTableValue : public SugaredValue {
                              << " is out of bounds (constant table has "
                              << constants_->size() << " entries)";
     }
-    Value* value = m.graph()->insertConstant(constants_->at(offset), loc);
+    auto ivalue = constants_->at(offset);
+    Value* value;
+
+    // see [Constant Object Weak CompilationUnit Reference]
+    if (ivalue.isObject() && !ivalue.toObject()->is_weak_compilation_ref()) {
+      auto obj = ivalue.toObject();
+      if (!non_holding_object_cache.count(obj)) {
+        non_holding_object_cache[obj] = obj->copy_to_weak_compilation_ref();
+      }
+      value = m.graph()->insertConstant(non_holding_object_cache[obj], loc);
+    } else {
+      value = m.graph()->insertConstant(constants_->at(offset), loc);
+    }
 
     // specializing tensor type on compilation messes up typing relations
     value->setType(unshapedType(value->type()));
@@ -87,6 +99,10 @@ struct ConstantTableValue : public SugaredValue {
   }
 
  private:
+  std::unordered_map<
+      c10::intrusive_ptr<at::ivalue::Object>,
+      c10::intrusive_ptr<at::ivalue::Object>>
+      non_holding_object_cache;
   const std::vector<at::IValue>* constants_;
 };
 

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -79,6 +79,7 @@ struct ConstantTableValue : public SugaredValue {
                              << constants_->size() << " entries)";
     }
     auto ivalue = constants_->at(offset);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     Value* value;
 
     // see [Constant Object Weak CompilationUnit Reference]


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/65442, make sure objects inserted into the graph from load do not holding owning reference.