### PR TITLE
[LTC] Add `c10::optional<at::Scalar>` code-gen support

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -401,16 +401,6 @@ class LazyTensor {
 
   static LazyTensor cholesky(const LazyTensor& input, bool upper);
 
-  static LazyTensor clamp(const LazyTensor& input,
-                          const c10::optional<at::Scalar>& min,
-                          const c10::optional<at::Scalar>& max);
-  static LazyTensor clamp(const LazyTensor& input,
-                          const c10::optional<at::Tensor>& min,
-                          const c10::optional<at::Tensor>& max);
-  static void clamp_out(LazyTensor& out, const LazyTensor& input,
-                        const c10::optional<at::Tensor>& min,
-                        const c10::optional<at::Tensor>& max);
-
   static LazyTensor clone(const LazyTensor& input);
 
   // Pad with the given value and size specified by the given list of low and

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -8,6 +8,7 @@ full_codegen:
   - addcdiv
   - addcmul
   - cos
+  - clamp
   - dropout
   - gelu
   - gelu_backward

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -45,24 +45,13 @@ def process_ir_type(typ: Type) -> Union[BaseCType, VectorCType, OptionalCType, L
         else:
             raise AssertionError(f"TODO add support for type {repr(typ)}")
     elif isinstance(typ, OptionalType):
-        if str(typ.elem) == 'Tensor':
-            return OptionalCType(BaseCType(valueT))
-        elif str(typ.elem) == 'ScalarType':
-            return OptionalCType(BaseCType(scalarTypeT))
-        else:
-            raise AssertionError(f"TODO add support for type {repr(typ)}")
+        return OptionalCType(process_ir_type(typ.elem))
     elif isinstance(typ, ListType):
-        if str(typ.elem) == 'Tensor':
-            return VectorCType(BaseCType(valueT))
-        elif str(typ.elem) == 'Tensor?':
+        if str(typ.elem) == 'Tensor?':
             # TODO(whc) is this actually correct? or should it use a Vector like above
             return ListCType(OptionalCType(BaseCType(valueT)))
-        elif str(typ.elem) == 'int':
-            return VectorCType(BaseCType(longT))
-        elif str(typ.elem) == 'bool':
-            return VectorCType(BaseCType(boolT))
         else:
-            raise AssertionError(f"TODO add support for type {repr(typ)}")
+            return VectorCType(process_ir_type(typ.elem))
     else:
         raise AssertionError(f"unrecognized type {repr(typ)}")
 


### PR DESCRIPTION
Adds `full_codegen` support for `clamp`.

Verified with the following script:

```python
import torch
import lazy_tensor_core as ltc
from lazy_tensor_core.debug import metrics

ltc._LAZYC._ltc_init_ts_backend()
device = 'lazy'
dtype = torch.float32

x = torch.randn((2,3,4), device=device, dtype=dtype)
y = torch.randn((2,3,4), device=device, dtype=dtype)

def computation(x,y):
    # clamp with scalar bounds
    a = torch.clamp(x, 0.2, 1.0)
    # clamp with tensor bounds
    b = torch.clamp(a, torch.tensor(0.5, device=device))
    # clamp with out tensor specified
    c = torch.clamp(b, 0.1, out=y)
    return c

computation(x, y)
print(metrics.metrics_report())
```

Output:

```
Metric: DeviceLockWait
  TotalSamples: 1
  Accumulator: 001.569us
  Percentiles: 1%=001.569us; 5%=001.569us; 10%=001.569us; 20%=001.569us; 50%=001.569us; 80%=001.569us; 90%=001.569us; 95%=001.569us; 99%=001.569us
Metric: IrValueTensorToDataHandle
  TotalSamples: 1
  Accumulator: 011.733us
  Percentiles: 1%=011.733us; 5%=011.733us; 10%=011.733us; 20%=011.733us; 50%=011.733us; 80%=011.733us; 90%=011.733us; 95%=011.733us; 99%=011.733us
Metric: TensorsGraphSize
  TotalSamples: 1
  Accumulator: 1.00
  Percentiles: 1%=1.00; 5%=1.00; 10%=1.00; 20%=1.00; 50%=1.00; 80%=1.00; 90%=1.00; 95%=1.00; 99%=1.00
Counter: CreateLtcTensor
  Value: 6
Counter: DestroyLtcTensor
  Value: 4
Counter: DeviceDataCacheMiss
  Value: 1
Counter: UncachedCompile
  Value: 1
Counter: aten::_local_scalar_dense
  Value: 1
Counter: aten::normal_
  Value: 2
Counter: lazy::_copy_from
  Value: 4
Counter: lazy::_copy_from_and_resize
  Value: 3
Counter: lazy::clamp
  Value: 3
```