### PR TITLE
[test][skip ci] Load tensor in place

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1399,7 +1399,7 @@ class Module:
                     continue
                 try:
                     with torch.no_grad():
-                        param.copy_(input_param)
+                        setattr(self, name, torch.nn.Parameter(input_param))
                 except Exception as ex:
                     error_msgs.append('While copying the parameter named "{}", '
                                       'whose dimensions in the model are {} and '


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#66023**

Right now loading a state_dict in the typical way involves allocating space for a bunch of parameters which are nearly immediately overwritten with data from `torch.load`. This example

```python
import torch
n = 16000
base_module = torch.nn.Linear(n, n)
torch.save(base_module.state_dict(), "out.pt")
```

loaded with this code

```python
regular = torch.nn.Linear(n, n)
regular.load_state_dict(torch.load("out.pt"))
```

generates 4035.7 MB of allocations (via `fil-profile run test.py`). The tensor itself is about 1900 MB. Using meta tensors to load (along with this hacky patch) skips this initial allocation, bringing the allocations down to 3059.1 MB:

```python
regular = torch.nn.Linear(n, n, device='meta')
regular.load_state_dict(torch.load("out.pt"))
```

TODO:
* These numbers don't make sense (the base library `import torch` makes about 2 GB of allocations, so the first example seems like the allocations are fine? So why does the second version use half the memory)
* This is probably missing some places where the device needs to be fixed up