### PR TITLE
[DataPipe] adding a method for FileLoader to close its streams

### DIFF
--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -41,19 +41,6 @@ def get_file_pathnames_from_root(
             break
 
 
-def get_file_binaries_from_pathnames(pathnames: Iterable, mode: str):
-    if not isinstance(pathnames, Iterable):
-        pathnames = [pathnames, ]
-
-    if mode in ('b', 't'):
-        mode = 'r' + mode
-
-    for pathname in pathnames:
-        if not isinstance(pathname, str):
-            raise TypeError("Expected string type for pathname, but got {}"
-                            .format(type(pathname)))
-        yield (pathname, open(pathname, mode))
-
 def validate_pathname_binary_tuple(data):
     if not isinstance(data, tuple):
         raise TypeError("pathname binary data should be tuple type, but got {}".format(type(data)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66036

The DataPipe will now remember what IO it has opened and allows the user to close them at a later time if desired.


cc @VitalyFedyunin @ejguan @NivekT