### PR TITLE
[PyTorch] Split c10 Type.cpp into two files to allow targets to include one of them

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -465,3 +465,13 @@ __host__ __device__
 #endif
 
 #endif // C10_MACROS_MACROS_H_
+
+#if defined(__ANDROID__) || defined(_WIN32) || defined(__EMSCRIPTEN__) || \
+    defined(__XROS__)
+#define HAS_DEMANGLE 0
+#elif defined(__APPLE__) && \
+    (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE)
+#define HAS_DEMANGLE 0
+#else
+#define HAS_DEMANGLE 1
+#endif

--- a/c10/util/Type_demangle.cpp
+++ b/c10/util/Type_demangle.cpp
@@ -4,16 +4,6 @@
 #include <functional>
 #include <memory>
 
-#if defined(__ANDROID__) || defined(_WIN32) || defined(__EMSCRIPTEN__) || \
-    defined(__XROS__)
-#define HAS_DEMANGLE 0
-#elif defined(__APPLE__) && \
-    (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE)
-#define HAS_DEMANGLE 0
-#else
-#define HAS_DEMANGLE 1
-#endif
-
 #if HAS_DEMANGLE
 
 #include <cxxabi.h>
@@ -51,11 +41,4 @@ std::string demangle(const char* name) {
 
 } // namespace c10
 
-#else // HAS_DEMANGLE
-namespace c10 {
-std::string demangle(const char* name) {
-  return std::string(name);
-}
-} // namespace c10
-
-#endif // HAS_DEMANGLE
+#endif

--- a/c10/util/Type_no_demangle.cpp
+++ b/c10/util/Type_no_demangle.cpp
@@ -1,0 +1,9 @@
+#include <c10/util/Type.h>
+
+#if HAS_DEMANGLE == 0
+namespace c10 {
+std::string demangle(const char* name) {
+  return std::string(name);
+}
+} // namespace c10
+#endif // !HAS_DEMANGLE


### PR DESCRIPTION
Summary: `Type.cpp` implements `demangle()` function based on the macro `HAS_DEMANGLE`. This diff splits it into two `.cpps` so that we can add either one into the build target. This change follows the patternof `flags_use_no_gflags.cpp` and `flags_use_gflags.cpp`.

Test Plan: Rely on CI

Reviewed By: iseeyuan

Differential Revision: D31551432

