### PR TITLE
Added an error message for RReLU lower>=upper.

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1557,6 +1557,11 @@ def rrelu(
 
     See :class:`~torch.nn.RReLU` for more details.
     """
+    if lower > upper:
+        raise ValueError(
+            "RReLU: Given lower bound ({}) is greater than "
+            "the given upper bound ({})".format(lower, upper)
+        )
     if has_torch_function_unary(input):
         return handle_torch_function(
             rrelu, (input,), input, lower=lower, upper=upper, training=training, inplace=inplace


### PR DESCRIPTION
Fixes #[{65980}](https://github.com/pytorch/pytorch/issues/65980) 

Maintaining similarity to embedded_bag error message on line 2219, an error message has been added to RReLU to inform the user that the lower bound is greater than the upper bound. 

To receive the error message and verify that the message is formatted appropriately, the following code was run: 


`from torch.nn import RReLU                                                                                                                                                                                                                    
from torch import randn                                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
m = RReLU(0.4, 0.3)                                                                                                                                                                                                                           
input = randn(2)                                                                                                                                                                                                                              
output = m(input)`


Output was as follows:

`ValueError: RReLU: Given lower bound (0.4) is greater than the given upper bound (0.3)`


