### PR TITLE
[PyTorch][easy] Use copy-and-move instead of copy-and-swap in IValue::operator=

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -205,7 +205,7 @@ struct TORCH_API IValue final {
   }
 
   IValue& operator=(IValue const& rhs) & {
-    IValue(rhs).swap(*this);
+    *this = IValue(rhs);
     return *this;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65826

Should be marginally more efficient.

Differential Revision: [D31272489](https://our.internmc.facebook.com/intern/diff/D31272489/)