### PR TITLE
[Do not review/land] Test if defined(__aarch64__) but not defined(__ARM_NEON__) is possible

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -22,6 +22,10 @@
 #include <arm_neon.h>
 #endif
 
+#if defined(__aarch64__) && !defined(__ARM_NEON)
+  This should break the build if reachable
+#endif
+
 namespace at {
 namespace native {
 namespace {


### PR DESCRIPTION
Summary: Relevant to D22072779 (https://github.com/pytorch/pytorch/commit/edd3fbc61ee4cb390bf462e8d440f37b525f26f1) and D31066997

Differential Revision: D31434605

