### PR TITLE
Make permission errors more human readable

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -18,9 +18,9 @@ from .numpy_ import USE_NUMPY, NUMPY_INCLUDE_DIR
 
 def _mkdir_p(d: str) -> None:
     try:
-        os.makedirs(d)
-    except OSError:
-        pass
+        os.makedirs(d, exist_ok = False)
+    except OSError as e:
+        raise RuntimeError(f"Failed to create folder {os.path.abspath(d)}: {e.strerror}") from e
 
 
 # Ninja

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -18,7 +18,7 @@ from .numpy_ import USE_NUMPY, NUMPY_INCLUDE_DIR
 
 def _mkdir_p(d: str) -> None:
     try:
-        os.makedirs(d, exist_ok = False)
+        os.makedirs(d, exist_ok=True)
     except OSError as e:
         raise RuntimeError(f"Failed to create folder {os.path.abspath(d)}: {e.strerror}") from e
 


### PR DESCRIPTION
`_mkdir_p` feels like a remnant of Python-2 era, add `exist_ok` argument and re-raise OSError to make it more human readable.

After the change attempt to build PyTorch in a folder that does not have write permissions will result in:
```
% python3.6 setup.py develop                            
Building wheel torch-1.10.0a0+git9509e8a
-- Building version 1.10.0a0+git9509e8a
Traceback (most recent call last):
  File "/Users/nshulga/git/pytorch-worktree/tools/setup_helpers/cmake.py", line 21, in _mkdir_p
    os.makedirs(d, exist_ok=True)
  File "/opt/homebrew/Cellar/python36/3.6.2+_254.20170915/Frameworks/Python.framework/Versions/3.6/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: 'build'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "setup.py", line 895, in <module>
    build_deps()
  File "setup.py", line 370, in build_deps
    cmake=cmake)
  File "/Users/nshulga/git/pytorch-worktree/tools/build_pytorch_libs.py", line 63, in build_caffe2
    rerun_cmake)
  File "/Users/nshulga/git/pytorch-worktree/tools/setup_helpers/cmake.py", line 225, in generate
    _mkdir_p(self.build_dir)
  File "/Users/nshulga/git/pytorch-worktree/tools/setup_helpers/cmake.py", line 23, in _mkdir_p
    raise RuntimeError(f"Failed to create folder {os.path.abspath(d)}: {e.strerror}") from e
RuntimeError: Failed to create folder /Users/nshulga/git/pytorch-worktree/build: Permission denied
```

Fixes https://github.com/pytorch/pytorch/issues/65920
