### PR TITLE
[oss/ci] skip TestDataLoaderPersistentWorkers on ASAN

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2132,6 +2132,8 @@ class DummyDataset(torch.utils.data.Dataset):
     TEST_WITH_TSAN,
     "Fails with TSAN with the following error: starting new threads after multi-threaded "
     "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN, "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223")
 class TestDataLoaderPersistentWorkers(TestDataLoader):
 
     def setUp(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66236

it's flaky, see https://github.com/pytorch/pytorch/issues/66223

Differential Revision: [D31462056](https://our.internmc.facebook.com/intern/diff/D31462056)