### PR TITLE
LLVM-12 fix for tensor_new.cpp

### DIFF
--- a/caffe2/contrib/shm_mutex/shm_mutex.h
+++ b/caffe2/contrib/shm_mutex/shm_mutex.h
@@ -331,7 +331,7 @@ struct shm_traits<ShmTicketMutex<T>> {
   using header_t = T;
 };
 
-using TicketStruct = struct : ShmBaseHeader {
+struct TicketStruct : ShmBaseHeader {
   std::atomic<unsigned> ticket;
   std::atomic<unsigned> now;
 };


### PR DESCRIPTION
Summary: Fixes offset to nullptr at fbcode/caffe2/torch/csrc/utils/tensor_new.cpp:206

Test Plan: Sandcastle

Differential Revision: D31250995

