### PR TITLE
Add `warn_only` kwarg to `use_deterministic_algorithms`

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -62,18 +62,32 @@ bool Context::deterministicAlgorithms() const {
   return _deterministic_algorithms;
 }
 
-void Context::setDeterministicAlgorithms(bool b) {
+bool Context::deterministicAlgorithmsWarnOnly() const {
+  return _deterministic_algorithms_warn_only;
+}
+
+void Context::setDeterministicAlgorithms(bool b, bool warn_only=false) {
   _deterministic_algorithms = b;
+  _deterministic_algorithms_warn_only = warn_only;
 }
 
 void Context::alertNotDeterministic(c10::string_view const& caller) {
   if (globalContext().deterministicAlgorithms()) {
-    TORCH_CHECK(false,
-      caller, " does not have a deterministic implementation, but you set "
-      "'torch.use_deterministic_algorithms(True)'. You can turn off determinism ",
-      "just for this operation if that's acceptable for your application. You "
-      "can also file an issue at https://github.com/pytorch/pytorch/issues "
-      "to help us prioritize adding deterministic support for this operation.");
+    if (globalContext().deterministicAlgorithmsWarnOnly()) {
+      TORCH_WARN(
+        caller, " does not have a deterministic implementation, but you set "
+        "'torch.use_deterministic_algorithms(True, warn_only=True)'. "
+        "You can file an issue at https://github.com/pytorch/pytorch/issues "
+        "to help us prioritize adding deterministic support for this operation.");
+    } else {
+      TORCH_CHECK(false,
+        caller, " does not have a deterministic implementation, but you set "
+        "'torch.use_deterministic_algorithms(True)'. You can turn off "
+        "determinism just for this operation, or you can use the "
+        "'warn_only=True' option, if that's acceptable for your application. "
+        "You can also file an issue at https://github.com/pytorch/pytorch/issues "
+        "to help us prioritize adding deterministic support for this operation.");
+    }
   }
 }
 

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -150,7 +150,8 @@ class TORCH_API Context {
   //    }
 
   bool deterministicAlgorithms() const;
-  void setDeterministicAlgorithms(bool);
+  bool deterministicAlgorithmsWarnOnly() const;
+  void setDeterministicAlgorithms(bool, bool);
 
   // Note [Writing Nondeterministic Operations]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -235,6 +236,7 @@ class TORCH_API Context {
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
   bool _deterministic_algorithms = false;
+  bool _deterministic_algorithms_warn_only = false;
   bool benchmark_cudnn = false;
   bool allow_tf32_cudnn = true;
   bool allow_tf32_cublas = true;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -127,12 +127,20 @@ class AbstractTestCases:
 
         @wrapDeterministicFlagAPITest
         def test_deterministic_flag(self):
-            for deterministic in [True, False]:
-                torch.use_deterministic_algorithms(deterministic)
+            for deterministic, warn_only in product([True, False], [True, False]):
+                torch.use_deterministic_algorithms(deterministic, warn_only=warn_only)
                 self.assertEqual(deterministic, torch.are_deterministic_algorithms_enabled())
+                self.assertEqual(warn_only, torch.is_deterministic_algorithms_warn_only_enabled())
 
-            with self.assertRaisesRegex(RuntimeError, r"use_deterministic_algorithms expects a bool, but got int"):
+            with self.assertRaisesRegex(
+                    TypeError,
+                    r"_set_deterministic_algorithms\(\): argument 'mode' \(position 1\) must be bool, not int"):
                 torch.use_deterministic_algorithms(1)
+
+            with self.assertRaisesRegex(
+                    TypeError,
+                    r"_set_deterministic_algorithms\(\): argument 'warn_only' must be bool, not int"):
+                torch.use_deterministic_algorithms(False, warn_only=1)
 
         def test_type_conversion_via_dtype_name(self):
             x = torch.tensor([1])
@@ -3877,7 +3885,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('avg_pool3d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('avg_pool3d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3889,7 +3897,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('adaptive_avg_pool2d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('adaptive_avg_pool2d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3901,7 +3909,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('adaptive_avg_pool3d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('adaptive_avg_pool3d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3913,7 +3921,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('max_pool3d_with_indices_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('max_pool3d_with_indices_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3925,7 +3933,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('adaptive_max_pool2d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('adaptive_max_pool2d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3937,7 +3945,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('fractional_max_pool2d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('fractional_max_pool2d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3949,7 +3957,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('fractional_max_pool3d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('fractional_max_pool3d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3964,7 +3972,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_linear1d_backward_out_cuda', 'cuda')
+        @expectedAlertNondeterministic('upsample_linear1d_backward_out_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3979,7 +3987,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_bilinear2d_backward_out_cuda', 'cuda')
+        @expectedAlertNondeterministic('upsample_bilinear2d_backward_out_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3994,7 +4002,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_bicubic2d_backward_out_cuda', 'cuda')
+        @expectedAlertNondeterministic('upsample_bicubic2d_backward_out_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4009,7 +4017,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_trilinear3d_backward_out_cuda', 'cuda')
+        @expectedAlertNondeterministic('upsample_trilinear3d_backward_out_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4021,7 +4029,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('reflection_pad1d_backward_out_cuda', 'cuda')
+        @expectedAlertNondeterministic('reflection_pad1d_backward_out_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4033,7 +4041,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('reflection_pad2d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('reflection_pad2d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4045,7 +4053,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('reflection_pad3d_backward_out_cuda', 'cuda')
+        @expectedAlertNondeterministic('reflection_pad3d_backward_out_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4057,7 +4065,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('replication_pad1d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('replication_pad1d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4069,7 +4077,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('replication_pad2d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('replication_pad2d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4081,7 +4089,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('replication_pad3d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('replication_pad3d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4092,7 +4100,7 @@ else:
         input = torch.randn(2, 3, 5, 5, device=device)
         target = torch.rand(2, 5, 5, device=device).mul(3).floor().long()
 
-        @expectedAlertNondeterministic('nll_loss2d_forward_out_cuda_template', 'cuda')
+        @expectedAlertNondeterministic('nll_loss2d_forward_out_cuda_template', ['cuda'])
         def forward_func(slf, device):
             module(input, target)
 
@@ -4107,9 +4115,10 @@ else:
         res = module(input, target, input_lengths, target_lengths)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('ctc_loss_backward_gpu', 'cuda')
+        @expectedAlertNondeterministic('ctc_loss_backward_gpu', ['cuda'], test_warning=False)
         def backward_func(slf, device):
-            res.backward(grad)
+            with warnings.catch_warnings(record=True) as w:
+                res.backward(grad)
 
         backward_func(self, device)
 
@@ -4121,7 +4130,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('embedding_bag_backward_cuda_max', 'cuda')
+        @expectedAlertNondeterministic('embedding_bag_backward_cuda_max', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4134,7 +4143,7 @@ else:
             index = torch.tensor([[3]], device=device)
             src = torch.tensor([[1.0]], device=device)
 
-            @expectedAlertNondeterministic('scatter_add_cuda_kernel', 'cuda')
+            @expectedAlertNondeterministic('scatter_add_cuda_kernel', ['cuda'])
             def forward_func(slf, device):
                 op_call(input, dim, index, src)
 
@@ -4166,7 +4175,7 @@ else:
             indices = torch.tensor([0, 0], device=device)
             values = torch.tensor([0., 1.], device=device)
 
-            @expectedAlertNondeterministic('put_', 'cuda')
+            @expectedAlertNondeterministic('put_', ['cuda'])
             def forward_func(slf, device):
                 op_call(a, indices, values, accumulate=True)
 
@@ -4179,7 +4188,7 @@ else:
         def test_func(op_call):
             a = torch.tensor([], device=device)
 
-            @expectedAlertNondeterministic('_histc_cuda', 'cuda')
+            @expectedAlertNondeterministic('_histc_cuda', ['cuda'])
             def forward_func(slf, device):
                 res = op_call(a, min=0, max=3)
 
@@ -4192,7 +4201,7 @@ else:
         def test_func(op_call):
             a = torch.tensor([], device=device, dtype=torch.long)
 
-            @expectedAlertNondeterministic('_bincount_cuda', 'cuda')
+            @expectedAlertNondeterministic('_bincount_cuda', ['cuda'])
             def forward_func(slf, device):
                 res = op_call(a)
 
@@ -4204,7 +4213,7 @@ else:
     # Ensures that kthvalue throws nondeterministic alerts in the correct cases
     @dtypes(torch.double)
     def test_nondeterministic_alert_kthvalue(self, device, dtype):
-        @expectedAlertNondeterministic('kthvalue CUDA', 'cuda')
+        @expectedAlertNondeterministic('kthvalue CUDA', ['cuda'])
         def test_func(slf, device, call_type):
             S = 10
             k = 5
@@ -4233,7 +4242,7 @@ else:
             res = op_call(a, dim, index)
             grad = torch.ones_like(res)
 
-            @expectedAlertNondeterministic('scatter_add_cuda_kernel', 'cuda')
+            @expectedAlertNondeterministic('scatter_add_cuda_kernel', ['cuda'], test_warning=False)
             def backward_func(slf, device):
                 res.backward(grad)
 
@@ -4248,7 +4257,7 @@ else:
         res = torch.nn.functional.grid_sample(input, grid, align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('grid_sampler_2d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('grid_sampler_2d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4260,7 +4269,7 @@ else:
         res = torch.nn.functional.grid_sample(input, grid, align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('grid_sampler_3d_backward_cuda', 'cuda')
+        @expectedAlertNondeterministic('grid_sampler_3d_backward_cuda', ['cuda'], test_warning=False)
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4311,7 +4320,7 @@ else:
             else:
                 self.fail(f"'{call_type}' is not a valid call type")
 
-        @expectedAlertNondeterministic('median CUDA with indices output', 'cuda')
+        @expectedAlertNondeterministic('median CUDA with indices output', ['cuda'])
         def test_func_expect_error(slf, device, call_type):
             test_func(slf, device, call_type)
 

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -586,7 +586,8 @@ def _set_cudnn_benchmark(arg: _bool) -> None: ...  # THPModule_setBenchmarkCuDNN
 def _get_cudnn_deterministic() -> _bool: ...  # THPModule_deterministicCuDNN
 def _set_cudnn_deterministic(arg: _bool) -> None: ...  # THPModule_setDeterministicCuDNN
 def _get_deterministic_algorithms() -> _bool: ...  # THPModule_deterministicAlgorithms
-def _set_deterministic_algorithms(arg: _bool) -> None: ...  # THPModule_setDeterministicAlgorithms
+def _get_deterministic_algorithms_warn_only() -> _bool: ...  # THPModule_deterministicAlgorithmsWarnOnly
+def _set_deterministic_algorithms(mode: _bool, *, warn_only: _bool) -> None: ...  # THPModule_setDeterministicAlgorithms
 def _get_warnAlways() -> _bool: ...  # THPModule_warnAlways
 def _set_warnAlways(arg: _bool) -> None: ...  # THPModule_setWarnAlways
 def _get_cudnn_allow_tf32() -> _bool: ...  # THPModule_allowTF32CuDNN

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -366,7 +366,7 @@ def set_default_dtype(d):
     """
     _C._set_default_dtype(d)
 
-def use_deterministic_algorithms(mode):
+def use_deterministic_algorithms(mode, *, warn_only=False):
     r""" Sets whether PyTorch operations must use "deterministic"
     algorithms. That is, algorithms which, given the same input, and when
     run on the same software and hardware, always produce the same output.
@@ -467,6 +467,11 @@ def use_deterministic_algorithms(mode):
             operations switch to a deterministic algorithm or throw a runtime
             error. If False, allows nondeterministic operations.
 
+    Keyword args:
+        warn_only (:class:`bool`, optional): If True, operations that do not
+            have a deterministic implementation will throw a warning instead of
+            an error. Default: ``False``
+
     Example::
 
         >>> torch.use_deterministic_algorithms(True)
@@ -481,13 +486,20 @@ def use_deterministic_algorithms(mode):
         ...
         RuntimeError: index_add_cuda_ does not have a deterministic implementation...
     """
-    _C._set_deterministic_algorithms(mode)
+    _C._set_deterministic_algorithms(mode, warn_only=warn_only)
 
 def are_deterministic_algorithms_enabled():
     r"""Returns True if the global deterministic flag is turned on. Refer to
     :func:`torch.use_deterministic_algorithms` documentation for more details.
     """
     return _C._get_deterministic_algorithms()
+
+def is_deterministic_algorithms_warn_only_enabled():
+    r"""Returns True if the global deterministic flag is set to warn only.
+    Refer to :func:`torch.use_deterministic_algorithms` documentation for more
+    details.
+    """
+    return _C._get_deterministic_algorithms_warn_only()
 
 def set_warn_always(b):
     r"""When this flag is False (default) then some PyTorch warnings may only

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -803,15 +803,21 @@ def skipIfNotMiopenSuggestNHWC(fn):
 # Context manager for setting deterministic flag and automatically
 # resetting it to its original value
 class DeterministicGuard:
-    def __init__(self, deterministic):
+    def __init__(self, deterministic, *, warn_only=False):
         self.deterministic = deterministic
+        self.warn_only = warn_only
 
     def __enter__(self):
         self.deterministic_restore = torch.are_deterministic_algorithms_enabled()
-        torch.use_deterministic_algorithms(self.deterministic)
+        self.warn_only_restore = torch.is_deterministic_algorithms_warn_only_enabled()
+        torch.use_deterministic_algorithms(
+            self.deterministic,
+            warn_only=self.warn_only)
 
     def __exit__(self, exception_type, exception_value, traceback):
-        torch.use_deterministic_algorithms(self.deterministic_restore)
+        torch.use_deterministic_algorithms(
+            self.deterministic_restore,
+            warn_only=self.warn_only_restore)
 
 # Context manager for setting cuda sync debug mode and reset it
 # to original value
@@ -860,7 +866,9 @@ class CudaSyncGuard:
 def wrapDeterministicFlagAPITest(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        with DeterministicGuard(torch.are_deterministic_algorithms_enabled()):
+        with DeterministicGuard(
+                torch.are_deterministic_algorithms_enabled(),
+                warn_only=torch.is_deterministic_algorithms_warn_only_enabled()):
             class CuBLASConfigGuard:
                 cublas_var_name = 'CUBLAS_WORKSPACE_CONFIG'
 


### PR DESCRIPTION
Fixes #64883

Adds a `warn_only` kwarg to `use_deterministic_algorithms`. When enabled, calling an operation that does not have a deterministic implementation will raise a warning, rather than an error.

`torch.testing._internal.common_device_type.expectedAlertNondeterministic` is also refactored and documented in this PR to make it easier to use and understand.

cc @mruberry @kurtamohler