### PR TITLE
[LTC] Code-gen dropout

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
@@ -16,9 +16,18 @@ namespace torch_lazy_tensors{
 namespace ir {
 namespace ops {
 
+std::vector<int64_t> compute_shape_dropout(const at::Tensor& input, double p, bool train) {
+  return input.sizes().vec();
+}
+
+c10::ScalarType compute_dtype_dropout(const at::Tensor& input, double p, bool train) {
+  return input.scalar_type();
+}
+
 std::vector<int64_t> compute_shape_mean(const at::Tensor& self, c10::optional<at::ScalarType> dtype) {
   return std::vector<int64_t>({1});
 }
+
 c10::ScalarType compute_dtype_mean(const at::Tensor& self, c10::optional<at::ScalarType> dtype) {
   if (dtype.has_value()) {
     return dtype.value();
@@ -26,11 +35,11 @@ c10::ScalarType compute_dtype_mean(const at::Tensor& self, c10::optional<at::Sca
   return self.scalar_type();
 }
 
-std::vector<int64_t> compute_shape_mv(const at::Tensor & self, const at::Tensor & vec) {
+std::vector<int64_t> compute_shape_mv(const at::Tensor& self, const at::Tensor& vec) {
   return std::vector<int64_t>({self.size(0)});
 }
 
-c10::ScalarType compute_dtype_mv(const at::Tensor & self, const at::Tensor & vec) {
+c10::ScalarType compute_dtype_mv(const at::Tensor& self, const at::Tensor& vec) {
   return self.scalar_type();
 }
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -5,6 +5,7 @@ full_codegen:
   - addcdiv
   - addcmul
   - cos
+  - dropout
   - gelu
   - gelu_backward
   - mean

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -5,7 +5,7 @@ from tools.codegen.model import (Type, BaseTy, BaseType, OptionalType,
 from tools.codegen.api.types import (BaseCppType, BaseCType, OptionalCType,
                                      ConstRefCType, NamedCType,
                                      MutRefCType,
-                                     VectorCType, boolT, intT, ListCType,
+                                     VectorCType, boolT, intT, doubleT, ListCType,
                                      scalarT, scalarTypeT, ArrayRefCType, ArrayCType, TupleCType)
 
 valueT = BaseCppType('ir', 'Value')
@@ -38,6 +38,8 @@ def process_ir_type(typ: Type) -> Union[BaseCType, VectorCType, OptionalCType, L
             return BaseCType(intT)
         elif typ.name == BaseTy.bool:
             return BaseCType(boolT)
+        elif typ.name == BaseTy.float:
+            return BaseCType(doubleT)
         else:
             raise AssertionError(f"TODO add support for type {repr(typ)}")
     elif isinstance(typ, OptionalType):


### PR DESCRIPTION
Summary:
This patch code-gen dropout.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestDropout*

Fixes #65837.
