### PR TITLE
[quantized] Implement 3d convolution in qnnpack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -153,11 +153,26 @@ at::SmallVector<int64_t, 5> MakeConvOutputShape<3>(
 
 #ifdef USE_PYTORCH_QNNPACK
 
+template <size_t kSpatialDim>
+std::array<int64_t, kSpatialDim> MakeInputShape(
+    int64_t D,
+    int64_t H,
+    int64_t W);
+
+template <>
+std::array<int64_t, 2> MakeInputShape(int64_t _, int64_t H, int64_t W) {
+  return {H, W};
+}
+template <>
+std::array<int64_t, 3> MakeInputShape(int64_t D, int64_t H, int64_t W) {
+  return {D, H, W};
+}
+
 template <int kSpatialDim>
 at::SmallVector<int64_t, kSpatialDim + 2> MakeConvOutputShape(
     int N, // mini-batch
     int M, // output channels
-    const std::vector<int>& input_image_shape,
+    const std::array<int64_t, kSpatialDim>& input_image_shape,
     const std::vector<int64_t>& kernel,
     const torch::List<int64_t>& stride,
     const torch::List<int64_t>& padding,
@@ -167,7 +182,7 @@ template <>
 at::SmallVector<int64_t, 4> MakeConvOutputShape<2>(
     int N, // mini-batch
     int M, // output channels
-    const std::vector<int>& input_image_shape,
+    const std::array<int64_t, 2>& input_image_shape,
     const std::vector<int64_t>& kernel,
     const torch::List<int64_t>& stride,
     const torch::List<int64_t>& padding,
@@ -185,7 +200,7 @@ template <>
 at::SmallVector<int64_t, 5> MakeConvOutputShape<3>(
     int N, // mini-batch
     int M, // output channels
-    const std::vector<int>& input_image_shape,
+    const std::array<int64_t, 3>& input_image_shape,
     const std::vector<int64_t>& kernel,
     const torch::List<int64_t>& stride,
     const torch::List<int64_t>& padding,
@@ -289,11 +304,11 @@ at::Tensor PackedConvWeight<kSpatialDim>::apply_impl(
   const int H = act.size(kSpatialDim);
   const int W = act.size(kSpatialDim + 1);
 
-  const at::Tensor act_nhwc = kSpatialDim == 2
+  const at::Tensor act_ndhwc = kSpatialDim == 2
       ? act.contiguous(c10::MemoryFormat::ChannelsLast)
       : at::native::fbgemm_utils::ConvertToChannelsLast3dTensor(act);
   const uint8_t* act_data =
-      reinterpret_cast<uint8_t*>(act_nhwc.data_ptr<c10::quint8>());
+      reinterpret_cast<uint8_t*>(act_ndhwc.data_ptr<c10::quint8>());
   auto* pack_w = w.get();
 
   const int M = pack_w->outputChannels();
@@ -571,10 +586,6 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
               kSpatialDim == 2,
               func_name, kSpatialDim,
               "d (qnnpack): ConvTranspose cannot be fused with ReLU.");
-  TORCH_CHECK(
-      kSpatialDim == 2,
-      func_name, kSpatialDim,
-      "d (qnnpack): QNNPACK only supports Conv2d now.");
   ConvDimChecks<kSpatialDim>(
       act.ndimension(), stride().size(), padding().size(),
       output_padding().size(), dilation().size(), func_name, transpose());
@@ -588,11 +599,15 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
   // inputs are in semantic NCHW format
   const int N = act.size(0);
   const int C = act.size(1);
-  const int H = act.size(2);
-  const int W = act.size(3);
+  const int D = kSpatialDim == 3 ? act.size(2) : 1;
+  const int H = act.size(kSpatialDim);
+  const int W = act.size(kSpatialDim + 1);
   const int M = out_ch; // output channels
 
-  const at::Tensor act_nhwc = act.contiguous(c10::MemoryFormat::ChannelsLast);
+  const auto channels_last = kSpatialDim == 2
+      ? c10::MemoryFormat::ChannelsLast
+      : c10::MemoryFormat::ChannelsLast3d;
+  const at::Tensor act_ndhwc = act.contiguous(channels_last);
 
   auto output_min = kReluFused
       // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
@@ -605,7 +620,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
             .second
       : std::numeric_limits<uint8_t>::max();
 
-  double act_input_scale = act_nhwc.q_scale();
+  double act_input_scale = act_ndhwc.q_scale();
 
   // Re-quantizing the bias based on input scale and weight scale.
   if (!input_scale.has_value() || input_scale.value() != act_input_scale) {
@@ -615,8 +630,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
         "Input channel size of weight and bias must match.");
 
     // Get the original weight and adjust it to uint8 from int8
-    auto weight_contig =
-        orig_weight.contiguous(c10::MemoryFormat::ChannelsLast);
+    auto weight_contig = orig_weight.contiguous(channels_last);
     auto bias_fp32 = bias;
     int8_t* w_data =
         reinterpret_cast<int8_t*>(weight_contig.template data_ptr<c10::qint8>());
@@ -633,9 +647,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
     // Still we should be consistent. Fix this.
     at::Tensor qnnp_weight = at::_empty_affine_quantized(
         weight_contig.sizes(),
-        at::device(c10::kCPU)
-            .dtype(c10::kQUInt8)
-            .memory_format(c10::MemoryFormat::ChannelsLast),
+        at::device(c10::kCPU).dtype(c10::kQUInt8).memory_format(channels_last),
         weight_scales_data[0],
         w_zero_points[0],
         c10::nullopt);
@@ -679,27 +691,39 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
     // to do it only once.
     if (zero_buffer_size) {
       memset(
-          convolution_op->zero_buffer, act_nhwc.q_zero_point(), zero_buffer_size);
+          convolution_op->zero_buffer,
+          act_ndhwc.q_zero_point(),
+          zero_buffer_size);
     }
   }
 
   TORCH_INTERNAL_ASSERT(pack_w != nullptr, "Packed Weights are NULL");
   at::SmallVector<int64_t, kSpatialDim + 2> output_shape;
+  const auto input_shape = MakeInputShape<kSpatialDim>(D, H, W);
   if (transpose()) {
-    output_shape = MakeDeConvOutputShape<kSpatialDim>(N, M, {H, W},
-        kernel_, stride(), padding(), output_padding(), dilation());
+    output_shape = MakeDeConvOutputShape<kSpatialDim>(
+        N,
+        M,
+        {H, W},
+        kernel_,
+        stride(),
+        padding(),
+        output_padding(),
+        dilation());
   } else {
-    output_shape = MakeConvOutputShape<kSpatialDim>(N, M, {H, W},
-        kernel_, stride(), padding(), dilation());
+    output_shape = MakeConvOutputShape<kSpatialDim>(
+        N, M, input_shape, kernel_, stride(), padding(), dilation());
   }
 
-  if (act_nhwc.numel() > 0) {
+  if (act_ndhwc.numel() > 0) {
     TORCH_CHECK(
         std::all_of(
             output_shape.begin(),
             output_shape.end(),
             [](int64_t i) { return i > 0; }),
-        "quantized::conv2d (qnnpack): each dimension of output tensor should "
+        func_name,
+        kSpatialDim,
+        "d (qnnpack): each dimension of output tensor should "
         "be greater than 0.")
   }
 
@@ -712,7 +736,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
       c10::nullopt /* pin_memory */,
       output_scale,
       output_zero_point,
-      c10::MemoryFormat::ChannelsLast);
+      channels_last);
 
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   pytorch_qnnp_status run_status;
@@ -723,8 +747,8 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
         N,
         H,
         W,
-        act_nhwc.q_zero_point(),
-        reinterpret_cast<uint8_t*>(act_nhwc.template data_ptr<c10::quint8>()),
+        act_ndhwc.q_zero_point(),
+        reinterpret_cast<uint8_t*>(act_ndhwc.template data_ptr<c10::quint8>()),
         w_zero_points.data(),
         requantization_scales.data(),
         output.q_zero_point(),
@@ -737,10 +761,11 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
         convolution_op.get(),
         pack_w->getPackedWeights(),
         N,
+        D,
         H,
         W,
-        act_nhwc.q_zero_point(),
-        reinterpret_cast<uint8_t*>(act_nhwc.template data_ptr<c10::quint8>()),
+        act_ndhwc.q_zero_point(),
+        reinterpret_cast<uint8_t*>(act_ndhwc.template data_ptr<c10::quint8>()),
         w_zero_points.data(),
         requantization_scales.data(),
         output.q_zero_point(),

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -225,8 +225,9 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsQnnp<
   // but PyTorch lays them out as {out_c, in_c/groups, kH, kW}
   // (or for ConvTranspose {in_c, out_c/groups, kH, kW})
   const auto out_ch = transpose ? weight.size(1) * groups : weight.size(0);
-  const uint32_t kernel_h = weight.size(2);
-  const uint32_t kernel_w = weight.size(3);
+  const uint32_t kernel_d = kSpatialDim == 3 ? weight.size(2) : 1;
+  const uint32_t kernel_h = weight.size(kSpatialDim);
+  const uint32_t kernel_w = weight.size(kSpatialDim + 1);
 
   at::Tensor bias_fp32;
   if (bias_in.has_value()) {
@@ -265,9 +266,13 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsQnnp<
       (transpose ? "True)." : "False).")
   );
 
-  auto weight_contig = weight.contiguous(c10::MemoryFormat::ChannelsLast);
+  auto weight_contig = weight.contiguous(
+      kSpatialDim == 2 ? c10::MemoryFormat::ChannelsLast
+                       : c10::MemoryFormat::ChannelsLast3d);
   const bool is_per_channel = weight_contig.qscheme() == at::kPerChannelAffine;
-
+  auto kernel_dim = kSpatialDim == 2
+      ? std::vector<int64_t>{kernel_h, kernel_w}
+      : std::vector<int64_t>{kernel_d, kernel_h, kernel_w};
   std::vector<uint8_t> w_zero_points;
   at::Tensor w_scales;
   std::tie(w_zero_points, w_scales) =
@@ -276,22 +281,21 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsQnnp<
   // during the first invocation of operator run. Refer to qconv.cpp for more
   // details. TODO Update to actually call pre-pack here once bias is removed
   // from pre-packing step.
-  auto ret_ptr =
-      c10::intrusive_ptr<PackedConvWeightsQnnp<kSpatialDim>>::make(
-              nullptr, /* PrePackConvWeights */
-              weight_contig, /* int8_t weight */
-              bias_fp32.contiguous(), /* fp32 bias */
-              stride,
-              padding,
-              output_padding,
-              dilation,
-              groups,
-              transpose,
-              c10::nullopt, /* input_scale */
-              std::vector<int64_t>{kernel_h, kernel_w},
-              w_scales,
-              std::move(w_zero_points),
-              is_per_channel);
+  auto ret_ptr = c10::intrusive_ptr<PackedConvWeightsQnnp<kSpatialDim>>::make(
+      nullptr, /* PrePackConvWeights */
+      weight_contig, /* int8_t weight */
+      bias_fp32.contiguous(), /* fp32 bias */
+      stride,
+      padding,
+      output_padding,
+      dilation,
+      groups,
+      transpose,
+      c10::nullopt, /* input_scale */
+      kernel_dim,
+      w_scales,
+      std::move(w_zero_points),
+      is_per_channel);
 
   return ret_ptr;
 }
@@ -366,10 +370,6 @@ class QConvPackWeightInt8 final {
 
 #ifdef USE_PYTORCH_QNNPACK
     if (ctx.qEngine() == at::QEngine::QNNPACK) {
-      TORCH_CHECK(
-          kSpatialDim == 2,
-          "quantized::conv_prepack (qnnpack): QNNPACK only supports Conv1d "
-          "and Conv2d now.");
       return PackedConvWeightsQnnp<kSpatialDim>::prepack(
           weight, bias, stride, padding, output_padding, dilation, groups,
           transpose);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
@@ -63,9 +63,52 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
     bool per_channel,
     pytorch_qnnp_operator_t* convolution);
 
+enum pytorch_qnnp_status pytorch_qnnp_create_convolution3d_ndhwc_q8(
+    uint32_t input_padding_front,
+    uint32_t input_padding_top,
+    uint32_t input_padding_right,
+    uint32_t input_padding_back,
+    uint32_t input_padding_bottom,
+    uint32_t input_padding_left,
+    uint32_t kernel_depth,
+    uint32_t kernel_height,
+    uint32_t kernel_width,
+    uint32_t subsampling_depth,
+    uint32_t subsampling_height,
+    uint32_t subsampling_width,
+    uint32_t dilation_depth,
+    uint32_t dilation_height,
+    uint32_t dilation_width,
+    uint32_t groups,
+    size_t group_input_channels,
+    size_t group_output_channels,
+    uint8_t input_zero_point,
+    const uint8_t* kernel_zero_points,
+    const uint8_t* kernel,
+    const int32_t* bias,
+    uint8_t output_zero_point,
+    uint8_t output_min,
+    uint8_t output_max,
+    uint32_t flags,
+    const float* requantization_scales,
+    bool per_channel,
+    pytorch_qnnp_operator_t* convolution);
+
 enum pytorch_qnnp_status pytorch_qnnp_setup_convolution2d_nhwc_q8(
     pytorch_qnnp_operator_t convolution,
     size_t batch_size,
+    size_t input_height,
+    size_t input_width,
+    const uint8_t* input,
+    size_t input_stride,
+    uint8_t* output,
+    size_t output_stride,
+    pthreadpool_t threadpool);
+
+enum pytorch_qnnp_status pytorch_qnnp_setup_convolution_ndhwc_q8(
+    pytorch_qnnp_operator_t convolution,
+    size_t batch_size,
+    size_t input_depth,
     size_t input_height,
     size_t input_width,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/qnnpack_func.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/qnnpack_func.h
@@ -112,6 +112,7 @@ enum pytorch_qnnp_status qnnpackConv(
     const pytorch_qnnp_operator_t convolution,
     void* packed_weights,
     const size_t batch_size,
+    const size_t input_depth,
     const size_t input_height,
     const size_t input_width,
     const uint8_t input_zero_point,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-prepack.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-prepack.cc
@@ -13,8 +13,10 @@ PrePackConvWeights::PrePackConvWeights(
   enum pytorch_qnnp_ukernel_type ukernel_type = convolution->ukernel_type;
   const uint32_t kernel_width = convolution->kernel_width;
   const uint32_t kernel_height = convolution->kernel_height;
+  // deconvolution leaves this 0 for now, remove when deconvolution supports 3d
+  const uint32_t kernel_depth =
+      convolution->kernel_depth ? convolution->kernel_depth : 1;
   const uint32_t groups = convolution->groups;
-  output_channels_ = convolution->group_output_channels * groups;
 
   if (convolution->transpose &&
       ukernel_type != pytorch_qnnp_ukernel_type_conv) {
@@ -22,7 +24,7 @@ PrePackConvWeights::PrePackConvWeights(
     assert("QNNPACK Runtime Error.");
   }
 
-  const size_t kernel_size = kernel_height * kernel_width;
+  const size_t kernel_size = kernel_height * kernel_width * kernel_depth;
   switch (ukernel_type) {
     case pytorch_qnnp_ukernel_type_dwconv: {
       const uint32_t cr = pytorch_qnnp_params.q8dw9.cr;

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/convolution.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/convolution.c
@@ -62,6 +62,68 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
     const float* requantization_scales,
     bool per_channel,
     pytorch_qnnp_operator_t* convolution_out) {
+  return pytorch_qnnp_create_convolution3d_ndhwc_q8(
+      0,
+      input_padding_top,
+      input_padding_right,
+      0,
+      input_padding_bottom,
+      input_padding_left,
+      1,
+      kernel_height,
+      kernel_width,
+      1,
+      subsampling_height,
+      subsampling_width,
+      1,
+      dilation_height,
+      dilation_width,
+      groups,
+      group_input_channels,
+      group_output_channels,
+      input_zero_point,
+      kernel_zero_points,
+      kernel,
+      bias,
+      output_zero_point,
+      output_min,
+      output_max,
+      flags,
+      requantization_scales,
+      per_channel,
+      convolution_out);
+}
+
+enum pytorch_qnnp_status pytorch_qnnp_create_convolution3d_ndhwc_q8(
+    uint32_t input_padding_front,
+    uint32_t input_padding_top,
+    uint32_t input_padding_right,
+    uint32_t input_padding_back,
+    uint32_t input_padding_bottom,
+    uint32_t input_padding_left,
+    uint32_t kernel_depth,
+    uint32_t kernel_height,
+    uint32_t kernel_width,
+    uint32_t subsampling_depth,
+    uint32_t subsampling_height,
+    uint32_t subsampling_width,
+    uint32_t dilation_depth,
+    uint32_t dilation_height,
+    uint32_t dilation_width,
+    uint32_t groups,
+    size_t group_input_channels,
+    size_t group_output_channels,
+    uint8_t input_zero_point,
+    const uint8_t* kernel_zero_points,
+    const uint8_t* kernel,
+    const int32_t* bias,
+    uint8_t output_zero_point,
+    uint8_t output_min,
+    uint8_t output_max,
+    uint32_t flags,
+    const float* requantization_scales,
+    bool per_channel,
+    pytorch_qnnp_operator_t* convolution_out) {
   pytorch_qnnp_operator_t convolution = NULL;
   enum pytorch_qnnp_status status = pytorch_qnnp_status_uninitialized;
 
@@ -196,11 +258,12 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
     goto error;
   }
 
-  const size_t kernel_size = kernel_height * kernel_width;
+  const size_t kernel_size = kernel_height * kernel_width * kernel_depth;
 
   enum pytorch_qnnp_ukernel_type ukernel_type = pytorch_qnnp_ukernel_type_none;
-  const bool any_padding = (input_padding_left | input_padding_top |
-                            input_padding_right | input_padding_bottom) != 0;
+  const bool any_padding =
+      (input_padding_front | input_padding_left | input_padding_top |
+       input_padding_back | input_padding_right | input_padding_bottom) != 0;
   if ((kernel_size == 9 || kernel_size == 25) && group_input_channels == 1 &&
       group_output_channels == 1 && groups > 1) {
     ukernel_type = pytorch_qnnp_ukernel_type_dwconv;
@@ -440,15 +503,20 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
     convolution->zero_pointer = (void*)((uintptr_t)zero_buffer + zero_offset);
   }
 
+  convolution->input_padding_front = input_padding_front;
   convolution->input_padding_top = input_padding_top;
   convolution->input_padding_right = input_padding_right;
+  convolution->input_padding_back = input_padding_back;
   convolution->input_padding_bottom = input_padding_bottom;
   convolution->input_padding_left = input_padding_left;
 
+  convolution->kernel_depth = kernel_depth;
   convolution->kernel_height = kernel_height;
   convolution->kernel_width = kernel_width;
+  convolution->stride_depth = subsampling_depth;
   convolution->stride_height = subsampling_height;
   convolution->stride_width = subsampling_width;
+  convolution->dilation_depth = dilation_depth;
   convolution->dilation_height = dilation_height;
   convolution->dilation_width = dilation_width;
   convolution->groups = groups;
@@ -495,9 +563,33 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_convolution2d_nhwc_q8(
     uint8_t* output,
     size_t output_pixel_stride,
     pthreadpool_t threadpool) {
+  return pytorch_qnnp_setup_convolution_ndhwc_q8(
+      convolution,
+      batch_size,
+      1,
+      input_height,
+      input_width,
+      input,
+      input_pixel_stride,
+      output,
+      output_pixel_stride,
+      threadpool);
+}
+
+enum pytorch_qnnp_status pytorch_qnnp_setup_convolution_ndhwc_q8(
+    pytorch_qnnp_operator_t convolution,
+    size_t batch_size,
+    size_t input_depth,
+    size_t input_height,
+    size_t input_width,
+    const uint8_t* input,
+    size_t input_pixel_stride,
+    uint8_t* output,
+    size_t output_pixel_stride,
+    pthreadpool_t threadpool) {
   if (!pytorch_qnnp_params.initialized) {
     pytorch_qnnp_log_error(
-        "pytorch_qnnp_setup_convolution2d_nhwc_q8 failed because QNNPACK is not properly initialized");
+        "pytorch_qnnp_setup_convolution_ndhwc_q8 failed because QNNPACK is not properly initialized");
     return pytorch_qnnp_status_uninitialized;
   }
 
@@ -506,20 +598,28 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_convolution2d_nhwc_q8(
     return pytorch_qnnp_status_success;
   }
 
-  if (input_width == 0 || input_height == 0) {
+  if (input_width == 0 || input_height == 0 || input_depth == 0) {
     pytorch_qnnp_log_error(
-        "failed to setup convolution with %zux%zu input: input dimensions must be non-zero",
+        "failed to setup convolution with %zux%zux%zu input: input dimensions must be non-zero",
         input_width,
-        input_height);
+        input_height,
+        input_depth);
     return pytorch_qnnp_status_invalid_parameter;
   }
 
   convolution->batch_size = batch_size;
+  convolution->input_depth = input_depth;
   convolution->input_height = input_height;
   convolution->input_width = input_width;
   convolution->input = input;
   convolution->input_pixel_stride = input_pixel_stride;
 
+  convolution->output_depth = compute_output_dimension(
+      convolution->input_padding_front + input_depth +
+          convolution->input_padding_back,
+      convolution->kernel_depth,
+      convolution->dilation_depth,
+      convolution->stride_depth);
   convolution->output_height = compute_output_dimension(
       convolution->input_padding_top + input_height +
           convolution->input_padding_bottom,
@@ -541,13 +641,14 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_convolution2d_nhwc_q8(
       return pytorch_qnnp_status_success;
     case pytorch_qnnp_ukernel_type_xzp_gemm: {
       const size_t groups = convolution->groups;
+      const size_t input_size = input_depth * input_height * input_width;
       void* a_sum = (void*)realloc(
           convolution->a_sum,
-          sizeof(int32_t) * batch_size * groups * input_height * input_width);
+          sizeof(int32_t) * batch_size * groups * input_size);
       if (a_sum == NULL) {
         pytorch_qnnp_log_error(
             "failed to allocate %zu bytes for row sum data",
-            sizeof(int32_t) * batch_size * groups * input_height * input_width);
+            sizeof(int32_t) * batch_size * groups * input_size);
         return pytorch_qnnp_status_out_of_memory;
       }
       convolution->a_sum = a_sum;
@@ -555,12 +656,14 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_convolution2d_nhwc_q8(
     }
     case pytorch_qnnp_ukernel_type_conv: {
       const size_t groups = convolution->groups;
+      const size_t kernel_depth = convolution->kernel_depth;
       const size_t kernel_height = convolution->kernel_height;
       const size_t kernel_width = convolution->kernel_width;
-      const size_t kernel_size = kernel_height * kernel_width;
+      const size_t kernel_size = kernel_depth * kernel_height * kernel_width;
+      const size_t output_depth = convolution->output_depth;
       const size_t output_height = convolution->output_height;
       const size_t output_width = convolution->output_width;
-      const size_t output_size = output_height * output_width;
+      const size_t output_size = output_depth * output_height * output_width;
       const size_t output_tile_size = pytorch_qnnp_params.q8conv.mr;
       const size_t tiled_output_size = round_up(output_size, output_tile_size);
       const size_t indirection_buffer_size =
@@ -575,15 +678,15 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_convolution2d_nhwc_q8(
         return pytorch_qnnp_status_out_of_memory;
       }
       convolution->indirection_buffer = indirection_buffer;
-
-      pytorch_qnnp_indirection_init_conv2d(
+      pytorch_qnnp_indirection_init_conv3d(
           convolution, output_tile_size, tiled_output_size);
       return pytorch_qnnp_status_success;
     }
     case pytorch_qnnp_ukernel_type_dwconv: {
+      const size_t kernel_depth = convolution->kernel_depth;
       const size_t kernel_height = convolution->kernel_height;
       const size_t kernel_width = convolution->kernel_width;
-      const size_t kernel_size = kernel_height * kernel_width;
+      const size_t kernel_size = kernel_depth * kernel_height * kernel_width;
       const size_t output_height = convolution->output_height;
       const size_t output_width = convolution->output_width;
       const size_t step_width = convolution->dilation_width == 1

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/indirection.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/indirection.c
@@ -14,7 +14,7 @@
 #include <qnnpack/math.h>
 #include <qnnpack/operator.h>
 
-void pytorch_qnnp_indirection_init_conv2d(
+void pytorch_qnnp_indirection_init_conv3d(
     pytorch_qnnp_operator_t op,
     size_t output_tile_size,
     size_t tiled_output_size) {
@@ -25,22 +25,30 @@ void pytorch_qnnp_indirection_init_conv2d(
   const size_t groups = op->groups;
   const size_t group_input_channels = op->group_input_channels;
   const size_t batch_size = op->batch_size;
+  const size_t input_depth = op->input_depth;
   const size_t input_height = op->input_height;
   const size_t input_width = op->input_width;
+  const size_t output_depth = op->output_depth;
   const size_t output_height = op->output_height;
   const size_t output_width = op->output_width;
+  const size_t kernel_depth = op->kernel_depth;
   const size_t kernel_height = op->kernel_height;
   const size_t kernel_width = op->kernel_width;
+  const size_t stride_depth = op->stride_depth;
   const size_t stride_height = op->stride_height;
   const size_t stride_width = op->stride_width;
+  const size_t dilation_depth = op->dilation_depth;
   const size_t dilation_height = op->dilation_height;
   const size_t dilation_width = op->dilation_width;
+  const size_t input_padding_front = op->input_padding_front;
   const size_t input_padding_top = op->input_padding_top;
   const size_t input_padding_left = op->input_padding_left;
 
-  const size_t output_size = output_height * output_width;
-  const size_t kernel_size = kernel_height * kernel_width;
-  const struct fxdiv_divisor_size_t output_width_divisor =
+  const size_t output_size = output_depth * output_height * output_width;
+  const size_t kernel_size = kernel_depth * kernel_height * kernel_width;
+  const struct fxdiv_divisor_size_t output_yx_divisor =
+      fxdiv_init_size_t(output_height * output_width);
+  const struct fxdiv_divisor_size_t output_x_divisor =
       fxdiv_init_size_t(output_width);
   for (size_t group = 0; group < groups; group++) {
     for (size_t image = 0; image < batch_size; image++) {
@@ -52,40 +60,71 @@ void pytorch_qnnp_indirection_init_conv2d(
           const size_t tiled_output_index =
               output_tile_start + output_tile_offset;
           const size_t output_index = min(tiled_output_index, output_size - 1);
-          const struct fxdiv_result_size_t output_index_components =
-              fxdiv_divide_size_t(output_index, output_width_divisor);
-          const size_t output_y = output_index_components.quotient;
-          const size_t output_x = output_index_components.remainder;
-          for (size_t kernel_y = 0; kernel_y < kernel_height; kernel_y++) {
-            const size_t input_y = output_y * stride_height +
-                kernel_y * dilation_height - input_padding_top;
-            if (input_y < input_height) {
-              for (size_t kernel_x = 0; kernel_x < kernel_width; kernel_x++) {
-                const size_t input_x = output_x * stride_width +
-                    kernel_x * dilation_width - input_padding_left;
-                const size_t index = (group * batch_size + image) *
-                        tiled_output_size * kernel_size +
-                    output_tile_start * kernel_size +
-                    (kernel_y * kernel_width + kernel_x) * output_tile_size +
-                    output_tile_offset;
-                if (input_x < input_width) {
-                  indirection_buffer[index] = (char*)input +
-                      ((image * input_height + input_y) * input_width +
-                       input_x) *
-                          input_pixel_stride +
-                      group * group_input_channels;
+          const struct fxdiv_result_size_t z_yx =
+              fxdiv_divide_size_t(output_index, output_yx_divisor);
+          const struct fxdiv_result_size_t y_x =
+              fxdiv_divide_size_t(z_yx.remainder, output_x_divisor);
+          const size_t output_z = z_yx.quotient;
+          const size_t output_y = y_x.quotient;
+          const size_t output_x = y_x.remainder;
+
+          for (size_t kernel_z = 0; kernel_z < kernel_depth; kernel_z++) {
+            const size_t input_z = output_z * stride_depth +
+                kernel_z * dilation_depth - input_padding_front;
+            if (input_z < input_depth) {
+              for (size_t kernel_y = 0; kernel_y < kernel_height; kernel_y++) {
+                const size_t input_y = output_y * stride_height +
+                    kernel_y * dilation_height - input_padding_top;
+                if (input_y < input_height) {
+                  for (size_t kernel_x = 0; kernel_x < kernel_width;
+                       kernel_x++) {
+                    const size_t input_x = output_x * stride_width +
+                        kernel_x * dilation_width - input_padding_left;
+                    const size_t index = (group * batch_size + image) *
+                            tiled_output_size * kernel_size +
+                        output_tile_start * kernel_size +
+                        ((kernel_height * kernel_z + kernel_y) * kernel_width +
+                         kernel_x) *
+                            output_tile_size +
+                        output_tile_offset;
+                    if (input_x < input_width) {
+                      indirection_buffer[index] = (char*)input +
+                          (((image * input_depth + input_z) * input_height +
+                            input_y) *
+                               input_width +
+                           input_x) *
+                              input_pixel_stride +
+                          group * group_input_channels;
+                    } else {
+                      indirection_buffer[index] = zero;
+                    }
+                  }
                 } else {
-                  indirection_buffer[index] = zero;
+                  for (size_t kernel_x = 0; kernel_x < kernel_width;
+                       kernel_x++) {
+                    const size_t index = (group * batch_size + image) *
+                            tiled_output_size * kernel_size +
+                        output_tile_start * kernel_size +
+                        ((kernel_height * kernel_z + kernel_y) * kernel_width +
+                         kernel_x) *
+                            output_tile_size +
+                        output_tile_offset;
+                    indirection_buffer[index] = zero;
+                  }
                 }
               }
             } else {
-              for (size_t kernel_x = 0; kernel_x < kernel_width; kernel_x++) {
-                const size_t index = (group * batch_size + image) *
-                        tiled_output_size * kernel_size +
-                    output_tile_start * kernel_size +
-                    (kernel_y * kernel_width + kernel_x) * output_tile_size +
-                    output_tile_offset;
-                indirection_buffer[index] = zero;
+              for (size_t kernel_y = 0; kernel_y < kernel_height; kernel_y++) {
+                for (size_t kernel_x = 0; kernel_x < kernel_width; kernel_x++) {
+                  const size_t index = (group * batch_size + image) *
+                          tiled_output_size * kernel_size +
+                      output_tile_start * kernel_size +
+                      ((kernel_height * kernel_z + kernel_y) * kernel_width +
+                       kernel_x) *
+                          output_tile_size +
+                      output_tile_offset;
+                  indirection_buffer[index] = zero;
+                }
               }
             }
           }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/indirection.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/indirection.h
@@ -18,27 +18,27 @@
 extern "C" {
 #endif
 
-  PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_conv2d(
-      pytorch_qnnp_operator_t op,
-      size_t output_tile_size,
-      size_t tiled_output_size);
+PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_conv3d(
+    pytorch_qnnp_operator_t op,
+    size_t output_tile_size,
+    size_t tiled_output_size);
 
-  PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_dwconv2d(
-      pytorch_qnnp_operator_t convolution,
-      size_t batch_start,
-      size_t step_height,
-      size_t step_width);
+PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_dwconv2d(
+    pytorch_qnnp_operator_t convolution,
+    size_t batch_start,
+    size_t step_height,
+    size_t step_width);
 
-  PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_deconv2d(
-      pytorch_qnnp_operator_t op,
-      size_t output_tile_size,
-      size_t tiled_output_size);
+PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_deconv2d(
+    pytorch_qnnp_operator_t op,
+    size_t output_tile_size,
+    size_t tiled_output_size);
 
-  PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_maxpool2d(
-      pytorch_qnnp_operator_t op,
-      size_t batch_start,
-      size_t step_height,
-      size_t step_width);
+PYTORCH_QNNP_INTERNAL void pytorch_qnnp_indirection_init_maxpool2d(
+    pytorch_qnnp_operator_t op,
+    size_t batch_start,
+    size_t step_height,
+    size_t step_width);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/operator.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/operator.h
@@ -47,16 +47,21 @@ typedef struct {
 
 struct pytorch_qnnp_operator {
   size_t batch_size;
+  uint32_t input_padding_front;
+  uint32_t input_padding_back;
   uint32_t input_padding_top;
   uint32_t input_padding_right;
   uint32_t input_padding_bottom;
   uint32_t input_padding_left;
   uint32_t adjustment_height;
   uint32_t adjustment_width;
+  uint32_t kernel_depth;
   uint32_t kernel_height;
   uint32_t kernel_width;
+  uint32_t stride_depth;
   uint32_t stride_height;
   uint32_t stride_width;
+  uint32_t dilation_depth;
   uint32_t dilation_height;
   uint32_t dilation_width;
   uint32_t groups;
@@ -66,6 +71,7 @@ struct pytorch_qnnp_operator {
   size_t group_output_channels;
   size_t channels;
 
+  size_t input_depth;
   size_t input_height;
   size_t input_width;
   size_t input_pixel_stride;
@@ -76,6 +82,7 @@ struct pytorch_qnnp_operator {
   size_t input2_pixel_stride;
   const void* input2;
 
+  size_t output_depth;
   size_t output_height;
   size_t output_width;
   size_t output_pixel_stride;

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/convolution-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/convolution-operator-tester.h
@@ -544,9 +544,10 @@ class ConvolutionOperatorTester {
         case Mode::Static: {
           ASSERT_EQ(
               pytorch_qnnp_status_success,
-              pytorch_qnnp_setup_convolution2d_nhwc_q8(
+              pytorch_qnnp_setup_convolution_ndhwc_q8(
                   convolution,
                   batchSize(),
+                  1, /* inputDepth */
                   inputHeight(),
                   inputWidth(),
                   inputPtr,
@@ -579,6 +580,7 @@ class ConvolutionOperatorTester {
                   convolution,
                   packW->getPackedWeights(),
                   batchSize(),
+                  1,
                   inputHeight(),
                   inputWidth(),
                   inputZeroPoint,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -140,7 +140,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
       } else if (
           kernel_size == 1 &&
           std::all_of(
-              stride_.begin(), stride_.end(), [](auto e) { return e == 1; }) &&
+              stride_.begin(), stride_.end(), [](const auto& e) { return e == 1; }) &&
           !any_padding) {
         ukernel_type = group_input_channels >= SIZE_MAX
             ? pytorch_qnnp_ukernel_type_xzp_gemm

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -118,7 +118,8 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
         w_zero_points(std::move(w_zps)) {
     const bool any_padding = std::any_of(
         padding_.begin(), padding_.end(), [](const auto& e) { return e != 0; });
-    const size_t kernel_size = kernel_[0] * kernel_[1];
+    const size_t kernel_size =
+        std::accumulate(kernel_.begin(), kernel_.end(), 1, std::multiplies<>());
 
     const size_t group_input_channels = transpose
         ? this->orig_weight.size(0) / groups
@@ -132,12 +133,14 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
       ukernel_type = pytorch_qnnp_ukernel_type_conv;
     } else {
       ukernel_type = pytorch_qnnp_ukernel_type_none;
-      if ((kernel_size == 9 || kernel_size == 25) &&
+      if (kSpatialDim == 2 && (kernel_size == 9 || kernel_size == 25) &&
           group_input_channels == 1 && group_output_channels == 1 &&
           groups > 1) {
         ukernel_type = pytorch_qnnp_ukernel_type_dwconv;
       } else if (
-          kernel_size == 1 && stride_[0] == 1 && stride_[1] == 1 &&
+          kernel_size == 1 &&
+          std::all_of(
+              stride_.begin(), stride_.end(), [](auto e) { return e == 1; }) &&
           !any_padding) {
         ukernel_type = group_input_channels >= SIZE_MAX
             ? pytorch_qnnp_ukernel_type_xzp_gemm
@@ -171,16 +174,21 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
     convolution->groups = groups;
     convolution->group_input_channels = group_input_channels;
     convolution->group_output_channels = group_output_channels;
-    convolution->kernel_height = kernel_[0];
-    convolution->kernel_width = kernel_[1];
-    convolution->stride_height = stride_[0];
-    convolution->stride_width = stride_[1];
-    convolution->dilation_height = dilation_[0];
-    convolution->dilation_width = dilation_[1];
-    convolution->input_padding_top = padding_[0];
-    convolution->input_padding_left = padding_[1];
-    convolution->input_padding_bottom = padding_[0];
-    convolution->input_padding_right = padding_[1];
+    convolution->kernel_depth = kSpatialDim == 3 ? kernel_[0] : 1;
+    convolution->kernel_height = kernel_[kSpatialDim - 2];
+    convolution->kernel_width = kernel_[kSpatialDim - 1];
+    convolution->stride_depth = kSpatialDim == 3 ? stride_[0] : 1;
+    convolution->stride_height = stride_[kSpatialDim - 2];
+    convolution->stride_width = stride_[kSpatialDim - 1];
+    convolution->dilation_depth = kSpatialDim == 3 ? dilation_[0] : 1;
+    convolution->dilation_height = dilation_[kSpatialDim - 2];
+    convolution->dilation_width = dilation_[kSpatialDim - 1];
+    convolution->input_padding_top = padding_[kSpatialDim - 2];
+    convolution->input_padding_left = padding_[kSpatialDim - 1];
+    convolution->input_padding_bottom = padding_[kSpatialDim - 2];
+    convolution->input_padding_right = padding_[kSpatialDim - 1];
+    convolution->input_padding_front = kSpatialDim == 3 ? padding_[0] : 0;
+    convolution->input_padding_back = kSpatialDim == 3 ? padding_[0] : 0;
     convolution->per_channel = is_per_channel;
     convolution->transpose = transpose_;
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4388,7 +4388,7 @@ class TestQuantizedConv(TestCase):
            use_bias=st.booleans(),
            use_relu=st.booleans(),
            use_channelwise=st.booleans(),
-           qengine=st.sampled_from(("fbgemm",)))
+           qengine=st.sampled_from(("qnnpack", "fbgemm")))
     def test_qconv3d(
         self,
         batch_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66350

Implements conv3d for QNNPACK by writing another kernel for the indirection buffer in 3 dimensions. Modifies all structs to take depth, with depth = 1 indicating 2d operation. gemm and conv (non transpose) work, next up is depthwise and tranpose.

Differential Revision: [D30858693](https://our.internmc.facebook.com/intern/diff/D30858693/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D30858693/)!