### PR TITLE
[ONNX] Fix duplicated output same name case (#64190)

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -933,6 +933,52 @@ class TestUtilityFuns(TestCase):
             assert node.kind() != "prim::Constant"
         assert len(list(graph.nodes())) == 2  # onnx::Sub and onnx::Add nodes only.
 
+    def test_duplicated_output_node(self):
+        class DuplicatedOutputNet(torch.nn.Module):
+            def __init__(self, input_size, num_classes):
+                super(DuplicatedOutputNet, self).__init__()
+                self.fc1 = torch.nn.Linear(input_size, num_classes)
+
+            def forward(self, input0, input1):
+                out1 = self.fc1(input0)
+                out2 = self.fc1(input1)
+                return out1, out1, out2, out1, out2
+
+        N, D_in, H, D_out = 64, 784, 500, 10
+        pt_model = DuplicatedOutputNet(D_in, D_out)
+
+        f = io.BytesIO()
+        x = torch.randn(N, D_in)
+        dynamic_axes = {
+            'input0': {0: 'input0_dim0', 1: 'input0_dim1'},
+            'input1': {0: 'input1_dim0', 1: 'input1_dim1'},
+            'output-0': {0: 'output-0_dim0', 1: 'output-0_dim1'},
+            'output-1': {0: 'output-1_dim0', 1: 'output-1_dim1'},
+            'output-2': {0: 'output-2_dim0', 1: 'output-2_dim1'},
+            'output-3': {0: 'output-3_dim0', 1: 'output-3_dim1'},
+            'output-4': {0: 'output-4_dim0', 1: 'output-4_dim1'}}
+
+        torch.onnx.export(pt_model,
+                          (x, x),
+                          f,
+                          input_names=['input0', 'input1'],
+                          output_names=['output-0', 'output-1', 'output-2', 'output-3', 'output-4'],
+                          do_constant_folding=False,
+                          training=torch.onnx.TrainingMode.TRAINING,
+                          dynamic_axes=dynamic_axes,
+                          verbose=True,
+                          keep_initializers_as_inputs=True)
+
+        graph = onnx.load(io.BytesIO(f.getvalue()))
+        assert graph.graph.input[0].name == "input0"
+        assert graph.graph.input[1].name == "input1"
+        for i in range(5):
+            assert graph.graph.output[i].name == "output-" + str(i)
+        assert graph.graph.node[0].op_type == "Gemm"
+        assert graph.graph.node[1].op_type == "Identity"
+        assert graph.graph.node[2].op_type == "Identity"
+        assert graph.graph.node[3].op_type == "Gemm"
+        assert graph.graph.node[4].op_type == "Identity"
 
 # opset 10 tests
 TestUtilityFuns_opset10 = type(str("TestUtilityFuns_opset10"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66149 [ONNX] Update slice process shape to support rank only inference (#65782)
* #66148 [ONNX] Support exporting with Apex O2 (#65374)
* #66147 [ONNX] Symbolic: dynamic input for OneHot, bool for Einsum (#65940)
* #66146 [ONNX] Modify softplus symbolic to support beta!=1 (#65001)
* #66145 [ONNX] Deprecate fold_if pass (#65697)
* #66144 [ONNX] Add diagonal symbolic (#64454)
* #66143 ONNX: Delete or document skipped ORT tests (#64470)
* #66142 [ONNX] Add warning for inplace updates on tensor.shape in tracing mode (#63170)
* #66141 [ONNX] Update sum symbolic to handle dtypes (#64289)
* #66140 [ONNX] Export nn.Module call as ONNX local function (#63589)
* #66139 Allow registration of custom symbolics for prim namespace (#64460)
* #66138 [ONNX] Enable scripting tests (#64780)
* **#66137 [ONNX] Fix duplicated output same name case (#64190)**
* #66175 [ONNX] Support tensorList when Infers shape and type uninitialized output (#60534)

* fix duplicated output node same output name issue.

Co-authored-by: hwangdeyu <dejack953@outlook.com>

Differential Revision: [D31424100](https://our.internmc.facebook.com/intern/diff/D31424100)