### PR TITLE
[Static Runtime] Add FuseListUnpackV2

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -104,6 +104,7 @@ void OptimizeGraph(
 #ifdef FBCODE_CAFFE2
     ReplaceWithCopy(graph);
     FuseListUnpack(graph);
+    FuseListUnpackV2(graph);
     EnableStaticRuntimeLayerNorm(graph);
 #endif
   }

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -600,6 +600,86 @@ void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
 #endif
 }
 
+void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph) {
+  const FastMap<c10::Symbol, c10::Symbol> unfused_to_fused = {};
+
+  AliasDb alias_db(
+      graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
+  const std::vector<Value*> graph_outputs(
+      graph->outputs().begin(), graph->outputs().end());
+  auto nodes = graph->nodes();
+  std::vector<Node*> to_remove;
+  for (auto* node : nodes) {
+    auto unfused_to_fused_it = unfused_to_fused.find(node->kind());
+    if (unfused_to_fused_it == unfused_to_fused.end()) {
+      continue;
+    }
+
+    const Value* value_out = node->outputs()[0];
+    if (value_out->uses().size() > 1) {
+      continue;
+    }
+
+    Node* list_unpack_node = value_out->uses()[0].user;
+    if (list_unpack_node->kind() != prim::ListUnpack) {
+      continue;
+    }
+
+    auto list_unpack_outputs = list_unpack_node->outputs();
+    if (list_unpack_outputs.empty()) {
+      continue;
+    }
+
+    const bool is_equally_split =
+        node->kind() == c10::Symbol::fromQualString("fb::equally_split");
+    if (!is_equally_split) {
+      // If any output of the ListUnpack node is unmanaged, disable fusion
+      // since the fused op assumes all outputs are either managed or not.
+      // "fb::equally_split" is excluded here since it does doublecheck
+      // individual outputs without having this assumption.
+      const std::vector<Value*> list_unpack_outputs_vec(
+          list_unpack_outputs.begin(), list_unpack_outputs.end());
+      if (alias_db.mayContainAlias(list_unpack_outputs_vec, graph_outputs)) {
+        continue;
+      }
+    }
+
+    if (is_equally_split && list_unpack_outputs.size() == 1) {
+      // This captures a case of `y = fb::equally_split(x, 1, _)` where y
+      // becomes just an alias of x.
+      // If this case is found, replace y with x to avoid executing this op.
+      node->output(0)->replaceAllUsesWith(node->input(0));
+      continue;
+    }
+
+    const auto& new_sym = unfused_to_fused_it->second;
+    auto* new_node = graph->create(new_sym, 0);
+
+    for (Value* in : node->inputs()) {
+      new_node->addInput(in);
+    }
+
+    for (Value* out : list_unpack_outputs) {
+      Value* new_out = new_node->addOutput();
+      new_out->copyMetadata(out);
+      out->replaceAllUsesWith(new_out);
+    }
+
+    new_node->insertAfter(node);
+    list_unpack_node->destroy();
+    to_remove.push_back(node);
+  }
+  for (Node* node : to_remove) {
+    node->destroy();
+  }
+
+#ifndef NDEBUG
+  graph->lint();
+  AliasDb db2(graph);
+  torch::jit::Lint(&db2);
+#endif
+} // namespace jit
+
 void EnableStaticRuntimeLayerNorm(std::shared_ptr<torch::jit::Graph>& graph) {
   const c10::Symbol static_runtime_layer_norm_symbol =
       c10::Symbol::fromQualString("static_runtime::layer_norm");

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -6,6 +6,7 @@ namespace jit {
 TORCH_API void FuseInferenceOpsForSparseNN(
     std::shared_ptr<torch::jit::Graph>& graph);
 TORCH_API void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
+TORCH_API void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph);
 
 // If outputs_are_immutable is set to false, don't replace the view ops that
 // produce aliases of graph outputs with the copy version.


### PR DESCRIPTION
Summary:
Like `FuseListUnpack`, but instead of adding arguments to the fused node's outputs, inserts a new fused op.

By using a new fused op, we can avoid runtime `is_fused` checks. This will make the op implementations significantly cleaner.

`FuseListUnpackV2` also fixes the bug described in T103159043.

Test Plan: CI

Differential Revision: D31492017

