### PR TITLE
[FX] fuse permute021 linear pass for trt lowering

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -182,9 +182,9 @@ def add_binary_elementwise_layer(network, lhs_val, rhs_val, op_type, name):
     # Check the limitation in the doc string.
     if network.has_implicit_batch_dimension:
         if is_lhs_trt_tensor and not is_rhs_trt_tensor:
-            assert len(lhs_val.shape) >= len(rhs_val.shape)
+            assert len(lhs_val.shape) >= len(rhs_val.shape), f"{lhs_val.shape} >= {rhs_val.shape}"
         elif not is_lhs_trt_tensor and is_rhs_trt_tensor:
-            assert len(rhs_val.shape) >= len(lhs_val.shape)
+            assert len(rhs_val.shape) >= len(lhs_val.shape), f"{rhs_val.shape} >= {lhs_val.shape}"
 
     lhs_val, rhs_val = broadcast(
         network, lhs_val, rhs_val, f"{name}_lhs", f"{name}_rhs"
@@ -1496,7 +1496,7 @@ def acc_ops_matmul(network, target, args, kwargs, name):
     for i in [input_val, other_val]:
         if not isinstance(i, trt.tensorrt.ITensor):
             raise RuntimeError(
-                f"matmul received input {i} that is not part " "of the TensorRT region!"
+                f"matmul received input {i} that is not part of the TensorRT region!"
             )
 
     return add_matrix_multiply_layer(network, input_val, other_val, name)

--- a/torch/fx/experimental/fx2trt/passes/fuse_permute_matmul.py
+++ b/torch/fx/experimental/fx2trt/passes/fuse_permute_matmul.py
@@ -12,19 +12,44 @@ def trt_transposed_matmul(lhs: torch.Tensor, rhs: torch.Tensor, lhs_transposed: 
     return torch.matmul(lhs, rhs)
 
 
+def trt_transposed_linear(input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):
+    return torch.matmul(input.transpose(-1, -2), weight.t()) + bias
+
+
+def check_permute(node: torch.fx.Node):
+    ranks = len(node.meta["tensor_meta"].shape)
+    permutation = list(i % ranks for i in node.kwargs["permutation"])  # type: ignore[union-attr]
+    allowed_permutation = list(i for i in range(ranks))
+    allowed_permutation[-1] = ranks - 2
+    allowed_permutation[-2] = ranks - 1
+    return len(node.users) == 1 and permutation == allowed_permutation
+
+
+def fuse_permute_linear(gm: torch.fx.GraphModule):
+    """
+    Fuse pattern like permute + linear if permute is transposing the last two dimension.
+    """
+    for node in gm.graph.nodes:
+        if node.target == acc_ops.linear:
+            inp = node.kwargs["input"]
+            if inp.target == acc_ops.permute and check_permute(inp) and len(inp.users) == 1:
+                inp = inp.kwargs["input"]
+                weight = node.kwargs["weight"]
+                bias = node.kwargs["bias"]
+                with gm.graph.inserting_before(node):
+                    fused_node = gm.graph.call_function(trt_transposed_linear, args=(inp, weight, bias))
+                    node.replace_all_uses_with(fused_node)
+
+    gm.graph.eliminate_dead_code()
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
 def fuse_permute_matmul(gm: torch.fx.GraphModule):
     """
     Fuse pattern like permute + matmul if permute is transposing the last two dimension.
     """
-
-    def check_permute(node: torch.fx.Node):
-        ranks = len(node.meta["tensor_meta"].shape)
-        permutation = list(i % ranks for i in node.kwargs["permutation"])  # type: ignore[union-attr]
-        allowed_permutation = list(i for i in range(ranks))
-        allowed_permutation[-1] = ranks - 2
-        allowed_permutation[-2] = ranks - 1
-        return len(node.users) == 1 and permutation == allowed_permutation
-
     for node in gm.graph.nodes:
         if node.target == acc_ops.matmul:
             lhs, rhs = node.kwargs["input"], node.kwargs["other"]
@@ -51,19 +76,13 @@ def fuse_permute_matmul(gm: torch.fx.GraphModule):
 try:
     import tensorrt as trt
     from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
-except Exception:
-    warnings.warn("Unable to import TensorRT related libraries.")
+    from torch.fx.experimental.fx2trt.converters.acc_ops_converters import get_trt_tensor, add_binary_elementwise_layer, broadcast
+except Exception as e:
+    warnings.warn(f"Unable to import TensorRT related libraries.: {e}")
 else:
     @tensorrt_converter(trt_transposed_matmul)
     def trt_transposed_matmul_converter(network, target, args, kwargs, name):
         lhs, rhs, lhs_transposed, rhs_transposed = args
-
-        for i in [lhs, rhs]:
-            if not isinstance(i, trt.tensorrt.ITensor):
-                raise RuntimeError(
-                    f"trt_transposed_matmul received input {i} that is not part "
-                    "of the TensorRT region!"
-                )
 
         layer = network.add_matrix_multiply(
             lhs,
@@ -73,3 +92,22 @@ else:
         )
         layer.name = name
         return layer.get_output(0)
+
+    @tensorrt_converter(trt_transposed_linear)
+    def trt_transposed_linear_converter(network, target, args, kwargs, name):
+        input, weight, bias = args
+
+        weight = get_trt_tensor(network, weight.t(), f"{name}_weight")
+        bias = get_trt_tensor(network, bias.reshape(1, -1), f"{name}_bias")
+
+        input, weight = broadcast(network, input, weight, f"{input.name}_broadcast", f"{weight.name}_broadcast")
+        layer = network.add_matrix_multiply(
+            input,
+            trt.MatrixOperation.TRANSPOSE,
+            weight,
+            trt.MatrixOperation.NONE,
+        )
+        layer.name = f"{name}_mm"
+        return add_binary_elementwise_layer(
+            network, layer.get_output(0), bias, trt.ElementWiseOperation.SUM, f"{name}_add"
+        )


### PR DESCRIPTION
Summary: In general we cannot rely on Permute021Linear being kept as is before lowering phase before our transformation could have traced through this module. A acc based fx pass is more reliable to recover the perf.

Test Plan:
```
buck run mode/opt -c python.package_style=inplace -c fbcode.nvcc_arch=a100 //hpc/new/models/ads/benchmarks:ads_dense_benchmark -- over-arch --model-version=23x_3tb --batch-size=2048

OverArch, PyTorch, FP16, BS: 2048, TFLOP/s: 53.22, Time per iter: 14.46ms, QPS: 141629.45
OverArch, TensorRT, FP16, BS: 2048, TFLOP/s: 92.20, Time per iter: 8.35ms, QPS: 245354.15
```

Unittest:
```
buck test mode/dev-nosan caffe2/torch/fb/fx2trt:test_fuse_permute_linear_trt
```

Differential Revision: D31525307

