### PR TITLE
[DataPipe] Fix deepcopy for Mapper and in-place modification for IterableWrapper

### DIFF
--- a/torch/utils/data/datapipes/README.md
+++ b/torch/utils/data/datapipes/README.md
@@ -21,7 +21,9 @@ class MapperIterDataPipe(IterDataPipe):
         self.dp = dp
         self.fn = fn
 ```
-Note: Avoid loading data from the source DataPipe in `__init__` function, in order to support lazy data loading and save memory.
+Note:
+- Avoid loading data from the source DataPipe in `__init__` function, in order to support lazy data loading and save memory.
+- If `IterDataPipe` instance holds data in memory, please be ware of the in-place modification of data. When second iterator is created from the instance, the data may have already changed. Please take [`IterableWrapper`](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/datapipes/iter/utils.py) class as reference to `deepcopy` data for each iterator.
 
 ### Iterator
 For `IterDataPipe`, an `__iter__` function is needed to consume data from the source `IterDataPipe` then apply operation over the data before yield.

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 from torch.utils.data import IterDataPipe, _utils, functional_datapipe, DataChunk
 from typing import Callable, Dict, Iterator, Optional, Sized, Tuple, TypeVar
@@ -99,8 +98,6 @@ class MapperIterDataPipe(IterDataPipe[T_co]):
             data = list(data)
         else:
             t_flag = False
-            # Deepcopy data to prevent the original data modified. E.g. list, dict
-            data = copy.deepcopy(data)
 
         if self.output_col is None:
             if isinstance(self.input_col, (list, tuple)):

--- a/torch/utils/data/datapipes/iter/utils.py
+++ b/torch/utils/data/datapipes/iter/utils.py
@@ -1,3 +1,5 @@
+import copy
+import warnings
 from torch.utils.data import IterDataPipe
 
 
@@ -8,12 +10,34 @@ class IterableWrapperIterDataPipe(IterDataPipe):
 
     Args:
         iterable: Iterable object to be wrapped into an IterDataPipe
+        deepcopy: Option to deepcopy input iterable object for each
+            iteration.
+
+    .. note::
+      If `deepcopy` is set to False explicitly, users should ensure
+      that data pipeline doesn't contain any in-place operations over
+      the iterable instance, in order to prevent data inconsistency
+      across iterations.
     """
-    def __init__(self, iterable):
+    def __init__(self, iterable, deepcopy=True):
         self.iterable = iterable
+        self.deepcopy = deepcopy
 
     def __iter__(self):
-        for data in self.iterable:
+        source_data = self.iterable
+        if self.deepcopy:
+            try:
+                source_data = copy.deepcopy(self.iterable)
+            # For the case that data cannot be deep-copied,
+            # all in-place operations will affect iterable variable.
+            # When this DataPipe is iterated second time, it will
+            # yield modified items.
+            except TypeError:
+                warnings.warn(
+                    "The input iterable can not be deepcopied, "
+                    "please be aware of in-place modification would affect source data"
+                )
+        for data in source_data:
             yield data
 
     def __len__(self):


### PR DESCRIPTION
This PR fixes a bug from a newly introduced feature in PR #64951


Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/65220

Fixes #65221

- Remove deepcopy from Mapper to support file handles
- Convert `IterableWrapper` to deepcopy iterable instance within each iterator to prevent in-place modification (different data per epoch)
- Convert `IDP` to `IterableWrapper` in test_datapipe.py
- Refine the variable names (prevent using `dp` that is module reference)

fbshipit-source-id: 72a9eee66c758e2717d591cd0942892bddedc223