### PR TITLE
GHA: make obvious when we are running smoke tests to user

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -178,9 +178,9 @@ class CIWorkflow:
         # If num_test_shards_on_pull_request is not user-defined, default to num_test_shards unless we are
         # only running smoke tests on the pull request.
         if self.num_test_shards_on_pull_request == -1:
-            # Don't waste resources on runner spinup and cooldown for another shard if we are only running a few tests
+            # Don't run the default if we are only running smoke tests
             if self.only_run_smoke_tests_on_pull_request:
-                self.num_test_shards_on_pull_request = 1
+                self.num_test_shards_on_pull_request = 0
             else:
                 self.num_test_shards_on_pull_request = self.num_test_shards
         self.assert_valid()

--- a/.github/scripts/generate_pytorch_test_matrix.py
+++ b/.github/scripts/generate_pytorch_test_matrix.py
@@ -15,6 +15,9 @@ from typing import Dict
 from typing_extensions import TypedDict
 
 
+BUILD_ENVIRONMENT = os.getenv('BUILD_ENVIRONMENT')
+
+
 class Config(TypedDict):
     num_shards: int
     runner: str
@@ -31,14 +34,40 @@ def get_disabled_issues() -> str:
     issue_numbers = [x[4] for x in re.findall(regex, pr_body)]
     return ','.join(issue_numbers)
 
+# When the user specifies labels that are NOT ciflow/default, the expectation is
+# that the workflows should be triggered as if they are on trunk. For example, when
+# ciflow/all is specified, we should run the full test suite for Windows CUDA
+# and NOT only the smoke tests.
+def run_as_if_on_trunk() -> bool:
+    ON_PULL_REQUEST = os.getenv('GITHUB_HEAD_REF')
+    if not ON_PULL_REQUEST:
+        return True
+
+    from pathlib import Path
+    GITHUB_DIR = Path(__file__).resolve().parent.parent
+
+    with open(f'{GITHUB_DIR}/generated-ciflow-ruleset.json') as f:
+        labels_to_workflows = json.load(f)['label_rules']
+
+    pr_labels = json.loads(os.getenv('PR_LABELS', '[]'))
+    current_workflow_triggered_by_label = False
+    for label in pr_labels:
+        if label != 'ciflow/default' and label in labels_to_workflows:
+            workflows_triggered_by_label = labels_to_workflows[label]
+            if any([BUILD_ENVIRONMENT in workflow for workflow in workflows_triggered_by_label]):
+                current_workflow_triggered_by_label = True
+                break
+
+    return current_workflow_triggered_by_label
 
 def main() -> None:
     TEST_RUNNER_TYPE = os.getenv('TEST_RUNNER_TYPE')
     assert TEST_RUNNER_TYPE is not None
-    ON_PULL_REQUEST = os.getenv('GITHUB_HEAD_REF')
+    RUN_SMOKE_TESTS_ONLY_ON_PR = os.getenv('RUN_SMOKE_TESTS_ONLY_ON_PR')
+    RUN_SMOKE_TESTS = RUN_SMOKE_TESTS_ONLY_ON_PR == "true" and not run_as_if_on_trunk()
     NUM_TEST_SHARDS_ON_PULL_REQUEST = os.getenv('NUM_TEST_SHARDS_ON_PULL_REQUEST')
-    NUM_TEST_SHARDS = int(os.getenv('NUM_TEST_SHARDS', '1'))
-    if ON_PULL_REQUEST and NUM_TEST_SHARDS_ON_PULL_REQUEST:
+    NUM_TEST_SHARDS = int(os.getenv('NUM_TEST_SHARDS', '0'))
+    if not run_as_if_on_trunk() and NUM_TEST_SHARDS_ON_PULL_REQUEST:
         NUM_TEST_SHARDS = int(NUM_TEST_SHARDS_ON_PULL_REQUEST)
     MULTIGPU_RUNNER_TYPE = os.getenv('MULTIGPU_RUNNER_TYPE')
     NOGPU_RUNNER_TYPE = os.getenv('NOGPU_RUNNER_TYPE')
@@ -66,6 +95,8 @@ def main() -> None:
         configs['xla'] = {'num_shards': 1, 'runner': TEST_RUNNER_TYPE}
     if os.getenv('ENABLE_NOARCH_TEST'):
         configs['noarch'] = {'num_shards': 1, 'runner': TEST_RUNNER_TYPE}
+    if RUN_SMOKE_TESTS:
+        configs['smoke_tests'] = {'num_shards': 1, 'runner': TEST_RUNNER_TYPE}
     matrix = {
         'include': [
             {

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -135,6 +135,7 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
       NOGPU_RUNNER_TYPE: windows.4xlarge
       ENABLE_FORCE_ON_CPU_TEST: !{{ enable_force_on_cpu_test }}
+      RUN_SMOKE_TESTS_ONLY_ON_PR: !{{ only_run_smoke_tests_on_pull_request }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -158,7 +159,6 @@ jobs:
       TEST_CONFIG: ${{ matrix.config }}
       http_proxy: "!{{ common.squid_proxy }}"
       https_proxy: "!{{ common.squid_proxy }}"
-      RUN_SMOKE_TESTS_ONLY_ON_PR: !{{ only_run_smoke_tests_on_pull_request }}
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     needs: [build, generate-test-matrix, !{{ ciflow_config.root_job_name }}]
     strategy:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -146,6 +146,7 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
       NOGPU_RUNNER_TYPE: windows.4xlarge
       ENABLE_FORCE_ON_CPU_TEST: ''
+      RUN_SMOKE_TESTS_ONLY_ON_PR: False
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -169,7 +170,6 @@ jobs:
       TEST_CONFIG: ${{ matrix.config }}
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
-      RUN_SMOKE_TESTS_ONLY_ON_PR: False
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     needs: [build, generate-test-matrix, ciflow_should_run]
     strategy:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -138,6 +138,7 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
       NOGPU_RUNNER_TYPE: windows.4xlarge
       ENABLE_FORCE_ON_CPU_TEST: ''
+      RUN_SMOKE_TESTS_ONLY_ON_PR: False
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -161,7 +162,6 @@ jobs:
       TEST_CONFIG: ${{ matrix.config }}
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
-      RUN_SMOKE_TESTS_ONLY_ON_PR: False
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     needs: [build, generate-test-matrix, ciflow_should_run]
     strategy:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -144,10 +144,11 @@ jobs:
     env:
       TEST_RUNNER_TYPE: windows.8xlarge.nvidia.gpu
       NUM_TEST_SHARDS: 2
-      NUM_TEST_SHARDS_ON_PULL_REQUEST: 1
+      NUM_TEST_SHARDS_ON_PULL_REQUEST: 0
       PR_BODY: ${{ github.event.pull_request.body }}
       NOGPU_RUNNER_TYPE: windows.4xlarge
       ENABLE_FORCE_ON_CPU_TEST: 1
+      RUN_SMOKE_TESTS_ONLY_ON_PR: True
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
@@ -171,7 +172,6 @@ jobs:
       TEST_CONFIG: ${{ matrix.config }}
       http_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
       https_proxy: "http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128"
-      RUN_SMOKE_TESTS_ONLY_ON_PR: True
       PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
     needs: [build, generate-test-matrix, ciflow_should_run]
     strategy:

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -58,7 +58,7 @@ fi
 if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
   # run the full test suite for force_on_cpu test
   export USE_CUDA=0
-elif [[ -n $GITHUB_HEAD_REF && "$RUN_SMOKE_TESTS_ONLY_ON_PR" == "true" ]]; then
+elif [[ "$TEST_CONFIG" == "smoke_tests" ]]; then
   export RUN_SMOKE_TESTS_ONLY=1
 fi
 


### PR DESCRIPTION
This PR clarifies what's run on PRs by explicitly stating when it runs smoke tests for windows CUDA and makes the logic so that user defined labels override other workflow logic.

1. Move smoke tests to its own config.

2. Make sure that when a user specifies a ciflow label that is not the default, the workflow runs as if it is on trunk.

Test plan: the default on PRs would generate this matrix (default replaced by smoke_tests)
![image](https://user-images.githubusercontent.com/31798555/135672182-64454ea3-ff43-4746-b8e4-09b0b28e9d33.png)
But when retriggered with a label, it looks like (note that there's no smoke_tests config):
![image](https://user-images.githubusercontent.com/31798555/135672601-5aa9a268-bc76-40f1-80c6-62b3fac6601d.png)
