### PR TITLE
Back out "[vulkan] Use push constants instead of SSBOs"

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -187,6 +187,42 @@ struct VulkanImpl final : public at::vulkan::VulkanImplInterface {
 };
 static at::vulkan::VulkanImplRegistrar g_vulkan_impl(new VulkanImpl());
 
+Descriptor::Set dispatch_prologue(
+    Command::Buffer& command_buffer,
+    const Shader::Layout::Signature& shader_layout_signature,
+    const Shader::Descriptor& shader_descriptor,
+    const Shader::WorkGroup& local_work_group_size) {
+  Context* const context = api::context();
+  const GPU gpu = context->gpu();
+  Descriptor& descriptor = context->descriptor();
+  Pipeline& pipeline = context->pipeline();
+  Shader& shader = context->shader();
+
+  const Shader::Layout::Object shader_layout =
+      shader.layout.cache.retrieve({
+        shader_layout_signature,
+      });
+
+  command_buffer.bind(
+      pipeline.cache.retrieve({
+        pipeline.layout.cache.retrieve({
+          shader_layout.handle,
+        }),
+        shader.cache.retrieve(shader_descriptor),
+        local_work_group_size,
+      }));
+
+  return descriptor.pool.allocate(shader_layout);
+}
+
+void dispatch_epilogue(
+    Command::Buffer& command_buffer,
+    const Descriptor::Set& descriptor_set,
+    const Shader::WorkGroup& global_work_group) {
+  command_buffer.bind(descriptor_set);
+  command_buffer.dispatch(global_work_group);
+}
+
 } // namespace api
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -41,14 +41,13 @@ class Context final {
   Resource& resource();
 
   // GPU RPC
-  template<typename Struct, typename... Arguments>
+  template<typename... Arguments>
   void dispatch(
       Command::Buffer& command_buffer,
       const Shader::Layout::Signature& shader_layout_signature,
       const Shader::Descriptor& shader_descriptor,
       const Shader::WorkGroup& global_work_group,
       const Shader::WorkGroup& local_work_group_size,
-      const Struct& params,
       Arguments&&... arguments);
 
   // This function is expensive and its use consequential for performance. Only
@@ -136,59 +135,44 @@ inline void bind(
 
 } // namespace detail
 
-template<typename Struct, typename... Arguments>
-void Context::dispatch(
+template<typename... Arguments>
+inline void Context::dispatch(
     Command::Buffer& command_buffer,
     const Shader::Layout::Signature& shader_layout_signature,
     const Shader::Descriptor& shader_descriptor,
     const Shader::WorkGroup& global_work_group,
     const Shader::WorkGroup& local_work_group_size,
-    const Struct& params,
     Arguments&&... arguments) {
-  // Create/retrieve descriptor set layout
-  Context* const context = api::context();
-  const GPU gpu = context->gpu();
-  Descriptor& descriptor = context->descriptor();
-  Pipeline& pipeline = context->pipeline();
-  Shader& shader = context->shader();
+  // Forward declaration
+  Descriptor::Set dispatch_prologue(
+      Command::Buffer&,
+      const Shader::Layout::Signature&,
+      const Shader::Descriptor&,
+      const Shader::WorkGroup&);
 
-  const Shader::Layout::Object shader_layout =
-      shader.layout.cache.retrieve({
-        shader_layout_signature,
-      });
+  // Factor out template parameter independent code to minimize code bloat.
+  Descriptor::Set descriptor_set = dispatch_prologue(
+      command_buffer,
+      shader_layout_signature,
+      shader_descriptor,
+      local_work_group_size);
 
-  const VkPipelineLayout pipe_layout =
-      pipeline.layout.cache.retrieve({
-        shader_layout.handle,
-        sizeof(params)
-      });
-
-  vkCmdPushConstants(
-      command_buffer.handle(),
-      pipe_layout,
-      VK_SHADER_STAGE_COMPUTE_BIT,
-      0,
-      sizeof(params),
-      &params);
-
-  command_buffer.bind(
-      pipeline.cache.retrieve({
-        pipe_layout,
-        shader.cache.retrieve(shader_descriptor),
-        local_work_group_size,
-      }));
-
-  Descriptor::Set descriptor_set = descriptor.pool.allocate(shader_layout);
-
-  // Bind textures
   detail::bind(
       descriptor_set,
       std::index_sequence_for<Arguments...>{},
       std::forward<Arguments>(arguments)...);
 
-  // Bind to command buffer
-  command_buffer.bind(descriptor_set);
-  command_buffer.dispatch(global_work_group);
+  // Forward declaration
+  void dispatch_epilogue(
+      Command::Buffer&,
+      const Descriptor::Set&,
+      const Shader::WorkGroup&);
+
+  // Factor out template parameter independent code to minimize code bloat.
+  dispatch_epilogue(
+      command_buffer,
+      descriptor_set,
+      global_work_group);
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/Pipeline.cpp
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.cpp
@@ -18,19 +18,14 @@ typename Pipeline::Layout::Factory::Handle Pipeline::Layout::Factory::operator()
       descriptor.descriptor_set_layout,
       "Invalid Vulkan descriptor set layout!");
 
-  VkPushConstantRange push_constant;
-  push_constant.offset = 0;
-  push_constant.size = descriptor.push_constant_size;
-  push_constant.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
   const VkPipelineLayoutCreateInfo pipeline_layout_create_info{
     VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
     nullptr,
     0u,
     1u,
     &descriptor.descriptor_set_layout,
-    1u,
-    &push_constant,
+    0u,
+    nullptr,
   };
 
   VkPipelineLayout pipeline_layout{};

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -60,7 +60,6 @@ struct Pipeline final {
 
     struct Descriptor final {
       VkDescriptorSetLayout descriptor_set_layout;
-      size_t push_constant_size=128;
     };
 
     /*

--- a/aten/src/ATen/native/vulkan/glsl/adaptive_avg_pool2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/adaptive_avg_pool2d.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 kernel;
   vec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/add.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add.glsl
@@ -8,8 +8,7 @@ layout(std430) buffer;
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput0;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uInput1;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
   ivec3 isize1;

--- a/aten/src/ATen/native/vulkan/glsl/add_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add_.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D   uOutput;
 layout(set = 0, binding = 1)          uniform PRECISION          sampler3D uInput0;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2)          uniform PRECISION restrict Block {
   ivec4 size;
   ivec3 isize;
   float alpha;

--- a/aten/src/ATen/native/vulkan/glsl/add_scalar.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add_scalar.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec3 size;
   float other;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/add_scalar_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add_scalar_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec3 size;
   float other;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/addmm.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/addmm.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOut
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uM1;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uM2;
 layout(set = 0, binding = 3) uniform PRECISION                    sampler3D uT;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 multiplier;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/avg_pool2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/avg_pool2d.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/clamp.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/clamp.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 clamp;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/clamp_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/clamp_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
   vec2 clamp;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOut
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
 layout(set = 0, binding = 3) uniform PRECISION                    sampler2D uBias;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOut
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
 layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_dw_clamp.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_dw_clamp.glsl
@@ -8,8 +8,7 @@ layout(set = 0, binding = 3) readonly buffer bias {
   vec4 data[];
 }
 uBias;
-
-layout(push_constant) uniform constBlock {
+layout(set = 0, binding = 4) uniform constBlock {
   ivec2 padding;
   ivec2 kernelSize;
   ivec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOut
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
 layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOut
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
 layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2_buffered.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2_buffered.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOut
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler2D uKernel;
 layout(set = 0, binding = 3) uniform PRECISION                    sampler1D uBias;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_winograd_2_3.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_winograd_2_3.glsl
@@ -11,8 +11,7 @@ layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uKer
 layout(set = 0, binding = 3) buffer  PRECISION restrict readonly  Bias {
   vec4 data[];
 } uBias;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 clamp;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/div.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/div.glsl
@@ -8,8 +8,7 @@ layout(std430) buffer;
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput0;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uInput1;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
   ivec3 isize1;

--- a/aten/src/ATen/native/vulkan/glsl/div_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/div_.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D   uOutput;
 layout(set = 0, binding = 1)          uniform PRECISION          sampler3D uInput0;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2)          uniform PRECISION restrict Block {
   ivec4 size;
   ivec3 isize;
   float alpha;

--- a/aten/src/ATen/native/vulkan/glsl/hardshrink.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/hardshrink.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   float lambd;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/hardshrink_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/hardshrink_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
   float lambd;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/hardsigmoid.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/hardsigmoid.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/hardsigmoid_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/hardsigmoid_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/hardswish.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/hardswish.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/hardswish_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/hardswish_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION                    sampler3D uIma
 layout(set = 0, binding = 1) buffer  PRECISION restrict writeonly Buffer {
   float data[];
 } uBuffer;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 offset;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/leaky_relu.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/leaky_relu.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   float negative_slope;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/leaky_relu_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/leaky_relu_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
   float negative_slope;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/log_softmax.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/log_softmax.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/max_pool2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/max_pool2d.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/mean.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mean.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec3 isize;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/mean2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mean2d.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec3 isize;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/mm.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mm.glsl
@@ -8,8 +8,7 @@ layout(std430) buffer;
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uM1;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uM2;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/mul.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul.glsl
@@ -8,8 +8,7 @@ layout(std430) buffer;
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput0;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uInput1;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
   ivec3 isize1;

--- a/aten/src/ATen/native/vulkan/glsl/mul_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul_.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D   uOutput;
 layout(set = 0, binding = 1)          uniform PRECISION          sampler3D uInput0;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2)          uniform PRECISION restrict Block {
   ivec4 size;
   ivec3 isize;
   float alpha;

--- a/aten/src/ATen/native/vulkan/glsl/mul_scalar.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul_scalar.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec3 size;
   float other;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/mul_scalar_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul_scalar_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec3 size;
   float other;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image.glsl
@@ -9,8 +9,7 @@ layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D uImage
 layout(set = 0, binding = 1) buffer  PRECISION restrict readonly  Buffer {
   float data[];
 } uBuffer;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 offset;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/permute.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/permute.glsl
@@ -8,8 +8,7 @@ layout(set = 0, binding = 1) readonly buffer inputBuffer {
   float data[];
 }
 uInput;
-
-layout(push_constant) uniform constBlock {
+layout(set = 0, binding = 2) uniform constBlock {
   ivec4 inStrides[2];
   ivec4 outStrides[2];
   ivec4 outDims[2];

--- a/aten/src/ATen/native/vulkan/glsl/reflection_pad2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/reflection_pad2d.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 pad;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/sigmoid.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sigmoid.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/sigmoid_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sigmoid_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/softmax.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/softmax.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/sub.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sub.glsl
@@ -8,8 +8,7 @@ layout(std430) buffer;
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput0;
 layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uInput1;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
   ivec3 isize1;

--- a/aten/src/ATen/native/vulkan/glsl/sub_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sub_.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D   uOutput;
 layout(set = 0, binding = 1)          uniform PRECISION          sampler3D uInput0;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2)          uniform PRECISION restrict Block {
   ivec4 size;
   ivec3 isize;
   float alpha;

--- a/aten/src/ATen/native/vulkan/glsl/tanh.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/tanh.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/tanh_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/tanh_.glsl
@@ -6,8 +6,7 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict image3D uOutput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 1)          uniform PRECISION restrict Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/transform_winograd_2_3_sh.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/transform_winograd_2_3_sh.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec2 limits;
   ivec2 padding;

--- a/aten/src/ATen/native/vulkan/glsl/upsample_nearest2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/upsample_nearest2d.glsl
@@ -7,8 +7,7 @@ layout(std430) buffer;
 
 layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
-
-layout(push_constant) uniform PRECISION restrict Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec2 isize;
   vec2 scale;

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -55,16 +55,20 @@ Tensor clamp(
           VK_KERNEL(clamp),
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_self.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -117,13 +121,15 @@ Tensor& clamp_(
           VK_KERNEL(clamp_),
           v_self.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Read-Write access triggers an async synchronization if necessory
+          // and inserts appropriate barriers if hazards are detected.
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write));
+              vTensor::Access::Read | vTensor::Access::Write),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -170,16 +176,20 @@ Tensor activation(
           shader_descriptor,
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_self.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -222,13 +232,15 @@ Tensor& activation_(
           shader_descriptor,
           v_self.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Read-Write access triggers an async synchronization if necessory
+          // and inserts appropriate barriers if hazards are detected.
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write));
+              vTensor::Access::Read | vTensor::Access::Write),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -316,16 +328,20 @@ Tensor activation_scalar(
           shader_descriptor,
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures,
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_self.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -371,13 +387,15 @@ Tensor& activation_scalar_(
           shader_descriptor,
           v_self.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Read-Write access triggers an async synchronization if necessory
+          // and inserts appropriate barriers if hazards are detected.
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write));
+              vTensor::Access::Read | vTensor::Access::Write),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -673,22 +673,30 @@ void Conv2dOpContext::conv2d_sliding_window(
         shader,
         global_size,
         adaptive_work_group_size(global_size),
-        // Shader parameters
-        block,
-        // Textures
+        // Write-only access bypasses synchronization but inserts appropriate
+        // barriers if necessary.
         v_output.image(
             command_buffer,
             vTensor::Stage::Compute,
             vTensor::Access::Write),
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
         v_input.image(
             command_buffer,
             vTensor::Stage::Compute),
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
         packed_.v_weight.image(
             command_buffer,
             vTensor::Stage::Compute),
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
         packed_.v_bias.image(
             command_buffer,
-            vTensor::Stage::Compute));
+            vTensor::Stage::Compute),
+        // Object lifetime is managed by the resource pool.
+        // It is OK not to keep track of the handle.
+        context->resource().pool.uniform(block).object);
   }
   command_pool.submit(context->gpu().queue, command_buffer);
 }
@@ -747,16 +755,14 @@ void Conv2dOpContext::conv2d_winograd_2_3(
         VK_KERNEL(transform_winograd_2_3_sh),
         v_input_winograd.extents(),
         adaptive_work_group_size(v_input_winograd.extents()),
-        // Shader parameters
-        transform_block,
-        // Textures
         v_input_winograd.image(
             command_buffer,
             vTensor::Stage::Compute,
             vTensor::Access::Write),
         v_input.image(
             command_buffer,
-            vTensor::Stage::Compute));
+            vTensor::Stage::Compute),
+        context->resource().pool.uniform(transform_block).object);
 
   }
   {
@@ -791,9 +797,6 @@ void Conv2dOpContext::conv2d_winograd_2_3(
         VK_KERNEL(conv2d_winograd_2_3),
         global_size,
         adaptive_work_group_size(global_size),
-        // Shader parameters
-        block,
-        // Textures
         v_output.image(
             command_buffer,
             vTensor::Stage::Compute,

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -78,16 +78,20 @@ Tensor mean(
           keepdim ? VK_KERNEL(mean) : VK_KERNEL(mean2d),
           v_input.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_input.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -324,22 +324,30 @@ Tensor LinearOpContext::run(
               1,
             },
             {8, 8, 1},
-            // Shader parameters
-            block,
-            // Textures
+            // Write-only access bypasses synchronization but inserts appropriate
+            // barriers if necessary.
             v_output.image(
                 command_buffer,
                 vTensor::Stage::Compute,
                 vTensor::Access::Write),
+            // Read-only access is implied on const tensors and triggers an async
+            // synchronization if necessary.
             v_input.image(
                 command_buffer,
                 vTensor::Stage::Compute),
+            // Read-only access is implied on const tensors and triggers an async
+            // synchronization if necessary.
             packed_.v_weight.image(
                 command_buffer,
                 vTensor::Stage::Compute),
+            // Read-only access is implied on const tensors and triggers an async
+            // synchronization if necessary.
             packed_.v_bias.image(
                 command_buffer,
-                vTensor::Stage::Compute));
+                vTensor::Stage::Compute),
+            // Object lifetime is managed by the resource pool.
+            // It is OK not to keep track of the handle.
+            context->resource().pool.uniform(block).object);
       }
       else {
         const struct {
@@ -365,18 +373,25 @@ Tensor LinearOpContext::run(
               1,
             },
             {8, 8, 1},
-            // Shader parameters
-            block_no_bias,
+            // Write-only access bypasses synchronization but inserts appropriate
+            // barriers if necessary.
             v_output.image(
                 command_buffer,
                 vTensor::Stage::Compute,
                 vTensor::Access::Write),
+            // Read-only access is implied on const tensors and triggers an async
+            // synchronization if necessary.
             v_input.image(
                 command_buffer,
                 vTensor::Stage::Compute),
+            // Read-only access is implied on const tensors and triggers an async
+            // synchronization if necessary.
             packed_.v_weight.image(
                 command_buffer,
-                vTensor::Stage::Compute));
+                vTensor::Stage::Compute),
+            // Object lifetime is managed by the resource pool.
+            // It is OK not to keep track of the handle.
+            context->resource().pool.uniform(block_no_bias).object);
       }
     }
     else {

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -75,18 +75,21 @@ Tensor reflection_pad2d(const Tensor& self_arg, IntArrayRef padding) {
           {
               VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
               VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
           },
           VK_KERNEL(reflection_pad2d),
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
-          block,
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
               command_buffer, vTensor::Stage::Compute, vTensor::Access::Write),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
-          v_self.image(command_buffer, vTensor::Stage::Compute));
+          v_self.image(command_buffer, vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -70,16 +70,20 @@ Tensor adaptive_avg_pool2d(
           VK_KERNEL(adaptive_avg_pool2d),
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_self.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -214,16 +218,20 @@ Tensor pool2d(
           shader_descriptor,
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_self.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -77,16 +77,20 @@ Tensor softmax_internal(
           shader_descriptor,
           global_work_group_size,
           local_work_group_size,
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_input.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -792,11 +792,9 @@ void vTensor::View::CMD::copy_buffer_to_image(
       VK_KERNEL(nchw_to_image),
       extents,
       adaptive_work_group_size(extents),
-      // Shader parameters
-      block,
-      // Textures
       image,
-      buffer);
+      buffer,
+      view_.context_->resource().pool.uniform(block).object);
 }
 
 void vTensor::View::CMD::copy_image_to_buffer(
@@ -852,11 +850,9 @@ void vTensor::View::CMD::copy_image_to_buffer(
       VK_KERNEL(image_to_nchw),
       view_.extents(),
       adaptive_work_group_size(view_.extents()),
-      // Shader parameters
-      block,
-      // Textures
       image,
-      buffer);
+      buffer,
+      view_.context_->resource().pool.uniform(block).object);
 }
 
 void vTensor::View::CMD::submit(const api::Resource::Fence fence) {

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -74,16 +74,20 @@ Tensor upsample_nearest2d(
           VK_KERNEL(upsample_nearest2d),
           v_output.extents(),
           adaptive_work_group_size(v_output.extents()),
-          // Shader parameters
-          block,
-          // Textures
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
               vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
           v_input.image(
               command_buffer,
-              vTensor::Stage::Compute));
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
     }
     else {
       TORCH_CHECK(false, "Not implemented!");


### PR DESCRIPTION
Summary:
Original change: D30368834 (https://github.com/pytorch/pytorch/commit/57e5ae530651b8ce55daf1213ab23a28f10d242c)

Switching to Push Constants from Uniform Buffers caused some unforseen memory errors when running Mac unit tests.

We'll switch back for now until we can pinpoint and resolve the issue.

Test Plan: Build and run `vulkan_api_test`

Differential Revision: D31409130

