### PR TITLE
pytorch quantization ao migration phase 2: torch/jit

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -131,7 +131,7 @@ def infer_concrete_type_builder(nn_module, share_types=True):
         concrete_type_builder.set_module_list()
 
     class_annotations = getattr(nn_module, '__annotations__', {})
-    if isinstance(nn_module, (torch.quantization.QuantWrapper)):
+    if isinstance(nn_module, (torch.ao.quantization.QuantWrapper)):
         class_annotations = {}
 
     # Get user-annotated ignored attributes.

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -475,7 +475,7 @@ class QuantizedGRU(QuantizedRNNBase):
 
 def quantize_rnn_cell_modules(module):
     warnings.warn("quantize_rnn_cell_modules function has been deprecated. "
-                  "Please use torch.quantization.quantize_dynamic API instead.")
+                  "Please use torch.ao.quantization.quantize_dynamic API instead.")
     reassign = {}
     for name, mod in module.named_modules():
         if mod is module:
@@ -496,7 +496,7 @@ def quantize_rnn_cell_modules(module):
 
 def quantize_linear_modules(module, dtype=torch.int8):
     warnings.warn("quantize_linear_modules function has been deprecated. "
-                  "Please use torch.quantization.quantize_dynamic API instead.")
+                  "Please use torch.ao.quantization.quantize_dynamic API instead.")
 
     reassign = {}
     for name, mod in module.named_modules():
@@ -521,7 +521,7 @@ def quantize_linear_modules(module, dtype=torch.int8):
 
 def quantize_rnn_modules(module, dtype=torch.int8):
     warnings.warn("quantize_rnn_modules function has been deprecated. "
-                  "Please use torch.quantization.quantize_dynamic API instead.")
+                  "Please use torch.ao.quantization.quantize_dynamic API instead.")
     reassign = {}
     for name, mod in module.named_modules():
         if mod is module:


### PR DESCRIPTION
Summary:
Renames `torch.quantization` to `torch.ao.quantization` in `torch/jit` folder.

```
find caffe2/torch/jit/ -type f -name "*.py" -print0 | xargs -0 sed -i "s/torch\.quantization/torch.ao.quantization/g"
```

Test Plan: CI

Differential Revision: D31273365

