### PR TITLE
Optimize backward pass of `grid_sample` (2d) when no input grad is needed

### DIFF
--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -775,7 +775,8 @@ Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 std::tuple<Tensor, Tensor>
 grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, const Tensor& grid,
-                             int64_t interpolation_mode, int64_t padding_mode, bool align_corners) {
+                             int64_t interpolation_mode, int64_t padding_mode, bool align_corners,
+                             std::array<bool,2> output_mask) {
 
   // AVX gather instructions use signed 32-bit offsets to gather float values.
   // Check for possible overflow and fallback to scalar implementation
@@ -801,7 +802,7 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
   }
 
   return grid_sampler_2d_backward_cpu_kernel(
-    kCPU, grad_output, input, grid, interpolation_mode, padding_mode, align_corners);
+    kCPU, grad_output, input, grid, interpolation_mode, padding_mode, align_corners, output_mask);
 }
 
 DEFINE_DISPATCH(grid_sampler_2d_backward_cpu_kernel);

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -1195,7 +1195,8 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
                                          const Tensor& grid,
                                          int64_t interpolation_mode,
                                          int64_t padding_mode,
-                                         bool align_corners) {
+                                         bool align_corners,
+                                         std::array<bool,2> output_mask) {
   // grad_output should be contiguous most of time. Ensuring that it is
   // contiguous can greatly simplify this code.
   auto grad_output = grad_output_.contiguous();

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -622,8 +622,9 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     sw_mask.store(i_sw_mask_arr);
     se_mask.store(i_se_mask_arr);
 
-    // ----- The following variables are unnecessary if input_requires_grad is
-    //       false, but required to make the code well-formed.
+    // i_gInp_*_offset_arr and gInp_corner_arr variables below are unnecessary
+    // when input_requires_grad is false (they are only used within the
+    // if-blocks), but required to make the code well-formed.
 
     // When reading input values, we used mask_gather. Unfortunately, there is
     // no mask_scatter_add (the backward of mask_gather) in Intel intrinsics.
@@ -652,8 +653,6 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     scalar_t gInp_corner_arr[Vec::size()];
-
-    // ----- End of unnecessary variables for input_requires_grad is false.
 
     auto gx = Vec(0), gy = Vec(0);
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -111,7 +111,7 @@ namespace at { namespace native { namespace {
  *          // This assimes that `grid_x` and `grid_y` all contain valid grid
  *          // values \in [-1, 1], even at indices greater than `len`.
  *          //
- *          // The `*_slice` argument namess mean samples within a batch (i.e.,
+ *          // The `*_slice` argument names mean samples within a batch (i.e.,
  *          // with the batch dimension sliced out).
  *          void forward(TensorAccessor<scalar_t, 3>& out_slice,
  *                       const TensorAccessor<scalar_t, 3>& inp_slice,
@@ -119,8 +119,14 @@ namespace at { namespace native { namespace {
  *                       int64_t len) const;
  *
  *          // Applies grid sampling (backward) procedure. Arguments semantics
- *          // and strategy are similar to those of `forward`.
- *          void backward(TensorAccessor<scalar_t, 3>& gInp_slice,
+ *          // and strategy are similar to those of `forward`, with the
+ *          // exception that `backward` has branches based on whether `input`
+ *          // requires gradient (passed in as a template parameter). The
+ *          // TensorAccessor for the input gradient is also given as a
+ *          // pointer instead of reference, so that it can be null if the
+ *          // gradient is not calculated.
+ *          template <bool input_requires_grad>
+ *          void backward(TensorAccessor<scalar_t, 3>* gInp_slice_ptr,
  *                        TensorAccessor<scalar_t, 3>& gGrid_slice,
  *                        const TensorAccessor<scalar_t, 3>& gOut_slice,
  *                        const TensorAccessor<scalar_t, 3>& inp_slice,
@@ -158,7 +164,7 @@ namespace at { namespace native { namespace {
  *      `apply_fn` will be called multiple times, and together cover the entire
  *      output spatial space.
  *
- *  Now you should be able tp understand everything about the implementation of
+ *  Now you should be able to understand everything about the implementation of
  *  2D forward kernel shown at the beginning of this note.
  *
  **/
@@ -580,7 +586,8 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     }
   }
 
-  inline void backward(TensorAccessor<scalar_t, 3>& gInp_slice,
+  template<bool input_requires_grad>
+  inline void backward(TensorAccessor<scalar_t, 3>* gInp_slice_ptr,
                        TensorAccessor<scalar_t, 3>& gGrid_slice,
                        const TensorAccessor<scalar_t, 3>& gOut_slice,
                        const TensorAccessor<scalar_t, 3>& inp_slice,
@@ -602,10 +609,21 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     auto i_sw_offset = i_nw_offset + iVec(inp_sH);
     auto i_se_offset = i_sw_offset + iVec(inp_sW);
 
-    auto i_gInp_nw_offset = i_y_n * iVec(inp_W) + i_x_w;
-    auto i_gInp_ne_offset = i_gInp_nw_offset + iVec(1);
-    auto i_gInp_sw_offset = i_gInp_nw_offset + iVec(inp_W);
-    auto i_gInp_se_offset = i_gInp_sw_offset + iVec(1);
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    integer_t i_nw_mask_arr[iVec::size()];
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    integer_t i_ne_mask_arr[iVec::size()];
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    integer_t i_sw_mask_arr[iVec::size()];
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    integer_t i_se_mask_arr[iVec::size()];
+    nw_mask.store(i_nw_mask_arr);
+    ne_mask.store(i_ne_mask_arr);
+    sw_mask.store(i_sw_mask_arr);
+    se_mask.store(i_se_mask_arr);
+
+    // ----- The following variables are unnecessary if input_requires_grad is
+    //       false, but required to make the code well-formed.
 
     // When reading input values, we used mask_gather. Unfortunately, there is
     // no mask_scatter_add (the backward of mask_gather) in Intel intrinsics.
@@ -620,26 +638,22 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     integer_t i_gInp_sw_offset_arr[iVec::size()];
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     integer_t i_gInp_se_offset_arr[iVec::size()];
-    i_gInp_nw_offset.store(i_gInp_nw_offset_arr);
-    i_gInp_ne_offset.store(i_gInp_ne_offset_arr);
-    i_gInp_sw_offset.store(i_gInp_sw_offset_arr);
-    i_gInp_se_offset.store(i_gInp_se_offset_arr);
+    if (input_requires_grad) {
+      auto i_gInp_nw_offset = i_y_n * iVec(inp_W) + i_x_w;
+      auto i_gInp_ne_offset = i_gInp_nw_offset + iVec(1);
+      auto i_gInp_sw_offset = i_gInp_nw_offset + iVec(inp_W);
+      auto i_gInp_se_offset = i_gInp_sw_offset + iVec(1);
 
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    integer_t i_nw_mask_arr[iVec::size()];
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    integer_t i_ne_mask_arr[iVec::size()];
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    integer_t i_sw_mask_arr[iVec::size()];
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    integer_t i_se_mask_arr[iVec::size()];
-    nw_mask.store(i_nw_mask_arr);
-    ne_mask.store(i_ne_mask_arr);
-    sw_mask.store(i_sw_mask_arr);
-    se_mask.store(i_se_mask_arr);
+      i_gInp_nw_offset.store(i_gInp_nw_offset_arr);
+      i_gInp_ne_offset.store(i_gInp_ne_offset_arr);
+      i_gInp_sw_offset.store(i_gInp_sw_offset_arr);
+      i_gInp_se_offset.store(i_gInp_se_offset_arr);
+    }
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     scalar_t gInp_corner_arr[Vec::size()];
+
+    // ----- End of unnecessary variables for input_requires_grad is false.
 
     auto gx = Vec(0), gy = Vec(0);
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
@@ -647,17 +661,20 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     #endif
     for (int64_t c = 0; c < C; ++c) {
       auto inp_slice_C_ptr = inp_slice[c].data();
-      auto gInp_slice_C_ptr = gInp_slice[c].data();
       auto gOut = Vec::loadu(gOut_slice[c].data() + offset, len);
 
-      (nw * gOut).store(gInp_corner_arr);
-      mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_nw_offset_arr, i_nw_mask_arr, len);
-      (ne * gOut).store(gInp_corner_arr);
-      mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_ne_offset_arr, i_ne_mask_arr, len);
-      (sw * gOut).store(gInp_corner_arr);
-      mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_sw_offset_arr, i_sw_mask_arr, len);
-      (se * gOut).store(gInp_corner_arr);
-      mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_se_offset_arr, i_se_mask_arr, len);
+      if (input_requires_grad) {
+        auto gInp_slice_C_ptr = (*gInp_slice_ptr)[c].data();
+
+        (nw * gOut).store(gInp_corner_arr);
+        mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_nw_offset_arr, i_nw_mask_arr, len);
+        (ne * gOut).store(gInp_corner_arr);
+        mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_ne_offset_arr, i_ne_mask_arr, len);
+        (sw * gOut).store(gInp_corner_arr);
+        mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_sw_offset_arr, i_sw_mask_arr, len);
+        (se * gOut).store(gInp_corner_arr);
+        mask_scatter_add(gInp_corner_arr, gInp_slice_C_ptr, i_gInp_se_offset_arr, i_se_mask_arr, len);
+      }
 
       // mask_gather zeros out the mask, so we need to make copies
       Vec nw_mask_copy = nw_mask;
@@ -747,40 +764,43 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest,
     }
   }
 
-  inline void backward(TensorAccessor<scalar_t, 3>& gInp_slice,
+  template<bool input_requires_grad>
+  inline void backward(TensorAccessor<scalar_t, 3>* gInp_slice_ptr,
                        TensorAccessor<scalar_t, 3>& gGrid_slice,
                        const TensorAccessor<scalar_t, 3>& gOut_slice,
                        const TensorAccessor<scalar_t, 3>& inp_slice,
                        int64_t offset, const Vec& grid_x, const Vec& grid_y,
                        int64_t len) const {
-    auto x = compute_W.apply(grid_x);
-    auto y = compute_H.apply(grid_y);
+    if (input_requires_grad) {
+      auto x = compute_W.apply(grid_x);
+      auto y = compute_H.apply(grid_y);
 
-    auto x_nearest = x.round();
-    auto y_nearest = y.round();
+      auto x_nearest = x.round();
+      auto y_nearest = y.round();
 
-    auto i_x_nearest = convert_to_int_of_same_size(x_nearest);
-    auto i_y_nearest = convert_to_int_of_same_size(y_nearest);
+      auto i_x_nearest = convert_to_int_of_same_size(x_nearest);
+      auto i_y_nearest = convert_to_int_of_same_size(y_nearest);
 
-    auto i_mask = must_in_bound ? iVec(-1)
-                                : (i_x_nearest > iVec(-1)) & (i_x_nearest < iVec(inp_W)) &
-                                  (i_y_nearest > iVec(-1)) & (i_y_nearest < iVec(inp_H));
+      auto i_mask = must_in_bound ? iVec(-1)
+                                  : (i_x_nearest > iVec(-1)) & (i_x_nearest < iVec(inp_W)) &
+                                    (i_y_nearest > iVec(-1)) & (i_y_nearest < iVec(inp_H));
 
-    auto i_gInp_offset = i_y_nearest * iVec(inp_W) + i_x_nearest;  // gInp is contiguous
+      auto i_gInp_offset = i_y_nearest * iVec(inp_W) + i_x_nearest;  // gInp is contiguous
 
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    integer_t mask_arr[iVec::size()];
-    i_mask.store(mask_arr);
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-    integer_t gInp_offset_arr[iVec::size()];
-    i_gInp_offset.store(gInp_offset_arr);
+      // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+      integer_t mask_arr[iVec::size()];
+      i_mask.store(mask_arr);
+      // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+      integer_t gInp_offset_arr[iVec::size()];
+      i_gInp_offset.store(gInp_offset_arr);
 
-    #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
-    # pragma unroll
-    #endif
-    for (int64_t c = 0; c < C; ++c) {
-      mask_scatter_add(gOut_slice[c].data() + offset, gInp_slice[c].data(),
-                       gInp_offset_arr, mask_arr, len);
+      #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
+      # pragma unroll
+      #endif
+      for (int64_t c = 0; c < C; ++c) {
+        mask_scatter_add(gOut_slice[c].data() + offset, (*gInp_slice_ptr)[c].data(),
+                        gInp_offset_arr, mask_arr, len);
+      }
     }
 
     // grid has zero 0 gradient in Nearest mode
@@ -932,13 +952,13 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
     }
   }
 
-  inline void backward(TensorAccessor<scalar_t, 3>& gInp_slice,
+  template<bool input_requires_grad>
+  inline void backward(TensorAccessor<scalar_t, 3>* gInp_slice_ptr,
                       TensorAccessor<scalar_t, 3>& gGrid_slice,
                       const TensorAccessor<scalar_t, 3>& gOut_slice,
                       const TensorAccessor<scalar_t, 3>& inp_slice,
                       int64_t offset, const Vec& grid_x, const Vec& grid_y,
                       int64_t len) const {
-
     Vec x = compute_W.unnormalize(grid_x);
     Vec y = compute_H.unnormalize(grid_y);
     Vec gx_mult = Vec(compute_W.scaling_factor);
@@ -967,7 +987,6 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
     #endif
     for (int64_t c = 0; c < C; ++c) {
       auto inp_slice_C_ptr = inp_slice[c].data();
-      auto gInp_slice_C_ptr = gInp_slice[c].data();
       auto gOut = Vec::loadu(gOut_slice[c].data() + offset, len);
 
       for (int64_t i = 0; i < 4; ++i) {
@@ -975,7 +994,10 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
           auto xx = ix + Vec(-1 + i);
           auto yy = iy + Vec(-1 + j);
 
-          add_value_bounded(gInp_slice_C_ptr, len, xx, yy, gOut * coeff_x[i] * coeff_y[j]);
+          if (input_requires_grad) {
+            auto gInp_slice_C_ptr = (*gInp_slice_ptr)[c].data();
+            add_value_bounded(gInp_slice_C_ptr, len, xx, yy, gOut * coeff_x[i] * coeff_y[j]);
+          }
 
           auto val = get_value_bounded(inp_slice_C_ptr, xx, yy);
           gx = gx - val * gOut * coeff_x_grad[i] * coeff_y[j];
@@ -1201,20 +1223,32 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
   // contiguous can greatly simplify this code.
   auto grad_output = grad_output_.contiguous();
 
-  auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  // If `input` gradient is not required, we skip computing it -- not needing to create
+  // the tensor to hold the gradient can markedly increase performance. (`grid` gradient
+  // is always computed.)
+  auto input_requires_grad = output_mask[0];
+
+  Tensor grad_input;
+  if (input_requires_grad) {
+    grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  }
   auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto N = input.size(0);
   auto spatial_size = grid.size(1) * grid.size(2);
   auto grain_size = spatial_size == 0 ? (N + 1)
                                       : at::divup(at::internal::GRAIN_SIZE, spatial_size * 10 /* 2d * 5 tensors*/);
 
-#define HANDLE_CASE(interp, padding, align_corners)                              \
+#define GINP_SLICE_PTR_true auto gInp_slice = gInp_acc[n]; auto gInp_slice_ptr = &gInp_slice;
+#define GINP_SLICE_PTR_false TensorAccessor<scalar_t, 3>* gInp_slice_ptr = nullptr;
+#define GINP_SLICE_PTR(input_requires_grad) GINP_SLICE_PTR_##input_requires_grad
+
+#define HANDLE_CASE(interp, padding, align_corners, input_requires_grad)         \
   case padding: {                                                                \
     ApplyGridSample<scalar_t, 2, interp, padding, align_corners>                 \
     grid_sample(inp_acc);                                                        \
     parallel_for(0, N, grain_size, [&](int64_t begin, int64_t end) {             \
       for (int64_t n = begin; n < end; n++) {                                    \
-        auto gInp_slice = gInp_acc[n];                                           \
+        GINP_SLICE_PTR(input_requires_grad)                                      \
         auto gGrid_slice = gGrid_acc[n];                                         \
         auto gOut_slice = gOut_acc[n];                                           \
         auto inp_slice = inp_acc[n];                                             \
@@ -1222,42 +1256,61 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
           grid_acc[n],                                                           \
           [&](const Vectorized<scalar_t>& grid_x, const Vectorized<scalar_t>& grid_y,    \
               int64_t spatial_offset, int64_t len) {                             \
-            grid_sample.backward(gInp_slice, gGrid_slice, gOut_slice, inp_slice, \
-                                 spatial_offset, grid_x, grid_y, len);           \
+            grid_sample.backward<input_requires_grad>(gInp_slice_ptr, gGrid_slice,       \
+                                                      gOut_slice, inp_slice,     \
+                                                      spatial_offset, grid_x,    \
+                                                      grid_y, len);              \
           });                                                                    \
       }                                                                          \
     });                                                                          \
     return;                                                                      \
   }
 
-#define HANDLE_INTERP(interp, align_corners)                                \
+#define HANDLE_INTERP(interp, align_corners, input_requires_grad)           \
   case interp: {                                                            \
     switch (static_cast<GridSamplerPadding>(padding_mode)) {                \
-      HANDLE_CASE(interp, GridSamplerPadding::Zeros, align_corners);        \
-      HANDLE_CASE(interp, GridSamplerPadding::Border, align_corners);       \
-      HANDLE_CASE(interp, GridSamplerPadding::Reflection, align_corners);   \
+      HANDLE_CASE(interp, GridSamplerPadding::Zeros, align_corners, input_requires_grad);      \
+      HANDLE_CASE(interp, GridSamplerPadding::Border, align_corners, input_requires_grad);     \
+      HANDLE_CASE(interp, GridSamplerPadding::Reflection, align_corners, input_requires_grad); \
     }                                                                       \
     return;                                                                 \
   }
 
   AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
-    auto gInp_acc = grad_input.accessor<scalar_t, 4>();
     auto gGrid_acc = grad_grid.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<scalar_t, 4>();
     auto grid_acc = grid.accessor<scalar_t, 4>();
     auto gOut_acc = grad_output.accessor<scalar_t, 4>();
-    if (align_corners) {
-      switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
-        HANDLE_INTERP(GridSamplerInterpolation::Bilinear, true);
-        HANDLE_INTERP(GridSamplerInterpolation::Nearest, true);
-        HANDLE_INTERP(GridSamplerInterpolation::Bicubic, true);
+    if (input_requires_grad) {
+      auto gInp_acc = grad_input.accessor<scalar_t, 4>();
+      if (align_corners) {
+        switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
+          HANDLE_INTERP(GridSamplerInterpolation::Bilinear, true, true);
+          HANDLE_INTERP(GridSamplerInterpolation::Nearest, true, true);
+          HANDLE_INTERP(GridSamplerInterpolation::Bicubic, true, true);
+        }
+      } else {
+        switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
+          HANDLE_INTERP(GridSamplerInterpolation::Bilinear, false, true);
+          HANDLE_INTERP(GridSamplerInterpolation::Nearest, false, true);
+          HANDLE_INTERP(GridSamplerInterpolation::Bicubic, false, true);
+        }
       }
     } else {
-      switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
-        HANDLE_INTERP(GridSamplerInterpolation::Bilinear, false);
-        HANDLE_INTERP(GridSamplerInterpolation::Nearest, false);
-        HANDLE_INTERP(GridSamplerInterpolation::Bicubic, false);
+      if (align_corners) {
+        switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
+          HANDLE_INTERP(GridSamplerInterpolation::Bilinear, true, false);
+          HANDLE_INTERP(GridSamplerInterpolation::Nearest, true, false);
+          HANDLE_INTERP(GridSamplerInterpolation::Bicubic, true, false);
+        }
+      } else {
+        switch (static_cast<GridSamplerInterpolation>(interpolation_mode)) {
+          HANDLE_INTERP(GridSamplerInterpolation::Bilinear, false, false);
+          HANDLE_INTERP(GridSamplerInterpolation::Nearest, false, false);
+          HANDLE_INTERP(GridSamplerInterpolation::Bicubic, false, false);
+        }
       }
+
     }
   });
 #undef HANDLE_CASE

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.h
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.h
@@ -11,7 +11,7 @@
 namespace at { namespace native {
 
 using forward_2d_fn = Tensor(*)(const Tensor &, const Tensor &, int64_t, int64_t, bool);
-using backward_2d_fn = std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, bool);
+using backward_2d_fn = std::tuple<Tensor, Tensor>(*)(const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, bool, std::array<bool,2>);
 DECLARE_DISPATCH(forward_2d_fn, grid_sampler_2d_cpu_kernel);
 DECLARE_DISPATCH(backward_2d_fn, grid_sampler_2d_backward_cpu_kernel);
 

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -794,7 +794,8 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
 std::tuple<Tensor, Tensor>
 grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
                               const Tensor& grid, int64_t interpolation_mode,
-                              int64_t padding_mode, bool align_corners) {
+                              int64_t padding_mode, bool align_corners,
+                              std::array<bool,2> output_mask) {
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("grid_sampler_2d_backward_cuda");

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -296,14 +296,14 @@ namespace {
 // lies relative to the entire tensor, so we pass the base grad_input.data and full offset information,
 // including batch * channel offset (NC_offset).
 
-  template <typename scalar_t, typename index_t>
+  template <typename scalar_t, typename index_t, bool input_requires_grad>
   C10_LAUNCH_BOUNDS_1(256)
   __global__ void grid_sampler_2d_backward_kernel(
       const index_t nthreads,
       TensorInfo<scalar_t, index_t> grad_output,
       TensorInfo<scalar_t, index_t> input,
       TensorInfo<scalar_t, index_t> grid,
-      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros
+      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros (or unused if input_requires_grad is false)
       TensorInfo<scalar_t, index_t> grad_grid,   // initialized to empty
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
@@ -327,10 +327,17 @@ namespace {
     index_t gOut_sC = grad_output.strides[1];
     index_t gOut_sH = grad_output.strides[2];
     index_t gOut_sW = grad_output.strides[3];
-    index_t gInp_sN = grad_input.strides[0];
-    index_t gInp_sC = grad_input.strides[1];
-    index_t gInp_sH = grad_input.strides[2];
-    index_t gInp_sW = grad_input.strides[3];
+    // gInp_* (and NC_offset below) are not really needed if input_requires_grad is false.
+    index_t gInp_sN;
+    index_t gInp_sC;
+    index_t gInp_sH;
+    index_t gInp_sW;
+    if (input_requires_grad) {
+      gInp_sN = grad_input.strides[0];
+      gInp_sC = grad_input.strides[1];
+      gInp_sH = grad_input.strides[2];
+      gInp_sW = grad_input.strides[3];
+    }
     index_t gGrid_sW = grad_grid.strides[2];
 
     CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
@@ -372,11 +379,13 @@ namespace {
         for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, NC_offset += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
           scalar_t gOut = *gOut_ptr_NCHW;
 
-          // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-          safe_add_2d(grad_input.data, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut, NC_offset, grad_input_memory_span);
-          safe_add_2d(grad_input.data, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut, NC_offset, grad_input_memory_span);
-          safe_add_2d(grad_input.data, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut, NC_offset, grad_input_memory_span);
-          safe_add_2d(grad_input.data, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut, NC_offset, grad_input_memory_span);
+          if (input_requires_grad) {
+            // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
+            safe_add_2d(grad_input.data, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut, NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut, NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut, NC_offset, grad_input_memory_span);
+            safe_add_2d(grad_input.data, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut, NC_offset, grad_input_memory_span);
+          }
 
           // calculate grad_grid
           if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
@@ -409,15 +418,17 @@ namespace {
         gGrid_ptr_NHW[0] = gix_mult * gix;
         gGrid_ptr_NHW[1] = giy_mult * giy;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        index_t ix_nearest = static_cast<index_t>(::round(ix));
-        index_t iy_nearest = static_cast<index_t>(::round(iy));
+        if (input_requires_grad) {
+          index_t ix_nearest = static_cast<index_t>(::round(ix));
+          index_t iy_nearest = static_cast<index_t>(::round(iy));
 
-        // assign nearest neighor pixel value to output pixel
-        scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-        index_t NC_offset = n * gInp_sN;
-        for (index_t c = 0; c < C; ++c, NC_offset += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
-          // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-          safe_add_2d(grad_input.data, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW, NC_offset, grad_input_memory_span);
+          // assign nearest neighor pixel value to output pixel
+          scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+          index_t NC_offset = n * gInp_sN;
+          for (index_t c = 0; c < C; ++c, NC_offset += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
+            // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
+            safe_add_2d(grad_input.data, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW, NC_offset, grad_input_memory_span);
+          }
         }
 
         // assuming grad_grid is contiguous
@@ -463,13 +474,15 @@ namespace {
             #pragma unroll 4
             for (index_t j = 0; j < 4; ++j) {
 
-              // set input gradient. See Note [Passing pointer and offset to fastAtomicAdd].
-              add_value_bounded<scalar_t>(grad_input.data, ix_nw - 1 + i, iy_nw - 1 + j, inp_W, inp_H, gInp_sW, gInp_sH,
-                gOut * x_coeffs[i] * y_coeffs[j],
-                padding_mode,
-                align_corners,
-                NC_offset,
-                grad_input_memory_span);
+              if (input_requires_grad) {
+                // set input gradient. See Note [Passing pointer and offset to fastAtomicAdd].
+                add_value_bounded<scalar_t>(grad_input.data, ix_nw - 1 + i, iy_nw - 1 + j, inp_W, inp_H, gInp_sW, gInp_sH,
+                  gOut * x_coeffs[i] * y_coeffs[j],
+                  padding_mode,
+                  align_corners,
+                  NC_offset,
+                  grad_input_memory_span);
+              }
 
               // set grid gradient
               scalar_t val = get_value_bounded<scalar_t>(inp_ptr_NC, ix_nw - 1 + i, iy_nw - 1 + j,
@@ -802,40 +815,82 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto N = input.size(0);
   auto H = grid.size(1);
   auto W = grid.size(2);
-  auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  // If `input` gradient is not required, we skip computing it -- not needing to create
+  // the tensor to hold the gradient can markedly increase performance. (`grid` gradient
+  // is always computed.)
+  auto input_requires_grad = output_mask[0];
+
+  Tensor grad_input;
+  if (input_requires_grad) {
+    grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  }
   auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   int64_t count = N * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_backward_cuda", [&] {
-      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
-          canUse32BitIndexMath(grad_output)) {
-        grid_sampler_2d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
-            static_cast<int>(count),
-            getTensorInfo<scalar_t, int>(grad_output),
-            getTensorInfo<scalar_t, int>(input),
-            getTensorInfo<scalar_t, int>(grid),
-            getTensorInfo<scalar_t, int>(grad_input),
-            getTensorInfo<scalar_t, int>(grad_grid),
-            static_cast<GridSamplerInterpolation>(interpolation_mode),
-            static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/static_cast<int>(grad_input.numel()));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      if (input_requires_grad) {
+        if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
+            canUse32BitIndexMath(grad_output)) {
+          grid_sampler_2d_backward_kernel<scalar_t, int, true>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<scalar_t, int>(grad_output),
+              getTensorInfo<scalar_t, int>(input),
+              getTensorInfo<scalar_t, int>(grid),
+              getTensorInfo<scalar_t, int>(grad_input),
+              getTensorInfo<scalar_t, int>(grad_grid),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/static_cast<int>(grad_input.numel()));
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          grid_sampler_2d_backward_kernel<scalar_t, int64_t, true>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<scalar_t, int64_t>(grad_output),
+              getTensorInfo<scalar_t, int64_t>(input),
+              getTensorInfo<scalar_t, int64_t>(grid),
+              getTensorInfo<scalar_t, int64_t>(grad_input),
+              getTensorInfo<scalar_t, int64_t>(grad_grid),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/grad_input.numel());
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
       } else {
-        grid_sampler_2d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
-            count,
-            getTensorInfo<scalar_t, int64_t>(grad_output),
-            getTensorInfo<scalar_t, int64_t>(input),
-            getTensorInfo<scalar_t, int64_t>(grid),
-            getTensorInfo<scalar_t, int64_t>(grad_input),
-            getTensorInfo<scalar_t, int64_t>(grad_grid),
-            static_cast<GridSamplerInterpolation>(interpolation_mode),
-            static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/grad_input.numel());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
+            canUse32BitIndexMath(grad_output)) {
+          grid_sampler_2d_backward_kernel<scalar_t, int, false>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<scalar_t, int>(grad_output),
+              getTensorInfo<scalar_t, int>(input),
+              getTensorInfo<scalar_t, int>(grid),
+              TensorInfo<scalar_t, int>(),  // grad_input not used
+              getTensorInfo<scalar_t, int>(grad_grid),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/0);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          grid_sampler_2d_backward_kernel<scalar_t, int64_t, false>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<scalar_t, int64_t>(grad_output),
+              getTensorInfo<scalar_t, int64_t>(input),
+              getTensorInfo<scalar_t, int64_t>(grid),
+              TensorInfo<scalar_t, int64_t>(),  // grad_input not used
+              getTensorInfo<scalar_t, int64_t>(grad_grid),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/0);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
       }
     });
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2104,9 +2104,6 @@
 # `interpolation_mode` because it only supports Bilinear interpolation mode.
 # Nor does it take in `align_corners` because it only supports the mode
 # `align_corners = True`.
-#
-# `grid_sampler_2d_backward` takes in `output_mask` to optimize performance
-# for the case where `input` doesn't require gradient.
 - func: grid_sampler(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
 
 - func: grid_sampler_2d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
@@ -2114,6 +2111,9 @@
     CPU: grid_sampler_2d_cpu
     CUDA: grid_sampler_2d_cuda
 
+# `grid_sampler_2d_backward` takes in `output_mask` to optimize performance for
+# the case where `input` doesn't require gradient. Gradient for `grid` is always
+# computed (only `output_mask[0]` is checked by the implementations).
 - func: grid_sampler_2d_backward(Tensor grad_output, Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners, bool[2] output_mask) -> (Tensor, Tensor)
   dispatch:
     CPU: grid_sampler_2d_backward_cpu

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2104,6 +2104,9 @@
 # `interpolation_mode` because it only supports Bilinear interpolation mode.
 # Nor does it take in `align_corners` because it only supports the mode
 # `align_corners = True`.
+#
+# `grid_sampler_2d_backward` takes in `output_mask` to optimize performance
+# for the case where `input` doesn't require gradient.
 - func: grid_sampler(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
 
 - func: grid_sampler_2d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
@@ -2111,7 +2114,7 @@
     CPU: grid_sampler_2d_cpu
     CUDA: grid_sampler_2d_cuda
 
-- func: grid_sampler_2d_backward(Tensor grad_output, Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> (Tensor, Tensor)
+- func: grid_sampler_2d_backward(Tensor grad_output, Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners, bool[2] output_mask) -> (Tensor, Tensor)
   dispatch:
     CPU: grid_sampler_2d_backward_cpu
     CUDA: grid_sampler_2d_backward_cuda

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9833,7 +9833,9 @@ class TestNN(NNTestCase):
 
     @skipIfRocm
     def test_grid_sample(self):
-        def test(N, C, H, W, mode, padding_mode, align_corners):
+        # Backward pass of native C++ and CUDA kernels branch depending on whether input requires gradient,
+        # so we test both cases.
+        def test(N, C, H, W, mode, padding_mode, align_corners, input_requires_grad):
             def test_shape(N, C, IH, IW, H, W, mode, padding_mode, align_corners):
                 for grid_dim_contig_order in [(0, 1, 2, 3), (0, 3, 1, 2), (3, 0, 1, 2), (0, 2, 1, 3)]:
                     # grid_dim_contig_order specifies the dimension order that can
@@ -9858,7 +9860,7 @@ class TestNN(NNTestCase):
                         assert grid.permute(grid_dim_contig_order).is_contiguous()
                         return grid
 
-                    input_cpu = torch.randn(C, N, IH, IW).transpose(0, 1).requires_grad_()
+                    input_cpu = torch.randn(C, N, IH, IW).transpose(0, 1).requires_grad_(input_requires_grad)
                     grid_cpu = get_grid().requires_grad_()
                     out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode,
                                             align_corners=align_corners)
@@ -9886,27 +9888,29 @@ class TestNN(NNTestCase):
                     self.assertEqual(out_fallback, out_cpu.float(), atol=1e-5, rtol=5e-5)
 
                     out_fallback.backward(gradients.float())
-                    self.assertEqual(input_fallback.grad, input_cpu.grad.float(), atol=1e-4, rtol=5e-5)
+                    if input_requires_grad:
+                        self.assertEqual(input_fallback.grad, input_cpu.grad.float(), atol=1e-4, rtol=5e-5)
                     self.assertEqual(grid_fallback.grad, grid_cpu.grad.float(), atol=1e-4, rtol=5e-5)
 
                     if TEST_CUDA:
-                        input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_()
+                        input_cuda = input_cpu.detach().transpose(0, 1).cuda().transpose(0, 1).requires_grad_(input_requires_grad)
                         grid_cuda = get_grid('cuda', grid_cpu.detach()).requires_grad_()
                         out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode,
                                                  align_corners=align_corners)
                         self.assertEqual(out_cpu, out_cuda)
 
                         out_cuda.backward(gradients.cuda())
-                        self.assertEqual(input_cpu.grad, input_cuda.grad)
+                        if input_requires_grad:
+                            self.assertEqual(input_cpu.grad, input_cuda.grad)
                         self.assertEqual(grid_cpu.grad, grid_cuda.grad, atol=5e-5, rtol=0)
 
                         # check that zero-dimensional input strides don't error out
                         base_input = torch.randn(N, C, 1, IW)
-                        input_cpu = base_input.expand_as(input_cuda).requires_grad_()
+                        input_cpu = base_input.expand_as(input_cuda).requires_grad_(input_requires_grad)
                         out_cpu = F.grid_sample(input_cpu, grid_cpu, mode=mode, padding_mode=padding_mode,
                                                 align_corners=align_corners)
 
-                        input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_()
+                        input_cuda = base_input.cuda().expand_as(input_cuda).requires_grad_(input_requires_grad)
                         out_cuda = F.grid_sample(input_cuda, grid_cuda, mode=mode, padding_mode=padding_mode,
                                                  align_corners=align_corners)
                         self.assertEqual(out_cpu, out_cuda)
@@ -10081,7 +10085,7 @@ class TestNN(NNTestCase):
                     self.assertEqual(output, groundtruth.float(), atol=1e-5, rtol=0)
 
                     # explicit check for gradient edge cases
-                    input = torch.arange(0., 5).expand((1, 1, 5, 5)).requires_grad_()
+                    input = torch.arange(0., 5).expand((1, 1, 5, 5))
                     grid = torch.tensor(
                         [[[1.0, 1.0], [1.0, -1.0], [0.8, 0.8], [0.8, -0.8]],
                          [[-1.0, -1.0], [-1.0, 1.0], [-0.8, -0.8], [-0.8, 0.8]]]).view(1, 2, 4, 2).requires_grad_()
@@ -10152,14 +10156,16 @@ class TestNN(NNTestCase):
                             raise AssertionError("missing gradient groundtruth test for padding mode '{}'".format(padding_mode))
                     else:
                         raise AssertionError("missing gradient groundtruth test for interpolation mode '{}'".format(mode))
-                    F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode,
-                                  align_corners=align_corners).sum().backward()
-                    self.assertEqual(grid.grad, groundtruth, atol=1e-5, rtol=0,
-                                     msg="gradient groundtruth comparison failed for mode={}, "
-                                     "padding_mode={}".format(mode, padding_mode))
+                    for input_requires_grad in [False, True]:
+                        input = input.requires_grad_(input_requires_grad)
+                        F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode,
+                                      align_corners=align_corners).sum().backward()
+                        self.assertEqual(grid.grad, groundtruth, atol=1e-5, rtol=0,
+                                         msg="gradient groundtruth comparison failed for mode={}, "
+                                         "padding_mode={}, input_requires_grad={}".format(mode, padding_mode, input_requires_grad))
+                        grid.grad.zero_()
 
                     # See NOTE [ grid_sample CPU fallback ]
-                    grid.grad.zero_()
                     torch._grid_sampler_2d_cpu_fallback(
                         input.float(), grid.float(),
                         F.GRID_SAMPLE_INTERPOLATION_MODES[mode],
@@ -10178,11 +10184,17 @@ class TestNN(NNTestCase):
                         lambda inp, grid: F.grid_sample(inp, grid, mode=mode, padding_mode=padding_mode,
                                                         align_corners=align_corners),
                         (input, grid)))
+                    input = input.requires_grad_(False)
+                    self.assertTrue(gradcheck(
+                        lambda grid: F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode,
+                                                   align_corners=align_corners),
+                        (grid,)))
 
-                    test(N, C, H, W, mode, padding_mode, align_corners=align_corners)
-                    if TEST_CUDNN:
-                        with cudnn.flags(enabled=False):
-                            test(N, C, H, W, mode, padding_mode, align_corners=align_corners)
+                    for input_requires_grad in [False, True]:
+                        test(N, C, H, W, mode, padding_mode, align_corners, input_requires_grad)
+                        if TEST_CUDNN:
+                            with cudnn.flags(enabled=False):
+                                test(N, C, H, W, mode, padding_mode, align_corners, input_requires_grad)
 
     def test_grid_sample_3d(self):
         def test(N, C, D, H, W, mode, padding_mode, align_corners):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -644,7 +644,7 @@
   output_differentiability: [False]
 
 - name: grid_sampler_2d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
-  input, grid: "grad.defined() ? grid_sampler_2d_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners) : std::tuple<Tensor, Tensor>()"
+  input, grid: "grad.defined() ? grid_sampler_2d_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners, grad_input_mask) : std::tuple<Tensor, Tensor>()"
 
 - name: grid_sampler_3d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
   input, grid: "grad.defined() ? grid_sampler_3d_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners) : std::tuple<Tensor, Tensor>()"


### PR DESCRIPTION
Fixes #64977

Avoids creating a tensor for and calculating `input` gradient if it's not needed in the backward pass of `grid_sample` (2d case, native CPU & CUDA kernels). Especially the tensor creation seemed time consuming (see #64977).

Brief description of the changes:
 * I have tried to go with rather minimal changes. It would probably be possible to make a more elegant version with a bit larger refactoring (or possibly with better understanding of PyTorch internals and C++ functionalities).
 * Changed the `native_functions.yaml` and `derivatives.yaml` so that the gradient input mask is passed to the functions.
 * Changed the CPU kernels: 
    (1) added `bool input_requires_grad` template parameter to the `backward` function,
    (2) added if branches based on it to remove `input` gradient computations if it's not requested, 
    (3) feed in `TensorAccessor<scalar_t, 3>* gInp_slice_ptr` instead of `TensorAccessor<scalar_t, 3>& gInp_slice` so that I can pass a `nullptr` in case gradient for `input` is not requested. (A bit inelegant perhaps, but allows to keep one signature for `backward` function and not require breaking it to smaller pieces. Perhaps there's a more elegant way to achieve this?)
 * Changed CUDA kernel:
   (1) added ~~`bool input_requires_grad` template parameter~~ `const bool input_requires_grad` argument to the `backward` function,
   (2) added if branches based on it to remove `input` gradient computations if it's not requested,
   (3) feed in `TensorInfo<scalar_t, index_t>()` instead of `getTensorInfo<scalar_t, index_t>(grad_input)` in case gradient for `input` is not requested.
 * Modified tests in `test/test_nn.py` so that they run also cases with no `input` gradient needed.
 * Have not touched the CPU fallback kernel.
