### PR TITLE
[ao_migration] torch/nn/quantizable: torch.quantization -> torch.ao.quantization

### DIFF
--- a/torch/nn/quantizable/modules/activation.py
+++ b/torch/nn/quantizable/modules/activation.py
@@ -76,11 +76,11 @@ class MultiheadAttention(nn.MultiheadAttention):
         self.q_scaling_product = nnq.FloatFunctional()
 
         # Quant/Dequant
-        self.quant_attn_output = torch.quantization.QuantStub()
-        self.quant_attn_output_weights = torch.quantization.QuantStub()
-        self.dequant_q = torch.quantization.DeQuantStub()
-        self.dequant_k = torch.quantization.DeQuantStub()
-        self.dequant_v = torch.quantization.DeQuantStub()
+        self.quant_attn_output = torch.ao.quantization.QuantStub()
+        self.quant_attn_output_weights = torch.ao.quantization.QuantStub()
+        self.dequant_q = torch.ao.quantization.DeQuantStub()
+        self.dequant_k = torch.ao.quantization.DeQuantStub()
+        self.dequant_v = torch.ao.quantization.DeQuantStub()
 
     def _get_name(self):
         return 'QuantizableMultiheadAttention'
@@ -146,7 +146,7 @@ class MultiheadAttention(nn.MultiheadAttention):
                 observed.linear_V.bias = nn.Parameter(other.in_proj_bias[(other.embed_dim * 2):])
         observed.eval()
         # Explicit prepare
-        observed = torch.quantization.prepare(observed, inplace=True)
+        observed = torch.ao.quantization.prepare(observed, inplace=True)
         return observed
 
     @torch.jit.unused
@@ -221,7 +221,7 @@ class MultiheadAttention(nn.MultiheadAttention):
 
     @classmethod
     def from_observed(cls, other):
-        converted = torch.quantization.convert(other, mapping=None,
+        converted = torch.ao.quantization.convert(other, mapping=None,
                                                inplace=False,
                                                remove_qconfig=True,
                                                convert_custom_config_dict=None)

--- a/torch/nn/quantizable/modules/rnn.py
+++ b/torch/nn/quantizable/modules/rnn.py
@@ -212,7 +212,7 @@ class _LSTMLayer(torch.nn.Module):
     def from_float(cls, other, layer_idx=0, qconfig=None, **kwargs):
         r"""
         There is no FP equivalent of this class. This function is here just to
-        mimic the behavior of the `prepare` within the `torch.quantization`
+        mimic the behavior of the `prepare` within the `torch.ao.quantization`
         flow.
         """
         assert hasattr(other, 'qconfig') or (qconfig is not None)
@@ -375,10 +375,10 @@ class LSTM(torch.nn.Module):
             observed.layers[idx] = _LSTMLayer.from_float(other, idx, qconfig,
                                                          batch_first=False)
         observed.eval()
-        observed = torch.quantization.prepare(observed, inplace=True)
+        observed = torch.ao.quantization.prepare(observed, inplace=True)
         return observed
 
     @classmethod
     def from_observed(cls, other):
-        return torch.quantization.convert(other, inplace=False,
+        return torch.ao.quantization.convert(other, inplace=False,
                                           remove_qconfig=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

This changes the imports in the `caffe2/torch/nn/quantizable` to include the new import locations.

```
codemod -d torch/nn/quantizable --extensions py 'torch.quantization' 'torch.ao.quantization'
```

Differential Revision: [D31301194](https://our.internmc.facebook.com/intern/diff/D31301194/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D31301194/)!