### PR TITLE
[deploy] remove ReplicatedObj::acquireSession

### DIFF
--- a/torch/csrc/deploy/example/benchmark.cpp
+++ b/torch/csrc/deploy/example/benchmark.cpp
@@ -73,7 +73,7 @@ struct RunPython {
         eg_(std::move(eg)),
         manager_(manager) {}
   void operator()(int i) {
-    auto I = obj_.acquireSession();
+    auto I = manager_.acquireOne();
     auto self = I.fromMovable(obj_);
     if (cuda) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -90,13 +90,13 @@ TEST(TorchpyTest, ResNet) {
 TEST(TorchpyTest, Movable) {
   torch::deploy::InterpreterManager m(1);
   torch::deploy::ReplicatedObj obj;
-  {
-    auto I = m.acquireOne();
-    auto model =
-        I.global("torch.nn", "Module")(std::vector<torch::deploy::Obj>());
-    obj = I.createMovable(model);
-  }
-  obj.acquireSession();
+  auto I = m.acquireOne();
+  auto model =
+      I.global("torch.nn", "Module")(std::vector<torch::deploy::Obj>());
+  obj = I.createMovable(model);
+
+  auto I2 = m.acquireOne();
+  __attribute__((unused)) auto obj2 = I2.fromMovable(obj);
 }
 
 TEST(TorchpyTest, MultiSerialSimpleModel) {
@@ -183,7 +183,7 @@ TEST(TorchpyTest, ErrorsReplicatingObj) {
   torch::deploy::Package p = manager.loadPackage(path("SIMPLE", simple));
   auto replicatedObj = p.loadPickle("model", "model.pkl");
   // Acquire two different interpreters
-  auto session1 = replicatedObj.acquireSession();
+  auto session1 = manager.acquireOne();
   auto session2 = manager.acquireOne();
   // Create an obj reference on interpreter 1
   auto obj = session1.fromMovable(replicatedObj);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66534
* #66533
* #66377

Previously, `InterpreterSession` behaved differently depending on who
created it (package vs. interpreter vs. replicatedobj). This is pretty
confusing to people, and was one of the major motivations for removing
`self` in https://github.com/pytorch/pytorch/pull/66377.

Now that `InterpreterSession` only behaves one way, we don't need the
`acquireSession` methods defined on Package or ReplicatedObj. This
  PR removes the one for ReplicatedObj.

Some places try to acquire a session from a ReplicatedObj without having a
reference to the InterpreterManager. This is suspicious (if you don't know the
lifetime of the InterpreterManager, bad things could happen if you arbitrarily
try to schedule work on it). But I expose a ReplicatedObj::getManager to compensate.

Differential Revision: [D31598339](https://our.internmc.facebook.com/intern/diff/D31598339)