### PR TITLE
[DataPipe] adding SequenceWrapperMapDataPipe

### DIFF
--- a/torch/utils/data/datapipes/map/__init__.py
+++ b/torch/utils/data/datapipes/map/__init__.py
@@ -1,6 +1,7 @@
 # Functional DataPipe
 from torch.utils.data.datapipes.map.callable import MapperMapDataPipe as Mapper
 from torch.utils.data.datapipes.map.combining import ConcaterMapDataPipe as Concater
+from torch.utils.data.datapipes.map.utils import SequenceWrapperMapDataPipe as SequenceWrapper
 
 
-__all__ = ['Concater', 'Mapper']
+__all__ = ['Concater', 'Mapper', 'SequenceWrapper']

--- a/torch/utils/data/datapipes/map/utils.py
+++ b/torch/utils/data/datapipes/map/utils.py
@@ -24,7 +24,7 @@ class SequenceWrapperMapDataPipe(MapDataPipe):
                 self.sequence = copy.deepcopy(sequence)
             except TypeError:
                 warnings.warn(
-                    "The input iterable can not be deepcopied, "
+                    "The input sequence can not be deepcopied, "
                     "please be aware of in-place modification would affect source data"
                 )
                 self.sequence = sequence

--- a/torch/utils/data/datapipes/map/utils.py
+++ b/torch/utils/data/datapipes/map/utils.py
@@ -1,0 +1,38 @@
+import copy
+import warnings
+from torch.utils.data import MapDataPipe
+
+
+class SequenceWrapperMapDataPipe(MapDataPipe):
+    r""":class:`SequenceWrapperMapDataPipe`.
+
+    Map DataPipe that wraps a sequence object.
+
+    Args:
+        sequence: Sequence object to be wrapped into an IterDataPipe
+        deepcopy: Option to deepcopy input sequence object
+
+    .. note::
+      If `deepcopy` is set to False explicitly, users should ensure
+      that data pipeline doesn't contain any in-place operations over
+      the iterable instance, in order to prevent data inconsistency
+      across iterations.
+    """
+    def __init__(self, sequence, deepcopy=True):
+        if deepcopy:
+            try:
+                self.sequence = copy.deepcopy(sequence)
+            except TypeError:
+                warnings.warn(
+                    "The input iterable can not be deepcopied, "
+                    "please be aware of in-place modification would affect source data"
+                )
+                self.sequence = sequence
+        else:
+            self.sequence = sequence
+
+    def __getitem__(self, index):
+        return self.sequence[index]
+
+    def __len__(self):
+        return len(self.sequence)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66277
* #66276
* __->__ #66275

Once this is added to Core, TorchData's PR will not need a custom class and can use this wrapper instead.

cc @VitalyFedyunin @ejguan @NivekT

Differential Revision: [D31485822](https://our.internmc.facebook.com/intern/diff/D31485822)