### PR TITLE
[fx2trt]add support for torch.tile

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -184,6 +184,10 @@ def add(*, input, other):
 def unsqueeze(*, input, dim):
     return torch.unsqueeze(**locals())
 
+@register_acc_op_mapping(op_and_target=("call_function", torch.tile))
+@register_acc_op
+def tile(*, input, dims):
+    return torch.tile(**locals())
 
 @register_custom_acc_mapper_fn(
     op_and_target=("call_function", torch.stack),


### PR DESCRIPTION
Summary: Add acc_ops.tile and converter for it.

Test Plan: buck test mode/dev-nosan caffe2/torch/fb/fx2trt:test_tile

Differential Revision: D30587939

