### PR TITLE
[TensorExpr] Add lowering for aten::max (reduction).

### DIFF
--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -185,6 +185,28 @@ void nnc_aten_mean(
   }
 }
 
+void nnc_aten_max_red(
+    int64_t bufs_num,
+    void** buf_data,
+    int64_t* buf_ranks,
+    int64_t* buf_dims,
+    int8_t* buf_dtypes,
+    int64_t args_num,
+    int64_t* extra_args) {
+  std::vector<at::Tensor> tensors =
+      constructTensors(bufs_num, buf_data, buf_ranks, buf_dims, buf_dtypes);
+
+  at::Tensor& r = tensors[0];
+  const at::Tensor& x = tensors[1];
+  int64_t max_dim = extra_args[0];
+  int64_t keep_dim = extra_args[1];
+  try {
+    r =  std::get<1>(at::max(x, max_dim, keep_dim));
+  } catch (...) {
+  }
+  memcpy(buf_data[0], r.data_ptr(), r.element_size() * r.numel());
+}
+
 void nnc_aten_addmm(
     int64_t bufs_num,
     void** buf_data,
@@ -325,6 +347,7 @@ const static RegisterNNCExternalFunction nnc_adaptive_avg_pool2d(
 const static RegisterNNCExternalFunction nnc_mean(
     "nnc_aten_mean",
     nnc_aten_mean);
+const static RegisterNNCExternalFunction nnc_max_red("nnc_aten_max_red", nnc_aten_max_red);
 const static RegisterNNCExternalFunction nnc_addmm(
     "nnc_aten_addmm",
     nnc_aten_addmm);

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -276,21 +276,21 @@ RegisterNNCLoweringFunction aten_min(
           });
     });
 
-RegisterNNCLoweringFunction aten_max(
-    "aten::max",
-    [](const std::vector<ArgValue>& inputs,
-       const std::vector<ExprHandle>& outputShape,
-       const c10::optional<ScalarType>& outputType,
-       at::Device device) {
-      return computeTwoOperand(
-          "aten_max",
-          inputs,
-          outputShape,
-          outputType,
-          [](const ExprHandle& lhs, const ExprHandle& rhs) {
-            return Max::make(boolToInteger(lhs), boolToInteger(rhs), false);
-          });
-    });
+// RegisterNNCLoweringFunction aten_max(
+//     "aten::max",
+//     [](const std::vector<ArgValue>& inputs,
+//        const std::vector<ExprHandle>& outputShape,
+//        const c10::optional<ScalarType>& outputType,
+//        at::Device device) {
+//       return computeTwoOperand(
+//           "aten_max",
+//           inputs,
+//           outputShape,
+//           outputType,
+//           [](const ExprHandle& lhs, const ExprHandle& rhs) {
+//             return Max::make(boolToInteger(lhs), boolToInteger(rhs), false);
+//           });
+//     });
 
 RegisterNNCLoweringFunction aten_masked_fill(
     "aten::masked_fill",
@@ -1389,6 +1389,7 @@ RegisterNNCLoweringFunction aten_conv1d("aten::conv1d", computeConv1d);
 RegisterNNCLoweringFunction aten_addmm("aten::addmm", computeAddMM);
 
 RegisterNNCLoweringFunction aten_mean("aten::mean", computeMean);
+RegisterNNCLoweringFunction aten_max("aten::max", computeMax);
 
 RegisterNNCLoweringFunction aten_adaptive_avg_pool2d(
     "aten::adaptive_avg_pool2d",

--- a/torch/csrc/jit/tensorexpr/operators/reduction.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/reduction.cpp
@@ -129,6 +129,26 @@ Tensor computeMean(
           ResultBuf, "nnc_aten_mean", {InputBuf}, mean_dims_expr));
 }
 
+Tensor computeMax(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  Dtype dtype = kFloat;
+  if (outputType) {
+    dtype = Dtype(*outputType);
+  }
+  BufHandle ResultBuf("max", outputShape, dtype);
+  BufHandle InputBuf = c10::get<BufHandle>(inputs[0]);
+  std::vector<ExprHandle> max_dims_expr;
+  auto max_dim = c10::get<int64_t>(inputs[1]);
+  auto keep_dim = c10::get<bool>(inputs[2]);
+  return Tensor(
+      ResultBuf.node(),
+      ExternalCall::make(
+          ResultBuf, "nnc_aten_max", {InputBuf}, {max_dim, (int64_t)keep_dim}));
+}
+
 Tensor computeAdaptiveAvgPool2d(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,

--- a/torch/csrc/jit/tensorexpr/operators/reduction.h
+++ b/torch/csrc/jit/tensorexpr/operators/reduction.h
@@ -21,6 +21,11 @@ TORCH_API Tensor computeAdaptiveAvgPool2d(
     const std::vector<ExprHandle>& outputShape,
     const c10::optional<ScalarType>& outputType,
     at::Device device);
+Tensor computeMax(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
 
 } // namespace tensorexpr
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66374
* __->__ #66373
* #66372
* #66371
* #66370
* #66369
* #66368
* #66367

Is it a hack?
Yes and no. Yes, because I had to disable lowering for pointwise max.
No, because eventually we would need to add max reduction lowering
anyway. A proper implementation requires #65843 - that would allow us to
distinguish pointwise case from the reduction case and have separate
lowerings for them. In the long run we should land #65843 and then a
cleaned up version of this PR.