### PR TITLE
Fix https://github.com/pytorch/pytorch/issues/61982

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -150,7 +150,13 @@ class _DDPSink(Function):
         ctx.set_materialize_grads(False)
         ctx.reducer = reducer
         ctx.state_dict = state_dict
-        return inputs
+        ret = tuple(
+            inp.clone()
+            if isinstance(inp, torch.Tensor)
+            else inp
+            for inp in inputs
+        )
+        return ret
 
     @staticmethod
     def backward(ctx, *grad_outputs):


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/61982 by clone of
tensors in DDPSink. Only applies once for static_graph and generally for unused
params which already has overhead, so perf hit should not be an issue. Will
verify with benchmark.

Test Plan: CI

Differential Revision: D31346633



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang