### PR TITLE
Autograd: Delay warnings until the end of backward execution

### DIFF
--- a/aten/src/ATen/native/TestOps.cpp
+++ b/aten/src/ATen/native/TestOps.cpp
@@ -70,5 +70,9 @@ Tensor _test_ambiguous_defaults(const Tensor& dummy, int64_t a, c10::string_view
   return c10::scalar_to_tensor(2);
 }
 
+Tensor _test_warn_in_autograd(const Tensor &self) {
+  return self.clone();
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10674,6 +10674,12 @@
   cpp_no_default_args: ['a', 'b']
   python_module: nn
 
+# Note: this function is only for testing.
+- func: _test_warn_in_autograd(Tensor self) -> Tensor
+  python_module: nn
+  dispatch:
+    CompositeExplicitAutograd: _test_warn_in_autograd
+
 - func: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False, Scalar? initial=None) -> Tensor
   variants: function
   dispatch:

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -160,6 +160,19 @@ C10_API void set_warning_handler(WarningHandler* handler) noexcept(true);
 /// Gets the global warning handler.
 C10_API WarningHandler* get_warning_handler() noexcept(true);
 
+class C10_API WarningHandlerGuard {
+  WarningHandler* prev_handler_;
+
+ public:
+  WarningHandlerGuard(WarningHandler* new_handler)
+      : prev_handler_(c10::Warning::get_warning_handler()) {
+    c10::Warning::set_warning_handler(new_handler);
+  }
+  ~WarningHandlerGuard() {
+    c10::Warning::set_warning_handler(prev_handler_);
+  }
+};
+
 /// The TORCH_WARN_ONCE macro is difficult to test for. Use
 /// setWarnAlways(true) to turn it into TORCH_WARN, which can be
 /// tested for more easily.

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8881,6 +8881,14 @@ class TestAutogradDeviceType(TestCase):
         out = torch.signbit(x)
         self.assertFalse(out.requires_grad)
 
+    def test_warning_in_backward(self, device):
+        a = torch.zeros((), device=device, requires_grad=True)
+        b = torch._C._nn._test_warn_in_autograd(a)
+
+        with self.assertWarnsRegex(UserWarning, "Warn from backward"):
+            b.backward()
+
+
 class TestAutogradInferenceMode(TestCase):
     def _is_inference_tensor(self, tensor):
         try:

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2314,3 +2314,6 @@
 
 - name: new_empty(Tensor self, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   output_differentiability: [False]
+
+- name: _test_warn_in_autograd(Tensor self) -> Tensor
+  self: warn_backwards(grad)

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -147,6 +147,7 @@ core_trainer_sources = [
     "torch/csrc/autograd/record_function_ops.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/variable.cpp",
+    "torch/csrc/autograd/utils/warnings.cpp",
     "torch/csrc/jit/frontend/name_mangler.cpp",
     "torch/csrc/jit/ir/type_hashing.cpp",
     "torch/csrc/jit/serialization/pickler.cpp",

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4166,6 +4166,11 @@ Tensor _lu_with_info_jvp(
   }
 }
 
+Tensor warn_backwards(const Tensor &grad_output) {
+  TORCH_WARN("Warn from backward");
+  return grad_output;
+}
+
 } // namespace details
 } // namespace generated
 } // namespace autograd

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -298,6 +298,7 @@ Tensor cat_jvp(at::TensorList tensors, int64_t dim);
 Tensor cumprod_jvp(Tensor self_t, Tensor self_p, Tensor result, int dim);
 Tensor gather_with_keepdimed_indices(const Tensor& input, int64_t dim, const Tensor& indices, bool keepdim);
 Tensor evenly_read_jvp(const Tensor& fw_grad, const Tensor & input, const Tensor & value);
+Tensor warn_backwards(const Tensor &grad_output);
 
 } // namespace details
 } // namespace generated

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -411,6 +411,7 @@ auto Engine::thread_main(const std::shared_ptr<GraphTask>& graph_task) -> void {
         // NB: The ThreadLocalStateGuard doesn't set the grad_mode because GraphTask
         // always saves ThreadLocalState without grad_mode.
         at::ThreadLocalStateGuard tls_guard(local_graph_task->thread_locals_);
+        c10::Warning::WarningHandlerGuard warnings_guard(&local_graph_task->warning_handler_);
 
         try {
           // The guard sets the thread_local current_graph_task on construction
@@ -1039,6 +1040,7 @@ auto Engine::execute(const edge_list& roots,
   // in dist_engine.cpp).
   auto& fut = graph_task->future_result_;
   fut->wait();
+  graph_task->warning_handler_.replay_warnings();
   return fut->value().toTensorVector();
 }
 

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -12,6 +12,7 @@
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/input_buffer.h>
 #include <torch/csrc/autograd/saved_variable_hooks.h>
+#include <torch/csrc/autograd/utils/warnings.h>
 
 #include <deque>
 #include <exception>
@@ -171,6 +172,8 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   // To protect reads and writes to final_callbacks_. Intentionally no reusing
   // mutex_ as the two are protecting different data structures.
   std::mutex final_callbacks_lock_;
+
+  utils::DelayWarningHandler warning_handler_;
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   GraphTask(

--- a/torch/csrc/autograd/utils/warnings.cpp
+++ b/torch/csrc/autograd/utils/warnings.cpp
@@ -1,0 +1,20 @@
+#include <torch/csrc/autograd/utils/warnings.h>
+
+namespace torch { namespace autograd { namespace utils {
+
+void DelayWarningHandler::process(
+    const at::SourceLocation &source_location,
+    const std::string &msg,
+    const bool verbatim) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  warnings_.push_back({source_location, msg, verbatim});
+}
+
+void DelayWarningHandler::replay_warnings() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& warning : warnings_) {
+    c10::Warning::warn(warning.source_location, warning.msg, warning.verbatim);
+  }
+}
+
+}}}  // namespace torch::autograd::utils

--- a/torch/csrc/autograd/utils/warnings.h
+++ b/torch/csrc/autograd/utils/warnings.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <c10/util/Exception.h>
+
+#include <vector>
+#include <mutex>
+
+
+namespace torch { namespace autograd { namespace utils {
+
+// Warning handler for multi-threaded contexts. Gather warnings from
+// all threads into a single queue, then process together at the end
+// in the main thread.
+class DelayWarningHandler: public at::WarningHandler {
+public:
+  ~DelayWarningHandler() noexcept(false) override = default;
+  void replay_warnings();
+
+private:
+
+  void process(const at::SourceLocation &source_location,
+               const std::string &msg,
+               bool verbatim) override;
+
+  struct Warning {
+    c10::SourceLocation source_location;
+    std::string msg;
+    bool verbatim;
+  };
+
+  std::vector<Warning> warnings_;
+  std::mutex mutex_;
+};
+
+}}}  // namespace torch::autograd::utils


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66240
* __->__ #66239

Fixes #50209

This adds a new warning handler that stores all warnings in a shared
queue, which can be "replayed" at a later time and, crucially, on
another thread. Then, I use this inside the autograd engine to ensure
that warnings are processed by the handler registered on the main
thread.

For testing, I also add an operator that always warns in the backward
pass and test that the warning is a normal Python warning.