### PR TITLE
Remove apparently unnecessary std::remove_cv_t

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -151,7 +151,7 @@ inline constexpr type_index get_type_index() {
   // type index through std::integral_constant.
   return type_index{std::integral_constant<
       uint64_t,
-      detail::type_index_impl<std::remove_cv_t<std::decay_t<T>>>()>::value};
+      detail::type_index_impl<std::decay_t<T>>()>::value};
 #else
   // There's nothing in theory preventing us from running this on device code
   // except for nvcc throwing a compiler error if we enable it.


### PR DESCRIPTION
Summary: `std::decay_t` already implies dropping the const

Differential Revision: D31465856

