### PR TITLE
pytorch quantization ao migration phase 2: caffe2/test

### DIFF
--- a/test/ao/sparsity/test_kernels.py
+++ b/test/ao/sparsity/test_kernels.py
@@ -8,7 +8,7 @@ import logging
 from itertools import product
 
 import torch
-import torch.quantization as tq
+import torch.ao.quantization as tq
 
 from torch import nn
 from torch.ao.nn.sparse import quantized as ao_nn_sq

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1306,11 +1306,11 @@ class TestFreezing(JitTestCase):
         class Parent(nn.Module):
             def __init__(self):
                 super(Parent, self).__init__()
-                self.quant = torch.quantization.QuantStub()
+                self.quant = torch.ao.quantization.QuantStub()
                 self.conv1 = nn.Conv2d(1, 1, 1).to(dtype=torch.float32)
                 self.child = Child()
                 self.child2 = Child()
-                self.dequant = torch.quantization.DeQuantStub()
+                self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
                 x = self.quant(x)
@@ -1321,11 +1321,11 @@ class TestFreezing(JitTestCase):
                 return x
 
         def _static_quant(model):
-            qModel = torch.quantization.QuantWrapper(model)
-            qModel.qconfig = torch.quantization.default_qconfig
-            torch.quantization.prepare(qModel, inplace=True)
+            qModel = torch.ao.quantization.QuantWrapper(model)
+            qModel.qconfig = torch.ao.quantization.default_qconfig
+            torch.ao.quantization.prepare(qModel, inplace=True)
             qModel(torch.rand(4, 1, 4, 4, dtype=torch.float32))
-            torch.quantization.convert(qModel, inplace=True)
+            torch.ao.quantization.convert(qModel, inplace=True)
             return model
 
         with override_quantized_engine('fbgemm'):

--- a/test/mobile/test_lite_script_module.py
+++ b/test/mobile/test_lite_script_module.py
@@ -475,10 +475,10 @@ class TestLiteScriptQuantizedModule(QuantizationLiteTestCase):
         class M(torch.nn.Module):
             def __init__(self):
                 super(M, self).__init__()
-                self.quant = torch.quantization.QuantStub()
+                self.quant = torch.ao.quantization.QuantStub()
                 self.conv = torch.nn.Conv2d(1, 1, 1)
                 self.relu = torch.nn.ReLU()
-                self.dequant = torch.quantization.DeQuantStub()
+                self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
                 x = self.quant(x)
@@ -490,12 +490,12 @@ class TestLiteScriptQuantizedModule(QuantizationLiteTestCase):
         model_fp32 = M()
 
         model_fp32.eval()
-        model_fp32.qconfig = torch.quantization.get_default_qconfig('qnnpack')
-        model_fp32_fused = torch.quantization.fuse_modules(model_fp32, [['conv', 'relu']])
-        model_fp32_prepared = torch.quantization.prepare(model_fp32_fused)
+        model_fp32.qconfig = torch.ao.quantization.get_default_qconfig('qnnpack')
+        model_fp32_fused = torch.ao.quantization.fuse_modules(model_fp32, [['conv', 'relu']])
+        model_fp32_prepared = torch.ao.quantization.prepare(model_fp32_fused)
         input_fp32 = torch.randn(4, 1, 4, 4)
         model_fp32_prepared(input_fp32)
-        model_int8 = torch.quantization.convert(model_fp32_prepared)
+        model_int8 = torch.ao.quantization.convert(model_fp32_prepared)
 
         input = torch.randn(4, 1, 4, 4)
         self._compare_script_and_mobile(model=model_int8, input=input)

--- a/test/mobile/test_quantize_fx_lite_script_module.py
+++ b/test/mobile/test_quantize_fx_lite_script_module.py
@@ -2,13 +2,13 @@ import torch
 import torch.nn as nn
 import torch.nn.quantized as nnq
 import torch.utils.bundled_inputs
-from torch.quantization import (
+from torch.ao.quantization import (
     default_qconfig,
     float_qparams_weight_only_qconfig,
 )
 
 # graph mode quantization based on fx
-from torch.quantization.quantize_fx import (
+from torch.ao.quantization.quantize_fx import (
     prepare_fx,
     convert_fx,
 )
@@ -79,7 +79,7 @@ class TestLiteFuseFx(QuantizationLiteTestCase):
         for config in configs:
             model = LinearModelWithSubmodule().eval()
             qconfig_dict = {
-                "": torch.quantization.get_default_qconfig("qnnpack"),
+                "": torch.ao.quantization.get_default_qconfig("qnnpack"),
                 **config,
             }
             model = prepare_fx(model, qconfig_dict)

--- a/test/onnx/model_defs/op_test.py
+++ b/test/onnx/model_defs/op_test.py
@@ -50,7 +50,7 @@ class PReluNet(nn.Module):
 class FakeQuantNet(nn.Module):
     def __init__(self):
         super(FakeQuantNet, self).__init__()
-        self.fake_quant = torch.quantization.FakeQuantize()
+        self.fake_quant = torch.ao.quantization.FakeQuantize()
         self.fake_quant.disable_observer()
 
     def forward(self, x):

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -190,14 +190,14 @@ class TestModels(TestCase):
         qat_resnet50.qconfig = quantization.QConfig(
             activation=quantization.default_fake_quant, weight=quantization.default_fake_quant)
         quantization.prepare_qat(qat_resnet50, inplace=True)
-        qat_resnet50.apply(torch.quantization.enable_observer)
-        qat_resnet50.apply(torch.quantization.enable_fake_quant)
+        qat_resnet50.apply(torch.ao.quantization.enable_observer)
+        qat_resnet50.apply(torch.ao.quantization.enable_fake_quant)
 
         _ = qat_resnet50(x)
         for module in qat_resnet50.modules():
             if isinstance(module, quantization.FakeQuantize):
                 module.calculate_qparams()
-        qat_resnet50.apply(torch.quantization.disable_observer)
+        qat_resnet50.apply(torch.ao.quantization.disable_observer)
 
         self.exportTest(toC(qat_resnet50), toC(x))
 
@@ -211,14 +211,14 @@ class TestModels(TestCase):
             activation=quantization.default_fake_quant,
             weight=quantization.default_per_channel_weight_fake_quant)
         quantization.prepare_qat(qat_resnet50, inplace=True)
-        qat_resnet50.apply(torch.quantization.enable_observer)
-        qat_resnet50.apply(torch.quantization.enable_fake_quant)
+        qat_resnet50.apply(torch.ao.quantization.enable_observer)
+        qat_resnet50.apply(torch.ao.quantization.enable_fake_quant)
 
         _ = qat_resnet50(x)
         for module in qat_resnet50.modules():
             if isinstance(module, quantization.FakeQuantize):
                 module.calculate_qparams()
-        qat_resnet50.apply(torch.quantization.disable_observer)
+        qat_resnet50.apply(torch.ao.quantization.disable_observer)
 
         self.exportTest(toC(qat_resnet50), toC(x))
 

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -741,8 +741,8 @@ class TestUtilityFuns(TestCase):
         class QModule(torch.nn.Module):
             def __init__(self):
                 super(QModule, self).__init__()
-                self.quant1 = torch.quantization.QuantStub()
-                self.dequant = torch.quantization.DeQuantStub()
+                self.quant1 = torch.ao.quantization.QuantStub()
+                self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
                 res = self.quant1(x)
@@ -751,9 +751,9 @@ class TestUtilityFuns(TestCase):
         model = QModule()
         torch.backends.quantized.engine = "qnnpack"
         pt_inputs = (torch.randn(1, 2, 3, 4))
-        model.qconfig = torch.quantization.default_qconfig
-        q_model = torch.quantization.prepare(model, inplace=False)
-        q_model = torch.quantization.convert(q_model, inplace=False)
+        model.qconfig = torch.ao.quantization.default_qconfig
+        q_model = torch.ao.quantization.prepare(model, inplace=False)
+        q_model = torch.ao.quantization.convert(q_model, inplace=False)
 
         q_model.eval()
 

--- a/test/quantization/bc/test_backward_compatibility.py
+++ b/test/quantization/bc/test_backward_compatibility.py
@@ -14,7 +14,7 @@ import torch.nn.intrinsic.quantized as nniq
 from torch.testing._internal.common_utils import TestCase, IS_AVX512_VNNI_SUPPORTED
 from torch.testing._internal.common_quantized import override_qengines, qengine_is_fbgemm
 
-from torch.quantization import MinMaxObserver, PerChannelMinMaxObserver
+from torch.ao.quantization import MinMaxObserver, PerChannelMinMaxObserver
 
 def remove_prefix(text, prefix):
     if text.startswith(prefix):
@@ -107,10 +107,10 @@ class TestSerialization(TestCase):
             def _eval_fn(model, data):
                 model(data)
 
-            qconfig_dict = {'': torch.quantization.default_qconfig}
-            scripted_q = torch.quantization.quantize_jit(
+            qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+            scripted_q = torch.ao.quantization.quantize_jit(
                 scripted, qconfig_dict, _eval_fn, [input_tensor])
-            traced_q = torch.quantization.quantize_jit(
+            traced_q = torch.ao.quantization.quantize_jit(
                 traced, qconfig_dict, _eval_fn, [input_tensor])
 
             torch.jit.save(scripted_q, scripted_module_file)
@@ -175,7 +175,7 @@ class TestSerialization(TestCase):
     @override_qengines
     def test_conv2d_graph(self):
         module = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0, dilation=1,
                       groups=1, bias=True, padding_mode="zeros"),
         )
@@ -184,7 +184,7 @@ class TestSerialization(TestCase):
     @override_qengines
     def test_conv2d_nobias_graph(self):
         module = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0, dilation=1,
                       groups=1, bias=False, padding_mode="zeros"),
         )
@@ -195,7 +195,7 @@ class TestSerialization(TestCase):
         # tests the same thing as test_conv2d_graph, but for version 2 of
         # ConvPackedParams{n}d
         module = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0, dilation=1,
                       groups=1, bias=True, padding_mode="zeros"),
         )
@@ -206,7 +206,7 @@ class TestSerialization(TestCase):
         # tests the same thing as test_conv2d_nobias_graph, but for version 2 of
         # ConvPackedParams{n}d
         module = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0, dilation=1,
                       groups=1, bias=False, padding_mode="zeros"),
         )
@@ -217,7 +217,7 @@ class TestSerialization(TestCase):
         # tests the same thing as test_conv2d_graph, but for version 3 of
         # ConvPackedParams{n}d
         module = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0, dilation=1,
                       groups=1, bias=True, padding_mode="zeros"),
         )
@@ -228,7 +228,7 @@ class TestSerialization(TestCase):
         # tests the same thing as test_conv2d_nobias_graph, but for version 3 of
         # ConvPackedParams{n}d
         module = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0, dilation=1,
                       groups=1, bias=False, padding_mode="zeros"),
         )
@@ -294,7 +294,7 @@ class TestSerialization(TestCase):
 
         model = Model()
         model.linear.weight = torch.nn.Parameter(torch.randn(5, 5))
-        model.qconfig = torch.quantization.get_default_qat_qconfig("fbgemm")
-        ref_model = torch.quantization.QuantWrapper(model)
-        ref_model = torch.quantization.prepare_qat(ref_model)
+        model.qconfig = torch.ao.quantization.get_default_qat_qconfig("fbgemm")
+        ref_model = torch.ao.quantization.QuantWrapper(model)
+        ref_model = torch.ao.quantization.prepare_qat(ref_model)
         self._test_obs(ref_model, input_size=[5, 5], generate=False, check_numerics=False)

--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -4,9 +4,9 @@ import torch.nn.intrinsic as nni
 import torch.nn.intrinsic.quantized as nniq
 import torch.nn.quantized as nnq
 import torch.nn.quantized.dynamic as nnqd
-import torch.quantization
+import torch.ao.quantization
 
-from torch.quantization import (
+from torch.ao.quantization import (
     get_default_static_quant_module_mappings,
     default_float_qparams_observer,
     PerChannelMinMaxObserver,
@@ -200,12 +200,12 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         for mut in modules_under_test:
             # Test from_float.
             float_linear = mut(in_features, out_features).float()
-            float_linear.qconfig = torch.quantization.default_qconfig
-            torch.quantization.prepare(float_linear, inplace=True)
+            float_linear.qconfig = torch.ao.quantization.default_qconfig
+            torch.ao.quantization.prepare(float_linear, inplace=True)
             float_linear(X.float())
             # Sequential allows swapping using "convert".
             quantized_float_linear = torch.nn.Sequential(float_linear)
-            quantized_float_linear = torch.quantization.convert(quantized_float_linear, inplace=True)
+            quantized_float_linear = torch.ao.quantization.convert(quantized_float_linear, inplace=True)
 
             # Smoke test to make sure the module actually runs
             quantized_float_linear(X_q)
@@ -361,13 +361,13 @@ class TestStaticQuantizedModule(QuantizationTestCase):
 
         # Test from_float
         fused_conv_module = torch.nn.intrinsic._FusedModule(conv_module)
-        fused_conv_module.qconfig = torch.quantization.default_qconfig
-        torch.quantization.prepare(fused_conv_module, inplace=True)
+        fused_conv_module.qconfig = torch.ao.quantization.default_qconfig
+        torch.ao.quantization.prepare(fused_conv_module, inplace=True)
         fused_conv_module(X.float())
         converted_qconv_module = fused_conv_module
         reference_mapping = get_default_static_quant_module_mappings()
         reference_mapping[type(conv_module)] = type(qconv_module)
-        torch.quantization.convert(converted_qconv_module, mapping=reference_mapping, inplace=True)
+        torch.ao.quantization.convert(converted_qconv_module, mapping=reference_mapping, inplace=True)
 
         # Smoke test to make sure the module actually runs
         if use_bias:
@@ -967,7 +967,7 @@ class TestDynamicQuantizedModule(QuantizationTestCase):
             # Test from_float
             float_linear = mut(in_features, out_features).float()
             if use_default_observer:
-                float_linear.qconfig = torch.quantization.default_dynamic_qconfig
+                float_linear.qconfig = torch.ao.quantization.default_dynamic_qconfig
             prepare_dynamic(float_linear)
             float_linear(X.float())
             quantized_float_linear = nnqd.Linear.from_float(float_linear)

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -26,7 +26,7 @@ from torch.testing._internal.common_quantization import skipIfNoFBGEMM, skipIfNo
 from torch.testing._internal.common_quantized import _quantize, _dequantize, _calculate_dynamic_qparams, \
     override_quantized_engine, supported_qengines, override_qengines, _snr
 from torch.testing._internal.common_quantized import qengine_is_qnnpack
-from torch.quantization import PerChannelMinMaxObserver
+from torch.ao.quantization import PerChannelMinMaxObserver
 
 from typing import Optional
 
@@ -2452,8 +2452,8 @@ class TestQuantizedOps(TestCase):
                 y_ref = lstm(x)
 
                 # Prepare
-                lstm.qconfig = torch.quantization.get_default_qconfig(qengine)
-                lstm_prepared = torch.quantization.prepare(
+                lstm.qconfig = torch.ao.quantization.get_default_qconfig(qengine)
+                lstm_prepared = torch.ao.quantization.prepare(
                     lstm, prepare_custom_config_dict=custom_module_config)
                 self.assertTrue(hasattr(lstm_prepared[0], 'layers'))
                 self.assertEqual(num_layers, len(lstm_prepared[0].layers))
@@ -2463,7 +2463,7 @@ class TestQuantizedOps(TestCase):
                 self.assertEqual(y_ref, y)
 
                 # Quantize
-                lstm_quantized = torch.quantization.convert(
+                lstm_quantized = torch.ao.quantization.convert(
                     lstm_prepared, convert_custom_config_dict=custom_module_config)
                 qy = lstm_quantized(qx)
 
@@ -2563,8 +2563,8 @@ class TestQuantizedOps(TestCase):
                     mha.eval()
 
                     # Prepare
-                    mha.qconfig = torch.quantization.get_default_qconfig(qengine)
-                    mha_prepared = torch.quantization.prepare(
+                    mha.qconfig = torch.ao.quantization.get_default_qconfig(qengine)
+                    mha_prepared = torch.ao.quantization.prepare(
                         mha, prepare_custom_config_dict=custom_module_config)
 
                     # Calibrate
@@ -2575,7 +2575,7 @@ class TestQuantizedOps(TestCase):
                     self.assertEqual(y_ref[1], y[1])  # Weight
 
                     # Quantize
-                    mha_quantized = torch.quantization.convert(
+                    mha_quantized = torch.ao.quantization.convert(
                         mha_prepared,
                         convert_custom_config_dict=custom_module_config)
                     qy = mha_quantized(*q_data)

--- a/test/quantization/eager/test_bias_correction_eager.py
+++ b/test/quantization/eager/test_bias_correction_eager.py
@@ -3,8 +3,8 @@ import torch.nn as nn
 from torch.testing._internal.common_quantization import QuantizationTestCase
 from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 
-from torch.quantization import default_qconfig
-from torch.quantization import QuantWrapper
+from torch.ao.quantization import default_qconfig
+from torch.ao.quantization import QuantWrapper
 import torch.ao.ns._numeric_suite as ns
 
 from torch.ao.quantization._correct_bias import (
@@ -31,10 +31,10 @@ class TestBiasCorrection(QuantizationTestCase):
         '''
         artificial_model = copy.deepcopy(float_model)
         artificial_model.qconfig = default_qconfig
-        torch.quantization.prepare(artificial_model, inplace=True)
+        torch.ao.quantization.prepare(artificial_model, inplace=True)
         for data in img_data:
             artificial_model(data[0])
-        torch.quantization.convert(artificial_model, inplace=True)
+        torch.ao.quantization.convert(artificial_model, inplace=True)
 
         # manually changing bias
         for name, submodule in artificial_model.named_modules():

--- a/test/quantization/eager/test_fusion.py
+++ b/test/quantization/eager/test_fusion.py
@@ -4,7 +4,7 @@ import torch.nn.quantized as nnq
 import torch.nn.intrinsic as nni
 import torch.nn.intrinsic.quantized as nniq
 import torch.nn.intrinsic.qat as nniqat
-from torch.quantization import (
+from torch.ao.quantization import (
     quantize,
     prepare,
     convert,
@@ -198,7 +198,7 @@ class TestFusion(QuantizationTestCase):
                                      msg="Non-fused submodule Conv")
                 self.assertEqual(type(model.classifier[0]), nni.LinearReLU)
                 self.assertEqual(type(model.classifier[1]), nn.Identity)
-                model.qconfig = torch.quantization.get_default_qat_qconfig(qengine)
+                model.qconfig = torch.ao.quantization.get_default_qat_qconfig(qengine)
                 prepare_qat(model, inplace=True)
                 self.checkObservers(model)
                 model(self.img_data_2d[0][0])
@@ -250,7 +250,7 @@ class TestFusion(QuantizationTestCase):
                                      msg="Non-fused submodule Conv")
                 self.assertEqual(type(model.classifier[0]), nni.LinearReLU)
                 self.assertEqual(type(model.classifier[1]), nn.Identity)
-                model.qconfig = torch.quantization.get_default_qconfig(qengine)
+                model.qconfig = torch.ao.quantization.get_default_qconfig(qengine)
                 prepare(model, inplace=True)
                 self.checkObservers(model)
                 model(self.img_data_2d[0][0])
@@ -284,7 +284,7 @@ class TestFusion(QuantizationTestCase):
                 out_fused = prep_model(self.img_data_2d[0][0])
                 self.assertEqual(out_ref, out_fused)
 
-                model.qconfig = torch.quantization.get_default_qconfig(qengine)
+                model.qconfig = torch.ao.quantization.get_default_qconfig(qengine)
                 prepare_qat(model, inplace=True)
 
                 model(self.img_data_2d[0][0])

--- a/test/quantization/eager/test_model_numerics.py
+++ b/test/quantization/eager/test_model_numerics.py
@@ -20,13 +20,13 @@ class TestModelNumericsEager(QuantizationTestCase):
                 calib_data = torch.rand(1024, 3, 15, 15, dtype=torch.float32)
                 eval_data = torch.rand(1, 3, 15, 15, dtype=torch.float32)
                 out_ref = my_model(eval_data)
-                qModel = torch.quantization.QuantWrapper(my_model)
+                qModel = torch.ao.quantization.QuantWrapper(my_model)
                 qModel.eval()
-                qModel.qconfig = torch.quantization.default_qconfig
+                qModel.qconfig = torch.ao.quantization.default_qconfig
                 torch.ao.quantization.fuse_modules(qModel.module, [['conv1', 'bn1', 'relu1']], inplace=True)
-                torch.quantization.prepare(qModel, inplace=True)
+                torch.ao.quantization.prepare(qModel, inplace=True)
                 qModel(calib_data)
-                torch.quantization.convert(qModel, inplace=True)
+                torch.ao.quantization.convert(qModel, inplace=True)
                 out_q = qModel(eval_data)
                 SQNRdB = 20 * torch.log10(torch.norm(out_ref) / torch.norm(out_ref - out_q))
                 # Quantized model output should be close to floating point model output numerically
@@ -42,13 +42,13 @@ class TestModelNumericsEager(QuantizationTestCase):
         calib_data = torch.rand(2048, 3, 15, 15, dtype=torch.float32)
         eval_data = torch.rand(10, 3, 15, 15, dtype=torch.float32)
         out_ref = my_model(eval_data)
-        q_model = torch.quantization.QuantWrapper(my_model)
+        q_model = torch.ao.quantization.QuantWrapper(my_model)
         q_model.eval()
-        q_model.qconfig = torch.quantization.default_per_channel_qconfig
+        q_model.qconfig = torch.ao.quantization.default_per_channel_qconfig
         torch.ao.quantization.fuse_modules(q_model.module, [['conv1', 'bn1', 'relu1']], inplace=True)
-        torch.quantization.prepare(q_model)
+        torch.ao.quantization.prepare(q_model)
         q_model(calib_data)
-        torch.quantization.convert(q_model)
+        torch.ao.quantization.convert(q_model)
         out_q = q_model(eval_data)
         SQNRdB = 20 * torch.log10(torch.norm(out_ref) / torch.norm(out_ref - out_q))
         # Quantized model output should be close to floating point model output numerically
@@ -64,23 +64,23 @@ class TestModelNumericsEager(QuantizationTestCase):
                 eval_data = torch.rand(10, 3, 15, 15, dtype=torch.float32)
                 my_model.eval()
                 out_ref = my_model(eval_data)
-                fq_model = torch.quantization.QuantWrapper(my_model)
+                fq_model = torch.ao.quantization.QuantWrapper(my_model)
                 fq_model.train()
-                fq_model.qconfig = torch.quantization.default_qat_qconfig
+                fq_model.qconfig = torch.ao.quantization.default_qat_qconfig
                 torch.ao.quantization.fuse_modules(fq_model.module, [['conv1', 'bn1', 'relu1']], inplace=True)
-                torch.quantization.prepare_qat(fq_model)
+                torch.ao.quantization.prepare_qat(fq_model)
                 fq_model.eval()
-                fq_model.apply(torch.quantization.disable_fake_quant)
+                fq_model.apply(torch.ao.quantization.disable_fake_quant)
                 fq_model.apply(torch.nn.intrinsic.qat.freeze_bn_stats)
                 fq_model(calib_data)
-                fq_model.apply(torch.quantization.enable_fake_quant)
-                fq_model.apply(torch.quantization.disable_observer)
+                fq_model.apply(torch.ao.quantization.enable_fake_quant)
+                fq_model.apply(torch.ao.quantization.disable_observer)
                 out_fq = fq_model(eval_data)
                 SQNRdB = 20 * torch.log10(torch.norm(out_ref) / torch.norm(out_ref - out_fq))
                 # Quantized model output should be close to floating point model output numerically
                 # Setting target SQNR to be 35 dB
                 self.assertGreater(SQNRdB, 35, msg='Quantized model numerics diverge from float, expect SQNR > 35 dB')
-                torch.quantization.convert(fq_model)
+                torch.ao.quantization.convert(fq_model)
                 out_q = fq_model(eval_data)
                 SQNRdB = 20 * torch.log10(torch.norm(out_fq) / (torch.norm(out_fq - out_q) + 1e-10))
                 self.assertGreater(SQNRdB, 60, msg='Fake quant and true quant numerics diverge, expect SQNR > 60 dB')
@@ -93,24 +93,24 @@ class TestModelNumericsEager(QuantizationTestCase):
                 torch.manual_seed(67)
                 calib_data = torch.rand(2048, 3, 15, 15, dtype=torch.float32)
                 eval_data = torch.rand(10, 3, 15, 15, dtype=torch.float32)
-                qconfigset = set([torch.quantization.default_weight_only_qconfig,
-                                  torch.quantization.default_activation_only_qconfig])
+                qconfigset = set([torch.ao.quantization.default_weight_only_qconfig,
+                                  torch.ao.quantization.default_activation_only_qconfig])
                 SQNRTarget = [35, 45]
                 for idx, qconfig in enumerate(qconfigset):
                     my_model = ModelMultipleOpsNoAvgPool().to(torch.float32)
                     my_model.eval()
                     out_ref = my_model(eval_data)
-                    fq_model = torch.quantization.QuantWrapper(my_model)
+                    fq_model = torch.ao.quantization.QuantWrapper(my_model)
                     fq_model.train()
                     fq_model.qconfig = qconfig
                     torch.ao.quantization.fuse_modules(fq_model.module, [['conv1', 'bn1', 'relu1']], inplace=True)
-                    torch.quantization.prepare_qat(fq_model)
+                    torch.ao.quantization.prepare_qat(fq_model)
                     fq_model.eval()
-                    fq_model.apply(torch.quantization.disable_fake_quant)
+                    fq_model.apply(torch.ao.quantization.disable_fake_quant)
                     fq_model.apply(torch.nn.intrinsic.qat.freeze_bn_stats)
                     fq_model(calib_data)
-                    fq_model.apply(torch.quantization.enable_fake_quant)
-                    fq_model.apply(torch.quantization.disable_observer)
+                    fq_model.apply(torch.ao.quantization.enable_fake_quant)
+                    fq_model.apply(torch.ao.quantization.disable_observer)
                     out_fq = fq_model(eval_data)
                     SQNRdB = 20 * torch.log10(torch.norm(out_ref) / torch.norm(out_ref - out_fq))
                     self.assertGreater(SQNRdB, SQNRTarget[idx], msg='Quantized model numerics diverge from float')

--- a/test/quantization/eager/test_numeric_suite_eager.py
+++ b/test/quantization/eager/test_numeric_suite_eager.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.quantized as nnq
-from torch.quantization import (
+from torch.ao.quantization import (
     DeQuantStub,
     QuantStub,
     convert,
@@ -277,7 +277,7 @@ class TestEagerModeNumericSuite(QuantizationTestCase):
         qengine = torch.backends.quantized.engine
 
         model = ModelWithFunctionals().eval()
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        model.qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
         q_model = prepare(model, inplace=False)
         q_model(self.img_data_2d[0][0])
         q_model = convert(q_model)
@@ -411,7 +411,7 @@ class TestEagerModeNumericSuite(QuantizationTestCase):
         qengine = torch.backends.quantized.engine
 
         model = ModelWithFunctionals().eval()
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        model.qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
         q_model = prepare(model, inplace=False)
         q_model(self.img_data_2d[0][0])
         q_model = convert(q_model)

--- a/test/quantization/fx/test_equalize_fx.py
+++ b/test/quantization/fx/test_equalize_fx.py
@@ -3,10 +3,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.intrinsic.quantized as nniq
 import torch.nn.quantized as nnq
-from torch.quantization import default_qconfig
-from torch.quantization.observer import MinMaxObserver, PerChannelMinMaxObserver
-from torch.quantization.quantize_fx import prepare_fx, convert_fx
-from torch.quantization.fx._equalize import (
+from torch.ao.quantization import default_qconfig
+from torch.ao.quantization.observer import MinMaxObserver, PerChannelMinMaxObserver
+from torch.ao.quantization.quantize_fx import prepare_fx, convert_fx
+from torch.ao.quantization.fx._equalize import (
     _InputEqualizationObserver,
     _WeightEqualizationObserver,
     calculate_equalization_scale,

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -6,10 +6,10 @@ import unittest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.quantization import default_dynamic_qconfig
+from torch.ao.quantization import default_dynamic_qconfig
 import torch.nn.quantized as nnq
 toq = torch.ops.quantized
-from torch.quantization.quantize_fx import (
+from torch.ao.quantization.quantize_fx import (
     convert_fx,
     prepare_fx,
     prepare_qat_fx,
@@ -26,15 +26,15 @@ from torch.testing._internal.common_quantization import (
     SparseNNModel,
     skip_if_no_torchvision,
 )
-from torch.quantization.quantization_mappings import (
+from torch.ao.quantization.quantization_mappings import (
     get_default_static_quant_module_mappings,
     get_default_dynamic_quant_module_mappings,
     get_default_float_to_quantized_operator_mappings,
 )
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_quantization import NodeSpec as ns
-from torch.quantization.fx.pattern_utils import get_default_quant_patterns
-import torch.quantization.fx.quantization_patterns as qp
+from torch.ao.quantization.fx.pattern_utils import get_default_quant_patterns
+import torch.ao.quantization.fx.quantization_patterns as qp
 from torch.ao.ns.fx.pattern_utils import (
     get_type_a_related_to_b,
 )
@@ -279,7 +279,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
     @skipIfNoFBGEMM
     def test_simple_mod(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -289,7 +289,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
             base_name_to_sets_of_related_ops, nn.Conv2d) + '_0'
 
         expected_types = {
-            conv_name_0: ((nn.Conv2d, torch.quantization.MinMaxObserver), (nnq.Conv2d, nnq.Conv2d)),
+            conv_name_0: ((nn.Conv2d, torch.ao.quantization.MinMaxObserver), (nnq.Conv2d, nnq.Conv2d)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
@@ -306,7 +306,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return F.linear(x, self.w, self.b)
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -317,14 +317,14 @@ class TestFXGraphMatcher(QuantizationTestCase):
 
         expected_types = {
             linear_name_0:
-                ((F.linear, torch.quantization.MinMaxObserver), (toq.linear, toq.linear))
+                ((F.linear, torch.ao.quantization.MinMaxObserver), (toq.linear, toq.linear))
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
     @skipIfNoFBGEMM
     def test_simple_fusion(self):
         m = LinearReluFunctional().eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -335,7 +335,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
 
         expected_types = {
             linear_name_0:
-                ((F.linear, torch.quantization.MinMaxObserver), (toq.linear_relu, toq.linear_relu)),
+                ((F.linear, torch.ao.quantization.MinMaxObserver), (toq.linear_relu, toq.linear_relu)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
@@ -347,7 +347,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
             ),
             nn.Conv2d(1, 1, 1),
         ).eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         # assume success if no exceptions
@@ -364,7 +364,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return z
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         # assume success if no exceptions
@@ -376,8 +376,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # different counts of matchable nodes fails
         m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
         m2 = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1)).eval()
-        mp1 = prepare_fx(m1, {'': torch.quantization.default_qconfig})
-        mp2 = prepare_fx(m2, {'': torch.quantization.default_qconfig})
+        mp1 = prepare_fx(m1, {'': torch.ao.quantization.default_qconfig})
+        mp2 = prepare_fx(m2, {'': torch.ao.quantization.default_qconfig})
         with self.assertRaises(GraphMatchingException) as ex:
             results = get_matching_subgraph_pairs(mp1, mp2)
 
@@ -386,8 +386,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # verify that matching graphs with non-matching node types fails
         m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
         m2 = nn.Sequential(nn.Linear(1, 1)).eval()
-        mp1 = prepare_fx(m1, {'': torch.quantization.default_qconfig})
-        mp2 = prepare_fx(m2, {'': torch.quantization.default_qconfig})
+        mp1 = prepare_fx(m1, {'': torch.ao.quantization.default_qconfig})
+        mp2 = prepare_fx(m2, {'': torch.ao.quantization.default_qconfig})
         with self.assertRaises(GraphMatchingException) as ex:
             results = get_matching_subgraph_pairs(mp1, mp2)
 
@@ -405,7 +405,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return x2
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -420,8 +420,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
 
         expected_types = {
             cat_name_0: ((torch.cat, torch.cat), (torch.cat, torch.cat)),
-            add_name_0: ((torch.add, torch.quantization.MinMaxObserver), (toq.add, toq.add)),
-            add_name_1: ((torch.add, torch.quantization.MinMaxObserver), (toq.add, toq.add)),
+            add_name_0: ((torch.add, torch.ao.quantization.MinMaxObserver), (toq.add, toq.add)),
+            add_name_1: ((torch.add, torch.ao.quantization.MinMaxObserver), (toq.add, toq.add)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
@@ -440,7 +440,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return a1
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -454,9 +454,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
             base_name_to_sets_of_related_ops, torch.add) + '_2'
 
         expected_types = {
-            add_name_0: ((torch.add, torch.quantization.MinMaxObserver), (toq.add, toq.add)),
-            add_name_1: ((torch.add, torch.quantization.MinMaxObserver), (toq.add, toq.add)),
-            add_name_2: ((torch.add, torch.quantization.MinMaxObserver), (toq.add, toq.add)),
+            add_name_0: ((torch.add, torch.ao.quantization.MinMaxObserver), (toq.add, toq.add)),
+            add_name_1: ((torch.add, torch.ao.quantization.MinMaxObserver), (toq.add, toq.add)),
+            add_name_2: ((torch.add, torch.ao.quantization.MinMaxObserver), (toq.add, toq.add)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
@@ -481,7 +481,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # prevent conv2 from getting quantized, so we can test
         # modules with equal types
         qconfig_dict = {
-            '': torch.quantization.default_qconfig,
+            '': torch.ao.quantization.default_qconfig,
             'module_name': [('conv2', None)],
         }
         mp = prepare_fx(m, qconfig_dict)
@@ -504,11 +504,11 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # all of these should be matched
         expected_types = {
             conv_name_1:
-                ((nn.Conv2d, torch.quantization.MinMaxObserver), (nnq.Conv2d, nnq.Conv2d)),
+                ((nn.Conv2d, torch.ao.quantization.MinMaxObserver), (nnq.Conv2d, nnq.Conv2d)),
             conv_name_0:
-                ((nn.Conv2d, torch.quantization.MinMaxObserver), (nn.Conv2d, nn.Conv2d)),
-            mul_name_0: ((torch.mul, torch.quantization.MinMaxObserver), (toq.mul, toq.mul)),
-            relu_name_0: ((F.relu, torch.quantization.MinMaxObserver), (F.relu, F.relu)),
+                ((nn.Conv2d, torch.ao.quantization.MinMaxObserver), (nn.Conv2d, nn.Conv2d)),
+            mul_name_0: ((torch.mul, torch.ao.quantization.MinMaxObserver), (toq.mul, toq.mul)),
+            relu_name_0: ((F.relu, torch.ao.quantization.MinMaxObserver), (F.relu, F.relu)),
             sigmoid_name_0:
                 ((torch.sigmoid, torch.sigmoid), (torch.sigmoid, torch.sigmoid)),
         }
@@ -526,7 +526,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
 
         m1 = M().eval()
         m2 = M().eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         m1p = prepare_fx(m1, qconfig_dict)
         m2p = prepare_fx(m2, qconfig_dict)
         results = get_matching_subgraph_pairs(m1p, m2p)
@@ -554,8 +554,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
         for fp32_type, int8_type in static_quant_mod_mappings.items():
             # skip quants and dequants, for the purposes of Numerical Suite
             types_to_skip = (
-                torch.quantization.QuantStub,
-                torch.quantization.DeQuantStub,
+                torch.ao.quantization.QuantStub,
+                torch.ao.quantization.DeQuantStub,
                 nnq.FloatFunctional,
             )
             if fp32_type in types_to_skip:
@@ -698,7 +698,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 x = _wrapped_hardswish(x)
                 return x
 
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         m1 = prepare_fx(M1().eval(), qconfig_dict)
         m2 = prepare_fx(M2().eval(), qconfig_dict)
 
@@ -715,7 +715,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
 
         expected_types = {
             hardswish_name_0:
-                ((F.hardswish, torch.quantization.MinMaxObserver), (_wrapped_hardswish, _wrapped_hardswish)),
+                ((F.hardswish, torch.ao.quantization.MinMaxObserver), (_wrapped_hardswish, _wrapped_hardswish)),
         }
         self.assert_types_for_matched_subgraph_pairs(
             results, expected_types, m1, m2)
@@ -726,7 +726,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
             nn.Conv2d(1, 1, 1),
             nn.Linear(1, 1),
         ).eval()
-        mp = prepare_fx(m, {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -748,7 +748,7 @@ class TestFXGraphMatcherModels(QuantizationTestCase):
         # verify that mobilenetv2 graph is able to be matched
         import torchvision
         m = torchvision.models.__dict__['mobilenet_v2'](pretrained=False).eval().float()
-        mp = prepare_fx(copy.deepcopy(m), {'': torch.quantization.default_qconfig})
+        mp = prepare_fx(copy.deepcopy(m), {'': torch.ao.quantization.default_qconfig})
         # assume success if no exceptions
         results_m_mp = get_matching_subgraph_pairs(torch.fx.symbolic_trace(m), mp)
         mp_copy = copy.deepcopy(mp)
@@ -764,7 +764,7 @@ class TestFXGraphMatcherModels(QuantizationTestCase):
         m = torchvision.models.__dict__['mobilenet_v2'](pretrained=False).float()
         mp = prepare_qat_fx(
             copy.deepcopy(m),
-            {'': torch.quantization.get_default_qat_qconfig('fbgemm')})
+            {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')})
         # assume success if no exceptions
         results_m_mp = get_matching_subgraph_pairs(torch.fx.symbolic_trace(m), mp)
         mp_copy = copy.deepcopy(mp)
@@ -779,7 +779,7 @@ class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
     ):
         m = torch.fx.symbolic_trace(m)
         if qconfig_dict is None:
-            qconfig_dict = {'': torch.quantization.default_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fn(copy.deepcopy(m), qconfig_dict)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
@@ -809,7 +809,7 @@ class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
         prepare_fn=prepare_fx,
     ):
         if qconfig_dict is None:
-            qconfig_dict = {'': torch.quantization.default_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         if prepare_fn == prepare_fx:
             m.eval()
         else:
@@ -872,7 +872,7 @@ class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
         prepare_fn=prepare_fx, compare_fp32_vs_fp32_prepared=True,
     ):
         if qconfig_dict is None:
-            qconfig_dict = {'': torch.quantization.default_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         if prepare_fn == prepare_fx:
             m.eval()
         else:
@@ -940,7 +940,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_extract_weights_mod_qat(self):
         m = AllConvAndLinearFusionModules().train()
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         self._test_extract_weights(
             m, results_len=14, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
 
@@ -952,7 +952,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_extract_weights_linear_fun_qat(self):
         m = LinearReluLinearFunctional().train()
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         self._test_extract_weights(
             m, results_len=2, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
 
@@ -976,7 +976,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         b2d = torch.randn(1)
         b3d = torch.randn(1)
         m = AllConvFunctional(w1d, w2d, w3d, b1d, b2d, b3d).train()
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         self._test_extract_weights(
             m, results_len=6, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
 
@@ -997,7 +997,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Sequential(nn.Conv2d(1, 1, 1)),
             nn.Conv2d(1, 1, 1),
         ).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mq = convert_fx(copy.deepcopy(mp))
         results = extract_weights('a', mp, 'b', mq)
@@ -1010,13 +1010,13 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
     def _test_match_activations_mod_impl(self, prepare_fn=prepare_fx):
         m = nn.Sequential(
-            torch.quantization.QuantStub(),
+            torch.ao.quantization.QuantStub(),
             nn.Conv2d(1, 1, 1),
             nn.Conv2d(1, 1, 1),
         ).eval()
         qconfig_dict = None
         if prepare_fn == prepare_qat_fx:
-            qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+            qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         expected_occurrence = {
             ns.call_module(OutputLogger): 2,
         }
@@ -1037,7 +1037,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         m = LinearReluLinearFunctional().eval()
         qconfig_dict = None
         if prepare_fn == prepare_qat_fx:
-            qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+            qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         expected_occurrence = {
             ns.call_module(OutputLogger): 2,
         }
@@ -1075,7 +1075,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Sequential(nn.Conv2d(1, 1, 1)),
             nn.Conv2d(1, 1, 1),
         ).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mq = convert_fx(copy.deepcopy(mp))
         mp_ns, mq_ns = add_loggers('a', mp, 'b', mq, OutputLogger)
@@ -1098,7 +1098,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         ).eval()
         qconfig_dict = None
         if prepare_fn == prepare_qat_fx:
-            qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+            qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         res = self._test_match_shadow_activations(
             m, (torch.randn(1, 1, 4, 4),), results_len=2,
             prepare_fn=prepare_fn, qconfig_dict=qconfig_dict)
@@ -1117,7 +1117,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         m = LinearReluLinearFunctional()
         qconfig_dict = None
         if prepare_fn == prepare_qat_fx:
-            qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+            qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         res = self._test_match_shadow_activations(
             m, (torch.randn(4, 4),), results_len=2, prepare_fn=prepare_fn,
             qconfig_dict=qconfig_dict)
@@ -1180,7 +1180,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Sequential(nn.Conv2d(1, 1, 1)),
             nn.Conv2d(1, 1, 1),
         ).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mq = convert_fx(copy.deepcopy(mp))
         mp_shadows_mq = add_shadow_loggers('a', mp, 'b', mq, OutputLogger)
@@ -1246,14 +1246,14 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
     @skipIfNoFBGEMM
     def test_linear_fp16_weights(self):
-        qconfig_dict = {'': torch.quantization.float16_static_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.float16_static_qconfig}
         m = LinearReluFunctional().eval()
         self._test_extract_weights(m, results_len=1, qconfig_dict=qconfig_dict)
 
     @skipIfNoFBGEMM
     def test_linear_fp16_activations(self):
         for should_log_inputs in (True, False):
-            qconfig_dict = {'': torch.quantization.float16_static_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.float16_static_qconfig}
             m = LinearReluFunctional().eval()
             num_loggers = 2 if should_log_inputs else 1
             expected_occurrence = {
@@ -1269,7 +1269,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_linear_fp16_shadow_activations(self):
         for should_log_inputs in (True, False):
-            qconfig_dict = {'': torch.quantization.float16_static_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.float16_static_qconfig}
             m = LinearReluFunctional().eval()
             num_loggers = 4 if should_log_inputs else 2
             expected_occurrence = {
@@ -1285,7 +1285,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_linear_fp16_vs_linear_fp16_shadow_activations(self):
         m = LinearFunctional().eval()
-        qconfig_dict = {'': torch.quantization.float16_static_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.float16_static_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mq1 = convert_fx(copy.deepcopy(mp))
         mq2 = convert_fx(copy.deepcopy(mp))
@@ -1324,7 +1324,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         """
         Verify that shadowing works where both modules are int8
         """
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mp(torch.randn(4, 1, 4, 4))
         mq1 = convert_fx(copy.deepcopy(mp))
@@ -1366,7 +1366,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 return x1, x2
 
         m = M2().eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         prepare_custom_config_dict = {
             'non_traceable_module_class': [M1],
         }
@@ -1410,7 +1410,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         m = M().eval()
 
         # quantize without tracing through UserModule
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         prepare_custom_config_dict = {'non_traceable_module_name': ['user_module']}
         mp = prepare_fx(m, qconfig_dict, prepare_custom_config_dict)
         mp(torch.randn(1, 1, 1))
@@ -1479,8 +1479,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         static_quant_mod_mappings = get_default_static_quant_module_mappings()
         for fp32_type, int8_type in static_quant_mod_mappings.items():
             types_to_skip = (
-                torch.quantization.QuantStub,
-                torch.quantization.DeQuantStub,
+                torch.ao.quantization.QuantStub,
+                torch.ao.quantization.DeQuantStub,
                 nnq.FloatFunctional,
                 # TODO(future PR): look into whether shadowing embeddings
                 # makes sense
@@ -1619,7 +1619,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 x = _wrapped_linear(x, self.w1, self.b1)
                 return x
 
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         m1 = prepare_fx(M1().eval(), qconfig_dict)
         m2 = prepare_fx(M2().eval(), qconfig_dict)
         data = torch.randn(1, 1)
@@ -1691,9 +1691,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Conv2d(1, 1, 1),
             nn.Sigmoid(),
         ).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
-        mp = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
-        mq = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
 
         # extract weights
         results = extract_weights('fp32', mp, 'int8', mq)
@@ -1702,7 +1702,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             self.assertTrue(layer_name in mq_node_names)
 
         # match activations
-        mq = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mp_ns, mq_ns = add_loggers(
             'fp32', copy.deepcopy(mp), 'int8', mq, OutputLogger)
         data = torch.randn(1, 1, 1, 1)
@@ -1714,7 +1714,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             self.assertTrue(layer_name in mq_node_names)
 
         # match shadow activations
-        mq = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mp_shadows_mq = add_shadow_loggers(
             'fp32', mp, 'int8', mq, OutputLogger)
         mp_shadows_mq(data)
@@ -1727,9 +1727,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_extend_logger_results_with_comparison(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1)).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
-        mp = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
-        mq = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
 
         # extract weights
         results = extract_weights('fp32', mp, 'int8', mq)
@@ -1752,11 +1752,11 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_int8_shadows_fp32_simple(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1), nn.ReLU()).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
-        mp = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
         mp(torch.randn(1, 1, 1, 1))
-        mq = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
-        mq_ref = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        mq_ref = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mp_shadows_mq = add_shadow_loggers(
             'int8', mq, 'fp32', mp, OutputLogger)
 
@@ -1806,11 +1806,11 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 return x
 
         m = M().eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
-        mp = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
         mp(torch.randn(1, 1, 1, 1))
-        mq = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
-        mq_ref = torch.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
+        mq_ref = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mp_shadows_mq = add_shadow_loggers(
             'int8', mq, 'fp32', mp, OutputLogger)
         mp_shadows_mq(torch.randn(1, 1, 1, 1))
@@ -1822,11 +1822,11 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_loggers_preserve_qat_numerics(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1))
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         mp = prepare_qat_fx(m, qconfig_dict)
         mp(torch.randn(1, 1, 1, 1))
         mc = convert_fx(copy.deepcopy(mp))
-        mp.apply(torch.quantization.disable_observer)
+        mp.apply(torch.ao.quantization.disable_observer)
 
         datum = torch.randn(1, 1, 1, 1)
         ref_fp32 = mp(datum)
@@ -1841,11 +1841,11 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_shadow_loggers_preserve_qat_numerics(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1))
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         mp = prepare_qat_fx(m, qconfig_dict)
         mp(torch.randn(1, 1, 1, 1))
         mc = convert_fx(copy.deepcopy(mp))
-        mp.apply(torch.quantization.disable_observer)
+        mp.apply(torch.ao.quantization.disable_observer)
 
         datum = torch.randn(1, 1, 1, 1)
         ref_fp32 = mp(datum)
@@ -2041,7 +2041,7 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
     def test_resnet18(self):
         import torchvision
         m = torchvision.models.quantization.resnet18(pretrained=True, quantize=False).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         self._test_match_shadow_activations(
             m, (torch.randn(1, 3, 224, 224),),
             qconfig_dict=qconfig_dict,
@@ -2053,7 +2053,7 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
     def test_mobilenet_v2(self):
         import torchvision
         m = torchvision.models.quantization.mobilenet_v2(pretrained=True, quantize=False).eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         self._test_match_shadow_activations(
             m, (torch.randn(1, 3, 224, 224),),
             qconfig_dict=qconfig_dict,

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -11,15 +11,15 @@ import torch.nn.intrinsic.quantized.dynamic as nniqd
 import torch.multiprocessing as mp
 
 # graph mode quantization based on fx
-from torch.quantization.quantize_fx import (
+from torch.ao.quantization.quantize_fx import (
     prepare_fx,
     convert_fx,
     prepare_qat_fx,
 )
 
-from torch.quantization.fx.quantization_patterns import DefaultNodeQuantizeHandler
+from torch.ao.quantization.fx.quantization_patterns import DefaultNodeQuantizeHandler
 
-from torch.quantization.fx.match_utils import (
+from torch.ao.quantization.fx.match_utils import (
     is_match,
     MatchAllNode,
 )
@@ -29,7 +29,7 @@ from torch.ao.quantization import (
     quant_type_to_str,
 )
 
-from torch.quantization import (
+from torch.ao.quantization import (
     QuantStub,
     DeQuantStub,
     QuantWrapper,
@@ -229,7 +229,7 @@ class TestFuseFx(QuantizationTestCase):
 
         # test eval mode
         m = M().eval()
-        from torch.quantization.quantize_fx import fuse_fx
+        from torch.ao.quantization.quantize_fx import fuse_fx
         # fuse_fx is a top level api and only supports eval mode
         m = fuse_fx(m)
         expected_nodes = [
@@ -277,7 +277,7 @@ class TestFuseFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        from torch.quantization.quantize_fx import fuse_fx
+        from torch.ao.quantization.quantize_fx import fuse_fx
         m = fuse_fx(m)
         expected_nodes = [
             ns.call_module(nni.ConvReLU1d),
@@ -360,7 +360,7 @@ class TestFuseFx(QuantizationTestCase):
         users will be notified of what keys are supported.
         """
         m = ConvModel().eval()
-        from torch.quantization.quantize_fx import fuse_fx
+        from torch.ao.quantization.quantize_fx import fuse_fx
         fuse_custom_config_dict = {"typo": None}
 
         with self.assertRaises(ValueError) as context:
@@ -840,7 +840,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         model = Model()
         qengine = torch.backends.quantized.engine
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig(qengine)}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
         device = torch.device('cuda:0')
         model.to(device)
 
@@ -1006,11 +1006,11 @@ class TestQuantizeFx(QuantizationTestCase):
         # input and output of first conv, observer for standalone module
         # will be inserted in the standalone module itself
         prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 2
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 2
         }
         # for input and output of conv in the standalone module
         standalone_prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 2
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 2
         }
         convert_count_check = {
             ns.call_function(torch.quantize_per_tensor) : 1,
@@ -1039,11 +1039,11 @@ class TestQuantizeFx(QuantizationTestCase):
         interface_config = quantized_interface_config
         # observer for input and output of first conv
         prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 2
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 2
         }
         # for output of conv in the standalone module
         standalone_prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 1
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 1
         }
         convert_count_check = {
             # quantizing input for conv
@@ -1306,12 +1306,12 @@ class TestQuantizeFx(QuantizationTestCase):
         qconfig_dict = {
             "module_name_object_type_order": [
                 # test various FQNs: global, single child, multiple children
-                ("", nn.Linear, 0, torch.quantization.default_qconfig),
-                ("", torch.add, 0, torch.quantization.default_qconfig),
-                ("m2", nn.Linear, 1, torch.quantization.default_qconfig),
-                ("m2", torch.add, 1, torch.quantization.default_qconfig),
-                ("m2.m1", nn.Linear, 0, torch.quantization.default_qconfig),
-                ("m2.m1", torch.add, 0, torch.quantization.default_qconfig),
+                ("", nn.Linear, 0, torch.ao.quantization.default_qconfig),
+                ("", torch.add, 0, torch.ao.quantization.default_qconfig),
+                ("m2", nn.Linear, 1, torch.ao.quantization.default_qconfig),
+                ("m2", torch.add, 1, torch.ao.quantization.default_qconfig),
+                ("m2.m1", nn.Linear, 0, torch.ao.quantization.default_qconfig),
+                ("m2.m1", torch.add, 0, torch.ao.quantization.default_qconfig),
             ],
         }
         m = prepare_fx(m, qconfig_dict)
@@ -1365,7 +1365,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M4().eval()
         qconfig_dict = {
-            "": torch.quantization.default_qconfig,
+            "": torch.ao.quantization.default_qconfig,
             "module_name_object_type_order": [
                 ("", nn.Linear, 1, None),
                 ("", torch.add, 1, None),
@@ -1469,7 +1469,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 pass
 
         m = M().eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         m = prepare_fx(m, qconfig_dict)
         m = convert_fx(m)
 
@@ -1637,7 +1637,7 @@ class TestQuantizeFx(QuantizationTestCase):
     def test_qat_and_script(self):
         model = LinearModelWithSubmodule().train()
         qengine = torch.backends.quantized.engine
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig(qengine)}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
         model = prepare_qat_fx(model, qconfig_dict)
 
         # ensure scripting works
@@ -1651,9 +1651,9 @@ class TestQuantizeFx(QuantizationTestCase):
         # disable fake_quant and observer
         for epoch in range(3):
             if epoch == 1:
-                scripted.apply(torch.quantization.disable_observer)
+                scripted.apply(torch.ao.quantization.disable_observer)
             if epoch == 2:
-                scripted.apply(torch.quantization.disable_fake_quant)
+                scripted.apply(torch.ao.quantization.disable_fake_quant)
 
         # ensure the fake_quant and observer have been disabled.
         matches = ['.fake_quant_enabled', '.observer_enabled']
@@ -1662,8 +1662,8 @@ class TestQuantizeFx(QuantizationTestCase):
                 self.assertEqual(v, torch.tensor([0], dtype=torch.int64))
 
         # enable them back
-        scripted.apply(torch.quantization.enable_fake_quant)
-        scripted.apply(torch.quantization.enable_observer)
+        scripted.apply(torch.ao.quantization.enable_fake_quant)
+        scripted.apply(torch.ao.quantization.enable_observer)
         for key, v in scripted.state_dict().items():
             if any(x in key for x in matches):
                 self.assertEqual(v, torch.tensor([1], dtype=torch.int64))
@@ -1672,7 +1672,7 @@ class TestQuantizeFx(QuantizationTestCase):
     def test_save_observer_state_dict(self):
         orig = LinearModelWithSubmodule().eval()
         model = orig
-        qconfig_dict = {'': torch.quantization.get_default_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qconfig('fbgemm')}
         model = prepare_fx(model, qconfig_dict)
 
         # run it through input
@@ -1682,7 +1682,7 @@ class TestQuantizeFx(QuantizationTestCase):
         quant = convert_fx(model)
 
         # save state_dict of model
-        obs_dict = torch.quantization.get_observer_state_dict(model)
+        obs_dict = torch.ao.quantization.get_observer_state_dict(model)
         b = io.BytesIO()
         torch.save(obs_dict, b)
         b.seek(0)
@@ -1692,7 +1692,7 @@ class TestQuantizeFx(QuantizationTestCase):
         model_2 = prepare_fx(model_2, qconfig_dict)
 
         loaded_dict = torch.load(b)
-        torch.quantization.load_observer_state_dict(model_2, loaded_dict)
+        torch.ao.quantization.load_observer_state_dict(model_2, loaded_dict)
 
         quant_2 = convert_fx(model_2)
 
@@ -1833,7 +1833,7 @@ class TestQuantizeFx(QuantizationTestCase):
             m(data)
             # all activation observers are inserted in the top level module
             count_check = {
-                ns.call_module(torch.quantization.MinMaxObserver): num_observers
+                ns.call_module(torch.ao.quantization.MinMaxObserver): num_observers
             }
             self.checkGraphModuleNodes(m, expected_node_occurrence=count_check)
 
@@ -1927,7 +1927,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M()
         m.eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         prepared = prepare_fx(m, qconfig_dict)
         # calibrate
         prepared(torch.randn(4, 1, 4, 4))
@@ -2001,21 +2001,21 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # quantized input, quantized output
         m = M()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         m.eval()
-        mp = torch.quantization.quantize_fx.prepare_fx(
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(
             m, qconfig_dict,
             prepare_custom_config_dict=prepare_custom_config_dict)
         self.checkGraphModuleNodes(mp, expected_node_occurrence=prepare_count_check)
         mp(torch.randn(1, 1, 4, 4))
-        mq = torch.quantization.quantize_fx.convert_fx(mp)
+        mq = torch.ao.quantization.quantize_fx.convert_fx(mp)
         self.checkGraphModuleNodes(mq, expected_node_occurrence=convert_count_check)
 
     def test_quantized_input_quantized_output(self):
         prepare_custom_config_dict = {
             'input_quantized_idxs': [0], 'output_quantized_idxs': [0]}
         prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 2,
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 2,
         }
         convert_count_check = {
             ns.call_function(torch.quantize_per_tensor): 0,
@@ -2028,7 +2028,7 @@ class TestQuantizeFx(QuantizationTestCase):
         prepare_custom_config_dict = {
             'output_quantized_idxs': [0]}
         prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 3,
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 3,
         }
         convert_count_check = {
             ns.call_function(torch.quantize_per_tensor): 1,
@@ -2041,7 +2041,7 @@ class TestQuantizeFx(QuantizationTestCase):
         prepare_custom_config_dict = {
             'input_quantized_idxs': [0]}
         prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 2,
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 2,
         }
         convert_count_check = {
             ns.call_function(torch.quantize_per_tensor): 0,
@@ -2053,7 +2053,7 @@ class TestQuantizeFx(QuantizationTestCase):
     def test_fp32_input_fp32_output(self):
         prepare_custom_config_dict = {}
         prepare_count_check = {
-            ns.call_module(torch.quantization.MinMaxObserver): 3,
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 3,
         }
         convert_count_check = {
             ns.call_function(torch.quantize_per_tensor): 1,
@@ -2070,7 +2070,7 @@ class TestQuantizeFx(QuantizationTestCase):
         """
         m = torch.nn.Sequential(torch.nn.ConvTranspose2d(1, 1, 1))
         m.eval()
-        qconfig_dict = {'': torch.quantization.get_default_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qconfig('fbgemm')}
         with self.assertRaises(AssertionError) as context:
             mp = prepare_fx(m, qconfig_dict)
         self.assertTrue(
@@ -2245,7 +2245,7 @@ class TestQuantizeFx(QuantizationTestCase):
         for cls in (M1, M2, M3):
             m = cls().eval()
             m(torch.rand(4, 4, 4, 4))
-            qconfig_dict = {'': torch.quantization.default_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.default_qconfig}
             mp = prepare_fx(m, qconfig_dict)
             mp(torch.rand(4, 4, 4, 4))
             mc = convert_fx(mp)
@@ -2267,7 +2267,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         m(torch.rand(4, 1, 4, 4))
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mp(torch.rand(4, 1, 4, 4))
         mc = convert_fx(mp)
@@ -2305,7 +2305,7 @@ class TestQuantizeFx(QuantizationTestCase):
         for cls in (M1, M2):
             m = cls().eval()
             m(torch.rand(4, 1, 4, 4))
-            qconfig_dict = {'': torch.quantization.default_qconfig}
+            qconfig_dict = {'': torch.ao.quantization.default_qconfig}
             mp = prepare_fx(m, qconfig_dict)
             mp(torch.rand(4, 1, 4, 4))
             mc = convert_fx(mp)
@@ -2339,7 +2339,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = Parent().eval()
         qconfig_dict = {
-            '': torch.quantization.default_qconfig,
+            '': torch.ao.quantization.default_qconfig,
             'module_name': [
                 ('child', None),
             ],
@@ -2550,7 +2550,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
 
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         # if an observer is inserted after _user_func_with_complex_return_type,
         # the following call will fail
@@ -2603,7 +2603,7 @@ class TestQuantizeFx(QuantizationTestCase):
         there is always an observer, even if the last non-output node is not
         quantizeable.
         """
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         prepare_custom_config_dict = {'output_quantized_idxs': [0]}
         data = (torch.randn(4, 1, 4, 4),)
 
@@ -2621,7 +2621,7 @@ class TestQuantizeFx(QuantizationTestCase):
         self.checkGraphModeFxOp(
             m1, data, QuantType.QAT,
             prepare_expected_node_occurrence={
-                ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 1,
+                ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 1,
             },
             expected_node_occurrence={
                 ns.call_function(torch.quantize_per_tensor): 1,
@@ -2643,7 +2643,7 @@ class TestQuantizeFx(QuantizationTestCase):
             m2, data, QuantType.QAT,
             prepare_expected_node_occurrence={
                 # one for weights, one for activations
-                ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 2,
+                ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 2,
             },
             expected_node_occurrence={
                 ns.call_function(torch.quantize_per_tensor): 1,
@@ -2665,7 +2665,7 @@ class TestQuantizeFx(QuantizationTestCase):
             m3, data, QuantType.QAT,
             prepare_expected_node_occurrence={
                 # one for weights, one for activations
-                ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 2,
+                ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 2,
             },
             expected_node_occurrence={
                 ns.call_function(torch.quantize_per_tensor): 1,
@@ -2704,7 +2704,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 return {'foo': [x]}, [{'foo': [[x]]}]
 
         m = M().eval()
-        qconfig_dict = {'': torch.quantization.default_qconfig}
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mc = convert_fx(mp)
 
@@ -2771,22 +2771,22 @@ class TestQuantizeFx(QuantizationTestCase):
             # Checks that we have an observer for both input and output
             occurrence_map = {
                 QuantType.STATIC: {
-                    ns.call_module(torch.quantization.MinMaxObserver): 2
+                    ns.call_module(torch.ao.quantization.MinMaxObserver): 2
                 },
                 QuantType.QAT: {
-                    ns.call_module(torch.quantization.FakeQuantize): 2
+                    ns.call_module(torch.ao.quantization.FakeQuantize): 2
                 }
             }
             if quant_type == QuantType.QAT:
                 m.train()
                 prepare = prepare_qat_fx
                 qconfig = default_qat_qconfig
-                actpp_module_class = torch.quantization.FakeQuantize
+                actpp_module_class = torch.ao.quantization.FakeQuantize
             else:
                 m.eval()
                 prepare = prepare_fx
                 qconfig = default_qconfig
-                actpp_module_class = torch.quantization.MinMaxObserver
+                actpp_module_class = torch.ao.quantization.MinMaxObserver
 
             m = prepare(m, {"": qconfig})
             # check that there is a duplicated observer instance
@@ -2850,10 +2850,10 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": torch.quantization.QConfig(
-            activation=torch.quantization.HistogramObserver.with_args(
+        m = prepare_fx(m, {"": torch.ao.quantization.QConfig(
+            activation=torch.ao.quantization.HistogramObserver.with_args(
                 qscheme=torch.per_tensor_symmetric, dtype=torch.qint8
-            ), weight=torch.quantization.default_per_channel_weight_observer)})
+            ), weight=torch.ao.quantization.default_per_channel_weight_observer)})
         m = convert_fx(m, is_reference=True)
         m(torch.rand(2, 1, 5, 5))
 
@@ -3193,12 +3193,12 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 QuantType.DYNAMIC: {},
                 # There should be 3 observers: after input, weight and activation.
                 QuantType.STATIC: {
-                    ns.call_module(torch.quantization.HistogramObserver): 2,
-                    ns.call_module(torch.quantization.PerChannelMinMaxObserver): 1,
+                    ns.call_module(torch.ao.quantization.HistogramObserver): 2,
+                    ns.call_module(torch.ao.quantization.PerChannelMinMaxObserver): 1,
                 },
                 # There should be 3 observers: after input, weight and activation.
                 QuantType.QAT: {
-                    ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 3,
+                    ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 3,
                 },
             }
             model = FuncLinear(use_bias, has_relu, f_relu)
@@ -3260,7 +3260,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
                     qlinear_fun = ns.call_function(torch.ops.quantized.linear_dynamic_fp16)
             prepare_node_occurrence = {
                 # weight
-                ns.call_module(torch.quantization.PlaceholderObserver): 1
+                ns.call_module(torch.ao.quantization.PlaceholderObserver): 1
             }
             convert_node_occurrence = {
                 qlinear_fun: 1,
@@ -3313,7 +3313,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             # when has_relu is False
             prepare_node_occurrence = {
                 # activation, weight, bias and output
-                ns.call_module(torch.quantization.PlaceholderObserver): 3 + int(use_bias),
+                ns.call_module(torch.ao.quantization.PlaceholderObserver): 3 + int(use_bias),
             }
             # We have extra to and dequantize when is_reference is True
             # and has_relu is False since when has_relu is False, we
@@ -3434,12 +3434,12 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 QuantType.DYNAMIC: {},
                 # There should be 3 observers: after input, weight and activation.
                 QuantType.STATIC: {
-                    ns.call_module(torch.quantization.HistogramObserver): 2,
-                    ns.call_module(torch.quantization.PerChannelMinMaxObserver): 1,
+                    ns.call_module(torch.ao.quantization.HistogramObserver): 2,
+                    ns.call_module(torch.ao.quantization.PerChannelMinMaxObserver): 1,
                 },
                 # There should be 3 observers: after input, weight and activation.
                 QuantType.QAT: {
-                    ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 3,
+                    ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 3,
                 },
             }
             data_dims = [2, 3] + [4] * dim
@@ -3695,8 +3695,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
     # TODO(future PR): make more generic
     def _test_quantized_add_mul_qat(self, model, expected_node_occurrence):
-        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
-        mp = torch.quantization.quantize_fx.prepare_qat_fx(model, qconfig_dict)
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
+        mp = torch.ao.quantization.quantize_fx.prepare_qat_fx(model, qconfig_dict)
         self.checkGraphModuleNodes(
             mp, expected_node_occurrence=expected_node_occurrence)
 
@@ -3718,7 +3718,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
         m = M()
         expected_node_occurrence = {
-            ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 6,
+            ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 6,
         }
         self._test_quantized_add_mul_qat(m, expected_node_occurrence)
 
@@ -3741,7 +3741,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
         m = M()
         expected_node_occurrence = {
-            ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 6,
+            ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 6,
         }
         self._test_quantized_add_mul_qat(m, expected_node_occurrence)
 
@@ -3761,11 +3761,11 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return self.add_func.add_scalar(x, self.scalar)
 
         m = M(0.5)
-        mp = torch.quantization.quantize_fx.prepare_qat_fx(
-            m, {'': torch.quantization.get_default_qat_qconfig('fbgemm')},
+        mp = torch.ao.quantization.quantize_fx.prepare_qat_fx(
+            m, {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')},
             prepare_custom_config_dict={"input_quantized_idxs": [0]})
         expected_node_occurrence = {
-            ns.call_module(torch.quantization.FusedMovingAvgObsFakeQuantize): 0,
+            ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 0,
         }
         self.checkGraphModuleNodes(
             mp, expected_node_occurrence=expected_node_occurrence)
@@ -4115,9 +4115,9 @@ class TestQuantizeFxOps(QuantizationTestCase):
         qconfig_dict = {"": qconfig}
 
         m = M(module, functional).eval()
-        m_prep = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict, prepare_custom_qconfig_dict)
+        m_prep = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict, prepare_custom_qconfig_dict)
         m_prep(data)
-        m_quant = torch.quantization.quantize_fx.convert_fx(m_prep, is_reference=is_reference)
+        m_quant = torch.ao.quantization.quantize_fx.convert_fx(m_prep, is_reference=is_reference)
         m_quant(data)
 
         self.checkGraphModuleNodes(m_quant, expected_node_list=node_list)
@@ -4125,7 +4125,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
     def test_gelu_normal(self):
         module = torch.nn.GELU
         functional = torch.nn.functional.gelu
-        qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
         is_reference = False
         node_list = [
             ns.call_module(module),
@@ -4137,7 +4137,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
     def test_softmax_normal(self):
         module = torch.nn.Softmax
         functional = torch.nn.functional.softmax
-        qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
         is_reference = False
         node_list = [
             ns.call_module(module),
@@ -4149,7 +4149,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
     def test_gelu_reference(self):
         module = torch.nn.GELU
         functional = torch.nn.functional.gelu
-        qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
         is_reference = True
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -4169,7 +4169,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
     def test_softmax_reference(self):
         module = torch.nn.Softmax
         functional = torch.nn.functional.softmax
-        qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        qconfig = torch.ao.quantization.get_default_qconfig("fbgemm")
         is_reference = True
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -4237,16 +4237,16 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
         data_x = torch.randn((2, 2, 2,))
         data_y = torch.randn((2, 2, 2,))
-        qconfig_dict = {"": torch.quantization.get_default_qconfig("fbgemm")}
+        qconfig_dict = {"": torch.ao.quantization.get_default_qconfig("fbgemm")}
         is_reference = True
         node_list = [
             ns.call_function(torch.bmm),
         ]
 
         m = M().eval()
-        m_prep = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        m_prep = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
         m_prep(data_x, data_y)
-        m_quant = torch.quantization.quantize_fx.convert_fx(m_prep, is_reference=is_reference)
+        m_quant = torch.ao.quantization.quantize_fx.convert_fx(m_prep, is_reference=is_reference)
         print(m_quant)
         m_quant(data_x, data_y)
 
@@ -4335,7 +4335,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
         data = (torch.randn((2, 2, 2, 2), dtype=torch.float),)
         quant_type = QuantType.STATIC
-        qconfig = torch.quantization.QConfig(
+        qconfig = torch.ao.quantization.QConfig(
             activation=HistogramObserver.with_args(qscheme=torch.per_tensor_symmetric, dtype=torch.qint8),
             weight=default_weight_observer)
         qconfig_dict = {"": qconfig}
@@ -4553,7 +4553,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = M().eval()
         m = prepare_fx(m, {"": default_qconfig})
         self.checkGraphModuleNodes(m, expected_node_occurrence={
-            ns.call_module(torch.quantization.MinMaxObserver): 0
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 0
         })
         m = convert_fx(m)
         m(torch.rand(1, 2))
@@ -4567,7 +4567,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m2 = M2().eval()
         m2 = prepare_fx(m2, {"": default_qconfig})
         self.checkGraphModuleNodes(m2, expected_node_occurrence={
-            ns.call_module(torch.quantization.MinMaxObserver): 1
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 1
         })
         m2 = convert_fx(m2)
         self.checkGraphModuleNodes(m2, expected_node_list=[
@@ -4587,7 +4587,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m3 = M3().eval()
         m3 = prepare_fx(m3, {"": default_qconfig})
         self.checkGraphModuleNodes(m3, expected_node_occurrence={
-            ns.call_module(torch.quantization.MinMaxObserver): 1
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 1
         })
         m3 = convert_fx(m3)
         self.checkGraphModuleNodes(m3, expected_node_list=[
@@ -4735,18 +4735,18 @@ class TestQuantizeFxOps(QuantizationTestCase):
         # activation_post_process in add_scalar and mul_scalar
         for quant_type in self.static_quant_types:
             m = M()
-            ref_m = torch.quantization.QuantWrapper(M())
+            ref_m = torch.ao.quantization.QuantWrapper(M())
             is_qat = quant_type == QuantType.QAT
             if is_qat:
                 m.train()
                 ref_m.train()
                 qconfig = default_qat_qconfig
-                expected_act_post_process = torch.quantization.FakeQuantize
+                expected_act_post_process = torch.ao.quantization.FakeQuantize
             else:
                 m.eval()
                 ref_m.eval()
                 qconfig = default_qconfig
-                expected_act_post_process = torch.quantization.MinMaxObserver
+                expected_act_post_process = torch.ao.quantization.MinMaxObserver
 
             prepare_fx_function = prepare_qat_fx if is_qat else prepare_fx
             qconfig_dict = {"": qconfig}
@@ -4801,7 +4801,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             qconfig_dict = {"": qconfig}
             m = prepare_fx(model, qconfig_dict)
             self.checkGraphModuleNodes(m, expected_node_occurrence={
-                ns.call_module(torch.quantization.MinMaxObserver): 0
+                ns.call_module(torch.ao.quantization.MinMaxObserver): 0
             })
             m = convert_fx(m)
             self.checkGraphModuleNodes(m, expected_node=node)
@@ -4843,7 +4843,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             m = M().eval()
             m = prepare_fx(model, qconfig_dict)
             self.checkGraphModuleNodes(m, expected_node_occurrence={
-                ns.call_module(torch.quantization.MinMaxObserver): 0
+                ns.call_module(torch.ao.quantization.MinMaxObserver): 0
             })
             m = convert_fx(m)
             self.checkGraphModuleNodes(m, expected_node=ns.call_module(nn.EmbeddingBag))
@@ -4899,7 +4899,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             m1 = torch.nn.Sequential(float_cls(1, 1, 1))
             m2 = torch.nn.Sequential(float_cls(1, 1, 1))
             m2.load_state_dict(m1.state_dict())
-            m2 = torch.quantization.QuantWrapper(m2)
+            m2 = torch.ao.quantization.QuantWrapper(m2)
             # FX graph
             result_dict = self.checkGraphModeFxOp(
                 m1, (data,), QuantType.STATIC,
@@ -4910,9 +4910,9 @@ class TestQuantizeFxOps(QuantizationTestCase):
             # Eager
             m2.qconfig = get_default_qconfig(torch.backends.quantized.engine)
             m2.eval()
-            m2p = torch.quantization.prepare(m2)
+            m2p = torch.ao.quantization.prepare(m2)
             m2p(data)
-            m2q = torch.quantization.convert(m2p)
+            m2q = torch.ao.quantization.convert(m2p)
             q_result2 = m2q(data)
             # verify results match
             self.assertEqual(q_result1, q_result2)
@@ -4955,9 +4955,9 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = prepare_fx(m, qconfig_dict)
         expected_occurrence = {
             # input and weight of first and second linear, output of first and second linear
-            ns.call_module(torch.quantization.MinMaxObserver): 6,
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 6,
             # we don't insert placeholder observer for output of reshape
-            ns.call_module(torch.quantization.PlaceholderObserver): 1
+            ns.call_module(torch.ao.quantization.PlaceholderObserver): 1
         }
         self.checkGraphModuleNodes(
             m,
@@ -5003,9 +5003,9 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = prepare_fx(m, qconfig_dict)
         expected_occurrence = {
             # input and weight of linear, output of linear
-            ns.call_module(torch.quantization.MinMaxObserver): 3,
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 3,
             # input and output of sigmoid
-            ns.call_module(torch.quantization.PlaceholderObserver): 2,
+            ns.call_module(torch.ao.quantization.PlaceholderObserver): 2,
         }
         self.checkGraphModuleNodes(
             m,
@@ -5035,7 +5035,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = M().eval()
         m = prepare_fx(m, {"": default_qconfig})
         expected_occurrence = {
-            ns.call_module(torch.quantization.MinMaxObserver): 0
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 0
         }
         self.checkGraphModuleNodes(
             m,
@@ -5077,7 +5077,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
 
         input = torch.randn((5, 1, 6, 6)).to('cuda')
         model = Net().to('cuda').eval()
-        qconfig_dict = {"": torch.quantization.get_default_qconfig('fbgemm')}
+        qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
         model_prepared = prepare_fx(model, qconfig_dict)
         model_prepared(input)
         model_quantized = convert_fx(model_prepared, is_reference=True)
@@ -5104,7 +5104,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             device_after = 'cuda' if device == 'cpu' else 'cpu'
             input = torch.randn((5, 1, 6, 6)).to(device)
             model = Net().to(device).eval()
-            qconfig_dict = {"": torch.quantization.get_default_qconfig('fbgemm')}
+            qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
             model_prepared = prepare_fx(model, qconfig_dict)
             model_prepared(input)
             model_prepared.to(device_after)
@@ -5130,7 +5130,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             for device_after in ['cuda', 'cpu']:
                 input = torch.randn((5, 1, 6, 6)).to(device)
                 model = Net().to(device).eval()
-                qconfig_dict = {"": torch.quantization.get_default_qconfig('fbgemm')}
+                qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
                 model_prepared_first = prepare_fx(model, qconfig_dict)
                 model_prepared_second = prepare_fx(model, qconfig_dict)
                 model_prepared_first(input)
@@ -5472,19 +5472,19 @@ class TestQuantizeFxModels(QuantizationTestCase):
         prepared.to(device)
         prepared_ref.to(device)
 
-        prepared.apply(torch.quantization.disable_fake_quant)
-        prepared.apply(torch.quantization.disable_observer)
-        prepared_ref.apply(torch.quantization.disable_fake_quant)
-        prepared_ref.apply(torch.quantization.disable_observer)
+        prepared.apply(torch.ao.quantization.disable_fake_quant)
+        prepared.apply(torch.ao.quantization.disable_observer)
+        prepared_ref.apply(torch.ao.quantization.disable_fake_quant)
+        prepared_ref.apply(torch.ao.quantization.disable_observer)
 
         inp = torch.randn(5, 5, device=device, requires_grad=True)
         for i in range(10):
             if i == 2:
-                prepared.apply(torch.quantization.enable_observer)
-                prepared_ref.apply(torch.quantization.enable_observer)
+                prepared.apply(torch.ao.quantization.enable_observer)
+                prepared_ref.apply(torch.ao.quantization.enable_observer)
             if i == 4:
-                prepared.apply(torch.quantization.enable_fake_quant)
-                prepared_ref.apply(torch.quantization.enable_fake_quant)
+                prepared.apply(torch.ao.quantization.enable_fake_quant)
+                prepared_ref.apply(torch.ao.quantization.enable_fake_quant)
 
             inp = torch.randn(5, 5, device=device, requires_grad=True)
             out_ref = prepared_ref(inp)

--- a/test/quantization/jit/test_quantize_jit.py
+++ b/test/quantization/jit/test_quantize_jit.py
@@ -6,8 +6,8 @@ import torch.nn.functional as F
 import torch.jit
 import torch.jit.quantized
 
-# torch.quantization
-from torch.quantization import (
+# torch.ao.quantization
+from torch.ao.quantization import (
     QConfig,
     default_dynamic_qconfig,
     float16_dynamic_qconfig,
@@ -26,8 +26,8 @@ from torch.quantization import (
     PlaceholderObserver,
 )
 
-# torch.quantization.quantize_jit
-from torch.quantization.quantize_jit import (
+# torch.ao.quantization.quantize_jit
+from torch.ao.quantization.quantize_jit import (
     convert_jit,
     convert_dynamic_jit,
     fuse_conv_bn_jit,
@@ -2963,10 +2963,10 @@ class TestQuantizeJitOps(QuantizationTestCase):
             m = torch.nn.Sequential(torch.nn.Conv2d(1, 1, 1))
             m.eval()
             m = torch.jit.trace(m, torch.rand(4, 1, 4, 4))
-            qconfig = torch.quantization.get_default_qconfig("qnnpack")
-            prepared_model = torch.quantization.prepare_jit(m, {"": qconfig})
+            qconfig = torch.ao.quantization.get_default_qconfig("qnnpack")
+            prepared_model = torch.ao.quantization.prepare_jit(m, {"": qconfig})
             prepared_model(torch.rand(4, 1, 4, 4))
-            converted_model = torch.quantization.convert_jit(prepared_model)
+            converted_model = torch.ao.quantization.convert_jit(prepared_model)
             FileCheck().check("quantized::conv2d").run(converted_model.graph)
 
     @skipIfNoFBGEMM

--- a/test/test_mobile_optimizer.py
+++ b/test/test_mobile_optimizer.py
@@ -286,10 +286,10 @@ class TestOptimizer(TestCase):
         class Parent(nn.Module):
             def __init__(self):
                 super(Parent, self).__init__()
-                self.quant = torch.quantization.QuantStub()
+                self.quant = torch.ao.quantization.QuantStub()
                 self.conv1 = nn.Conv2d(1, 1, 1)
                 self.child = Child()
-                self.dequant = torch.quantization.DeQuantStub()
+                self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
                 x = self.quant(x)
@@ -300,10 +300,10 @@ class TestOptimizer(TestCase):
 
         with override_quantized_engine('qnnpack'):
             model = Parent()
-            model.qconfig = torch.quantization.get_default_qconfig('qnnpack')
-            torch.quantization.prepare(model, inplace=True)
+            model.qconfig = torch.ao.quantization.get_default_qconfig('qnnpack')
+            torch.ao.quantization.prepare(model, inplace=True)
             model(torch.randn(4, 1, 4, 4))
-            torch.quantization.convert(model, inplace=True)
+            torch.ao.quantization.convert(model, inplace=True)
             model = torch.jit.script(model)
             # this line should not have ASAN failures
             model_optim = optimize_for_mobile(model)
@@ -424,11 +424,11 @@ class TestOptimizer(TestCase):
         class Standalone(nn.Module):
             def __init__(self):
                 super(Standalone, self).__init__()
-                self.quant = torch.quantization.QuantStub()
+                self.quant = torch.ao.quantization.QuantStub()
                 self.conv1 = nn.Conv2d(1, 1, 1)
                 self.conv2 = nn.Conv2d(1, 1, 1)
                 self.relu = nn.ReLU()
-                self.dequant = torch.quantization.DeQuantStub()
+                self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
                 x = self.quant(x)
@@ -439,7 +439,7 @@ class TestOptimizer(TestCase):
                 return x
 
             def fuse_model(self):
-                torch.quantization.fuse_modules(self, [['conv2', 'relu']], inplace=True)
+                torch.ao.quantization.fuse_modules(self, [['conv2', 'relu']], inplace=True)
                 pass
 
         class Child(nn.Module):
@@ -454,11 +454,11 @@ class TestOptimizer(TestCase):
         class Parent(nn.Module):
             def __init__(self):
                 super(Parent, self).__init__()
-                self.quant = torch.quantization.QuantStub()
+                self.quant = torch.ao.quantization.QuantStub()
                 self.conv1 = nn.Conv2d(1, 1, 1)
                 self.child = Child()
                 # TODO: test nn.Sequential after #42039 is fixed
-                self.dequant = torch.quantization.DeQuantStub()
+                self.dequant = torch.ao.quantization.DeQuantStub()
 
             def forward(self, x):
                 x = self.quant(x)
@@ -472,11 +472,11 @@ class TestOptimizer(TestCase):
 
         with override_quantized_engine('qnnpack'):
             def _quant_script_and_optimize(model):
-                model.qconfig = torch.quantization.get_default_qconfig('qnnpack')
+                model.qconfig = torch.ao.quantization.get_default_qconfig('qnnpack')
                 model.fuse_model()
-                torch.quantization.prepare(model, inplace=True)
+                torch.ao.quantization.prepare(model, inplace=True)
                 model(torch.randn(4, 1, 4, 4))
-                torch.quantization.convert(model, inplace=True)
+                torch.ao.quantization.convert(model, inplace=True)
                 model = torch.jit.script(model)
                 model_optim = optimize_for_mobile(model)
                 return model, model_optim

--- a/test/test_model_dump.py
+++ b/test/test_model_dump.py
@@ -34,8 +34,8 @@ class SimpleModel(torch.nn.Module):
 class QuantModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.quant = torch.quantization.QuantStub()
-        self.dequant = torch.quantization.DeQuantStub()
+        self.quant = torch.ao.quantization.QuantStub()
+        self.dequant = torch.ao.quantization.DeQuantStub()
         self.core = SimpleModel()
 
     def forward(self, x):
@@ -155,14 +155,14 @@ class TestModelDump(TestCase):
 
     def get_quant_model(self):
         fmodel = QuantModel().eval()
-        fmodel = torch.quantization.fuse_modules(fmodel, [
+        fmodel = torch.ao.quantization.fuse_modules(fmodel, [
             ["core.layer1", "core.relu1"],
             ["core.layer2", "core.relu2"],
         ])
-        fmodel.qconfig = torch.quantization.get_default_qconfig("qnnpack")
-        prepped = torch.quantization.prepare(fmodel)
+        fmodel.qconfig = torch.ao.quantization.get_default_qconfig("qnnpack")
+        prepped = torch.ao.quantization.prepare(fmodel)
         prepped(torch.randn(2, 16))
-        qmodel = torch.quantization.convert(prepped)
+        qmodel = torch.ao.quantization.convert(prepped)
         return qmodel
 
     @unittest.skipUnless("qnnpack" in supported_qengines, "QNNPACK not available")

--- a/test/test_module_init.py
+++ b/test/test_module_init.py
@@ -166,13 +166,13 @@ def build_constructor_arg_db():
         torch.nn.UpsamplingNearest2d: ((), {}),
         torch.nn.ZeroPad2d: ((0,), {}),
         torch.nn.qat.Conv2d: ((3, 3, 3), {
-            'qconfig': torch.quantization.default_qconfig,
+            'qconfig': torch.ao.quantization.default_qconfig,
         }),
         torch.nn.qat.Conv3d: ((3, 3, 3), {
-            'qconfig': torch.quantization.default_qconfig,
+            'qconfig': torch.ao.quantization.default_qconfig,
         }),
         torch.nn.qat.Linear: ((5, 2), {
-            'qconfig': torch.quantization.default_qconfig,
+            'qconfig': torch.ao.quantization.default_qconfig,
         }),
         torch.nn.quantizable.LSTM: ((5, 6), {}),
         torch.nn.quantizable.LSTMCell: ((5, 6), {}),

--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -514,10 +514,10 @@ class TestNNAPI(TestCase):
                     if "quant" in kind:
                         model = torch.nn.Sequential(model)
                         model.eval()
-                        model.qconfig = torch.quantization.get_default_qconfig('qnnpack')
-                        model = torch.quantization.prepare(model)
+                        model.qconfig = torch.ao.quantization.get_default_qconfig('qnnpack')
+                        model = torch.ao.quantization.prepare(model)
                         model(inp)
-                        model = torch.quantization.convert(model)
+                        model = torch.ao.quantization.convert(model)
                         inp = qpt(inp, 1.0 / 16, 128)
                         # I've seen numerical differences between QNNPACK and NNAPI,
                         # but never more than 1 quantum, and never more than ~1% of
@@ -556,7 +556,7 @@ class TestNNAPI(TestCase):
 
                 if "quant" in kind:
                     model = torch.nn.quantized.ConvTranspose2d(in_ch, out_ch, kernel)
-                    model.qconfig = torch.quantization.get_default_qconfig('qnnpack')
+                    model.qconfig = torch.ao.quantization.get_default_qconfig('qnnpack')
                     inp = qpt(inp, 1.0 / 16, 128)
                     # I've seen numerical differences between QNNPACK and NNAPI,
                     # but never more than 1 quantum, and never more than ~10% of


### PR DESCRIPTION
Summary:
Renames `torch.quantization` to `torch.ao.quantization` in `caffe2/test`
folder.

```
find caffe2/test/ -type f -name "*.py" -print0 | xargs -0 sed -i "s/torch\.quantization/torch.ao.quantization/g"
HG: manually revert the files testing this migration
hg revert caffe2/test/quantization/ao_migration/common.py
hg revert caffe2/test/quantization/ao_migration/test_ao_migration.py
```

Test Plan: CI

Differential Revision: D31275754

