### PR TITLE
[quant] Fix the parts that were missing after initial migration

### DIFF
--- a/torch/ao/__init__.py
+++ b/torch/ao/__init__.py
@@ -1,2 +1,3 @@
 from torch.ao import nn
+from torch.ao import quantization
 from torch.ao import sparsity

--- a/torch/ao/nn/sparse/quantized/dynamic/linear.py
+++ b/torch/ao/nn/sparse/quantized/dynamic/linear.py
@@ -107,7 +107,7 @@ class Linear(torch.nn.Module):
             # We have the circular import issues if we import the qconfig in the beginning of this file:
             # https://github.com/pytorch/pytorch/pull/24231. The current workaround is to postpone the
             # import until we need it.
-            from torch.quantization.qconfig import default_dynamic_qconfig
+            from torch.ao.quantization.qconfig import default_dynamic_qconfig
             weight_observer = default_dynamic_qconfig.weight()
 
         # It is important to multiply by the mask BEFORE calling the `weight_observer`

--- a/torch/ao/ns/_numeric_suite.py
+++ b/torch/ao/ns/_numeric_suite.py
@@ -2,10 +2,10 @@ import torch
 import torch.nn as nn
 import torch.nn.quantized as nnq
 import torch.nn.quantized.dynamic as nnqd
-from torch.quantization import prepare
+from torch.ao.quantization import prepare
 from typing import Dict, List, Optional, Any, Union, Callable, Set
 
-from torch.quantization.quantization_mappings import (
+from torch.ao.quantization.quantization_mappings import (
     get_default_compare_output_module_list,
 )
 
@@ -433,7 +433,7 @@ def prepare_model_outputs(
     if allow_list is None:
         allow_list = get_default_compare_output_module_list()
 
-    qconfig_debug = torch.quantization.QConfig(activation=logger_cls, weight=None)
+    qconfig_debug = torch.ao.quantization.QConfig(activation=logger_cls, weight=None)
     float_module.qconfig = qconfig_debug  # type: ignore[assignment]
     prepare(float_module, inplace=True, allow_list=allow_list)
     q_module.qconfig = qconfig_debug  # type: ignore[assignment]

--- a/torch/ao/ns/_numeric_suite_fx.py
+++ b/torch/ao/ns/_numeric_suite_fx.py
@@ -2,7 +2,7 @@ import collections
 
 import torch
 import torch.nn as nn
-import torch.quantization.quantize_fx as quantize_fx
+import torch.ao.quantization.quantize_fx as quantize_fx
 from torch.fx import GraphModule
 from torch.fx.graph import Node
 from torch.ao.ns.fx.mappings import (
@@ -122,9 +122,9 @@ class NSTracer(quantize_fx.QuantizationTracer):
     modules as leaf modules.
     """
     def is_leaf_module(self, m: torch.nn.Module, module_qualified_name : str) -> bool:
-        if isinstance(m, torch.quantization.ObserverBase):
+        if isinstance(m, torch.ao.quantization.ObserverBase):
             return True
-        elif isinstance(m, torch.quantization.FakeQuantizeBase):
+        elif isinstance(m, torch.ao.quantization.FakeQuantizeBase):
             return True
         return super().is_leaf_module(m, module_qualified_name)
 

--- a/torch/ao/ns/fx/graph_matcher.py
+++ b/torch/ao/ns/fx/graph_matcher.py
@@ -7,7 +7,7 @@ toq = torch.ops.quantized
 from torch.fx import GraphModule
 from torch.fx.graph import Graph, Node
 
-from torch.quantization.utils import getattr_from_fqn
+from torch.ao.quantization.utils import getattr_from_fqn
 from .ns_types import NSSubgraph, NSNodeTargetType
 from .mappings import (
     get_base_name_to_sets_of_related_ops,
@@ -18,7 +18,7 @@ from .pattern_utils import (
     get_reversed_fusions,
     end_node_matches_reversed_fusion,
 )
-from torch.quantization import (
+from torch.ao.quantization import (
     ObserverBase,
     FakeQuantizeBase,
 )

--- a/torch/ao/ns/fx/graph_passes.py
+++ b/torch/ao/ns/fx/graph_passes.py
@@ -1,7 +1,7 @@
 import torch
 from torch.fx import GraphModule, map_arg
 from torch.fx.graph import Graph, Node
-from torch.quantization.fx.utils import get_new_attr_name_with_prefix
+from torch.ao.quantization.fx.utils import get_new_attr_name_with_prefix
 
 from .utils import (
     get_node_first_input_and_output_type,
@@ -22,7 +22,7 @@ from .ns_types import (
 from torch.ao.ns.fx.mappings import (
     get_node_type_to_io_type_map,
 )
-from torch.quantization.quantize import is_activation_post_process
+from torch.ao.quantization.quantize import is_activation_post_process
 
 from typing import Dict, Tuple, Callable, List, Any, Union, Optional, Set
 

--- a/torch/ao/ns/fx/pattern_utils.py
+++ b/torch/ao/ns/fx/pattern_utils.py
@@ -6,10 +6,10 @@ toq = torch.ops.quantized
 from torch.fx import GraphModule
 from torch.fx.graph import Node
 
-from torch.quantization.utils import getattr_from_fqn
+from torch.ao.quantization.utils import getattr_from_fqn
 from .ns_types import NSNodeTargetType
-from torch.quantization.fx.pattern_utils import get_default_quant_patterns
-from torch.quantization import (
+from torch.ao.quantization.fx.pattern_utils import get_default_quant_patterns
+from torch.ao.quantization import (
     ObserverBase,
     FakeQuantizeBase,
 )

--- a/torch/ao/ns/fx/utils.py
+++ b/torch/ao/ns/fx/utils.py
@@ -11,12 +11,12 @@ from typing import Tuple, Callable, Dict, Set, List, Optional, Union
 
 from torch.fx import GraphModule
 from torch.fx.graph import Node
-from torch.quantization import (
+from torch.ao.quantization import (
     ObserverBase,
     FakeQuantizeBase,
 )
-from torch.quantization.utils import getattr_from_fqn
-from torch.quantization.quantize import is_activation_post_process
+from torch.ao.quantization.utils import getattr_from_fqn
+from torch.ao.quantization.quantize import is_activation_post_process
 
 from .ns_types import NSNodeTargetType, NSResultsType
 

--- a/torch/ao/quantization/_correct_bias.py
+++ b/torch/ao/quantization/_correct_bias.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.quantized as nnq
 
-import torch.quantization
+import torch.ao.quantization
 import torch.ao.ns._numeric_suite as ns
 
 _supported_modules = {nn.Linear, nn.Conv2d}

--- a/torch/ao/quantization/_learnable_fake_quantize.py
+++ b/torch/ao/quantization/_learnable_fake_quantize.py
@@ -2,7 +2,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 
-class _LearnableFakeQuantize(torch.quantization.FakeQuantizeBase):
+class _LearnableFakeQuantize(torch.ao.quantization.FakeQuantizeBase):
     r""" This is an extension of the FakeQuantize module in fake_quantize.py, which
     supports more generalized lower-bit quantization and support learning of the scale
     and zero point parameters through backpropagation. For literature references,

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -1,6 +1,6 @@
 import torch
 from torch.nn import Module
-from torch.quantization.observer import (
+from torch.ao.quantization.observer import (
     MovingAverageMinMaxObserver,
     HistogramObserver,
     MovingAveragePerChannelMinMaxObserver,
@@ -264,7 +264,7 @@ class FusedMovingAvgObsFakeQuantize(FakeQuantize):
     The output of this module is given by
     x_out = (clamp(round(x/scale + zero_point), quant_min, quant_max)-zero_point)*scale
 
-    Similar to :class:`~torch.quantization.FakeQuantize`, and accepts the same attributes as the
+    Similar to :class:`~torch.ao.quantization.FakeQuantize`, and accepts the same attributes as the
     base class.
 
     Attributes:

--- a/torch/ao/quantization/fuse_modules.py
+++ b/torch/ao/quantization/fuse_modules.py
@@ -3,10 +3,10 @@ import copy
 
 import torch.nn as nn
 
-from torch.quantization.fuser_method_mappings import get_fuser_method
+from torch.ao.quantization.fuser_method_mappings import get_fuser_method
 # for backward compatiblity
-from torch.quantization.fuser_method_mappings import fuse_conv_bn  # noqa: F401
-from torch.quantization.fuser_method_mappings import fuse_conv_bn_relu  # noqa: F401
+from torch.ao.quantization.fuser_method_mappings import fuse_conv_bn  # noqa: F401
+from torch.ao.quantization.fuser_method_mappings import fuse_conv_bn_relu  # noqa: F401
 
 from typing import List, Optional
 
@@ -103,7 +103,7 @@ def fuse_modules(model, modules_to_fuse, inplace=False, fuser_func=fuse_known_mo
         fuser_func: Function that takes in a list of modules and outputs a list of fused modules
                     of the same length. For example,
                     fuser_func([convModule, BNModule]) returns the list [ConvBNModule, nn.Identity()]
-                    Defaults to torch.quantization.fuse_known_modules
+                    Defaults to torch.ao.quantization.fuse_known_modules
         `fuse_custom_config_dict`: custom configuration for fusion
 
     .. code-block:: python

--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -44,7 +44,7 @@ class _InputEqualizationObserver(nn.Module):
             follow the 8-bit setup.
 
     The running minimum/maximum :math:`x_\text{min/max}` are computed in the
-    same way as :class:`~torch.quantization.observer.PerChannelMinMaxObserver`,
+    same way as :class:`~torch.ao.quantization.observer.PerChannelMinMaxObserver`,
     with the difference that the running min/max values are stored per column.
     This observer is intended to be used along with a WeightEqualizationObserver
     to calculate the equalization scale.
@@ -130,7 +130,7 @@ class _WeightEqualizationObserver(nn.Module):
     InputEqualizationObserver to calculate the equalization scale.
 
     The running minimum/maximum :math:`w_\text{min/max}` are computed in the
-    same way as :class:`~torch.quantization.observer.PerChannelMinMaxObserver`.
+    same way as :class:`~torch.ao.quantization.observer.PerChannelMinMaxObserver`.
     """
 
     def __init__(self, dtype=torch.qint8, qscheme=torch.per_tensor_affine, quant_min=None,

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -1098,7 +1098,7 @@ def run_prepare_fx_on_standalone_modules(
 
         standalone_module = modules[root_node.target]
         prepare = \
-            torch.quantization.quantize_fx._prepare_standalone_module_fx  # type: ignore[attr-defined]
+            torch.ao.quantization.quantize_fx._prepare_standalone_module_fx  # type: ignore[attr-defined]
         observed_standalone_module = \
             prepare(standalone_module, sm_qconfig_dict, sm_prepare_config_dict)
         preserved_attributes = \
@@ -1170,10 +1170,10 @@ def prepare(
     # {
     #   # match a single node
     #   (<class 'torch.nn.modules.conv.Conv3d'>:
-    #     <class 'torch.quantization.fx.quantize.ConvRelu'>),
+    #     <class 'torch.ao.quantization.fx.quantize.ConvRelu'>),
     #   # match multiple nodes in reverse order
     #   ((<function relu at 0x7f766a7360d0>, <built-in function add>):
-    #     <class 'torch.quantization.fx.quantize.Add'>),
+    #     <class 'torch.ao.quantization.fx.quantize.Add'>),
     # }
     quant_patterns = backend_config_dict["quant_patterns"]
     patterns: Dict[Pattern, QuantizeHandler] = get_combined_dict(

--- a/torch/ao/quantization/fx/qconfig_utils.py
+++ b/torch/ao/quantization/fx/qconfig_utils.py
@@ -1,7 +1,7 @@
 import torch
 from collections import OrderedDict, defaultdict
 from typing import Union, Callable, Any, Dict, Tuple, Set
-from torch.quantization.qconfig import add_module_to_qconfig_obs_ctr, QConfigAny
+from torch.ao.quantization.qconfig import add_module_to_qconfig_obs_ctr, QConfigAny
 
 import re
 

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -1683,7 +1683,7 @@ class StandaloneModuleQuantizeHandler(QuantizeHandler):
                 is_reference: bool = False,
                 convert_custom_config_dict: Dict[str, Any] = None) -> Node:
         assert node.op == 'call_module'
-        convert = torch.quantization.quantize_fx._convert_standalone_module_fx  # type: ignore[attr-defined]
+        convert = torch.ao.quantization.quantize_fx._convert_standalone_module_fx  # type: ignore[attr-defined]
         # We know that observed standalone module is a GraphModule since
         # it's produced by us
         observed_standalone_module : GraphModule = modules[str(node.target)]  # type: ignore[assignment]

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -113,7 +113,7 @@ class _ObserverBase(ObserverBase):
     r"""Internal common base for all qint/quint8 observers.
 
     This base is for commonly used parameters used internally.
-    Users should use `~torch.quantization.observer.ObserverBase` as a base class
+    Users should use `~torch.ao.quantization.observer.ObserverBase` as a base class
     for custom observers.
 
     Args:
@@ -497,7 +497,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
     is the incoming tensor, and :math:`c` is the ``averaging_constant``.
 
     The scale and zero point are then computed as in
-    :class:`~torch.quantization.observer.MinMaxObserver`.
+    :class:`~torch.ao.quantization.observer.MinMaxObserver`.
 
     .. note:: Only works with ``torch.per_tensor_affine`` quantization scheme.
 
@@ -561,7 +561,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
         quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     The quantization parameters are computed the same way as in
-    :class:`~torch.quantization.observer.MinMaxObserver`, with the difference
+    :class:`~torch.ao.quantization.observer.MinMaxObserver`, with the difference
     that the running min/max values are stored per channel.
     Scales and zero points are thus computed per channel as well.
 
@@ -745,7 +745,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     The quantization parameters are computed the same way as in
-    :class:`~torch.quantization.observer.MovingAverageMinMaxObserver`, with the
+    :class:`~torch.ao.quantization.observer.MovingAverageMinMaxObserver`, with the
     difference that the running min/max values are stored per channel.
     Scales and zero points are thus computed per channel as well.
 
@@ -824,7 +824,7 @@ class HistogramObserver(_ObserverBase):
         The search for the min/max values ensures the minimization of the
         quantization error with respect to the floating point model.
     3. Compute the scale and zero point the same way as in the
-        :class:`~torch.quantization.MinMaxObserver`
+        :class:`~torch.ao.quantization.MinMaxObserver`
     """
     histogram: torch.Tensor
     min_val: torch.Tensor
@@ -1267,7 +1267,7 @@ class NoopObserver(ObserverBase):
 def _is_observer_script_module(mod, obs_type_name):
     """Returns true if given mod is an instance of Observer script module."""
     if isinstance(mod, torch.jit.RecursiveScriptModule):
-        # qualified name looks like '__torch__.torch.quantization.observer.___torch_mangle_2.MinMaxObserver'
+        # qualified name looks like '__torch__.torch.ao.quantization.observer.___torch_mangle_2.MinMaxObserver'
         suffix = mod._c.qualified_name.split(".", 1)[1]
         name = re.sub(r"\.___torch_mangle_\d+", "", suffix)
         return obs_type_name in name
@@ -1276,8 +1276,8 @@ def _is_observer_script_module(mod, obs_type_name):
 
 def _is_activation_post_process(module):
     return (
-        isinstance(module, torch.quantization.ObserverBase)
-        or isinstance(module, torch.quantization.FakeQuantize)
+        isinstance(module, torch.ao.quantization.ObserverBase)
+        or isinstance(module, torch.ao.quantization.FakeQuantize)
         or _is_observer_script_module(module, "quantization.observer")
     )
 
@@ -1315,7 +1315,7 @@ def load_observer_state_dict(mod, obs_dict):
     r"""
     Given input model and a state_dict containing model observer stats,
     load the stats back into the model. The observer state_dict can be saved
-    using torch.quantization.get_observer_state_dict
+    using torch.ao.quantization.get_observer_state_dict
     """
     missing_keys: List[str] = []
     unexpected_keys: List[str] = []

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -168,8 +168,8 @@ def assert_valid_qconfig(qconfig: Optional[Union[QConfig, QConfigDynamic]],
     if is_conv_transpose_mod:
         example_observer = qconfig.weight()
         is_per_channel = (
-            isinstance(example_observer, torch.quantization.PerChannelMinMaxObserver) or
-            isinstance(example_observer, torch.quantization.MovingAveragePerChannelMinMaxObserver)
+            isinstance(example_observer, torch.ao.quantization.PerChannelMinMaxObserver) or
+            isinstance(example_observer, torch.ao.quantization.MovingAveragePerChannelMinMaxObserver)
         )
         assert not is_per_channel, \
             'Per channel weight observer is not supported yet for ConvTranspose{n}d.'

--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.nn.quantized as nnq
 from torch.nn.intrinsic import _FusedModule
 
-from torch.quantization.quantization_mappings import (
+from torch.ao.quantization.quantization_mappings import (
     get_default_dynamic_quant_module_mappings,
     get_default_static_quant_module_mappings,
     get_default_qat_module_mappings,
@@ -18,15 +18,15 @@ from torch.quantization.quantization_mappings import (
 )
 
 from torch.ao.quantization.stubs import DeQuantStub, QuantWrapper
-from torch.quantization.qconfig import (
+from torch.ao.quantization.qconfig import (
     add_module_to_qconfig_obs_ctr,
     default_dynamic_qconfig,
     float16_dynamic_qconfig,
     float_qparams_weight_only_qconfig)
 
 def is_activation_post_process(module):
-    return (isinstance(module, torch.quantization.ObserverBase) or
-            isinstance(module, torch.quantization.FakeQuantizeBase))
+    return (isinstance(module, torch.ao.quantization.ObserverBase) or
+            isinstance(module, torch.ao.quantization.FakeQuantizeBase))
 
 def _propagate_qconfig_helper(module, qconfig_dict, allow_list=None,
                               qconfig_parent=None, prefix=''):
@@ -54,7 +54,7 @@ def _propagate_qconfig_helper(module, qconfig_dict, allow_list=None,
     module_qconfig = qconfig_dict.get(prefix, module_qconfig)
     module_qconfig = getattr(module, 'qconfig', module_qconfig)
 
-    torch.quantization.qconfig.assert_valid_qconfig(module_qconfig, module)
+    torch.ao.quantization.qconfig.assert_valid_qconfig(module_qconfig, module)
 
     qconfig_with_device_check = add_module_to_qconfig_obs_ctr(module_qconfig, module)
     module.qconfig = qconfig_with_device_check

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -150,13 +150,13 @@ def _prepare_fx(model: torch.nn.Module,
     r""" Internal helper function for prepare_fx
     Args:
       `model`, `qconfig_dict`, `prepare_custom_config_dict`, `equalization_qonfig_dict`:
-      see docs for :func:`~torch.quantization.prepare_fx`
+      see docs for :func:`~torch.ao.quantization.prepare_fx`
       `is_standalone_module`: a boolean flag indicates whether we are
       quantizing a standalone module or not, a standalone module
       is a submodule of the parent module that is not inlined in the
 forward graph of the parent module,
       the way we quantize standalone module is described in:
-      :func:`~torch.quantization._prepare_standalone_module_fx`
+      :func:`~torch.ao.quantization._prepare_standalone_module_fx`
     """
     if prepare_custom_config_dict is None:
         prepare_custom_config_dict = {}
@@ -235,7 +235,7 @@ def _prepare_standalone_module_fx(
 def fuse_fx(model: torch.nn.Module,
             fuse_custom_config_dict: Dict[str, Any] = None) -> GraphModule:
     r""" Fuse modules like conv+bn, conv+bn+relu etc, model must be in eval mode.
-    Fusion rules are defined in torch.quantization.fx.fusion_pattern.py
+    Fusion rules are defined in torch.ao.quantization.fx.fusion_pattern.py
     Args:
         `model`: a torch.nn.Module model
         `fuse_custom_config_dict`: Dictionary for custom configurations for fuse_fx, e.g.
@@ -253,7 +253,7 @@ def fuse_fx(model: torch.nn.Module,
 
     Example:
     ```python
-    from torch.quantization import fuse_fx
+    from torch.ao.quantization import fuse_fx
     m = Model().eval()
     m = fuse_fx(m)
     ```
@@ -412,8 +412,8 @@ def prepare_fx(
     Example:
     ```python
     import torch
-    from torch.quantization import get_default_qconfig
-    from torch.quantization import prepare_fx
+    from torch.ao.quantization import get_default_qconfig
+    from torch.ao.quantization import prepare_fx
 
     float_model.eval()
     qconfig = get_default_qconfig('fbgemm')
@@ -446,9 +446,9 @@ def prepare_qat_fx(
     r""" Prepare a model for quantization aware training
     Args:
       `model`: torch.nn.Module model, must be in train mode
-      `qconfig_dict`: see :func:`~torch.quantization.prepare_fx`
-      `prepare_custom_config_dict`: see :func:`~torch.quantization.prepare_fx`
-      `backend_config_dict`: see :func:`~torch.quantization.prepare_fx`
+      `qconfig_dict`: see :func:`~torch.ao.quantization.prepare_fx`
+      `prepare_custom_config_dict`: see :func:`~torch.ao.quantization.prepare_fx`
+      `backend_config_dict`: see :func:`~torch.ao.quantization.prepare_fx`
 
     Return:
       A GraphModule with fake quant modules (configured by qconfig_dict), ready for
@@ -457,8 +457,8 @@ def prepare_qat_fx(
     Example:
     ```python
     import torch
-    from torch.quantization import get_default_qat_qconfig
-    from torch.quantization import prepare_fx
+    from torch.ao.quantization import get_default_qat_qconfig
+    from torch.ao.quantization import prepare_fx
 
     qconfig = get_default_qat_qconfig('fbgemm')
     def train_loop(model, train_data):
@@ -487,7 +487,7 @@ def _convert_fx(
         convert_custom_config_dict: Dict[str, Any] = None,
         is_standalone_module: bool = False,
         _remove_qconfig: bool = True) -> QuantizedGraphModule:
-    """ `is_standalone_module`: see docs in :func:`~torch.quantization.prepare_standalone_module_fx`
+    """ `is_standalone_module`: see docs in :func:`~torch.ao.quantization.prepare_standalone_module_fx`
     """
     if convert_custom_config_dict is None:
         convert_custom_config_dict = {}
@@ -568,7 +568,7 @@ def convert_fx(
 def _convert_standalone_module_fx(
         graph_module: GraphModule, is_reference: bool = False,
         convert_custom_config_dict: Dict[str, Any] = None) -> QuantizedGraphModule:
-    r""" [Internal use only] Convert a model produced by :func:`~torch.quantization.prepare_standalone_module_fx`
+    r""" [Internal use only] Convert a model produced by :func:`~torch.ao.quantization.prepare_standalone_module_fx`
     and convert it to a quantized model
 
     Returns a quantized standalone module, whether input/output is quantized is

--- a/torch/ao/quantization/quantize_jit.py
+++ b/torch/ao/quantization/quantize_jit.py
@@ -1,7 +1,7 @@
 
 import torch
-from torch.quantization.qconfig import QConfig
-from torch.quantization.quant_type import QuantType
+from torch.ao.quantization.qconfig import QConfig
+from torch.ao.quantization.quant_type import QuantType
 from torch.jit._recursive import wrap_cpp_module
 
 def _check_is_script_module(model):
@@ -150,8 +150,8 @@ def quantize_jit(model, qconfig_dict, run_fn, run_args, inplace=False, debug=Fal
     Example:
     ```python
     import torch
-    from torch.quantization import get_default_qconfig
-    from torch.quantization import quantize_jit
+    from torch.ao.quantization import get_default_qconfig
+    from torch.ao.quantization import quantize_jit
 
     ts_model = torch.jit.script(float_model.eval())  # or torch.jit.trace(float_model, input)
     qconfig = get_default_qconfig('fbgemm')
@@ -180,7 +180,7 @@ def quantize_dynamic_jit(model, qconfig_dict, inplace=False, debug=False):
         `model`: input float TorchScript model
         `qconfig_dict`: qconfig_dict is a dictionary with names of sub modules as key and
         qconfig for that module as value, please see detailed
-        descriptions in :func:`~torch.quantization.quantize_jit`
+        descriptions in :func:`~torch.ao.quantization.quantize_jit`
         `inplace`: carry out model transformations in-place, the original module is
         mutated
         `debug`: flag for producing a debug friendly model (preserve weight attribute)
@@ -191,8 +191,8 @@ def quantize_dynamic_jit(model, qconfig_dict, inplace=False, debug=False):
     Example:
     ```python
     import torch
-    from torch.quantization import per_channel_dynamic_qconfig
-    from torch.quantization import quantize_dynmiac_jit
+    from torch.ao.quantization import per_channel_dynamic_qconfig
+    from torch.ao.quantization import quantize_dynmiac_jit
 
     ts_model = torch.jit.script(float_model.eval())  # or torch.jit.trace(float_model, input)
     qconfig = get_default_qconfig('fbgemm')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66058
* #66057

After the initial migration from `torch.quantization` to `torch.ao.quantization`, some of the files did not change.
This happened because the migration was done in parallel, and some of the files were landed while the others were still in the original location.
This is the last fix in the AO migration phase 1, which completely enables the ao.quantization namespace.

Test Plan:

`python test/test_quantization.py`

Differential Revision: [D31366066](https://our.internmc.facebook.com/intern/diff/D31366066)