### PR TITLE
Fix gcc11 build error in ir_emitter.cpp

### DIFF
--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1678,7 +1678,7 @@ struct to_ir {
               << "Union type annotation `" << type_hint->repr_str()
               << "` can hold " << vector_repr.str() << ", but none of "
               << "those list types can hold the types of the given dict"
-              << " elements, which were unified to " << candidate->repr_str();
+              << " elements.";
         } else {
           refined_type_hint = candidate;
         }


### PR DESCRIPTION
```
../torch/csrc/jit/frontend/ir_emitter.cpp: In lambda function:
../torch/csrc/jit/frontend/ir_emitter.cpp:1681:76: error: 'this' pointer is null [-Werror=nonnull]
 1681 |               << " elements, which were unified to " << candidate->repr_str();
      |                                                         ~~~~~~~~~~~~~~~~~~~^~
cc1plus: some warnings being treated as errors
```