### PR TITLE
[fx-acc] add optimize_quantization to FX graph opts

### DIFF
--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -1943,5 +1943,7 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.gelu,
                 acc_ops.cumsum,
                 acc_ops.chunk,
+                acc_ops.rescale_quantize_per_tensor,
+                acc_ops.rescale_quantize_per_channel,
             },
         )

--- a/torch/fx/experimental/fx_acc/acc_op_properties.py
+++ b/torch/fx/experimental/fx_acc/acc_op_properties.py
@@ -7,6 +7,7 @@ import torch.fx
 
 class AccOpProperty(Flag):
     pointwise = auto()
+    quantized = auto()
 
 acc_op_properties: DefaultDict[Callable, Set[AccOpProperty]] = defaultdict(set)
 acc_ops_with_property: DefaultDict[AccOpProperty, Set[Callable]] = defaultdict(set)


### PR DESCRIPTION
Summary: This adds a set of quantize/dequantize graph optimizations.

Test Plan:
```
buck test mode/opt glow/fb/fx/graph_opts:test_fx_graph_opts
```
```
Processing filesystem changes: finished in 1.2 sec
Parsing buck files: finished in 0.7 sec
Downloaded 0/3 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 38.7 sec (100%) 10325/10325 jobs, 3/10325 updated
  Total time: 39.4 sec
More details at https://www.internalfb.com/intern/buck/build/08405ff4-3a4a-4c4f-ab8c-5358045ef1fe
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 935fef65-3201-4a06-a8ad-8b2e9805342c
Trace available for this run at /tmp/tpx-20210929-171248.860083/trace.log
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/8444249356527952
    ✓ ListingSuccess: glow/fb/fx/graph_opts:test_fx_graph_opts - main (6.341)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_remove_one_3 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.106)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_5 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.123)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_transpose_to_reshape_1_optimizable (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestTransposeToReshape) (0.053)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_remove_one_0 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.171)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_7 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.274)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_dequantize_clamp_remove_one_2 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.244)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_1 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.141)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantization_2_Dequantize_Quantize_Dequantize_X_Dequantize_rescale_X_Dequantize_X_ (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantization) (0.380)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_transpose_to_reshape_0_identity (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestTransposeToReshape) (0.015)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_2 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.196)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantization_0_Dequantize_Quantize_X_X (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantization) (0.157)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_0 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.203)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantization_1_Quantize_Dequantize_X_RescaleQuantized_X_ (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantization) (0.249)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_6 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.231)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_dequantize_clamp_remove_one_0 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.501)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantization_3_Rescale_QuantizeNode_QuantizeNode_ (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantization) (0.445)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_clamp_tensor (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.261)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_remove_one_1 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.514)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_transpose_to_reshape_2_unoptimizable (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestTransposeToReshape) (0.215)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_4 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.375)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_dequantize_clamp_remove_one_3 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.736)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_remove_one_2 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.380)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_quantize_clamp_ignore_one_3 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.106)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_optimize_dequantize_clamp_remove_one_1 (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestOptimizeQuantizeClamp) (0.651)
Summary
  Pass: 24
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/8444249356527952
```

# Before
```
Model before opt.
graph():
    %x : [#users=2] = placeholder[target=x]
    %quantize_per_tensor_3 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantize_per_tensor](args = (), kwargs = {input: %x, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)})
    %quantize_per_tensor_4 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantize_per_tensor](args = (), kwargs = {input: %x, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)})
    %add_1 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantized_add](args = (), kwargs = {input: %quantize_per_tensor_3, other: %quantize_per_tensor_4, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 2e-06, 0)})
    %dequantize_1 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.dequantize](args = (), kwargs = {input: %add_1})
    %quantize_per_tensor_5 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantize_per_tensor](args = (), kwargs = {input: %dequantize_1, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-06, 0)})
    return quantize_per_tensor_5
opcode         name                   target                                            args                      kwargs
-------------  ---------------------  ------------------------------------------------  ------------------------  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
placeholder    x                      x                                                 ()                        {}
call_function  quantize_per_tensor_3  <function quantize_per_tensor at 0x7f4ceeb05dc0>  ()                        {'input': x, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)}
call_function  quantize_per_tensor_4  <function quantize_per_tensor at 0x7f4ceeb05dc0>  ()                        {'input': x, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)}
call_function  add_1                  <function quantized_add at 0x7f4ceeb05ca0>        ()                        {'input': quantize_per_tensor_3, 'other': quantize_per_tensor_4, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 2e-06, 0)}
call_function  dequantize_1           <function dequantize at 0x7f4ceeb05e50>           ()                        {'input': add_1}
call_function  quantize_per_tensor_5  <function quantize_per_tensor at 0x7f4ceeb05dc0>  ()                        {'input': dequantize_1, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-06, 0)}
output         output                 output                                            (quantize_per_tensor_5,)  {}
```

# After
```
Model after opt.
graph():
    %x : [#users=2] = placeholder[target=x]
    %quantize_per_tensor_3 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantize_per_tensor](args = (), kwargs = {input: %x, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)})
    %quantize_per_tensor_4 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantize_per_tensor](args = (), kwargs = {input: %x, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)})
    %add_1 : [#users=1] = call_function[target=torch.fx.experimental.fx_acc.acc_ops.quantized_add](args = (), kwargs = {input: %quantize_per_tensor_3, other: %quantize_per_tensor_4, acc_out_ty: ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-06, 0)})
    return add_1
opcode         name                   target                                            args      kwargs
-------------  ---------------------  ------------------------------------------------  --------  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
placeholder    x                      x                                                 ()        {}
call_function  quantize_per_tensor_3  <function quantize_per_tensor at 0x7f4ceeb05dc0>  ()        {'input': x, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)}
call_function  quantize_per_tensor_4  <function quantize_per_tensor at 0x7f4ceeb05dc0>  ()        {'input': x, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-05, 0)}
call_function  add_1                  <function quantized_add at 0x7f4ceeb05ca0>        ()        {'input': quantize_per_tensor_3, 'other': quantize_per_tensor_4, 'acc_out_ty': ((8, 4, 2), torch.qint32, False, (8, 2, 1), torch.contiguous_format, True, torch.per_tensor_affine, 1e-06, 0)}
output         output                 output                                            (add_1,)  {}
```

Differential Revision: D30945732

