### PR TITLE
[FX] Specifies a default value when possible for placeholders created…

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2314,6 +2314,20 @@ class TestFX(JitTestCase):
         nf = symbolic_trace(f_higher, concrete_args={'f': lambda x: x * 2})
         self.assertEqual(nf(3, lambda x: x * 2), 6)
 
+    def test_concrete_args_default_value(self):
+        def f(a=None, b=None):
+            res = a
+            if b is not None:
+                res = res + b
+            return res
+        b_val = torch.tensor(5)
+        traced = symbolic_trace(f, concrete_args={'b': b_val})
+        inp = torch.tensor(3)
+        self.assertEqual(traced(inp), f(inp, b_val))
+        # Currently, we bake in the value of b, so this test maintains that.
+        self.assertEqual(traced(inp, inp), f(inp, b_val))
+
+
     def test_custom_traceback_raised_when_exception_source_is_graphmodule(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -457,7 +457,9 @@ class Tracer(TracerBase):
                 def replace_ph(x):
                     nonlocal cnt
                     cnt += 1
-                    out = self.create_proxy('placeholder', f'{name}_{str(cnt)}', (), {})
+                    param = sig.parameters[name]
+                    default = () if param.default is inspect.Parameter.empty else (param.default,)
+                    out = self.create_proxy('placeholder', f'{name}_{str(cnt)}', default, {})
                     if x == PH:
                         return out
                     # Union[int, bool] == bool in Python <= 3.6


### PR DESCRIPTION
… from concrete_args (#59569)

Summary:
```python
class Foo(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, a=None, b=None):
        res = a
        if b is not None:
            res = res + b
        return res

concrete_args = {'b': torch.tensor(5)}
traced = fx.symbolic_trace(Foo(), concrete_args=concrete_args)
```

Gives the following error:

```
  File "<eval_with_key_9>", line 2
    def forward(self, a = None, b_1):
                ^
SyntaxError: non-default argument follows default argument
```

Since https://github.com/pytorch/pytorch/issues/55888, placeholders are also created for concrete arguments. But these placeholders do not have default values even when  it was provided for the argument in question, causing the error above.

To solve this, I add a default value when it is available during placeholder creation for concrete arguments.

I also tried to set the default value to the value specified in concrete_args (since it many cases it will actually use this value anyway), but ran into an error because the default value is never defined:

```
def forward(self, a = None, b_1 = _tensor_constant0):
    _tensor_constant0 = self._tensor_constant0
    _tensor_constant1 = self._tensor_constant1
    add = a + _tensor_constant1;  a = _tensor_constant1 = None

NameError: name '_tensor_constant0' is not defined
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/59569

Reviewed By: albanD

Differential Revision: D31385607

Pulled By: Chillee

fbshipit-source-id: 44a8ce28b5eabdb9b4c773e73a68ff0bb9c464cc

Fixes #{issue number}
