### PR TITLE
use irange for loops

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <c10/core/MemoryFormat.h>
+#include <c10/util/irange.h>
 
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
@@ -97,7 +98,7 @@ static at::Tensor newAtTensor(
   std::vector<int64_t> shapeVec{};
   shapeVec.reserve(rank);
   auto numel = 1;
-  for (auto i = 0; i < rank; ++i) {
+  for (const auto i : c10::irange(rank)) {
     shapeVec.push_back(shapeArr[i]);
     numel *= shapeArr[i];
   }
@@ -521,7 +522,7 @@ at::IValue JIValue::JIValueToAtIValue(
 
     std::vector<at::IValue> elements;
     elements.reserve(n);
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto jivalue_element = jarray->getElement(i);
       auto element = JIValue::JIValueToAtIValue(jivalue_element);
       elements.push_back(std::move(element));
@@ -535,7 +536,7 @@ at::IValue JIValue::JIValueToAtIValue(
     size_t n = jArrayPinned.size();
     c10::List<bool> list{};
     list.reserve(n);
-    for (size_t i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       list.push_back(jArrayPinned[i]);
     }
     return at::IValue{std::move(list)};
@@ -547,7 +548,7 @@ at::IValue JIValue::JIValueToAtIValue(
     size_t n = jArrayPinned.size();
     c10::List<int64_t> list{};
     list.reserve(n);
-    for (size_t i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       list.push_back(jArrayPinned[i]);
     }
     return at::IValue{std::move(list)};
@@ -559,7 +560,7 @@ at::IValue JIValue::JIValueToAtIValue(
     size_t n = jArrayPinned.size();
     c10::List<double> list{};
     list.reserve(n);
-    for (size_t i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       list.push_back(jArrayPinned[i]);
     }
     return at::IValue{std::move(list)};
@@ -572,7 +573,7 @@ at::IValue JIValue::JIValueToAtIValue(
     size_t n = jArray->size();
     c10::List<at::Tensor> list{};
     list.reserve(n);
-    for (size_t i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       list.push_back(
           TensorHybrid::newAtTensorFromJTensor(jArray->getElement(i)));
     }
@@ -594,7 +595,7 @@ at::IValue JIValue::JIValueToAtIValue(
     c10::impl::GenericList list{c10::unshapedType(first_element.type())};
     list.reserve(n);
     list.push_back(first_element);
-    for (auto i = 1; i < n; ++i) {
+    for (const auto i : c10::irange(1, n)) {
       auto jivalue_element = jarray->getElement(i);
       auto element = JIValue::JIValueToAtIValue(jivalue_element);
       list.push_back(element);

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
@@ -6,6 +6,7 @@
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
@@ -157,7 +158,7 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     std::vector<at::IValue> inputs{};
     size_t n = jinputs->size();
     inputs.reserve(n);
-    for (size_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
       at::IValue atIValue = JIValue::JIValueToAtIValue(jinputs->getElement(i));
       if (at::kVulkan == deviceType_) {
         inputs.push_back(
@@ -186,7 +187,7 @@ class PytorchJni : public facebook::jni::HybridClass<PytorchJni> {
     std::vector<at::IValue> inputs{};
     size_t n = jinputs->size();
     inputs.reserve(n);
-    for (size_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
       at::IValue atIValue = JIValue::JIValueToAtIValue(jinputs->getElement(i));
       if (at::kVulkan == deviceType_) {
         inputs.push_back(

--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -3,6 +3,7 @@
 #include <ATen/BatchedFallback.h>
 #include <ATen/native/ResizeCommon.h>
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -329,7 +330,7 @@ Tensor permute_batching_rule(const Tensor& self, IntArrayRef dims) {
 
   VmapDimVector all_dims_physical;
   all_dims_physical.reserve(self_physical.tensor().dim());
-  for (int64_t bdim = 0; bdim < self_physical.numBatchDims(); bdim++) {
+  for (const auto bdim : c10::irange(self_physical.numBatchDims())) {
     all_dims_physical.push_back(bdim);
   }
   all_dims_physical.insert(

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -2,6 +2,7 @@
 
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 #include <limits>
 #include <utility>
 #include <cstring>
@@ -130,7 +131,7 @@ inline Tensor sort_strides(Tensor& tensor_) {
   IntArrayRef strides = tensor_.strides();
   std::vector<int64_t> indices;
   indices.reserve(tensor_.ndimension());
-  for (int64_t i = 0; i < tensor_.ndimension(); i++) {
+  for (const auto i : c10::irange(tensor_.ndimension())) {
     indices.push_back(i);
   }
   std::sort(indices.begin(), indices.end(), [&strides](int64_t i1, int64_t i2) {
@@ -196,7 +197,7 @@ inline bool _all_equal_numel(at::ArrayRef<Tensor> tensors) {
   if (tensors.size() == 0)
     return true;
   int64_t all_numel = tensors[0].numel();
-  for (size_t i = 1; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     if (tensors[i].numel() != all_numel)
       return false;
   }

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -11,6 +11,7 @@
 #include <c10/util/Exception.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/QEngine.h>
+#include <c10/util/irange.h>
 
 #include <memory>
 #include <mutex>
@@ -349,7 +350,7 @@ static inline void manual_seed(uint64_t seed) {
   // available. In that case, we must not seed CUDA; it will fail!
   const auto num_gpus = detail::getCUDAHooks().getNumGPUs();
   if (hasCUDA() && num_gpus > 0) {
-    for (int i = 0; i < num_gpus; i++) {
+    for (const auto i : c10::irange(num_gpus)) {
       auto cuda_gen = globalContext().defaultGenerator(
         Device(at::kCUDA, static_cast<c10::DeviceIndex>(i))
       );

--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -197,7 +197,7 @@ std::vector<int64_t> infer_dense_strides(IntArrayRef tensor_sizes, IntArrayRef t
   // compute output strides which preserves the input tensor's memory layout
   std::vector<int64_t> out_strides(ndim);
   int64_t curr_stride = 1;
-  for (size_t i = 0; i < ndim; ++i) {
+  for (const auto i : c10::irange(ndim)) {
     int64_t idx = perm[i];
     out_strides[idx] = curr_stride;
     // Note: for size 0, we simply treated it as 1, it really doesn't matter here

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -4,6 +4,7 @@
 #include <ATen/Tensor.h>
 #include <c10/util/Exception.h>
 #include <c10/util/MaybeOwned.h>
+#include <c10/util/irange.h>
 
 #include <functional>
 #include <sstream>
@@ -266,7 +267,7 @@ inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
   // expands a list of Tensors; ignores undefined (null) tensors
   bool first = true;
   DimVector sizes;
-  for (size_t i = 0; i < to_expand.size(); ++i) {
+  for (const auto i : c10::irange(to_expand.size())) {
     if (!to_expand[i].defined()) {
       continue;
     } else if (first) {
@@ -278,7 +279,7 @@ inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
   }
 
   std::vector<Tensor> result(to_expand.size());
-  for (size_t i = 0; i < to_expand.size(); ++i) {
+  for (const auto i : c10::irange(to_expand.size())) {
     if (!to_expand[i].defined()) {
       continue;
     } else if (to_expand[i].sizes().equals(sizes)) {
@@ -299,7 +300,7 @@ static inline Tensor sum_to(Tensor tensor, const IntArrayRef shape) {
   c10::SmallVector<int64_t, 8> reduce_dims;
   const at::IntArrayRef sizes = tensor.sizes();
   const int64_t leading_dims = sizes.size() - shape.size();
-  for (int64_t i = 0; i < leading_dims; ++i) {
+  for (const auto i : c10::irange(leading_dims)) {
     reduce_dims.push_back(i);
   }
   for (int64_t i = leading_dims; i < static_cast<int64_t>(sizes.size()); ++i) {
@@ -320,7 +321,7 @@ static inline bool is_expandable_to(IntArrayRef shape, IntArrayRef desired) {
   if (ndim > target_dim) {
     return false;
   }
-  for (size_t i = 0; i < ndim; i++) {
+  for (const auto i : c10::irange(ndim)) {
     int64_t size = shape[ndim - i - 1];
     int64_t target = desired[target_dim - i - 1];
     if (size != target && size != 1) {

--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -1,6 +1,7 @@
 #include <ATen/MemoryOverlap.h>
 #include <ATen/core/TensorBase.h>
 #include <c10/core/Layout.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -17,7 +18,7 @@ MemOverlap has_internal_overlap(TensorImpl* t) {
 
   auto strides = t->strides();
   auto sizes = t->sizes();
-  for (size_t i = 0; i < strides.size(); ++i) {
+  for (const auto i : c10::irange(strides.size())) {
     if (strides[i] == 0 && sizes[i] > 1) {
       return MemOverlap::YES;
     }

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -225,7 +225,7 @@ std::vector<Dimname> compute_squeeze_outnames(const Tensor& tensor) {
   }
   std::vector<Dimname> outnames;
   auto tensor_names = tensor.names();
-  for (int64_t d = 0; d < tensor.dim(); d++) {
+  for (const auto d : c10::irange(tensor.dim())) {
     if (tensor.sizes()[d] != 1) {
       outnames.push_back(tensor_names[d]);
     }
@@ -242,7 +242,7 @@ std::vector<Dimname> compute_diagonal_outnames(
   }
   std::vector<Dimname> outnames;
   auto tensor_names = tensor.names();
-  for (int64_t d = 0; d < tensor.dim(); d++) {
+  for (const auto d : c10::irange(tensor.dim())) {
     if (d == dim1 || d == dim2) {
       continue;
     }

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -6,6 +6,7 @@
 
 #ifndef C10_MOBILE
 #include <c10/core/thread_pool.h>
+#include <c10/util/irange.h>
 #else
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #endif // C10_MOBILE
@@ -87,7 +88,7 @@ TaskThreadPoolBase& _get_intraop_pool() {
 // `fn` will be called with params: (thread_pool_task_id, task_id).
 void _run_with_pool(const std::function<void(int, size_t)>& fn, size_t range) {
 #ifndef C10_MOBILE
-  for (size_t i = 1; i < range; ++i) {
+  for (const auto i : c10::irange(1, range)) {
     _get_intraop_pool().run([fn, i]() { fn((int)i, i); });
   }
   // Run the first task on the current thread directly.

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -3,6 +3,7 @@
 #include <ATen/Tensor.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 namespace at {
 struct TORCH_API SparseTensorImpl : public TensorImpl {
@@ -109,7 +110,7 @@ public:
       bool shrinking_dense_dim = false;
       auto sparse_size_original = sizes().slice(0, sparse_dim);
       auto sparse_size_new = size.slice(0, sparse_dim);
-      for (int64_t i = 0; i < sparse_dim; i++) {
+      for (const auto i : c10::irange(sparse_dim)) {
         if (sparse_size_new[i] < sparse_size_original[i]) {
           shrinking_sparse_dims = true;
           break;
@@ -117,7 +118,7 @@ public:
       }
       auto dense_size_original = sizes().slice(sparse_dim);
       auto dense_size_new = size.slice(sparse_dim);
-      for (int64_t i = 0; i < dense_dim; i++) {
+      for (const auto i : c10::irange(dense_dim)) {
         if (dense_size_new[i] < dense_size_original[i]) {
           shrinking_dense_dim = true;
           break;

--- a/aten/src/ATen/SparseTensorUtils.cpp
+++ b/aten/src/ATen/SparseTensorUtils.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/SparseTensorImpl.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace sparse {
 
@@ -98,7 +99,7 @@ Tensor coo_to_csr(const int64_t* indices, int64_t dim, int64_t nnz) {
     at::parallel_for(0, nnz, 10000, [&](int64_t start, int64_t end) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t h, hp0, hp1;
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         hp0 = indices[i];
         hp1 = (i+1 == nnz) ?  dim : indices[i+1];
         if (hp0 != hp1) {

--- a/aten/src/ATen/TensorIndexing.cpp
+++ b/aten/src/ATen/TensorIndexing.cpp
@@ -1,6 +1,7 @@
 #include <ATen/TensorIndexing.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace indexing {
@@ -31,7 +32,7 @@ std::ostream& operator<<(std::ostream& stream, const TensorIndex& tensor_index) 
 
 std::ostream& operator<<(std::ostream& stream, const std::vector<TensorIndex>& tensor_indices) {
   stream << "(";
-  for (size_t i = 0; i < tensor_indices.size(); i++) {
+  for (const auto i : c10::irange(tensor_indices.size())) {
     stream << tensor_indices[i];
     if (i < tensor_indices.size() - 1) stream << ", ";
   }

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include <ATen/core/TensorBody.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/Functions.h>
@@ -335,7 +336,7 @@ static inline Tensor scalarToTensor(const Scalar& v, const TensorOptions& option
 // strip away unit dimensions from the left of 'src'
 static inline IntArrayRef slicePrefix1sSize(const IntArrayRef& sizes) {
   size_t first_non1_src = sizes.size();
-  for (size_t i = 0; i < sizes.size(); ++i) {
+  for (const auto i : c10::irange(sizes.size())) {
     if (sizes[i] != 1) {
       first_non1_src = i;
       break;
@@ -439,7 +440,7 @@ static inline Tensor applySlicing(
     "too many indices for tensor of dimension ", (int)self_sizes.size());
 
   Tensor result = self;
-  for (size_t i = 0; i < indices.size(); i++) {
+  for (const auto i : c10::irange(indices.size())) {
     auto& obj = indices[i];
     result = handleDimInMultiDimIndexing(
       /*prev_dim_result=*/result,

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -36,8 +36,8 @@ inline void get_base_ptrs(char** ptrs, ArrayRef<OperandInfo> operands) {
 }
 
 inline void get_strides(int64_t* strides, ArrayRef<OperandInfo> operands, int64_t ndim) {
-  for (int64_t dim = 0; dim < ndim; ++dim) {
-    for (size_t arg = 0; arg < operands.size(); ++arg) {
+  for (const auto dim : c10::irange(ndim)) {
+    for (const auto arg : c10::irange(operands.size())) {
       *strides++ = operands[arg].stride_bytes[dim];
     }
   }
@@ -214,7 +214,7 @@ void TensorIteratorBase::reorder_dimensions() {
   // returns 1 if the dim0 should come after dim1, -1 if dim0 should come
   // before dim1, and 0 if the comparison is ambiguous.
   auto should_swap = [&](size_t dim0, size_t dim1) {
-    for (int arg = 0; arg < ntensors(); arg++) {
+    for (const auto arg : c10::irange(ntensors())) {
       // ignore undefined or incorrectly sized tensors
       if (operands_[arg].stride_bytes.empty() || operands_[arg].will_resize) {
         continue;
@@ -251,7 +251,7 @@ void TensorIteratorBase::reorder_dimensions() {
   };
 
   // insertion sort with support for ambiguous comparisons
-  for (int i = 1; i < ndim(); i++) {
+  for (const auto i : c10::irange(1, ndim())) {
     int dim1 = i;
     for (int dim0 = i - 1; dim0 >= 0; dim0--) {
       int comparison = should_swap(perm_[dim0], perm_[dim1]);
@@ -497,7 +497,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
 StrideVector TensorIteratorBase::compatible_stride(int element_size) const {
   auto stride = StrideVector();
   int64_t next_stride = element_size;
-  for (int dim = 0; dim < ndim(); dim++) {
+  for (const auto dim : c10::irange(ndim())) {
     stride.push_back(next_stride);
     next_stride *= shape_[dim];
   }
@@ -510,14 +510,14 @@ DimVector TensorIteratorBase::invert_perm(IntArrayRef input) const {
   TORCH_INTERNAL_ASSERT(!has_coalesced_dimensions_);
   TORCH_INTERNAL_ASSERT(input.size()==perm_.size());
   auto res = DimVector(input.size()); //no initialization needed, every value in res should be written to.
-  for (int dim = 0; dim < ndim(); dim++) {
+  for (const auto dim : c10::irange(ndim())) {
     res[perm_[dim]] = input[dim];
   }
   return res;
 }
 
 void TensorIteratorBase::allocate_or_resize_outputs() {
-  for (int i = 0; i < num_outputs_; i++) {
+  for (const auto i : c10::irange(num_outputs_)) {
     auto& op = operands_[i];
     if (!op.tensor_base().defined() || op.will_resize) {
       TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
@@ -525,7 +525,7 @@ void TensorIteratorBase::allocate_or_resize_outputs() {
       op.stride_bytes = compatible_stride(element_size);
       // check if permutation is just an inverted order
       bool inverted = true;
-      for (int i = 0; i < ndim(); i++) {
+      for (const auto i : c10::irange(ndim())) {
         if (perm_[i] != ndim() - i - 1) {
           inverted = false;
           break;
@@ -539,7 +539,7 @@ void TensorIteratorBase::allocate_or_resize_outputs() {
         set_output(i, tensor_shape, {}, original_options(op), names_);
       } else {
         auto tensor_stride = invert_perm(op.stride_bytes);
-        for (int dim = 0; dim < ndim(); dim++) {
+        for (const auto dim : c10::irange(ndim())) {
           tensor_stride[dim] /= element_size;
         }
         set_output(i, tensor_shape, tensor_stride, original_options(op), names_);
@@ -593,7 +593,7 @@ void TensorIteratorBase::coalesce_dimensions() {
     if (shape0 == 1 || shape1 == 1) {
       return true;
     }
-    for (int i = 0; i < ntensors(); i++) {
+    for (const auto i : c10::irange(ntensors())) {
       auto& stride = operands_[i].stride_bytes;
       if (shape0 * stride[dim0] != stride[dim1]) {
         return false;
@@ -604,14 +604,14 @@ void TensorIteratorBase::coalesce_dimensions() {
 
   // replace each operands stride at dim0 with its stride at dim1
   auto replace_stride = [&](int dim0, int dim1) {
-    for (int i = 0; i < ntensors(); i++) {
+    for (const auto i : c10::irange(ntensors())) {
       auto& stride = operands_[i].stride_bytes;
       stride[dim0] = stride[dim1];
     }
   };
 
   int prev_dim = 0;
-  for (int dim = 1; dim < ndim(); dim++) {
+  for (const auto dim : c10::irange(1, ndim())) {
     if (can_coalesce(prev_dim, dim)) {
       if (shape_[prev_dim] == 1) {
         replace_stride(prev_dim, dim);
@@ -627,7 +627,7 @@ void TensorIteratorBase::coalesce_dimensions() {
   }
 
   shape_.resize(prev_dim + 1);
-  for (int i = 0; i < ntensors(); i++) {
+  for (const auto i : c10::irange(ntensors())) {
     operands_[i].stride_bytes.resize(ndim());
   }
   has_coalesced_dimensions_ = true;
@@ -670,7 +670,7 @@ void TensorIteratorBase::permute_dimensions(IntArrayRef perm) {
 
   auto reorder = [perm](IntArrayRef data) {
     auto res = DimVector(data.size(), 0);
-    for (size_t i = 0; i < perm.size(); i++) {
+    for (const auto i : c10::irange(perm.size())) {
       res[i] = data[perm[i]];
     }
     return res;
@@ -687,7 +687,7 @@ void TensorIteratorBase::permute_dimensions(IntArrayRef perm) {
 
 int64_t TensorIteratorBase::num_output_elements() const {
   int64_t elem = 1;
-  for (int dim = 0; dim < ndim(); dim++) {
+  for (const auto dim : c10::irange(ndim())) {
     if (operands_[0].stride_bytes[dim] != 0 || shape_[dim] == 0)  {
       elem *= shape_[dim];
     }
@@ -697,7 +697,7 @@ int64_t TensorIteratorBase::num_output_elements() const {
 
 int TensorIteratorBase::num_reduce_dims() const {
   int count = 0;
-  for (int dim = 0; dim < ndim(); dim++) {
+  for (const auto dim : c10::irange(ndim())) {
     if (operands_[0].stride_bytes[dim] == 0) {
       count++;
     }
@@ -760,7 +760,7 @@ bool TensorIteratorBase::is_contiguous() const {
 
 bool TensorIteratorBase::is_scalar(int arg) const {
   const auto& stride = operands_[arg].stride_bytes;
-  for (int i = 0; i < ndim(); i++) {
+  for (const auto i : c10::irange(ndim())) {
     if (stride[i] != 0 && shape_[i] != 1) {
       return false;
     }
@@ -815,7 +815,7 @@ void TensorIteratorBase::narrow(int dim, int64_t start, int64_t size) {
 
 void TensorIteratorBase::select_all_keeping_dim(int start_dim, IntArrayRef indices) {
   TORCH_INTERNAL_ASSERT(start_dim <= ndim());
-  for (int i = start_dim; i < ndim(); ++i) {
+  for (const auto i : c10::irange(start_dim, ndim())) {
     for (auto& op : operands_) {
       op.data = ((char*)op.data) + op.stride_bytes[i] * indices[i - start_dim];
     }
@@ -1063,13 +1063,13 @@ void TensorIteratorBase::populate_operands(TensorIteratorConfig& config) {
 
 void TensorIteratorBase::mark_outputs() {
   // TODO: merge this into populate_operands
-  for (int i = 0; i < num_outputs_; i++) {
+  for (const auto i : c10::irange(num_outputs_)) {
     operands_[i].is_output = true;
     const auto& output = tensor(i);
     if (!output.defined()) continue;
 
     // check if output is also an input
-    for (int arg = num_outputs_; arg < ntensors(); arg++) {
+    for (const auto arg : c10::irange(num_outputs_, ntensors())) {
       const auto& input = tensor(arg);
       if (output.is_same(input)) {
         operands_[i].is_read_write = true;
@@ -1086,7 +1086,7 @@ void TensorIteratorBase::mark_resize_outputs(const TensorIteratorConfig& config)
   if (config.static_shape_.has_value()) {
     return;
   }
-  for (int i = 0; i < num_outputs_; i++) {
+  for (const auto i : c10::irange(num_outputs_)) {
     const auto& output = tensor(i);
     if (output.defined() && !output.sizes().equals(shape_)) {
       if (config.resize_outputs_ && !operands_[i].is_read_write) {
@@ -1104,11 +1104,11 @@ void TensorIteratorBase::compute_mem_overlaps(const TensorIteratorConfig& config
   if (!config.check_mem_overlap_) {
     return;
   }
-  for (int i = 0; i < num_outputs_; i++) {
+  for (const auto i : c10::irange(num_outputs_)) {
     const auto& output = tensor_base(i);
     if (!output.defined()) continue;
     assert_no_internal_overlap(output);
-    for (int j = num_outputs_; j < ntensors(); j++) {
+    for (const auto j : c10::irange(num_outputs_, ntensors())) {
       const auto& input = tensor_base(j);
       if (!input.is_same(output)) {
         assert_no_partial_overlap(output, input);
@@ -1164,7 +1164,7 @@ void TensorIteratorBase::compute_strides(const TensorIteratorConfig& config) {
           op.stride_bytes.resize(ndim(), 0);
       else
           op.stride_bytes.resize(ndim());
-      for (size_t i = 0; i < original_shape.size(); i++) {
+      for (const auto i : c10::irange(original_shape.size())) {
         // see NOTE: [Computing output strides]
         if (original_shape[i] == 1 && shape_[offset + i] !=1) {
           op.stride_bytes[offset + i] = 0;
@@ -1183,7 +1183,7 @@ bool TensorIteratorBase::can_use_32bit_indexing() const {
   }
   for (auto& op : operands_) {
     int64_t max_offset = 1;
-    for (int dim = 0; dim < ndim(); dim++) {
+    for (const auto dim : c10::irange(ndim())) {
       max_offset += (shape_[dim] - 1) * op.stride_bytes[dim];
     }
     if (max_offset > max_value) {
@@ -1245,7 +1245,7 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
   switch (setup_type) {
     case FastSetupType::CONTIGUOUS:
       {
-        for (int i = 0; i < num_outputs_; i++){
+        for (const auto i : c10::irange(num_outputs_)) {
           auto& op = operands_[i];
           if (!op.tensor_base().defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
@@ -1256,7 +1256,7 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
       }
     case FastSetupType::CHANNELS_LAST:
       {
-        for (int i = 0; i < num_outputs_; i++){
+        for (const auto i : c10::irange(num_outputs_)) {
           auto& op = operands_[i];
           if (!op.tensor_base().defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
@@ -1273,7 +1273,7 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
           if (tensor(i_defined).defined()) break;
         }
         TORCH_CHECK(i_defined >= 0, "Can not find a defined tensor when fast allocating memory to outputs");
-        for (int i = 0; i < num_outputs_; i++){
+        for (const auto i : c10::irange(num_outputs_)) {
           auto& op = operands_[i];
           if (!op.tensor_base().defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -4,6 +4,7 @@
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/TypeCast.h>
+#include <c10/util/irange.h>
 #include <ATen/core/Dimname.h>
 #include <ATen/core/Range.h>
 #include <ATen/core/TensorBase.h>
@@ -322,9 +323,9 @@ private:
         char** base, const int64_t* strides, int64_t size0, int64_t size1) {
       PtrVector data(base, base + ntensor);
       const int64_t* outer_strides = &strides[ntensor];
-      for (int64_t i = 0; i < size1; i++) {
+      for (const auto i : c10::irange(size1)) {
         if (i > 0) {
-          for (int64_t arg = 0; arg < ntensor; arg++) {
+          for (const auto arg : c10::irange(ntensor)) {
             data[arg] += outer_strides[arg];
           }
         }
@@ -397,7 +398,7 @@ public:
 
   bool has_contiguous_first_dim() const {
     int num_tensors = ntensors();
-    for (int i = 0; i < num_tensors; i++) {
+    for (const auto i : c10::irange(num_tensors)) {
       if (strides(i)[0] != element_size(i)) {
         return false;
       }

--- a/aten/src/ATen/TensorIteratorInternal.h
+++ b/aten/src/ATen/TensorIteratorInternal.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/native/TensorIterator.h>
 #include <c10/util/SmallBuffer.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -24,9 +25,9 @@ inline void get_data_ptrs(
   const int64_t ntensors = base.size();
   const int64_t ndim = counter.size();
   std::copy(base.begin(), base.end(), ptrs);
-  for (int64_t dim = 0; dim < ndim; ++dim) {
+  for (const auto dim : c10::irange(ndim)) {
     int64_t value = counter[dim];
-    for (int64_t arg = 0; arg < ntensors; ++arg) {
+    for (const auto arg : c10::irange(ntensors)) {
       ptrs[arg] += value * strides[dim * ntensors + arg];
     }
   }

--- a/aten/src/ATen/TensorNames.cpp
+++ b/aten/src/ATen/TensorNames.cpp
@@ -56,7 +56,7 @@ TensorNames::TensorNames(ArrayRef<Dimname> names, int64_t start, int64_t end) {
   start = maybe_wrap_dim(start, names.size());
   end = maybe_wrap_dim(end, names.size());
   names_.reserve(end - start);
-  for (int64_t idx = start; idx < end; ++idx) {
+  for (const auto idx : c10::irange(start, end)) {
     names_.emplace_back(names, idx);
   }
 }

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Config.h>
 #include <ATen/TensorUtils.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 
 #include <ostream>
 #include <sstream>
@@ -323,7 +324,7 @@ size_t computeStorageNbytes(
   // size of the underlying storage is 1 bigger than the offset
   // of the last element according to stride
   size_t size = 1;
-  for(size_t i = 0; i < sizes.size(); i++) {
+  for (const auto i : c10::irange(sizes.size())) {
     if(sizes[i] == 0) {
       return 0;
     }

--- a/aten/src/ATen/VmapTransforms.cpp
+++ b/aten/src/ATen/VmapTransforms.cpp
@@ -83,7 +83,7 @@ VmapDimVector VmapPhysicalView::getPhysicalShape(IntArrayRef logical_shape) cons
 static BatchDims computeFrontBatchDimsFromLevels(std::bitset<kVmapNumLevels> levels_bitset) {
   BatchDims bdims;
   int64_t dim = 0;
-  for (int64_t level = 0; level < kVmapNumLevels; level++) {
+  for (const auto level : c10::irange(kVmapNumLevels)) {
     if (!levels_bitset[level]) {
       continue;
     }
@@ -208,7 +208,7 @@ MultiBatchVmapTransform::logicalToPhysical(TensorList logical_tensors) {
   VmapDimVector batch_sizes(num_batch_dims, 1);
   for (const auto& physical_tensor : physical_tensors) {
     auto physical_sizes = physical_tensor.sizes();
-    for (int64_t dim = 0; dim < num_batch_dims; dim++) {
+    for (const auto dim : c10::irange(num_batch_dims)) {
       if (physical_sizes[dim] != 1) {
         batch_sizes[dim] = physical_sizes[dim];
       }

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/core/TensorImpl.h>
+#include <c10/util/irange.h>
 #include <ATen/core/Tensor.h>
 
 namespace at {
@@ -40,7 +41,7 @@ static inline void maybe_wrap_dims_n(int64_t* dims, int64_t ndims, int64_t dim_p
   }
   int64_t min = -dim_post_expr;
   int64_t max = dim_post_expr - 1;
-  for (int64_t i = 0; i < ndims; ++i) {
+  for (const auto i : c10::irange(ndims)) {
     auto &dim = dims[i];
     if (dim < min || dim > max) {
       TORCH_CHECK_INDEX(false,
@@ -85,7 +86,7 @@ static inline int64_t legacy_cat_wrap_dim(int64_t dim, TensorList tensors) {
 
 // wrap negative dims in a vector
 static inline void wrap_all_dims(std::vector<int64_t>& dims_to_wrap, int64_t tensor_total_dims) {
-  for (size_t i = 0; i < dims_to_wrap.size(); i++) {
+  for (const auto i : c10::irange(dims_to_wrap.size())) {
     dims_to_wrap[i] = maybe_wrap_dim(dims_to_wrap[i], tensor_total_dims);
   }
 }

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/TensorImpl.h>
+#include <c10/util/irange.h>
 #include <ATen/WrapDimUtils.h>
 #include <sstream>
 #include <bitset>
@@ -15,7 +16,7 @@ constexpr size_t dim_bitset_size = 64;
 static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntArrayRef dims, int64_t ndims) {
   TORCH_CHECK(ndims <= (int64_t) dim_bitset_size, "only tensors with up to ", dim_bitset_size, " dims are supported");
   std::bitset<dim_bitset_size> seen;
-  for (size_t i = 0; i < dims.size(); i++) {
+  for (const auto i : c10::irange(dims.size())) {
     size_t dim = maybe_wrap_dim(dims[i], ndims);
     TORCH_CHECK(!seen[dim], "dim ", dim, " appears multiple times in the list of dims");
     seen[dim] = true;

--- a/aten/src/ATen/benchmarks/stateful_conv1d.cpp
+++ b/aten/src/ATen/benchmarks/stateful_conv1d.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/xnnpack_rewrite.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/jit/api/module.h>
@@ -33,7 +34,7 @@ static void stateful_conv1d(benchmark::State& state) {
   )");
 
   std::vector<std::vector<torch::jit::IValue>> inputs;
-  for (int i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     std::vector<torch::jit::IValue> input;
     // NOLINTNEXTLINE(modernize-use-emplace)
     input.push_back(torch::rand({batch_size, input_channels, width}));
@@ -70,8 +71,8 @@ static void GenerateSizes(benchmark::internal::Benchmark* b) {
 
   for (size_t input_channels = 32; input_channels < 256; input_channels *= 2) {
     for (size_t output_channels = 32; output_channels < 256; output_channels *= 2) {
-      for (size_t kernel = 3; kernel < 8; ++kernel) {
-        for (size_t batch_size = 1; batch_size < 5; ++batch_size) {
+      for (const auto kernel : c10::irange(3, 8)) {
+        for (const auto batch_size : c10::irange(1, 5)) {
           for (size_t width = 32; width < 256; width *= 2) {
             b->Args({input_channels, output_channels, kernel, batch_size, width, true});
             b->Args({input_channels, output_channels, kernel, batch_size, width, false});

--- a/aten/src/ATen/core/Array.h
+++ b/aten/src/ATen/core/Array.h
@@ -4,6 +4,7 @@
 // device code.
 
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace detail {
 

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/Formatting.h>
+#include <c10/util/irange.h>
 
 #include <cmath>
 #include <cstdint>
@@ -44,7 +45,7 @@ static std::tuple<double, int64_t> __printFormat(std::ostream& stream, const Ten
   }
   bool intMode = true;
   auto self_p = self.data_ptr<double>();
-  for(int64_t i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     auto z = self_p[i];
     if(std::isfinite(z)) {
       if(z != std::ceil(z)) {
@@ -70,7 +71,7 @@ static std::tuple<double, int64_t> __printFormat(std::ostream& stream, const Ten
   } else {
     expMin = fabs(self_p[offset]);
     expMax = fabs(self_p[offset]);
-    for(int64_t i = offset; i < size; i++) {
+    for (const auto i : c10::irange(offset, size)) {
       double z = fabs(self_p[i]);
       if(std::isfinite(z)) {
         if(z < expMin) {
@@ -130,7 +131,8 @@ static std::tuple<double, int64_t> __printFormat(std::ostream& stream, const Ten
 
 static void __printIndent(std::ostream &stream, int64_t indent)
 {
-  for(int64_t i = 0; i < indent; i++) {
+  for (const auto i : c10::irange(indent)) {
+    (void)i; //Suppress unused variable warning
     stream << " ";
   }
 }
@@ -168,7 +170,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
       printScale(stream,scale);
       __printIndent(stream, indent);
     }
-    for(int64_t l = 0; l < self.size(0); l++) {
+    for (const auto l : c10::irange(self.size(0))) {
       Tensor row = self.select(0,l);
       double *row_ptr = row.data_ptr<double>();
       for(int64_t c = firstColumn; c < lastColumn+1; c++) {
@@ -198,8 +200,7 @@ void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize)
   bool start = true;
   bool finished = false;
   counter[0] = -1;
-  for(size_t i = 1; i < counter.size(); i++)
-    counter[i] = 0;
+  for (const auto i : c10::irange(1, counter.size()))counter[i] = 0;
   while(true) {
     for(int64_t i = 0; self.ndimension()-2; i++) {
       counter[i] = counter[i] + 1;
@@ -269,7 +270,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
           printScale(stream, scale);
         }
         double* tensor_p = tensor.data_ptr<double>();
-        for (int64_t i = 0; i < tensor.size(0); i++) {
+        for (const auto i : c10::irange(tensor.size(0))) {
           stream << std::setw(sz) << tensor_p[i]/scale << std::endl;
         }
       }
@@ -284,7 +285,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
         __printTensor(stream, tensor, linesize);
       }
       stream << "[ " << tensor_.toString() << "{" << tensor.size(0);
-      for(int64_t i = 1; i < tensor.ndimension(); i++) {
+      for (const auto i : c10::irange(1, tensor.ndimension())) {
         stream << "," << tensor.size(i);
       }
       stream << "}";

--- a/aten/src/ATen/core/MT19937RNGEngine.h
+++ b/aten/src/ATen/core/MT19937RNGEngine.h
@@ -155,7 +155,7 @@ private:
     data_.seed_ = seed;
     data_.seeded_ = true;
     data_.state_[0] = seed & 0xffffffff;
-    for(int j = 1; j < MERSENNE_STATE_N; j++) {
+    for (const auto j : c10::irange(1, MERSENNE_STATE_N)) {
       data_.state_[j] = (1812433253 * (data_.state_[j-1] ^ (data_.state_[j-1] >> 30)) + j);
     }
     data_.left_ = 1;

--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -3,6 +3,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <stdint.h>
 #include <cstddef>
 
@@ -134,7 +135,7 @@ public:
       const source_index_t* sizes_,
       const source_index_t* strides_)
       : data_(data_) {
-    for (int i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       this->sizes_[i] = sizes_[i];
       this->strides_[i] = strides_[i];
     }

--- a/aten/src/ATen/core/boxing/impl/test_helpers.h
+++ b/aten/src/ATen/core/boxing/impl/test_helpers.h
@@ -7,6 +7,7 @@
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/ivalue.h>
 #include <c10/core/CPUAllocator.h>
+#include <c10/util/irange.h>
 
 template<class... Inputs>
 inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
@@ -87,7 +88,7 @@ inline void expectThrows(Functor&& functor, const char* expectMessageContains) {
 template<class T, size_t N>
 void expectListEquals(c10::ArrayRef<T> expected, std::array<T, N> actual) {
   EXPECT_EQ(expected.size(), actual.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     EXPECT_EQ(expected[i], actual[i]);
   }
 }
@@ -95,7 +96,7 @@ void expectListEquals(c10::ArrayRef<T> expected, std::array<T, N> actual) {
 template<class T>
 void expectListEquals(c10::ArrayRef<T> expected, c10::ArrayRef<T> actual) {
   EXPECT_EQ(expected.size(), actual.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     EXPECT_EQ(expected[i], actual[i]);
   }
 }
@@ -103,7 +104,7 @@ void expectListEquals(c10::ArrayRef<T> expected, c10::ArrayRef<T> actual) {
 template<class T>
 void expectListEquals(c10::ArrayRef<T> expected, c10::List<T> actual) {
   EXPECT_EQ(expected.size(), actual.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     EXPECT_EQ(expected[i], actual.get(i));
   }
 }
@@ -111,7 +112,7 @@ void expectListEquals(c10::ArrayRef<T> expected, c10::List<T> actual) {
 template<class T>
 void expectListEquals(c10::ArrayRef<T> expected, std::vector<T> actual) {
   EXPECT_EQ(expected.size(), actual.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     EXPECT_EQ(expected[i], actual[i]);
   }
 }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -5,6 +5,7 @@
 #include <ATen/core/jit_type.h>
 #include <c10/util/Bitset.h>
 #include <c10/core/DispatchKeySet.h>
+#include <c10/util/irange.h>
 #include <ATen/core/Variadic.h>
 #include <ATen/core/stack.h>
 
@@ -171,7 +172,7 @@ private:
         "The function schema has ", schema.arguments().size(),
         " arguments but this PyTorch build only supports ", c10::utils::bitset::NUM_BITS());
     c10::utils::bitset dispatch_arg_indices_reverse;
-    for (size_t index = 0; index < schema.arguments().size(); ++index) {
+    for (const auto index : c10::irange(schema.arguments().size())) {
       if (schema.arguments()[index].type()->isSubtypeOf(*TensorType::get()) ||
           schema.arguments()[index].type()->isSubtypeOf(
               *ListType::ofTensors()) ||

--- a/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
+++ b/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
@@ -5,6 +5,7 @@
 #include <ATen/Functions.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/op_registration/op_registration.h>
+#include <c10/util/irange.h>
 #include <torch/library.h>
 
 using namespace at;
@@ -51,7 +52,7 @@ void generic_wrapper_fallback(const c10::OperatorHandle& op, torch::jit::Stack* 
 
   // Unwrap all arguments
   auto args = torch::jit::pop(*stack, num_arguments);
-  for (size_t i = 0; i < num_arguments; i++) {
+  for (const auto i : c10::irange(num_arguments)) {
     // TODO: Handle tensor list
     if (args[i].isTensor()) {
       auto* impl = args[i].unsafeToTensorImpl();
@@ -70,7 +71,7 @@ void generic_wrapper_fallback(const c10::OperatorHandle& op, torch::jit::Stack* 
 
   // Rewrap outputs
   auto rets = torch::jit::pop(*stack, num_returns);
-  for (size_t i = 0; i < num_returns; i++) {
+  for (const auto i : c10::irange(num_returns)) {
     // TODO: Handle tensor list
     if (rets[i].isTensor()) {
       torch::jit::push(*stack, at::detail::make_tensor<GenericWrapperTensorImpl>(std::move(rets[i]).toTensor()));  // yes move!

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -2,6 +2,7 @@
 
 #include <c10/util/StringUtil.h>
 #include <c10/util/string_view.h>
+#include <c10/util/irange.h>
 #include <ATen/core/jit_type.h>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -16,7 +16,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
   out << "(";
 
   bool seen_kwarg_only = false;
-  for(size_t i = 0; i < schema.arguments().size(); ++i) {
+  for (const auto i : c10::irange(schema.arguments().size())) {
     if (i > 0) out << ", ";
     if (schema.arguments()[i].kwarg_only() && !seen_kwarg_only) {
       out << "*, ";
@@ -35,7 +35,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
 
   const auto& returns = schema.returns();
   out << "(";
-  for(size_t i = 0; i < returns.size(); ++i) {
+  for (const auto i : c10::irange(returns.size())) {
     if (i > 0) {
       out << ", ";
     }
@@ -53,7 +53,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
 
 inline size_t findFirstOutArg(const std::vector<Argument>& args) {
   // find the start of out args in the schema
-  for (size_t out_start_idx = 0; out_start_idx < args.size(); out_start_idx++) {
+  for (const auto out_start_idx : c10::irange(args.size())) {
     if (args.at(out_start_idx).is_out()) {
       return out_start_idx;
     }
@@ -122,7 +122,7 @@ inline bool FunctionSchema::isBackwardCompatibleWith(
         && arguments().size() >= old.arguments().size())) {
     return false;
   }
-  for (size_t i = 0; i < returns().size(); ++i) {
+  for (const auto i : c10::irange(returns().size())) {
     // Backwards compatibility requires covariance on argument types
     // (i.e. more generic), and contravariance on return types (i.e.
     //  more specific).
@@ -138,7 +138,7 @@ inline bool FunctionSchema::isBackwardCompatibleWith(
   size_t new_out_start_idx = findFirstOutArg(arguments());
 
   // make sure among the default args, they are backward compatible
-  for (size_t i = 0; i < old_out_start_idx; i++) {
+  for (const auto i : c10::irange(old_out_start_idx)) {
     if (!arguments().at(i).isBackwardCompatibleWith(
           old.arguments().at(i), why_not)) {
       return false;
@@ -146,7 +146,7 @@ inline bool FunctionSchema::isBackwardCompatibleWith(
   }
 
   // // Validate that all new arguments provided has a default value
-  for (size_t i = old_out_start_idx; i < new_out_start_idx; ++i) {
+  for (const auto i : c10::irange(old_out_start_idx, new_out_start_idx)) {
     if (!arguments().at(i).default_value()) {
       if (why_not) {
         *why_not
@@ -160,7 +160,7 @@ inline bool FunctionSchema::isBackwardCompatibleWith(
   }
 
   // now compare the out args
-  for (size_t i = old_out_start_idx; i < old.arguments().size(); i++) {
+  for (const auto i : c10::irange(old_out_start_idx, old.arguments().size())) {
     if (!arguments()
              .at(i - old_out_start_idx + new_out_start_idx)
              .isBackwardCompatibleWith(old.arguments().at(i), why_not)) {
@@ -238,7 +238,7 @@ inline void FunctionSchema::checkAndNormalizeInputs(
       *this);
 
   size_t consumed_kwargs = 0;
-  for (size_t pos = 0; pos < arguments().size(); ++pos) {
+  for (const auto pos : c10::irange(arguments().size())) {
     const auto& argument = arguments()[pos];
     if (pos < inputs.size()) {
       checkArg(inputs[pos], argument, pos);
@@ -298,7 +298,7 @@ inline bool isSubtypeOfList(
   if (child.size() != parent.size()) {
     return false;
   }
-  for (size_t i = 0; i < child.size(); ++i) {
+  for (const auto i : c10::irange(child.size())) {
     const Argument& c = child[i];
     const Argument& p = parent[i];
     if (c.name() != p.name()) {

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -21,6 +21,7 @@
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/hash.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace jit {
@@ -750,7 +751,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
     }
     std::ostringstream oss;
     oss << devices[0];
-    for (size_t idx = 1; idx < devices.size(); idx++) {
+    for (const auto idx : c10::irange(1, devices.size())) {
       if (idx == devices.size() - 1) {
         oss << " and ";
       } else {
@@ -767,7 +768,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
       return c10::kCPU;
     }
     c10::DeviceType deviceType = devices[0].type();
-    for (size_t idx = 1; idx < devices.size(); idx++) {
+    for (const auto idx : c10::irange(1, devices.size())) {
       TORCH_CHECK_VALUE(
           devices[idx].type() == deviceType,
           "Expected all devices to be of the same type, but got a mismatch between ",
@@ -787,7 +788,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
       [](const c10::Device& a, const c10::Device& b) { return a.index() < b.index(); });
     // Deduplicate by compacting.
     size_t targetIdx = 0;
-    for (size_t sourceIdx = 0; sourceIdx < devices.size(); sourceIdx++) {
+    for (const auto sourceIdx : c10::irange(devices.size())) {
       TORCH_CHECK_VALUE(
           devices[sourceIdx].has_index(),
           "Expected devices to have indices, got ", devices[sourceIdx]);

--- a/aten/src/ATen/core/op_registration/infer_schema.cpp
+++ b/aten/src/ATen/core/op_registration/infer_schema.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/op_registration/infer_schema.h>
+#include <c10/util/irange.h>
 #include <sstream>
 
 namespace c10 {
@@ -20,7 +21,7 @@ std::string fastToString(size_t x) {
 std::vector<Argument> createArgumentVector(c10::ArrayRef<ArgumentDef> args) {
   std::vector<Argument> result;
   result.reserve(args.size());
-  for (size_t i = 0; i < args.size(); ++i) {
+  for (const auto i : c10::irange(args.size())) {
     // Arguments are named "_<index>"
     result.emplace_back(fastToString(i), (*args[i].getTypeFn)());
   }
@@ -49,7 +50,7 @@ C10_EXPORT c10::optional<std::string> findSchemaDifferences(const FunctionSchema
              " vs " + guts::to_string(rhs.returns().size());
   }
 
-  for (size_t i = 0; i < lhs.arguments().size(); ++i) {
+  for (const auto i : c10::irange(lhs.arguments().size())) {
     const TypePtr& leftType = lhs.arguments()[i].type();
     const TypePtr& rightType = rhs.arguments()[i].type();
     // Type::operator== is virtual. Comparing pointers first is
@@ -61,7 +62,7 @@ C10_EXPORT c10::optional<std::string> findSchemaDifferences(const FunctionSchema
     }
   }
 
-  for (size_t i = 0; i < lhs.returns().size(); ++i) {
+  for (const auto i : c10::irange(lhs.returns().size())) {
     const TypePtr& leftType = lhs.returns()[i].type();
     const TypePtr& rightType = rhs.returns()[i].type();
     // See above about comparing pointers first.

--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -3,6 +3,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
+#include <c10/util/irange.h>
 #include <string>
 
 namespace c10 {
@@ -69,7 +70,7 @@ struct QualifiedName {
       // Can't be a prefix if it's bigger
       return false;
     }
-    for (size_t i = 0; i < thisAtoms.size(); i++) {
+    for (const auto i : c10::irange(thisAtoms.size())) {
       if (thisAtoms[i] != otherAtoms[i]) {
         return false;
       }
@@ -116,7 +117,7 @@ struct QualifiedName {
       reserve += e.size() + 1;
     }
     out.reserve(reserve);
-    for (size_t i = 0; i < v.size(); ++i) {
+    for (const auto i : c10::irange(v.size())) {
       if (i != 0) {
         out.push_back(delimiter);
       }

--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -4,6 +4,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <c10/util/Deprecated.h>
+#include <c10/util/irange.h>
 
 // TODO move this to c10 namespace
 
@@ -108,7 +109,7 @@ static inline IValue pop(Stack* stack) {
 static inline std::vector<IValue> pop(Stack& stack, size_t n) {
   std::vector<IValue> result;
   result.reserve(n);
-  for (size_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     result.push_back(std::move(peek(stack, i, n)));
   }
   drop(stack, n);

--- a/aten/src/ATen/cpu/vec/functional_base.h
+++ b/aten/src/ATen/cpu/vec/functional_base.h
@@ -4,6 +4,7 @@
 // See Note [Do not compile initializers with AVX]
 
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace vec {
 
@@ -16,7 +17,7 @@ inline scalar_t vec_reduce_all(
   using Vec = vec::Vectorized<scalar_t>;
   scalar_t acc_arr[Vec::size()];
   acc_vec.store(acc_arr);
-  for (int64_t i = 1; i < size; i++) {
+  for (const auto i : c10::irange(1, size)) {
     std::array<scalar_t, Vec::size()> acc_arr_next = {0};
     acc_arr_next[0] = acc_arr[i];
     Vec acc_vec_next = Vec::loadu(acc_arr_next.data());

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -4,6 +4,7 @@
 // See Note [Do not compile initializers with AVX]
 
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 
@@ -109,7 +110,7 @@ public:
   Vectorized<c10::complex<double>> map(c10::complex<double> (*const f)(const c10::complex<double> &)) const {
     __at_align__ c10::complex<double> tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -293,7 +294,7 @@ public:
     __at_align__ c10::complex<double> y_tmp[size()];
     store(x_tmp);
     exp.store(y_tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       x_tmp[i] = std::pow(x_tmp[i], y_tmp[i]);
     }
     return loadu(x_tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -4,6 +4,7 @@
 // See Note [Do not compile initializers with AVX]
 
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
@@ -144,7 +145,7 @@ public:
   Vectorized<c10::complex<float>> map(c10::complex<float> (*const f)(const c10::complex<float> &)) const {
     __at_align__ c10::complex<float> tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -327,7 +328,7 @@ public:
     __at_align__ c10::complex<float> y_tmp[size()];
     store(x_tmp);
     exp.store(y_tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       x_tmp[i] = std::pow(x_tmp[i], y_tmp[i]);
     }
     return loadu(x_tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
 #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -72,7 +73,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(
@@ -103,7 +104,7 @@ public:
   Vectorized<double> map(double (*const f)(double)) const {
     __at_align__ double tmp[size()];
     store(tmp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -180,7 +181,7 @@ public:
     __at_align__ double tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igamma(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);
@@ -190,7 +191,7 @@ public:
     __at_align__ double tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igammac(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
 #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -80,7 +81,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(
@@ -109,7 +110,7 @@ public:
   Vectorized<float> map(float (*const f)(float)) const {
     __at_align__ float tmp[size()];
     store(tmp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -217,7 +218,7 @@ public:
     __at_align__ float tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igamma(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);
@@ -227,7 +228,7 @@ public:
     __at_align__ float tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igammac(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
 // Sleef offers vectorized versions of some transcedentals
 // such as sin, cos, tan etc..
 // However for now opting for STL, since we are not building
@@ -221,7 +222,7 @@ public:
     }
     else {
       __at_align__ float tmp_values[size()];
-      for (auto i = 0; i < size(); ++i) {
+      for (const auto i : c10::irange(size())) {
         tmp_values[i] = 0.0;
       }
       std::memcpy(
@@ -287,7 +288,7 @@ public:
     __at_align__ float tmp[size()];
     __at_align__ float res[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       if (_isnan(tmp[i])) {
         std::memset(static_cast<void*>(&res[i]), 0xFF, sizeof(float));
       } else {
@@ -299,7 +300,7 @@ public:
   Vectorized<float> map(float (*const f)(float)) const {
     __at_align__ float tmp[size()];
     store(tmp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -336,7 +337,7 @@ public:
     __at_align__ float tmp_exp[size()];
     store(tmp);
     exp.store(tmp_exp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = std::atan2(tmp[i], tmp_exp[i]);
     }
     return loadu(tmp);
@@ -371,7 +372,7 @@ public:
     __at_align__ float tmp_q[size()];
     store(tmp);
     q.store(tmp_q);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = std::fmod(tmp[i], tmp_q[i]);
     }
     return loadu(tmp);
@@ -381,7 +382,7 @@ public:
     __at_align__ float tmp_b[size()];
     store(tmp);
     b.store(tmp_b);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = std::hypot(tmp[i], tmp_b[i]);
     }
     return loadu(tmp);
@@ -397,7 +398,7 @@ public:
     __at_align__ float tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igamma(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);
@@ -407,7 +408,7 @@ public:
     __at_align__ float tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igammac(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);
@@ -429,7 +430,7 @@ public:
     __at_align__ float tmp_b[size()];
     store(tmp);
     b.store(tmp_b);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = std::nextafter(tmp[i], tmp_b[i]);
     }
     return loadu(tmp);
@@ -494,7 +495,7 @@ public:
     __at_align__ float tmp_exp[size()];
     store(tmp);
     exp.store(tmp_exp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = std::pow(tmp[i], tmp_exp[i]);
     }
     return loadu(tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 #include <iostream>
 
 namespace at {
@@ -98,7 +99,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
@@ -221,7 +222,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
@@ -435,7 +436,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
@@ -684,7 +685,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int8_t));

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_double_vsx.h
@@ -3,6 +3,7 @@
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace vec {
@@ -167,7 +168,7 @@ class Vectorized<ComplexDbl> {
   Vectorized<ComplexDbl> map(ComplexDbl (*const f)(ComplexDbl)) const {
     __at_align__ ComplexDbl tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -176,7 +177,7 @@ class Vectorized<ComplexDbl> {
   Vectorized<ComplexDbl> map(ComplexDbl (*const f)(const ComplexDbl&)) const {
     __at_align__ ComplexDbl tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -454,7 +455,7 @@ class Vectorized<ComplexDbl> {
     __at_align__ ComplexDbl y_tmp[size()];
     store(x_tmp);
     exp.store(y_tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       x_tmp[i] = std::pow(x_tmp[i], y_tmp[i]);
     }
     return loadu(x_tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_float_vsx.h
@@ -4,6 +4,7 @@
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace vec {
@@ -222,7 +223,7 @@ class Vectorized<ComplexFlt> {
   Vectorized<ComplexFlt> map(ComplexFlt (*const f)(ComplexFlt)) const {
     __at_align__ ComplexFlt tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -231,7 +232,7 @@ class Vectorized<ComplexFlt> {
   Vectorized<ComplexFlt> map(ComplexFlt (*const f)(const ComplexFlt&)) const {
     __at_align__ ComplexFlt tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -430,7 +431,7 @@ class Vectorized<ComplexFlt> {
     __at_align__ ComplexFlt y_tmp[size()];
     store(x_tmp);
     exp.store(y_tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       x_tmp[i] = std::pow(x_tmp[i], y_tmp[i]);
     }
     return loadu(x_tmp);

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_quint8_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_quint8_vsx.h
@@ -3,6 +3,8 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/quint8.h>
 #include <array>
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -4,6 +4,7 @@
 // See Note [Do not compile initializers with AVX]
 
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
@@ -149,7 +150,7 @@ public:
   Vectorized<c10::complex<double>> map(c10::complex<double> (*const f)(const c10::complex<double> &)) const {
     __at_align__ c10::complex<double> tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -357,7 +358,7 @@ public:
     __at_align__ c10::complex<double> y_tmp[size()];
     store(x_tmp);
     exp.store(y_tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       x_tmp[i] = std::pow(x_tmp[i], y_tmp[i]);
     }
     return loadu(x_tmp);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -4,6 +4,7 @@
 // See Note [Do not compile initializers with AVX]
 
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
@@ -667,7 +668,7 @@ public:
   Vectorized<c10::complex<float>> map(c10::complex<float> (*const f)(const c10::complex<float> &)) const {
     __at_align__ c10::complex<float> tmp[size()];
     store(tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -858,7 +859,7 @@ public:
     __at_align__ c10::complex<float> y_tmp[size()];
     store(x_tmp);
     exp.store(y_tmp);
-    for (int i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       x_tmp[i] = std::pow(x_tmp[i], y_tmp[i]);
     }
     return loadu(x_tmp);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_double.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
 #if (defined(CPU_CAPABILITY_AVX512)) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -87,7 +88,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(
@@ -120,7 +121,7 @@ public:
   Vectorized<double> map(double (*const f)(double)) const {
     __at_align__ double tmp[size()];
     store(tmp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -200,7 +201,7 @@ public:
     __at_align__ double tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igamma(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);
@@ -210,7 +211,7 @@ public:
     __at_align__ double tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igammac(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -5,6 +5,7 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
 #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -104,7 +105,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(
@@ -135,7 +136,7 @@ public:
   Vectorized<float> map(float (*const f)(float)) const {
     __at_align__ float tmp[size()];
     store(tmp);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
@@ -246,7 +247,7 @@ public:
     __at_align__ float tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igamma(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);
@@ -256,7 +257,7 @@ public:
     __at_align__ float tmp_x[size()];
     store(tmp);
     x.store(tmp_x);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       tmp[i] = calc_igammac(tmp[i], tmp_x[i]);
     }
     return loadu(tmp);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_int.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_int.h
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace vec {
@@ -100,7 +101,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
@@ -253,7 +254,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
@@ -485,7 +486,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
@@ -761,7 +762,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int8_t));

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -6,6 +6,8 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/native/quantized/affine_quantizer_base.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>
 #include <c10/util/quint8.h>
@@ -744,7 +746,7 @@ struct VectorizedQuantizedConverter {
   std::array<value_type, size_> vals;
 
   VectorizedQuantizedConverter(T val) {
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       vals[i] = val.val_;
     }
   }
@@ -762,9 +764,9 @@ struct VectorizedQuantizedConverter {
       Vectorized<float> zero_point,
       Vectorized<float> scale_zp_premul) const {
     float_vec_return_type rv;
-    for (int i = 0; i < float_num_vecs(); ++i) {
+    for (const auto i : c10::irange(float_num_vecs())) {
       float tmp_vals[16];
-      for (int j = 0; j < 16; ++j) {
+      for (const auto j : c10::irange(16)) {
         tmp_vals[j] = at::native::dequantize_val<T>(
             scale[j], zero_point[j], T(vals[16 * i + j]));
       }
@@ -829,7 +831,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
     std::array<value_type, size()> qvals;
     std::array<float, float_num_vecs() * 16> float_vals;
 
-    for (int i = 0; i < float_num_vecs(); ++i) {
+    for (const auto i : c10::irange(float_num_vecs())) {
       rhs[i].store(&float_vals[i * 16], 16);
     }
 
@@ -845,7 +847,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
 
   Vectorized<c10::qint32> maximum(Vectorized<c10::qint32> b) const {
     Vectorized<c10::qint32> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::max<value_type>(vals[i], b.vals[i]);
     }
     return retval;
@@ -853,7 +855,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
 
   Vectorized<c10::qint32> minimum(Vectorized<c10::qint32> b) const {
     Vectorized<c10::qint32> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::min<value_type>(vals[i], b.vals[i]);
     }
     return retval;
@@ -868,7 +870,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
       Vectorized<c10::qint32> zero_point,
       Vectorized<c10::qint32> q_six) {
     Vectorized<c10::qint32> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::min<value_type>(
           std::max<value_type>(vals[i], zero_point.vals[i]), q_six.vals[i]);
     }
@@ -877,7 +879,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
 
   int_vec_return_type widening_subtract(Vectorized<c10::qint32> b) const {
     int_vec_return_type retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval[0].vals[i] = vals[i] - b.vals[i];
     }
     return retval;
@@ -888,7 +890,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
       float multiplier,
       int32_t zero_point) {
     Vectorized<c10::qint32> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] =
           nearbyint(static_cast<float>(inp[0].vals[i]) * multiplier) +
           zero_point;
@@ -961,7 +963,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     std::array<value_type, size()> qvals;
     std::array<float, float_num_vecs() * 16> float_vals;
 
-    for (int i = 0; i < float_num_vecs(); ++i) {
+    for (const auto i : c10::irange(float_num_vecs())) {
       rhs[i].store(&float_vals[i * 16], 16);
     }
 
@@ -977,7 +979,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
 
   Vectorized<c10::qint8> maximum(Vectorized<c10::qint8> b) const {
     Vectorized<c10::qint8> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::max<value_type>(vals[i], b.vals[i]);
     }
     return retval;
@@ -985,7 +987,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
 
   Vectorized<c10::qint8> minimum(Vectorized<c10::qint8> b) const {
     Vectorized<c10::qint8> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::min<value_type>(vals[i], b.vals[i]);
     }
     return retval;
@@ -999,7 +1001,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
       Vectorized<c10::qint8> zero_point,
       Vectorized<c10::qint8> q_six) {
     Vectorized<c10::qint8> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::min<value_type>(
           std::max<value_type>(vals[i], zero_point.vals[i]), q_six.vals[i]);
     }
@@ -1009,8 +1011,8 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
   int_vec_return_type widening_subtract(Vectorized<c10::qint8> b) const {
     int_vec_return_type retval;
     constexpr int elem_per_int_vec = size() / int_num_vecs();
-    for (size_t i = 0; i < int_num_vecs(); ++i) {
-      for (size_t j = 0; j < elem_per_int_vec; ++j) {
+    for (const auto i : c10::irange(int_num_vecs())) {
+      for (const auto j : c10::irange(elem_per_int_vec)) {
         retval[i].vals[j] =
             static_cast<int32_t>(vals[i * elem_per_int_vec + j]) -
             static_cast<int32_t>(b.vals[i * elem_per_int_vec + j]);
@@ -1026,8 +1028,8 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     constexpr auto min_val = std::numeric_limits<value_type>::min();
     constexpr auto max_val = std::numeric_limits<value_type>::max();
     Vectorized<c10::qint8> retval;
-    for (size_t i = 0; i < int_num_vecs(); ++i) {
-      for (size_t j = 0; j < elem_per_int_vec; ++j) {
+    for (const auto i : c10::irange(int_num_vecs())) {
+      for (const auto j : c10::irange(elem_per_int_vec)) {
         int32_t rounded =
             nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
             zero_point;
@@ -1081,7 +1083,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     std::array<value_type, size()> qvals;
     std::array<float, float_num_vecs() * 16> float_vals;
 
-    for (int i = 0; i < float_num_vecs(); ++i) {
+    for (const auto i : c10::irange(float_num_vecs())) {
       rhs[i].store(&float_vals[i * 16], 16);
     }
 
@@ -1097,7 +1099,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
 
   Vectorized<c10::quint8> maximum(Vectorized<c10::quint8> b) const {
     Vectorized<c10::quint8> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::max<value_type>(vals[i], b.vals[i]);
     }
     return retval;
@@ -1105,7 +1107,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
 
   Vectorized<c10::quint8> minimum(Vectorized<c10::quint8> b) const {
     Vectorized<c10::quint8> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::min<value_type>(vals[i], b.vals[i]);
     }
     return retval;
@@ -1120,7 +1122,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
       Vectorized<c10::quint8> zero_point,
       Vectorized<c10::quint8> q_six) {
     Vectorized<c10::quint8> retval;
-    for (size_t i = 0; i < size(); ++i) {
+    for (const auto i : c10::irange(size())) {
       retval.vals[i] = std::min<value_type>(
           std::max<value_type>(vals[i], zero_point.vals[i]), q_six.vals[i]);
     }
@@ -1130,8 +1132,8 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
   int_vec_return_type widening_subtract(Vectorized<c10::quint8> b) const {
     int_vec_return_type retval;
     constexpr int elem_per_int_vec = size() / int_num_vecs();
-    for (size_t i = 0; i < int_num_vecs(); ++i) {
-      for (size_t j = 0; j < elem_per_int_vec; ++j) {
+    for (const auto i : c10::irange(int_num_vecs())) {
+      for (const auto j : c10::irange(elem_per_int_vec)) {
         retval[i].vals[j] =
             static_cast<int32_t>(vals[i * elem_per_int_vec + j]) -
             static_cast<int32_t>(b.vals[i * elem_per_int_vec + j]);
@@ -1147,8 +1149,8 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     constexpr auto min_val = std::numeric_limits<value_type>::min();
     constexpr auto max_val = std::numeric_limits<value_type>::max();
     Vectorized<c10::quint8> retval;
-    for (size_t i = 0; i < int_num_vecs(); ++i) {
-      for (size_t j = 0; j < elem_per_int_vec; ++j) {
+    for (const auto i : c10::irange(int_num_vecs())) {
+      for (const auto j : c10::irange(elem_per_int_vec)) {
         int32_t rounded =
             nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
             zero_point;

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -31,6 +31,7 @@
 #include <ATen/native/cpu/zmath.h>
 #include <c10/util/TypeCast.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 
 // These macros helped us unify vec_base.h
 #ifdef CPU_CAPABILITY_AVX512
@@ -150,7 +151,7 @@ public:
   static Vectorized<T> blend(const Vectorized<T>& a, const Vectorized<T>& b) {
     int64_t mask = mask_;
     Vectorized vector;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       if (mask & 0x01) {
         vector[i] = b[i];
       } else {
@@ -165,7 +166,7 @@ public:
     Vectorized vector;
     int_same_size_t<T> buffer[size()];
     mask.store(buffer);
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       if (buffer[i] & 0x01)
        {
         vector[i] = b[i];
@@ -178,14 +179,14 @@ public:
   template<typename step_t>  // step sometimes requires a higher precision type (e.g., T=int, step_t=double)
   static Vectorized<T> arange(T base = static_cast<T>(0), step_t step = static_cast<step_t>(1)) {
     Vectorized vector;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       vector.values[i] = base + i * step;
     }
     return vector;
   }
   static Vectorized<T> set(const Vectorized<T>& a, const Vectorized<T>& b, int64_t count = size()) {
     Vectorized vector;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       if (i < count) {
         vector[i] = b[i];
       } else {
@@ -340,7 +341,7 @@ public:
   }
   Vectorized<T> atan2(const Vectorized<T> &exp) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = std::atan2(values[i], exp[i]);
     }
     return ret;
@@ -380,7 +381,7 @@ public:
     // U is for SFINAE purposes only. Make sure it is not changed.
     static_assert(std::is_same<U, T>::value, "U must be T");
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = std::fmod(values[i], q[i]);
     }
     return ret;
@@ -423,7 +424,7 @@ public:
   }
   Vectorized<T> hypot(const Vectorized<T> &b) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = std::hypot(values[i], b[i]);
     }
     return ret;
@@ -436,14 +437,14 @@ public:
   }
   Vectorized<T> igamma(const Vectorized<T> &x) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = calc_igamma(values[i], x[i]);
     }
     return ret;
   }
   Vectorized<T> igammac(const Vectorized<T> &x) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = calc_igammac(values[i], x[i]);
     }
     return ret;
@@ -456,7 +457,7 @@ public:
   }
   Vectorized<T> nextafter(const Vectorized<T> &b) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = std::nextafter(values[i], b[i]);
     }
     return ret;
@@ -494,7 +495,7 @@ public:
   }
   Vectorized<T> pow(const Vectorized<T> &exp) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i < size(); i++) {
+    for (const auto i : c10::irange(size())) {
       ret[i] = std::pow(values[i], exp[i]);
     }
     return ret;
@@ -808,7 +809,7 @@ inline gather(T const* base_addr, const Vectorized<int_same_size_t<T>>& vindex) 
   int_same_size_t<T> index_arr[size];
   vindex.store(static_cast<void*>(index_arr));
   T buffer[size];
-  for (int64_t i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     buffer[i] = base_addr[index_arr[i] * scale / sizeof(T)];
   }
   return Vectorized<T>::loadu(static_cast<void*>(buffer));
@@ -826,7 +827,7 @@ inline mask_gather(const Vectorized<T>& src, T const* base_addr,
   mask.store(static_cast<void*>(mask_arr));
   vindex.store(static_cast<void*>(index_arr));
   T buffer[size];
-  for (int64_t i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     if (mask_arr[i] & 0x01) {  // check highest bit
       buffer[i] = base_addr[index_arr[i] * scale / sizeof(T)];
     } else {
@@ -872,7 +873,7 @@ inline Vectorized<int_same_size_t<T>> convert_to_int_of_same_size(const Vectoriz
   T src_arr[size];
   src.store(static_cast<void*>(src_arr));
   int_same_size_t<T> buffer[size];
-  for (int64_t i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     buffer[i] = static_cast<int_same_size_t<T>>(src_arr[i]);
   }
   return Vectorized<int_same_size_t<T>>::loadu(static_cast<void*>(buffer));
@@ -899,7 +900,7 @@ deinterleave2(const Vectorized<T>& a, const Vectorized<T>& b) {
   T buffer2[size];
   a.store(static_cast<void*>(a_arr));
   b.store(static_cast<void*>(b_arr));
-  for (int64_t i = 0; i < half_size; i++) {
+  for (const auto i : c10::irange(half_size)) {
     buffer1[i] = a_arr[i * 2];
     buffer1[half_size + i] = b_arr[i * 2];
     buffer2[i] = a_arr[i * 2 + 1];
@@ -931,7 +932,7 @@ interleave2(const Vectorized<T>& a, const Vectorized<T>& b) {
   T buffer2[size];
   a.store(static_cast<void*>(a_arr));
   b.store(static_cast<void*>(b_arr));
-  for (int64_t i = 0; i < half_size; i++) {
+  for (const auto i : c10::irange(half_size)) {
     buffer1[i * 2] = a_arr[i];
     buffer1[i * 2 + 1] = b_arr[i];
     buffer2[i * 2] = a_arr[half_size + i];
@@ -946,7 +947,8 @@ inline void convert(const src_T *src, dst_T *dst, int64_t n) {
 #ifndef _MSC_VER
 # pragma unroll
 #endif
-  for (int64_t i = 0; i < n; i++) {
+  for (const auto i : c10::irange(n)) {
+    (void)i; //Suppress unused variable warning
     *dst = c10::static_cast_with_inter_type<dst_T, src_T>::apply(*src);
     src++;
     dst++;

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/cuda/CUDABlas.h>
 #include <ATen/cuda/Exceptions.h>
+#include <c10/util/irange.h>
 
 #define CUDABLAS_POSINT_CHECK(FD, X)         \
   TORCH_CHECK(                               \
@@ -295,7 +296,7 @@ void bgemm<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half)) {
       c, CUDA_R_16F, ldc, stridec,
       num_batches, CUDA_R_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP));
   } else {
-    for (int64_t i = 0; i < num_batches; ++i) {
+    for (const auto i : c10::irange(num_batches)) {
       at::cuda::blas::gemm<at::Half>(
         transa, transb,
         m, n, k,

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -1,6 +1,7 @@
 #include <ATen/cudnn/Descriptors.h>
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 #include <iostream>
 #include <sstream>
@@ -47,11 +48,11 @@ void TensorDescriptor::set(cudnnDataType_t datatype, IntArrayRef t_sizes, IntArr
 #undef STR
   int size[CUDNN_DIM_MAX];
   int stride[CUDNN_DIM_MAX];
-  for (size_t i = 0; i < dim; ++i) {
+  for (const auto i : c10::irange(dim)) {
     size[i] = static_cast<int>(t_sizes[i]);
     stride[i] = static_cast<int>(t_strides[i]);
   }
-  for (size_t i = dim; i < pad; ++i) {
+  for (const auto i : c10::irange(dim, pad)) {
     size[i] = 1;
     stride[i] = 1;
   }
@@ -126,10 +127,10 @@ void FilterDescriptor::set(const at::Tensor &t, const at::MemoryFormat memory_fo
       "cuDNN filters (a.k.a. weights) must be contiguous in desired memory_format");
 
   int size[CUDNN_DIM_MAX];
-  for (int i = 0; i < dim; ++i) {
+  for (const auto i : c10::irange(dim)) {
     size[i] = (int) t.size(i);
   }
-  for (int i = dim; i < pad; ++i) {
+  for (const auto i : c10::irange(dim, pad)) {
     size[i] = (int) 1;
   }
   dim = std::max(dim, pad);

--- a/aten/src/ATen/miopen/Descriptors.cpp
+++ b/aten/src/ATen/miopen/Descriptors.cpp
@@ -1,5 +1,6 @@
 #include <ATen/miopen/Descriptors.h>
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 #include <iostream>
 
@@ -39,11 +40,11 @@ void TensorDescriptor::set(miopenDataType_t datatype, IntArrayRef t_sizes, IntAr
 #undef STR
   int size[MIOPEN_DIM_MAX];
   int stride[MIOPEN_DIM_MAX];
-  for (size_t i = 0; i < dim; ++i) {
+  for (const auto i : c10::irange(dim)) {
     size[i] = static_cast<int>(t_sizes[i]);
     stride[i] = static_cast<int>(t_strides[i]);
   }
-  for (size_t i = dim; i < pad; ++i) {
+  for (const auto i : c10::irange(dim, pad)) {
     size[i] = 1;
     stride[i] = 1;
   }
@@ -103,10 +104,10 @@ void FilterDescriptor::set(const at::Tensor &t, const at::MemoryFormat memory_fo
 
   int size[MIOPEN_DIM_MAX];
   int stride[MIOPEN_DIM_MAX];
-  for (int i = 0; i < dim; ++i) {
+  for (const auto i : c10::irange(dim)) {
     size[i] = (int) t.size(i);
   }
-  for (int i = dim; i < pad; ++i) {
+  for (const auto i : c10::irange(dim, pad)) {
     size[i] = (int) 1;
   }
 

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -500,7 +500,7 @@ inline void _rrelu_with_noise_train(
   scalar_t* noise_data = noise.data_ptr<scalar_t>();
   auto gen  = at::get_generator_or_default<CPUGeneratorImpl>(generator, detail::getDefaultCPUGenerator());
   std::lock_guard<std::mutex> lock(gen->mutex_);
-  for (int64_t i = 0; i < input.numel(); i++) {
+  for (const auto i : c10::irange(input.numel())) {
     if (input_data[i] <= 0) {
       at::uniform_real_distribution<double> uniform(lower, upper);
       const scalar_t r = (scalar_t)uniform(gen);
@@ -610,7 +610,7 @@ void inline prelu_cpu_kernel_share_weights(
   auto weight_val = weight.data_ptr<scalar_t>()[0];
 
   at::parallel_for(0, input_numel, 1000, [&](int64_t start, int64_t end) {
-    for (auto i = start; i < end; i++) {
+    for (const auto i : c10::irange(start, end)) {
       scalar_t input_data_val = input_data[i];
       // to allow for compiler optimization, here splitting into two lines:
       scalar_t r = (input_data_val > 0) ? scalar_t(1) : weight_val;
@@ -725,7 +725,7 @@ void inline prelu_cpu_backward_kernel_share_weights(
   scalar_t sum = at::parallel_reduce(0, input_numel, 1000, scalar_t(0),
       [&](int64_t start, int64_t end, scalar_t ident) -> scalar_t {
     scalar_t partial_sum = ident;
-    for (auto i = start; i < end; i++) {
+    for (const auto i : c10::irange(start, end)) {
       scalar_t input_data_val = input_data[i];
       scalar_t grad_out_data_val = grad_out_data[i];
       // to allow for compiler optimization, here splitting into two lines:
@@ -839,7 +839,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
     std::vector<int64_t> reduce_dims;
     reduce_dims.push_back(0);
     if (dims > 2) {
-      for(int64_t i = 2; i < dims; i++) reduce_dims.push_back(i);
+      for (const auto i : c10::irange(2, dims))reduce_dims.push_back(i);
     }
     weight_grad = weight_grad_collector.sum(reduce_dims);
   }

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/AdaptivePooling.h>
 #include <ATen/native/xnnpack/Engine.h>
+#include <c10/util/irange.h>
 
 
 namespace at {
@@ -16,7 +17,7 @@ namespace {
   {
     TORCH_CHECK(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
     int64_t ndim = input.ndimension();
-    for (int64_t i = 1; i < ndim; i++) {
+    for (const auto i : c10::irange(1, ndim)) {
       TORCH_CHECK(input.size(i) > 0,
         "adaptive_avg_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i, " being "
@@ -52,7 +53,7 @@ namespace {
     const Tensor& input)
   {
     int64_t ndim = grad_output.ndimension();
-    for (int64_t i = 1; i < ndim; i++) {
+    for (const auto i : c10::irange(1, ndim)) {
       TORCH_CHECK(grad_output.size(i) > 0,
         "adaptive_avg_pool2d_backward(): Expected grad_output to have non-zero size for non-batch dimensions, "
         "but grad_output has sizes ", grad_output.sizes(), " with dimension ", i, " being "

--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -33,19 +34,19 @@ static void adaptive_avg_pool3d_out_frame(
     int64_t istrideH,
     int64_t istrideW) {
   at::parallel_for(0, sizeD, 1, [&](int64_t start, int64_t end) {
-    for (int64_t d = start; d < end; d++) {
+    for (const auto d : c10::irange(start, end)) {
       /* loop over output */
-      for (int64_t ot = 0; ot < osizeT; ot++) {
+      for (const auto ot : c10::irange(osizeT)) {
         int istartT = start_index(ot, osizeT, isizeT);
         int iendT = end_index(ot, osizeT, isizeT);
         int kT = iendT - istartT;
 
-        for (int64_t oh = 0; oh < osizeH; oh++) {
+        for (const auto oh : c10::irange(osizeH)) {
           int istartH = start_index(oh, osizeH, isizeH);
           int iendH = end_index(oh, osizeH, isizeH);
           int kH = iendH - istartH;
 
-          for (int64_t ow = 0; ow < osizeW; ow++) {
+          for (const auto ow : c10::irange(osizeW)) {
             int istartW = start_index(ow, osizeW, isizeW);
             int iendW = end_index(ow, osizeW, isizeW);
             int kW = iendW - istartW;
@@ -58,9 +59,9 @@ static void adaptive_avg_pool3d_out_frame(
 
             /* compute local average: */
             scalar_t sum = 0;
-            for (int it = 0; it < kT; it++) {
-              for (int ih = 0; ih < kH; ih++) {
-                for (int iw = 0; iw < kW; iw++) {
+            for (const auto it : c10::irange(kT)) {
+              for (const auto ih : c10::irange(kH)) {
+                for (const auto iw : c10::irange(kW)) {
                   scalar_t val =
                       *(ip + it * istrideT + ih * istrideH + iw * istrideW);
                   sum += val;
@@ -83,7 +84,7 @@ void adaptive_avg_pool3d_out_cpu_template(
     IntArrayRef output_size) {
   TORCH_CHECK(output_size.size() == 3, "adaptive_avg_pool3d: output_size must be 3");
 
-  for (int64_t i = 1; i < input.ndimension(); i++) {
+  for (const auto i : c10::irange(1, input.ndimension())) {
     TORCH_CHECK(
         input.size(i) > 0,
         "adaptive_avg_pool3d(): Expected input to have non-zero size for non-batch dimensions, "
@@ -148,7 +149,7 @@ void adaptive_avg_pool3d_out_cpu_template(
           auto input_data = input.data_ptr<scalar_t>();
           auto output_data = output.data_ptr<scalar_t>();
           at::parallel_for(0, n, 1, [&](int64_t start, int64_t end) {
-            for (int64_t b = start; b < end; ++b) {
+            for (const auto b : c10::irange(start, end)) {
               adaptive_avg_pool3d_out_frame<scalar_t>(
                   input_data + b * input.stride(0),
                   output_data + b * sizeD * osizeT * osizeH * osizeW,
@@ -181,22 +182,22 @@ static void adaptive_avg_pool3d_backward_out_frame(
     int64_t osizeH,
     int64_t osizeW) {
   at::parallel_for(0, sizeD, 1, [&](int64_t start, int64_t end) {
-    for (int64_t d = start; d < end; d++) {
+    for (const auto d : c10::irange(start, end)) {
       scalar_t* gradInput_p_d = gradInput_p + d * isizeT * isizeW * isizeH;
       scalar_t* gradOutput_p_d = gradOutput_p + d * osizeT * osizeW * osizeH;
 
       /* calculate average */
-      for (int64_t ot = 0; ot < osizeT; ot++) {
+      for (const auto ot : c10::irange(osizeT)) {
         int istartT = start_index(ot, osizeT, isizeT);
         int iendT = end_index(ot, osizeT, isizeT);
         int kT = iendT - istartT;
 
-        for (int64_t oh = 0; oh < osizeH; oh++) {
+        for (const auto oh : c10::irange(osizeH)) {
           int istartH = start_index(oh, osizeH, isizeH);
           int iendH = end_index(oh, osizeH, isizeH);
           int kH = iendH - istartH;
 
-          for (int64_t ow = 0; ow < osizeW; ow++) {
+          for (const auto ow : c10::irange(osizeW)) {
             int istartW = start_index(ow, osizeW, isizeW);
             int iendW = end_index(ow, osizeW, isizeW);
             int kW = iendW - istartW;
@@ -205,9 +206,9 @@ static void adaptive_avg_pool3d_backward_out_frame(
                 gradOutput_p_d[ot * osizeH * osizeW + oh * osizeW + ow] / kT /
                 kH / kW;
 
-            for (int it = istartT; it < iendT; it++) {
-              for (int ih = istartH; ih < iendH; ih++) {
-                for (int iw = istartW; iw < iendW; iw++) {
+            for (const auto it : c10::irange(istartT, iendT)) {
+              for (const auto ih : c10::irange(istartH, iendH)) {
+                for (const auto iw : c10::irange(istartW, iendW)) {
                   /* update gradient */
                   gradInput_p_d[it * isizeH * isizeW + ih * isizeW + iw] +=
                       grad_delta;
@@ -265,7 +266,7 @@ Tensor& adaptive_avg_pool3d_backward_out_cpu_template(
           scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
           scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
           at::parallel_for(0, n, 1, [&](int64_t start, int64_t end) {
-            for (int64_t b = start; b < end; b++) {
+            for (const auto b : c10::irange(start, end)) {
               adaptive_avg_pool3d_backward_out_frame<scalar_t>(
                   gradInput_data + b * sizeD * isizeT * isizeH * isizeW,
                   gradOutput_data + b * sizeD * osizeT * osizeH * osizeW,

--- a/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/AdaptivePooling.h>
+#include <c10/util/irange.h>
 
 
 namespace at {
@@ -10,7 +11,7 @@ TORCH_META_FUNC(adaptive_max_pool2d) (const Tensor& input, IntArrayRef output_si
   TORCH_CHECK(ndim == 3 || ndim == 4,
               "adaptive_max_pool2d(): Expected 3D or 4D tensor, but got: ",
               input.sizes());
-  for (int64_t i = 1; i < ndim; i++) {
+  for (const auto i : c10::irange(1, ndim)) {
     TORCH_CHECK(input.size(i) > 0,
         "adaptive_max_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i,
@@ -51,7 +52,7 @@ TORCH_META_FUNC(adaptive_max_pool2d_backward)
   int64_t ndim = grad_output.ndimension();
   TORCH_CHECK(ndim == 3 || ndim == 4,
     "adaptive_max_pooling2d_backward(): Expected 3D or 4D grad_output, but got: ", grad_output.sizes());
-  for (int64_t i = 1; i < ndim; i++) {
+  for (const auto i : c10::irange(1, ndim)) {
     TORCH_CHECK(grad_output.size(i) > 0,
       "adaptive_max_pooling2d_backward(): Expected grad_output to have non-zero size for non-batch dimensions, "
       "but grad_output has sizes ", grad_output.sizes(), " with dimension ", i,

--- a/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 #include <tuple>
 
 
@@ -11,7 +12,7 @@ TORCH_META_FUNC(adaptive_max_pool3d) (const Tensor& input, IntArrayRef output_si
   TORCH_CHECK(
     ndim == 4 || ndim == 5,
     "adaptive_max_pool3d(): Expected 4D or 5D tensor, but got: ", input.sizes());
-  for (int64_t i = 1; i < ndim; i++) {
+  for (const auto i : c10::irange(1, ndim)) {
     TORCH_CHECK(
         input.size(i) > 0,
         "adaptive_max_pool3d(): Expected input to have non-zero size for non-batch dimensions, "
@@ -96,8 +97,7 @@ static void adaptive_max_pool3d_single_out_frame(
           int64_t istrideW)
 {
   at::parallel_for(0, sizeD, 0, [&](int64_t start, int64_t end) {
-    for (auto d = start; d < end; d++)
-    {
+    for (const auto d : c10::irange(start, end)) {
       /* loop over output */
       int64_t ot, oh, ow;
       for(ot = 0; ot < osizeT; ot++)
@@ -176,8 +176,7 @@ static void adaptive_max_pool3d_out_frame(
           int64_t istrideW)
 {
   at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
-    for (auto b = start; b < end; b++)
-    {
+    for (const auto b : c10::irange(start, end)) {
       adaptive_max_pool3d_single_out_frame<scalar_t>(input_data+b*istrideB, output_data+b*sizeD*osizeT*osizeH*osizeW,
                                                      indices_data+b*sizeD*osizeT*osizeH*osizeW,
                                                      sizeD,
@@ -203,8 +202,7 @@ static void adaptive_max_pool3d_backward_single_out_frame(
           int64_t osizeW)
 {
   at::parallel_for(0, sizeD, 0, [&](int64_t start, int64_t end) {
-    for (auto d = start; d < end; d++)
-    {
+    for (const auto d : c10::irange(start, end)) {
       scalar_t *gradInput_p_d = gradInput_p + d*isizeT*isizeH*isizeW;
       scalar_t *gradOutput_p_d = gradOutput_p + d*osizeT*osizeH*osizeW;
       int64_t *ind_p_d = ind_p + d*osizeT*osizeH*osizeW;
@@ -244,8 +242,7 @@ static void adaptive_max_pool3d_backward_out_frame(
           int64_t osizeW)
 {
   at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
-    for (auto b = start; b < end; b++)
-    {
+    for (const auto b : c10::irange(start, end)) {
       adaptive_max_pool3d_backward_single_out_frame<scalar_t>(gradInput_data+b*sizeD*isizeT*isizeH*isizeW, gradOutput_data+b*sizeD*osizeT*osizeH*osizeW,
                                                               indices_data+b*sizeD*osizeT*osizeH*osizeW,
                                                               sizeD,

--- a/aten/src/ATen/native/AveragePool3d.cpp
+++ b/aten/src/ATen/native/AveragePool3d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/irange.h>
 #include <tuple>
 
 
@@ -169,8 +170,7 @@ static void avg_pool3d_out_frame(
           c10::optional<int64_t> divisor_override)
 {
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t i, j, ti;
 
@@ -315,7 +315,7 @@ TORCH_IMPL_FUNC(avg_pool3d_out_cpu) (
         scalar_t *output_data = output.data_ptr<scalar_t>();
 
         at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-          for (auto p = start; p < end; p++) {
+          for (const auto p : c10::irange(start, end)) {
             avg_pool3d_out_frame(
               input_data + p * istride, output_data + p * ostride, nslices,
               itime, iwidth, iheight,
@@ -358,8 +358,7 @@ static void avg_pool3d_backward_out_frame(
           c10::optional<int64_t> divisor_override)
 {
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t i, j, ti;
 
@@ -500,8 +499,7 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cpu) (
         scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
 
         at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-          for (auto p = start; p < end; p++)
-          {
+          for (const auto p : c10::irange(start, end)) {
             avg_pool3d_backward_out_frame(
               gradInput_data  + p * istride, gradOutput_data + p * ostride, nslices,
               itime, iwidth, iheight,

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -63,7 +63,7 @@ void apply_reflect_conj_tri_single(scalar_t* self, int64_t n, int64_t stride, bo
   std::function<void(int64_t, int64_t)> loop = [](int64_t, int64_t){};
   if (upper) {
     loop = [&](int64_t start, int64_t end) {
-      for (int64_t i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         for (int64_t j = i + 1; j < n; j++) {
           self[i * stride + j] = conj_impl(self[j * stride + i]);
         }
@@ -71,8 +71,8 @@ void apply_reflect_conj_tri_single(scalar_t* self, int64_t n, int64_t stride, bo
     };
   } else {
     loop = [&](int64_t start, int64_t end) {
-      for (int64_t i = start; i < end; i++) {
-        for (int64_t j = 0; j < i; j++) {
+      for (const auto i : c10::irange(start, end)) {
+        for (const auto j : c10::irange(i)) {
           self[i * stride + j] = conj_impl(self[j * stride + i]);
         }
       }
@@ -106,7 +106,7 @@ void apply_cholesky_inverse(Tensor& input, Tensor& infos, bool upper) {
   auto n = input.size(-2);
   auto lda = std::max<int64_t>(1, n);
 
-  for (int64_t i = 0; i < batch_size; i++) {
+  for (const auto i : c10::irange(batch_size)) {
     scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
     int* info_working_ptr = &infos_data[i];
     lapackCholeskyInverse<scalar_t>(uplo, n, input_working_ptr, lda, info_working_ptr);
@@ -501,7 +501,7 @@ inline void apply_orgqr(Tensor& self, const Tensor& tau) {
   lwork = std::max<int>(1, real_impl<scalar_t, value_t>(wkopt));
   Tensor work = at::empty({lwork}, self.options());
 
-  for (int64_t i = 0; i < batch_size; i++) {
+  for (const auto i : c10::irange(batch_size)) {
     scalar_t* self_working_ptr = &self_data[i * self_matrix_stride];
     scalar_t* tau_working_ptr = &tau_data[i * tau_stride];
 

--- a/aten/src/ATen/native/BlasKernel.cpp
+++ b/aten/src/ATen/native/BlasKernel.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
+#include <c10/util/irange.h>
 
 #if AT_BUILD_WITH_BLAS()
 extern "C" double ddot_(int *n, double *x, int *incx, double *y, int *incy);
@@ -151,7 +152,7 @@ inline void scal(int64_t n, scalar_t a, scalar_t *x, int64_t incx)
     blas_impl::scal_fast_path<scalar_t>(&i_n, &a, x, &i_incx);
     return;
   }
-  for (int64_t i = 0; i < n; i++) {
+  for (const auto i : c10::irange(n)) {
     if (a == scalar_t(0)) {
       x[i * incx] = 0;
     } else {
@@ -176,11 +177,10 @@ void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, scalar_t *a, int64_t
   }
 
   if ((trans == 'T') || (trans == 't')) {
-    for (int64_t i = 0; i < n; i++)
-    {
+    for (const auto i : c10::irange(n)) {
       scalar_t sum = 0;
       scalar_t *row_ = a + lda * i;
-      for (int64_t j = 0; j < m; j++) {
+      for (const auto j : c10::irange(m)) {
         sum += x[j * incx] * row_[j];
       }
       if (beta == scalar_t(0)) {
@@ -192,10 +192,10 @@ void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, scalar_t *a, int64_t
   } else {
     if (beta != scalar_t(1) && beta != scalar_t(0)) scal<scalar_t>(m, beta, y, incy);
 
-    for (int64_t j = 0; j < n; j++) {
+    for (const auto j : c10::irange(n)) {
       scalar_t *column_ = a + lda * j;
       scalar_t z = alpha * x[j * incx];
-      for (int64_t i = 0; i < m; i++) {
+      for (const auto i : c10::irange(m)) {
         //output values are ignored if beta is 0, and set to 0, nans and infs are not propagated
         if (j==0 && beta==scalar_t(0)) {
          y[i * incy] = scalar_t(0);

--- a/aten/src/ATen/native/Bucketization.cpp
+++ b/aten/src/ATen/native/Bucketization.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/BucketizationUtils.h>
 #include <ATen/native/Resize.h>
+#include <c10/util/irange.h>
 
 /* Implement a TF like searchsorted and a bucketize function running on cpu
  *
@@ -58,7 +59,7 @@ void searchsorted_cpu_contiguous(Tensor& result, const Tensor& input, const Tens
 
   bool is_1d_boundaries = boundaries.dim() == 1;
   at::parallel_for(0, numel_in, SEARCHSORTED_GRAIN_SIZE, [&](int64_t start, int64_t end) {
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       // If boundaries tensor is 1d, we always search the entire boundary tensor
       int64_t start_bd = is_1d_boundaries ? 0 : i / idim_in * idim_bd;
       const input_t *data_bd_start = &data_bd[start_bd];

--- a/aten/src/ATen/native/Col2Im.cpp
+++ b/aten/src/ATen/native/Col2Im.cpp
@@ -5,6 +5,7 @@
 
 #include <ATen/native/im2col.h>
 #include <ATen/native/im2col_shape_check.h>
+#include <c10/util/irange.h>
 
 // Note [im2col/col2im output padding]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,7 +151,7 @@ static void col2im_out_cpu_template(
                 stride_width +
             1;
 
-        for (int64_t elt = 0; elt < batch_size; elt++) {
+        for (const auto elt : c10::irange(batch_size)) {
           input_n = input.select(0, elt);
           output_n = output.select(0, elt);
 

--- a/aten/src/ATen/native/ComplexHelper.h
+++ b/aten/src/ATen/native/ComplexHelper.h
@@ -24,7 +24,7 @@ inline Tensor view_tensor(
 
 inline DimVector computeStrideForViewAsReal(IntArrayRef oldstride) {
   DimVector res(oldstride.size() + 1);
-  for(size_t i = 0; i < oldstride.size(); i++) {
+  for (const auto i : c10::irange(oldstride.size())) {
     res[i] = oldstride[i] * 2;
   }
   res.back() = 1;

--- a/aten/src/ATen/native/ConstantPadNd.cpp
+++ b/aten/src/ATen/native/ConstantPadNd.cpp
@@ -47,7 +47,7 @@ Tensor constant_pad_nd(const Tensor& self, IntArrayRef pad, const Scalar& value)
         new_shape.emplace_back(input_sizes[i]);
     }
 
-    for (size_t i = 0; i < (size_t)l_pad; i++) {
+    for (const auto i : c10::irange((size_t)l_pad)) {
         auto pad_idx = pad.size() - ((i + 1) * 2);
         auto new_dim = input_sizes[l_diff + i] + pad[pad_idx] + pad[pad_idx + 1];
         TORCH_CHECK(new_dim > 0, "The input size ", input_sizes[l_diff + i], ", plus negative padding ",

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/env.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -35,7 +36,7 @@ static inline std::vector<int64_t> conv_output_size(
   std::vector<int64_t> output_size(dim);
   output_size[0] = input_size[input_batch_size_dim];
   output_size[1] = weight_size[weight_output_channels_dim];
-  for (size_t d = 2; d < dim; ++d) {
+  for (const auto d : c10::irange(2, dim)) {
     auto dilation_ = has_dilation ? dilation[d - 2] : 1;
     auto kernel = dilation_ * (weight_size[d] - 1) + 1;
     output_size[d] = (input_size[d] + (2 * padding[d - 2]) - kernel) / stride[d - 2] + 1;
@@ -53,7 +54,7 @@ static inline std::vector<int64_t> conv_input_size(
   std::vector<int64_t> input_size(dim);
   input_size[0] = output_size[output_batch_size_dim];
   input_size[1] = weight_size[weight_input_channels_dim] * groups;
-  for (size_t d = 2; d < dim; ++d) {
+  for (const auto d : c10::irange(2, dim)) {
     int kernel = dilation[d - 2] * (weight_size[d] - 1) + 1;
     input_size[d] = (output_size[d] - 1) * stride[d - 2] - (2 * padding[d - 2]) +
                      kernel + output_padding[d - 2];
@@ -69,7 +70,7 @@ static inline std::vector<int64_t> conv_weight_size(
   std::vector<int64_t> weight_size(dim);
   weight_size[0] = output_size[1];
   weight_size[1] = input_size[1] / groups;
-  for (size_t d = 2; d < dim; ++d) {
+  for (const auto d : c10::irange(2, dim)) {
     int kernel = input_size[d] - (output_size[d] - 1) * stride[d - 2]
                + 2 * padding[d - 2] - output_padding[d - 2];
     weight_size[d] = (kernel - 1) / dilation[d - 2] + 1;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -975,7 +975,7 @@ at::Tensor _convolution(
     } else {
       std::vector<Tensor> outputs(params.groups);
       input = input.contiguous();
-      for (int g = 0; g < params.groups; ++g) {
+      for (const auto g : c10::irange(params.groups)) {
         auto input_g = subtensor(input, 1, params.groups, g);
         auto weight_g = subtensor(weight, 0, params.groups, g);
         auto bias_g = subtensor(bias, 0, params.groups, g);
@@ -1212,7 +1212,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
         }
       } else {
         std::vector<Tensor> gWt_list(groups);
-        for (int g = 0; g < groups; ++g) {
+        for (const auto g : c10::irange(groups)) {
           auto ggIt_g = subvariable(ggIt, 0, groups, g);
           auto gOt_g = subvariable(gOt, 0, groups, g);
           if (gOt_g.is_cuda()) {
@@ -1239,7 +1239,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
       // the ConvForward kernels don't support asymmetric padding.
       auto gW_size = gW.sizes();
       auto w_size = weight.sizes();
-      for (size_t i = 2; i < gW_size.size(); ++i) {
+      for (const auto i : c10::irange(2, gW_size.size())) {
         if (gW_size[i] > w_size[i]) {
             gW = gW.narrow(i, 0, w_size[i]);
             gW_size = gW.sizes();
@@ -1268,7 +1268,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
         // rather than narrowing the computed gI
         auto gI_size = gI.sizes();
         auto i_size = input.sizes();
-        for (size_t i = 2; i < gI_size.size(); ++i) {
+        for (const auto i : c10::irange(2, gI_size.size())) {
           if (gI_size[i] > i_size[i]) {
             gI = gI.narrow(i, 0, i_size[i]);
             gI_size = gI.sizes();
@@ -1289,7 +1289,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
             gi_conv_params.output_padding[1] = input_shape[0] - expected_input_shape;
           }
         } else {
-          for(size_t i = 0; i < kernel_size.size(); ++i) {
+          for (const auto i : c10::irange(kernel_size.size())) {
             // Check if whole input has been used or not
             auto expected_input_shape = (kernel_size[i] - 1) * gi_conv_params.dilation[i]
               - 2 * gi_conv_params.padding[i]

--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -7,6 +7,7 @@
 #include <ATen/div_rtn.h>
 #include <ATen/native/CPUBlas.h>
 #include <ATen/native/Unfold2d.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -299,7 +300,7 @@ void slow_conv2d_backward_out_cpu_template(
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
       auto fgrad_input = std::make_unique<scalar_t[]>(
           c10::multiply_integers(finput.sizes().slice(1)));
-      for (int64_t t = start; t < end; t++) {
+      for (const auto t : c10::irange(start, end)) {
         auto grad_input_t = grad_input_a[t];
         auto grad_output_t = grad_output_a[t];
         slow_conv2d_backward_update_grad_input_frame(
@@ -478,7 +479,7 @@ std::tuple<Tensor&, Tensor&> slow_conv2d_forward_out_cpu(
     auto weight_2d_a = weight_2d.accessor<scalar_t, 2>();
 
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-      for (int64_t t = start; t < end; t++) {
+      for (const auto t : c10::irange(start, end)) {
         auto input_t = input_a[t];
         auto output_t = output_a[t];
         auto finput_t = finput_a[t];

--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -6,6 +6,7 @@
 #include <ATen/div_rtn.h>
 #include <ATen/native/CPUBlas.h>
 #include <ATen/native/Unfold3d.h>
+#include <c10/util/irange.h>
 
 constexpr int64_t CONV3D_GRAIN_SALT = 20;
 
@@ -358,7 +359,7 @@ void slow_conv3d_backward_out_cpu_template(
         auto fgrad_input_a = fgrad_input.accessor<scalar_t, 3>();
         auto weight_2d_a = weight2d.accessor<scalar_t, 2>();
 
-        for (int64_t t = start; t < end; t++) {
+        for (const auto t : c10::irange(start, end)) {
           auto grad_input_t = grad_input_a[t];
           auto grad_output_t = grad_output_a[t];
           auto fgrad_input_t = fgrad_input_a[t];
@@ -462,7 +463,7 @@ static void slow_conv3d_backward_parameters_out_cpu_template(
     auto grad_weight_2d_a = grad_weight_2d.accessor<scalar_t, 2>();
     auto grad_output_a = grad_output_contiguous.accessor<scalar_t, 5>();
     auto finput_a = finput.accessor<scalar_t, 3>();
-    for (int64_t t = 0; t < batch_size; t++) {
+    for (const auto t : c10::irange(batch_size)) {
       auto grad_output_t = grad_output_a[t];
       auto finput_t = finput_a[t];
       slow_conv3d_backward_weight_frame(
@@ -564,7 +565,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> slow_conv3d_forward_out_cpu(const Tensor& 
 
     at::parallel_for(
         0, batch_size, CONV3D_GRAIN_SALT, [&](int64_t start, int64_t end) {
-          for (int64_t t = start; t < end; t++) {
+          for (const auto t : c10::irange(start, end)) {
             auto input_t = input_a[t];
             auto output_t = output_a[t];
             auto finput_t = finput_a[t];

--- a/aten/src/ATen/native/ConvolutionTBC.cpp
+++ b/aten/src/ATen/native/ConvolutionTBC.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
+#include <c10/util/irange.h>
 #include <tuple>
 
 namespace at {
@@ -39,7 +40,7 @@ Tensor conv_tbc(const Tensor& self, const Tensor& weight, const Tensor& bias, in
     weight_size[2],
   }, self.options());
   output.copy_(bias.expand(output.sizes()));
-  for (int k = 0; k < kw; k++) {
+  for (const auto k : c10::irange(kw)) {
     int iShift = std::max(0, static_cast<int>(k - real_pad));
     int oShift = std::max(0, static_cast<int>(real_pad - k));
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)

--- a/aten/src/ATen/native/Cross.cpp
+++ b/aten/src/ATen/native/Cross.cpp
@@ -3,6 +3,7 @@
 #include <ATen/NativeFunctions.h>
 
 #include <ATen/native/Cross.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -30,7 +31,7 @@ Tensor & cross_out(const Tensor & input, const Tensor & other, const c10::option
 
   int64_t dim = -1;
   if(!dimension.has_value()) {
-    for(int64_t i = 0; i < input.dim(); i++) {
+    for (const auto i : c10::irange(input.dim())) {
       if(input.size(i) == 3) {
         dim = i;
         break;

--- a/aten/src/ATen/native/DilatedConvolutionUtils.h
+++ b/aten/src/ATen/native/DilatedConvolutionUtils.h
@@ -5,6 +5,7 @@
 
 #include <ATen/div_rtn.h>
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 #define TORCH_CHECK_DIM_SIZE(T, DIM, DIM_SIZE, SIZE) \
   TORCH_CHECK(                                       \
@@ -43,7 +44,7 @@ std::vector<int64_t> get_output_size(
     IntArrayRef pad_size,
     IntArrayRef dilation_size) {
   std::vector<int64_t> sizes;
-  for (int index = 0; index < dim; index++) {
+  for (const auto index : c10::irange(dim)) {
     sizes.push_back(
         div_rtn<int64_t>(
             input.size(index + input.dim() - dim) + 2 * pad_size[index] -

--- a/aten/src/ATen/native/DilatedMaxPool3d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool3d.cpp
@@ -3,6 +3,7 @@
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/irange.h>
 #include <tuple>
 
 
@@ -37,8 +38,7 @@ static void max_pool3d_with_indices_single_out_frame(
           int dilationH)
 {
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       /* loop over output */
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t i, j, ti;
@@ -120,8 +120,7 @@ static void max_pool3d_with_indices_out_frame(
           int dilationT, int dilationW, int dilationH)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       max_pool3d_with_indices_single_out_frame(
         input_data   + p * istride,
         output_data  + p * ostride,
@@ -285,8 +284,7 @@ static void max_pool3d_with_indices_backward_single_out_frame(
           int dilationH)
 {
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       scalar_t *gradInput_p_k  = gradInput_p  + k * itime * iwidth * iheight;
       scalar_t *gradOutput_p_k = gradOutput_p + k * otime * owidth * oheight;
       int64_t *indz_p_k = indz_p + k * otime * owidth * oheight;
@@ -330,8 +328,7 @@ static void max_pool3d_with_indices_backward_out_frame(
           int dilationT, int dilationW, int dilationH)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       max_pool3d_with_indices_backward_single_out_frame<scalar_t>(
         gradInput_data + p * istride,
         gradOutput_data + p * ostride,

--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NamedTensorUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -16,8 +17,10 @@ Tensor make_feature_noise(const Tensor& input) {
   sizes.reserve(input.dim());
   sizes.push_back(input_sizes[0]);
   sizes.push_back(input_sizes[1]);
-  for (int64_t i = 2; i < input.dim(); ++i)
+  for (const auto i : c10::irange(2, input.dim())) {
+    (void)i; //Suppress unused variable warning
     sizes.push_back(1);
+  }
   return at::empty(sizes, input.options());
 }
 

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -123,7 +123,7 @@ Tensor embedding_dense_backward_cpu(
 
     auto parallel_section = [&](index_t start, index_t end) {
       TensorIterator iter(add_iter);
-      for (int64_t i = 0; i < numel; i++) {
+      for (const auto i : c10::irange(numel)) {
         if (indices_data[i] != padding_idx) {
           index_t k = indices_data[i];
           if (k >= start && k < end) {
@@ -167,7 +167,7 @@ Tensor & embedding_renorm_cpu_(
 
     // Note that we cannot use at::parallel_for here because we perform operations on
     // Tensor inside the loop. See github.com/pytorch/pytorch/issues/28370 for more details.
-    for (auto i = 0; i < num_indices; i++) {
+    for (const auto i : c10::irange(num_indices)) {
       if (i > 0 && sorted_indices[i] == sorted_indices[i - 1]) {
         continue;
       }

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -107,7 +107,7 @@ index_select_add(const Tensor &select_indices,
   auto output_stride0 = output.strides()[0];
   auto output_stride1 = output.strides()[1];
 
-  for (int64_t i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // We can skip indices equal to padding_idx so they are not included in
     // the reduction
     if (select_indices_data[i] != padding_idx) {
@@ -247,7 +247,7 @@ index_select_add(const Tensor &select_indices,
     auto output_stride0 = output.strides()[0];
     auto output_stride1 = output.strides()[1];
     auto numel = add_indices.numel();
-    for (int64_t i = 0; i < numel; i++) {
+    for (const auto i : c10::irange(numel)) {
       // We can skip indices equal to padding_idx so they are not included in
       // the reduction
       if (select_indices_data[i] != padding_idx) {
@@ -302,14 +302,14 @@ index_select_scale_add(const Tensor &select_indices,
   auto* scale_data = scale.data_ptr<data_t>();
   auto scale_stride = scale.strides()[0];
 
-  for (int64_t i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // We can skip indices equal to padding_idx so they are not included in
     // the reduction
     if (select_indices_data[i] != padding_idx) {
       auto* src_base = src_data + src_stride0 * select_indices_data[i];
       auto* output_base = output_data + output_stride0 * add_indices_data[i];
       auto scale = scale_data[i * scale_stride];
-      for (int64_t j = 0; j < ddim; j++) {
+      for (const auto j : c10::irange(ddim)) {
         output_base[j * output_stride1] += src_base[j * src_stride1] * scale;
       }
     } else if (bag_size.defined()) {
@@ -419,14 +419,14 @@ index_select_scale_add(const Tensor &select_indices,
     auto numel = add_indices.numel();
 
 
-    for (int64_t i = 0; i < numel; i++) {
+    for (const auto i : c10::irange(numel)) {
       // We can skip indices equal to padding_idx so they are not included in
       // the reduction
       if (select_indices_data[i] != padding_idx) {
         auto* src_base = src_data + src_stride0 * select_indices_data[i];
         auto* output_base = output_data + output_stride0 * add_indices_data[i];
         auto scale = scale_data[i * scale_stride];
-        for (int64_t j = 0; j < ddim; j++) {
+        for (const auto j : c10::irange(ddim)) {
           output_base[j * output_stride1] += src_base[j * src_stride1] * scale;
         }
       } else if (bag_size.defined()) {

--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -6,6 +6,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/Utils.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -63,7 +64,7 @@ Tensor& fill_diagonal_(Tensor& self, const Scalar& fill_value, bool wrap) {
 
   if (nDims > 2) {
     int64_t dim1 = height;
-    for (int64_t i = 1; i < nDims; i++) {
+    for (const auto i : c10::irange(1, nDims)) {
       if (self.size(i) != dim1) {
         AT_ERROR("all dimensions of input must be of equal length");
       }
@@ -76,7 +77,7 @@ Tensor& fill_diagonal_(Tensor& self, const Scalar& fill_value, bool wrap) {
   int64_t size = std::min(height, width);
 
   int64_t stride = 0;
-  for (int64_t i = 0; i < nDims; i++) {
+  for (const auto i : c10::irange(nDims)) {
     stride += self.stride(i);
   }
   strides.push_back(stride);

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #include <tuple>
 #include <vector>
@@ -32,7 +33,7 @@ TORCH_META_FUNC(fractional_max_pool2d) (
   int64_t ndims = input.ndimension();
   TORCH_CHECK(ndims == 3 || ndims == 4,
               "fractional_max_pool2d(): Expected 3D or 4D tensor, but got: ", input.sizes());
-  for (int64_t i = 1; i < ndims; ++i) {
+  for (const auto i : c10::irange(1, ndims)) {
     TORCH_CHECK(input.size(i) > 0,
                 "fractional_max_pool2d(): Expected input to have non-zero size for non-batch dimensions, but got",
                 input.sizes(), " with dimension ", i, " being empty.");
@@ -106,7 +107,7 @@ static void fractional_max_pool2d_out_single_batch_frame(
   int outputW, int outputH,
   int poolSizeW, int poolSizeH) {
   at::parallel_for(0, numPlanes, 0, [&](int64_t start, int64_t end) {
-    for (auto plane = start; plane < end; ++plane) {
+    for (const auto plane : c10::irange(start, end)) {
       /* each plane contains 2 random samples, one for W and one for H */
       scalar_t* randomSamplesForPlane = randomSamples + plane * 2;
 
@@ -177,7 +178,7 @@ static void fractional_max_pool2d_out_frame(
       return;
     }
     at::parallel_for(0, numBatch, 0, [&](int64_t start, int64_t end) {
-      for (auto batch = start; batch < end; ++batch) {
+      for (const auto batch : c10::irange(start, end)) {
         fractional_max_pool2d_out_single_batch_frame<scalar_t>(
           input + batch * numPlanes * inputH * inputW,
           output + batch * numPlanes * outputH * outputW,
@@ -254,7 +255,7 @@ static void fractional_max_pool2d_backward_out_single_batch_frame(
   int inputW, int inputH,
   int outputW, int outputH) {
   at::parallel_for(0, numPlanes, 0, [&](int64_t start, int64_t end) {
-    for (auto plane = start; plane < end; plane++) {
+    for (const auto plane : c10::irange(start, end)) {
       scalar_t* gradInputForPlane = gradInput + plane * inputW * inputH;
       scalar_t* gradOutputForPlane = gradOutput + plane * outputW * outputH;
       int64_t* indicesForPlane = indices + plane * outputW * outputH;
@@ -291,7 +292,7 @@ static void fractional_max_pool2d_backward_out_frame(
       return;
     }
     at::parallel_for(0, numBatch, 0, [&](int64_t start, int64_t end) {
-      for (auto batch = start; batch < end; ++batch) {
+      for (const auto batch : c10::irange(start, end)) {
         fractional_max_pool2d_backward_out_single_batch_frame<scalar_t>(
           gradInput + batch * numPlanes * inputH * inputW,
           gradOutput + batch * numPlanes * outputH * outputW,

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -44,7 +44,7 @@ static void fractional_max_pool3d_out_single_batch_frame(
   int64_t poolSizeT, int64_t poolSizeH, int64_t poolSizeW) {
 
   at::parallel_for(0, numPlanes, 0, [&](int64_t start, int64_t end) {
-    for (auto plane = start; plane < end; ++plane) {
+    for (const auto plane : c10::irange(start, end)) {
       /* each plane contains 3 random samples,
          one for T, one for W, and one for H */
       scalar_t* randomSamplesForPlane = randomSamples + plane * 3;
@@ -126,7 +126,7 @@ static void fractional_max_pool3d_out_frame(
     }
 
     at::parallel_for(0, numBatch, 0, [&](int64_t start, int64_t end) {
-      for (auto batch = start; batch < end; ++batch) {
+      for (const auto batch : c10::irange(start, end)) {
         fractional_max_pool3d_out_single_batch_frame<scalar_t>(
           input + batch * numPlanes * inputW * inputH * inputT,
           output + batch * numPlanes * outputW * outputH * outputT,
@@ -171,7 +171,7 @@ void fractional_max_pool3d_out_cpu_template(
   TORCH_CHECK(ndims == 4 || ndims == 5,
               "fractional_max_pool3d_out(): Expected 4D or 5D tensor, but got: ",
               input_.sizes());
-  for (int64_t i = 1; i < ndims; ++i) {
+  for (const auto i : c10::irange(1, ndims)) {
     TORCH_CHECK(input_.size(i) > 0,
                 "fractional_max_pool3d_out(): Expected input to have non-zero size for non-batch dimensions, but got",
                 input_.sizes(), " with dimension ", i, " being empty.");
@@ -243,7 +243,7 @@ static void fractional_max_pool3d_backward_out_single_batch_frame(
   int64_t outputT, int64_t outputH, int64_t outputW) {
 
   at::parallel_for(0, numPlanes, 0, [&](int64_t start, int64_t end) {
-    for (auto plane = start; plane < end; plane++) {
+    for (const auto plane : c10::irange(start, end)) {
       scalar_t* gradInputForPlane = gradInput + plane * inputT * inputH * inputW;
       scalar_t* gradOutputForPlane = gradOutput +
                   plane * outputT * outputH * outputW;
@@ -284,7 +284,7 @@ static void fractional_max_pool3d_backward_out_frame(
     }
 
     at::parallel_for(0, numBatch, 0, [&](int64_t start, int64_t end) {
-      for (auto batch = start; batch < end; ++batch) {
+      for (const auto batch : c10::irange(start, end)) {
         fractional_max_pool3d_backward_out_single_batch_frame<scalar_t>(
           gradInput + batch * numPlanes * inputW * inputH * inputT,
           gradOutput + batch * numPlanes * outputW * outputH * outputT,

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/UpSample.h>
 #include <ATen/native/cpu/GridSamplerKernel.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -51,12 +52,12 @@ namespace {
     scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
     // loop over each output pixel
     at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-      for (int64_t n = start; n < end; ++n) {
+      for (const auto n : c10::irange(start, end)) {
         scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
         scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
-        for (int64_t d = 0; d < out_D; ++d) {
-          for (int64_t h = 0; h < out_H; ++h) {
-            for (int64_t w = 0; w < out_W; ++w) {
+        for (const auto d : c10::irange(out_D)) {
+          for (const auto h : c10::irange(out_H)) {
+            for (const auto w : c10::irange(out_W)) {
               // get the corresponding input x, y, z co-ordinates from grid
               scalar_t *grid_ptr_NDHW = grid_ptr_N + d * grid_sD + h * grid_sH + w * grid_sW;
               scalar_t ix = *grid_ptr_NDHW;
@@ -222,12 +223,12 @@ namespace {
     scalar_t *gGrid_ptr = grad_grid.data_ptr<scalar_t>();
     // loop over each output pixel
     at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-      for (int64_t n = start; n < end; ++n) {
+      for (const auto n : c10::irange(start, end)) {
         scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
         scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
         scalar_t *gGrid_ptr_NDHW = gGrid_ptr + n * gGrid_sN;
-        for (int64_t d = 0; d < out_D; ++d) {
-          for (int64_t h = 0; h < out_H; ++h) {
+        for (const auto d : c10::irange(out_D)) {
+          for (const auto h : c10::irange(out_H)) {
             for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NDHW += gGrid_sW /* grad_grid is contiguous */ ) {
               // get the corresponding input x, y, z co-ordinates from grid
               scalar_t *grid_ptr_NDHW = grid_ptr_N + d * grid_sD + h * grid_sH + w * grid_sW;
@@ -416,11 +417,11 @@ Tensor _grid_sampler_2d_cpu_fallback(const Tensor& input, const Tensor& grid,
   scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
   // loop over each output pixel
   at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-    for (int64_t n = start; n < end; ++n) {
+    for (const auto n : c10::irange(start, end)) {
       scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
       scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
-      for (int64_t h = 0; h < out_H; ++h) {
-        for (int64_t w = 0; w < out_W; ++w) {
+      for (const auto h : c10::irange(out_H)) {
+        for (const auto w : c10::irange(out_W)) {
           // get the corresponding input x, y, z co-ordinates from grid
           scalar_t *grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
           scalar_t x = *grid_ptr_NHW;
@@ -505,7 +506,7 @@ Tensor _grid_sampler_2d_cpu_fallback(const Tensor& input, const Tensor& grid,
               scalar_t coefficients[4];
 
               // Interpolate 4 values in the x directon
-              for (int64_t i = 0; i < 4; ++i) {
+              for (const auto i : c10::irange(4)) {
                 coefficients[i] = cubic_interp1d<scalar_t>(
                   get_value_bounded<scalar_t>(inp_ptr_NC, ix_nw - 1, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
                   get_value_bounded<scalar_t>(inp_ptr_NC, ix_nw + 0, iy_nw - 1 + i, inp_W, inp_H, inp_sW, inp_sH, padding_mode, align_corners),
@@ -578,11 +579,11 @@ _grid_sampler_2d_cpu_fallback_backward(const Tensor& grad_output,
   scalar_t *gGrid_ptr = grad_grid.data_ptr<scalar_t>();
   // loop over each output pixel
   at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-    for (int64_t n = start; n < end; ++n) {
+    for (const auto n : c10::irange(start, end)) {
       scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
       scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
       scalar_t *gGrid_ptr_NHW = gGrid_ptr + n * gGrid_sN;
-      for (int64_t h = 0; h < out_H; ++h) {
+      for (const auto h : c10::irange(out_H)) {
         for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NHW += gGrid_sW /* grad_grid is contiguous */ ) {
           // get the corresponding input x, y co-ordinates from grid
           scalar_t *grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
@@ -703,8 +704,8 @@ _grid_sampler_2d_cpu_fallback_backward(const Tensor& grad_output,
             for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC+= inp_sC) {
               scalar_t gOut = *gOut_ptr_NCHW;
 
-              for (int64_t i = 0; i < 4; ++i) {
-                for (int64_t j = 0; j < 4; ++j) {
+              for (const auto i : c10::irange(4)) {
+                for (const auto j : c10::irange(4)) {
 
                   // set input gradient
                   add_value_bounded<scalar_t>(gInp_ptr_NC, ix_nw - 1 + i, iy_nw - 1 + j,
@@ -857,7 +858,7 @@ Tensor grid_sampler(const Tensor& input, const Tensor& grid,
     !(input.dim() == 5 && static_cast<GridSamplerInterpolation>(interpolation_mode) == GridSamplerInterpolation::Bicubic),
     "grid_sampler(): bicubic interpolation only supports 4D input"
   );
-  for (int64_t i = 2; i < input.dim(); i++) {
+  for (const auto i : c10::irange(2, input.dim())) {
     TORCH_CHECK(input.size(i) > 0,
       "grid_sampler(): expected input to have non-empty spatial dimensions, "
       "but input has sizes ", input.sizes(), " with dimension ", i, " being "

--- a/aten/src/ATen/native/Im2Col.cpp
+++ b/aten/src/ATen/native/Im2Col.cpp
@@ -5,6 +5,7 @@
 
 #include <ATen/native/im2col.h>
 #include <ATen/native/im2col_shape_check.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -91,7 +92,7 @@ static void im2col_out_cpu_template(
         Tensor input_n;
         Tensor output_n;
 
-        for (int64_t elt = 0; elt < batch_size; elt++) {
+        for (const auto elt : c10::irange(batch_size)) {
           input_n = input.select(0, elt);
           output_n = output.select(0, elt);
 

--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -2,6 +2,7 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/core/List.h>
+#include <c10/util/irange.h>
 
 #include <limits>
 
@@ -31,7 +32,7 @@ static C10_UNUSED std::vector<Tensor> expandTensors(const Tensor & self, const t
         }
         // The sizes of the ByteTensor mask or bool tensor must match the sizes of the
         // corresponding dimensions in self
-        for (int64_t j = 0; j < index.dim(); j++) {
+        for (const auto j : c10::irange(index.dim())) {
           int64_t srcIdx = result.size() + j;
           if (index.size(j) != self.size(srcIdx)) {
             invalid_mask(self, srcIdx, index, j);
@@ -39,7 +40,7 @@ static C10_UNUSED std::vector<Tensor> expandTensors(const Tensor & self, const t
         }
         // Replace with nonzeros
         auto nonzero = index.nonzero();
-        for (int64_t j = 0; j < index.dim(); j++) {
+        for (const auto j : c10::irange(index.dim())) {
           result.emplace_back(nonzero.select(1, j));
         }
       } else {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1158,7 +1158,7 @@ static void addbmm_impl_(
   }
 
   auto adjusted_beta(beta);
-  for (int64_t batch = 0; batch < num_batches; ++batch) {
+  for (const auto batch : c10::irange(num_batches)) {
     result.addmm_(batch1[batch], batch2[batch], adjusted_beta, alpha);
     adjusted_beta = 1; // accumulate output once
   }
@@ -1215,23 +1215,23 @@ inline void baddbmm_cpu_kernel(const Tensor& result, const Tensor& self, const T
 
   int64_t grain_size = std::min(internal::GRAIN_SIZE / (is * js * ks), (int64_t)1);
   parallel_for(0, bs, grain_size, [&](int64_t b_begin, int64_t b_end) {
-      for (int64_t b = b_begin; b < b_end; b++) {
+      for (const auto b : c10::irange(b_begin, b_end)) {
         auto r1 = r0[b];
         auto s1 = s0[b];
         auto m1 = m0[b];
-        for (int64_t i = 0; i < is; i++) {
+        for (const auto i : c10::irange(is)) {
           auto r2 = r1[i];
           auto s2 = s1[i];
-          for (int64_t j = 0; j < js; j++) {
+          for (const auto j : c10::irange(js)) {
             scalar_t &r = r2[j];
             if (is_bmm) {
               r = 0;
-              for (int64_t k = 0; k < ks; k++) {
+              for (const auto k : c10::irange(ks)) {
                 r += s2[k] * m1[k][j];
               }
             } else {
               r *= beta;
-              for (int64_t k = 0; k < ks; k++) {
+              for (const auto k : c10::irange(ks)) {
                 r += alpha * s2[k] * m1[k][j];
               }
             }
@@ -1994,10 +1994,11 @@ void compute_T18_scale_square(
   auto mexp_scaled = at::native::compute_T18<scalar_t>(a_scaled);
   auto s_cpu = (s.device().type() == at::kCPU)
     ? s : s.to(at::kCPU);
-  for (int64_t i = 0; i < mexp_scaled.size(0); ++i) {
+  for (const auto i : c10::irange(mexp_scaled.size(0))) {
     auto s_val = s_cpu.select(0, i).template item<int64_t>();
     auto mexp = mexp_scaled.select(0, i);
-    for (int64_t p = 0; p < s_val; ++p) {
+    for (const auto p : c10::irange(s_val)) {
+      (void)p; //Suppress unused variable warning
       mexp = at::matmul(mexp, mexp);
     }
     mexp_out.select(0, i).copy_(mexp);
@@ -2265,7 +2266,7 @@ Tensor& nuclear_norm_out(const Tensor& self, IntArrayRef dim, bool keepdim, Tens
 // (e.g. [0, 1, 2, ..., ndim-1])
 static std::vector<int64_t> make_dim_list(int64_t ndim) {
   std::vector<int64_t> dim_list(ndim);
-  for (int64_t ind = 0; ind < ndim; ind++) {
+  for (const auto ind : c10::irange(ndim)) {
     dim_list[ind] = ind;
   }
   return dim_list;
@@ -2818,7 +2819,7 @@ struct KronImpl final {
       a_reshape = c10::SmallVector<int64_t, 10>(2 * maxdim);
       b_reshape = c10::SmallVector<int64_t, 10>(2 * maxdim);
       result_reshape = c10::SmallVector<int64_t, 10>(maxdim);
-      for (int64_t i = 0; i < maxdim; i++) {
+      for (const auto i : c10::irange(maxdim)) {
         a_reshape[2 * i] = (i >= pad_self ? self.sizes()[i - pad_self] : 1);
         a_reshape[2 * i + 1] = 1;
         b_reshape[2 * i] = 1;
@@ -2833,7 +2834,7 @@ struct KronImpl final {
       TORCH_INTERNAL_ASSERT(result.defined(), "Cannot call kron_out with an undefined result tensor as the out argument. Please allocate a Tensor before calling kron_out with it.");
 
       c10::SmallVector<int64_t, 10> mul_shape(2 * maxdim);
-      for (int64_t i = 0; i < maxdim; i++) {
+      for (const auto i : c10::irange(maxdim)) {
         mul_shape[2 * i] = a_reshape[2 * i];
         mul_shape[2 * i + 1] = b_reshape[2 * i + 1];
       }

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/ScalarType.h>
+#include <c10/util/irange.h>
 #include <ATen/ATen.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/TensorUtils.h>
@@ -169,7 +170,8 @@ void batch_iterator_with_broadcasting(const Tensor& a, const Tensor& b, const fu
     auto* b_batch_idx_ptr = data[0];
     auto* a_batch_idx_ptr = data[1];
 
-    for (int64_t elem = 0; elem < nelems; ++elem) {
+    for (const auto elem : c10::irange(nelems)) {
+      (void)elem; //Suppress unused variable warning
       auto b_curr_linear_batch_idx = *reinterpret_cast<int64_t*>(b_batch_idx_ptr);
       auto a_curr_linear_batch_idx = *reinterpret_cast<int64_t*>(a_batch_idx_ptr);
 
@@ -332,7 +334,7 @@ static inline Tensor _move_to_end(const Tensor& self, IntArrayRef axes) {
   const int64_t ndim = self.ndimension();
   std::vector<int64_t> perm;
 
-  for (int64_t i = 0; i < ndim; i++) {
+  for (const auto i : c10::irange(ndim)) {
     auto it = std::find(a.begin(), a.end(), i);
     if (it == a.end()) {
        perm.push_back(i);
@@ -476,7 +478,7 @@ static inline std::vector<int64_t> create_dim_backshift_permutation(int64_t dim0
     "duplicate or invalid dimensions");
   std::vector<int64_t> permutation(ndim);
   int64_t cur_permuted_dim = 0;
-  for (int64_t dim_ind = 0; dim_ind < ndim; dim_ind++) {
+  for (const auto dim_ind : c10::irange(ndim)) {
     if ((dim_ind != dim0) && (dim_ind != dim1)) {
       permutation[cur_permuted_dim++] = dim_ind;
     }
@@ -493,7 +495,7 @@ static inline std::vector<int64_t> create_dim_backshift_permutation(int64_t dim0
 static inline std::vector<int64_t> create_reverse_permutation(std::vector<int64_t> permutation) {
   int64_t ndim = permutation.size();
   std::vector<int64_t> reverse_permutation(ndim);
-  for (int64_t dim_ind = 0; dim_ind < ndim; dim_ind++) {
+  for (const auto dim_ind : c10::irange(ndim)) {
     reverse_permutation[permutation[dim_ind]] = dim_ind;
   }
   return reverse_permutation;

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -11,6 +11,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/native/Fill.h>
+#include <c10/util/irange.h>
 
 #include <numeric>
 #include <type_traits>
@@ -60,7 +61,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
   std::vector<int64_t> tg_batch_offsets(batch_size);
   if (targets.dim() == 1) { // concatenated targets
     int64_t pos = 0;
-    for (int64_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       tg_batch_offsets[i] = pos;
       pos += target_lengths[i];
       if (max_target_length < target_lengths[i])
@@ -72,7 +73,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
   else { // batch x max_target_length
     // dim is 2
     int64_t tg_batch_stride = targets.stride(0);
-    for (int64_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       tg_batch_offsets[i] = i * tg_batch_stride;
       if (max_target_length < target_lengths[i])
         max_target_length = target_lengths[i];
@@ -84,7 +85,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
              " (while checking arguments for ", c, ")");
   }
   int64_t max_input_length = log_probs.size(0);
-  for (int64_t b = 0; b < batch_size; b++) {
+  for (const auto b : c10::irange(batch_size)) {
     TORCH_CHECK(input_lengths[b] <= max_input_length,
              "Expected input_lengths to have value at most ", max_input_length, ", but got value ", input_lengths[b],
              " (while checking arguments for ", c, ")");
@@ -103,7 +104,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
   // first the default
   log_alpha.narrow(1, 0, 1).fill_(neginf);
   at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-    for (int64_t b = start; b < end; b++) {
+    for (const auto b : c10::irange(start, end)) {
       int64_t input_length = input_lengths[b];
       int64_t target_length = target_lengths[b];
       auto log_probs_a = log_probs_a_global[b];
@@ -116,7 +117,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
         log_alpha_a[0][1] = log_probs_a[0][get_target_prime(targets_data, tg_batch_offset, tg_target_stride, 1, BLANK)];
 
       // now the loop over the inputs
-      for (int64_t t=1; t<input_length; t++) {
+      for (const auto t : c10::irange(1, input_length)) {
         for (int64_t s=0; s<2*target_length+1; s++) {
           auto current_target_prime = get_target_prime(targets_data, tg_batch_offset, tg_target_stride, s, BLANK);
           // this loop over s could be parallel/vectorized, too, but the required items are one index apart
@@ -189,7 +190,7 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
   if (targets.dim() == 1) { // concatenated targets
     int64_t pos = 0;
     max_target_length = 0;
-    for (int64_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       tg_batch_offsets[i] = pos;
       pos += target_lengths[i];
       if (max_target_length < target_lengths[i])
@@ -200,7 +201,7 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
   else { // batch x max_target_length
     // dim is 2
     int64_t tg_batch_stride = targets.stride(0);
-    for (int64_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       tg_batch_offsets[i] = i * tg_batch_stride;
     }
     tg_target_stride = targets.stride(1);
@@ -234,7 +235,7 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
     TensorIterator fill_1d_iter_local(fill_1d_iter);
     TensorIterator fill_log_beta_1d_iter_local(fill_log_beta_1d_iter);
 
-    for (int64_t b = start; b < end; b++) {
+    for (const auto b : c10::irange(start, end)) {
       scalar_t nll = neg_log_likelihood.accessor<scalar_t, 1>()[b];
       auto grad_a = grad_a_global[b];
       if (zero_infinity && nll == std::numeric_limits<scalar_t>::infinity()) {
@@ -322,8 +323,8 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
       // this could be a great target for further vectorization.
       // grad is the output gradient, nll is the loss. Note that the likelihood -nll is the Z of eq (16)
       scalar_t gr = grad_out.accessor<scalar_t, 1>()[b];
-      for (int64_t t = 0; t < input_length; t++) { // or go for the full thing?
-        for (int64_t c = 0; c < num_labels; c++) {
+      for (const auto t : c10::irange(input_length)) { // or go for the full thing?
+        for (const auto c : c10::irange(num_labels)) {
           scalar_t& res = grad_a[t][c];
           scalar_t lp = log_probs_a[t][c];
           res = (std::exp(lp)-std::exp(res + nll - lp)) * gr;

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -9,6 +9,7 @@
 #include <c10/util/SmallBuffer.h>
 
 #include <c10/core/TensorOptions.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -155,7 +156,7 @@ static void nll_loss_out_frame(
     auto output_acc = output.accessor<scalar_t, 1>();
 
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         const auto cur_target = target_acc[i];
 
         if (cur_target == ignore_index) {
@@ -215,7 +216,7 @@ static void nll_loss_out_frame(
   scalar_t weight_partial_sums[cascade_sum_num_levels] = {0};
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   scalar_t loss_partial_sums[cascade_sum_num_levels] = {0};
-  for (int64_t b = 0; b < batch_size; b++) {
+  for (const auto b : c10::irange(batch_size)) {
     const int64_t cur_target = target_data[b];
     if (cur_target == ignore_index) {
       ++num_ignored;
@@ -330,7 +331,7 @@ static void nll_loss_backward_out_frame(
     auto grad_input_acc = grad_input.accessor<scalar_t, 2>();
     auto grad_output_acc = grad_output.accessor<scalar_t, 1>();
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         auto cur_target = target_acc[i];
         if (cur_target == ignore_index) {
           continue;

--- a/aten/src/ATen/native/LossNLL2d.cpp
+++ b/aten/src/ATen/native/LossNLL2d.cpp
@@ -5,6 +5,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/native/cpu/utils.h>
 #include <ATen/native/Resize.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -109,9 +110,9 @@ static void nll_loss2d_forward_out_frame(
     auto target_acc = target.accessor<int64_t, 3>();
 
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-      for (int64_t b = start; b < end; b++) {
-        for (int64_t h = 0; h < H; h++) {
-          for (int64_t w = 0; w < W; w++) {
+      for (const auto b : c10::irange(start, end)) {
+        for (const auto h : c10::irange(H)) {
+          for (const auto w : c10::irange(W)) {
             const int64_t cur_target = (int64_t)target_acc[b][h][w];
 
             if (cur_target == ignore_index) {
@@ -176,8 +177,8 @@ static void nll_loss2d_forward_out_frame(
   const int64_t level_mask = level_step - 1;
 
   int64_t num_ignored = 0;
-  for (int64_t b = 0; b < batch_size; b++) {
-    for (int64_t elem = 0; elem < map_size; elem++) {
+  for (const auto b : c10::irange(batch_size)) {
+    for (const auto elem : c10::irange(map_size)) {
       const int64_t cur_target = target_data[b * map_size + elem];
       if (cur_target == ignore_index) {
         ++num_ignored;
@@ -286,9 +287,9 @@ static void nll_loss2d_backward_out_frame(
     auto target_acc = target.accessor<int64_t, 3>();
 
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-      for (int64_t b = start; b < end; b++) {
-        for (int64_t h = 0; h < H; h++) {
-          for (int64_t w = 0; w < W; w++) {
+      for (const auto b : c10::irange(start, end)) {
+        for (const auto h : c10::irange(H)) {
+          for (const auto w : c10::irange(W)) {
             const int64_t cur_target = target_acc[b][h][w];
             if (cur_target == ignore_index) {
               continue;
@@ -329,8 +330,8 @@ static void nll_loss2d_backward_out_frame(
                                                    : grad_output_value);
 
   at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-    for (int64_t b = start; b < end; b++) {
-      for (int64_t elem = 0; elem < map_size; elem++) {
+    for (const auto b : c10::irange(start, end)) {
+      for (const auto elem : c10::irange(map_size)) {
         const int64_t t = target_data[b * map_size + elem];
 
         if (t != ignore_index) {

--- a/aten/src/ATen/native/NNPACK.cpp
+++ b/aten/src/ATen/native/NNPACK.cpp
@@ -60,6 +60,7 @@ bool _nnpack_available() {
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <ATen/native/ConvUtils.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -238,7 +239,7 @@ Tensor _nnpack_spatial_convolution(
       const size_t input_size_per_batch = input_channels * input_size.width * input_size.height;
       const size_t output_size_per_batch = output_channels * output_size.width * output_size.height;
 
-      for (size_t batch = 0u; batch < batch_size; ++batch) {
+      for (const auto batch : c10::irange(0u, batch_size)) {
         const nnp_status status = nnp_convolution_inference(
             algorithm,
             nnp_convolution_transform_strategy_compute,

--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -100,7 +100,7 @@ Tensor refine_names(const Tensor& self, DimnameList names) {
       self_names.size(), " and ", names.size(), " respectively).");
   check_names_valid_for(self, names);
 
-  for (size_t idx = 0; idx < self_names.size(); idx++) {
+  for (const auto idx : c10::irange(self_names.size())) {
     const auto& self_name = self_names[idx];
     const auto& out_name = names[idx];
     if (self_name == out_name || self_name.isWildcard()) {
@@ -221,7 +221,7 @@ Tensor align_to(const Tensor& tensor, DimnameList order, int64_t ellipsis_idx) {
   };
 
   // Fill in the non-ellipsis dimensions
-  for (auto order_idx = 0U; order_idx < order.size(); ++order_idx) {
+  for (const auto order_idx : c10::irange(0U, order.size())) {
     auto out_idx = order_idx;
     if (order_idx >= ellipsis_idx) {
       out_idx = order_idx + num_ellipsis_names;

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -77,7 +77,7 @@ std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Ten
   // more elements below in our column, we lower the counter (prev_l), and append the new
   // block to the output.
   int64_t prev_l = 0;
-  for (int64_t i = 0; i < batch_size; ++i) {
+  for (const auto i : c10::irange(batch_size)) {
     int64_t l = lengths[batch_size - 1 - i];
     if (l > prev_l) {
       auto current_batch_size = batch_size - i;
@@ -109,7 +109,7 @@ Tensor _pack_padded_sequence_backward(const Tensor& grad, at::IntArrayRef input_
   int64_t offset = 0;
   int64_t max_seq_len = batch_sizes_t.size(0);
   int64_t * batch_sizes = batch_sizes_t.data_ptr<int64_t>();
-  for (int64_t i = 0; i < max_seq_len; ++i) {
+  for (const auto i : c10::irange(max_seq_len)) {
     grad_input[i].slice(0, 0, batch_sizes[i]).copy_(grad.slice(0, offset, offset + batch_sizes[i]));
     offset += batch_sizes[i];
   }
@@ -170,7 +170,8 @@ std::tuple<Tensor, Tensor> _pad_packed_sequence(const Tensor& data, const Tensor
     }
     int64_t dec = prev_batch_size - batch_size;
     if (dec > 0) {
-      for (int64_t j = 0; j < dec; ++j) {
+      for (const auto j : c10::irange(dec)) {
+        (void)j; //Suppress unused variable warning
         (*lengths--) = i;
       }
     }
@@ -206,7 +207,7 @@ Tensor pad_sequence(TensorList sequences, bool batch_first, double padding_value
   out_dims.insert(out_dims.end(), trailing_dims.begin(), trailing_dims.end());
 
   Tensor out = at::full(out_dims, padding_value, sequences[0].options());
-  for (int64_t i = 0; i < sequences_size; i++) {
+  for (const auto i : c10::irange(sequences_size)) {
     const Tensor currseq = sequences[i];
     const int64_t length_i = currseq.size(0);
     // use index notation to prevent duplicate references to the tensor

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/div_rtn.h>
 #include <ATen/native/DispatchStub.h>
+#include <c10/util/irange.h>
 
 #pragma once
 
@@ -212,7 +213,7 @@ pool3d_shape_check(
   TORCH_CHECK(ndim == 4 || ndim == 5,
               fn_name, ": Expected 4D or 5D tensor for input, but got: ", input.sizes());
 
-  for (int64_t i = 1; i < ndim; ++i) {
+  for (const auto i : c10::irange(1, ndim)) {
     TORCH_CHECK(input.size(i) > 0,
                 fn_name, "Expected input to have non-zero size for non-batch dimensions, but got",
                 input.sizes(), " with dimension ", i, " being empty.");

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -206,9 +206,9 @@ void CalcColOffsetsTranspose(
     const int8_t* Bint8,
     int32_t B_zero_point,
     int32_t* col_offsets) {
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     int32_t sum = 0;
-    for (int j = 0; j < K; ++j) {
+    for (const auto j : c10::irange(K)) {
       sum += Bint8[i * K + j];
     }
     col_offsets[i] = sum - B_zero_point * K;
@@ -353,7 +353,7 @@ bool CheckAndSaturate(T max_val, T* element) {
 void HandleWeightsSaturation(int64_t N, float* weight) {
   const float kFp16Max = RawUint16ToFp16(0x7BFF);
   bool found_out_of_range = false;
-  for (int64_t i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     if (CheckAndSaturate<float>(kFp16Max, weight + i)) {
       found_out_of_range = true;
     }

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/irange.h>
 #include <cmath>
 #include <limits>
 
@@ -95,7 +96,7 @@ Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
       double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
       const int64_t halfway = steps / 2;
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-        for (int64_t i=p_begin; i < p_end; i++) {
+        for (const auto i : c10::irange(p_begin, p_end)) {
           if (i < halfway) {
             data_ptr[i] = std::pow(scalar_base, scalar_start + step*i);
           } else {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -627,7 +627,7 @@ void cummax_cummin_helper(const T1* self_data, T1* values_data, T2* indices_data
       Operation op;
       T1 out = self_data[0];
       int idx = 0;
-      for(int i = 0; i < self_dim_size; i++) {
+      for (const auto i : c10::irange(self_dim_size)) {
         T1 curr_elem = self_data[i*self_stride];
         if(isnan_(curr_elem) || (!isnan_(out) && op(curr_elem, out))) {
             out = self_data[i*self_stride];
@@ -738,7 +738,7 @@ static inline void diff_check_compatible_shape(const Tensor& self, const c10::op
         other.value().dim() == self.dim(),
         "diff expects prepend or append to be the same dimension as input");
 
-    for (int i = 0; i < other.value().dim(); i++) {
+    for (const auto i : c10::irange(other.value().dim())) {
       TORCH_CHECK(
           other.value().size(i) == self.size(i) || i == wrapped_dim,
           "diff expects the shape of tensor to prepend or append to match that of"
@@ -1065,7 +1065,7 @@ Tensor trace_cpu(const Tensor& self) {
     t_stride_1 = self.stride(1);
 
     t_diag_size = std::min(self.size(0), self.size(1));
-    for (int64_t i = 0; i < t_diag_size; i++) {
+    for (const auto i : c10::irange(t_diag_size)) {
       sum += t_data[i * (t_stride_0 + t_stride_1)];
     }
 
@@ -1478,9 +1478,9 @@ static double std_var_all_cpu(const Tensor& self, int64_t correction, bool take_
         const int64_t outer_stride = strides[1];
 
         double local_sum = 0.0;
-        for (int64_t i = 0; i < size1; ++i) {
+        for (const auto i : c10::irange(size1)) {
           const char* row_ptr = data[0] + outer_stride * i;
-          for (int64_t j = 0; j < size0; ++j) {
+          for (const auto j : c10::irange(size0)) {
             const auto ptr = reinterpret_cast<const scalar_t*>(row_ptr + inner_stride * j);
             auto dx = (static_cast<double>(*ptr) - local_mean);
             local_sum += dx * dx;
@@ -1908,7 +1908,8 @@ bool cpu_equal(const Tensor& self, const Tensor& other) {
       }
       char* self_data = data[0];
       char* other_data = data[1];
-      for (int64_t i = 0; i < dim_size; ++i) {
+      for (const auto i : c10::irange(dim_size)) {
+        (void)i; //Suppress unused variable warning
         if (*((scalar_t*)self_data) != *((scalar_t*)other_data)) {
           result = false;
           return;

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -168,7 +168,7 @@ static Tensor review_reduce_result(const Tensor& result, int ndim, DimMask mask,
   }
   auto shape = DimVector(result.sizes());
   auto stride = DimVector(result.strides());
-  for (int dim = 0; dim < ndim; dim++) {
+  for (const auto dim : c10::irange(ndim)) {
     if (mask[dim]) {
       shape.insert(shape.begin() + dim, 1);
       stride.insert(stride.begin() + dim, 0);

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -226,8 +227,8 @@ static void reflection_pad1d_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x;
-    for (auto k = start; k < end; k++) {
-      for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto j : c10::irange(output_w)) {
         if (j < pad_l) {
           ip_x = pad_l * 2 - j;
         } else if (j >= pad_l && j < input_w + pad_l) {
@@ -252,7 +253,7 @@ inline void reflection_pad1d_out_loop(
     int64_t input_w, int64_t output_w,
     int64_t pad_l) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad1d_out_frame<scalar_t>(
         input_p + p * nplane * input_w,
         output_p + p * nplane * output_w,
@@ -352,8 +353,8 @@ static void reflection_pad1d_backward_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x;
-    for (auto k = start; k < end; k++) {
-      for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto j : c10::irange(output_w)) {
         if (j < pad_l) {
           ip_x = pad_l * 2 - j;
         } else if (j >= pad_l && j < input_w + pad_l) {
@@ -378,7 +379,7 @@ inline void reflection_pad1d_backward_out_loop(
     int64_t input_w, int64_t output_w,
     int64_t pad_l) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad1d_backward_out_frame<scalar_t>(
         grad_input + p * nplane * input_w,
         grad_output + p * nplane * output_w,
@@ -404,9 +405,9 @@ static void reflection_pad2d_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++) {
-      for (int64_t i = 0; i < output_h; i++) {
-        for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(output_h)) {
+        for (const auto j : c10::irange(output_w)) {
           if (j < pad_l) {
             ip_x = pad_l * 2 - j;
           } else if (j >= pad_l && j < input_w + pad_l) {
@@ -442,7 +443,7 @@ inline void reflection_pad2d_out_loop(
     int64_t output_w, int64_t output_h,
     int64_t pad_l, int64_t pad_t) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad2d_out_frame(
         input_p + p * nplane * input_w * input_h,
         output_p + p * nplane * output_w * output_h,
@@ -560,9 +561,9 @@ static void reflection_pad2d_backward_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++) {
-      for (int64_t i = 0; i < output_h; i++) {
-        for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(output_h)) {
+        for (const auto j : c10::irange(output_w)) {
           if (j < pad_l) {
             ip_x = pad_l * 2 - j;
           } else if (j >= pad_l && j < input_w + pad_l) {
@@ -600,7 +601,7 @@ inline void reflection_pad2d_backward_out_loop(
     int64_t output_w, int64_t output_h,
     int64_t pad_l, int64_t pad_t) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad2d_backward_out_frame(
         grad_input + p * nplane * input_h * input_w,
         grad_output + p * nplane * output_h * output_w,
@@ -690,10 +691,10 @@ inline void parallel_reflection_pad3d(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y, ip_z;
-    for (int64_t k = start; k < end; k++) {
-      for (int64_t op_z = 0; op_z < output_d; op_z++) {
-        for (int64_t op_y = 0; op_y < output_h; op_y++) {
-          for (int64_t op_x = 0; op_x < output_w; op_x++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto op_z : c10::irange(output_d)) {
+        for (const auto op_y : c10::irange(output_h)) {
+          for (const auto op_x : c10::irange(output_w)) {
             if (op_x < pad_left) {
               ip_x = pad_left * 2 - op_x;
             } else if (op_x >= pad_left && op_x < input_w + pad_left) {
@@ -772,7 +773,7 @@ static void reflection_pad3d_out_loop(
     int64_t pad_left, int64_t pad_top, int64_t pad_front)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (int64_t p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad3d_out_frame(
           input_p + p * nplane * input_w * input_h * input_d,
           output_p + p * nplane * output_w * output_h * output_d,
@@ -833,7 +834,7 @@ static void reflection_pad3d_backward_out_loop(
     int64_t pad_left, int64_t pad_top, int64_t pad_front
 ) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (int64_t p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad3d_backward_out_frame<scalar_t>(
           grad_input + p * nplane * input_w * input_h * input_d,
           grad_output + p * nplane * output_w * output_h * output_d,

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/Repeat.h>
+#include <c10/util/irange.h>
 
 template <typename index_t>
 static void compute_cpu(
@@ -13,12 +14,12 @@ static void compute_cpu(
       (result_size == cumsum_ptr[size - 1]),
       "allocated size does not match required size");
   at::parallel_for(0, size, 1, [&](int64_t i_begin, int64_t i_end) {
-    for (int64_t i = i_begin; i < i_end; i++) {
+    for (const auto i : c10::irange(i_begin, i_end)) {
       int64_t end = cumsum_ptr[i];
       index_t size = repeat_ptr[i];
       TORCH_CHECK((size >= 0), "repeats can not be negative");
       int64_t start = end - size;
-      for (int64_t j = start; j < end; j++) {
+      for (const auto j : c10::irange(start, end)) {
         result_ptr[j] = i;
       }
     }

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 #include <algorithm>
 
 namespace at {
@@ -237,8 +238,7 @@ static void replication_pad1d_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     long ip_x;
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       for (long j = 0; j < owidth; j++) {
         if (j < pad_l) {
           ip_x = pad_l;
@@ -267,8 +267,7 @@ static void replication_pad1d_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data+p*nslices*iwidth;
       scalar_t *output_p = output_data+p*nslices*owidth;
       replication_pad1d_out_frame(input_p, output_p, nslices, iwidth, owidth, pad_l, pad_r);
@@ -290,8 +289,7 @@ static void replication_pad1d_backward_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     long ip_x;
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       for (long j = 0; j < owidth; j++) {
         if (j < pad_l) {
           ip_x = pad_l;
@@ -320,8 +318,7 @@ static void replication_pad1d_backward_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *ginput_p = ginput_data + p * nslices * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * owidth;
       replication_pad1d_backward_out_frame(ginput_p, goutput_p,
@@ -347,10 +344,9 @@ static void replication_pad2d_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++)
-    {
-      for (int64_t i = 0; i < oheight; i++) {
-        for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(oheight)) {
+        for (const auto j : c10::irange(owidth)) {
           if (j < pad_l) {
             ip_x = pad_l;
           } else if (j >= pad_l && j < iwidth + pad_l) {
@@ -389,8 +385,7 @@ static void replication_pad2d_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data+p*nslices*iwidth*iheight;
       scalar_t *output_p = output_data+p*nslices*owidth*oheight;
       replication_pad2d_out_frame(input_p, output_p, nslices,
@@ -416,10 +411,9 @@ static void replication_pad2d_backward_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++)
-    {
-      for (int64_t i = 0; i < oheight; i++) {
-        for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(oheight)) {
+        for (const auto j : c10::irange(owidth)) {
           if (j < pad_l) {
             ip_x = pad_l;
           } else if (j >= pad_l && j < iwidth + pad_l) {
@@ -458,8 +452,7 @@ static void replication_pad2d_backward_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *ginput_p = ginput_data + p * nslices * iheight * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * oheight * owidth;
       replication_pad2d_backward_out_frame(ginput_p, goutput_p, nslices,
@@ -572,10 +565,10 @@ static void replication_pad3d_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y, ip_z;
-    for (auto k = start; k < end; k++) {
-      for (int64_t z = 0; z < odepth; z++) {
-        for (int64_t i = 0; i < oheight; i++) {
-          for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto z : c10::irange(odepth)) {
+        for (const auto i : c10::irange(oheight)) {
+          for (const auto j : c10::irange(owidth)) {
             if (j < pleft) {
               ip_x = pleft;
             } else if (j >= pleft && j < iwidth + pleft) {
@@ -627,8 +620,7 @@ static void replication_pad3d_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data + p * nslices * iwidth * iheight * idepth;
       scalar_t *output_p = output_data + p * nslices * owidth * oheight * odepth;
       replication_pad3d_out_frame(input_p, output_p, nslices,
@@ -658,10 +650,10 @@ static void replication_pad3d_backward_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y, ip_z;
-    for (auto k = start; k < end; k++) {
-      for (int64_t z = 0; z < odepth; z++) {
-        for (int64_t i = 0; i < oheight; i++) {
-          for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto z : c10::irange(odepth)) {
+        for (const auto i : c10::irange(oheight)) {
+          for (const auto j : c10::irange(owidth)) {
             if (j < pleft) {
               ip_x = pleft;
             } else if (j >= pleft && j < iwidth + pleft) {
@@ -713,8 +705,7 @@ static void replication_pad3d_backward_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *ginput_p = ginput_data + p * nslices * idepth * iheight * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * odepth * oheight * owidth;
       replication_pad3d_backward_out_frame(ginput_p, goutput_p, nslices,

--- a/aten/src/ATen/native/ResizeCommon.h
+++ b/aten/src/ATen/native/ResizeCommon.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/NamedTensorUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -10,7 +11,7 @@ inline int64_t storage_size_for(IntArrayRef size, IntArrayRef stride) {
       "storage_size_for(size, stride) requires that size and stride ",
       "have the same size as a precondition.");
   int64_t storage_size = 1;
-  for (size_t dim = 0; dim < size.size(); ++dim) {
+  for (const auto dim : c10::irange(size.size())) {
     if (size[dim] == 0) {
       storage_size = 0;
       break;

--- a/aten/src/ATen/native/RowwisePrune.cpp
+++ b/aten/src/ATen/native/RowwisePrune.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 
 namespace at {
@@ -15,7 +16,7 @@ std::tuple<Tensor, Tensor> _rowwise_prune_helper(
   int num_non_masked_rows = 0;
   auto mask_contig = mask.contiguous();
   auto mask_data = mask_contig.data_ptr<bool>();
-  for (int i = 0; i < mask.numel(); ++i) {
+  for (const auto i : c10::irange(mask.numel())) {
     num_non_masked_rows += (((mask_data[i] == true)) ? 1 : 0);
   }
   int num_cols = weights.size(1);
@@ -32,7 +33,7 @@ std::tuple<Tensor, Tensor> _rowwise_prune_helper(
         compressed_indices_mapping.data_ptr<input_t>();
     auto weights_data = weights.data_ptr<scalar_t>();
     int last_row_kept = 0;
-    for (int i = 0; i < mask.numel(); i++) {
+    for (const auto i : c10::irange(mask.numel())) {
       if (mask_data[i]) {
         memcpy(pruned_2d_tensor_data + last_row_kept * num_cols,
               weights_data + i * num_cols,

--- a/aten/src/ATen/native/ScatterGatherChecks.h
+++ b/aten/src/ATen/native/ScatterGatherChecks.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <ATen/ATen.h>
 #include <ATen/native/ReduceOpsUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -45,7 +46,7 @@ static C10_UNUSED void gather_shape_check(const Tensor& self, int64_t dim,
     "Index tensor must have the same number of dimensions as input tensor"
   );
 
-  for (int64_t i = 0; i < self_dims; ++i) {
+  for (const auto i : c10::irange(self_dims)) {
     if (i != dim) {
       TORCH_CHECK(
         ensure_nonempty_size(index, i) <= ensure_nonempty_size(self, i),
@@ -77,7 +78,7 @@ static C10_UNUSED void scatter_shape_check(
   int64_t self_dims = ensure_nonempty_dim(self.dim());
 
   //  Check: index.size(d) <= self.size(d) for all d != dim
-  for (int64_t d = 0; d < self_dims; ++d) {
+  for (const auto d : c10::irange(self_dims)) {
     int64_t index_d_size = ensure_nonempty_size(index, d);
     if (d == dim) continue;
     if (index_d_size > ensure_nonempty_size(self, d)) {
@@ -89,7 +90,7 @@ static C10_UNUSED void scatter_shape_check(
   //  Check: index.size(d) <= src.size(d) for all d if src is Tensor
   if (!is_wrong_shape && src_opt.has_value()) {
     auto src = src_opt.value();
-    for (int64_t d = 0; d < self_dims; ++d) {
+    for (const auto d : c10::irange(self_dims)) {
       int64_t index_d_size = ensure_nonempty_size(index, d);
       if (index_d_size > ensure_nonempty_size(src, d)) {
         is_wrong_shape = true;

--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NumericUtils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -41,8 +42,8 @@ void _segment_reduce_cpu_kernel1(
         auto* output_data = output.data_ptr<scalar_t>();
         const auto* values_data = data.data_ptr<scalar_t>();
         int64_t lengths_cum_sum = 0;
-        for (int64_t i = 0; i < segment_count; ++i) {
-          for (int64_t l = 0; l < stride_count; ++l) {
+        for (const auto i : c10::irange(segment_count)) {
+          for (const auto l : c10::irange(stride_count)) {
             // ===== step1: initialize starting value
             scalar_t initial_value;
             if (initial.has_value()) {
@@ -141,12 +142,12 @@ void _segment_reduce_cpu_backward_kernel1(
         const auto* values_data = data_contig.data_ptr<scalar_t>();
 
         int64_t lengths_cum_sum = 0;
-        for (int64_t i = 0; i < segment_count; ++i) {
+        for (const auto i : c10::irange(segment_count)) {
           if (lengths_data[i] == 0) {
             continue;
           }
 
-          for (int64_t l = 0; l < stride_count; ++l) {
+          for (const auto l : c10::irange(stride_count)) {
             int64_t output_index = (i * stride_count) + l;
 
             if (reduction == SegmentReductionType::MAX ||

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -9,6 +9,7 @@
 #include <ATen/NamedTensorUtils.h>
 
 #include <c10/core/TensorOptions.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -129,8 +130,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
   int64_t outer_size = 1;
   int64_t dim_size = input.size(dim);
   int64_t inner_size = 1;
-  for (int64_t i = 0; i < dim; ++i)
-    outer_size *= input.size(i);
+  for (const auto i : c10::irange(dim))outer_size *= input.size(i);
   for (int64_t i = dim + 1; i < input.dim(); ++i)
     inner_size *= input.size(i);
   int64_t dim_stride = inner_size;
@@ -141,7 +141,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
   parallel_for(
       0, outer_size * inner_size, grain_size,
       [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* input_data =
@@ -149,11 +149,10 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
           scalar_t* output_data =
               output_data_base + outer_idx * outer_stride + inner_idx;
           scalar_t max_input = input_data[0];
-          for (int64_t d = 1; d < dim_size; d++)
-            max_input = std::max(max_input, input_data[d * dim_stride]);
+          for (const auto d : c10::irange(1, dim_size))max_input = std::max(max_input, input_data[d * dim_stride]);
 
           acc_type<scalar_t, false> tmpsum = 0;
-          for (int64_t d = 0; d < dim_size; d++) {
+          for (const auto d : c10::irange(dim_size)) {
             scalar_t z = std::exp(input_data[d * dim_stride] - max_input);
             if (!LogSoftMax) {
               output_data[d * dim_stride] = z;
@@ -166,8 +165,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
           else
             tmpsum = 1 / tmpsum;
 
-          for (int64_t d = 0; d < dim_size; d++)
-            if (LogSoftMax)
+          for (const auto d : c10::irange(dim_size))if (LogSoftMax)
               output_data[d * dim_stride] =
                   input_data[d * dim_stride] - max_input - tmpsum;
             else
@@ -186,8 +184,7 @@ void host_softmax_backward(
   int64_t outer_size = 1;
   int64_t dim_size = grad.size(dim);
   int64_t inner_size = 1;
-  for (int64_t i = 0; i < dim; ++i)
-    outer_size *= grad.size(i);
+  for (const auto i : c10::irange(dim))outer_size *= grad.size(i);
   for (int64_t i = dim + 1; i < grad.dim(); ++i)
     inner_size *= grad.size(i);
   int64_t dim_stride = inner_size;
@@ -198,7 +195,7 @@ void host_softmax_backward(
   int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
   parallel_for(
       0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* gradInput_data =
@@ -209,14 +206,13 @@ void host_softmax_backward(
               gradOutput_data_base + outer_idx * outer_stride + inner_idx;
 
           acc_type<scalar_t, false> sum = 0;
-          for (int64_t d = 0; d < dim_size; d++)
-            if (LogSoftMax)
+          for (const auto d : c10::irange(dim_size))if (LogSoftMax)
               sum += gradOutput_data[d * dim_stride];
             else
               sum +=
                   gradOutput_data[d * dim_stride] * output_data[d * dim_stride];
 
-          for (int64_t d = 0; d < dim_size; d++) {
+          for (const auto d : c10::irange(dim_size)) {
             if (LogSoftMax) {
               gradInput_data[d * dim_stride] = gradOutput_data[d * dim_stride] -
                   std::exp(output_data[d * dim_stride]) * sum;

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/Sorting.h>
 #include <ATen/native/SortingUtils.h>
 #include <ATen/native/ReduceOpsUtils.h>
+#include <c10/util/irange.h>
 
 #include <utility>
 
@@ -315,7 +316,7 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
 
   AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "kthvalue_cpu", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
-      for (int64_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         TensorAccessor<scalar_t, 1> tmp_values(
             reinterpret_cast<scalar_t*>(data[0] + i * strides[0]),
             &sizes[dim], &tmp_values_stride);
@@ -325,7 +326,7 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
         auto mode_value = reinterpret_cast<scalar_t*>(data[2] + i * strides[2]);
         auto mode_index = reinterpret_cast<int64_t*>(data[3] + i * strides[3]);
 
-        for (int64_t j = 0; j < tmp_indices.size(0); j++) {
+        for (const auto j : c10::irange(tmp_indices.size(0))) {
           tmp_indices[j] = j;
         }
 
@@ -411,7 +412,7 @@ std::tuple<Tensor&, Tensor&> median_with_indices_impl(
 
   AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, in.scalar_type(), "median_out", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
-      for (int64_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         auto valp = reinterpret_cast<scalar_t*>(data[0] + i * strides[0]);
         auto indp = reinterpret_cast<int64_t*>(data[1] + i * strides[1]);
         auto ip = reinterpret_cast<const scalar_t*>(data[2] + i * strides[2]);

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -2,6 +2,7 @@
 
 #include <ATen/NumericUtils.h>
 #include <ATen/native/Resize.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -97,7 +98,7 @@ void topk_impl_loop(
     const bool largest,
     const bool sorted,
     char** data, const int64_t* strides, const int64_t n) {
-  for (int64_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     TensorAccessor<scalar_t, 1> mode_values(
         reinterpret_cast<scalar_t*>(data[0] + i * strides[0]),
         &k, &mode_values_stride);
@@ -113,7 +114,7 @@ void topk_impl_loop(
 
     using elem_t = std::pair<accscalar_t, int64_t>;
     std::vector<elem_t> queue(n);
-    for (int64_t j = 0; j < n; j++) {
+    for (const auto j : c10::irange(n)) {
       queue[j].first = tmp_values[j];
       queue[j].second = j;
     }
@@ -157,7 +158,7 @@ void topk_impl_loop(
       }
     }
 
-    for (int64_t j = 0; j < k; j++) {
+    for (const auto j : c10::irange(k)) {
       mode_values[j] = queue[j].first;
       mode_indices[j] = queue[j].second;
     }

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -252,7 +252,7 @@ ShapeAndDims canonicalize_fft_shape_and_dim_args(
 
     // Translate shape of -1 to the default length
     ret.shape.resize(transform_ndim);
-    for (int64_t i = 0; i < transform_ndim; ++i) {
+    for (const auto i : c10::irange(transform_ndim)) {
       const auto n = (*shape)[i];
       ret.shape[i] = n == -1 ? input_sizes[ret.dim[i]] : n;
     }

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <c10/util/irange.h>
 
 #include <tuple>
 
@@ -45,13 +46,13 @@ Tensor _bincount_cpu_template(
         weights.options().pinned_memory_opt());
     weights_t* output_p = output.data_ptr<weights_t>();
     const weights_t* weights_p = weights.data_ptr<weights_t>();
-    for (int64_t i = 0; i < self_size; i++) {
+    for (const auto i : c10::irange(self_size)) {
       output_p[self_p[i]] += weights_p[i];
     }
   } else {
     output = native::zeros({nbins}, kLong);
     int64_t* output_p = output.data_ptr<int64_t>();
-    for (int64_t i = 0; i < self_size; i++) {
+    for (const auto i : c10::irange(self_size)) {
       output_p[self_p[i]] += 1L;
     }
   }

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 namespace at {
   namespace native {
@@ -20,7 +21,7 @@ namespace at {
         func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
         if(ndims == 1)
            break;
-        for(int dim_i = 0; dim_i < ndims; dim_i++) {
+        for (const auto dim_i : c10::irange(ndims)) {
           if(dim_i == dim) {
             if(dim_i == (ndims - 1)) {
               tensor_dim_apply_has_finished = 1;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -14,6 +14,7 @@
 #include <c10/core/TensorOptions.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/native/UnaryOps.h>
 
@@ -423,8 +424,7 @@ Tensor& eye_out_cpu(int64_t n, int64_t m, Tensor& result) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::Bool, result.scalar_type(), "eye", [&]() -> void {
     scalar_t* result_data = result.data_ptr<scalar_t>();
     at::parallel_for(0, sz, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-      for(int64_t i = p_begin; i < p_end; i++)
-        result_data[i*(result.strides()[0] + result.strides()[1])] = 1;
+      for (const auto i : c10::irange(p_begin, p_end))result_data[i*(result.strides()[0] + result.strides()[1])] = 1;
     });
   });
 
@@ -864,8 +864,7 @@ void randperm_cpu(Tensor& result, int64_t n, CPUGeneratorImpl* generator) {
 
   at::parallel_for(0, n, internal::GRAIN_SIZE,
                   [&r__data, &r__stride_0](int64_t p_begin, int64_t p_end) {
-    for(int64_t i = p_begin; i < p_end; i++)
-      r__data[i*r__stride_0] = static_cast<scalar_t>(i);
+    for (const auto i : c10::irange(p_begin, p_end))r__data[i*r__stride_0] = static_cast<scalar_t>(i);
   });
 
   for(int64_t i = 0; i < n - 1; i++)

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -5,6 +5,7 @@
 #include <torch/library.h>
 
 #include <ATen/Config.h>
+#include <c10/util/irange.h>
 namespace at {
 namespace native {
 
@@ -72,7 +73,7 @@ bool is_set_to(const Tensor& self, const Tensor& src) {
   if (self.storage().unsafeGetStorageImpl() == src.storage().unsafeGetStorageImpl() &&
       self.storage_offset() == src.storage_offset() &&
       self.dim() == src.dim()) {
-    for (int64_t d = 0; d < self.dim(); ++d) {
+    for (const auto d : c10::irange(self.dim())) {
       if (self.size(d) != src.size(d) || self.stride(d) != src.stride(d)) {
         return false;
       }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1421,7 +1421,7 @@ static inline std::vector<Tensor> get_stack_inputs(TensorList tensors, int64_t d
   std::vector<Tensor> inputs(tensors.size());
   at::IntArrayRef entry_shape = tensors[0].sizes();
   inputs[0] = tensors[0].unsqueeze(dim);
-  for (size_t i = 1; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     TORCH_CHECK(tensors[i].sizes() == entry_shape,
       "stack expects each tensor to be equal size, but got ", entry_shape,
       " at entry 0 and ", tensors[i].sizes(), " at entry ", i);
@@ -1449,7 +1449,7 @@ bool inline can_use_native_serial_stack(Tensor& result, TensorList tensors, int6
   if (result.dtype() != firstTensor.dtype()) return false;
 
   // Inputs cannot alias the output tensor
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     auto lap = at::get_overlap_status(result, tensors[i]);
     TORCH_CHECK(lap != at::MemOverlapStatus::PARTIAL &&
         lap != at::MemOverlapStatus::FULL, 0,
@@ -1471,7 +1471,7 @@ bool inline can_use_native_serial_stack(Tensor& result, TensorList tensors, int6
 
   // check remainder of inputs
   auto const &first_tensor_shape = firstTensor.sizes();
-  for (size_t i = 1; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     auto const &tensor = tensors[i];
     TORCH_CHECK(tensors[i].sizes() == firstTensor.sizes(),
       "stack expects each tensor to be equal size, but got ", first_tensor_shape,

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -5,6 +5,7 @@
 #include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/core/DimVector.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <vector>
@@ -22,7 +23,7 @@ Tensor flip(const Tensor& self, IntArrayRef dims) {
   // Count dimensions in which we need to do work
   int n = 0;
   auto strides = DimVector(self.strides());
-  for(int64_t i = 0; i < total_dims; i++) {
+  for (const auto i : c10::irange(total_dims)) {
     if(flip_dims_b[i] && self.size(i) > 1 && self.stride(i) != 0) {
       n++;
       strides[i] = 0;
@@ -61,7 +62,7 @@ Tensor flip(const Tensor& self, IntArrayRef dims) {
   //   - We move the pointer to the opposite vertex of the cube
   //   - We iterate in the opposite direction (invert the strides)
 
-  for (int i=0; i<iter.ndim(); i++){
+  for (const auto i : c10::irange(iter.ndim())) {
     // We know that an dimension has a zero stride and self[i] does not, as we defined above
     // Note that it may be the case that strides_dummy[i] = 0 not because we set it, but because
     // strides_self[i] == 0. We do not want to do anything there

--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -6,6 +6,7 @@
 
 #include <ATen/Parallel.h>
 #include <ATen/native/TriangularOpsUtils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -23,7 +24,7 @@ static void apply_triu_tril_single(
 
   if (upper) {
     at::parallel_for(0, n, 0, [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         for (int64_t j = 0; j < std::min(m, i + k); j++) {
           result[i * res_row_stride + j * res_col_stride] = 0;
         }
@@ -36,7 +37,7 @@ static void apply_triu_tril_single(
     });
   } else {
     at::parallel_for(0, n, 0, [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         for (int64_t j = std::max(zero, i + k + 1); j < m; j++) {
           result[i * res_row_stride + j * res_col_stride] = 0;
         }
@@ -74,7 +75,7 @@ void apply_triu_tril(Tensor& result, const Tensor& self, bool inplace, int64_t k
   }
 
   at::parallel_for(0, batchsize, 0, [&](int64_t start, int64_t end) {
-    for (auto b = start; b < end; b++) {
+    for (const auto b : c10::irange(start, end)) {
       scalar_t* self_batch = &self_data[b * self_stride];
       scalar_t* result_batch = &result_data[b * result_stride];
       apply_triu_tril_single<scalar_t, upper>(

--- a/aten/src/ATen/native/Unfold3d.cpp
+++ b/aten/src/ATen/native/Unfold3d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #if AT_MKL_ENABLED()
 #include <mkl.h>
@@ -17,7 +18,7 @@ bool IsAGeZeroAndALtB(int64_t a, int64_t b) {
 
 template <typename T>
 void MatCopy(int64_t M, int64_t N, int64_t lda, int64_t ldb, const T* A, T* B) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     std::memcpy(B + i * ldb, A + i * lda, N * sizeof(T));
   }
 }
@@ -32,10 +33,10 @@ void MatCopy(
     int64_t strideb,
     const T* A,
     T* B) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     const T* A_ptr = A + i * lda;
     T* B_ptr = B + i * ldb;
-    for (int64_t j = 0; j < N; ++j) {
+    for (const auto j : c10::irange(N)) {
       B_ptr[j * strideb] = A_ptr[j * stridea];
     }
   }
@@ -44,8 +45,8 @@ void MatCopy(
 // Y += X
 template <typename T>
 void MatAdd(int64_t M, int64_t N, int64_t ldx, int64_t ldy, const T* X, T* Y) {
-  for (int64_t i = 0; i < M; ++i) {
-    for (int64_t j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       Y[i * ldy + j] += X[i * ldx + j];
     }
   }
@@ -62,8 +63,8 @@ void MatAdd(
     int64_t stridey,
     const T* X,
     T* Y) {
-  for (int64_t i = 0; i < M; ++i) {
-    for (int64_t j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       Y[i * ldy + j * stridey] += X[i * ldx + j * stridex];
     }
   }
@@ -151,7 +152,7 @@ void MatAdd(
     int64_t stridey,
     const float* X,
     float* Y) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     cblas_saxpy(N, 1.0f, X + i * ldx, stridex, Y + i * ldy, stridey);
   }
 }
@@ -166,7 +167,7 @@ void MatAdd(
     int64_t stridey,
     const double* X,
     double* Y) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     cblas_daxpy(N, 1.0, X + i * ldx, stridex, Y + i * ldy, stridey);
   }
 }
@@ -194,7 +195,7 @@ void Unfold3dZeroPaddingCopyKernelImpl(
   const int64_t X_size = X_D * X_H * X_W;
   const int64_t Y_size = Y_D * Y_H * Y_W;
   at::parallel_for(0, n, 0, [=](int64_t begin, int64_t end) {
-    for (int64_t p = begin; p < end; ++p) {
+    for (const auto p : c10::irange(begin, end)) {
       int64_t c = p;
       const int64_t kw = c % kernel_w;
       c /= kernel_w;
@@ -202,7 +203,7 @@ void Unfold3dZeroPaddingCopyKernelImpl(
       c /= kernel_h;
       const int64_t kd = c % kernel_d;
       c /= kernel_d;
-      for (int64_t yd = 0; yd < Y_D; ++yd) {
+      for (const auto yd : c10::irange(Y_D)) {
         const int64_t xd = yd * stride_d + kd;
         const T* src_ptr = src + c * X_size + xd * X_H * X_W + kh * X_W + kw;
         T* dst_ptr = dst + p * Y_size + yd * Y_H * Y_W;
@@ -261,7 +262,7 @@ void Unfold3dCopyKernelImpl(
   const int64_t X_size = X_D * X_H * X_W;
   const int64_t Y_size = Y_D * Y_H * Y_W;
   at::parallel_for(0, n, 0, [=](int64_t begin, int64_t end) {
-    for (int64_t p = begin; p < end; ++p) {
+    for (const auto p : c10::irange(begin, end)) {
       int64_t c = p;
       const int64_t kw = c % kernel_w;
       c /= kernel_w;
@@ -271,20 +272,20 @@ void Unfold3dCopyKernelImpl(
       c /= kernel_d;
       const T* src_ptr = src + c * X_size;
       T* dst_ptr = dst + p * Y_size;
-      for (int64_t yd = 0; yd < Y_D; ++yd) {
+      for (const auto yd : c10::irange(Y_D)) {
         const int64_t xd = yd * stride_d - pad_d + kd;
         if (!IsAGeZeroAndALtB(xd, X_D)) {
           std::memset(dst_ptr + yd * Y_H * Y_W, 0, Y_H * Y_W * sizeof(T));
           continue;
         }
-        for (int64_t yh = 0; yh < Y_H; ++yh) {
+        for (const auto yh : c10::irange(Y_H)) {
           const int64_t xh = yh * stride_h - pad_h + kh;
           if (!IsAGeZeroAndALtB(xh, X_H)) {
             std::memset(
                 dst_ptr + yd * Y_H * Y_W + yh * Y_W, 0, Y_W * sizeof(T));
             continue;
           }
-          for (int64_t yw = 0; yw < Y_W; ++yw) {
+          for (const auto yw : c10::irange(Y_W)) {
             const int64_t xw = yw * stride_w - pad_w + kw;
             dst_ptr[yd * Y_H * Y_W + yh * Y_W + yw] = IsAGeZeroAndALtB(xw, X_W)
                 ? src_ptr[xd * X_H * X_W + xh * X_W + xw]
@@ -318,13 +319,13 @@ void Unfold3dZeroPaddingAccKernelImpl(
   const int64_t kernel_size = kernel_d * kernel_h * kernel_w;
   at::parallel_for(0, C, 0, [=](int64_t begin, int64_t end) {
     std::memset(dst + begin * X_size, 0, (end - begin) * X_size * sizeof(T));
-    for (int64_t c = begin; c < end; ++c) {
-      for (int64_t kd = 0; kd < kernel_d; ++kd) {
-        for (int64_t kh = 0; kh < kernel_h; ++kh) {
-          for (int64_t kw = 0; kw < kernel_w; ++kw) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto kd : c10::irange(kernel_d)) {
+        for (const auto kh : c10::irange(kernel_h)) {
+          for (const auto kw : c10::irange(kernel_w)) {
             const int64_t p =
                 c * kernel_size + kd * kernel_h * kernel_w + kh * kernel_w + kw;
-            for (int64_t yd = 0; yd < Y_D; ++yd) {
+            for (const auto yd : c10::irange(Y_D)) {
               const int64_t xd = yd * stride_d + kd;
               const T* src_ptr = src + p * Y_size + yd * Y_H * Y_W;
               T* dst_ptr = dst + c * X_size + xd * X_H * X_W + kh * X_W + kw;
@@ -393,25 +394,25 @@ void Unfold3dAccKernelImpl(
   const int64_t kernel_size = kernel_d * kernel_h * kernel_w;
   at::parallel_for(0, C, 0, [=](int64_t begin, int64_t end) {
     std::memset(dst + begin * X_size, 0, (end - begin) * X_size * sizeof(T));
-    for (int64_t c = begin; c < end; ++c) {
+    for (const auto c : c10::irange(begin, end)) {
       T* dst_ptr = dst + c * X_size;
-      for (int64_t kd = 0; kd < kernel_d; ++kd) {
-        for (int64_t kh = 0; kh < kernel_h; ++kh) {
-          for (int64_t kw = 0; kw < kernel_w; ++kw) {
+      for (const auto kd : c10::irange(kernel_d)) {
+        for (const auto kh : c10::irange(kernel_h)) {
+          for (const auto kw : c10::irange(kernel_w)) {
             const int64_t p =
                 c * kernel_size + kd * kernel_h * kernel_w + kh * kernel_w + kw;
             const T* src_ptr = src + p * Y_size;
-            for (int64_t yd = 0; yd < Y_D; ++yd) {
+            for (const auto yd : c10::irange(Y_D)) {
               const int64_t xd = yd * stride_d - pad_d + kd;
               if (!IsAGeZeroAndALtB(xd, X_D)) {
                 continue;
               }
-              for (int64_t yh = 0; yh < Y_H; ++yh) {
+              for (const auto yh : c10::irange(Y_H)) {
                 const int64_t xh = yh * stride_h - pad_h + kh;
                 if (!IsAGeZeroAndALtB(xh, X_H)) {
                   continue;
                 }
-                for (int64_t yw = 0; yw < Y_W; ++yw) {
+                for (const auto yw : c10::irange(Y_W)) {
                   const int64_t xw = yw * stride_w - pad_w + kw;
                   if (IsAGeZeroAndALtB(xw, X_W)) {
                     dst_ptr[xd * X_H * X_W + xh * X_W + xw] +=

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <c10/util/irange.h>
 
 #include <set>
 #include <tuple>
@@ -51,25 +52,25 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
     int64_t* inverse_indices_data = inverse_indices.data_ptr<int64_t>();
     std::unordered_map<scalar_t, int64_t> inverse_map;
     inverse_map.reserve(output.numel());
-    for (int64_t i = 0; i < output.numel(); ++i) {
+    for (const auto i : c10::irange(output.numel())) {
       inverse_map[output_data[i]] = i;
     }
-    for(int64_t i = 0; i < numel; ++i) {
+    for (const auto i : c10::irange(numel)) {
       inverse_indices_data[i] = inverse_map[input_data[i]];
     }
     if (return_counts) {
       std::unordered_map<scalar_t, int64_t> counts_map;
       counts_map.reserve(output.numel());
-      for (int64_t i = 0; i < output.numel(); ++i) {
+      for (const auto i : c10::irange(output.numel())) {
         counts_map[output_data[i]] = 0;
       }
-      for(int64_t i = 0; i < numel; i++) {
+      for (const auto i : c10::irange(numel)) {
         counts_map[input_data[i]] += 1;
       }
       counts.resize_(output.sizes());
       counts.fill_(0);
       int64_t *counts_data = counts.data_ptr<int64_t>();
-      for(int64_t i = 0; i < output.numel(); i++) {
+      for (const auto i : c10::irange(output.numel())) {
         counts_data[i] = counts_map[output_data[i]];
       }
     }
@@ -106,7 +107,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_consecutive_cpu_template(
     scalar_t *p = output_data;
     int64_t *q = counts_data;
     int64_t last = 0;
-    for (int64_t i = 0; i < numel; i++) {
+    for (const auto i : c10::irange(numel)) {
       if (input_data[i] != *p) {
         *(++p) = input_data[i];
         if (return_counts) {
@@ -202,7 +203,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
   if (!consecutive) {
     std::sort(indices.begin(), indices.end(),
       [&](int64_t a, int64_t b) -> bool {
-        for (int64_t i = 0; i < numel; ++i) {
+        for (const auto i : c10::irange(numel)) {
           scalar_t lhs = input_flat_ptr[i + a * numel];
           scalar_t rhs = input_flat_ptr[i + b * numel];
           if (lhs < rhs) {
@@ -218,7 +219,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
   Tensor input_sorted;
   if (!consecutive) {
     input_sorted = at::empty(input_flat.sizes(), input_flat.options());
-    for (size_t i = 0; i < indices.size(); ++i) {
+    for (const auto i : c10::irange(indices.size())) {
       input_sorted[i] = input_flat[indices[i]];
     }
   } else {

--- a/aten/src/ATen/native/UpSample.cpp
+++ b/aten/src/ATen/native/UpSample.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -20,7 +21,7 @@ TORCH_API c10::SmallVector<int64_t, 3> compute_output_size(
     TORCH_CHECK(!output_size, "Must specify exactly one of output_size and scale_factors");
     TORCH_CHECK(static_cast<int64_t>(scale_factors->size()) == spatial_dimensions);
     c10::SmallVector<int64_t, 3> ret;
-    for (int i = 0; i < spatial_dimensions; ++i) {
+    for (const auto i : c10::irange(spatial_dimensions)) {
       ret.push_back(static_cast<double>(input_size[i+2]) * scale_factors.value()[i]);
     }
     return ret;

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -33,7 +34,7 @@ TORCH_META_FUNC(upsample_bicubic2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",
@@ -65,11 +66,12 @@ static void upsample_bicubic2d_backward_out_frame(
 
   // Special case: input/output same size, just copy
   if (input_height == output_height && input_width == output_width) {
-    for (int64_t output_y = 0; output_y < output_height; output_y++) {
-      for (int64_t output_x = 0; output_x < output_width; output_x++) {
+    for (const auto output_y : c10::irange(output_height)) {
+      for (const auto output_x : c10::irange(output_width)) {
         scalar_t* in = &idata[output_y * input_width + output_x];
         scalar_t* out = &odata[output_y * output_width + output_x];
-        for (int64_t c = 0; c < channels; ++c) {
+        for (const auto c : c10::irange(channels)) {
+          (void)c; //Suppress unused variable warning
           in[0] = out[0];
           in += input_width * input_height;
           out += output_width * output_height;
@@ -84,8 +86,8 @@ static void upsample_bicubic2d_backward_out_frame(
   const scalar_t width_scale = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners, scales_w);
 
-  for (int64_t output_y = 0; output_y < output_height; output_y++) {
-    for (int64_t output_x = 0; output_x < output_width; output_x++) {
+  for (const auto output_y : c10::irange(output_height)) {
+    for (const auto output_x : c10::irange(output_width)) {
       scalar_t* in = idata;
       scalar_t* out = odata;
 
@@ -105,11 +107,12 @@ static void upsample_bicubic2d_backward_out_frame(
       get_cubic_upsample_coefficients<scalar_t>(x_coeffs, t_x);
       get_cubic_upsample_coefficients<scalar_t>(y_coeffs, t_y);
 
-      for (int64_t c = 0; c < channels; c++) {
+      for (const auto c : c10::irange(channels)) {
+        (void)c; //Suppress unused variable warning
         scalar_t out_value = out[output_y * output_width + output_x];
 
-        for (int64_t i = 0; i < 4; i++) {
-          for (int64_t j = 0; j < 4; j++) {
+        for (const auto i : c10::irange(4)) {
+          for (const auto j : c10::irange(4)) {
             upsample_increment_value_bounded<scalar_t>(
                 in,
                 input_width,

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -36,7 +37,7 @@ TORCH_META_FUNC(upsample_bilinear2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -33,7 +34,7 @@ TORCH_META_FUNC(upsample_nearest2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -37,7 +38,7 @@ TORCH_META_FUNC(upsample_nearest3d_backward) (
       grad_output.dim() == 5,
       "Expected grad_output to be a tensor of dimension 5 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 5; ++i) {
+  for (const auto i : c10::irange(5)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -42,7 +43,7 @@ TORCH_META_FUNC(upsample_trilinear3d_backward) (
       grad_output.dim() == 5,
       "Expected grad_output to be a tensor of dimension 5 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 5; ++i) {
+  for (const auto i : c10::irange(5)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
@@ -5,6 +5,7 @@
 
 #include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+#include <c10/util/irange.h>
 
 namespace ao {
 namespace sparse {
@@ -64,7 +65,7 @@ at::Tensor PackedLinearWeight::apply_impl(
     // Process the per channel quantization.
     output_multiplier_float.resize(out_channels, 0.0);
     act_times_w_scale.resize(out_channels, 1.0f);
-    for (int i = 0; i < out_channels; ++i) {
+    for (const auto i : c10::irange(out_channels)) {
       act_times_w_scale[i] = (input_scale_float * w_scale[i]);
       output_multiplier_float[i] =
           act_times_w_scale[i] / static_cast<float>(output_scale);
@@ -126,7 +127,7 @@ at::Tensor PackedLinearWeight::apply_impl(
 
   int num_tasks = at::get_num_threads();
   at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
-    for (int task_id = begin; task_id < end; ++task_id) {
+    for (const auto task_id : c10::irange(begin, end)) {
       fbgemm::trRequantizationParams_t reqParams = {
           input_zero_point_int32,
           w_zp.data(),

--- a/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -34,16 +35,16 @@ void cpu_adaptive_max_pool(
 
   // parallel on dim of N, C
   at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t* input_ptr = input_data + c * input_height * input_width;
       scalar_t* output_ptr = output_data + c * output_height * output_width;
       int64_t* indices_ptr = indices_data + c * output_height * output_width;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
+      for (const auto oh : c10::irange(output_height)) {
         int64_t ih0 = start_index(oh, output_height, input_height);
         int64_t ih1 = end_index(oh, output_height, input_height);
 
-        for (int64_t ow = 0; ow < output_width; ow++) {
+        for (const auto ow : c10::irange(output_width)) {
           int64_t iw0 = start_index(ow, output_width, input_width);
           int64_t iw1 = end_index(ow, output_width, input_width);
 
@@ -121,7 +122,7 @@ void cpu_adaptive_max_pool_channels_last(
     // temp buffer holding index with integer_t
     std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = start_index(oh, output_height, input_height);
       int64_t ih1 = end_index(oh, output_height, input_height);
 
@@ -216,13 +217,13 @@ void cpu_adaptive_max_pool_backward(
 
   // parallel on dim of N, C
   at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
       scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
       int64_t* indices_ptr = indices_data + c * output_height * output_width;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           // retrieve position of max
           int64_t index = oh * output_width + ow;
           int64_t maxindex = indices_ptr[index];
@@ -264,17 +265,17 @@ void cpu_adaptive_max_pool_backward_channels_last(
 
   // parallel on dim N
   at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t n = begin; n < end; n++) {
+    for (const auto n : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
       scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
       int64_t* indices_ptr = indices_data + n * output_height * output_width * channels;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
           int64_t* ind = indices_ptr + oh * output_width * channels + ow * channels;
           // TODO: gcc vectorization
-          for (int64_t c = 0; c < channels; c++) {
+          for (const auto c : c10::irange(channels)) {
             int64_t maxindex = ind[c];
             grad_input_ptr[maxindex * channels + c] += gout[c];
           }

--- a/aten/src/ATen/native/cpu/BlasKernel.cpp
+++ b/aten/src/ATen/native/cpu/BlasKernel.cpp
@@ -1,5 +1,6 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/CPUBlas.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -13,16 +14,16 @@ void scale_(int64_t m, int64_t n, scalar_t alpha, scalar_t *a, int64_t lda) {
   }
 
   if (alpha == scalar_t(0)) {
-    for (int64_t j = 0; j < n; j++) {
-      for (int64_t i = 0; i < m; i++) {
+    for (const auto j : c10::irange(n)) {
+      for (const auto i : c10::irange(m)) {
         a[j * lda + i] = scalar_t(0);
       }
     }
     return;
   }
 
-  for (int64_t j = 0; j < n; j++) {
-    for (int64_t i = 0; i < m; i++) {
+  for (const auto j : c10::irange(n)) {
+    for (const auto i : c10::irange(m)) {
       a[j * lda + i] *= alpha;
     }
   }
@@ -41,11 +42,11 @@ void gemm_notrans_(
   scale_(m, n, beta, c, ldc);
 
   // c += alpha * (a @ b)
-  for (int64_t l = 0; l < k; l++) {
-    for (int64_t j = 0; j < n; j++) {
+  for (const auto l : c10::irange(k)) {
+    for (const auto j : c10::irange(n)) {
       scalar_t val = b[l + j * ldb] * alpha;
       int64_t i_m = m / 4;
-      for (int64_t i_i = 0; i_i < i_m; i_i++) {
+      for (const auto i_i : c10::irange(i_m)) {
         c[j * ldc + i_i * 4 + 0] += a[i_i * 4 + 0 + l * lda] * val;
         c[j * ldc + i_i * 4 + 1] += a[i_i * 4 + 1 + l * lda] * val;
         c[j * ldc + i_i * 4 + 2] += a[i_i * 4 + 2 + l * lda] * val;
@@ -68,14 +69,11 @@ void gemm_transa_(
     scalar_t *c, int64_t ldc) {
   // c = alpha * (a.T @ b) + beta * c
   const scalar_t *a_ = a;
-  for (int64_t i = 0; i < m; i++)
-  {
+  for (const auto i : c10::irange(m)) {
     const scalar_t *b_ = b;
-    for (int64_t j = 0; j < n; j++)
-    {
+    for (const auto j : c10::irange(n)) {
       scalar_t sum = 0;
-      for(int64_t l = 0; l < k; l++)
-        sum += a_[l]*b_[l];
+      for (const auto l : c10::irange(k))sum += a_[l]*b_[l];
       b_ += ldb;
       if (beta == scalar_t(0))
         c[j*ldc+i] = alpha*sum;
@@ -98,11 +96,11 @@ void gemm_transb_(
   scale_(m, n, beta, c, ldc);
 
   // c += alpha * (a @ b.T)
-  for (int64_t l = 0; l < k; l++) {
-    for (int64_t j = 0; j < n; j++) {
+  for (const auto l : c10::irange(k)) {
+    for (const auto j : c10::irange(n)) {
       scalar_t val = b[j + l * ldb] * alpha;
       int64_t i_m = m / 4;
-      for (int64_t i_i = 0; i_i < i_m; i_i++) {
+      for (const auto i_i : c10::irange(i_m)) {
         c[j * ldc + i_i * 4 + 0] += a[i_i * 4 + 0 + l * lda] * val;
         c[j * ldc + i_i * 4 + 1] += a[i_i * 4 + 1 + l * lda] * val;
         c[j * ldc + i_i * 4 + 2] += a[i_i * 4 + 2 + l * lda] * val;
@@ -127,10 +125,10 @@ void gemm_transab_(
   scale_(m, n, beta, c, ldc);
 
   // c += alpha * (a.T @ b.T)
-  for (int64_t i = 0; i < m; i++) {
-    for (int64_t j = 0; j < n; j++) {
+  for (const auto i : c10::irange(m)) {
+    for (const auto j : c10::irange(n)) {
       int64_t l_k = k / 4;
-      for (int64_t l_l = 0; l_l < l_k; l_l++) {
+      for (const auto l_l : c10::irange(l_k)) {
         c[j * ldc + i] += a[i * lda + l_l * 4 + 0] //
           * b[(l_l * 4 + 0) * ldb + j] * alpha;
         c[j * ldc + i] += a[i * lda + l_l * 4 + 1] //

--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/cpu/CatKernel.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -33,8 +34,8 @@ void cat_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 
   using Vec = vec::Vectorized<scalar_t>;
   scalar_t* result_ptr = result_data;
-  for (int64_t i = 0; i < outer; ++i) {
-    for (int64_t j = 0; j < ninputs; j++) {
+  for (const auto i : c10::irange(outer)) {
+    for (const auto j : c10::irange(ninputs)) {
       int64_t local_inner = inputs[j].inner_size;
       scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
       int64_t d = 0;

--- a/aten/src/ATen/native/cpu/CrossKernel.cpp
+++ b/aten/src/ATen/native/cpu/CrossKernel.cpp
@@ -8,6 +8,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vml.h>
+#include <c10/util/irange.h>
 namespace at { namespace native { namespace {
 
 template<typename scalar_t>
@@ -28,7 +29,7 @@ static void apply_cross(Tensor& result, const Tensor& a, const Tensor& b, const 
     int64_t a_start = 0;
     int64_t b_start = 0;
     int64_t r_start = 0;
-    for (int64_t i = 0; i < a.dim(); i++) {
+    for (const auto i : c10::irange(a.dim())) {
       if (i == dim) continue;
       position_in_dims[i] = index_in_curr_dim % a.size(i);
       a_start += (index_in_curr_dim % a.size(i)) * a.stride(i);
@@ -43,7 +44,7 @@ static void apply_cross(Tensor& result, const Tensor& a, const Tensor& b, const 
       r_ptr[r_start+2*r_stride] = a_ptr[a_start+0*a_stride]*b_ptr[b_start+1*b_stride] - a_ptr[a_start+1*a_stride]*b_ptr[b_start+0*b_stride];
       s++;
 
-      for (int i = 0; i < a.dim(); i++) {
+      for (const auto i : c10::irange(a.dim())) {
         if (i == dim) {
           continue;
         }

--- a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+++ b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
@@ -1,6 +1,7 @@
 #include <ATen/native/cpu/DepthwiseConvKernel.h>
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
@@ -152,7 +153,7 @@ void convolution_depthwise3x3_winograd_impl(
       &input_tile.val[2],                                     \
       &input_tile.val[3]);                                    \
                                                               \
-  for (int64_t row = 0; row < 4; ++row) {                         \
+  for (const auto row : c10::irange(4)) {                         \
     input_tile.val[row] =                                     \
         vmulq_f32(input_tile.val[row], kernel_tile.val[row]); \
   }                                                           \
@@ -186,22 +187,22 @@ void convolution_depthwise3x3_winograd_impl(
                   2 * otw + 1 < args.out_cols
               )) {
         float32x4x4_t input_tile;
-        for (int64_t row = 0; row < 4; ++row) {
+        for (const auto row : c10::irange(4)) {
           input_tile.val[row] =
               vld1q_f32(input + (ih + row) * args.in_cols + iw);
         }
 
         TILE;
 
-        for (size_t row = 0; row < 2; ++row) {
+        for (const auto row : c10::irange(2)) {
           vst1_f32(
               output + (oth * 2 + row) * args.out_cols + otw * 2,
               vget_low_f32(input_tile.val[row]));
         }
       } else {
         float block[4][4];
-        for (int64_t row = 0; row < 4; ++row) {
-          for (int64_t col = 0; col < 4; ++col) {
+        for (const auto row : c10::irange(4)) {
+          for (const auto col : c10::irange(4)) {
             if (ih + row >= 0 && iw + col >= 0 && ih + row < args.in_rows &&
                 iw + col < args.in_cols) {
               block[row][col] = input[(ih + row) * args.in_cols + iw + col];
@@ -212,18 +213,18 @@ void convolution_depthwise3x3_winograd_impl(
         }
 
         float32x4x4_t input_tile;
-        for (int64_t row = 0; row < 4; ++row) {
+        for (const auto row : c10::irange(4)) {
           input_tile.val[row] = vld1q_f32(&block[row][0]);
         }
 
         TILE;
 
         float oblock[2][2];
-        for (int64_t row = 0; row < 2; ++row) {
+        for (const auto row : c10::irange(2)) {
           vst1_f32(&oblock[row][0], vget_low_f32(input_tile.val[row]));
         }
-        for (int64_t row = 0; row < 2; ++row) {
-          for (int64_t col = 0; col < 2; ++col) {
+        for (const auto row : c10::irange(2)) {
+          for (const auto col : c10::irange(2)) {
             if (2 * oth + row < args.out_rows &&
                 2 * otw + col < args.out_cols) {
               output[(2 * oth + row) * args.out_cols + 2 * otw + col] =
@@ -285,7 +286,7 @@ Tensor _convolution_depthwise3x3_winograd(
                       at::zeros({kernel_sizes[0]}, input.options());
 
   at::parallel_for(0, args.batch * args.out_channels, 0, [&](int64_t start, int64_t end) {
-    for (int64_t k = start; k < end; ++k) {
+    for (const auto k : c10::irange(start, end)) {
       const int64_t g = k % args.out_channels;
       const int64_t i = k / (args.out_channels / groups);
       convolution_depthwise3x3_winograd_impl(

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vml.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native { namespace {
 
@@ -227,7 +228,7 @@ struct Dist {
         const scalar_t * self_j = t2_start + size2 * l + j;
 
         scalar_t agg = 0;
-        for (int x = 0; x < m; x++) {
+        for (const auto x : c10::irange(m)) {
           scalar_t a = *(self_i + x);
           scalar_t b = *(self_j + x);
           agg = F::red(agg, F::map(std::abs(a-b), p));
@@ -392,7 +393,8 @@ struct Dist {
     const scalar_t * t1_end = t1 + l1_size;
     const scalar_t * t2_end = t2 + l2_size;
 
-    for (int64_t l = 0; l < d; l++) {
+    for (const auto l : c10::irange(d)) {
+      (void)l; //Suppress unused variable warning
       for (; t1 != t1_end; t1 += m, res += m) {
         const Vec vec_t1 = Vec::loadu(t1, count);
         Vec res_vec = Vec::loadu(res, count);

--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -10,6 +10,7 @@
 
 #ifdef CPU_CAPABILITY_AVX2
 #include <ATen/native/cpu/avx_mathfun.h>
+#include <c10/util/irange.h>
 #endif
 
 
@@ -108,7 +109,7 @@ void normal_fill_AVX2(Tensor& self, const float mean, const float std, RNG gener
   float *data = self.data_ptr<float>();
   auto size = self.numel();
   std::lock_guard<std::mutex> lock(generator->mutex_);
-  for (int64_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     at::uniform_real_distribution<float> uniform(0, 1);
     data[i] = uniform(generator);
   }
@@ -125,7 +126,7 @@ void normal_fill_AVX2(Tensor& self, const float mean, const float std, RNG gener
   if (size % 16 != 0) {
     // Recompute the last 16 values.
     data = data + size - 16;
-    for (int64_t i = 0; i < 16; ++i) {
+    for (const auto i : c10::irange(16)) {
       at::uniform_real_distribution<float> uniform(0, 1);
       data[i] = uniform(generator);
     }
@@ -136,7 +137,7 @@ void normal_fill_AVX2(Tensor& self, const float mean, const float std, RNG gener
 
 template <typename scalar_t>
 static void normal_fill_16(scalar_t *data, const scalar_t mean, const scalar_t std) {
-  for (int j = 0; j < 8; ++j) {
+  for (const auto j : c10::irange(8)) {
     const scalar_t u1 = 1 - data[j]; // [0, 1) -> (0, 1] for log.
     const scalar_t u2 = data[j + 8];
     const scalar_t radius = std::sqrt(-2 * std::log(u1));
@@ -151,7 +152,7 @@ void normal_fill(Tensor& self, const scalar_t mean, const scalar_t std, RNG gene
   scalar_t *data = self.data_ptr<scalar_t>();
   auto size = self.numel();
   std::lock_guard<std::mutex> lock(generator->mutex_);
-  for (int64_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     at::uniform_real_distribution<scalar_t> uniform(0, 1);
     data[i] = uniform(generator);
   }
@@ -162,7 +163,7 @@ void normal_fill(Tensor& self, const scalar_t mean, const scalar_t std, RNG gene
   if (size % 16 != 0) {
     // Recompute the last 16 values.
     data = data + size - 16;
-    for (int64_t i = 0; i < 16; ++i) {
+    for (const auto i : c10::irange(16)) {
       at::uniform_real_distribution<scalar_t> uniform(0, 1);
       data[i] = uniform(generator);
     }

--- a/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
+++ b/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
@@ -1,6 +1,7 @@
 #include <ATen/native/FunctionOfAMatrixUtils.h>
 
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 
 #if (defined(_WIN32) || defined(_WIN64))
 #define RESTRICT __restrict
@@ -27,14 +28,15 @@ void _compute_linear_combination_cpu_kernel(
         auto* RESTRICT in_ptr = data[1];
         auto* RESTRICT coeff_ptr = data[2];
 
-        for (int64_t elem = 0; elem < n; ++elem) {
+        for (const auto elem : c10::irange(n)) {
+          (void)elem; //Suppress unused variable warning
           auto* RESTRICT out_data = reinterpret_cast<scalar_t*>(out_ptr);
           auto* RESTRICT in_data = reinterpret_cast<scalar_t*>(in_ptr);
           using primitive_t = typename scalar_value_type<scalar_t>::type;
           auto* RESTRICT coeff_data = reinterpret_cast<primitive_t*>(coeff_ptr);
 
           // perform summation
-          for (int32_t i = 0; i < num_summations; ++i) {
+          for (const auto i : c10::irange(num_summations)) {
             *out_data += in_data[i * in_stride] * coeff_data[i * coeff_stride];
           }
 

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/cpu/GridSamplerKernel.h>
 #include <ATen/cpu/vml.h>
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <cstring>
@@ -50,7 +51,7 @@ namespace at { namespace native { namespace {
  *      //           from the beginning of this slice.
  *      //      iii. `len` as the number of valid locations in the vectors.
  *      //           (There might not be enough near boundary.)
- *      for (int n = 0; n < input_accessor.size(0); n++) {
+ *      for (const auto n : c10::irange(input_accessor.size(0))) {
  *        grid_sample_2d_grid_slice_iterator(
  *          grid_accessor[n],
  *          [&](const Vectorized<scalar_t>& grid_x,
@@ -443,7 +444,7 @@ mask_scatter_add(const scalar_t *src, scalar_t* base_addr,
   #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
   # pragma unroll
   #endif
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     if (mask[i] & 0x01) {
       base_addr[offsets[i]] += src[i];
     }
@@ -568,7 +569,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
 
       // mask_gather zeros out the mask, so we need to make copies
@@ -658,7 +659,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
       auto gOut = Vec::loadu(gOut_slice[c].data() + offset, len);
 
@@ -796,7 +797,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest,
       #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
       # pragma unroll
       #endif
-      for (int64_t c = 0; c < C; ++c) {
+      for (const auto c : c10::irange(C)) {
         mask_scatter_add(gOut_slice[c].data() + offset, (*gInp_slice_ptr)[c].data(),
                         gInp_offset_arr, mask_arr, len);
       }
@@ -930,13 +931,13 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
 
       // Interpolate the 4 values in the x direction
       // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
       Vec interp_x[4];
-      for (int64_t i = 0; i < 4; ++i) {
+      for (const auto i : c10::irange(4)) {
         interp_x[i] =
           coeff_x[0] * get_value_bounded(inp_slice_C_ptr, ix - Vec(1), iy + Vec(-1 + i)) +
           coeff_x[1] * get_value_bounded(inp_slice_C_ptr, ix + Vec(0), iy + Vec(-1 + i)) +
@@ -984,12 +985,12 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
       auto gOut = Vec::loadu(gOut_slice[c].data() + offset, len);
 
-      for (int64_t i = 0; i < 4; ++i) {
-        for (int64_t j = 0; j < 4; ++j) {
+      for (const auto i : c10::irange(4)) {
+        for (const auto j : c10::irange(4)) {
           auto xx = ix + Vec(-1 + i);
           auto yy = iy + Vec(-1 + j);
 
@@ -1099,7 +1100,7 @@ static inline void grid_sample_2d_grid_slice_iterator(
     } else {
       // If only [W] is contiguous, apply line_fn once for each h slice.
       auto grid_ptr_NH = grid_ptr;
-      for (int64_t h = 0; h < out_H; h++) {
+      for (const auto h : c10::irange(out_H)) {
         line_fn(grid_ptr_NH, grid_ptr_NH + grid_sCoor, h * out_W, out_W);
         grid_ptr_NH += grid_sH;
       }
@@ -1115,7 +1116,7 @@ static inline void grid_sample_2d_grid_slice_iterator(
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t h = 0; h < out_H; h++) {
+    for (const auto h : c10::irange(out_H)) {
       auto grid_ptr_x = grid_ptr + h * grid_sH;
       auto grid_ptr_y = grid_ptr_x + grid_sCoor;
       auto i_offsets = iVec::arange(0, grid_sW);
@@ -1161,7 +1162,7 @@ Tensor grid_sampler_2d_cpu_kernel_impl(const Tensor& input, const Tensor& grid,
     ApplyGridSample<scalar_t, 2, interp, padding, align_corners>               \
     grid_sample(inp_acc);                                                      \
     parallel_for(0, N, grain_size, [&](int64_t begin, int64_t end) {           \
-      for (int64_t n = begin; n < end; n++) {                                  \
+      for (const auto n : c10::irange(begin, end)) {                                  \
         auto out_slice = out_acc[n];                                           \
         auto inp_slice = inp_acc[n];                                           \
         grid_sample_2d_grid_slice_iterator(                                    \
@@ -1246,7 +1247,7 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
     ApplyGridSample<scalar_t, 2, interp, padding, align_corners>                 \
     grid_sample(inp_acc);                                                        \
     parallel_for(0, N, grain_size, [&](int64_t begin, int64_t end) {             \
-      for (int64_t n = begin; n < end; n++) {                                    \
+      for (const auto n : c10::irange(begin, end)) {                             \
         GINP_SLICE_PTR(input_requires_grad)                                      \
         auto gGrid_slice = gGrid_acc[n];                                         \
         auto gOut_slice = gOut_acc[n];                                           \

--- a/aten/src/ATen/native/cpu/HistogramKernel.cpp
+++ b/aten/src/ATen/native/cpu/HistogramKernel.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <mutex>
@@ -98,7 +99,7 @@ void histogram_cpu_contiguous(Tensor& hist, const Tensor& bin_edges,
         // Allocates a buffer for the thread's local results
         std::vector<input_t> data_out_local(numel_be - 1, input_t(0));
 
-        for (int64_t i = start; i < end; ++i) {
+        for (const auto i : c10::irange(start, end)) {
             const input_t elt = accessor_in[i];
 
             // Skips elements which fall outside the specified bins

--- a/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/cpu/Reduce.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native { namespace {
 
@@ -135,13 +136,14 @@ void unpack_pivots_cpu_kernel(
     auto* unpacked_pivots_ptr = data[0];
     const auto* pivots_ptr = data[1];
 
-    for (int64_t elem = 0; elem < nelems; ++elem) {
+    for (const auto elem : c10::irange(nelems)) {
+      (void)elem; //Suppress unused variable warning
       // WARNING: torch.lu returns int32 pivots,
       // this behavior could change in the future.
       auto* unpacked_pivots_data = reinterpret_cast<int32_t*>(unpacked_pivots_ptr);
       auto* pivots_data = reinterpret_cast<const int32_t*>(pivots_ptr);
 
-      for (int64_t i = 0; i < dim_size; ++i) {
+      for (const auto i : c10::irange(dim_size)) {
         std::swap(
           unpacked_pivots_data[i],
           unpacked_pivots_data[pivots_data[i]]

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/cpu/IsContiguous.h>
 #include <ATen/native/TensorIterator.h>
@@ -120,7 +121,7 @@ basic_loop(char* C10_RESTRICT data[], const int64_t* strides_, int64_t i, int64_
   // Copying strides to temporary array helps auto vectorization in older GCC
   // versions.
   int64_t strides[ntensors];
-  for (int arg = 0; arg < ntensors; arg++) {
+  for (const auto arg : c10::irange(ntensors)) {
     strides[arg] = strides_[arg];
   }
 
@@ -178,7 +179,7 @@ multiple_outputs_loop(char* C10_RESTRICT data[], const int64_t* strides_, int64_
   // Copying strides to temporary array helps auto vectorization in older GCC
   // versions.
   int64_t strides[ntensors];
-  for (int arg = 0; arg < ntensors; arg++) {
+  for (const auto arg : c10::irange(ntensors)) {
     strides[arg] = strides_[arg];
   }
 
@@ -204,7 +205,7 @@ vectorized_loop(char** C10_RESTRICT data_, int64_t n, int64_t S, func_t&& op, ve
   constexpr int ntensors = traits::arity + 1;
 
   char* C10_RESTRICT data[ntensors];
-  for (int arg = 0; arg < ntensors; arg++) {
+  for (const auto arg : c10::irange(ntensors)) {
     data[arg] = data_[arg];
   }
 
@@ -220,7 +221,7 @@ vectorized_loop(char** C10_RESTRICT data_, int64_t n, int64_t S, func_t&& op, ve
   }
   if (i < n) {
     int64_t strides[ntensors];
-    for (int arg = 0; arg < ntensors; arg++) {
+    for (const auto arg : c10::irange(ntensors)) {
       strides[arg] = (S > 0 && arg == S) ? 0 : sizeof(scalar_t);
     }
     basic_loop(data, strides, i, n, std::forward<func_t>(op));

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -43,7 +44,7 @@ void cpu_max_pool(
     int64_t ow = 0;
     data_index_init(begin, c, channels, oh, output_height, ow, output_width);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = oh * dH - padH;
       int64_t iw0 = ow * dW - padW;
       int64_t ih1 = std::min(ih0 + (kH - 1) * dilationH + 1, input_height);
@@ -133,7 +134,7 @@ void cpu_max_pool_channels_last(
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = oh * dH - padH;
       int64_t iw0 = ow * dW - padW;
       int64_t ih1 = std::min(ih0 + (kH - 1) * dilationH + 1, input_height);
@@ -229,13 +230,13 @@ void cpu_max_pool_backward(
 
   // parallel on dim of N, C
   at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
       scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
       int64_t * indices_ptr = indices_data + c * output_height * output_width;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           // retrieve position of max
           int64_t index = oh * output_width + ow;
           int64_t maxindex = indices_ptr[index];
@@ -278,17 +279,17 @@ void cpu_max_pool_backward_channels_last(
 
   // parallel on dim N
   at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t n = begin; n < end; n++) {
+    for (const auto n : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
       scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
       int64_t* indices_ptr = indices_data + n * output_height * output_width * channels;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
           int64_t* ind = indices_ptr + oh * output_width * channels + ow * channels;
           // TODO: gcc vectorization
-          for (int64_t c = 0; c < channels; c++) {
+          for (const auto c : c10::irange(channels)) {
             int64_t maxindex = ind[c];
             if (maxindex != -1) {
               grad_input_ptr[maxindex * channels + c] += gout[c];

--- a/aten/src/ATen/native/cpu/MaxPooling.cpp
+++ b/aten/src/ATen/native/cpu/MaxPooling.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/MaxPooling.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -13,7 +14,7 @@ inline void max_pool1d_kernel(
     scalar_t* C10_RESTRICT op,
     const scalar_t* C10_RESTRICT ip,
     const PoolingParams1D& p) {
-  for (int64_t kj = 0; kj < p.KW; ++kj) {
+  for (const auto kj : c10::irange(p.KW)) {
     int64_t oj = p.valid_output_start(kj);
     int64_t oe = p.valid_output_end(kj);
     int64_t ij = p.index(kj, oj);
@@ -40,7 +41,7 @@ void max_pool1d_impl(
         : std::numeric_limits<scalar_t>::lowest();
 
     at::parallel_for(0, p.NB * p.NC, 0, [&](int64_t begin, int64_t end) {
-      for (int64_t it = begin; it < end; ++it) {
+      for (const auto it : c10::irange(begin, end)) {
         scalar_t* op = OP + it * p.OW;
         const scalar_t* ip = IP + it * p.IW;
         std::fill_n(op, p.OW, FILL);

--- a/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 #include <c10/util/Optional.h>
 
@@ -60,7 +61,7 @@ void cpu_max_unpool(
     int64_t ip = 0;
     data_index_init(begin, c, channels, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* output_ptr = output_data + c * output_image_size;
 
       int64_t maxp = indices_data[i];
@@ -124,13 +125,13 @@ void cpu_max_unpool_channels_last(
     int64_t ip = 0;
     data_index_init(begin, n, nbatch, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* input_ptr = input_data + i * channels;
       int64_t* indices_ptr = indices_data + i * channels;
       scalar_t* output_ptr = output_data + n * output_image_size * channels;
 
       // can't do scatter on avx2 (only available on avx512)
-      for (int64_t c = 0; c < channels; c++) {
+      for (const auto c : c10::irange(channels)) {
         int64_t maxp = indices_ptr[c];
         if (maxp < 0 || maxp >= output_image_size) {
           optional_error_index = maxp;
@@ -197,7 +198,7 @@ void cpu_max_unpool_backward(
     int64_t ip = 0;
     data_index_init(begin, c, channels, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* grad_output_ptr = grad_output_data + c * output_image_size;
 
       int64_t maxp = indices_data[i];
@@ -262,12 +263,12 @@ void cpu_max_unpool_backward_channels_last(
     int64_t ip = 0;
     data_index_init(begin, n, nbatch, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* grad_output_ptr = grad_output_data + n * output_image_size * channels;
       scalar_t* grad_input_ptr = grad_input_data + i * channels;
       int64_t* indices_ptr = indices_data + i * channels;
 
-      for (int64_t c = 0; c < channels; c++) {
+      for (const auto c : c10::irange(channels)) {
         int64_t maxp = indices_ptr[c];
         if (maxp < 0 || maxp >= output_image_size) {
           optional_error_index = maxp;

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -4,6 +4,7 @@
 #include <ATen/Parallel.h>
 #include <c10/util/TypeList.h>
 #include <c10/core/Scalar.h>
+#include <c10/util/irange.h>
 
 #include <sstream>
 
@@ -38,10 +39,10 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
   VEC_LOOP_HEADER(func_t, data)
   const char* in1_ptr = data[1];
   Vec acc[4];
-  for  (int j = 0; j < 4; j++) {
+  for (const auto j : c10::irange(4)) {
     acc[j] = Vec::loadu(in1_ptr + j * Vec::size() * sizeof(scalar_t));
   }
-  for (int64_t i = 1; i < n; i++) {
+  for (const auto i : c10::irange(1, n)) {
     const char* ptr = in1_ptr + stride * i;
     acc[0] = vop(acc[0], Vec::loadu(ptr + (0 * Vec::size() * sizeof(scalar_t))));
     acc[1] = vop(acc[1], Vec::loadu(ptr + (1 * Vec::size() * sizeof(scalar_t))));
@@ -58,7 +59,7 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
     auto dst = (scalar_t*)out_ptr;
     *dst = op(*dst, buffer[0]);
   } else {
-    for (int j = 0; j < 4; j++) {
+    for (const auto j : c10::irange(4)) {
       auto dst = out_ptr + j * Vec::size() * sizeof(scalar_t);
       acc[j] = vop(acc[j], Vec::loadu(dst));
       acc[j].store(dst);
@@ -68,7 +69,8 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
 
 template <typename F>
 static inline void UNARY_OUTER_LOOP(char* data[2], const int64_t strides[2], int64_t n, F f) {
-  for (int j = 0; j < n; j++) {
+  for (const auto j : c10::irange(n)) {
+    (void)j; //Suppress unused variable warning
     f();
     data[0] += strides[0];
     data[1] += strides[1];
@@ -215,7 +217,7 @@ void binary_kernel_reduce(TensorIteratorBase& iter, ops_t ops, init_t init) {
         AT_ASSERT(ntensors - num_outputs == 1);
         char *in = data[ntensors - 1];
         int64_t stride = strides[ntensors - 1];
-        for (int64_t i = 0; i < size; ++i) {
+        for (const auto i : c10::irange(size)) {
           acc = ops.reduce(acc, *(data_t*)in, begin + i);
           in += stride;
         }
@@ -241,7 +243,7 @@ void binary_kernel_reduce(TensorIteratorBase& iter, ops_t ops, init_t init) {
           acc = reduction_body(acc, begin, end);
         }
       );
-      for (int i = 0; i < max_threads; ++i) {
+      for (const auto i : c10::irange(max_threads)) {
         total_acc = ops.combine(total_acc, buffer[i]);
       }
     }

--- a/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/native/cpu/zmath.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 namespace {
@@ -51,7 +52,7 @@ inline void reduce_all_impl(
   scalar_t result = at::parallel_reduce(0, input_numel, internal::GRAIN_SIZE, ident_v,
     [&](int64_t start, int64_t end, const scalar_t ident) -> scalar_t {
       scalar_t partial_out = ident;
-      for (int64_t i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
          partial_out = op(partial_out, input_data[i]);
       }
       return partial_out;
@@ -124,7 +125,7 @@ inline void reduce_all_impl_two_outputs(
   scalar_t_pair result = at::parallel_reduce(0, input_numel, internal::GRAIN_SIZE, ident_v,
     [&](int64_t start, int64_t end, const scalar_t_pair& ident) -> scalar_t_pair {
       scalar_t_pair partial_out(ident);
-      for (int64_t i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
          partial_out = reduce_chunk_func(partial_out, input_data[i]);
       }
       return partial_out;

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -13,6 +13,7 @@
 #include <ATen/native/cpu/Reduce.h>
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include <ATen/AccumulateType.h>
 
 namespace at { namespace native { namespace {
@@ -54,7 +55,8 @@ static inline void cpu_cum_base_kernel(const Tensor& result,
     auto* result_data_bytes = data[0];
     const auto* self_data_bytes = data[1];
 
-    for (int64_t i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
+      (void)i; //Suppress unused variable warning
       f(
         (scalar_t*)result_data_bytes, result_dim_stride,
         (scalar_t*)self_data_bytes, self_dim_stride, init_val
@@ -77,7 +79,7 @@ static void cumsum_cpu_kernel(const Tensor& result, const Tensor& self, int64_t 
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         // NOLINTNEXTLINE(bugprone-signed-char-misuse)
         auto cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
+        for (const auto i : c10::irange(self_dim_size)) {
           cum_number += self_data[i * self_dim_stride];
           result_data[i * result_dim_stride] = (scalar_t)cum_number;
         }
@@ -96,7 +98,7 @@ static void cumprod_cpu_kernel(const Tensor& result, const Tensor& self, int64_t
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         // NOLINTNEXTLINE(bugprone-signed-char-misuse)
         auto cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
+        for (const auto i : c10::irange(self_dim_size)) {
           cum_number *= self_data[i * self_dim_stride];
           result_data[i * result_dim_stride] = (scalar_t)cum_number;
         }
@@ -114,7 +116,7 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
       scalar_t* result_data, auto result_dim_stride,
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         scalar_t cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
+        for (const auto i : c10::irange(self_dim_size)) {
           scalar_t x = self_data[i * self_dim_stride];
 
           // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -52,7 +53,7 @@ struct _cpu_scatter_gather_dim_loop {
     func_t& f
   ) {
 
-    for (int64_t i = 0; i < index_dim_size; ++i) {
+    for (const auto i : c10::irange(index_dim_size)) {
       int64_t idx_dim = index_data[i * index_dim_stride];
       // we are not putting idx_dim in the error message because it disables
       // loop optimization in clang-7
@@ -79,7 +80,7 @@ struct _cpu_scatter_gather_dim_loop {
     func_t& f
   ) {
 
-    for (int64_t i = 0; i < index_dim_size; ++i) {
+    for (const auto i : c10::irange(index_dim_size)) {
       int64_t idx_dim = index_data[i * index_dim_stride];
       // we are not putting idx_dim in the error message because it disables
       // loop optimization in clang-7
@@ -146,7 +147,8 @@ struct cpu_scatter_gather_base_kernel {
           // whether `n` is smaller than `index_dim_size`
 
           if ((dim== self.dim() - 1) || (n < index_dim_size)) {
-            for (int64_t nelem = 0; nelem < n; ++nelem) {
+            for (const auto nelem : c10::irange(n)) {
+              (void)nelem; //Suppress unused variable warning
               // dim loop is a separate code block
               // for better performance
               _cpu_scatter_gather_dim_loop<is_scatter_like>()(
@@ -160,10 +162,11 @@ struct cpu_scatter_gather_base_kernel {
             }
           }
           else {
-            for (int64_t i = 0; i < index_dim_size; ++i) {
+            for (const auto i : c10::irange(index_dim_size)) {
               auto* self_data = self_data_bytes;
               auto* index_data = (char*)((int64_t*)index_data_bytes + i * index_dim_stride);
-              for (int64_t nelem = 0; nelem < n; ++nelem) {
+              for (const auto nelem : c10::irange(n)) {
+                (void)nelem; //Suppress unused variable warning
                 int64_t idx_dim = *(int64_t*)index_data;
                 // we are not putting idx_dim in the error message because it disables
                 // loop optimization in clang-7
@@ -227,7 +230,8 @@ struct cpu_scatter_gather_base_kernel {
           // whether dim is the last dimension and/or
           // whether `n` is smaller than `index_dim_size`
           if ((dim== self.dim() - 1) || (n < index_dim_size)) {
-            for (int64_t nelem = 0; nelem < n; ++nelem) {
+            for (const auto nelem : c10::irange(n)) {
+              (void)nelem; //Suppress unused variable warning
               // dim loop is a separate code block
               // for better performance
               _cpu_scatter_gather_dim_loop<is_scatter_like>()(
@@ -244,11 +248,12 @@ struct cpu_scatter_gather_base_kernel {
             }
           }
           else {
-            for (int64_t i = 0; i < index_dim_size; ++i) {
+            for (const auto i : c10::irange(index_dim_size)) {
               auto* self_data = self_data_bytes;
               auto* index_data = (char*)((int64_t*)index_data_bytes + i * index_dim_stride);
               auto* src_data = src_data_bytes;
-              for (int64_t nelem = 0; nelem < n; ++nelem) {
+              for (const auto nelem : c10::irange(n)) {
+                (void)nelem; //Suppress unused variable warning
                 int64_t idx_dim = *(int64_t*)index_data;
                 // we are not putting idx_dim in the error message because it disables
                 // loop optimization in clang-7

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/CompositeRandomAccessor.h>
 #include <ATen/native/Sorting.h>
 #include <ATen/native/SortingUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -55,7 +56,8 @@ void _dim_apply(
         auto* values_data_bytes = data[0];
         auto* indices_data_bytes = data[1];
 
-        for (int64_t i = 0; i < n; ++i) {
+        for (const auto i : c10::irange(n)) {
+          (void)i; //Suppress unused variable warning
           f(
             reinterpret_cast<scalar_t*>(values_data_bytes),
             values_dim_stride,

--- a/aten/src/ATen/native/cpu/StackKernel.cpp
+++ b/aten/src/ATen/native/cpu/StackKernel.cpp
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/StackKernel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -37,8 +38,8 @@ void stack_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 
   using Vec = vec::Vectorized<scalar_t>;
   scalar_t* result_ptr = result_data;
-  for (int64_t i = 0; i < outer; ++i) {
-    for (int64_t j = 0; j < ninputs; j++) {
+  for (const auto i : c10::irange(outer)) {
+    for (const auto j : c10::irange(ninputs)) {
       int64_t local_inner = inputs[j].inner_size;
       scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
 
@@ -46,7 +47,7 @@ void stack_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
 #pragma unroll
 #endif
-        for (int64_t k = 0; k < local_inner; k++) {
+        for (const auto k : c10::irange(local_inner)) {
           result_ptr[k] = input_ptr[k];
         }
       } else {

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Reduce.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 
@@ -26,7 +27,7 @@ Vectorized<acc_t> load_reduce_vec(const scalar_t* data, F reduce, acc_t ident) {
   constexpr int vstride = vec_t::size() / vacc_t::size();
   alignas(64) std::array<acc_t, vacc_t::size()> acc;
   acc.fill(ident);
-  for (int k = 0; k < vstride; ++k) {
+  for (const auto k : c10::irange(vstride)) {
     for (int i = 0; i < vacc_t::size(); ++i) {
       acc[i] = reduce(acc[i], values[i * vstride + k]);
     }
@@ -280,7 +281,7 @@ template <typename StorePolicy, typename scalar_t, size_t numel>
 static void store(char * C10_RESTRICT data, int64_t stride, int64_t index,
                   const std::array<scalar_t, numel> &values) {
   auto *base_ptr = data + stride * index;
-  for (size_t k = 0; k < numel; ++k) {
+  for (const auto k : c10::irange(numel)) {
     auto val = values[k];
     StorePolicy::store(base_ptr, stride, k, val);
   }
@@ -314,7 +315,7 @@ A simplified recursive implementation would look like this:
     scalar_t sum = 0;
     if (n <= min_chunk_size) {
       // Recursive base case, calculate a simple running sum
-      for (int64_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         sum += data[i];
       }
       return sum;
@@ -352,16 +353,16 @@ std::array<scalar_t, nrows> multi_row_sum(
       #if !defined(COMPILING_FOR_MIN_SIZE)
       # pragma unroll
       #endif
-      for (int64_t k = 0; k < nrows; ++k) {
+      for (const auto k : c10::irange(nrows)) {
         acc[0][k] += LoadPolicy::load(sum_base, col_stride, k);
       }
     }
 
-    for (int64_t j = 1; j < num_levels; ++j) {
+    for (const auto j : c10::irange(1, num_levels)) {
       #if !defined(COMPILING_FOR_MIN_SIZE)
       # pragma unroll
       #endif
-      for (int64_t k = 0; k < nrows; ++k) {
+      for (const auto k : c10::irange(nrows)) {
         acc[j][k] += acc[j-1][k];
         acc[j-1][k] = scalar_t(0);
       }
@@ -378,23 +379,23 @@ std::array<scalar_t, nrows> multi_row_sum(
     #if !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t k = 0; k < nrows; ++k) {
+    for (const auto k : c10::irange(nrows)) {
       acc[0][k] += LoadPolicy::load(sum_base, col_stride, k);
     }
   }
 
-  for (int64_t j = 1; j < num_levels; ++j) {
+  for (const auto j : c10::irange(1, num_levels)) {
     #if !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t k = 0; k < nrows; ++k) {
+    for (const auto k : c10::irange(nrows)) {
       acc[0][k] += acc[j][k];
     }
   }
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   std::array<scalar_t, nrows> ret;
-  for (int64_t k = 0; k < nrows; ++k) {
+  for (const auto k : c10::irange(nrows)) {
     ret[k] = acc[0][k];
   }
   return ret;
@@ -414,7 +415,7 @@ scalar_t row_sum(const char * C10_RESTRICT in_data,
     partial_sums[0] += LoadPolicy::load(in_data, in_stride, i);
   }
 
-  for (int64_t k = 1; k < ilp_factor; ++k) {
+  for (const auto k : c10::irange(1, ilp_factor)) {
     partial_sums[0] += partial_sums[k];
   }
 
@@ -433,7 +434,7 @@ void vectorized_inner_sum(
   const int64_t vec_size = size0 / vec_numel;
 
   // Input is contiguous over the first (reduced) dimension
-  for (int64_t j = 0; j < size1; ++j) {
+  for (const auto j : c10::irange(size1)) {
     const auto *row_in = data[1] + j * outer_stride;
     auto vec_acc = row_sum<vacc_t, VecLoadPolicy>(row_in, vec_stride, vec_size);
 
@@ -444,7 +445,7 @@ void vectorized_inner_sum(
 
     alignas(64) std::array<acc_t, vacc_t::size()> partials{};
     vec_acc.store(partials.data());
-    for (size_t k = 0; k < partials.size(); ++k) {
+    for (const auto k : c10::irange(partials.size())) {
       final_acc += partials[k];
     }
     store<StorePolicy>(data[0], out_stride, j, final_acc);
@@ -456,7 +457,7 @@ void scalar_inner_sum(
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char * C10_RESTRICT data[2], int64_t in_strides[2], int64_t out_stride,
     int64_t size0, int64_t size1) {
-  for (int64_t j = 0; j < size1; ++j) {
+  for (const auto j : c10::irange(size1)) {
     const auto *row_in = data[1] + j * in_strides[1];
     auto ans = row_sum<acc_t, LoadPolicy>(row_in, in_strides[0], size0);
     store<StorePolicy>(data[0], out_stride, j, ans);
@@ -480,7 +481,7 @@ void vectorized_outer_sum(
     auto sums = multi_row_sum<vacc_t, nrows, VecLoadPolicy>(
         row_in, inner_stride, vec_stride, size0);
 
-    for (int64_t i = 0; i < nrows; ++i) {
+    for (const auto i : c10::irange(nrows)) {
       const int64_t base_idx = j + i * vacc_t::size();
       store<StorePolicy>(data[0], out_stride, base_idx, sums[i]);
     }

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -18,6 +18,7 @@
 
 #include <c10/util/MathConstants.h>
 #include <c10/core/Scalar.h>
+#include <c10/util/irange.h>
 
 #if AT_MKL_ENABLED()
 #include <mkl.h>
@@ -103,7 +104,7 @@ void LogitMKLKernel(T eps, TensorIteratorBase* it) {
   T* Y_data = static_cast<T*>(it->data_ptr(0));
   if (eps < T(0)) {
     at::parallel_for(0, N, K, [=](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; ++i) {
+      for (const auto i : c10::irange(begin, end)) {
         Y_data[i] = X_data[i] == T(1) ? std::numeric_limits<T>::infinity()
                                       : X_data[i] / (T(1) - X_data[i]);
       }
@@ -113,7 +114,7 @@ void LogitMKLKernel(T eps, TensorIteratorBase* it) {
     const T lo = eps;
     const T hi = T(1) - eps;
     at::parallel_for(0, N, K, [=](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; ++i) {
+      for (const auto i : c10::irange(begin, end)) {
         const T x = X_data[i] < lo ? lo : (X_data[i] > hi ? hi : X_data[i]);
         Y_data[i] =
             x == T(1) ? std::numeric_limits<T>::infinity() : (x / (T(1) - x));
@@ -552,10 +553,10 @@ static void erfcx_kernel(TensorIteratorBase& iter){
                 scalar_t buffer[WIDTH];                                       \
                 int64_t width = WIDTH;                                        \
                 width = std::min(width, n - i);                               \
-                for (int64_t j = 0; j < width; j++)                           \
+                for (const auto j : c10::irange(width))\
                   buffer[j] = in_data[in_stride * (i + j)];                   \
                 vml::v##op(buffer, buffer, width);                            \
-                for (int64_t j = 0; j < width; j++)                           \
+                for (const auto j : c10::irange(width))\
                   out_data[out_stride * (i + j)] = buffer[j];                 \
               }                                                               \
             }                                                                 \

--- a/aten/src/ATen/native/cpu/Unfold2d.cpp
+++ b/aten/src/ATen/native/cpu/Unfold2d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/Unfold2d.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 #include <cmath>
 
 namespace at {
@@ -46,7 +47,7 @@ static void unfolded2d_acc(
     int64_t output_height,
     int64_t output_width) {
   at::parallel_for(0, n_input_plane, 0, [&](int64_t start, int64_t end) {
-    for (auto nip = start; nip < end; nip++) {
+    for (const auto nip : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t kw, kh, y, x;
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -172,7 +173,7 @@ static void unfolded2d_copy(
     int64_t output_width) {
   at::parallel_for(
       0, (int64_t)n_input_plane * kH * kW, 0, [&](int64_t start, int64_t end) {
-        for (auto k = start; k < end; k++) {
+        for (const auto k : c10::irange(start, end)) {
           int64_t nip = k / (kH * kW);
           int64_t rest = k % (kH * kW);
           int64_t kh = rest / kW;

--- a/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
@@ -2,6 +2,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/UnfoldBackward.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 
 #if (defined(_WIN32) || defined(_WIN64))
 #define RESTRICT __restrict
@@ -77,7 +78,8 @@ void _unfold_backward_internal_kernel(
     if (is_step_ge_size) {
       auto* RESTRICT idx_last_dim_ptr = data[3];
 
-      for (int64_t elem = 0; elem < nelems; ++elem) {
+      for (const auto elem : c10::irange(nelems)) {
+        (void)elem; //Suppress unused variable warning
         auto* RESTRICT grad_out_data = reinterpret_cast<scalar_t*>(grad_out_ptr);
         auto* RESTRICT grad_in_data = reinterpret_cast<scalar_t*>(grad_in_ptr);
 
@@ -94,7 +96,8 @@ void _unfold_backward_internal_kernel(
       }
     }
     else {
-      for (int64_t elem = 0; elem < nelems; ++elem) {
+      for (const auto elem : c10::irange(nelems)) {
+        (void)elem; //Suppress unused variable warning
         auto* RESTRICT grad_out_data = reinterpret_cast<scalar_t*>(grad_out_ptr);
         auto* RESTRICT grad_in_data = reinterpret_cast<scalar_t*>(grad_in_ptr);
 

--- a/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/UpSample.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -55,8 +56,8 @@ void cpu_upsample_linear_backward(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t iw0, iw1;
     scalar_t w0lambda, w1lambda;
-    for (int64_t c = begin; c < end; c++){
-      for (int64_t ow = 0; ow < output_width; ow++) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto ow : c10::irange(output_width)) {
         compute_source_index_and_lambda(
             iw0, iw1, w0lambda, w1lambda, width_scale, ow, input_width, output_width, align_corners);
         scalar_t grad_output_value = grad_output_data[c * output_slice_size + ow];
@@ -79,11 +80,11 @@ void cpu_upsample_linear_backward(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ih0, ih1, iw0, iw1;
     scalar_t h0lambda, h1lambda, w0lambda, w1lambda;
-    for (int64_t c = begin; c < end; c++) {
-      for (int64_t oh = 0; oh < output_height; oh++) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto oh : c10::irange(output_height)) {
         compute_source_index_and_lambda(
             ih0, ih1, h0lambda, h1lambda, height_scale, oh, input_height, output_height, align_corners);
-        for (int64_t ow = 0; ow < output_width; ow++) {
+        for (const auto ow : c10::irange(output_width)) {
           compute_source_index_and_lambda(
               iw0, iw1, w0lambda, w1lambda, width_scale, ow, input_width, output_width, align_corners);
           scalar_t grad_output_value = grad_output_data[c * output_slice_size + oh * output_width + ow];
@@ -112,14 +113,14 @@ void cpu_upsample_linear_backward(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t id0, id1, ih0, ih1, iw0, iw1;
     scalar_t d0lambda, d1lambda, h0lambda, h1lambda, w0lambda, w1lambda;
-    for (int64_t c = begin; c < end; c++) {
-      for (int64_t od = 0; od < output_depth; od++) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto od : c10::irange(output_depth)) {
         compute_source_index_and_lambda(
             id0, id1, d0lambda, d1lambda, depth_scale, od, input_depth, output_depth, align_corners);
-        for (int64_t oh = 0; oh < output_height; oh++) {
+        for (const auto oh : c10::irange(output_height)) {
           compute_source_index_and_lambda(
               ih0, ih1, h0lambda, h1lambda, height_scale, oh, input_height, output_height, align_corners);
-          for (int64_t ow = 0; ow < output_width; ow++) {
+          for (const auto ow : c10::irange(output_width)) {
             compute_source_index_and_lambda(
                 iw0, iw1, w0lambda, w1lambda, width_scale, ow, input_width, output_width, align_corners);
             scalar_t grad_output_value = grad_output_data[c * output_slice_size +

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 namespace {
@@ -42,7 +43,7 @@ void batch_norm_cpu_collect_linear_and_constant_terms(
   ///   the constant term beta(c) = bias(c) - mean(c) * inv_var(c) * weight(c)
   /// Note that this is only a good idea if (input_size >> c), in degenerate
   /// cases where image_size == 1 && batch_size == 1, it is slow.
-  for (int64_t c = 0; c < n_channel; c++) {
+  for (const auto c : c10::irange(n_channel)) {
     scalar_t mean, invstd;
     if (train) {
       mean = save_mean_a[c];
@@ -90,7 +91,7 @@ void batch_norm_cpu_contiguous_impl(Tensor& output, const Tensor& input,
       int64_t c = 0;
       data_index_init(begin, n, n_batch, c, n_channel);
 
-      for (int64_t i = begin; i < end; i++) {
+      for (const auto i : c10::irange(begin, end)) {
         const Vec alpha_vec(alpha_data[c]);
         const Vec beta_vec(beta_data[c]);
         int64_t offset = i * image_size;
@@ -113,7 +114,7 @@ void batch_norm_cpu_contiguous_impl(Tensor& output, const Tensor& input,
     // image_size == 1
     const int64_t loop_size = n_channel - (n_channel % Vec::size());
     at::parallel_for(0, n_batch, 1, [&](int64_t begin, int64_t end) {
-      for (int64_t n = begin; n < end; n++) {
+      for (const auto n : c10::irange(begin, end)) {
         int64_t offset = n * n_channel;
         int64_t d = 0;
         for (; d < loop_size; d += Vec::size()) {
@@ -161,7 +162,7 @@ void batch_norm_cpu_channels_last_impl(Tensor& output, const Tensor& input,
   // output(n, c, h, w) = input(n, c, h, w) * alpha(c) + beta(c)
   const int64_t loop_size = n_channel - (n_channel % Vec::size());
   at::parallel_for(0, n_batch * image_size, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t offset = i * n_channel;
       int64_t d = 0;
       // vectorize on channel dimension, for normal batch_norm input size,
@@ -200,11 +201,11 @@ void batch_norm_cpu_collect_stats_contiguous_impl(
 
   // parallel dim reduce on 'channel'
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       // compute mean per input
       accscalar_t sum = 0;
-      for (int64_t n = 0; n < n_batch; n++) {
-        for (int64_t i = 0; i < image_size; i++) {
+      for (const auto n : c10::irange(n_batch)) {
+        for (const auto i : c10::irange(image_size)) {
           auto offset = n * n_channel * image_size + c * image_size + i;
           sum += input_data[offset];
         }
@@ -214,8 +215,8 @@ void batch_norm_cpu_collect_stats_contiguous_impl(
 
       // compute variance per input
       accscalar_t _var_sum = 0;
-      for (int64_t n = 0; n < n_batch; n++) {
-        for (int64_t i = 0; i < image_size; i++) {
+      for (const auto n : c10::irange(n_batch)) {
+        for (const auto i : c10::irange(image_size)) {
           auto offset = n * n_channel * image_size + c * image_size + i;
           auto x = input_data[offset];
           _var_sum += (x - mean) * (x - mean);
@@ -259,7 +260,7 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
     TORCH_CHECK(tid < num_threads,
                 "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     scalar_t* buffer_ptr = buffer_data + tid * n_channel;
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       const scalar_t* x_ptr = input_data + i * n_channel;
       vec::map2<scalar_t>(
           [](Vec x, Vec y) { return x + y; },
@@ -271,9 +272,9 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
   });
 
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       accscalar_t sum = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         sum += buffer_data[t * n_channel + c];
       }
       scalar_t mean = sum / N;
@@ -287,7 +288,7 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
     int tid = at::get_thread_num();
     TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     scalar_t* buffer_ptr = buffer_data + tid * n_channel;
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       const scalar_t* x_ptr = input_data + i * n_channel;
       vec::map3<scalar_t>(
           [](Vec x, Vec y, Vec mean) { return y + (x - mean) * (x - mean); },
@@ -300,9 +301,9 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
   });
 
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       accscalar_t _var_sum = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         _var_sum += buffer_data[t * n_channel + c];
       }
       var_sum_data[c] = _var_sum;
@@ -341,7 +342,7 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
 
   // parallel dim reduce on 'channel'
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t w = weight.defined() ? weight_a[c] : 1;
 
       scalar_t mean, invstd;
@@ -359,7 +360,7 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
       //
       accscalar_t sum = 0;
       accscalar_t dotp = 0;
-      for (int64_t n = 0; n < n_batch; n++) {
+      for (const auto n : c10::irange(n_batch)) {
         const scalar_t* x_ptr = input_data + n * n_channel * image_size + c * image_size;
         const scalar_t* dy_ptr = grad_output_data + n * n_channel * image_size + c * image_size;
 
@@ -381,13 +382,13 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
           scalar_t k = (scalar_t) dotp * invstd * invstd / N;
           scalar_t grad_mean = sum / N;
 
-          for (int64_t n = 0; n < n_batch; n++) {
+          for (const auto n : c10::irange(n_batch)) {
             const scalar_t* x_ptr = input_data + n * n_channel * image_size + c * image_size;
             scalar_t* dx_ptr = grad_input_data + n * n_channel * image_size + c * image_size;
             const scalar_t* dy_ptr = grad_output_data + n * n_channel * image_size + c * image_size;
 
             // Scalar math:
-            // for (int64_t j = 0; j < image_size; ++j) {
+            // for (const auto j : c10::irange(image_size)) {
             //   scalar_t dx = (x_ptr[j] - mean) * k;
             //   dx_ptr[j] = (dy_ptr[j] - grad_mean - dx) * invstd * w;
             // }
@@ -402,12 +403,12 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
                 image_size);
           }
         } else { // evaluation mode
-          for (int64_t n = 0; n < n_batch; n++) {
+          for (const auto n : c10::irange(n_batch)) {
             scalar_t* dx_ptr = grad_input_data + n * n_channel * image_size + c * image_size;
             const scalar_t* dy_ptr = grad_output_data + n * n_channel * image_size + c * image_size;
 
             // Scalar math:
-            // for (int64_t j = 0; j < image_size; ++j) {
+            // for (const auto j : c10::irange(image_size)) {
             //   dx_ptr[j] = dy_ptr[j] * invstd * w;
             // }
             vec::map<scalar_t>(
@@ -467,7 +468,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
 
     invstd.resize_({n_channel});
     invstd_ptr = invstd.data_ptr<scalar_t>();
-    for (int64_t c = 0; c < n_channel; c++) {
+    for (const auto c : c10::irange(n_channel)) {
       invstd_ptr[c] = 1 / std::sqrt(running_var_data[c] + eps);
     }
   }
@@ -491,7 +492,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
     TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     scalar_t* sum_ptr = sum_data + tid * n_channel;
     scalar_t* dotp_ptr = dotp_data + tid * n_channel;
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       const scalar_t* x_ptr = input_data + i * n_channel;
       const scalar_t* dy_ptr = grad_output_data + i * n_channel;
 
@@ -514,17 +515,17 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
   });
 
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       // store the final result of sum and dotp in the 1st lane of immediate buffer,
       // so that we won't need to allocate anther buffer to store the temp values.
       accscalar_t _sum = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         _sum += sum_data[t * n_channel + c];
       }
       sum_data[/* 0 * n_channel + */c] = _sum;
 
       accscalar_t _dotp = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         _dotp += dotp_data[t * n_channel + c];
       }
       dotp_data[/* 0 * n_channel + */c] = _dotp;
@@ -535,7 +536,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
   const int64_t loop_size = n_channel - (n_channel % Vec::size());
   if (grad_input.defined()) {
     at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; i++) {
+      for (const auto i : c10::irange(begin, end)) {
         scalar_t* dx_ptr = grad_input_data + i * n_channel;
         const scalar_t* x_ptr = input_data + i * n_channel;
         const scalar_t* dy_ptr = grad_output_data + i * n_channel;

--- a/aten/src/ATen/native/cpu/group_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/group_norm_kernel.cpp
@@ -9,6 +9,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/moments_utils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -44,7 +45,7 @@ void GroupNormKernelImplInternal(
   const int64_t inner_size = D * HxW;
 
   at::parallel_for(0, N * G, 1, [&](int64_t start, int64_t end) {
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* X_ptr = X_data + i * inner_size;
       T mean_val;
       T rstd_val;
@@ -52,18 +53,18 @@ void GroupNormKernelImplInternal(
       rstd_val = T(1) / std::sqrt(std::max(rstd_val, T(0)) + eps);
       if (gamma_null && beta_null) {
         T* Y_ptr = Y_data + i * inner_size;
-        for (int j = 0; j < inner_size; ++j) {
+        for (const auto j : c10::irange(inner_size)) {
           Y_ptr[j] = (X_ptr[j] - mean_val) * rstd_val;
         }
       } else {
         const int64_t g = i % G;
-        for (int64_t j = 0; j < D; ++j) {
+        for (const auto j : c10::irange(D)) {
           const int64_t c = g * D + j;
           const T scale = rstd_val * (gamma_null ? T(1) : gamma_data[c]);
           const T bias = -scale * mean_val + (beta_null ? T(0) : beta_data[c]);
           X_ptr = X_data + (i * D + j) * HxW;
           T* Y_ptr = Y_data + (i * D + j) * HxW;
-          for (int64_t k = 0; k < HxW; ++k) {
+          for (const auto k : c10::irange(HxW)) {
             Y_ptr[k] = scale * X_ptr[k] + bias;
           }
         }
@@ -110,10 +111,10 @@ void GroupNormKernelImplChannelsLastInternal(
   at::parallel_for(0, N, 1, [&](int64_t start, int64_t end) {
     constexpr int64_t K = Vec::size();
     const int64_t inner_size = C / K * K;
-    for (int64_t n = start; n < end; ++n) {
+    for (const auto n : c10::irange(start, end)) {
       T* mean_ptr = buffer_data + n * 2 * C;
       T* rstd_ptr = mean_ptr + C;
-      for (int64_t i = 0; i < HxW; ++i) {
+      for (const auto i : c10::irange(HxW)) {
         const T* X_ptr = X_data + n * HxW * C + i * C;
         for (int64_t j = 0; j < inner_size; j += K) {
           const Vec x_vec = Vec::loadu(X_ptr + j);
@@ -122,16 +123,16 @@ void GroupNormKernelImplChannelsLastInternal(
           mean_vec.store(mean_ptr + j);
           rstd_vec.store(rstd_ptr + j);
         }
-        for (int64_t j = inner_size; j < C; ++j) {
+        for (const auto j : c10::irange(inner_size, C)) {
           mean_ptr[j] += X_ptr[j];
           rstd_ptr[j] += X_ptr[j] * X_ptr[j];
         }
       }
 
-      for (int64_t g = 0; g < G; ++g) {
+      for (const auto g : c10::irange(G)) {
         T mean_val = T(0);
         T rstd_val = T(0);
-        for (int64_t d = 0; d < D; ++d) {
+        for (const auto d : c10::irange(D)) {
           mean_val += mean_ptr[g * D + d];
           rstd_val += rstd_ptr[g * D + d];
         }
@@ -141,7 +142,7 @@ void GroupNormKernelImplChannelsLastInternal(
 
         // continue to use the temp buffer for mean and rstd value,
         // so that we can vectorize the following math on entire C dimension.
-        for (int64_t d = 0; d < D; ++d) {
+        for (const auto d : c10::irange(D)) {
           mean_ptr[g * D + d] = mean_val;
           rstd_ptr[g * D + d] = rstd_val;
         }
@@ -152,7 +153,7 @@ void GroupNormKernelImplChannelsLastInternal(
 
       // expand gamma_null and beta_null to reduce if-else on critial path.
       if (!gamma_null && !beta_null) {
-        for (int64_t i = 0; i < HxW; ++i) {
+        for (const auto i : c10::irange(HxW)) {
           const T* X_ptr = X_data + n * HxW * C + i * C;
           T* Y_ptr = Y_data + n * HxW * C + i * C;
           for (int64_t j = 0; j < inner_size; j += K) {
@@ -161,14 +162,14 @@ void GroupNormKernelImplChannelsLastInternal(
             Vec y_vec = scale_vec * Vec::loadu(X_ptr + j) + bias_vec;
             y_vec.store(Y_ptr + j);
           }
-          for (int64_t j = inner_size; j < C; ++j) {
+          for (const auto j : c10::irange(inner_size, C)) {
             T scale = rstd_ptr[j] * gamma_data[j];
             T bias = -scale * mean_ptr[j] + beta_data[j];
             Y_ptr[j] = scale * X_ptr[j] + bias;
           }
         }
       } else if (gamma_null && beta_null) {
-        for (int64_t i = 0; i < HxW; ++i) {
+        for (const auto i : c10::irange(HxW)) {
           const T* X_ptr = X_data + n * HxW * C + i * C;
           T* Y_ptr = Y_data + n * HxW * C + i * C;
           for (int64_t j = 0; j < inner_size; j += K) {
@@ -176,13 +177,13 @@ void GroupNormKernelImplChannelsLastInternal(
             Vec y_vec = scale_vec * Vec::loadu(X_ptr + j) - scale_vec * Vec::loadu(mean_ptr + j);
             y_vec.store(Y_ptr + j);
           }
-          for (int64_t j = inner_size; j < C; ++j) {
+          for (const auto j : c10::irange(inner_size, C)) {
             T scale = rstd_ptr[j];
             Y_ptr[j] = scale * X_ptr[j] -scale * mean_ptr[j];
           }
         }
       } else {
-        for (int64_t i = 0; i < HxW; ++i) {
+        for (const auto i : c10::irange(HxW)) {
           const T* X_ptr = X_data + n * HxW * C + i * C;
           T* Y_ptr = Y_data + n * HxW * C + i * C;
           for (int64_t j = 0; j < inner_size; j += K) {
@@ -193,7 +194,7 @@ void GroupNormKernelImplChannelsLastInternal(
             Vec y_vec = scale_vec * Vec::loadu(X_ptr + j) + bias_vec;
             y_vec.store(Y_ptr + j);
           }
-          for (int64_t j = inner_size; j < C; ++j) {
+          for (const auto j : c10::irange(inner_size, C)) {
             T scale = rstd_ptr[j] * (gamma_null ? T(1) : gamma_data[j]);
             T bias = -scale * mean_ptr[j] + (beta_null ? T(0) : beta_data[j]);
             Y_ptr[j] = scale * X_ptr[j] + bias;
@@ -252,7 +253,7 @@ void ComputeInternalGradients(
     std::array<T, K> ds_arr;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     std::array<T, K> db_arr;
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* dY_ptr = dY + i * HxW;
       const T* X_ptr = X + i * HxW;
       vec::Vectorized<T> ds_vec(0);
@@ -267,7 +268,7 @@ void ComputeInternalGradients(
       db_vec.store(db_arr.data());
       T ds_val = std::accumulate(ds_arr.cbegin(), ds_arr.cend(), T(0));
       T db_val = std::accumulate(db_arr.cbegin(), db_arr.cend(), T(0));
-      for (int64_t j = inner_size; j < HxW; ++j) {
+      for (const auto j : c10::irange(inner_size, HxW)) {
         ds_val += dY_ptr[j] * X_ptr[j];
         db_val += dY_ptr[j];
       }
@@ -302,7 +303,7 @@ void GroupNormInputBackward(
     std::array<T, K> ds_arr;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     std::array<T, K> db_arr;
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const int64_t g = i % G;
       const T* ds_ptr = ds + i * D;
       const T* db_ptr = db + i * D;
@@ -319,7 +320,7 @@ void GroupNormInputBackward(
       db_vec.store(db_arr.data());
       T ds_val = std::accumulate(ds_arr.cbegin(), ds_arr.cend(), T(0));
       T db_val = std::accumulate(db_arr.cbegin(), db_arr.cend(), T(0));
-      for (int64_t j = d; j < D; ++j) {
+      for (const auto j : c10::irange(d, D)) {
         const T gamma_v = gamma_null ? T(1) : gamma[g * D + j];
         ds_val += ds_ptr[j] * gamma_v;
         db_val += db_ptr[j] * gamma_v;
@@ -327,13 +328,13 @@ void GroupNormInputBackward(
       const T c2 =
           (db_val * mean[i] - ds_val) * rstd[i] * rstd[i] * rstd[i] * s;
       const T c3 = -c2 * mean[i] - db_val * rstd[i] * s;
-      for (int64_t j = 0; j < D; ++j) {
+      for (const auto j : c10::irange(D)) {
         const int64_t c = g * D + j;
         const T* dY_ptr = dY + (i * D + j) * HxW;
         const T* X_ptr = X + (i * D + j) * HxW;
         T* dX_ptr = dX + (i * D + j) * HxW;
         const T c1 = rstd[i] * (gamma_null ? T(1) : gamma[c]);
-        for (int64_t k = 0; k < HxW; ++k) {
+        for (const auto k : c10::irange(HxW)) {
           dX_ptr[k] = c1 * dY_ptr[k] + c2 * X_ptr[k] + c3;
         }
       }
@@ -355,14 +356,14 @@ void GammaBackward(
   const int64_t D = C / G;
   constexpr int64_t K = vec::Vectorized<T>::size();
   at::parallel_for(0, D, K, [=](int64_t start, int64_t end) {
-    for (int64_t i = 0; i < G; ++i) {
+    for (const auto i : c10::irange(G)) {
       std::memset(dgamma + i * D + start, 0, (end - start) * sizeof(T));
     }
     for (int64_t i = 0; i < N * G; ++i) {
       const T* ds_ptr = ds + i * D;
       const T* db_ptr = db + i * D;
       const int64_t g = i % G;
-      for (int64_t j = start; j < end; ++j) {
+      for (const auto j : c10::irange(start, end)) {
         const int64_t c = g * D + j;
         dgamma[c] += (ds_ptr[j] - db_ptr[j] * mean[i]) * rstd[i];
       }
@@ -375,9 +376,9 @@ void BetaBackward(int64_t N, int64_t C, const T* db, T* dbeta) {
   constexpr int64_t K = vec::Vectorized<T>::size();
   at::parallel_for(0, C, K, [=](int64_t start, int64_t end) {
     std::memset(dbeta + start, 0, (end - start) * sizeof(T));
-    for (int64_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       const T* db_ptr = db + i * C;
-      for (int64_t j = start; j < end; ++j) {
+      for (const auto j : c10::irange(start, end)) {
         dbeta[j] += db_ptr[j];
       }
     }

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -9,6 +9,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/moments_utils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -40,7 +41,7 @@ void LayerNormKernelImplInternal(
   const bool gamma_null = gamma_data == nullptr;
   const bool beta_null = beta_data == nullptr;
   at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* X_ptr = X_data + i * N;
       T* Y_ptr = Y_data + i * N;
       T mean_val;
@@ -50,7 +51,7 @@ void LayerNormKernelImplInternal(
       const T_ACC scale = rstd_val;
       const T_ACC bias = -rstd_val * mean_val;
       if (gamma_null || beta_null) {
-        for (int64_t j = 0; j < N; ++j) {
+        for (const auto j : c10::irange(N)) {
           const T gamma_v = gamma_null ? T(1) : gamma_data[j];
           const T beta_v = beta_null ? T(0) : beta_data[j];
           Y_ptr[j] = (X_ptr[j] * scale + bias) * gamma_v + beta_v;
@@ -153,14 +154,14 @@ void LayerNormBackwardKernelImplInternal(
     T* dgamma_buffer_ptr = dgamma_null ? nullptr : buffer_data + tid * N;
     T* dbeta_buffer_ptr =
         dbeta_null ? nullptr : buffer_data + num_threads * N + tid * N;
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* dY_ptr = dY_data + i * N;
       const T* X_ptr = X_data + i * N;
       if (!dgamma_null) {
         const T_ACC a = rstd_data[i];
         const T_ACC b = -a * mean_data[i];
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   dgamma_data[j] += dY_ptr[j] * (a * X_ptr[j] + b);
         // }
         vec::map3<T>(
@@ -175,7 +176,7 @@ void LayerNormBackwardKernelImplInternal(
       }
       if (!dbeta_null) {
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   dbeta_data[j] += dY_ptr[j];
         // }
         vec::map2<T>(
@@ -190,7 +191,7 @@ void LayerNormBackwardKernelImplInternal(
         T_ACC ds = T_ACC(0);
         T_ACC db = T_ACC(0);
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   const T gamma_v = gamma_null ? T(1) : gamma_data[j];
         //   ds += dY_ptr[j] * X_ptr[j] * gamma_v;
         //   db += dY_ptr[j] * gamma_v;
@@ -223,7 +224,7 @@ void LayerNormBackwardKernelImplInternal(
         const T_ACC b = (db * mean_data[i] - ds) * a * a * a * scale;
         const T_ACC c = -b * mean_data[i] - db * a * scale;
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   const T gamma_v = gamma_null ? T(1) : gamma_data[j];
         //   dX_ptr[j] = a * dY_ptr[j] * gamma_v + b * X_ptr[j] + c;
         // }
@@ -254,10 +255,10 @@ void LayerNormBackwardKernelImplInternal(
   // Second path of dgamma/dbeta
   if (buffer_data != nullptr) {
     parallel_for(0, N, 1, [&](int64_t start, int64_t end) {
-      for (int64_t j = start; j < end; ++j) {
+      for (const auto j : c10::irange(start, end)) {
         T_ACC dgamma_v = T_ACC(0);
         T_ACC dbeta_v = T_ACC(0);
-        for (int64_t i = 0; i < num_threads; ++i) {
+        for (const auto i : c10::irange(num_threads)) {
           dgamma_v += buffer_data[i * N + j];
           dbeta_v += buffer_data[num_threads * N + i * N + j];
         }

--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -10,6 +10,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/SmallVector.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -69,12 +70,12 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
   c10::SmallVector<Vec, kMaxDepth> m1_stk(depth, kZeroVec);
   c10::SmallVector<Vec, kMaxDepth> m2_stk(depth, kZeroVec);
 
-  for (int64_t i = 0; i < m; ++i) {
+  for (const auto i : c10::irange(m)) {
     const T* X_ptr = X + i * kChunkSize * kVecSize;
     const int64_t m0 = std::min(kChunkSize, n - i * kChunkSize);
     Vec m1_vec(0);
     Vec m2_vec(0);
-    for (int64_t j = 0; j < m0; ++j) {
+    for (const auto j : c10::irange(m0)) {
       const Vec x_vec = Vec::loadu(X_ptr + j * kVecSize);
       const Vec delta_vec = x_vec - m1_vec;
       const Vec c_vec = Vec(T(1) / static_cast<T>(j + 1));
@@ -97,7 +98,7 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
       mask >>= 1;
     }
   }
-  for (int64_t i = 1; i < depth; ++i) {
+  for (const auto i : c10::irange(1, depth)) {
     AddMomentsVec(
         m0_stk[i], m1_stk[i], m2_stk[i], m0_stk[0], m1_stk[0], m2_stk[0]);
   }
@@ -116,7 +117,7 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
     m1 += delta / static_cast<T>(m0);
     m2 += delta * (X[i] - m1);
   }
-  for (int64_t i = 0; i < kVecSize; ++i) {
+  for (const auto i : c10::irange(kVecSize)) {
     AddMoments(n, m1_arr[i], m2_arr[i], m0, m1, m2);
   }
 

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -275,7 +275,7 @@ public:
                "cuFFT doesn't support signals of half type with compute "
                "capability less than SM_53, but the device containing input half "
                "tensor only has SM_", dev_prop->major, dev_prop->minor);
-      for (int64_t i = 0; i < signal_ndim; i++) {
+      for (const auto i : c10::irange(signal_ndim)) {
         TORCH_CHECK(is_pow_of_two(sizes[i + 1]),
             "cuFFT only supports dimensions whose sizes are powers of two when"
             " computing in half precision, but got a signal size of",

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/SpectralOpsUtils.h>
 #include <ATen/native/cuda/CuFFTUtils.h>
 #include <ATen/native/cuda/CuFFTPlanCache.h>
+#include <c10/util/irange.h>
 
 #include <cufft.h>
 #include <cufftXt.h>
@@ -229,7 +230,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
   const auto batch_size = input.sizes()[0];
   DimVector signal_size(signal_ndim + 1);
   signal_size[0] = batch_size;
-  for (int64_t i = 0; i < signal_ndim; ++i) {
+  for (const auto i : c10::irange(signal_ndim)) {
     auto in_size = input.sizes()[i + 1];
     auto out_size = out_sizes[dim[i]];
     signal_size[i + 1] = std::max(in_size, out_size);
@@ -241,7 +242,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
 
   batched_sizes[0] = batch_size;
   DimVector batched_out_sizes(batched_sizes.begin(), batched_sizes.end());
-  for (size_t i = 0; i < dim.size(); ++i) {
+  for (const auto i : c10::irange(dim.size())) {
     batched_out_sizes[i + 1] = out_sizes[dim[i]];
   }
   out.resize_(batched_out_sizes, MemoryFormat::Contiguous);
@@ -303,7 +304,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
     out_strides[dim_permute[i]] = batch_numel * out.strides()[0];
     batch_numel *= out_sizes[dim_permute[i]];
   }
-  for (int64_t i = batch_dims; i < ndim; ++i) {
+  for (const auto i : c10::irange(batch_dims, ndim)) {
     out_strides[dim_permute[i]] = out.strides()[1 + (i - batch_dims)];
   }
   return out.as_strided_(out_sizes, out_strides, out.storage_offset());

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -20,6 +20,7 @@
 #include <ATen/native/utils/ParamsHash.h>
 
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 
 #include <functional>
 #include <iterator>
@@ -204,7 +205,7 @@ size_t getMaxWorkspaceSize(
   THCudaCheck(cudaGetDevice(&device));
   c10::cuda::CUDACachingAllocator::cacheInfo(device, &tmp_bytes, &max_block_size);
 
-  for (int i = 0; i < n_algo; i++) {
+  for (const auto i : c10::irange(n_algo)) {
     cudnnStatus_t err;
     size_t sz;
     err = getWorkspaceSize(args, algo[i], &sz);
@@ -229,7 +230,7 @@ std::vector<perf_t> getValidAlgorithms(perf_t *perfResults, const ConvolutionArg
 
   std::vector<perf_t> result;
   result.reserve(n_algo);
-  for (int i = 0; i < n_algo; i++) {
+  for (const auto i : c10::irange(n_algo)) {
     perf_t perf = perfResults[i];
 
     // TODO: Shouldn't all returned results be successful?
@@ -579,7 +580,7 @@ static inline void split_batch_dim_to_32bit_out(
   int64_t split_size = std::max<int64_t>(max_worksize / max_inner_size, 1L);
   int64_t num_splits = (n + split_size - 1) / split_size;
   if (split_size * max_inner_size < int_max) {
-    for (int64_t i = 0; i < num_splits; i++) {
+    for (const auto i : c10::irange(num_splits)) {
       int64_t start = split_size * i;
       int64_t split_size_ = std::min<int64_t>(split_size, n - start);
       Tensor input_ = input.narrow(0, start, split_size_);
@@ -805,7 +806,7 @@ void raw_cudnn_convolution_backward_weight_out(
   int64_t split_size = std::max<int64_t>(1024 * 1024 * 512 / max_inner_size, 1L);
   int64_t num_splits = (n + split_size - 1) / split_size;
   if (split_size * max_inner_size < int_max) {
-    for (int64_t i = 0; i < num_splits; i++) {
+    for (const auto i : c10::irange(num_splits)) {
       int64_t start = split_size * i;
       int64_t split_size_ = std::min<int64_t>(split_size, n - start);
       Tensor input_ = input.narrow(0, start, split_size_);

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -30,6 +30,7 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
 #include <ATen/cuda/Exceptions.h>
 
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 
 // TODO: descriptor checking
 
@@ -41,7 +42,7 @@ namespace {
 void setSamplerDescriptor(SpatialTransformerDescriptor& desc, cudnnDataType_t dataType, const at::Tensor& tensor)
 {
   int inputSize[4] = {0};
-  for (int i = 0; i < tensor.dim(); ++i) {
+  for (const auto i : c10::irange(tensor.dim())) {
     inputSize[i] = (int) tensor.size(i);
   }
   desc.set(dataType, 4, inputSize);

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -34,6 +34,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(const Tensor& log_probs, const Tensor
 #include <ATen/cudnn/Utils.h>
 
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -57,7 +58,7 @@ bool _use_cudnn_ctc_loss(
     for (const auto input_length : input_lengths) {
       use_cudnn &= ((input_length == max_input_length) ? 1 : 0);
     }
-    for (size_t b = 0; b < target_lengths.size(); b++) {
+    for (const auto b : c10::irange(target_lengths.size())) {
       // target length < 256 is documented, but we see illegal memory accesses
       // when target lengths > input lengths for CuDNN
       use_cudnn &=

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -11,6 +11,7 @@
 #include <ATen/TensorUtils.h>
 #include <c10/util/accumulate.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #if !AT_CUDNN_ENABLED()
 
@@ -191,7 +192,7 @@ namespace {
 
   std::vector<TensorDescriptor> rnn_descriptor(const Tensor& tensor, int64_t N) {
     std::vector<TensorDescriptor> descriptors(N);
-    for (int64_t i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       descriptors[i].set(tensor, 5);
     }
     return descriptors;
@@ -470,10 +471,10 @@ namespace {
     int64_t num_layers = rnn.num_directions() * rnn.num_layers;
     size_t cur_offset = 0;
     size_t global_layer_params_count = 0;
-    for (int64_t layer = 0; layer < num_layers; layer++) {
+    for (const auto layer : c10::irange(num_layers)) {
       size_t layer_params_count = 0;
       for (auto cudnn_method : cudnn_methods) {
-        for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
+        for (const auto linear_id : c10::irange(num_linear_layers)) {
           FilterDescriptor lin_layer_mat_desc;
           void* matrix_pointer;
           AT_CUDNN_CHECK(cudnn_method(
@@ -566,7 +567,7 @@ namespace {
     } else {
       data_ptrs.reserve(num_dir_layers * 2 * 2);
     }
-    for (int64_t layer = 0; layer < num_dir_layers; layer++) {
+    for (const auto layer : c10::irange(num_dir_layers)) {
       for (auto cudnn_method : cudnn_methods) {
         // This API returns a separate pointer for weight of every gate,
         // but we represent them as a single tensor, so we're only interested
@@ -629,7 +630,7 @@ namespace {
   void _viewOrCopyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to,
                          bool copy, bool allow_type_change=false) {
     TORCH_INTERNAL_ASSERT(params_from.size(0) == params_to.size(0), "number of layers mismatch");
-    for (size_t i = 0; i < params_from.size(0); i++) {
+    for (const auto i : c10::irange(params_from.size(0))) {
       auto layer_params_from = params_from[i];
       auto layer_params_to = params_to[i];
       // NOTE: these lists have all weights before all biases, so if the layer
@@ -845,7 +846,7 @@ copy_weights_to_flat_buf_views(
   _viewOrCopyParams(weight, params, /*copy=*/true, allow_type_change);
   if (set_orig_weights_to_flat_buf) {
     // Update the storage
-    for (size_t i = 0; i < weight.size(0); i++) {
+    for (const auto i : c10::irange(weight.size(0))) {
       // There is a special case for LSTM with projections and no bias,
       // where weight copy is done in 0->0, 1->1, 2->4 layout
       if (weight[i].size() == 3 && params[i].size() == 5) {
@@ -1525,7 +1526,7 @@ Tensor try_get_weight_buf(
     AT_ASSERT(num_ptrs % 5 == 0);
     if (has_biases) {
       AT_ASSERT(num_ptrs == num_parameters);
-      for (int64_t i = 0; i < num_parameters; i++) {
+      for (const auto i : c10::irange(num_parameters)) {
         if (expected_data_ptrs[i] != parameters[i].data_ptr()) return {};
       }
     } else {

--- a/aten/src/ATen/native/im2col.h
+++ b/aten/src/ATen/native/im2col.h
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 
@@ -30,15 +31,15 @@ static void im2col(
   const int64_t width_col = output_width;
   const int64_t channels_col = channels * kernel_h * kernel_w;
 
-  for (int64_t c_col = 0; c_col < channels_col; ++c_col) {
+  for (const auto c_col : c10::irange(channels_col)) {
     int64_t w_offset = c_col % kernel_w;
     int64_t h_offset = (c_col / kernel_w) % kernel_h;
     int64_t c_im = c_col / kernel_h / kernel_w;
 
-    for (int64_t h_col = 0; h_col < height_col; ++h_col) {
+    for (const auto h_col : c10::irange(height_col)) {
       int64_t h_im = h_col * stride_h - pad_h + h_offset * dilation_h;
 
-      for (int64_t w_col = 0; w_col < width_col; ++w_col) {
+      for (const auto w_col : c10::irange(width_col)) {
         int64_t w_im = w_col * stride_w - pad_w + w_offset * dilation_w;
         data_col[(c_col * height_col + h_col) * width_col + w_col] =
             (h_im >= 0 && w_im >= 0 && h_im < height && w_im < width)
@@ -72,15 +73,15 @@ static void col2im(
   const int64_t width_col = output_width;
   const int64_t channels_col = channels * kernel_h * kernel_w;
 
-  for (int64_t c_col = 0; c_col < channels_col; ++c_col) {
+  for (const auto c_col : c10::irange(channels_col)) {
     int64_t w_offset = c_col % kernel_w;
     int64_t h_offset = (c_col / kernel_w) % kernel_h;
     int64_t c_im = c_col / kernel_h / kernel_w;
 
-    for (int64_t h_col = 0; h_col < height_col; ++h_col) {
+    for (const auto h_col : c10::irange(height_col)) {
       int64_t h_im = h_col * stride_h - pad_h + h_offset * dilation_h;
 
-      for (int64_t w_col = 0; w_col < width_col; ++w_col) {
+      for (const auto w_col : c10::irange(width_col)) {
         int64_t w_im = w_col * stride_w - pad_w + w_offset * dilation_w;
 
         if (h_im >= 0 && h_im < height && w_im >= 0 && w_im < width)

--- a/aten/src/ATen/native/metal/MetalShaders.h
+++ b/aten/src/ATen/native/metal/MetalShaders.h
@@ -516,7 +516,7 @@ kernel void reshape(texture2d_array<half, access::read> in_arr[[texture(0), func
     const ushort n2 = gid.z / slices2; //image index
     const ushort s2 = gid.z - n2 * slices2; // slice offest
     half4 value;
-    for (int idx = 0; idx < 4; ++idx){
+    for (const auto idx : c10::irange(4)) {
         // we compute the "linear index" of the output element,
         // and convert it to the equivalent "linear index" of the input element.
         ushort offset = 4 * s2 + idx;
@@ -590,7 +590,7 @@ kernel void transpose(texture2d_array<half, access::read>in_arr[[texture(0),func
     half4 value;
     ushort4 threadIndexBufferLower{1, 1, 1, 1};
     ushort4 threadIndexBufferUpper{1, 1, 1 ,1};
-    for (int idx = 0; idx < 4; ++idx){
+    for (const auto idx : c10::irange(4)) {
         ushort offset = 4 * s2 + idx;
         size_t linear_idx2 = n2 * C2 * H2 * W2 + offset * H2 * W2 + gid.y * W2 + gid.x;
         if(linear_idx2 >= numel) {
@@ -810,8 +810,8 @@ kernel void roi_align(texture2d_array<half, access::sample> ina[[texture(0), fun
 
     constexpr sampler s2(coord::pixel, address::clamp_to_edge, filter::linear);
 
-    for (int iy = 0; iy < roi_bin_grid_h; iy++) {
-        for (int ix = 0; ix < roi_bin_grid_w; ix++) {
+    for (const auto iy : c10::irange(roi_bin_grid_h)) {
+        for (const auto ix : c10::irange(roi_bin_grid_w)) {
             // Shift the pixel by 0.5. This is critical to achieve high accuracy.
             const half y =
             roi_start_h + ph * bin_size_h + (iy+0.5) * bin_size_h / static_cast<half>(roi_bin_grid_h);

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -112,6 +112,7 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_depthwise_convolution_backwa
 
 #include <ATen/TensorUtils.h>
 #include <ATen/native/ConvUtils.h>
+#include <c10/util/irange.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
 
@@ -255,7 +256,7 @@ struct ParamsHash {
   std::size_t operator()(const ConvolutionParams& params) const {
     auto ptr = reinterpret_cast<const uint8_t*>(&params);
     uint32_t value = 0x811C9DC5;
-    for (int i = 0; i < (int)sizeof(ConvolutionParams); ++i) {
+    for (const auto i : c10::irange((int)sizeof(ConvolutionParams))) {
       value ^= ptr[i];
       value *= 0x01000193;
     }

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -8,6 +8,7 @@
 
 #include <ATen/cuda/CUDAConfig.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #if !AT_ROCM_ENABLED()
 
@@ -136,7 +137,7 @@ std::vector<TensorDescriptor> rnn_descriptor_sequence(const Tensor& tensor, IntA
 
 std::vector<TensorDescriptor> rnn_descriptor(const Tensor& tensor, int64_t N) {
     std::vector<TensorDescriptor> descriptors(N);
-    for (int64_t i = 0; i < N ; i++) {
+    for (const auto i : c10::irange(N)) {
         descriptors[i].set(tensor, 5);
     }
 
@@ -246,7 +247,7 @@ Tensor permute_wei_for_miopen(Tensor wei, int64_t mode)
 
 void _viewOrCopyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to, bool copy) {
     TORCH_CHECK(params_from.size(0) == params_to.size(0), "number of layers mismatch");
-    for (size_t i = 0; i < params_from.size(0); i++) {
+    for (const auto i : c10::irange(params_from.size(0))) {
         auto layer_params_from = params_from[i];
         auto layer_params_to = params_to[i];
         // NOTE: these lists have all weights before all biases, so if the layer
@@ -268,7 +269,7 @@ void _viewOrCopyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_t
 
 void _copyParams_and_permute(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to, int64_t mode) {
     TORCH_CHECK(params_from.size(0) == params_to.size(0), "number of layers mismatch");
-    for (size_t i = 0; i < params_from.size(0); i++) {
+    for (const auto i : c10::irange(params_from.size(0))) {
         auto layer_params_from = params_from[i];
         auto layer_params_to = params_to[i];
         for (auto a = layer_params_from.begin(), b = layer_params_to.begin();
@@ -327,11 +328,11 @@ std::pair<std::vector<Tensor>, size_t> get_parameters(miopenHandle_t handle, con
     auto elem_size = dataSize(getMiopenDataType(weight_buf));
     auto bias_mode = rnn.bias_mode;
 
-    for (int64_t layer = 0; layer < num_layers; layer++) {
+    for (const auto layer : c10::irange(num_layers)) {
         size_t layer_params_count = 0;
 
         // Get layer params
-        for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
+        for (const auto linear_id : c10::irange(num_linear_layers)) {
             FilterDescriptor lin_layer_mat_desc;
             size_t offset;
             MIOPEN_CHECK(miopenGetRNNLayerParamOffset(
@@ -366,7 +367,7 @@ std::pair<std::vector<Tensor>, size_t> get_parameters(miopenHandle_t handle, con
 
         // Get bias params
         if (bias_mode == miopenRNNwithBias) {
-            for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
+            for (const auto linear_id : c10::irange(num_linear_layers)) {
                 FilterDescriptor lin_layer_mat_desc;
                 size_t offset;
                 MIOPEN_CHECK(miopenGetRNNLayerBiasOffset(
@@ -776,7 +777,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> miopen_rnn_backward(
     if (output_mask[3]) {
         dw = at::native::miopen_rnn_backward_weight(input, weight, weight_stride0, weight_buf, hx, cx, output, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, ws);
         if (mode > 1) {
-            for (int i = 0; i < dw.size(); i++) {
+            for (const auto i : c10::irange(dw.size())) {
                 dw[i] = permute_wei_for_miopen(dw[i], mode);
             }
         }

--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -42,6 +42,7 @@ void mkl_gemm_batched(
 #else // AT_MKL_ENABLED
 
 #include <mkl.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -29,7 +29,7 @@ void _fft_fill_with_conjugate_symmetry_slice(
   // n-dimensions. This advances iter_index by one row, while updating in_ptr
   // and out_ptr to point to the new row of data.
   auto advance_index = [&] () __ubsan_ignore_undefined__ {
-    for (size_t i = 1; i < iter_index.size(); ++i) {
+    for (const auto i : c10::irange(1, iter_index.size())) {
       if (iter_index[i] + 1 < signal_half_sizes[i]) {
         ++iter_index[i];
         in_ptr += in_strides[i];
@@ -93,7 +93,7 @@ void _fft_fill_with_conjugate_symmetry_slice(
     while (numel_remaining > 0) {
       auto end = std::min(signal_half_sizes[0], numel_remaining);
       out_ptr[0] = std::conj(in_ptr[0]);
-      for (int64_t i = 1; i < end; ++i) {
+      for (const auto i : c10::irange(1, end)) {
         out_ptr[(signal_half_sizes[0] - i) * out_strides[0]] = std::conj(in_ptr[i * in_strides[0]]);
       }
       numel_remaining -= end;
@@ -448,7 +448,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
   const auto batch_size = input.sizes()[0];
   DimVector signal_size(signal_ndim + 1);
   signal_size[0] = batch_size;
-  for (int64_t i = 0; i < signal_ndim; ++i) {
+  for (const auto i : c10::irange(signal_ndim)) {
     auto in_size = input.sizes()[i + 1];
     auto out_size = out_sizes[dim[i]];
     signal_size[i + 1] = std::max(in_size, out_size);
@@ -460,7 +460,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
 
   batched_sizes[0] = batch_size;
   DimVector batched_out_sizes(batched_sizes.begin(), batched_sizes.end());
-  for (size_t i = 0; i < dim.size(); ++i) {
+  for (const auto i : c10::irange(dim.size())) {
     batched_out_sizes[i + 1] = out_sizes[dim[i]];
   }
 
@@ -485,7 +485,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
     out_strides[dim_permute[i]] = batch_numel * out.strides()[0];
     batch_numel *= out_sizes[dim_permute[i]];
   }
-  for (int64_t i = batch_dims; i < ndim; ++i) {
+  for (const auto i : c10::irange(batch_dims, ndim)) {
     out_strides[dim_permute[i]] = out.strides()[1 + (i - batch_dims)];
   }
   out.as_strided_(out_sizes, out_strides, out.storage_offset());

--- a/aten/src/ATen/native/mkldnn/Pooling.cpp
+++ b/aten/src/ATen/native/mkldnn/Pooling.cpp
@@ -229,7 +229,7 @@ static Tensor _mkldnn_pooling(
           false /*ceil_mode */);
 
       all_equal = true;
-      for (size_t i = 2; i < input.sizes().size(); ++i) {
+      for (const auto i : c10::irange(2, input.sizes().size())) {
         if (output_sizes[i] < output_sizes_ceil[i]) {
            padding_vec_r[i - 2]++;
            all_equal = false;
@@ -318,7 +318,7 @@ static Tensor _mkldnn_pooling_backward(
           false /*ceil_mode */);
 
       all_equal = true;
-      for (size_t i = 2; i < input.sizes().size(); ++i) {
+      for (const auto i : c10::irange(2, input.sizes().size())) {
         if (output_sizes[i] < output_sizes_ceil[i]) {
            padding_vec_r[i - 2]++;
            all_equal = false;
@@ -479,7 +479,7 @@ Tensor mkldnn_adaptive_avg_pool2d(
   auto output_size_vec =
       expand_param_if_needed(output_size, "output_size", input.dim() - 2);
   std::vector<int64_t> kernel_size(input.dim() - 2);
-  for (int64_t i = 2; i < input.dim(); ++i) {
+  for (const auto i : c10::irange(2, input.dim())) {
     auto s1 = input.size(i);
     auto s2 = output_size_vec[i - 2];
     TORCH_CHECK(s2 != 0, "output size can not be zero");

--- a/aten/src/ATen/native/mkldnn/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/Utils.cpp
@@ -1,5 +1,6 @@
 #include <ATen/native/mkldnn/Utils.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -16,7 +17,7 @@ std::vector<int64_t> pool_output_sizes(
   output_size[0] = input_size[0];
   output_size[1] = input_size[1];
 
-  for (size_t i = 2; i < input_size.size(); ++i) {
+  for (const auto i : c10::irange(2, input_size.size())) {
     output_size[i] = pooling_output_shape_pad_lr<int64_t>(
       input_size[i],
       kernel_size[i - 2],

--- a/aten/src/ATen/native/quantized/Copy.cpp
+++ b/aten/src/ATen/native/quantized/Copy.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/quantized/affine_quantizer.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -23,7 +24,7 @@ Tensor& quantized_copy_from_float_cpu_(Tensor& self, const Tensor& src) {
   AT_DISPATCH_QINT_TYPES(self.scalar_type(), "Copy", [&]() {
     float* src_data = src.data_ptr<float>();
     scalar_t* self_data = self.data_ptr<scalar_t>();
-    for (int i = 0; i < self.numel(); ++i) {
+    for (const auto i : c10::irange(self.numel())) {
       self_data[i] = quantize_val<scalar_t>(
           self.q_scale(), self.q_zero_point(), src_data[i]);
     }

--- a/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/quantized/affine_quantizer_base.h>
+#include <c10/util/irange.h>
 #include <cfenv>
 #include <climits>
 
@@ -145,7 +146,7 @@ void quantize_vec(
     T* dst,
     size_t count) {
   checkZeroPoint<typename T::underlying>("quantize_vec", zero_point);
-  for (size_t i = 0; i < count; ++i) {
+  for (const auto i : c10::irange(count)) {
     dst[i] = quantize_val<T>(scale, zero_point, src[i]);
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -11,6 +11,7 @@
 #include <c10/core/QScheme.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 #include <torch/custom_class.h>
 
 torch::class_<LinearPackedParamsBase> register_linear_params();
@@ -47,9 +48,9 @@ void CopyToChannelsLast3dTensor(
     const T* src,
     T* dst) {
   const int64_t inner_size = D * H * W;
-  for (int64_t i = 0; i < N; ++i) {
-    for (int64_t j = 0; j < inner_size; ++j) {
-      for (int64_t k = 0; k < C; ++k) {
+  for (const auto i : c10::irange(N)) {
+    for (const auto j : c10::irange(inner_size)) {
+      for (const auto k : c10::irange(C)) {
         dst[(i * inner_size + j) * C + k] = src[(i * C + k) * inner_size + j];
       }
     }
@@ -69,8 +70,8 @@ void CopyICFirst3dTensorToChannelsLast3dTensor(
   // IC OC/G THW -> G OC/G THW IC/G
   const int64_t inner_size = D * H * W;
   for (int64_t i = 0; i < G * OC_G; ++i) {
-    for (int64_t j = 0; j < inner_size; ++j) {
-      for (int64_t ic = 0; ic < IC_G; ++ic) {
+    for (const auto j : c10::irange(inner_size)) {
+      for (const auto ic : c10::irange(IC_G)) {
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
         int g = i / OC_G;
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -5,6 +5,7 @@
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/embedding_packed_params.h>
 #include <c10/core/QScheme.h>
+#include <c10/util/irange.h>
 
 #ifdef USE_FBGEMM
 #include <fbgemm/Fbgemm.h>
@@ -240,7 +241,7 @@ inline void convert_uint8_int8(
     int len,
     const uint8_t* src_uint8,
     int8_t* dst_int8) {
-  for (int i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     dst_int8[i] = static_cast<int8_t>(static_cast<int32_t>(src_uint8[i]) - 128);
   }
 }
@@ -250,7 +251,7 @@ inline void convert_int8_uint8(
     int len,
     const int8_t* src_int8,
     uint8_t* dst_uint8) {
-  for (int i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     dst_uint8[i] =
         static_cast<uint8_t>(static_cast<int32_t>(src_int8[i]) + 128);
   }

--- a/aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/DispatchStub.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -22,7 +23,7 @@ Tensor int_repr_quantized_cpu(const Tensor& self) {
           self.options().dtype(UNDERLYING_TYPE),
           self.suggest_memory_format());
       const underlying_t* qdata = reinterpret_cast<underlying_t*>(self.data_ptr<scalar_t>());
-      for (int64_t i = 0; i < dst.numel(); ++i) {
+      for (const auto i : c10::irange(dst.numel())) {
         dst[i] = static_cast<underlying_t>(qdata[i]);
       }
     } else {

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -104,9 +104,9 @@ Tensor qcat_nhwc_kernel(
   // which causes an internal compiler error if they're not
   AT_DISPATCH_QINT_TYPES(output.scalar_type(), "qcat_nhwc", [&, N, H, W]() {
     using Vec = Vectorized<scalar_t>;
-    for (int64_t batch = 0; batch < N; ++batch) {
-      for (int64_t row = 0; row < H; ++row) {
-        for (int64_t col = 0; col < W; ++col) {
+    for (const auto batch : c10::irange(N)) {
+      for (const auto row : c10::irange(H)) {
+        for (const auto col : c10::irange(W)) {
           // loop over input tensors
           for (const auto tidx : c10::irange(Cs_in.size())) {
             scalar_t::underlying* optr =
@@ -1294,13 +1294,13 @@ void qmaxpool_2d_nhwc_kernel(
     scalar_t* odata = static_cast<scalar_t*>(qy.data_ptr());
 
     // Loop over N
-    for (int64_t b = 0; b < qx.size(0); ++b) {
+    for (const auto b : c10::irange(qx.size(0))) {
       // Loop over H
       auto* i_p =
           reinterpret_cast<scalar_t::underlying*>(idata + b * iW * iH * iC);
-      for (int64_t row = 0; row < oH; ++row) {
+      for (const auto row : c10::irange(oH)) {
         // Loop over W
-        for (int64_t col = 0; col < oW; ++col) {
+        for (const auto col : c10::irange(oW)) {
           // Pointer to output data for this specific N,H,W position
           auto* o_p = reinterpret_cast<scalar_t::underlying*>(
               odata + b * oH * oW * iC + row * oW * iC + col * iC);
@@ -1328,7 +1328,7 @@ void qmaxpool_2d_nhwc_kernel(
             int64_t x, y;
             for (y = h_start; y < h_end; y += dH) {
               for (x = w_start; x < w_end; x += dW) {
-                for (int i = 0; i < 4; ++i) {
+                for (const auto i : c10::irange(4)) {
                   tcntr = y * iW + x;
                   auto vals = Vectorized<scalar_t>::loadu(
                       i_p + tcntr * iC + c + Vectorized<scalar_t>::size() * i);
@@ -1336,7 +1336,7 @@ void qmaxpool_2d_nhwc_kernel(
                 }
               } // for x
             } // for y
-            for (int i = 0; i < 4; ++i) {
+            for (const auto i : c10::irange(4)) {
               accs[i].store(o_p + c + Vectorized<scalar_t>::size() * i);
             }
           } // for c
@@ -1417,18 +1417,18 @@ void do_avg_pool_nhwc_on_AVX_n(
     for (int c = c_start; c < csize; c += cb_step) {
       int cend = std::min(cb_size, (csize - c) / vec_width);
       // initialize loop
-      for (int ic = 0; ic < cend; ic++) {
+      for (const auto ic : c10::irange(cend)) {
         acc_buffer[ic] = Vectorized<int32_t>(input_zero_point_m_size);
       }
       // compute loop
-      for (int id = dstart; id < dend; id++) {
-        for (int ih = hstart; ih < hend; ih++) {
-          for (int iw = wstart; iw < wend; iw++) {
+      for (const auto id : c10::irange(dstart, dend)) {
+        for (const auto ih : c10::irange(hstart, hend)) {
+          for (const auto iw : c10::irange(wstart, wend)) {
             const int i_idx =
                 (id * wsize * hsize + ih * wsize + iw) *
                     csize +
                 c;
-            for (int ic = 0; ic < cend; ic++) {
+            for (const auto ic : c10::irange(cend)) {
               auto vals = vec::convert_to_int32<typename T::underlying>(
                   i_p + i_idx + ic * vec_width);
               acc_buffer[ic] = acc_buffer[ic] + vals;
@@ -1493,9 +1493,9 @@ void do_avg_pool_on_AVX_n(
       int64_t tcntr = 0;
 
       Vectorized<int32_t> acc(input_zero_point_m_size);
-      for (int64_t id = dstart; id < dend; id++) {
-        for (int64_t ih = hstart; ih < hend; ih++) {
-          for (int64_t iw = wstart; iw < wend; iw++) {
+      for (const auto id : c10::irange(dstart, dend)) {
+        for (const auto ih : c10::irange(hstart, hend)) {
+          for (const auto iw : c10::irange(wstart, wend)) {
             tcntr = id * stride_D + ih * stride_H + iw * stride_W;
             auto vals = vec::convert_to_int32<typename T::underlying>(
                 i_p + tcntr * channel_multiplier + c * stride_C);
@@ -1546,11 +1546,11 @@ void _qadaptive_avg_pool_kernel(
     int input_zero_point = qx.q_zero_point();
     int output_zero_point = qy.q_zero_point();
 
-    for (int64_t od = 0; od < osizeD; od++) {
+    for (const auto od : c10::irange(osizeD)) {
       int istartD = (int)std::floor((float)(od * isizeD) / osizeD);
       int iendD = (int)std::ceil((float)((od + 1) * isizeD) / osizeD);
       int kD = iendD - istartD;
-      for (int64_t oh = 0; oh < osizeH; oh++) {
+      for (const auto oh : c10::irange(osizeH)) {
         int istartH = (int)std::floor((float)(oh * isizeH) / osizeH);
         int iendH = (int)std::ceil((float)((oh + 1) * isizeH) / osizeH);
         int kH = iendH - istartH;
@@ -1603,9 +1603,9 @@ void _qadaptive_avg_pool_kernel(
           for (; c < sizeC; ++c) {
             int32_t acc_int32 = input_zero_point_m_size;
             int64_t tcntr = 0;
-            for (int64_t id = 0; id < kD; ++id) {
-              for (int64_t ih = 0; ih < kH; ++ih) {
-                for (int64_t iw = 0; iw < kW; ++iw) {
+            for (const auto id : c10::irange(kD)) {
+              for (const auto ih : c10::irange(kH)) {
+                for (const auto iw : c10::irange(kW)) {
                   tcntr = id * istrideD +
                           ih * istrideH +
                           iw * istrideW;
@@ -1945,7 +1945,7 @@ int64_t do_quantized_bilinear_on_AVX_n(
           pos1 + h1p * input_width * channels);
       pos1_int_v[3] = vec::convert_to_int32<typename T::underlying>(
           pos1 + (h1p * input_width + w1p) * channels);
-      for (int i = 0; i < 4; i++) {
+      for (const auto i : c10::irange(4)) {
         int32_t pos1_int[vec_width];
         float pos1_fp[vec_width];
         pos1_int_v[i].store(pos1_int);
@@ -1999,13 +1999,13 @@ void qupsample_bilinear2d_nhwc_kernel(
         const auto rwidth = area_pixel_compute_scale<float>(
             input_width, output_width, align_corners, scales_w);
 
-        for (int64_t b = 0; b < nbatch; ++b) {
+        for (const auto b : c10::irange(nbatch)) {
           auto* i_p = reinterpret_cast<typename scalar_t::underlying*>(
               idata + b * input_height * input_width * channels);
           auto* o_p = reinterpret_cast<typename scalar_t::underlying*>(
               odata + b * output_height * output_width * channels);
 
-          for (int64_t h2 = 0; h2 < output_height; ++h2) {
+          for (const auto h2 : c10::irange(output_height)) {
             const auto h1r = area_pixel_compute_source_index<float>(
                 rheight, h2, align_corners, /*cubic=*/false);
 
@@ -2014,7 +2014,7 @@ void qupsample_bilinear2d_nhwc_kernel(
             const float h1lambda = h1r - h1;
             const float h0lambda = static_cast<float>(1.) - h1lambda;
 
-            for (int64_t w2 = 0; w2 < output_width; ++w2) {
+            for (const auto w2 : c10::irange(output_width)) {
               const auto w1r = area_pixel_compute_source_index<float>(
                   rwidth, w2, align_corners, /*cubic=*/false);
               const int64_t w1 = w1r;
@@ -2250,7 +2250,7 @@ void _fake_quantize_tensor_helper(
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_type_handling", [&] {
     iter_combined.for_each([&](char** data, const int64_t* strides, int64_t n) {
-      for (int64_t i = 0; i < n; i++) {
+      for (const auto i : c10::irange(n)) {
         scalar_t* output_val = (scalar_t*)(data[0] + i * strides[0]);
         bool* mask_val = (bool*)(data[1] + i * strides[1]);
         scalar_t* input_val = (scalar_t*)(data[2] + i * strides[2]);
@@ -2319,7 +2319,7 @@ void fake_quantize_learnable_tensor_grad_kernel_cpu(
         (to move onto different elements), can allow accessing of the input and assignment
         to the right output.
     */
-    for (int64_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
       float* dXOutput = (float*)(data[0] + i * strides[0]);
       float* dScaleOutput = (float*)(data[1] + i * strides[1]);
       float* dZeroPointOutput = (float*)(data[2] + i * strides[2]);
@@ -2429,7 +2429,7 @@ void fake_quantize_learnable_channel_grad_kernel_cpu(
         please see the implemenetation of
         fake_quantize_learnable_tensor_grad_kernel_cpu.
     */
-    for (int64_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
       float* dx_output = (float*)(data[0] + i * strides[0]);
       float* dscale_output = (float*)(data[1] + i * strides[1]);
       float* dzero_point_output = (float*)(data[2] + i * strides[2]);
@@ -2516,7 +2516,7 @@ void quantized_normalize_kernel(
     int64_t kNonVecRemInChannel = NPerChannel % kIntVLen;
 
     at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-      for (int64_t i = start; i < end; ++i) {
+      for (const auto i : c10::irange(start, end)) {
 
         scalar_t* X_ptr = X_data + i * N;
         scalar_t* Y_ptr = Y_data + i * N;
@@ -2546,7 +2546,7 @@ void quantized_normalize_kernel(
 
           // if scaling per channel, scaling parameters can be pre-multiplied
           // with normalization parameters
-          for (int64_t chIdx = 0; chIdx < channels_per_group; chIdx++) {
+          for (const auto chIdx : c10::irange(channels_per_group)) {
             int scalingIdx = (i * channels_per_group + chIdx) % (num_channels);
             float gamma = gamma_null ? 1.0f : gamma_data[scalingIdx];
             // scale_x / layer_std * gamma
@@ -2558,7 +2558,7 @@ void quantized_normalize_kernel(
             int64_t chStartIdx = chIdx * NPerChannel;
             int64_t chEndIdx = chStartIdx + NPerChannel;
 
-            for (int64_t vecIdx = 0; vecIdx < kNumIntVecInChannel; vecIdx++) {
+            for (const auto vecIdx : c10::irange(kNumIntVecInChannel)) {
               int64_t vecStartIdx = chStartIdx + vecIdx * kIntVLen;
               auto qXVec = qVec::loadu(X_ptr + vecStartIdx);
               auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
@@ -2584,7 +2584,7 @@ void quantized_normalize_kernel(
 
         } else {
 
-          for (int64_t vecIdx = 0; vecIdx < kNumIntVecInLayer; vecIdx++) {
+          for (const auto vecIdx : c10::irange(kNumIntVecInLayer)) {
             int64_t vecStartIdx = vecIdx * kIntVLen;
             auto qXVec = qVec::loadu(X_ptr + vecStartIdx);
             auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
@@ -2638,7 +2638,7 @@ void quantize_tensor_per_tensor_affine_cpu(
         qparams.precision = CHAR_BIT * sizeof(underlying_t);
         int num_tasks = at::get_num_threads();
         at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
-          for (int task_id = begin; task_id < end; ++task_id) {
+          for (const auto task_id : c10::irange(begin, end)) {
             fbgemm::Quantize<underlying_t, false /*LEGACY*/>(
                 // NOLINTNEXTLINE(bugprone-argument-comment)
                 rd, /*src=*/
@@ -2672,7 +2672,7 @@ void dequantize_tensor_per_tensor_affine_cpu(
         float* rd = rtensor.data_ptr<float>();
         int num_tasks = at::get_num_threads();
         at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
-          for (int task_id = begin; task_id < end; ++task_id) {
+          for (const auto task_id : c10::irange(begin, end)) {
             fbgemm::Dequantize<underlying_t>(
                 // NOLINTNEXTLINE(bugprone-argument-comment)
                 qd, /*src=*/
@@ -2700,7 +2700,7 @@ void quantize_tensor_arm(
     const float scale,
     const int32_t zero_point) {
   auto out = qtensor.data_ptr<T>();
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     out[i] = at::native::quantize_val<T>(scale, zero_point, in[i]);
   }
 }
@@ -2802,7 +2802,7 @@ void quantize_tensor_per_tensor_affine_cpu(
         const float* const rdata = rtensor.data_ptr<float>();
         auto qdata = qtensor.data_ptr<scalar_t>();
         auto numel = rtensor.numel();
-        for (int i = 0; i < numel; ++i) {
+        for (const auto i : c10::irange(numel)) {
           qdata[i] = quantize_val<scalar_t>(scale, zero_point, rdata[i]);
         }
       });
@@ -2820,7 +2820,7 @@ void dequantize_tensor_per_tensor_affine_cpu(
         const auto* qd = qtensor.data_ptr<scalar_t>();
         float* rd = rtensor.data_ptr<float>();
         auto numel = qtensor.numel();
-        for (auto i = 0; i < numel; ++i) {
+        for (const auto i : c10::irange(numel)) {
           rd[i] = dequantize_val<scalar_t>(scale, zero_point, qd[i]);
         }
       });
@@ -2857,9 +2857,9 @@ void quantize_tensor_per_channel_impl(
     // channels_last contig.
     // If axis = 0 and channels_last contig, implementation for channels
     // first (NCHW) works.
-    for (auto b = 0; b < batches; ++b) {
-      for (auto e = 0; e < elements_per_channel; ++e) {
-        for (auto c = 0; c < channels; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
+        for (const auto c : c10::irange(channels)) {
           auto i = b * channels * elements_per_channel + e * channels + c;
           out[i] = at::native::quantize_val<T>(
               scales_data[c], zero_points_data[c], in[i]);
@@ -2867,9 +2867,9 @@ void quantize_tensor_per_channel_impl(
       }
     }
   } else {
-    for (auto b = 0; b < batches; ++b) {
-      for (auto c = 0; c < channels; ++c) {
-        for (auto e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channels)) {
+        for (const auto e : c10::irange(elements_per_channel)) {
           auto i = b * channels * elements_per_channel +
               c * elements_per_channel + e;
           out[i] = at::native::quantize_val<T>(
@@ -2919,7 +2919,7 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
   // Copy zero_points with magic int (int64_t) into int32_t array
   std::vector<float> inv_scales(channels);
   std::vector<int32_t> zero_points_int32t(channels);
-  for (int i = 0; i < channels; ++i) {
+  for (const auto i : c10::irange(channels)) {
     inv_scales[i] = 1.0f / (float)scales_data[i];
     zero_points_int32t[i] = (int32_t)(uint32_t)zero_points_data[i] - 0x4B400000;
   }
@@ -2930,8 +2930,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
     // channels_last contig.
     // If axis = 0 and channels_last contig, implementation for channels
     // first (NCHW) works.
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
         uint32_t c = 0;
         while (c + 8 < channels) {
           const int32x4_t voffset0123 = vld1q_s32(&zero_points_int32t[c]);
@@ -2965,8 +2965,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
       }
     }
   } else {
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t c = 0; c < channels; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channels)) {
         uint32_t e = 0;
         const int32x4_t voffset = vdupq_n_s32(zero_points_int32t[c]);
         const float32x4_t vinv_scale = vdupq_n_f32(inv_scales[c]);
@@ -3001,7 +3001,7 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
   // Copy zero_points (int64_t) into int16_t array
   std::vector<float> inv_scales(channels);
   std::vector<int16_t> zero_points_int16t(channels);
-  for (int i = 0; i < channels; ++i) {
+  for (const auto i : c10::irange(channels)) {
     inv_scales[i] = 1.0f / (float)scales_data[i];
     zero_points_int16t[i] = (int16_t)(uint16_t)zero_points_data[i];
   }
@@ -3012,8 +3012,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
     // channels_last contig.
     // If axis = 0 and channels_last contig, implementation for channels
     // first (NCHW) works.
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
         uint32_t c = 0;
         while (c + 8 < channels) {
           const int16x8_t vzero_point = vld1q_s16(&zero_points_int16t[c]);
@@ -3043,8 +3043,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
       }
     }
   } else {
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t c = 0; c < channels; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channels)) {
         uint32_t e = 0;
         const int16x8_t vzero_point = vdupq_n_s16(zero_points_int16t[c]);
         const float32x4_t vinv_scale = vdupq_n_f32(inv_scales[c]);
@@ -3123,9 +3123,9 @@ void dequantize_per_channel_affine_kernel(
   const auto elem_per_byte = 8 / bit_width;
   if (axis == 1 && (rtensor.is_contiguous(MemoryFormat::ChannelsLast) ||
       rtensor.is_contiguous(MemoryFormat::ChannelsLast3d))) {
-    for (auto b = 0; b < batches; ++b) {
-      for (auto e = 0; e < elements_per_channel; ++e) {
-        for (auto c = 0; c < channel; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
+        for (const auto c : c10::irange(channel)) {
           auto i = b * channel * elements_per_channel + e * channel + c;
           // We need to convert the qint8 value to float to ensure the
           // subtraction subexpression returns a float
@@ -3139,9 +3139,9 @@ void dequantize_per_channel_affine_kernel(
       }
     }
   } else {
-    for (auto b = 0; b < batches; ++b) {
-      for (auto c = 0; c < channel; ++c) {
-        for (auto e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channel)) {
+        for (const auto e : c10::irange(elements_per_channel)) {
           auto i = b * channel * elements_per_channel +
               c * elements_per_channel + e;
           // We need to convert the qint8 value to float to ensure the
@@ -3201,9 +3201,9 @@ void quantize_tensor_per_channel_float_qparams_cpu(
         int qvalue = 0;
         if (axis == 1 && (rtensor.is_contiguous(MemoryFormat::ChannelsLast) ||
             rtensor.is_contiguous(MemoryFormat::ChannelsLast3d))) {
-          for (auto b = 0; b < batches; ++b) {
-            for (auto e = 0; e < elements_per_channel; ++e) {
-              for (auto c = 0; c < channel; ++c) {
+          for (const auto b : c10::irange(batches)) {
+            for (const auto e : c10::irange(elements_per_channel)) {
+              for (const auto c : c10::irange(channel)) {
                 auto i = b * channel * elements_per_channel + e * channel + c;
                 qvalue = quantize_val_float_qparams(
                     scales_data[c], zero_points_data[c], rdata[i], quant_min, quant_max);
@@ -3217,9 +3217,9 @@ void quantize_tensor_per_channel_float_qparams_cpu(
             }
           }
         } else {
-          for (auto b = 0; b < batches; ++b) {
-            for (auto c = 0; c < channel; ++c) {
-              for (auto e = 0; e < elements_per_channel; ++e) {
+          for (const auto b : c10::irange(batches)) {
+            for (const auto c : c10::irange(channel)) {
+              for (const auto e : c10::irange(elements_per_channel)) {
                 auto i = b * channel * elements_per_channel +
                     c * elements_per_channel + e;
                 qvalue = quantize_val_float_qparams(
@@ -3263,7 +3263,7 @@ void quantize_tensor_per_tensor_affine_sub_byte_cpu(
       auto qdata = reinterpret_cast<underlying_t*>(qtensor.data_ptr<scalar_t>());
       auto numel = rtensor.numel();
       const auto elem_per_byte = CHAR_BIT / bit_width;
-      for (int i = 0; i < numel; ++i) {
+      for (const auto i : c10::irange(numel)) {
         float inv_scale = scale == 0 ? 1.0f : 1.0f / scale;
         int64_t qvalue = lrintf(std::nearbyint(rdata[i] * inv_scale) + zero_point);
         qvalue = std::max(quant_min, std::min(qvalue, quant_max));
@@ -3296,7 +3296,7 @@ void dequantize_tensor_per_tensor_affine_sub_byte_cpu(
       auto numel = rtensor.numel();
       const auto elem_per_byte = CHAR_BIT / bit_width;
 
-      for (int i = 0; i < numel; ++i) {
+      for (const auto i : c10::irange(numel)) {
         // NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
         underlying_t qvalue = qdata[i / elem_per_byte];
         qvalue >>= (i % elem_per_byte) * bit_width;

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -6,6 +6,8 @@
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/math_compat.h>
 
 #include <algorithm>
@@ -39,7 +41,7 @@ static void avg_pool2d_out_frame(
     bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++) {
+    for (const auto k : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t xx, yy;
       /* For all output pixels... */
@@ -224,7 +226,7 @@ Tensor q_avg_pool2d(
           divisor_override);
     } else {
       at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++) {
+        for (const auto b : c10::irange(start, end)) {
           qavg_pool2d_nhwc_stub(
               input.device().type(),
               input,
@@ -270,7 +272,7 @@ Tensor q_avg_pool2d(
           divisor_override);
     } else {
       at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++) {
+        for (const auto b : c10::irange(start, end)) {
           avg_pool2d_out_frame<scalar_t>(
               input,
               output,

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
@@ -5,6 +5,8 @@
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/math_compat.h>
 
 #include <algorithm>
@@ -154,7 +156,7 @@ Tensor q_avg_pool3d(
         divisor_override);
   } else {
     at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-      for (auto b = start; b < end; b++) {
+      for (const auto b : c10::irange(start, end)) {
         qavg_pool3d_nhwc_stub(
             input_nhwc.device().type(),
             input_nhwc,

--- a/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Parallel.h>
 #include <torch/library.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <vector>
@@ -30,7 +31,7 @@ void compute_fused_params(
   //     = (input(n, c, h, w) - mean(c)) / sqrt(var(c) + eps) * weight(c)
   //         + bias(c)
   // We factor out inv_sigma(c) = 1 / sqrt(var(c) + eps).
-  for (int64_t c = 0; c < channels; c++) {
+  for (const auto c : c10::irange(channels)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     float inv_sigma = 1.0 / std::sqrt(var_data[c] + static_cast<float>(eps));
     float weight_v = weight_data ? weight_data[c] : 1;

--- a/aten/src/ATen/native/quantized/cpu/qclamp.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qclamp.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/quantized/Quantizer.h>
+#include <c10/util/irange.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 #include <algorithm>
@@ -29,7 +30,7 @@ Tensor qnnpack_clamp(Tensor input, const Scalar& min, const Scalar& max) {
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());
   size_t num_elems = 1;
-  for (int i = 1; i < input_contig.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, input_contig.ndimension())) {
     num_elems *= input_contig.size(i);
   }
 

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -95,7 +95,7 @@ at::SmallVector<int64_t, kSpatialDim + 2> MakeDeConvOutputShape(
   output_shape.resize(kSpatialDim + 2);
   output_shape[0] = N;  // Batch size
   output_shape[1] = M;  // Output channels
-  for (int64_t idx = 0; idx < kSpatialDim; ++idx) {
+  for (const auto idx : c10::irange(kSpatialDim)) {
     output_shape[idx + 2] = compute_deconv_shape(input_shape[idx],
                                                  kernel[idx],
                                                  stride[idx],
@@ -250,7 +250,7 @@ void PackedConvWeight<kSpatialDim>::GetQuantizationParams(
     const int M = w->outputChannels();
     output_multiplier_float->resize(M);
     act_times_w_scale->resize(M);
-    for (int i = 0; i < M; ++i) {
+    for (const auto i : c10::irange(M)) {
       act_times_w_scale->at(i) = (act_scale * w_scale[i]);
       output_multiplier_float->at(i) = act_times_w_scale->at(i) / out_scale;
     }
@@ -653,7 +653,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
         c10::nullopt);
     auto* qnnp_w_data = qnnp_weight.template data_ptr<c10::quint8>();
     auto wt_numel = weight_contig.numel();
-    for (int i = 0; i < wt_numel; ++i) {
+    for (const auto i : c10::irange(wt_numel)) {
       qnnp_w_data[i] = static_cast<c10::quint8>(w_data[i] + 128);
     }
     at::Tensor qbias;

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -91,7 +91,7 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
         !transpose,
         "Per Channel Quantization is currently disabled for transposed conv");
     zero_points.resize(output_channels);
-    for (int i = 0; i < output_channels; ++i) {
+    for (const auto i : c10::irange(output_channels)) {
       zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
     }
   } else {
@@ -120,11 +120,11 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
   const int inner_size =
       kernel_d * kernel_h * kernel_w * input_channels_per_group;
   for (const auto g : c10::irange(groups)) {
-    for (int i = 0; i < output_channels_per_group; ++i) {
+    for (const auto i : c10::irange(output_channels_per_group)) {
       // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
       const int c = g * output_channels_per_group + i;
       int32_t sum = 0;
-      for (int j = 0; j < inner_size; ++j) {
+      for (const auto j : c10::irange(inner_size)) {
         sum += static_cast<int32_t>(weight_data_int8[c * inner_size + j]);
       }
       if (qtype == c10::kPerTensorAffine) {
@@ -140,7 +140,7 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
     scales = {static_cast<float>(weight.q_scale())};
   } else if (qtype == c10::kPerChannelAffine) {
     scales.resize(output_channels);
-    for (int i = 0; i < output_channels; ++i) {
+    for (const auto i : c10::irange(output_channels)) {
       scales[i] = weight.q_per_channel_scales()[i].item<float>();
     }
   }
@@ -330,7 +330,8 @@ class QConvPackWeightInt8 final {
       int64_t groups) {
     torch::List<int64_t> output_padding;
     output_padding.reserve(kSpatialDim);
-    for (int idx = 0; idx < kSpatialDim; ++idx) {
+    for (const auto idx : c10::irange(kSpatialDim)) {
+      (void)idx; //Suppress unused variable warning
       output_padding.push_back((int64_t)0);
     }
     return _run(weight, bias, stride, padding, output_padding, dilation, groups,

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
 
@@ -44,7 +45,7 @@ at::Tensor& embedding_lookup_fallback_impl(
   std::vector<OffsetType> lengths_data;
 
   int64_t lower = accessor[0];
-  for (int64_t i = 1; i < offsets.numel(); ++i) {
+  for (const auto i : c10::irange(1, offsets.numel())) {
     lengths_data.push_back(accessor[i] - lower);
     lower = accessor[i];
   }
@@ -58,7 +59,7 @@ at::Tensor& embedding_lookup_fallback_impl(
   if (per_sample_weights_.has_value()) {
     per_sample_weights_data = per_sample_weights_.value().data_ptr<float>();
   }
-  for (int m = 0; m < output_size; ++m) {
+  for (const auto m : c10::irange(output_size)) {
     memset(output_data, 0, block_size * sizeof(float));
     TORCH_CHECK(
         current + lengths_data[m] <= index_size,
@@ -126,7 +127,7 @@ at::Tensor& embedding_lookup_fallback_impl(
         bias = weight_val * bias_val;
       }
 
-      for (int j = 0; j < block_size; ++j) {
+      for (const auto j : c10::irange(block_size)) {
         uint8_t quantized =
             weight_data[idx * weight_size + j / NUM_ELEM_PER_BYTE];
         quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -67,7 +67,7 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
   weight_scales_tensor.copy_(qweight.q_per_channel_scales());
   weight_zero_points_tensor.copy_(qweight.q_per_channel_zero_points());
 
-  for (int64_t i = 0; i < embedding_rows; ++i) {
+  for (const auto i : c10::irange(embedding_rows)) {
     weight_bias[i] = weight_zero_points[i] * weight_scales[i] * -1;
   }
 
@@ -88,14 +88,14 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
   if (bit_width == 8) {
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             const uint8_t* input_row = weight_data + row * embedding_cols;
             std::uint8_t* output_row = output_data + row * output_columns;
             float* output_row_scale_bias =
                 reinterpret_cast<float*>(output_row + embedding_cols);
             output_row_scale_bias[0] = weight_scales[row];
             output_row_scale_bias[1] = weight_bias[row];
-            for (int64_t col = 0; col < embedding_cols; ++col) {
+            for (const auto col : c10::irange(embedding_cols)) {
               output_row[col] = input_row[col];
             }
           }
@@ -107,14 +107,14 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
         (embedding_cols + num_elem_per_byte - 1) / num_elem_per_byte;
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             const uint8_t* input_row = weight_data + row * embedding_cols;
             std::uint8_t* output_row = output_data + row * output_columns;
             at::Half* output_row_scale_bias =
                 reinterpret_cast<at::Half*>(output_row + embedding_cols);
             output_row_scale_bias[0] = weight_scales[row];
             output_row_scale_bias[1] = weight_bias[row];
-            for (int64_t col = 0; col < embedding_cols; ++col) {
+            for (const auto col : c10::irange(embedding_cols)) {
               // The weight values have already been packed, so here we just
               // store it in the output tensor.
               output_row[col] = input_row[col];
@@ -229,7 +229,7 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
     const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<fbgemm::float16>(
               weight_data + row * embedding_cols, 1,
                 embedding_cols, output_data + row * output_columns);
@@ -240,7 +240,7 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
     const auto weight_data = weight.data_ptr<float>();
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
               weight_data + row * embedding_cols, 1,
                 embedding_cols, output_data + row * output_columns);
@@ -344,7 +344,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
       const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
       at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<fbgemm::float16>(
               bit_width, weight_data + row * embedding_cols, 1,
               embedding_cols, output_data + row * output_shape[1]);
@@ -355,7 +355,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
       const auto weight_data = weight.data_ptr<float>();
       at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
               bit_width, weight_data + row * embedding_cols, 1,
               embedding_cols, output_data + row * output_shape[1]);
@@ -369,7 +369,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
         ? weight_contig.to(at::ScalarType::Float)
         : weight_contig;
     const auto weight_data = float_weight.data_ptr<float>();
-    for (int row = 0; row < embedding_rows; ++row) {
+    for (const auto row : c10::irange(embedding_rows)) {
       const float* input_row = weight_data + row * embedding_cols;
       std::uint8_t* output_row = output_data + row * output_columns;
 

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -303,7 +303,7 @@ at::Tensor PackedLinearWeightsQnnp::apply_impl(
         w_zero_points[0]);
     auto* qnnp_w_data = qnnp_weight.data_ptr<c10::quint8>();
     auto wt_numel = weight_contig.numel();
-    for (int i = 0; i < wt_numel; ++i) {
+    for (const auto i : c10::irange(wt_numel)) {
       qnnp_w_data[i] = static_cast<c10::quint8>(w_data[i] + 128);
     }
     // Original bias was float, so we requantize it here.

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -290,7 +290,7 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(at::Tensor input) {
     auto* qnnp_w_data = qnnp_weight.data_ptr<c10::quint8>();
     int8_t* w_data = (int8_t*)weight_contig.data_ptr<c10::qint8>();
     auto wt_numel = weight_contig.numel();
-    for (int i = 0; i < wt_numel; ++i) {
+    for (const auto i : c10::irange(wt_numel)) {
       qnnp_w_data[i] = static_cast<c10::quint8>(w_data[i] + 128);
     }
 

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <c10/util/irange.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 #include <algorithm>
@@ -43,7 +44,7 @@ void spatial_dilated_max_pooling(
     int64_t dW, // dilation
     T* oData) { // output arrays (data and max-index)
   at::parallel_for(0, iC, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; ++p) {
+    for (const auto p : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t row, col;
       const T* i_p = iData + p * iW * iH;
@@ -195,7 +196,7 @@ Tensor q_maxpool_2d(
           oData);
     } else {
       at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto p = start; p < end; ++p) {
+        for (const auto p : c10::irange(start, end)) {
           auto* iData = qxd + p * iC * iW * iH;
           auto* oData = qyd + p * oC * oW * oH;
           spatial_dilated_max_pooling<Q>(

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -6,6 +6,7 @@
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <c10/util/irange.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
 
@@ -31,7 +32,7 @@ Tensor qnnpack_relu(Tensor input) {
   initQNNPACK();
 
   size_t num_elems = 1;
-  for (int i = 1; i < input_contig.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, input_contig.ndimension())) {
     num_elems *= input_contig.size(i);
   }
 

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <c10/util/irange.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 #include <algorithm>
@@ -26,7 +27,7 @@ Tensor qnnpack_sigmoid(
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());
   size_t num_elems = 1;
-  for (int i = 1; i < input_contig.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, input_contig.ndimension())) {
     num_elems *= input_contig.size(i);
   }
 

--- a/aten/src/ATen/native/quantized/cpu/qtanh.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qtanh.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <c10/util/irange.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 #include <algorithm>
@@ -29,7 +30,7 @@ Tensor qnnpack_tanh(Tensor input) {
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());
   size_t num_elems = 1;
-  for (int i = 1; i < input_contig.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, input_contig.ndimension())) {
     num_elems *= input_contig.size(i);
   }
   const auto zero_point = input_contig.q_zero_point();

--- a/aten/src/ATen/native/quantized/cpu/quant_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/quant_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 #include <algorithm>
 #include <cmath>
 
@@ -193,7 +194,7 @@ static C10_UNUSED torch::List<int64_t> MakeArgForConv1d(const torch::List<int64_
 inline void HandleWeightsSaturation(int64_t N, float* weight) {
   const float kFp16Max = RawUint16ToFp16(0x7BFF);
   bool found_out_of_range = false;
-  for (int64_t i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     bool saturate = CheckAndSaturate<float>(kFp16Max, weight + i);
     if (saturate) {
       found_out_of_range = true;

--- a/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/native/UpSample.h>
 #include <ATen/native/quantized/affine_quantizer.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <cmath>
@@ -57,7 +58,7 @@ static void upsample_bilinear2d_out_frame(
   const int64_t input_q_zero_point = input.q_zero_point();
   const int64_t output_q_zero_point = output.q_zero_point();
 
-  for (int64_t h2 = 0; h2 < output_height; ++h2) {
+  for (const auto h2 : c10::irange(output_height)) {
     const auto h1r = area_pixel_compute_source_index<float>(
         rheight, h2, align_corners, /*cubic=*/false);
 
@@ -67,7 +68,7 @@ static void upsample_bilinear2d_out_frame(
     const float h1lambda = h1r - h1;
     const float h0lambda = static_cast<float>(1.) - h1lambda;
 
-    for (int64_t w2 = 0; w2 < output_width; ++w2) {
+    for (const auto w2 : c10::irange(output_width)) {
       const auto w1r = area_pixel_compute_source_index<float>(
           rwidth, w2, align_corners, /*cubic=*/false);
 
@@ -79,7 +80,8 @@ static void upsample_bilinear2d_out_frame(
       const typename scalar_t::underlying* pos1 = i_p + h1 * input_width + w1;
       typename scalar_t::underlying* pos2 = o_p + h2 * output_width + w2;
 
-      for (int64_t c = 0; c < channels; ++c) {
+      for (const auto c : c10::irange(channels)) {
+        (void)c; //Suppress unused variable warning
         float result = h0lambda * (w0lambda * pos1[0] + w1lambda * pos1[w1p]) +
             h1lambda *
                 (w0lambda * pos1[h1p * input_width] +

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
@@ -41,18 +41,19 @@ static void upsample_nearest2d_out_frame(
     return;
   }
 
-  for (int64_t h2 = 0; h2 < output_height; ++h2) {
+  for (const auto h2 : c10::irange(output_height)) {
     const int64_t h1 =
         nearest_neighbor_compute_source_index(height_scale, h2, input_height);
 
-    for (int64_t w2 = 0; w2 < output_width; ++w2) {
+    for (const auto w2 : c10::irange(output_width)) {
       const int64_t w1 =
           nearest_neighbor_compute_source_index(width_scale, w2, input_width);
 
       const auto* pos1 = &i_p[h1 * input_width + w1];
       auto* pos2 = &o_p[h2 * output_width + w2];
 
-      for (int64_t c = 0; c < channels; ++c) {
+      for (const auto c : c10::irange(channels)) {
+        (void)c; //Suppress unused variable warning
         pos2[0] = pos1[0];
         pos1 += input_height * input_width;
         pos2 += output_height * output_width;
@@ -85,11 +86,11 @@ static void upsample_nearest2d_out_frame_nhwc(
       return;
     }
 
-    for (int64_t h2 = 0; h2 < output_height; ++h2) {
+    for (const auto h2 : c10::irange(output_height)) {
       const int64_t h1 =
           nearest_neighbor_compute_source_index(height_scale, h2, input_height);
 
-      for (int64_t w2 = 0; w2 < output_width; ++w2) {
+      for (const auto w2 : c10::irange(output_width)) {
         const int64_t w1 =
             nearest_neighbor_compute_source_index(width_scale, w2, input_width);
 

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest3d.cpp
@@ -45,22 +45,23 @@ static void upsample_nearest3d_out_frame(
     return;
   }
 
-  for (int64_t d2 = 0; d2 < output_depth; ++d2) {
+  for (const auto d2 : c10::irange(output_depth)) {
     const int64_t d1 =
           nearest_neighbor_compute_source_index(depth_scale, d2, input_depth);
 
-    for (int64_t h2 = 0; h2 < output_height; ++h2) {
+    for (const auto h2 : c10::irange(output_height)) {
       const int64_t h1 =
           nearest_neighbor_compute_source_index(height_scale, h2, input_height);
 
-      for (int64_t w2 = 0; w2 < output_width; ++w2) {
+      for (const auto w2 : c10::irange(output_width)) {
         const int64_t w1 =
             nearest_neighbor_compute_source_index(width_scale, w2, input_width);
 
         const auto* pos1 = &i_p[d1 * input_height * input_width + h1 * input_width + w1];
         auto* pos2 = &o_p[d2 * output_height * output_width + h2 * output_width + w2];
 
-        for (int64_t c = 0; c < channels; ++c) {
+        for (const auto c : c10::irange(channels)) {
+          (void)c; //Suppress unused variable warning
           pos2[0] = pos1[0];
           pos1 += input_depth * input_height * input_width;
           pos2 += output_depth * output_height * output_width;
@@ -98,14 +99,14 @@ static void upsample_nearest3d_out_frame_nhwc(
       return;
     }
 
-    for (int64_t d2 = 0; d2 < output_depth; ++d2) {
+    for (const auto d2 : c10::irange(output_depth)) {
       const int64_t d1 =
           nearest_neighbor_compute_source_index(depth_scale, d2, input_depth);
-      for (int64_t h2 = 0; h2 < output_height; ++h2) {
+      for (const auto h2 : c10::irange(output_height)) {
         const int64_t h1 =
             nearest_neighbor_compute_source_index(height_scale, h2, input_height);
 
-        for (int64_t w2 = 0; w2 < output_width; ++w2) {
+        for (const auto w2 : c10::irange(output_width)) {
           const int64_t w1 =
               nearest_neighbor_compute_source_index(width_scale, w2, input_width);
 

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -217,7 +217,7 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_b
   // into the same shapes as X along the channel axis.
   // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
   int64_t* axis_mask = (int64_t *) calloc(numDimensions, sizeof(int64_t));
-  for (int i = 0; i < numDimensions; ++i) {
+  for (const auto i : c10::irange(numDimensions)) {
     axis_mask[i] = (i == axis) ? X.size(axis) : 1;
   }
   auto X_shape = X.sizes();

--- a/aten/src/ATen/native/sparse/SoftMax.cpp
+++ b/aten/src/ATen/native/sparse/SoftMax.cpp
@@ -7,6 +7,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/SparseTensorUtils.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 
 #include <map>
 
@@ -71,9 +72,9 @@ std::vector<int64_t> get_offsets(const Tensor& indices, const IntArrayRef& sizes
     }
   }
 
-  for (int64_t i=0; i < nnz; i++) {
+  for (const auto i : c10::irange(nnz)) {
     int64_t acc = 0;
-    for (int64_t j=0; j < ndim; j++) {
+    for (const auto j : c10::irange(ndim)) {
       auto indices_row = indices_accessor[j];
       auto stride = strides[j];
       if (j != dim) {
@@ -119,9 +120,9 @@ std::vector<std::vector<int64_t>> get_pools(const Tensor& indices, const IntArra
     }
   }
 
-  for (int64_t i=0; i < nnz; i++) {
+  for (const auto i : c10::irange(nnz)) {
     int64_t pool_index = 0;
-    for (int64_t j=0; j < ndim; j++) {
+    for (const auto j : c10::irange(ndim)) {
       if (j != dim) {
         const auto indices_row = indices_accessor[j];
         const auto stride = strides[j];
@@ -315,7 +316,7 @@ void cpu_sparse_coo_softmax(Tensor output, const Tensor& input, const int64_t di
 
   int64_t grain_size = 1;
   parallel_for(0, pools.size(), grain_size, [&](int64_t begin, int64_t end) {
-      for (auto p = begin; p < end; p++) {
+      for (const auto p : c10::irange(begin, end)) {
         auto pool_indices = pools[p];
 
         // Skip empty pools
@@ -329,7 +330,7 @@ void cpu_sparse_coo_softmax(Tensor output, const Tensor& input, const int64_t di
         /* Compute mx */
         for (int64_t i : pool_indices) {
           auto values_row = values_accessor[i];
-          for (int64_t j=0; j < nvalues; j++) {
+          for (const auto j : c10::irange(nvalues)) {
             mx_row[j] = std::max(mx_row[j], values_row[j]);
           }
         }
@@ -338,7 +339,7 @@ void cpu_sparse_coo_softmax(Tensor output, const Tensor& input, const int64_t di
         for (int64_t i : pool_indices) {
           auto values_row = values_accessor[i];
           auto out_values_row = out_values_accessor[i];
-          for (int64_t j=0; j < nvalues; j++) {
+          for (const auto j : c10::irange(nvalues)) {
             auto v = std::exp(values_row[j] - mx_row[j]);
             if (!LogSoftMax) {
               out_values_row[j] = v;
@@ -347,7 +348,7 @@ void cpu_sparse_coo_softmax(Tensor output, const Tensor& input, const int64_t di
           }
         }
 
-        for (int64_t j=0; j < nvalues; j++) {
+        for (const auto j : c10::irange(nvalues)) {
           if (LogSoftMax) {
             mx_row[j] += std::log(exp_sums_row[j]);
           } else {
@@ -359,7 +360,7 @@ void cpu_sparse_coo_softmax(Tensor output, const Tensor& input, const int64_t di
         for (int64_t i : pool_indices) {
           auto values_row = values_accessor[i];
           auto out_values_row = out_values_accessor[i];
-          for (int64_t j=0; j < nvalues; j++) {
+          for (const auto j : c10::irange(nvalues)) {
             if (LogSoftMax) {
               out_values_row[j] = values_row[j] - mx_row[j];
             } else {
@@ -421,7 +422,7 @@ void cpu_sparse_coo_softmax_backward(const Tensor& grad_input, const Tensor& gra
         values.set_(r);
       }
     } else {
-      for(int64_t i=0; i<out_nnz; i++) {
+      for (const auto i : c10::irange(out_nnz)) {
         auto low = std::lower_bound(grad_offsets.begin(), grad_offsets.end(), out_offsets[i]);
         auto j = low - grad_offsets.begin();
         if (j < grad_nnz && out_offsets[i] == grad_offsets[j]) {
@@ -456,7 +457,7 @@ void cpu_sparse_coo_softmax_backward(const Tensor& grad_input, const Tensor& gra
 
   int64_t grain_size = 1;
   parallel_for(0, pools.size(), grain_size, [&](int64_t begin, int64_t end) {
-      for (auto p = begin; p < end; p++) {
+      for (const auto p : c10::irange(begin, end)) {
         auto pool_indices = pools[p];
 
         // Skip empty pools
@@ -473,7 +474,7 @@ void cpu_sparse_coo_softmax_backward(const Tensor& grad_input, const Tensor& gra
 
           if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
             auto grad_values_row = grad_values_accessor[j];
-            for (int64_t k=0; k<nvalues; k++) {
+            for (const auto k : c10::irange(nvalues)) {
               if (LogSoftMax) {
                 tmp_row[k] -= grad_values_row[k];
               } else {
@@ -492,7 +493,7 @@ void cpu_sparse_coo_softmax_backward(const Tensor& grad_input, const Tensor& gra
 
           if (j < grad_nnz && (out_offsets[i] == grad_offsets[j])) {
             auto grad_values_row = grad_values_accessor[j];
-            for (int64_t k=0; k<nvalues; k++) {
+            for (const auto k : c10::irange(nvalues)) {
               if (LogSoftMax) {
                 values_row[k] = grad_values_row[k] + std::exp(out_values_row[k]) * tmp_row[k];
               } else {
@@ -500,7 +501,7 @@ void cpu_sparse_coo_softmax_backward(const Tensor& grad_input, const Tensor& gra
               }
             }
           } else {
-            for (int64_t k=0; k<nvalues; k++) {
+            for (const auto k : c10::irange(nvalues)) {
               if (LogSoftMax) {
                 values_row[k] = std::exp(out_values_row[k]) * tmp_row[k];
               } else {

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -11,6 +11,7 @@
 #include <ATen/native/CPUBlas.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/mkl/SparseCsrLinearAlgebra.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 
@@ -48,7 +49,7 @@ void convert_indices_from_coo_to_csr_cpu(const Tensor& result, const Tensor& inp
 
   at::parallel_for(0, numel - 1, GRAIN_SIZE, [&](int64_t start, int64_t end) {
     input_t curr_value = data_in[start], next_value;
-    for (int64_t i = start; i < end; i++) {
+    for (const auto i : c10::irange(start, end)) {
       next_value = data_in[i + 1];
       for (; curr_value < next_value; curr_value++)
         data_out[curr_value + 1] = static_cast<output_t>(i + 1);

--- a/aten/src/ATen/native/sparse/SparseMatMul.cpp
+++ b/aten/src/ATen/native/sparse/SparseMatMul.cpp
@@ -5,6 +5,7 @@
 #include <ATen/SparseTensorImpl.h>
 #include <ATen/SparseTensorUtils.h>
 #include <ATen/native/Resize.h>
+#include <c10/util/irange.h>
 #include <unordered_map>
 
 namespace at { namespace native {
@@ -30,7 +31,7 @@ void csr_to_coo(const int64_t n_row, const int64_t Ap[], int64_t Bi[]) {
     Output:
       `Bi` is the row indices
   */
-  for (int64_t i = 0; i < n_row; i++) {
+  for (const auto i : c10::irange(n_row)) {
     for (int64_t jj = Ap[i]; jj < Ap[i + 1]; jj++) {
       Bi[jj] = i;
     }
@@ -56,7 +57,7 @@ int64_t _csr_matmult_maxnnz(
   */
   std::vector<int64_t> mask(n_col, -1);
   int64_t nnz = 0;
-  for (int64_t i = 0; i < n_row; i++) {
+  for (const auto i : c10::irange(n_row)) {
     int64_t row_nnz = 0;
 
     for (int64_t jj = Ap[i]; jj < Ap[i + 1]; jj++) {
@@ -127,19 +128,19 @@ void _csr_matmult(
 
   Cp[0] = 0;
 
-  for (int64_t i = 0; i < n_row; i++) {
+  for (const auto i : c10::irange(n_row)) {
     int64_t head = -2;
     int64_t length = 0;
 
     int64_t jj_start = Ap[i];
     int64_t jj_end = Ap[i + 1];
-    for (int64_t jj = jj_start; jj < jj_end; jj++) {
+    for (const auto jj : c10::irange(jj_start, jj_end)) {
       int64_t j = Aj[jj];
       scalar_t v = Ax[jj];
 
       int64_t kk_start = Bp[j];
       int64_t kk_end = Bp[j + 1];
-      for (int64_t kk = kk_start; kk < kk_end; kk++) {
+      for (const auto kk : c10::irange(kk_start, kk_end)) {
         int64_t k = Bj[kk];
 
         sums[k] += v * Bx[kk];
@@ -152,7 +153,8 @@ void _csr_matmult(
       }
     }
 
-    for (int64_t jj = 0; jj < length; jj++) {
+    for (const auto jj : c10::irange(length)) {
+      (void)jj; //Suppress unused variable warning
       Cj[nnz] = head;
       Cx[nnz] = sums[head];
       nnz++;

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -12,6 +12,7 @@
 
 #include <ATen/native/Copy.h>
 #include <ATen/native/CPUBlas.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -229,7 +230,7 @@ Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values_,
     auto cpu_min_indices_accessor = cpu_min_indices.accessor<int64_t, 1>();
     auto cpu_computed_indices_sizes_accessor =
         cpu_computed_indices_sizes.accessor<int64_t, 1>();
-    for (int64_t d = 0; d < sparse_dim; d++) {
+    for (const auto d : c10::irange(sparse_dim)) {
       int64_t min_index_in_dim = cpu_min_indices_accessor[d];
       TORCH_CHECK(
           min_index_in_dim >= 0,
@@ -244,11 +245,11 @@ Tensor sparse_coo_tensor(const Tensor& indices, const Tensor& values_,
     // If the indices doesn't have elements in it, there is not enough
     // information to know what the minimum sparse dimension sizes should be,
     // and in this case we set them to 0
-    for (int64_t d = 0; d < sparse_dim; d++) {
+    for (const auto d : c10::irange(sparse_dim)) {
       computed_sizes[static_cast<size_t>(d)] = 0;
     }
   }
-  for (int64_t d = 0; d < dense_dim; d++) {
+  for (const auto d : c10::irange(dense_dim)) {
     computed_sizes[static_cast<size_t>(sparse_dim + d)] = values.size(d + 1);
   }
 
@@ -305,7 +306,7 @@ void _validate_sparse_coo_tensor_args(
     }
     auto cpu_min_indices_accessor = cpu_min_indices.accessor<int64_t, 1>();
     auto cpu_max_indices_accessor = cpu_max_indices.accessor<int64_t, 1>();
-    for (int64_t d = 0; d < sparse_dim; d++) {
+    for (const auto d : c10::irange(sparse_dim)) {
       // NB: This used to sync ndim times to access each entry; now we copy
       // everything to CPU first and then access it.
       int64_t min_index_in_dim = cpu_min_indices_accessor[d];
@@ -597,7 +598,7 @@ SparseTensor _coalesce_sparse_cpu(const SparseTensor& self) {
     int64_t blockSize = values.stride(0);
     scalar_t* values_ptr = values.data_ptr<scalar_t>();
     scalar_t* newValues_ptr = newValues.data_ptr<scalar_t>();
-    for (int64_t j = 0; j < nnz; j++) {
+    for (const auto j : c10::irange(nnz)) {
       int64_t pos = indicesPermutationAccessor[j];
       int64_t curr = indicesBufferAccessor[j];
       if (curr == prev) {
@@ -613,7 +614,7 @@ SparseTensor _coalesce_sparse_cpu(const SparseTensor& self) {
         }
       } else {
         ++i;
-        for (int64_t d = 0; d < sparse_dim; d++) {
+        for (const auto d : c10::irange(sparse_dim)) {
           newIndicesAccessor[d][i] = indicesAccessor[d][pos];
         }
         if (values.numel() >
@@ -656,9 +657,9 @@ void inline sparse_mask_out_cpu_kernel(
   auto t_strides = t.strides();
 
   at::parallel_for(0, r_nnz, 1000, [&](int64_t start, int64_t end) {
-    for (auto i = start; i < end; i++) {
+    for (const auto i : c10::irange(start, end)) {
       int64_t idx = 0;
-      for (int64_t d = 0; d < sparse_dim; d++) {
+      for (const auto d : c10::irange(sparse_dim)) {
         idx += mask_indices_accessor[d][i] * t_strides[d];
       }
       r_values_accessor[i] = t_ptr[idx];
@@ -706,14 +707,14 @@ SparseTensor& sparse_mask_out_cpu(
     // ]. Keeping this implementation because it is faster than
     // flatten_indices()
     Tensor indices = at::zeros({mask._nnz()}, mask_indices.options());
-    for (int64_t d = 0; d < mask.sparse_dim(); d++) {
+    for (const auto d : c10::irange(mask.sparse_dim())) {
       indices.mul_(mask.size(d));
       indices.add_(mask_indices.select(0, d));
     }
 
     std::vector<int64_t> view_size(1 + mask.dense_dim());
     view_size[0] = -1;
-    for (int64_t d = 0; d < mask.dense_dim(); d++) {
+    for (const auto d : c10::irange(mask.dense_dim())) {
       view_size[d + 1] = mask.size(mask.sparse_dim() + d);
     }
 
@@ -777,7 +778,7 @@ Tensor sparse_mask_helper_cpu(
 
   // Step 1: flatten the sparse indices `t._indices()` tensor and then  map this
   // flatten value `index` to the original position `i`
-  for (int64_t i = 0; i < t_nnz; i++) {
+  for (const auto i : c10::irange(t_nnz)) {
     int64_t index = ti_flattened_indices.data_ptr<int64_t>()[i];
     t_flatten_indices[index] = i;
   }
@@ -802,7 +803,7 @@ Tensor sparse_mask_helper_cpu(
     const auto r_values_stride = r_values.strides()[0] * r_values.element_size();
     const auto t_values_stride = t_v.strides()[0] * t_v.element_size();
 
-    for (auto i = start; i < end; i++) {
+    for (const auto i : c10::irange(start, end)) {
       int64_t index = flattened_mask_indices.data_ptr<int64_t>()[i];
       auto iter = t_flatten_indices.find(index);
       if (iter != t_flatten_indices.end()) {

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -700,9 +700,9 @@ Tensor& add_out_dense_sparse_cpu(Tensor& r, const Tensor& dense, const SparseTen
   // accessors rely on nnz test
   if (nDim > nDimI) {
     auto indices_accessor = indices.accessor<int64_t, 2>();
-    for (int64_t k = 0; k < sparse._nnz(); k++) {
+    for (const auto k : c10::irange(sparse._nnz())) {
       Tensor dstBuffer = resultBuffer;
-      for (int64_t d = 0; d < sparse.sparse_dim(); d++) {
+      for (const auto d : c10::irange(sparse.sparse_dim())) {
         dstBuffer = dstBuffer.select(0, indices_accessor[d][k]);
       }
       Tensor srcBuffer = valuesBuffer.select(0, k);
@@ -1069,7 +1069,7 @@ SparseTensor& hspmm_out_sparse_cpu(const SparseTensor& sparse_, const Tensor& de
   auto indices_accessor = indices.accessor<int64_t, 2>();
 
   int64_t i = -1, prevIdx = -1;
-  for (int64_t j = 0; j < nnz; j++) {
+  for (const auto j : c10::irange(nnz)) {
     int64_t currIdx = valueIndices_accessor[j];
     if (currIdx != prevIdx) {
       indices_accessor[0][++i] = currIdx;
@@ -1185,10 +1185,10 @@ SparseTensor& _sspaddmm_out_cpu(
         scalar_t* newv_ptr = newv.data_ptr<scalar_t>();
         scalar_t cast_alpha = alpha.to<scalar_t>();
 
-        for (int64_t h = 0; h < dim_i; h++) {
+        for (const auto h : c10::irange(dim_i)) {
           int64_t i_start = csr_accessor[h];
           int64_t i_end = csr_accessor[h+1];
-          for (int64_t i = i_start; i < i_end; i++) {
+          for (const auto i : c10::irange(i_start, i_end)) {
             scalar_t val = values_accessor[i];
             int64_t col = indices_accessor[1][i];
             if (col >= 0 && col < dim_j) {
@@ -1202,7 +1202,7 @@ SparseTensor& _sspaddmm_out_cpu(
           }
           // Fill up the indices with the right values
           if (i_start != i_end) {
-            for (int64_t i = 0; i < dim_k; i++) {
+            for (const auto i : c10::irange(dim_k)) {
               newi_accessor[0][p+i] = h;
               newi_accessor[1][p+i] = i;
             }
@@ -1277,7 +1277,7 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
 
   auto dims_to_keep_v = std::vector<int64_t>();
   auto dense_dims_to_sum_v = std::vector<int64_t>();
-  for (int64_t d = 0; d < input_dim; d++) {
+  for (const auto d : c10::irange(input_dim)) {
     if (dims_to_sum_b[d]) {
       if (d >= sparse_dim) dense_dims_to_sum_v.emplace_back(d + 1 - sparse_dim);
     }

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/SparseTensorUtils.h>
 #include <ATen/cuda/CUDAUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -34,7 +35,7 @@ SparseTensor& sparse_mask_out_cuda(SparseTensor& r, const Tensor& t, const Spars
   // Get a flattened sparse indices, similar to NOTE [ Flatten Sparse Indices ].
   // Keeping this implementation because it is faster than flatten_indices()
   Tensor indices = at::zeros({mask._nnz()}, mask_indices.options());
-  for (int64_t d = 0; d < mask.sparse_dim(); d++) {
+  for (const auto d : c10::irange(mask.sparse_dim())) {
     indices.mul_(mask.size(d));
     // This used to use a buffer but I deoptimized it
     indices.add_(mask_indices.select(0, d));
@@ -42,7 +43,7 @@ SparseTensor& sparse_mask_out_cuda(SparseTensor& r, const Tensor& t, const Spars
 
   std::vector<int64_t> view_size(1 + mask.dense_dim());
   view_size[0] = -1;
-  for (int64_t d = 0; d < mask.dense_dim(); d++) {
+  for (const auto d : c10::irange(mask.dense_dim())) {
     view_size[d + 1] = mask.size(mask.sparse_dim() + d);
   }
 

--- a/aten/src/ATen/native/utils/ParamsHash.h
+++ b/aten/src/ATen/native/utils/ParamsHash.h
@@ -17,7 +17,7 @@ struct ParamsHash {
   size_t operator()(const Params& params) const {
     auto ptr = reinterpret_cast<const uint8_t*>(&params);
     uint32_t value = 0x811C9DC5;
-    for (int i = 0; i < (int)sizeof(Params); ++i) {
+    for (const auto i : c10::irange((int)sizeof(Params))) {
       value ^= ptr[i];
       value *= 0x01000193;
     }

--- a/aten/src/ATen/native/vulkan/Vulkan.cpp
+++ b/aten/src/ATen/native/vulkan/Vulkan.cpp
@@ -2,6 +2,7 @@
 #include <c10/util/accumulate.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #ifdef USE_VULKAN_WRAPPER
 #include <vulkan_wrapper.h>
@@ -192,7 +193,7 @@ uint32_t VContext::getComputeQueueFamilyIndex() {
   vkGetPhysicalDeviceQueueFamilyProperties(
       physicalDevice_, &queueFamilyCount, queueFamilies.data());
 
-  for (uint32_t i = 0; i < queueFamilies.size(); ++i) {
+  for (const auto i : c10::irange(queueFamilies.size())) {
     VkQueueFamilyProperties props = queueFamilies[i];
     if (props.queueCount > 0 && (props.queueFlags & VK_QUEUE_COMPUTE_BIT)) {
       return i;
@@ -274,7 +275,7 @@ uint32_t findMemoryType(
     const VkMemoryPropertyFlags properties) {
   VkPhysicalDeviceMemoryProperties memoryProperties{};
   vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memoryProperties);
-  for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i) {
+  for (const auto i : c10::irange(memoryProperties.memoryTypeCount)) {
     if ((memoryTypeBits & (1 << i)) &&
         ((memoryProperties.memoryTypes[i].propertyFlags & properties) ==
          properties)) {

--- a/aten/src/ATen/native/vulkan/VulkanAten.cpp
+++ b/aten/src/ATen/native/vulkan/VulkanAten.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/vulkan/VulkanOpaqueTensorImpl.h>
 #include <ATen/native/vulkan/VulkanOps.h>
 #include <ATen/vulkan/Context.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -265,13 +266,13 @@ Tensor cat(const TensorList tensors, int64_t dim) {
   int64_t cat_dim_size = 0;
 
   std::vector<VulkanTensor> vTensors{};
-  for (int i = 0; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(tensors.size())) {
     const auto& t = tensors[i];
     TORCH_INTERNAL_ASSERT(
         t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
     TORCH_INTERNAL_ASSERT(t.is_vulkan(), "Vulkan cat expects Vulkan inputs");
 
-    for (int d = 0; d < 4; ++d) {
+    for (const auto d : c10::irange(4)) {
       if (d == dim) {
         continue;
       }

--- a/aten/src/ATen/native/vulkan/VulkanOps.cpp
+++ b/aten/src/ATen/native/vulkan/VulkanOps.cpp
@@ -3,6 +3,7 @@
 #include <c10/util/accumulate.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <ATen/native/vulkan/Vulkan.h>
 #include <ATen/native/vulkan/VulkanCommon.h>
@@ -629,17 +630,17 @@ VBuffer kernelNCHW_OCHW_repack_O4C4HWi4o4(
     memset(basePtr, 0, size);
     const float* src = weights;
     int ridx = 0;
-    for (int oc = 0; oc < OC; ++oc) {
+    for (const auto oc : c10::irange(OC)) {
       int oc_4 = oc / 4;
       int oc_4_i = oc % 4;
       float* dst_oc = basePtr + oc_4 * oc_4SizeNumel;
-      for (int ic = 0; ic < C; ++ic) {
+      for (const auto ic : c10::irange(C)) {
         int ic_4 = ic / 4;
         int ic_4_i = ic % 4;
         float* dst_ic = dst_oc + ic_4 * KW * KH * 16;
-        for (int ky = 0; ky < KH; ++ky) {
+        for (const auto ky : c10::irange(KH)) {
           float* dst_ky = dst_ic + ky * KW * 16;
-          for (int kx = 0; kx < KW; ++kx) {
+          for (const auto kx : c10::irange(KW)) {
             float* dst_kx = dst_ky + kx * 16;
             dst_kx[4 * ic_4_i + oc_4_i] = src[ridx++];
           }

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -1,5 +1,6 @@
 #include <ATen/native/vulkan/api/Runtime.h>
 #include <ATen/native/vulkan/api/Adapter.h>
+#include <c10/util/irange.h>
 
 #include <sstream>
 
@@ -244,7 +245,7 @@ uint32_t query_compute_queue_family_index(const VkPhysicalDevice physical_device
       &queue_family_count,
       queue_families_properties.data());
 
-  for (uint32_t i = 0; i < queue_families_properties.size(); ++i) {
+  for (const auto i : c10::irange(queue_families_properties.size())) {
     const VkQueueFamilyProperties& properties = queue_families_properties[i];
     if (properties.queueCount > 0 && (properties.queueFlags & VK_QUEUE_COMPUTE_BIT)) {
       return i;

--- a/aten/src/ATen/native/vulkan/api/vk_mem_alloc.h
+++ b/aten/src/ATen/native/vulkan/api/vk_mem_alloc.h
@@ -1005,8 +1005,7 @@ VmaDefragmentationContext defragCtx;
 vmaDefragmentationBegin(allocator, &defragInfo, nullptr, &defragCtx);
 vmaDefragmentationEnd(allocator, defragCtx);
 
-for(uint32_t i = 0; i < allocCount; ++i)
-{
+for (const auto i : c10::irange(allocCount)) {
     if(allocationsChanged[i])
     {
         // Destroy buffer that is immutably bound to memory region which is no longer valid.
@@ -1083,8 +1082,7 @@ vkEndCommandBuffer(commandBuffer);
 
 vmaDefragmentationEnd(allocator, defragCtx);
 
-for(uint32_t i = 0; i < allocCount; ++i)
-{
+for (const auto i : c10::irange(allocCount)) {
     if(allocationsChanged[i])
     {
         // Destroy buffer that is immutably bound to memory region which is no longer valid.
@@ -4818,8 +4816,7 @@ T must be pointer type, e.g. VmaAllocation, VmaPool.
 template<typename T>
 static bool VmaValidatePointerArray(uint32_t count, const T* arr)
 {
-    for(uint32_t i = 0; i < count; ++i)
-    {
+    for (const auto i : c10::irange(count)) {
         const T iPtr = arr[i];
         if(iPtr == VMA_NULL)
         {
@@ -7459,8 +7456,7 @@ private:
         {
             FreeSpace s = {};
             s.blockInfoIndex = SIZE_MAX;
-            for(size_t i = 0; i < MAX_COUNT; ++i)
-            {
+            for (const auto i : c10::irange(MAX_COUNT)) {
                 m_FreeSpaces[i] = s;
             }
         }
@@ -7474,8 +7470,7 @@ private:
 
             // Find first invalid or the smallest structure.
             size_t bestIndex = SIZE_MAX;
-            for(size_t i = 0; i < MAX_COUNT; ++i)
-            {
+            for (const auto i : c10::irange(MAX_COUNT)) {
                 // Empty structure.
                 if(m_FreeSpaces[i].blockInfoIndex == SIZE_MAX)
                 {
@@ -7502,8 +7497,7 @@ private:
         {
             size_t bestIndex = SIZE_MAX;
             VkDeviceSize bestFreeSpaceAfter = 0;
-            for(size_t i = 0; i < MAX_COUNT; ++i)
-            {
+            for (const auto i : c10::irange(MAX_COUNT)) {
                 // Structure is valid.
                 if(m_FreeSpaces[i].blockInfoIndex != SIZE_MAX)
                 {
@@ -7846,8 +7840,7 @@ struct VmaCurrentBudgetData
 
     VmaCurrentBudgetData()
     {
-        for(uint32_t heapIndex = 0; heapIndex < VK_MAX_MEMORY_HEAPS; ++heapIndex)
-        {
+        for (const auto heapIndex : c10::irange(VK_MAX_MEMORY_HEAPS)) {
             m_BlockBytes[heapIndex] = 0;
             m_AllocationBytes[heapIndex] = 0;
 #if VMA_MEMORY_BUDGET
@@ -8447,8 +8440,7 @@ void VmaJsonWriter::ContinueString(const char* pStr)
     VMA_ASSERT(m_InsideString);
 
     const size_t strLen = strlen(pStr);
-    for(size_t i = 0; i < strLen; ++i)
-    {
+    for (const auto i : c10::irange(strLen)) {
         char ch = pStr[i];
         if(ch == '\\')
         {
@@ -8583,8 +8575,7 @@ void VmaJsonWriter::WriteIndent(bool oneLess)
         {
             --count;
         }
-        for(size_t i = 0; i < count; ++i)
-        {
+        for (const auto i : c10::irange(count)) {
             m_SB.Add(INDENT);
         }
     }
@@ -9123,8 +9114,7 @@ bool VmaBlockMetadata_Generic::Validate() const
     VMA_VALIDATE(m_FreeSuballocationsBySize.size() == freeSuballocationsToRegister);
 
     VkDeviceSize lastSize = 0;
-    for(size_t i = 0; i < m_FreeSuballocationsBySize.size(); ++i)
-    {
+    for (const auto i : c10::irange(m_FreeSuballocationsBySize.size())) {
         VmaSuballocationList::iterator suballocItem = m_FreeSuballocationsBySize[i];
 
         // Only free suballocations can be registered in m_FreeSuballocationsBySize.
@@ -10075,8 +10065,7 @@ bool VmaBlockMetadata_Linear::Validate() const
     {
         const size_t suballoc2ndCount = suballocations2nd.size();
         size_t nullItem2ndCount = 0;
-        for(size_t i = 0; i < suballoc2ndCount; ++i)
-        {
+        for (const auto i : c10::irange(suballoc2ndCount)) {
             const VmaSuballocation& suballoc = suballocations2nd[i];
             const bool currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
 
@@ -10100,8 +10089,7 @@ bool VmaBlockMetadata_Linear::Validate() const
         VMA_VALIDATE(nullItem2ndCount == m_2ndNullItemsCount);
     }
 
-    for(size_t i = 0; i < m_1stNullItemsBeginCount; ++i)
-    {
+    for (const auto i : c10::irange(m_1stNullItemsBeginCount)) {
         const VmaSuballocation& suballoc = suballocations1st[i];
         VMA_VALIDATE(suballoc.type == VMA_SUBALLOCATION_TYPE_FREE &&
             suballoc.hAllocation == VK_NULL_HANDLE);
@@ -10109,8 +10097,7 @@ bool VmaBlockMetadata_Linear::Validate() const
 
     size_t nullItem1stCount = m_1stNullItemsBeginCount;
 
-    for(size_t i = m_1stNullItemsBeginCount; i < suballoc1stCount; ++i)
-    {
+    for (const auto i : c10::irange(m_1stNullItemsBeginCount, suballoc1stCount)) {
         const VmaSuballocation& suballoc = suballocations1st[i];
         const bool currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
 
@@ -11301,10 +11288,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(
             // If conflict exists, allocation cannot be made here.
             if(allocSize % bufferImageGranularity || resultOffset % bufferImageGranularity)
             {
-                for(size_t nextSuballocIndex = index1st;
-                    nextSuballocIndex < suballocations1st.size();
-                    nextSuballocIndex++)
-                {
+                for (const auto nextSuballocIndex : c10::irange(index1st, suballocations1st.size())) {
                     const VmaSuballocation& nextSuballoc = suballocations1st[nextSuballocIndex];
                     if(VmaBlocksOnSamePage(resultOffset, allocSize, nextSuballoc.offset, bufferImageGranularity))
                     {
@@ -11712,8 +11696,7 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
         {
             const size_t nonNullItemCount = suballoc1stCount - nullItem1stCount;
             size_t srcIndex = m_1stNullItemsBeginCount;
-            for(size_t dstIndex = 0; dstIndex < nonNullItemCount; ++dstIndex)
-            {
+            for (const auto dstIndex : c10::irange(nonNullItemCount)) {
                 while(suballocations1st[srcIndex].hAllocation == VK_NULL_HANDLE)
                 {
                     ++srcIndex;
@@ -11817,8 +11800,7 @@ bool VmaBlockMetadata_Buddy::Validate() const
     VMA_VALIDATE(m_SumFreeSize == ctx.calculatedSumFreeSize);
 
     // Validate free node lists.
-    for(uint32_t level = 0; level < m_LevelCount; ++level)
-    {
+    for (const auto level : c10::irange(m_LevelCount)) {
         VMA_VALIDATE(m_FreeList[level].front == VMA_NULL ||
             m_FreeList[level].front->free.prev == VMA_NULL);
 
@@ -11840,8 +11822,7 @@ bool VmaBlockMetadata_Buddy::Validate() const
     }
 
     // Validate that free lists ar higher levels are empty.
-    for(uint32_t level = m_LevelCount; level < MAX_LEVELS; ++level)
-    {
+    for (const auto level : c10::irange(m_LevelCount, MAX_LEVELS)) {
         VMA_VALIDATE(m_FreeList[level].front == VMA_NULL && m_FreeList[level].back == VMA_NULL);
     }
 
@@ -11850,8 +11831,7 @@ bool VmaBlockMetadata_Buddy::Validate() const
 
 VkDeviceSize VmaBlockMetadata_Buddy::GetUnusedRangeSizeMax() const
 {
-    for(uint32_t level = 0; level < m_LevelCount; ++level)
-    {
+    for (const auto level : c10::irange(m_LevelCount)) {
         if(m_FreeList[level].front != VMA_NULL)
         {
             return LevelToNodeSize(level);
@@ -12668,8 +12648,7 @@ VmaBlockVector::~VmaBlockVector()
 
 VkResult VmaBlockVector::CreateMinBlocks()
 {
-    for(size_t i = 0; i < m_MinBlockCount; ++i)
-    {
+    for (const auto i : c10::irange(m_MinBlockCount)) {
         VkResult res = CreateBlock(m_PreferredBlockSize, VMA_NULL);
         if(res != VK_SUCCESS)
         {
@@ -12692,8 +12671,7 @@ void VmaBlockVector::GetPoolStats(VmaPoolStats* pStats)
     pStats->unusedRangeSizeMax = 0;
     pStats->blockCount = blockCount;
 
-    for(uint32_t blockIndex = 0; blockIndex < blockCount; ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(blockCount)) {
         const VmaDeviceMemoryBlock* const pBlock = m_Blocks[blockIndex];
         VMA_ASSERT(pBlock);
         VMA_HEAVY_ASSERT(pBlock->Validate());
@@ -12873,8 +12851,7 @@ VkResult VmaBlockVector::AllocatePage(
             if(strategy == VMA_ALLOCATION_CREATE_STRATEGY_BEST_FIT_BIT)
             {
                 // Forward order in m_Blocks - prefer blocks with smallest amount of free space.
-                for(size_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex )
-                {
+                for (const auto blockIndex : c10::irange(m_Blocks.size())) {
                     VmaDeviceMemoryBlock* const pCurrBlock = m_Blocks[blockIndex];
                     VMA_ASSERT(pCurrBlock);
                     VkResult res = AllocateFromBlock(
@@ -12932,8 +12909,7 @@ VkResult VmaBlockVector::AllocatePage(
             {
                 // Allocate 1/8, 1/4, 1/2 as first blocks.
                 const VkDeviceSize maxExistingBlockSize = CalcMaxBlockSize();
-                for(uint32_t i = 0; i < NEW_BLOCK_SIZE_SHIFT_MAX; ++i)
-                {
+                for (const auto i : c10::irange(NEW_BLOCK_SIZE_SHIFT_MAX)) {
                     const VkDeviceSize smallerNewBlockSize = newBlockSize / 2;
                     if(smallerNewBlockSize > maxExistingBlockSize && smallerNewBlockSize >= size * 2)
                     {
@@ -13013,8 +12989,7 @@ VkResult VmaBlockVector::AllocatePage(
             if(strategy == VMA_ALLOCATION_CREATE_STRATEGY_BEST_FIT_BIT)
             {
                 // Forward order in m_Blocks - prefer blocks with smallest amount of free space.
-                for(size_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex )
-                {
+                for (const auto blockIndex : c10::irange(m_Blocks.size())) {
                     VmaDeviceMemoryBlock* const pCurrBlock = m_Blocks[blockIndex];
                     VMA_ASSERT(pCurrBlock);
                     VmaAllocationRequest currRequest = {};
@@ -13238,8 +13213,7 @@ VkDeviceSize VmaBlockVector::CalcMaxBlockSize() const
 
 void VmaBlockVector::Remove(VmaDeviceMemoryBlock* pBlock)
 {
-    for(uint32_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(m_Blocks.size())) {
         if(m_Blocks[blockIndex] == pBlock)
         {
             VmaVectorRemove(m_Blocks, blockIndex);
@@ -13254,8 +13228,7 @@ void VmaBlockVector::IncrementallySortBlocks()
     if(m_Algorithm != VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT)
     {
         // Bubble sort only until first swap.
-        for(size_t i = 1; i < m_Blocks.size(); ++i)
-        {
+        for (const auto i : c10::irange(1, m_Blocks.size())) {
             if(m_Blocks[i - 1]->m_pMetadata->GetSumFreeSize() > m_Blocks[i]->m_pMetadata->GetSumFreeSize())
             {
                 VMA_SWAP(m_Blocks[i - 1], m_Blocks[i]);
@@ -13413,8 +13386,7 @@ void VmaBlockVector::ApplyDefragmentationMovesCpu(
 
     // Go over all moves. Mark blocks that are used with BLOCK_FLAG_USED.
     const size_t moveCount = moves.size();
-    for(size_t moveIndex = 0; moveIndex < moveCount; ++moveIndex)
-    {
+    for (const auto moveIndex : c10::irange(moveCount)) {
         const VmaDefragmentationMove& move = moves[moveIndex];
         blockInfo[move.srcBlockIndex].flags |= BLOCK_FLAG_USED;
         blockInfo[move.dstBlockIndex].flags |= BLOCK_FLAG_USED;
@@ -13448,8 +13420,7 @@ void VmaBlockVector::ApplyDefragmentationMovesCpu(
         const VkDeviceSize nonCoherentAtomSize = m_hAllocator->m_PhysicalDeviceProperties.limits.nonCoherentAtomSize;
         VkMappedMemoryRange memRange = { VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
 
-        for(size_t moveIndex = 0; moveIndex < moveCount; ++moveIndex)
-        {
+        for (const auto moveIndex : c10::irange(moveCount)) {
             const VmaDefragmentationMove& move = moves[moveIndex];
 
             const BlockInfo& srcBlockInfo = blockInfo[move.srcBlockIndex];
@@ -13520,8 +13491,7 @@ void VmaBlockVector::ApplyDefragmentationMovesGpu(
 
     // Go over all moves. Mark blocks that are used with BLOCK_FLAG_USED.
     const size_t moveCount = moves.size();
-    for(size_t moveIndex = 0; moveIndex < moveCount; ++moveIndex)
-    {
+    for (const auto moveIndex : c10::irange(moveCount)) {
         const VmaDefragmentationMove& move = moves[moveIndex];
 
         //if(move.type == VMA_ALLOCATION_TYPE_UNKNOWN)
@@ -13560,8 +13530,7 @@ void VmaBlockVector::ApplyDefragmentationMovesGpu(
     // Go over all moves. Post data transfer commands to command buffer.
     if(pDefragCtx->res == VK_SUCCESS)
     {
-        for(size_t moveIndex = 0; moveIndex < moveCount; ++moveIndex)
-        {
+        for (const auto moveIndex : c10::irange(moveCount)) {
             const VmaDefragmentationMove& move = moves[moveIndex];
 
             const VmaBlockDefragmentationContext& srcBlockCtx = pDefragCtx->blockContexts[move.srcBlockIndex];
@@ -13686,8 +13655,7 @@ void VmaBlockVector::PrintDetailedMap(class VmaJsonWriter& json)
 
     json.WriteString("Blocks");
     json.BeginObject();
-    for(size_t i = 0; i < m_Blocks.size(); ++i)
-    {
+    for (const auto i : c10::irange(m_Blocks.size())) {
         json.BeginString();
         json.ContinueString(m_Blocks[i]->GetId());
         json.EndString();
@@ -13895,8 +13863,7 @@ void VmaBlockVector::CommitDefragmentations(
 size_t VmaBlockVector::CalcAllocationCount() const
 {
     size_t result = 0;
-    for(size_t i = 0; i < m_Blocks.size(); ++i)
-    {
+    for (const auto i : c10::irange(m_Blocks.size())) {
         result += m_Blocks[i]->m_pMetadata->GetAllocationCount();
     }
     return result;
@@ -13928,8 +13895,7 @@ void VmaBlockVector::MakePoolAllocationsLost(
 {
     VmaMutexLockWrite lock(m_Mutex, m_hAllocator->m_UseMutex);
     size_t lostAllocationCount = 0;
-    for(uint32_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(m_Blocks.size())) {
         VmaDeviceMemoryBlock* const pBlock = m_Blocks[blockIndex];
         VMA_ASSERT(pBlock);
         lostAllocationCount += pBlock->m_pMetadata->MakeAllocationsLost(currentFrameIndex, m_FrameInUseCount);
@@ -13948,8 +13914,7 @@ VkResult VmaBlockVector::CheckCorruption()
     }
 
     VmaMutexLockRead lock(m_Mutex, m_hAllocator->m_UseMutex);
-    for(uint32_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(m_Blocks.size())) {
         VmaDeviceMemoryBlock* const pBlock = m_Blocks[blockIndex];
         VMA_ASSERT(pBlock);
         VkResult res = pBlock->CheckCorruption(m_hAllocator);
@@ -13968,8 +13933,7 @@ void VmaBlockVector::AddStats(VmaStats* pStats)
 
     VmaMutexLockRead lock(m_Mutex, m_hAllocator->m_UseMutex);
 
-    for(uint32_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(m_Blocks.size())) {
         const VmaDeviceMemoryBlock* const pBlock = m_Blocks[blockIndex];
         VMA_ASSERT(pBlock);
         VMA_HEAVY_ASSERT(pBlock->Validate());
@@ -13998,8 +13962,7 @@ VmaDefragmentationAlgorithm_Generic::VmaDefragmentationAlgorithm_Generic(
 {
     // Create block info for each block.
     const size_t blockCount = m_pBlockVector->m_Blocks.size();
-    for(size_t blockIndex = 0; blockIndex < blockCount; ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(blockCount)) {
         BlockInfo* pBlockInfo = vma_new(m_hAllocator, BlockInfo)(m_hAllocator->GetAllocationCallbacks());
         pBlockInfo->m_OriginalBlockIndex = blockIndex;
         pBlockInfo->m_pBlock = m_pBlockVector->m_Blocks[blockIndex];
@@ -14197,8 +14160,7 @@ VkResult VmaDefragmentationAlgorithm_Generic::DefragmentRound(
 size_t VmaDefragmentationAlgorithm_Generic::CalcBlocksWithNonMovableCount() const
 {
     size_t result = 0;
-    for(size_t i = 0; i < m_Blocks.size(); ++i)
-    {
+    for (const auto i : c10::irange(m_Blocks.size())) {
         if(m_Blocks[i]->m_HasNonMovableAllocations)
         {
             ++result;
@@ -14219,8 +14181,7 @@ VkResult VmaDefragmentationAlgorithm_Generic::Defragment(
     }
 
     const size_t blockCount = m_Blocks.size();
-    for(size_t blockIndex = 0; blockIndex < blockCount; ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(blockCount)) {
         BlockInfo* pBlockInfo = m_Blocks[blockIndex];
 
         if(m_AllAllocations)
@@ -14325,8 +14286,7 @@ VkResult VmaDefragmentationAlgorithm_Fast::Defragment(
     // Sort blocks in order from most destination.
 
     m_BlockInfos.resize(blockCount);
-    for(size_t i = 0; i < blockCount; ++i)
-    {
+    for (const auto i : c10::irange(blockCount)) {
         m_BlockInfos[i].origBlockIndex = i;
     }
 
@@ -14539,8 +14499,7 @@ VkResult VmaDefragmentationAlgorithm_Fast::Defragment(
 void VmaDefragmentationAlgorithm_Fast::PreprocessMetadata()
 {
     const size_t blockCount = m_pBlockVector->GetBlockCount();
-    for(size_t blockIndex = 0; blockIndex < blockCount; ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(blockCount)) {
         VmaBlockMetadata_Generic* const pMetadata =
             (VmaBlockMetadata_Generic*)m_pBlockVector->GetBlock(blockIndex)->m_pMetadata;
         pMetadata->m_FreeCount = 0;
@@ -14567,8 +14526,7 @@ void VmaDefragmentationAlgorithm_Fast::PreprocessMetadata()
 void VmaDefragmentationAlgorithm_Fast::PostprocessMetadata()
 {
     const size_t blockCount = m_pBlockVector->GetBlockCount();
-    for(size_t blockIndex = 0; blockIndex < blockCount; ++blockIndex)
-    {
+    for (const auto blockIndex : c10::irange(blockCount)) {
         VmaBlockMetadata_Generic* const pMetadata =
             (VmaBlockMetadata_Generic*)m_pBlockVector->GetBlock(blockIndex)->m_pMetadata;
         const VkDeviceSize blockSize = pMetadata->GetSize();
@@ -14778,8 +14736,7 @@ VmaDefragmentationContext_T::~VmaDefragmentationContext_T()
 
 void VmaDefragmentationContext_T::AddPools(uint32_t poolCount, const VmaPool* pPools)
 {
-    for(uint32_t poolIndex = 0; poolIndex < poolCount; ++poolIndex)
-    {
+    for (const auto poolIndex : c10::irange(poolCount)) {
         VmaPool pool = pPools[poolIndex];
         VMA_ASSERT(pool);
         // Pools with algorithm other than default are not defragmented.
@@ -14817,8 +14774,7 @@ void VmaDefragmentationContext_T::AddAllocations(
     VkBool32* pAllocationsChanged)
 {
     // Dispatch pAllocations among defragmentators. Create them when necessary.
-    for(uint32_t allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
-    {
+    for (const auto allocIndex : c10::irange(allocationCount)) {
         const VmaAllocation hAlloc = pAllocations[allocIndex];
         VMA_ASSERT(hAlloc);
         // DedicatedAlloc cannot be defragmented.
@@ -15615,14 +15571,12 @@ void VmaRecorder::WriteConfiguration(
     fprintf(m_File, "PhysicalDeviceLimits,nonCoherentAtomSize,%llu\n", devProps.limits.nonCoherentAtomSize);
 
     fprintf(m_File, "PhysicalDeviceMemory,HeapCount,%u\n", memProps.memoryHeapCount);
-    for(uint32_t i = 0; i < memProps.memoryHeapCount; ++i)
-    {
+    for (const auto i : c10::irange(memProps.memoryHeapCount)) {
         fprintf(m_File, "PhysicalDeviceMemory,Heap,%u,size,%llu\n", i, memProps.memoryHeaps[i].size);
         fprintf(m_File, "PhysicalDeviceMemory,Heap,%u,flags,%u\n", i, memProps.memoryHeaps[i].flags);
     }
     fprintf(m_File, "PhysicalDeviceMemory,TypeCount,%u\n", memProps.memoryTypeCount);
-    for(uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
-    {
+    for (const auto i : c10::irange(memProps.memoryTypeCount)) {
         fprintf(m_File, "PhysicalDeviceMemory,Type,%u,heapIndex,%u\n", i, memProps.memoryTypes[i].heapIndex);
         fprintf(m_File, "PhysicalDeviceMemory,Type,%u,propertyFlags,%u\n", i, memProps.memoryTypes[i].propertyFlags);
     }
@@ -15830,8 +15784,7 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
 
     if(pCreateInfo->pHeapSizeLimit != VMA_NULL)
     {
-        for(uint32_t heapIndex = 0; heapIndex < GetMemoryHeapCount(); ++heapIndex)
-        {
+        for (const auto heapIndex : c10::irange(GetMemoryHeapCount())) {
             const VkDeviceSize limit = pCreateInfo->pHeapSizeLimit[heapIndex];
             if(limit != VK_WHOLE_SIZE)
             {
@@ -15844,8 +15797,7 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
         }
     }
 
-    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-    {
+    for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
         const VkDeviceSize preferredBlockSize = CalcPreferredBlockSize(memTypeIndex);
 
         m_pBlockVectors[memTypeIndex] = vma_new(this, VmaBlockVector)(
@@ -16747,14 +16699,11 @@ void VmaAllocator_T::CalculateStats(VmaStats* pStats)
 {
     // Initialize.
     InitStatInfo(pStats->total);
-    for(size_t i = 0; i < VK_MAX_MEMORY_TYPES; ++i)
-        InitStatInfo(pStats->memoryType[i]);
-    for(size_t i = 0; i < VK_MAX_MEMORY_HEAPS; ++i)
-        InitStatInfo(pStats->memoryHeap[i]);
+    for (const auto i : c10::irange(VK_MAX_MEMORY_TYPES))InitStatInfo(pStats->memoryType[i]);
+    for (const auto i : c10::irange(VK_MAX_MEMORY_HEAPS))InitStatInfo(pStats->memoryHeap[i]);
 
     // Process default pools.
-    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-    {
+    for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
         VmaBlockVector* const pBlockVector = m_pBlockVectors[memTypeIndex];
         VMA_ASSERT(pBlockVector);
         pBlockVector->AddStats(pStats);
@@ -16770,8 +16719,7 @@ void VmaAllocator_T::CalculateStats(VmaStats* pStats)
     }
 
     // Process dedicated allocations.
-    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-    {
+    for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
         const uint32_t memHeapIndex = MemoryTypeIndexToHeapIndex(memTypeIndex);
         VmaMutexLockRead dedicatedAllocationsLock(m_DedicatedAllocationsMutex[memTypeIndex], m_UseMutex);
         AllocationVectorType* const pDedicatedAllocVector = m_pDedicatedAllocations[memTypeIndex];
@@ -16788,10 +16736,8 @@ void VmaAllocator_T::CalculateStats(VmaStats* pStats)
 
     // Postprocess.
     VmaPostprocessCalcStatInfo(pStats->total);
-    for(size_t i = 0; i < GetMemoryTypeCount(); ++i)
-        VmaPostprocessCalcStatInfo(pStats->memoryType[i]);
-    for(size_t i = 0; i < GetMemoryHeapCount(); ++i)
-        VmaPostprocessCalcStatInfo(pStats->memoryHeap[i]);
+    for (const auto i : c10::irange(GetMemoryTypeCount()))VmaPostprocessCalcStatInfo(pStats->memoryType[i]);
+    for (const auto i : c10::irange(GetMemoryHeapCount()))VmaPostprocessCalcStatInfo(pStats->memoryHeap[i]);
 }
 
 void VmaAllocator_T::GetBudget(VmaBudget* outBudget, uint32_t firstHeap, uint32_t heapCount)
@@ -17114,8 +17060,7 @@ VkResult VmaAllocator_T::CheckCorruption(uint32_t memoryTypeBits)
     VkResult finalRes = VK_ERROR_FEATURE_NOT_PRESENT;
 
     // Process default pools.
-    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-    {
+    for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
         if(((1u << memTypeIndex) & memoryTypeBits) != 0)
         {
             VmaBlockVector* const pBlockVector = m_pBlockVectors[memTypeIndex];
@@ -17463,8 +17408,7 @@ VkResult VmaAllocator_T::FlushOrInvalidateAllocations(
     typedef VmaSmallVector<VkMappedMemoryRange, RangeAllocator, 16> RangeVector;
     RangeVector ranges = RangeVector(RangeAllocator(GetAllocationCallbacks()));
 
-    for(uint32_t allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
-    {
+    for (const auto allocIndex : c10::irange(allocationCount)) {
         const VmaAllocation alloc = allocations[allocIndex];
         const VkDeviceSize offset = offsets != VMA_NULL ? offsets[allocIndex] : 0;
         const VkDeviceSize size = sizes != VMA_NULL ? sizes[allocIndex] : VK_WHOLE_SIZE;
@@ -17559,8 +17503,7 @@ uint32_t VmaAllocator_T::CalculateGlobalMemoryTypeBits() const
     if(!m_UseAmdDeviceCoherentMemory)
     {
         // Exclude memory types that have VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD.
-        for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-        {
+        for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
             if((m_MemProps.memoryTypes[memTypeIndex].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY) != 0)
             {
                 memoryTypeBits &= ~(1u << memTypeIndex);
@@ -17650,8 +17593,7 @@ void VmaAllocator_T::UpdateVulkanBudget()
     {
         VmaMutexLockWrite lockWrite(m_Budget.m_BudgetMutex, m_UseMutex);
 
-        for(uint32_t heapIndex = 0; heapIndex < GetMemoryHeapCount(); ++heapIndex)
-        {
+        for (const auto heapIndex : c10::irange(GetMemoryHeapCount())) {
             m_Budget.m_VulkanUsage[heapIndex] = budgetProps.heapUsage[heapIndex];
             m_Budget.m_VulkanBudget[heapIndex] = budgetProps.heapBudget[heapIndex];
             m_Budget.m_BlockBytesAtBudgetFetch[heapIndex] = m_Budget.m_BlockBytes[heapIndex].load();
@@ -17713,8 +17655,7 @@ uint32_t VmaAllocator_T::GetGpuDefragmentationMemoryTypeBits()
 void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
 {
     bool dedicatedAllocationsStarted = false;
-    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-    {
+    for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
         VmaMutexLockRead dedicatedAllocationsLock(m_DedicatedAllocationsMutex[memTypeIndex], m_UseMutex);
         AllocationVectorType* const pDedicatedAllocVector = m_pDedicatedAllocations[memTypeIndex];
         VMA_ASSERT(pDedicatedAllocVector);
@@ -17751,8 +17692,7 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
 
     {
         bool allocationsStarted = false;
-        for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
-        {
+        for (const auto memTypeIndex : c10::irange(GetMemoryTypeCount())) {
             if(m_pBlockVectors[memTypeIndex]->IsEmpty() == false)
             {
                 if(allocationsStarted == false)
@@ -17783,8 +17723,7 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
         {
             json.WriteString("Pools");
             json.BeginObject();
-            for(size_t poolIndex = 0; poolIndex < poolCount; ++poolIndex)
-            {
+            for (const auto poolIndex : c10::irange(poolCount)) {
                 json.BeginString();
                 json.ContinueString(m_Pools[poolIndex]->GetId());
                 json.EndString();
@@ -18425,8 +18364,7 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(
 
     if(pAllocationInfo != VMA_NULL && result == VK_SUCCESS)
     {
-        for(size_t i = 0; i < allocationCount; ++i)
-        {
+        for (const auto i : c10::irange(allocationCount)) {
             allocator->GetAllocationInfo(pAllocations[i], pAllocationInfo + i);
         }
     }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/utils/ParamUtils.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/api/Utils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -32,7 +33,7 @@ inline bool is_pointwise(const IntArrayRef filter) {
 
 bool all_lessthan(const IntArrayRef arr, const int t) {
   bool retval = true;
-  for (size_t i = 0; i < arr.size(); i++) {
+  for (const auto i : c10::irange(arr.size())) {
     retval = retval && (arr[i] < t);
   }
   return retval;
@@ -173,8 +174,8 @@ vTensor pack_weights_2d(
     for (int64_t src_ic = 0; src_ic < src_filter[Layout::Filter::input]; ++src_ic) {
       const int64_t dst_ic4 = src_ic / 4;
 
-      for (int64_t src_ih = 0; src_ih < src_kh_sz; ++src_ih) {
-        for (int64_t src_iw = 0; src_iw < src_kw_sz; ++src_iw) {
+      for (const auto src_ih : c10::irange(src_kh_sz)) {
+        for (const auto src_iw : c10::irange(src_kw_sz)) {
           memcpy(
               dst_weight_c_ptr + (dst_oh * src_kh_sz + src_ih) * dst_kw_sz +
                 dst_ic4 * src_kw_sz * 4 + src_iw * 4 + src_ic % 4,
@@ -225,11 +226,11 @@ vTensor pack_weights_2d_winograd_2_3(
   float* const dst_weight_ptr = v_weight_payload.get();
   memset(dst_weight_ptr, 0, v_weight.nbytes());
 
-  for (int64_t src_oc = 0; src_oc < src_oc_sz; ++src_oc) {
+  for (const auto src_oc : c10::irange(src_oc_sz)) {
     const int64_t dst_oh = src_oc / 4;
     const int64_t dst_iw = src_oc % 4;
 
-    for (int64_t src_ic = 0; src_ic < src_ic_sz; ++src_ic) {
+    for (const auto src_ic : c10::irange(src_ic_sz)) {
       const int64_t dst_ow = src_ic / 4;
       const int64_t dst_c = src_ic % 4;
 
@@ -344,7 +345,7 @@ vTensor pack_biases(
     float* const dst_bias_ptr = v_bias_payload.get();
 
     memset(dst_bias_ptr, 0, v_bias.nbytes());
-    for (int64_t i = 0; i < src_w; ++i) {
+    for (const auto i : c10::irange(src_w)) {
       const int64_t c = i % 4;
       const int64_t x = i / 4;
       dst_bias_ptr[c * packed_w + x] = src_bias_ptr[i];

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/vulkan/ops/Mm.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -47,8 +48,8 @@ vTensor pack_weights(
   float* const dst_weight_ptr = v_weight_payload.get();
   memset(dst_weight_ptr, 0, v_weight.nbytes());
 
-  for (int64_t src_h = 0; src_h < src_kh_sz; ++src_h) {
-    for (int64_t src_w = 0; src_w < src_kw_sz; ++src_w) {
+  for (const auto src_h : c10::irange(src_kh_sz)) {
+    for (const auto src_w : c10::irange(src_kw_sz)) {
       int64_t dst_plane = 2*(src_h%2) + (src_w%2);
       int64_t dst_index = (src_h/2)*dst_kw_sz + (src_w/2);
       memcpy(
@@ -109,8 +110,8 @@ vTensor pack_biases(
     float* const dst_bias_ptr = v_bias_payload.get();
     memset(dst_bias_ptr, 0, v_bias.nbytes());
 
-    for (int64_t src_h = 0; src_h < src_kh_sz; ++src_h) {
-      for (int64_t src_w = 0; src_w < src_kw_sz; ++src_w) {
+    for (const auto src_h : c10::irange(src_kh_sz)) {
+      for (const auto src_w : c10::irange(src_kw_sz)) {
         int64_t dst_plane = 2*(src_h%2) + (src_w%2);
         int64_t dst_index = (src_h/2)*dst_kw_sz + (src_w/2);
         memcpy(

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/vulkan/ops/Common.h>
+#include <c10/util/irange.h>
 #include <torch/library.h>
 
 namespace at {
@@ -35,7 +36,7 @@ Tensor reflection_pad2d(const Tensor& self_arg, IntArrayRef padding) {
   const vTensor& v_self = convert(self);
 
   c10::SmallVector<int64_t, 4> output_size(input_dim);
-  for (size_t d = 0; d < input_dim; ++d) {
+  for (const auto d : c10::irange(input_dim)) {
     if (d == input_dim - 1) {
       output_size[d] = input_size[d] + pad_right + pad_left;
     } else if (d == input_dim - 2) {

--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -4,6 +4,7 @@
 #include <ATen/nnapi/nnapi_bind.h>
 #include <ATen/nnapi/nnapi_wrapper.h>
 #include <ATen/nnapi/nnapi_model_loader.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace nnapi {
@@ -103,7 +104,7 @@ void NnapiCompilation::run(
   TORCH_CHECK((int32_t)inputs.size() == num_inputs_);
   TORCH_CHECK((int32_t)outputs.size() == num_outputs_);
 
-  for (size_t i = 0; i < inputs.size(); i++) {
+  for (const auto i : c10::irange(inputs.size())) {
     auto& t = inputs[i];
     // TODO: Check contiguous and dtype.
     ANeuralNetworksOperandType op_type;
@@ -117,7 +118,7 @@ void NnapiCompilation::run(
         t.nbytes());
   }
 
-  for (size_t i = 0; i < outputs.size(); i++) {
+  for (const auto i : c10::irange(outputs.size())) {
     auto& t = outputs[i];
     // TODO: Check contiguous and dtype.
     check_nnapi->Execution_setOutput(
@@ -131,7 +132,7 @@ void NnapiCompilation::run(
   check_nnapi->Execution_compute(execution);
 
   // TODO: Maybe skip this for fixed-size outputs?
-  for (size_t i = 0; i < outputs.size(); i++) {
+  for (const auto i : c10::irange(outputs.size())) {
     auto& t = outputs[i];
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint32_t rank;

--- a/aten/src/ATen/test/apply_utils_test.cpp
+++ b/aten/src/ATen/test/apply_utils_test.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/CPUApplyUtils.h>
 #include <ATen/test/test_assert.h>
+#include <c10/util/irange.h>
 
 #include <iostream>
 using namespace std;
@@ -10,7 +11,7 @@ using namespace at;
 
 void fill_tensor(int64_t scalar, Tensor& t_) {
   auto t = t_.view(-1);
-  for (int64_t i = 0; i < t.numel(); i++) {
+  for (const auto i : c10::irange(t.numel())) {
     t[i] = (i + 1) * scalar;
   }
 }
@@ -42,7 +43,7 @@ void test(DeprecatedTypeProperties& type, IntArrayRef shape, int64_t a = 0, int6
   auto a4 = at::empty({0}, at::TensorOptions(kCPU).dtype(kDouble));
 
   std::vector<Tensor> tensors({a0, a1, a2, a3, a4});
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     tensors[i].resize_(shape);
     fill_tensor(i + 1, tensors[i]);
     if (a >= 0 && b >= 0) {
@@ -55,7 +56,7 @@ void test(DeprecatedTypeProperties& type, IntArrayRef shape, int64_t a = 0, int6
         a0, a1, [](scalar_t& y, const scalar_t& x) { y = x * x; });
     CPU_tensor_apply2<double, scalar_t>(
         a4, a1, [](double& y, scalar_t x) { y = (double)(x * x); });
-    for (int64_t i = 0; i < a0.numel(); i++) {
+    for (const auto i : c10::irange(a0.numel())) {
       auto target = a1.data_ptr<scalar_t>()[i] * a1.data_ptr<scalar_t>()[i];
       ASSERT(a0.data_ptr<scalar_t>()[i] == target);
       ASSERT(a4.data_ptr<double>()[i] == target);
@@ -71,7 +72,7 @@ void test(DeprecatedTypeProperties& type, IntArrayRef shape, int64_t a = 0, int6
         a4, a1, a2, [](double& y, const scalar_t& x, const scalar_t& z) {
           y = (double)(x * x + z);
         });
-    for (int64_t i = 0; i < a0.numel(); i++) {
+    for (const auto i : c10::irange(a0.numel())) {
       auto target = a1.data_ptr<scalar_t>()[i] * a1.data_ptr<scalar_t>()[i];
       target = target + a2.data_ptr<scalar_t>()[i];
       ASSERT(a0.data_ptr<scalar_t>()[i] == target);
@@ -97,7 +98,7 @@ void test(DeprecatedTypeProperties& type, IntArrayRef shape, int64_t a = 0, int6
         [](double& y, const scalar_t& x, const scalar_t& z, const scalar_t& a) {
           y = (double)(x * x + z * a);
         });
-    for (int64_t i = 0; i < a0.numel(); i++) {
+    for (const auto i : c10::irange(a0.numel())) {
       auto target = a1.data_ptr<scalar_t>()[i] * a1.data_ptr<scalar_t>()[i];
       target = target + a2.data_ptr<scalar_t>()[i] * a3.data_ptr<scalar_t>()[i];
       ASSERT(a0.data_ptr<scalar_t>()[i] == target);

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 #include <iostream>
 using namespace std;
@@ -102,7 +103,7 @@ void trace() {
   auto foo_a = foo.accessor<float, 2>();
   float trace = 0;
 
-  for (int i = 0; i < foo_a.size(0); i++) {
+  for (const auto i : c10::irange(foo_a.size(0))) {
     trace += foo_a[i][i];
   }
 
@@ -237,8 +238,8 @@ TEST_F(atest, atest) {
   // foo = foo[3];
   auto foo_v = foo.accessor<uint8_t, 2>();
 
-  for (int i = 0; i < foo_v.size(0); i++) {
-    for (int j = 0; j < foo_v.size(1); j++) {
+  for (const auto i : c10::irange(foo_v.size(0))) {
+    for (const auto j : c10::irange(foo_v.size(1))) {
       foo_v[i][j]++;
     }
   }

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -4,6 +4,7 @@
 #include <ATen/core/Reduction.h>
 #include <torch/cuda.h>
 #include <ATen/test/test_assert.h>
+#include <c10/util/irange.h>
 
 // for TH compat test only...
 struct THFloatTensor;
@@ -84,7 +85,7 @@ void TestAdd(DeprecatedTypeProperties& type) {
 void TestZeros(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor a = zeros({1024, 1024}, type);
-  for (int i = 1; i < 1000; ++i) {
+  for (const auto i : c10::irange(1, 1000)) {
     a = zeros({128, 128}, type);
   }
   auto end = std::chrono::high_resolution_clock::now();
@@ -102,7 +103,7 @@ void TestLoadsOfAdds(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor d = ones({3, 4}, type);
   Tensor r = zeros({3, 4}, type);
-  for (auto i = 0; i < 100000; i++) {
+  for (const auto i : c10::irange(100000)) {
     add_out(r, r, d);
   }
   auto end = std::chrono::high_resolution_clock::now();
@@ -119,7 +120,7 @@ void TestLoadOfAddsWithCopy(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor d = ones({3, 4}, type);
   Tensor r = zeros({3, 4}, type);
-  for (auto i = 0; i < 100000; i++) {
+  for (const auto i : c10::irange(100000)) {
     r = add(r, d);
   }
   auto end = std::chrono::high_resolution_clock::now();
@@ -176,7 +177,7 @@ void TestCopyBroadcasting(DeprecatedTypeProperties& type) {
   Tensor a = zeros({4, 3}, type);
   Tensor e = rand({3}, type);
   a.copy_(e);
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_TRUE(a[i].equal(e));
   }
 }
@@ -247,13 +248,13 @@ void TestToString() {
 void TestIndexingByScalar() {
   Tensor tensor = arange(0, 10, kInt);
   Tensor one = ones({}, kInt);
-  for (int64_t i = 0; i < tensor.numel(); ++i) {
+  for (const auto i : c10::irange(tensor.numel())) {
     ASSERT_TRUE(tensor[i].equal(one * i));
   }
   for (size_t i = 0; i < static_cast<uint64_t>(tensor.numel()); ++i) {
     ASSERT_TRUE(tensor[i].equal(one * static_cast<int64_t>(i)));
   }
-  for (int i = 0; i < tensor.numel(); ++i) {
+  for (const auto i : c10::irange(tensor.numel())) {
     ASSERT_TRUE(tensor[i].equal(one * i));
   }
   // NOLINTNEXTLINE(bugprone-too-small-loop-variable)
@@ -272,7 +273,7 @@ void TestIndexingByScalar() {
 void TestIndexingByZerodimTensor() {
   Tensor tensor = arange(0, 10, kInt);
   Tensor one = ones({}, kInt);
-  for (int i = 0; i < tensor.numel(); ++i) {
+  for (const auto i : c10::irange(tensor.numel())) {
     ASSERT_TRUE(tensor[one * i].equal(one * i));
   }
   // Throw StartsWith(

--- a/aten/src/ATen/test/cpu_generator_test.cpp
+++ b/aten/src/ATen/test/cpu_generator_test.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Utils.h>
 #include <ATen/CPUGeneratorImpl.h>
 #include <ATen/core/PhiloxRNGEngine.h>
+#include <c10/util/irange.h>
 #include <thread>
 #include <limits>
 #include <random>
@@ -160,7 +161,7 @@ TEST(CPUGeneratorImpl, TestPhiloxEngineOffset1) {
   // So if you want to skip 8 values, offset would
   // be 2, since 2*4=8.
   at::Philox4_32_10 engine2(123, 1, 2);
-  for(int i = 0; i < 8; i++){
+  for (const auto i : c10::irange(8)) {
     // Note: instead of using the engine() call 8 times
     // we could have achieved the same functionality by
     // calling the incr() function twice.
@@ -221,14 +222,14 @@ TEST(CPUGeneratorImpl, TestMT19937EngineReproducibility) {
   // test with zero seed
   at::mt19937 engine1(0);
   std::mt19937 engine2(0);
-  for(int i = 0; i < 10000; i++) {
+  for (const auto i : c10::irange(10000)) {
     ASSERT_EQ(engine1(), engine2());
   }
 
   // test with large seed
   engine1 = at::mt19937(2147483647);
   engine2 = std::mt19937(2147483647);
-  for(int i = 0; i < 10000; i++) {
+  for (const auto i : c10::irange(10000)) {
     ASSERT_EQ(engine1(), engine2());
   }
 
@@ -237,7 +238,7 @@ TEST(CPUGeneratorImpl, TestMT19937EngineReproducibility) {
   auto seed = rd();
   engine1 = at::mt19937(seed);
   engine2 = std::mt19937(seed);
-  for(int i = 0; i < 10000; i++) {
+  for (const auto i : c10::irange(10000)) {
     ASSERT_EQ(engine1(), engine2());
   }
 

--- a/aten/src/ATen/test/cuda_tensor_interop_test.cpp
+++ b/aten/src/ATen/test/cuda_tensor_interop_test.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/util/irange.h>
 #include <caffe2/core/init.h>
 #include <caffe2/core/operator.h>
 #include <caffe2/core/context_gpu.h>
@@ -34,7 +35,7 @@ TEST(CUDACaffe2ToPytorch, SimpleLegacy) {
 
   auto at_cpu = at_tensor.cpu();
   auto it = at_cpu.data_ptr<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(it[i], 777);
   }
 }
@@ -53,7 +54,7 @@ TEST(CUDACaffe2ToPytorch, Simple) {
 
   auto at_cpu = at_tensor.cpu();
   auto it = at_cpu.data_ptr<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(it[i], 777);
   }
 }
@@ -109,7 +110,7 @@ TEST(CUDAPytorchToCaffe2, Op) {
   ASSERT_EQ(result.GetDeviceType(), caffe2::CUDA);
 
   auto data = result.data<float>();
-  for (int64_t i = 0; i < 25; i++) {
+  for (const auto i : c10::irange(25)) {
     ASSERT_EQ(cuda_get(data + i), 3.0);
   }
   at::Tensor at_result(result);

--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <torch/torch.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/irange.h>
 #include <ATen/core/Dict.h>
 
 // Snippets for checking assembly.
@@ -640,7 +641,7 @@ TEST(IValueTest, IdentityComparisonAndHashing) {
   auto moreSampleIValues = makeMoreSampleIValues();
 
   ASSERT_EQ(sampleIValues.size(), moreSampleIValues.size());
-  for (int ii = 0; ii < sampleIValues.size(); ++ii) {
+  for (const auto ii : c10::irange(sampleIValues.size())) {
     if (sampleIValues[ii].isComplexDouble() ||
         sampleIValues[ii].isBlob() ||
         sampleIValues[ii].isList() ||

--- a/aten/src/ATen/test/math_kernel_test.cpp
+++ b/aten/src/ATen/test/math_kernel_test.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/CPUFunctions.h>
+#include <c10/util/irange.h>
 
 using namespace at;
 
@@ -115,7 +116,7 @@ TEST(MathKernelTest, MishBackward) {
 
 TEST(MathKernelTest, NarrowCopy)  {
   auto x = rand({5, 8, 7});
-  for (int64_t dim = 0; dim < 3; ++dim) {
+  for (const auto dim : c10::irange(3)) {
     const int64_t start = 1, length = 4;
     auto y_ref = x.narrow(dim, start, length);
     auto y_test = at::native::narrow_copy_dense(x, dim, start, length);

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 using namespace at;
 
@@ -16,7 +17,7 @@ using namespace at;
 
 void requireEqualTensorList(TensorList t1, TensorList t2) {
   ASSERT_EQ(t1.size(), t2.size());
-  for (size_t i = 0; i < t1.size(); ++i) {
+  for (const auto i : c10::irange(t1.size())) {
     ASSERT_EQUAL(t1[i], t2[i]);
   }
 }
@@ -74,7 +75,7 @@ void TestStack(TensorOptions T, Tensor& t) {
     auto z = rand({2, 3, 4});
 
     auto inputs = {x, y, z};
-    for (int64_t dim = 0; dim < 4; ++dim) {
+    for (const auto dim : c10::irange(4)) {
       _test_stack(inputs, dim, at::stack);
     }
   }
@@ -85,7 +86,7 @@ void TestStack(TensorOptions T, Tensor& t) {
     auto z = rand({2, 3, 4});
 
     auto inputs = {x, y, z};
-    for (int64_t dim = 0; dim < 4; ++dim) {
+    for (const auto dim : c10::irange(4)) {
       _test_stack(inputs, dim, at::native::_stack);
     }
   }
@@ -96,7 +97,7 @@ void TestStack(TensorOptions T, Tensor& t) {
     auto z = rand({2, 3, 4});
 
     auto inputs = {x, y, z};
-    for (int64_t dim = 0; dim < 4; ++dim) {
+    for (const auto dim : c10::irange(4)) {
       _test_stack(inputs, dim, at::native::_stack_cpu);
     }
   }

--- a/aten/src/ATen/test/packedtensoraccessor_test.cpp
+++ b/aten/src/ATen/test/packedtensoraccessor_test.cpp
@@ -1,6 +1,7 @@
 #include <ATen/Operators.h>
 #include <ATen/test/test_assert.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
@@ -34,7 +35,7 @@ TEST(PackedtensoraccessorTest, TransposeTest) {
   t = rand({size}, CPU(kFloat));
   auto original_1d = t.packed_accessor64<float, 1, DefaultPtrTraits>();
   auto transposed_1d = original_1d.transpose(0, 0);
-  for (int i = 0; i < size; i++){
+  for (const auto i : c10::irange(size)) {
     ASSERT_EQ(original_1d[i], transposed_1d[i]);
   }
 

--- a/aten/src/ATen/test/pow_test.cpp
+++ b/aten/src/ATen/test/pow_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/native/Pow.h>
+#include <c10/util/irange.h>
 
 #include <torch/types.h>
 #include <torch/utils.h>
@@ -203,7 +204,7 @@ void tensor_pow_tensor(const Vals vals, c10::ScalarType vals_dtype, Pows pows, c
   std::cout.precision(dbl::max_digits10);
 
   const auto vals_tensor = torch::tensor(vals, vals_dtype);
-  for (size_t shift = 0; shift < pows.size(); shift++) {
+  for (const auto shift : c10::irange(pows.size())) {
     const auto pows_tensor = torch::tensor(pows, pows_dtype);
 
     const auto actual_pow = vals_tensor.pow(pows_tensor);

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -11,6 +11,7 @@
 // For quantize_val
 #include <ATen/native/quantized/affine_quantizer.h>
 #include <c10/core/ScalarType.h>
+#include <c10/util/irange.h>
 #include <ATen/quantized/Quantizer.h>
 
 using namespace at;
@@ -30,14 +31,14 @@ TEST(TestQTensor, QuantDequantAPIs) {
   // int_repr
   Tensor int_repr = qr.int_repr();
   auto* int_repr_data = int_repr.data_ptr<uint8_t>();
-  for (auto i = 0; i < num_elements; ++i) {
+  for (const auto i : c10::irange(num_elements)) {
     ASSERT_EQ(int_repr_data[i], 3);
   }
 
   // Check for correct quantization
   auto r_data = r.data_ptr<float>();
   auto qr_data = qr.data_ptr<quint8>();
-  for (auto i = 0; i < num_elements; ++i) {
+  for (const auto i : c10::irange(num_elements)) {
     ASSERT_EQ(
         native::quantize_val<quint8>(scale, zero_point, r_data[i]).val_,
         qr_data[i].val_);
@@ -46,10 +47,10 @@ TEST(TestQTensor, QuantDequantAPIs) {
   // Check for correct dequantization
   Tensor rqr = qr.dequantize();
   auto rqr_data = rqr.data_ptr<float>();
-  for (auto i = 0; i < num_elements; ++i) {
+  for (const auto i : c10::irange(num_elements)) {
     ASSERT_EQ(r_data[i], rqr_data[i]);
   }
-  for (auto i = 0; i < num_elements; ++i) {
+  for (const auto i : c10::irange(num_elements)) {
     ASSERT_EQ(
         r_data[i],
         native::dequantize_val(qr.q_scale(), qr.q_zero_point(), qr_data[i]));
@@ -60,7 +61,7 @@ TEST(TestQTensor, QuantDequantAPIs) {
   int64_t new_zero_point = 1;
   Tensor reqr = at::quantize_per_tensor(r, new_scale, new_zero_point, kQInt8);
   auto reqr_data = reqr.data_ptr<qint8>();
-  for (auto i = 0; i < num_elements; ++i) {
+  for (const auto i : c10::irange(num_elements)) {
     reqr_data[i].val_ =
         native::requantize_val<quint8, qint8>(
             scale, zero_point, new_scale, new_zero_point, qr_data[i])
@@ -85,7 +86,7 @@ TEST(TestQTensor, RoundingMode) {
   Tensor qx = at::quantize_per_tensor(x, /*scale=*/1.0, zero_point, kQUInt8);
 
   auto qx_data = qx.data_ptr<quint8>();
-  for (size_t idx = 0; idx < x_values.size(); ++idx) {
+  for (const auto idx : c10::irange(x_values.size())) {
     ASSERT_EQ(qx_expect[idx], qx_data[idx].val_)
         << "Tie breaking during rounding element " << idx << " failed!";
   }
@@ -108,14 +109,14 @@ TEST(TestQTensor, EmptyQuantized) {
       {numel}, at::device(at::kCPU).dtype(kQUInt8), scale, zero_point);
   // Assigning to QTensor
   auto* q_data = q.data_ptr<quint8>();
-  for (int i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     q_data[i].val_ = val;
   }
 
   // dequantize
   auto r = q.dequantize();
   auto* r_data = r.data_ptr<float>();
-  for (int i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     ASSERT_EQ(r_data[i], (val - zero_point) * scale);
   }
 }
@@ -134,14 +135,14 @@ TEST(TestQTensor, EmptyPerchannelQuantized) {
       at::device(at::kCPU).dtype(kQUInt8));
   // Assigning to QTensor
   auto* q_data = q.data_ptr<quint8>();
-  for (int i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     q_data[i].val_ = val;
   }
 
   // dequantize
   auto r = q.dequantize();
   auto* r_data = r.data_ptr<float>();
-  for (int i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     ASSERT_EQ(
         r_data[i],
         (val - zero_points[i].item().to<int>()) * scales[i].item().to<float>());
@@ -222,7 +223,7 @@ TEST(TestQTensor, FromBlobQuantizedPerTensor) {
   custom_vec->reserve(numel);
 
   uint8_t* custom_data = custom_vec->data();
-  for (auto i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     custom_data[i] = i;
   }
   bool customDataDeleted{false};
@@ -236,7 +237,7 @@ TEST(TestQTensor, FromBlobQuantizedPerTensor) {
   Tensor qtensor = at::from_blob_quantized_per_tensor_affine(custom_data, shape, deleter, scale, zero_point, options);
 
   uint8_t* q_data = (uint8_t*)qtensor.data_ptr<quint8>();
-  for (auto i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     ASSERT_EQ((int)custom_data[i], (int)q_data[i]);
   }
   ASSERT_EQ((float)qtensor.q_scale(), (float)scale);
@@ -258,7 +259,7 @@ TEST(TestQTensor, FromBlobQuantizedPerChannel) {
   custom_vec->reserve(numel);
 
   uint8_t* custom_data = custom_vec->data();
-  for (auto i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     custom_data[i] = i;
   }
   bool customDataDeleted{false};
@@ -271,7 +272,7 @@ TEST(TestQTensor, FromBlobQuantizedPerChannel) {
   {
   Tensor qtensor = at::from_blob_quantized_per_channel_affine(custom_data, shape, deleter, scales, zero_points, ch_axis, options);
   uint8_t* q_data = (uint8_t*)qtensor.data_ptr<quint8>();
-  for (auto i = 0; i < numel; ++i) {
+  for (const auto i : c10::irange(numel)) {
     ASSERT_EQ((int)custom_data[i], (int)q_data[i]);
   }
   ASSERT_TRUE(at::allclose(qtensor.q_per_channel_scales(), scales));

--- a/aten/src/ATen/test/tensor_interop_test.cpp
+++ b/aten/src/ATen/test/tensor_interop_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 #include <caffe2/core/init.h>
 #include <caffe2/core/operator.h>
 
@@ -8,13 +9,13 @@ TEST(Caffe2ToPytorch, SimpleLegacy) {
   caffe2::Tensor c2_tensor(caffe2::CPU);
   c2_tensor.Resize(4, 4);
   auto data = c2_tensor.mutable_data<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     data[i] = i;
   }
   at::Tensor at_tensor(c2_tensor);
 
   auto it = at_tensor.data_ptr<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(it[i], i);
   }
 }
@@ -22,13 +23,13 @@ TEST(Caffe2ToPytorch, SimpleLegacy) {
 TEST(Caffe2ToPytorch, Simple) {
   caffe2::Tensor c2_tensor = caffe2::empty({4, 4}, at::kLong);
   auto data = c2_tensor.mutable_data<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     data[i] = i;
   }
   at::Tensor at_tensor(c2_tensor);
 
   auto it = at_tensor.data_ptr<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(it[i], i);
   }
 }
@@ -37,7 +38,7 @@ TEST(Caffe2ToPytorch, ExternalData) {
   caffe2::Tensor c2_tensor = caffe2::empty({4, 4}, at::kLong);
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers)
   int64_t buf[16];
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     buf[i] = i;
   }
   c2_tensor.ShareExternalPointer(buf, 16 * sizeof(int64_t));
@@ -48,7 +49,7 @@ TEST(Caffe2ToPytorch, ExternalData) {
   at_tensor.permute({1, 0});
   at_tensor.permute({1, 0});
   auto it = at_tensor.data_ptr<int64_t>();
-  for (int64_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(it[i], i);
   }
   ASSERT_FALSE(at_tensor.storage().resizable());
@@ -60,7 +61,7 @@ TEST(Caffe2ToPytorch, Op) {
   caffe2::Tensor c2_tensor(caffe2::CPU);
   c2_tensor.Resize(3, 3);
   auto data = c2_tensor.mutable_data<int64_t>();
-  for (int64_t i = 0; i < 9; i++) {
+  for (const auto i : c10::irange(9)) {
     data[i] = i;
   }
   at::Tensor at_tensor(c2_tensor);
@@ -107,7 +108,7 @@ TEST(Caffe2ToPytorch, PartiallyInitialized) {
 TEST(Caffe2ToPytorch, MutualResizes) {
   caffe2::Tensor c2_tensor = caffe2::empty({5, 5}, at::kFloat);
   auto data = c2_tensor.mutable_data<float>();
-  for (int64_t i = 0; i < 25; i++) {
+  for (const auto i : c10::irange(25)) {
     data[i] = 0;
   }
 
@@ -171,7 +172,7 @@ TEST(PytorchToCaffe2, Op) {
   auto result = XBlobGetMutableTensor(workspace.CreateBlob("d"), {5, 5}, at::kCPU);
 
   auto it = result.data<float>();
-  for (int64_t i = 0; i < 25; i++) {
+  for (const auto i : c10::irange(25)) {
     ASSERT_EQ(it[i], 3.0);
   }
   at::Tensor at_result(result);
@@ -202,7 +203,7 @@ TEST(PytorchToCaffe2, SharedStorageRead) {
 
   auto result = XBlobGetMutableTensor(workspace.CreateBlob("c"), {5, 5}, at::kCPU);
   auto it = result.data<float>();
-  for (int64_t i = 0; i < 25; i++) {
+  for (const auto i : c10::irange(25)) {
     ASSERT_EQ(it[i], 2.0);
   }
   at::Tensor at_result(result);
@@ -259,7 +260,7 @@ TEST(PytorchToCaffe2, Strided) {
   ASSERT_ANY_THROW(caffe2::Tensor c2_tensor(at_tensor));
   // but calling contiguous is fine
   caffe2::Tensor c2_tensor(at_tensor.contiguous());
-  for (int64_t i = 0; i < 25; i++) {
+  for (const auto i : c10::irange(25)) {
     ASSERT_EQ(c2_tensor.data<float>()[i], 1.0);
   }
 }

--- a/aten/src/ATen/test/thread_init_test.cpp
+++ b/aten/src/ATen/test/thread_init_test.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/test_base.h>
 #include <thread>
 
@@ -13,7 +14,7 @@ void test(int given_num_threads) {
   ASSERT_TRUE(given_num_threads >= 0);
   ASSERT_EQ(at::get_num_threads(), given_num_threads);
   auto t_sum = t.sum();
-  for (int i = 0; i < 1000; ++i) {
+  for (const auto i : c10::irange(1000)) {
     t_sum = t_sum + t.sum();
   }
 }

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -1,4 +1,5 @@
 #include <ATen/test/vec_test_all_types.h>
+#include <c10/util/irange.h>
 namespace {
 #if GTEST_HAS_TYPED_TEST
     template <typename T>
@@ -455,7 +456,7 @@ namespace {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         CACHE_ALIGN VT expected_vals[vec::size()];
         auto vals = 1 << (vec::size());
-        for (int val = 0; val < vals; ++val) {
+        for (const auto val : c10::irange(vals)) {
           for (int i = 0; i < vec::size(); ++i) {
             if (val & (1 << i)) {
               test_vals[i] = std::numeric_limits<VT>::quiet_NaN();
@@ -747,7 +748,7 @@ namespace {
         CACHE_ALIGN VT test_vals[vec::size()];
         //all sets will be within 0  2^(n-1)
         auto power_sets = 1 << (vec::size());
-        for (int expected = 0; expected < power_sets; expected++) {
+        for (const auto expected : c10::irange(power_sets)) {
             // generate test_val based on expected
             for (int i = 0; i < vec::size(); ++i)
             {
@@ -894,7 +895,7 @@ namespace {
     void blend_init(T(&a)[N], T(&b)[N]) {
         a[0] = (T)1.0;
         b[0] = a[0] + (T)N;
-        for (int i = 1; i < N; i++) {
+        for (const auto i : c10::irange(1, N)) {
             a[i] = a[i - 1] + (T)(1.0);
             b[i] = b[i - 1] + (T)(1.0);
         }
@@ -905,7 +906,7 @@ namespace {
         auto add = Complex<float>(1., 100.);
         a[0] = Complex<float>(1., 100.);
         b[0] = Complex<float>(5., 1000.);
-        for (int i = 1; i < 4; i++) {
+        for (const auto i : c10::irange(1, 4)) {
             a[i] = a[i - 1] + add;
             b[i] = b[i - 1] + add;
         }
@@ -1051,7 +1052,8 @@ namespace {
         float minv = static_cast<float>(static_cast<double>(min_val) * 2.0);
         float maxv = static_cast<float>(static_cast<double>(max_val) * 2.0);
         ValueGen<float> gen(minv, maxv, seed.add(2));
-        for (int i = 0; i < trials; i++) {
+        for (const auto i : c10::irange(trials)) {
+            (void)i; // Suppress unused variable warning
             float scale = generator_sc.get();
             float inv_scale = 1.0f / static_cast<float>(scale);
             auto zero_point_val = generator_zp.get();
@@ -1088,7 +1090,8 @@ namespace {
         ValueGen<int> generator(min_val, max_val, seed.add(1));
         //scale
         ValueGen<float> generator_sc(1.f, 15.f, seed.add(2));
-        for (int i = 0; i < trials; i++) {
+        for (const auto i : c10::irange(trials)) {
+            (void)i; // Suppress unused variable warning
             float scale = generator_sc.get();
             int32_t zero_point_val = generator.get();
             float scale_zp_premul = -(scale * zero_point_val);
@@ -1135,7 +1138,8 @@ namespace {
         ValueGen<int32_t> generator(min_val, max_val, seed);
         //scale
         ValueGen<float> generator_sc(1.f, 15.f, seed.add(1));
-        for (int i = 0; i < trials; i++) {
+        for (const auto i : c10::irange(trials)) {
+            (void)i; // Suppress unused variable warning
             float multiplier = 1.f / (generator_sc.get());
             auto zero_point_val = generator.get();
             int index = 0;
@@ -1172,7 +1176,8 @@ namespace {
         typename vec::int_vec_return_type  expected_int_ret;
         auto seed = TestSeed();
         ValueGen<underlying> generator(min_val, max_val, seed);
-        for (int i = 0; i < trials; i++) {
+        for (const auto i : c10::irange(trials)) {
+            (void)i; // Suppress unused variable warning
             //generate vals
             for (int j = 0; j < vec::size(); j++) {
                 qint_vals[j] = generator.get();
@@ -1251,7 +1256,7 @@ namespace {
         CACHE_ALIGN VT ref_y[N];
         auto seed = TestSeed();
         ValueGen<VT> generator(VT(-100), VT(100), seed);
-        for (int64_t i = 0; i < N; i++) {
+        for (const auto i : c10::irange(N)) {
           x1[i] = generator.get();
           x2[i] = generator.get();
           x3[i] = generator.get();
@@ -1263,19 +1268,19 @@ namespace {
         };
         // test map: y = x1
         at::vec::map<VT>([](vec x) { return x; }, y, x1, N);
-        for (int64_t i = 0; i < N; i++) { ref_y[i] = x1[i]; }
+        for (const auto i : c10::irange(N)) { ref_y[i] = x1[i]; }
         cmp(y, ref_y);
         // test map2: y = x1 + x2
         at::vec::map2<VT>([](vec x1, vec x2) { return x1 + x2; }, y, x1, x2, N);
-        for (int64_t i = 0; i < N; i++) { ref_y[i] = x1[i] + x2[i]; }
+        for (const auto i : c10::irange(N)) { ref_y[i] = x1[i] + x2[i]; }
         cmp(y, ref_y);
         // test map3: y = x1 + x2 + x3
         at::vec::map3<VT>([](vec x1, vec x2, vec x3) { return x1 + x2 + x3; }, y, x1, x2, x3, N);
-        for (int64_t i = 0; i < N; i++) { ref_y[i] = x1[i] + x2[i] + x3[i]; }
+        for (const auto i : c10::irange(N)) { ref_y[i] = x1[i] + x2[i] + x3[i]; }
         cmp(y, ref_y);
         // test map4: y = x1 + x2 + x3 + x4
         at::vec::map4<VT>([](vec x1, vec x2, vec x3, vec x4) { return x1 + x2 + x3 + x4; }, y, x1, x2, x3, x4, N);
-        for (int64_t i = 0; i < N; i++) { ref_y[i] = x1[i] + x2[i] + x3[i] + x4[i]; }
+        for (const auto i : c10::irange(N)) { ref_y[i] = x1[i] + x2[i] + x3[i] + x4[i]; }
         cmp(y, ref_y);
     }
       TYPED_TEST(FunctionalBF16Tests, Reduce) {
@@ -1294,7 +1299,7 @@ namespace {
       CACHE_ALIGN VT x_b3[N];
       auto seed = TestSeed();
       ValueGen<RT> generator(RT(-1), RT(1), seed);
-      for (int64_t i = 0; i < N; i++) {
+      for (const auto i : c10::irange(N)) {
         x_f1[i] = generator.get();
         x_f2[i] = generator.get();
         x_f3[i] = generator.get();
@@ -1362,7 +1367,7 @@ namespace {
       CACHE_ALIGN VT y_b[N];
       auto seed = TestSeed();
       ValueGen<RT> generator(RT(-1), RT(1), seed);
-      for (int64_t i = 0; i < N; i++) {
+      for (const auto i : c10::irange(N)) {
         x_f1[i] = generator.get();
         x_f2[i] = generator.get();
         x_f3[i] = generator.get();
@@ -1379,7 +1384,7 @@ namespace {
       for (int64_t len = 1; len <= N; len++) {
         at::vec::map<RT>([](auto x) { return x; }, y_f, x_f1, len);
         at::vec::map<VT>([](auto x) { return x; }, y_b, x_b1, len);
-        for (int64_t i = 0; i < len; i++) {
+        for (const auto i : c10::irange(len)) {
           ASSERT_TRUE(cmp(y_f[i], y_b[i])) << "Failure Details:\nTest Seed to reproduce: " << seed
               << "\nmap, Length: " << len << "; index: " << i << "; fp32 reference: " << y_f[i] << "; bf16 value: " << RT(y_b[i]);
         }
@@ -1388,7 +1393,7 @@ namespace {
       for (int64_t len = 1; len <= N; len++) {
         at::vec::map2<RT>([](auto x, auto y) { return x + y; }, y_f, x_f1, x_f2, len);
         at::vec::map2<VT>([](auto x, auto y) { return x + y; }, y_b, x_b1, x_b2, len);
-        for (int64_t i = 0; i < len; i++) {
+        for (const auto i : c10::irange(len)) {
           ASSERT_TRUE(cmp(y_f[i], y_b[i])) << "Failure Details:\nTest Seed to reproduce: " << seed
               << "\nmap2, Length: " << len << "; index: " << i << "; fp32 reference: " << y_f[i] << "; bf16 value: " << RT(y_b[i]);
         }
@@ -1397,7 +1402,7 @@ namespace {
       for (int64_t len = 1; len <= N; len++) {
         at::vec::map3<RT>([](auto x, auto y, auto z) { return x + y * z; }, y_f, x_f1, x_f2, x_f3, len);
         at::vec::map3<VT>([](auto x, auto y, auto z) { return x + y * z; }, y_b, x_b1, x_b2, x_b3, len);
-        for (int64_t i = 0; i < len; i++) {
+        for (const auto i : c10::irange(len)) {
           ASSERT_TRUE(cmp(y_f[i], y_b[i])) << "Failure Details:\nTest Seed to reproduce: " << seed
               << "\nmap3, Length: " << len << "; index: " << i << "; fp32 reference: " << y_f[i] << "; bf16 value: " << RT(y_b[i]);
         }
@@ -1406,7 +1411,7 @@ namespace {
       for (int64_t len = 1; len <= N; len++) {
          at::vec::map4<RT>([](auto x, auto y, auto z, auto w) { return x + y * z - w; }, y_f, x_f1, x_f2, x_f3, x_f4, len);
          at::vec::map4<VT>([](auto x, auto y, auto z, auto w) { return x + y * z - w; }, y_b, x_b1, x_b2, x_b3, x_b4, len);
-         for (int64_t i = 0; i < len; i++) {
+         for (const auto i : c10::irange(len)) {
            ASSERT_TRUE(cmp(y_f[i], y_b[i])) << "Failure Details:\nTest Seed to reproduce: " << seed
                << "\nmap4, Length: " << len << "; index: " << i << "; fp32 reference: " << y_f[i] << "; bf16 value: " << RT(y_b[i]);
          }

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/cpu/vec/functional.h>
+#include <c10/util/irange.h>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <exception>
@@ -869,8 +870,7 @@ public:
         act.store(actArr);
         if (bitwise)
         {
-            for (int i = 0; i < sizeX; i++)
-            {
+            for (const auto i : c10::irange(sizeX)) {
                 BVT b_exp = bit_cast<BVT>(expArr[i]);
                 BVT b_act = bit_cast<BVT>(actArr[i]);
                 EXPECT_EQ(b_exp, b_act) << getDetail(i / unitStorageCount);
@@ -880,8 +880,7 @@ public:
         }
         else if (checkWithTolerance)
         {
-            for (int i = 0; i < sizeX; i++)
-            {
+            for (const auto i : c10::irange(sizeX)) {
                 EXPECT_EQ(nearlyEqual<UVT>(expArr[i], actArr[i], absErr), true) << expArr[i] << "!=" << actArr[i] << "\n" << getDetail(i / unitStorageCount);
                 if (::testing::Test::HasFailure())
                     return true;
@@ -889,8 +888,7 @@ public:
         }
         else
         {
-            for (int i = 0; i < sizeX; i++)
-            {
+            for (const auto i : c10::irange(sizeX)) {
                 if (std::is_same<UVT, float>::value)
                 {
                     if (!check_both_nan(expArr[i], actArr[i])) {
@@ -952,8 +950,9 @@ void test_unary(
         UVT start = dmn_argc > 0 ? dmn.ArgsDomain[0].start : default_start;
         UVT end = dmn_argc > 0 ? dmn.ArgsDomain[0].end : default_end;
         ValueGen<VT> generator(start, end, seed.add(changeSeedBy));
-        for (int trial = 0; trial < trialCount; trial++) {
-            for (int k = 0; k < el_count; k++) {
+        for (const auto trial : c10::irange(trialCount)) {
+            (void)trial; // Suppress unused variable warning
+            for (const auto k : c10::irange(el_count)) {
                 vals[k] = generator.get();
                 call_filter(filter, vals[k]);
                 //map operator
@@ -1011,8 +1010,9 @@ void test_binary(
         UVT end1 = dmn_argc > 1 ? dmn.ArgsDomain[1].end : default_end;
         ValueGen<VT> generator0(start0, end0, seed.add(changeSeedBy));
         ValueGen<VT> generator1(start1, end1, seed.add(changeSeedBy + 1));
-        for (int trial = 0; trial < trialCount; trial++) {
-            for (int k = 0; k < el_count; k++) {
+        for (const auto trial : c10::irange(trialCount)) {
+            (void)trial; // Suppress unused variable warning
+            for (const auto k : c10::irange(el_count)) {
                 vals0[k] = generator0.get();
                 vals1[k] = generator1.get();
                 call_filter(filter, vals0[k], vals1[k]);
@@ -1076,8 +1076,9 @@ void test_ternary(
         ValueGen<VT> generator1(start1, end1, seed.add(changeSeedBy + 1));
         ValueGen<VT> generator2(start2, end2, seed.add(changeSeedBy + 2));
 
-        for (int trial = 0; trial < trialCount; trial++) {
-            for (int k = 0; k < el_count; k++) {
+        for (const auto trial : c10::irange(trialCount)) {
+            (void)trial; // Suppress unused variable warning
+            for (const auto k : c10::irange(el_count)) {
                 vals0[k] = generator0.get();
                 vals1[k] = generator1.get();
                 vals2[k] = generator2.get();

--- a/aten/src/ATen/test/vitals.cpp
+++ b/aten/src/ATen/test/vitals.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/Vitals.h>
+#include <c10/util/irange.h>
 #include <cstdlib>
 
 using namespace at::vitals;
@@ -62,7 +63,7 @@ TEST(Vitals, MultiString) {
 }
 
 TEST(Vitals, OnAndOff) {
-  for (auto i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     std::stringstream buffer;
 
     std::streambuf* sbuf = std::cout.rdbuf();

--- a/aten/src/ATen/test/vmap_test.cpp
+++ b/aten/src/ATen/test/vmap_test.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/BatchedTensorImpl.h>
 #include <ATen/VmapTransforms.h>
+#include <c10/util/irange.h>
 
 using namespace at;
 
@@ -55,7 +56,7 @@ TEST(VmapTest, TestBatchedTensor) {
 // returns {{lvl=0,dim=0}, {lvl=1,dim=1}, ..., {lvl=kVmapNumLevels-1,dim=kVmapNumLevels-1}};
 static BatchDims maxBatchDimsAtFront() {
   BatchDims result;
-  for (int64_t lvl = 0; lvl < kVmapNumLevels; lvl++) {
+  for (const auto lvl : c10::irange(kVmapNumLevels)) {
     result.emplace_back(lvl, /*dim=*/lvl);
   }
   return result;
@@ -169,7 +170,7 @@ TEST(VmapTest, TestBatchedTensorActualDim) {
   {
     // ActualDim on kVmapMaxTensorDims sized underlying tensor
     auto tensor = ones({});
-    for (int64_t i = 0; i < kVmapMaxTensorDims; i++) {
+    for (const auto i : c10::irange(kVmapMaxTensorDims)) {
       tensor = tensor.unsqueeze(0);
     }
     ASSERT_EQ(tensor.dim(), kVmapMaxTensorDims);
@@ -260,7 +261,7 @@ TEST(VmapTest, TestMultiBatchVmapTransform) {
     BatchDims batch_dims = {
       {0, 2}, {1, 1}, {2, kVmapNumLevels - 1}, {3, 5}, {4, 0}, {5, 3}, {6, 4}
     };
-    for (int64_t level = 7; level < kVmapNumLevels; level++ ) {
+    for (const auto level : c10::irange(7, kVmapNumLevels)) {
       batch_dims.emplace_back(level, /*dim=*/level - 1);
     }
     auto tensor = ones(sizes);
@@ -303,7 +304,7 @@ TEST(VmapTest, TestVmapPhysicalViewGetPhysicalDims) {
 
 static void checkBatchDimsEqual(BatchDimsRef bdims, BatchDimsRef expected_bdims) {
   ASSERT_EQ(bdims.size(), expected_bdims.size());
-  for (int64_t idx = 0; idx < bdims.size(); idx++) {
+  for (const auto idx : c10::irange(bdims.size())) {
     ASSERT_EQ(bdims[idx].dim(), expected_bdims[idx].dim());
     ASSERT_EQ(bdims[idx].level(), expected_bdims[idx].level());
   }
@@ -394,7 +395,7 @@ TEST(VmapTest, TestBatchedTensorSum) {
 static void checkBroadcastingVmapTransform(TensorList inputs, TensorList expected_outputs) {
   auto outputs = BroadcastingVmapTransform::logicalToPhysical(inputs);
   ASSERT_EQ(outputs.size(), expected_outputs.size());
-  for (int64_t idx = 0; idx < outputs.size(); idx++) {
+  for (const auto idx : c10::irange(outputs.size())) {
     const auto& output = outputs[idx].tensor();
     ASSERT_EQ(output.data_ptr(), expected_outputs[idx].data_ptr());
     ASSERT_TRUE(at::allclose(output, expected_outputs[idx]));
@@ -878,7 +879,7 @@ TEST(VmapTest, TestBatchedTensorPermute) {
 static void checkMultiBatchVmapTransform(TensorList inputs, TensorList expected_outputs) {
   auto outputs = MultiBatchVmapTransform::logicalToPhysical(inputs);
   ASSERT_EQ(outputs.size(), expected_outputs.size());
-  for (int64_t idx = 0; idx < outputs.size(); idx++) {
+  for (const auto idx : c10::irange(outputs.size())) {
     const auto& output = outputs[idx].tensor();
     ASSERT_EQ(output.data_ptr(), expected_outputs[idx].data_ptr());
     ASSERT_EQ(output.sizes(), expected_outputs[idx].sizes());

--- a/aten/src/ATen/test/vulkan_test.cpp
+++ b/aten/src/ATen/test/vulkan_test.cpp
@@ -5,6 +5,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/vulkan/Context.h>
+#include <c10/util/irange.h>
 
 bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
   double maxValue = 0.0;
@@ -145,7 +146,7 @@ TEST(VulkanTest, addScalar) {
   auto t_in = at::rand({3, 2, 2, 3}, at::device(at::kCPU).dtype(at::kFloat));
   float* data = t_in.data_ptr<float>();
   auto numel = t_in.numel();
-  for (int i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     data[i] = i;
   }
@@ -772,7 +773,7 @@ TEST(VulkanTest, tensor5d_transpose) {
       at::empty({1, 2, 3, 2, 1}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   float* data = t_in.data_ptr<float>();
   auto numel = t_in.numel();
-  for (int i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     data[i] = i;
   }
@@ -816,7 +817,7 @@ TEST(VulkanTest, slice) {
       at::empty({1, 4, 2, 2}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   float* data = t_in.data_ptr<float>();
   auto numel = t_in.numel();
-  for (int i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     data[i] = i;
   }
@@ -841,7 +842,7 @@ TEST(VulkanTest, select) {
       at::empty({1, 4, 2, 2}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   float* data = t_in.data_ptr<float>();
   auto numel = t_in.numel();
-  for (int i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     data[i] = i;
   }
@@ -866,7 +867,7 @@ TEST(VulkanTest, unsqueeze) {
       at::empty({1, 2, 2}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   float* data = t_in.data_ptr<float>();
   auto numel = t_in.numel();
-  for (int i = 0; i < numel; i++) {
+  for (const auto i : c10::irange(numel)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     data[i] = i;
   }

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/irange.h>
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -57,16 +58,15 @@ void THCudaInit(THCState* state)
   // Currently the max number of gpus in P2P group is 8, so if there are more
   // we enable P2P in groups of 8
   state->p2pAccessEnabled = (int**) calloc(numDevices, sizeof(int*));
-  for (int i = 0; i < numDevices; ++i) {
+  for (const auto i : c10::irange(numDevices)) {
     state->p2pAccessEnabled[i] = (int*) calloc(numDevices, sizeof(int));
-    for (int j = 0; j < numDevices; ++j)
-      if (i == j)
+    for (const auto j : c10::irange(numDevices))if (i == j)
         state->p2pAccessEnabled[i][j] = 1;
       else
         state->p2pAccessEnabled[i][j] = -1;
   }
 
-  for (int i = 0; i < numDevices; ++i) {
+  for (const auto i : c10::irange(numDevices)) {
     THCCudaResourcesPerDevice* res = THCState_getDeviceResourcePtr(state, i);
     THCudaCheck(cudaSetDevice(i));
 
@@ -96,7 +96,7 @@ void THCudaShutdown(THCState* state)
   THCudaCheck(cudaGetDeviceCount(&deviceCount));
 
   /* cleanup p2p access state */
-  for (int dev = 0; dev < deviceCount; ++dev) {
+  for (const auto dev : c10::irange(deviceCount)) {
     free(state->p2pAccessEnabled[dev]);
   }
   free(state->p2pAccessEnabled);

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -16,6 +16,7 @@
 #include <THC/THCGenerateBFloat16Type.h>
 
 #include <ATen/native/cuda/Resize.h>
+#include <c10/util/irange.h>
 
 void THCTensor_resizeAs(THCState *state, THCTensor *self, THCTensor *src) {
   int isSame = 0;

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/InferSize.h>
 #include <ATen/NativeFunctions.h>
+#include <c10/util/irange.h>
 
 /**** creation methods ****/
 

--- a/benchmarks/cpp/tensorexpr/bench_concat.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_concat.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
@@ -15,14 +16,14 @@ class ConcatBench : public benchmark::Fixture {
     input_sizes_ = std::move(input_sizes);
     concat_dim_ = concat_dim;
     inputs_.resize(input_sizes_.size());
-    for (size_t i = 0; i < input_sizes_.size(); ++i) {
+    for (const auto i : c10::irange(input_sizes_.size())) {
       inputs_[i] = torch::ones({input_sizes_[i][0], input_sizes_[i][1]});
     }
     output_size_.resize(input_sizes_.front().size());
-    for (size_t i = 0; i < output_size_.size(); ++i) {
+    for (const auto i : c10::irange(output_size_.size())) {
       if (i == static_cast<size_t>(concat_dim_)) {
         output_size_[i] = 0;
-        for (size_t j = 0; j < input_sizes_.size(); ++j) {
+        for (const auto j : c10::irange(input_sizes_.size())) {
           output_size_[i] += input_sizes_[j][i];
         }
       } else {
@@ -65,7 +66,7 @@ class ConcatBench : public benchmark::Fixture {
         [&](const VarHandle& m, const VarHandle& n) {
           int d = 0;
           std::vector<int> cumulative_concat_dim_sizes(num_inputs);
-          for (size_t i = 0; i < num_inputs; ++i) {
+          for (const auto i : c10::irange(num_inputs)) {
             cumulative_concat_dim_sizes[i] = d;
             d += input_sizes_[i][concat_dim_];
           }
@@ -121,7 +122,7 @@ class ConcatBench : public benchmark::Fixture {
           {input_sizes_[i][0], input_sizes_[i][1]},
           kFloat));
       std::vector<VarPtr> for_vars(num_inputs);
-      for (size_t d = 0; d < num_dims; ++d) {
+      for (const auto d : c10::irange(num_dims)) {
         for_vars[d] =
             alloc<Var>("i" + std::to_string(i) + "_" + std::to_string(d), kInt);
       }

--- a/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/torch.h>
 #include <c10/core/InferenceMode.h>
+#include <c10/util/irange.h>
 
 using namespace torch::jit;
 
@@ -22,7 +23,7 @@ static void FusedOverhead(benchmark::State& state) {
   auto z = torch::ones({1});
 
   // Warmup.
-  for (int i = 0; i < 8; i++) {
+  for (const auto i : c10::irange(8)) {
     m.run_method("two_adds", x, y, z);
   }
 
@@ -43,7 +44,7 @@ static void UnfusedOverhead(benchmark::State& state) {
   auto z = torch::ones({1});
 
   // Warmup.
-  for (int i = 0; i < 8; i++) {
+  for (const auto i : c10::irange(8)) {
     m.run_method("two_adds", x, y, z);
   }
 

--- a/benchmarks/cpp/tensorexpr/bench_parallel.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_parallel.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
@@ -54,7 +55,7 @@ BENCHMARK_DEFINE_F(ParallelAdd, Simple)(benchmark::State& state) {
   float* c_ptr = C.data_ptr<float>();
   std::vector<void*> args({c_ptr, a_ptr, b_ptr});
   cg.value<int>(args);
-  for (int i = 0; i < M; i++) {
+  for (const auto i : c10::irange(M)) {
     float diff = fabs(a_ptr[i] + b_ptr[i] - c_ptr[i]);
     TORCH_CHECK(diff < 1e-5);
   }

--- a/benchmarks/cpp/tensorexpr/bench_reduce.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_reduce.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
@@ -72,7 +73,7 @@ static void reduce1d_naive(at::Tensor& A, at::Tensor& B) {
   int size = A.numel();
   TORCH_CHECK(B.numel() == 1);
   *pB = 0.;
-  for (int i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     *pB += pA[i];
   }
 }
@@ -95,18 +96,18 @@ static void reduce1d_native_rfactor(at::Tensor& A, at::Tensor& B) {
   TORCH_CHECK(size % kChunkSize == 0);
   *pB = 0.;
   float temp[kChunkSize];
-  for (int j = 0; j < kChunkSize; j++) {
+  for (const auto j : c10::irange(kChunkSize)) {
     temp[j] = 0;
   }
 
   int chunk_count = size / kChunkSize;
-  for (int i = 0; i < chunk_count; i++) {
-    for (int j = 0; j < kChunkSize; j++) {
+  for (const auto i : c10::irange(chunk_count)) {
+    for (const auto j : c10::irange(kChunkSize)) {
       temp[j] += pA[i * kChunkSize + j];
     }
   }
 
-  for (int j = 0; j < kChunkSize; j++) {
+  for (const auto j : c10::irange(kChunkSize)) {
     *pB += temp[j];
   }
 }
@@ -157,7 +158,7 @@ static void reduce1d_native_vector(at::Tensor& A, at::Tensor& B) {
   temp = _mm256_setzero_ps();
 
   int tile_count = size / kChunkSize;
-  for (int i = 0; i < tile_count; i++) {
+  for (const auto i : c10::irange(tile_count)) {
     __m256 data = _mm256_load_ps(pA + i * kChunkSize);
     temp = _mm256_add_ps(temp, data);
   }
@@ -184,14 +185,14 @@ static void reduce1d_native_tiled(at::Tensor& A, at::Tensor& B) {
   TORCH_CHECK(B.numel() == 1, "Invalid size: ", B.numel(), " != 1");
   TORCH_CHECK(size % kChunkSize == 0, "Invalid size: ", size, " % ", kChunkSize , " ! = 0");
   __m256 t[kTileSize];
-  for (int j = 0; j < kTileSize; j++) {
+  for (const auto j : c10::irange(kTileSize)) {
     t[j] = _mm256_setzero_ps();
   }
 
   int tile_count = size / kChunkSize / kTileSize;
-  for (int i = 0; i < tile_count; i++) {
+  for (const auto i : c10::irange(tile_count)) {
     #pragma unroll
-    for (int j = 0; j < kTileSize; j++) {
+    for (const auto j : c10::irange(kTileSize)) {
       float *p = pA + (i * kTileSize + j) * kChunkSize;
       __m256 data = _mm256_loadu_ps(p);
       t[j] = _mm256_add_ps(t[j], data);
@@ -199,7 +200,7 @@ static void reduce1d_native_tiled(at::Tensor& A, at::Tensor& B) {
   }
 
   float result = sum_f32x8(t[0]);
-  for (int j = 1; j < kTileSize; j++) {
+  for (const auto j : c10::irange(1, kTileSize)) {
     result += sum_f32x8(t[j]);
   }
   *pB = result;
@@ -531,15 +532,15 @@ BENCHMARK_DEFINE_F(Reduce2DRow, Hand)(benchmark::State& state) {
     for (int m_outer = 0; m_outer < M; m_outer += Mb) {
       float bregs[Mb][Nb] = {0.0f};
       for (int n_outer = 0; n_outer < N; n_outer += Nb) {
-        for (int m_inner = 0; m_inner < Mb; m_inner++) {
-          for (int n_inner = 0; n_inner < Nb; n_inner++) {
+        for (const auto m_inner : c10::irange(Mb)) {
+          for (const auto n_inner : c10::irange(Nb)) {
             bregs[m_inner][n_inner] += a[(m_outer + m_inner) * N + n_outer + n_inner];
           }
         }
       }
-      for (int m_inner = 0; m_inner < Mb; m_inner++) {
+      for (const auto m_inner : c10::irange(Mb)) {
         b[m_outer + m_inner] = 0.f;
-        for (int n_inner = 0; n_inner < Nb; n_inner++) {
+        for (const auto n_inner : c10::irange(Nb)) {
           b[m_outer + m_inner] += bregs[m_inner][n_inner];
         }
       }

--- a/binaries/benchmark_helper.h
+++ b/binaries/benchmark_helper.h
@@ -24,6 +24,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/string_utils.h"
 #include "c10/util/string_utils.h"
+#include <c10/util/irange.h>
 
 using std::map;
 using std::shared_ptr;
@@ -55,12 +56,12 @@ void writeTextOutput(
   int dims_size = tensor_proto.dims_size();
   long long elem_dim_size =
       dims_size > 1 ? tensor_proto.dims(1) : tensor_proto.dims(0);
-  for (int i = 2; i < dims_size; i++) {
+  for (const auto i : c10::irange(2, dims_size)) {
     elem_dim_size *= tensor_proto.dims(i);
   }
   std::vector<std::string> lines;
   std::string dims;
-  for (int i = 0; i < dims_size; i++) {
+  for (const auto i : c10::irange(dims_size)) {
     int dim = tensor_proto.dims(i);
     if (i > 0) {
       dims += ", ";

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -2,6 +2,7 @@
 #include <c10/core/DeviceType.h>
 #include <c10/mobile/CPUCachingAllocator.h>
 #include <c10/mobile/CPUProfilingAllocator.h>
+#include <c10/util/irange.h>
 
 // TODO: rename flags to C10
 C10_DEFINE_bool(
@@ -30,7 +31,7 @@ void memset_junk(void* data, size_t num) {
   int32_t int64_count = num / sizeof(kJunkPattern64);
   int32_t remaining_bytes = num % sizeof(kJunkPattern64);
   int64_t* data_i64 = reinterpret_cast<int64_t*>(data);
-  for (int i = 0; i < int64_count; i++) {
+  for (const auto i : c10::irange(int64_count)) {
     data_i64[i] = kJunkPattern64;
   }
   if (remaining_bytes > 0) {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -5,6 +5,7 @@
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 C10_DEFINE_bool(
     caffe2_keep_on_shrink,
@@ -335,7 +336,7 @@ bool TensorImpl::compute_non_overlapping_and_dense() const {
   }
   SmallVector<int64_t, 5> perm;
   perm.resize(dim());
-  for (int64_t i = 0; i < dim(); i++) {
+  for (const auto i : c10::irange(dim())) {
     perm[i] = i;
   }
   // Sort by strides, leaving 0 and 1 sized dims at the end of the array
@@ -349,7 +350,7 @@ bool TensorImpl::compute_non_overlapping_and_dense() const {
         sizes_and_strides_.stride_at_unchecked(b);
   });
   auto require_stride = 1;
-  for (int64_t i = 0; i < dim(); i++) {
+  for (const auto i : c10::irange(dim())) {
     const auto size_perm_i = sizes_and_strides_.size_at_unchecked(perm[i]);
     if (size_perm_i < 2) {
       return true;

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -19,6 +19,7 @@
 #include <c10/util/Logging.h>
 #include <c10/util/Optional.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 #include <c10/util/python_stub.h>
 
 // A global boolean variable to control whether we free memory when a Tensor
@@ -68,7 +69,7 @@ inline std::vector<int64_t> ToVectorint64_t(ArrayRef<int> src) {
  */
 inline int64_t size_from_dim_(int k, IntArrayRef dims) {
   int64_t r = 1;
-  for (size_t i = k; i < dims.size(); ++i) {
+  for (const auto i : c10::irange(k, dims.size())) {
     r *= dims[i];
   }
   return r;
@@ -78,7 +79,7 @@ inline int64_t size_from_dim_(int k, IntArrayRef dims) {
 inline int64_t size_to_dim_(int k, IntArrayRef dims) {
   TORCH_CHECK((unsigned)k <= dims.size());
   int64_t r = 1;
-  for (int i = 0; i < k; ++i) {
+  for (const auto i : c10::irange(k)) {
     r *= dims[i];
   }
   return r;
@@ -2143,7 +2144,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     auto old_numel = numel_;
     sizes_and_strides_.resize(src.size());
     int64_t new_numel = 1;
-    for (size_t i = 0; i < src.size(); ++i) {
+    for (const auto i : c10::irange(src.size())) {
       new_numel *= src[i];
       sizes_and_strides_.size_at_unchecked(i) = src[i];
     }

--- a/c10/core/impl/InlineStreamGuard.h
+++ b/c10/core/impl/InlineStreamGuard.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/impl/InlineDeviceGuard.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/irange.h>
 
 namespace c10 {
 namespace impl {
@@ -237,7 +238,7 @@ class InlineMultiStreamGuard {
   static DeviceType getDeviceTypeOfStreams(ArrayRef<Stream> streams) {
     TORCH_INTERNAL_ASSERT(!streams.empty());
     DeviceType type = streams[0].device_type();
-    for (size_t idx = 1; idx < streams.size(); idx++) {
+    for (const auto idx : c10::irange(1, streams.size())) {
       TORCH_CHECK_VALUE(
           streams[idx].device_type() == type,
           "Streams have a mix of device types: stream 0 is on ",

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -201,7 +201,7 @@ static SizesAndStrides makeBig(int offset = 0) {
 
 static void checkSmall(const SizesAndStrides& sm, int offset = 0) {
   std::vector<int64_t> sizes(3), strides(3);
-  for (int ii = 0; ii < 3; ++ii) {
+  for (const auto ii : c10::irange(3)) {
     sizes[ii] = ii + 1 + offset;
     strides[ii] = 2 * (ii + 1 + offset);
   }
@@ -210,7 +210,7 @@ static void checkSmall(const SizesAndStrides& sm, int offset = 0) {
 
 static void checkBig(const SizesAndStrides& big, int offset = 0) {
   std::vector<int64_t> sizes(8), strides(8);
-  for (int ii = 0; ii < 8; ++ii) {
+  for (const auto ii : c10::irange(8)) {
     sizes[ii] = ii - 1 + offset;
     strides[ii] = 2 * (ii - 1 + offset);
   }

--- a/c10/test/util/Bitset_test.cpp
+++ b/c10/test/util/Bitset_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <c10/util/Bitset.h>
+#include <c10/util/irange.h>
 
 using c10::utils::bitset;
 
@@ -37,7 +38,7 @@ TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenIsSet) {
 TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenOthersStayUnset) {
   bitset b;
   b.set(6);
-  for (size_t i = 0; i < 6; ++i) {
+  for (const auto i : c10::irange(6)) {
     EXPECT_FALSE(b.get(i));
   }
   for (size_t i = 7; i < bitset::NUM_BITS(); ++i) {
@@ -56,10 +57,10 @@ TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenOthersStayAtOldValue) {
   bitset b;
   b.set(6);
   b.set(30);
-  for (size_t i = 0; i < 6; ++i) {
+  for (const auto i : c10::irange(6)) {
     EXPECT_FALSE(b.get(i));
   }
-  for (size_t i = 7; i < 30; ++i) {
+  for (const auto i : c10::irange(7, 30)) {
     EXPECT_FALSE(b.get(i));
   }
   for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
@@ -82,7 +83,7 @@ TEST(
   b.set(6);
   b.set(30);
   b.unset(6);
-  for (size_t i = 0; i < 30; ++i) {
+  for (const auto i : c10::irange(30)) {
     EXPECT_FALSE(b.get(i));
   }
   EXPECT_TRUE(b.get(30));
@@ -100,7 +101,7 @@ struct IndexCallbackMock final {
 
   void expect_was_called_for_indices(std::vector<size_t> expected_indices) {
     EXPECT_EQ(expected_indices.size(), called_for_indices.size());
-    for (size_t i = 0; i < expected_indices.size(); ++i) {
+    for (const auto i : c10::irange(expected_indices.size())) {
       EXPECT_EQ(expected_indices[i], called_for_indices[i]);
     }
   }

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -1,6 +1,7 @@
 // clang-format off
 #include <c10/util/BFloat16.h>
 #include <c10/util/BFloat16-math.h>
+#include <c10/util/irange.h>
 // clang-format on
 #include <gtest/gtest.h>
 
@@ -24,7 +25,7 @@ float float_from_bytes(uint32_t sign, uint32_t exponent, uint32_t fraction) {
 TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   float in[100];
-  for (int i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-avoid-magic-numbers)
     in[i] = i + 1.25;
   }
@@ -34,7 +35,7 @@ TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   float out[100];
 
-  for (int i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     bfloats[i].x = c10::detail::bits_from_f32(in[i]);
     out[i] = c10::detail::f32_from_bits(bfloats[i].x);
 
@@ -47,7 +48,7 @@ TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
 TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   float in[100];
-  for (int i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-avoid-magic-numbers)
     in[i] = i + 1.25;
   }
@@ -57,7 +58,7 @@ TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   float out[100];
 
-  for (int i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     bfloats[i].x = c10::detail::round_to_nearest_even(in[i]);
     out[i] = c10::detail::f32_from_bits(bfloats[i].x);
 

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -4,6 +4,7 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <c10/util/order_preserving_flat_hash_map.h>
 #include <gtest/gtest.h>
 
@@ -15,7 +16,7 @@ using dict_int_int =
     ska_ordered::order_preserving_flat_hash_map<int64_t, int64_t>;
 
 dict_int_int test_dict(dict_int_int& dict) {
-  for (int64_t i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     dict[i] = i + 1;
   }
 
@@ -33,18 +34,18 @@ dict_int_int test_dict(dict_int_int& dict) {
 
   // erase via iterators
   auto begin = dict.begin();
-  for (size_t i = 0; i < 20; ++i)
+  for (const auto i : c10::irange(20))
     begin++;
 
   auto end = begin;
-  for (size_t i = 0; i < 20; ++i) {
+  for (const auto i : c10::irange(20)) {
     erase_set.insert(end->first);
     end++;
   }
   dict.erase(begin, end);
 
   std::vector<size_t> order;
-  for (size_t i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     if (!erase_set.count(i)) {
       order.push_back(i);
     }
@@ -113,7 +114,7 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
 
   for (auto init_dict_size : {27, 34, 41}) {
     bad_hash_dict dict;
-    for (int64_t i = 0; i < init_dict_size; ++i) {
+    for (const auto i : c10::irange(init_dict_size)) {
       dict[i] = i + 1;
     }
 
@@ -131,18 +132,18 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
 
     // erase a few entries via iterator
     auto begin = dict.begin();
-    for (size_t i = 0; i < 10; ++i) {
+    for (const auto i : c10::irange(10)) {
       begin++;
     }
     auto end = begin;
-    for (size_t i = 0; i < 7; ++i) {
+    for (const auto i : c10::irange(7)) {
       erase_set.insert(end->first);
       end++;
     }
     dict.erase(begin, end);
 
     std::vector<int64_t> order;
-    for (int64_t i = 0; i < init_dict_size; ++i) {
+    for (const auto i : c10::irange(init_dict_size)) {
       if (!erase_set.count(i)) {
         order.push_back(i);
       }
@@ -167,7 +168,7 @@ TEST(OrderedPreservingDictTest, test_range_insert) {
   // check values
   const int nb_values = 1000;
   std::vector<std::pair<int, int>> values;
-  for (int i = 0; i < nb_values; i++) {
+  for (const auto i : c10::irange(nb_values)) {
     // NOLINTNEXTLINE(modernize-use-emplace,performance-inefficient-vector-operation)
     values.push_back(std::make_pair(i, i + 1));
   }
@@ -190,7 +191,7 @@ TEST(OrderedPreservingDictTest, test_range_erase_all) {
   // insert x values, delete all
   const std::size_t nb_values = 1000;
   dict_int_int map;
-  for (size_t i = 0; i < nb_values; ++i) {
+  for (const auto i : c10::irange(nb_values)) {
     map[i] = i + 1;
   }
   auto it = map.erase(map.begin(), map.end());
@@ -206,7 +207,7 @@ TEST(OrderedPreservingDictTest, test_range_erase) {
 
   const std::size_t nb_values = 1000;
   HMap map;
-  for (size_t i = 0; i < nb_values; ++i) {
+  for (const auto i : c10::irange(nb_values)) {
     map[c10::guts::to_string(i)] = i;
     auto begin = map.begin();
     for (size_t j = 0; j <= i; ++j, begin++) {
@@ -305,7 +306,7 @@ TEST(OrderedPreservingDictTest, test_copy_constructor_and_operator) {
 
   const std::size_t nb_values = 100;
   HMap map;
-  for (size_t i = 0; i < nb_values; ++i) {
+  for (const auto i : c10::irange(nb_values)) {
     map[c10::guts::to_string(i)] = c10::guts::to_string(i);
   }
 

--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/Backtrace.h>
 #include <c10/util/Optional.h>
 #include <c10/util/Type.h>
+#include <c10/util/irange.h>
 
 #include <functional>
 #include <memory>
@@ -281,8 +282,7 @@ std::string get_backtrace(
   // Toggles to true after the first skipped python frame.
   bool has_skipped_python_frames = false;
 
-  for (size_t frame_number = 0; frame_number < callstack.size();
-       ++frame_number) {
+  for (const auto frame_number : c10::irange(callstack.size())) {
     const auto frame = parse_frame_information(symbols[frame_number]);
 
     if (skip_python_frames && frame && is_python_frame(*frame)) {

--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -27,6 +27,7 @@
 #include <c10/util/flat_hash_map.h>
 
 #include <c10/core/ScalarType.h>
+#include <c10/util/irange.h>
 
 /*
  * TypeIdentifier is a small type containing an id.
@@ -170,7 +171,7 @@ struct TypeMetaData final {
 template <typename T>
 inline void _PlacementNew(void* ptr, size_t n) {
   T* typed_ptr = static_cast<T*>(ptr);
-  for (size_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     new (typed_ptr + i) T;
   }
 }
@@ -234,7 +235,7 @@ template <typename T>
 inline void _Copy(const void* src, void* dst, size_t n) {
   const T* typed_src = static_cast<const T*>(src);
   T* typed_dst = static_cast<T*>(dst);
-  for (size_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     typed_dst[i] = typed_src[i];
   }
 }
@@ -274,7 +275,7 @@ inline constexpr TypeMetaData::Copy* _PickCopy() {
 template <typename T>
 inline void _PlacementDelete(void* ptr, size_t n) {
   T* typed_ptr = static_cast<T*>(ptr);
-  for (size_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     typed_ptr[i].~T();
   }
 }

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <ATen/ATen.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 #include <caffe2/core/context.h>
 #include <caffe2/core/operator.h>
 #include <caffe2/utils/math.h>
@@ -130,7 +131,7 @@ private:
   void assignListStartingAt(
       size_t offset,
       const std::vector<at::Tensor>& tensors) {
-    for (size_t i = 0; i < tensors.size(); i++) {
+    for (const auto i : c10::irange(tensors.size())) {
       assignTo(Output(offset + i), tensors[i]);
     }
   }
@@ -176,7 +177,7 @@ private:
     std::stringstream descriptor;
     descriptor << op;
     std::vector<std::string> attrs;
-    for(size_t i = 0; i < operator_def.arg_size(); i++) {
+    for (const auto i : c10::irange(operator_def.arg_size())) {
       auto & attr = operator_def.arg(i);
       if(attr.name() == "operator" || attr.name() == "type" )
         continue;
@@ -223,7 +224,7 @@ private:
     std::vector<int64_t> ints =
         OperatorBase::GetRepeatedArgument<int64_t>(name, {});
     std::array<bool, N> result;
-    for (size_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       result[i] = ints.at(i);
     }
     return result;

--- a/caffe2/contrib/fakelowp/fp16_fc_acc_op.h
+++ b/caffe2/contrib/fakelowp/fp16_fc_acc_op.h
@@ -118,8 +118,8 @@ class Fp16FCAccOp final : public Operator<Context> {
         if (!W_fbgemm->packed()) {
           float* W_fp16_trans = new float[W_size];
           fbgemm::Float16ToFloat_avx2(W_fbgemm->pmat(), W_fp16_trans, W_size);
-          for (int i = 0; i < N; i++) {
-            for (int j = 0; j < K; j++) {
+          for (const auto i : c10::irange(N)) {
+            for (const auto j : c10::irange(K)) {
               W_fp16_[j * N + i] = W_fp16_trans[i * K + j];
             }
           }
@@ -136,8 +136,8 @@ class Fp16FCAccOp final : public Operator<Context> {
         const auto& W = Input(1);
         W_data = W.template data<T_W>();
         // Transpose W
-        for (int i = 0; i < N; i++) {
-          for (int j = 0; j < K; j++) {
+        for (const auto i : c10::irange(N)) {
+          for (const auto j : c10::irange(K)) {
             W_fp16_[j * N + i] = W_data[i * K + j];
           }
         }
@@ -352,7 +352,7 @@ class Fp16FCAccOp final : public Operator<Context> {
 #ifdef LOG_LEVEL_FOR_FBFCPACKEDACC16_ACCURACY_LOG
   float compute_L2_norm(float* A, int size) {
     float square_sum = 0.0;
-    for (int i = 0; i < size; i++) {
+    for (const auto i : c10::irange(size)) {
       square_sum += A[i] * A[i];
     }
     return std::sqrt(square_sum);
@@ -360,7 +360,7 @@ class Fp16FCAccOp final : public Operator<Context> {
 
   float compute_relative_error(float* A, float* A_ref, int size) {
     float error = 0.0;
-    for (int i = 0; i < size; i++) {
+    for (const auto i : c10::irange(size)) {
       error += (A[i] - A_ref[i]) * (A[i] - A_ref[i]);
     }
     error = std::sqrt(error);

--- a/caffe2/contrib/fakelowp/int8_dequantize_op_nnpi.h
+++ b/caffe2/contrib/fakelowp/int8_dequantize_op_nnpi.h
@@ -22,7 +22,7 @@ void Int8DequantizeNNPI(
     const float X_scale,
     const int32_t X_offset) {
   float X_scale_fp32 = 1.0f / X_scale;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     out[i] = (float)(static_cast<int32_t>(in[i]) - X_offset) / X_scale_fp32;
   }
 } // namespace

--- a/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
+++ b/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
@@ -53,12 +53,12 @@ void Int8QuantizeNNPI(
   std::vector<float> inv_scalev(N, inv_scale_fp16);
   std::vector<float> offsetv(N, -offset_tmp);
   fake_fp16::fma_fp16(N, in_fp16.data(), inv_scalev.data(), offsetv.data());
-  for (int i = 0; i < N; i++) {
+  for (const auto i : c10::irange(N)) {
     offsetv[i] = round(offsetv[i]);
   }
   fbgemm::RoundToFloat16(
       offsetv.data(), offsetv.data(), N, false /* no clamping */);
-  for (int i = 0; i < N; i++) {
+  for (const auto i : c10::irange(N)) {
     float halfRes = offsetv[i];
     if (std::isinf(halfRes)) {
       if (halfRes > 0) {

--- a/caffe2/contrib/fakelowp/int8_swish_op_nnpi.h
+++ b/caffe2/contrib/fakelowp/int8_swish_op_nnpi.h
@@ -29,7 +29,7 @@ void SwishFakeInt8NNPI(
   int32_t quant_val = 0;
   uint8_t result = 0;
 
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     deq_val = (static_cast<uint8_t>(in[i]) - X_offset) / X_scale_fp32;
     deq_swish = deq_val / (1 + exp(-deq_val));
     quant_val = round(deq_swish / Y_scale + Y_offset);

--- a/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.h
@@ -129,7 +129,7 @@ class LayerNormFakeFp16Op final : public Operator<CPUContext> {
           FLAGS_caffe2_fbgemm_fake_fp16_clamp,
           false /*USE_ACC_FP16*/);
 
-      for (int i = 0; i < M; ++i) {
+      for (const auto i : c10::irange(M)) {
         // fma_fp16(A, B, Out) -> Out = A * B + Out
         std::vector<float> out(N);
         std::memcpy(out.data(), bias_data.data(), sizeof(float) * N);
@@ -169,7 +169,7 @@ class LayerNormFakeFp16Op final : public Operator<CPUContext> {
       const int32_t qmin = std::numeric_limits<uint8_t>::min();
       const int32_t qmax = std::numeric_limits<uint8_t>::max();
 
-      for (int i = 0; i < Nout; i++) {
+      for (const auto i : c10::irange(Nout)) {
         float halfRes = offsetv[i];
         halfRes = round(halfRes);
         if (std::isinf(halfRes)) {

--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h
@@ -85,7 +85,7 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
     const auto scale_bias_offset = 2 * sizeof(at::Half);
     const int64_t input_fused_block_size = input_block_size + scale_bias_offset;
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       if (!use_fp16_for_embedding_only) {
         memset(rowTempSums[0].data(), 0, sizeof(float) * output_block_size);
         memset(rowTempSums[1].data(), 0, sizeof(float) * output_block_size);
@@ -135,7 +135,7 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
         // Unpack int4 elements
         std::vector<float> input_rounded(output_block_size);
         int k = 0;
-        for (int j = 0; j < input_block_size; j++) {
+        for (const auto j : c10::irange(input_block_size)) {
           input_rounded[k++] =
               input[input_fused_block_size * indices_data[current] + j] & 0x0f;
           input_rounded[k++] =
@@ -150,7 +150,7 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
               input_rounded.data(),
               product_rounded.data());
 
-          for (int j = 0; j < output_block_size; ++j) {
+          for (const auto j : c10::irange(output_block_size)) {
             product_rounded[j] += bias;
           }
 
@@ -190,7 +190,7 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
       }
 
       if (!use_fp16_for_embedding_only) {
-        for (int j = 0; j < output_block_size; ++j) {
+        for (const auto j : c10::irange(output_block_size)) {
           out[j] = rowTempSums[0][j] + rowTempSums[1][j];
         }
         fbgemm::RoundToFloat16(

--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
@@ -84,7 +84,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
     const auto scale_bias_offset = 8 / sizeof(uint8_t);
     const int64_t fused_block_size = block_size + scale_bias_offset;
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       memset(out, 0, sizeof(float) * block_size);
       memset(rowTempSums[0].data(), 0, sizeof(float) * block_size);
       memset(rowTempSums[1].data(), 0, sizeof(float) * block_size);
@@ -152,7 +152,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
 
         // Fake fp16 rounding of input/ it is already ints
         std::vector<float> input_rounded(block_size);
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           input_rounded[j] =
               input[fused_block_size * indices_data[current] + j];
         }
@@ -164,7 +164,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
           TypedAxpy<float, float>(
               block_size, scale, input_rounded.data(), product_rounded.data());
 
-          for (int j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             product_rounded[j] += bias;
           }
 
@@ -215,7 +215,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
               block_size,
               FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
-          for (int j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             product_rounded[j] += bias;
           }
           // Fake fp16 rounding of w x scale x input + w x bias
@@ -239,7 +239,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
               block_size,
               FLAGS_caffe2_fbgemm_fake_fp16_clamp);
         } else if (use_acc_fp32) {
-          for (int j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             float deqVal = fake_fp16::fmafp32_avx_emulation(
                 scale,
                 input_rounded[j],
@@ -256,7 +256,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
 
           TypedAxpy<float, float>(block_size, scale, input_rounded.data(), out);
 
-          for (int j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             out[j] += bias;
           }
         }
@@ -264,7 +264,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
       }
 
       if (use_nnpi_fma || use_acc_fp32) {
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           out[j] = rowTempSums[0][j] + rowTempSums[1][j];
         }
       }

--- a/caffe2/contrib/fakelowp/lengths_reducer_ops.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_ops.h
@@ -94,7 +94,7 @@ class SparseLengthsReductionFakeFp16Op final : public Operator<CPUContext> {
     float* out = out_data;
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       memset(out, 0, sizeof(float) * block_size);
       if (current + lengths[m] > index_size) {
         return false;

--- a/caffe2/contrib/fakelowp/quant_lut_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/quant_lut_fp16_fake_op.h
@@ -39,7 +39,7 @@ class TanhInt8QuantizeNNPIOp final : public Operator<CPUContext> {
     Y_scale = 1.0f / Y_scale;
 
     // create table once
-    for (int i = 0; i < lutSize; i++) {
+    for (const auto i : c10::irange(lutSize)) {
         short input = i + tanhLUTMinOffset;
         float x = _cvtsh_ss(input);
         float tanh_x = tanh(x);
@@ -54,7 +54,7 @@ class TanhInt8QuantizeNNPIOp final : public Operator<CPUContext> {
     }
 
     const float* X_data = X.template data<float>();
-    for (int i = 0; i < X.numel(); i++) {
+    for (const auto i : c10::irange(X.numel())) {
         short val = _cvtss_sh(X_data[i], 0);
         unsigned short max16BitPositive = 0x7FFF;
         unsigned short input16Bit = (*(unsigned short*)& val);

--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
@@ -159,7 +159,7 @@ class SpatialBNFakeLoweredFp16Op : public Operator<CPUContext> {
     const int stride = C * HxW;
     const float* X_ptr = X;
     float* Y_ptr = Y;
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       EigenArrayMap<float>(Y_ptr, HxW, C) =
           ConstEigenArrayMap<float>(X_ptr, HxW, C).rowwise() -
           mean_arr.transpose();
@@ -356,9 +356,9 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
     float* Y_ptr = Y;
 
     // Do Y = X * scale + bias
-    for (int i = 0; i < N; i++) {
-      for (int j = 0; j < C; j++) {
-        for (int k = 0; k < HxW; k++) {
+    for (const auto i : c10::irange(N)) {
+      for (const auto j : c10::irange(C)) {
+        for (const auto k : c10::irange(HxW)) {
           Y_ptr[HxW * j + k] = bias[j];
         }
 

--- a/caffe2/contrib/fakelowp/sum_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/sum_fp16_fake_op.h
@@ -18,7 +18,7 @@ class SumFP16FP16AccOp : public Operator<Context> {
     size_t N = input0.numel();
     auto* output = Output(0, input0.sizes(), at::dtype<float>());
     // Dimension checking
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       if (output->sizes() != Input(i).sizes()) {
         CAFFE_THROW(
             "Check failed: output->sizes() == Input(i).sizes().",
@@ -37,7 +37,7 @@ class SumFP16FP16AccOp : public Operator<Context> {
     std::vector<float> t1(N);
     std::vector<float> t2(N);
 
-    for (auto i = 0; i < InputSize(); i++) {
+    for (const auto i : c10::irange(InputSize())) {
       fbgemm::RoundToFloat16(
           Input(i).template data<float>(),
           t1.data(),

--- a/caffe2/contrib/gloo/allgather_ops.h
+++ b/caffe2/contrib/gloo/allgather_ops.h
@@ -85,13 +85,13 @@ class AllgatherOp final : public Operator<Context> {
 
     // Verify tensors all have same size
     size_t size = Input(1).numel();
-    for (auto i = 2; i < InputSize(); i++) {
+    for (const auto i : c10::irange(2, InputSize())) {
       CAFFE_ENFORCE_EQ(Input(i).numel(), size);
     }
 
     // Verify tensors all have same type
     TypeMeta meta = Input(1).dtype();
-    for (auto i = 2; i < InputSize(); i++) {
+    for (const auto i : c10::irange(2, InputSize())) {
       CAFFE_ENFORCE(Input(i).dtype() == meta);
     }
 
@@ -113,7 +113,7 @@ class AllgatherOp final : public Operator<Context> {
     params.inputs.resize(InputSize() - 1);
     params.size = Input(1).numel();
     params.meta = Input(1).dtype();
-    for (auto i = 0; i < params.inputs.size(); i++) {
+    for (const auto i : c10::irange(params.inputs.size())) {
       params.inputs[i] = Input(i + 1).raw_data();
     }
     params.outputs.resize(OutputSize());

--- a/caffe2/contrib/gloo/allreduce_ops.h
+++ b/caffe2/contrib/gloo/allreduce_ops.h
@@ -65,19 +65,19 @@ class AllreduceOp final : public Operator<Context> {
 
     // Verify inputs == outputs
     CAFFE_ENFORCE_EQ(init_.inputs.size(), init_.outputs.size());
-    for (auto i = 0U; i < init_.inputs.size(); i++) {
+    for (const auto i : c10::irange(0U, init_.inputs.size())) {
       CAFFE_ENFORCE_EQ(init_.inputs[i], init_.outputs[i]);
     }
 
     // Verify tensors all have same size
     auto size = Input(1).numel();
-    for (auto i = 2; i < InputSize(); i++) {
+    for (const auto i : c10::irange(2, InputSize())) {
       CAFFE_ENFORCE_EQ(Input(i).numel(), size);
     }
 
     // Verify tensors all have same type
     TypeMeta meta = Input(1).dtype();
-    for (auto i = 2; i < InputSize(); i++) {
+    for (const auto i : c10::irange(2, InputSize())) {
       CAFFE_ENFORCE(Input(i).dtype() == meta);
     }
 
@@ -115,7 +115,7 @@ class AllreduceOp final : public Operator<Context> {
     params.context = OperatorBase::Input<std::shared_ptr<::gloo::Context>>(0);
     params.inputs.resize(InputSize() - 1);
     params.outputs.resize(OutputSize());
-    for (auto i = 0U; i < params.inputs.size(); i++) {
+    for (const auto i : c10::irange(0U, params.inputs.size())) {
       params.inputs[i] = Input(i + 1).raw_data();
       params.outputs[i] = Output(i)->raw_mutable_data();
     }

--- a/caffe2/contrib/gloo/broadcast_ops.h
+++ b/caffe2/contrib/gloo/broadcast_ops.h
@@ -60,19 +60,19 @@ class BroadcastOp final : public Operator<Context> {
 
     // Verify inputs == outputs
     CAFFE_ENFORCE_EQ(init_.inputs.size(), init_.outputs.size());
-    for (auto i = 0; i < init_.inputs.size(); i++) {
+    for (const auto i : c10::irange(init_.inputs.size())) {
       CAFFE_ENFORCE_EQ(init_.inputs[i], init_.outputs[i]);
     }
 
     // Verify tensors all have same size
     size_t size = Input(1).numel();
-    for (auto i = 2; i < InputSize(); i++) {
+    for (const auto i : c10::irange(2, InputSize())) {
       CAFFE_ENFORCE_EQ(Input(i).numel(), size);
     }
 
     // Verify tensors all have same size
     TypeMeta meta = Input(1).dtype();
-    for (auto i = 2; i < InputSize(); i++) {
+    for (const auto i : c10::irange(2, InputSize())) {
       CAFFE_ENFORCE(Input(i).dtype() == meta);
     }
 
@@ -94,7 +94,7 @@ class BroadcastOp final : public Operator<Context> {
     params.context = OperatorBase::Input<std::shared_ptr<::gloo::Context>>(0);
     params.inputs.resize(InputSize() - 1);
     params.outputs.resize(OutputSize());
-    for (auto i = 0; i < params.inputs.size(); i++) {
+    for (const auto i : c10::irange(params.inputs.size())) {
       params.inputs[i] = Input(i + 1).raw_data();
       params.outputs[i] = Output(i)->raw_mutable_data();
     }

--- a/caffe2/contrib/gloo/reduce_scatter_ops.h
+++ b/caffe2/contrib/gloo/reduce_scatter_ops.h
@@ -75,7 +75,7 @@ class ReduceScatterOp final : public Operator<Context> {
 
     // Verify inputs == outputs
     CAFFE_ENFORCE_EQ(init_.inputs.size(), init_.outputs.size());
-    for (auto i = 0; i < init_.inputs.size(); i++) {
+    for (const auto i : c10::irange(init_.inputs.size())) {
       CAFFE_ENFORCE_EQ(init_.inputs[i], init_.outputs[i]);
     }
 
@@ -107,7 +107,7 @@ class ReduceScatterOp final : public Operator<Context> {
     params.context = OperatorBase::Input<std::shared_ptr<::gloo::Context>>(0);
     params.inputs.resize(InputSize() - 2);
     params.outputs.resize(OutputSize() - 1);
-    for (auto i = 0; i < params.inputs.size(); i++) {
+    for (const auto i : c10::irange(params.inputs.size())) {
       params.inputs[i] = Input(i + 1).raw_data();
       params.outputs[i] = Output(i)->raw_mutable_data();
     }

--- a/caffe2/contrib/opencl/OpenCL/cl.hpp
+++ b/caffe2/contrib/opencl/OpenCL/cl.hpp
@@ -1241,7 +1241,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, size_t<N>* param, long)
         return err;
     }
 
-    for(int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
         (*param)[i] = value[i];
     }
 

--- a/caffe2/core/blob_serialization.h
+++ b/caffe2/core/blob_serialization.h
@@ -9,6 +9,8 @@
 #include "caffe2/core/blob.h"
 #include "caffe2/core/blob_serializer_base.h"
 #include "caffe2/core/tensor.h"
+
+#include <c10/util/irange.h>
 #include <c10/util/typeid.h>
 #include "caffe2/core/types.h"
 #include "caffe2/utils/simple_queue.h"
@@ -201,7 +203,7 @@ void ExtendRepeatedField(
 #else
   // We unfortunately do still need to support old protobuf versions in some
   // build configurations.
-  for (size_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     field->Add(0);
   }
 #endif
@@ -236,7 +238,7 @@ inline void CopyToProtoWithCast(
   context->template CopyToCPU<SrcType>(size, src, buffer.get());
   context->FinishDeviceComputation();
   field->Reserve(size);
-  for (size_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     field->Add(static_cast<DstType>(buffer[i]));
   }
 }
@@ -267,7 +269,7 @@ inline void CopyFromProtoWithCast(
   // CPUContext. Remove it if it is performance critical.
   unique_ptr<DstType[]> buffer(new DstType[size]);
   const SrcType* src = field.data();
-  for (size_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     buffer[i] = static_cast<DstType>(src[i]);
   }
   context->template CopyFromCPU<DstType>(size, buffer.get(), dst);

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -17,6 +17,7 @@
 
 #if !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
 #include <c10/core/GeneratorImpl.h>
+#include <c10/util/irange.h>
 #include <ATen/core/DistributionsHelper.h>
 #include <ATen/core/MT19937RNGEngine.h>
 #else
@@ -155,7 +156,7 @@ class TORCH_API CPUContext final : public BaseContext {
           static_cast<const void*>(src),
           static_cast<void*>(dst));
     } else {
-      for (size_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         dst[i] = src[i];
       }
     }

--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -4,6 +4,7 @@
 #include <mutex>
 
 #include <c10/util/Registry.h>
+#include <c10/util/irange.h>
 #include <c10/util/string_view.h>
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/proto/caffe2_pb.h"
@@ -248,7 +249,8 @@ class TORCH_API DBReader {
     *value = cursor_->value();
 
     // In sharded mode, each read skips num_shards_ records
-    for (uint32_t s = 0; s < num_shards_; s++) {
+    for (const auto s : c10::irange(num_shards_)) {
+      (void)s; // Suppress unused variable
       cursor_->Next();
       if (!cursor_->Valid()) {
         MoveToBeginning();
@@ -292,7 +294,8 @@ class TORCH_API DBReader {
 
   void MoveToBeginning() const {
     cursor_->SeekToFirst();
-    for (uint32_t s = 0; s < shard_id_; s++) {
+    for (const auto s : c10::irange(shard_id_)) {
+      (void)s; // Suppress unused variable
       cursor_->Next();
       CAFFE_ENFORCE(
           cursor_->Valid(), "Db has fewer rows than shard id: ", s, shard_id_);

--- a/caffe2/core/export_c10_op_to_caffe2.h
+++ b/caffe2/core/export_c10_op_to_caffe2.h
@@ -12,6 +12,7 @@
 #include <c10/util/C++17.h>
 #include <c10/util/Metaprogramming.h>
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -136,7 +137,7 @@ class C10OperatorWrapper final : public Operator<Context> {
 
   void popOutputs_() {
     AT_ASSERT(stack_.size() == op_.schema().returns().size());
-    for (size_t i = 0; i < op_.schema().returns().size(); ++i) {
+    for (const auto i : c10::irange(op_.schema().returns().size())) {
       OperatorBase::SetOutputTensor(i, Tensor(std::move(stack_[i]).toTensor()));
     }
     stack_.clear();
@@ -146,7 +147,7 @@ class C10OperatorWrapper final : public Operator<Context> {
     c10::List<at::Tensor> result;
     result.reserve(InputSize());
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       result.emplace_back(Input(i));
     }
     return result;
@@ -156,7 +157,7 @@ class C10OperatorWrapper final : public Operator<Context> {
     c10::List<at::Tensor> result;
     result.reserve(OutputSize());
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       result.emplace_back(OperatorBase::OutputTensorOrUndefined(i));
     }
     return result;

--- a/caffe2/core/export_caffe2_op_to_c10.h
+++ b/caffe2/core/export_caffe2_op_to_c10.h
@@ -9,6 +9,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
 #include <c10/core/CompileTimeFunctionPointer.h>
+#include <c10/util/irange.h>
 #include <torch/library.h>
 #include <vector>
 
@@ -94,7 +95,7 @@ inline void _call_caffe2_op_from_c10(
     // We should not unwrap the list if we expect tensor list in the schema.
     torch::jit::push(*stack, outputs);
   } else {
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       torch::jit::push(*stack, outputs.extract(i));
     }
   }

--- a/caffe2/core/nomnigraph/include/nomnigraph/Converters/Dot.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Converters/Dot.h
@@ -1,6 +1,7 @@
 #ifndef NOM_CONVERTERS_DOT_H
 #define NOM_CONVERTERS_DOT_H
 
+#include "c10/util/irange.h"
 #include "nomnigraph/Graph/Algorithms.h"
 #include "nomnigraph/Graph/Graph.h"
 #include "nomnigraph/Support/Casting.h"
@@ -42,7 +43,7 @@ class DotGenerator {
     for (const auto& node : sg.getNodes()) {
       generateNode(node, sg, output);
     }
-    for (size_t i = 0; i < subgraphs.size(); ++i) {
+    for (const auto i : c10::irange(subgraphs.size())) {
       const auto& subgraph = subgraphs[i];
       output << "subgraph cluster" << i << " {\n";
       output << "style=dotted;\n";

--- a/caffe2/core/nomnigraph/include/nomnigraph/Transformations/SubgraphMatcher.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Transformations/SubgraphMatcher.h
@@ -1,6 +1,7 @@
 #ifndef NOM_TRANFORMATIONS_SUBGRAPH_MATCHER_H
 #define NOM_TRANFORMATIONS_SUBGRAPH_MATCHER_H
 
+#include "c10/util/irange.h"
 #include "caffe2/core/common.h"
 #include "nomnigraph/Graph/Graph.h"
 
@@ -240,8 +241,7 @@ class MatchGraph : public Graph<MatchPredicate<GraphType>> {
     // criteria in the given order.
 
     int currentEdgeIdx = 0;
-    for (int criteriaIdx = 0; criteriaIdx < numChildrenCriteria;
-         criteriaIdx++) {
+    for (const auto criteriaIdx : c10::irange(numChildrenCriteria)) {
       auto childrenCriteriaRef = invertGraphTraversal
           ? criteriaEdges[criteriaIdx]->tail()
           : criteriaEdges[criteriaIdx]->head();

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "c10/util/Registry.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/types.h"
@@ -519,7 +520,7 @@ inline uint64_t nElemFromDim(const TensorShape& X, int dim = 0) {
   CAFFE_ENFORCE_GE(dim, 0, "Invalid maximum index specified");
 
   uint64_t nElem = 1;
-  for (int i = dim; i < X.dims_size(); ++i) {
+  for (const auto i : c10::irange(dim, X.dims_size())) {
     nElem *= X.dims(i);
   }
   return nElem;
@@ -531,7 +532,7 @@ inline uint64_t nElemBetweenDim(const TensorShape& X, int start, int stop) {
   CAFFE_ENFORCE_LE(stop, X.dims_size(), "Invalid maximum index specified");
 
   uint64_t nElem = 1;
-  for (int i = start; i < stop; ++i) {
+  for (const auto i : c10::irange(start, stop)) {
     nElem *= X.dims(i);
   }
   return nElem;
@@ -560,7 +561,7 @@ OpSchema::Cost PointwiseCostInference(
   const TensorShape X = inputs[0];
   uint64_t nElemX = nElemFromDim(X);
   uint64_t nElemRead = 0;
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     nElemRead += nElemFromDim(inputs[i]);
   }
 

--- a/caffe2/core/qtensor.h
+++ b/caffe2/core/qtensor.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/tensor.h"
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 #include <c10/util/typeid.h>
 
 #include <algorithm>
@@ -218,7 +219,7 @@ class C10_EXPORT QTensor {
    */
   inline int64_t size_from_dim(int k) const {
     int64_t r = 1;
-    for (int i = k; i < dims_.size(); ++i) {
+    for (const auto i : c10::irange(k, dims_.size())) {
       r *= dims_[i];
     }
     return r;
@@ -230,7 +231,7 @@ class C10_EXPORT QTensor {
   inline int64_t size_to_dim(int k) const {
     CAFFE_ENFORCE(k < dims_.size());
     int64_t r = 1;
-    for (int i = 0; i < k; ++i) {
+    for (const auto i : c10::irange(k)) {
       r *= dims_[i];
     }
     return r;

--- a/caffe2/core/qtensor_serialization.h
+++ b/caffe2/core/qtensor_serialization.h
@@ -46,7 +46,7 @@ void QTensorSerializer<Context>::Serialize(
   blob_proto.set_type(kQTensorBlobQType);
   QTensorProto& proto = *blob_proto.mutable_qtensor();
   proto.set_name(name);
-  for (int i = 0; i < qtensor.ndim(); ++i) {
+  for (const auto i : c10::irange(qtensor.ndim())) {
     proto.add_dims(qtensor.dim32(i));
   }
   proto.set_precision(qtensor.precision());

--- a/caffe2/core/stats.h
+++ b/caffe2/core/stats.h
@@ -73,7 +73,7 @@ TORCH_API ExportedStatMap toMap(const ExportedStatList& stats);
  * int main() {
  *   MyCaffeClass a("first");
  *   MyCaffeClass b("second");
- *   for (int i = 0; i < 10; ++i) {
+ *   for (const auto i : c10::irange(10)) {
  *     a.run(10);
  *     b.run(5);
  *   }

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -6,6 +6,7 @@
 #include "caffe2/utils/proto_utils.h"
 
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 
 #include <cmath>
 #include <string>
@@ -34,7 +35,7 @@ void assertTensorEquals(
     float epsilon = 0.1f) {
   CAFFE_ENFORCE(tensor.IsType<T>());
   CAFFE_ENFORCE_EQ(tensor.numel(), data.size());
-  for (auto idx = 0; idx < tensor.numel(); ++idx) {
+  for (const auto idx : c10::irange(tensor.numel())) {
     if (tensor.IsType<float>()) {
       assertNear(tensor.data<T>()[idx], data[idx], epsilon);
     } else {
@@ -88,7 +89,7 @@ void randomFill(
   std::mt19937 gen(42);
   std::uniform_real_distribution<RealType> dis(
       static_cast<RealType>(min), static_cast<RealType>(max));
-  for (size_t i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     data[i] = dis(gen);
   }
 }

--- a/caffe2/cuda_rtc/common_rtc.h
+++ b/caffe2/cuda_rtc/common_rtc.h
@@ -109,7 +109,7 @@ inline std::string GetUniqueName() {
 
   std::stringstream ss;
   ss << "_cuda_kernel_";
-  for (int i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     ss << alpha[rand() % (sizeof(alpha) - 1)];
   }
   return ss.str();

--- a/caffe2/experiments/operators/fully_connected_op_prune.h
+++ b/caffe2/experiments/operators/fully_connected_op_prune.h
@@ -32,7 +32,7 @@ namespace caffe2 {
       const std::vector<int64_t>& shape(Shape<N> vs) {
         static thread_local std::vector<int64_t> cache;
         cache.resize(vs.size());
-        for (auto i = 0; i < vs.size(); ++i) {
+        for (const auto i : c10::irange(vs.size())) {
           cache[i] = vs[i];
         }
         return cache;
@@ -70,8 +70,8 @@ namespace caffe2 {
       void MaskMatrix<float, CPUContext>(
           const float* mask, float* mat, int M, int N) {
         int offset = 0;
-        for (int i = 0; i < M; ++i) {
-          for (int j = 0; j < N; ++j) {
+        for (const auto i : c10::irange(M)) {
+          for (const auto j : c10::irange(N)) {
             mat[offset] = mask[offset]? mat[offset] : 0;
             offset++;
           }
@@ -86,7 +86,7 @@ namespace caffe2 {
           int /*N*/,
           int seq_len,
           float target) {
-        for (int i = 0; i < seq_len; ++i) {
+        for (const auto i : c10::irange(seq_len)) {
           // assume that the mask_seq is smaller than size
           // Although it seems that random access gets bad performance,
           // we make sure that seq is in order;
@@ -107,8 +107,8 @@ namespace caffe2 {
           float* mask_seq, int M, int N) {
         int seq_len = 0;
         int offset = 0;
-        for (int i = 0 ; i < M; ++i) {
-          for (int j = 0; j < N; ++j) {
+        for (const auto i : c10::irange(M)) {
+          for (const auto j : c10::irange(N)) {
             if (mat[offset] != 0 &&
                 (mat[offset] < thres && mat[offset] > -thres)) {
               mask_seq[seq_len++] = static_cast<float>(offset);

--- a/caffe2/experiments/operators/fully_connected_op_sparse.h
+++ b/caffe2/experiments/operators/fully_connected_op_sparse.h
@@ -35,7 +35,7 @@ template<int N>
 const std::vector<int64_t>& shape(Shape<N> vs) {
   static thread_local std::vector<int64_t> cache;
   cache.resize(vs.size());
-  for (auto i = 0; i < vs.size(); ++i) {
+  for (const auto i : c10::irange(vs.size())) {
     cache[i] = vs[i];
   }
   return cache;
@@ -63,8 +63,8 @@ void trans_mat<float, CPUContext>(
     int m,
     int n,
     CPUContext* /*context*/) {
-  for(int i = 0; i < m; ++i){
-    for(int j = 0; j < n; ++j){
+  for (const auto i : c10::irange(m)) {
+    for (const auto j : c10::irange(n)) {
       t[j*m+i]=o[i*n+j];
     }
   }

--- a/caffe2/experiments/operators/funhash_op.h
+++ b/caffe2/experiments/operators/funhash_op.h
@@ -67,7 +67,7 @@ class FunHashOp : public Operator<Context> {
 
     int64_t n_segments = num_segments_;
     if (num_segments_ == -1) {
-      for (int64_t i = 0; i < num_nz_ent; ++i) {
+      for (const auto i : c10::irange(num_nz_ent)) {
         if (seg_data[i] > n_segments) {
           n_segments = seg_data[i];
         }
@@ -86,14 +86,14 @@ class FunHashOp : public Operator<Context> {
     const auto* val_data = val.template data<T>();
     const auto* key_data = key.template data<int64_t>();
 
-    for (int64_t j = 0; j < num_nz_ent; ++j) {
+    for (const auto j : c10::irange(num_nz_ent)) {
       int64_t cur_seg = seg_data[j];
       int64_t cur_key = key_data[j];
       T cur_val = val_data[j];
       int64_t output_stride = cur_seg * num_outputs_;
-      for (int64_t i = 0; i < num_outputs_; ++i) {
+      for (const auto i : c10::irange(num_outputs_)) {
         T sum = 0;
-        for (int64_t k = 0; k < num_alpha; ++k) {
+        for (const auto k : c10::irange(num_alpha)) {
           uint64_t hash;
           // The hash function takes as input four integers:
           // 1. feature index
@@ -186,14 +186,14 @@ class FunHashGradientOp : public Operator<Context> {
 
     memset(grad_weight_data, 0, sizeof(T) * num_weight);
 
-    for (int64_t j = 0; j < num_nz_ent; ++j) {
+    for (const auto j : c10::irange(num_nz_ent)) {
       int64_t cur_seg = seg_data[j];
       int64_t cur_key = key_data[j];
       T cur_val = val_data[j];
       int64_t grad_out_stride = cur_seg * num_outputs_;
-      for (int64_t i = 0; i < num_outputs_; ++i) {
+      for (const auto i : c10::irange(num_outputs_)) {
         T grad_out_scale = grad_out_data[grad_out_stride + i] * cur_val;
-        for (int64_t k = 0; k < num_alpha; ++k) {
+        for (const auto k : c10::irange(num_alpha)) {
           uint64_t hash;
           hash_data[0] = cur_key;
           hash_data[1] = i;

--- a/caffe2/experiments/operators/sparse_funhash_op.h
+++ b/caffe2/experiments/operators/sparse_funhash_op.h
@@ -66,7 +66,7 @@ class SparseFunHashOp : public Operator<Context> {
 
     int64_t n_segments = num_segments_;
     if (num_segments_ == -1) {
-      for (int64_t i = 0; i < num_nz_ent; ++i) {
+      for (const auto i : c10::irange(num_nz_ent)) {
         if (seg_data[i] > n_segments) {
           n_segments = seg_data[i];
         }
@@ -85,14 +85,14 @@ class SparseFunHashOp : public Operator<Context> {
     const auto* val_data = val.template data<T>();
     const auto* key_data = key.template data<int64_t>();
 
-    for (int64_t j = 0; j < num_nz_ent; ++j) {
+    for (const auto j : c10::irange(num_nz_ent)) {
       int64_t cur_seg = seg_data[j];
       int64_t cur_key = key_data[j];
       T cur_val = val_data[j];
       int64_t output_stride = cur_seg * num_outputs_;
-      for (int64_t i = 0; i < num_outputs_; ++i) {
+      for (const auto i : c10::irange(num_outputs_)) {
         T sum = 0;
-        for (int64_t k = 0; k < num_alpha; ++k) {
+        for (const auto k : c10::irange(num_alpha)) {
           // The hash function takes as input three integers:
           // 1. feature index
           // 2. output index
@@ -190,14 +190,14 @@ class SparseFunHashGradientOp : public Operator<Context> {
     const auto* key_data = key.template data<int64_t>();
 
     int64_t w_ind = 0;
-    for (int64_t j = 0; j < num_nz_ent; ++j) {
+    for (const auto j : c10::irange(num_nz_ent)) {
       int64_t cur_seg = seg_data[j];
       int64_t cur_key = key_data[j];
       T cur_val = val_data[j];
       int64_t grad_out_stride = cur_seg * num_outputs_;
-      for (int64_t i = 0; i < num_outputs_; ++i) {
+      for (const auto i : c10::irange(num_outputs_)) {
         T grad_out_scale = grad_out_data[grad_out_stride + i] * cur_val;
-        for (int64_t k = 0; k < num_alpha; ++k) {
+        for (const auto k : c10::irange(num_alpha)) {
           hash_data[0] = cur_key;
           hash_data[1] = i;
           hash_data[2] = k;

--- a/caffe2/experiments/operators/sparse_matrix_reshape_op.h
+++ b/caffe2/experiments/operators/sparse_matrix_reshape_op.h
@@ -111,7 +111,7 @@ class SparseMatrixReshapeOp : public Operator<Context> {
     auto* new_col_data = new_col->template mutable_data<int64_t>();
     auto* new_row_data = new_row->template mutable_data<int>();
 
-    for (int i = 0; i < nnz; ++i) {
+    for (const auto i : c10::irange(nnz)) {
       int64_t offset = old_row_data[i] * old_stride_ + old_col_data[i];
       new_row_data[i] = offset / new_stride_;
       new_col_data[i] = offset % new_stride_;

--- a/caffe2/ideep/operators/conv_pool_base_op.h
+++ b/caffe2/ideep/operators/conv_pool_base_op.h
@@ -53,7 +53,7 @@ class IDEEPConvPoolOpBase : public ConvPoolOpBase<IDEEPContext> {
 
   bool RunOnDevice() override {
     if (!global_pooling_) {
-      for (int dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE_GT(kernel_[dim], 0);
       }
     }

--- a/caffe2/ideep/operators/conv_transpose_unpool_base_op.h
+++ b/caffe2/ideep/operators/conv_transpose_unpool_base_op.h
@@ -109,7 +109,7 @@ class IDEEPConvTransposeUnpoolBase : public IDEEPOperator {
       CAFFE_ENFORCE_EQ(pads_.size(), 2 * kernel_.size());
     }
 
-    for (int dim = 0; dim < kernel_.size(); ++dim) {
+    for (const auto dim : c10::irange(kernel_.size())) {
       CAFFE_ENFORCE_GT(kernel_[dim], 0);
       CAFFE_ENFORCE_GT(stride_[dim], 0);
       CAFFE_ENFORCE_GE(adj_[dim], 0);
@@ -143,7 +143,7 @@ class IDEEPConvTransposeUnpoolBase : public IDEEPOperator {
     auto input_dims = input.get_dims();
     itensor::dims dims;
     dims.assign(input_dims.begin() + 2, input_dims.end());
-    for (int dim = 0; dim < dims.size(); ++dim) {
+    for (const auto dim : c10::irange(dims.size())) {
       int dim_size = 0;
       ComputeSizeAndPad(
           dims[dim],

--- a/caffe2/ideep/operators/operator_fallback_ideep.h
+++ b/caffe2/ideep/operators/operator_fallback_ideep.h
@@ -52,7 +52,7 @@ class IDEEPFallbackOp final : public IDEEPOperator {
     // Create output blobs in parent workspace,
     // then forward output blobs to local workspace.
     std::unordered_map<string, string> forwarded_output_blobs;
-    for (int i = 0; i < base_def_.output_size(); i++) {
+    for (const auto i : c10::irange(base_def_.output_size())) {
       // For in-place case, the in/output tensor for local_ws must be
       // re-created, instead of forwarding from current workspace.
       string parent_name(base_def_.output(i));
@@ -81,7 +81,7 @@ class IDEEPFallbackOp final : public IDEEPOperator {
   }
 
   bool RunOnDevice() override {
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       if (InputIsType<itensor>(i)
           && (Input(i).has_scale()
             || Input(i).get_data_type() == idtype::f32)) {
@@ -128,7 +128,7 @@ class IDEEPFallbackOp final : public IDEEPOperator {
       return false;
     }
 
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       if (SkipOutputCopy::Contains(i)) {
         VLOG(1) << "Copy output: index " << i << " skipped.";
         continue;

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -83,7 +83,7 @@ class IDEEPContext final : public BaseContext {
           static_cast<const void*>(src),
           static_cast<void*>(dst));
     } else {
-      for (size_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         dst[i] = src[i];
       }
     }

--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn_kernels.h
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn_kernels.h
@@ -523,7 +523,7 @@ kernel void col2im(
                 }
             } else {
                 half4 components(0, 0, 0, 0);
-                for (auto i = 0; i < 4; ++i) {
+                for (const auto i : c10::irange(4)) {
                     ushort c_col_i = n * divRoundUp(kernel_h * kernel_w * C, 4) * 4 + h_k * kernel_w * C +
                     w_k * C + c * 4 + i;
                     ushort c_col_i_z = c_col_i / 4;
@@ -826,7 +826,7 @@ kernel void concat(
   ushort2 gid_ = ushort2(gid.x, gid.y);
   half4 value;
   
-  for (int off = 0; off < 4; ++off) {
+  for (const auto off : c10::irange(4)) {
     ushort cur_channel = c * 4 + off;
     ushort cur_idx = 0;
     if (cur_channel >= C) {
@@ -1013,8 +1013,8 @@ kernel void roi_warp(texture2d_array<half, access::sample> ina[[texture(0), func
   const RoIT count = iy_upper * ix_upper;
 
   RoIT4 output_val = 0.0;
-  for (int iy = 0; iy < iy_upper; iy++) {
-    for (int ix = 0; ix < ix_upper; ix++) {
+  for (const auto iy : c10::irange(iy_upper)) {
+    for (const auto ix : c10::irange(ix_upper)) {
       const RoIT y =
           roi_start_h + ph * bin_size_h + iy * bin_size_h / static_cast<RoIT>(roi_bin_grid_h);
       const RoIT x =
@@ -1141,7 +1141,7 @@ kernel void channel_shuffle(
   const ushort c = gid.z - n * divRoundUp(C, 4);
   half4 value;
   ushort2 gid_ = gid.xy;
-  for (int off = 0; off < 4; ++off) {
+  for (const auto off : c10::irange(4)) {
     ushort cur_channel = c * 4 + off;
     if (cur_channel >= C) {
       break;

--- a/caffe2/mobile/contrib/libopencl-stub/include/CL/cl.hpp
+++ b/caffe2/mobile/contrib/libopencl-stub/include/CL/cl.hpp
@@ -1196,7 +1196,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, size_t<N>* param, long)
         return err;
     }
 
-    for(int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
         (*param)[i] = value[i];
     }
 

--- a/caffe2/operators/arg_ops.h
+++ b/caffe2/operators/arg_ops.h
@@ -43,7 +43,7 @@ class ArgOp final : public Operator<Context> {
     Y_dims.reserve(ndim);
     int prev_size = 1;
     int next_size = 1;
-    for (int i = 0; i < axis_; ++i) {
+    for (const auto i : c10::irange(axis_)) {
       Y_dims.push_back(X_dims[i]);
       prev_size *= X_dims[i];
     }

--- a/caffe2/operators/assert_op.h
+++ b/caffe2/operators/assert_op.h
@@ -23,7 +23,7 @@ class AssertOp final : public Operator<Context> {
     cmp_tensor_.CopyFrom(Input(0));
     auto* cmp_data = cmp_tensor_.template data<T>();
 
-    for (int64_t i = 0; i < cmp_tensor_.numel(); ++i) {
+    for (const auto i : c10::irange(cmp_tensor_.numel())) {
       CAFFE_ENFORCE((bool)cmp_data[i], [&]() {
         std::stringstream ss;
         ss << "Assert failed for element " << i

--- a/caffe2/operators/batch_gather_ops.h
+++ b/caffe2/operators/batch_gather_ops.h
@@ -80,7 +80,7 @@ class BatchGatherGradientOp final : public Operator<Context> {
     CAFFE_ENFORCE_GE(data.dim(), 2, "DATA should be at least 2-D");
     // Outer dimensions of input data and gradient should be the same
     // because they are preserved for gathers with axis > 0.
-    for (int acheck = 0; acheck < axis; acheck++) {
+    for (const auto acheck : c10::irange(axis)) {
       CAFFE_ENFORCE_EQ(
           data.size(acheck),
           grad.size(acheck),
@@ -105,7 +105,7 @@ class BatchGatherGradientOp final : public Operator<Context> {
     auto idx_inner_dims_product = indices.size_from_dim(axis);
     if (match_outer) {
       CAFFE_ENFORCE_GE(axis, 1, "Axis should be at least 1");
-      for (auto i = 0; i < axis; i++) {
+      for (const auto i : c10::irange(axis)) {
         CAFFE_ENFORCE_EQ(
             data.size(i),
             indices.size(i),
@@ -120,11 +120,11 @@ class BatchGatherGradientOp final : public Operator<Context> {
     gather_helper::check_indexarray_range<TInd>(
         idxs, N, src_indexing_axis_dim, false);
 
-    for (auto batch = 0; batch < outer_dims_product; ++batch) {
+    for (const auto batch : c10::irange(outer_dims_product)) {
       auto grad_batch_base = grad_data + batch * gathered_grad_batch_size;
       auto out_batch_base = out_data + batch * batch_size;
 
-      for (auto i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         auto idx = idxs[i];
         if (match_outer) {
           idx = idxs[batch * idx_inner_dims_product + i];

--- a/caffe2/operators/bisect_percentile_op.h
+++ b/caffe2/operators/bisect_percentile_op.h
@@ -74,11 +74,12 @@ class BisectPercentileOp final : public Operator<Context> {
     int feature_length = 0;
     int cur_index = 0;
 
-    for (int i = 0; i < num_features; ++i) {
+    for (const auto i : c10::irange(num_features)) {
       cur_index = i;
       feature_start_index = index[i];
       feature_length = pct_lens_[i];
-      for (int j = 0; j < batch_size; ++j) {
+      for (const auto j : c10::irange(batch_size)) {
+        (void)j; // Suppress unused variable warning
         pct_output[cur_index] = compute_percentile(
             pct_raw_.begin() + feature_start_index,
             pct_mapping_.begin() + feature_start_index,

--- a/caffe2/operators/byte_weight_dequant_op.h
+++ b/caffe2/operators/byte_weight_dequant_op.h
@@ -25,7 +25,7 @@ class ByteWeightDequantOp : public Operator<Context> {
     auto* Y = Output(0, shape_, at::dtype<float>());
     float bin_interval = (max_ - min_) / 255.0;
     int total = 1;
-    for (auto i = 0U; i < shape_.size(); i++) {
+    for (const auto i : c10::irange(0U, shape_.size())) {
       total *= Y->size(i);
     }
     const uint8_t* Xdata;

--- a/caffe2/operators/cast_op.h
+++ b/caffe2/operators/cast_op.h
@@ -41,7 +41,7 @@ class CastOp : public Operator<Context> {
     const auto* data = input.template data<SrcType>();
     auto* out = output->template mutable_data<DstType>();
     auto N = input.size();
-    for (int64_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       out[i] = static_cast<DstType>(data[i]);
     }
     return true;

--- a/caffe2/operators/cc_bmm_bg_op.h
+++ b/caffe2/operators/cc_bmm_bg_op.h
@@ -38,7 +38,7 @@ bool ConcatBatchMatMulBatchGatherOp<Context>::RunOnDevice() {
   int adj_size = input_zero.dim() + 1;
   int canonical_axis = 1;
   CAFFE_ENFORCE_LT(canonical_axis, adj_size, "Axis not in input ndim range.");
-  for (int i = 2; i < InputSize(); ++i) {
+  for (const auto i : c10::irange(2, InputSize())) {
     CAFFE_ENFORCE(
         Input(i).dtype() == input_zero.dtype(),
         "All inputs must have the same type, expected: ",
@@ -50,7 +50,7 @@ bool ConcatBatchMatMulBatchGatherOp<Context>::RunOnDevice() {
   }
 
   int before = 1, after = 1;
-  for (int i = 0; i < input_zero.dim(); ++i) {
+  for (const auto i : c10::irange(input_zero.dim())) {
     int dim = input_zero.dim32(i);
     if (i < canonical_axis) {
       before *= dim;
@@ -58,7 +58,7 @@ bool ConcatBatchMatMulBatchGatherOp<Context>::RunOnDevice() {
       after *= dim;
     }
     // check the input dims are compatible.
-    for (int j = 2; j < InputSize(); ++j) {
+    for (const auto j : c10::irange(2, InputSize())) {
       int dim_j = Input(j).dim32(i);
       CAFFE_ENFORCE(
           dim == dim_j,
@@ -93,7 +93,7 @@ bool ConcatBatchMatMulBatchGatherOp<Context>::RunOnDevice() {
   auto* output = Output(0, output_dims, at::dtype<T>());
   // std::stringstream ss;
   // ss << "[";
-  // for(int i = 0; i < output_dims.size(); i++) ss << output_dims[i];
+  // for (const auto i : c10::irange(output_dims.size()))ss << output_dims[i];
   // ss << "]";
   // LOG(INFO) << "output size: " << ss.str();
 
@@ -107,7 +107,7 @@ bool ConcatBatchMatMulBatchGatherOp<Context>::RunOnDevice() {
 #pragma omp for
     for (int b = 0; b < batch_size; ++b) {
       // concat input to scratch
-      for (int i = 1; i < InputSize(); ++i) {
+      for (const auto i : c10::irange(1, InputSize())) {
         auto* input_data = Input(i).template data<T>();
         memcpy(
             &scratch_input[(i - 1) * embed_size],
@@ -130,7 +130,7 @@ bool ConcatBatchMatMulBatchGatherOp<Context>::RunOnDevice() {
       // do gather
 
       int64_t output_offset = b * gather_size;
-      for (int i = 0; i < gather_size; i++) {
+      for (const auto i : c10::irange(gather_size)) {
         output_data[output_offset + i] = scratch_output[indices_data[i]];
       }
     }

--- a/caffe2/operators/ceil_op.h
+++ b/caffe2/operators/ceil_op.h
@@ -21,7 +21,7 @@ class CeilOp final : public Operator<Context> {
 
     const float* Xdata = X.template data<float>();
     float* Ydata = Y->template mutable_data<float>();
-    for (int i = 0; i < X.numel(); ++i) {
+    for (const auto i : c10::irange(X.numel())) {
       Ydata[i] = std::ceil(Xdata[i]);
     }
     return true;

--- a/caffe2/operators/concat_split_op.h
+++ b/caffe2/operators/concat_split_op.h
@@ -161,7 +161,7 @@ bool SplitOp<Context>::RunOnDevice() {
       input_channels);
   vector<int64_t> output_dims(input.sizes().vec());
   int before = 1, after = 1;
-  for (int i = 0; i < canonical_axis; ++i) {
+  for (const auto i : c10::irange(canonical_axis)) {
     before *= input.dim32(i);
   }
   for (int i = canonical_axis + 1; i < input.dim(); ++i) {
@@ -174,7 +174,7 @@ bool SplitOp<Context>::RunOnDevice() {
   const auto *const input_ptr = static_cast<const char*>(input.raw_data());
 
   size_t input_offset = 0;
-  for (int i = 0; i < OutputSize(); ++i) {
+  for (const auto i : c10::irange(OutputSize())) {
     auto *const output = Output(i);
     const auto axis_dim = add_axis_ ? 1 : axis_data[i];
     if (!add_axis_) {
@@ -264,7 +264,7 @@ bool SplitByLengthsOp<Context>::RunOnDevice() {
     dim_multiplier = 1;
   }
 
-  for (int i = 0; i < OutputSize(); ++i) {
+  for (const auto i : c10::irange(OutputSize())) {
     auto* output = Output(i);
     const auto* axis_offset = axis_data + lengths_length / OutputSize() * i;
     auto axis_dim =
@@ -301,7 +301,7 @@ bool ConcatOp<Context>::RunOnDevice() {
   int adj_size = input_zero.dim() + (add_axis_ ? 1 : 0);
   int canonical_axis = canonical_axis_index_(axis_, adj_size);
   CAFFE_ENFORCE_LT(canonical_axis, adj_size, "Axis not in input ndim range.");
-  for (int i = 1; i < InputSize(); ++i) {
+  for (const auto i : c10::irange(1, InputSize())) {
     CAFFE_ENFORCE_EQ(
         Input(i).dtype(),
         input_zero.dtype(),
@@ -315,7 +315,7 @@ bool ConcatOp<Context>::RunOnDevice() {
 
   int before = 1, after = 1;
   vector<int64_t> output_dims(input_zero.sizes().vec());
-  for (int i = 0; i < input_zero.dim(); ++i) {
+  for (const auto i : c10::irange(input_zero.dim())) {
     if (i == canonical_axis && !add_axis_) {
       continue;
     }
@@ -326,7 +326,7 @@ bool ConcatOp<Context>::RunOnDevice() {
       after *= dim;
     }
     // check the input dims are compatible.
-    for (int j = 1; j < InputSize(); ++j) {
+    for (const auto j : c10::irange(1, InputSize())) {
       int dim_j = Input(j).dim32(i);
       CAFFE_ENFORCE_EQ(
           dim,
@@ -351,7 +351,7 @@ bool ConcatOp<Context>::RunOnDevice() {
   }
 
   int output_channels = 0;
-  for (int i = 0; i < InputSize(); ++i) {
+  for (const auto i : c10::irange(InputSize())) {
     axis_data[i] = add_axis_ ? 1 : Input(i).dim32(canonical_axis);
     output_channels += axis_data[i];
   }
@@ -368,7 +368,7 @@ bool ConcatOp<Context>::RunOnDevice() {
   }
 
   size_t output_offset = 0;
-  for (int i = 0; i < InputSize(); ++i) {
+  for (const auto i : c10::irange(InputSize())) {
     auto& input = Input(i);
     auto axis_dim = add_axis_ ? 1 : input.dim32(canonical_axis);
     math::CopyMatrix<Context>(

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -139,7 +139,7 @@ class ConvPoolOpBase : public Operator<Context> {
     }
 
     if (global_pooling_) {
-      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE(
             pads_[2 * dim] == 0 && pads_[2 * dim + 1] == 0 &&
                 dilation_[dim] == 1 && stride_[dim] == 1,
@@ -152,7 +152,7 @@ class ConvPoolOpBase : public Operator<Context> {
     // need to clean this up.
     if (operator_def.name().find("Conv") == 0 ||
         operator_def.name().find("Pool") != std::string::npos) {
-      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE_GE(pads_[dim], 0);
         CAFFE_ENFORCE_GE(pads_[kernel_.size() + dim], 0);
         CAFFE_ENFORCE(
@@ -162,7 +162,7 @@ class ConvPoolOpBase : public Operator<Context> {
       }
     }
 
-    for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+    for (const auto dim : c10::irange(kernel_.size())) {
       CAFFE_ENFORCE_GE(kernel_[dim], 0);
       CAFFE_ENFORCE_GE(dilation_[dim], 0);
       CAFFE_ENFORCE_GE(stride_[dim], 0);
@@ -281,7 +281,7 @@ class ConvPoolOpBase : public Operator<Context> {
       std::copy_n(input_dims.cbegin() + offset, ndim, kernel->begin());
       std::fill_n(output_dims->begin() + offset, ndim, 1LL);
     } else {
-      for (int i = 0; i < ndim; ++i) {
+      for (const auto i : c10::irange(ndim)) {
         ComputeSizeAndPad(
             input_dims[i + offset],
             stride[i],
@@ -320,7 +320,7 @@ class ConvPoolOpBase : public Operator<Context> {
       std::copy_n(input_dims.cbegin() + offset, ndim, kernel->begin());
       std::fill_n(output_dims->begin() + offset, ndim, 1LL);
     } else {
-      for (int i = 0; i < ndim; ++i) {
+      for (const auto i : c10::irange(ndim)) {
         ComputeSizeAndPad64(
             input_dims[i + offset],
             stride[i],
@@ -342,7 +342,7 @@ class ConvPoolOpBase : public Operator<Context> {
     } else if (legacy_pad_ != LegacyPadding::NOTSET) {
       int output_unused;
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (int dim = 0; dim < dims.size(); ++dim) {
+      for (const auto dim : c10::irange(dims.size())) {
         ComputeSizeAndPad(
             dims[dim],
             stride_[dim],
@@ -381,7 +381,7 @@ class ConvPoolOpBase : public Operator<Context> {
       reset_tensor_device_ = true;
     } else {
       const int* tensor_data = tensor->template data<int>();
-      for (int d_i = 0; d_i < data.size(); ++d_i) {
+      for (const auto d_i : c10::irange(data.size())) {
         if (tensor_data[d_i] != data[d_i]) {
           reset_tensor_device_ = true;
           break;
@@ -411,7 +411,7 @@ class ConvPoolOpBase : public Operator<Context> {
 
   bool RunOnDevice() override {
     if (!global_pooling_) {
-      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE_GT(kernel_[dim], 0);
       }
     }

--- a/caffe2/operators/conv_transpose_op_impl.h
+++ b/caffe2/operators/conv_transpose_op_impl.h
@@ -78,7 +78,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
         buffer_shape,
         at::dtype<T>().device(Context::GetDeviceType()));
     T* col_buffer_data = col_buffer->template mutable_data<T>();
-    for (int image_id = 0; image_id < N; ++image_id) {
+    for (const auto image_id : c10::irange(N)) {
       // Weight term
       if (G == 1) {
         math::Gemm<T, Context>(
@@ -231,7 +231,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
         buffer_shape,
         at::dtype<T>().device(Context::GetDeviceType()));
     T* col_buffer_data = col_buffer_.template mutable_data<T>();
-    for (int image_id = 0; image_id < N; ++image_id) {
+    for (const auto image_id : c10::irange(N)) {
       // Weight term
       if (G == 1) {
         math::Gemm<T, Context>(
@@ -247,7 +247,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
             col_buffer_data,
             &context_);
       } else {
-        for (int group_id = 0; group_id < G; ++group_id) {
+        for (const auto group_id : c10::irange(G)) {
           math::GemmEx<T, Context>(
               CblasNoTrans,
               CblasNoTrans,
@@ -374,7 +374,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       at::dtype<T>().device(Context::GetDeviceType()));
   T* col_buffer_data = col_buffer_.template mutable_data<T>();
 
-  for (int image_id = 0; image_id < N; ++image_id) {
+  for (const auto image_id : c10::irange(N)) {
     // gradient w.r.t. filters. Im2Col followed by Gemm
     // Im2Col.
     math::Im2Col<T, Context, StorageOrder::NCHW>(
@@ -539,7 +539,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
       at::dtype<T>().device(Context::GetDeviceType()));
   T* col_buffer_data = col_buffer_.template mutable_data<T>();
 
-  for (int image_id = 0; image_id < N; ++image_id) {
+  for (const auto image_id : c10::irange(N)) {
     // gradient w.r.t. filters. Im2Col followed by Gemm
     // Im2Col.
     math::Im2Col<T, Context, StorageOrder::NHWC>(
@@ -575,7 +575,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
           dfilter_data,
           &context_);
     } else {
-      for (int group_id = 0; group_id < G; ++group_id) {
+      for (const auto group_id : c10::irange(G)) {
         math::GemmEx<T, Context>(
             CblasTrans,
             CblasNoTrans,
@@ -610,7 +610,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
             dX_data + image_id * M * X_HxW,
             &context_);
       } else {
-        for (int group_id = 0; group_id < G; ++group_id) {
+        for (const auto group_id : c10::irange(G)) {
           math::GemmEx<T, Context>(
               CblasNoTrans,
               CblasTrans,

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -76,7 +76,7 @@ void runTileContiguous(
   int colBlockSize = (W + kernelW / strideW);
   int numColBlocks = strideW;
 
-  for (int c = 0; c < kernelDataSize; ++c) {
+  for (const auto c : c10::irange(kernelDataSize)) {
     int w_offset = c % kernelW;
     int h_offset = (c / kernelW) % kernelH;
     int c_im = c / kernelH / kernelW;
@@ -276,13 +276,13 @@ void reinterleaveRows(
     float32x4_t v0[kStrideW];
     float32x4_t v1[kStrideW];
 
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v0[i] = vld1q_f32(src + i * colBlockSize);
       v1[i] = vld1q_f32(src + i * colBlockSize + 4);
     }
 
     // add per-channel bias
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v0[i] = vaddq_f32(v0[i], biasV);
       v1[i] = vaddq_f32(v1[i], biasV);
     }
@@ -300,12 +300,12 @@ void reinterleaveRows(
   for (; w < inputW - 1; ++w) {
     float v[kStrideW];
 
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v[i] = src[i * colBlockSize];
     }
 
     // add per-channel bias
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v[i] += b;
     }
 
@@ -614,12 +614,12 @@ bool ConvTransposeMobileOp<T, Context>::RunOnDeviceWithOrderNCHW() {
         numThreads * threadColBufferSize);
     // Group together thread buffers for accumulation
     std::vector<T*> toSum(numThreads - 1);
-    for (int i = 1; i < numThreads; ++i) {
+    for (const auto i : c10::irange(1, numThreads)) {
       toSum[i - 1] = threadBuffer->template mutable_data<T>() +
           i * threadYBufferSizeAligned;
     }
 
-    for (auto image_id = 0; image_id < N; ++image_id) {
+    for (const auto image_id : c10::irange(N)) {
       // Each time through, we have to reset all per-thread output
       // buffers, since the output buffer is only per-batch element
       // The column buffers are overwritten by the matrix multiplication

--- a/caffe2/operators/conv_transpose_unpool_op_base.h
+++ b/caffe2/operators/conv_transpose_unpool_op_base.h
@@ -121,7 +121,7 @@ class ConvTransposeUnpoolBase : public Operator<Context> {
     }
 
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int dim = 0; dim < kernel_.size(); ++dim) {
+    for (const auto dim : c10::irange(kernel_.size())) {
       CAFFE_ENFORCE_GT(kernel_[dim], 0);
       CAFFE_ENFORCE_GT(stride_[dim], 0);
       CAFFE_ENFORCE_GE(adj_[dim], 0);

--- a/caffe2/operators/deform_conv_op_impl.h
+++ b/caffe2/operators/deform_conv_op_impl.h
@@ -77,7 +77,7 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
           1);
 
   int kernel_dims_size = 1;
-  for (int i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE(filter.dim32(i + 2) == kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
@@ -155,8 +155,8 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     col_buffer->Resize(buffer_shape);
     T* col_buffer_data = col_buffer->template mutable_data<T>();
     // Im2col, followed by gemm.
-    for (int image_id = 0; image_id < N; ++image_id) {
-      for (int group_id = 0; group_id < group_; ++group_id) {
+    for (const auto image_id : c10::irange(N)) {
+      for (const auto group_id : c10::irange(group_)) {
         DeformableIm2col(
             Xdata + group_id * input_offset,
             offset_data,
@@ -271,7 +271,7 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
           1);
 
   int kernel_dims_size = 1;
-  for (int i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE(filter.dim32(i + 2) == kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
@@ -342,8 +342,8 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     math::Set<T, Context>(dX->numel(), 0, dXdata, &context_);
   }
 
-  for (int image_id = 0; image_id < N; ++image_id) {
-    for (int group_id = 0; group_id < group_; ++group_id) {
+  for (const auto image_id : c10::irange(N)) {
+    for (const auto group_id : c10::irange(group_)) {
       math::Gemm<T, Context>(
           CblasTrans,
           CblasNoTrans,
@@ -378,7 +378,7 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     DeformableIm2col(
         Xdata, offset_data, X.sizes(), col_buffer_shape, col_buffer_data);
 
-    for (int group_id = 0; group_id < group_; ++group_id) {
+    for (const auto group_id : c10::irange(group_)) {
       math::Gemm<T, Context>(
           CblasNoTrans,
           CblasTrans,

--- a/caffe2/operators/dense_vector_to_id_list_op.h
+++ b/caffe2/operators/dense_vector_to_id_list_op.h
@@ -33,9 +33,9 @@ class DenseVectorToIdListOp : public Operator<Context> {
 
     auto v_pos = 0;
     auto l_pos = 0;
-    for (auto i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       auto length = 0;
-      for (int j = 0; j < col_num; j++) {
+      for (const auto j : c10::irange(col_num)) {
         if ((int)(input_data[i * col_num + j] + 0.5) != 0) {
           out_values_data[v_pos++] = j;
           length++;

--- a/caffe2/operators/distance_op.h
+++ b/caffe2/operators/distance_op.h
@@ -37,7 +37,7 @@ class SquaredL2DistanceGradientOp final : public Operator<Context> {
     int N = X.dim() > 0 ? X.dim32(0) : 1;
     int D = N > 0 ? X.numel() / N : 0;
     CAFFE_ENFORCE(X.dim() == Y.dim());
-    for (int i = 0; i < X.dim(); ++i) {
+    for (const auto i : c10::irange(X.dim())) {
       CAFFE_ENFORCE(X.dim32(i) == Y.dim32(i));
     }
     CAFFE_ENFORCE(dDistance.dim() == 1);
@@ -50,7 +50,7 @@ class SquaredL2DistanceGradientOp final : public Operator<Context> {
         Y.template data<T>(),
         dX->template mutable_data<T>(),
         &context_);
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       math::Scale<T, T, Context>(
           D,
           dDistance.template data<T>() + i,
@@ -227,7 +227,7 @@ class DotProductWithPaddingGradientOp final : public Operator<Context> {
     const auto* dDot_data = dDot.template data<T>();
     auto* dX_data = dX->template mutable_data<T>();
     auto* dY_data = dY->template mutable_data<T>();
-    for (int i = 0; i < N; ++i) { // TODO: multithreading
+    for (const auto i : c10::irange(N)) { // TODO: multithreading
       auto offsetX = i * DX;
       auto offsetY = i * DY;
       if (replicate_) {

--- a/caffe2/operators/do_op.h
+++ b/caffe2/operators/do_op.h
@@ -46,7 +46,7 @@ class DoOp final : public Operator<Context> {
 
     const auto& outer_blob_names = checkAndGetOuterNames(operator_def);
     std::unordered_set<std::string> used_outer_names;
-    for (size_t blob_idx = 0; blob_idx < inner_blobs.size(); ++blob_idx) {
+    for (const auto blob_idx : c10::irange(inner_blobs.size())) {
       CAFFE_ENFORCE(
           !blob_bindings_.count(inner_blobs[blob_idx]),
           "Invalid blob bindings: redefinition of inner blob " +
@@ -154,7 +154,7 @@ class DoOp final : public Operator<Context> {
       const OperatorDef& operator_def) const {
     std::vector<std::string> names;
     names.reserve(operator_def.input_size());
-    for (auto idx = 0; idx < operator_def.input_size(); ++idx) {
+    for (const auto idx : c10::irange(operator_def.input_size())) {
       names.push_back(operator_def.input(idx));
     }
     return names;
@@ -164,7 +164,7 @@ class DoOp final : public Operator<Context> {
       const OperatorDef& operator_def) const {
     std::vector<std::string> names;
     names.reserve(operator_def.output_size());
-    for (auto idx = 0; idx < operator_def.output_size(); ++idx) {
+    for (const auto idx : c10::irange(operator_def.output_size())) {
       names.push_back(operator_def.output(idx));
     }
     return names;

--- a/caffe2/operators/elementwise_logical_ops.h
+++ b/caffe2/operators/elementwise_logical_ops.h
@@ -51,7 +51,7 @@ class WhereOp final : public Operator<Context> {
 
     if (enable_broadcast_) {
       size_t block_size = left.size_from_dim(1);
-      for (int i = 0; i < select.numel(); i++) {
+      for (const auto i : c10::irange(select.numel())) {
         size_t offset = i * block_size;
         if (select_data[i]) {
           context_.CopyItemsSameDevice(
@@ -68,7 +68,7 @@ class WhereOp final : public Operator<Context> {
         }
       }
     } else {
-      for (int i = 0; i < select.numel(); ++i) {
+      for (const auto i : c10::irange(select.numel())) {
         output_data[i] = select_data[i] ? left_data[i] : right_data[i];
       }
     }
@@ -159,7 +159,7 @@ class IsMemberOfOp final : public Operator<Context> {
 
     const T* input_data = input.template data<T>();
     bool* output_data = output->template mutable_data<bool>();
-    for (int i = 0; i < input.numel(); ++i) {
+    for (const auto i : c10::irange(input.numel())) {
       output_data[i] = values.find(input_data[i]) != values.end();
     }
     return true;

--- a/caffe2/operators/elementwise_op_test.h
+++ b/caffe2/operators/elementwise_op_test.h
@@ -62,7 +62,7 @@ void elementwiseAnd() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{true, false, false, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -83,7 +83,7 @@ void elementwiseAnd() {
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{
         true, false, false, false, true, false, false, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -108,7 +108,7 @@ void elementwiseOr() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{true, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -128,7 +128,7 @@ void elementwiseOr() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{true, true, true, false, true, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -153,7 +153,7 @@ void elementwiseXor() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{false, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -174,7 +174,7 @@ void elementwiseXor() {
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{
         false, true, true, false, false, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -198,7 +198,7 @@ void elementwiseNot() {
   caffe2::Tensor Y(blob->Get<caffe2::Tensor>(), caffe2::CPU);
   EXPECT_EQ(Y.numel(), N);
   std::vector<bool> result{false, true};
-  for (size_t i = 0; i < Y.numel(); ++i) {
+  for (const auto i : c10::irange(Y.numel())) {
     EXPECT_EQ(Y.template data<bool>()[i], result[i]);
   }
 }
@@ -220,7 +220,7 @@ void elementwiseEQ() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{false, true, false, true};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -237,7 +237,7 @@ void elementwiseEQ() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{true, true, false, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -257,7 +257,7 @@ void elementwiseEQ() {
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{
         true, false, false, true, false, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }

--- a/caffe2/operators/enforce_finite_op.h
+++ b/caffe2/operators/enforce_finite_op.h
@@ -32,7 +32,7 @@ class EnforceFiniteOp final : public Operator<Context> {
     const T* input_data = input.template data<T>();
     auto size = input.numel();
 
-    for (auto i = 0; i < size; i++) {
+    for (const auto i : c10::irange(size)) {
       auto isfinite = std::isfinite(input_data[i]);
       if (!isfinite) {
         LogBlobFiniteness();

--- a/caffe2/operators/expand_op.h
+++ b/caffe2/operators/expand_op.h
@@ -95,7 +95,7 @@ class ExpandGradientOp final : public Operator<Context> {
     auto* dX = Output(0, X.sizes(), at::dtype<T>());
     std::vector<int> axes;
     const int offset = ndim - X.dim();
-    for (int i = 0; i < ndim; i++) {
+    for (const auto i : c10::irange(ndim)) {
       if (i < offset || dX_dims[i - offset] == 1) {
         axes.push_back(i);
       }

--- a/caffe2/operators/expand_squeeze_dims_op.h
+++ b/caffe2/operators/expand_squeeze_dims_op.h
@@ -91,7 +91,7 @@ class SqueezeOp : public Operator<Context> {
       const std::vector<int>& dims) {
     size_t j = 0;
     std::vector<int> newDims;
-    for (size_t i = 0; i < inputDims.size(); ++i) {
+    for (const auto i : c10::irange(inputDims.size())) {
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       if (j < dims.size() && dims[j] == i) {
         CAFFE_ENFORCE_EQ(

--- a/caffe2/operators/feature_maps_ops.h
+++ b/caffe2/operators/feature_maps_ops.h
@@ -32,8 +32,8 @@ class MergeDenseFeatureTensorsOp : public Operator<Context> {
 
     const bool* inPresenceData = Input(1).template data<bool>();
     int totalNumFeatures = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
-      for (int inputIndex = 0; inputIndex < numFeatures; ++inputIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
+      for (const auto inputIndex : c10::irange(numFeatures)) {
         if (inPresenceData[exampleIndex * numFeatures + inputIndex]) {
           ++totalNumFeatures;
         }
@@ -51,10 +51,10 @@ class MergeDenseFeatureTensorsOp : public Operator<Context> {
       Input(0).template data<T>();
 
     int keysOffset = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
       auto offset = exampleIndex * numFeatures;
-      for (int inputIndex = 0; inputIndex < numFeatures; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numFeatures)) {
         if (inPresenceData[offset]) {
           ++outLengthsData[exampleIndex];
           outKeysData[keysOffset] = featureIDs_[inputIndex];
@@ -94,10 +94,10 @@ class MergeSingleScalarFeatureTensorsOp : public Operator<Context> {
   bool DoRunWithType() {
     int numExamples = Input(0).numel();
     int totalNumFeatures = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       const bool* inPresenceData =
           Input(kNumTensorsPerInput * inputIndex + 1).template data<bool>();
-      for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+      for (const auto exampleIndex : c10::irange(numExamples)) {
         if (inPresenceData[exampleIndex]) {
           ++totalNumFeatures;
         }
@@ -113,9 +113,9 @@ class MergeSingleScalarFeatureTensorsOp : public Operator<Context> {
     T* outValuesData = outValues->template mutable_data<T>();
 
     int keysOffset = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
-      for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numInputs_)) {
         const T* inData =
             Input(kNumTensorsPerInput * inputIndex).template data<T>();
         const bool* inPresenceData =
@@ -158,7 +158,7 @@ class MergeSingleScalarFeatureTensorsGradientOp : public Operator<Context> {
   template <typename T>
   bool DoRunWithType() {
     int numExamples = Input(0).numel();
-    for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
       Output(inputIndex)->ResizeLike(Input(inputIndex));
     }
 
@@ -166,8 +166,8 @@ class MergeSingleScalarFeatureTensorsGradientOp : public Operator<Context> {
 
     T default_value = T();
     int valuesOffset = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
-      for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
+      for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
         const bool* inPresenceData = Input(inputIndex).template data<bool>();
         T* outFeatureData = Output(inputIndex)->template mutable_data<T>();
         if (inPresenceData[exampleIndex]) {
@@ -210,12 +210,12 @@ class MergeSingleListFeatureTensorsOp : public Operator<Context> {
     int numExamples = Input(0).numel();
     int totalNumFeatures = 0;
     int totalNumValues = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       const int32_t* inLengthsData =
           Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
       const bool* inPresenceData =
           Input(kNumTensorsPerInput * inputIndex + 2).template data<bool>();
-      for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+      for (const auto exampleIndex : c10::irange(numExamples)) {
         if (inPresenceData[exampleIndex]) {
           ++totalNumFeatures;
           totalNumValues += inLengthsData[exampleIndex];
@@ -237,12 +237,12 @@ class MergeSingleListFeatureTensorsOp : public Operator<Context> {
 
     int keysOffset = 0;
     int valuesOffset = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       inValuesOffset_[inputIndex] = 0;
     }
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
-      for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         const auto& inValues = Input(kNumTensorsPerInput * inputIndex + 1);
@@ -295,13 +295,13 @@ class MergeSingleListOrMapFeatureTensorsGradientOp : public Operator<Context> {
   bool DoRunWithType() {
     int numExamples = Input(0).numel();
     std::vector<int> outValuesOffset(numFeatureInputs_);
-    for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
       int inputNumValues = 0;
       const int32_t* inLengthsData =
           Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
       const bool* inPresenceData =
           Input(kNumTensorsPerInput * inputIndex + 1).template data<bool>();
-      for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+      for (const auto exampleIndex : c10::irange(numExamples)) {
         if (inPresenceData[exampleIndex]) {
           inputNumValues += inLengthsData[exampleIndex];
         }
@@ -313,8 +313,8 @@ class MergeSingleListOrMapFeatureTensorsGradientOp : public Operator<Context> {
     const T* inValuesValuesGradData = inValuesValuesGrad.template data<T>();
 
     int inValuesValuesOffset = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
-      for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
+      for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         const bool* inPresenceData =
@@ -371,12 +371,12 @@ class MergeSingleMapFeatureTensorsOp : public Operator<Context> {
     int numExamples = Input(0).numel();
     int totalNumFeatures = 0;
     int totalNumValues = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       const int32_t* inLengthsData =
           Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
       const bool* inPresenceData =
           Input(kNumTensorsPerInput * inputIndex + 3).template data<bool>();
-      for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+      for (const auto exampleIndex : c10::irange(numExamples)) {
         if (inPresenceData[exampleIndex]) {
           ++totalNumFeatures;
           totalNumValues += inLengthsData[exampleIndex];
@@ -400,12 +400,12 @@ class MergeSingleMapFeatureTensorsOp : public Operator<Context> {
 
     int keysOffset = 0;
     int valuesOffset = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       inValuesOffset_[inputIndex] = 0;
     }
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
-      for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         const auto& inKeys = Input(kNumTensorsPerInput * inputIndex + 1);
@@ -465,7 +465,7 @@ class MergeMultiScalarFeatureTensorsOp : public Operator<Context> {
   bool DoRunWithType() {
     int numExamples = Input(0).numel();
     int totalNumFeatures = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       totalNumFeatures += Input(kNumTensorsPerInput * inputIndex + 1).numel();
     }
 
@@ -478,12 +478,12 @@ class MergeMultiScalarFeatureTensorsOp : public Operator<Context> {
     T* outValuesData = outValues->template mutable_data<T>();
 
     int outKeysOffset = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       inKeysOffset_[inputIndex] = 0;
     }
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
-      for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         auto inputKeysBlobIdx = kNumTensorsPerInput * inputIndex + 1;
@@ -537,11 +537,11 @@ class MergeMultiScalarFeatureTensorsGradientOp : public Operator<Context> {
   bool DoRunWithType() {
     int numExamples = Input(0).numel();
     std::vector<int> outValuesOffset(numFeatureInputs_);
-    for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
       int inputNumValues = 0;
       const int32_t* inLengthsData =
           Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
-      for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+      for (const auto exampleIndex : c10::irange(numExamples)) {
         inputNumValues += inLengthsData[exampleIndex];
       }
       Output(inputIndex)->Resize(inputNumValues);
@@ -551,8 +551,8 @@ class MergeMultiScalarFeatureTensorsGradientOp : public Operator<Context> {
     const T* inValuesGradData = inValuesGrad.template data<T>();
 
     int inValuesOffset = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
-      for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
+      for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         if (inLengthsData[exampleIndex] > 0) {
@@ -600,7 +600,7 @@ class MergeMultiListFeatureTensorsOp : public Operator<Context> {
     int numExamples = Input(0).numel();
     int totalNumFeatures = 0;
     int totalNumValues = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       totalNumFeatures += Input(kNumTensorsPerInput * inputIndex + 1).numel();
       totalNumValues += Input(kNumTensorsPerInput * inputIndex + 3).numel();
     }
@@ -619,13 +619,13 @@ class MergeMultiListFeatureTensorsOp : public Operator<Context> {
 
     int outKeysOffset = 0;
     int outValuesValuesOffset = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       inKeysOffset_[inputIndex] = 0;
       inValuesValuesOffset_[inputIndex] = 0;
     }
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
-      for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         const int64_t* inKeysData = Input(kNumTensorsPerInput * inputIndex + 1)
@@ -699,7 +699,7 @@ class MergeMultiMapFeatureTensorsOp : public Operator<Context> {
     int numExamples = Input(0).numel();
     int totalNumFeatures = 0;
     int totalNumValues = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       totalNumFeatures += Input(kNumTensorsPerInput * inputIndex + 1).numel();
       totalNumValues += Input(kNumTensorsPerInput * inputIndex + 4).numel();
     }
@@ -720,13 +720,13 @@ class MergeMultiMapFeatureTensorsOp : public Operator<Context> {
 
     int outKeysOffset = 0;
     int outValuesValuesOffset = 0;
-    for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numInputs_)) {
       inKeysOffset_[inputIndex] = 0;
       inValuesValuesOffset_[inputIndex] = 0;
     }
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
       outLengthsData[exampleIndex] = 0;
-      for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
+      for (const auto inputIndex : c10::irange(numInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         const int64_t* inKeysData = Input(kNumTensorsPerInput * inputIndex + 1)
@@ -798,13 +798,12 @@ class MergeMultiListOrMapFeatureTensorsGradientOp : public Operator<Context> {
     int numExamples = Input(0).numel();
     std::vector<int> outValuesLengthOffset(numFeatureInputs_);
     std::vector<int> outValuesValuesOffset(numFeatureInputs_);
-    for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
       int inputNumValues = 0;
       auto& inValuesLength = Input(kNumTensorsPerInput * inputIndex + 1);
       const int32_t* inValuesLengthsData =
           inValuesLength.template data<int32_t>();
-      for (int valuesIndex = 0; valuesIndex < inValuesLength.numel();
-           ++valuesIndex) {
+      for (const auto valuesIndex : c10::irange(inValuesLength.numel())) {
         inputNumValues += inValuesLengthsData[valuesIndex];
       }
       Output(inputIndex)->Resize(inputNumValues);
@@ -814,8 +813,8 @@ class MergeMultiListOrMapFeatureTensorsGradientOp : public Operator<Context> {
     const T* inValuesValuesGradData = inValuesValuesGrad.template data<T>();
 
     int inValuesValuesOffset = 0;
-    for (int exampleIndex = 0; exampleIndex < numExamples; ++exampleIndex) {
-      for (int inputIndex = 0; inputIndex < numFeatureInputs_; ++inputIndex) {
+    for (const auto exampleIndex : c10::irange(numExamples)) {
+      for (const auto inputIndex : c10::irange(numFeatureInputs_)) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
         const int32_t* inValuesLengthsData =

--- a/caffe2/operators/filler_op.h
+++ b/caffe2/operators/filler_op.h
@@ -536,7 +536,7 @@ class LengthsRangeFillOp : public Operator<Context> {
     auto* output_data = output->template mutable_data<int32_t>();
 
     int32_t offset = 0;
-    for (int i = 0; i < input.numel(); ++i) {
+    for (const auto i : c10::irange(input.numel())) {
       auto len = input_data[i];
       auto start = output_data + offset;
       std::iota(

--- a/caffe2/operators/find_duplicate_elements_op.h
+++ b/caffe2/operators/find_duplicate_elements_op.h
@@ -44,7 +44,7 @@ class FindDuplicateElementsOp final : public Operator<Context> {
     auto* output =
         Output(0, {static_cast<int64_t>(dupSize)}, at::dtype<int64_t>());
     auto* out_ptr = output->template mutable_data<int64_t>();
-    for (size_t i = 0; i < dupSize; ++i) {
+    for (const auto i : c10::irange(dupSize)) {
       out_ptr[i] = dupIndices[i];
     }
 

--- a/caffe2/operators/find_op.h
+++ b/caffe2/operators/find_op.h
@@ -42,7 +42,7 @@ class FindOp final : public Operator<Context> {
     // index into a map
     if (needles.numel() < 16) {
       // Brute force O(nm)
-      for (int i = 0; i < needles.numel(); i++) {
+      for (const auto i : c10::irange(needles.numel())) {
         T x = needles_data[i];
         T res = static_cast<T>(missing_value_);
         for (int j = idx_size - 1; j >= 0; j--) {
@@ -56,10 +56,10 @@ class FindOp final : public Operator<Context> {
     } else {
       // O(n + m)
       std::unordered_map<T, int> idx_map;
-      for (int j = 0; j < idx_size; j++) {
+      for (const auto j : c10::irange(idx_size)) {
         idx_map[idx_data[j]] = j;
       }
-      for (int i = 0; i < needles.numel(); i++) {
+      for (const auto i : c10::irange(needles.numel())) {
         T x = needles_data[i];
         auto it = idx_map.find(x);
         res_data[i] = (it == idx_map.end() ? missing_value_ : it->second);

--- a/caffe2/operators/floor_op.h
+++ b/caffe2/operators/floor_op.h
@@ -21,7 +21,7 @@ class FloorOp final : public Operator<Context> {
 
     const float* Xdata = X.template data<float>();
     float* Ydata = Y->template mutable_data<float>();
-    for (int i = 0; i < X.numel(); ++i) {
+    for (const auto i : c10::irange(X.numel())) {
       Ydata[i] = std::floor(Xdata[i]);
     }
     return true;

--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/reducer_functors.h"
@@ -82,7 +83,7 @@ class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
 
       vector<float> tmp(input_columns);
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t row = 0; row < input_rows; ++row) {
+      for (const auto row : c10::irange(input_rows)) {
         convert(tmp.data(), input_data + row * input_columns, input_columns);
         if (out_sb_half) {
           FloatToFusedNBitRowwiseQuantizedSBHalf(
@@ -163,7 +164,7 @@ class Fused8BitRowwiseQuantizedToFloatOp : public Operator<Context> {
 
       vector<float> tmp(input_columns);
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t row = 0; row < input_rows; ++row) {
+      for (const auto row : c10::irange(input_rows)) {
         if (in_sb_half) {
           FusedNBitRowwiseQuantizedSBHalfToFloat(
               8,

--- a/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
@@ -131,7 +131,7 @@ class FloatToFusedNBitRowwiseQuantizedOp final : public Operator<CPUContext> {
         *output_row_scale = scale;
         *output_row_bias = Xmin;
 
-        for (int col = 0; col < input_columns; ++col) {
+        for (const auto col : c10::irange(input_columns)) {
           float X = tmp[col];
           std::uint8_t quantized = std::max(
               0,
@@ -206,7 +206,7 @@ class FusedNBitRowwiseQuantizedToFloatOp final : public Operator<CPUContext> {
       std::vector<float> tmp(output_columns);
 
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t row = 0; row < input_rows; ++row) {
+      for (const auto row : c10::irange(input_rows)) {
         const std::uint8_t* input_row = input_data + row * input_columns;
         float scale = *reinterpret_cast<const at::Half*>(
             input_row +
@@ -216,7 +216,7 @@ class FusedNBitRowwiseQuantizedToFloatOp final : public Operator<CPUContext> {
             (output_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE +
             sizeof(at::Half));
 
-        for (int col = 0; col < output_columns; ++col) {
+        for (const auto col : c10::irange(output_columns)) {
           std::uint8_t quantized = input_row[col / NUM_ELEM_PER_BYTE];
           quantized >>= (col % NUM_ELEM_PER_BYTE) * BIT_RATE;
           quantized &= (1 << BIT_RATE) - 1;

--- a/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h
@@ -118,7 +118,7 @@ class FloatToFusedNBitFakeRowwiseQuantizedOp final
       output_row_scale_bias[1] = minimum_element;
 
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t col = 0; col < input_columns; ++col) {
+      for (const auto col : c10::irange(input_columns)) {
         output_row[col] = std::max(
             0,
             std::min<int>(

--- a/caffe2/operators/gather_fused_8bit_rowwise_op.h
+++ b/caffe2/operators/gather_fused_8bit_rowwise_op.h
@@ -37,7 +37,7 @@ class GatherFused8BitRowwiseOp : public Operator<Context> {
     const Index* idxs = indices.template data<Index>();
     auto out = output->template mutable_data<float>();
 
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       auto idx = idxs[i];
       CAFFE_ENFORCE(
           0 <= idx && idx < data.size(0),

--- a/caffe2/operators/gather_op.h
+++ b/caffe2/operators/gather_op.h
@@ -44,7 +44,7 @@ static void check_indexarray_range(
     IndexType indexing_axis_dim,
     bool wrap_indices) {
   //
-  for (auto i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     auto idx = indices[i];
     if (wrap_indices && idx < 0) {
       idx = idx + indexing_axis_dim;
@@ -114,7 +114,7 @@ static bool gather_impl(
   auto N = indices.numel();
   if (match_outer) {
     CAFFE_ENFORCE_GE(axis, 1, "Axis should be at least 1");
-    for (auto i = 0; i < axis; i++) {
+    for (const auto i : c10::irange(axis)) {
       CAFFE_ENFORCE_EQ(
           data.size(i),
           indices.size(i),
@@ -129,12 +129,12 @@ static bool gather_impl(
 
   // Special-case single-float copy for efficiency
   if (data.template IsType<float>() && block_size == 1) {
-    for (auto batch = 0; batch < outer_dims_product; ++batch) {
+    for (const auto batch : c10::irange(outer_dims_product)) {
       const float* src_floats =
           (const float*)(src_base + batch * src_batch_bytesize);
       float* dst_floats = (float*)(out + batch * gathered_batch_bytesize);
 
-      for (auto i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         auto idx = idxs[i];
         if (match_outer) {
           idx = idxs[batch * idx_inner_dims_product + i];
@@ -148,8 +148,8 @@ static bool gather_impl(
   } else {
     // outer_dims_product specifies how many times we repeat inner dimensions,
     // so we just iterate over it to cover all outer dimensions.
-    for (auto batch = 0; batch < outer_dims_product; ++batch) {
-      for (auto i = 0; i < N; ++i) {
+    for (const auto batch : c10::irange(outer_dims_product)) {
+      for (const auto i : c10::irange(N)) {
         auto idx = idxs[i];
         if (match_outer) {
           idx = idxs[batch * idx_inner_dims_product + i];

--- a/caffe2/operators/gather_ranges_to_dense_op.h
+++ b/caffe2/operators/gather_ranges_to_dense_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/common_omp.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
@@ -42,7 +43,8 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     CAFFE_ENFORCE_GT(
         minObservation_, 0, "The number of observations is at least 1");
     // Initialize the empty and mismatch counter.
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
+      (void)i; // Suppress unused variable warning
       emptyRanges_.push_back(0);
       mismatchedRanges_.push_back(0);
       mismatchedLengths_.push_back(set<int>());
@@ -105,7 +107,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     auto batchSize = ranges.size(0);
     vector<int64_t> outputDims{batchSize, 0};
     vector<char*> outputRawData;
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       auto* output = Output(i);
       outputDims[1] = lengths_[i];
       output->Resize(outputDims);
@@ -114,8 +116,8 @@ class GatherRangesToDenseOp final : public Operator<Context> {
       outputRawData.push_back(ptr);
     }
 
-    for (int i = 0; i < batchSize; ++i) {
-      for (int j = 0; j < OutputSize(); ++j) {
+    for (const auto i : c10::irange(batchSize)) {
+      for (const auto j : c10::irange(OutputSize())) {
         auto rangeStart = rangesData[rangesDataOffset++];
         auto rangeLength = rangesData[rangesDataOffset++];
 
@@ -143,7 +145,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
           auto& key = Input(KEY);
           auto* key_data = key.template data<int64_t>();
           vector<std::pair<int64_t, const char*>> buffer;
-          for (int b_i = 0; b_i < rangeLength; ++b_i) {
+          for (const auto b_i : c10::irange(rangeLength)) {
             int64_t one_key_item = key_data[rangeStart + b_i];
             auto* one_data_item = rawData + (rangeStart + b_i) * itemsize;
             buffer.emplace_back(one_key_item, one_data_item);
@@ -155,7 +157,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
                  const std::pair<int64_t, const char*>& right) {
                 return left.first < right.first;
               });
-          for (int b_i = 0; b_i < rangeLength; ++b_i) {
+          for (const auto b_i : c10::irange(rangeLength)) {
             // Since this CPU only, directly copy to the destination.
             std::memcpy(
                 outputRawData[j] + (i * lengths_[j] + b_i) * itemsize,
@@ -170,7 +172,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
 
     // Check whether the empty and mismatch ratio exceeded the threshold.
     totalRanges_ += batchSize;
-    for (int j = 0; j < OutputSize(); ++j) {
+    for (const auto j : c10::irange(OutputSize())) {
       // Only check when the ratio is not set to allow all mismatches.
       if (maxMismatchedRatio_ < 1.0) {
         CAFFE_ENFORCE_GE(

--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -294,7 +294,7 @@ EArrXXt<typename Derived::Scalar> clip_boxes_rotated(
 
   EArrXXt<typename Derived::Scalar> ret(boxes.rows(), boxes.cols());
   ret = boxes;
-  for (int i = 0; i < upright_boxes.rows(); ++i) {
+  for (const auto i : c10::irange(upright_boxes.rows())) {
     ret.row(indices[i]) = upright_boxes.row(i);
   }
   return ret;

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -247,7 +247,7 @@ int rotated_rect_intersection_pts(
   // Specical case of rect1 == rect2
   bool same = true;
 
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     if (fabs(pts1[i].x() - pts2[i].x()) > samePointEps ||
         (fabs(pts1[i].y() - pts2[i].y()) > samePointEps)) {
       same = false;
@@ -256,7 +256,7 @@ int rotated_rect_intersection_pts(
   }
 
   if (same) {
-    for (int i = 0; i < 4; i++) {
+    for (const auto i : c10::irange(4)) {
       intersections[i] = pts1[i];
     }
     num = 4;
@@ -265,14 +265,14 @@ int rotated_rect_intersection_pts(
 
   // Line vector
   // A line from p1 to p2 is: p1 + (p2-p1)*t, t=[0,1]
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     vec1[i] = pts1[(i + 1) % 4] - pts1[i];
     vec2[i] = pts2[(i + 1) % 4] - pts2[i];
   }
 
   // Line test - test all line combos for intersection
-  for (int i = 0; i < 4; i++) {
-    for (int j = 0; j < 4; j++) {
+  for (const auto i : c10::irange(4)) {
+    for (const auto j : c10::irange(4)) {
       // Solve for 2x2 Ax=b
 
       // This takes care of parallel lines
@@ -298,7 +298,7 @@ int rotated_rect_intersection_pts(
     const auto& DA = vec2[3];
     auto ABdotAB = AB.squaredNorm();
     auto ADdotAD = DA.squaredNorm();
-    for (int i = 0; i < 4; i++) {
+    for (const auto i : c10::irange(4)) {
       // assume ABCD is the rectangle, and P is the point to be judged
       // P is inside ABCD iff. P's projection on AB lies within AB
       // and P's projection on AD lies within AD
@@ -321,7 +321,7 @@ int rotated_rect_intersection_pts(
     const auto& DA = vec1[3];
     auto ABdotAB = AB.squaredNorm();
     auto ADdotAD = DA.squaredNorm();
-    for (int i = 0; i < 4; i++) {
+    for (const auto i : c10::irange(4)) {
       auto AP = pts2[i] - pts1[0];
 
       auto APdotAB = AP.dot(AB);
@@ -351,7 +351,7 @@ int convex_hull_graham(
   // if more than 1 points have the same minimum y,
   // pick the one with the mimimum x.
   int t = 0;
-  for (int i = 1; i < num_in; i++) {
+  for (const auto i : c10::irange(1, num_in)) {
     if (p[i].y() < p[t].y() || (p[i].y() == p[t].y() && p[i].x() < p[t].x())) {
       t = i;
     }
@@ -360,7 +360,7 @@ int convex_hull_graham(
 
   // Step 2:
   // Subtract starting point from every points (for sorting in the next step)
-  for (int i = 0; i < num_in; i++) {
+  for (const auto i : c10::irange(num_in)) {
     q[i] = p[i] - s;
   }
 
@@ -415,8 +415,7 @@ int convex_hull_graham(
   // But if we're only interested in getting the area/perimeter of the shape
   // We can simply return.
   if (!shift_to_zero) {
-    for (int i = 0; i < m; i++)
-      q[i] += s;
+    for (const auto i : c10::irange(m))q[i] += s;
   }
 
   return m;
@@ -518,8 +517,8 @@ Eigen::ArrayXXf bbox_overlaps_rotated(
   const auto& query_boxes_areas = query_boxes.col(2) * query_boxes.col(3);
 
   Eigen::ArrayXXf overlaps(boxes.rows(), query_boxes.rows());
-  for (int i = 0; i < boxes.rows(); ++i) {
-    for (int j = 0; j < query_boxes.rows(); ++j) {
+  for (const auto i : c10::irange(boxes.rows())) {
+    for (const auto j : c10::irange(query_boxes.rows())) {
       auto inter = bbox_intersection_rotated(boxes.row(i), query_boxes.row(j));
       overlaps(i, j) = (inter == 0.0)
           ? 0.0
@@ -554,7 +553,7 @@ std::vector<int> nms_cpu_rotated(
   EArrX areas = widths * heights;
 
   std::vector<RotatedRect> rotated_rects(proposals.rows());
-  for (int i = 0; i < proposals.rows(); ++i) {
+  for (const auto i : c10::irange(proposals.rows())) {
     rotated_rects[i] = bbox_to_rotated_rect(proposals.row(i));
   }
 
@@ -616,7 +615,7 @@ std::vector<int> soft_nms_cpu_rotated(
   EArrX areas = widths * heights;
 
   std::vector<RotatedRect> rotated_rects(proposals.rows());
-  for (int i = 0; i < proposals.rows(); ++i) {
+  for (const auto i : c10::irange(proposals.rows())) {
     rotated_rects[i] = bbox_to_rotated_rect(proposals.row(i));
   }
 

--- a/caffe2/operators/given_tensor_byte_string_to_uint8_fill_op.h
+++ b/caffe2/operators/given_tensor_byte_string_to_uint8_fill_op.h
@@ -61,7 +61,7 @@ class GivenTensorByteStringToUInt8FillOp final : public FillerOp<Context> {
         at::dtype<uint8_t>().device(CPU));
     uint8_t* values_data = values_.template mutable_data<uint8_t>();
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < str.size(); i++) {
+    for (const auto i : c10::irange(str.size())) {
       values_data[i] = static_cast<uint8_t>(str[i]);
     }
   }

--- a/caffe2/operators/given_tensor_fill_op.h
+++ b/caffe2/operators/given_tensor_fill_op.h
@@ -68,7 +68,7 @@ class GivenTensorFillOp final : public FillerOp<Context> {
         at::dtype<Type>().device(CPU));
     Type* values_data = values_.template mutable_data<Type>();
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < source_values.size(); i++) {
+    for (const auto i : c10::irange(source_values.size())) {
       values_data[i] = static_cast<Type>(source_values[i]);
     }
     body_ = &GivenTensorFillOp::FillWithType<Type>;

--- a/caffe2/operators/gru_unit_op.h
+++ b/caffe2/operators/gru_unit_op.h
@@ -29,10 +29,10 @@ void GRUUnit(
     bool drop_states,
     T* H,
     Context* /*context*/) {
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
 
-    for (int d = 0; d < D; ++d) {
+    for (const auto d : c10::irange(D)) {
       if (!valid) {
         if (drop_states) {
           H[d] = 0;
@@ -68,10 +68,10 @@ void GRUUnitGradient(
     T* H_prev_diff,
     T* X_diff,
     Context* /*context*/) {
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
 
-    for (int d = 0; d < D; ++d) {
+    for (const auto d : c10::irange(D)) {
       T* h_prev_diff = H_prev_diff + d;
       T* reset_diff = X_diff + 0 * D + d;
       T* update_diff = X_diff + 1 * D + d;

--- a/caffe2/operators/h_softmax_op.h
+++ b/caffe2/operators/h_softmax_op.h
@@ -2,6 +2,7 @@
 #define CAFFE2_OPERATORS_H_SOFTMAX_OP_H_
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -51,7 +52,7 @@ class HSoftmaxOpBase : public Operator<Context> {
       int M,
       std::unordered_map<int, PathProto>& hierarchy) const {
     int size = 0;
-    for (int label = 0; label < M; ++label) {
+    for (const auto label : c10::irange(M)) {
       int word_id = labels[label];
       const auto& path = hierarchy[word_id];
       size += std::accumulate(

--- a/caffe2/operators/histogram_op.h
+++ b/caffe2/operators/histogram_op.h
@@ -19,7 +19,7 @@ class HistogramOp final : public Operator<Context> {
         2,
         "Number of bin edges must be greater than or equal to 2.");
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 1; i < bin_edges_.size(); i++) {
+    for (const auto i : c10::irange(1, bin_edges_.size())) {
       CAFFE_ENFORCE_GT(
           bin_edges_[i],
           bin_edges_[i - 1],
@@ -41,11 +41,11 @@ class HistogramOp final : public Operator<Context> {
     math::Set<int64_t, Context>(
         bin_edges_.size() - 1, 0, histogram_data, &context_);
 
-    for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+    for (const auto input_idx : c10::irange(InputSize())) {
       const auto& x = Input(input_idx);
       const int64_t N = x.numel();
       const auto* x_data = x.template data<T>();
-      for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+      for (const auto data_idx : c10::irange(N)) {
         const auto bisection_it = std::upper_bound(
             bin_edges_.begin(), bin_edges_.end(), x_data[data_idx]);
         const int bisection_idx = bisection_it - bin_edges_.begin();
@@ -67,7 +67,7 @@ class HistogramOp final : public Operator<Context> {
 
   void CheckInputs() {
     const auto& input_zero = Input(0);
-    for (int i = 1; i < InputSize(); i++) {
+    for (const auto i : c10::irange(1, InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).dtype(),
           input_zero.dtype(),

--- a/caffe2/operators/im2col_op.h
+++ b/caffe2/operators/im2col_op.h
@@ -84,7 +84,7 @@ class Im2ColOp final : public Operator<Context> {
 
         const size_t dx = X.numel() / N;
         const size_t dy = Y->numel() / N;
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Im2Col<T, Context, StorageOrder::NCHW>(
@@ -114,7 +114,7 @@ class Im2ColOp final : public Operator<Context> {
 
         const size_t dx = X.numel() / N;
         const size_t dy = Y->numel() / N;
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Im2Col<T, Context, StorageOrder::NHWC>(
@@ -230,7 +230,7 @@ class Col2ImOp final : public Operator<Context> {
     // could template-specialize this, but it's test code...
     switch (order_) {
       case StorageOrder::NCHW: {
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Col2Im<T, Context, StorageOrder::NCHW>(
@@ -253,7 +253,7 @@ class Col2ImOp final : public Operator<Context> {
         }
       }; break;
       case StorageOrder::NHWC: {
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Col2Im<T, Context, StorageOrder::NHWC>(

--- a/caffe2/operators/index_hash_ops.h
+++ b/caffe2/operators/index_hash_ops.h
@@ -2,6 +2,7 @@
 #define CAFFE2_OPERATORS_INDEX_HASH_OPS_H_
 
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 
@@ -42,7 +43,7 @@ class IndexHashOp : public Operator<Context> {
     auto* indices_data = indices.template data<T>();
     auto* hashed_indices_data = hashed_indices->template mutable_data<T>();
 
-    for (auto i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       hashed_indices_data[i] = hash(indices_data[i]);
     }
 

--- a/caffe2/operators/index_ops.h
+++ b/caffe2/operators/index_ops.h
@@ -64,7 +64,7 @@ struct Index : IndexBase {
     }
     std::lock_guard<std::mutex> lock(dictMutex_);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < numKeys; ++i) {
+    for (const auto i : c10::irange(numKeys)) {
       auto it = dict_.find(keys[i]);
       if (it != dict_.end()) {
         values[i] = it->second;
@@ -84,7 +84,7 @@ struct Index : IndexBase {
         numKeys <= maxElements_,
         "Cannot load index: Tensor is larger than max_elements.");
     decltype(dict_) dict;
-    for (auto i = 0U; i < numKeys; ++i) {
+    for (const auto i : c10::irange(0U, numKeys)) {
       CAFFE_ENFORCE(
           dict.insert({keys[i], i + 1}).second,
           "Repeated elements found: cannot load into dictionary.");
@@ -111,7 +111,7 @@ struct Index : IndexBase {
 
  private:
   void FrozenGet(const T* keys, int64_tValue* values, size_t numKeys) {
-    for (auto i = 0U; i < numKeys; ++i) {
+    for (const auto i : c10::irange(0U, numKeys)) {
       auto it = dict_.find(keys[i]);
       values[i] = it != dict_.end() ? it->second : 0;
     }

--- a/caffe2/operators/key_split_ops.h
+++ b/caffe2/operators/key_split_ops.h
@@ -26,21 +26,21 @@ class KeySplitOp : public Operator<Context> {
     const T* keys_data = keys.template data<T>();
     std::vector<int> counts(categorical_limit_);
     std::vector<int*> eids(categorical_limit_);
-    for (int k = 0; k < categorical_limit_; k++) {
+    for (const auto k : c10::irange(categorical_limit_)) {
       counts[k] = 0;
     }
-    for (int i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       int k = keys_data[i];
       CAFFE_ENFORCE_GT(categorical_limit_, k);
       CAFFE_ENFORCE_GE(k, 0);
       counts[k]++;
     }
-    for (int k = 0; k < categorical_limit_; k++) {
+    for (const auto k : c10::irange(categorical_limit_)) {
       auto* eid = Output(k, {counts[k]}, at::dtype<int>());
       eids[k] = eid->template mutable_data<int>();
       counts[k] = 0;
     }
-    for (int i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       int k = keys_data[i];
       eids[k][counts[k]++] = i;
     }

--- a/caffe2/operators/length_split_op.h
+++ b/caffe2/operators/length_split_op.h
@@ -55,11 +55,11 @@ class LengthsSplitOp final : public Operator<Context> {
     const int32_t* Ldata = L.template data<int32_t>();
     int32_t* Ydata = Y->template mutable_data<int32_t>();
 
-    for (int i = 0; i < M; i++) {
+    for (const auto i : c10::irange(M)) {
       int32_t mod = Ldata[i] % n_split_;
       int32_t res =
           mod != 0 ? math::DivUp(Ldata[i], n_split_) : Ldata[i] / n_split_ + 1;
-      for (int j = 0; j < n_split_; j++) {
+      for (const auto j : c10::irange(n_split_)) {
         Ydata[(i * n_split_) + j] = mod-- > 0 ? res : res - 1;
       }
     }

--- a/caffe2/operators/lengths_pad_op.h
+++ b/caffe2/operators/lengths_pad_op.h
@@ -56,7 +56,7 @@ class LengthsPadOp : public Operator<Context> {
 
     math::Set(
         output->numel(), static_cast<T>(padding_value_), out_data, &context_);
-    for (int64_t i = 0; i < lengths_size; ++i) {
+    for (const auto i : c10::irange(lengths_size)) {
       auto length = lengths_data[i];
       CAFFE_ENFORCE_GE(length, 0);
       CAFFE_ENFORCE_GE(

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -121,7 +121,7 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     auto indices_data = indices.template data<IndexType>();
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       for (int i = 0; i < lengths_data[m]; ++i) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -137,7 +137,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
 
     // Error handling
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       for (int i = 0; i < lengths_data[m]; ++i) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
@@ -164,7 +164,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
         << "Running slow path because FBGEMM is not available";
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       memset(output_data, 0, block_size * sizeof(float));
       if (current + lengths_data[m] > index_size) {
         return false;
@@ -185,7 +185,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
         const float scale = weight * scale_bias[0];
         const float bias = weight * scale_bias[1];
 
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           uint8_t quantized =
               input_data[idx * data.size(1) + j / NUM_ELEM_PER_BYTE];
           quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;
@@ -196,7 +196,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
       } // for each i
       if (is_mean && lengths_data[m]) {
         float scale = 1.0f / lengths_data[m];
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           output_data[j] *= scale;
         }
       }
@@ -284,13 +284,14 @@ class SparseLengthsSumSparseLookupOp final : public Operator<CPUContext> {
     const IndexType compressed_data_size = compressed_indices_mapping.size(0);
     IndexType current = 0;
     IndexType current_output = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       const auto current_length = lengths_data[m];
       if (current + current_length > index_size) {
         return false;
       }
       int32_t skipped = 0;
-      for (int i = 0; i < current_length; ++i) {
+      for (const auto i : c10::irange(current_length)) {
+        (void)i; // Suppress unused variable warning
         IndexType compressed_idx = indices_data[current];
         if (compressed_idx < 0 || compressed_idx >= compressed_data_size) {
           return false;
@@ -554,7 +555,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
 
     // Error handling
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       for (int i = 0; i < lengths_data[m]; ++i) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
@@ -592,7 +593,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
         << "Running slow path because FBGEMM is not available";
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       memset(output_data, 0, block_size * sizeof(float));
       if (current + lengths_data[m] > index_size) {
         return false;
@@ -632,7 +633,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
           bias = weight * reinterpret_cast<const at::Half*>(scale_bias)[1];
         }
 
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           uint8_t quantized =
               input_data[idx * data.size(1) + j / NUM_ELEM_PER_BYTE];
           quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;
@@ -643,7 +644,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
       } // for each i
       if (is_mean && lengths_data[m]) {
         float scale = 1.0f / lengths_data[m];
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           output_data[j] *= scale;
         }
       }

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -192,7 +192,7 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
     }
 
     int64_t current = 0;
-    for (int m = 0; m < M; ++m) {
+    for (const auto m : c10::irange(M)) {
       for (int i = 0; i < lengths[m]; ++i) {
         CAFFE_ENFORCE_LT(
             current,
@@ -280,7 +280,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
         emb_size(this->template GetSingleArgument<int>("emb_size", 64)) {
     // cumprod of i, used for index slice
     l_cumprod.push_back(1);
-    for (size_t i = 1; i < factor_i.size(); ++i) {
+    for (const auto i : c10::irange(1, factor_i.size())) {
       l_cumprod.push_back(l_cumprod[i - 1] * factor_i[i - 1]);
     }
   }
@@ -290,7 +290,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
   void Ind2Sub(int64_t* out_factor_index, const int64_t* indices, int len) {
     // TODO: vectorization
     auto N = factor_i.size();
-    for (int j = 0; j < len; j++) {
+    for (const auto j : c10::irange(len)) {
       auto idx = indices[j];
       for (int i = N; i > 0; i--) {
         out_factor_index[j * N + i - 1] = idx / l_cumprod[i - 1];
@@ -307,7 +307,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
       int idx) {
     // implement the functinality index_select(core, 1, ind_slice)
     auto num_of_elements = ranks[idx] * factor_j[idx] * ranks[idx + 1];
-    for (int i = 0; i < bs; i++) {
+    for (const auto i : c10::irange(bs)) {
       memcpy(
           tgt_slice[i].data(),
           core + ind_slice[i] * num_of_elements,
@@ -345,16 +345,16 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
     // Store the intermediate result in each layer
     vector<T*> Z_ptr(bs);
 
-    for (int b = 0; b < bs; b++) {
+    for (const auto b : c10::irange(bs)) {
       Y_ptr[b] = res[b].data();
       Z_ptr[b] = int_res[b].data();
     }
 
     vector<int64_t> ind_slice(bs);
     int rows = 0;
-    for (int i = 0; i < x_len; i++) {
+    for (const auto i : c10::irange(x_len)) {
       // slice cur
-      for (int j = 0; j < bs; j++) {
+      for (const auto j : c10::irange(bs)) {
         ind_slice[j] = ind[x_len * j + i];
       }
       if (i == 0) {
@@ -364,7 +364,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
         std::vector<std::vector<T>> slice(
             bs, std::vector<T>(ranks[i] * factor_j[i] * ranks[i + 1], 0));
         vector<const T*> X_ptr(bs);
-        for (int b = 0; b < bs; b++) {
+        for (const auto b : c10::irange(bs)) {
           X_ptr[b] = slice[b].data();
         }
         GetSlice(slice, cores[i], ind_slice, bs, i);
@@ -382,7 +382,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
             0.0f,
             Z_ptr.data(),
             &context_);
-        for (int b = 0; b < bs; b++) {
+        for (const auto b : c10::irange(bs)) {
           std::memcpy(Y_ptr[b], Z_ptr[b], (emb_size * max_rank) * sizeof(T));
         }
         rows *= factor_j[i];
@@ -393,7 +393,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
       if (i < 2) {
         auto* core_data = Output(i + 1, shape, at::dtype<T>());
         T* out_core = core_data->template mutable_data<T>();
-        for (int b = 0; b < bs; b++) {
+        for (const auto b : c10::irange(bs)) {
           std::memcpy(
               out_core + b * rows * ranks[i + 1],
               Y_ptr[b],
@@ -404,7 +404,7 @@ class TTSparseLengthsSumOp final : public Operator<Context> {
 
     // reduction and store back to output
     vector<int64_t> cum_lengths(segments);
-    for (int seg = 0; seg < segments; seg++) {
+    for (const auto seg : c10::irange(segments)) {
       cum_lengths[seg] =
           seg == 0 ? lengths[0] : lengths[seg] + cum_lengths[seg - 1];
     }
@@ -549,7 +549,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   int64_t* index_out_data = index_out.template mutable_data<int64_t>();
 
   vector<vector<int64_t>> index_slice(bs, vector<int64_t>(3, 0));
-  for (int64_t b = 0; b < bs; b++) {
+  for (const auto b : c10::irange(bs)) {
     memcpy(index_slice[b].data(), index_out_data + b * 3, 3 * sizeof(int64_t));
   }
 
@@ -563,7 +563,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   // expand the gradient into all indices
   vector<vector<T>> core2_out_grad(bs, vector<T>(emb_size, 0));
   int64_t data_index = 0;
-  for (int64_t range_index = 0; range_index < num_segments; ++range_index) {
+  for (const auto range_index : c10::irange(num_segments)) {
     for (int64_t start = data_index;
          data_index < start + lengths_data[range_index];
          ++data_index) {
@@ -582,7 +582,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
       bs, vector<T>(core2_shape[1] * core2_shape[2] * core2_shape[3], 0));
   const T* core1_out_data = core1_out.template data<T>();
   // const T* core1_out_p[bs];
-  for (int64_t b = 0; b < bs; b++) {
+  for (const auto b : c10::irange(bs)) {
     A_ptr[b] = core1_out_data + b * core1_out.size(1) * core1_out.size(2);
     B_ptr[b] = core2_out_grad[b].data();
     C_ptr[b] = dCore2_data_slice_grad[b].data();
@@ -609,8 +609,8 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   vector<vector<T>> core2_slice(
       bs, vector<T>(core2_shape[1] * core2_shape[2] * core2_shape[3], 0));
 
-  for (int64_t b = 0; b < bs; b++) {
-    for (int i = 0; i < num_of_elements; i++) {
+  for (const auto b : c10::irange(bs)) {
+    for (const auto i : c10::irange(num_of_elements)) {
       dCore2_data[index_slice[b][2] * num_of_elements + i] += C_ptr[b][i];
     }
     memcpy(
@@ -623,7 +623,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   vector<vector<T>> core1_out_grad(
       bs, vector<T>(core1_out_shape[1] * core1_out_shape[2], 0));
 
-  for (int64_t b = 0; b < bs; b++) {
+  for (const auto b : c10::irange(bs)) {
     A_ptr[b] = core2_out_grad[b].data();
     B_ptr[b] = core2_slice[b].data();
     C_ptr[b] = core1_out_grad[b].data();
@@ -650,7 +650,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   vector<vector<T>> dCore1_data_slice_grad(
       bs, vector<T>(core1_shape[1] * core1_shape[2] * core1_shape[3], 0));
   const T* core0_out_data = core0_out.template data<T>();
-  for (int64_t b = 0; b < bs; b++) {
+  for (const auto b : c10::irange(bs)) {
     A_ptr[b] = core0_out_data + b * core0_out.size(1) * core0_out.size(2);
     B_ptr[b] = core1_out_grad[b].data();
     C_ptr[b] = dCore1_data_slice_grad[b].data();
@@ -676,8 +676,8 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   vector<vector<T>> core1_slice(
       bs, vector<T>(core1_shape[1] * core1_shape[2] * core1_shape[3], 0));
 
-  for (int64_t b = 0; b < bs; b++) {
-    for (int i = 0; i < num_of_elements; i++) {
+  for (const auto b : c10::irange(bs)) {
+    for (const auto i : c10::irange(num_of_elements)) {
       dCore1_data[index_slice[b][1] * num_of_elements + i] += C_ptr[b][i];
     }
     memcpy(
@@ -690,7 +690,7 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
   vector<vector<T>> core0_out_grad(
       bs, vector<T>(core0_out_shape[1] * core0_out_shape[2], 0));
 
-  for (int64_t b = 0; b < bs; b++) {
+  for (const auto b : c10::irange(bs)) {
     A_ptr[b] = core1_out_grad[b].data();
     B_ptr[b] = core1_slice[b].data();
     C_ptr[b] = core0_out_grad[b].data();
@@ -712,8 +712,8 @@ bool TTSparseLengthsSumGradientOp<T, Context>::RunOnDevice() {
 
   num_of_elements = core0_shape[1] * core0_shape[2] * core0_shape[3];
 
-  for (int64_t b = 0; b < bs; b++) {
-    for (int i = 0; i < num_of_elements; i++) {
+  for (const auto b : c10::irange(bs)) {
+    for (const auto i : c10::irange(num_of_elements)) {
       dCore0_data[index_slice[b][0] * num_of_elements + i] += C_ptr[b][i];
     }
   }

--- a/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
+++ b/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
@@ -110,7 +110,7 @@ class FloatToRowwiseQuantized8BitsOp : public Operator<Context> {
     float* scale_bias_data = scale_bias->template mutable_data<float>();
     size_t n_blocks = input.size(0);
     size_t block_size = input.size_from_dim(1);
-    for (size_t i = 0; i < n_blocks; ++i) {
+    for (const auto i : c10::irange(n_blocks)) {
       ConstEigenVectorArrayMap<float> input_row(
           input_data + i * block_size, block_size);
       EigenVectorArrayMap<uint8_t> output_row(
@@ -164,7 +164,7 @@ class Rowwise8BitQuantizedToFloatOp : public Operator<Context> {
     size_t block_size = input.size_from_dim(1);
     size_t n_blocks = input.size(0);
 
-    for (size_t i = 0; i < n_blocks; ++i) {
+    for (const auto i : c10::irange(n_blocks)) {
       ConstEigenVectorArrayMap<uint8_t> input_row(
           input_data + i * block_size, block_size);
       EigenVectorArrayMap<float> output_row(

--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -5,6 +5,8 @@
 #include <map>
 #include <unordered_set>
 
+
+#include <c10/util/irange.h>
 #include <c10/util/string_view.h>
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/core/context.h"
@@ -129,13 +131,13 @@ class LoadOp final : public Operator<Context> {
     int total_loaded_blobs = 0;
     std::unordered_map<string, load_save_op_util::BlobState> blob_states;
     if (InputSize() > 0) {
-      for (int i = 0; i < InputSize(); ++i) {
+      for (const auto i : c10::irange(InputSize())) {
         const db::DBReader& reader = this->template Input<db::DBReader>(i);
         extract(i, reader.cursor(), &blob_states, &total_loaded_blobs);
       }
     } else {
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (int i = 0; i < db_names_.size(); ++i) {
+      for (const auto i : c10::irange(db_names_.size())) {
         string full_db_name = absolute_path_
             ? db_names_[i]
             : (ws_->RootFolder() + "/" + db_names_[i]);

--- a/caffe2/operators/locally_connected_op_impl.h
+++ b/caffe2/operators/locally_connected_op_impl.h
@@ -45,7 +45,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(*Y);
   const std::vector<int> output_image_dims = GetDims(*Y);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
 
@@ -82,7 +82,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   if (InputSize() == 3) {
     const auto& bias = Input(BIAS);
     CAFFE_ENFORCE_EQ(bias.dim(), image_ndim + 1);
-    for (int i = 0; i < image_ndim; ++i) {
+    for (const auto i : c10::irange(image_ndim)) {
       CAFFE_ENFORCE_EQ(bias.dim32(i), output_image_dims[i]);
     }
     CAFFE_ENFORCE_EQ(bias.dim32(image_ndim), shape.M);
@@ -129,7 +129,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(*Y);
   const std::vector<int> output_image_dims = GetDims(*Y);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
 
@@ -159,7 +159,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   if (InputSize() == 3) {
     const auto& bias = Input(BIAS);
     CAFFE_ENFORCE_EQ(bias.dim(), image_ndim + 1);
-    for (int i = 0; i < image_ndim; ++i) {
+    for (const auto i : c10::irange(image_ndim)) {
       CAFFE_ENFORCE_EQ(bias.dim32(i), output_image_dims[i]);
     }
     CAFFE_ENFORCE_EQ(bias.dim32(image_ndim), shape.M);
@@ -200,8 +200,9 @@ void LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHWImpl(
   T* column_buffer_data = column_buffer->template mutable_data<T>();
   T* Y_transposed_buffer_data = Y_transposed_buffer->template mutable_data<T>();
 
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
-    for (int group_id = 0; group_id < group_; ++group_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
+    (void)image_id; // Suppress unused variable warning
+    for (const auto group_id : c10::irange(group_)) {
       if (kernel_.size() == 2) {
         math::Im2Col<T, Context, StorageOrder::NCHW>(
             shape.C / group_,
@@ -302,7 +303,7 @@ void LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWCImpl(
   Y_transposed_buffer->Resize(shape.Y_transposed_dims);
   T* column_buffer_data = column_buffer->template mutable_data<T>();
   T* Y_transposed_buffer_data = Y_transposed_buffer->template mutable_data<T>();
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
     math::Im2Col<T, Context, StorageOrder::NHWC>(
         shape.C,
         shape.X_dims[0],
@@ -387,7 +388,7 @@ bool LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   shape.input_image_size = GetDimsSize(X);
   const std::vector<int> output_image_dims = GetDims(dY);
   shape.output_image_size = GetDimsSize(dY);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
   ConvPoolOpBase<Context>::ComputePads(input_image_dims);
@@ -484,7 +485,7 @@ bool LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(dY);
   const std::vector<int> output_image_dims = GetDims(dY);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
 
@@ -568,8 +569,9 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHWImpl(
   T* dY_transposed_buffer_data =
       dY_transposed_buffer->template mutable_data<T>();
 
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
-    for (int group_id = 0; group_id < group_; ++group_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
+    (void)image_id; // Suppress unused variable warning
+    for (const auto group_id : c10::irange(group_)) {
       if (kernel_.size() == 2) {
         math::Im2Col<T, Context, StorageOrder::NCHW>(
             shape.C / group_,
@@ -681,8 +683,9 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHWImpl(
         column_buffer->template mutable_data<T>(),
         &context_);
     const T* const_column_buffer_data = column_buffer->template data<T>();
-    for (int image_id = 0; image_id < shape.N; ++image_id) {
-      for (int group_id = 0; group_id < group_; ++group_id) {
+    for (const auto image_id : c10::irange(shape.N)) {
+      (void)image_id; // Suppress unused variable warning
+      for (const auto group_id : c10::irange(group_)) {
         if (kernel_.size() == 2) {
           math::Col2Im<T, Context, StorageOrder::NCHW>(
               shape.C / group_,
@@ -743,7 +746,7 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNHWCImpl(
   T* column_buffer_data = column_buffer->template mutable_data<T>();
   T* dY_transposed_buffer_data =
       dY_transposed_buffer->template mutable_data<T>();
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
     math::Im2Col<T, Context, StorageOrder::NHWC>(
         shape.C,
         shape.X_dims[0],
@@ -835,7 +838,8 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNHWCImpl(
         column_buffer->template mutable_data<T>(),
         &context_);
     const T* const_column_buffer_data = column_buffer->template data<T>();
-    for (int image_id = 0; image_id < shape.N; ++image_id) {
+    for (const auto image_id : c10::irange(shape.N)) {
+      (void)image_id; // Suppress unused variable warning
       math::Col2Im<T, Context, StorageOrder::NHWC>(
           shape.C,
           shape.X_dims[0],

--- a/caffe2/operators/lstm_utils.h
+++ b/caffe2/operators/lstm_utils.h
@@ -78,7 +78,7 @@ template <typename T>
 static std::vector<T> unpair_vec(std::vector<std::pair<T, T>>&& vals) {
   std::vector<T> result;
   result.reserve(vals.size() * 2);
-  for (int64_t i = 0; i < vals.size(); i++) {
+  for (const auto i : c10::irange(vals.size())) {
     result.push_back(std::move(vals[i].first));
     result.push_back(std::move(vals[i].second));
   }
@@ -150,7 +150,7 @@ chunk(const Tensor& input, int chunks, int axis, CPUContext* context) {
   auto split_size = input_channels / chunks;
   vector<int64_t> output_dims(input.sizes().vec());
   int before = 1, after = 1;
-  for (int i = 0; i < canonical_axis; ++i) {
+  for (const auto i : c10::irange(canonical_axis)) {
     before *= input.dim32(i);
   }
   for (int i = canonical_axis + 1; i < input.dim(); ++i) {
@@ -158,7 +158,8 @@ chunk(const Tensor& input, int chunks, int axis, CPUContext* context) {
   }
   size_t input_offset = 0;
   std::vector<Tensor> outputs;
-  for (int i = 0; i < chunks; ++i) {
+  for (const auto i : c10::irange(chunks)) {
+    (void)i; // Suppress unused variable warning
     auto axis_dim = split_size;
     output_dims[canonical_axis] = split_size;
     Tensor output(output_dims, CPU);
@@ -187,7 +188,7 @@ std::vector<Tensor> unbind(const Tensor& input, int axis, CPUContext* context) {
   newDims.erase(newDims.begin() + axis);
 
   // 3 - Reshape chunks to drop the extra dimension
-  for (int i = 0; i < chunks.size(); i++) {
+  for (const auto i : c10::irange(chunks.size())) {
     CAFFE_ENFORCE_EQ(
         chunks[i].sizes()[axis], 1, "Got an unexpected chunk size");
     chunks[i].Reshape(newDims);
@@ -201,14 +202,14 @@ cat(const std::vector<Tensor>& tensorList, int axis, CPUContext* context) {
   auto input_zero = copy_ctor(tensorList.at(0));
   vector<int64_t> outputDims(input_zero.sizes().vec());
   CAFFE_ENFORCE(outputDims.size() > 0);
-  for (int i = 1; i < tensorList.size(); i++) {
+  for (const auto i : c10::irange(1, tensorList.size())) {
     CAFFE_ENFORCE(input_zero.dtype() == tensorList.at(i).dtype());
     outputDims[axis] += tensorList.at(i).sizes()[axis];
   }
   auto output_channels = outputDims[axis];
   Tensor output(outputDims, CPU);
   int before = 1, after = 1;
-  for (int i = 0; i < tensorList.at(0).dim(); ++i) {
+  for (const auto i : c10::irange(tensorList.at(0).dim())) {
     if (i == axis) {
       continue;
     }
@@ -245,7 +246,7 @@ stack(const std::vector<Tensor>& tensorList, int axis, CPUContext* context) {
   std::vector<int64_t> newDims(tensorList[0].sizes().vec());
   std::vector<Tensor> expandedTensorList;
   newDims.insert(newDims.begin() + axis, 1);
-  for (int i = 0; i < tensorList.size(); i++) {
+  for (const auto i : c10::irange(tensorList.size())) {
     expandedTensorList.emplace_back(tensorList[i].Clone());
     expandedTensorList.at(i).Reshape(newDims);
   }
@@ -301,7 +302,7 @@ Tensor transpose(const Tensor& X, int dim0, int dim1, CPUContext* context) {
   std::swap(axes[dim0], axes[dim1]);
   const std::vector<std::int64_t> X_dims = X.sizes().vec();
   std::vector<std::int64_t> Y_dims(ndim);
-  for (int i = 0; i < ndim; ++i) {
+  for (const auto i : c10::irange(ndim)) {
     Y_dims[i] = X_dims[axes[i]];
   }
   Tensor Y(Y_dims, CPU);

--- a/caffe2/operators/map_ops.h
+++ b/caffe2/operators/map_ops.h
@@ -130,7 +130,7 @@ class KeyValueToMapOp final : public Operator<Context> {
 
     auto* map_data = this->template Output<MapType>(MAP);
 
-    for (int i = 0; i < key_input.numel(); ++i) {
+    for (const auto i : c10::irange(key_input.numel())) {
       map_data->emplace(key_data[i], value_data[i]);
     }
 
@@ -257,7 +257,7 @@ class MapDeserializer : public BlobDeserializerBase {
     auto* value_data = value_tensor.data<VALUE_T>();
 
     auto* map_ptr = blob->template GetMutable<MapType>();
-    for (int i = 0; i < key_tensor.numel(); ++i) {
+    for (const auto i : c10::irange(key_tensor.numel())) {
       map_ptr->emplace(key_data[i], value_data[i]);
     }
   }

--- a/caffe2/operators/mean_op.h
+++ b/caffe2/operators/mean_op.h
@@ -29,7 +29,7 @@ class MeanOp final : public Operator<Context> {
     }
 
     // Dimension checking
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       if (output->sizes() != Input(i).sizes()) {
         CAFFE_THROW(
             "Check failed: output->sizes() == Input(i).sizes().",
@@ -43,7 +43,7 @@ class MeanOp final : public Operator<Context> {
     }
 
     T* output_data = output->template mutable_data<T>();
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       math::Add(
           output->numel(),
           output_data,
@@ -101,7 +101,7 @@ class MeanGradientOp : public Operator<Context> {
         size, scale, dY_data, dX0->template mutable_data<T>(), &context_);
 
     // Copy the rest dX
-    for (int i = 1; i < num_inputs; i++) {
+    for (const auto i : c10::irange(1, num_inputs)) {
       auto* cur_dX = Output(i);
       cur_dX->ResizeLike(dY);
       cur_dX->CopyFrom(*dX0, true /*async*/);

--- a/caffe2/operators/merge_id_lists_op.h
+++ b/caffe2/operators/merge_id_lists_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 
 C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(MergeIdLists);
 
@@ -50,7 +51,7 @@ class MergeIdListsOp : public Operator<Context> {
     // TODO(badri): Use unordered_set if performance is an issue
     std::set<T> deduped;
     std::vector<int> offsets(InputSize(), 0);
-    for (auto sample = 0; sample < batch_size; sample++) {
+    for (const auto sample : c10::irange(batch_size)) {
       for (size_t i = 0; i < InputSize(); i += 2) {
         auto& lengths = Input(i);
         const auto* lengths_data = lengths.template data<int32_t>();

--- a/caffe2/operators/minmax_ops.h
+++ b/caffe2/operators/minmax_ops.h
@@ -39,7 +39,7 @@ class MaxOp final : public Operator<Context> {
         Y->sizes());
     const T* X1_data = X1.template data<T>();
     math::Max<T, Context>(N, X0_data, X1_data, Y_data, &context_);
-    for (int i = 2; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(2, InputSize())) {
       const auto& Xi = Input(i);
       CAFFE_ENFORCE_EQ(
           Xi.sizes(),
@@ -87,7 +87,7 @@ class MinOp final : public Operator<Context> {
         Y->sizes());
     const T* X1_data = X1.template data<T>();
     math::Min<T, Context>(N, X0_data, X1_data, Y_data, &context_);
-    for (int i = 2; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(2, InputSize())) {
       const auto& Xi = Input(i);
       CAFFE_ENFORCE_EQ(
           Xi.sizes(),

--- a/caffe2/operators/moments_op.h
+++ b/caffe2/operators/moments_op.h
@@ -45,7 +45,7 @@ class MomentsOp final : public Operator<Context> {
     std::vector<std::int64_t> output_dims;
     output_dims.reserve(ndim);
     std::size_t cur_axis = 0;
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       if (cur_axis < axes_.size() && i == axes_[cur_axis]) {
         if (keep_dims_) {
           output_dims.push_back(1);

--- a/caffe2/operators/ngram_ops.h
+++ b/caffe2/operators/ngram_ops.h
@@ -35,9 +35,9 @@ class NGramFromCategoricalOp : public Operator<Context> {
     }
     int base = 1;
     int idx = 0;
-    for (int k = 0; k < col_num_; k++) {
+    for (const auto k : c10::irange(col_num_)) {
       int l = categorical_limits_[k];
-      for (int m = 0; m < l; m++) {
+      for (const auto m : c10::irange(l)) {
         int v = vals_[idx++];
         ngram_maps_[k][v] = m * base;
       }
@@ -56,8 +56,8 @@ class NGramFromCategoricalOp : public Operator<Context> {
     math::Set<T, Context>(output->numel(), 0, output_data, &context_);
 
     CAFFE_ENFORCE_GT(D, max_col_id_);
-    for (int i = 0; i < N; i++) {
-      for (int k = 0; k < col_num_; k++) {
+    for (const auto i : c10::irange(N)) {
+      for (const auto k : c10::irange(col_num_)) {
         int j = col_ids_[k];
         int v = round(floats_data[i * D + j]);
         // for out-of-vocabulary values, we always treat them the same as the

--- a/caffe2/operators/normalize_op.h
+++ b/caffe2/operators/normalize_op.h
@@ -48,7 +48,7 @@ class NormalizeOp final : public Operator<Context> {
     using ConstStridedVec =
         Eigen::Map<const Eigen::Matrix<T, 1, Eigen::Dynamic>, 0, InnerStride>;
 
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto base = (i / sf) * sf * m + (i % sf);
       ConstStridedVec xVec(xData + base, 1, m, InnerStride(sf));
       auto norm = xVec.template lpNorm<2>();

--- a/caffe2/operators/numpy_tile_op.h
+++ b/caffe2/operators/numpy_tile_op.h
@@ -33,7 +33,7 @@ class NumpyTileOp : public Operator<Context> {
         " number of elements as `inputs` has dimensions.");
     const int64_t* repeats_data = repeats.template data<int64_t>();
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < repeats.numel(); ++i) {
+    for (const auto i : c10::irange(repeats.numel())) {
       CAFFE_ENFORCE_GE(repeats_data[i], 0);
     }
 
@@ -45,7 +45,7 @@ class NumpyTileOp : public Operator<Context> {
     Tensor *src = &buffer, *dst = output;
     src->CopyFrom(input);
     vector<int64_t> output_dims(input.sizes().vec());
-    for (size_t i = 0; i < repeats.numel(); ++i) {
+    for (const auto i : c10::irange(repeats.numel())) {
       if (repeats_data[i] == 1) {
         continue;
       }
@@ -100,8 +100,10 @@ class NumpyTileOp : public Operator<Context> {
       int64_t num_tiles,
       const char* input_data,
       char* output_data) {
-    for (auto i = 0; i < outer_dim; ++i) {
-      for (auto t = 0; t < num_tiles; ++t) {
+    for (const auto i : c10::irange(outer_dim)) {
+      (void)i; // Suppress unused variable warning
+      for (const auto t : c10::irange(num_tiles)) {
+        (void)t; // Suppress unused variable warning
         context_.CopyItemsSameDevice(meta, inner_dim, input_data, output_data);
         output_data += inner_dim * item_size;
       }

--- a/caffe2/operators/onnx_while_op.h
+++ b/caffe2/operators/onnx_while_op.h
@@ -94,7 +94,7 @@ class ONNXWhileOp final : public Operator<Context> {
         "outputs");
 
     // Copy initial loop-carried dependencies
-    for (int i = 0; i < num_loop_carried_deps; ++i) {
+    for (const auto i : c10::irange(num_loop_carried_deps)) {
       scope_->lcd_tensor(i)->CopyFrom(Input(i + num_inputs_before_lcds));
     }
 
@@ -126,7 +126,7 @@ class ONNXWhileOp final : public Operator<Context> {
     };
 
     // Allocate scan_outputs for zero-iteration case
-    for (int i = 0; i < num_scan_outputs; ++i) {
+    for (const auto i : c10::irange(num_scan_outputs)) {
       Output(i + num_loop_carried_deps)->Resize(0);
       Output(i + num_loop_carried_deps)->template mutable_data<int32_t>();
     }
@@ -154,13 +154,13 @@ class ONNXWhileOp final : public Operator<Context> {
         }
 
         // Copy forward loop-carried dependencies
-        for (int i = 0; i < num_loop_carried_deps; ++i) {
+        for (const auto i : c10::irange(num_loop_carried_deps)) {
           Blob* b = cur_ws->GetBlob(scope_->net()->external_output()[i + 1]);
           const Tensor& t = b->template Get<Tensor>();
           scope_->lcd_tensor(i)->CopyFrom(t);
         }
         // Copy out scan_outputs
-        for (int i = 0; i < num_scan_outputs; ++i) {
+        for (const auto i : c10::irange(num_scan_outputs)) {
           int net_output_idx = i + 1 + num_loop_carried_deps;
           const Tensor& scan_output =
               cur_ws->GetBlob(scope_->net()->external_output()[net_output_idx])
@@ -202,7 +202,7 @@ class ONNXWhileOp final : public Operator<Context> {
     }
 
     // Copy out final loop-carried dependencies
-    for (int i = 0; i < num_loop_carried_deps; ++i) {
+    for (const auto i : c10::irange(num_loop_carried_deps)) {
       Output(i)->CopyFrom(*scope_->lcd_tensor(i));
     }
 

--- a/caffe2/operators/op_utils_cudnn.h
+++ b/caffe2/operators/op_utils_cudnn.h
@@ -36,7 +36,7 @@ inline void LogCuDNNPerfStats(
     const ArrayOfcudnnConvolutionAlgoPerf_t& perf_stat,
     int returned_algo_count) {
   VLOG(1) << "Perf result: (algo: stat, time, memory)";
-  for (int i = 0; i < returned_algo_count; ++i) {
+  for (const auto i : c10::irange(returned_algo_count)) {
     const auto& stat = perf_stat[i];
     VLOG(1) << stat.algo << ": " << stat.status << " " << stat.time << " "
             << stat.memory;

--- a/caffe2/operators/operator_fallback_gpu.h
+++ b/caffe2/operators/operator_fallback_gpu.h
@@ -62,7 +62,7 @@ class GPUFallbackOpEx final : public Operator<CUDAContext> {
   }
 
   bool RunOnDevice() override {
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       if (this->InputIsTensorType(i, CUDA)) {
         // use sync copy
         BlobGetMutableTensor(local_input_blobs_[i], CPU)->CopyFrom(Input(i));
@@ -82,7 +82,7 @@ class GPUFallbackOpEx final : public Operator<CUDAContext> {
                  << ProtoDebugString(this->debug_def());
       return false;
     }
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       if (SkipOutputCopy::Contains(i)) {
         VLOG(1) << "Copy output: index " << i << " skipped.";
         continue;

--- a/caffe2/operators/order_switch_ops.h
+++ b/caffe2/operators/order_switch_ops.h
@@ -30,7 +30,7 @@ class NHWC2NCHWOp final : public Operator<Context> {
     Y_dims[0] = N;
     Y_dims[1] = C;
     int HxW = 1;
-    for (int i = 2; i < ndim; ++i) {
+    for (const auto i : c10::irange(2, ndim)) {
       Y_dims[i] = X.dim32(i - 1);
       HxW *= Y_dims[i];
     }

--- a/caffe2/operators/pack_rnn_sequence_op.h
+++ b/caffe2/operators/pack_rnn_sequence_op.h
@@ -69,7 +69,7 @@ class PackRNNSequenceOpBase : public Operator<Context> {
     math::Set<ValT, Context>(output->numel(), 0, output_data, &context_);
 
     int32_t offset = 0;
-    for (int c = 0; c < cols; c++) {
+    for (const auto c : c10::irange(cols)) {
       for (int r = 0; r < lengths_vec[c]; r++) {
         auto input_offset = Forward ? (offset + r) : (r * cols + c);
         auto output_offset = Forward ? (r * cols + c) : (offset + r);

--- a/caffe2/operators/partition_ops.h
+++ b/caffe2/operators/partition_ops.h
@@ -48,7 +48,7 @@ class GatherByKeyOp : public Operator<CPUContext> {
     CAFFE_ENFORCE_GE(outShape.size(), 1);
     auto totalSize = in0Shape[0];
     auto meta = Input(1).dtype();
-    for (int i = 2; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(2, InputSize())) {
       const auto& input = Input(i);
       CAFFE_ENFORCE(meta == input.dtype());
       CAFFE_ENFORCE_GE(input.dim(), 1);
@@ -66,7 +66,7 @@ class GatherByKeyOp : public Operator<CPUContext> {
     const auto blockSize = outTensor->size_from_dim(1);
 
     inputDatas_.resize(numPartitions);
-    for (int i = 0; i < numPartitions; ++i) {
+    for (const auto i : c10::irange(numPartitions)) {
       inputDatas_[i] = static_cast<const char*>(Input(i + 1).raw_data());
     }
     inStartOffsets_.assign(numPartitions, 0);
@@ -127,7 +127,7 @@ class PartitionOpBase : public Operator<CPUContext> {
     int64_t size = main_input.numel();
     const Index* data = main_input.template data<Index>();
     counts_.assign(partitions, 0);
-    for (int64_t p = 0; p < size; p++) {
+    for (const auto p : c10::irange(size)) {
       int shard = moduloPartition(data[p], partitions);
       ++counts_[shard];
     }
@@ -136,7 +136,7 @@ class PartitionOpBase : public Operator<CPUContext> {
     block_sizes_.resize(inputSize);
     metas_.resize(inputSize);
     out_datas_.resize(OutputSize());
-    for (int i = mainInputIndex; i < inputSize; ++i) {
+    for (const auto i : c10::irange(mainInputIndex, inputSize)) {
       auto& input = Input(i);
       if (i > mainInputIndex) {
         CAFFE_ENFORCE_GE(
@@ -145,7 +145,7 @@ class PartitionOpBase : public Operator<CPUContext> {
             "Prefix of extra input's shape must match main input's shape, ",
             "input: ",
             i);
-        for (int j = 0; j < main_input.dim(); ++j) {
+        for (const auto j : c10::irange(main_input.dim())) {
           CAFFE_ENFORCE_GE(
               input.size(j),
               main_input.size(j),
@@ -162,7 +162,7 @@ class PartitionOpBase : public Operator<CPUContext> {
       // shape = partition_size + suffix of input dims
       vector<int64_t> shape(
           input.sizes().begin() + main_input.dim() - 1, input.sizes().end());
-      for (int j = 0; j < partitions; ++j) {
+      for (const auto j : c10::irange(partitions)) {
         int out_idx = i + j * inputSize;
         auto output = Output(out_idx);
         shape[0] = counts_[j];
@@ -172,7 +172,7 @@ class PartitionOpBase : public Operator<CPUContext> {
     }
 
     counts_.assign(partitions, 0);
-    for (int64_t p = 0; p < size; p++) {
+    for (const auto p : c10::irange(size)) {
       int shard = moduloPartition(data[p], partitions);
       int64_t idx = counts_[shard]++;
 
@@ -254,7 +254,7 @@ class LengthsPartitionOp : public PartitionOpBase {
 
     if (partitions == 1) {
       // Specialization when partitions == 1 which just becomes a copy.
-      for (int i = 0; i < InputSize(); ++i) {
+      for (const auto i : c10::irange(InputSize())) {
         auto& input = Input(i);
         auto& output = *Output(i);
         output.ResizeLike(input);
@@ -279,14 +279,14 @@ class LengthsPartitionOp : public PartitionOpBase {
     int64_t elements = length_input.numel();
     const int32_t* lengths_data = length_input.template data<int32_t>();
     out_length_.resize(partitions);
-    for (int i = 0; i < partitions; ++i) {
+    for (const auto i : c10::irange(partitions)) {
       auto& output = *Output(i * InputSize());
       output.Resize(elements);
       out_length_[i] = output.template mutable_data<int32_t>();
     }
 
     int total_length = 0;
-    for (int i = 0; i < elements; ++i) {
+    for (const auto i : c10::irange(elements)) {
       total_length += lengths_data[i];
     }
     CAFFE_ENFORCE(
@@ -294,8 +294,8 @@ class LengthsPartitionOp : public PartitionOpBase {
         "Total length is not matching to the number of elements");
 
     int index = 0;
-    for (int i = 0; i < elements; ++i) {
-      for (int j = 0; j < partitions; ++j) {
+    for (const auto i : c10::irange(elements)) {
+      for (const auto j : c10::irange(partitions)) {
         out_length_[j][i] = 0;
       }
       for (int j = 0; j < lengths_data[i]; ++j, ++index) {

--- a/caffe2/operators/piecewise_linear_transform_op.h
+++ b/caffe2/operators/piecewise_linear_transform_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/operator.h"
 
 C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(PiecewiseLinearTransform);
@@ -61,7 +62,7 @@ class PiecewiseLinearTransformOp final : public Operator<Context> {
       const int64_t num_bounds_per_group,
       const int64_t num_group) {
     const T* start = bounds;
-    for (int64_t i = 0; i < num_group; i++) {
+    for (const auto i : c10::irange(num_group)) {
       if (!std::is_sorted(start, start + num_bounds_per_group)) {
         return false;
       }
@@ -153,11 +154,11 @@ class PiecewiseLinearTransformOp final : public Operator<Context> {
         &bounds, &slopes, &intercepts, &num_func_per_group, &num_group);
     CAFFE_ENFORCE_EQ(num_group, M);
 
-    for (int64_t j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       const T* bounds_group = bounds + j * (num_func_per_group + 1);
       const T* slopes_group = slopes + j * num_func_per_group;
       const T* intercepts_group = intercepts + j * num_func_per_group;
-      for (int64_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         Ydata[i * M + j] = PiecewiseLinearTransform(
             Xdata[i * M + j],
             bounds_group,
@@ -192,12 +193,12 @@ class PiecewiseLinearTransformOp final : public Operator<Context> {
     CAFFE_ENFORCE_EQ(num_group, 1);
 
     if (M == 1) {
-      for (int64_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         Ydata[i] = PiecewiseLinearTransform(
             Xdata[i], bounds, slopes, intercepts, num_func_per_group);
       }
     } else {
-      for (int64_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         Ydata[i * M + 1] = PiecewiseLinearTransform(
             Xdata[i * M + 1], bounds, slopes, intercepts, num_func_per_group);
         Ydata[i * M] = 1.0f - Ydata[i * M + 1];

--- a/caffe2/operators/pool_op.h
+++ b/caffe2/operators/pool_op.h
@@ -20,12 +20,12 @@ class PoolOp final : public ConvPoolOpBase<Context> {
   explicit PoolOp(Args&&... args)
       : ConvPoolOpBase<Context>(std::forward<Args>(args)...), functor_(*this) {
     const int kernel_size = kernel_.size();
-    for (int i = 0; i < kernel_size; ++i) {
+    for (const auto i : c10::irange(kernel_size)) {
       CAFFE_ENFORCE_EQ(
           dilation_[i], 1, "Pooling op does not support dilation right now.");
     }
     if (!global_pooling_) {
-      for (int i = 0; i < kernel_size; ++i) {
+      for (const auto i : c10::irange(kernel_size)) {
         CAFFE_ENFORCE(
             pads_[i] < kernel_[i] && pads_[i + kernel_size] < kernel_[i],
             "Pad should be smaller than kernel.");

--- a/caffe2/operators/prepend_dim_op.h
+++ b/caffe2/operators/prepend_dim_op.h
@@ -35,7 +35,7 @@ class PrependDimOp : public Operator<Context> {
     actual_new_shape[0] = dim_size_;
     actual_new_shape[1] = input.size(0) / dim_size_;
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 1; i < input.sizes().size(); ++i) {
+    for (const auto i : c10::irange(1, input.sizes().size())) {
       actual_new_shape[i + 1] = input.size(i);
     }
     output->Resize(actual_new_shape);

--- a/caffe2/operators/quant_decode_op.h
+++ b/caffe2/operators/quant_decode_op.h
@@ -1,6 +1,8 @@
 #ifndef QUANT_DECODE_OP_H_
 #define QUANT_DECODE_OP_H_
 
+
+#include <c10/util/irange.h>
 #include <c10/util/typeid.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
@@ -34,7 +36,7 @@ void Decode(
     }
 
     int sz = output->numel();
-    for (int i = 0; i < sz; i++) {
+    for (const auto i : c10::irange(sz)) {
       DCHECK_LE(*code_ptr, cb_size);
       *out_ptr++ = cb_ptr[*code_ptr++];
     }
@@ -116,7 +118,7 @@ class QuantDecodeOp final : public Operator<CPUContext> {
     const auto& codebook = Input(0);
     CAFFE_ENFORCE(codebook.template IsType<float>(), codebook.dtype().name());
 
-    for (int i = 0; i < OutputSize(); i++) {
+    for (const auto i : c10::irange(OutputSize())) {
       auto& ci = Input(i + 1);
       auto* co = Output(i);
 
@@ -157,7 +159,7 @@ class QuantDecodeGradientOp final : public Operator<CPUContext> {
     auto* gradient_ptr = gradient->template mutable_data<float>();
     std::fill(gradient_ptr, gradient_ptr + gradient->numel(), 0);
 
-    for (int i = 0; i < num_code_tensors; i++) {
+    for (const auto i : c10::irange(num_code_tensors)) {
       auto& codes_i = Input(i + 1);
       auto& output_gradient_i = Input(i + num_code_tensors + 1);
       DecodeGeneral(codebook, codes_i, &output_gradient_i, gradient, false);

--- a/caffe2/operators/quantile_op.h
+++ b/caffe2/operators/quantile_op.h
@@ -42,7 +42,7 @@ class QuantileOp final : public Operator<Context> {
 
     auto& input_zero = Input(0);
     int64_t numel = input_zero.numel();
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).dtype(),
           input_zero.dtype(),
@@ -116,9 +116,9 @@ class QuantileOp final : public Operator<Context> {
   void GetRangeFromInputs(T* lo, T* hi) {
     *hi = std::numeric_limits<T>::lowest();
     *lo = std::numeric_limits<T>::max();
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto* input = Input(i).template data<T>();
-      for (int j = 0; j < Input(i).numel(); j++) {
+      for (const auto j : c10::irange(Input(i).numel())) {
         const T val = abs_ ? std::abs(input[j]) : input[j];
         if (*hi < val) {
           *hi = val;
@@ -133,9 +133,9 @@ class QuantileOp final : public Operator<Context> {
   template <typename T>
   int64_t CountLowerEq(const T& thd) {
     int64_t count = 0;
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto* input = Input(i).template data<T>();
-      for (int j = 0; j < Input(i).numel(); j++) {
+      for (const auto j : c10::irange(Input(i).numel())) {
         const T val = abs_ ? std::abs(input[j]) : input[j];
         if (val <= thd) {
           count++;

--- a/caffe2/operators/quantized/int8_concat_op.h
+++ b/caffe2/operators/quantized/int8_concat_op.h
@@ -46,10 +46,10 @@ class Int8ConcatOp final : public Operator<CPUContext> {
     if (this->template GetSingleArgument<string>("order", "") == "NHWC") {
       CHECK_EQ(Y_dims.size(), 4);
     }
-    for (auto i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       const auto& Xi = Inputs()[i]->template Get<Int8TensorCPU>();
       CHECK_EQ(Xi.t.dim(), Y_dims.size());
-      for (auto j = 0; j < Y_dims.size(); ++j) {
+      for (const auto j : c10::irange(Y_dims.size())) {
         if (j != axis_) {
           CHECK_EQ(Xi.t.size(j), Y_dims[j]);
         }
@@ -61,7 +61,7 @@ class Int8ConcatOp final : public Operator<CPUContext> {
     int after = X0.t.size_from_dim(axis_ + 1);
     const auto C_total = Y_dims[axis_];
     size_t C_offset = 0;
-    for (auto i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto& Xi = Inputs()[i]->template Get<Int8TensorCPU>();
       // Copy the NxHxWxC input slice to NxHxWx[C_offset:C_offset + C].
       const auto Ci = Xi.t.size(axis_);

--- a/caffe2/operators/quantized/int8_dequantize_op.h
+++ b/caffe2/operators/quantized/int8_dequantize_op.h
@@ -18,7 +18,7 @@ void Int8Dequantize(
     const int64_t N,
     const float X_scale,
     const int32_t X_offset) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     out[i] = (static_cast<int32_t>(in[i]) - X_offset) * X_scale;
   }
 }

--- a/caffe2/operators/quantized/int8_given_tensor_fill_op.h
+++ b/caffe2/operators/quantized/int8_given_tensor_fill_op.h
@@ -40,7 +40,7 @@ class Int8GivenTensorFillOp final : public Operator<CPUContext> {
         {static_cast<int64_t>(source_values.size())},
         at::dtype<uint8_t>().device(CPU));
     uint8_t* values_data = values_.template mutable_data<uint8_t>();
-    for (int i = 0; i < source_values.size(); i++) {
+    for (const auto i : c10::irange(source_values.size())) {
       values_data[i] = static_cast<uint8_t>(source_values[i]);
     }
   }
@@ -92,7 +92,7 @@ class Int8GivenIntTensorFillOp final : public Operator<CPUContext> {
         {static_cast<int64_t>(source_values.size())},
         at::dtype<int32_t>().device(CPU));
     auto* values_data = values_.template mutable_data<int32_t>();
-    for (int i = 0; i < source_values.size(); i++) {
+    for (const auto i : c10::irange(source_values.size())) {
       values_data[i] = static_cast<int32_t>(source_values[i]);
     }
   }

--- a/caffe2/operators/quantized/int8_resize_nearest_op.h
+++ b/caffe2/operators/quantized/int8_resize_nearest_op.h
@@ -54,10 +54,10 @@ class Int8ResizeNearestOp final : public Operator<CPUContext> {
     const uint8_t* Xdata = X.t.data<uint8_t>();
     uint8_t* Ydata = Y->t.mutable_data<uint8_t>();
 
-    for (int n = 0; n < N; ++n) {
-      for (int y = 0; y < OH; ++y) {
+    for (const auto n : c10::irange(N)) {
+      for (const auto y : c10::irange(OH)) {
         const int in_y = std::min((int)(y / height_scale_), (IH - 1));
-        for (int x = 0; x < OW; ++x) {
+        for (const auto x : c10::irange(OW)) {
           const int in_x = std::min((int)(x / width_scale_), (IW - 1));
           std::memcpy(
               &Ydata[C * x + C * OW * y + C * OW * OH * n],

--- a/caffe2/operators/quantized/int8_roi_align_op.h
+++ b/caffe2/operators/quantized/int8_roi_align_op.h
@@ -44,13 +44,13 @@ void pre_calc_for_bilinear_interpolate(
   int pre_calc_index = 0;
   // boltnn use a smaller multiplier here. Sometimes w will shrink to 0.
   const float w_multiplier = 255.0;
-  for (int ph = 0; ph < pooled_height; ph++) {
-    for (int pw = 0; pw < pooled_width; pw++) {
-      for (int iy = 0; iy < iy_upper; iy++) {
+  for (const auto ph : c10::irange(pooled_height)) {
+    for (const auto pw : c10::irange(pooled_width)) {
+      for (const auto iy : c10::irange(iy_upper)) {
         const float yy = roi_start_h + ph * bin_size_h +
             static_cast<float>(iy + .5f) * bin_size_h /
                 static_cast<float>(roi_bin_grid_h); // e.g., 0.5, 1.5
-        for (int ix = 0; ix < ix_upper; ix++) {
+        for (const auto ix : c10::irange(ix_upper)) {
           const float xx = roi_start_w + pw * bin_size_w +
               static_cast<float>(ix + .5f) * bin_size_w /
                   static_cast<float>(roi_bin_grid_w);
@@ -152,7 +152,7 @@ void ROIAlignForward(
 
   int n_rois = nthreads / channels / pooled_width / pooled_height;
 
-  for (int n = 0; n < n_rois; n++) {
+  for (const auto n : c10::irange(n_rois)) {
     int index_n = n * channels * pooled_width * pooled_height;
 
     // roi could have 4 or 5 columns
@@ -224,19 +224,19 @@ void ROIAlignForward(
     const uint8_t* offset_bottom_data =
         bottom_data + roi_batch_ind * channels * height * width;
     int pre_calc_index = 0;
-    for (int ph = 0; ph < pooled_height; ph++) {
-      for (int pw = 0; pw < pooled_width; pw++) {
+    for (const auto ph : c10::irange(pooled_height)) {
+      for (const auto pw : c10::irange(pooled_width)) {
         vector<int32_t> acc_buffer(channels, 0);
 
-        for (int iy = 0; iy < roi_bin_grid_h; iy++) {
-          for (int ix = 0; ix < roi_bin_grid_w; ix++) {
+        for (const auto iy : c10::irange(roi_bin_grid_h)) {
+          for (const auto ix : c10::irange(roi_bin_grid_w)) {
             PreCalc pc = pre_calc[pre_calc_index];
 
             const uint8_t* data_1 = offset_bottom_data + channels * pc.pos1;
             const uint8_t* data_2 = offset_bottom_data + channels * pc.pos2;
             const uint8_t* data_3 = offset_bottom_data + channels * pc.pos3;
             const uint8_t* data_4 = offset_bottom_data + channels * pc.pos4;
-            for (int c = 0; c < channels; ++c) {
+            for (const auto c : c10::irange(channels)) {
               acc_buffer[c] += (uint32_t)(pc.w1) * (uint32_t)(data_1[c]);
               acc_buffer[c] += (uint32_t)(pc.w2) * (uint32_t)(data_2[c]);
               acc_buffer[c] += (uint32_t)(pc.w3) * (uint32_t)(data_3[c]);
@@ -251,7 +251,7 @@ void ROIAlignForward(
         }
         int index_nhw = index_n + (ph * pooled_width + pw) * channels;
         uint8_t* out_ptr = top_data + index_nhw;
-        for (int c = 0; c < channels; ++c) {
+        for (const auto c : c10::irange(channels)) {
           int32_t a_mul = MultiplyByQuantizedMultiplierSmallerThanOne(
                               acc_buffer[c], Y_multiplier, Y_shift) +
               y_offset;

--- a/caffe2/operators/quantized/int8_test_utils.h
+++ b/caffe2/operators/quantized/int8_test_utils.h
@@ -77,7 +77,7 @@ inline std::unique_ptr<TensorCPU> biasdq(const int8::Int8TensorCPU& XQ) {
 #define EXPECT_TENSOR_EQ(_YA, _YE)                                     \
   do {                                                                 \
     EXPECT_TRUE((_YA).sizes() == (_YE).sizes());                       \
-    for (auto i = 0; i < (_YA).numel(); ++i) {                         \
+    for (const auto i : c10::irange((_YA).numel())) {                         \
       EXPECT_FLOAT_EQ((_YA).data<float>()[i], (_YE).data<float>()[i]); \
     }                                                                  \
   } while (0);
@@ -85,7 +85,7 @@ inline std::unique_ptr<TensorCPU> biasdq(const int8::Int8TensorCPU& XQ) {
 #define EXPECT_TENSOR_APPROX_EQ(_YA, _YE, _tol)                            \
   do {                                                                     \
     EXPECT_TRUE((_YA).sizes() == (_YE).sizes());                           \
-    for (auto i = 0; i < (_YA).numel(); ++i) {                             \
+    for (const auto i : c10::irange((_YA).numel())) {                             \
       EXPECT_NEAR((_YA).data<float>()[i], (_YE).data<float>()[i], (_tol)); \
     }                                                                      \
   } while (0);

--- a/caffe2/operators/reduce_front_back_max_ops.h
+++ b/caffe2/operators/reduce_front_back_max_ops.h
@@ -35,7 +35,7 @@ class MaxReduceDimsOp final : public Operator<Context> {
     int start_index = FIRSTDIMS ? num_reduce_dims_ : 0;
     int end_index = FIRSTDIMS ? X.dim() : X.dim() - num_reduce_dims_;
 
-    for (int i = start_index; i < end_index; ++i) {
+    for (const auto i : c10::irange(start_index, end_index)) {
       output_shape.push_back(X.sizes()[i]);
     }
     auto* Y = Output(0, output_shape, at::dtype<float>());

--- a/caffe2/operators/reduce_front_back_sum_mean_ops.h
+++ b/caffe2/operators/reduce_front_back_sum_mean_ops.h
@@ -35,7 +35,7 @@ class SumReduceDimsOp final : public Operator<Context> {
     vector<int64_t> output_shape;
     int start_index = FIRSTDIMS ? num_reduce_dims_ : 0;
     int end_index = FIRSTDIMS ? X.dim() : X.dim() - num_reduce_dims_;
-    for (int i = start_index; i < end_index; ++i) {
+    for (const auto i : c10::irange(start_index, end_index)) {
       output_shape.push_back(X.sizes()[i]);
     }
     auto* Y = Output(0, output_shape, at::dtype<T>());

--- a/caffe2/operators/reduce_ops.h
+++ b/caffe2/operators/reduce_ops.h
@@ -50,7 +50,7 @@ class ReduceOp final : public Operator<Context> {
     std::vector<int64_t> output_dims;
     output_dims.reserve(ndim);
     std::size_t cur_axis = 0;
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       if (cur_axis < axes_.size() && i == axes_[cur_axis]) {
         if (keep_dims_) {
           output_dims.push_back(1);

--- a/caffe2/operators/reducer_functors.h
+++ b/caffe2/operators/reducer_functors.h
@@ -50,7 +50,7 @@ class SumRangeReducerGradient {
       const T* /*data_out*/, // unused
       Context* context) {
     // do we have some op that does it smartly with minimum number of memcpy?
-    for (int64_t i = 0; i < blocks; ++i) {
+    for (const auto i : c10::irange(blocks)) {
       context->template CopySameDevice<T>(
           block_size, segment_grad, data_grad + block_size * i);
     }
@@ -83,13 +83,13 @@ class LogSumExpRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T max_value = std::numeric_limits<T>::lowest();
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         max_value = std::max(max_value, in[i * block_size + j]);
       }
       T scaled_exp_sum = 0;
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         scaled_exp_sum += std::exp(in[i * block_size + j] - max_value);
       }
       *(out++) = std::log(scaled_exp_sum) + max_value;
@@ -109,10 +109,10 @@ class LogSumExpRangeReducerGradient {
       const T* data_in, // I
       const T* data_out, // O
       Context* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
       const T offset = *(data_out++);
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         data_grad[idx] = out_grad * std::exp(data_in[idx] - offset);
       }
@@ -145,13 +145,13 @@ class LogMeanExpRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T max_value = std::numeric_limits<T>::lowest();
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         max_value = std::max(max_value, in[i * block_size + j]);
       }
       T scaled_exp_sum = 0;
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         scaled_exp_sum += std::exp(in[i * block_size + j] - max_value);
       }
       scaled_exp_sum /= blocks;
@@ -171,10 +171,10 @@ class LogMeanExpRangeReducerGradient {
       const T* data_in, // I
       const T* data_out, // O
       Context* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
       const T offset = *(data_out++);
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         data_grad[idx] = out_grad * std::exp(data_in[idx] - offset) / blocks;
       }
@@ -207,9 +207,9 @@ class MeanRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T avg_value = 0;
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         avg_value += in[i * block_size + j] / blocks;
       }
       *(out++) = avg_value;
@@ -229,9 +229,9 @@ class MeanRangeReducerGradient {
       const T* /*data_out*/, // O
       Context* /*context*/) {
     const auto in_grad = 1.0 / blocks;
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         data_grad[idx] = out_grad * in_grad;
       }
@@ -266,9 +266,9 @@ class MaxRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T max_value = std::numeric_limits<T>::lowest();
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         max_value = std::max(max_value, in[i * block_size + j]);
       }
       *(out++) = max_value;
@@ -289,10 +289,10 @@ class MaxRangeReducerGradient {
       Context* /*context*/) {
     std::memset(
         static_cast<void*>(data_grad), 0, blocks * block_size * sizeof(T));
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
       const T out = data_out[j];
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         if (out == data_in[idx]) {
           data_grad[idx] = out_grad;
@@ -813,7 +813,7 @@ class MaxReducerGradient : public BaseReducerGradient {
       int64_t /*offset*/,
       Context* /*context*/,
       const int /*length*/) {
-    for (int64_t i = 0; i < meta.block_size; ++i) {
+    for (const auto i : c10::irange(meta.block_size)) {
       data_grad[i] = data[i] == forward_output[i] ? s_grad_[i] : 0;
     }
   }

--- a/caffe2/operators/reduction_ops.h
+++ b/caffe2/operators/reduction_ops.h
@@ -164,7 +164,7 @@ class MaxReductionOp : public Operator<Context> {
           &context_);
     } else {
       const int input_size = N * M;
-      for (int i = 0; i < batch_size; ++i) {
+      for (const auto i : c10::irange(batch_size)) {
         math::ColwiseMax<T, Context>(
             M,
             N,

--- a/caffe2/operators/remove_data_blocks_op.h
+++ b/caffe2/operators/remove_data_blocks_op.h
@@ -40,7 +40,7 @@ class RemoveDataBlocksOp final : public Operator<Context> {
     const auto* ind_ptr = indices.template data<T>();
 
     std::vector<T> ind_vec;
-    for (int64_t i = 0; i < indices_size; i++) {
+    for (const auto i : c10::irange(indices_size)) {
       ind_vec.push_back(ind_ptr[i]);
     }
     std::sort(ind_vec.begin(), ind_vec.end());
@@ -60,7 +60,7 @@ class RemoveDataBlocksOp final : public Operator<Context> {
 
     ind_vec.insert(ind_vec.begin(), -1);
     int64_t ind_vec_size = ind_vec.size();
-    for (auto i = 0; i < ind_vec_size; i++) {
+    for (const auto i : c10::irange(ind_vec_size)) {
       int64_t interval_start = ind_vec[i] + 1;
       int64_t interval_end =
           (i == ind_vec_size - 1) ? outer_size : ind_vec[i + 1];

--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -97,7 +97,7 @@ class ReshapeOp : public Operator<Context> {
     }
 
     int unknown_idx = -1;
-    for (int i = 0; i < actual_new_shape.size(); ++i) {
+    for (const auto i : c10::irange(actual_new_shape.size())) {
       const auto dim = actual_new_shape[i];
       if (dim == -1) {
         CAFFE_ENFORCE(
@@ -153,7 +153,7 @@ class ReshapeOp : public Operator<Context> {
     old_shape->Resize(input.sizes().size());
     T* old_shape_data = old_shape->template mutable_data<T>();
     std::vector<T> old_shape_vector(input.sizes().begin(), input.sizes().end());
-    for (int i = 0; i < old_shape_vector.size(); ++i) {
+    for (const auto i : c10::irange(old_shape_vector.size())) {
       old_shape_data[i] = old_shape_vector[i];
     }
 

--- a/caffe2/operators/reverse_packed_segs_op.h
+++ b/caffe2/operators/reverse_packed_segs_op.h
@@ -62,7 +62,7 @@ class ReversePackedSegsOp final : public Operator<Context> {
     context_.FinishDeviceComputation();
 
     T* rev_data_ptr = output->template mutable_data<T>();
-    for (int64_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       const auto& seg_length = lengths_host[i];
       CAFFE_ENFORCE_LE(seg_length, max_length);
       int64_t j = 0;

--- a/caffe2/operators/rnn/recurrent_network_blob_fetcher_op.h
+++ b/caffe2/operators/rnn/recurrent_network_blob_fetcher_op.h
@@ -32,7 +32,7 @@ class RecurrentNetworkBlobFetcherOp final : public Operator<Context> {
     std::vector<std::string> blob_names_vector = {};
 
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int64_t i = 0; i < stepWorkspaces.size(); i++) {
+    for (const auto i : c10::irange(stepWorkspaces.size())) {
       Workspace* currentStepWorkspace = stepWorkspaces[i].get();
       std::vector<std::string> blob_names = currentStepWorkspace->LocalBlobs();
 

--- a/caffe2/operators/rnn/recurrent_network_executor.h
+++ b/caffe2/operators/rnn/recurrent_network_executor.h
@@ -38,7 +38,7 @@ class RecurrentNetworkExecutorBase {
         recurrent_input_map_(recurrent_input_map),
         timestep_blob_(timestep_blob) {
     const bool net_def_has_device_option = step_net_def_.has_device_option();
-    for (int i = 0; i < step_net_def_.op_size(); i++) {
+    for (const auto i : c10::irange(step_net_def_.op_size())) {
       if (net_def_has_device_option) {
         // In the case when net def specifies device option, final device option
         // will be equal to merge of operator and net def device options, with
@@ -86,7 +86,7 @@ class RecurrentNetworkExecutorBase {
       for (auto& rnn_op : timestep_ops_template_) {
         rnn_op.has_timestep_blob = false;
         const OperatorDef& op = step_net_def_.op(rnn_op.order);
-        for (int i = 0; i < op.input_size(); i++) {
+        for (const auto i : c10::irange(op.input_size())) {
           if (op.input(i) == timestep_blob_) {
             rnn_op.has_timestep_blob = true;
             break;
@@ -137,7 +137,7 @@ class RecurrentNetworkExecutorBase {
         if (rnn_op.has_timestep_blob) {
           OperatorDef op_copy = step_net_def_.op(rnn_op.order);
 
-          for (int i = 0; i < op_copy.input_size(); i++) {
+          for (const auto i : c10::irange(op_copy.input_size())) {
             if (op_copy.input(i) == timestep_blob_) {
               op_copy.set_input(i, this_timestep_blob);
             }
@@ -283,7 +283,7 @@ class RecurrentNetworkExecutorBase {
       int opidx,
       std::vector<RNNNetOperator>& rnn_ops,
       std::unordered_set<int>* dep_ops) {
-    for (int i = 0; i < rnn_ops.size(); i++) {
+    for (const auto i : c10::irange(rnn_ops.size())) {
       if (i == opidx) {
         continue;
       }
@@ -315,7 +315,7 @@ class RecurrentNetworkExecutorBase {
    * for each timestep.
    */
   void CalculateInternalDependencies() {
-    for (int i = 0; i < step_net_def_.op_size(); i++) {
+    for (const auto i : c10::irange(step_net_def_.op_size())) {
       timestep_ops_template_.push_back(RNNNetOperator(step_net_def_.op(i), i));
     }
     // Then see which outputs appear as inputs, and those are

--- a/caffe2/operators/rnn/recurrent_network_op.h
+++ b/caffe2/operators/rnn/recurrent_network_op.h
@@ -103,7 +103,7 @@ void repeatCopy(
     T* dst,
     Context* context) {
   // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-  for (int i = 0; i < repeat_n; ++i) {
+  for (const auto i : c10::irange(repeat_n)) {
     context->template CopySameDevice<T>(n, src, dst + i * n);
   }
 }
@@ -228,7 +228,7 @@ class RecurrentNetworkOp final : public Operator<Context> {
     CAFFE_ENFORCE_EQ(states.size(), inputs.size(), "states/inputs mismatch");
     std::vector<detail::RecurrentInput> ris;
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (auto i = 0; i < states.size(); ++i) {
+    for (const auto i : c10::irange(states.size())) {
       // States need to be "global" (since they are shared between
       // forward and backward).
       sharedWs->CreateBlob(states[i]);
@@ -254,7 +254,7 @@ class RecurrentNetworkOp final : public Operator<Context> {
         dst.size() == offset.size(), "alias_dst/alias_offset mismatch");
     std::vector<detail::OffsetAlias> aliases;
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (auto i = 0; i < src.size(); ++i) {
+    for (const auto i : c10::irange(src.size())) {
       detail::OffsetAlias oc;
       oc.src = src[i];
       oc.dst = dst[i];
@@ -343,7 +343,7 @@ class RecurrentNetworkOp final : public Operator<Context> {
       stepWorkspaces.resize(num_workspaces_on_fwd_only);
     }
 
-    for (auto t = 0; t < seqLen; ++t) {
+    for (const auto t : c10::irange(seqLen)) {
       auto& currentStepWorkspace =
           (has_backward_pass ? stepWorkspaces[t] :
               stepWorkspaces[t % num_workspaces_on_fwd_only]);
@@ -472,7 +472,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
   }
 
   void renameOpInputOutput(std::string from_name, std::string to_name) {
-    for (int j = 0; j < stepNetDef_.op_size(); j++) {
+    for (const auto j : c10::irange(stepNetDef_.op_size())) {
       auto* op = stepNetDef_.mutable_op(j);
       for (int i = 0; i < op->input_size(); i++) {
         if (op->input(i) == from_name) {
@@ -498,7 +498,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
         " != ",
         param_grads.size());
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < param.size(); ++i) {
+    for (const auto i : c10::irange(param.size())) {
       detail::Param p;
       // Forward inputs come after [outputs_with_grads] gradient inputs
       p.param = operator_def.input(param[i] + gradInputs_.size());
@@ -526,17 +526,17 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
         this->template GetRepeatedArgument<int32_t>("alias_offset");
 
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (auto i = 0; i < recurrent.size(); ++i) {
+    for (const auto i : c10::irange(recurrent.size())) {
       detail::RecurrentGradient rg;
       rg.param = recurrent[i];
       rg.grad = remappedName(recurrent[i] + "_grad");
 
-      for (int j = 0; j < alias_src.size(); ++j) {
+      for (const auto j : c10::irange(alias_src.size())) {
         if (alias_src[j] != recurrent[i]) {
           continue;
         }
         int idx = -1;
-        for (int k = 0; k < gradInputs_.size(); ++k) {
+        for (const auto k : c10::irange(gradInputs_.size())) {
           if (gradInputs_[k] == j) {
             idx = k;
           }
@@ -575,7 +575,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
         "",
         &links);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < links.size(); i++) {
+    for (const auto i : c10::irange(links.size())) {
       links[i] = remappedLink(links[i]);
     }
     return links;
@@ -715,7 +715,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
     // This code assumes that there are several inputs
     // sequences. Actually it is not supported by the rest of the code,
     // and numSequences_ is a constant, equal to 1.
-    for (int i = 0; i < numSequences_; ++i) {
+    for (const auto i : c10::irange(numSequences_)) {
       // Offseting as the first gradInputs_.size() inputs of the op
       // are from GO. Then all I(0..N).
       const int gradientInputIndex = i + gradInputs_.size();
@@ -790,7 +790,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
 
     CAFFE_ENFORCE_EQ(recurrentInputIds_.size(), recurrentGradients_.size());
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < recurrentInputIds_.size(); ++i) {
+    for (const auto i : c10::irange(recurrentInputIds_.size())) {
       // See GetRecurrentNetworkGradient to understand offseting here
       // Outputs of the gradient are inputs of the forward pass.
       // So we need to offset on all inputs that go before recurrent

--- a/caffe2/operators/rowmul_op.h
+++ b/caffe2/operators/rowmul_op.h
@@ -32,9 +32,9 @@ class RowMulOp : public Operator<Context> {
         "Length of w should be equal to the first dim of mat");
 
     auto block_size = mat.size_from_dim(1);
-    for (int i = 0; i < w.numel(); i++) {
+    for (const auto i : c10::irange(w.numel())) {
       size_t offset = i * block_size;
-      for (int j = 0; j < block_size; j++) {
+      for (const auto j : c10::irange(block_size)) {
         output_data[offset + j] = mat_data[offset + j] * w_data[i];
       }
     }
@@ -60,10 +60,10 @@ class ReduceTailSumOp : public Operator<Context> {
     T* output_data = output->template mutable_data<T>();
     const T* mat_data = mat.template data<T>();
 
-    for (int i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       output_data[i] = 0;
       size_t offset = i * block_size;
-      for (int j = 0; j < block_size; j++) {
+      for (const auto j : c10::irange(block_size)) {
         output_data[i] += mat_data[offset + j];
       }
     }

--- a/caffe2/operators/scale_blobs_op.h
+++ b/caffe2/operators/scale_blobs_op.h
@@ -20,7 +20,7 @@ class ScaleBlobsOp final : public Operator<Context> {
   bool DoRunWithType() {
     int batchSize = InputSize();
 
-    for (int i = 0; i < batchSize; ++i) {
+    for (const auto i : c10::irange(batchSize)) {
       const auto& X = Input(i);
       auto* Y = Output(i, X.sizes(), at::dtype<T>());
       math::Scale<float, T, Context>(
@@ -34,7 +34,7 @@ class ScaleBlobsOp final : public Operator<Context> {
   }
 
   bool RunOnDevice() override {
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       auto& input = this->template Input<Tensor>(i, CPU);
       auto* output = this->template Output<Tensor>(i, CPU);
       output->ResizeLike(input);

--- a/caffe2/operators/self_binning_histogram_op.h
+++ b/caffe2/operators/self_binning_histogram_op.h
@@ -59,12 +59,12 @@ class SelfBinningHistogramOp final : public Operator<Context> {
     T max = 0;
     T min = 0;
     int64_t total_count = 0;
-    for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+    for (const auto input_idx : c10::irange(InputSize())) {
       const auto& x = Input(input_idx);
       const int64_t N = x.numel();
       total_count += N;
       const auto* x_data = x.template data<T>();
-      for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+      for (const auto data_idx : c10::irange(N)) {
         const T val = this->abs_ ? abs(x_data[data_idx]) :  x_data[data_idx];
         if (!first_seen) {
           max = val;
@@ -91,7 +91,7 @@ class SelfBinningHistogramOp final : public Operator<Context> {
       scaled_max = min + (max - min) * RANGE_SCALING;
       T scaled_range = (scaled_max - min);
       // Avoid underflow by calculating advancement through multiplication.
-      for (int i = 0; i < num_edges_; i++) {
+      for (const auto i : c10::irange(num_edges_)) {
         T advancement_ratio = T(i) / num_bins_;
         histogram_values_data[i] = min + advancement_ratio * scaled_range;
       }
@@ -112,7 +112,7 @@ class SelfBinningHistogramOp final : public Operator<Context> {
       T log_multiplier_numerator =log(scaled_max) - log(min);
       // Avoid underflow by:
       // - Calculating each advancement separately for each i.
-      for (int i = 0; i < num_edges_; i++) {
+      for (const auto i : c10::irange(num_edges_)) {
         T advancement_ratio = T(i)/num_bins_;
         histogram_values_data[i] = min * exp(log_multiplier_numerator * advancement_ratio);
       }
@@ -127,11 +127,11 @@ class SelfBinningHistogramOp final : public Operator<Context> {
       histogram_counts_data[0] = total_count;
     }
     else {
-      for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+      for (const auto input_idx : c10::irange(InputSize())) {
         const auto& x = Input(input_idx);
         const int64_t N = x.numel();
         const auto* x_data = x.template data<T>();
-        for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+        for (const auto data_idx : c10::irange(N)) {
           const T val = this->abs_ ? abs(x_data[data_idx]) :  x_data[data_idx];
           const auto bisection_it = std::upper_bound(
               histogram_values_data,
@@ -163,7 +163,7 @@ class SelfBinningHistogramOp final : public Operator<Context> {
 
   void CheckInputs() {
     const auto& input_zero = Input(0);
-    for (int i = 1; i < InputSize(); i++) {
+    for (const auto i : c10::irange(1, InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).dtype(),
           input_zero.dtype(),

--- a/caffe2/operators/shape_op.h
+++ b/caffe2/operators/shape_op.h
@@ -34,7 +34,7 @@ class ShapeOp : public Operator<Context> {
     auto* output = Output(0, {numAxes}, at::dtype<int64_t>());
     auto src = reinterpret_cast<const char*>(data.sizes().data());
     auto out = reinterpret_cast<char*>(output->template mutable_data<int64_t>());
-    for (int i = 0; i < numAxes; i++) {
+    for (const auto i : c10::irange(numAxes)) {
       auto axis = axes_[i];
       CAFFE_ENFORCE_LT(axis, numDims, "Axis out of range");
       CAFFE_ENFORCE_GE(axis, 0, "Each axis should be non-negative");

--- a/caffe2/operators/sinusoid_position_encoding_op.h
+++ b/caffe2/operators/sinusoid_position_encoding_op.h
@@ -51,7 +51,7 @@ class SinusoidPositionEncodingOp : public Operator<Context> {
     float max_alpha_pow =
         ((float)embedding_size_ - 1.0f) / (float)embedding_size_;
 
-    for (int i = 0; i < M; ++i) {
+    for (const auto i : c10::irange(M)) {
       float pos = (float)idxs[i * K];
 
       // Compute the embedding for position i, example 0 first
@@ -72,7 +72,7 @@ class SinusoidPositionEncodingOp : public Operator<Context> {
       row_array = amplitude_ * row_array.sin().eval();
 
       // Copy the embedding to position i in the other examples
-      for (int j = 1; j < K; ++j) {
+      for (const auto j : c10::irange(1, K)) {
         int base = i * K * embedding_size_;
         std::copy(
             &out[base],

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -30,7 +30,7 @@ bool SliceImpl(
   std::vector<SIndex> ends_idx(data.dim());
   std::vector<SIndex> dst_sizes(data.dim());
 
-  for (int i = 0; i < data.dim(); ++i) {
+  for (const auto i : c10::irange(data.dim())) {
     if (i >= starts.numel()) {
       starts_idx[i] = 0;
       ends_idx[i] = data.size(i);
@@ -78,7 +78,7 @@ bool SliceImpl(
   }
   // for now only supports slicing in 1 dimension
   int dim = -1;
-  for (int i = 0; i < data.dim(); ++i) {
+  for (const auto i : c10::irange(data.dim())) {
     if (starts_idx[i] > 0 || ends_idx[i] < data.size(i)) {
       CAFFE_ENFORCE_EQ(
           dim, -1, "Currently only possible to slice in 1 dimension.");
@@ -131,7 +131,7 @@ bool SliceImpl(
 
     char* src_offset_bytes = src_bytes + itemsize * src_offset;
     char* dst_offset_bytes = dst_bytes;
-    for (size_t i = 0; i < num_blocks; ++i) {
+    for (const auto i : c10::irange(num_blocks)) {
       char* local_src_offset_bytes =
           src_offset_bytes + i * src_block_size_bytes;
       char* local_dst_offset_bytes =
@@ -177,7 +177,7 @@ bool SliceImpl(
       return true;
     }
 
-    for (size_t i = 0; i < num_blocks; ++i) {
+    for (const auto i : c10::irange(num_blocks)) {
       char* local_src_offset_bytes =
           src_offset_bytes + i * src_block_size_bytes;
       char* local_dst_offset_bytes =

--- a/caffe2/operators/space_batch_op.h
+++ b/caffe2/operators/space_batch_op.h
@@ -29,14 +29,14 @@ void spaceToBatch(
   const int input_height = input.dim32(2);
   const int input_width = input.dim32(3);
 
-  for (int out_b = 0; out_b < output_batch; ++out_b) {
+  for (const auto out_b : c10::irange(output_batch)) {
     const int in_b = out_b % input_batch;
     const int offset_w = (out_b / input_batch) % block_size;
     const int offset_h = (out_b / input_batch) / block_size;
-    for (int d = 0; d < input_depth; ++d) {
-      for (int out_h = 0; out_h < output_height; ++out_h) {
+    for (const auto d : c10::irange(input_depth)) {
+      for (const auto out_h : c10::irange(output_height)) {
         const int in_h = out_h * block_size + offset_h - pad_t;
-        for (int out_w = 0; out_w < output_width; ++out_w) {
+        for (const auto out_w : c10::irange(output_width)) {
           const int in_w = out_w * block_size + offset_w - pad_l;
           const auto output_offset =
               ((out_b * output_depth + d) * output_height + out_h) *
@@ -80,14 +80,14 @@ void batchToSpace(
   const int input_width = input.dim32(3);
 
   CAFFE_ENFORCE(input_depth == output_depth);
-  for (int in_b = 0; in_b < input_batch; ++in_b) {
+  for (const auto in_b : c10::irange(input_batch)) {
     const int out_b = in_b % output_batch;
     const int offset_w = (in_b / output_batch) % block_size;
     const int offset_h = (in_b / output_batch) / block_size;
-    for (int d = 0; d < input_depth; ++d) {
-      for (int in_h = 0; in_h < input_height; ++in_h) {
+    for (const auto d : c10::irange(input_depth)) {
+      for (const auto in_h : c10::irange(input_height)) {
         const int out_h = in_h * block_size + offset_h - pad_t;
-        for (int in_w = 0; in_w < input_width; ++in_w) {
+        for (const auto in_w : c10::irange(input_width)) {
           const int out_w = in_w * block_size + offset_w - pad_l;
           if (out_h >= 0 && out_w >= 0 && out_h < output_height &&
               out_w < output_width) {

--- a/caffe2/operators/sparse_to_dense_mask_op.h
+++ b/caffe2/operators/sparse_to_dense_mask_op.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/utils/math.h"
@@ -29,7 +30,7 @@ class SparseToDenseMaskBase : public Operator<Context> {
     auto biggest = *std::max_element(mask.begin(), mask.end());
     dense_.assign(std::min(kMaxDenseSize, biggest + 1), -1);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < mask.size(); i++) {
+    for (const auto i : c10::irange(mask.size())) {
       int64_t id = mask[i];
       CAFFE_ENFORCE_GE(id, 0, "Only positive IDs are allowed.");
       if (id >= kMaxDenseSize) {
@@ -155,7 +156,7 @@ class SparseToDenseMaskOp : public SparseToDenseMaskBase<Context> {
     }
 
     int64_t offset = 0;
-    for (int r = 0; r < rows; r++) {
+    for (const auto r : c10::irange(rows)) {
       bool skippedSparseIndex = false;
       for (int c = 0; c < lengths_vec[r]; c++) {
         const auto sparse_index = sparse_indices_vec[offset + c];
@@ -272,7 +273,7 @@ class SparseToDenseMaskGradientOp : public SparseToDenseMaskBase<Context> {
     // SparseToDenseMask is not injective; gradient_used records
     // if the gradient is used for other input value from the same row
     vector<bool> gradient_used(cols, false);
-    for (int r = 0; r < rows; r++) {
+    for (const auto r : c10::irange(rows)) {
       std::fill(gradient_used.begin(), gradient_used.end(), false);
       for (int c = lengths_vec[r] - 1; c >= 0; c--) {
         int idx = this->getFeatureIdx(sparse_indices_vec[offset + c]);

--- a/caffe2/operators/sparse_to_dense_op.h
+++ b/caffe2/operators/sparse_to_dense_op.h
@@ -89,7 +89,7 @@ class SparseToDenseOp final : public Operator<Context> {
     const auto block_nitems = sparse_values.size_from_dim(1);
     const TData* sparse_values_vec = sparse_values.template data<TData>();
 
-    for (int32_t i = 0; i < sparse_indices_len; i++) {
+    for (const auto i : c10::irange(sparse_indices_len)) {
       const TInd idx = sparse_indices_vec[i];
       CAFFE_ENFORCE_GE(idx, 0);
       CAFFE_ENFORCE_LT(idx, output_first_dim);

--- a/caffe2/operators/square_root_divide_op.h
+++ b/caffe2/operators/square_root_divide_op.h
@@ -41,7 +41,7 @@ class SquareRootDivideOp final : public Operator<Context> {
     auto* scalePtr = scale.template data<TScale>();
     auto* dataPtr = data.template data<TData>();
     auto* yPtr = Y->template mutable_data<TData>();
-    for (auto i = 0U; i < batchSize; ++i) {
+    for (const auto i : c10::irange(0U, batchSize)) {
       auto scale = scalePtr[i];
       CAFFE_ENFORCE(scale >= 0, scale, " < 0");
       auto multiplier = scale == 0 ? 1.0 : 1 / std::sqrt(scale);

--- a/caffe2/operators/string_ops.h
+++ b/caffe2/operators/string_ops.h
@@ -20,7 +20,7 @@ struct ForEach {
 
   template <typename In, typename Out, typename Context>
   bool operator()(int n, const In* in, Out* out, Context* /*c*/) {
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       out[i] = functor(in[i]);
     }
     return true;

--- a/caffe2/operators/tensor_protos_db_input.h
+++ b/caffe2/operators/tensor_protos_db_input.h
@@ -51,7 +51,7 @@ bool TensorProtosDBInput<Context>::Prefetch() {
     TensorProtos protos;
     CAFFE_ENFORCE(protos.ParseFromString(value_));
     CAFFE_ENFORCE(protos.protos_size() == OutputSize());
-    for (int i = 0; i < protos.protos_size(); ++i) {
+    for (const auto i : c10::irange(protos.protos_size())) {
       if (protos.protos(i).has_device_detail()) {
         protos.mutable_protos(i)->clear_device_detail();
       }
@@ -62,14 +62,14 @@ bool TensorProtosDBInput<Context>::Prefetch() {
       //     CPU));
     }
   } else {
-    for (int item_id = 0; item_id < batch_size_; ++item_id) {
+    for (const auto item_id : c10::irange(batch_size_)) {
       reader.Read(&key_, &value_);
       TensorProtos protos;
       CAFFE_ENFORCE(protos.ParseFromString(value_));
       CAFFE_ENFORCE(protos.protos_size() == OutputSize());
       // Note: shape_inferred_ is ignored, we'll always get dimensions from
       // proto
-      for (int i = 0; i < protos.protos_size(); ++i) {
+      for (const auto i : c10::irange(protos.protos_size())) {
         vector<int64_t> dims(
             protos.protos(i).dims().begin(), protos.protos(i).dims().end());
         dims.insert(dims.begin(), batch_size_);
@@ -94,7 +94,7 @@ bool TensorProtosDBInput<Context>::Prefetch() {
 
 template <class Context>
 bool TensorProtosDBInput<Context>::CopyPrefetched() {
-  for (int i = 0; i < OutputSize(); ++i) {
+  for (const auto i : c10::irange(OutputSize())) {
     OperatorBase::template Output<Tensor>(i, Context::GetDeviceType())
         ->CopyFrom(
             prefetched_blobs_[i].template Get<TensorCPU>(), /* async */ true);

--- a/caffe2/operators/tile_op.h
+++ b/caffe2/operators/tile_op.h
@@ -113,12 +113,12 @@ class TileOp final : public Operator<Context> {
   bool DoTile(const int outer_size, const int inner_size, const T* X, T* Y) {
     if (inner_size == 1) {
       EigenArrayMap<T> Y_arr(Y, tiles_, outer_size);
-      for (int i = 0; i < outer_size; ++i) {
+      for (const auto i : c10::irange(outer_size)) {
         Y_arr.col(i) = X[i];
       }
     } else {
       ConstEigenArrayMap<T> X_arr(X, inner_size, outer_size);
-      for (int i = 0; i < outer_size; ++i) {
+      for (const auto i : c10::irange(outer_size)) {
         EigenArrayMap<T>(Y + i * tiles_ * inner_size, inner_size, tiles_)
             .colwise() = X_arr.col(i);
       }
@@ -245,10 +245,10 @@ class TileGradientOp final : public Operator<Context> {
           dX,
           inner_size,
           &context_);
-      for (int i = 0; i < outer_size; ++i) {
+      for (const auto i : c10::irange(outer_size)) {
         const T* dY_ptr = dY + i * tiles_ * inner_size;
         T* dX_ptr = dX + i * inner_size;
-        for (int j = 1; j < tiles_; ++j) {
+        for (const auto j : c10::irange(1, tiles_)) {
           math::Add<T, Context>(
               inner_size, dX_ptr, dY_ptr + j * inner_size, dX_ptr, &context_);
         }

--- a/caffe2/operators/transpose_op.h
+++ b/caffe2/operators/transpose_op.h
@@ -49,7 +49,7 @@ class TransposeOp : public Operator<Context> {
     }
     const at::IntArrayRef X_dims = X.sizes();
     std::vector<std::int64_t> Y_dims(ndim);
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       Y_dims[i] = X_dims[axes_[i]];
     }
     Y->Resize(Y_dims);

--- a/caffe2/operators/tt_linear_op.h
+++ b/caffe2/operators/tt_linear_op.h
@@ -127,7 +127,7 @@ class TTLinearOp final : public Operator<Context> {
     // Check that output size of Y is the element-wise product of out_sizes
     int prod_out_sizes = 1;
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < out_sizes_.size(); i++) {
+    for (const auto i : c10::irange(out_sizes_.size())) {
       prod_out_sizes *= out_sizes_[i];
     }
     CAFFE_ENFORCE(

--- a/caffe2/operators/unsafe_coalesce.h
+++ b/caffe2/operators/unsafe_coalesce.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/operator.h"
 
 
@@ -16,7 +17,7 @@ class UnsafeCoalesceOp final : public Operator<Context> {
 
   bool RunOnDevice() override {
     size_t coalesced_size = 0;
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       // For now only float type is supported
       CAFFE_ENFORCE(
           Input(i).dtype().template Match<float>(),
@@ -24,14 +25,14 @@ class UnsafeCoalesceOp final : public Operator<Context> {
           i);
     }
 
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       coalesced_size += Input(i).numel();
     }
     auto* coalesced = Output(OutputSize() - 1, coalesced_size, at::dtype<float>());
     auto coalesced_data = coalesced->template mutable_data<float>();
 
     size_t coalesced_offset = 0;
-    for (auto i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto num_elems = Input(i).numel();
       auto input_sizes = Input(i).sizes().vec();
       // Don't do anything if both tensors are already pointing on the same data

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -8,6 +8,7 @@
 #include "caffe2/core/common_omp.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
@@ -64,7 +65,7 @@ class IsNanOp final : public Operator<Context> {
     const auto* X_data = X.template data<T>();
     uint8_t* Y_data = Y->template mutable_data<uint8_t>();
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < X.numel(); i++) {
+    for (const auto i : c10::irange(X.numel())) {
       Y_data[i] = (uint8_t)(std::isnan(X_data[i]));
     }
     return true;
@@ -299,7 +300,7 @@ class SumOp : public Operator<Context> {
     auto* output = Output(0, input0.sizes(), at::dtype<T>());
     T* output_data = output->template mutable_data<T>();
     // Dimension checking
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       if (output->sizes() != Input(i).sizes()) {
         CAFFE_THROW(
             "Check failed: output->sizes() == Input(i).sizes().",
@@ -320,7 +321,7 @@ class SumOp : public Operator<Context> {
         output_data,
         &context_);
     // Add remaining.
-    for (int i = 2; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(2, InputSize())) {
       math::Add(
           output->numel(),
           output_data,
@@ -577,7 +578,7 @@ class ScatterWeightedSumOp : public Operator<Context> {
     float w0 = *weight0.template data<float>();
     // It's most likely a constant so exact comparison is fine
     if (w0 != 1.0) {
-      for (int i = 0; i < K; ++i) {
+      for (const auto i : c10::irange(K)) {
         Index idx = idxs[i];
         CAFFE_ENFORCE(
             0 <= idx && idx < N,
@@ -600,7 +601,7 @@ class ScatterWeightedSumOp : public Operator<Context> {
       CAFFE_ENFORCE_EQ(weight.numel(), 1);
       const T* x_data = X.template data<T>();
       float w = *weight.template data<float>();
-      for (int i = 0; i < K; ++i) {
+      for (const auto i : c10::irange(K)) {
         Index idx = idxs[i];
         // double-checking the indices, but it's fine as it's DCHECK only
         DCHECK(0 <= idx && idx < N)
@@ -746,7 +747,7 @@ class ScatterAssignOp : public Operator<Context> {
       int64_t N,
       int64_t K,
       int64_t block_size) {
-    for (int i = 0; i < K; ++i) {
+    for (const auto i : c10::irange(K)) {
       Index idx = idxs[i];
       // double-checking the indices, but it's fine as it's DCHECK only
       DCHECK(0 <= idx && idx < N)
@@ -838,11 +839,9 @@ class ScatterOp : public Operator<CPUContext> {
     // dst should have the same rank as idxs and src, but the dimension of dim
     // axis can be different. That is why in the above equation, there is the
     // difference of J_src and J_dst.
-    for (int64_t outer_batch = 0; outer_batch < outer_dims_product;
-         ++outer_batch) {
-      for (int64_t i = 0; i < N; ++i) {
-        for (int64_t inner_batch = 0; inner_batch < idxs_block_size;
-             ++inner_batch) {
+    for (const auto outer_batch : c10::irange(outer_dims_product)) {
+      for (const auto i : c10::irange(N)) {
+        for (const auto inner_batch : c10::irange(idxs_block_size)) {
           auto idxs_elem_idx =
               outer_batch * idxs_batch_size + i * idxs_block_size + inner_batch;
           auto src_elem_idx =
@@ -867,7 +866,7 @@ class ScatterOp : public Operator<CPUContext> {
       const IndexType* indices,
       int64_t n,
       IndexType indexing_axis_dim) {
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       CAFFE_ENFORCE(
           0 <= idx && idx < indexing_axis_dim,
@@ -900,7 +899,7 @@ class LengthsToSegmentIdsOp : public Operator<Context> {
     output->Resize(total_length);
     auto* output_data = output->template mutable_data<int32_t>();
 
-    for (int i = 0; i < input.numel(); ++i) {
+    for (const auto i : c10::irange(input.numel())) {
       auto len = input_data[i];
       std::fill(output_data, output_data + len, i);
       output_data += len;
@@ -927,7 +926,7 @@ class LengthsToRangesOp : public Operator<Context> {
     auto* output_data = output->template mutable_data<int32_t>();
 
     int32_t offset = 0;
-    for (int i = 0; i < size; ++i) {
+    for (const auto i : c10::irange(size)) {
       auto len = input_data[i];
       output_data[i * 2] = offset;
       output_data[i * 2 + 1] = len;
@@ -961,7 +960,7 @@ class LengthsToOffsetsOp : public Operator<Context> {
     auto* output_data = output->template mutable_data<int32_t>();
 
     int32_t offset = 0;
-    for (int i = 0; i < size; ++i) {
+    for (const auto i : c10::irange(size)) {
       auto len = input_data[i];
       output_data[i] = offset;
       offset += len;
@@ -1018,7 +1017,7 @@ class SegmentIdsToLengthsOp : public Operator<Context> {
     }
     std::fill(output_data, output_data + num_segments, 0);
     Index prev = 0; // Assume that segment_id >= 0.
-    for (int64_t i = 0; i < input_size; i++) {
+    for (const auto i : c10::irange(input_size)) {
       CAFFE_ENFORCE(
           prev <= input_data[i],
           "Segment ids must be sorted: ",
@@ -1069,7 +1068,7 @@ class SegmentIdsToRangesOp : public Operator<Context> {
     }
     std::fill(output_data, output_data + num_segments * 2, 0);
     Index prev = input_data[0];
-    for (int64_t i = 0; i < input_size; i++) {
+    for (const auto i : c10::irange(input_size)) {
       CAFFE_ENFORCE(
           prev <= input_data[i],
           "Segment ids must be sorted: ",
@@ -1109,7 +1108,7 @@ class LengthsToWeightsOp : public Operator<Context> {
     auto* output = Output(0);
 
     int64_t output_size = 0;
-    for (auto i = 0; i < input_size; i++) {
+    for (const auto i : c10::irange(input_size)) {
       CAFFE_ENFORCE_GE(input_data[i], 0, "unexpected negative length value");
       output_size += input_data[i];
     }
@@ -1132,7 +1131,7 @@ class LengthsToWeightsOp : public Operator<Context> {
     output->Resize(output_size);
     auto* output_data = output->template mutable_data<float>();
     int64_t cnt = 0;
-    for (auto i = 0; i < input_size; i++) {
+    for (const auto i : c10::irange(input_size)) {
       auto len = input_data[i];
       if (len == 0) {
         continue;
@@ -1159,7 +1158,7 @@ class HasElementsOp : public Operator<Context> {
 
   bool RunOnDevice() override {
     bool res = false;
-    for (auto i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto& input = Input(i);
       res = res || input.numel() > 0;
     }
@@ -1208,7 +1207,7 @@ class LengthsToShapeOp : public Operator<Context> {
     auto size = input.numel();
     auto first = input_data[0];
 
-    for (int i = 1; i < size; i++) {
+    for (const auto i : c10::irange(1, size)) {
       CAFFE_ENFORCE(
           input_data[i] == first, "All elements of input must be same ");
     }
@@ -1255,7 +1254,7 @@ class GatherRangesOp : public Operator<Context> {
     size_t start = 0;
     size_t blockSize = ranges.size_from_dim(1);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < batchSize; ++i) {
+    for (const auto i : c10::irange(batchSize)) {
       auto end = start + blockSize;
       outputLengthsPtr[i] = accumulate(rangesData, start, end);
       start = end;
@@ -1329,7 +1328,7 @@ class LengthsGatherOp : public Operator<Context> {
 
     int64_t total_length = 0;
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < indices.numel(); ++i) {
+    for (const auto i : c10::irange(indices.numel())) {
       auto idx = indices_data[i];
       CAFFE_ENFORCE_LT(idx, lengths.numel());
       total_length += lengths_data[idx];
@@ -1341,7 +1340,7 @@ class LengthsGatherOp : public Operator<Context> {
     offsets_.clear();
     int64_t running_offset = 0;
     offsets_.reserve(lengths.numel());
-    for (size_t i = 0; i < lengths.numel(); ++i) {
+    for (const auto i : c10::irange(lengths.numel())) {
       offsets_.push_back(running_offset);
       running_offset += lengths_data[i];
     }
@@ -1355,7 +1354,7 @@ class LengthsGatherOp : public Operator<Context> {
     auto block_bytesize = block_size * items.itemsize();
     auto out = static_cast<char*>(output->raw_mutable_data(items.dtype()));
 
-    for (size_t i = 0; i < indices.numel(); ++i) {
+    for (const auto i : c10::irange(indices.numel())) {
       auto idx = indices_data[i];
       auto length = lengths_data[idx];
       context_.CopyItemsSameDevice(
@@ -1406,7 +1405,7 @@ class AccumulateHistogramOp : public Operator<Context> {
     math::Set<int64_t, Context>(
         num_output_buckets_, 0, cur_hist_data, &context_);
 
-    for (int i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       int bucket_index = -1;
       if (X_data[i] < lower_bound_) {
         bucket_index = 0;
@@ -1419,7 +1418,7 @@ class AccumulateHistogramOp : public Operator<Context> {
       accumulate_hist_[bucket_index] += 1;
     }
 
-    for (int i = 0; i < num_output_buckets_; i++) {
+    for (const auto i : c10::irange(num_output_buckets_)) {
       acc_hist_data[i] = accumulate_hist_[i];
     }
 
@@ -1464,7 +1463,7 @@ class RangeOp : public Operator<Context> {
     T start = 0;
     T step = 1;
 
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).numel(), 1, "All inputs must be scalar/1D tensor.");
     }

--- a/caffe2/operators/variable_length_sequence_padding.h
+++ b/caffe2/operators/variable_length_sequence_padding.h
@@ -17,7 +17,7 @@ void VariableLengthSequencePadding(
     const int32_t* seqLengths,
     const T padValue,
     Context* /*context*/) {
-  for (int j = 0; j < B; j++) {
+  for (const auto j : c10::irange(B)) {
     for (int i = seqLengths[j]; i < N; i++) {
       EigenVectorArrayMap<T>(X + B * M * i + M * j, M).setConstant(padValue);
     }

--- a/caffe2/opt/nql/ast.h
+++ b/caffe2/opt/nql/ast.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "c10/util/irange.h"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -20,8 +21,7 @@ struct ASTExpr {
     return starInputsFlag;
   }
   void dump(int level = 0) const {
-    for (int i = 0; i < level; i++)
-      std::cout << "  ";
+    for (const auto i : c10::irange(level))std::cout << "  ";
     if (!isCall())
       std::cout << "Var: " << name << std::endl;
     else {
@@ -41,8 +41,7 @@ struct ASTStmt {
     delete rhs;
   }
   void dump(int level = 0) const {
-    for (int i = 0; i < level; i++)
-      std::cout << "  ";
+    for (const auto i : c10::irange(level))std::cout << "  ";
     std::cout << "LHS:" << std::endl;
     for (auto s : lhs) {
       for (int i = 0; i < level + 1; i++)

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -6,6 +6,7 @@
 
 #include <c10/util/Exception.h>
 #include <c10/util/SmallVector.h>
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -138,7 +139,7 @@ class OnnxifiOp final : public Operator<Context> {
 
     if (use_passed_output_shapes_) {
       // Populate output_shapes_per_bs_
-      for (int bs = 1; bs < max_batch_size_; ++bs) {
+      for (const auto bs : c10::irange(1, max_batch_size_)) {
         auto output_shapes_tp = helper.GetRepeatedArgument<TensorProto>("output_shapes_bs_" + caffe2::to_string(bs));
         auto output_qshapes_tp = helper.GetRepeatedArgument<TensorProto>("output_qshapes_bs_" + caffe2::to_string(bs));
         CAFFE_ENFORCE_EQ(output_names_.size(), output_shapes_tp.size() + output_qshapes_tp.size());
@@ -267,7 +268,7 @@ class OnnxifiOp final : public Operator<Context> {
           ONNXIFI_STATUS_SUCCESS);
 
       // Release unused backend ids.
-      for (size_t i = 0; i < num_backends; ++i) {
+      for (const auto i : c10::irange(num_backends)) {
         if (i == static_cast<size_t>(backend_index)) {
           continue;
         }
@@ -287,7 +288,7 @@ class OnnxifiOp final : public Operator<Context> {
 
       // Extra weight shapes
       std::unordered_map<std::string, ShapeInfo> weight_shape_info;
-      for (size_t i = 0; i < weight_names.size(); ++i) {
+      for (const auto i : c10::irange(weight_names.size())) {
         TensorShape shape;
         const auto& shape0 = weight_shapes[i];
         for (const auto d : shape0) {

--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -6,6 +6,7 @@
 #include <immintrin.h>
 #endif
 #include <c10/util/Half.h>
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -26,7 +27,7 @@ static inline void adagrad_update_base_inlined(
     float epsilon,
     float lr,
     float weight_decay = 0.f) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = std::fma(weight_decay, w[i], g[i]);
     float hi = decay * h[i] + gi * gi;
     nh[i] = hi;

--- a/caffe2/perfkernels/lstm_unit_cpu-impl.h
+++ b/caffe2/perfkernels/lstm_unit_cpu-impl.h
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <cstdint>
 #include <string.h>
+#include "c10/util/irange.h"
 #include "caffe2/utils/conversions.h"
 
 #if (ENABLE_VECTORIZATION > 0) && !defined(_DEBUG) && !defined(DEBUG)
@@ -53,7 +54,7 @@ inline void LstmUnitImpl(
     T* H,
     const float forget_bias) {
   const T forgetBias = convert::To<float, T>(forget_bias);
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
     if (!valid) {
       if (drop_states) {
@@ -67,7 +68,7 @@ inline void LstmUnitImpl(
       const T* X_D = &X[D];
       const T* X_2D = &X[2 * D];
       const T* X_3D = &X[3 * D];
-      VECTOR_LOOP for (int d = 0; d < D; ++d) {
+      VECTOR_LOOP for (const auto d : c10::irange(D)) {
         const T i = sigmoid(X[d]);
         const T f = sigmoid(X_D[d] + forgetBias);
         const T o = sigmoid(X_2D[d]);
@@ -105,7 +106,7 @@ inline void LstmUnitGradientImpl(
     T* X_diff,
     const float forget_bias) {
   const T localForgetBias = convert::To<float, T>(forget_bias);
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
 
     if (!valid) {
@@ -118,7 +119,7 @@ inline void LstmUnitGradientImpl(
       }
       memset(X_diff, 0, 4 * sizeof(T) * D);
     } else {
-      VECTOR_LOOP for (int d = 0; d < D; ++d) {
+      VECTOR_LOOP for (const auto d : c10::irange(D)) {
         T* c_prev_diff = C_prev_diff + d;
         T* h_prev_diff = H_prev_diff + d;
         T* i_diff = X_diff + d;

--- a/caffe2/predictor/emulator/data_filler.h
+++ b/caffe2/predictor/emulator/data_filler.h
@@ -59,12 +59,12 @@ class DataNetFiller : public Filler {
       : init_net_(init_net), data_net_(data_net) {
     // The output of the data_net_ will be served as the input
     int op_size = data_net_.op_size();
-    for (int i = 0; i < op_size; ++i) {
+    for (const auto i : c10::irange(op_size)) {
       OperatorDef op_def = data_net_.op(i);
       // We rely on Fill op to generate inputs
       CAFFE_ENFORCE(op_def.type().find("Fill") != std::string::npos);
       int output_size = op_def.output_size();
-      for (int j = 0; j < output_size; ++j) {
+      for (const auto j : c10::irange(output_size)) {
         input_names_.push_back(op_def.output(j));
       }
     }
@@ -105,7 +105,7 @@ class DataRandomFiller : public Filler {
       int input_index,
       const std::vector<std::vector<int64_t>>& input_dims) {
     Workspace ws;
-    for (int i = 0; i < op_def.input_size(); ++i) {
+    for (const auto i : c10::irange(op_def.input_size())) {
       // CreateOperator requires all input blobs present
       ws.CreateBlob(op_def.input(i));
     }

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -153,12 +153,12 @@ class TensorFetcher : public BlobFetcherBase {
     if (numpy_type == NPY_OBJECT) {
       PyObject** outObj = reinterpret_cast<PyObject**>(outPtr);
       auto* str = tensor.template data<std::string>();
-      for (int i = 0; i < tensor.numel(); ++i) {
+      for (const auto i : c10::irange(tensor.numel())) {
         outObj[i] = PyBytes_FromStringAndSize(str->data(), str->size());
         str++;
         // cleanup on failure
         if (outObj[i] == nullptr) {
-          for (int j = 0; j < i; ++j) {
+          for (const auto j : c10::irange(i)) {
             Py_DECREF(outObj[j]);
           }
           CAFFE_THROW("Failed to allocate string for ndarray of strings.");
@@ -212,7 +212,7 @@ class TensorFeeder : public BlobFeederBase {
     int ndim = PyArray_NDIM(array);
     npy_intp* npy_dims = PyArray_DIMS(array);
     std::vector<int64_t> dims;
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       dims.push_back(npy_dims[i]);
     }
 
@@ -229,7 +229,7 @@ class TensorFeeder : public BlobFeederBase {
               dims, at::dtype<std::string>().device(Context::GetDeviceType()));
         }
         auto* outPtr = tensor.template mutable_data<std::string>();
-        for (int i = 0; i < tensor.numel(); ++i) {
+        for (const auto i : c10::irange(tensor.numel())) {
           char* str;
           Py_ssize_t strSize;
           if (PyBytes_Check(input[i])) {
@@ -375,7 +375,7 @@ class PythonOpBase : public Operator<Context> {
 
       std::vector<py::object> inputs;
       inputs.reserve(InputSize());
-      for (auto i = 0; i < InputSize(); ++i) {
+      for (const auto i : c10::irange(InputSize())) {
         const auto* blob = &InputBlob(i);
         // Allow CPU tensors in addition to operator context's tensors
         py::object py_obj;
@@ -395,7 +395,7 @@ class PythonOpBase : public Operator<Context> {
       }
       std::vector<py::object> outputs;
       outputs.reserve(OutputSize());
-      for (auto i = 0; i < OutputSize(); ++i) {
+      for (const auto i : c10::irange(OutputSize())) {
         auto* blob = OutputBlob(i);
 
         // Python op is always used with CPUContext only and treats inputs and

--- a/caffe2/quantization/server/elementwise_dnnlowp_op.h
+++ b/caffe2/quantization/server/elementwise_dnnlowp_op.h
@@ -127,7 +127,7 @@ class BinaryElementwiseDNNLowPOp : public DNNLowPOp<T, FP32_OP> {
         size_t n,                                                            \
         size_t post,                                                         \
         CPUContext*) {                                                       \
-      for (int i = 0; i < pre; ++i) {                                        \
+      for (const auto i : c10::irange(pre)) {                                        \
         EigenArrayMap<R>(out + i * n * post, post, n) = eigen_op(            \
             (ConstEigenArrayMap<T>(a + i * n * post, post, n).rowwise()),    \
             (Eigen::Map<const Eigen::Array<T, 1, Eigen::Dynamic>>(b, n)));   \

--- a/caffe2/quantization/server/im2col_dnnlowp.h
+++ b/caffe2/quantization/server/im2col_dnnlowp.h
@@ -50,7 +50,7 @@ static void Im2ColNCHW(
       auto* dst = data_col + nip * (kernel_h * kernel_w * output_h * output_w) +
           kh * (kernel_w * output_h * output_w) + kw * (output_h * output_w);
       const auto* src = data_im + nip * (height * width);
-      for (auto y = 0; y < output_h; y++) {
+      for (const auto y : c10::irange(output_h)) {
         const auto iy = y * stride_h + kh;
         const auto ix = kw;
         if (stride_w == 1) {
@@ -59,7 +59,7 @@ static void Im2ColNCHW(
               src + (iy * width + ix),
               sizeof(T) * output_w);
         } else {
-          for (auto x = 0; x < output_w; x++) {
+          for (const auto x : c10::irange(output_w)) {
             memcpy(
                 dst + (y * output_w + x),
                 src + (iy * width + ix + x * stride_w),
@@ -78,8 +78,8 @@ static void Im2ColNCHW(
     const int pad_w = pad_l;
     const int channel_size = height * width;
     for (int channel = channels; channel--; data_im += channel_size) {
-      for (int kernel_row = 0; kernel_row < kernel_h; kernel_row++) {
-        for (int kernel_col = 0; kernel_col < kernel_w; kernel_col++) {
+      for (const auto kernel_row : c10::irange(kernel_h)) {
+        for (const auto kernel_col : c10::irange(kernel_w)) {
           int input_row = -pad_h + kernel_row * dilation_h;
           for (int output_rows = output_h; output_rows; output_rows--) {
             if (!utils::IsAGeZeroAndALtB(input_row, height)) {
@@ -113,12 +113,12 @@ static void Im2ColNCHW(
   int width_col = (width + pad_l + pad_r - dkernel_w) / stride_w + 1;
 
   int channels_col = channels * kernel_h * kernel_w;
-  for (int c = 0; c < channels_col; ++c) {
+  for (const auto c : c10::irange(channels_col)) {
     int w_offset = c % kernel_w;
     int h_offset = (c / kernel_w) % kernel_h;
     int c_im = c / kernel_h / kernel_w;
-    for (int h = 0; h < height_col; ++h) {
-      for (int w = 0; w < width_col; ++w) {
+    for (const auto h : c10::irange(height_col)) {
+      for (const auto w : c10::irange(width_col)) {
         int h_pad = h * stride_h - pad_t + h_offset * dilation_h;
         int w_pad = w * stride_w - pad_l + w_offset * dilation_w;
         if (h_pad >= 0 && h_pad < height && w_pad >= 0 && w_pad < width)
@@ -152,20 +152,20 @@ static void Im2ColNdNCHW(
       kernel_shape, kernel_shape + N, 1, std::multiplies<int>());
   std::vector<int> d_offset(N, 0);
   std::vector<int> d_iter(N, 0);
-  for (int i = 0; i < outer_size; ++i) {
+  for (const auto i : c10::irange(outer_size)) {
     // Loop over spatial axes in reverse order to compute a per-axis offset.
     int offset = i;
     for (int d_i = N - 1; d_i >= 0; --d_i) {
       d_offset[d_i] = offset % kernel_shape[d_i];
       offset /= kernel_shape[d_i];
     }
-    for (int j = 0; j < inner_size; ++j) {
+    for (const auto j : c10::irange(inner_size)) {
       // Loop over spatial axes in forward order to compute the indices in the
       // image and column, and whether the index lies in the padding.
       const int col_index = i * inner_size + j;
       int img_index = i / kernel_size;
       bool is_padding = false;
-      for (int d_i = 0; d_i < N; ++d_i) {
+      for (const auto d_i : c10::irange(N)) {
         const int d_img = d_iter[d_i] * stride[d_i] - pad[d_i] +
             d_offset[d_i] * dilation[d_i];
         is_padding |= d_img < 0 || d_img >= img_shape[d_i + 1];
@@ -216,13 +216,13 @@ static void Im2ColNHWC(
     T* data_col_temp =
         data_col + h * width_col * kernel_h * kernel_w * channels;
     int w_pad = -pad_l;
-    for (int w = 0; w < width_col; ++w) {
+    for (const auto w : c10::irange(width_col)) {
       int r = 0;
       for (int ih = h_pad; ih < h_pad + dkernel_h; ih += dilation_h, ++r) {
         int s = 0;
         for (int iw = w_pad; iw < w_pad + dkernel_w; iw += dilation_w, ++s) {
           if (ih >= 0 && ih < height && iw >= 0 && iw < width) {
-            for (int g = 0; g < groups; ++g) {
+            for (const auto g : c10::irange(groups)) {
               memcpy(
                   data_col_temp +
                       ((g * kernel_h + r) * kernel_w + s) * (channels / groups),
@@ -232,7 +232,7 @@ static void Im2ColNHWC(
             }
           } else {
             // This should be simply padded with zero.
-            for (int g = 0; g < groups; ++g) {
+            for (const auto g : c10::irange(groups)) {
               for (int i = 0; i < channels / groups; ++i) {
                 data_col_temp
                     [(((g * kernel_h + r) * kernel_w) + s) *
@@ -293,12 +293,12 @@ static void Im2Col3DNHWC(
 #endif
   for (int t = 0; t < frame_col; ++t) {
     int t_pad = -pad_p + t * stride_t;
-    for (int h = 0; h < height_col; ++h) {
+    for (const auto h : c10::irange(height_col)) {
       int h_pad = -pad_t + h * stride_h;
       T* data_col_temp = data_col +
           (t * height_col + h) * width_col * kernel_t * kernel_h * kernel_w *
               channels;
-      for (int w = 0; w < width_col; ++w) {
+      for (const auto w : c10::irange(width_col)) {
         int w_pad = -pad_l + w * stride_w;
         int q = 0;
         for (int it = t_pad; it < t_pad + dkernel_t; it += dilation_t, ++q) {
@@ -309,7 +309,7 @@ static void Im2Col3DNHWC(
                  iw += dilation_w, ++s) {
               if (it >= 0 && it < num_frames && ih >= 0 && ih < height &&
                   iw >= 0 && iw < width) {
-                for (int g = 0; g < groups; ++g) {
+                for (const auto g : c10::irange(groups)) {
                   memcpy(
                       data_col_temp +
                           (((g * kernel_t + q) * kernel_h + r) * kernel_w + s) *
@@ -320,7 +320,7 @@ static void Im2Col3DNHWC(
                 }
               } else {
                 // This should be simply padded with zero.
-                for (int g = 0; g < groups; ++g) {
+                for (const auto g : c10::irange(groups)) {
                   for (int i = 0; i < channels / groups; ++i) {
                     data_col_temp
                         [((((g * kernel_t + q) * kernel_h + r) * kernel_w) +

--- a/caffe2/quantization/server/mmio.h
+++ b/caffe2/quantization/server/mmio.h
@@ -36,8 +36,8 @@ void StoreMatrixInMatrixMarketFormat(
     }
     fprintf(fp, "%d %d\n", m, n);
     // matrix market array format uses column-major order
-    for (int j = 0; j < n; ++j) {
-      for (int i = 0; i < m; ++i) {
+    for (const auto j : c10::irange(n)) {
+      for (const auto i : c10::irange(m)) {
         if (is_integral<T>::value) {
           // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
           fprintf(fp, "%d\n", static_cast<int>(a[j * m + i]));

--- a/caffe2/quantization/server/utility_dnnlowp_ops.h
+++ b/caffe2/quantization/server/utility_dnnlowp_ops.h
@@ -54,7 +54,7 @@ class GatherDNNLowPOp final : public GatherOp<CPUContext> {
     const Index* idxs = indices.template data<Index>();
     auto out = static_cast<char*>(output->raw_mutable_data(data.dtype()));
 
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       auto idx = idxs[i];
       CAFFE_ENFORCE(
           0 <= idx && idx < data.size(0),

--- a/caffe2/queue/queue_ops.h
+++ b/caffe2/queue/queue_ops.h
@@ -147,7 +147,7 @@ class SafeDequeueBlobsOp final : public Operator<Context> {
     }
 
     const int kTensorGrowthPct = 40;
-    for (int i = 0; i < numRecords_; ++i) {
+    for (const auto i : c10::irange(numRecords_)) {
       if (!queue->blockingRead(blobPtrs_)) {
         // if we read at least one record, status is still true
         return i > 0;

--- a/caffe2/queue/rebatching_queue_ops.h
+++ b/caffe2/queue/rebatching_queue_ops.h
@@ -32,7 +32,7 @@ class EnqueueRebatchingQueueOp : public Operator<CPUContext> {
     CAFFE_ENFORCE_EQ(InputSize(), queue->numBlobs() + 1);
     std::vector<const Tensor*> inputTensors;
     inputTensors.reserve(InputSize() - 1);
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       inputTensors.push_back(&Input(i));
     }
 
@@ -56,7 +56,7 @@ class DequeueRebatchingQueueOp : public Operator<CPUContext> {
 
     std::vector<Tensor*> outputTensors;
     outputTensors.reserve(OutputSize());
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       outputTensors.push_back(Output(i));
     }
 

--- a/caffe2/sgd/adadelta_op.h
+++ b/caffe2/sgd/adadelta_op.h
@@ -18,7 +18,7 @@ void AdadeltaUpdate(
     float* nh,
     float* nd,
     Context* /*context*/) {
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float di = d[i];
     float hi = nh[i] = decay * h[i] + (1.0f - decay) * gi * gi;
@@ -120,7 +120,7 @@ class SparseAdadeltaOp final : public Operator<Context> {
     }
 
     auto block_size = Input(GRAD).numel() / n;
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       if (block_size == 1) {
         float gi = gradIn[i];

--- a/caffe2/sgd/adagrad_fused.h
+++ b/caffe2/sgd/adagrad_fused.h
@@ -82,8 +82,8 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
     auto* grad_buffer_data =
         is_mean ? grad_buffer_.template mutable_data<T>() : NULL;
     if (is_mean) {
-      for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
-        for (auto tmpIndex = 0; tmpIndex < block_size; ++tmpIndex) {
+      for (const auto rangeIndex : c10::irange(numSegments)) {
+        for (const auto tmpIndex : c10::irange(block_size)) {
           auto offsetI = rangeIndex * block_size;
           grad_buffer_data[offsetI + tmpIndex] = lengths[rangeIndex] > 0
               ? gradIn[offsetI + tmpIndex] / lengths[rangeIndex]
@@ -92,7 +92,7 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
       }
     }
 
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -243,7 +243,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     // ignores this dependency and fuses these two loops.
     std::vector<T> temp_grad(block_size);
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -277,7 +277,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     CAFFE_ENFORCE_EQ(dataIndex, n);
 
     dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -285,7 +285,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         auto offsetIdx = idx * block_size;
         auto localOffset = dataIndex - start;
 
-        for (int i = 0; i < block_size; ++i) {
+        for (const auto i : c10::irange(block_size)) {
           temp_grad[i] = auxParamIn[localOffset] * gradIn[offsetI + i];
         }
 
@@ -409,7 +409,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
 
     std::vector<T> temp_grad(block_size);
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -440,7 +440,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
             auxGrad + dataIndex,
             &context_);
 
-        for (int i = 0; i < block_size; ++i) {
+        for (const auto i : c10::irange(block_size)) {
           temp_grad[i] = auxParamIn[localOffset] * gradIn[offsetI + i];
         }
 

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -39,7 +39,7 @@ void adagrad_update_output_effective_lr(
     const float* lr,
     Context* /*context*/,
     float weight_decay = 0.f) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float grad = std::fma(weight_decay, paramIn[i], gradIn[i]);
     float moment = momentOut[i] = decay * momentIn[i] + grad * grad;
     float effective_lr = effectiveLROut[i] =
@@ -63,7 +63,7 @@ void adagrad_update_output_effective_lr_and_update(
     const float* lr,
     Context* /*context*/,
     float weight_decay = 0.f) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float grad = std::fma(weight_decay, paramIn[i], gradIn[i]);
     float moment = momentOut[i] = decay * momentIn[i] + grad * grad;
     float effective_lr = effectiveLROut[i] =
@@ -300,7 +300,7 @@ class SparseAdagradOp final : public Operator<CPUContext> {
     const auto* momentIn = Input(MOMENT_1).template data<float>();
 
     std::vector<float> grad(block_size);
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       auto offsetI = i * block_size;
       auto offsetIdx = idx * block_size;
@@ -504,7 +504,7 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
 #else
     VLOG(1) << "using plain adagrad updates in RowWiseSparseAdagradOp";
 
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       float freq = (counter_halflife_ > 0 && count[idx] > 0)
           ? counter_halflife_ / count[idx]
@@ -542,13 +542,13 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
         const float* g = gradIn + offsetI;
         float* h = moment + idx;
         float hs = 0.;
-        for (auto j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           float gj = std::fma(weight_decay_ * freq, w[j], g[j]);
           hs += gj * gj;
         }
         float hi = h[0] = h[0] + hs / block_size;
         float step = lr[0] / (std::sqrt(hi) + epsilon_);
-        for (auto j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           float gj = std::fma(weight_decay_ * freq, w[j], g[j]);
           w[j] = w[j] + gj * step;
         }

--- a/caffe2/sgd/adam_op.h
+++ b/caffe2/sgd/adam_op.h
@@ -21,7 +21,7 @@ void adam_update(
     float correction,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
@@ -45,7 +45,7 @@ void adam_compute(
     float correction,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
@@ -74,7 +74,7 @@ void adam_compute_smart_decay(
     Context* /*context*/) {
   float k = (float)(t - lastSeenIn[0]);
   lastSeenOut[0] = t;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     // The number of steps since this param was last seen.
     // We don't need integer precision for k.  Float is fine and it's faster to convert here.
@@ -107,7 +107,7 @@ void adam_compute_output_grad(
     float correction,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
@@ -135,7 +135,7 @@ void radam_update(
     float r_correction,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
@@ -169,7 +169,7 @@ void radam_compute(
     float r_correction,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
@@ -204,7 +204,7 @@ void radam_compute_output_grad(
     float r_correction,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float mi = nm[i] = m[i] * beta1 + gi * (1 - beta1);
     float vi = nv[i] = v[i] * beta2 + gi * gi * (1 - beta2);
@@ -350,7 +350,7 @@ class SparseAdamOp final : public Operator<Context> {
     auto* moment2Out = Output(OUTPUT_MOMENT_2)->template mutable_data<T>();
 
     if (OutputSize() == 3) {
-      for (auto i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         auto idx = indices[i];
 
         if (block_size == 1) {
@@ -444,7 +444,7 @@ class SparseAdamOp final : public Operator<Context> {
     } else {
       Output(OUTPUT_GRAD)->ResizeLike(Input(GRAD));
       auto* gradOut = Output(OUTPUT_GRAD)->template mutable_data<T>();
-      for (auto i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         auto idx = indices[i];
 
         if (block_size == 1) {
@@ -593,7 +593,7 @@ class SmartDecaySparseAdamOp final : public Operator<Context> {
     auto* moment2Out = Output(OUTPUT_MOMENT_2)->template mutable_data<T>();
     int64_t* lastSeenOut = Output(OUTPUT_LAST_SEEN)->template mutable_data<int64_t>();
 
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
         auto idx = indices[i];
         auto offsetI = i * block_size;
         auto offsetIdx = idx * block_size;
@@ -673,7 +673,7 @@ class RowWiseSparseAdamOp final : public Operator<Context> {
     auto* moment2Out = Output(OUTPUT_MOMENT_2)->template mutable_data<T>();
 
     if (OutputSize() == 3) {
-      for (auto i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         auto idx = indices[i];
 
         if (block_size == 1) {
@@ -719,13 +719,13 @@ class RowWiseSparseAdamOp final : public Operator<Context> {
           float* nm2 = moment2Out + idx;
 
           float m2_sum = 0.;
-          for (auto j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             float gj = g[j];
             m2_sum += gj * gj;
           }
           float vi = nm2[0] =
               m2[0] * beta2_ + (m2_sum / block_size) * (1 - beta2_);
-          for (auto j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             float mi = nm1[j] = m1[j] * beta1_ + g[j] * (1 - beta1_);
             nw[j] = w[j] + lr[0] * correction * mi / (std::sqrt(vi) + epsilon_);
           }
@@ -734,7 +734,7 @@ class RowWiseSparseAdamOp final : public Operator<Context> {
     } else {
       Output(OUTPUT_GRAD)->ResizeLike(Input(GRAD));
       auto* gradOut = Output(OUTPUT_GRAD)->template mutable_data<T>();
-      for (auto i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         auto idx = indices[i];
 
         if (block_size == 1) {
@@ -781,13 +781,13 @@ class RowWiseSparseAdamOp final : public Operator<Context> {
           float* ng = gradOut + offsetI;
 
           float m2_sum = 0.;
-          for (auto j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             float gj = g[j];
             m2_sum += gj * gj;
           }
           float vi = nm2[0] =
               m2[0] * beta2_ + (m2_sum / block_size) * (1 - beta2_);
-          for (auto j = 0; j < block_size; ++j) {
+          for (const auto j : c10::irange(block_size)) {
             float mi = nm1[j] = m1[j] * beta1_ + g[j] * (1 - beta1_);
             float ngi = ng[j] = correction * mi / (std::sqrt(vi) + epsilon_);
             nw[j] = w[j] + lr[0] * ngi;

--- a/caffe2/sgd/learning_rate_adaption_op.h
+++ b/caffe2/sgd/learning_rate_adaption_op.h
@@ -21,7 +21,7 @@ void lr_update(
   float x = 0;
   float y = 0, z = 0;
   const float kEps = 1e-12f;
-  for (auto i = 0; i < n; i++) {
+  for (const auto i : c10::irange(n)) {
     x += grad[i] * effgrad[i];
     if (normalized_lr_adaption) {
       y += grad[i] * grad[i];

--- a/caffe2/sgd/learning_rate_op.h
+++ b/caffe2/sgd/learning_rate_op.h
@@ -5,6 +5,7 @@
 #include <cmath>
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/operator.h"
 #include "caffe2/sgd/learning_rate_functors.h"
 
@@ -162,7 +163,7 @@ class LearningRateOp final : public Operator<Context> {
           sub_policy_num_iters.size(),
           0,
           "Must specify at least one sub learning rate policy.");
-      for (size_t i = 0; i < sub_policy_num_iters.size(); ++i) {
+      for (const auto i : c10::irange(sub_policy_num_iters.size())) {
         CAFFE_ENFORCE_GT(
             sub_policy_num_iters[i],
             0,

--- a/caffe2/sgd/momentum_sgd_op.h
+++ b/caffe2/sgd/momentum_sgd_op.h
@@ -17,7 +17,7 @@ void momentum_sgd_update(
     float* param,
     Context* /*context*/) {
   const float LR = lr[0];
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     if (!nesterov) {
       const float adjusted_gradient = LR * g[i] + momentum * m[i];
       nm[i] = adjusted_gradient;
@@ -154,7 +154,7 @@ class SparseMomentumSGDUpdateOp final : public Operator<Context> {
     auto* momentumOut = Output(OUTPUT_MOMENTUM)->template mutable_data<T>();
     auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<T>();
 
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       auto offsetI = i * block_size;
       auto offsetIdx = idx * block_size;

--- a/caffe2/sgd/rowwise_adagrad_fused.h
+++ b/caffe2/sgd/rowwise_adagrad_fused.h
@@ -217,8 +217,8 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
     auto* grad_buffer_data =
         is_mean ? grad_buffer_.template mutable_data<T>() : NULL;
     if (is_mean) {
-      for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
-        for (auto tmpIndex = 0; tmpIndex < block_size; ++tmpIndex) {
+      for (const auto rangeIndex : c10::irange(numSegments)) {
+        for (const auto tmpIndex : c10::irange(block_size)) {
           auto offsetI = rangeIndex * block_size;
           grad_buffer_data[offsetI + tmpIndex] = lengths[rangeIndex] > 0
               ? gradIn[offsetI + tmpIndex] / lengths[rangeIndex]
@@ -269,7 +269,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       T counter_halflife,
       rowWiseAdagradT& kernel) {
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       auto offsetI = rangeIndex * block_size;
       const float* g = gradIn + offsetI;
 
@@ -557,7 +557,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     // ignores this dependency and fuses these two loops.
     std::vector<T> temp_grad(block_size);
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -591,7 +591,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     CAFFE_ENFORCE_EQ(dataIndex, n);
 
     dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       auto offsetI = rangeIndex * block_size;
       const float* g = gradIn + offsetI;
 
@@ -606,7 +606,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         auto offsetIdx = idx * block_size;
         auto localOffset = dataIndex - start;
 
-        for (int i = 0; i < block_size; ++i) {
+        for (const auto i : c10::irange(block_size)) {
           temp_grad[i] = auxParamIn[localOffset] * g[i];
         }
 
@@ -839,7 +839,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
 
     std::vector<T> temp_grad(block_size);
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       auto offsetI = rangeIndex * block_size;
       const float* g = gradIn + offsetI;
 
@@ -902,7 +902,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
 
         alignas(64) float temp[VLEN];
         _mm256_store_ps(temp, acc_v);
-        for (int j = 0; j < VLEN; ++j) {
+        for (const auto j : c10::irange(VLEN)) {
           acc += temp[j];
         }
 #endif

--- a/caffe2/sgd/rowwise_counter.h
+++ b/caffe2/sgd/rowwise_counter.h
@@ -40,7 +40,7 @@ class RowWiseCounterOp final : public Operator<CPUContext> {
       return true;
     }
 
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       const std::size_t idx = indices[i];
       CAFFE_ENFORCE_GE(
           Input(COUNTER).numel(),

--- a/caffe2/sgd/storm_op.h
+++ b/caffe2/sgd/storm_op.h
@@ -19,7 +19,7 @@ void storm_update(
     const float beta,
     Context* /*context*/) {
   float gradSqSumTmp = 0.0;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     const float gi = gradIn[i];
     gradSqSumTmp += gi * gi;
   }
@@ -27,7 +27,7 @@ void storm_update(
 
   const float nlr = lr[0] * std::pow(beta + gradSqSumOut[0], -1.0 / 3.0);
   const float alpha = momentum * nlr * nlr;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     const float gi = gradIn[i];
     const float mi = momentIn[i];
     float new_mi = momentOut[i] = gi + (1.0 - alpha) * (mi - gi);
@@ -120,7 +120,7 @@ class SparseStormOp final : public Operator<Context> {
     }
 
     float gradSqSumTmp = 0.0;
-    for (auto i = 0; i < Input(GRAD).numel(); ++i) {
+    for (const auto i : c10::irange(Input(GRAD).numel())) {
       const float gi = gradIn[i];
       gradSqSumTmp += gi * gi;
     }
@@ -130,7 +130,7 @@ class SparseStormOp final : public Operator<Context> {
     const float alpha = momentum_ * nlr * nlr;
     const auto block_size = Input(GRAD).numel() / n;
 
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       if (block_size == 1) {
         const float gi = gradIn[i];
@@ -162,7 +162,7 @@ class SparseStormOp final : public Operator<Context> {
             i);
 #endif
 
-        for (auto j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           const float gi = gradIn[offsetI + j];
           const float mi = momentIn[offsetIdx + j];
           float new_mi = momentOut[offsetIdx + j] =

--- a/caffe2/sgd/wngrad_op.h
+++ b/caffe2/sgd/wngrad_op.h
@@ -15,12 +15,12 @@ void wngrad_update(
     float epsilon,
     const float* lr,
     Context* /*context*/) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     nw[i] = w[i] + lr[0] * gi / (h[0] + epsilon);
   }
   float nhTmp = 0.0;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     nhTmp += gi * gi;
   }
@@ -42,13 +42,13 @@ void wngrad_update_output_effective_lr(
     Context* /*context*/) {
   effectiveLROut[0] = lr[0] / (seqBIn[0] + epsilon);
   float seqBTmp = 0.0;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = gradIn[i];
     seqBTmp += gi * gi;
   }
   seqBTmp /= (seqBIn[0] + epsilon);
   seqBOut[0] = seqBIn[0] + seqBTmp;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float grad = gradIn[i];
     paramOut[i] = paramIn[i] + effectiveLROut[0] * grad;
   }
@@ -69,14 +69,14 @@ void wngrad_update_output_effective_lr_and_update(
     Context* /*context*/) {
   effectiveLROut[0] = lr[0] / (seqBIn[0] + epsilon);
   float seqBTmp = 0.0;
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = gradIn[i];
     seqBTmp += gi * gi;
   }
   seqBTmp /= (seqBIn[0] + epsilon);
   seqBOut[0] = seqBIn[0] + seqBTmp;
 
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float grad = gradIn[i];
     float update = updateOut[i] = effectiveLROut[0] * grad;
     paramOut[i] = paramIn[i] + update;
@@ -193,7 +193,7 @@ class SparseWngradOp final : public Operator<Context> {
 
     auto block_size = Input(GRAD).numel() / n;
 
-    for (auto i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       if (block_size == 1) {
         float gi = gradIn[i];
@@ -222,7 +222,7 @@ class SparseWngradOp final : public Operator<Context> {
             " for input i:",
             i);
 #endif
-        for (auto j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           float gi = gradIn[offsetI + j];
           paramOut[offsetIdx + j] =
               paramIn[offsetIdx + j] + lr[0] * gi / (seqBIn[0] + epsilon_);
@@ -230,7 +230,7 @@ class SparseWngradOp final : public Operator<Context> {
       }
     }
     float seqBTmp = 0.0;
-    for (auto i = 0; i < Input(GRAD).numel(); ++i) {
+    for (const auto i : c10::irange(Input(GRAD).numel())) {
       float gi = gradIn[i];
       seqBTmp += gi * gi;
     }

--- a/caffe2/sgd/yellowfin_op.h
+++ b/caffe2/sgd/yellowfin_op.h
@@ -133,7 +133,7 @@ CAFFE_ENFORCE_EQ(param_tensor.dim(), moment_tensor.dim());
 CAFFE_ENFORCE_EQ(param_tensor.dim(), g_avg_tensor.dim());
 CAFFE_ENFORCE_EQ(param_tensor.dim(), g2_avg_tensor.dim());
 CAFFE_ENFORCE_EQ(param_tensor.dim(), grad_tensor.dim());
-for (int i = 0; i < param_tensor.dim(); ++i) {
+for (const auto i : c10::irange(param_tensor.dim())) {
   CAFFE_ENFORCE_EQ(param_tensor.dim32(i), moment_tensor.dim32(i));
   CAFFE_ENFORCE_EQ(param_tensor.dim32(i), g_avg_tensor.dim32(i));
   CAFFE_ENFORCE_EQ(param_tensor.dim32(i), g2_avg_tensor.dim32(i));

--- a/caffe2/transforms/pattern_net_transform.h
+++ b/caffe2/transforms/pattern_net_transform.h
@@ -28,7 +28,7 @@ class TORCH_API PatternNetTransform : public Transform {
         "External outputs do not match!");
     ordered_ops_ = GetPatternTraversalOrder(p_);
     inverse_ops_.resize(ordered_ops_.size());
-    for (size_t i = 0; i < ordered_ops_.size(); i++) {
+    for (const auto i : c10::irange(ordered_ops_.size())) {
       inverse_ops_[ordered_ops_[i]] = i;
     }
   }

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -9,6 +9,7 @@
 
 #include <c10/util/Logging.h>
 #include <c10/util/string_view.h>
+#include <c10/util/irange.h>
 
 #include "caffe2/utils/proto_wrap.h"
 #include "caffe2/proto/caffe2_pb.h"

--- a/caffe2/utils/threadpool/WorkersPool.h
+++ b/caffe2/utils/threadpool/WorkersPool.h
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <thread>
 #include "c10/util/thread_name.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
 
@@ -339,7 +340,7 @@ class WorkersPool {
     CreateWorkers(workers_count);
     DCHECK_LE(workers_count, (int)workers_.size());
     counter_to_decrement_when_ready_.Reset(workers_count);
-    for (size_t task = 1; task < tasks.size(); ++task) {
+    for (const auto task : c10::irange(1, tasks.size())) {
       workers_[task - 1]->StartWork(tasks[task].get());
     }
     // Execute the remaining workload immediately on the current thread.

--- a/caffe2/video/video_input_op.h
+++ b/caffe2/video/video_input_op.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <c10/core/thread_pool.h>
+#include <c10/util/irange.h>
 #include <caffe2/core/db.h>
 #include <caffe2/core/logging.h>
 #include <caffe2/operators/prefetch_op.h>
@@ -225,7 +226,7 @@ void VideoInputOp<Context>::CheckParamsAndPrint() {
     if (random_sampling_rate_) {
       LOG(INFO) << "random sampling with max:" << random_sampling_rate_;
     }
-    for (int i = 0; i < channels_rgb_; i++) {
+    for (const auto i : c10::irange(channels_rgb_)) {
       LOG(INFO) << "    RGB " << i << "-th channel mean: " << mean_rgb_[i]
                 << " std: " << 1.f / inv_std_rgb_[i];
     }
@@ -237,7 +238,7 @@ void VideoInputOp<Context>::CheckParamsAndPrint() {
               << "and a sampling rate of 1:" << sampling_rate_of_
               << " flow_data_type_: " << flow_data_type_
               << " flow_alg_type_: " << flow_alg_type_;
-    for (int i = 0; i < channels_of_; i++) {
+    for (const auto i : c10::irange(channels_of_)) {
       LOG(INFO) << "    Optical flow" << i
                 << "-th channel mean: " << mean_of_[i]
                 << " std: " << 1.f / inv_std_of_[i];
@@ -257,7 +258,7 @@ void VideoInputOp<Context>::CheckParamsAndPrint() {
   if (video_res_type_ == VideoResType::USE_SHORT_EDGE) {
     if (jitter_scales_.size() > 0) {
       LOG(INFO) << "Using scale jittering:";
-      for (int idx = 0; idx < jitter_scales_.size(); idx++) {
+      for (const auto idx : c10::irange(jitter_scales_.size())) {
         LOG(INFO) << "scale " << idx << ": " << jitter_scales_[idx];
       }
     } else {
@@ -390,7 +391,7 @@ VideoInputOp<Context>::VideoInputOp(
       }
 
       channels_rgb_ = 3;
-      for (int i = 4; i < 7; i++) {
+      for (const auto i : c10::irange(4, 7)) {
         mean_rgb_.push_back(InputDataMean[i]);
         inv_std_rgb_.push_back(1.f / InputDataStd[i]);
       }
@@ -403,7 +404,7 @@ VideoInputOp<Context>::VideoInputOp(
       get_optical_flow_ = false;
       get_rgb_ = true;
       sampling_rate_rgb_ = 1;
-      for (int i = 4; i < 7; i++) {
+      for (const auto i : c10::irange(4, 7)) {
         mean_rgb_.push_back(InputDataMean[i]);
         inv_std_rgb_.push_back(1.f / InputDataStd[i]);
       }
@@ -420,7 +421,7 @@ VideoInputOp<Context>::VideoInputOp(
       switch (flow_data_type_) {
         case FlowDataType::Flow2C:
           channels_of_ = 2;
-          for (int i = 0; i < channels_of_; i++) {
+          for (const auto i : c10::irange(channels_of_)) {
             mean_of_.push_back(InputDataMean[i]);
             inv_std_of_.push_back(1.f / InputDataStd[i]);
           }
@@ -428,7 +429,7 @@ VideoInputOp<Context>::VideoInputOp(
 
         case FlowDataType::Flow3C:
           channels_of_ = 3;
-          for (int i = 0; i < channels_of_; i++) {
+          for (const auto i : c10::irange(channels_of_)) {
             mean_of_.push_back(InputDataMean[i]);
             inv_std_of_.push_back(1.f / InputDataStd[i]);
           }
@@ -437,7 +438,7 @@ VideoInputOp<Context>::VideoInputOp(
         // early fusion with gray
         case FlowDataType::FlowWithGray:
           channels_of_ = 3;
-          for (int i = 0; i < 2; i++) {
+          for (const auto i : c10::irange(2)) {
             mean_of_.push_back(InputDataMean[i]);
             inv_std_of_.push_back(1.f / InputDataStd[i]);
           }
@@ -448,11 +449,11 @@ VideoInputOp<Context>::VideoInputOp(
         // early fusion with RGB
         case FlowDataType::FlowWithRGB:
           channels_of_ = 5;
-          for (int i = 0; i < 2; i++) {
+          for (const auto i : c10::irange(2)) {
             mean_of_.push_back(InputDataMean[i]);
             inv_std_of_.push_back(1.f / InputDataStd[i]);
           }
-          for (int i = 4; i < 7; i++) {
+          for (const auto i : c10::irange(4, 7)) {
             mean_of_.push_back(InputDataMean[i]);
             inv_std_of_.push_back(1.f / InputDataStd[i]);
           }
@@ -527,15 +528,15 @@ void VideoInputOp<Context>::GetLabelsFromProto(
     int* label_data) {
   int num_clips = clip_per_video_ * crop_per_clip_;
   if (!do_multi_label_) {
-    for (int i = 0; i < num_clips; i++) {
+    for (const auto i : c10::irange(num_clips)) {
       label_data[i] = label_proto.int32_data(0);
     }
   } else {
     // For multiple label case, output label is a binary vector
     // where presented concepts are marked 1
     memset(label_data, 0, sizeof(int) * num_of_class_ * num_clips);
-    for (int i = 0; i < num_clips; i++) {
-      for (int j = 0; j < label_proto.int32_data_size(); j++) {
+    for (const auto i : c10::irange(num_clips)) {
+      for (const auto j : c10::irange(label_proto.int32_data_size())) {
         CAFFE_ENFORCE_LT(
             label_proto.int32_data(j),
             num_of_class_,
@@ -657,7 +658,7 @@ bool VideoInputOp<Context>::GetClipsAndLabelsFromDBValue(
     const TensorProto& start_frm_proto = protos.protos(curr_proto_idx++);
     start_frm = start_frm_proto.int32_data(0);
     if (get_start_frame_) {
-      for (int i = 0; i < num_clips; i++) {
+      for (const auto i : c10::irange(num_clips)) {
         start_frame_data[i] = start_frm;
       }
     }
@@ -667,7 +668,7 @@ bool VideoInputOp<Context>::GetClipsAndLabelsFromDBValue(
     CAFFE_ENFORCE_GE(
         protos.protos_size(), curr_proto_idx + 1, "Video Id not provided");
     const TensorProto& video_id_proto = protos.protos(curr_proto_idx);
-    for (int i = 0; i < num_clips; i++) {
+    for (const auto i : c10::irange(num_clips)) {
       video_id_data[i] = video_id_proto.int64_data(0);
     }
   }
@@ -772,7 +773,7 @@ void VideoInputOp<Context>::DecodeAndTransform(
     int clip_offset_of = channels_of_ * length_of_ * crop_size_ * crop_size_;
     for (int i = 0; i < std::min(clip_per_video_, int(buffer_rgb.size()));
          i++) {
-      for (int j = 0; j < crop_per_clip_; j++) {
+      for (const auto j : c10::irange(crop_per_clip_)) {
         // get the rectangle for cropping
         int h_off = 0;
         int w_off = 0;
@@ -855,7 +856,7 @@ void VideoInputOp<Context>::DecodeAndTransform(
       }
     }
     if (buffer_rgb.size() > 0) {
-      for (int i = 0; i < buffer_rgb.size(); i++) {
+      for (const auto i : c10::irange(buffer_rgb.size())) {
         unsigned char* buff = buffer_rgb[i];
         delete[] buff;
       }
@@ -884,12 +885,12 @@ bool VideoInputOp<Context>::Prefetch() {
     // Prefetching handled with a thread pool of "decode_threads" threads.
     std::mt19937 meta_randgen(time(nullptr));
     std::vector<std::mt19937> randgen_per_thread;
-    for (int i = 0; i < num_decode_threads_; ++i) {
+    for (const auto i : c10::irange(num_decode_threads_)) {
       randgen_per_thread.emplace_back(meta_randgen());
     }
 
     std::bernoulli_distribution mirror_this_clip(0.5);
-    for (int item_id = 0; item_id < batch_size_; ++item_id) {
+    for (const auto item_id : c10::irange(batch_size_)) {
       std::mt19937* randgen =
           &randgen_per_thread[item_id % num_decode_threads_];
 

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -5,6 +5,7 @@
 #include <test/cpp/api/support.h>
 
 #include <c10/util/ArrayRef.h>
+#include <c10/util/irange.h>
 #include <c10/util/tempfile.h>
 
 #include <algorithm>
@@ -173,7 +174,7 @@ TEST(DataTest, InfiniteStreamDataset) {
   for (auto& batch : *data_loader) {
     ASSERT_LT(batch_index, 3);
     ASSERT_EQ(batch.size(), kBatchSize);
-    for (size_t j = 0; j < kBatchSize; ++j) {
+    for (const auto j : c10::irange(kBatchSize)) {
       ASSERT_EQ(batch.at(j), 1 + (batch_index * kBatchSize) + j);
     }
     batch_index += 1;
@@ -837,7 +838,7 @@ TEST(DataTest, CanUseCustomTypeAsIndexType) {
 
   size_t i = 0;
   for (auto batch : *data_loader) {
-    for (int j = 0; j < kBatchSize; ++j) {
+    for (const auto j : c10::irange(kBatchSize)) {
       ASSERT_EQ(batch.at(j), 10 + j);
     }
     i += 1;
@@ -857,7 +858,7 @@ TEST(DataTest, DistributedRandomSamplerSingleReplicaProduceCorrectSamples) {
   ASSERT_EQ(res.size(), sample_count);
 
   std::sort(res.begin(), res.end());
-  for (size_t i = 0; i < res.size(); ++i) {
+  for (const auto i : c10::irange(res.size())) {
     ASSERT_EQ(res[i], i);
   }
 }
@@ -872,14 +873,14 @@ TEST(DataTest, DistributedRandomSamplerMultiReplicaProduceCorrectSamples) {
                            size_t batch_size) {
     std::vector<std::unique_ptr<samplers::DistributedRandomSampler>> samplers;
 
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       samplers.emplace_back(
           torch::make_unique<samplers::DistributedRandomSampler>(
               sample_count, num_replicas, i, allow_duplicates));
     }
 
     std::vector<size_t> res;
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       (*samplers[i]).reset();
       torch::optional<std::vector<size_t>> idx;
       while ((idx = (*samplers[i]).next(batch_size)).has_value()) {
@@ -953,7 +954,7 @@ TEST(DataTest, DistributedSequentialSamplerSingleReplicaProduceCorrectSamples) {
   ASSERT_EQ(res.size(), sample_count);
 
   std::sort(res.begin(), res.end());
-  for (size_t i = 0; i < res.size(); ++i) {
+  for (const auto i : c10::irange(res.size())) {
     ASSERT_EQ(res[i], i);
   }
 }
@@ -969,14 +970,14 @@ TEST(DataTest, DistributedSequentialSamplerMultiReplicaProduceCorrectSamples) {
     std::vector<std::unique_ptr<samplers::DistributedSequentialSampler>>
         samplers;
 
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       samplers.emplace_back(
           torch::make_unique<samplers::DistributedSequentialSampler>(
               sample_count, num_replicas, i, allow_duplicates));
     }
 
     std::vector<size_t> res;
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       (*samplers[i]).reset();
       torch::optional<std::vector<size_t>> idx;
       while ((idx = (*samplers[i]).next(batch_size)).has_value()) {
@@ -1490,7 +1491,7 @@ TEST(DataLoaderTest, StatefulDatasetWithNoWorkers) {
 
   auto data_loader = torch::data::make_data_loader(D{});
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     const auto number_of_iterations =
         std::distance(data_loader->begin(), data_loader->end());
     ASSERT_EQ(
@@ -1531,7 +1532,7 @@ TEST(DataLoaderTest, StatefulDatasetWithManyWorkers) {
       torch::data::datasets::make_shared_dataset<D>(),
       DataLoaderOptions().workers(kNumberOfWorkers));
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     const auto number_of_iterations =
         std::distance(data_loader->begin(), data_loader->end());
     ASSERT_EQ(
@@ -1574,7 +1575,7 @@ TEST(DataLoaderTest, StatefulDatasetWithMap) {
               })),
       DataLoaderOptions{});
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     const auto number_of_iterations =
         std::distance(data_loader->begin(), data_loader->end());
     ASSERT_EQ(
@@ -1675,7 +1676,7 @@ TEST(DataLoaderTest, ChunkDataSetGetBatch) {
             dataset,
             DataLoaderOptions(batch_size).workers(dataloader_worker_count));
 
-        for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+        for (const auto epoch_index : c10::irange(epoch_count)) {
           std::vector<bool> result(total_example_count, false);
           int iteration_count = 0;
           for (auto iterator = data_loader->begin();
@@ -1687,11 +1688,11 @@ TEST(DataLoaderTest, ChunkDataSetGetBatch) {
             // When prefetch_count is equal to 1 and no worker thread, the batch
             // order is deterministic. So we can verify elements in each batch.
             if (prefetch_count == 1 && dataloader_worker_count == 0) {
-              for (size_t j = 0; j < batch_size; ++j) {
+              for (const auto j : c10::irange(batch_size)) {
                 ASSERT_EQ(batch[j], iteration_count * batch_size + j);
               }
             }
-            for (size_t j = 0; j < batch_size; ++j) {
+            for (const auto j : c10::irange(batch_size)) {
               result[batch[j]] = true;
             }
           }
@@ -1978,7 +1979,7 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
         dataset,
         DataLoaderOptions(batch_size).workers(dataloader_worker_count));
 
-    for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+    for (const auto epoch_index : c10::irange(epoch_count)) {
       int iteration_count = 0;
       for (auto iterator = data_loader->begin(); iterator != data_loader->end();
            ++iterator, ++iteration_count) {
@@ -2079,7 +2080,7 @@ TEST(DataLoaderTest, ChunkDatasetLoad) {
   auto data_loader = torch::data::make_data_loader(
       dataset, DataLoaderOptions(batch_size).workers(dataloader_worker_count));
 
-  for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+  for (const auto epoch_index : c10::irange(epoch_count)) {
     int iteration_count = 0;
 
     // For the first epoch, the returned batch should be returned from the
@@ -2128,7 +2129,7 @@ TEST(DataLoaderTest, ChunkDatasetCrossChunkShuffle) {
       size_t index = 0;
 
       // Repeatly sample every 5 indices.
-      for (size_t i = 0; i < batch_size; ++i) {
+      for (const auto i : c10::irange(batch_size)) {
         for (size_t j = 0; j < size_ / batch_size; ++j) {
           indices_[index++] = i + batch_size * j;
         }
@@ -2225,8 +2226,8 @@ TEST(DataLoaderTest, ChunkDatasetCrossChunkShuffle) {
         for (int i = 0; i < (chunk_count + cross_chunk_shuffle_count - 1) /
                  cross_chunk_shuffle_count;
              i++) {
-          for (int j = 0; j < chunk_size; ++j) {
-            for (int k = 0; k < cross_chunk_shuffle_count; ++k) {
+          for (const auto j : c10::irange(chunk_size)) {
+            for (const auto k : c10::irange(cross_chunk_shuffle_count)) {
               if (i * cross_chunk_shuffle_count + k < chunk_count) {
                 expected_result.push_back(i * cross_chunk_shuffle_count + k);
               }

--- a/test/cpp/api/dispatch.cpp
+++ b/test/cpp/api/dispatch.cpp
@@ -2,6 +2,7 @@
 
 #include <torch/torch.h>
 #include <ATen/native/Pow.h>
+#include <c10/util/irange.h>
 #include <torch/types.h>
 #include <torch/utils.h>
 #include <test/cpp/api/support.h>
@@ -24,7 +25,7 @@ TEST_F(DispatchTest, TestAVX2) {
   setenv("ATEN_CPU_CAPABILITY", "avx2", 1);
 #endif
   const auto actual_pow_avx2 = vals_tensor.pow(pows_tensor);
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_EQ(result[i], actual_pow_avx2[i].item<int>());
   }
 }
@@ -40,7 +41,7 @@ TEST_F(DispatchTest, TestAVX512) {
   setenv("ATEN_CPU_CAPABILITY", "avx512", 1);
 #endif
   const auto actual_pow_avx512 = vals_tensor.pow(pows_tensor);
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_EQ(result[i], actual_pow_avx512[i].item<int>());
   }
 }
@@ -56,7 +57,7 @@ TEST_F(DispatchTest, TestDefault) {
   setenv("ATEN_CPU_CAPABILITY", "default", 1);
 #endif
   const auto actual_pow_default = vals_tensor.pow(pows_tensor);
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_EQ(result[i], actual_pow_default[i].item<int>());
   }
 }

--- a/test/cpp/api/expanding-array.cpp
+++ b/test/cpp/api/expanding-array.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -13,7 +14,7 @@ struct ExpandingArrayTest : torch::test::SeedingFixture {};
 TEST_F(ExpandingArrayTest, CanConstructFromInitializerList) {
   torch::ExpandingArray<5> e({1, 2, 3, 4, 5});
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], i + 1);
   }
 }
@@ -21,7 +22,7 @@ TEST_F(ExpandingArrayTest, CanConstructFromInitializerList) {
 TEST_F(ExpandingArrayTest, CanConstructFromVector) {
   torch::ExpandingArray<5> e(std::vector<int64_t>{1, 2, 3, 4, 5});
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], i + 1);
   }
 }
@@ -29,7 +30,7 @@ TEST_F(ExpandingArrayTest, CanConstructFromVector) {
 TEST_F(ExpandingArrayTest, CanConstructFromArray) {
   torch::ExpandingArray<5> e(std::array<int64_t, 5>({1, 2, 3, 4, 5}));
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], i + 1);
   }
 }
@@ -37,7 +38,7 @@ TEST_F(ExpandingArrayTest, CanConstructFromArray) {
 TEST_F(ExpandingArrayTest, CanConstructFromSingleValue) {
   torch::ExpandingArray<5> e(5);
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], 5);
   }
 }

--- a/test/cpp/api/fft.cpp
+++ b/test/cpp/api/fft.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 #include <test/cpp/api/support.h>
 
@@ -14,15 +15,15 @@ torch::Tensor naive_dft(torch::Tensor x, bool forward=true) {
   // Roots of unity, exp(-2*pi*j*n/N) for n in [0, N), reversed for inverse transform
   std::vector<c10::complex<double>> roots(len);
   const auto angle_base = (forward ? -2.0 : 2.0) * M_PI / len;
-  for (int64_t i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     auto angle = i * angle_base;
     roots[i] = c10::complex<double>(std::cos(angle), std::sin(angle));
   }
 
   const auto in = x.data_ptr<c10::complex<double>>();
   const auto out = out_tensor.data_ptr<c10::complex<double>>();
-  for (int64_t i = 0; i < len; ++i) {
-    for (int64_t j = 0; j < len; ++j) {
+  for (const auto i : c10::irange(len)) {
+    for (const auto j : c10::irange(len)) {
       out[i] += roots[(j * i) % len] * in[j];
     }
   }

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -1127,7 +1128,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
   int dims[] = {1, -1};
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers)
   int expected[] = {5*3, 5*4};
-  for(auto i=0; i<2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto logits = torch::randn({5, 4, 3});
     int expected_count = expected[i];
     auto y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true).dim(dims[i]));
@@ -1149,7 +1150,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
 
     auto counts = torch::zeros_like(logits);
     torch::Tensor y_draw;
-    for (auto i=0; i<num_draws; i++) {
+    for (const auto i : c10::irange(num_draws)) {
         y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true));
         counts += y_draw;
     }
@@ -1175,7 +1176,7 @@ TEST_F(FunctionalTest, Softmax) {
   auto output = F::softmax(input, /*dim=*/1);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -1187,7 +1188,7 @@ TEST_F(FunctionalTest, Softmin) {
   auto output = F::softmin(input, /*dim=*/1);
   auto sum = torch::sum(torch::exp(-input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(-input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -1199,7 +1200,7 @@ TEST_F(FunctionalTest, LogSoftmax) {
   auto output = F::log_softmax(input, /*dim=*/1);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::log(torch::exp(input[i]) / sum[i]);
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }

--- a/test/cpp/api/init.cpp
+++ b/test/cpp/api/init.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/init_baseline.h>
@@ -14,7 +15,7 @@ void check_exact_values(
     const std::vector<std::vector<torch::Tensor>>& expected_parameters) {
   ASSERT_EQ(parameters.size(), expected_parameters.size());
 
-  for (size_t i = 0; i < parameters.size(); i++) {
+  for (const auto i : c10::irange(parameters.size())) {
     auto layerParameters = parameters[i];
     auto expectedLayerParameters = expected_parameters[i];
 
@@ -27,7 +28,7 @@ void check_exact_values(
       ASSERT_TRUE(false);
     }
 
-    for (size_t p = 0; p < layerParameters.size(0); p++) {
+    for (const auto p : c10::irange(layerParameters.size(0))) {
       // Always compare using double dtype, regardless of the original dtype of the tensors
       auto tensor = layerParameters[p].to(torch::kFloat64);
       auto expectedTensor = expectedLayerParameters[p].to(torch::kFloat64);

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -122,7 +123,7 @@ bool test_mnist(
   torch::Device device(with_cuda ? torch::kCUDA : torch::kCPU);
   model->to(device);
 
-  for (size_t epoch = 0; epoch < number_of_epochs; epoch++) {
+  for (const auto epoch : c10::irange(number_of_epochs)) {
     // NOLINTNEXTLINE(performance-for-range-copy)
     for (torch::data::Example<> batch : *data_loader) {
       auto data = batch.data.to(device), targets = batch.target.to(device);
@@ -196,7 +197,7 @@ TEST_F(IntegrationTest, CartPole) {
 
     std::vector<torch::Tensor> policy_loss;
     std::vector<torch::Tensor> value_loss;
-    for (auto i = 0U; i < saved_log_probs.size(); i++) {
+    for (const auto i : c10::irange(0U, saved_log_probs.size())) {
       auto advantage = r_t[i] - saved_values[i].item<float>();
       policy_loss.push_back(-advantage * saved_log_probs[i]);
       value_loss.push_back(

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -699,7 +700,7 @@ TEST_F(ModuleTest, ModulesReturnsExpectedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model.ptr(), model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].get(), expected[i].get());
   }
@@ -712,7 +713,7 @@ TEST_F(ModuleTest, ModulesExcludesSelfWhenIncludeSelfSetToFalse) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].get(), expected[i].get());
   }
@@ -725,7 +726,7 @@ TEST_F(ModuleTest, NamedModulesReturnsExpectedNamedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model.ptr(), model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].key(), i ? std::to_string(i - 1) : std::string());
     ASSERT_EQ(modules[i].value().get(), expected[i].get());
@@ -740,7 +741,7 @@ TEST_F(ModuleTest, NamedModulesExcludesSelfWhenIncludeSelfSetToFalse) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].key(), std::to_string(i));
     ASSERT_EQ(modules[i].value().get(), expected[i].get());
@@ -753,7 +754,7 @@ TEST_F(ModuleTest, ChildrenReturnsExpectedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].get(), expected[i].get());
   }
@@ -769,7 +770,7 @@ TEST_F(ModuleTest, NamedChildrenReturnsExpectedNamedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].key(), std::to_string(i));
     ASSERT_EQ(modules[i].value().get(), expected[i].get());
@@ -817,7 +818,7 @@ TEST_F(ModuleTest, NamedBuffersReturnsExpectedTensorsForFlatModel) {
 struct TestContainer : torch::nn::Module {
   TestContainer(int64_t number, std::vector<TestContainer> modules = {})
       : tensor(torch::tensor(number)) {
-    for (size_t i = 0; i < modules.size(); ++i) {
+    for (const auto i : c10::irange(modules.size())) {
       register_module(
           std::to_string(i),
           std::make_shared<TestContainer>(std::move(modules[i])));
@@ -861,7 +862,7 @@ TEST_F(ModuleTest, ModulesReturnsExpectedSubmodulesForDeepModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> modules = model->modules();
 
   ASSERT_EQ(modules.size(), 10);
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(get_test_container_item(modules[i]), i);
   }
 }
@@ -874,7 +875,7 @@ TEST_F(ModuleTest, NamedModulesReturnsExpectedNamedSubmodulesForDeepModel) {
 
   ASSERT_EQ(modules.size(), expected.size());
 
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     ASSERT_EQ(modules[i].key(), expected[i].first);
     ASSERT_EQ(get_test_container_item(modules[i].value()), expected[i].second);
   }

--- a/test/cpp/api/modulelist.cpp
+++ b/test/cpp/api/modulelist.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <algorithm>
@@ -118,7 +119,7 @@ TEST_F(ModuleListTest, AccessWithAt) {
   ASSERT_EQ(list->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(&list->at<M>(i), modules[i].get());
   }
 
@@ -143,7 +144,7 @@ TEST_F(ModuleListTest, AccessWithPtr) {
   ASSERT_EQ(list->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(list->ptr(i).get(), modules[i].get());
     ASSERT_EQ(list[i].get(), modules[i].get());
     ASSERT_EQ(list->ptr<M>(i).get(), modules[i].get());

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -1148,7 +1149,7 @@ TEST_F(ModulesTest, LayerNorm) {
   s.backward();
   ASSERT_EQ(y.ndimension(), 2);
   ASSERT_EQ(s.ndimension(), 0);
-  for (auto i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(y.size(i), 2);
   }
 
@@ -1166,7 +1167,7 @@ TEST_F(ModulesTest, GroupNorm) {
   s.backward();
   ASSERT_EQ(y.ndimension(), 2);
   ASSERT_EQ(s.ndimension(), 0);
-  for (auto i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(y.size(i), 2);
   }
 
@@ -2595,7 +2596,7 @@ TEST_F(ModulesTest, Softmax) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -2607,7 +2608,7 @@ TEST_F(ModulesTest, Softmin) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(-input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(-input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -2619,7 +2620,7 @@ TEST_F(ModulesTest, LogSoftmax) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::log(torch::exp(input[i]) / sum[i]);
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -2656,7 +2657,7 @@ TEST_F(ModulesTest, AdaptiveLogSoftmaxWithLoss) {
     auto logprob_out = asfm->log_prob(x);
     NLLLoss nll_loss;
 
-    for (int64_t v = 0; v < 4; ++v) {
+    for (const auto v : c10::irange(4)) {
       auto y = torch::full({4}, v, torch::kLong);
       auto asm_out = asfm(x, y);
       auto out = asm_out.output;
@@ -2675,10 +2676,10 @@ TEST_F(ModulesTest, Softmax2d) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 1; i++) {
-    for (int j = 0; j < 2; j++) {
-      for (int k = 0; k < 3; k++) {
-        for (int l = 0; l < 4; l++) {
+  for (const auto i : c10::irange(1)) {
+    for (const auto j : c10::irange(2)) {
+      for (const auto k : c10::irange(3)) {
+        for (const auto l : c10::irange(4)) {
           auto expected = torch::exp(input[i][j][k][l]) / sum[i][k][l];
           ASSERT_TRUE(torch::allclose(output[i][j][k][l], expected));
         }
@@ -3389,8 +3390,8 @@ namespace detail {
     TORCH_INTERNAL_ASSERT(a.size(0) == b.size(0));
     TORCH_INTERNAL_ASSERT(a.size(1) == b.size(1));
     auto retval = torch::zeros({a.size(0), a.size(1), a.size(2), b.size(3)}, torch::kFloat32);
-    for (int i = 0; i < a.size(0); i++) {
-      for (int j = 0; j < a.size(1); j++) {
+    for (const auto i : c10::irange(a.size(0))) {
+      for (const auto j : c10::irange(a.size(1))) {
         retval[i][j] = torch::matmul(a[i][j], b[i][j]);
       }
     }
@@ -3399,9 +3400,9 @@ namespace detail {
 
   torch::Tensor _softmax(const torch::Tensor& x) {
     auto output = torch::zeros(x.sizes());
-    for (int i = 0; i < x.size(0); i++) {
-      for (int j = 0; j < x.size(1); j++) {
-        for (int k = 0; k < x.size(2); k++) {
+    for (const auto i : c10::irange(x.size(0))) {
+      for (const auto j : c10::irange(x.size(1))) {
+        for (const auto k : c10::irange(x.size(2))) {
           const auto& x_curr = x[i][j][k];
           const auto e_x = torch::exp(x_curr - torch::max(x_curr));
           output[i][j][k] = e_x / torch::sum(e_x);
@@ -3424,10 +3425,10 @@ namespace detail {
     const auto s1 = QKT.size(2);
     const auto s2 = QKT.size(3);
     if (unseen_mask.defined() || key_padding_mask.defined()) {
-      for (int i = 0; i < b1; i++) {
-        for (int j = 0; j < b2; j++) {
-          for (int m = 0; m < s1; m++) {
-            for (int n = 0; n < s2; n++) {
+      for (const auto i : c10::irange(b1)) {
+        for (const auto j : c10::irange(b2)) {
+          for (const auto m : c10::irange(s1)) {
+            for (const auto n : c10::irange(s2)) {
               if (unseen_mask.defined() && unseen_mask[m][n].item<double>() == 0) {
                 QKT[i][j][m][n] = -std::numeric_limits<double>::infinity();
               }
@@ -3475,7 +3476,7 @@ namespace detail {
     std::uniform_int_distribution<int> d_2_10(2, 10);
     std::uniform_int_distribution<int> d_3_10(3, 10);
     bool registration_checked = false;
-    for (int i = 0; i < 100; i++) {
+    for (const auto i : c10::irange(100)) {
       const auto batch_sz = d_2_10(generator);
       const auto seq_len = d_2_10(generator);
       const auto d_head = d_3_10(generator);

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -40,7 +41,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   auto compare_scaling =
       [&](const std::vector<torch::Tensor>& grads) -> torch::Tensor {
     std::vector<torch::Tensor> p_scale;
-    for (int i = 0; i < grads.size(); i++) {
+    for (const auto i : c10::irange(grads.size())) {
       auto param = l->parameters()[i];
       auto grad = grads[i];
       p_scale.push_back(param.grad().data().div(grad).view(-1));
@@ -61,7 +62,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
       std::numeric_limits<float>::infinity(),
   };
   for (auto norm_type : norm_types) {
-    for (int i = 0; i < grads.size(); i++) {
+    for (const auto i : c10::irange(grads.size())) {
       l->parameters()[i].mutable_grad() =
           grads[i].clone().view_as(l->parameters()[i].data());
     }
@@ -80,7 +81,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
       torch::ones(10).div(500),
   };
   for (auto norm_type : norm_types) {
-    for (int i = 0; i < grads.size(); i++) {
+    for (const auto i : c10::irange(grads.size())) {
       l->parameters()[i].grad().data().copy_(grads[i]);
     }
     auto norm_before = compute_norm(norm_type);
@@ -227,7 +228,7 @@ TEST_F(NNUtilsTest, ClipGradNormErrorIfNonfinite) {
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
       EXPECT_THROW(utils::clip_grad_norm_(parameters, 1., norm_type, true), std::exception) << msg;
       // Grads should not change if error is thrown
-      for (int64_t p_idx = 0; p_idx < parameters.size(); p_idx++) {
+      for (const auto p_idx : c10::irange(parameters.size())) {
         ASSERT_TRUE(torch::allclose(parameters[p_idx].grad(), grads_before[p_idx], 1.0, 0.0, /*equal_nan*/ true)) << msg;
       }
     } else {
@@ -285,7 +286,7 @@ TEST_F(NNUtilsTest, ClipGradValue) {
   std::vector<std::vector<torch::Tensor>> grad_lists = {
       {grad_w, grad_b}, {grad_w, torch::Tensor()}};
   for (auto grad_list : grad_lists) {
-    for (int i = 0; i < grad_list.size(); i++) {
+    for (const auto i : c10::irange(grad_list.size())) {
       auto p = l->parameters()[i];
       auto g = grad_list[i];
       p.mutable_grad() = g.defined() ? g.clone().view_as(p.data()) : g;
@@ -335,7 +336,7 @@ TEST_F(NNUtilsTest, ConvertParameters) {
   };
 
   utils::vector_to_parameters(vector, zero_parameters);
-  for (int i = 0; i < zero_parameters.size(); ++i) {
+  for (const auto i : c10::irange(zero_parameters.size())) {
     ASSERT_TRUE(zero_parameters[i].allclose(parameters[i]));
   }
 
@@ -368,7 +369,7 @@ int64_t PackedSequenceTest_max_length = 6;
 std::vector<torch::Tensor> PackedSequenceTest_ordered_sequence(torch::ScalarType tensor_type) {
   std::vector<torch::Tensor> seqs;
   seqs.reserve(PackedSequenceTest_batch_size);
-  for (int64_t i = 0; i < PackedSequenceTest_batch_size; i++) {
+  for (const auto i : c10::irange(PackedSequenceTest_batch_size)) {
     seqs.emplace_back(torch::empty({
       torch::randint(1, PackedSequenceTest_max_length, {1}).item<int64_t>()
     }, tensor_type));
@@ -390,7 +391,7 @@ std::tuple<torch::Tensor, torch::Tensor> PackedSequenceTest_padded_sequence(torc
   // Create Tensor of random padded sequences
   auto ordered = PackedSequenceTest_ordered_sequence(tensor_type);
   auto lengths = torch::empty({(int64_t)ordered.size()}, torch::kInt64);
-  for (int64_t i = 0; i < ordered.size(); i++) {
+  for (const auto i : c10::irange(ordered.size())) {
     lengths[i] = ordered[i].size(0);
   }
   auto padded_tensor = rnn_utils::pad_sequence(ordered);
@@ -619,9 +620,9 @@ TEST_F(NNUtilsTest, PackPaddedSequence) {
     }
     auto padded = torch::cat(tensors_to_be_cat, 1);
     std::vector<torch::Tensor> expected_data_vec;
-    for (int64_t n = 0; n < batch_sizes.size(0); n++) {
+    for (const auto n : c10::irange(batch_sizes.size(0))) {
       int64_t batch_size = batch_sizes[n].item<int64_t>();
-      for (int64_t i = 0; i < batch_size; i++) {
+      for (const auto i : c10::irange(batch_size)) {
         expected_data_vec.emplace_back(torch::arange(1., 6) + (i + 1) * 100 + 5 * n);
       }
     }
@@ -631,7 +632,7 @@ TEST_F(NNUtilsTest, PackPaddedSequence) {
     if (should_shuffle) {
       // Shuffle the padded sequence to create an unsorted sequence
       std::vector<int64_t> permutation;
-      for (int64_t i = 0; i < sorted_lengths.size(); i++) {
+      for (const auto i : c10::irange(sorted_lengths.size())) {
         permutation.emplace_back(i);
       }
       std::shuffle(
@@ -702,7 +703,7 @@ TEST_F(NNUtilsTest, PackPaddedSequence) {
       if (batch_first) {
         grad_output.transpose_(0, 1);
       }
-      for (int64_t i = 0; i < lengths.size(0); i++) {
+      for (const auto i : c10::irange(lengths.size(0))) {
         int64_t l = lengths[i].item<int64_t>();
         ASSERT_TRUE(torch::allclose(
           padded.grad().narrow(0, 0, l).select(1, i),

--- a/test/cpp/api/operations.cpp
+++ b/test/cpp/api/operations.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -11,7 +12,7 @@ struct OperationTest : torch::test::SeedingFixture {
 };
 
 TEST_F(OperationTest, Lerp) {
-  for (auto i = 0; i < TEST_AMOUNT; i++) {
+  for (const auto i : c10::irange(TEST_AMOUNT)) {
     // test lerp_kernel_scalar
     auto start = torch::rand({3, 5});
     auto end = torch::rand({3, 5});
@@ -35,13 +36,13 @@ TEST_F(OperationTest, Lerp) {
 }
 
 TEST_F(OperationTest, Cross) {
-  for (auto i = 0; i < TEST_AMOUNT; i++) {
+  for (const auto i : c10::irange(TEST_AMOUNT)) {
     // input
     auto a = torch::rand({10, 3});
     auto b = torch::rand({10, 3});
     // expected
     auto exp = torch::empty({10, 3});
-    for (int j = 0; j < 10; j++) {
+    for (const auto j : c10::irange(10)) {
       auto u1 = a[j][0], u2 = a[j][1], u3 = a[j][2];
       auto v1 = b[j][0], v2 = b[j][1], v3 = b[j][2];
       exp[j][0] = u2 * v3 - v2 * u3;

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/optim_baseline.h>
@@ -36,7 +37,7 @@ bool test_optimizer_xor(Options options) {
   while (running_loss > 0.1) {
     auto inputs = torch::empty({kBatchSize, 2});
     auto labels = torch::empty({kBatchSize});
-    for (size_t i = 0; i < kBatchSize; i++) {
+    for (const auto i : c10::irange(kBatchSize)) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
@@ -112,7 +113,7 @@ void check_exact_values(
   torch::Tensor input =
       torch::tensor({0.1, 0.2, 0.3, 0.4, 0.5, 0.6}, torch::kFloat64).reshape({3, 2});
 
-  for (size_t i = 0; i < kIterations; ++i) {
+  for (const auto i : c10::irange(kIterations)) {
     optimizer.zero_grad();
     auto output = model->forward(input);
     auto loss = output.sum();
@@ -124,7 +125,7 @@ void check_exact_values(
     if (i % kSampleEvery == 0) {
       ASSERT_TRUE(
           expected_parameters.at(i / kSampleEvery).size() == parameters.size());
-      for (size_t p = 0; p < parameters.size(); ++p) {
+      for (const auto p : c10::irange(parameters.size())) {
         ASSERT_TRUE(parameters[p]->defined());
         // Always compare using double dtype, regardless of the original dtype of the tensors
         auto computed = parameters[p]->flatten().to(torch::kFloat64);
@@ -143,7 +144,7 @@ void check_exact_values(
 TEST(OptimTest, OptimizerAccessors) {
   auto options = AdagradOptions(1.0);
   std::vector<torch::Tensor> params;
-  for (size_t i = 0; i < 3; i++) {
+  for (const auto i : c10::irange(3)) {
     params.push_back(torch::randn(10));
   }
   auto optimizer = Adagrad(params, options);
@@ -155,7 +156,7 @@ TEST(OptimTest, OptimizerAccessors) {
   // NOLINTNEXTLINE(modernize-use-emplace)
   params_groups.push_back(OptimizerParamGroup(params));
   auto& params_1 = params_groups[1].params();
-  for (size_t i = 0; i < params_1.size(); i++) {
+  for (const auto i : c10::irange(params_1.size())) {
     torch::equal(params[i], params_1[i]);
   }
 
@@ -225,7 +226,7 @@ TEST(OptimTest, OldInterface) {
 
     std::vector<torch::Tensor> params_;
     OLD_INTERFACE_WARNING_CHECK(params_ = optimizer.parameters());
-    for (size_t p = 0; p < size; ++p) {
+    for (const auto p : c10::irange(size)) {
       ASSERT_TRUE(params_[p].allclose(parameters[p]));
     }
   }

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/functions/comm.h>
 #include <torch/nn/module.h>
 #include <torch/nn/modules/conv.h>
@@ -86,7 +87,7 @@ TEST_F(ParallelTest, Replicate_MultiCUDA) {
   }
   replicas[0]->to(torch::kCPU);
   ASSERT_EQ(replica1_parameters.size(), original_parameters.size());
-  for (size_t i = 0; i < original_parameters.size(); ++i) {
+  for (const auto i : c10::irange(original_parameters.size())) {
     ASSERT_TRUE(replica1_parameters[i].allclose(original_parameters[i]));
     ASSERT_TRUE(
         replica1_parameters[i].data_ptr<float>() !=
@@ -99,7 +100,7 @@ TEST_F(ParallelTest, Replicate_MultiCUDA) {
   }
   replicas[1]->to(torch::kCPU);
   ASSERT_EQ(replica2_parameters.size(), original_parameters.size());
-  for (size_t i = 0; i < original_parameters.size(); ++i) {
+  for (const auto i : c10::irange(original_parameters.size())) {
     ASSERT_TRUE(replica2_parameters[i].allclose(original_parameters[i]));
     ASSERT_TRUE(
         replica2_parameters[i].data_ptr<float>() !=
@@ -222,7 +223,7 @@ TEST_F(ParallelTest, DataParallelUsesAllAvailableCUDADevices_CUDA) {
   auto output = parallel::data_parallel(m, input);
 
   ASSERT_EQ(output.numel(), device_count);
-  for (size_t i = 0; i < device_count; ++i) {
+  for (const auto i : c10::irange(device_count)) {
     ASSERT_EQ(output[i].item<int32_t>(), i);
   }
 }
@@ -258,7 +259,7 @@ TEST_F(ParallelTest, DataParallelNumericalEquivalence_MultiCUDA) {
     auto model_dp = std::dynamic_pointer_cast<M>(model->clone());
 
     // run 3 training iterations
-    for (int i = 0; i < 3; ++i) {
+    for (const auto i : c10::irange(3)) {
       input += i;
       input_dp += i;
 

--- a/test/cpp/api/parameterlist.cpp
+++ b/test/cpp/api/parameterlist.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <algorithm>
@@ -78,11 +79,11 @@ TEST_F(ParameterListTest, AccessWithAt) {
   ASSERT_EQ(list->size(), 4);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < params.size(); ++i) {
+  for (const auto i : c10::irange(params.size())) {
     ASSERT_TRUE(torch::all(torch::eq(list->at(i), params[i])).item<bool>());
   }
 
-  for (size_t i = 0; i < params.size(); ++i) {
+  for (const auto i : c10::irange(params.size())) {
     ASSERT_TRUE(torch::all(torch::eq(list[i], params[i])).item<bool>());
   }
 

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <algorithm>
@@ -172,7 +173,7 @@ TEST_F(SequentialTest, AccessWithAt) {
   ASSERT_EQ(sequential->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(&sequential->at<M>(i), modules[i].get());
   }
 
@@ -201,7 +202,7 @@ TEST_F(SequentialTest, AccessWithPtr) {
   ASSERT_EQ(sequential->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(sequential->ptr(i).get(), modules[i].get());
     ASSERT_EQ(sequential[i].get(), modules[i].get());
     ASSERT_EQ(sequential->ptr<M>(i).get(), modules[i].get());

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/util/tempfile.h>
 #include <c10/util/flat_hash_map.h>
+#include <c10/util/irange.h>
 
 #include <torch/torch.h>
 
@@ -41,7 +42,7 @@ void is_optimizer_param_group_equal(const OptimizerParamGroup& lhs, const Optimi
   const auto& rhs_params = rhs.params();
 
   ASSERT_TRUE(lhs_params.size() == rhs_params.size());
-  for (size_t j = 0; j < lhs_params.size(); j++) {
+  for (const auto j : c10::irange(lhs_params.size())) {
     ASSERT_TRUE(torch::equal(lhs_params[j], rhs_params[j]));
   }
   ASSERT_TRUE(static_cast<const DerivedOptions&>(lhs.options()) == static_cast<const DerivedOptions&>(rhs.options()));
@@ -136,7 +137,7 @@ void test_serialize_optimizer(DerivedOptimizerOptions options, bool only_has_glo
   ASSERT_TRUE(optim3_2_state.size() == optim3_state.size());
 
   // checking correctness of serialization logic for optimizer.param_groups_ and optimizer.state_
-  for (int i = 0; i < optim3_2_param_groups.size(); i++) {
+  for (const auto i : c10::irange(optim3_2_param_groups.size())) {
     is_optimizer_param_group_equal<DerivedOptimizerOptions>(
       optim3_2_param_groups[i], optim3_param_groups[i]);
     is_optimizer_state_equal<DerivedOptimizerParamState>(optim3_2_state, optim3_state);
@@ -173,7 +174,7 @@ void write_tensors_to_archive(
     const BufferContainer& buffers) {
   archive.write(
       key + "/size", torch::tensor(static_cast<int64_t>(buffers.size())));
-  for (size_t index = 0; index < buffers.size(); ++index) {
+  for (const auto index : c10::irange(buffers.size())) {
     archive.write(
         key + "/" + c10::to_string(index), buffers[index], /*is_buffer=*/true);
   }
@@ -203,7 +204,7 @@ void write_step_buffers(
 TEST(SerializeTest, KeysFunc) {
   auto tempfile = c10::make_tempfile();
   torch::serialize::OutputArchive output_archive;
-  for (size_t i = 0; i < 3; i++) {
+  for (const auto i : c10::irange(3)) {
     output_archive.write("element/" + c10::to_string(i), c10::IValue(static_cast<int64_t>(i)));
   }
   output_archive.save_to(tempfile.name);
@@ -211,7 +212,7 @@ TEST(SerializeTest, KeysFunc) {
   input_archive.load_from(tempfile.name);
   std::vector<std::string> keys = input_archive.keys();
   ASSERT_EQ(keys.size(), 3);
-  for (size_t i = 0; i < keys.size(); i++) {
+  for (const auto i : c10::irange(keys.size())) {
     ASSERT_EQ(keys[i], "element/" + c10::to_string(i));
   }
 }
@@ -219,7 +220,7 @@ TEST(SerializeTest, KeysFunc) {
 TEST(SerializeTest, TryReadFunc) {
   auto tempfile = c10::make_tempfile();
   torch::serialize::OutputArchive output_archive;
-  for (size_t i = 0; i < 3; i++) {
+  for (const auto i : c10::irange(3)) {
     output_archive.write("element/" + c10::to_string(i), c10::IValue(static_cast<int64_t>(i)));
   }
   output_archive.save_to(tempfile.name);
@@ -363,7 +364,7 @@ TEST(SerializeTest, XOR) {
   auto getLoss = [](Sequential model, uint32_t batch_size) {
     auto inputs = torch::empty({batch_size, 2});
     auto labels = torch::empty({batch_size});
-    for (size_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
@@ -533,7 +534,7 @@ TEST(SerializeTest, Optim_SGD) {
   int64_t iteration_{0};
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const SGDParamState& curr_state_ = static_cast<const SGDParamState&>(*(optim1_state.at(key_).get()));
@@ -577,7 +578,7 @@ TEST(SerializeTest, Optim_Adam) {
   std::vector<at::Tensor> max_exp_average_sq_buffers;
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const AdamParamState& curr_state_ = static_cast<const AdamParamState&>(*(optim1_state.at(key_).get()));
@@ -627,7 +628,7 @@ TEST(SerializeTest, Optim_AdamW) {
   std::vector<at::Tensor> max_exp_average_sq_buffers;
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const AdamWParamState& curr_state_ = static_cast<const AdamWParamState&>(*(optim1_state.at(key_).get()));
@@ -678,7 +679,7 @@ TEST(SerializeTest, Optim_RMSprop) {
   std::vector<at::Tensor> grad_average_buffers;
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const RMSpropParamState& curr_state_ = static_cast<const RMSpropParamState&>(*(optim1_state.at(key_).get()));
@@ -703,7 +704,7 @@ TEST(SerializeTest, Optim_RMSprop) {
   const auto& params1_2_ = optim1_2.param_groups()[0].params();
   auto& optim1_2_state = optim1_2.state();
   // old RMSprop didn't track step value
-  for (size_t i = 0; i < params1_2_.size(); i++) {
+  for (const auto i : c10::irange(params1_2_.size())) {
     if(i != (params1_2_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       auto key1_2_ = c10::guts::to_string(params1_2_[i].unsafeGetTensorImpl());
@@ -788,7 +789,7 @@ TEST(SerializeTest, XOR_CUDA) {
       inputs = inputs.cuda();
       labels = labels.cuda();
     }
-    for (size_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
@@ -879,7 +880,7 @@ TEST(SerializeTest, VectorOfTensors) {
   std::vector<torch::Tensor> y_vec;
   torch::load(y_vec, stream);
 
-  for (int64_t i = 0; i < x_vec.size(); i++) {
+  for (const auto i : c10::irange(x_vec.size())) {
     auto& x = x_vec[i];
     auto& y = y_vec[i];
     ASSERT_TRUE(y.defined());

--- a/test/cpp/api/static.cpp
+++ b/test/cpp/api/static.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/detail/static.h>
 #include <torch/csrc/utils/variadic.h>
 #include <torch/torch.h>
@@ -95,7 +96,7 @@ TEST(TestStatic, Apply) {
   std::vector<int> v;
   torch::apply([&v](int x) { v.push_back(x); }, 1, 2, 3, 4, 5);
   ASSERT_EQ(v.size(), 5);
-  for (size_t i = 0; i < v.size(); ++i) {
+  for (const auto i : c10::irange(v.size())) {
     ASSERT_EQ(v.at(i), i + 1);
   }
 }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <test/cpp/api/support.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <cmath>
@@ -263,7 +264,7 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   tensor = at::tensor(v);
   ASSERT_EQ(tensor.numel(), v.size());
   ASSERT_EQ(tensor.dtype(), at::kInt);
-  for (size_t i = 0; i < v.size(); ++i) {
+  for (const auto i : c10::irange(v.size())) {
     ASSERT_TRUE(exactly_equal(tensor[i], v.at(i)));
   }
 
@@ -271,7 +272,7 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   tensor = at::tensor(w);
   ASSERT_EQ(tensor.numel(), w.size());
   ASSERT_EQ(tensor.dtype(), at::kDouble);
-  for (size_t i = 0; i < w.size(); ++i) {
+  for (const auto i : c10::irange(w.size())) {
     ASSERT_TRUE(almost_equal(tensor[i], w.at(i)));
   }
 
@@ -282,7 +283,7 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   tensor = at::tensor(x);
   ASSERT_EQ(tensor.numel(), x.size());
   ASSERT_EQ(tensor.dtype(), at::kComplexDouble);
-  for (size_t i = 0; i < x.size(); ++i) {
+  for (const auto i : c10::irange(x.size())) {
     ASSERT_TRUE(almost_equal(tensor[i], x.at(i)));
   }
 }
@@ -913,8 +914,8 @@ TEST(TensorTest, FromBlobWithStrides) {
   ASSERT_EQ(tensor.numel(), 9);
   const std::vector<int64_t> expected_strides = {1, 3};
   ASSERT_EQ(tensor.strides(), expected_strides);
-  for (int64_t i = 0; i < tensor.size(0); ++i) {
-    for (int64_t j = 0; j < tensor.size(1); ++j) {
+  for (const auto i : c10::irange(tensor.size(0))) {
+    for (const auto j : c10::irange(tensor.size(1))) {
       // NOTE: This is column major because the strides are swapped.
       EXPECT_EQ(tensor[i][j].item<int32_t>(), 1 + (j * tensor.size(1)) + i);
     }

--- a/test/cpp/c10d/ProcessGroupGlooTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooTest.cpp
@@ -242,7 +242,7 @@ void checkProfiledEvents(
       auto match = !strcmp(evt.name(), expected_profile_str);
       if (verify_shapes && match) {
         auto shapesVec = evt.shapes();
-        for (int i = 0; i < expected_count; i++) {
+        for (const auto i : c10::irange(expected_count)) {
           // Assumptions: no two expected shapes are the same
           if (shapesVec[0] == expected_shapes[i]) {
             matched_shapes[i] = true;

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -312,8 +312,7 @@ class ReduceScatterBaseNCCLTest : public NCCLTest {
       : NCCLTest(path, worldSize) {
         output_tensor_ = at::empty({1}, at::kCUDA);
         input_tensor_ = at::empty({worldSize}, at::kCUDA);
-        for(int i = 0; i < worldSize; i++)
-        {
+        for (const auto i : c10::irange(worldSize)) {
           input_tensor_[i] = i;
         }
       }

--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -2,6 +2,7 @@
 
 #include <tensorpipe/common/cpu_buffer.h>
 #include <tensorpipe/core/message.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/distributed/rpc/tensorpipe_utils.h>
 #include <torch/torch.h>
 
@@ -64,7 +65,7 @@ TEST(TensorpipeSerialize, Base) {
   // Mimic tensorpipe data transfer
   EXPECT_EQ(
       recvingTpAllocation.payloads.size(), sendingTpMessage.payloads.size());
-  for (int i = 0; i < recvingTpAllocation.payloads.size(); i++) {
+  for (const auto i : c10::irange(recvingTpAllocation.payloads.size())) {
     tensorpipe::Message::Payload& srcPayload = sendingTpMessage.payloads[i];
     tensorpipe::Allocation::Payload& dstPayload =
         recvingTpAllocation.payloads[i];
@@ -76,7 +77,7 @@ TEST(TensorpipeSerialize, Base) {
   }
   EXPECT_EQ(
       recvingTpAllocation.tensors.size(), sendingTpMessage.tensors.size());
-  for (int i = 0; i < recvingTpAllocation.tensors.size(); i++) {
+  for (const auto i : c10::irange(recvingTpAllocation.tensors.size())) {
     tensorpipe::Message::Tensor& srcTensor = sendingTpMessage.tensors[i];
     tensorpipe::Allocation::Tensor& dstTensor = recvingTpAllocation.tensors[i];
     memcpy(

--- a/test/cpp/rpc/test_wire_serialization.cpp
+++ b/test/cpp/rpc/test_wire_serialization.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 #include <torch/torch.h>
 
@@ -27,7 +28,7 @@ TEST(WireSerialize, Base) {
       EXPECT_TRUE(
           memcmp(deser.first.data(), payload.data(), payload.size()) == 0);
     }
-    for (size_t i = 0; i < tensors.size(); ++i) {
+    for (const auto i : c10::irange(tensors.size())) {
       EXPECT_TRUE(torch::equal(tensors[i], deser.second[i]));
     }
   };

--- a/test/cpp/tensorexpr/padded_buffer.cpp
+++ b/test/cpp/tensorexpr/padded_buffer.cpp
@@ -1,6 +1,7 @@
 #include "test/cpp/tensorexpr/padded_buffer.h"
 
 #include <c10/util/Logging.h>
+#include <c10/util/irange.h>
 #include <sstream>
 
 namespace torch {
@@ -10,7 +11,7 @@ namespace tensorexpr {
 int PaddedBufferBase::Index(const std::vector<int>& indices) const {
   DCHECK_EQ(dims_.size(), indices.size());
   int total_index = 0;
-  for (size_t i = 0; i < dims_.size(); i++) {
+  for (const auto i : c10::irange(dims_.size())) {
     total_index += indices[i] * strides_[i];
   }
   return total_index;

--- a/test/cpp/tensorexpr/padded_buffer.h
+++ b/test/cpp/tensorexpr/padded_buffer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include <c10/util/irange.h>
 #include "torch/csrc/jit/tensorexpr/eval.h"
 
 namespace torch {
@@ -168,7 +169,7 @@ class PaddedBuffer : public PaddedBufferBase {
 
   // Verify the watermarks in the paddings are intact.
   void ValidateWatermark() const {
-    for (int i = 0; i < kPaddingSize; i++) {
+    for (const auto i : c10::irange(kPaddingSize)) {
       ASSERT_EQ(data_[i], kPaddingValue);
       ASSERT_EQ(data_[i + total_size_ + kPaddingSize], kPaddingValue);
     }
@@ -178,7 +179,7 @@ class PaddedBuffer : public PaddedBufferBase {
     ValidateWatermark();
     DCHECK(backup_data_.size() == data_.size())
         << "Please make sure you have call Backup() before calling CheckBackup()";
-    for (int i = 0; i < total_size_; i++) {
+    for (const auto i : c10::irange(total_size_)) {
       ASSERT_EQ(data_[i + kPaddingSize], backup_data_[i + kPaddingSize]);
     }
   }
@@ -214,7 +215,7 @@ void ExpectAllEqual(const PaddedBuffer<T>& f1, const PaddedBuffer<T>& f2) {
   ASSERT_EQ(v1.size(), v2.size());
   f1.ValidateWatermark();
   f2.ValidateWatermark();
-  for (int i = 0; i < total_size; i++) {
+  for (const auto i : c10::irange(total_size)) {
     ASSERT_EQ(v1[kPaddingSize + i], v2[kPaddingSize + i]);
   }
 }
@@ -231,7 +232,7 @@ void ExpectAllNear(
   ASSERT_EQ(v1.size(), v2.size());
   f1.ValidateWatermark();
   f2.ValidateWatermark();
-  for (int i = 0; i < total_size; i++) {
+  for (const auto i : c10::irange(total_size)) {
     ASSERT_NEAR(v1[kPaddingSize + i], v2[kPaddingSize + i], abs_error);
   }
 }

--- a/test/cpp/tensorexpr/test_aten.cpp
+++ b/test/cpp/tensorexpr/test_aten.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 #include "test/cpp/tensorexpr/padded_buffer.h"
 #include "test/cpp/tensorexpr/test_base.h"
 #include "torch/csrc/jit/tensorexpr/ir_printer.h"
@@ -28,14 +29,14 @@ TEST(ATen, _cast_Float) {
   PaddedBuffer<int> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), static_cast<float>(i));
   }
@@ -55,14 +56,14 @@ TEST(ATen, negInt) {
   PaddedBuffer<int> a_v(kTotalSize);
   PaddedBuffer<int> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), -static_cast<float>(i));
   }
@@ -82,14 +83,14 @@ TEST(ATen, negFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), -i);
   }
@@ -114,7 +115,7 @@ TEST(ATen, addInt) {
   PaddedBuffer<int> c_v(kTotalSize);
   PaddedBuffer<int> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -123,7 +124,7 @@ TEST(ATen, addInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -150,7 +151,7 @@ TEST(ATen, addFloat) {
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -159,7 +160,7 @@ TEST(ATen, addFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -186,7 +187,7 @@ TEST(ATen, subInt) {
   PaddedBuffer<int> c_v(kTotalSize);
   PaddedBuffer<int> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -195,7 +196,7 @@ TEST(ATen, subInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -222,7 +223,7 @@ TEST(ATen, subFloat) {
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -231,7 +232,7 @@ TEST(ATen, subFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -258,7 +259,7 @@ TEST(ATen, lerp) {
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -267,7 +268,7 @@ TEST(ATen, lerp) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -297,7 +298,7 @@ TEST(ATen, addcmulInt) {
   PaddedBuffer<int> d_v(kTotalSize);
   PaddedBuffer<int> e_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -307,7 +308,7 @@ TEST(ATen, addcmulInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf, e_buf});
   ir_eval(a_v, b_v, c_v, d_v, e_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -338,7 +339,7 @@ TEST(ATen, addcmulFloat) {
   PaddedBuffer<float> d_v(kTotalSize);
   PaddedBuffer<float> e_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -348,7 +349,7 @@ TEST(ATen, addcmulFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf, e_buf});
   ir_eval(a_v, b_v, c_v, d_v, e_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -373,7 +374,7 @@ TEST(ATen, mulInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -381,7 +382,7 @@ TEST(ATen, mulInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), a_v(i) * b_v(i));
@@ -404,7 +405,7 @@ TEST(ATen, mulFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -412,7 +413,7 @@ TEST(ATen, mulFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), a_v(i) * b_v(i));
@@ -435,7 +436,7 @@ TEST(ATen, divInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = 2 * i + 1;
     b_v(i) = i + 1;
   }
@@ -443,7 +444,7 @@ TEST(ATen, divInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), 2 * i + 1);
     ASSERT_EQ(b_v(i), i + 1);
     ASSERT_EQ(c_v(i), a_v(i) / b_v(i));
@@ -466,7 +467,7 @@ TEST(ATen, divFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = 2 * i + 1;
     b_v(i) = i + 1;
   }
@@ -474,7 +475,7 @@ TEST(ATen, divFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), 2 * i + 1);
     ASSERT_EQ(b_v(i), i + 1);
     ASSERT_EQ(c_v(i), a_v(i) / b_v(i));
@@ -497,7 +498,7 @@ TEST(ATen, maxInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -505,7 +506,7 @@ TEST(ATen, maxInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::max(a_v(i), b_v(i)));
@@ -528,7 +529,7 @@ TEST(ATen, maxFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -536,7 +537,7 @@ TEST(ATen, maxFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::fmax(a_v(i), b_v(i)));
@@ -559,7 +560,7 @@ TEST(ATen, minInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -567,7 +568,7 @@ TEST(ATen, minInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::min(a_v(i), b_v(i)));
@@ -590,7 +591,7 @@ TEST(ATen, minFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -598,7 +599,7 @@ TEST(ATen, minFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::fmin(a_v(i), b_v(i)));
@@ -618,14 +619,14 @@ void __ubsan_ignore_float_divide_by_zero__ testATenreciprocal() {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 1.0f / i);
   }
@@ -644,14 +645,14 @@ TEST(ATen, reluInt) {
   PaddedBuffer<int> a_v(kTotalSize);
   PaddedBuffer<int> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i - 64;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i - 64);
     ASSERT_EQ(b_v(i), std::max(a_v(i), 0));
   }
@@ -672,14 +673,14 @@ TEST(ATen, reluFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i - 64;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i - 64);
     ASSERT_EQ(b_v(i), std::fmax(a_v(i), 0));
   }
@@ -698,14 +699,14 @@ TEST(ATen, logFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i + 10;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i + 10);
     ASSERT_EQ(b_v(i), std::log(a_v(i)));
   }
@@ -724,14 +725,14 @@ TEST(ATen, fastLogFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = at::randn({1}).item().to<float>();
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     auto test = b_v(i);
     auto ref = std::log(a_v(i));
     if (std::isnan(ref)) {
@@ -755,14 +756,14 @@ TEST(ATen, fastTanhFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = at::randn({1}).item().to<float>();
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     auto test = b_v(i);
     auto ref = std::tanh(a_v(i));
     if (std::isnan(ref)) {
@@ -786,14 +787,14 @@ TEST(ATen, fastSigmoidFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = at::randn({1}).item().to<float>();
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     auto test = b_v(i);
     at::Tensor t = at::ones({1}) * a_v(i);
     float ref = at::sigmoid(t).item().to<float>();
@@ -818,14 +819,14 @@ TEST(ATen, log10Float) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i + 10;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i + 10);
     ASSERT_EQ(b_v(i), std::log10(a_v(i)));
   }
@@ -844,14 +845,14 @@ TEST(ATen, log2Float) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i + 10;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i + 10);
     ASSERT_EQ(b_v(i), std::log2(a_v(i)));
   }
@@ -870,7 +871,7 @@ TEST(ATen, expFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     a_v(i) = i / 10.0f;
   }
@@ -878,7 +879,7 @@ TEST(ATen, expFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i / 10.0f);
     ASSERT_EQ(b_v(i), std::exp(a_v(i)));
   }
@@ -897,7 +898,7 @@ TEST(ATen, erfFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     a_v(i) = i / 10.0f;
   }
@@ -905,7 +906,7 @@ TEST(ATen, erfFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i / 10.0f);
     ASSERT_EQ(b_v(i), std::erf(a_v(i)));
   }
@@ -924,7 +925,7 @@ TEST(ATen, cosFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     a_v(i) = i / 10.0f;
   }
@@ -932,7 +933,7 @@ TEST(ATen, cosFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i / 10.0f);
     ASSERT_EQ(b_v(i), std::cos(a_v(i)));
   }

--- a/test/cpp/tensorexpr/test_cpp_codegen.cpp
+++ b/test/cpp/tensorexpr/test_cpp_codegen.cpp
@@ -2,6 +2,7 @@
 
 #include "test/cpp/tensorexpr/test_base.h"
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/cpp_codegen.h>
 #include <torch/csrc/jit/tensorexpr/fwd_decls.h>
 #include <torch/csrc/jit/tensorexpr/stmt.h>
@@ -207,7 +208,7 @@ TEST(CppPrinter, Cond) {
 TEST(CppPrinter, Intrinsics) {
   const std::unordered_set<IntrinsicsOp, std::hash<int>> unsupported_ops{
       kRand, kSigmoid};
-  for (int i = 0; i < kMaxIntrinsicsOp; i++) {
+  for (const auto i : c10::irange(static_cast<uint32_t>(kMaxIntrinsicsOp))) {
     IntrinsicsOp op = static_cast<IntrinsicsOp>(i);
     if (unsupported_ops.count(op)) {
       continue;

--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -2,6 +2,7 @@
 
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/padded_buffer.h>
 #include <test/cpp/tensorexpr/test_utils.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
@@ -163,7 +164,7 @@ TEST(Expr, VectorAdd01) {
 
   /*
   Build the following:
-    for (int index = 0; index < kVectorCount; index++) {
+    for (const auto index : c10::irange(kVectorCount)) {
       store(c_buf, ramp(index * 8, 1, 8),
             load(a_buf, ramp(index * 8, 1, 8) +
             load(b_buf, ramp(index * 8, 1, 8))))
@@ -187,7 +188,7 @@ TEST(Expr, VectorAdd01) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> c_ref(kTotalSize);
-  for (int i = 0; i < kTotalSize; i++) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i * i;
     b_v(i) = i * i * 4;
     c_ref(i) = a_v(i) + b_v(i);
@@ -568,7 +569,7 @@ void testCond01() {
   SimpleIREvaluator(for_stmt, {a_buf})(a_v);
 
   PaddedBuffer<float> a_ref(N);
-  for (int i = 0; i < N; i++) {
+  for (const auto i : c10::irange(N)) {
     if (i % 2 == 0) {
       a_ref(i) = i * 2;
     } else {

--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/test_base.h>
 #include <torch/csrc/jit/frontend/code_template.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -416,13 +417,13 @@ TEST_F(Kernel, DISABLED_Shape_Inference) {
     // Check sizes
     CHECK_EQ(o.sizes().size(), ref.sizes().size());
     size_t num_el = 1;
-    for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+    for (const auto idx : c10::irange(ref.sizes().size())) {
       CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
       num_el *= ref.sizes()[idx];
     }
 
     // Check the contents
-    for (size_t i = 0; i < num_el; i++) {
+    for (const auto i : c10::irange(num_el)) {
       CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
     }
   }
@@ -469,13 +470,13 @@ TEST_F(Kernel, DISABLED_Shape_Inference) {
     // Check sizes
     CHECK_EQ(o.sizes().size(), ref.sizes().size());
     size_t num_el = 1;
-    for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+    for (const auto idx : c10::irange(ref.sizes().size())) {
       CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
       num_el *= ref.sizes()[idx];
     }
 
     // Check the contents
-    for (size_t i = 0; i < num_el; i++) {
+    for (const auto i : c10::irange(num_el)) {
       CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
     }
   }
@@ -569,13 +570,13 @@ TEST_F(Kernel, CatInputTypesPromotion) {
     CHECK_EQ(o.sizes().size(), ref.sizes().size());
     CHECK_EQ(o.dtype(), ref.dtype());
     size_t num_el = 1;
-    for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+    for (const auto idx : c10::irange(ref.sizes().size())) {
       CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
       num_el *= ref.sizes()[idx];
     }
 
     // Check the contents
-    for (size_t i = 0; i < num_el; i++) {
+    for (const auto i : c10::irange(num_el)) {
       CHECK_EQ(((double*)o.data_ptr())[i], ((double*)ref.data_ptr())[i]);
     }
   }
@@ -658,13 +659,13 @@ TEST_F(Kernel, CatWoConditionals) {
   CHECK_EQ(o.sizes().size(), ref.sizes().size());
   CHECK_EQ(o.dtype(), ref.dtype());
   size_t num_el = 1;
-  for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+  for (const auto idx : c10::irange(ref.sizes().size())) {
     CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
     num_el *= ref.sizes()[idx];
   }
 
   // Check the contents
-  for (size_t i = 0; i < num_el; i++) {
+  for (const auto i : c10::irange(num_el)) {
     CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
   }
   getCatWoConditionals() = false;
@@ -723,13 +724,13 @@ TEST_F(Kernel, OptimizeConditionals) {
   CHECK_EQ(o.sizes().size(), ref.sizes().size());
   CHECK_EQ(o.dtype(), ref.dtype());
   size_t num_el = 1;
-  for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+  for (const auto idx : c10::irange(ref.sizes().size())) {
     CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
     num_el *= ref.sizes()[idx];
   }
 
   // Check the contents
-  for (size_t i = 0; i < num_el; i++) {
+  for (const auto i : c10::irange(num_el)) {
     CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
   }
   getOptConditionals() = old_opt_conditionals;
@@ -904,7 +905,7 @@ TEST_F(Kernel, SumMultipleAxes) {
 
   // Only iterate over positive values of axes to keep the running time
   // reasonable, since the number of pairs is quadratic.
-  for (int dim1 = 0; dim1 < a.dim(); ++dim1) {
+  for (const auto dim1 : c10::irange(a.dim())) {
     for (int dim2 = dim1 + 1; dim2 < a.dim(); ++dim2) {
       for (bool keepdim : {false, true}) {
         TemplateEnv env;
@@ -977,7 +978,7 @@ TEST_F(Kernel, Softmax2D) {
         # CHECK-NEXT: aten_softmax)IR";
 
   for (auto log_softmax : {false, true}) {
-    for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
+    for (const auto softmax_dim : c10::irange(a.dim())) {
       auto softmax_dim_size = a.sizes()[softmax_dim];
       auto other_dim = (softmax_dim + 1) % a.dim();
       auto ref =
@@ -1046,10 +1047,10 @@ TEST_F(Kernel, Softmax3D) {
         # CHECK-NEXT: aten_softmax)IR";
 
   for (auto log_softmax : {false, true}) {
-    for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
+    for (const auto softmax_dim : c10::irange(a.dim())) {
       auto softmax_dim_size = a.sizes()[softmax_dim];
       std::vector<int> other_dims;
-      for (int i = 0; i < a.dim(); ++i) {
+      for (const auto i : c10::irange(a.dim())) {
         if (i != softmax_dim) {
           other_dims.push_back(i);
         }
@@ -1127,10 +1128,10 @@ TEST_F(Kernel, Softmax4D) {
         # CHECK-NEXT: aten_softmax)IR";
 
   for (auto log_softmax : {false, true}) {
-    for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
+    for (const auto softmax_dim : c10::irange(a.dim())) {
       auto softmax_dim_size = a.sizes()[softmax_dim];
       std::vector<int> other_dims;
-      for (int i = 0; i < a.dim(); ++i) {
+      for (const auto i : c10::irange(a.dim())) {
         if (i != softmax_dim) {
           other_dims.push_back(i);
         }

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -8,6 +8,7 @@
 
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/padded_buffer.h>
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
@@ -28,7 +29,7 @@ TEST(Reductions, ReduceSum0D_1) {
 
   BufHandle b("b", {M}, kFloat);
   std::vector<float> in(M);
-  for (int j = 0; j < M; ++j) {
+  for (const auto j : c10::irange(M)) {
     in[j] = j;
   }
 
@@ -43,7 +44,7 @@ TEST(Reductions, ReduceSum0D_1) {
   SimpleIREvaluator cg(s, {b, c});
 
   cg.call({in, out});
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[i], in[i]);
   }
 }
@@ -73,7 +74,7 @@ TEST(Reductions, ReduceSum0D_2) {
 TEST(Reductions, ReduceSum1D) {
   BufHandle b("b", {10}, kFloat);
   std::vector<float> in(10);
-  for (int j = 0; j < 10; ++j) {
+  for (const auto j : c10::irange(10)) {
     in[j] = j;
   }
 
@@ -100,8 +101,8 @@ TEST(Reductions, ReduceSum2D) {
 
   BufHandle b("b", {m, n}, kFloat);
   std::vector<float> in(M * N);
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       in[i * N + j] = j;
     }
   }
@@ -119,12 +120,12 @@ TEST(Reductions, ReduceSum2D) {
   cg.call({in, out, 5, 7});
 
   float expected = 0;
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected += i;
   }
 
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[i], expected);
   }
 }
@@ -151,14 +152,14 @@ TEST(Reductions, ReduceSum3D) {
   std::vector<float> eData(2, 1.0f);
 
   for (int i = 0; i < 2 * 3; ++i) {
-    for (int j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       bData[i * M + j] = j;
     }
   }
 
   cg.call({bData, cData, M});
   float expected = 0;
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected += i;
   }
@@ -179,7 +180,7 @@ TEST(Reductions, ReduceSum3D) {
   // We're combining an additional dimension of 3, so the sum is 3x.
   expected = expected * 3;
 
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(dData[i], expected);
   }
 
@@ -194,7 +195,7 @@ TEST(Reductions, ReduceSum3D) {
   SimpleIREvaluator cg3(s3, {c, e});
   cg3.call({cData, eData});
 
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(eData[i], expected);
   }
 }
@@ -226,7 +227,7 @@ TEST(Reductions, ReduceSum10D) {
 
   // NOLINTNEXTLINE(bugprone-integer-division)
   float expected = InputSize / OutputSize;
-  for (int i = 0; i < OutputSize; ++i) {
+  for (const auto i : c10::irange(OutputSize)) {
     ASSERT_EQ(out[i], expected);
   }
 }
@@ -238,8 +239,8 @@ TEST(Reductions, ReduceProduct) {
 
   BufHandle b("b", {M, N}, kFloat);
   std::vector<float> in(M * N);
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       in[i * N + j] = 2 + j;
     }
   }
@@ -260,12 +261,12 @@ TEST(Reductions, ReduceProduct) {
   cg.call({in, out});
 
   float expected = 1;
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected *= 2 + i;
   }
 
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[i], expected);
   }
 }
@@ -276,7 +277,7 @@ TEST(Reductions, ReduceMax) {
 
   std::vector<float> in(10);
   std::vector<float> out(1, -1.f);
-  for (int j = 0; j < 10; ++j) {
+  for (const auto j : c10::irange(10)) {
     in[j] = j;
   }
 
@@ -316,7 +317,7 @@ TEST(Reductions, ReduceMinCustomInitializer) {
 
   std::vector<float> in(10);
   std::vector<float> out(1, -1.f);
-  for (int j = 0; j < 10; ++j) {
+  for (const auto j : c10::irange(10)) {
     in[j] = 10 + j;
   }
 
@@ -374,7 +375,7 @@ TEST(Reductions, ReduceAnyAll) {
   std::vector<int> out(4, 0);
 
   // input has 0-39 in 4 rows.
-  for (int i = 0; i < 40; ++i) {
+  for (const auto i : c10::irange(40)) {
     in[i] = i;
   }
   cg.call({in, out, 1});
@@ -438,8 +439,8 @@ TEST(Reductions, ReduceMatmul2D) {
   std::vector<float> tB_(6);
 
   std::vector<float> out(9, -1.f);
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 2; ++j) {
+  for (const auto i : c10::irange(3)) {
+    for (const auto j : c10::irange(2)) {
       tA_[i * 2 + j] = i * 2 + j;
       tB_[j * 3 + i] = i * 2 + j;
     }
@@ -465,7 +466,7 @@ TEST(Reductions, ReduceMatmul2D) {
   std::vector<float> expected(
       {1.f, 3.f, 5.f, 3.f, 13.f, 23.f, 5.f, 23.f, 41.f});
 
-  for (int i = 0; i < 9; ++i) {
+  for (const auto i : c10::irange(9)) {
     ASSERT_EQ(out[i], expected[i]);
   }
 }
@@ -473,7 +474,7 @@ TEST(Reductions, ReduceMatmul2D) {
 TEST(Reductions, ReduceRfactorLike) {
   BufHandle in("in", {10, 10}, kFloat);
   std::vector<float> in_(100);
-  for (int i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     in_[i] = i;
   }
   std::vector<float> in_rf_(10, -2.f);
@@ -522,14 +523,14 @@ TEST(Reductions, ReduceAsProducer) {
 
   for (int i = 0; i < 2 * 3; ++i) {
     aData[i] = 6 - i;
-    for (int j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       bData[i * M + j] = j;
     }
   }
 
   cg.call({aData, bData, dData, M});
   float expected = 0;
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected += i;
   }
@@ -564,7 +565,7 @@ TEST(Reductions, ReduceAsConsumer) {
   std::vector<float> dData(2, 6.0f);
 
   for (int i = 0; i < 2 * 3; ++i) {
-    for (int j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       bData[i * M + j] = j + 1;
       aData[i * M + j] = 6 - i;
     }
@@ -573,16 +574,16 @@ TEST(Reductions, ReduceAsConsumer) {
   cg.call({aData, bData, dData, M});
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   float expected[2] = {0, 0};
-  for (int i = 0; i < 2; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      for (int k = 0; k < M; ++k) {
+  for (const auto i : c10::irange(2)) {
+    for (const auto j : c10::irange(3)) {
+      for (const auto k : c10::irange(M)) {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         expected[i] += (k + 1) * (6 - (i * 3 + j));
       }
     }
   }
 
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(dData[i], expected[i]);
   }
 }
@@ -591,8 +592,8 @@ TEST(Reductions, SplitReduceAxis) {
   BufHandle in("in", {16, 8}, kFloat);
 
   std::vector<float> in_(16 * 8);
-  for (int i = 0; i < 16; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(16)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }
@@ -611,7 +612,7 @@ TEST(Reductions, SplitReduceAxis) {
   SimpleIREvaluator cg(s, {in, tensor});
   cg.call({in_, out});
 
-  for (int i = 0; i < 16; ++i) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(out[i], i * 8);
   }
 }
@@ -620,8 +621,8 @@ TEST(Reductions, SplitNonReduceAxis) {
   BufHandle in("in", {16, 8}, kFloat);
 
   std::vector<float> in_(16 * 8);
-  for (int i = 0; i < 16; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(16)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }
@@ -640,7 +641,7 @@ TEST(Reductions, SplitNonReduceAxis) {
   SimpleIREvaluator cg(s, {in, tensor});
   cg.call({in_, out});
 
-  for (int i = 0; i < 16; ++i) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(out[i], i * 8);
   }
 }
@@ -689,7 +690,7 @@ TEST(Reductions, ReorderedReductionInitializer) {
   SimpleIREvaluator cg2(s, {in, tensor});
   cg2.call({in_, out2});
 
-  for (int i = 0; i < 16; ++i) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(out1[i], out2[i]);
   }
 }
@@ -807,7 +808,7 @@ TEST(Reductions, ReduceRepeatedInternalRfactor) {
   LoopNest orig_loop({c});
 
   // Try rfactoring N outer loops
-  for (int rfac_number = 1; rfac_number < 5; rfac_number++) {
+  for (const auto rfac_number : c10::irange(1, 5)) {
     LoopNest refloop(orig_loop);
     LoopNest loop(orig_loop);
     refloop.prepareForCodegen();
@@ -817,7 +818,7 @@ TEST(Reductions, ReduceRepeatedInternalRfactor) {
 
     BufPtr tmp_buf = c.buf();
 
-    for (int idx = 0; idx < rfac_number; idx++) {
+    for (const auto idx : c10::irange(rfac_number)) {
       auto reduce = loop.getAllWritesToBuf(tmp_buf)[1];
       ASSERT_TRUE(loop.rfactor(
           reduce, loop.getLoopStmtsFor(tmp_buf).at(idx), &tmp_buf));
@@ -846,7 +847,7 @@ TEST(Reductions, ReduceSplitTail) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -876,7 +877,7 @@ TEST(Reductions, ReduceSplitNoTail) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -908,7 +909,7 @@ TEST(Reductions, ReduceOverSplitTail) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -939,7 +940,7 @@ TEST(Reductions, ReduceSplitMask) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -969,7 +970,7 @@ TEST(Reductions, ReduceSplitNoMask) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -1000,7 +1001,7 @@ TEST(Reductions, ReduceOverSplitMask) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -1029,7 +1030,7 @@ TEST(Reductions, ReduceSplitRfactor) {
 
   BufHandle b("b", {M, N, K}, kFloat);
   std::vector<float> in(M * N * K);
-  for (int m = 0; m < M; ++m) {
+  for (const auto m : c10::irange(M)) {
     for (int j = 0; j < N * K; ++j) {
       in[m * N * K + j] = j;
     }
@@ -1056,7 +1057,7 @@ TEST(Reductions, ReduceSplitRfactor) {
   SimpleIREvaluator cg(s, {b, c});
 
   cg.call({in, out});
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[0], 4950);
   }
 }
@@ -1134,12 +1135,12 @@ TEST(Reductions, ReduceInlineReduction) {
   PaddedBuffer<float> a_v(M);
   PaddedBuffer<float> b_v(M, N, K);
 
-  for (int i = 0; i < M; i++) {
+  for (const auto i : c10::irange(M)) {
     a_v(i) = i * i;
   }
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      for (int k = 0; k < K; k++) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
+      for (const auto k : c10::irange(K)) {
         b_v(i, j, k) = j * j * k;
       }
     }
@@ -1169,9 +1170,9 @@ TEST(Reductions, ReduceInlineConsumer) {
   PaddedBuffer<float> a_v(M, N, K);
   PaddedBuffer<float> b_v(M, N, K);
 
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      for (int k = 0; k < K; k++) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
+      for (const auto k : c10::irange(K)) {
         a_v(i, j, k) = i * i + k;
         b_v(i, j, k) = j * j + k;
       }
@@ -1226,9 +1227,9 @@ TEST(Reductions, ReduceInlineReducerInternal) {
   PaddedBuffer<float> a_v(M, N, K);
   PaddedBuffer<float> b_v(M, N, K);
 
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      for (int k = 0; k < K; k++) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
+      for (const auto k : c10::irange(K)) {
         a_v(i, j, k) = i * i + k;
         b_v(i, j, k) = j * j + k;
       }
@@ -1319,9 +1320,9 @@ TEST(Reductions, ReductionCacheAccessesOperatorAxis) {
   PaddedBuffer<float> e_before(L, "e_before");
   PaddedBuffer<float> e_after(L, "e_after");
 
-  for (int l = 0; l < L; l++) {
-    for (int m = 0; m < M; m++) {
-      for (int n = 0; n < N; n++) {
+  for (const auto l : c10::irange(L)) {
+    for (const auto m : c10::irange(M)) {
+      for (const auto n : c10::irange(N)) {
         a_v(l, m, n) = at::randn({1}).item().to<float>();
         b_v(l, m, n) = at::randn({1}).item().to<float>();
       }
@@ -1392,9 +1393,9 @@ TEST(Reductions, ReductionCacheAccessesOuterReduceAxis) {
   PaddedBuffer<float> e_before(L, "e_before");
   PaddedBuffer<float> e_after(L, "e_after");
 
-  for (int l = 0; l < L; l++) {
-    for (int m = 0; m < M; m++) {
-      for (int n = 0; n < N; n++) {
+  for (const auto l : c10::irange(L)) {
+    for (const auto m : c10::irange(M)) {
+      for (const auto n : c10::irange(N)) {
         a_v(l, m, n) = at::randn({1}).item().to<float>();
         b_v(l, m, n) = at::randn({1}).item().to<float>();
       }
@@ -1465,9 +1466,9 @@ TEST(Reductions, ReductionCacheAccessesInnerReduceAxis) {
   PaddedBuffer<float> e_before(L, "e_before");
   PaddedBuffer<float> e_after(L, "e_after");
 
-  for (int l = 0; l < L; l++) {
-    for (int m = 0; m < M; m++) {
-      for (int n = 0; n < N; n++) {
+  for (const auto l : c10::irange(L)) {
+    for (const auto m : c10::irange(M)) {
+      for (const auto n : c10::irange(N)) {
         a_v(l, m, n) = at::randn({1}).item().to<float>();
         b_v(l, m, n) = at::randn({1}).item().to<float>();
       }
@@ -1782,8 +1783,8 @@ TEST(Reductions, ReductionRfactorCacheTempInner) {
 
 TEST(Reductions, ReductionVectorize) {
   std::vector<float> in_(8 * 8);
-  for (int i = 0; i < 8; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(8)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }
@@ -1820,7 +1821,7 @@ TEST(Reductions, ReductionVectorize) {
   s = IRSimplifier::simplify(l.root_stmt());
   SimpleIREvaluator cg_after(s, {in, tensor});
   cg_after.call({in_, out_after});
-  for (int i = 0; i < 8; ++i) {
+  for (const auto i : c10::irange(8)) {
     ASSERT_EQ(out_before[i], out_after[i]);
   }
 }
@@ -1836,8 +1837,8 @@ TEST(Reductions, ReductionVectorizeInner) {
 
 TEST(Reductions, ReductionVectorizeRfactor) {
   std::vector<float> in_(8 * 8);
-  for (int i = 0; i < 8; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(8)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/test_utils.h>
 #include <torch/csrc/jit/tensorexpr/hash_provider.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
@@ -1132,7 +1133,7 @@ TEST(Simplify, SimplifyDivWithLoopContext0) {
 
 TEST(Simplify, SimplifyDivWithLoopContext1) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) / 6;
   //}
   VarHandle i("i", kInt);
@@ -1153,7 +1154,7 @@ TEST(Simplify, SimplifyDivWithLoopContext1) {
 
 TEST(Simplify, SimplifyDivWithLoopContext2) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i + 25) / 6;
   //}
   VarHandle i("i", kInt);
@@ -1174,7 +1175,7 @@ TEST(Simplify, SimplifyDivWithLoopContext2) {
 
 TEST(Simplify, SimplifyDivWithLoopContext3) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) / (-6);
   //}
   VarHandle i("i", kInt);
@@ -1195,7 +1196,7 @@ TEST(Simplify, SimplifyDivWithLoopContext3) {
 
 TEST(Simplify, SimplifyDivWithLoopContext4) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i - 5) / 6;
   //}
   VarHandle i("i", kInt);
@@ -1216,8 +1217,8 @@ TEST(Simplify, SimplifyDivWithLoopContext4) {
 
 TEST(Simplify, SimplifyDivWithLoopContext5) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) / 6;
   //  }
   //}
@@ -1242,7 +1243,7 @@ TEST(Simplify, SimplifyDivWithLoopContext5) {
 
 TEST(Simplify, SimplifyDivWithLoopContext6) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  for (int j = -1; j < 9; j++) {
   //    A[i, j+1] = (i + 6*j) / 6;
   //  }
@@ -1269,8 +1270,8 @@ TEST(Simplify, SimplifyDivWithLoopContext6) {
 
 TEST(Simplify, SimplifyDivWithLoopContext7) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) / (-6);
   //  }
   //}
@@ -1296,7 +1297,7 @@ TEST(Simplify, SimplifyDivWithLoopContext7) {
 
 TEST(Simplify, SimplifyModWithLoopContext0) {
   // Stmt to simplify:
-  // for (int i = 0; i < 100; i++) {
+  // for (const auto i : c10::irange(100)) {
   //  A[i] = i % 100;
   //}
   VarHandle i("i", kInt);
@@ -1317,7 +1318,7 @@ TEST(Simplify, SimplifyModWithLoopContext0) {
 
 TEST(Simplify, SimplifyModWithLoopContext1) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) % 6;
   //}
   VarHandle i("i", kInt);
@@ -1338,7 +1339,7 @@ TEST(Simplify, SimplifyModWithLoopContext1) {
 
 TEST(Simplify, SimplifyModWithLoopContext2) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i + 25) % 6;
   //}
   VarHandle i("i", kInt);
@@ -1359,7 +1360,7 @@ TEST(Simplify, SimplifyModWithLoopContext2) {
 
 TEST(Simplify, SimplifyModWithLoopContext3) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) % (-6);
   //}
   VarHandle i("i", kInt);
@@ -1380,7 +1381,7 @@ TEST(Simplify, SimplifyModWithLoopContext3) {
 
 TEST(Simplify, SimplifyModWithLoopContext4) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i - 5) % 6;
   //}
   VarHandle i("i", kInt);
@@ -1401,8 +1402,8 @@ TEST(Simplify, SimplifyModWithLoopContext4) {
 
 TEST(Simplify, SimplifyModWithLoopContext5) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) % 6;
   //  }
   //}
@@ -1427,7 +1428,7 @@ TEST(Simplify, SimplifyModWithLoopContext5) {
 
 TEST(Simplify, SimplifyModWithLoopContext6) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  for (int j = -1; j < 9; j++) {
   //    A[i, j+1] = (i + 6*j) % 6;
   //  }
@@ -1454,8 +1455,8 @@ TEST(Simplify, SimplifyModWithLoopContext6) {
 
 TEST(Simplify, SimplifyModWithLoopContext7) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) % (-6);
   //  }
   //}
@@ -3884,7 +3885,7 @@ TEST(Simplify, SimplifyEliminateEmptyFor) {
   {
     // Flatten many layers around an empty block to an empty block.
     StmtPtr last = alloc<Block>(std::vector<StmtPtr>({}));
-    for (int i = 0; i < 11; ++i) {
+    for (const auto i : c10::irange(11)) {
       VarHandle loopVar("loopVar", kInt);
       last = For::make(loopVar, 0, 10, last);
     }
@@ -3968,7 +3969,7 @@ TEST(Simplify, SimplifyFlattenBlock) {
   {
     // Flatten many layers around an empty block to an empty block.
     StmtPtr last = alloc<Block>(std::vector<StmtPtr>({}));
-    for (int i = 0; i < 11; ++i) {
+    for (const auto i : c10::irange(11)) {
       last = alloc<Block>(std::vector<StmtPtr>({last}));
     }
 
@@ -4817,18 +4818,18 @@ TEST(Simplify, SimplifyBroadcastTermExpander) {
   SimpleIREvaluator eval(store, {buf});
   std::vector<int> output(num_lanes);
   eval(output);
-  for (int i = 0; i < num_lanes; ++i) {
+  for (const auto i : c10::irange(num_lanes)) {
     ASSERT_EQ(output[i], 2);
   }
 }
 
 TEST(Simplify, DISABLED_CompareSelectCondAlwaysInLoopBounds) {
   // Before:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = n < 1 ? 0.f : 1.f;
   //   }
   // After:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = 1.f;
   //   }
   constexpr int N = 8;
@@ -4848,11 +4849,11 @@ TEST(Simplify, DISABLED_CompareSelectCondAlwaysInLoopBounds) {
 
 TEST(Simplify, DISABLED_IfThenCondAlwaysInLoopBounds) {
   // Before:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = IfThenElse(n < 1 ? 1 : 0, 0.f, 1.f);
   //   }
   // After:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = 1.f;
   //   }
   constexpr int N = 8;
@@ -4875,13 +4876,13 @@ TEST(Simplify, DISABLED_MultiClauseCondAlwaysInLoopBounds) {
   // conditional that is provably satisfied (or unsatisfied) by the entire loop
   // range.
   // Before:
-  //   for (int i = 1; i < 7; i++) {
-  //     for (int j = 1; j < 7; j++) {
+  //   for (const auto i : c10::irange(1, 7)) {
+  //     for (const auto j : c10::irange(1, 7)) {
   //       b[i, j] = IfThenElse(
   //         j>=7 ? 1 : (i>=7 ? 1 : (j<1 ? 1 : (i<1 ? 1 : 0))), 0.f, 1.f);
   // After:
-  //   for (int i = 1; i < 7; i++) {
-  //     for (int j = 1; j < 7; j++) {
+  //   for (const auto i : c10::irange(1, 7)) {
+  //     for (const auto j : c10::irange(1, 7)) {
   //       b[i, j] = 1.f;
   constexpr int N = 8;
   BufHandle b("b", {N, N}, kFloat);
@@ -4910,13 +4911,13 @@ TEST(Simplify, DISABLED_SimplifyLoopBounds) {
   // could be solved by peeling, and applying the range-based conditional
   // simplification in the previous tests.
   // Before:
-  //   for (int i = 0; i < 3; i++) {
-  //     for (int j = 0; j < 3; j++) {
+  //   for (const auto i : c10::irange(3)) {
+  //     for (const auto j : c10::irange(3)) {
   //       b[i, j] = (b[i, j]) + (IfThenElse(
   //         j>=7 ? 1 : (i>=7 ? 1 : (j<1 ? 1 : (i<1 ? 1 : 0))), 0.f, a[i, j]));
   // After:
-  //   for (int i = 1; i < 3; i++) {
-  //     for (int j = 1; j < 3; j++) {
+  //   for (const auto i : c10::irange(1, 3)) {
+  //     for (const auto j : c10::irange(1, 3)) {
   //       b[i, j] = (b[i, j]) + 1.f;
   constexpr int N = 8;
   constexpr int K = 3;
@@ -4937,8 +4938,8 @@ TEST(Simplify, DISABLED_SimplifyLoopBounds) {
   oss << *s;
   torch::jit::testing::FileCheck().run(
       R"IR(
-# CHECK: for (int i = 1; i < 3; i++) {
-# CHECK: for (int j = 1; j < 3; j++) {
+# CHECK: for (const auto i : c10::irange(1, 3)) {
+# CHECK: for (const auto j : c10::irange(1, 3)) {
 # CHECK-NOT: IfThenElse
 )IR",
       oss.str());

--- a/test/cpp/tensorexpr/tutorial.cpp
+++ b/test/cpp/tensorexpr/tutorial.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <string>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
@@ -146,8 +147,8 @@ int main(int argc, char* argv[]) {
     std::cout << "Nested for loops: " << std::endl << *loop_i_a << std::endl;
     // Prints:
     // Nested for loops:
-    // for (int i = 0; i < 64; i++) {
-    //   for (int j = 0; j < 32; j++) {
+    // for (const auto i : c10::irange(64)) {
+    //   for (const auto j : c10::irange(32)) {
     //     A[i, j] = i + j;
     //   }
     // }
@@ -166,13 +167,13 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Compound Block statement:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       A[i, j] = i + j;
     //     }
     //   }
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       B[i, j] = A[i, j];
     //     }
     //   }
@@ -193,8 +194,8 @@ int main(int argc, char* argv[]) {
               << *C.stmt() << std::endl;
     // Prints:
     // Stmt produced by 'Compute' API:
-    // for (int i = 0; i < 64; i++) {
-    //   for (int j = 0; j < 32; j++) {
+    // for (const auto i : c10::irange(64)) {
+    //   for (const auto j : c10::irange(32)) {
     //     C[i, j] = i * j;
     //   }
     // }
@@ -239,13 +240,13 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt produced by 'Compute' API:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       C[i, j] = i * (j + 1);
     //     }
     //   }
-    //   for (int i_1 = 0; i_1 < 64; i_1++) {
-    //     for (int j_1 = 0; j_1 < 32; j_1++) {
+    //   for (const auto i_1 : c10::irange(64)) {
+    //     for (const auto j_1 : c10::irange(32)) {
     //       D[i_1, j_1] = (C[i_1, j_1]) - i_1;
     //     }
     //   }
@@ -265,13 +266,13 @@ int main(int argc, char* argv[]) {
     // Prints:
     // LoopNest root stmt:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       C[i, j] = i * (j + 1);
     //     }
     //   }
-    //   for (int i_1 = 0; i_1 < 64; i_1++) {
-    //     for (int j_1 = 0; j_1 < 32; j_1++) {
+    //   for (const auto i_1 : c10::irange(64)) {
+    //     for (const auto j_1 : c10::irange(32)) {
     //       D[i_1, j_1] = (C[i_1, j_1]) - i_1;
     //     }
     //   }
@@ -284,8 +285,8 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt after inlining:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       D[i, j] = i * (j + 1) - i;
     //     }
     //   }
@@ -298,8 +299,8 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt after simplification:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       D[i, j] = i * j;
     //     }
     //   }
@@ -319,15 +320,15 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt after splitWithTail:
     // {
-    //   for (int i_outer = 0; i_outer < 4; i_outer++) {
-    //     for (int i_inner = 0; i_inner < 13; i_inner++) {
-    //       for (int j = 0; j < 32; j++) {
+    //   for (const auto i_outer : c10::irange(4)) {
+    //     for (const auto i_inner : c10::irange(13)) {
+    //       for (const auto j : c10::irange(32)) {
     //         D[i_inner + 13 * i_outer, j] = i_inner * j + 13 * (i_outer * j);
     //       }
     //     }
     //   }
-    //   for (int i_tail = 0; i_tail < 12; i_tail++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i_tail : c10::irange(12)) {
+    //     for (const auto j : c10::irange(32)) {
     //       D[i_tail + 52, j] = i_tail * j + 52 * j;
     //     }
     //   }
@@ -365,8 +366,8 @@ int main(int argc, char* argv[]) {
     std::cout << *loopnest.root_stmt() << std::endl;
     // Prints:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       X[i, j] = (A[i, j]) + (B[i, j]);
     //     }
     //   }
@@ -469,8 +470,8 @@ int main(int argc, char* argv[]) {
     // Prints:
     // TE Stmt constructed from TorchScript:
     // {
-    //   for (int v = 0; v < 5; v++) {
-    //     for (int _tail_tail = 0; _tail_tail < 3; _tail_tail++) {
+    //   for (const auto v : c10::irange(5)) {
+    //     for (const auto _tail_tail : c10::irange(3)) {
     //       aten_add[_tail_tail + 3 * v] = (tA[_tail_tail + 3 * v]) *
     //       ((tA[_tail_tail + 3 * v]) * (tB[_tail_tail + 3 * v])) +
     //       (tB[_tail_tail + 3 * v]);

--- a/test/custom_operator/op.cpp
+++ b/test/custom_operator/op.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/script.h>
 
 #include "op.h"
@@ -11,7 +12,7 @@ torch::List<torch::Tensor> custom_op(
     int64_t repeat) {
   torch::List<torch::Tensor> output;
   output.reserve(repeat);
-  for (int64_t i = 0; i < repeat; ++i) {
+  for (const auto i : c10::irange(repeat)) {
     output.push_back(tensor * scalar);
   }
   return output;

--- a/test/custom_operator/test_custom_ops.cpp
+++ b/test/custom_operator/test_custom_ops.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/script.h>
 #include <torch/cuda.h>
 
@@ -44,7 +45,7 @@ void get_operator_from_registry_and_execute() {
   const auto manual = custom_op(torch::ones(5), 2.0, 3);
 
   TORCH_INTERNAL_ASSERT(output.size() == 3);
-  for (size_t i = 0; i < output.size(); ++i) {
+  for (const auto i : c10::irange(output.size())) {
     TORCH_INTERNAL_ASSERT(output[i].allclose(torch::ones(5) * 2));
     TORCH_INTERNAL_ASSERT(output[i].allclose(manual[i]));
   }

--- a/test/mobile/custom_build/predictor.cpp
+++ b/test/mobile/custom_build/predictor.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <string>
+#include <c10/util/irange.h>
 #include <torch/script.h>
 
 using namespace std;
@@ -40,7 +41,7 @@ int main(int argc, const char* argv[]) {
   }();
 
   std::cout << std::setprecision(3) << std::fixed;
-  for (int i = 0; i < 5; i++) {
+  for (const auto i : c10::irange(5)) {
     std::cout << output.data_ptr<float>()[i] << std::endl;
   }
   return 0;

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -4,8 +4,6 @@
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
 
-#include <c10/util/irange.h>
-
 #include <memory>
 #include <string>
 #include <vector>

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -589,7 +589,7 @@ static void _trace_post_record(
   // to the original tuple type.
   if (!unpack_output) {
     std::vector<TypePtr> new_tuple_values;
-    for (int i = 0; i < num_outputs; ++i) {
+    for (const auto i : c10::irange(num_outputs)) {
       TypePtr ptr = node->outputs()[i]->type();
       new_tuple_values.push_back(ptr);
     }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1706,7 +1706,7 @@ void concrete_dispatch_fn(
   }
 
   // Find overloaded tensors
-  for (int64_t idx = 0; idx < arguments.size(); idx++) {
+  for (const auto idx : c10::irange(arguments.size())) {
     const auto& ivalue = arguments[idx];
     if (ivalue.isTensor()) {
       const auto& tensor = ivalue.toTensor();
@@ -1728,12 +1728,12 @@ void concrete_dispatch_fn(
   }
 
   // Populate positional arguments
-  for (int64_t idx = 0; idx < positional_default_start; idx++) {
+  for (const auto idx : c10::irange(positional_default_start)) {
     PyTuple_SET_ITEM(args.ptr(), idx, torch::jit::toPyObject(std::move(arguments[idx])).release().ptr());
   }
 
   // Populate keyword arguments
-  for (int64_t idx = kwarg_only_start; idx < arguments.size(); idx++) {
+  for (const auto idx : c10::irange(kwarg_only_start, arguments.size())) {
     // But don't populate default keyword arguments
     if (is_default(idx)) continue;
     const auto& arg = schema.arguments()[idx];

--- a/torch/csrc/deploy/loader.cpp
+++ b/torch/csrc/deploy/loader.cpp
@@ -54,6 +54,7 @@
 #include <sys/user.h>
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <fmt/format.h>
 #include <torch/csrc/deploy/loader.h>
@@ -152,7 +153,7 @@ size_t phdr_table_get_load_size(
   Elf64_Addr max_vaddr = 0;
 
   bool found_pt_load = false;
-  for (size_t i = 0; i < phdr_count; ++i) {
+  for (const auto i : c10::irange(phdr_count)) {
     const Elf64_Phdr* phdr = &phdr_table[i];
 
     if (phdr->p_type != PT_LOAD) {
@@ -383,7 +384,7 @@ std::pair<const char*, std::vector<const char*>> load_needed_from_elf_file(
   auto program_headers = (Elf64_Phdr*)(data + header_->e_phoff);
   auto n_program_headers = header_->e_phnum;
   const Elf64_Dyn* dynamic = nullptr;
-  for (size_t i = 0; i < n_program_headers; ++i) {
+  for (const auto i : c10::irange(n_program_headers)) {
     const Elf64_Phdr* phdr = &program_headers[i];
     if (phdr->p_type == PT_DYNAMIC) {
       dynamic = reinterpret_cast<const Elf64_Dyn*>(data + phdr->p_offset);
@@ -405,7 +406,7 @@ std::pair<const char*, std::vector<const char*>> load_needed_from_elf_file(
   const char* segment_string_table =
       data + segment_headers[header_->e_shstrndx].sh_offset;
 
-  for (size_t i = 0; i < n_segments; ++i) {
+  for (const auto i : c10::irange(n_segments)) {
     const Elf64_Shdr* shdr = &segment_headers[i];
     if (shdr->sh_type == SHT_STRTAB &&
         strcmp(".dynstr", segment_string_table + shdr->sh_name) == 0) {
@@ -641,7 +642,7 @@ struct AlreadyLoadedSymTable {
       const Elf64_Phdr* program_headers,
       size_t n_program_headers) {
     Elf64_Dyn* dynamic = nullptr;
-    for (size_t i = 0; i < n_program_headers; ++i) {
+    for (const auto i : c10::irange(n_program_headers)) {
       const Elf64_Phdr* phdr = &program_headers[i];
 
       // Segment addresses in memory.
@@ -871,7 +872,7 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
 
   void load_segments() {
     // from bionic
-    for (size_t i = 0; i < n_program_headers_; ++i) {
+    for (const auto i : c10::irange(n_program_headers_)) {
       const Elf64_Phdr* phdr = &program_headers_[i];
 
       // Segment addresses in memory.
@@ -1141,17 +1142,17 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
   }
 
   void relocate() {
-    for (size_t i = 0; i < dyninfo_.n_rela_; ++i) {
+    for (const auto i : c10::irange(dyninfo_.n_rela_)) {
       relocate_one(dyninfo_.rela_[i]);
     }
-    for (size_t i = 0; i < dyninfo_.n_plt_rela_; ++i) {
+    for (const auto i : c10::irange(dyninfo_.n_plt_rela_)) {
       relocate_one(dyninfo_.plt_rela_[i]);
     }
   }
 
   void initialize() {
     call_function(dyninfo_.init_func_);
-    for (size_t i = 0; i < dyninfo_.n_init_array_; ++i) {
+    for (const auto i : c10::irange(dyninfo_.n_init_array_)) {
       call_function(dyninfo_.init_array_[i]);
     }
     initialized_ = true;


### PR DESCRIPTION
Summary:
Modified loops in files under fbsource/fbcode/caffe2/ from the format

`for(TYPE var=x0;var<x_max;x++)`

to the format

`for(const auto var: irange(xmax))`

This was achieved by running r-barnes's loop upgrader script (D28874212) with some modification to exclude all files under /torch/jit.

Test Plan: `buck run //caffe2/torch/fb/sparsenn:test`

Differential Revision: D30652629



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang