### PR TITLE
Fix shape inference dim_type for Clip, Mean, Div

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -1061,3 +1061,95 @@ TEST(BoundShapeInference, Transpose) {
       {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
       {16, 1});
 }
+
+TEST(BoundShapeInference, Clip) {
+  NetDef net;
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "Clip",
+      "",
+      {"input"},
+      {"output"},
+      {MakeArgument<int>("min", 10.0), MakeArgument<int>("max", 20.0)}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "input",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {8, 16}));
+  BoundShapeSpec spec(32, 1000);
+  BoundShapeInferencer eng(spec);
+  eng.InferBoundShapeAndType(net, shape_map, nullptr);
+  const auto& out_shape = eng.shape_info();
+  verifyShapeInfo(
+      out_shape,
+      "output",
+      {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
+      {8, 16});
+}
+
+TEST(BoundShapeInference, Mean) {
+  NetDef net;
+    net.add_op()->CopyFrom(CreateOperatorDef(
+      "Mean",
+      "",
+      {"input0", "input1", "input2"},
+      {"output"}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "input0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {8, 16}));
+  shape_map.emplace(
+      "input1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {8, 16}));
+  shape_map.emplace(
+      "input2",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {8, 16}));
+  BoundShapeSpec spec(32, 1000);
+  BoundShapeInferencer eng(spec);
+  eng.InferBoundShapeAndType(net, shape_map, nullptr);
+  const auto& out_shape = eng.shape_info();
+  verifyShapeInfo(
+      out_shape,
+      "output",
+      {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
+      {8, 16});
+}
+
+TEST(BoundShapeInference, Div) {
+  NetDef net;
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "Div",
+      "",
+      {"input0", "input1"},
+      {"output"}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "input0",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT},
+          {16}));
+  shape_map.emplace(
+      "input1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT},
+          {16}));
+  BoundShapeSpec spec(32, 1000);
+  BoundShapeInferencer eng(spec);
+  eng.InferBoundShapeAndType(net, shape_map, nullptr);
+  const auto& out_shape = eng.shape_info();
+  verifyShapeInfo(
+      out_shape,
+      "output",
+      {TensorBoundShape_DimType_CONSTANT},
+      {16});
+}

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -180,6 +180,12 @@ void BoundShapeInferencer::InferOps(
     InferTranspose(op);
   } else if (op.type() == "Bucketize") {
     InferBucketize(op);
+  } else if (op.type() == "Clip") {
+    InferClip(op);
+  } else if (op.type() == "Div") {
+    InferDiv(op);
+  } else if (op.type() == "Mean") {
+    InferMean(op);
   } else {
     InferCommonOp(op);
   }
@@ -958,6 +964,42 @@ void BoundShapeInferencer::InferLpNorm(const OperatorDef& op) {
   if (it != shape_info_.end()) {
     it->second.setDimType(std::vector<TensorBoundShape::DimType>(
         it->second.shape.dims_size(), TensorBoundShape_DimType_CONSTANT));
+  }
+}
+
+void BoundShapeInferencer::InferClip(const OperatorDef& op) {
+  CAFFE_ENFORCE_EQ(op.output_size(), 1, op.type(), " must have 1 output");
+  InferCommonOp(op);
+  auto it = shape_info_.find(op.output(0));
+  if (it != shape_info_.end()) {
+    auto it_input = shape_info_.find(op.input(0));
+    if (it_input != shape_info_.end()) {
+      it->second.setDimType(it_input->second.getDimType());
+    }
+  }
+}
+
+void BoundShapeInferencer::InferMean(const OperatorDef& op) {
+  CAFFE_ENFORCE_EQ(op.output_size(), 1, op.type(), " must have at 1 output");
+  InferCommonOp(op);
+  auto it = shape_info_.find(op.output(0));
+  if (it != shape_info_.end()) {
+    auto it_input = shape_info_.find(op.input(0));
+    if (it_input != shape_info_.end()) {
+      it->second.setDimType(it_input->second.getDimType());
+    }
+  }
+}
+
+void BoundShapeInferencer::InferDiv(const OperatorDef& op) {
+  CAFFE_ENFORCE_EQ(op.output_size(), 1, op.type(), " must have 1 output");
+  InferCommonOp(op);
+  auto it = shape_info_.find(op.output(0));
+  if (it != shape_info_.end()) {
+    auto it_input = shape_info_.find(op.input(0));
+    if (it_input != shape_info_.end()) {
+      it->second.setDimType(it_input->second.getDimType());
+    }
   }
 }
 

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -138,6 +138,9 @@ class TORCH_API BoundShapeInferencer : public BoundShapeInferencerBase {
   void InferSoftmax(const OperatorDef& op);
   void InferBucketize(const OperatorDef& op);
   void InferLpNorm(const OperatorDef& op);
+  void InferClip(const OperatorDef& op);
+  void InferMean(const OperatorDef& op);
+  void InferDiv(const OperatorDef& op);
   void InferTranspose(const OperatorDef& op);
 
   // Standard shape/type inference using op schema registered shape inference


### PR DESCRIPTION
Test Plan:
Facebook
```
buck build caffe2/caffe2/opt:bound_shape_inference_test && ./buck-out/gen/caffe2/caffe2/opt/bound_shape_inference_test --gtest_filter=*Clip*
```
```
buck build caffe2/caffe2/opt:bound_shape_inference_test && ./buck-out/gen/caffe2/caffe2/opt/bound_shape_inference_test --gtest_filter=*Div*
```
```
buck build caffe2/caffe2/opt:bound_shape_inference_test && ./buck-out/gen/caffe2/caffe2/opt/bound_shape_inference_test --gtest_filter=*Mean*
```

Reviewed By: yinghai

Differential Revision: D31121298

