### PR TITLE
docker: Ensure libgnutls30 for all docker builds

### DIFF
--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -28,7 +28,7 @@ login() {
 
 
 # Only run these steps if not on github actions
-if [[ -n "${GITHUB_ACTIONS}" ]]; then
+if [[ -z "${GITHUB_ACTIONS}" ]]; then
   # Retry on timeouts (can happen on job stampede).
   retry login "${registry}"
   # Logout on exit

--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -26,11 +26,14 @@ login() {
     docker login -u AWS --password-stdin "$1"
 }
 
-# Retry on timeouts (can happen on job stampede).
-retry login "${registry}"
 
-# Logout on exit
-trap "docker logout ${registry}" EXIT
+# Only run these steps if not on github actions
+if [[ -n "${GITHUB_ACTIONS}" ]]; then
+  # Retry on timeouts (can happen on job stampede).
+  retry login "${registry}"
+  # Logout on exit
+  trap "docker logout ${registry}" EXIT
+fi
 
 # export EC2=1
 # export JENKINS=1

--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -48,8 +48,8 @@ fi
 
 docker push "${image}:${tag}"
 
-docker save -o "${IMAGE_NAME}:${tag}.tar" "${image}:${tag}"
-
 if [ -z "${DOCKER_SKIP_S3_UPLOAD:-}" ]; then
+  trap "rm -rf ${IMAGE_NAME}:${tag}.tar" EXIT
+  docker save -o "${IMAGE_NAME}:${tag}.tar" "${image}:${tag}"
   aws s3 cp "${IMAGE_NAME}:${tag}.tar" "s3://ossci-linux-build/pytorch/base/${IMAGE_NAME}:${tag}.tar" --acl public-read
 fi

--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -44,6 +44,10 @@ install_ubuntu() {
     wget \
     vim
 
+  # Should resolve issues related to various apt package repository cert issues
+  # see: https://github.com/pytorch/pytorch/issues/65931
+  apt-get install -y libgnutls30
+
   # Cleanup package manager
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -113,10 +113,7 @@ esac
 # Install Valgrind separately since the apt-get version is too old.
 mkdir valgrind_build && cd valgrind_build
 VALGRIND_VERSION=3.16.1
-if ! wget http://valgrind.org/downloads/valgrind-${VALGRIND_VERSION}.tar.bz2
-then
-  wget https://sourceware.org/ftp/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2
-fi
+wget https://ossci-linux.s3.amazonaws.com/valgrind-${VALGRIND_VERSION}.tar.bz2
 tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
 cd valgrind-${VALGRIND_VERSION}
 ./configure --prefix=/usr/local

--- a/.circleci/docker/common/install_katex.sh
+++ b/.circleci/docker/common/install_katex.sh
@@ -3,10 +3,6 @@
 set -ex
 
 if [ -n "$KATEX" ]; then
-  # Should resolve issues related to deb.nodesource.com cert issues
-  # see: https://github.com/pytorch/pytorch/issues/65931
-  apt-get update
-  apt-get install -y libgnutls30
 
   curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
   sudo apt-get install -y nodejs

--- a/.circleci/docker/common/install_katex.sh
+++ b/.circleci/docker/common/install_katex.sh
@@ -3,6 +3,10 @@
 set -ex
 
 if [ -n "$KATEX" ]; then
+  # Should resolve issues related to deb.nodesource.com cert issues
+  # see: https://github.com/pytorch/pytorch/issues/65931
+  apt-get update
+  apt-get install -y libgnutls30
 
   curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
   sudo apt-get install -y nodejs

--- a/.circleci/docker/common/install_openssl.sh
+++ b/.circleci/docker/common/install_openssl.sh
@@ -4,7 +4,7 @@ set -ex
 
 OPENSSL=openssl-1.1.1k
 
-wget -q -O "${OPENSSL}.tar.gz" "https://www.openssl.org/source/${OPENSSL}.tar.gz"
+wget -q -O "${OPENSSL}.tar.gz" "https://ossci-linux.s3.amazonaws.com/${OPENSSL}.tar.gz"
 tar xf "${OPENSSL}.tar.gz"
 cd "${OPENSSL}"
 ./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66258

Installing libgnutls30 has shown to be good when confronted with the
CERT issue related to deb.nodesource.com

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D31477789](https://our.internmc.facebook.com/intern/diff/D31477789)