### PR TITLE
[torch][launch] Add ability to override sys.executable for `torch.distributed.run`

### DIFF
--- a/test/distributed/launcher/run_test.py
+++ b/test/distributed/launcher/run_test.py
@@ -91,6 +91,9 @@ class ElasticLaunchTest(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_launch_user_script_python(self):
+        self._test_launch_user_script_python()
+
+    def _test_launch_user_script_python(self):
         run_id = str(uuid.uuid4().int)
         nnodes = 1
         nproc_per_node = 4
@@ -592,3 +595,10 @@ class ElasticLaunchTest(unittest.TestCase):
             ]
         )
         # nothing to validate, just make sure it runs
+
+    def test_get_default_executable(self):
+        self.assertEqual(sys.executable, launch.get_executable())
+
+    def test_get_override_executable(self):
+        os.environ["PYTHON_EXEC"] = "python"
+        self._test_launch_user_script_python()

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -206,6 +206,9 @@ The following environment variables are made available to you in your script:
 
 12. ``TORCHELASTIC_RUN_ID`` - Equal to the rendezvous ``run_id`` (e.g. unique job id).
 
+13. ``PYTHON_EXEC`` - System executable override. If provided, the python user script will
+    use the value of ``PYTHON_EXEC`` as executable. The `sys.executable` is used by default.
+
 **Deployment:**
 
 1. (Not needed for the C10d backend) Start the rendezvous backend server and get the endpoint (to be
@@ -642,7 +645,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
         cmd_args.append(args.training_script)
     else:
         if with_python:
-            cmd = sys.executable
+            cmd = os.getenv("PYTHON_EXEC", sys.executable)
             cmd_args.append("-u")
             if args.module:
                 cmd_args.append("-m")


### PR DESCRIPTION
Summary:
The diff adds check for `SYS_EXECUTABLE` environment variable. If the variable is set, it will override `sys.executable` for `torch.distibuted.run`.
This means that  if `SYS_EXECUTABLE` is set, user scripts executed via `torch.distributed.run` will start via value of `os.environ["SYS_EXECUTABLE"]`

Test Plan: unittest

Differential Revision: D31329003



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang