### PR TITLE
[jit] Clean up unneeded methods from Function interface.

### DIFF
--- a/aten/src/ATen/core/builtin_function.h
+++ b/aten/src/ATen/core/builtin_function.h
@@ -27,10 +27,6 @@ struct BuiltinOpFunction : public Function {
     return doc_string_;
   }
 
-  bool isGraphFunction() const override {
-    return false;
-  }
-
   void run(Stack& stack) override {
     callable_(stack);
   }
@@ -68,22 +64,10 @@ struct BuiltinOpFunction : public Function {
     // nop
   }
 
-  std::shared_ptr<Graph> optimized_graph() const override {
-    TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had a graph requested "
-      "from it. This probably indicates that the JIT calling context needs a "
-      "special case on Function::isGraphFunction()");
-  }
-
-  void clear_execution_info() override {
-    TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had a graph requested "
-      "from it. This probably indicates that the JIT calling context needs a "
-      "special case on Function::isGraphFunction()");
-  }
-
   GraphExecutor& get_executor() override {
     TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had a GraphExecutor requested "
       "from it. This probably indicates that the JIT calling context needs a "
-      "special case on Function::isGraphFunction()");
+      "special case on torch::jit::tryToGraphFunction()");
   }
 
   const c10::FunctionSchema& getSchema() const override {

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -35,7 +35,9 @@ struct TORCH_API Function {
     return no_doc_string;
   }
 
-  virtual bool isGraphFunction() const = 0;
+  virtual bool isGraphFunction() const {
+    return false;
+  }
 
   virtual void run(Stack& stack) = 0;
 
@@ -55,10 +57,6 @@ struct TORCH_API Function {
 
   // if this isn't yet defined, run its method_creator function
   virtual void ensure_defined() = 0;
-
-  virtual std::shared_ptr<Graph> optimized_graph() const = 0;
-
-  virtual void clear_execution_info() = 0;
 
   virtual GraphExecutor& get_executor() = 0;
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -2002,7 +2002,7 @@ def foo(x):
   }
 
   // Check that inlining doesn't corrupt callstack of the callee's nodes.
-  const Function& baz = cu->get_function("baz");
+  const auto& baz = toGraphFunction(cu->get_function("baz"));
   for (Node* n : baz.optimized_graph()->nodes()) {
     if (n->kind() == prim::Constant) {
       if (!n->hasAttribute(attr::value) ||

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -37,7 +37,7 @@ struct TORCH_API GraphFunction : public Function {
     return graph_;
   }
 
-  std::shared_ptr<Graph> optimized_graph() const override {
+  std::shared_ptr<Graph> optimized_graph() const {
     std::lock_guard<std::recursive_mutex> lock(compile_mutex);
     if (optimized_graph_) {
       return *optimized_graph_;
@@ -47,14 +47,6 @@ struct TORCH_API GraphFunction : public Function {
       preoptimizeGraph(*optimized_graph_);
     }
     return *optimized_graph_;
-  }
-
-  void clear_execution_info() override {
-    std::lock_guard<std::recursive_mutex> lock(compile_mutex);
-    if (optimized_graph_) {
-      optimized_graph_.reset();
-    }
-    executor_.reset();
   }
 
   const c10::QualifiedName& qualname() const override {

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -2081,7 +2081,6 @@ std::vector<Value*> inlineCallTo(
     GraphFunction* callee,
     bool inline_optimized_graph /*=true*/) {
   WithInsertPoint guard(to_replace);
-  TORCH_INTERNAL_ASSERT(callee->isGraphFunction());
   std::unordered_map<Value*, Value*> value_map;
   std::vector<torch::jit::Value*> new_outputs;
 

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -360,7 +360,7 @@ class AttributePropagator {
               "' to ",
               *user_node);
 
-          GRAPH_UPDATE("Function body: ", *function.optimized_graph());
+          GRAPH_UPDATE("Function body: ", graphFunction->optimized_graph());
           inlineCallTo(user_node, graphFunction);
           inlined = true;
         }

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -30,8 +30,7 @@ void inlineCalls(Block* block) {
               fun_type->function()->name(),
               "' to ",
               *cur);
-          GRAPH_UPDATE(
-              "Function body: ", *fun_type->function()->optimized_graph());
+          GRAPH_UPDATE("Function body: ", graphFunction->optimized_graph());
           inlineCallTo(cur, graphFunction);
         }
       } break;
@@ -41,7 +40,7 @@ void inlineCalls(Block* block) {
           Function& function = class_type->getMethod(name);
           if (auto graphFunction = tryToGraphFunction(function)) {
             GRAPH_UPDATE("Inlining method '", function.name(), "' to ", *cur);
-            GRAPH_UPDATE("Function body: ", *function.optimized_graph());
+            GRAPH_UPDATE("Function body: ", graphFunction->optimized_graph());
             inlineCallTo(cur, graphFunction);
           }
         }

--- a/torch/csrc/jit/passes/onnx/function_substitution.cpp
+++ b/torch/csrc/jit/passes/onnx/function_substitution.cpp
@@ -42,7 +42,7 @@ void functionCallSubstitution(Block* block) {
               "' to aten::__interpolate");
           GRAPH_UPDATE(
               "Function in ONNX function call substitution body: ",
-              *fun_type->function()->optimized_graph());
+              toGraphFunction(*fun_type->function()).optimized_graph());
         } else {
           // Remove input[0] and the node that feeds into it
           auto input_node_0 = cur->input(0)->node();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65805
* #65804
* #65803
* #65802
* __->__ #65801
* #65800
* #65799
* #65798

tryToGraphFunction() should cover all cases and more composable than
adhoc virtual methods.

Differential Revision: [D31262114](https://our.internmc.facebook.com/intern/diff/D31262114/)