### PR TITLE
[LTC] Autogen sigmoid and rsqrt for TS backend

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -944,8 +944,6 @@ class LazyTensor {
                                               const at::Scalar& upper,
                                               bool training);
 
-  static LazyTensor rsqrt(const LazyTensor& input);
-
   static LazyTensor rsub(
       const LazyTensor& input, const LazyTensor& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
@@ -975,7 +973,7 @@ class LazyTensor {
                            lazy_tensors::int64 index);
 
   static void silu_out(LazyTensor& input, LazyTensor& out);
-  static LazyTensor sigmoid(const LazyTensor& input);
+
   static LazyTensor sigmoid_backward(const LazyTensor& grad_output,
                                      const LazyTensor& output);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -2159,10 +2159,6 @@ LazyTensor LazyTensor::rrelu_with_noise_backward(const LazyTensor& grad_output,
       upper, training));
 }
 
-LazyTensor LazyTensor::rsqrt(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::Rsqrt(input.GetIrValue()));
-}
-
 LazyTensor LazyTensor::rsub(
     const LazyTensor& input, const LazyTensor& other, const at::Scalar& alpha,
     c10::optional<at::ScalarType> logical_element_type) {
@@ -2257,10 +2253,6 @@ LazyTensor LazyTensor::select(const LazyTensor& input, lazy_tensors::int64 dim,
 
 void LazyTensor::silu_out(LazyTensor& input, LazyTensor& out) {
   out.SetInPlaceIrValue(ir::ops::SiLU(input.GetIrValue()));
-}
-
-LazyTensor LazyTensor::sigmoid(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::Sigmoid(input.GetIrValue()));
 }
 
 LazyTensor LazyTensor::sigmoid_backward(const LazyTensor& grad_output,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -16,6 +16,8 @@ full_codegen:
   - mv
   - native_layer_norm
   - native_layer_norm_backward
+  - rsqrt
+  - sigmoid
   - topk
 supported:
   - add.Tensor


### PR DESCRIPTION
Adds `full_codegen` support for `sigmoid` and `rsqrt` ops using the same approach used in #64104 to add codegen support for `cos`.

Verified with the following script:

```python
import torch
import lazy_tensor_core as ltc
from lazy_tensor_core.debug import metrics

ltc._LAZYC._ltc_init_ts_backend()
device = 'lazy'
dtype = torch.float32

x = torch.randn((2,3,4), device=device, dtype=dtype)

def computation(x):
    return x.sigmoid() * x.rsqrt()

computation(x)
print(metrics.metrics_report())
```

Output:

```
Metric: IrValueTensorToDataHandle
  TotalSamples: 1
  Accumulator: 009.717us
  Percentiles: 1%=009.717us; 5%=009.717us; 10%=009.717us; 20%=009.717us; 50%=009.717us; 80%=009.717us; 90%=009.717us; 95%=009.717us; 99%=009.717us
Counter: CreateLtcTensor
  Value: 7
Counter: DestroyLtcTensor
  Value: 6
Counter: aten::normal_
  Value: 1
Counter: lazy::_copy_from
  Value: 1
Counter: lazy::_copy_from_and_resize
  Value: 1
Counter: lazy::mul
  Value: 2
Counter: lazy::rsqrt
  Value: 2
Counter: lazy::sigmoid
  Value: 2
```