### PR TITLE
Fix test reporting git merge-base

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -108,7 +108,7 @@ def plural(n: int) -> str:
 
 def get_base_commit(sha1: str) -> str:
     return subprocess.check_output(
-        ["git", "merge-base", sha1, "origin/master"],
+        ["git", "merge-base", sha1, "origin/release/1.10"],
         encoding="ascii",
     ).strip()
 


### PR DESCRIPTION
Fixes test reporting issue like this:
https://app.circleci.com/pipelines/github/pytorch/pytorch/386411/workflows/59176345-894b-4e0a-bf37-649aeabb8925/jobs/16240624

```
Sep 28 19:28:35 + python -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
Sep 28 19:28:38 ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: Command '['git', 'merge-base', '16a4dff539a7464782e2c2a372b0be0c27fd8b5f', 'origin/master']' returned non-zero exit status 1.
```