### PR TITLE
[Static Runtime] Make module_ optional in StaticModule

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -535,8 +535,7 @@ void PrepareGraphForStaticModule(
   OptimizeGraph(graph, opts);
 }
 
-std::pair<std::shared_ptr<Graph>, std::shared_ptr<Module>>
-PrepareForStaticModule(
+std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
     const torch::jit::Module& m,
     bool is_frozen,
     const StaticModuleOptions& opts) {
@@ -546,30 +545,26 @@ PrepareForStaticModule(
           << opts.optimize_memory << ", optimize_graph_output_memory"
           << opts.optimize_graph_output_memory;
 
-  std::shared_ptr<Module> module_ptr;
+  Module module = m.copy();
   if (!is_frozen) {
-    auto module = m.copy();
     module.eval();
-    module_ptr = std::make_shared<Module>(freeze_module(module));
-  } else {
-    module_ptr = std::make_shared<Module>(m.copy());
+    module = freeze_module(module);
   }
 
-  Method method = module_ptr->get_method("forward");
-  auto graph = module_ptr->get_method("forward").graph();
+  Method method = module.get_method("forward");
+  auto graph = module.get_method("forward").graph();
 
   // graph->dump();
   PrepareGraphForStaticModule(graph, opts);
 
-  return std::make_pair(graph, module_ptr);
+  return std::make_pair(graph, module);
 }
 
-std::pair<std::shared_ptr<Graph>, std::shared_ptr<Module>>
-PrepareForStaticModule(
+std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
     const StaticModuleOptions& opts) {
   PrepareGraphForStaticModule(graph, opts);
-  return std::make_pair(graph, nullptr);
+  return std::make_pair(graph, c10::nullopt);
 }
 
 } // namespace
@@ -586,7 +581,7 @@ StaticModule::StaticModule(
     : StaticModule(PrepareForStaticModule(m, is_frozen, opts), opts) {}
 
 StaticModule::StaticModule(
-    std::pair<std::shared_ptr<torch::jit::Graph>, std::shared_ptr<Module>>
+    std::pair<std::shared_ptr<torch::jit::Graph>, c10::optional<Module>>
         graph_and_module,
     const StaticModuleOptions& opts)
     : opts_(opts),
@@ -605,7 +600,7 @@ StaticModule::StaticModule(
   }
 
   // handle schema
-  if (module_) {
+  if (module_.has_value()) {
     Method method = module_->get_method("forward");
     schema_ = method.function().getSchema();
     if (RemoveSelfFromGraphInput(graph_)) {

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -113,7 +113,7 @@ class TORCH_API StaticModule {
 
  private:
   explicit StaticModule(
-      std::pair<std::shared_ptr<torch::jit::Graph>, std::shared_ptr<Module>>
+      std::pair<std::shared_ptr<torch::jit::Graph>, c10::optional<Module>>
           graph_and_module,
       const StaticModuleOptions& opts);
 
@@ -188,7 +188,7 @@ class TORCH_API StaticModule {
   StaticModuleOptions opts_;
   bool first_input_is_self_{false};
   std::shared_ptr<torch::jit::Graph> graph_;
-  std::shared_ptr<torch::jit::Module> module_;
+  c10::optional<torch::jit::Module> module_;
   c10::optional<c10::FunctionSchema> schema_;
   std::unique_ptr<StaticRuntime> cached_runtime_;
 


### PR DESCRIPTION
Summary: `torch::jit::Module` is refcounted. There is no need to wrap it in a `shared_ptr`.

Test Plan:
```
buck run //caffe2/benchmarks/static_runtime:static_runtime_cpptest
```

Differential Revision: D31012222

