### PR TITLE
[PyTorch][JIT] Return a reference from caching specializations of getTypePtr

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1789,35 +1789,35 @@ struct getTypePtr_<at::Dimname> final {
 };
 template <class T>
 struct getTypePtr_<std::vector<T>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type = ListType::create(getTypePtr_<T>::call());
     return type;
   }
 };
 template <class T>
 struct getTypePtr_<c10::ArrayRef<T>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type = ListType::create(getTypePtr_<T>::call());
     return type;
   }
 };
 template <class T>
 struct getTypePtr_<c10::List<T>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type = ListType::create(getTypePtr_<T>::call());
     return type;
   }
 };
 template <class T, size_t N>
 struct getTypePtr_<std::array<T, N>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type = ListType::create(getTypePtr_<T>::call());
     return type;
   }
 };
 template <class K, class V>
 struct getTypePtr_<std::unordered_map<K, V>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type =
         DictType::create(getTypePtr_<K>::call(), getTypePtr_<V>::call());
     return type;
@@ -1825,7 +1825,7 @@ struct getTypePtr_<std::unordered_map<K, V>> final {
 };
 template <class K, class V>
 struct getTypePtr_<c10::Dict<K, V>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type =
         DictType::create(getTypePtr_<K>::call(), getTypePtr_<V>::call());
     return type;
@@ -1833,14 +1833,14 @@ struct getTypePtr_<c10::Dict<K, V>> final {
 };
 template <class T>
 struct getTypePtr_<at::optional<T>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type = OptionalType::create(getTypePtr_<T>::call());
     return type;
   }
 };
 template <class... Contained>
 struct getTypePtr_<std::tuple<Contained...>> final {
-  static decltype(auto) call() {
+  static const auto& call() {
     static auto type = ([]() {
       std::vector<TypePtr> contained_types = {
         (getTypePtr_<Contained>::call())...

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -10,6 +10,10 @@
 
 namespace c10 {
 
+static_assert(
+    std::is_same<decltype(getTypePtr<std::tuple<int64_t, int64_t>>()), const TupleTypePtr&>::value,
+    "getTypePtr<std::tuple<int64_t, int64_t>> not returning const ref!");
+
 namespace {
 inline bool is_contiguous_strides(
     const IntArrayRef sizes,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66342
* #66340
* #66286
* #66282

`decltype(auto)` in D31486117 wasn't the right choice in these specializations, because it will *still* deduce a copy.
See https://godbolt.org/z/GjbcPE1c4 for example.

Differential Revision: [D31514960](https://our.internmc.facebook.com/intern/diff/D31514960/)