### PR TITLE
[RFC] Reduce logging noise from AdagradOptimizer

### DIFF
--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -584,9 +584,6 @@ class AdagradOptimizer(Optimizer):
         counter_halflife=-1,
         **kwargs
     ):
-        for k, v in locals().items():
-            logger.info("AdagradOptimizer: input arguments: {}: {}".format(k, v))
-
         super(AdagradOptimizer, self).__init__()
         self.alpha = alpha
         self.epsilon = epsilon


### PR DESCRIPTION
Summary:
For some reason, this logging is adding noise to a lot of flow jobs. I am not sure if this is actually needed.
This is called from the __init__ so it's logged all the time and logs all key:values the current local symbol.

Test Plan: N/A

Reviewed By: chowarfb

Differential Revision: D31534372

