### PR TITLE
[LTC] Code-gen gelu and gelu_backward

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
@@ -372,24 +372,6 @@ NodePtr EluBackward(const Value& grad_output, const Value& output,
                positive_output_branch, negative_output_branch);
 }
 
-NodePtr Gelu(const Value& input) {
-  ScopePusher ir_scope("aten::gelu");
-  // input * 0.5 * (1.0 + torch.erf(input / math.sqrt(2.0)))
-  const lazy_tensors::Shape& shape = input.shape();
-  return input * ScalarOp(0.5, shape) *
-         (Erf(input * ScalarOp(M_SQRT1_2, shape)) + ScalarOp(1.0, shape));
-}
-
-NodePtr GeluBackward(const Value& grad, const Value& input) {
-  ScopePusher ir_scope("aten::gelu_backward");
-  const float kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
-  const lazy_tensors::Shape& shape = input.shape();
-  NodePtr scratch = Erf(input * ScalarOp(M_SQRT1_2, shape));
-  NodePtr dinput = Exp(input * input * ScalarOp(-0.5, shape));
-  return grad * (ScalarOp(0.5, shape) * (ScalarOp(1.0, shape) + scratch) +
-                 input * dinput * ScalarOp(kAlpha, shape));
-}
-
 NodePtr Lshift(const Value& input, const at::Scalar& other) {
   ScopePusher ir_scope(at::aten::__lshift__.toQualString());
   return input * ScalarOp(pow(2, other.to<double>()), input.shape());

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
@@ -189,10 +189,6 @@ NodePtr EluBackward(const Value& grad_output, const Value& output,
                     const at::Scalar& alpha, const at::Scalar& scale,
                     const at::Scalar& input_scale);
 
-NodePtr Gelu(const Value& input);
-
-NodePtr GeluBackward(const Value& grad, const Value& input);
-
 NodePtr Lshift(const Value& input, const at::Scalar& other);
 
 NodePtr Lshift(const Value& input, const Value& other);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -565,10 +565,6 @@ class LazyTensor {
 
   static LazyTensor ge(const LazyTensor& input, const LazyTensor& other);
 
-  static LazyTensor gelu(const LazyTensor& input);
-  static LazyTensor gelu_backward(const LazyTensor& grad,
-                                  const LazyTensor& input);
-
   static LazyTensor ger(const LazyTensor& input, const LazyTensor& vec2);
 
   static LazyTensor gt(const LazyTensor& input, const at::Scalar& other);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -1282,16 +1282,6 @@ LazyTensor LazyTensor::ge(const LazyTensor& input, const LazyTensor& other) {
   return DispatchComparisonOp(at::aten::ge, input, other);
 }
 
-LazyTensor LazyTensor::gelu(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::Gelu(input.GetIrValue()));
-}
-
-LazyTensor LazyTensor::gelu_backward(const LazyTensor& grad,
-                                     const LazyTensor& input) {
-  return input.CreateFrom(
-      ir::ops::GeluBackward(grad.GetIrValue(), input.GetIrValue()));
-}
-
 LazyTensor LazyTensor::ger(const LazyTensor& input, const LazyTensor& vec2) {
   return input.CreateFrom(ir::ops::Ger(input.GetIrValue(), vec2.GetIrValue()));
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -511,19 +511,6 @@ at::Tensor LazyNativeFunctions::ge(const at::Tensor& self,
       LazyTensor::ge(bridge::GetLtcTensor(self), bridge::GetLtcTensor(other)));
 }
 
-at::Tensor LazyNativeFunctions::gelu(const at::Tensor& self) {
-  LTC_FN_COUNTER("lazy::");
-  return bridge::AtenFromLtcTensor(
-      LazyTensor::gelu(bridge::GetLtcTensor(self)));
-}
-
-at::Tensor LazyNativeFunctions::gelu_backward(const at::Tensor& grad,
-                                              const at::Tensor& self) {
-  LTC_FN_COUNTER("lazy::");
-  return bridge::AtenFromLtcTensor(LazyTensor::gelu_backward(
-      bridge::GetLtcTensor(grad), bridge::GetLtcTensor(self)));
-}
-
 at::Tensor LazyNativeFunctions::gt(const at::Tensor& self,
                                    const at::Scalar& other) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -2,10 +2,12 @@ backend: Lazy
 cpp_namespace: torch_lazy_tensors
 full_codegen:
   - _log_softmax
-  - mean
   - addcdiv
   - addcmul
   - cos
+  - gelu
+  - gelu_backward
+  - mean
   - mm
   - mv
   # - mv.out
@@ -40,8 +42,6 @@ supported:
   - native_batch_norm_backward
   - nll_loss_backward
   - nll_loss_forward
-  - gelu
-  - gelu_backward
   - max_pool2d_with_indices
   - max_pool2d_with_indices_backward
   - max_pool3d_with_indices


### PR DESCRIPTION
Summary:
This commit code-gen gelu and gelu_backward.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestGelu*

Fixes #65837.
