### PR TITLE
.github: Bump linux and windows gpu max available

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -25,7 +25,7 @@ runner_types:
   linux.8xlarge.nvidia.gpu:
     instance_type: g3.8xlarge
     os: linux
-    max_available: 100
+    max_available: 125
     disk_size: 150
   linux.16xlarge.nvidia.gpu:
     instance_type: g3.16xlarge
@@ -40,5 +40,5 @@ runner_types:
   windows.8xlarge.nvidia.gpu:
     instance_type: p3.2xlarge
     os: windows
-    max_available: 25
+    max_available: 50
     disk_size: 256


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65923

Still noticing that queues are long particularly for windows GPU
machines, bumping this to compensate

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D31308728](https://our.internmc.facebook.com/intern/diff/D31308728)