### PR TITLE
Wextra fix for CUDAApplyUtils.cuh

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -961,7 +961,7 @@ UnionType::UnionType(std::vector<TypePtr> reference, TypeKind kind) : Type(kind)
     std::stringstream msg;
     msg << "After type unification was performed, the Union with the "
         << "original types {";
-    for (auto i = 0; i < reference.size(); ++i) {
+    for (const auto i : c10::irange(reference.size())) {
       msg << reference[i]->repr_str();
       if (i > 0) {
         msg << ",";

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -9,6 +9,9 @@
 #include <sleef.h>
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+
 namespace at {
 namespace vec {
 // See Note [Acceptable use of anonymous namespace in header]
@@ -775,3 +778,5 @@ C10_UNUSED void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>
 #endif
 
 }}}
+
+#pragma GCC diagnostic pop

--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -300,14 +300,14 @@ struct ApplyOp2 {
 __device__ __forceinline__
 static void apply(detail::TensorInfo<scalar1, IndexType> &a,
                   detail::TensorInfo<scalar2, IndexType> &b,
-                  const Op &op, int n, IndexType linearIndex,
+                  const Op &op, int64_t n, IndexType linearIndex,
                   Offsets... aOffsets, Offsets... bOffsets) {
   // Convert `linearIndex` into an offset of `a`
-  const IndexType aOffset = sizeof...(Offsets) < n ?
+  const IndexType aOffset = static_cast<int64_t>(sizeof...(Offsets)) < n ?
     detail::IndexToOffset<scalar1, IndexType, ADims>::get(linearIndex, a) : 0;
 
   // Convert `linearIndex` into an offset of `b`
-  const IndexType bOffset = sizeof...(Offsets) < n ?
+  const IndexType bOffset = static_cast<int64_t>(sizeof...(Offsets)) < n ?
     detail::IndexToOffset<scalar2, IndexType, BDims>::get(linearIndex, b) : 0;
 
   ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, remaining_steps - 1, const IndexType, Offsets...>::apply(

--- a/aten/src/ATen/native/Integration.cpp
+++ b/aten/src/ATen/native/Integration.cpp
@@ -3,6 +3,7 @@
 #include <ATen/WrapDimUtils.h>
 #include <ATen/core/DimVector.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/Scalar.h>
 
@@ -59,11 +60,12 @@ Tensor do_cumulative_trapezoid(const Tensor& y, double dx, int64_t dim) {
 // Note that no padding will be added if the current shape has the greater than or equal
 // number of dimensions than the target numbers of dimensions.
 DimVector add_padding_to_shape(IntArrayRef curr_shape, int64_t target_n_dim) {
-    if (curr_shape.size() >= target_n_dim)
-        target_n_dim = curr_shape.size();
+    const auto curr_size = static_cast<int64_t>(curr_shape.size());
+    if (curr_size >= target_n_dim)
+        target_n_dim = curr_size;
     DimVector new_shape(target_n_dim, 1);
-    for (decltype(curr_shape.size()) i = 0; i < curr_shape.size(); i++) {
-        new_shape[target_n_dim-i-1] = curr_shape[curr_shape.size()-i-1];
+    for (const auto i : c10::irange(curr_size)) {
+        new_shape[target_n_dim-i-1] = curr_shape[curr_size-i-1];
     }
     return new_shape;
 }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -616,7 +616,7 @@ std::vector<Tensor> tensor_split(const Tensor& self, const Tensor& tensor_indice
     auto stride = tensor_indices_or_sections.stride(0);
     auto numel = tensor_indices_or_sections.numel();
     std::vector<int64_t> indices(numel);
-    for (size_t offset = 0; offset < numel; offset++) {
+    for (const auto offset : c10::irange(numel)) {
       // indices tensor could be non-contiguous
       indices[offset] = *(indices_data + offset * stride);
     }


### PR DESCRIPTION
Summary:
Fixes
```
/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh:310:48: error: comparison of integers of different signs: 'unsigned long' and 'int' [-Werror,-Wsign-compare]
  const IndexType bOffset = sizeof...(Offsets) < n ?
                            ~~~~~~~~~~~~~~~~~~ ^ ~
/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/fbcode/caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh:306:48: error: comparison of integers of different signs: 'unsigned long' and 'int' [-Werror,-Wsign-compare]
  const IndexType aOffset = sizeof...(Offsets) < n ?
                            ~~~~~~~~~~~~~~~~~~ ^ ~
```

Test Plan: Sandcastle

Reviewed By: ngimel

Differential Revision: D31505428

