### PR TITLE
Skip test_nccl_errors_nonblocking

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2228,6 +2228,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
     @requires_nccl_version((2, 4, 0), "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
     @skip_if_rocm
+    @sandcastle_skip("Test does not pass when run locally")
     def test_nccl_errors_nonblocking(self):
         # Note: we unset and restore NCCL_ASYNC_ERROR_HANDLING for this test
         # since test_c10d_common runs with async error handling by default, but this


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66393
* __->__ #66394

Skips this test as it currently does not seem to pass after several
internal local runs.

Differential Revision: [D31534806](https://our.internmc.facebook.com/intern/diff/D31534806/)