### PR TITLE
Fix strict aliasing rule violation in bitwise_binary_op

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -739,8 +739,10 @@ template<class T, typename Op>
 static inline Vectorized<T> bitwise_binary_op(const Vectorized<T> &a, const Vectorized<T> &b, Op op) {
   static constexpr uint32_t element_no = VECTOR_WIDTH / sizeof(intmax_t);
   __at_align__ intmax_t buffer[element_no];
-  const intmax_t *a_ptr = reinterpret_cast<const intmax_t*>((const T*) a);
-  const intmax_t *b_ptr = reinterpret_cast<const intmax_t*>((const T*) b);
+  intmax_t a_ptr[element_no];
+  intmax_t b_ptr[element_no];
+  std::memcpy(&a_ptr, &a, sizeof(intmax_t) * element_no);
+  std::memcpy(&b_ptr, &b, sizeof(intmax_t) * element_no);
   for (uint32_t i = 0U; i < element_no; ++ i) {
     buffer[i] = op(a_ptr[i], b_ptr[i]);
   }

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -741,12 +741,12 @@ static inline Vectorized<T> bitwise_binary_op(const Vectorized<T> &a, const Vect
   __at_align__ intmax_t buffer[element_no];
   // We should be using memcpy (through .store) in order to respect the strict aliasing rule
   // see: https://github.com/pytorch/pytorch/issues/66119
-  std::array<intmax_t, element_no> a_arr;
-  std::array<intmax_t, element_no> b_arr;
-  a.store(&a_arr);
-  b.store(&b_arr);
   for (uint32_t i = 0U; i < element_no; ++ i) {
-    buffer[i] = op(a_arr[i], b_arr[i]);
+    intmax_t a_val;
+    intmax_t b_val;
+    std::memcpy(&a_val, &a, sizeof(intmax_t));
+    std::memcpy(&b_val, &b, sizeof(intmax_t));
+    buffer[i] = op(a_val, b_val);
   }
   return Vectorized<T>::loadu(buffer);
 }

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -148,7 +148,7 @@ public:
   }
   // Return the values as char* for type punning
   auto as_bytes() const -> const char* {
-    return (const char*)values;
+    return reinterpret_cast<const char*>(values);
   }
   template <int64_t mask_>
   static Vectorized<T> blend(const Vectorized<T>& a, const Vectorized<T>& b) {


### PR DESCRIPTION
Fixes #66119

Failure on ARM Neoverse N1 before this PR:
```
======================================================================
FAIL: test_bitwise_ops_cpu_int16 (__main__.TestBinaryUfuncsCPU)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 373, in instantiated_test
    result = test(self, **param_kwargs)
  File "test_binary_ufuncs.py", line 315, in test_bitwise_ops
    self.assertEqual(op(a, b), op(a_np, b_np))
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 1633, in assertEqual
    self.assertEqual(
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 1611, in assertEqual
    super().assertTrue(result, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
AssertionError: False is not true : Tensors failed to compare as equal!Found 176 different element(s) (out of 225), with the greatest difference of 21850 (-21846 vs. 4) occuring at index (0, 2).

======================================================================
FAIL: test_bitwise_ops_cpu_int32 (__main__.TestBinaryUfuncsCPU)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 373, in instantiated_test
    result = test(self, **param_kwargs)
  File "test_binary_ufuncs.py", line 315, in test_bitwise_ops
    self.assertEqual(op(a, b), op(a_np, b_np))
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 1633, in assertEqual
    self.assertEqual(
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 1611, in assertEqual
    super().assertTrue(result, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
AssertionError: False is not true : Tensors failed to compare as equal!Found 188 different element(s) (out of 225), with the greatest difference of 1335341061 (-1335341056 vs. 5) occuring at index (14, 8).

----------------------------------------------------------------------
```
which passes now.

CC @malfet @ezyang 