### PR TITLE
[Vulkan] cat operator for height dimension

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Helper.cpp
+++ b/aten/src/ATen/native/vulkan/api/Helper.cpp
@@ -1,0 +1,41 @@
+#include <ATen/native/vulkan/api/Helper.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+namespace helper {
+
+#ifdef USE_VULKAN_API
+
+void copy_texture_to_texture(
+    api::Command::Buffer& command_buffer,
+    api::Resource::Image::Object& src_image,
+    api::Resource::Image::Object& dst_image,
+    api::utils::uvec3 src_extents,
+    api::utils::uvec3 dst_offset) {
+  VkImageCopy copy_info{};
+  copy_info.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  copy_info.srcSubresource.layerCount = 1;
+  copy_info.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  copy_info.dstSubresource.layerCount = 1;
+  copy_info.extent.width = src_extents.data[0u];
+  copy_info.extent.height = src_extents.data[1u];
+  copy_info.extent.depth = src_extents.data[2u];
+  copy_info.dstOffset.y = dst_offset.data[1u];
+
+  vkCmdCopyImage(
+    command_buffer.handle(),
+    src_image.handle, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+    dst_image.handle, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+    1,
+    &copy_info);
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace helper
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/api/Helper.h
+++ b/aten/src/ATen/native/vulkan/api/Helper.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Command.h>
+#include <ATen/native/vulkan/api/Resource.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+namespace helper {
+//
+// Copy Texture
+//
+
+void copy_texture_to_texture(
+    api::Command::Buffer& command_buffer,
+    api::Resource::Image::Object& src_image,
+    api::Resource::Image::Object& dst_image,
+    api::utils::uvec3 src_extents,
+    api::utils::uvec3 dst_offset);
+
+} // namespace utils
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -1,0 +1,128 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/api/Helper.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+namespace {
+inline int64_t normalize_dim(int64_t d, int64_t n) {
+  return (d % n + n) % n;
+}
+} // namespace
+
+Tensor cat_batch(const TensorList tensors, vTensor& v_output) {
+  TORCH_CHECK(false, "Vulkan cat not implemented for batch dimension!");
+}
+
+Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
+  TORCH_CHECK(false, "Vulkan cat not implemented for feature dimension!");
+}
+
+Tensor cat_width(const TensorList tensors, vTensor& v_output) {
+  TORCH_CHECK(false, "Vulkan cat not implemented for width dimension!");
+}
+
+Tensor cat_height(const TensorList tensors, vTensor& v_output) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  auto dst_image = v_output.image(
+    command_buffer,
+    vTensor::Stage::Compute,
+    vTensor::Access::Write);
+
+  uvec3 dst_offset{};
+  for (const auto& tensor : tensors) {
+    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Compute);
+
+      api::helper::copy_texture_to_texture(command_buffer,
+        src_image,
+        dst_image,
+        v_self.extents(),
+        dst_offset);
+
+      // Increment by height
+      dst_offset.data[1u] += v_self.extents().data[1u];
+    }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+
+  return convert(v_output);
+}
+
+Tensor cat(
+  const at::TensorList tensors,
+  const int64_t dim) {
+  const auto norm_dim = normalize_dim(dim, 4);
+  TORCH_CHECK(
+    tensors.size() > 0,
+    "Vulkan cat expects at least one tensor");
+
+  at::Tensor tensor = tensors[0];
+  int64_t cat_dim_size = 0;
+
+  for (int i = 0; i < tensors.size(); ++i) {
+    const auto& t = tensors[i];
+    TORCH_INTERNAL_ASSERT(
+      t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
+
+    for (int d = 0; d < 4; ++d) {
+      if (d == dim) {
+        continue;
+      }
+      TORCH_INTERNAL_ASSERT(
+        t.size(d) == tensor.size(d),
+        "Vulkan cat inputs must have matching sizes except concatenated dimension");
+    }
+    cat_dim_size += t.size(dim);
+  }
+
+  auto result_size = tensor.sizes().vec();
+  result_size[dim] = cat_dim_size;
+
+  vTensor v_output{
+    api::context(),
+    result_size,
+    tensor.options()};
+
+  if (dim == 3) {
+    return cat_width(tensors, v_output);
+  }
+  if (dim == 2) {
+    return cat_height(tensors, v_output);
+  }
+  else if (dim == 1) {
+    return cat_feature(tensors, v_output);
+  }
+  return cat_batch(tensors, v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl("_cat", TORCH_FN(cat));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Summary: Implemented `cat` operator for height dimension

Test Plan:
On Mac
```
cd ~/fbsource
buck build //xplat/caffe2:pt_vulkan_api_test_binAppleMac
./buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAppleMac\#macosx-x86_64

[ RUN      ] VulkanAPITest.cat_dim2_sameheight_success
[       OK ] VulkanAPITest.cat_dim2_sameheight_success (272 ms)
[ RUN      ] VulkanAPITest.cat_dim2_diffheight_success
[       OK ] VulkanAPITest.cat_dim2_diffheight_success (161 ms)
[ RUN      ] VulkanAPITest.cat_dim2_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_dim2_invalidinputs_exceptions (235 ms)
```

On Android
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"

[ RUN      ] VulkanAPITest.cat_dim2_sameheight_success
[       OK ] VulkanAPITest.cat_dim2_sameheight_success (98 ms)
[ RUN      ] VulkanAPITest.cat_dim2_diffheight_success
[       OK ] VulkanAPITest.cat_dim2_diffheight_success (105 ms)
[ RUN      ] VulkanAPITest.cat_dim2_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_dim2_invalidinputs_exceptions (101 ms)
```

Differential Revision: D31323141

