### PR TITLE
[quant] Fixing the hypothesis test for topk

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1597,9 +1597,9 @@ class TestQuantizedOps(TestCase):
                                  X_hat.q_zero_point()))
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
-                                              min_side=1, max_side=10),
+                                              min_side=1, max_side=6),
                        qparams=hu.qparams()),
-           k=st.integers(1, 10),
+           k=st.integers(1, 6),
            dim=st.integers(1, 4),
            largest=st.booleans(),
            sorted=st.booleans())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66058
* __->__ #66057

The current test is creating the sets that are too slow.
This will cause either "Filtering too much" or "Timeout" errors in the future versions of hypothesis.
This PR preemptively fixes the issue.

Test plan:

`python test/test_quantization.py`

Differential Revision: [D31366065](https://our.internmc.facebook.com/intern/diff/D31366065)