### PR TITLE
Fix Windows ninja builds when MAX_JOBS is specified (#65444)

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -387,7 +387,7 @@ class CMake:
             # then. Until then, we use "--" to pass parameters to the
             # underlying build system.
             build_args += ['--']
-            if IS_WINDOWS:
+            if IS_WINDOWS and not USE_NINJA:
                 # We are likely using msbuild here
                 build_args += ['/p:CL_MPCount={}'.format(max_jobs)]
             else:

--- a/tools/test/test_cmake.py
+++ b/tools/test/test_cmake.py
@@ -22,7 +22,11 @@ class TestCMake(unittest.TestCase):
             # MAX_JOBS, USE_NINJA, IS_WINDOWS,         want
             ((     '8',      True,     False),          ['-j', '8']),  # noqa: E201,E241
             ((    None,      True,     False),                 None),  # noqa: E201,E241
+            ((     '7',     False,     False),          ['-j', '7']),  # noqa: E201,E241
+            ((    None,     False,     False),         ['-j', '13']),  # noqa: E201,E241
+            ((     '6',      True,      True),          ['-j', '6']),  # noqa: E201,E241
             ((    None,      True,      True),                 None),  # noqa: E201,E241
+            ((    '11',     False,      True), ['/p:CL_MPCount=11']),  # noqa: E201,E241
             ((    None,     False,      True), ['/p:CL_MPCount=13']),  # noqa: E201,E241
         ]
         for (max_jobs, use_ninja, is_windows), want in cases:


### PR DESCRIPTION
Summary:
Reported by cloudhan in https://github.com/pytorch/pytorch/pull/64733#issuecomment-924545463

Fixes regression introduced by https://github.com/pytorch/pytorch/commit/047e68235f8ebf8dc9fd816829ba90561d423ff9

cc malfet seemethere

Pull Request resolved: https://github.com/pytorch/pytorch/pull/65444

Reviewed By: dagitses, seemethere

Differential Revision: D31103260

Pulled By: malfet

fbshipit-source-id: 9d5454a64cb8a0b96264119cf16582cc5afed284
