### PR TITLE
[Pytorch Edge] Make Metal Ops Selective

### DIFF
--- a/aten/src/ATen/native/metal/MetalAten.mm
+++ b/aten/src/ATen/native/metal/MetalAten.mm
@@ -104,8 +104,8 @@ at::Tensor empty_strided(
 
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("empty.memory_format", empty);
-  m.impl("empty_strided", TORCH_FN(empty_strided));
+  m.impl(TORCH_SELECTIVE_NAME("aten::empty.memory_format"), empty);
+  m.impl(TORCH_SELECTIVE_NAME("aten::empty_strided"), TORCH_FN(empty_strided));
 }
 
 } // namespace metal

--- a/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
+++ b/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
@@ -74,24 +74,24 @@ TORCH_LIBRARY(metal, m) {
                 std::get<2>(state),
                 std::get<3>(state));
           });
-  m.def("copy_to_host(Tensor X) -> Tensor Y");
+  m.def(TORCH_SELECTIVE_SCHEMA("metal::copy_to_host(Tensor X) -> Tensor Y"));
 }
 
 TORCH_LIBRARY(metal_prepack, m) {
-  m.def(
-      "conv2d_prepack(Tensor W, Tensor? B, int[2] stride, "
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "metal_prepack::conv2d_prepack(Tensor W, Tensor? B, int[2] stride, "
       "int[2] padding, int[2] dilation, int groups, "
       "Scalar? output_min=None, Scalar? output_max=None) "
-      "-> __torch__.torch.classes.metal.Conv2dOpContext");
-  m.def(
-      "conv2d_run(Tensor X, "
-      "__torch__.torch.classes.metal.Conv2dOpContext W_prepack) -> Tensor Y");
+      "-> __torch__.torch.classes.metal.Conv2dOpContext"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "metal_prepack::conv2d_run(Tensor X, "
+      "__torch__.torch.classes.metal.Conv2dOpContext W_prepack) -> Tensor Y"));
 
-  m.def(
-      "linear_prepack(Tensor W, Tensor? B, Scalar? output_min=None, Scalar? output_max=None) -> __torch__.torch.classes.metal.LinearOpContext");
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "metal_prepack::linear_prepack(Tensor W, Tensor? B, Scalar? output_min=None, Scalar? output_max=None) -> __torch__.torch.classes.metal.LinearOpContext"));
 
-  m.def(
-      "linear_run(Tensor X, __torch__.torch.classes.metal.LinearOpContext W_prepack) -> Tensor Y");
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "metal_prepack::linear_run(Tensor X, __torch__.torch.classes.metal.LinearOpContext W_prepack) -> Tensor Y"));
 }
 
 c10::intrusive_ptr<Conv2dOpContext> conv2d_prepack(
@@ -125,8 +125,8 @@ c10::intrusive_ptr<LinearOpContext> linear_prepack(
 }
 
 TORCH_LIBRARY_IMPL(metal_prepack, CPU, m) {
-  m.impl("conv2d_prepack", TORCH_FN(conv2d_prepack));
-  m.impl("linear_prepack", TORCH_FN(linear_prepack));
+  m.impl(TORCH_SELECTIVE_NAME("metal_prepack::conv2d_prepack"), TORCH_FN(conv2d_prepack));
+  m.impl(TORCH_SELECTIVE_NAME("metal_prepack::linear_prepack"), TORCH_FN(linear_prepack));
 }
 
 } // namespace metal

--- a/aten/src/ATen/native/metal/ops/MetalAddmm.mm
+++ b/aten/src/ATen/native/metal/ops/MetalAddmm.mm
@@ -135,11 +135,11 @@ Tensor linear_run(
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("addmm", TORCH_FN(addmm));
+  m.impl(TORCH_SELECTIVE_NAME("aten::addmm"), TORCH_FN(addmm));
 };
 
 TORCH_LIBRARY_IMPL(metal_prepack, Metal, m) {
-  m.impl("linear_run", TORCH_FN(prepack::linear_run));
+  m.impl(TORCH_SELECTIVE_NAME("metal_prepack::linear_run"), TORCH_FN(prepack::linear_run));
 }
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
+++ b/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
@@ -297,14 +297,14 @@ Tensor& div__Tensor(Tensor& input1, const Tensor& input2) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("add.Tensor", TORCH_FN(add_Tensor));
-  m.impl("add_.Tensor", TORCH_FN(add__Tensor));
-  m.impl("mul.Tensor", TORCH_FN(mul_Tensor));
-  m.impl("mul_.Tensor", TORCH_FN(mul__Tensor));
-  m.impl("sub.Tensor", TORCH_FN(sub_Tensor));
-  m.impl("sub_.Tensor", TORCH_FN(sub__Tensor));
-  m.impl("div.Tensor", TORCH_FN(div_Tensor));
-  m.impl("div_.Tensor", TORCH_FN(div__Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::add.Tensor"), TORCH_FN(add_Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::add_.Tensor"), TORCH_FN(add__Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::mul.Tensor"), TORCH_FN(mul_Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::mul_.Tensor"), TORCH_FN(mul__Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::sub.Tensor"), TORCH_FN(sub_Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::sub_.Tensor"), TORCH_FN(sub__Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::div.Tensor"), TORCH_FN(div_Tensor));
+  m.impl(TORCH_SELECTIVE_NAME("aten::div_.Tensor"), TORCH_FN(div__Tensor));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalChunk.mm
+++ b/aten/src/ATen/native/metal/ops/MetalChunk.mm
@@ -60,7 +60,7 @@ std::vector<Tensor> chunk(const Tensor& input, int64_t chunks, int64_t dim) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("chunk", TORCH_FN(chunk));
+  m.impl(TORCH_SELECTIVE_NAME("aten::chunk"), TORCH_FN(chunk));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalClamp.mm
+++ b/aten/src/ATen/native/metal/ops/MetalClamp.mm
@@ -61,9 +61,9 @@ at::Tensor clamp(
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("hardtanh_", TORCH_FN(hardtanh_));
-  m.impl("hardtanh", TORCH_FN(hardtanh));
-  m.impl("clamp", TORCH_FN(clamp));
+  m.impl(TORCH_SELECTIVE_NAME("aten::hardtanh_"), TORCH_FN(hardtanh_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::hardtanh"), TORCH_FN(hardtanh));
+  m.impl(TORCH_SELECTIVE_NAME("aten::clamp"), TORCH_FN(clamp));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalConcat.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConcat.mm
@@ -203,7 +203,7 @@ Tensor cat(const TensorList tensors, int64_t dim) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("_cat", TORCH_FN(cat));
+  m.impl(TORCH_SELECTIVE_NAME("aten::_cat"), TORCH_FN(cat));
 }
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalConvolution.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConvolution.mm
@@ -106,11 +106,11 @@ Tensor conv2d_prepack_run(
 } // namespace prepack
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("conv2d", TORCH_FN(conv2d));
+  m.impl(TORCH_SELECTIVE_NAME("aten::conv2d"), TORCH_FN(conv2d));
 };
 
 TORCH_LIBRARY_IMPL(metal_prepack, Metal, m) {
-  m.impl("conv2d_run", prepack::conv2d_prepack_run);
+  m.impl(TORCH_SELECTIVE_NAME("metal_prepack::conv2d_run"), prepack::conv2d_prepack_run);
 }
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalCopy.mm
+++ b/aten/src/ATen/native/metal/ops/MetalCopy.mm
@@ -51,7 +51,7 @@ Tensor copy_to_host(const Tensor& input) {
 }
 
 TORCH_LIBRARY_IMPL(metal, Metal, m) {
-  m.impl("copy_to_host", TORCH_FN(copy_to_host));
+  m.impl(TORCH_SELECTIVE_NAME("metal::copy_to_host"), TORCH_FN(copy_to_host));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalHardswish.mm
+++ b/aten/src/ATen/native/metal/ops/MetalHardswish.mm
@@ -80,8 +80,8 @@ Tensor hardswish(const at::Tensor& input) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("hardswish_", TORCH_FN(hardswish_));
-  m.impl("hardswish", TORCH_FN(hardswish));
+  m.impl(TORCH_SELECTIVE_NAME("aten::hardswish_"), TORCH_FN(hardswish_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::hardswish"), TORCH_FN(hardswish));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalNeurons.mm
+++ b/aten/src/ATen/native/metal/ops/MetalNeurons.mm
@@ -81,12 +81,12 @@ Tensor tanh(const Tensor& input) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("tanh", tanh);
-  m.impl("relu", TORCH_FN(relu));
-  m.impl("relu_", TORCH_FN(relu_));
-  m.impl("sigmoid", TORCH_FN(sigmoid));
+  m.impl(TORCH_SELECTIVE_NAME("aten::tanh"), tanh);
+  m.impl(TORCH_SELECTIVE_NAME("aten::relu"), TORCH_FN(relu));
+  m.impl(TORCH_SELECTIVE_NAME("aten::relu_"), TORCH_FN(relu_));
+  m.impl(TORCH_SELECTIVE_NAME("aten::sigmoid"), TORCH_FN(sigmoid));
   if (@available(iOS 11.0, *)) {
-    m.impl("hardsigmoid_", TORCH_FN(hardsigmoid_));
+    m.impl(TORCH_SELECTIVE_NAME("aten::hardsigmoid_"), TORCH_FN(hardsigmoid_));
   }
 };
 

--- a/aten/src/ATen/native/metal/ops/MetalPadding.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPadding.mm
@@ -86,7 +86,7 @@ Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("reflection_pad2d", TORCH_FN(reflection_pad2d));
+  m.impl(TORCH_SELECTIVE_NAME("aten::reflection_pad2d"), TORCH_FN(reflection_pad2d));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalPooling.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPooling.mm
@@ -104,8 +104,8 @@ Tensor adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("max_pool2d", TORCH_FN(max_pool2d));
-  m.impl("adaptive_avg_pool2d", TORCH_FN(adaptive_avg_pool2d));
+  m.impl(TORCH_SELECTIVE_NAME("aten::max_pool2d"), TORCH_FN(max_pool2d));
+  m.impl(TORCH_SELECTIVE_NAME("aten::adaptive_avg_pool2d"), TORCH_FN(adaptive_avg_pool2d));
 }
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalReduce.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReduce.mm
@@ -76,7 +76,7 @@ Tensor wrapper_mean_dim(
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("mean.dim", TORCH_FN(wrapper_mean_dim));
+  m.impl(TORCH_SELECTIVE_NAME("aten::mean.dim"), TORCH_FN(wrapper_mean_dim));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalReshape.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReshape.mm
@@ -102,10 +102,10 @@ Tensor detach(const Tensor& input) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("detach", TORCH_FN(detach));
-  m.impl("view", TORCH_FN(view));
-  m.impl("reshape", TORCH_FN(reshape));
-  m.impl("flatten.using_ints", TORCH_FN(flatten_using_ints));
+  m.impl(TORCH_SELECTIVE_NAME("aten::detach"), TORCH_FN(detach));
+  m.impl(TORCH_SELECTIVE_NAME("aten::view"), TORCH_FN(view));
+  m.impl(TORCH_SELECTIVE_NAME("aten::reshape"), TORCH_FN(reshape));
+  m.impl(TORCH_SELECTIVE_NAME("aten::flatten.using_ints"), TORCH_FN(flatten_using_ints));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
+++ b/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
@@ -65,8 +65,8 @@ Tensor softmax_int(
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("log_softmax.int", TORCH_FN(metal::log_softmax_int));
-  m.impl("softmax.int", TORCH_FN(metal::softmax_int));
+  m.impl(TORCH_SELECTIVE_NAME("aten::log_softmax.int"), TORCH_FN(metal::log_softmax_int));
+  m.impl(TORCH_SELECTIVE_NAME("aten::softmax.int"), TORCH_FN(metal::softmax_int));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalTranspose.mm
+++ b/aten/src/ATen/native/metal/ops/MetalTranspose.mm
@@ -94,8 +94,8 @@ Tensor t(const Tensor& input) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("t", TORCH_FN(t));
-  m.impl("transpose.int", TORCH_FN(transpose));
+  m.impl(TORCH_SELECTIVE_NAME("aten::t"), TORCH_FN(t));
+  m.impl(TORCH_SELECTIVE_NAME("aten::transpose.int"), TORCH_FN(transpose));
 };
 
 }

--- a/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
+++ b/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
@@ -86,7 +86,7 @@ Tensor upsample_nearest2d_vec(
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("upsample_nearest2d.vec", TORCH_FN(upsample_nearest2d_vec));
+  m.impl(TORCH_SELECTIVE_NAME("aten::upsample_nearest2d.vec"), TORCH_FN(upsample_nearest2d_vec));
 };
 
 }


### PR DESCRIPTION
Summary: Metal ops are currently not selective. This change makes them selective internally and sets it up to be migrated externally eventually as well.

Test Plan: CI, test on internal apps and verify models run.

Differential Revision: D30413427

