### PR TITLE
[fxtrace] avoid N^2 selecting module name

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -221,6 +221,16 @@ class TestFX(JitTestCase):
         x, y = torch.rand(1), torch.rand(1)
         self.assertEqual(torch.sin(x + y), gm(x, y))
 
+    def test_many_modules(self):
+        graph = torch.fx.Graph()
+        # When dict is used to select new name, this test will finish in <10 sec.
+        # When complexity is worse (N^2 due to bug) the timing will blow up and
+        # test will fail.
+        N = 300000
+        for _ in range(N):
+            _ = graph.placeholder("a")
+        self.assertEqual(graph._graph_namespace._used_names["a"], N)
+
     def test_args_kwargs(self):
         class T(torch.nn.Module):
             def forward(self, *args, **kwargs):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -138,12 +138,22 @@ class _Namespace:
 
         candidate = base if num is None else f'{base}_{num}'
         num = num if num else 0
+        # Get the next available index if ever set.
+        num = max(num + 1, self._used_names.get(base, num + 1))
 
-        while candidate in self._used_names or self._is_illegal_name(candidate, obj):
-            num += 1
+        if candidate in self._used_names or self._is_illegal_name(candidate, obj):
+            # we can have a situation when num was parsed but such candidate
+            # already exists. This will advance to next available index ignoring
+            # parsed num.
             candidate = f'{base}_{num}'
+            num += 1
+            if candidate in self._used_names or self._is_illegal_name(candidate, obj):
+                raise RuntimeError(
+                    "System error, module with this name already exists! %s" % candidate
+                )
 
         self._used_names.setdefault(candidate)
+        self._used_names[base] = num
         if obj is None:
             self._unassociated_names.add(candidate)
         else:


### PR DESCRIPTION
Summary:
Selecting next module name when the same base name is used has exponential complexity. This affects creation of many placeholder modules for examples.

Fixing the issue by relying on dict to store next available id, thus leading to O(1) selection.

Test Plan:
$ buck test mode/opt caffe2/test:fx -- test_many_modules

https://www.internalfb.com/intern/testinfra/testrun/7318349451991129

Differential Revision: D31236307

