### PR TITLE
[quant] Add quantization import in the ao/__init__

### DIFF
--- a/torch/ao/__init__.py
+++ b/torch/ao/__init__.py
@@ -1,2 +1,3 @@
-from torch.ao import nn
-from torch.ao import sparsity
+from torch.ao import nn  # noqa: F401
+from torch.ao import quantization  # noqa: F401
+from torch.ao import sparsity  # noqa: F401


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #65889
* #65888
* #65887
* #65886
* #65885
* __->__ #66035

When importing the package __init__.py it is important to include the subpackages as imports in the __init__. However, during the migration, that was not done. This fixes it

Differential Revision: [D31354228](https://our.internmc.facebook.com/intern/diff/D31354228/)