### PR TITLE
[PG Wrapper][BE] Add collective information when monitored barrier error is
raised

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -344,7 +344,7 @@ void ProcessGroupWrapper::runCollectiveChecks(
   auto finger_print = CollectiveFingerPrint(op_type, tensors);
   try {
     glooPg_->monitoredBarrier(options, /* waitAllRanks */ true);
-  } catch (const std::exception& e) {
+  } catch (const std::runtime_error& e) {
     // Attach collective info to the exception and re-raise.
     std::stringstream ss;
     ss << finger_print;

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -341,8 +341,21 @@ void ProcessGroupWrapper::runCollectiveChecks(
   c10d::BarrierOptions options;
   // TODO: we should use wrapped pg_'s timeout here, but C++ ProcessGroup API
   // does not expose timeout.
-  glooPg_->monitoredBarrier(options, /* waitAllRanks */ true);
   auto finger_print = CollectiveFingerPrint(op_type, tensors);
+  try {
+    glooPg_->monitoredBarrier(options, /* waitAllRanks */ true);
+  } catch (const std::exception& e) {
+    // Attach collective info to the exception and re-raise.
+    std::stringstream ss;
+    ss << finger_print;
+    auto collective_info = ss.str();
+    auto err_msg = c10::str(
+        "ProcessGroupWrapper: Monitored Barrier encountered error running collective: ",
+        collective_info,
+        ". Error: \n",
+        e.what());
+    TORCH_CHECK(false, err_msg);
+  }
   // Will throw if an ill-formed collective is detected.
   finger_print.verify(glooPg_);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66167
* #66166

raised

Sometimes due to desync we see PG wrapper monitored barrier fail. In
this case it would be useful to print the info about the collective that was
trying to run along with the actual error.

Differential Revision: [D31353021](https://our.internmc.facebook.com/intern/diff/D31353021/)