### PR TITLE
[LTC] Pass lazy_tensors::Shape to generated IR ctors

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -335,5 +335,15 @@ bool IsInteropView(const at::Tensor& t) {
   return impl && impl->IsInteropView();
 }
 
+// template <typename T, size_t... Indices>
+// auto TupleAtenFromLtcTensorsImpl(const std::vector<T>& tensors, std::index_sequence<Indices...>) {
+//     return std::make_tuple(tensors[Indices]...);
+// }
+
+// template <size_t N, typename T>
+// auto TupleAtenFromLtcTensors(const std::vector<T>& tensors) {
+//     return TupleAtenFromLtcTensorsImpl(tensors, std::make_index_sequence<N>{});
+// }
+
 }  // namespace bridge
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -102,5 +102,13 @@ std::vector<at::Tensor> CreateLtcTensors(const std::vector<at::Tensor>& tensors,
 // Returns true if the tensor is a view created via interoperability.
 bool IsInteropView(const at::Tensor& t);
 
+template <size_t... Indices>
+auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>)  {
+    return std::make_tuple(AtenFromLtcTensor(tensors[Indices])...);
+}
+
+// template <size_t N, typename T>
+// auto TupleAtenFromLtcTensors(const std::vector<T>& tensors);
+
 }  // namespace bridge
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ir.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ir.h
@@ -284,6 +284,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Node& node) {
   return stream;
 }
 
+// TODO (@alanwaketan): Support r-value reference argument type.
 template <typename T, typename... Args>
 NodePtr MakeNode(Args&&... args) {
   return std::make_shared<T>(std::forward<Args>(args)...);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
@@ -133,7 +133,7 @@ LazyTensor SmoothL1Loss(const LazyTensor& input, const LazyTensor& target,
       return elementwise_loss.CreateFrom(
           ir::MakeNode<ir::ops::Mean>(
               elementwise_loss.GetIrValue(), broadcasted_input.dtype(),
-              broadcasted_input.dtype(), std::vector<int64_t>({1})),
+              lazy_tensors::Shape(broadcasted_input.dtype(), std::vector<int64_t>({1}))),
           broadcasted_input.dtype());
 
     case ReductionMode::kSum:

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
@@ -1061,4 +1061,22 @@ lazy_tensors::PrimitiveType GetShapeDimensionType(const Device* device) {
              : lazy_tensors::PrimitiveType::S32;
 }
 
+// template<typename... TupleType>
+// lazy_tensors::Shape CreateComputationShapeFromMetaTensors(const std::tuple<TupleType...>& tensors) {
+//   std::vector<lazy_tensors::Shape> shape;
+//   c10::guts::apply([&shape] (const auto&... tensors) {
+//       ((shape.emplace_back(tensors.scalar_type(), tensors.sizes().vec())), ...);
+//   }, tensors);
+//   return lazy_tensors::Shape(shape);
+// }
+
+// template<typename... TupleType>
+// std::vector<at::ScalarType> CreateDTypeFromMetaTensors(const std::tuple<TupleType...>& tensors) {
+//   std::vector<at::ScalarType> dtypes;
+//   c10::guts::apply([&dtypes] (const auto&... tensors) {
+//       ((dtypes.push_back(tensors.scalar_type())), ...);
+//   }, tensors);
+//   return dtypes;
+// }
+
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
@@ -87,4 +87,22 @@ bool RequiresRawTypeCasting(at::ScalarType scalar_type, const Device* device);
 
 lazy_tensors::PrimitiveType GetShapeDimensionType(const Device* device);
 
+template<typename... TupleType>
+lazy_tensors::Shape CreateComputationShapeFromMetaTensors(const std::tuple<TupleType...>& tensors) {
+  std::vector<lazy_tensors::Shape> shape;
+  c10::guts::apply([&shape] (const auto&... tensors) {
+      ((shape.emplace_back(tensors.scalar_type(), tensors.sizes().vec())), ...);
+  }, tensors);
+  return lazy_tensors::Shape(shape);
+}
+
+template<typename... TupleType>
+std::vector<at::ScalarType> CreateDTypeFromMetaTensors(const std::tuple<TupleType...>& tensors) {
+  std::vector<at::ScalarType> dtypes;
+  c10::guts::apply([&dtypes] (const auto&... tensors) {
+      ((dtypes.push_back(tensors.scalar_type())), ...);
+  }, tensors);
+  return dtypes;
+}
+
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -764,17 +764,17 @@ LazyNativeFunctions::nll_loss_forward(const at::Tensor& self,
 // fallback for them because we've customized the autograd function for them
 // (backward needs saved indices from forward).
 
-std::tuple<at::Tensor, at::Tensor> LazyNativeFunctions::max_pool2d_with_indices(
-    const at::Tensor& self, at::IntArrayRef kernel_size, at::IntArrayRef stride,
-    at::IntArrayRef padding, at::IntArrayRef dilation, bool ceil_mode) {
-  return at::native::call_fallback_fn<
-      &ltc_eager_fallback, ATEN_OP(max_pool2d_with_indices)>::call(self,
-                                                                   kernel_size,
-                                                                   stride,
-                                                                   padding,
-                                                                   dilation,
-                                                                   ceil_mode);
-}
+// std::tuple<at::Tensor, at::Tensor> LazyNativeFunctions::max_pool2d_with_indices(
+//     const at::Tensor& self, at::IntArrayRef kernel_size, at::IntArrayRef stride,
+//     at::IntArrayRef padding, at::IntArrayRef dilation, bool ceil_mode) {
+//   return at::native::call_fallback_fn<
+//       &ltc_eager_fallback, ATEN_OP(max_pool2d_with_indices)>::call(self,
+//                                                                    kernel_size,
+//                                                                    stride,
+//                                                                    padding,
+//                                                                    dilation,
+//                                                                    ceil_mode);
+// }
 
 at::Tensor LazyNativeFunctions::max_pool2d_with_indices_backward(
     const at::Tensor& grad_output, const at::Tensor& self,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -1,10 +1,11 @@
 backend: Lazy
 cpp_namespace: torch_lazy_tensors
 full_codegen:
-  - mean
   - addcdiv
   - addcmul
   - cos
+  - max_pool2d_with_indices
+  - mean
   - mm
 supported:
   - _log_softmax
@@ -40,7 +41,7 @@ supported:
   - nll_loss_forward
   - gelu
   - gelu_backward
-  - max_pool2d_with_indices
+  # - max_pool2d_with_indices
   - max_pool2d_with_indices_backward
   - max_pool3d_with_indices
   - max_pool3d_with_indices_backward

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -5,7 +5,7 @@ from tools.codegen.model import (Type, BaseTy, BaseType, OptionalType,
 from tools.codegen.api.types import (BaseCppType, BaseCType, OptionalCType,
                                      ConstRefCType, NamedCType,
                                      MutRefCType,
-                                     VectorCType, intT, ListCType,
+                                     VectorCType, boolT, intT, ListCType,
                                      scalarT, scalarTypeT, ArrayRefCType, ArrayCType, TupleCType)
 
 valueT = BaseCppType('ir', 'Value')
@@ -34,6 +34,10 @@ def process_ir_type(typ: Type) -> Union[BaseCType, VectorCType, OptionalCType, L
             return BaseCType(valueT)
         elif typ.name == BaseTy.Scalar:
             return BaseCType(scalarT)
+        elif typ.name == BaseTy.bool:
+            return BaseCType(boolT)
+        elif typ.name == BaseTy.int:
+            return BaseCType(intT)
         else:
             raise AssertionError(f"TODO add support for type {repr(typ)}")
     elif isinstance(typ, OptionalType):

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -115,7 +115,6 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
 
         # Generate native function impls that build IR nodes
         fm.write_with_template(f'{backend_dispatch_key}NativeFunctions.cpp', 'DispatchKeyNativeFunctions.cpp', lambda: {
-            'generated_comment': '',
             'includes': [f'#include "{path}"' for path in [
                 "lazy_tensor_core/csrc/tensor.h",
                 "lazy_tensor_core/csrc/aten_ltc_bridge.h",

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -116,12 +116,14 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         # Generate native function impls that build IR nodes
         fm.write_with_template(f'{backend_dispatch_key}NativeFunctions.cpp', 'DispatchKeyNativeFunctions.cpp', lambda: {
             'includes': [f'#include "{path}"' for path in [
-                "lazy_tensor_core/csrc/tensor.h",
+                "ATen/MetaFunctions.h",
                 "lazy_tensor_core/csrc/aten_ltc_bridge.h",
+                "lazy_tensor_core/csrc/helpers.h",
+                "lazy_tensor_core/csrc/tensor.h",
+                "lazy_tensor_core/csrc/tensor_util.h",
                 f"{output_dir}/{backend_key}NativeFunctions.h",
                 f"{output_dir}/{backend_key}LazyIr.h",
                 f"{output_dir}/{backend_key}ShapeDtype.h",
-                "ATen/MetaFunctions.h",
             ]],
             'native_functions_include': '',
             'backend_namespace': 'torch_lazy_tensors',  # this is wrong


### PR DESCRIPTION
Summary:
Pass lazy_tensors::Shape to generated IR ctors instead of vector<int64_t> and dtype. This improves the structure of the generated IR nodes a bit since out_dtype_ and out_shape_ aren't actually needed in the IR Node besides the .Clone() method. Also, it allows the caller of the ctors to pass a lazy_tensor::shape, which is a tuple shape, after processing the tuple meta-tensors instead of passing tuples of vector<int64_t> and dtype. The benefit is that the ctors are much simpler.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.

Fixes #65576.

P.S. This current commit is the first step to codegen `max_pool2d_with_indices`. The PR will be developed towards the final goal.