### PR TITLE
model_dump: Fix memory computation when both constants and data tensors are present

### DIFF
--- a/test/test_model_dump.py
+++ b/test/test_model_dump.py
@@ -217,6 +217,22 @@ class TestModelDump(TestCase):
             torch.jit.freeze(torch.jit.script(SimpleModel()).eval()),
             simple_model_memory)
 
+        # Make sure we can handle a model with both constants and data tensors.
+        class ComposedModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w1 = torch.zeros(1, 2)
+                self.w2 = torch.ones(2, 2)
+
+            def forward(self, arg):
+                return arg * self.w2 + self.w1
+
+        check_memory(
+            torch.jit.freeze(
+                torch.jit.script(ComposedModule()).eval(),
+                preserved_attrs=["w1"]),
+            4 * (2 + 4))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/utils/model_dump/code.js
+++ b/torch/utils/model_dump/code.js
@@ -533,10 +533,14 @@ function getTensorStorages(data) {
   throw new Error("Can't handle data type.", data);
 }
 
-function getTensorMemoryByDevice(data) {
-  const tensors = getTensorStorages(data);
+function getTensorMemoryByDevice(pickles) {
+  let all_tensors = [];
+  for (const [name, pickle] of pickles) {
+    const tensors = getTensorStorages(pickle);
+    all_tensors.push(...tensors.values());
+  }
   let result = {};
-  for (const storage of tensors.values()) {
+  for (const storage of all_tensors.values()) {
     const [dtype, key, device, numel] = storage;
     const size = computeTensorMemory(numel, dtype);
     result[device] = (result[device] || 0) + size;
@@ -547,7 +551,10 @@ function getTensorMemoryByDevice(data) {
 // Make this a separate component so it is rendered lazily.
 class OpenTensorMemorySection extends Component {
   render({model: {model_data, constants}}) {
-    let sizes = getTensorMemoryByDevice([model_data, constants]);
+    let sizes = getTensorMemoryByDevice(new Map([
+      ["data", model_data],
+      ["constants", constants],
+    ]));
     return html`
       <table>
         <thead>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66006
* #66005

Previously, this was resulting in a key collision and a crash.

Differential Revision: [D31281092](https://our.internmc.facebook.com/intern/diff/D31281092/)