### PR TITLE
[CUDA graphs] fix typo

### DIFF
--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -639,7 +639,7 @@ Violating any of these will likely cause a runtime error:
   :meth:`CUDAGraph.capture_end<torch.cuda.CUDAGraph.capture_end>` calls.
   :class:`~torch.cuda.graph` and
   :func:`~torch.cuda.make_graphed_callables` set a side stream for you.)
-* Ops that sychronize the CPU with the GPU (e.g., ``.item()`` calls) are prohibited.
+* Ops that synchronize the CPU with the GPU (e.g., ``.item()`` calls) are prohibited.
 * CUDA RNG ops are allowed, but must use default generators. For example, explicitly constructing a
   new :class:`torch.Generator` instance and passing it as the ``generator`` argument to an RNG function
   is prohibited.


### PR DESCRIPTION
sychronize->synchronize

Update: Looks like https://github.com/pytorch/pytorch/pull/68557/files#diff-4840823ff4b0cd7fe61b9ada2a1746f6936c944bfbcc4d1bdb8b3dc1561d4401R683 took care of it. Closing.