### PR TITLE
Disable "-Wignored-qualifiers" for vec256_bfloat16.h

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -961,7 +961,7 @@ UnionType::UnionType(std::vector<TypePtr> reference, TypeKind kind) : Type(kind)
     std::stringstream msg;
     msg << "After type unification was performed, the Union with the "
         << "original types {";
-    for (auto i = 0; i < reference.size(); ++i) {
+    for (const auto i : c10::irange(reference.size())) {
       msg << reference[i]->repr_str();
       if (i > 0) {
         msg << ",";

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -9,6 +9,9 @@
 #include <sleef.h>
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+
 namespace at {
 namespace vec {
 // See Note [Acceptable use of anonymous namespace in header]
@@ -775,3 +778,5 @@ C10_UNUSED void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>
 #endif
 
 }}}
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Summary:
This error appears when compiling with "-Wextra" and cannot be resolved by fixing the code since the return type of the instrinic being passed to `map` is fixed.

Fixes:
```
caffe2/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h:204:28: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  Vectorized<BFloat16> map(const __m256 (*const vop)(__m256)) const {
                           ^~~~~~
caffe2/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h:204:28: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  Vectorized<BFloat16> map(const __m256 (*const vop)(__m256)) const {
                           ^~~~~~
```

Differential Revision: D31480888

