### PR TITLE
[torch.fx] Fix replace pattern mechanism

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -491,4 +491,3 @@ class TestSubgraphRewriter(JitTestCase):
         ref_outs = comparison_fn(x)
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
-

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -460,3 +460,35 @@ class TestSubgraphRewriter(JitTestCase):
             if n.op == 'placeholder':
                 assert n.type == int
                 assert m.type == int
+
+    def test_subgraph_writer_replace_consecutive_submodules(self):
+
+        def f(x):
+            x = torch.sigmoid(x)
+            x = torch.sigmoid(x)
+            return torch.sigmoid(x)
+
+        def pattern(x):
+            return torch.sigmoid(x)
+
+        def replacement(x):
+            return torch.exp(x)
+
+        def comparison(x):
+            x = torch.exp(x)
+            x = torch.exp(x)
+            return torch.exp(x)
+
+        traced = symbolic_trace(f)
+        comparison_fn = symbolic_trace(comparison)
+
+        x = torch.randn(3, 4)
+
+        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+
+        traced.graph.lint()
+
+        ref_outs = comparison_fn(x)
+        test_outs = traced.forward(x)
+        self.assertEqual(ref_outs, test_outs)
+

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -131,7 +131,7 @@ def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
 
     gm.graph.lint()
 
-def add_suffix_to_graph(graph, suffix):
+def _add_suffix_to_graph(graph, suffix):
     for node in graph.nodes:
         node.name += suffix
 
@@ -327,7 +327,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
             continue
 
         suffixed_replacement_graph = replacement_graph.__deepcopy__()
-        add_suffix_to_graph(suffixed_replacement_graph, f"_{i}")
+        _add_suffix_to_graph(suffixed_replacement_graph, f"_{i}")
         # Map replacement graph nodes to their copy in `original_graph`
         val_map: Dict[Node, Node] = {}
 
@@ -401,7 +401,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
                 for pn_input, rn_input in zip(pn.all_input_nodes, rn.all_input_nodes):
                     gn_input = match.nodes_map[pn_input]
                     rn_input_in_original_graph = val_map[rn_input]
-                    gn.replace_input_with(gn_input, rn_input_in_original_graph)
+                    gn_input.replace_all_uses_with(rn_input_in_original_graph)
                     # We store the updated node point in case other nodes want to use it
                     match_changed_node[gn_input] = rn_input_in_original_graph
 

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -374,7 +374,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
         if subgraph_output.op != "output":
             pattern_outputs = [n for n in pattern_graph.nodes
                                if n.op == "output"]
-            assert len(pattern_outputs)
+            assert len(pattern_outputs) > 0
             replacement_outputs = [n for n in replacement_graph.nodes
                                    if n.op == "output"]
             assert len(replacement_outputs) == len(pattern_outputs)

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -304,7 +304,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     # The set of all nodes in `original_graph` that we've seen thus far
     # as part of a pattern match
     replaced_nodes: Set[Node] = set()
-    # As we progressively replace node, we need to keep track on how the match results need to change also
+    # As we progressively replace nodes, we'll need to keep track of how the match results should change
     match_changed_node: Dict[Node, Node] = dict()
 
     # Return True if one of the nodes in the current match has already
@@ -317,7 +317,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
                 return True
         return False
 
-    for i, match in enumerate(matches):
+    for match in matches:
         # Skip overlapping matches
         if overlaps_with_prev_match(match):
             continue
@@ -327,7 +327,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
 
         pattern_placeholders = [n for n in pattern_graph.nodes
                                 if n.op == "placeholder"]
-        assert len(pattern_placeholders)
+        assert len(pattern_placeholders) > 0
         replacement_placeholders = [n for n in replacement_graph.nodes
                                     if n.op == "placeholder"]
         assert len(pattern_placeholders) == len(replacement_placeholders)
@@ -385,12 +385,12 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
                 if gn.op == "placeholder":
                     continue
 
-                # We search for the node corresponding to the output of the pattern.
+                # Search for the node corresponding to the output of the pattern
                 if pn.op != "output":
                     continue
                 assert subgraph_output == gn
 
-                # We update all anchor inputs to the new nodes
+                # Update all anchor inputs to the new nodes
                 rn = outputs_map[pn]
                 for pn_input, rn_input in zip(pn.all_input_nodes, rn.all_input_nodes):
                     gn_input = match.nodes_map[pn_input]


### PR DESCRIPTION
Fixes #{issue number}

The following code would not return the pattern correctly:

```python
        def f(x):
            x = torch.sigmoid(x)
            x = torch.sigmoid(x)
            return torch.sigmoid(x)

        def pattern(x):
            return torch.sigmoid(x)

        def replacement(x):
            return torch.exp(x)

        def comparison(x):
            x = torch.exp(x)
            x = torch.exp(x)
            return torch.exp(x)

        traced = symbolic_trace(f) 
        comparison_fn = symbolic_trace(comparison)
        
        subgraph_rewriter.replace_pattern(traced, pattern, replacement) # Only one sigmoid gets converted.
```

This PR fixes this by adding a new test.