### PR TITLE
Get rid of "Update Homebrew" step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1186,7 +1186,7 @@ jobs:
             set -x
 
             chmod a+x .jenkins/pytorch/macos-build.sh
-            unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-build.sh 2>&1
 
       - persist_to_workspace:
           root: /Users/distiller/workspace/
@@ -1223,7 +1223,7 @@ jobs:
             set -x
 
             chmod a+x .jenkins/pytorch/macos-build.sh
-            unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-build.sh 2>&1
 
       - persist_to_workspace:
           root: /Users/distiller/workspace/
@@ -1249,7 +1249,7 @@ jobs:
             export JOB_BASE_NAME=$CIRCLE_JOB
 
             chmod a+x .jenkins/pytorch/macos-test.sh
-            unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-test.sh 2>&1
       - run:
           name: Report results
           no_output_timeout: "5m"
@@ -1288,7 +1288,7 @@ jobs:
             export BUILD_LITE_INTERPRETER=1
             export JOB_BASE_NAME=$CIRCLE_JOB
             chmod a+x ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
-            unbuffer ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh 2>&1 | ts
+            unbuffer ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh 2>&1
       - store_test_results:
           path: test/test-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1544,7 +1544,7 @@ jobs:
             if [ ${IOS_PLATFORM} != "SIMULATOR" ]; then
               export USE_PYTORCH_METAL=${USE_METAL}
             fi
-            unbuffer ${PROJ_ROOT}/scripts/build_ios.sh 2>&1 | ts
+            unbuffer ${PROJ_ROOT}/scripts/build_ios.sh 2>&1
       - run:
           name: Run Build Test
           no_output_timeout: "30m"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,14 @@ commands:
   run_brew_for_macos_build:
     steps:
       - brew_install:
+          formulae: expect
+      - brew_install:
           formulae: libomp
 
   run_brew_for_ios_build:
     steps:
+      - brew_install:
+          formulae: expect
       - brew_install:
           formulae: libtool
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,37 +80,6 @@ commands:
           no_output_timeout: "1h"
           command: .circleci/scripts/setup_ci_environment.sh
 
-  brew_update:
-    description: "Update Homebrew and install base formulae"
-    steps:
-      - run:
-          name: Update Homebrew
-          no_output_timeout: "10m"
-          command: |
-            set -ex
-
-            # Update repositories manually.
-            # Running `brew update` produces a comparison between the
-            # current checkout and the updated checkout, which takes a
-            # very long time because the existing checkout is 2y old.
-            for path in $(find /usr/local/Homebrew -type d -name .git)
-            do
-            cd $path/..
-            git fetch --depth=1 origin
-            git reset --hard origin/master
-            done
-
-            export HOMEBREW_NO_AUTO_UPDATE=1
-
-            # Install expect and moreutils so that we can call `unbuffer` and `ts`.
-            # moreutils installs a `parallel` executable by default, which conflicts
-            # with the executable from the GNU `parallel`, so we must unlink GNU
-            # `parallel` first, and relink it afterwards.
-            brew unlink parallel
-            brew install moreutils
-            brew link parallel --overwrite
-            brew install expect
-
   brew_install:
     description: "Install Homebrew formulae"
     parameters:
@@ -128,13 +97,11 @@ commands:
 
   run_brew_for_macos_build:
     steps:
-      - brew_update
       - brew_install:
           formulae: libomp
 
   run_brew_for_ios_build:
     steps:
-      - brew_update
       - brew_install:
           formulae: libtool
 
@@ -827,7 +794,6 @@ jobs:
           <<: *binary_checkout
       - run:
           <<: *binary_populate_env
-      - brew_update
       - run:
           <<: *binary_install_miniconda
       - run:
@@ -853,7 +819,6 @@ jobs:
         <<: *binary_checkout
     - run:
         <<: *binary_populate_env
-    - brew_update
     - run:
         <<: *binary_install_miniconda
 
@@ -897,7 +862,6 @@ jobs:
         <<: *binary_checkout
     - run:
         <<: *binary_populate_env
-    - brew_update
     - run:
         <<: *binary_install_miniconda
 

--- a/.circleci/verbatim-sources/commands.yml
+++ b/.circleci/verbatim-sources/commands.yml
@@ -57,10 +57,14 @@ commands:
   run_brew_for_macos_build:
     steps:
       - brew_install:
+          formulae: expect
+      - brew_install:
           formulae: libomp
 
   run_brew_for_ios_build:
     steps:
+      - brew_install:
+          formulae: expect
       - brew_install:
           formulae: libtool
 

--- a/.circleci/verbatim-sources/commands.yml
+++ b/.circleci/verbatim-sources/commands.yml
@@ -39,37 +39,6 @@ commands:
           no_output_timeout: "1h"
           command: .circleci/scripts/setup_ci_environment.sh
 
-  brew_update:
-    description: "Update Homebrew and install base formulae"
-    steps:
-      - run:
-          name: Update Homebrew
-          no_output_timeout: "10m"
-          command: |
-            set -ex
-
-            # Update repositories manually.
-            # Running `brew update` produces a comparison between the
-            # current checkout and the updated checkout, which takes a
-            # very long time because the existing checkout is 2y old.
-            for path in $(find /usr/local/Homebrew -type d -name .git)
-            do
-            cd $path/..
-            git fetch --depth=1 origin
-            git reset --hard origin/master
-            done
-
-            export HOMEBREW_NO_AUTO_UPDATE=1
-
-            # Install expect and moreutils so that we can call `unbuffer` and `ts`.
-            # moreutils installs a `parallel` executable by default, which conflicts
-            # with the executable from the GNU `parallel`, so we must unlink GNU
-            # `parallel` first, and relink it afterwards.
-            brew unlink parallel
-            brew install moreutils
-            brew link parallel --overwrite
-            brew install expect
-
   brew_install:
     description: "Install Homebrew formulae"
     parameters:
@@ -87,13 +56,11 @@ commands:
 
   run_brew_for_macos_build:
     steps:
-      - brew_update
       - brew_install:
           formulae: libomp
 
   run_brew_for_ios_build:
     steps:
-      - brew_update
       - brew_install:
           formulae: libtool
 

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -142,7 +142,6 @@
           <<: *binary_checkout
       - run:
           <<: *binary_populate_env
-      - brew_update
       - run:
           <<: *binary_install_miniconda
       - run:
@@ -168,7 +167,6 @@
         <<: *binary_checkout
     - run:
         <<: *binary_populate_env
-    - brew_update
     - run:
         <<: *binary_install_miniconda
 
@@ -212,7 +210,6 @@
         <<: *binary_checkout
     - run:
         <<: *binary_populate_env
-    - brew_update
     - run:
         <<: *binary_install_miniconda
 

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -497,7 +497,7 @@
             if [ ${IOS_PLATFORM} != "SIMULATOR" ]; then
               export USE_PYTORCH_METAL=${USE_METAL}
             fi
-            unbuffer ${PROJ_ROOT}/scripts/build_ios.sh 2>&1 | ts
+            unbuffer ${PROJ_ROOT}/scripts/build_ios.sh 2>&1
       - run:
           name: Run Build Test
           no_output_timeout: "30m"

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -143,7 +143,7 @@
             set -x
 
             chmod a+x .jenkins/pytorch/macos-build.sh
-            unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-build.sh 2>&1
 
       - persist_to_workspace:
           root: /Users/distiller/workspace/
@@ -180,7 +180,7 @@
             set -x
 
             chmod a+x .jenkins/pytorch/macos-build.sh
-            unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-build.sh 2>&1
 
       - persist_to_workspace:
           root: /Users/distiller/workspace/
@@ -206,7 +206,7 @@
             export JOB_BASE_NAME=$CIRCLE_JOB
 
             chmod a+x .jenkins/pytorch/macos-test.sh
-            unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
+            unbuffer .jenkins/pytorch/macos-test.sh 2>&1
       - run:
           name: Report results
           no_output_timeout: "5m"
@@ -245,7 +245,7 @@
             export BUILD_LITE_INTERPRETER=1
             export JOB_BASE_NAME=$CIRCLE_JOB
             chmod a+x ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
-            unbuffer ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh 2>&1 | ts
+            unbuffer ${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh 2>&1
       - store_test_results:
           path: test/test-reports
 


### PR DESCRIPTION
It is unnecessary and doing some sort of shallow checkout, which forces brew to un-shallow it later, which makes overall checkout slower