### PR TITLE
[ONNX] Update value name copying logic for onnx

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1093,6 +1093,35 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             self.assertNotEqual(node.kind(), "prim::Constant")
         self.assertEqual(len(list(graph.nodes())), 2)  # onnx::Sub and onnx::Add nodes only.
 
+    def test_onnx_value_name(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.in_weight = torch.nn.Parameter(torch.Tensor(3, 3))
+                self.in_bias = torch.nn.Parameter(torch.Tensor(3))
+
+            def forward(self, x):
+                start = 0
+                end = None
+                weight = self.in_weight
+                bias = self.in_bias
+                weight = weight[start:end, :]
+                if bias is not None:
+                    bias = bias[start:end]
+                return torch.nn.functional.linear(x, weight, bias)
+
+        model = MyModule()
+        x = torch.randn(3, 3)
+        f = io.BytesIO()
+
+        model.eval()
+        torch.onnx.export(model, (x,), f,
+                          opset_version=self.opset_version,
+                          keep_initializers_as_inputs=True)
+        graph = onnx.load(io.BytesIO(f.getvalue()))
+        self.assertEqual(graph.graph.input[1].name, "in_weight")
+        self.assertEqual(graph.graph.input[2].name, "in_bias")
+
     def test_duplicated_output_node(self):
         class DuplicatedOutputNet(torch.nn.Module):
             def __init__(self, input_size, num_classes):

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -275,6 +275,10 @@ void NodeToONNX(
                  env.begin(), env.end(), [&outputs, i](const auto& vt) {
                    return vt.second == outputs[i];
                  }));
+        // Update ONNX value debug name with ATen value debug name if existed.
+        // Skip if ONNX value already exist in environment.
+        // This implies the op is a noop, and the value is owned by
+        // other node created elsewhere.
         if (old->hasDebugName() && !exist_in_env) {
           auto old_name = outputs[i]->debugName();
           auto new_name = old->debugNameBase();

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -269,7 +269,13 @@ void NodeToONNX(
     for (const auto i : c10::irange(num_old_outputs)) {
       auto old = old_outputs[i];
       if (outputs[i]) {
-        if (old->hasDebugName()) {
+        bool exist_in_env =
+            (env.end() !=
+             std::find_if(
+                 env.begin(), env.end(), [&outputs, i](const auto& vt) {
+                   return vt.second == outputs[i];
+                 }));
+        if (old->hasDebugName() && !exist_in_env) {
           auto old_name = outputs[i]->debugName();
           auto new_name = old->debugNameBase();
           auto debug_names = new_block->owningGraph()->debugNames();
@@ -314,11 +320,7 @@ void NodeToONNX(
           // Copy over source location and scope information to all nodes
           // created by the symbolic
           // Do not set metadata if outputs[i] is already in env.
-          if (env.end() ==
-              std::find_if(
-                  env.begin(), env.end(), [&outputs, i](const auto& vt) {
-                    return vt.second == outputs[i];
-                  })) {
+          if (!exist_in_env) {
             outputs[i]->node()->copyMetadata(node);
           }
           env[old] = outputs[i];


### PR DESCRIPTION
Specifically targets the symbolic functions that directly returns input as output. The old logic will override the value name with output value name. But since the input is unmodified and unchanged, it is more logically to keep its original input name. Especially for cases where inputs are directly from model parameters.