### PR TITLE
[MicroBench] Added a micro benchmark for prefix sum

### DIFF
--- a/benchmarks/cpp/tensorexpr/CMakeLists.txt
+++ b/benchmarks/cpp/tensorexpr/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   bench_fuser_overhead.cpp
   bench_gemm.cpp
   bench_parallel.cpp
+  bench_prefix_sum.cpp
   bench_reduce.cpp
   main.cpp)
 

--- a/benchmarks/cpp/tensorexpr/bench_prefix_sum.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_prefix_sum.cpp
@@ -1,0 +1,227 @@
+#include <benchmark/benchmark.h>
+
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/operators/operators.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/torch.h>
+
+#include <immintrin.h>
+
+using namespace torch::jit::tensorexpr;
+
+namespace {
+
+class PrefixSumBench : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    input_size_ = state.range(0);
+    input_ = torch::rand(input_size_);
+    ref_ = prefixSum(input_);
+  }
+
+  void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(ref_, output_, 1e-3, 1e-3));
+    state.counters["GB/s"] = benchmark::Counter(
+        uint64_t(state.iterations()) * 2 * output_.nbytes(),
+        benchmark::Counter::kIsRate);
+  }
+
+  at::Tensor prefixSum(const at::Tensor& inp) {
+    return at::cumsum(inp, 0);
+  }
+
+  void runATen(benchmark::State& state) {
+    for (auto _ : state) {
+      output_ = prefixSum(input_);
+    }
+  }
+
+  void runLocal(benchmark::State& state) {
+    for (auto _ : state) {
+      output_ = at::empty_like(ref_);
+      auto input_data = input_.data_ptr<float>();
+      auto output_data = output_.data_ptr<float>();
+      float sum = 0.0f;
+      for (int i = 0; i < input_size_; ++i) {
+        sum = sum + input_data[i];
+        output_data[i] = sum;
+      }
+    }
+  }
+
+  void runNNC(benchmark::State& state) {
+    BufHandle input("input", {input_size_}, kFloat);
+    BufHandle output("output", {input_size_}, kFloat);
+    BufHandle s("s", {1}, kFloat);
+    VarHandle i("i", kInt);
+    auto allocS = Allocate::make(s);
+    auto initS = Store::make(s, {0}, 0.0f);
+    auto accumS = Store::make(
+        s, {0}, Add::make(Load::make(s, {0}), Load::make(input, {i})));
+    auto store = Store::make(output, {i}, Load::make(s, {0}));
+    auto forI = For::make(i, 0, input_size_, Block::make({accumS, store}));
+    auto freeS = Free::make(s);
+    auto par = Block::make({allocS, initS, forI, freeS});
+    LoopNest nest(par, {output.node()});
+
+    std::vector<CodeGen::BufferArg> buf_args;
+    buf_args.emplace_back(input);
+    buf_args.emplace_back(output);
+    LLVMCodeGen cg(nest.root_stmt(), buf_args);
+
+    std::vector<CodeGen::CallArg> call_args;
+    for (auto _ : state) {
+      output_ = at::empty_like(ref_);
+      call_args.clear();
+      call_args.emplace_back(input_.data_ptr<float>());
+      call_args.emplace_back(output_.data_ptr<float>());
+      cg.call(call_args);
+    }
+  }
+
+#ifdef __AVX2__
+
+#define _mm256_slli_si1(x)                                                   \
+  _mm256_blend_epi32(                                                        \
+      _mm256_permutevar8x32_ps(x, _mm256_set_epi32(6, 5, 4, 3, 2, 1, 0, 7)), \
+      _mm256_setzero_si256(),                                                \
+      1)
+#define _mm256_slli_si2(x)                                                   \
+  _mm256_blend_epi32(                                                        \
+      _mm256_permutevar8x32_ps(x, _mm256_set_epi32(5, 4, 3, 2, 1, 0, 7, 6)), \
+      _mm256_setzero_si256(),                                                \
+      3)
+#define _mm256_slli_si4(x)                                                   \
+  _mm256_blend_epi32(                                                        \
+      _mm256_permutevar8x32_ps(x, _mm256_set_epi32(3, 2, 1, 0, 7, 6, 5, 4)), \
+      _mm256_setzero_si256(),                                                \
+      15)
+
+  __m256i PrefixSum(__m256i x) {
+    x = _mm256_add_ps(x, _mm256_slli_si1(x));
+    x = _mm256_add_ps(x, _mm256_slli_si2(x));
+    x = _mm256_add_ps(x, _mm256_slli_si4(x));
+    return x; // local prefix sums
+  }
+
+  // Util function to log the given value. Not used during benchmarking.
+  template <class T>
+  inline void Log(const __m256i& value) {
+    const size_t n = sizeof(__m256i) / sizeof(T);
+    T buffer[n];
+    _mm256_storeu_si256((__m256i*)buffer, value);
+    for (int i = 0; i < n; i++)
+      std::cout << buffer[n - i - 1] << " ";
+    std::cout << std::endl;
+  }
+
+  void runLocalAVX2(benchmark::State& state) {
+    for (auto _ : state) {
+      output_ = at::empty_like(ref_);
+      auto input_data = input_.data_ptr<float>();
+      auto output_data = output_.data_ptr<float>();
+
+      float carry = 0.0f;
+      for (int i = 0; i < input_size_ / 8; i++) {
+        __m256i x = (reinterpret_cast<__m256i*>(input_data))[i];
+        x = PrefixSum(x);
+        x = _mm256_add_ps(x, _mm256_set1_ps(carry));
+        (reinterpret_cast<__m256i*>(output_data))[i] = x;
+        carry = _mm256_cvtss_f32(_mm256_permutevar8x32_ps(
+            x, _mm256_set_epi32(6, 5, 4, 3, 2, 1, 0, 7)));
+      }
+    }
+  }
+#endif
+
+#ifdef __AVX512F__
+
+#define _mm512_slli_si512(x, k) \
+  _mm512_alignr_epi32(x, _mm512_setzero_si512(), 16 - k)
+
+  __m512i PrefixSum(__m512i x) {
+    x = _mm512_add_epi32(x, _mm512_slli_si512(x, 1));
+    x = _mm512_add_epi32(x, _mm512_slli_si512(x, 2));
+    x = _mm512_add_epi32(x, _mm512_slli_si512(x, 4));
+    x = _mm512_add_epi32(x, _mm512_slli_si512(x, 8));
+    return x; // local prefix sums
+  }
+
+  template <int index>
+  int _mm512_extract_epi32(__m512i target) {
+    return _mm512_cvtsi512_si32(_mm512_alignr_epi32(target, target, index));
+  }
+
+  void runLocalAVX512(benchmark::State& state) {
+    for (auto _ : state) {
+      output_ = at::empty_like(ref_);
+      auto input_data = input_.data_ptr<float>();
+      auto output_data = output_.data_ptr<float>();
+
+      __m512i acc = _mm512_setzero_si512();
+      int32_t carry = 0;
+      for (int i = 0; i < input_size_ / 16; i++) {
+        __m512i x = reinterpret_cast<__m512i*>(input_data)[i];
+        x = PrefixSum(x);
+        x += _mm512_set1_epi32(carry);
+        carry = _mm512_extract_epi32<15>(x);
+        reinterpret_cast<__m512i*>(output_data)[i] = x;
+      }
+    }
+  }
+#endif
+
+ private:
+  int input_size_;
+  at::Tensor input_;
+  at::Tensor output_;
+  at::Tensor ref_;
+};
+
+} // namespace
+
+BENCHMARK_DEFINE_F(PrefixSumBench, ATen)(benchmark::State& state) {
+  runATen(state);
+}
+
+BENCHMARK_DEFINE_F(PrefixSumBench, Local)(benchmark::State& state) {
+  runLocal(state);
+}
+
+BENCHMARK_DEFINE_F(PrefixSumBench, NNC)(benchmark::State& state) {
+  runNNC(state);
+}
+
+BENCHMARK_REGISTER_F(PrefixSumBench, ATen)
+    ->RangeMultiplier(4)
+    ->Ranges({{1 << 6, 1 << 20}});
+
+BENCHMARK_REGISTER_F(PrefixSumBench, Local)
+    ->RangeMultiplier(4)
+    ->Ranges({{1 << 6, 1 << 20}});
+
+BENCHMARK_REGISTER_F(PrefixSumBench, NNC)
+    ->RangeMultiplier(4)
+    ->Ranges({{1 << 6, 1 << 20}});
+
+#ifdef __AVX2__
+BENCHMARK_DEFINE_F(PrefixSumBench, LocalAVX2)(benchmark::State& state) {
+  runLocalAVX2(state);
+}
+BENCHMARK_REGISTER_F(PrefixSumBench, LocalAVX2)
+    ->RangeMultiplier(4)
+    ->Ranges({{1 << 6, 1 << 20}});
+#endif
+
+#ifdef __AVX512F__
+BENCHMARK_DEFINE_F(PrefixSumBench, LocalAVX512)(benchmark::State& state) {
+  runLocalAVX512(state);
+}
+BENCHMARK_REGISTER_F(PrefixSumBench, LocalAVX512)
+    ->RangeMultiplier(4)
+    ->Ranges({{1 << 6, 1 << 20}});
+#endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65790

Here are the results of the benchmark:
  * ATen - version that calls `at::cumsum`
  * NNC - a simple prefix-sum loop implemented in NNC (not vectorized)
  * Local - a C++ implementation of the simple prefix-sum loop
  * LocalAVX2 - a vectorized C++ implementation of prefix-sum, only using AVX2
  * LocalAVX512 - a vectorized C++ implementation of prefix-sum, using AVX512.

The vectorized implementations are from the paper "Parallel Prefix Sum with SIMD" in ADMS' 20.

```
$ OMP_NUM_THREADS=1 ./buck-out/opt/gen/caffe2/benchmarks/cpp/tensorexpr/tensorexpr_bench --benchmark_filter=PrefixSumBench
Run on (36 X 1601 MHz CPU s)
2021-09-28 23:13:12
------------------------------------------------------------------------------------------
Benchmark                                   Time           CPU Iterations UserCounters...
------------------------------------------------------------------------------------------
PrefixSumBench/ATen/64                   1289 ns       1289 ns     543199 GB/s=397.069M/s
PrefixSumBench/ATen/256                  1867 ns       1867 ns     374232 GB/s=1096.8M/s
PrefixSumBench/ATen/1024                 4169 ns       4169 ns     167889 GB/s=1.9649G/s
PrefixSumBench/ATen/4096                14137 ns      14136 ns      49266 GB/s=2.31806G/s
PrefixSumBench/ATen/16384               49887 ns      49883 ns      13988 GB/s=2.6276G/s
PrefixSumBench/ATen/65536              193742 ns     193686 ns       3628 GB/s=2.7069G/s
PrefixSumBench/ATen/262144             764803 ns     764774 ns        917 GB/s=2.74219G/s
PrefixSumBench/ATen/1048576           3040653 ns    3040277 ns        231 GB/s=2.75916G/s
PrefixSumBench/Local/64                   586 ns        586 ns    1197003 GB/s=873.244M/s
PrefixSumBench/Local/256                 1077 ns       1077 ns     646265 GB/s=1.90143G/s
PrefixSumBench/Local/1024                3050 ns       3050 ns     229458 GB/s=2.68579G/s
PrefixSumBench/Local/4096               11910 ns      11910 ns      58953 GB/s=2.75132G/s
PrefixSumBench/Local/16384              43204 ns      43202 ns      16081 GB/s=3.03393G/s
PrefixSumBench/Local/65536             167966 ns     167966 ns       4154 GB/s=3.12139G/s
PrefixSumBench/Local/262144            667631 ns     667613 ns       1048 GB/s=3.14127G/s
PrefixSumBench/Local/1048576          2654785 ns    2654631 ns        264 GB/s=3.15999G/s
PrefixSumBench/NNC/64                     642 ns        642 ns    1095277 GB/s=797.442M/s
PrefixSumBench/NNC/256                   1139 ns       1138 ns     617214 GB/s=1.799G/s
PrefixSumBench/NNC/1024                  3103 ns       3103 ns     225531 GB/s=2.63979G/s
PrefixSumBench/NNC/4096                 12053 ns      12052 ns      58084 GB/s=2.71883G/s
PrefixSumBench/NNC/16384                43227 ns      43225 ns      16192 GB/s=3.03231G/s
PrefixSumBench/NNC/65536               168065 ns     168056 ns       4153 GB/s=3.11972G/s
PrefixSumBench/NNC/262144              668974 ns     668921 ns       1045 GB/s=3.13513G/s
PrefixSumBench/NNC/1048576            2657464 ns    2657341 ns        263 GB/s=3.15677G/s
PrefixSumBench/LocalAVX2/64               523 ns        523 ns    1351308 GB/s=979.537M/s
PrefixSumBench/LocalAVX2/256              755 ns        755 ns     927762 GB/s=2.71159G/s
PrefixSumBench/LocalAVX2/1024            1759 ns       1759 ns     400355 GB/s=4.65609G/s
PrefixSumBench/LocalAVX2/4096            6708 ns       6706 ns     103959 GB/s=4.88649G/s
PrefixSumBench/LocalAVX2/16384          22143 ns      22142 ns      31229 GB/s=5.91951G/s
PrefixSumBench/LocalAVX2/65536          83649 ns      83642 ns       8350 GB/s=6.26828G/s
PrefixSumBench/LocalAVX2/262144        330433 ns     330427 ns       2133 GB/s=6.34679G/s
PrefixSumBench/LocalAVX2/1048576      1302301 ns    1302179 ns        537 GB/s=6.44198G/s
PrefixSumBench/LocalAVX512/64             474 ns        474 ns    1459151 GB/s=1080.8M/s
PrefixSumBench/LocalAVX512/256            576 ns        576 ns    1217442 GB/s=3.55524G/s
PrefixSumBench/LocalAVX512/1024           994 ns        994 ns     703387 GB/s=8.24434G/s
PrefixSumBench/LocalAVX512/4096          3642 ns       3641 ns     190646 GB/s=8.99857G/s
PrefixSumBench/LocalAVX512/16384        10140 ns      10140 ns      68947 GB/s=12.9267G/s
PrefixSumBench/LocalAVX512/65536        35739 ns      35736 ns      19567 GB/s=14.6711G/s
PrefixSumBench/LocalAVX512/262144      156415 ns     156413 ns       4467 GB/s=13.4078G/s
PrefixSumBench/LocalAVX512/1048576     613952 ns     613876 ns       1144 GB/s=13.665G/s
```

The version using AVX512 vector instructions is **~4x** faster than the non-vectorized version.

Differential Revision: [D31253849](https://our.internmc.facebook.com/intern/diff/D31253849)