### PR TITLE
[PyTorchEdge] make separate targets

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -589,6 +589,8 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/jit/serialization/onnx.cpp
       ${TORCH_SRC_DIR}/csrc/jit/serialization/export.cpp
       ${TORCH_SRC_DIR}/csrc/jit/serialization/export_module.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/serialization/import_read.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/serialization/unpickler.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
       ${TORCH_SRC_DIR}/csrc/jit/api/module_save.cpp
       ${TORCH_SRC_DIR}/csrc/utils/byte_order.cpp

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -114,8 +114,8 @@ core_sources_common = [
     "torch/csrc/jit/runtime/vararg_functions.cpp",
     "torch/csrc/jit/mobile/promoted_prim_ops.cpp",
     "torch/csrc/jit/mobile/prim_ops_registery.cpp",
-    "torch/csrc/jit/serialization/import_read.cpp",
-    "torch/csrc/jit/serialization/unpickler.cpp",
+    # "torch/csrc/jit/serialization/import_read.cpp",
+    # "torch/csrc/jit/serialization/unpickler.cpp",
 ]
 
 libtorch_sources_common = core_sources_common


### PR DESCRIPTION
Summary: The serialization part of the runtime can be organized into a specific target. For example, import_read.cpp, unpickler.cpp and caffe2_serialize.

Test Plan:
```
(base) [pavithran@devvm1803.vll0 ~/fbsource] cd ~/fbsource && buck build //xplat/caffe2:torch_mobile_import
Parsing buck files: finished in 1.0 sec
Building: finished in 0.4 sec (100%) 1/1 jobs, 0/1 updated
  Total time: 1.5 sec
More details at https://www.internalfb.com/intern/buck/build/ccdd6183-4228-44bc-9e72-7f32711798c3
BUILD SUCCEEDED

(base) [pavithran@devvm1803.vll0 ~/fbsource] cd ~/fbsource && buck build //xplat/caffe2:torch_mobile_core
Building: finished in 0.6 sec (100%) 1/1 jobs, 0/1 updated
  Total time: 0.7 sec
More details at https://www.internalfb.com/intern/buck/build/8e62d00d-fd2f-4836-8cb0-a8d3b6a99268
BUILD SUCCEEDED

(base) [pavithran@devvm1803.vll0 ~/fbsource] cd ~/fbsource && buck build //xplat/caffe2:torch_common
Building: finished in 0.6 sec (100%) 1/1 jobs, 0/1 updated
  Total time: 0.7 sec
More details at https://www.internalfb.com/intern/buck/build/4929981d-84cc-4a12-8578-d81921f13e15
BUILD SUCCEEDED
(base) [pavithran@devvm1803.vll0 ~/fbsource]
```

Differential Revision: D31479809

