### PR TITLE
[TensorExpr] Add lowering for aten::conv1d.

### DIFF
--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -99,6 +99,45 @@ void nnc_aten_conv2d(
   memcpy(buf_data[0], r.data_ptr(), r.element_size() * r.numel());
 }
 
+void nnc_aten_conv1d(
+    int64_t bufs_num,
+    void** buf_data,
+    int64_t* buf_ranks,
+    int64_t* buf_dims,
+    int8_t* buf_dtypes,
+    int64_t args_num,
+    int64_t* extra_args) {
+  std::vector<at::Tensor> tensors =
+      constructTensors(bufs_num, buf_data, buf_ranks, buf_dims, buf_dtypes);
+
+  at::Tensor& r = tensors[0];
+  const at::Tensor& x = tensors[1];
+  const at::Tensor& w = tensors[2];
+  if (args_num > 0) {
+    // Check that if the extra arguments are provided, then the bias tensor is
+    // also present
+    TORCH_INTERNAL_ASSERT(args_num == 7 && bufs_num == 4);
+    const at::Tensor& b = tensors[3];
+
+    int64_t stride = extra_args[0];
+    int64_t padding = extra_args[2];
+    int64_t dilation = extra_args[4];
+    int64_t groups = extra_args[6];
+
+    try {
+      r = at::conv1d(x, w, b, {stride}, {padding}, {dilation}, groups);
+    } catch (...) {
+    }
+  } else {
+    try {
+      r = at::conv1d(x, w);
+    } catch (...) {
+    }
+  }
+
+  memcpy(buf_data[0], r.data_ptr(), r.element_size() * r.numel());
+}
+
 void nnc_aten_adaptive_avg_pool2d(
     int64_t bufs_num,
     void** buf_data,
@@ -242,6 +281,9 @@ void nnc_prepacked_conv2d_clamp_run(
 const static RegisterNNCExternalFunction nnc_conv2d(
     "nnc_aten_conv2d",
     nnc_aten_conv2d);
+const static RegisterNNCExternalFunction nnc_conv1d(
+    "nnc_aten_conv1d",
+    nnc_aten_conv1d);
 const static RegisterNNCExternalFunction nnc_adaptive_avg_pool2d(
     "nnc_aten_adaptive_avg_pool2d",
     nnc_aten_adaptive_avg_pool2d);

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -1384,6 +1384,7 @@ RegisterNNCLoweringFunction aten_log_softmax(
     });
 
 RegisterNNCLoweringFunction aten_conv2d("aten::conv2d", computeConv2d);
+RegisterNNCLoweringFunction aten_conv1d("aten::conv1d", computeConv1d);
 
 RegisterNNCLoweringFunction aten_addmm("aten::addmm", computeAddMM);
 

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
@@ -250,6 +250,14 @@ std::vector<int64_t> _pair_int(ArgValue v) {
   return {i, i};
 }
 
+std::vector<int64_t> _single_int_list(ArgValue v) {
+  if (auto t = c10::get_if<IntList>(&v)) {
+    return {(*t)[0]};
+  }
+  auto i = c10::get<int64_t>(v);
+  return {i};
+}
+
 bool conv2dIsSupported(
     const TensorInfo& input,
     const TensorInfo& weight,
@@ -340,6 +348,42 @@ Tensor computeConv2d(
        padding[1],
        dilation[0],
        dilation[1],
+       groups});
+  return Tensor(ResultBuf.node(), s);
+}
+
+Tensor computeConv1d(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  Dtype dtype = kFloat;
+  if (outputType) {
+    dtype = Dtype(*outputType);
+  }
+
+  BufHandle ResultBuf("conv", outputShape, dtype);
+  const BufHandle& inp = c10::get<BufHandle>(inputs[0]);
+  const BufHandle& w = c10::get<BufHandle>(inputs[1]);
+  const BufHandle& b = c10::get<BufHandle>(inputs[2]);
+
+  auto strides = _single_int_list(inputs[3]);
+  auto padding = _single_int_list(inputs[4]);
+  auto dilation = _single_int_list(inputs[5]);
+
+  int groups = c10::get<int64_t>(inputs[6]);
+
+  auto inpInfo = getTensorInfo(inp);
+  auto wInfo = getTensorInfo(w);
+  auto bInfo = getTensorInfo(b);
+
+  StmtPtr s = ExternalCall::make(
+      ResultBuf,
+      "nnc_aten_conv1d",
+      {inp, w, b},
+      {strides[0],
+       padding[0],
+       dilation[0],
        groups});
   return Tensor(ResultBuf.node(), s);
 }

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.h
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.h
@@ -68,6 +68,11 @@ Tensor computeConv2d(
     const std::vector<ExprHandle>& outputShape,
     const c10::optional<ScalarType>& outputType,
     at::Device device);
+Tensor computeConv1d(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
 Tensor computePrepackedConv2dClampRun(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66374
* #66373
* #66372
* __->__ #66371
* #66370
* #66369
* #66368
* #66367

Is it a hack?
No, it should be cleaned up and upstreamed properly.