### PR TITLE
Docker: Fix valgrind install

### DIFF
--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -39,6 +39,7 @@ install_ubuntu() {
     libjpeg-dev \
     libasound2-dev \
     libsndfile-dev \
+    libssl1.0.0 \
     software-properties-common \
     sudo \
     wget \
@@ -109,10 +110,7 @@ esac
 # Install Valgrind separately since the apt-get version is too old.
 mkdir valgrind_build && cd valgrind_build
 VALGRIND_VERSION=3.16.1
-if ! wget http://valgrind.org/downloads/valgrind-${VALGRIND_VERSION}.tar.bz2
-then
-  wget https://sourceware.org/ftp/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2
-fi
+wget https://sourceware.org/ftp/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2
 tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
 cd valgrind-${VALGRIND_VERSION}
 ./configure --prefix=/usr/local

--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -29,7 +29,6 @@ install_ubuntu() {
     automake \
     build-essential \
     ca-certificates \
-    curl \
     git \
     libatlas-base-dev \
     libc6-dbg \
@@ -39,11 +38,14 @@ install_ubuntu() {
     libjpeg-dev \
     libasound2-dev \
     libsndfile-dev \
-    libssl1.0.0 \
+    libssl-dev \
+    openssl \
     software-properties-common \
     sudo \
     wget \
     vim
+
+  apt-get remove -y libcurl3
 
   # Cleanup package manager
   apt-get autoclean && apt-get clean
@@ -68,7 +70,6 @@ install_centos() {
     bzip2 \
     cmake \
     cmake3 \
-    curl \
     gcc \
     gcc-c++ \
     gflags-devel \
@@ -79,8 +80,10 @@ install_centos() {
     hiredis-devel \
     libstdc++-devel \
     libsndfile-devel \
+    libssl-dev \
     make \
     opencv-devel \
+    openssl \
     sudo \
     wget \
     vim
@@ -106,6 +109,19 @@ case "$ID" in
     exit 1
     ;;
 esac
+
+# Install curl separately since the apt-get version is too old
+mkdir curl_build && cd curl_build
+CURL_VERSION=7.79.1
+wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
+tar -xzf curl-${CURL_VERSION}.tar.gz
+cd curl-${CURL_VERSION}
+PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig LDFLAGS=-Wl,-rpath,/usr/local/lib/ \
+               ./configure --with-openssl
+make -j 4
+sudo make install
+cd ../../
+rm -rf curl_build
 
 # Install Valgrind separately since the apt-get version is too old.
 mkdir valgrind_build && cd valgrind_build

--- a/.circleci/docker/common/install_openssl.sh
+++ b/.circleci/docker/common/install_openssl.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-OPENSSL=openssl-1.1.1k
+OPENSSL=openssl-1.1.1l
 
 wget -q -O "${OPENSSL}.tar.gz" "https://www.openssl.org/source/${OPENSSL}.tar.gz"
 tar xf "${OPENSSL}.tar.gz"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #62550
* #62445
* __->__ #66262

The docker builds are currently failing with a certificate error:
```
ERROR: cannot verify sourceware.org's certificate, issued by 'CN=R3,O=Let\'s Encrypt,C=US':
  Issued certificate has expired.
```
https://github.com/pytorch/pytorch/pull/62445/checks?check_run_id=3827819732

This is because the cuda docker image's OpenSSL version is too old.
I've also removed the valgrind.org download attempt since the link
404s.