### PR TITLE
fix type error in hipify_python.py

### DIFF
--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -193,7 +193,7 @@ def preprocess(
         show_progress: bool = True,
         hip_clang_launch: bool = False,
         is_pytorch_extension: bool = False,
-        clean_ctx: GeneratedFileCleaner = None) -> HipifyFinalResult:
+        clean_ctx: Optional[GeneratedFileCleaner] = None) -> HipifyFinalResult:
     """
     Call preprocessor on selected files.
 
@@ -940,7 +940,7 @@ def hipify(
     show_progress: bool = True,
     hip_clang_launch: bool = False,
     is_pytorch_extension: bool = False,
-    clean_ctx: GeneratedFileCleaner = None
+    clean_ctx: Optional[GeneratedFileCleaner] = None
 ) -> HipifyFinalResult:
     if project_directory == "":
         project_directory = os.getcwd()


### PR DESCRIPTION
- [x] Fixed the Pyre type checking errors in `torch/utils/hipify/hipify_python.py`:
```
torch/utils/hipify/hipify_python.py:196:8 Incompatible variable type [9]: clean_ctx is declared to have type `GeneratedFileCleaner` but is used as type `None`.
torch/utils/hipify/hipify_python.py:944:4 Incompatible variable type [9]: clean_ctx is declared to have type `GeneratedFileCleaner` but is used as type `None`.
```

Fixing the issue: https://github.com/MLH-Fellowship/pyre-check/issues/78