### PR TITLE
(torchelastic) make --max_restarts explicit in the quickstart and runner docs (#65675)

### DIFF
--- a/docs/source/elastic/quickstart.rst
+++ b/docs/source/elastic/quickstart.rst
@@ -8,6 +8,7 @@ To launch a **fault-tolerant** job, run the following on all nodes.
     torchrun
        --nnodes=NUM_NODES
        --nproc_per_node=TRAINERS_PER_NODE
+       --max_restarts=NUM_ALLOWED_FAILURES
        --rdzv_id=JOB_ID
        --rdzv_backend=c10d
        --rdzv_endpoint=HOST_NODE_ADDR
@@ -22,10 +23,19 @@ and at most ``MAX_SIZE`` nodes.
     torchrun
         --nnodes=MIN_SIZE:MAX_SIZE
         --nproc_per_node=TRAINERS_PER_NODE
+        --max_restarts=NUM_ALLOWED_FAILURES_OR_MEMBERSHIP_CHANGES
         --rdzv_id=JOB_ID
         --rdzv_backend=c10d
         --rdzv_endpoint=HOST_NODE_ADDR
         YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
+.. note::
+   TorchElastic models failures as membership changes. When a node fails,
+   this is treated as a "scale down" event. When the failed node is replaced by
+   the scheduler, it is a "scale up" event. Hence for both fault tolerant
+   and elastic jobs, ``--max_restarts`` is used to control the total number of
+   restarts before giving up, regardless of whether the restart was caused
+   due to a failure or a scaling event.
 
 ``HOST_NODE_ADDR``, in form <host>[:<port>] (e.g. node1.example.com:29400),
 specifies the node and the port on which the C10d rendezvous backend should be

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -81,13 +81,14 @@ Usage
         --nproc_per_node=$NUM_TRAINERS
         YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
 
-2. Fault tolerant (fixed sized number of workers, no elasticity):
+2. Fault tolerant (fixed sized number of workers, no elasticity, tolerates 3 failures):
 
 ::
 
     >>> torchrun
         --nnodes=$NUM_NODES
         --nproc_per_node=$NUM_TRAINERS
+        --max_restarts=3
         --rdzv_id=$JOB_ID
         --rdzv_backend=c10d
         --rdzv_endpoint=$HOST_NODE_ADDR
@@ -100,13 +101,14 @@ node in your training cluster, but ideally you should pick a node that has a hig
 .. note::
    If no port number is specified ``HOST_NODE_ADDR`` defaults to 29400.
 
-3. Elastic (``min=1``, ``max=4``):
+3. Elastic (``min=1``, ``max=4``, tolerates up to 3 membership changes or failures):
 
 ::
 
     >>> torchrun
         --nnodes=1:4
         --nproc_per_node=$NUM_TRAINERS
+        --max_restarts=3
         --rdzv_id=$JOB_ID
         --rdzv_backend=c10d
         --rdzv_endpoint=$HOST_NODE_ADDR


### PR DESCRIPTION
Summary:
closes https://github.com/pytorch/pytorch/pull/65675

The default `--max_restarts` for `torch.distributed.run` was changed to `0` from `3` to make things backwards compatible with `torch.distributed.launch`. Since the default `--max_restarts` used to be greater than `0` we never documented passing `--max_restarts` explicitly in any of our example code.

Test Plan: N/A doc change only

Differential Revision: D31279544



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang