### PR TITLE
[qat]Removed outdated context manager in unit test.

### DIFF
--- a/test/quantization/eager/test_fusion.py
+++ b/test/quantization/eager/test_fusion.py
@@ -1,3 +1,5 @@
+import copy
+
 import torch
 import torch.nn as nn
 import torch.nn.quantized as nnq
@@ -271,18 +273,32 @@ class TestFusion(QuantizationTestCase):
     def test_fusion_conv_with_bias(self):
         for qengine in supported_qengines:
             with override_quantized_engine(qengine):
-                model = ModelForFusionWithBias().train()
-                # output with no fusion.
-                out_ref = model(self.img_data_2d[0][0])
+                model_orig = ModelForFusionWithBias().train()
 
-                model.qconfig = QConfig(activation=torch.nn.Identity,
-                                        weight=torch.nn.Identity)
-                model = fuse_modules(model, [["conv1", "bn1", "relu1"],
-                                             ["conv2", "bn2"]])
+                # reference model
+                model_ref = copy.deepcopy(model_orig)
+                # output with no fusion.
+                out_ref = model_ref(self.img_data_2d[0][0])
+
+                # fused model
+                model_orig.qconfig = QConfig(activation=torch.nn.Identity,
+                                             weight=torch.nn.Identity)
+                model = fuse_modules(model_orig, [["conv1", "bn1", "relu1"],
+                                                  ["conv2", "bn2"]])
                 prep_model = prepare_qat(model, inplace=False)
                 # output with fusion but no observers.
                 out_fused = prep_model(self.img_data_2d[0][0])
+
                 self.assertEqual(out_ref, out_fused)
+
+                def checkBN(bn_ref, bn):
+                    self.assertEqual(bn_ref.weight, bn.weight)
+                    self.assertEqual(bn_ref.bias, bn.bias)
+                    self.assertEqual(bn_ref.running_mean, bn.running_mean)
+                    self.assertEqual(bn_ref.running_var, bn.running_var)
+
+                checkBN(model_ref.bn1, prep_model.conv1.bn)
+                checkBN(model_ref.bn2, prep_model.conv2.bn)
 
                 model.qconfig = torch.ao.quantization.get_default_qconfig(qengine)
                 prepare_qat(model, inplace=True)

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -565,112 +565,107 @@ class TestConvBNQATModule(TestCase):
             momentum,
             freeze_bn
     ):
-        # **** WARNING: This is used to temporarily disable MKL-DNN convolution due
-        # to a bug: https://github.com/pytorch/pytorch/issues/23825
-        # Once this bug is fixed, this context manager as well as its callsites
-        # should be removed!
-        with torch.backends.mkldnn.flags(enabled=False):
-            input_channels = input_channels_per_group * groups
-            output_channels = output_channels_per_group * groups
-            dilation_h = dilation_w = dilation
+        input_channels = input_channels_per_group * groups
+        output_channels = output_channels_per_group * groups
+        dilation_h = dilation_w = dilation
 
-            conv_op = Conv2d(
-                input_channels,
-                output_channels,
-                (kernel_h, kernel_w),
-                (stride_h, stride_w),
-                (pad_h, pad_w),
-                (dilation_h, dilation_w),
-                groups,
-                False,  # No bias
-                padding_mode
-            ).to(dtype=torch.double)
-            bn_op = BatchNorm2d(output_channels, eps, momentum).to(dtype=torch.double)
-            relu_op = ReLU()
+        conv_op = Conv2d(
+            input_channels,
+            output_channels,
+            (kernel_h, kernel_w),
+            (stride_h, stride_w),
+            (pad_h, pad_w),
+            (dilation_h, dilation_w),
+            groups,
+            False,  # No bias
+            padding_mode
+        ).to(dtype=torch.double)
+        bn_op = BatchNorm2d(output_channels, eps, momentum).to(dtype=torch.double)
+        relu_op = ReLU()
 
-            cls = ConvBnReLU2d if use_relu else ConvBn2d
-            qat_op = cls(
-                input_channels,
-                output_channels,
-                (kernel_h, kernel_w),
-                (stride_h, stride_w),
-                (pad_h, pad_w),
-                (dilation_h, dilation_w),
-                groups,
-                None,  # bias
-                padding_mode,
-                eps,
-                momentum,
-                freeze_bn=True,
-                qconfig=default_qat_qconfig
-            ).to(dtype=torch.double)
-            qat_op.apply(torch.ao.quantization.disable_fake_quant)
-            if freeze_bn:
-                qat_op.apply(torch.nn.intrinsic.qat.freeze_bn_stats)
-            else:
-                qat_op.apply(torch.nn.intrinsic.qat.update_bn_stats)
+        cls = ConvBnReLU2d if use_relu else ConvBn2d
+        qat_op = cls(
+            input_channels,
+            output_channels,
+            (kernel_h, kernel_w),
+            (stride_h, stride_w),
+            (pad_h, pad_w),
+            (dilation_h, dilation_w),
+            groups,
+            None,  # bias
+            padding_mode,
+            eps,
+            momentum,
+            freeze_bn=True,
+            qconfig=default_qat_qconfig
+        ).to(dtype=torch.double)
+        qat_op.apply(torch.ao.quantization.disable_fake_quant)
+        if freeze_bn:
+            qat_op.apply(torch.nn.intrinsic.qat.freeze_bn_stats)
+        else:
+            qat_op.apply(torch.nn.intrinsic.qat.update_bn_stats)
 
-            # align inputs and internal parameters
-            input = torch.randn(batch_size, input_channels, height, width, dtype=torch.double, requires_grad=True)
-            conv_op.weight = torch.nn.Parameter(qat_op.weight.detach())
-            bn_op.running_mean = qat_op.bn.running_mean.clone()
-            bn_op.running_var = qat_op.bn.running_var.clone()
-            bn_op.weight = torch.nn.Parameter(qat_op.bn.weight.detach())
-            bn_op.bias = torch.nn.Parameter(qat_op.bn.bias.detach())
+        # align inputs and internal parameters
+        input = torch.randn(batch_size, input_channels, height, width, dtype=torch.double, requires_grad=True)
+        conv_op.weight = torch.nn.Parameter(qat_op.weight.detach())
+        bn_op.running_mean = qat_op.bn.running_mean.clone()
+        bn_op.running_var = qat_op.bn.running_var.clone()
+        bn_op.weight = torch.nn.Parameter(qat_op.bn.weight.detach())
+        bn_op.bias = torch.nn.Parameter(qat_op.bn.bias.detach())
 
-            def compose(functions):
-                # functions are reversed for natural reading order
-                return reduce(lambda f, g: lambda x: f(g(x)), functions[::-1], lambda x: x)
+        def compose(functions):
+            # functions are reversed for natural reading order
+            return reduce(lambda f, g: lambda x: f(g(x)), functions[::-1], lambda x: x)
 
-            if not use_relu:
-                def relu_op(x):
-                    return x
+        if not use_relu:
+            def relu_op(x):
+                return x
 
-            if freeze_bn:
-                def ref_op(x):
-                    x = conv_op(x)
-                    x = (x - bn_op.running_mean.reshape([1, -1, 1, 1])) * \
-                        (bn_op.weight / torch.sqrt(bn_op.running_var + bn_op.eps)) \
-                        .reshape([1, -1, 1, 1]) + bn_op.bias.reshape([1, -1, 1, 1])
-                    x = relu_op(x)
-                    return x
-            else:
-                ref_op = compose([conv_op, bn_op, relu_op])
+        if freeze_bn:
+            def ref_op(x):
+                x = conv_op(x)
+                x = (x - bn_op.running_mean.reshape([1, -1, 1, 1])) * \
+                    (bn_op.weight / torch.sqrt(bn_op.running_var + bn_op.eps)) \
+                    .reshape([1, -1, 1, 1]) + bn_op.bias.reshape([1, -1, 1, 1])
+                x = relu_op(x)
+                return x
+        else:
+            ref_op = compose([conv_op, bn_op, relu_op])
 
-            input_clone = input.clone().detach().requires_grad_()
-            for i in range(2):
-                result_ref = ref_op(input)
-                result_actual = qat_op(input_clone)
-                self.assertEqual(result_ref, result_actual)
+        input_clone = input.clone().detach().requires_grad_()
+        for i in range(2):
+            result_ref = ref_op(input)
+            result_actual = qat_op(input_clone)
+            self.assertEqual(result_ref, result_actual)
 
-                # backward
-                dout = torch.randn(result_ref.size(), dtype=torch.double)
-                loss = (result_ref - dout).sum()
-                loss.backward()
-                input_grad_ref = input.grad.cpu()
-                weight_grad_ref = conv_op.weight.grad.cpu()
-                gamma_grad_ref = bn_op.weight.grad.cpu()
-                beta_grad_ref = bn_op.bias.grad.cpu()
-                running_mean_ref = bn_op.running_mean
-                running_var_ref = bn_op.running_var
-                num_batches_tracked_ref = bn_op.num_batches_tracked
-                loss = (result_actual - dout).sum()
-                loss.backward()
-                input_grad_actual = input_clone.grad.cpu()
-                weight_grad_actual = qat_op.weight.grad.cpu()
-                gamma_grad_actual = qat_op.bn.weight.grad.cpu()
-                beta_grad_actual = qat_op.bn.bias.grad.cpu()
-                running_mean_actual = qat_op.bn.running_mean
-                running_var_actual = qat_op.bn.running_var
-                num_batches_tracked_actual = qat_op.bn.num_batches_tracked
-                precision = 1e-10
-                self.assertEqual(input_grad_ref, input_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(weight_grad_ref, weight_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(gamma_grad_ref, gamma_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(beta_grad_ref, beta_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(num_batches_tracked_ref, num_batches_tracked_actual, atol=precision, rtol=0)
-                self.assertEqual(running_mean_ref, running_mean_actual, atol=precision, rtol=0)
-                self.assertEqual(running_var_ref, running_var_actual, atol=precision, rtol=0)
+            # backward
+            dout = torch.randn(result_ref.size(), dtype=torch.double)
+            loss = (result_ref - dout).sum()
+            loss.backward()
+            input_grad_ref = input.grad.cpu()
+            weight_grad_ref = conv_op.weight.grad.cpu()
+            gamma_grad_ref = bn_op.weight.grad.cpu()
+            beta_grad_ref = bn_op.bias.grad.cpu()
+            running_mean_ref = bn_op.running_mean
+            running_var_ref = bn_op.running_var
+            num_batches_tracked_ref = bn_op.num_batches_tracked
+            loss = (result_actual - dout).sum()
+            loss.backward()
+            input_grad_actual = input_clone.grad.cpu()
+            weight_grad_actual = qat_op.weight.grad.cpu()
+            gamma_grad_actual = qat_op.bn.weight.grad.cpu()
+            beta_grad_actual = qat_op.bn.bias.grad.cpu()
+            running_mean_actual = qat_op.bn.running_mean
+            running_var_actual = qat_op.bn.running_var
+            num_batches_tracked_actual = qat_op.bn.num_batches_tracked
+            precision = 1e-10
+            self.assertEqual(input_grad_ref, input_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(weight_grad_ref, weight_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(gamma_grad_ref, gamma_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(beta_grad_ref, beta_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(num_batches_tracked_ref, num_batches_tracked_actual, atol=precision, rtol=0)
+            self.assertEqual(running_mean_ref, running_mean_actual, atol=precision, rtol=0)
+            self.assertEqual(running_var_ref, running_var_actual, atol=precision, rtol=0)
 
     @given(batch_size=st.integers(2, 4),
            input_channels_per_group=st.sampled_from([2, 3, 4]),
@@ -711,122 +706,117 @@ class TestConvBNQATModule(TestCase):
             freeze_bn,
             bias,
     ):
-        # **** WARNING: This is used to temporarily disable MKL-DNN convolution due
-        # to a bug: https://github.com/pytorch/pytorch/issues/23825
-        # Once this bug is fixed, this context manager as well as its callsites
-        # should be removed!
-        with torch.backends.mkldnn.flags(enabled=False):
-            input_channels = input_channels_per_group * groups
-            output_channels = output_channels_per_group * groups
-            dilation_h = dilation_w = dilation
+        input_channels = input_channels_per_group * groups
+        output_channels = output_channels_per_group * groups
+        dilation_h = dilation_w = dilation
 
-            qat_op = ConvBn2d(
-                input_channels,
-                output_channels,
-                (kernel_h, kernel_w),
-                (stride_h, stride_w),
-                (pad_h, pad_w),
-                (dilation_h, dilation_w),
-                groups,
-                bias,  # bias
-                padding_mode,
-                eps,
-                momentum,
-                freeze_bn=freeze_bn,
-                qconfig=default_qat_qconfig
-            ).to(dtype=torch.double)
+        qat_op = ConvBn2d(
+            input_channels,
+            output_channels,
+            (kernel_h, kernel_w),
+            (stride_h, stride_w),
+            (pad_h, pad_w),
+            (dilation_h, dilation_w),
+            groups,
+            bias,  # bias
+            padding_mode,
+            eps,
+            momentum,
+            freeze_bn=freeze_bn,
+            qconfig=default_qat_qconfig
+        ).to(dtype=torch.double)
 
-            qat_ref_op = _ReferenceConvBn2d(
-                input_channels,
-                output_channels,
-                (kernel_h, kernel_w),
-                (stride_h, stride_w),
-                (pad_h, pad_w),
-                (dilation_h, dilation_w),
-                groups,
-                bias,  # bias
-                padding_mode,
-                eps,
-                momentum,
-                freeze_bn=freeze_bn,
-                qconfig=default_qat_qconfig
-            ).to(dtype=torch.double)
+        qat_ref_op = _ReferenceConvBn2d(
+            input_channels,
+            output_channels,
+            (kernel_h, kernel_w),
+            (stride_h, stride_w),
+            (pad_h, pad_w),
+            (dilation_h, dilation_w),
+            groups,
+            bias,  # bias
+            padding_mode,
+            eps,
+            momentum,
+            freeze_bn=freeze_bn,
+            qconfig=default_qat_qconfig
+        ).to(dtype=torch.double)
 
-            qat_op.apply(torch.ao.quantization.disable_fake_quant)
-            qat_ref_op.apply(torch.ao.quantization.disable_fake_quant)
+        qat_op.apply(torch.ao.quantization.disable_fake_quant)
+        qat_ref_op.apply(torch.quantization.disable_fake_quant)
 
-            # align inputs and internal parameters
-            qat_ref_op.weight = torch.nn.Parameter(qat_op.weight.detach().clone())
-            qat_ref_op.running_mean = qat_op.bn.running_mean.clone()
-            qat_ref_op.running_var = qat_op.bn.running_var.clone()
-            qat_ref_op.gamma = torch.nn.Parameter(qat_op.bn.weight.detach().clone())
-            qat_ref_op.beta = torch.nn.Parameter(qat_op.bn.bias.detach().clone())
-            if qat_op.bias is not None:
-                qat_ref_op.bias = torch.nn.Parameter(qat_op.bias.detach().clone())
+        # align inputs and internal parameters
+        qat_ref_op.weight = torch.nn.Parameter(qat_op.weight.detach().clone())
+        qat_ref_op.running_mean = qat_op.bn.running_mean.clone()
+        qat_ref_op.running_var = qat_op.bn.running_var.clone()
+        qat_ref_op.gamma = torch.nn.Parameter(qat_op.bn.weight.detach().clone())
+        qat_ref_op.beta = torch.nn.Parameter(qat_op.bn.bias.detach().clone())
+        if qat_op.bias is not None:
+            qat_ref_op.bias = torch.nn.Parameter(qat_op.bias.detach().clone())
 
-            lr = 0.01
-            qat_op_optim = torch.optim.SGD(qat_op.parameters(), lr=lr)
-            qat_ref_op_optim = torch.optim.SGD(qat_ref_op.parameters(), lr=lr)
+        lr = 0.01
+        qat_op_optim = torch.optim.SGD(qat_op.parameters(), lr=lr)
+        qat_ref_op_optim = torch.optim.SGD(qat_ref_op.parameters(), lr=lr)
 
-            for i in range(5):
+        for i in range(5):
 
-                # make sure that calling model.train() does not override the
-                # bn freeze setting
-                qat_op.train()
-                qat_ref_op.train()
+            # make sure that calling model.train() does not override the
+            # bn freeze setting
+            qat_op.train()
+            qat_ref_op.train()
 
-                qat_op_optim.zero_grad()
-                qat_ref_op_optim.zero_grad()
+            qat_op_optim.zero_grad()
+            qat_ref_op_optim.zero_grad()
 
-                input = torch.randn(batch_size, input_channels, height, width, dtype=torch.double, requires_grad=True)
-                input_clone = input.clone().detach().requires_grad_()
+            input = torch.randn(batch_size, input_channels, height, width, dtype=torch.double, requires_grad=True)
+            input_clone = input.clone().detach().requires_grad_()
 
-                if i > 2:
-                    qat_op.apply(torch.nn.intrinsic.qat.freeze_bn_stats)
-                    qat_ref_op.freeze_bn_stats()
+            if i > 2:
+                qat_op.apply(torch.nn.intrinsic.qat.freeze_bn_stats)
+                qat_ref_op.freeze_bn_stats()
 
-                if i > 3:
-                    qat_op.apply(torch.ao.quantization.disable_observer)
-                    qat_ref_op.apply(torch.ao.quantization.disable_observer)
+            if i > 3:
+                qat_op.apply(torch.ao.quantization.disable_observer)
+                qat_ref_op.apply(torch.ao.quantization.disable_observer)
 
-                result_ref = qat_ref_op(input)
-                result_actual = qat_op(input_clone)
-                self.assertEqual(result_ref, result_actual)
+            result_ref = qat_ref_op(input)
+            result_actual = qat_op(input_clone)
+            self.assertEqual(result_ref, result_actual)
 
-                # backward
-                dout = torch.randn(result_ref.size(), dtype=torch.double) + 10.0
+            # backward
+            dout = torch.randn(result_ref.size(), dtype=torch.double) + 10.0
 
-                loss = (result_ref - dout).sum()
-                loss.backward()
-                input_grad_ref = input.grad.cpu()
-                weight_grad_ref = qat_ref_op.weight.grad.cpu()
-                gamma_grad_ref = qat_ref_op.gamma.grad.cpu()
-                beta_grad_ref = qat_ref_op.beta.grad.cpu()
-                running_mean_ref = qat_ref_op.running_mean
-                running_var_ref = qat_ref_op.running_var
-                num_batches_tracked_ref = qat_ref_op.num_batches_tracked
+            loss = (result_ref - dout).sum()
+            loss.backward()
+            input_grad_ref = input.grad.cpu()
+            weight_grad_ref = qat_ref_op.weight.grad.cpu()
+            gamma_grad_ref = qat_ref_op.gamma.grad.cpu()
+            beta_grad_ref = qat_ref_op.beta.grad.cpu()
+            running_mean_ref = qat_ref_op.running_mean
+            running_var_ref = qat_ref_op.running_var
+            num_batches_tracked_ref = qat_ref_op.num_batches_tracked
 
-                loss = (result_actual - dout).sum()
-                loss.backward()
-                input_grad_actual = input_clone.grad.cpu()
-                weight_grad_actual = qat_op.weight.grad.cpu()
-                gamma_grad_actual = qat_op.bn.weight.grad.cpu()
-                beta_grad_actual = qat_op.bn.bias.grad.cpu()
-                running_mean_actual = qat_op.bn.running_mean
-                running_var_actual = qat_op.bn.running_var
-                num_batches_tracked_actual = qat_op.bn.num_batches_tracked
+            loss = (result_actual - dout).sum()
+            loss.backward()
+            input_grad_actual = input_clone.grad.cpu()
+            weight_grad_actual = qat_op.weight.grad.cpu()
+            gamma_grad_actual = qat_op.bn.weight.grad.cpu()
+            beta_grad_actual = qat_op.bn.bias.grad.cpu()
+            running_mean_actual = qat_op.bn.running_mean
+            running_var_actual = qat_op.bn.running_var
+            num_batches_tracked_actual = qat_op.bn.num_batches_tracked
 
-                precision = 1e-5
-                self.assertEqual(input_grad_ref, input_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(weight_grad_ref, weight_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(gamma_grad_ref, gamma_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(beta_grad_ref, beta_grad_actual, atol=precision, rtol=0)
-                self.assertEqual(num_batches_tracked_ref, num_batches_tracked_actual, atol=precision, rtol=0)
-                self.assertEqual(running_mean_ref, running_mean_actual, atol=precision, rtol=0)
-                self.assertEqual(running_var_ref, running_var_actual, atol=precision, rtol=0)
+            precision = 1e-5
+            self.assertEqual(input_grad_ref, input_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(weight_grad_ref, weight_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(gamma_grad_ref, gamma_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(beta_grad_ref, beta_grad_actual, atol=precision, rtol=0)
+            self.assertEqual(num_batches_tracked_ref, num_batches_tracked_actual, atol=precision, rtol=0)
+            self.assertEqual(running_mean_ref, running_mean_actual, atol=precision, rtol=0)
+            self.assertEqual(running_var_ref, running_var_actual, atol=precision, rtol=0)
 
-                qat_op_optim.step()
-                qat_ref_op_optim.step()
+            qat_op_optim.step()
+            qat_ref_op_optim.step()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
Removed outdated context manager in unit test.
* The linked issue (https://github.com/pytorch/pytorch/issues/23825) seemed have been be fixed in 2020.

Test Plan: buck run mode/dev-nosan //caffe2/test:quantization -- -r quantization.eager.test_quantize_eager_qat

Differential Revision: D29507087

