### PR TITLE
[vulkan] Release GPU resources when vTensor::View is destroyed

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -208,7 +208,7 @@ vTensor::Buffer allocate_buffer(
     };
   }();
 
-  return pool->buffer({
+  return pool->create_buffer({
       buffer_bytes(sizes, options.dtype()),
       // Usage
       {
@@ -272,7 +272,7 @@ vTensor::Image allocate_image(
 
   verify(options);
 
-  return pool->image({
+  return pool->create_image({
       extents.depth == 1 ? VK_IMAGE_TYPE_2D : VK_IMAGE_TYPE_3D,
       vk_format(options.dtype()),
       extents,
@@ -325,7 +325,7 @@ vTensor::Buffer allocate_staging(
   TORCH_CHECK(!sizes.empty(), "Invalid Vulkan tensor size!");
   verify(options);
 
-  return pool->buffer({
+  return pool->create_buffer({
       buffer_bytes(sizes, options.dtype()),
       // Usage
       {
@@ -503,6 +503,18 @@ vTensor::View::View(
     sizes_(sizes),
     strides_(sizes.size()) {
   ops::verify(options);
+}
+
+vTensor::View::~View() {
+  release();
+}
+
+void vTensor::View::release() {
+  pool_->register_image_cleanup(image_);
+  pool_->register_buffer_cleanup(buffer_);
+  if (staging_) {
+      pool_->register_buffer_cleanup(staging_);
+  }
 }
 
 class vTensor::View::CMD final {

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -240,7 +240,9 @@ class vTensor final {
     View& operator=(const View&) = delete;
     View(View&&) = default;
     View operator=(View&&) = delete;
-    ~View() = default;
+    ~View();
+
+    void release();
 
     /*
       Buffer


### PR DESCRIPTION
Summary:
Currently, Vulkan tensor memory is allocated and deallocated through the following mechanism:

1. During inference, ops will request buffer and/or texture memory for tensors from the [Resource Pool](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/api/Resource.h#L324-L327)
2. The resource pool allocates the memory and [adds it to a vector](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/api/Resource.cpp#L609-L622) containing all the memory allocations it has made this inference, then returns the most recently allocated block of memory
3. At the end of inference, results are transferred back to the CPU and the [context is flushed](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/ops/Copy.cpp#L150)
4. As part of the context flush the [resource pool is purged](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/api/Context.cpp#L143) which [deallocates all buffer and texture memory](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/api/Resource.cpp#L683-L684) allocated by the resource pool

This pattern makes it impossible to have models with multiple outputs. When the first output tensor is transferred back to the CPU, the memory of the other output tensors will be deallocated when the context is flushed.

Instead, an alternative is to tie resource destruction to the destructor of the [vTensor::View](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/ops/Tensor.h#L243) class, which holds the actual implementation and storage of Vulkan tensors. This will ensure that memory associated with a tensor will be cleaned up whenever it is no longer used.

The new deallocation mechanism proposed is:

1. During inference, `vTensor` objects will request GPU memory from the resource pool, same as before.
2. The resource pool allocates buffer or texture memory and returns it directly to  the `vTensor`
3. Throughout inference, intermediate tensors' reference counts will go to 0 and the destructor of the `View` class will be called
4. The destructor will any texture and buffer memory it's holding to the resource pool's list of GPU memory allocations to be cleaned
5. At the end of inference `purge()` will be called which will destroy all allocations in the list of allocations to be cleaned
6. GPU memory for output tensors will not be destroyed, since their reference counts will be greater than 0, thus they have not yet been added to the list of allocations to be destroyed

Note that it is not correct to have the destructor directly deallocate GPU memory. This is due to the fact that Vulkan ops simply submit work to the GPU but does not guarantee that work has completed when the op returns. Therefore we must keep all allocated GPU memory until the end of inference, when we wait for the GPU to complete work.

Test Plan:
build and run `vulkan_api_test` to make sure existing functionality is not impacted.

Also test in a later diff that checks that output tensors stay alive after inference completes.

Reviewed By: dreiss

Differential Revision: D31510899

