### PR TITLE
[PyTorch] Avoid string construction from const char* and speedup empty string creation if error messages are suppressed

### DIFF
--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -9,10 +9,10 @@ namespace {
   // don't have to allocate strings all the time
   std::string debugString(std::string debug, const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
-    return std::string("", 0);
+    return std::string();
 #else
     if (debug.empty()) {
-      return c10::str("registered at ", file, ":", line);
+      return debugString(nullptr, file, line);
     } else {
       return debug;
     }
@@ -21,7 +21,7 @@ namespace {
 
   std::string debugString(const char* debug, const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
-    return std::string("", 0);
+    return std::string();
 #else
     if (debug == nullptr || debug[0] == '\0') {
       return c10::str("registered at ", file, ":", line);

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -7,18 +7,6 @@ namespace torch {
 namespace {
   // TODO: Consider representing debug info as a struct instead so you
   // don't have to allocate strings all the time
-  std::string debugString(std::string debug, const char* file, uint32_t line) {
-#ifdef STRIP_ERROR_MESSAGES
-    return std::string();
-#else
-    if (debug.empty()) {
-      return debugString(nullptr, file, line);
-    } else {
-      return debug;
-    }
-#endif
-  }
-
   std::string debugString(const char* debug, const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
     return std::string();
@@ -27,6 +15,18 @@ namespace {
       return c10::str("registered at ", file, ":", line);
     } else {
       return std::string(debug);
+    }
+#endif
+  }
+
+  std::string debugString(std::string debug, const char* file, uint32_t line) {
+#ifdef STRIP_ERROR_MESSAGES
+    return std::string();
+#else
+    if (debug.empty()) {
+      return debugString(nullptr, file, line);
+    } else {
+      return debug;
     }
 #endif
   }

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -24,7 +24,7 @@ namespace {
     return std::string();
 #else
     if (debug.empty()) {
-      return debugString(nullptr, file, line);
+      return debugString(static_cast<const char*>(nullptr), file, line);
     } else {
       return debug;
     }

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -9,12 +9,24 @@ namespace {
   // don't have to allocate strings all the time
   std::string debugString(std::string debug, const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
-    return "";
+    return std::string("", 0);
 #else
     if (debug.empty()) {
       return c10::str("registered at ", file, ":", line);
     } else {
       return debug;
+    }
+#endif
+  }
+
+  std::string debugString(const char* debug, const char* file, uint32_t line) {
+#ifdef STRIP_ERROR_MESSAGES
+    return std::string("", 0);
+#else
+    if (debug == nullptr || debug[0] == '\0') {
+      return c10::str("registered at ", file, ":", line);
+    } else {
+      return std::string(debug);
     }
 #endif
   }

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -7,15 +7,11 @@ namespace torch {
 namespace {
   // TODO: Consider representing debug info as a struct instead so you
   // don't have to allocate strings all the time
-  std::string debugString(const char* debug, const char* file, uint32_t line) {
+  std::string debugString(const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
     return std::string();
 #else
-    if (debug == nullptr || debug[0] == '\0') {
-      return c10::str("registered at ", file, ":", line);
-    } else {
-      return std::string(debug);
-    }
+    return c10::str("registered at ", file, ":", line);
 #endif
   }
 
@@ -24,7 +20,7 @@ namespace {
     return std::string();
 #else
     if (debug.empty()) {
-      return debugString(static_cast<const char*>(nullptr), file, line);
+      return debugString(file, line);
     } else {
       return debug;
     }
@@ -67,7 +63,7 @@ Library::Library(Kind kind, std::string ns, c10::optional<c10::DispatchKey> k, c
         // don't register a library
         registrars_.emplace_back(
           c10::Dispatcher::singleton().registerLibrary(
-            *ns_, debugString("", file_, line_)
+            *ns_, debugString(file_, line_)
           )
         );
         // fallthrough
@@ -130,7 +126,7 @@ Library& Library::_def(c10::FunctionSchema&& schema, c10::OperatorName* out_name
   registrars_.emplace_back(
     c10::Dispatcher::singleton().registerDef(
       std::move(schema),
-      debugString("", file_, line_)
+      debugString(file_, line_)
     )
   );
   return *this;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #65939

This change includes 2 separate optimizations.

1. Provide an overload of `debugString(const char*, ...)` in addition to `debugString(std::string, ...)` for cases where `const char*` is passed in to avoid `std::string` construction in cases where `STRIP_ERROR_MESSAGES` is also defined and the caller is passing in a `const char*`
2. Return `std::string("", 0)` instead of `""` since the former triggers no call to `std::basic_string`'s constructor whereas the latter does. [Godbolt Link](https://godbolt.org/z/oTExed5h8). However, I'm surprosed by this since the man page for [std::basic_string](https://en.cppreference.com/w/cpp/string/basic_string/basic_string) clearly states that the constexpr overload is since C++20, and I am building using `-Os -std=c++17`

Godbolt Screenshot:

{F667311023}

#accept2ship

Differential Revision: [D31312942](https://our.internmc.facebook.com/intern/diff/D31312942/)