### PR TITLE
torch.sparse.sum result has wrong dtype when reducing over all dimensions

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4861,16 +4861,11 @@
   dispatch:
     SparseCPU, SparseCUDA: norm_sparse
 
-# TODO: reduce signatures down to one when optional args is available
-- func: _sparse_sum(Tensor self) -> Tensor
+- func: _sparse_sum.dtype(Tensor self, *, ScalarType? dtype=None) -> Tensor
 
-- func: _sparse_sum.dtype(Tensor self, *, ScalarType dtype) -> Tensor
-
-- func: _sparse_sum.dim(Tensor self, int[1] dim) -> Tensor
+- func: _sparse_sum.dim_dtype(Tensor self, int[1] dim, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     CompositeExplicitAutograd: _sparse_sum
-
-- func: _sparse_sum.dim_dtype(Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
 
 - func: _sparse_sum_backward(Tensor grad, Tensor self, int[] dim) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1163,11 +1163,7 @@ Tensor sspaddmm(const Tensor& self, const Tensor& mat1, const Tensor& mat2,
 // sparse dims. Ideally in the future there should be unified reduction function
 // for ops like sum, max, and min.
 // --------------------------------------------------------------------
-Tensor _sparse_sum(const SparseTensor& input) {
-  return input.coalesce().values().sum();
-}
-
-Tensor _sparse_sum(const SparseTensor& input, ScalarType dtype) {
+Tensor _sparse_sum(const SparseTensor& input, c10::optional<ScalarType> dtype) {
   // don't have to do a conversion to the correct dtype first
   // just need to setup the accumulator correctly
   return input.coalesce().values().sum(dtype);
@@ -1203,8 +1199,9 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, c10::opti
   // new values
   Tensor new_values;
   if (sum_dense_dim) {
-      new_values = values.sum(dense_dims_to_sum_v, false, dtype);
-  } else {
+    new_values = values.sum(dense_dims_to_sum_v, false, dtype);
+  }
+  else {
     if (!dtype.has_value() && isIntegralType(input.scalar_type(), /*includeBool=*/false) && input.scalar_type() != ScalarType::Long) {
       new_values = values.to(ScalarType::Long, false, false, at::MemoryFormat::Contiguous);
     } else {
@@ -1246,14 +1243,6 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, c10::opti
     return new_sparse;
   }
 
-}
-
-Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, ScalarType dtype) {
-  return _sparse_sum(input, dims_to_sum, c10::optional<c10::ScalarType>(dtype));
-}
-
-Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
-  return _sparse_sum(input, dims_to_sum, c10::nullopt);
 }
 
 // --------------------------------------------------------------------

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1207,8 +1207,10 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, c10::opti
   }
   else {
     new_values = values.clone(at::MemoryFormat::Contiguous);
-    if (!dtype.has_value() && isIntegralType(input.scalar_type(), /*includeBool=*/false)) {
-        new_values = new_values.to(ScalarType::Long);
+    if (!dtype.has_value() && isIntegralType(input.scalar_type(), /*includeBool=*/false) && input.scalar_type() != ScalarType::Long) {
+        new_values = values.to(ScalarType::Long, at::MemoryFormat::Contiguous);
+    } else {
+        new_values = values.clone(at::MemoryFormat::Contiguous);
     }
   }
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1203,14 +1203,12 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, c10::opti
   // new values
   Tensor new_values;
   if (sum_dense_dim) {
-    new_values = values.sum(dense_dims_to_sum_v, false, dtype);
-  }
-  else {
-    new_values = values.clone(at::MemoryFormat::Contiguous);
+      new_values = values.sum(dense_dims_to_sum_v, false, dtype);
+  } else {
     if (!dtype.has_value() && isIntegralType(input.scalar_type(), /*includeBool=*/false) && input.scalar_type() != ScalarType::Long) {
-        new_values = values.to(ScalarType::Long, at::MemoryFormat::Contiguous);
+      new_values = values.to(ScalarType::Long, false, false, at::MemoryFormat::Contiguous);
     } else {
-        new_values = values.clone(at::MemoryFormat::Contiguous);
+      new_values = values.clone(at::MemoryFormat::Contiguous);
     }
   }
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1170,8 +1170,6 @@ Tensor _sparse_sum(const SparseTensor& input, c10::optional<ScalarType> dtype) {
 }
 
 Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, c10::optional<ScalarType> dtype) {
-  TORCH_CHECK(input._nnz() > 0, "_sparse_sum: sparse tensor input._nnz() == 0, please call torch.sparse.sum(input) instead.")
-
   const int64_t input_dim = input.dim();
   auto dims_to_sum_b = dim_list_to_bitset(dims_to_sum, input_dim);
   auto dims_to_sum_v = dims_to_sum.vec();
@@ -1238,7 +1236,7 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, c10::opti
     if (sum_all_sparse_dim) new_sizes.emplace(new_sizes.begin(), 1);
 
     // use coalesce() to do sum reduction
-    SparseTensor new_sparse = at::_sparse_coo_tensor_with_dims_and_tensors(new_sparse_dim, new_dense_dim, new_sizes, new_indices, new_values, new_values.options().layout(kSparse));
+    SparseTensor new_sparse = at::_sparse_coo_tensor_with_dims_and_tensors(new_sparse_dim, new_dense_dim, new_sizes, new_indices, new_values, input.options().dtype(new_values.scalar_type()));
     new_sparse = new_sparse.coalesce();
     return new_sparse;
   }

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1213,7 +1213,7 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
 
   if (sum_all_sparse_dim) {
     // return a dense tensor if sum over all sparse dims
-    new_values = new_values.sum(0);
+    new_values = new_values.sum(0, false, input.scalar_type());
     return new_values;
   }
   else { // !sum_all_sparse_dim

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1464,26 +1464,26 @@ class TestSparse(TestCase):
     @dtypes(torch.double)
     def test_sparse_sum(self, device, dtype, coalesced):
 
-        def run_tests(S, td=None):
+        def run_tests(S, td=None, dtype=None):
             D = S.coalesce().to_dense().detach().requires_grad_(True)
             if td is None:
-                S_sum = torch.sparse.sum(S)
-                D_sum = D.sum()
+                S_sum = torch.sparse.sum(S, dtype=dtype)
+                D_sum = D.sum(dtype=dtype)
                 self.assertEqual(S_sum.item(), D_sum.item())
 
                 def fn(S):
-                    res = torch.sparse.sum(S)
+                    res = torch.sparse.sum(S, dtype=dtype)
                     if res.is_sparse:
                         res = res.to_dense()
                     return res
                 gradcheck(fn, (S,), check_sparse_nnz=True)
             else:
-                S_sum = torch.sparse.sum(S, td)
-                D_sum = D.sum(td)
+                S_sum = torch.sparse.sum(S, td, dtype=dtype)
+                D_sum = D.sum(td, dtype=dtype)
                 self.assertEqual(S_sum.to_dense() if S_sum.is_sparse else S_sum, D_sum)
 
                 def fn(S):
-                    res = torch.sparse.sum(S, td)
+                    res = torch.sparse.sum(S, td, dtype=dtype)
                     if res.is_sparse:
                         res = res.to_dense()
                     return res
@@ -1530,6 +1530,7 @@ class TestSparse(TestCase):
         for test_dim in test_dims:
             S = self._gen_sparse(sparse_dims, nnz, with_size, dtype, device, coalesced)[0]
             run_tests(S.requires_grad_(True), test_dim)
+            run_tests(S.requires_grad_(True), test_dim, dtype)
 
     @dtypes(*get_all_dtypes(include_bool=False, include_half=False, include_bfloat16=False))
     def test_sparse_sum_int(self, device, dtype):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1531,6 +1531,18 @@ class TestSparse(TestCase):
             S = self._gen_sparse(sparse_dims, nnz, with_size, dtype, device, coalesced)[0]
             run_tests(S.requires_grad_(True), test_dim)
 
+    @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
+    def test_sparse_sum_int(self, device, dtype):
+        x = torch.sparse_coo_tensor([[0, 1], [1, 0]], [1, 2], dtype=dtype, device=device)
+
+        # https://github.com/pytorch/pytorch/issues/65392
+        self.assertEqual(torch.sparse.sum(x).dtype, torch.int64)
+        self.assertEqual(torch.sparse.sum(x, dim=0).dtype, dtype)
+        self.assertEqual(torch.sparse.sum(x, dtype=dtype).dtype, dtype)
+        self.assertEqual(torch.sparse.sum(x, dim=0, dtype=dtype).dtype, dtype)
+        self.assertEqual(torch.sparse.sum(x, dim=(0, 1)).dtype, dtype)
+        self.assertEqual(torch.sparse.sum(x, dim=(0, 1), dtype=dtype).dtype, dtype)
+
     def _test_basic_ops_shape(self, nnz_x1, nnz_x2, shape_i, shape_v, dtype, device, coalesced):
         shape = shape_i + (shape_v)
         x1, _, _ = self._gen_sparse(len(shape_i), nnz_x1, shape, dtype, device, coalesced)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1548,16 +1548,11 @@ class TestSparse(TestCase):
             {"dim": (0, 1), "dtype": dtype}
         ]
         for p in params:
-            self.assertEqual(torch.sparse.sum(x, **p).dtype, torch.sum(y, **p).dtype)
-
-        if dtype in get_all_int_dtypes():
-            self.assertEqual(torch.sparse.sum(x).dtype, torch.int64)
-            self.assertEqual(torch.sparse.sum(x, dim=0).dtype, torch.int64)
-            self.assertEqual(torch.sparse.sum(x, dim=(0, 1)).dtype, torch.int64)
-
-        self.assertEqual(torch.sparse.sum(x, dtype=dtype).dtype, dtype)
-        self.assertEqual(torch.sparse.sum(x, dim=0, dtype=dtype).dtype, dtype)
-        self.assertEqual(torch.sparse.sum(x, dim=(0, 1), dtype=dtype).dtype, dtype)
+            t = torch.sparse.sum(x, **p)
+            if t.is_sparse:
+                t = t.to_dense()
+            self.assertEqual(t, torch.sum(y, **p))
+            self.assertEqual(t.dtype, torch.sum(y, **p).dtype)
 
     def _test_basic_ops_shape(self, nnz_x1, nnz_x2, shape_i, shape_v, dtype, device, coalesced):
         shape = shape_i + (shape_v)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1531,7 +1531,7 @@ class TestSparse(TestCase):
             S = self._gen_sparse(sparse_dims, nnz, with_size, dtype, device, coalesced)[0]
             run_tests(S.requires_grad_(True), test_dim)
 
-    @dtypes(torch.int8, torch.int16, torch.int32, torch.int64, torch.float32, torch.float64)
+    @dtypes(*get_all_dtypes(include_bool=False, include_half=False, include_bfloat16=False))
     def test_sparse_sum_int(self, device, dtype):
         x = torch.sparse_coo_tensor([[0, 1], [1, 0]], [1, 2], dtype=dtype, device=device)
         y = x.to_dense()
@@ -1549,7 +1549,7 @@ class TestSparse(TestCase):
         for p in params:
             self.assertEqual(torch.sparse.sum(x, **p).dtype, torch.sum(y, **p).dtype)
 
-        if dtype in (torch.int8, torch.int16, torch.int32, torch.int64):
+        if dtype in get_all_int_dtypes():
             self.assertEqual(torch.sparse.sum(x).dtype, torch.int64)
             self.assertEqual(torch.sparse.sum(x, dim=0).dtype, torch.int64)
             self.assertEqual(torch.sparse.sum(x, dim=(0, 1)).dtype, torch.int64)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1672,7 +1672,7 @@
 - name: _sparse_coo_tensor_with_dims_and_tensors(int sparse_dim, int dense_dim, int[] size, Tensor indices, Tensor values, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=False) -> Tensor
   values: sparse_constructor_values_backward(grad, indices)
 
-- name: _sparse_sum.dim(Tensor self, int[1] dim) -> Tensor
+- name: _sparse_sum.dim_dtype(Tensor self, int[1] dim, *, ScalarType? dtype=None) -> Tensor
   self: at::_sparse_sum_backward(grad, self, dim)
 
 - name: _standard_gamma(Tensor self, Generator? generator=None) -> Tensor

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -161,7 +161,7 @@ def sum(input: Tensor, dim: DimOrDims = None,
         dim (int or tuple of ints): a dimension or a list of dimensions to reduce. Default: reduce
             over all dims.
         dtype (:class:`torch.dtype`, optional): the desired data type of returned Tensor.
-            Default: dtype of :attr:`input`.
+            Default: dtype of :attr:`input` or ``torch.int64`` when :attr:`input` is of integer type.
 
     Example::
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14989,6 +14989,7 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         promotes_int_to_int64=True,
+        supports_sparse=True,
         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
         ref=reference_reduction_numpy(np.sum),
         skips=(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14990,6 +14990,7 @@ op_db: List[OpInfo] = [
         supports_fwgrad_bwgrad=True,
         promotes_int_to_int64=True,
         supports_sparse=True,
+        supports_sparse_csr=True,
         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
         ref=reference_reduction_numpy(np.sum),
         skips=(


### PR DESCRIPTION
Fixes #65392.