### PR TITLE
Allow registration of custom symbolics for prim namespace (#64460)

### DIFF
--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -119,7 +119,7 @@ class TestCustomAutogradFunction(unittest.TestCase):
                 return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
 
         from torch.onnx import register_custom_op_symbolic
-        register_custom_op_symbolic("::prim_PythonOp", symbolic_pythonop, 1)
+        register_custom_op_symbolic("prim::PythonOp", symbolic_pythonop, 1)
 
         x = torch.randn(2, 3, 4, requires_grad=True)
         model = MyModule()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -37,6 +37,7 @@ from collections import OrderedDict
 
 from torch.nn.utils.rnn import PackedSequence
 from torch.onnx import register_custom_op_symbolic, unregister_custom_op_symbolic
+from torch.onnx.symbolic_helper import _unimplemented
 from torch.onnx.utils import ONNXCheckerError
 
 
@@ -3359,6 +3360,46 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.arange(1., 6., requires_grad=True)
         k = torch.tensor(3)
         self.run_test(MyModuleDynamic(), [x, k])
+
+    @disableScriptTest()  # Python builtin apply of FunctionMeta object is currently not supported in Torchscript.
+    @skipIfUnsupportedMinOpsetVersion(11)  # Clip op min is an input since opset 11.
+    def test_auto_grad(self):
+        class MyClip(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input, scalar):
+                ctx.save_for_backward(input)
+                return input.clamp(min=scalar)
+
+        class MyRelu(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input):
+                ctx.save_for_backward(input)
+                return input.clamp(min=0)
+
+        def symbolic_python_op(g: torch._C.Graph, n: torch._C.Node, *args, **kwargs):
+            name = kwargs["name"]
+            if name == "MyClip":
+                return g.op("Clip", args[0], args[1])
+            elif name == "MyRelu":
+                return g.op("Relu", args[0])
+            else:
+                return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
+
+        register_custom_op_symbolic("prim::PythonOp", symbolic_python_op, 1)
+        self.addCleanup(unregister_custom_op_symbolic, "prim::PythonOp", 1)
+
+        class MyClipModule(torch.nn.Module):
+            def forward(self, x, min):
+                return MyClip.apply(x, min)
+        x = torch.randn(3, 3)
+        min = torch.tensor([0.0])
+        self.run_test(MyClipModule(), (x, min))
+
+        class MyReluModule(torch.nn.Module):
+            def forward(self, x):
+                return MyRelu.apply(x)
+        x = torch.randn(3, 3)
+        self.run_test(MyReluModule(), x)
 
     @skipIfUnsupportedOpsetVersion([7])
     def test_normalize(self):

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -394,7 +394,7 @@ void NodeToONNX(
 
     py::object opset_version = onnx_symbolic.attr("_export_onnx_opset_version");
     py::object is_registered_op = onnx_registry.attr("is_registered_op")(
-        "prim_PythonOp", "", opset_version);
+        "PythonOp", "prim", opset_version);
     if (!py::hasattr(pyobj, "symbolic") &&
         (!PyObject_IsTrue(is_registered_op.ptr()))) {
       // Simply clone the node, unless either

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -69,13 +69,13 @@ void validateBlock(
   throw std::runtime_error(                        \
       std::string("ONNX export failed: ") + name + \
       "\n\nGraph we tried to export:\n" + b->owningGraph()->toString());
+    // Special error messages for certain types of operators
     if (node->kind() == prim::PythonOp) {
       auto py_node = static_cast<PythonOp*>(node);
       FAIL_EXPORT(
           "Couldn't export Python operator " + py_node->name() +
           "\n\nDefined at:\n" + getNodeStackTraceString(node))
     } else {
-      // Special error messages for certain types of operators
       if (node->kind() == aten::expand) {
         if (operator_export_type ==
             onnx_torch::OperatorExportTypes::ONNX_ATEN_FALLBACK) {
@@ -530,9 +530,7 @@ void EncoderBase::EncodeBlock(
       p_n->set_domain(domain);
     }
     if (operator_export_type_ == onnx_torch::OperatorExportTypes::ONNX) {
-      AT_ASSERT(
-          !node->kind().is_aten() && !node->kind().is_prim() &&
-          !node->kind().is_attr());
+      AT_ASSERT(!node->kind().is_aten() && !node->kind().is_attr());
     }
     p_n->set_op_type(node->kind().toUnqualString());
     if (add_node_names) {

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -36,8 +36,12 @@ def register_ops_helper(domain, version, iter_version):
             op = ("any", op[1])
         if op[0] == "_all":
             op = ("all", op[1])
-        if isfunction(op[1]) and not is_registered_op(op[0], domain, version):
-            register_op(op[0], op[1], domain, version)
+        domain_register = domain
+        if op[0].startswith("prim_"):
+            op = (op[0][5:], op[1])
+            domain_register = "prim"
+        if isfunction(op[1]) and not is_registered_op(op[0], domain_register, version):
+            register_op(op[0], op[1], domain_register, version)
 
 
 def register_ops_in_version(domain, version):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1142,14 +1142,15 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                         torch._C._jit_pass_onnx_node_shape_type_inference(new_node, _params_dict, opset_version)
                     return new_op_outputs
             else:
-                symbolic_name = "prim_" + op_name
-                domain = ""
-                symbolic_fn = _find_symbolic_in_registry(domain, symbolic_name, opset_version,
+                symbolic_fn = _find_symbolic_in_registry("prim", op_name, opset_version,
                                                          operator_export_type)
                 if symbolic_fn is None:
                     return None
                 attrs = {k: n[k] for k in n.attributeNames()}
-                if op_name == 'PythonOp':
+                # TODO: https://msdata.visualstudio.com/Vienna/_workitems/edit/1408006
+                # PythonOp symbolic need access thde node to resolve the name conflict,
+                # this is inconsistent with regular op symbolic.
+                if op_name == "PythonOp":
                     inputs = (n, *inputs)
                 return symbolic_fn(g, *inputs, **attrs)
 
@@ -1250,8 +1251,9 @@ def get_ns_op_name_from_custom_op(symbolic_name):
                            alphanumerical characters"
                            .format(symbolic_name))
     ns, op_name = symbolic_name.split("::")
-    unaccepted_domain_names = ["onnx", "aten", "prim"]
-    if ns in unaccepted_domain_names:
+    # TODO: Allow users to register custom symbolic in aten domain.
+    # https://msdata.visualstudio.com/Vienna/_workitems/edit/1407799
+    if ns in ("onnx", "aten"):
         raise RuntimeError("Failed to register operator {}. The domain {} is already a used domain."
                            .format(symbolic_name, ns))
     return ns, op_name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66149 [ONNX] Update slice process shape to support rank only inference (#65782)
* #66148 [ONNX] Support exporting with Apex O2 (#65374)
* #66147 [ONNX] Symbolic: dynamic input for OneHot, bool for Einsum (#65940)
* #66146 [ONNX] Modify softplus symbolic to support beta!=1 (#65001)
* #66145 [ONNX] Deprecate fold_if pass (#65697)
* #66144 [ONNX] Add diagonal symbolic (#64454)
* #66143 ONNX: Delete or document skipped ORT tests (#64470)
* #66142 [ONNX] Add warning for inplace updates on tensor.shape in tracing mode (#63170)
* #66141 [ONNX] Update sum symbolic to handle dtypes (#64289)
* #66140 [ONNX] Export nn.Module call as ONNX local function (#63589)
* **#66139 Allow registration of custom symbolics for prim namespace (#64460)**
* #66138 [ONNX] Enable scripting tests (#64780)
* #66137 [ONNX] Fix duplicated output same name case (#64190)
* #66175 [ONNX] Support tensorList when Infers shape and type uninitialized output (#60534)

[ONNX] Add prim::PythonOp check back in export.cpp (#64944)

Add prim::PythonOp check back in export.cpp

Co-authored-by: jiafatom <jiafa@microsoft.com>

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)

Differential Revision: [D31424102](https://our.internmc.facebook.com/intern/diff/D31424102)