### PR TITLE
.github: Bump linux gpu max limit to 100

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -25,7 +25,7 @@ runner_types:
   linux.8xlarge.nvidia.gpu:
     instance_type: g3.8xlarge
     os: linux
-    max_available: 50
+    max_available: 100
     disk_size: 150
   linux.16xlarge.nvidia.gpu:
     instance_type: g3.16xlarge


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65831

Was noticing scaling issues last night due to the lack of
linux.8xlarge.nvidia.gpu machines, seems as though that even at max
capacity we were still about ~50 queued workflows behind, this should
close that gap.

Also since these run the longest types of tests these are the most
likely to overlap with scale messages being processed while available
runners are still maxed out

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D31275892](https://our.internmc.facebook.com/intern/diff/D31275892)