### PR TITLE
[TensorExpr] Add lowering for aten::embedding.

### DIFF
--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -1412,6 +1412,7 @@ RegisterNNCLoweringFunction aten_add(
           : computeTwoOperand(
                 "aten_add", inputs, outputShape, outputType, add_lambda);
     });
+RegisterNNCLoweringFunction aten_embedding("aten::embedding", computeEmbedding);
 
 } // namespace
 

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -638,6 +638,25 @@ Tensor computeCat(
       });
 }
 
+Tensor computeEmbedding(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  Dtype dtype = kFloat;
+  if (outputType) {
+    dtype = Dtype(*outputType);
+  }
+
+  BufHandle ResultBuf("emb", outputShape, dtype);
+  const BufHandle& w = c10::get<BufHandle>(inputs[0]);
+  const BufHandle& indices = c10::get<BufHandle>(inputs[1]);
+
+  StmtPtr s =
+      ExternalCall::make(ResultBuf, "nnc_aten_embedding", {w, indices}, {});
+  return Tensor(ResultBuf.node(), s);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/operators/misc.h
+++ b/torch/csrc/jit/tensorexpr/operators/misc.h
@@ -86,6 +86,11 @@ Tensor computeCat(
     const std::vector<ExprHandle>& outputShape,
     const c10::optional<ScalarType>& outputType,
     at::Device device);
+Tensor computeEmbedding(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
 
 } // namespace tensorexpr
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66374
* #66373
* __->__ #66372
* #66371
* #66370
* #66369
* #66368
* #66367

Is it a hack?
No, this should be cleaned up and upstreamed properly.