### PR TITLE
[PyTorch][jit] Cache TupleType objects in getTypePtr

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1841,10 +1841,13 @@ struct getTypePtr_<at::optional<T>> final {
 template <class... Contained>
 struct getTypePtr_<std::tuple<Contained...>> final {
   static decltype(auto) call() {
-    std::vector<TypePtr> contained_types = {
-      (getTypePtr_<Contained>::call())...
-    };
-    return TupleType::create(std::move(contained_types));
+    static auto type = ([]() {
+      std::vector<TypePtr> contained_types = {
+        (getTypePtr_<Contained>::call())...
+      };
+      return TupleType::create(std::move(contained_types));
+    })();
+    return type;
   }
 };
 template <>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66342
* __->__ #66340
* #66286
* #66282

For functions that take std::vectors with tuples in them, getTypePtr can get hit on every call, in which case creating a new TupleType object every time is expensive.

Differential Revision: [D31514792](https://our.internmc.facebook.com/intern/diff/D31514792/)