### PR TITLE
[fx][const_fold] Refactor to use base split module to simplify, and correctly handle non-single-Tensor outputs

### DIFF
--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -1,16 +1,9 @@
-import operator
-from typing import Dict, Set, List, Optional, Union
+from typing import Dict, Set, Optional, Union
 
 import torch.fx
 import torch.fx.experimental.fx_acc.acc_utils as acc_utils
+from torch.fx.node import map_arg
 from torch.fx.passes.split_module import split_module
-
-
-def _make_tuple(x):
-    """
-    Helper to convert x into a one item tuple if it's not a tuple already.
-    """
-    return x if isinstance(x, tuple) else (x,)
 
 
 class FoldedGraphModule(torch.fx.GraphModule):
@@ -28,7 +21,7 @@ class FoldedGraphModule(torch.fx.GraphModule):
         root: torch.nn.Module,
         graph: torch.fx.Graph,
         const_subgraph: Optional[torch.fx.Graph] = None,
-        const_output_names: Optional[List[str]] = None,
+        fx_const_folded_attrs_name: str = None,
     ):
         super().__init__(root, graph)
         self.const_subgraph_module = (
@@ -36,8 +29,8 @@ class FoldedGraphModule(torch.fx.GraphModule):
             if const_subgraph is None
             else torch.fx.GraphModule(root, const_subgraph)
         )
-        self.const_output_names = const_output_names
         self.has_folding_been_run = False
+        self.fx_const_folded_attrs_name = fx_const_folded_attrs_name
 
     def __call__(self, *args, **kwargs):
         if not self.has_folding_been_run:
@@ -47,23 +40,70 @@ class FoldedGraphModule(torch.fx.GraphModule):
     def run_folding(self):
         # If there's no const subgraph module or attr output names to use, return
         # early as there is no const folding to perform.
-        if self.const_subgraph_module is None or self.const_output_names is None:
+        if (
+            self.const_subgraph_module is None
+            or self.fx_const_folded_attrs_name is None
+        ):
             return
 
         assert not self.has_folding_been_run
         self.has_folding_been_run = True
 
-        # Actually run const folding subgraph. We _make_tuple here because
-        # single attr const fold subgraphs output a single Tensor while
-        # multiple outputs are returned as Tuple[Tensor,].
-        folded_attrs = _make_tuple(self.const_subgraph_module())
+        # Actually run const folding subgraph. Note that single attr const fold
+        # subgraphs output a single Tensor while multiple outputs are returned as
+        # Tuple[Tensor,].
+        folded_attrs = self.const_subgraph_module()
+        params = (
+            torch.nn.ParameterList([torch.nn.Parameter(i) for i in folded_attrs])
+            if isinstance(folded_attrs, tuple)
+            else torch.nn.Parameter(folded_attrs)
+        )
+        setattr(self, self.fx_const_folded_attrs_name, params)
 
-        # Look for output node from const folding subgraph and set attrs on the
-        # module with the results.
-        for i in range(len(folded_attrs)):
-            setattr(
-                self, self.const_output_names[i], torch.nn.Parameter(folded_attrs[i])
-            )
+
+def _inline_module(gm: torch.fx.GraphModule, inline_mod_name: str):
+    """
+    Given `gm` and some graph module which is called with target name `inline_mod_name`,
+    this helper will inline all of the nodes from that called graph module into `gm`.
+    """
+    # Fetch the inner graph module that we want to inline inside `gm`.
+    inline_mod = dict(gm.named_modules())[inline_mod_name]
+    assert isinstance(inline_mod, torch.fx.GraphModule)
+    call_mod_node_to_replace = None
+    for node in gm.graph.nodes:
+        if node.op == "call_module" and node.target == inline_mod_name:
+            call_mod_node_to_replace = node
+            break
+    assert call_mod_node_to_replace is not None
+
+    # Now actually do the swap. Note that we have to keep track of new nodes that are
+    # copied into `gm` -- we do this via replacement_mapping.
+    call_mod_args = call_mod_node_to_replace.args
+    replacement_mapping: Dict[torch.fx.Node, torch.fx.Node] = {}
+    ph_count = 0
+
+    def replacement_fn(node):
+        new_node = replacement_mapping[node]
+        new_node.meta = node.meta.copy()
+        return new_node
+
+    for inline_node in inline_mod.graph.nodes:
+        if inline_node.op == "placeholder":
+            replacement_mapping[inline_node] = call_mod_args[ph_count]
+            ph_count += 1
+            continue
+
+        if inline_node.op == "output":
+            outputs = inline_node.args[0]
+            output_replacements = map_arg(outputs, replacement_fn)
+            call_mod_node_to_replace.replace_all_uses_with(output_replacements)
+            continue
+
+        with gm.graph.inserting_before(call_mod_node_to_replace):
+            new_node = gm.graph.node_copy(inline_node, replacement_fn)
+        replacement_mapping[inline_node] = new_node
+
+    gm.graph.eliminate_dead_code()
 
 
 def split_const_subgraphs(
@@ -109,192 +149,94 @@ def split_const_subgraphs(
 
     split = split_module(mod_traced, module, mod_partition)
 
+    const_gm, non_const_gm = split.submod_0, split.submod_1
+    const_mod_name, non_const_mod_name = "submod_0", "submod_1"
+
     # Later we are creating get_attr nodes from main module get_attr nodes and we use the
     # same node.target. If there's a get_attr that refers to an attributes in a module and
-    # this module is not included in submod_1 then we would have a trouble when creating
+    # this module is not included in non_const_gm then we would have a trouble when creating
     # get_attr ndoes because it will try to find the module that owns the attribute first.
-    # Setting owning_module here makes the owning_module of submod_1.graph to None then
+    # Setting owning_module here makes the owning_module of non_const_gm.graph to None then
     # the check when creating get_attr nodes will get skipped.
-    split.submod_1.graph.owning_module = mod_traced
+    non_const_gm.graph.owning_module = split
 
     # The module that a call_module node refers to gets copied to submodules during split.
     # The path to the module also gets inlined, i.e. mod.a.b -> mod_a_b. Here we need to
-    # attach inlined modules to `mod_traced` as it's the owning module now.
-    for node in split.submod_1.graph.nodes:
+    # attach inlined modules to `split` as it's the owning module now.
+    for node in non_const_gm.graph.nodes:
         if node.op == "call_module":
-            setattr(mod_traced, node.target, getattr(split.submod_1, node.target))
-
-    # Gather all names that are output from the const folding subgraph, which we
-    # will need to set dummy params on the module.
-    const_output_names: List[str] = []
-    for node in split.submod_0.graph.nodes:
-        if node.op == "output":
-            # Note: we _make_tuple here because the output Node either contains
-            # a single output Node, or Tuple[Node], so this simplifies things.
-            const_output_names = [o.name for o in _make_tuple(node.args[0])]
-            break
-
-    # Make sure the attr name we want to use is uniquely named in the module.
-    for i in range(len(const_output_names)):
-        # Add a suffix to make it easier to tell these were the result of const folding.
-        name = const_output_names[i] + "__CF"
-        # Get an unique name for the attr.
-        name = acc_utils.get_unique_attr_name_in_module(mod_traced, name)
-        const_output_names[i] = name
-
-    # Now track the const_output_names to what name is used in the parent graph
-    # from the split via call_function getitem, to see what order it is passed
-    # into the non-const subgraph submod_1. First look to the parent module
-    # containing/calling into the const/non-const submodules to determine what
-    # the inputs are to each. Note if submod_0 had a single output then there is
-    # no getitem, and we can simply use the output from the call to submoid_0.
-    call_submod_0_args, call_submod_1_args = None, None
-    orig_ph_targets: List[str] = []
-    for node in split.graph.nodes:
-        if node.op == "placeholder":
-            orig_ph_targets.append(node.target)
-
-        if node.op == "call_module":
-            if node.target == "submod_0":
-                call_submod_0_args = node.args
-                continue
-            elif node.target == "submod_1":
-                call_submod_1_args = node.args
-                continue
-    assert call_submod_0_args is not None and call_submod_1_args is not None
-
-    # Look through the args for the call into submod_1, and find the args that
-    # come from submod_0. Also look for get_attrs fed directly from the parent
-    # split into submod_1, i.e. those attrs that are not constant folded.
-    submod_1_input_idx_to_folded_attr_name: Dict[int, str] = {}
-    submod_1_input_idx_to_unfolded_attr_name: Dict[int, str] = {}
-    for i, node in enumerate(call_submod_1_args):
-        const_output_name = None
-        # If we only had a single output from submod_0 then we simply look for
-        # the call_module into it.
-        if len(const_output_names) == 1:
-            if node.op == "call_module" and node.target == "submod_0":
-                const_output_name = const_output_names[0]
-
-        # Else we had multiple outputs from submod_0, so we need to look for all
-        # getitems from the call to it.
-        else:
-            if (
-                node.op == "call_function"
-                and node.target == operator.__getitem__
-                and node.args[0].target == "submod_0"
-            ):
-                const_output_name = const_output_names[node.args[1]]
-
-        # Now map from the index of the constant into calling submod_1 and map
-        # to the constant output name, which we use for swapping in getattrs
-        # instead of placeholders in submod_1.
-        if const_output_name is not None:
-            submod_1_input_idx_to_folded_attr_name[i] = const_output_name
-        elif node.op == "get_attr":
-            submod_1_input_idx_to_unfolded_attr_name[i] = node.target
-
-    assert len(submod_1_input_idx_to_folded_attr_name) == len(const_output_names)
-
-    # Now we have a mapping from const output names to the index they are passed
-    # into submod_1, so swap in getattrs for placeholders.
-    ph_idx = 0
-
-    for node in split.submod_1.graph.nodes:
-        if node.op != "placeholder":
-            continue
-        is_folded_attr = ph_idx in submod_1_input_idx_to_folded_attr_name
-        is_unfolded_attr = ph_idx in submod_1_input_idx_to_unfolded_attr_name
-        if not is_folded_attr and not is_unfolded_attr:
-            ph_idx += 1
-            continue
-
-        const_output_name = (
-            submod_1_input_idx_to_folded_attr_name[ph_idx]
-            if is_folded_attr
-            else submod_1_input_idx_to_unfolded_attr_name[ph_idx]
-        )
-
-        if is_folded_attr:
-            assert not hasattr(mod_traced, const_output_name)
-            # Use a dummy param, which will be overwritten when we run const folding.
-            setattr(
-                mod_traced,
-                const_output_name,
-                torch.nn.Parameter(torch.randn(1)),
-            )
-
-        with split.submod_1.graph.inserting_before(node):
-            new_node = split.submod_1.graph.get_attr(const_output_name)
-            new_node.meta = node.meta.copy()
-            node.replace_all_uses_with(new_node)
-        split.submod_1.graph.erase_node(node)
-        ph_idx += 1
-
-    # We may need to reorder placeholders to ensure they have the same order as
-    # they do in the original split.
-    ph_idx = 0
-    node = next(iter(split.submod_1.graph.nodes))
-    while node.op != "root":
-        if node.op != "placeholder":
-            node = node.next
-            continue
-
-        curr_orig_ph_target = orig_ph_targets[ph_idx]
-        ph_idx += 1
-        # If this ph is in the correct position, nothing to do.
-        if curr_orig_ph_target == node.target:
-            node = node.next
-            continue
-
-        # This ph is not in the correct order, so search the rest of the graph
-        # for the ph we expected and prepend it before the current ph.
-        later_node = node.next
-        while later_node.op != "root":
-            if (
-                later_node.op == "placeholder"
-                and curr_orig_ph_target == later_node.target
-            ):
-                break
-            later_node = later_node.next
-
-        # The placeholder is in split.graph but not in split.submod_1.graph.
-        # In this case we add the placeholder to submod_1.graph.
-        if later_node.op == "root":
-            with split.submod_1.graph.inserting_before(node):
-                split.submod_1.graph.placeholder(curr_orig_ph_target)
-        else:
-            node.prepend(later_node)
-
-        # Note we do not increment node here, as it still may be in the wrong
-        # place (we just prepended the ph that should have come before it).
-
-    # There might be more placeholders left in orig_ph_targets.
-    last_placeholder = next(n for n in split.submod_1.graph.nodes if n.target == orig_ph_targets[ph_idx - 1])
-    while ph_idx < len(orig_ph_targets):
-        with split.submod_1.graph.inserting_after(last_placeholder):
-            split.submod_1.graph.placeholder(orig_ph_targets[ph_idx])
-        ph_idx += 1
+            setattr(split, node.target, getattr(non_const_gm, node.target))
 
     # split_module currently does not use get_attrs for attrs. Instead it passes
     # them in as args from the parent module, which used get_attrs. Here we set
-    # them as get_attrs inside submod_0, allowing for running folding without
+    # them as get_attrs inside const_gm, allowing for running folding without
     # somehow a priori knowing the attrs that should be passed as args. We can
     # unconditionally do this for all placeholders because we know all
-    # placeholders to submod_0 must be constants accessible via get_attr.
-    # Note that here we set the split.submod_0.graph into a new root_submod_0 with split
-    # as the root module, because we are fetching attributes directly from the root
-    # module, instead of fetching them from split.submod_0.
-    root_submod_0 = torch.fx.GraphModule(split, split.submod_0.graph)
-    for node in root_submod_0.graph.nodes:
+    # placeholders to const_gm must be constants accessible via get_attr.
+    call_const_gm_args = None
+    for node in split.graph.nodes:
+        if node.op == "call_module":
+            if node.target == const_mod_name:
+                call_const_gm_args = node.args
+                break
+    assert call_const_gm_args is not None
+
+    # Here we do the actual replacement of placeholders to get_attrs. Note that here we
+    # set the const_gm.graph into a new root_const_gm with split as the root module,
+    # because we are fetching attributes directly from the root module, instead of
+    # fetching them from const_gm. Example: The const_gm must have some format like:
+    # graph():
+    #    %inp : [#users=1] = placeholder[target=const_inp]
+    #    %add : [#users=1] = call_function[target=operator.add](args = (%inp, %inp), kwargs = {})
+    #    return add
+    # We replace that with the following, which does not have any placeholders:
+    # graph():
+    #    %inp_1 : [#users=1] = get_attr[target=const_inp]
+    #    %add : [#users=1] = call_function[target=operator.add](args = (%inp_1, %inp_1), kwargs = {})
+    #    return add
+    root_const_gm = torch.fx.GraphModule(split, const_gm.graph)
+    for node in root_const_gm.graph.nodes:
+        if node.op == "output":
+            multiple_outputs = isinstance(node.args[0], tuple)
+            continue
         if node.op != "placeholder":
             continue
-        in_node = next(n for n in call_submod_0_args if n.name == node.target)
+        in_node = next(n for n in call_const_gm_args if n.name == node.target)
         assert in_node.op == "get_attr"
-        with root_submod_0.graph.inserting_before(node):
-            node.replace_all_uses_with(root_submod_0.graph.get_attr(in_node.target))
-        root_submod_0.graph.erase_node(node)
+        with root_const_gm.graph.inserting_before(node):
+            new_node = root_const_gm.graph.get_attr(in_node.target)
+        new_node.meta = node.meta.copy()
+        node.replace_all_uses_with(new_node)
+        root_const_gm.graph.erase_node(node)
+    assert "multiple_outputs" in locals()
+
+    # Now find the call to const_gm inside split, and replace it with a getattr to the
+    # folded tensor(s) that result from constant folding. Note that we don't need to
+    # worry about whether this is one or more tensors because the original graph
+    # correctly uses getitem to extract individual tensors if there are multiple folded.
+    fx_const_folded_attrs_name = acc_utils.get_unique_attr_name_in_module(
+        split, "_FX_CONST_FOLDED_ATTRS"
+    )
+    setattr(
+        split,
+        fx_const_folded_attrs_name,
+        torch.nn.ParameterList() if multiple_outputs else torch.nn.Parameter(),
+    )
+    for node in split.graph.nodes:
+        if node.op == "call_module" and node.target == const_mod_name:
+            with node.graph.inserting_before(node):
+                folded_attrs = node.graph.get_attr(fx_const_folded_attrs_name)
+            folded_attrs.meta = node.meta.copy()
+            node.replace_all_uses_with(folded_attrs)
+            break
+
+    split.graph.eliminate_dead_code()
+
+    # Finally, inline the non-constant submod into the split submod. This is so that the
+    # original caller who may have passed in a graph module will get back out a graph
+    # module whose graph is traced to the same granularity.
+    _inline_module(split, non_const_mod_name)
 
     return FoldedGraphModule(
-        mod_traced, split.submod_1.graph, root_submod_0.graph, const_output_names
+        split, split.graph, root_const_gm.graph, fx_const_folded_attrs_name
     )

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -137,8 +137,10 @@ def split_module(
     for node in m.graph.nodes:
         if node.op == 'placeholder':
             base_mod_env[node.name] = base_mod_graph.placeholder(node.name)
+            base_mod_env[node.name].meta = node.meta.copy()
         elif node.op == 'get_attr':
             base_mod_env[node.name] = base_mod_graph.get_attr(node.target)
+            base_mod_env[node.name].meta = node.meta.copy()
             attr_val = m
             for atom in node.target.split('.'):
                 if not hasattr(attr_val, atom):


### PR DESCRIPTION
Summary:
We use `split_module` to split the input model that we want to const fold into const and non-const subgraphs. Previously we were taking the non-const graph and trying to hack it back into the same signature as the input model. However this was complex/buggy.

Instead, refactor to just keep using the base split module that contains both const and non-const graphs. This means we:
- Inline the non-const graph into the split module
- Remove the const graph from the module and replace it with a getattr that will be run to insert that attr when we `run_folding`

Test Plan: Added test coverage to cover newly supported folding, and updated other tests for new strategy.

Differential Revision: D31293307

