### PR TITLE
[FX] Fix issue where GraphModule.delete_all_unused_submodules deletes submodules from called leaf modules

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -536,11 +536,16 @@ class {module_name}(torch.nn.Module):
                 # For a `call_module` node, also register all recursive submodules
                 # as used
                 if node.op == "call_module":
-                    submod = self.get_submodule(node.target)
+                    try:
+                        submod = self.get_submodule(node.target)
 
-                    for submod_name, _ in submod.named_modules():
-                        if submod_name != '':
-                            used.append('.'.join([node.target, submod_name]))
+                        for submod_name, _ in submod.named_modules():
+                            if submod_name != '':
+                                used.append('.'.join([node.target, submod_name]))
+                    except AttributeError:
+                        # Node referenced nonexistent submodule, don't need to
+                        # worry about GCing anything
+                        pass
 
         to_delete = [name for name, _ in self.named_modules()
                      if name not in used]

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -533,6 +533,15 @@ class {module_name}(torch.nn.Module):
                 for path in itertools.accumulate(fullpath, join_fn):
                     used.append(path)
 
+                # For a `call_module` node, also register all recursive submodules
+                # as used
+                if node.op == "call_module":
+                    submod = self.get_submodule(node.target)
+
+                    for submod_name, _ in submod.named_modules():
+                        if submod_name != '':
+                            used.append('.'.join([node.target, submod_name]))
+
         to_delete = [name for name, _ in self.named_modules()
                      if name not in used]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66430

On the whole, I'm not totally satisfied with this approach. I think we should be building a prefix tree data structure during initial iteration over the submodules and querying that when deleting submodules. But I think this approach works and I want to see if we can get it in before 1.10

Differential Revision: [D31546137](https://our.internmc.facebook.com/intern/diff/D31546137)