### PR TITLE
support counter-based fused rowwise adagrad

### DIFF
--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -506,7 +506,7 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
 
     for (auto i = 0; i < n; ++i) {
       auto idx = indices[i];
-      float freq = (count[idx] > 0 && counter_halflife_ > 0)
+      float freq = (counter_halflife_ > 0 && count[idx] > 0)
           ? counter_halflife_ / count[idx]
           : 1.0;
       if (block_size == 1) {

--- a/caffe2/sgd/rowwise_adagrad_fused.cc
+++ b/caffe2/sgd/rowwise_adagrad_fused.cc
@@ -3,7 +3,7 @@
 namespace caffe2 {
 
 OPERATOR_SCHEMA(RowWiseSparseAdagradFusedWithSparseLengthsSumGradient)
-    .NumInputs(6)
+    .NumInputs(6,7)
     .NumOutputs(2)
     .EnforceOneToOneInplace()
     .SetDoc(R"DOC(
@@ -30,6 +30,11 @@ SparseLengthsSumGradient operator.
         5,
         "lengths",
         "Non negative vector with sum of elements equal to indices length")
+    .Input(
+        6,
+        "counter",
+        "Optional input when weight_decay is adjusted by frequency ignored "
+        "when counter_halflife == -1")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment", "Updated moment")
     .Arg(
@@ -59,7 +64,7 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
 // Match the GPU Approx op, here Approx and Exact are the same for
 // RowWiseSparseAdagradFusedWithSparseLengthsSumGradient op
 OPERATOR_SCHEMA(RowWiseSparseAdagradFusedWithSparseLengthsSumGradientApprox)
-    .NumInputs(6)
+    .NumInputs(6,7)
     .NumOutputs(2)
     .EnforceOneToOneInplace()
     .SetDoc(R"DOC(
@@ -86,6 +91,11 @@ SparseLengthsSumGradient operator.
         5,
         "lengths",
         "Non negative vector with sum of elements equal to indices length")
+    .Input(
+        6,
+        "counter",
+        "Optional input when weight_decay is adjusted by frequency ignored "
+        "when counter_halflife == -1")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment", "Updated moment")
     .Arg(
@@ -113,7 +123,7 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
         /*is_mean=*/false>);
 
 OPERATOR_SCHEMA(RowWiseSparseAdagradFusedWithSparseLengthsMeanGradient)
-    .NumInputs(6)
+    .NumInputs(6,7)
     .NumOutputs(2)
     .EnforceOneToOneInplace()
     .SetDoc(R"DOC(
@@ -140,6 +150,11 @@ SparseLengthsMeanGradient operator.
         5,
         "lengths",
         "Non negative vector with sum of elements equal to indices length")
+    .Input(
+        6,
+        "counter",
+        "Optional input when weight_decay is adjusted by frequency ignored "
+        "when counter_halflife == -1")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment", "Updated moment")
     .Arg("epsilon", "Default 1e-5");
@@ -166,7 +181,7 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
 // Match the GPU Approx op, here Approx and Exact are the same for
 // RowWiseSparseAdagradFusedWithSparseLengthsMeanGradient op
 OPERATOR_SCHEMA(RowWiseSparseAdagradFusedWithSparseLengthsMeanGradientApprox)
-    .NumInputs(6)
+    .NumInputs(6,7)
     .NumOutputs(2)
     .EnforceOneToOneInplace()
     .SetDoc(R"DOC(
@@ -193,6 +208,11 @@ SparseLengthsMeanGradient operator.
         5,
         "lengths",
         "Non negative vector with sum of elements equal to indices length")
+    .Input(
+        6,
+        "counter",
+        "Optional input when weight_decay is adjusted by frequency ignored "
+        "when counter_halflife == -1")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment", "Updated moment")
     .Arg(
@@ -220,7 +240,7 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
         /*is_mean=*/true>);
 
 OPERATOR_SCHEMA(RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradient)
-    .NumInputs(7)
+    .NumInputs(7,8)
     .NumOutputs(3)
     .EnforceInplace({{0, 0}, {1, 1}})
     .SetDoc(R"DOC(
@@ -251,6 +271,11 @@ operator.
         6,
         "lengths",
         "Non negative vector with sum of elements equal to indices length")
+    .Input(
+        7,
+        "counter",
+        "Optional input when weight_decay is adjusted by frequency ignored "
+        "when counter_halflife == -1")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment", "Updated moment")
     .Output(2, "aux_grad", "Auxiliary gradient")
@@ -275,7 +300,7 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
 
 OPERATOR_SCHEMA(
     RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApprox)
-    .NumInputs(7)
+    .NumInputs(7,8)
     .NumOutputs(3)
     .EnforceInplace({{0, 0}, {1, 1}})
     .SetDoc(R"DOC(
@@ -309,6 +334,11 @@ operator.
         6,
         "lengths",
         "Non negative vector with sum of elements equal to indices length")
+    .Input(
+        7,
+        "counter",
+        "Optional input when weight_decay is adjusted by frequency ignored "
+        "when counter_halflife == -1")
     .Output(0, "output_param", "Updated parameters")
     .Output(1, "output_moment", "Updated moment")
     .Output(2, "aux_grad", "Auxiliary gradient")

--- a/caffe2/sgd/rowwise_adagrad_fused.h
+++ b/caffe2/sgd/rowwise_adagrad_fused.h
@@ -140,9 +140,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
         weight_decay_(
-            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+            this->template GetSingleArgument<float>("weight_decay", 0.f)),
+        counter_halflife_(
+            this->template GetSingleArgument<int64_t>("counter_halflife", -1)) {
     VLOG(1) << "gradient optimization operator in use: "
-            << "RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp";
+            << " weight_decay_=" << weight_decay_
+            << " counter_halflife=" << counter_halflife_
+            << " RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp bcyuan";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -182,6 +186,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
     const auto* gradIn = segmentGradsInput.template data<T>();
     const auto* paramIn = Input(PARAM).template data<Tdata>();
     const auto* momentIn = Input(MOMENT_1).template data<T>();
+    const auto* count = counter_halflife_ == -1
+      ? nullptr
+      : Input(COUNTER).template data<double>();
 
     auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<Tdata>();
     auto* momentOut = Output(OUTPUT_MOMENT_1)->template mutable_data<T>();
@@ -230,11 +237,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
         paramIn,
         numParams,
         momentIn,
+        count,
         paramOut,
         momentOut,
         epsilon_,
         lr[0],
         weight_decay_,
+        counter_halflife_,
         kernel_);
 
     return true;
@@ -251,11 +260,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       const Tdata* paramIn,
       int64_t numParams,
       const T* momentIn,
+      const double* count,
       Tdata* paramOut,
       T* momentOut,
       float epsilon,
       T lr,
       T weight_decay,
+      T counter_halflife,
       rowWiseAdagradT& kernel) {
     int dataIndex = 0;
     for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
@@ -287,8 +298,12 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
             " max size:",
             numParams);
 
+        float freq = (counter_halflife > 0 && count[idx] > 0)
+        ? counter_halflife / count[idx]
+        : 1.0;
+
         if (block_size == 1) {
-          float gi = std::fma(weight_decay, paramIn[idx], *g);
+          float gi = std::fma(weight_decay * freq, paramIn[idx], *g);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] = paramIn[idx] + lr / (std::sqrt(hi) + epsilon) * gi;
         } else {
@@ -301,7 +316,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
           if (HAS_WEIGHT_DECAY) {
             g_sq_avg =
                 internal::compute_square_average_with_weight_decay_inlined_(
-                    g, paramOut + offsetIdx, block_size, weight_decay);
+                    g, paramOut + offsetIdx, block_size, weight_decay * freq);
           }
 
           kernel(
@@ -318,7 +333,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
 
               epsilon,
               lr,
-              HAS_WEIGHT_DECAY ? weight_decay : 0.0f);
+              HAS_WEIGHT_DECAY ? weight_decay * freq : 0.0f);
         }
       }
     }
@@ -336,11 +351,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       const Tdata* paramIn,
       int64_t numParams,
       const T* momentIn,
+      const double* count,
       Tdata* paramOut,
       T* momentOut,
       float epsilon,
       T lr,
       T weight_decay,
+      T counter_halflife,
       rowWiseAdagradT& kernel) {
     if (weight_decay == 0.0f) {
       compute<SIndex, false>(
@@ -353,11 +370,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
           paramIn,
           numParams,
           momentIn,
+          count,
           paramOut,
           momentOut,
           epsilon,
           lr,
           0.0f,
+          /*counter_halflife=*/-1,
           kernel);
     } else {
       compute<SIndex, true>(
@@ -370,11 +389,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
           paramIn,
           numParams,
           momentIn,
+          count,
           paramOut,
           momentOut,
           epsilon,
           lr,
           weight_decay,
+          counter_halflife,
           kernel);
     }
   }
@@ -382,10 +403,11 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
  protected:
   T epsilon_;
   T weight_decay_;
+  T counter_halflife_;
   rowWiseAdagradT kernel_;
   Tensor grad_buffer_{CPU};
 
-  INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR, LENGTHS);
+  INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR, LENGTHS, COUNTER);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1);
 };
 
@@ -403,10 +425,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
         weight_decay_(
-            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
-    VLOG(1)
-        << "gradient optimization operator in use: "
-        << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
+            this->template GetSingleArgument<float>("weight_decay", 0.f)),
+        counter_halflife_(
+            this->template GetSingleArgument<int64_t>("counter_halflife", -1)) {
+    VLOG(1) << "gradient optimization operator in use: "
+            << " weight_decay_=" << weight_decay_
+            << " counter_halflife=" << counter_halflife_
+            << " RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp bcyuan";
   }
 
   bool RunOnDevice() override {
@@ -444,6 +469,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     const auto* paramIn = Input(PARAM).template data<Tdata>();
     const auto* momentIn = Input(MOMENT_1).template data<T>();
     const auto* auxParamIn = Input(AUX_PARAM).template data<T>();
+    const auto* count = counter_halflife_ == -1
+      ? nullptr
+      : Input(COUNTER).template data<double>();
 
     auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<Tdata>();
     auto* momentOut = Output(OUTPUT_MOMENT_1)->template mutable_data<T>();
@@ -483,6 +511,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         paramIn,
         numParams,
         momentIn,
+        count,
         auxParamIn,
         paramOut,
         momentOut,
@@ -490,6 +519,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         epsilon_,
         lr[0],
         weight_decay_,
+        counter_halflife_,
         kernel_,
         &context_);
 
@@ -507,6 +537,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const Tdata* paramIn,
       int64_t numParams,
       const T* momentIn,
+      const double* count,
       const T* auxParamIn,
       Tdata* paramOut,
       T* momentOut,
@@ -514,6 +545,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       float epsilon,
       T lr,
       T weight_decay,
+      T counter_halflife,
       rowWiseAdagradT& kernel,
       CPUContext* context) {
     // Cannot fuse this loop with the loop below because paramIn is updated
@@ -578,8 +610,12 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           temp_grad[i] = auxParamIn[localOffset] * g[i];
         }
 
+        float freq = (counter_halflife > 0 && count[idx] > 0)
+        ? counter_halflife / count[idx]
+        : 1.0;
+
         if (block_size == 1) {
-          float gi = std::fma(weight_decay, paramIn[idx], temp_grad[0]);
+          float gi = std::fma(weight_decay * freq, paramIn[idx], temp_grad[0]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] = paramIn[idx] + lr / (std::sqrt(hi) + epsilon) * gi;
         } else {
@@ -595,7 +631,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
                     temp_grad.data(),
                     paramOut + offsetIdx,
                     block_size,
-                    weight_decay);
+                    weight_decay * freq);
           }
 
           kernel(
@@ -615,7 +651,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
 
               epsilon,
               lr,
-              HAS_WEIGHT_DECAY ? weight_decay : 0.0f);
+              HAS_WEIGHT_DECAY ? weight_decay * freq : 0.0f);
         }
       }
     }
@@ -632,6 +668,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const Tdata* paramIn,
       int64_t numParams,
       const T* momentIn,
+      const double* count,
       const T* auxParamIn,
       Tdata* paramOut,
       T* momentOut,
@@ -639,6 +676,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       float epsilon,
       T lr,
       T weight_decay,
+      T counter_halflife,
       rowWiseAdagradT& kernel,
       CPUContext* context) {
     if (weight_decay == 0.0f) {
@@ -652,6 +690,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           paramIn,
           numParams,
           momentIn,
+          count,
           auxParamIn,
           paramOut,
           momentOut,
@@ -659,6 +698,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           epsilon,
           lr,
           0.0f,
+          /*counter_halflife=*/-1,
           kernel,
           context);
     } else {
@@ -672,6 +712,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           paramIn,
           numParams,
           momentIn,
+          count,
           auxParamIn,
           paramOut,
           momentOut,
@@ -679,6 +720,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           epsilon,
           lr,
           weight_decay,
+          counter_halflife,
           kernel,
           context);
     }
@@ -687,9 +729,10 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
  protected:
   T epsilon_;
   T weight_decay_;
+  T counter_halflife_;
   rowWiseAdagradT kernel_;
 
-  INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS);
+  INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS, COUNTER);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1, AUX_GRAD);
 };
 
@@ -707,10 +750,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
         weight_decay_(
-            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
-    VLOG(1)
-        << "gradient optimization operator in use: "
-        << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
+            this->template GetSingleArgument<float>("weight_decay", 0.f)),
+        counter_halflife_(
+            this->template GetSingleArgument<int64_t>("counter_halflife", -1)) {
+    VLOG(1) << "gradient optimization operator in use: "
+            << " weight_decay_=" << weight_decay_
+            << " counter_halflife=" << counter_halflife_
+            << " RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp bcyuan";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -758,6 +804,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
     const auto* gradIn = segmentGradsInput.template data<T>();
     const auto* paramIn = Input(PARAM).template data<Tdata>();
     const auto* momentIn = Input(MOMENT_1).template data<T>();
+    const auto* count = counter_halflife_ == -1
+      ? nullptr
+      : Input(COUNTER).template data<double>();
     const auto* auxParamIn = Input(AUX_PARAM).template data<T>();
 
     auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<Tdata>();
@@ -865,8 +914,12 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
         }
         auxGrad[dataIndex] = acc;
 
+        float freq = (counter_halflife_ > 0 && count[idx] > 0)
+        ? counter_halflife_ / count[idx]
+        : 1.0;
+
         if (block_size == 1) {
-          float gi = std::fma(weight_decay_, paramIn[idx], temp_grad[0]);
+          float gi = std::fma(weight_decay_ * freq, paramIn[idx], temp_grad[0]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] =
               paramIn[idx] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
@@ -883,7 +936,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
                     temp_grad.data(),
                     paramOut + offsetIdx,
                     block_size,
-                    weight_decay_);
+                    weight_decay_ * freq);
           }
 
           kernel_(
@@ -903,7 +956,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
 
               epsilon_,
               lr[0],
-              HAS_WEIGHT_DECAY ? weight_decay_ : 0.0f);
+              HAS_WEIGHT_DECAY ? weight_decay_ * freq : 0.0f);
         }
       }
     }
@@ -915,9 +968,10 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
  protected:
   T epsilon_;
   T weight_decay_;
+  T counter_halflife_;
   rowWiseAdagradT kernel_;
 
-  INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS);
+  INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS, COUNTER);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1, AUX_GRAD);
 };
 


### PR DESCRIPTION
Summary: As title, with additional change to enable counter for SparseAdagrad.

Test Plan:
buck test //caffe2/caffe2/fb/net_transforms/tests:fuse_sparse_ops_test

Testing with canary packages

baseline: f297789852

counter run: f297789912

Differential Revision: D30903029

