### PR TITLE
Revert "Port `sort` kernel to structured kernels. (#62391)"

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -13,40 +13,30 @@
 
 namespace at {
 namespace meta {
-
 using namespace native;
+  TORCH_META_FUNC(topk) (
+    const Tensor& self,
+    int64_t k,
+    int64_t dim_,
+    bool largest,
+    bool sorted) {
 
-TORCH_META_FUNC(topk)
-(const Tensor& self, int64_t k, int64_t dim_, bool largest, bool sorted) {
-  int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
-  TORCH_CHECK(
-      k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
-      "selected index k out of range");
-  int64_t sliceSize = self.dim() == 0 ? 1 : self.size(dim);
-  TORCH_CHECK(k >= 0 && k <= sliceSize, "k not in range for dimension");
+    int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
+    TORCH_CHECK(
+        k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
+        "selected index k out of range");
+    int64_t sliceSize = self.dim() == 0 ? 1 : self.size(dim);
+    TORCH_CHECK(k >= 0 && k <= sliceSize, "k not in range for dimension");
 
-  // Build the output size, which is the dim being selected set to
-  // size k
-  DimVector topKSize(self.sizes().vec());
-  if (topKSize.size() > 0) {
-    topKSize[dim] = k;
+    // Build the output size, which is the dim being selected set to
+    // size k
+    DimVector topKSize(self.sizes().vec());
+    if (topKSize.size() > 0) {
+      topKSize[dim] = k;
+    }
+    set_output(0, topKSize, self.options());
+    set_output(1, topKSize, self.options().dtype(at::kLong));
   }
-  set_output(0, topKSize, self.options());
-  set_output(1, topKSize, self.options().dtype(at::kLong));
-}
-
-TORCH_META_FUNC2(sort, stable)
-(const Tensor& self, c10::optional<bool> stable, int64_t dim, bool descending) {
-  TORCH_INTERNAL_ASSERT(
-      stable.has_value(),
-      "sort(): c10::optional<bool> for stable has to have value.");
-  maybe_wrap_dim(dim, self.dim());
-  // 'set_output' will only modify the strides, if the output was resized.
-  // Which means that we can ignore the output's strides here.
-  set_output(0, self.sizes(), self.strides(), self.options(), {});
-  set_output(1, self.sizes(), self.strides(), self.options().dtype(kLong), {});
-}
-
 } // namespace meta
 
 namespace native {
@@ -898,37 +888,52 @@ Tensor nanmedian_cpu(const Tensor& self) {
   return median_impl(self, /*ignore_nan=*/true);
 }
 
-TORCH_IMPL_FUNC(sort_stable_out)
-(const Tensor& self,
- c10::optional<bool> stable,
- int64_t dim,
- bool descending,
- const Tensor& values,
- const Tensor& indices) {
-  // check if self is scalar
-  if (self.dim() == 0 && self.numel() == 1) {
-    values.copy_(self);
-    indices.zero_();
-  } else {
-    dim = maybe_wrap_dim(dim, self.dim());
-    sort_stub(self.device().type(), self, dim, descending, stable.value(), values, indices);
-  }
-}
-
-std::tuple<Tensor&, Tensor&> sort_out(
-    const Tensor& self,
+std::tuple<Tensor&, Tensor&> sort_out_cpu_stable(const Tensor& self,
+    c10::optional<bool> stable,
     int64_t dim,
     bool descending,
     Tensor& values,
     Tensor& indices) {
-  return at::sort_out(values, indices, self, false, dim, descending);
+  values.resize_(self.sizes()).copy_(self);
+  indices.resize_(self.sizes());
+
+  // check if self is scalar
+  if (self.dim() == 0 && self.numel() == 1) {
+    indices.zero_();
+    return std::forward_as_tuple(values, indices);
+  }
+
+  TORCH_INTERNAL_ASSERT(stable.has_value(), "sort_out(): c10::optional<bool> for stable has to have value.");
+  sort_stub(kCPU, values, indices, dim, descending, stable.value());
+
+  return std::forward_as_tuple(values, indices);
 }
 
-std::tuple<Tensor, Tensor> sort(
+std::tuple<Tensor&, Tensor&> sort_out_cpu(const Tensor& self,
+    int64_t dim,
+    bool descending,
+    Tensor& values,
+    Tensor& indices) {
+  return at::native::sort_out_cpu_stable(
+      self, /*stable=*/false, dim, descending, values, indices);
+}
+
+std::tuple<Tensor, Tensor> sort_cpu_stable(
+    const Tensor& self,
+    c10::optional<bool> stable,
+    int64_t dim,
+    bool descending) {
+  TORCH_CHECK(!self.is_complex(), "sort(): input tensor must be of non-complex type");
+  Tensor values = at::empty({0}, self.options());
+  Tensor indices = at::empty({0}, self.options().dtype(kLong));
+  return at::native::sort_out_cpu_stable(self, stable, dim, descending, values, indices);
+}
+
+std::tuple<Tensor, Tensor> sort_cpu(
     const Tensor& self,
     int64_t dim,
     bool descending) {
-  return at::sort(self, false, dim, descending);
+  return sort_cpu_stable(self, /*stable=*/false, dim, descending);
 }
 
 Tensor& msort_out(const Tensor& self, Tensor& values) {

--- a/aten/src/ATen/native/Sorting.h
+++ b/aten/src/ATen/native/Sorting.h
@@ -14,7 +14,7 @@ enum class QUANTILE_INTERPOLATION_MODE : uint8_t {
   NEAREST
 };
 
-using sort_fn = void(*)(const Tensor&, int64_t, bool, bool, const Tensor&, const Tensor&);
+using sort_fn = void(*)(Tensor& values, Tensor& indices, int64_t dim, bool descending, bool stable);
 using topk_fn = void(*)(const Tensor&, const Tensor&, const Tensor&, int64_t, int64_t, bool, bool);
 
 DECLARE_DISPATCH(sort_fn, sort_stub);

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -12,7 +12,7 @@ namespace at { namespace native {
 
 namespace {
 
-void _fill_indices(const Tensor& indices, int64_t dim) {
+void _fill_indices(Tensor& indices, int64_t dim) {
   auto dim_size = indices.size(dim);
   auto idx_dim = at::arange(0, dim_size, indices.options().dtype(at::kLong));
   auto idx_dim_sizes = std::vector<int64_t>(indices.dim(), 1);
@@ -25,11 +25,17 @@ void _fill_indices(const Tensor& indices, int64_t dim) {
 
 template <typename func_t>
 void _dim_apply(
-    const Tensor& values,
-    const Tensor& indices,
+    Tensor& values,
+    Tensor& indices,
     int64_t dim,
     const std::string& method_name,
     const func_t& f) {
+  dim = maybe_wrap_dim(dim, values.dim());
+  TORCH_CHECK(
+    dim >= 0 && dim < values.dim(),
+    method_name, "(): invalid dimension parameter ", dim
+  );
+
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
     .resize_outputs(false)
@@ -87,13 +93,11 @@ struct KeyValueCompDesc {
 };
 
 static void sort_kernel(
-    const Tensor& self,
+    Tensor& values,
+    Tensor& indices,
     int64_t dim,
     bool descending,
-    bool stable,
-    const Tensor& values,
-    const Tensor& indices) {
-  values.copy_(self);
+    bool stable) {
   dim = maybe_wrap_dim(dim, values.dim());
   _fill_indices(indices, dim);
   _dim_apply(

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -10,7 +10,6 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/SortUtils.cuh>
 #include <ATen/native/cuda/SortingCommon.cuh>
-#include <ATen/native/Sorting.h>
 
 namespace at { namespace native {
 
@@ -28,7 +27,7 @@ bool should_use_small_sort(const Tensor &self, int64_t dim) {
 
 std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t dim);
 
-void fillSliceWithIndex(const Tensor& t,int dim) {
+void fillSliceWithIndex(Tensor& t,int dim) {
   if (t.numel()) {
     auto sizes = DimVector(t.dim(), 1);
     sizes[dim] = t.sizes()[dim];
@@ -292,14 +291,12 @@ inline void segmented_sort_pairs_by_full_sort(
 // We perform a segmented sort in cub with inputs that have
 // more than 1024/2048 elements along the selected dimension.
 // Otherwise, we do an inplace bitonic sort (see sortKeyValueInplace).
-void sort_cuda_kernel(
-    const Tensor& self,
-    int64_t dim,
-    bool descending,
-    bool stable,
-    const Tensor& values,
-    const Tensor& indices) {
+std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::optional<bool> stable, int64_t dim, bool descending, Tensor & values, Tensor & indices) {
   // this algorithm is always stable
+  TORCH_INTERNAL_ASSERT(stable.has_value(), "sort_out(): c10::optional<bool> for stable has to have value.");
+  TensorArg self_arg{self, "self", 1}, values_arg{values, "values", 2}, indices_arg{indices, "indices", 3};
+  checkAllSameGPU(__func__, {self_arg, values_arg, indices_arg});
+
   bool is_non_overlapping_and_dense = self.is_non_overlapping_and_dense();
   int64_t numel = self.numel();
   int64_t ndim = self.dim();
@@ -316,10 +313,37 @@ void sort_cuda_kernel(
   TORCH_CHECK(self_dtype != ScalarType::ComplexFloat && self_dtype != ScalarType::ComplexDouble,
     "Sort currently does not support complex dtypes on CUDA.");
 
+  if (ndim == 0) {
+    if (!values.defined()) {
+      values = self.clone();
+    } else {
+      values.resize_as_(self);
+      values.copy_(self);
+    }
+    if (!indices.defined()) {
+      indices = at::zeros({}, self.options().dtype(kLong));
+    } else {
+      indices.resize_as_(self);
+      indices.zero_();
+    }
+    return std::forward_as_tuple(values, indices);
+  }
+
   // use inplace algorithm for smaller input sizes without stable=True
-  if (should_use_small_sort(self, dim) && !stable) {
+  if (should_use_small_sort(self, dim) && !stable.value()) {
     // from thc: sorted->values, indices->indices, input->self
+
+    if (!values.defined()) {
+      values = at::empty_like(self);
+    }
+    if (!indices.defined()) {
+      indices = at::empty_like(self, self.options().dtype(kLong));
+    }
+
     // Make sure sufficient output space is allocated
+    auto self_size = self.sizes();
+    at::native::resize_output(values, self_size);
+    at::native::resize_output(indices, self_size);
     fillSliceWithIndex(indices, dim);
 
     // We sort k/v pairs in-place; copy unsorted input to output
@@ -328,7 +352,7 @@ void sort_cuda_kernel(
     // Sort using our in-place k/v kernel that supports arbitrary
     // layout
     sortKeyValueInplace(values, indices, dim, descending);
-    return;
+    return std::forward_as_tuple(values, indices);
   }
 
   Tensor self_;
@@ -345,6 +369,19 @@ void sort_cuda_kernel(
   Tensor values_tmp, indices_tmp;
   void *values_ptr_;
   int64_t *indices_ptr;
+  if (!values.defined()) {
+    if (is_non_overlapping_and_dense) {
+      values = at::empty_strided(self.sizes(), self.strides(), self.options());
+    } else {
+      auto strides = at::infer_dense_strides(self.sizes(), self.strides());
+      values = at::empty_strided(self.sizes(), strides, self.options());
+    }
+  } else {
+    TORCH_CHECK(self_.scalar_type() == values.scalar_type(),
+      "Unexpected dtype for values, expect ", self_.scalar_type(), ", got ", values.scalar_type());
+    values.resize_as_(self);
+  }
+
   if (values.strides() == self_.strides() && (newself || get_overlap_status(self, values) == MemOverlapStatus::NO)) {
     values_ptr_ = values.data_ptr();
   } else {
@@ -352,6 +389,18 @@ void sort_cuda_kernel(
     values_ptr_ = values_tmp.data_ptr();
   }
 
+  if (!indices.defined()) {
+    if (is_non_overlapping_and_dense) {
+      indices = at::empty_strided(self.sizes(), self.strides(), self.options().dtype(kLong));
+    } else {
+      auto strides = at::infer_dense_strides(self.sizes(), self.strides());
+      indices = at::empty_strided(self.sizes(), strides, self.options().dtype(kLong));
+    }
+  } else {
+    TORCH_CHECK(kLong == indices.scalar_type(),
+      "Unexpected dtype for values, expect torch.long, got ", indices.scalar_type());
+    indices.resize_as_(self);
+  }
   if (indices.strides() != self_.strides()) {
     indices_tmp = at::empty_strided(self_.sizes(), self_.strides(), self_.options().dtype(kLong));
     indices_ptr = indices_tmp.data_ptr<int64_t>();
@@ -360,7 +409,7 @@ void sort_cuda_kernel(
   }
 
   if (numel == 0) {
-    return;
+    return std::forward_as_tuple(values, indices);
   }
 
   int64_t numel_or_intmax = std::min(numel, static_cast<int64_t>(std::numeric_limits<int>::max()));
@@ -405,9 +454,20 @@ void sort_cuda_kernel(
   if (indices_tmp.defined()) {
     indices.copy_(indices_tmp);
   }
+  return std::forward_as_tuple(values, indices);
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_DISPATCH(sort_stub, &sort_cuda_kernel);
+std::tuple<Tensor &,Tensor &> sort_out_cuda(const Tensor & self, int64_t dim, bool descending, Tensor & values, Tensor & indices) {
+  return sort_out_stable_cuda(self, /*stable=*/false, dim, descending, values, indices);
+}
+
+std::tuple<Tensor,Tensor> sort_stable_cuda(const Tensor & self, c10::optional<bool> stable, int64_t dim, bool descending) {
+  Tensor values, indices;
+  return sort_out_stable_cuda(self, stable, dim, descending, values, indices);
+}
+
+std::tuple<Tensor,Tensor> sort_cuda(const Tensor & self, int64_t dim, bool descending) {
+  return sort_stable_cuda(self, /*stable=*/false, dim, descending);
+}
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -311,7 +311,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
 
       Tensor sortedIndices = at::empty_like(indices);
       Tensor sortedValues = at::empty_like(values);
-      at::native::sort_out(values, dim, largest, sortedValues, sortedIndices);
+      sort_out_cuda(values, dim, largest, sortedValues, sortedIndices);
       indices.copy_(indices.gather(dim, sortedIndices));
       values.copy_(sortedValues);
     }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7329,23 +7329,27 @@
 - func: sort.values(Tensor self, int dim=-1, bool descending=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CompositeExplicitAutograd: sort_out
+    CPU: sort_out_cpu
+    CUDA: sort_out_cuda
 
 - func: sort.values_stable(Tensor self, *, bool? stable, int dim=-1, bool descending=False, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
-  structured: True
   dispatch:
-    CPU, CUDA: sort_stable_out
+    CPU: sort_out_cpu_stable
+    CUDA: sort_out_stable_cuda
 
 - func: sort(Tensor self, int dim=-1, bool descending=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
   variants: method, function
   dispatch:
-    CompositeExplicitAutograd: sort
+    CPU: sort_cpu
+    CUDA: sort_cuda
+    QuantizedCPU: sort_quantized_cpu
 
 - func: sort.stable(Tensor self, *, bool? stable, int dim=-1, bool descending=False) -> (Tensor values, Tensor indices)
-  structured_delegate: sort.values_stable
   variants: method, function
   dispatch:
+    CPU: sort_cpu_stable
+    CUDA: sort_stable_cuda
     QuantizedCPU: sort_quantized_cpu_stable
 
 - func: sort.dimname_values(Tensor self, Dimname dim, bool descending=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)

--- a/aten/src/ATen/native/quantized/TensorCompare.cpp
+++ b/aten/src/ATen/native/quantized/TensorCompare.cpp
@@ -35,5 +35,12 @@ std::tuple<Tensor, Tensor> sort_quantized_cpu_stable(
       sort_indicies);
 }
 
+std::tuple<Tensor, Tensor> sort_quantized_cpu(
+    const Tensor& self,
+    int64_t dim,
+    bool descending) {
+  return sort_quantized_cpu_stable(self, /*stable=*/false, dim, descending);
+}
+
 } // namespace native
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#65876 Revert "Port `sort` kernel to structured kernels. (#62391)"**

This reverts commit 93852bb2d41d90b6ac660015d79f7474bcebb774.

Differential Revision: [D31296329](https://our.internmc.facebook.com/intern/diff/D31296329)