### PR TITLE
[JIT] Selectively enable precise alias analysis for TupleConstruct

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -189,9 +189,13 @@ struct AliasDb::WriteRegistry {
   std::unordered_set<Node*> writesToAllWildcards_;
 };
 
-AliasDb::AliasDb(std::shared_ptr<Graph> graph, bool isFrozen)
+AliasDb::AliasDb(
+    std::shared_ptr<Graph> graph,
+    bool isFrozen,
+    bool enablePreciseTupleContainerAnalysis)
     : graph_(std::move(graph)),
       isFrozen_(isFrozen),
+      enablePreciseTupleContainerAnalysis_(enablePreciseTupleContainerAnalysis),
       memoryDAGBuilder_(std::make_unique<MemoryDAGBuilder>()),
       writeRegistry_(std::make_unique<AliasDb::WriteRegistry>()) {
   analyze(graph_);
@@ -1047,6 +1051,9 @@ bool AliasDb::functionalNonEscapingListUse(const Use& use) const {
 }
 
 bool AliasDb::functionalNonEscapingTupleUse(const Use& use) const {
+  if (!enablePreciseTupleContainerAnalysis_) {
+    return false;
+  }
   Node* n = use.user;
   size_t offset = use.offset;
   Value* container = n->inputs().at(offset);

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -45,7 +45,8 @@ class AliasDb {
  public:
   TORCH_API explicit AliasDb(
       std::shared_ptr<Graph> graphi,
-      bool isFrozen = false);
+      bool isFrozen = false,
+      bool enablePreciseTupleContainerAnalysis = false);
   TORCH_API ~AliasDb();
 
   // There are limitations to what effects the alias analysis can track. Two
@@ -156,6 +157,9 @@ class AliasDb {
   // Create a new `value` that does not alias anything else.
   void createValue(const Value* value);
 
+  // Enable more precise treatment of prim::TupleConstruct.
+  void enablePreciseTupleContainerAnalysis();
+
   friend struct MutationRemover;
 
  private:
@@ -242,6 +246,9 @@ class AliasDb {
   // objects. Freezing API invokes alias analysis to check if they are mutated
   // internally.
   bool isFrozen_;
+
+  // Enable precise treatment of prim::TupleConstruct.
+  bool enablePreciseTupleContainerAnalysis_ = false;
 
   // The points-to graph that stores aliasing relationships
   std::unique_ptr<MemoryDAGBuilder> memoryDAGBuilder_;

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -517,7 +517,8 @@ void ReplaceWithCopy(
 // NB: The alias type of the fused op needs to be changed to
 // c10::AliasAnalysisKind::PURE_FUNCTION to make alias analysis work.
 void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
-  AliasDb alias_db(graph);
+  AliasDb alias_db(
+      graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
   const std::vector<Value*> graph_outputs(
       graph->outputs().begin(), graph->outputs().end());
   auto nodes = graph->nodes();


### PR DESCRIPTION
Summary: This change adds an option to selectively enable precise alias analysis for `prim::`TupleConstruct` (introduced by D30437737 (https://github.com/pytorch/pytorch/commit/cd458fe092ab4671b627e114a3b150ac4fe93353)) to minimize its exposure only to `StaticRuntime` as of now.

Test Plan: Modified existing unit tests whose behavior depends on D30437737 (https://github.com/pytorch/pytorch/commit/cd458fe092ab4671b627e114a3b150ac4fe93353).

Differential Revision: D31350285

