### PR TITLE
[vulkan] Remove uniform buffer arg from winograd convolutions

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -806,8 +806,7 @@ void Conv2dOpContext::conv2d_winograd_2_3(
             vTensor::Stage::Compute),
         packed_.v_bias.buffer(
             command_buffer,
-            vTensor::Stage::Compute),
-        context->resource().pool.uniform(block).object);
+            vTensor::Stage::Compute));
   }
   command_pool.submit(context->gpu().queue, command_buffer);
 }


### PR DESCRIPTION
Summary: Forgot to remove a uniform block object argument in D30368834 (https://github.com/pytorch/pytorch/commit/57e5ae530651b8ce55daf1213ab23a28f10d242c), fixing it here.

Test Plan: Build and run `vulkan_api_test`

Differential Revision: D31382828

