### PR TITLE
fix vmap issue in implementation of narrow_copy_backward + separate entry in derivatives.yaml

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -544,10 +544,7 @@ class TestGradients(TestCase):
                 if is_iterable_of_tensors(sample.input):
                     n = len(sample.input)
                     inputs = (inputs[:n], *inputs[n:])
-                print(inputs[0].size())
-                print("inputs: ", inputs)
                 output = op.gradcheck_wrapper(variant, *inputs, **sample.kwargs)
-                print("nice")
                 if sample.output_process_fn_grad is not None:
                     return sample.output_process_fn_grad(output)
                 return output

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1019,8 +1019,8 @@
   self: grad * at::isfinite(self)
   result: auto_element_wise
 
-  name: narrow_copy(Tensor self, int dim, int start, int length) -> Tensor
-  self: narrow_copy_backward(grad, self.sizes(), dim, start, length)
+- name: narrow_copy(Tensor self, int dim, int start, int length) -> Tensor
+  self: narrow_copy_backward(grad, self, dim, start, length)
 
 - name: native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)
   input, weight, bias: "grad.defined() ? native_batch_norm_backward(grad, input, weight, running_mean, running_var, result1, result2, training, eps, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -172,8 +172,8 @@ std::tuple<Tensor, Tensor> _euclidean_dist_backward(const Tensor & grad, const T
             x2 * ratio.sum(-2, false).unsqueeze(-1) - ratio.transpose(-2, -1).matmul(x1)};
 }
 
-Tensor narrow_copy_backward(const Tensor& grad, IntArrayRef input_sizes, int64_t dimension, int64_t start, int64_t length) {
-  Tensor out = at::zeros(input_sizes, grad.options());
+Tensor narrow_copy_backward(const Tensor& grad, const Tensor& self, int64_t dimension, int64_t start, int64_t length) {
+  Tensor out = grad.new_zeros(self.sizes());
   Tensor narrowed = out.narrow(dimension, start, length);
   narrowed.copy_(grad);
   return out;

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -46,7 +46,7 @@ at::Tensor maybe_multiply(const at::Tensor & t, const at::Scalar & s);
 int64_t _safe_size(IntArrayRef sizes, IntArrayRef dim);
 Tensor restore_reduced_dims(const Tensor &output, IntArrayRef dims, bool keepdim);
 Tensor scale_grad_by_count(const Tensor &grad, const Tensor &mask, IntArrayRef dims);
-at::Tensor narrow_copy_backward(const Tensor& grad, IntArrayRef input_sizes, int64_t dimension, int64_t start, int64_t length);
+at::Tensor narrow_copy_backward(const Tensor& grad, const Tensor& self, int64_t dimension, int64_t start, int64_t length);
 at::Tensor norm_backward(const at::Tensor & grad, const at::Tensor & self, const optional<at::Scalar> & p_, const at::Tensor & norm);
 at::Tensor norm_backward(at::Tensor grad, const at::Tensor & self, const optional<at::Scalar> & p_, at::Tensor norm, at::IntArrayRef dim, bool keepdim);
 at::Tensor linalg_vector_norm_backward(at::Tensor grad, const at::Tensor & self, const at::Scalar & ord, at::Tensor norm, const c10::optional<at::IntArrayRef> & opt_dim, bool keepdim);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66255
* #66225

Differential Revision: [D31476688](https://our.internmc.facebook.com/intern/diff/D31476688)