### PR TITLE
Expose iterator-local generator to RandomSampler instance

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1547,6 +1547,26 @@ except RuntimeError as e:
                     ls[i].append(next(its[i]))
             self.assertEqual(ls[0], ls[1])
 
+    def test_serialize_sampler(self):
+        from torch.utils.data import RandomSampler
+        sampler = RandomSampler(self.dataset, num_samples=5, replacement=True)
+        it1 = iter(sampler)
+        torch.manual_seed(0)
+        _ = next(it1)
+
+        torch.manual_seed(0)
+        seed = torch.empty((), dtype=torch.int64).random_()
+        self.assertEqual(list(sampler._iterators.values())[0].initial_seed(), seed)
+
+        it2 = iter(sampler)
+        torch.manual_seed(1)
+        _ = next(it2)
+
+        torch.manual_seed(1)
+        seed = torch.empty((), dtype=torch.int64).random_()
+        _ = list(it1)
+        self.assertEqual(list(sampler._iterators.values())[0].initial_seed(), seed)
+
     def _test_sampler(self, **kwargs):
         indices = range(2, 12)  # using a regular iterable
         dl = self._get_data_loader(self.dataset, sampler=indices, batch_size=2, **kwargs)

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -129,10 +129,10 @@ class RandomSampler(Sampler[int]):
 
         if self.replacement:
             for _ in range(self.num_samples // 32):
-                yield from torch.randint(high=n, size=(32,), dtype=torch.int64, generator=generator).tolist()
-            yield from torch.randint(high=n, size=(self.num_samples % 32,), dtype=torch.int64, generator=generator).tolist()
+                yield from torch.randint(high=n, size=(32,), dtype=torch.int64, generator=rng).tolist()
+            yield from torch.randint(high=n, size=(self.num_samples % 32,), dtype=torch.int64, generator=rng).tolist()
         else:
-            yield from torch.randperm(n, generator=generator).tolist()
+            yield from torch.randperm(n, generator=rng).tolist()
 
     def __len__(self) -> int:
         return self.num_samples


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65857
* #63646

Make sure the iter-local generator is attached to Sampler. Then, the state of iter-local generator is able to be serialized and resumed.

Differential Revision: [D31288686](https://our.internmc.facebook.com/intern/diff/D31288686)