### PR TITLE
[Draft] Introduce `torch.distributed.nn.utils.init_meta()`

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -449,6 +449,36 @@ Note that you can use ``torch.profiler`` (recommended, only available after 1.8.
 
 Please refer to the `profiler documentation <https://pytorch.org/docs/master/profiler.html>`__ for a full overview of profiler features.
 
+Lazy Model Materialization
+--------------------------
+
+.. warning::
+    This is an experimental feature and is subject to change. If you experience
+    any issues, let us know by opening a GitHub issue.
+
+.. autofunction:: torch.distributed.nn.utils.describe
+.. autofunction:: torch.distributed.nn.utils.is_described
+
+describe() vs. skip_init()
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Although they sound similar ``describe()`` and ``torch.nn.utils.skip_init()``
+serve different purposes. ``describe()`` is meant for lazy model materialization
+and targets model users, while ``skip_init()`` is meant for optimized module
+initialization and targets model authors.
+
+Technical differences between the two functions are:
+
+- ``describe()`` returns a module where all its parameters and buffers reside on
+  the meta device, while ``skip_init()`` returns a module where some or all its
+  parameters or buffers are empty tensors allocated on a real device.
+- ``describe()`` does not require any code changes in the module, while
+  ``skip_init()`` expects the module and its submodules to take a ``device``
+  argument. This means ``skip_init()`` is intrusive, but also guaranteed to
+  work; on the other hand ``describe()`` can potentially fail to construct a
+  module if the module initializes its state in an unconventional way that
+  conflicts with the meta device.
+
 Autograd-enabled communication primitives
 -----------------------------------------
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -456,28 +456,34 @@ Lazy Model Materialization
     This is an experimental feature and is subject to change. If you experience
     any issues, let us know by opening a GitHub issue.
 
-.. autofunction:: torch.distributed.nn.utils.describe
-.. autofunction:: torch.distributed.nn.utils.is_described
+.. autofunction:: torch.distributed.nn.utils.init_meta
+.. autofunction:: torch.distributed.nn.utils.is_meta_init
 
-describe() vs. skip_init()
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+``init_meta()`` vs. ``MyModule(device="meta")``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you are a model author, an alternative to ``init_meta()`` is to have a
+``device`` parameter as part of your constructor that will be used to initialize
+the model state (i.e. parameters, buffers, and other auxiliary tensors). The
+tradeoff is that this approach is intrusive and requires all (sub)modules of the
+model to accept a ``device`` parameter. Moreover for existing large models
+introducing a new constructor parameter can be prohibitively expensive.
 
-Although they sound similar ``describe()`` and ``torch.nn.utils.skip_init()``
-serve different purposes. ``describe()`` is meant for lazy model materialization
-and targets model users, while ``skip_init()`` is meant for optimized module
-initialization and targets model authors.
+``init_meta`` on the other hand does not require any code changes, but can
+potentially fail to construct the model if the model initializes its state in an
+unconventional way that conflicts with the meta device.
 
-Technical differences between the two functions are:
+``init_meta()`` vs. ``skip_init()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- ``describe()`` returns a module where all its parameters and buffers reside on
-  the meta device, while ``skip_init()`` returns a module where some or all its
-  parameters or buffers are empty tensors allocated on a real device.
-- ``describe()`` does not require any code changes in the module, while
-  ``skip_init()`` expects the module and its submodules to take a ``device``
-  argument. This means ``skip_init()`` is intrusive, but also guaranteed to
-  work; on the other hand ``describe()`` can potentially fail to construct a
-  module if the module initializes its state in an unconventional way that
-  conflicts with the meta device.
+Although they sound similar ``init_meta()`` and ``skip_init()`` serve different
+purposes. ``init_meta()`` is meant for lazy model materialization and targets
+model users, while ``skip_init()`` is meant for optimized module initialization
+and targets model authors.
+
+Technically ``init_meta()`` returns a module where all its parameters and
+buffers reside on the meta device, while ``skip_init()`` returns a module where
+some or all its parameters or buffers are empty tensors allocated on a real
+device.
 
 Autograd-enabled communication primitives
 -----------------------------------------

--- a/torch/distributed/nn/utils/__init__.py
+++ b/torch/distributed/nn/utils/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .describe import describe, is_described
+from .meta_init import init_meta, is_meta_init

--- a/torch/distributed/nn/utils/__init__.py
+++ b/torch/distributed/nn/utils/__init__.py
@@ -4,6 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from . import utils
-from .api.remote_module import RemoteModule
-from .functional import *  # noqa: F403
+from .describe import describe, is_described

--- a/torch/distributed/nn/utils/describe.py
+++ b/torch/distributed/nn/utils/describe.py
@@ -1,0 +1,183 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import threading
+from contextlib import contextmanager
+from typing import Callable, Dict, Iterator, Optional
+
+import torch
+from torch import Tensor
+from torch._C import _DisableTorchDispatch  # type: ignore[attr-defined]
+from torch.nn.modules import Module
+from torch.utils._python_dispatch import enable_python_mode
+
+_tls = threading.local()
+
+# Used to check nested `describe()` calls.
+_tls.in_call = False
+
+
+@contextmanager
+def _no_dispatch() -> Iterator[None]:
+    """Temporarily disables the Python dispatch mode."""
+    guard = _DisableTorchDispatch()
+    try:
+        yield
+    finally:
+        del guard
+
+
+def _handle_arange(func, args, kwargs):
+    kwargs["device"] = torch.device("cpu")
+
+    # Although not ideal we first instantiate a CPU tensor and then immediately
+    # convert it to a meta tensor. Since `arange()` is typically used for small
+    # auxiliary vectors, in most cases this isn't a problem.
+    return torch.empty_like(func(*args, **kwargs), device="meta")
+
+
+def _handle_tril(func, args, kwargs):
+    if args and isinstance(args[0], Tensor):
+        return torch.empty_like(args[0], device="meta")
+
+    return NotImplemented
+
+
+class _MetaContext(Tensor):
+    """Represents the Python dispatcher to be used with `enable_python_mode()`.
+
+    Note:
+        A known limitation of the Python dispatch API is that it requires the
+        dispatcher to derive from `Tensor` or from one of its subclassses. In
+        our implementation `_MetaContext` is a subclass of `Tensor` solely to
+        fulfill this requirement.
+    """
+
+    _op_handlers: Dict[Callable, Callable] = {}
+
+    @classmethod
+    def _ensure_handlers_initialized(cls) -> None:
+        # The `torch.ops` module is only available once the `torch` module is
+        # fully imported; therefore, we lazy initialize our handlers.
+        if cls._op_handlers:
+            return
+
+        cls._op_handlers.update(
+            {
+                torch.ops.aten.arange: _handle_arange,
+                torch.ops.aten.tril: _handle_tril,
+            }
+        )
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        cls._ensure_handlers_initialized()
+
+        op_handler: Optional[Callable]
+
+        # Some operators such as `arange()` and `tril()` do not support the meta
+        # backend. For such operators we use special handlers.
+        try:
+            op_handler = cls._op_handlers[func]
+        except KeyError:
+            op_handler = None
+
+        with _no_dispatch():
+            if op_handler:
+                result = op_handler(func, args, kwargs)
+                # If for some reason the operator handler could not handle the
+                # dispatch (e.g. due to unexpected arguments), we fall back to
+                # our common handler below; otherwise, we return the result of
+                # the handler.
+                if result is not NotImplemented:
+                    return result
+
+            # We use a simple heuristic. If the function call has a device
+            # argument, we simply override it with the meta device.
+            if "device" in kwargs:
+                kwargs["device"] = torch.device("meta")
+
+            return func(*args, **kwargs)
+
+
+def describe(module_fn: Callable[..., Module], *args, **kwargs) -> Module:
+    """Constructs a module on the meta device for inspection purposes.
+
+    This function is meant to be used if the size of a module is too big to fit
+    on a single machine and you want to inspect it without instantiating.
+
+    Internally ``describe()`` forces all parameters, buffers, and other tensors
+    within the scope of the module and its sub-modules to use the meta device
+    regardless of the actual device type. The returned module can be used for
+    inspection purposes and afterwards its ``materialize()`` method can be
+    called to construct a fully-instantiated module (see the example below).
+
+    However note that ``describe()`` uses a "best effort" algorithm and is not
+    guaranteed to succeed if the underlying module's implementation cannot be
+    mapped to the meta device. If you are the module author, you can use the
+    ``is_described()`` function described below to find out whether your module
+    is being instantiated in the scope of a ``describe()`` call and use an
+    alternate logic if required:
+
+    ::
+
+        class MyModule(Module):
+            def __init__(self):
+                if torch.distributed.nn.utils.is_described():
+                    self.myparam = torch.empty([10,10], device="meta")
+                else:
+                    self.myparam = load_myparam()
+
+    Args:
+        module_fn (Callable[..., Module]):
+            The constructor or the factory function of the module.
+        args:
+            The positional arguments to pass to ``module_fn()``.
+        kwargs:
+            The keyword arguments to pass to ``module_fn()``.
+
+    Returns:
+        A ``torch.nn.Module`` instance on the meta device.
+
+    :Example:
+        >>> import torch.distributed.nn
+        >>> m = torch.distributed.nn.utils.describe(torch.nn.Linear, 5, 1)
+        >>> m.weight
+        Parameter containing:
+        tensor(..., device='meta', requires_grad=True)
+        >>> m = m.materialize()
+        >>> m.weight
+        Parameter containing:
+        tensor([[-1.4677e+24,  4.5915e-41,  1.4013e-45,  0.0000e+00,
+                 -1.4677e+24, 4.5915e-41]], requires_grad=True)
+
+    Note:
+        The ``args`` and ``kwargs`` arguments must be treated as immutable by
+        the module since they might be used a second time if ``materialize()``
+        is called.
+    """
+
+    def create_instance() -> Module:
+        return module_fn(*args, **kwargs)
+
+    if _tls.in_call:
+        module = create_instance()
+    else:
+        _tls.in_call = True
+        try:
+            with enable_python_mode(_MetaContext):
+                module = create_instance()
+        finally:
+            _tls.in_call = False
+
+    module.materialize = create_instance  # type: ignore[assignment]
+
+    return module
+
+
+def is_described() -> bool:
+    """Indicates whether the module is being instantiated by ``describe()``."""
+    return _tls.in_call


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66317

This PR introduces the `init_meta()` function that enables constructing `torch.nn.Module` instances on the meta device for inspection purposes. It is meant to be used if the size of a module is too big to fit on a single machine and you want to inspect it without instantiating.

Internally ``init_meta()`` forces all parameters, buffers, and other tensors within the scope of the module and its sub-modules to use the meta device regardless of the actual device type. The returned module can be used for inspection purposes and afterwards its ``materialize()`` method can be called to construct a fully-instantiated module.

```
>>> import torch.distributed.nn
>>> m = torch.distributed.nn.utils.init_meta(torch.nn.Linear, 5, 1)
>>> m.weight
Parameter containing:
tensor(..., device='meta', requires_grad=True)
>>> m = m.materialize()
>>> m.weight
Parameter containing:
tensor([[-1.4677e+24,  4.5915e-41,  1.4013e-45,  0.0000e+00,
             -1.4677e+24, 4.5915e-41]], requires_grad=True)
```

However note that ``init_meta()`` uses a "best effort" algorithm and is not guaranteed to succeed if the underlying module's implementation cannot be mapped to the meta device. If you are the module author, you can use the `is_meta_init()` function to find out whether your module is being instantiated in the scope of a ``init_meta()`` call and use an alternate logic if required.

```
class MyModule(Module):
    def __init__(self):
        if torch.distributed.nn.utils.is_meta_init():
            self.myparam = torch.empty([10,10], device="meta")
        else:
            self.myparam = load_myparam()
```



**init_meta() vs. skip_init()**

Although they sound similar `init_meta()` and `skip_init()` serve different purposes. `init_meta()` is meant for lazy model materialization and targets model users, while ``skip_init()`` is meant for optimized module initialization and targets model authors.

Technical differences between the two functions are:

- `init_meta()` returns a module where all its parameters and buffers reside on the meta device, while `skip_init()` returns a module where some or all its parameters or buffers are empty tensors allocated on a real device.
- `init_meta()` does not require any code changes in the module, while `skip_init()` expects the module and its submodules to take a `device` argument. This means ``skip_init()`` is intrusive, but also guaranteed to work; on the other hand ``init_meta()`` can potentially fail to construct a module if the module initializes its state in an unconventional way that conflicts with the meta device.

Differential Revision: [D31504090](https://our.internmc.facebook.com/intern/diff/D31504090/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang