### PR TITLE
speed up quantized interpolate for channels last

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
@@ -54,6 +54,9 @@ static void upsample_bilinear2d_out_frame(
   // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
   float output_scale = output.q_scale() / input.q_scale();
 
+  const int64_t input_q_zero_point = input.q_zero_point();
+  const int64_t output_q_zero_point = output.q_zero_point();
+
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
     const auto h1r = area_pixel_compute_source_index<float>(
         rheight, h2, align_corners, /*cubic=*/false);
@@ -80,10 +83,10 @@ static void upsample_bilinear2d_out_frame(
         float result = h0lambda * (w0lambda * pos1[0] + w1lambda * pos1[w1p]) +
             h1lambda *
                 (w0lambda * pos1[h1p * input_width] +
-                 w1lambda * pos1[h1p * input_width + w1p]) - input.q_zero_point();
+                 w1lambda * pos1[h1p * input_width + w1p]) - input_q_zero_point;
         // requantization
         pos2[0] = at::native::quantize_val<scalar_t>(
-                      output_scale, output.q_zero_point(), result)
+                      output_scale, output_q_zero_point, result)
                       .val_;
         pos1 += input_width * input_height;
         pos2 += output_width * output_height;

--- a/benchmarks/operator_benchmark/pt/qinterpolate_test.py
+++ b/benchmarks/operator_benchmark/pt/qinterpolate_test.py
@@ -29,6 +29,7 @@ qinterpolate_short_configs = op_bench.config_list(
         [32, 32, 32, torch.quint8, 'bilinear', 0.5, True],  # Downsample
         [32, 32, 32, torch.quint8, 'nearest', 2.0, True],  # Upsample
         [32, 32, 32, torch.quint8, 'bilinear', 2.0, True],  # Upsample
+        [3, 720, 1280, torch.quint8, 'bilinear', 0.83333, True],  # Downsample
     ],
     tags=['short'],
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66525

Summary:

This should solve https://github.com/pytorch/pytorch/issues/60015

There were two `q_zero_point()` accesses inside a for loop which was
expensive. Moving them to before the loop sped things up 10x for a
microbenchmark.

Test Plan:

```
// comment out benchmarks unrelated to original issue, for simplicity
cd benchmarks/operator_benchmark
python -m pt.qinterpolate_test

// before: 2994 us
// after: 324 us
// full results: https://gist.github.com/vkuzo/cc5ef9526dc0cda170d6d63498c16453
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31592422](https://our.internmc.facebook.com/intern/diff/D31592422)