### PR TITLE
[FX] Support torch.layout as arg

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1707,6 +1707,18 @@ class TestFX(JitTestCase):
 
         self.assertTrue('typing.List[float]' in str(graph))
 
+    def test_layout(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.empty_like(x, layout=torch.strided, pin_memory=False).fill_(0)
+
+        traced = symbolic_trace(M())
+        x = torch.rand(5, 9, 3, 4)
+        self.assertEqual(traced(x), torch.zeros_like(x))
+
     def test_ellipsis(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -10,7 +10,7 @@ from torch.fx.operator_schemas import normalize_function, normalize_module, Args
 if TYPE_CHECKING:
     from .graph import Graph
 
-BaseArgumentTypes = Union[str, int, float, bool, torch.dtype, torch.Tensor, torch.device, torch.memory_format]
+BaseArgumentTypes = Union[str, int, float, bool, torch.dtype, torch.Tensor, torch.device, torch.memory_format, torch.layout]
 base_types = BaseArgumentTypes.__args__  # type: ignore[attr-defined]
 
 Target = Union[Callable[..., Any], str]


### PR DESCRIPTION
Summary: Previously, create_arg would fail if it encountered a not `None` layout argument. Adding it to `BaseArgumentTypes` list should be enough to fix that.

Test Plan: Added unittest

Differential Revision: D31362662

