### PR TITLE
Fix for failure in test_autocast.py

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -196,10 +196,15 @@ else:
         _load_global_deps()
     from torch._C import *  # noqa: F403
 
-# Appease the type checker; ordinarily this binding is inserted by the
-# torch._C module initialization code in C
-if TYPE_CHECKING:
-    import torch._C as _C
+import torch._C as _C
+
+def get_autocast_gpu_dtype():
+    return_dtype = _C.get_autocast_gpu_dtype()
+    return torch.bfloat16 if str(return_dtype) == str(torch.bfloat16) else torch.float16
+
+def get_autocast_cpu_dtype():
+    return_dtype = _C.get_autocast_cpu_dtype()
+    return torch.bfloat16 if str(return_dtype) == str(torch.bfloat16) else torch.float16
 
 # Check to see if we can load C extensions, and if not provide some guidance
 # on what the problem might be.


### PR DESCRIPTION
The latest update to autocast.py added new tests which picked up an old failure.
```
Traceback (most recent call last):
  File "test_autocast.py", line 126, in test_autocast_fast_dtype
    self.assertEqual(gpu_fast_dtype, torch.half)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_utils.py", line 1693, in assertEqual
    super().assertEqual(x, y, msg=msg)
AssertionError: torch.half != torch.float16
```

I isolated and reproduced this bug with the following code:

```
>>> torch.get_autocast_cpu_dtype()
torch.half
>>> torch.get_autocast_cpu_dtype()
torch.bfloat16
>>> torch.get_autocast_cpu_dtype() == torch.bfloat16
False
>>> torch.get_autocast_gpu_dtype() == torch.half
False
```

This bug  is not hardware specific.
In the torch backend the get_autocast_gpu_dtype function is defined in cpp as follows:
```
at::ScalarType get_autocast_gpu_dtype() {
  return autocast_gpu_dtype;
}
```

Then it gets exposed to python as follows:

```
static PyObject * get_autocast_gpu_dtype(PyObject* _unused, PyObject *arg){
  HANDLE_TH_ERRORS
  at::ScalarType current_dtype = at::autocast::get_autocast_gpu_dtype();
  return THPDtype_New(current_dtype, scalarTypeName(current_dtype));
  END_HANDLE_TH_ERRORS
```

The  issue is that `torch.get_autocast_xxx_dtype()` is basically returning a brand new instantiation of `torch.half` through `THPDtype_New` that behaves identically but is not an identical torch dtype object. This causes the basic python `== ` operator complains.  The reason for this occurring is:
```
>>> torch._C.get_autocast_cpu_dtype().__eq__(torch.bfloat16)
NotImplemented
>>> torch.bfloat16.__eq__(torch.bfloat16)
True
```
Because the `__eq__ `method is not implemented for the `THPDtype_New` dtype, the `==`  operator behaves the same as  `is`

I think for proper user experience this should be fixed.

After fix:
```
>>> import torch
>>> torch.get_autocast_gpu_dtype() == torch.float16
True
>>> torch.get_autocast_cpu_dtype() == torch.bfloat16
True
```

