### PR TITLE
[Static Runtime][easy] Clone scripts do not use aten::add

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -221,13 +221,13 @@ const auto flatten_script_2 = R"JIT(
 const auto clone_script_0 = R"JIT(
   def forward(self, input):
       a = torch.clone(input)
-      return (a + a)
+      return (a * a)
 )JIT";
 
 const auto clone_script_1 = R"JIT(
   def forward(self, input: Tensor, memory_format: int):
       a = torch.clone(input, memory_format=memory_format)
-      return (a + a)
+      return (a * a)
 )JIT";
 
 const auto aten_sum = R"JIT(


### PR DESCRIPTION
Summary: `aten::add` is not guaranteed to be bit exact with the JIT interpreter. This was causing non-deterministic test failures on master.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D31406764

