### PR TITLE
[LTC] Migrate the CI from linux-xenial-cuda11.1 to linux-xenial-cuda11.3

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -112,7 +112,9 @@ jobs:
       {%- if not is_libtorch %}
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: !{{ common.upload_artifact_s3_action }}
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -215,7 +215,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -215,7 +215,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-puretorch-linux-xenial-py3.6-gcc5.4.yml
@@ -217,7 +217,9 @@ jobs:
           docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
       - name: Archive artifacts into zip
         run: |
-          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+          # Don't merge LazyTensor specific hacks back to master.
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json \
+          lazy_tensor_core/build/ lazy_tensor_core/test/cpp/build/
       - uses: seemethere/upload-artifact-s3@v3
         name: Store PyTorch Build Artifacts on S3
         with:

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -328,7 +328,7 @@ fi
 
 # Test Lazy Tensor Core. Don't merge to master.
 # Restrict lazy tensor to cuda environments to limit potential breakages for the feature branch.
-if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.1* ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.3* ]]; then
   pushd lazy_tensor_core/
   ./scripts/apply_patches.sh
   python setup.py install

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -497,7 +497,12 @@ test_docs_test() {
   .jenkins/pytorch/docs-test.sh
 }
 
+# lazy_tensor_staging branch specific hacks, don't merge back to master.
 test_lazy_tensor_core() {
+  ln -sf "$TORCH_LIB_DIR"/libtorch* torch/lib/
+  ln -sf "$TORCH_LIB_DIR"/libshm* torch/lib/
+  ln -sf "$TORCH_LIB_DIR"/libc10* torch/lib/
+  ln -sf "$PWD"/lazy_tensor_core/build/lib.linux-x86_64-3.6/_LAZYC.cpython-36m-x86_64-linux-gnu.so lazy_tensor_core/build/lib.linux-x86_64-3.6/libptltc.so
   lazy_tensor_core/test/cpp/build/test_ptltc
   assert_git_not_dirty
 }
@@ -519,9 +524,11 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   # TODO: run some C++ tests
   echo "no-op at the moment"
 elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 || ("${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1) ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *linux-xenial-cuda11.3* ]]; then
+    test_lazy_tensor_core
+  fi
   if [[ "${BUILD_ENVIRONMENT}" == *linux-xenial-cuda11.1*-test1* ]]; then
     test_torch_deploy
-    test_lazy_tensor_core
   fi
   test_without_numpy
   install_torchvision


### PR DESCRIPTION
Summary:
This pull reqeust migrated the CI from linux-xenial-cuda11.1 to linux-xenial-cuda11.3.

Test Plan:
linux-xenial-cuda11.3 CI.

