### PR TITLE
[deploy] Remove `Package::acquireSession`

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -343,19 +343,12 @@ ReplicatedObj Package::loadPickle(
     const std::string& module,
     const std::string& file) {
   TORCH_DEPLOY_TRY
-  auto I = acquireSession();
-  auto self =
-      I.impl_->createOrGetPackageImporterFromContainerFile(containerFile_);
+  auto I = manager_->acquireOne();
+  auto self = I.getPackage(*this);
   auto loaded = self.attr("load_pickle")({module, file});
   return I.createMovable(loaded, this);
   TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
-InterpreterSession Package::acquireSession() {
-  TORCH_DEPLOY_TRY
-  auto I = manager_->acquireOne();
-  return I;
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
-}
 } // namespace deploy
 } // namespace torch

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -41,7 +41,6 @@ struct TORCH_API InterpreterSession {
   Obj getPackage(const Package& package);
 
  private:
-  friend struct Package;
   friend struct InterpreterManager;
   friend struct ReplicatedObjImpl;
   std::unique_ptr<InterpreterSessionImpl> impl_;
@@ -261,7 +260,6 @@ class PythonMethodWrapper : public torch::IMethod {
 struct TORCH_API Package {
   // shorthand for getting the object as a pickle resource in the package
   ReplicatedObj loadPickle(const std::string& module, const std::string& file);
-  InterpreterSession acquireSession();
 
  private:
   Package(const std::string& uri, InterpreterManager* pm);

--- a/torch/csrc/deploy/example/benchmark.cpp
+++ b/torch/csrc/deploy/example/benchmark.cpp
@@ -199,7 +199,7 @@ struct Benchmark {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<at::IValue> eg;
     {
-      auto I = package.acquireSession();
+      auto I = manager_.acquireOne();
       auto pkg = I.getPackage(package);
 
       eg = I.global("builtins", "tuple")(

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -184,7 +184,7 @@ TEST(TorchpyTest, ErrorsReplicatingObj) {
   auto replicatedObj = p.loadPickle("model", "model.pkl");
   // Acquire two different interpreters
   auto session1 = replicatedObj.acquireSession();
-  auto session2 = p.acquireSession();
+  auto session2 = manager.acquireOne();
   // Create an obj reference on interpreter 1
   auto obj = session1.fromMovable(replicatedObj);
   // should throw an error when trying to access obj from different session
@@ -213,26 +213,6 @@ TEST(TorchpyTest, ThrowsSafely) {
   auto model = p.loadPickle("model", "model.pkl");
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(model(at::IValue("unexpected input")), c10::Error);
-}
-
-TEST(TorchpyTest, AcquireMultipleSessionsInTheSamePackage) {
-  torch::deploy::InterpreterManager m(1);
-
-  torch::deploy::Package p = m.loadPackage(path("SIMPLE", simple));
-  auto I = p.acquireSession();
-
-  auto I1 = p.acquireSession();
-}
-
-TEST(TorchpyTest, AcquireMultipleSessionsInDifferentPackages) {
-  torch::deploy::InterpreterManager m(1);
-
-  torch::deploy::Package p = m.loadPackage(path("SIMPLE", simple));
-  auto I = p.acquireSession();
-
-  torch::deploy::Package p1 = m.loadPackage(
-      path("RESNET", "torch/csrc/deploy/example/generated/resnet"));
-  auto I1 = p1.acquireSession();
 }
 
 TEST(TorchpyTest, TensorSharingNotAllowed) {

--- a/torch/csrc/deploy/test_deploy_gpu.cpp
+++ b/torch/csrc/deploy/test_deploy_gpu.cpp
@@ -39,7 +39,7 @@ TEST(TorchDeployGPUTest, SimpleModel) {
   }
   std::vector<at::IValue> inputs;
   {
-    auto I = p.acquireSession();
+    auto I = m.acquireOne();
     auto pkg = I.getPackage(p);
     auto eg = pkg.attr("load_pickle")({"model", "example.pkl"}).toIValue();
     inputs = eg.toTuple()->elements();
@@ -63,7 +63,7 @@ TEST(TorchDeployGPUTest, UsesDistributed) {
   torch::deploy::InterpreterManager m(1);
   torch::deploy::Package p = m.loadPackage(model_filename);
   {
-    auto I = p.acquireSession();
+    auto I = m.acquireOne();
     auto pkg = I.getPackage(p);
     pkg.attr("import_module")({"uses_distributed"});
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66534
* __->__ #66533
* #66377

Previously, `InterpreterSession` behaved differently depending on who
created it (package vs. interpreter vs. replicatedobj). This is pretty
confusing to people, and was one of the major motivations for removing
`self` in https://github.com/pytorch/pytorch/pull/66377.

Now that `InterpreterSession` only behaves one way, we don't need the
`acquireSession` methods defined on Package or ReplicatedObj. This
PR removes the one for Package.

Differential Revision: [D31598340](https://our.internmc.facebook.com/intern/diff/D31598340)