### PR TITLE
[Static Runtime][DI] Add variadic grouped_accessor_op

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -111,6 +111,7 @@ void OptimizeGraph(
   ConstantPropagation(graph);
   RemoveImmutableInputDictLookups(graph);
   UseVariadicTupleUnpack(graph);
+  UseVariadicGroupedAccessor(graph);
   GRAPH_DUMP("Final graph after optimizations: ", graph);
 }
 

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/passes/variadic_ops.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 
@@ -771,6 +772,21 @@ void RemoveImmutableInputDictLookups(
   }
   graph->setInsertPoint(graph->block());
   marker->destroy();
+}
+
+void UseVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph) {
+  // Migration to v2 is still in progress. For now, SR will support
+  // both versions of this op.
+  UseVariadicOp(
+      graph,
+      c10::Symbol::fromQualString("grouped_accessor::grouped_accessor_op"),
+      c10::Symbol::fromQualString(
+          "static_runtime::variadic_grouped_accessor_op"));
+  UseVariadicOp(
+      graph,
+      c10::Symbol::fromQualString("grouped_accessor::grouped_accessor_op_v2"),
+      c10::Symbol::fromQualString(
+          "static_runtime::variadic_grouped_accessor_op_v2"));
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -36,5 +36,7 @@ inline c10::Symbol fromQualString(const std::string& qual_string) {
   return c10::Symbol::fromQualString(qual_string);
 }
 
+TORCH_API void UseVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Add a variadic version of `grouped_accessor_op` to eliminate list construction overhead and associated refcount bumps in static runtime.

Test Plan: TODO accuracy test + benchmark

Differential Revision: D31482816

