### PR TITLE
Fix ubsan resize in concat_split_op.h

### DIFF
--- a/caffe2/operators/concat_split_op.h
+++ b/caffe2/operators/concat_split_op.h
@@ -170,9 +170,18 @@ bool SplitOp<Context>::RunOnDevice() {
   if (add_axis_) {
     output_dims.erase(output_dims.begin() + canonical_axis);
   }
+
+  const auto *const input_ptr = static_cast<const char*>(input.raw_data());
+
   size_t input_offset = 0;
   for (int i = 0; i < OutputSize(); ++i) {
-    auto* output = Output(i);
+    auto *const output = Output(i);
+    // We need `output_ptr` before the early exit since
+    // `raw_mutable_data` sets the output's data type
+    auto *const output_ptr = output->raw_mutable_data(input.dtype());
+    if(input_ptr==nullptr || output_ptr==nullptr){
+      continue;
+    }
     auto axis_dim = add_axis_ ? 1 : axis_data[i];
     if (!add_axis_) {
       output_dims[canonical_axis] = axis_data[i];
@@ -182,9 +191,9 @@ bool SplitOp<Context>::RunOnDevice() {
         input.itemsize(),
         before,
         axis_dim * after,
-        static_cast<const char*>(input.raw_data()) + input_offset,
+        input_ptr + input_offset,
         input.dim32(canonical_axis) * after,
-        output->raw_mutable_data(input.dtype()),
+        output_ptr,
         axis_dim * after,
         &context_,
         input.dtype().copy());

--- a/caffe2/operators/concat_split_op.h
+++ b/caffe2/operators/concat_split_op.h
@@ -358,11 +358,11 @@ bool ConcatOp<Context>::RunOnDevice() {
     output_dims[canonical_axis] = output_channels;
   }
 
-  output->Resize(output_dims);
   auto *const output_ptr = static_cast<char*>(output->raw_mutable_data(input_zero.dtype()));
   if(output_ptr == nullptr){
     return true;
   }
+  output->Resize(output_dims);
 
   size_t output_offset = 0;
   for (int i = 0; i < InputSize(); ++i) {


### PR DESCRIPTION
Summary:
Fixes
```
UndefinedBehaviorSanitizer: nullptr-with-nonzero-offset caffe2/caffe2/operators/concat_split_op.h:361:74 in
```

Test Plan: Sandcastle

Differential Revision: D31486487

