### PR TITLE
[PyTorch Edge][Model Loading] Load Models with Mmap

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1266,6 +1266,7 @@ filegroup(
         "caffe2/serialize/file_adapter.cc",
         "caffe2/serialize/inline_container.cc",
         "caffe2/serialize/istream_adapter.cc",
+        "caffe2/serialize/mmap_storage_region.cc",
         "caffe2/serialize/read_adapter_interface.cc",
     ],
 )

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -80,7 +80,7 @@ PyTorchStreamReader::PyTorchStreamReader(
     std::shared_ptr<ReadAdapterInterface> in,
     c10::optional<intrusive_ptr<MmapStorageRegion>> mmapping)
     : ar_(std::make_unique<mz_zip_archive>()), in_(std::move(in)),
-      mmapping_(mmapping) {
+      mmapping_(std::move(mmapping)) {
   init();
 }
 

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -11,8 +11,10 @@
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Backend.h>
+#include <c10/util/Optional.h>
 
 #include "caffe2/serialize/istream_adapter.h"
+#include "caffe2/serialize/mmap_storage_region.h"
 #include "caffe2/serialize/read_adapter_interface.h"
 #include "caffe2/serialize/versions.h"
 
@@ -98,6 +100,9 @@ class TORCH_API PyTorchStreamReader final {
   explicit PyTorchStreamReader(const std::string& file_name);
   explicit PyTorchStreamReader(std::istream* in);
   explicit PyTorchStreamReader(std::shared_ptr<ReadAdapterInterface> in);
+  explicit PyTorchStreamReader(
+    std::shared_ptr<ReadAdapterInterface> in,
+    c10::optional<intrusive_ptr<MmapStorageRegion>> mmapping);
 
   // return dataptr, size
   std::tuple<at::DataPtr, size_t> getRecord(const std::string& name);
@@ -124,6 +129,7 @@ class TORCH_API PyTorchStreamReader final {
   std::shared_ptr<ReadAdapterInterface> in_;
   int64_t version_;
   std::mutex reader_lock_;
+  c10::optional<intrusive_ptr<MmapStorageRegion>> mmapping_;
 };
 
 class TORCH_API PyTorchStreamWriter final {

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -521,7 +521,8 @@ mobile::Module _load_for_mobile(
       ? c10::optional<c10::intrusive_ptr<caffe2::serialize::MmapStorageRegion>>(
             c10::make_intrusive<caffe2::serialize::MmapStorageRegion>(filename))
       : c10::nullopt;
-  auto module = _load_for_mobile(std::move(rai), mmapping, device, extra_files);
+  auto module = _load_for_mobile(
+      std::move(rai), std::move(mmapping), device, extra_files);
   return module;
 }
 
@@ -537,7 +538,11 @@ mobile::Module _load_for_mobile(
             c10::make_intrusive<caffe2::serialize::MmapStorageRegion>(filename))
       : c10::nullopt;
   auto module = _load_for_mobile_impl(
-      std::move(rai), mmapping, device, extra_files, module_load_options);
+      std::move(rai),
+      std::move(mmapping),
+      device,
+      extra_files,
+      module_load_options);
   return module;
 }
 
@@ -558,7 +563,7 @@ mobile::Module _load_for_mobile(
     ExtraFilesMap& extra_files) {
   auto module = _load_for_mobile_impl(
       std::move(rai),
-      mmapping,
+      std::move(mmapping),
       device,
       extra_files,
       _default_mobile_module_load_options);
@@ -587,8 +592,8 @@ mobile::Module _load_for_mobile_impl(
   }
 
   const size_t model_size = rai != nullptr ? rai->size() : 0;
-  auto reader =
-      torch::make_unique<PyTorchStreamReader>(std::move(rai), mmapping);
+  auto reader = torch::make_unique<PyTorchStreamReader>(
+      std::move(rai), std::move(mmapping));
   BytecodeDeserializer deserializer(std::move(reader), module_load_options);
 
   std::string error_message;

--- a/torch/csrc/jit/mobile/import.h
+++ b/torch/csrc/jit/mobile/import.h
@@ -4,7 +4,9 @@
 #include <istream>
 #include <memory>
 
+#include <c10/util/intrusive_ptr.h>
 #include <caffe2/serialize/file_adapter.h>
+#include <caffe2/serialize/mmap_storage_region.h>
 
 namespace torch {
 namespace jit {
@@ -27,6 +29,13 @@ TORCH_API mobile::Module _load_for_mobile(
 TORCH_API mobile::Module _load_for_mobile(
     const std::string& filename,
     c10::optional<at::Device> device,
+    ExtraFilesMap& extra_files);
+
+TORCH_API mobile::Module _load_for_mobile(
+    std::unique_ptr<ReadAdapterInterface> rai,
+    c10::optional<at::intrusive_ptr<caffe2::serialize::MmapStorageRegion>>
+        mmapping,
+    c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files);
 
 TORCH_API mobile::Module _load_for_mobile(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66075
* #66074

Use mmap rather than eagerly reading all the data

This change results in approximately 22% and 27% speedup in model loading time on Galaxy S8 and Pixel 3a devices respectively when run against an 87MB speech model that jiatong provided (as in D29826210)

Differential Revision: [D30812912](https://our.internmc.facebook.com/intern/diff/D30812912/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D30812912/)!