### PR TITLE
Remove unused `dump` method from VSX vec256 methods

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_double_vsx.h
@@ -356,11 +356,6 @@ class Vectorized<ComplexDbl> {
     return {vec_sqrt(_vec0), vec_sqrt(_vec1)};
   }
 
-  void dump() const {
-    std::cout << _vec0[0] << "," << _vec0[1] << ",";
-    std::cout << _vec1[0] << "," << _vec1[1] << std::endl;
-  }
-
   Vectorized<ComplexDbl> sqrt() const {
     return map(std::sqrt);
   }

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_float_vsx.h
@@ -144,7 +144,6 @@ class Vectorized<ComplexFlt> {
     // convert std::complex<V> index mask to V index mask: xy -> xxyy
     auto mask_complex = Vectorized<ComplexFlt>(
         vec_mergeh(mask._vec0, mask._vec0), vec_mergeh(mask._vec1, mask._vec1));
-    // mask_complex.dump();
     return {
         vec_sel(a._vec0, b._vec0, mask_complex._vec0),
         vec_sel(a._vec1, b._vec1, mask_complex._vec1),
@@ -407,13 +406,6 @@ class Vectorized<ComplexFlt> {
 
   Vectorized<ComplexFlt> elwise_sqrt() const {
     return {vec_sqrt(_vec0), vec_sqrt(_vec1)};
-  }
-
-  void dump() const {
-    std::cout << _vec0[0] << "," << _vec0[1] << "," << _vec0[2] << ","
-              << _vec0[3] << ",";
-    std::cout << _vec1[0] << "," << _vec1[1] << "," << _vec1[2] << ","
-              << _vec1[3] << std::endl;
   }
 
   Vectorized<ComplexFlt> sqrt() const {

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
@@ -188,9 +188,6 @@ class Vectorized<double> {
   }
   const double& operator[](int idx) const = delete;
   double& operator[](int idx) = delete;
-  void dump() const {
-      std::cout << _vec0[0] << "," << _vec0[1] << "," << _vec1[0] << "," << _vec1[1] << std::endl;
-  }
   Vectorized<double> map(double (*const f)(double)) const {
     Vectorized<double> ret;
     for (int i = 0; i < size()/2; i++) {

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
@@ -436,13 +436,6 @@ class Vectorized<float> {
     return {vec_neg(_vec0), vec_neg(_vec1)};
   }
 
-  void dump() const {
-    std::cout << _vec0[0] << "," << _vec0[1] << "," << _vec0[2] << ","
-              << _vec0[3] << ",";
-    std::cout << _vec1[0] << "," << _vec1[1] << "," << _vec1[2] << ","
-              << _vec1[3] << std::endl;
-  }
-
   Vectorized<float> C10_ALWAYS_INLINE round() const {
     return {vec_round(_vec0), vec_round(_vec1)};
   }

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_quint8_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_quint8_vsx.h
@@ -369,15 +369,6 @@ struct Vectorized<c10::quint8> {
     return {vec0, vec1};
   }
 
-  void dump() const {
-    value_type vals[size()];
-    store((void*)vals);
-    for (int i = 0; i < size(); ++i) {
-      std::cout << (int)(vals[i]) << " ";
-    }
-    std::cout << std::endl;
-  }
-
   DEFINE_MEMBER_OP(operator==, c10::quint8, vec_cmpeq)
   DEFINE_MEMBER_OP(operator!=, c10::quint8, vec_cmpne)
   DEFINE_MEMBER_OP(operator<, c10::quint8, vec_cmplt)


### PR DESCRIPTION
Follow up after https://github.com/pytorch/pytorch/pull/63533

Probably fixes https://github.com/pytorch/pytorch/issues/65956

