### PR TITLE
Update link to example pytorch/examples

### DIFF
--- a/docs/cpp/source/frontend.rst
+++ b/docs/cpp/source/frontend.rst
@@ -103,7 +103,7 @@ neural network on the MNIST dataset:
   }
 
 To see more complete examples of using the PyTorch C++ frontend, see `the example repository
-<https://github.com/goldsborough/examples/tree/cpp/cpp>`_.
+<https://github.com/pytorch/examples/tree/master/cpp>`_.
 
 Philosophy
 ----------

--- a/docs/cpp/source/index.rst
+++ b/docs/cpp/source/index.rst
@@ -105,7 +105,7 @@ namespace related to the C++ Frontend include `torch::nn
 and `torch::python
 <https://pytorch.org/cppdocs/api/namespace_torch__python.html#namespace-torch-python>`_.
 Examples of the C++ frontend can be found in `this repository
-<https://github.com/goldsborough/examples/tree/cpp/cpp>`_ which is being
+<https://github.com/pytorch/examples/tree/master/cpp>`_ which is being
 expanded on a continuous and active basis.
 
 .. note::


### PR DESCRIPTION
`https://github.com/goldsborough/examples/tree/cpp/cpp` -> `https://github.com/pytorch/examples/tree/master/cpp`
As C++ examples in  https://github.com/pytorch/examples are more update

Partially addresses https://github.com/pytorch/pytorch/issues/65388
