### PR TITLE
[TensorExpr] Fix lowering for aten::softmax for the case when dtype parameter is None.

### DIFF
--- a/torch/csrc/jit/tensorexpr/operators/softmax.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/softmax.cpp
@@ -93,7 +93,9 @@ Tensor computeSoftmax(
     return new_indices;
   };
 
-  c10::optional<Dtype> dtype = ToDtype(ScalarType::Undefined);
+  auto inp_buf = c10::get<BufHandle>(inputs[0]);
+
+  auto dtype = inp_buf.dtype();
   if (auto d = c10::get_if<int64_t>(&inputs[2])) {
     dtype = ToDtype(static_cast<ScalarType>(*d));
   }
@@ -101,7 +103,7 @@ Tensor computeSoftmax(
   auto max = Reduce(
       "aten_softmax_max",
       non_softmax_dims,
-      Maximum(dtype.value()),
+      Maximum(dtype),
       [&](ParameterList& indices) {
         return tensorOrConstant(
             inputs[0], move_softmax_dim_index_to_pos(indices));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66374
* #66373
* #66372
* #66371
* __->__ #66370
* #66369
* #66368
* #66367

Is it a hack?
No, this should be cleaned up and upstreamed properly.