### PR TITLE
Fix typo in name of LayerNormBackwardCUDAKernel

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -140,7 +140,7 @@ __global__ void ComputeGradientFusedParamsCUDAKernel(
 }
 
 template <typename T>
-__global__ void LayerNormBackwardCUDAKenrel(
+__global__ void LayerNormBackwardCUDAKernel(
     int64_t N,
     const T* dY,
     const T* X,
@@ -374,7 +374,7 @@ void LayerNormBackwardKernelImplInternal(
             scale_data,
             bias_data);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
-    LayerNormBackwardCUDAKenrel<T><<<M, kCUDANumThreads, 0, cuda_stream>>>(
+    LayerNormBackwardCUDAKernel<T><<<M, kCUDANumThreads, 0, cuda_stream>>>(
         N,
         dY_data,
         X_data,

--- a/caffe2/operators/layer_norm_op.cu
+++ b/caffe2/operators/layer_norm_op.cu
@@ -166,7 +166,7 @@ __global__ void ComputeFusedParamsCUDAKernel(
 }
 
 template <typename T>
-__global__ void LayerNormBackwardCUDAKenrel(
+__global__ void LayerNormBackwardCUDAKernel(
     const int M,
     const int N,
     const T* dY,
@@ -183,7 +183,7 @@ __global__ void LayerNormBackwardCUDAKenrel(
 }
 
 template <typename T>
-__global__ void LayerNormBackwardCUDAKenrel(
+__global__ void LayerNormBackwardCUDAKernel(
     const int M,
     const int N,
     const T* dY,
@@ -316,12 +316,12 @@ void LayerNormGradientOp<CUDAContext>::LayerNormBackward(
   if (M * N > 0) {
     const int K = math::DivUp(M * N, CAFFE_CUDA_NUM_THREADS);
     if (gamma != nullptr) {
-      LayerNormBackwardCUDAKenrel<T>
+      LayerNormBackwardCUDAKernel<T>
           <<<K, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
               M, N, dY, X, gamma, dY_scale, X_scale, bias, dX);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
-      LayerNormBackwardCUDAKenrel<T>
+      LayerNormBackwardCUDAKernel<T>
           <<<K, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
               M, N, dY, X, dY_scale, X_scale, bias, dX);
       C10_CUDA_KERNEL_LAUNCH_CHECK();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66000

Saw this in nvprof and I'm just a little too nitpicky to let it slide!

Differential Revision: [D31340262](https://our.internmc.facebook.com/intern/diff/D31340262/)