### PR TITLE
Add some graph-rewrite passes to prepare BT model for compilation.

### DIFF
--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -206,6 +206,23 @@ std::shared_ptr<Graph> removeUnusedSelfArgument(
   return graph;
 }
 
+std::shared_ptr<Graph> removeGraphOutput(
+    const std::shared_ptr<Graph>& graph,
+    size_t idx) {
+  graph->eraseOutput(idx);
+  return graph;
+}
+
+std::shared_ptr<Graph> replaceListOutputWithTuple(
+    const std::shared_ptr<Graph>& graph) {
+  auto out = graph->outputs()[0];
+  auto out_node = out->node();
+  auto tuple_node = graph->createTuple(out_node->inputs());
+  tuple_node->insertAfter(out_node);
+  out->replaceAllUsesWith(tuple_node->output());
+  return graph;
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/graph_opt.h
+++ b/torch/csrc/jit/tensorexpr/graph_opt.h
@@ -63,6 +63,11 @@ TORCH_API void annotateInputShapes(
     const std::vector<c10::optional<at::Tensor>>& example_inputs);
 TORCH_API std::shared_ptr<Graph> removeUnusedSelfArgument(
     const std::shared_ptr<Graph>& graph);
+TORCH_API std::shared_ptr<Graph> removeGraphOutput(
+    const std::shared_ptr<Graph>& graph,
+    size_t idx);
+TORCH_API std::shared_ptr<Graph> replaceListOutputWithTuple(
+    const std::shared_ptr<Graph>& graph);
 
 } // namespace tensorexpr
 } // namespace jit

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -841,6 +841,8 @@ void initTensorExprBindings(PyObject* module) {
       });
   te.def("annotate_input_shapes", &tensorexpr::annotateInputShapes);
   te.def("remove_unused_self_argument", &tensorexpr::removeUnusedSelfArgument);
+  te.def("remove_graph_output", &tensorexpr::removeGraphOutput);
+  te.def("replace_list_output_with_tuple", &tensorexpr::replaceListOutputWithTuple);
 }
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66374
* #66373
* #66372
* #66371
* #66370
* __->__ #66369
* #66368
* #66367

Is it a hack?
Yes, we won't be able to use this everywhere, probably we'll have to
require users to adapt their model manually.