### PR TITLE
Don't build shared library for AOT Compiler

### DIFF
--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -110,4 +110,4 @@ caffe2_binary_target("dump_operator_names.cc")
 caffe2_binary_target("optimize_for_mobile.cc")
 
 caffe2_binary_target(aot_model_compiler "aot_model_compiler.cc")
-target_link_libraries(aot_model_compiler aot_compiler)
+target_link_libraries(aot_model_compiler torch)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -9,13 +9,6 @@ if(NOT CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
-if(BUILD_BINARY)
-  add_library(aot_compiler SHARED
-          ${TORCH_SRC_DIR}/csrc/jit/mobile/nnc/aot_compiler.cpp
-          )
-  install(TARGETS aot_compiler DESTINATION lib)
-endif()
-
 if(NOT BUILD_PYTHON)
   return()
 endif()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66227

Building a shared library for AOT Compiler is not necessary as it's included in libtorch. Also having this built as a shared library was affecting android builds and we don't need to build AOT Compiler for mobile builds

Before fix:
```
(pytorch)  ~/local/pytorch master
└─ $ ANDROID_NDK=/opt/android_ndk/r20/ BUILD_PYTORCH_MOBILE=1 ANDROID_ABI=armeabi-v7a ./scripts/build_android.sh -DBUILD_BINARY=ON
Build with ANDROID_ABI[armeabi-v7a], ANDROID_NATIVE_API_LEVEL[21]
Bash: GNU bash, version 5.0.11(1)-release (x86_64-redhat-linux-gnu)
Python: 3.9.7 (default, Sep 16 2021, 13:09:58)
[GCC 7.5.0]
Caffe2 path: /data/users/priyaramani/pytorch
Using Android NDK at /opt/android_ndk/r20/
.
.
FAILED: lib/libaot_compiler.so
: && /opt/android_ndk/r20/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=armv7-none-linux-androideabi21 --gcc-toolchain=/opt/android_ndk/r20/toolchains/llvm/prebuilt/linux-x86_64 --sysroot=/opt/and
roid_ndk/r20/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fPIC -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fno-addrsig -march=armv7-a -mt
humb -Wa,--noexecstack -Wformat -Werror=format-security -frtti -fexceptions  -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DUSE_KINETO -DLIBKINETO_NOCUPTI -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -
DBUILD_LITE_INTERPRETER -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -DEDGE_PROFILER_USE_KINETO -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bound
s -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-function -Wno-unused-result -Wno-unused-local-typedefs -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -W
no-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -Wno-invalid-partial-specialization -Wno-typedef-redefinition -Wno-unknown-warning-option -Wno-unused-private-field -Wno-inconsistent-miss
ing-override -Wno-aligned-allocation-unavailable -Wno-c++14-extensions -Wno-constexpr-not-const -Wno-missing-braces -Qunused-arguments -fcolor-diagnostics -Wno-unused-but-set-variable -Wno-maybe-uninitialized
-fno-math-errno -fno-trapping-math -Werror=format -Werror=cast-function-type -g0 -Oz -DNDEBUG  -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libatomic.a -static-libstdc++ -Wl,--build-id -Wl,--warn-shared-text
rel -Wl,--fatal-warnings -Wl,--exclude-libs,libunwind.a -Wl,--no-undefined -Qunused-arguments -Wl,-z,noexecstack  -rdynamic -shared -Wl,-soname,libaot_compiler.so -o lib/libaot_compiler.so caffe2/torch/CMakeFi
les/aot_compiler.dir/csrc/jit/mobile/nnc/aot_compiler.cpp.o  -latomic -lm && :
caffe2/torch/CMakeFiles/aot_compiler.dir/csrc/jit/mobile/nnc/aot_compiler.cpp.o:aot_compiler.cpp:function at::from_blob(void*, c10::ArrayRef<long long>, c10::TensorOptions const&): error: undefined reference t
o 'at::TensorMaker::make_tensor()'
.
.
caffe2/torch/CMakeFiles/aot_compiler.dir/csrc/jit/mobile/nnc/aot_compiler.cpp.o:aot_compiler.cpp:function torch::jit::mobile::nnc::Function::Function(): error: undefined reference to 'c10::AnyType::get()'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

After fix:
```
(pytorch)  ~/local/pytorch master
└─ $ ANDROID_NDK=/opt/android_ndk/r20/ BUILD_PYTORCH_MOBILE=1 ANDROID_ABI=armeabi-v7a ./scripts/build_android.sh -DBUILD_BINARY=ON
Build with ANDROID_ABI[armeabi-v7a], ANDROID_NATIVE_API_LEVEL[21]
Bash: GNU bash, version 5.0.11(1)-release (x86_64-redhat-linux-gnu)
Python: 3.9.7 (default, Sep 16 2021, 13:09:58)
[GCC 7.5.0]
Caffe2 path: /data/users/priyaramani/pytorch
Using Android NDK at /opt/android_ndk/r20/
. 
.
-- Build files have been written to: /data/users/priyaramani/pytorch/build_android
Will install headers and libs to /data/users/priyaramani/pytorch/build_android/install for further Android project usage.
[2/3] Install the project...
-- Install configuration: "Release"
Installation completed, now you can copy the headers/libs from /data/users/priyaramani/pytorch/build_android/install to your Android project directory.
```

Differential Revision: [D31450970](https://our.internmc.facebook.com/intern/diff/D31450970)