### PR TITLE
Refactor `OperatorSupport` related code and fix TRT not supporting int64 dtype

### DIFF
--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -1,8 +1,10 @@
+import abc
 import typing as t
 
 import torch
 import torch.fx
 from torch.fx._compatibility import compatibility
+from .shape_prop import TensorMetadata
 from .tools_common import get_node_target, CALLABLE_NODE_OPS
 
 
@@ -17,9 +19,21 @@ SupportedArgumentDTypes = t.Optional[
     ]
 ]
 
+SupportDict = t.Mapping[TargetTypeName, SupportedArgumentDTypes]
+
 
 @compatibility(is_backward_compatible=False)
-class OperatorSupport:
+class OperatorSupportBase(abc.ABC):
+    """Interface for determining if a fx.Node is supported by a backend"""
+    @abc.abstractmethod
+    def is_node_supported(
+        self, submodules: t.Mapping[str, torch.nn.Module], node: torch.fx.Node
+    ) -> bool:
+        raise NotImplementedError()
+
+
+@compatibility(is_backward_compatible=False)
+class OperatorSupport(OperatorSupportBase):
     """
     `_support_dict` maps node.target typename to supported inputs dtypes.
 
@@ -38,7 +52,13 @@ class OperatorSupport:
     be checked.
     """
 
-    _support_dict: t.Mapping[TargetTypeName, SupportedArgumentDTypes] = {}
+    _support_dict: SupportDict
+
+    def __init__(
+        self,
+        support_dict: t.Optional[SupportDict] = None
+    ):
+        self._support_dict = support_dict or {}
 
     def is_node_supported(
         self, submodules: t.Mapping[str, torch.nn.Module], node: torch.fx.Node
@@ -81,9 +101,7 @@ class OperatorSupport:
             if not isinstance(node.args[i], torch.fx.Node):
                 continue
 
-            arg_tensor_meta = node.args[i].meta.get("tensor_meta")  # type: ignore[union-attr]
-            arg_dtype = arg_tensor_meta.dtype if arg_tensor_meta else None
-
+            arg_dtype = _get_arg_dtype(node.args[i])  # type: ignore[arg-type]
             if arg_dtype not in dtypes:
                 return False
 
@@ -96,10 +114,73 @@ class OperatorSupport:
             if not isinstance(node.kwargs[k], torch.fx.Node):
                 continue
 
-            kwarg_tensor_meta = node.kwargs[k].meta.get("tensor_meta")  # type: ignore[union-attr]
-            kwarg_dtype = kwarg_tensor_meta.dtype if kwarg_tensor_meta else None
-
+            kwarg_dtype = _get_arg_dtype(node.kwargs[k])  # type: ignore[arg-type]
             if kwarg_dtype not in dtypes:
                 return False
 
         return True
+
+
+# ======================================================================
+# Functional interfaces and utils for defining basic operator support logic
+# and composing them into more complex ones
+# ======================================================================
+
+IsNodeSupported = t.Callable[[t.Mapping[str, torch.nn.Module], torch.fx.Node], bool]
+
+
+@compatibility(is_backward_compatible=False)
+def create_op_support(is_node_supported: IsNodeSupported) -> OperatorSupportBase:
+    """Wraps a `IsNodeSupported` function into an `OperatorSupportBase` instance
+
+    `IsNodeSupported` has the same call signature as
+    `OperatorSupportBase.is_node_supported`
+    """
+    class FunctionalOperatorSupport(OperatorSupportBase):
+        def is_node_supported(
+                self, submodules: t.Mapping[str, torch.nn.Module], node: torch.fx.Node
+        ) -> bool:
+            return is_node_supported(submodules, node)
+    return FunctionalOperatorSupport()
+
+
+@compatibility(is_backward_compatible=False)
+def chain(*op_support: OperatorSupportBase) -> OperatorSupportBase:
+    """Combines a sequence of `OperatorSupportBase` instances to form a single `OperatorSupportBase`
+    instance by evaluating each input `OperatorSupportBase` instance, and returns False if
+    any of it reports False.
+    """
+    def _chain(submods, node) -> bool:
+        return all(
+            x.is_node_supported(submods, node)
+            for x in op_support
+        )
+    return create_op_support(_chain)
+
+
+@compatibility(is_backward_compatible=False)
+class OpSupports:
+    """A set of atomic `OperatorSupportBase` instances that can be combined together
+    to form more complex operator support logic.
+    """
+    @classmethod
+    def decline_if_input_dtype(cls, dtype: torch.dtype) -> OperatorSupportBase:
+        """Report a node as non-supported, if any of its arguments is of dtype"""
+
+        def _decline_if_input_dtype(
+            submodules: t.Mapping[str, torch.nn.Module],
+            node: torch.fx.Node,
+        ) -> bool:
+            for arg in node._input_nodes:
+                arg_dtype = _get_arg_dtype(arg)
+                if arg_dtype == dtype:
+                    return False
+            return True
+        return create_op_support(_decline_if_input_dtype)
+
+
+def _get_arg_dtype(arg: torch.fx.Node) -> t.Any:
+    assert isinstance(arg, torch.fx.Node)
+    tensor_meta = arg.meta.get("tensor_meta")  # type: ignore[union-attr]
+    dtype = tensor_meta.dtype if isinstance(tensor_meta, TensorMetadata) else arg.meta["type"]
+    return dtype

--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -11,7 +11,7 @@ from torch.fx._compatibility import compatibility
 
 from .operator_support import (
     get_node_target,
-    OperatorSupport,
+    OperatorSupportBase,
 )
 from .graph_drawer import FxGraphDrawer
 from .shape_prop import ShapeProp
@@ -82,7 +82,7 @@ class FxNetAccNodesFinder:
     def __init__(
         self,
         module: torch.fx.GraphModule,
-        operator_support: OperatorSupport,
+        operator_support: OperatorSupportBase,
         allow_non_tensor: bool,
     ):
         self.module = module
@@ -226,7 +226,7 @@ class _SplitterBase:
         self,
         module: torch.fx.GraphModule,
         sample_input: Tensors,
-        operator_support: OperatorSupport,
+        operator_support: OperatorSupportBase,
         settings: _SplitterSettingBase,
     ):
         """


### PR DESCRIPTION
Summary:
* [fix]: The initialization of `OperatorSupport._support_dict` makes it a class variable, so we need to move its initialization into constructor.
* [refactor]: what `TRToperatorSupport` really does is to populate a `OperatorSupport._support_dict`, so there really is no reason for subclassing. So removing it, and changing it to instantiating a `OperatorSupport` with properly populated `_support_dict`.
* Add abstract class (more of an interface) `OperatorSupportBase`, since `OperatorSupport`'s purpose is too specific.
* Add a framework for defining simple and basic op support logic, and composing them into more complex ones:
    1. `create_op_support` wraps a function into a `OperatorSupportBase` instance
    2. `chain` can combine several simple `OperatorSupportBase` into more complex ones
    3. `OpSupports` provides a set of pre-defined, simple `OperatorSupportBase` that can be composed together using `chain`.
        1. Currently the only pre-defined one is `decline_if_input_dtype(..)`, which declares a node non-supported, if its args are of user specified dtype
* Fix `TRTOperatorSupport` so that it not only looks for registered converters, but also decline a node if its arg is of int64

Test Plan: linter and CI

Differential Revision: D31275525

