### PR TITLE
pytorch quantization ao migration phase 2: caffe2/benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/qobserver_test.py
+++ b/benchmarks/operator_benchmark/pt/qobserver_test.py
@@ -1,7 +1,7 @@
 
 import operator_benchmark as op_bench
 import torch
-import torch.quantization.observer as obs
+import torch.ao.quantization.observer as obs
 
 qobserver_short_configs_dict = {
     'attr_names': ('C', 'M', 'N', 'dtype', 'device'),

--- a/benchmarks/operator_benchmark/pt/qrnn_test.py
+++ b/benchmarks/operator_benchmark/pt/qrnn_test.py
@@ -41,9 +41,9 @@ class LSTMBenchmark(op_bench.TorchBenchmarkBase):
             bidirectional=D,
         )
         cell_temp = nn.Sequential(cell_nn)
-        self.cell = torch.quantization.quantize_dynamic(cell_temp,
-                                                        {nn.LSTM, nn.Linear},
-                                                        dtype=dtype)[0]
+        self.cell = torch.ao.quantization.quantize_dynamic(cell_temp,
+                                                           {nn.LSTM, nn.Linear},
+                                                           dtype=dtype)[0]
 
         x = torch.randn(sequence_len,  # sequence length
                         batch_size,    # batch size

--- a/benchmarks/operator_benchmark/pt/quantization_test.py
+++ b/benchmarks/operator_benchmark/pt/quantization_test.py
@@ -2,7 +2,7 @@
 import operator_benchmark as op_bench
 import torch
 import torch.nn.quantized as nnq
-import torch.quantization as tq
+import torch.ao.quantization as tq
 import torch.nn as nn
 
 """Microbenchmarks for general quantization operations."""


### PR DESCRIPTION
Summary:
Renames `torch.quantization` to `torch.ao.quantization` in `caffe2/benchmarks`
folder.

```
find caffe2/benchmarks/ -type f -name "*.py" -print0 | xargs -0 sed -i "s/torch\.quantization/torch.ao.quantization/g"
```

Test Plan: CI

Differential Revision: D31275963

