### PR TITLE
[acc_shape_inference] add shape inference for quantize_per_channel

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -2,6 +2,7 @@ import math
 import operator
 from typing import Optional
 
+
 import numpy as np
 import tensorrt as trt
 import torch
@@ -12,6 +13,7 @@ from torch.fx.experimental.fx2trt.fx2trt import (
     torch_dtype_from_trt,
     get_dynamic_dims,
 )
+from torch.fx.immutable_collections import immutable_list
 
 try:
     TRT_LOGGER = trt.Logger()
@@ -1630,8 +1632,9 @@ def acc_ops_dequantize(network, target, args, kwargs, name):
         q_scale = qparams["scale"]
         q_zero_point = qparams["zero_point"]
         q_axis = qparams["axis"]
-        scale_shape = q_scale.shape
-        if not torch.equal(q_zero_point, torch.zeros(q_zero_point.shape, dtype=q_zero_point.dtype)):
+        assert isinstance(q_scale, immutable_list), "expected q_scale to be immutable_list got {}".format(type(q_scale))
+        scale_shape = (len(q_scale),)
+        if any(x != 0 for x in q_zero_point):
             raise RuntimeError(f"Only support zero_point == 0, get {q_zero_point}")
     else:
         raise RuntimeError("Unsupported qscheme in dequantize: {qscheme}")

--- a/torch/fx/experimental/fx2trt/example/quantized_resnet_test.py
+++ b/torch/fx/experimental/fx2trt/example/quantized_resnet_test.py
@@ -29,9 +29,9 @@ def build_int8_trt(rn18):
         activation=torch.ao.quantization.observer.HistogramObserver.with_args(
             qscheme=torch.per_tensor_symmetric, dtype=torch.qint8
         ),
-        weight=torch.ao.quantization.default_weight_observer
+        # weight=torch.ao.quantization.default_weight_observer
         # uncomment to check per channel quant works
-        # weight=torch.quantization.default_per_channel_weight_observer
+        weight=torch.quantization.default_per_channel_weight_observer
     )
     prepared = prepare_fx(rn18, {"": qconfig})
     for _ in range(10):

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -559,10 +559,10 @@ def quantize_per_channel(*, input, acc_out_ty=None):
     assert acc_out_ty is not None
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     dtype = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "dtype")
-    return torch.quantize_per_tensor(
+    return torch.quantize_per_channel(
         input,
-        qparams["scale"],
-        qparams["zero_point"],
+        torch.tensor(qparams["scale"]),
+        torch.tensor(qparams["zero_point"]),
         qparams["axis"],
         dtype)  # type: ignore[call-overload]
 

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -51,8 +51,11 @@ def _extract_tensor_metadata(result : torch.Tensor) -> TensorMetadata:
             qparams["scale"] = result.q_scale()  # type: ignore[assignment]
             qparams["zero_point"] = result.q_zero_point()  # type: ignore[assignment]
         elif qscheme in {torch.per_channel_affine, torch.per_channel_affine_float_qparams, torch.per_channel_symmetric}:
-            qparams["scale"] = result.q_per_channel_scales()  # type: ignore[assignment]
-            qparams["zero_point"] = result.q_per_channel_zero_points()  # type: ignore[assignment]
+            # In this branch, scale and zero_point are expected to be tensors,
+            # we store the values as immutable_list in TensorMetadata for
+            # easier serialization downstream
+            qparams["scale"] = result.q_per_channel_scales().tolist()  # type: ignore[assignment]
+            qparams["zero_point"] = result.q_per_channel_zero_points().tolist()  # type: ignore[assignment]
             qparams["axis"] = result.q_per_channel_axis()  # type: ignore[assignment]
 
     return TensorMetadata(


### PR DESCRIPTION
Summary:
Adding shape inference for `acc_ops.quantize_per_channel`, and fixing some bugs.

Bugs were related to the fact that `quantize_per_channel` arguments `scales` and `zero_points` take tensors, so when we fetch the values (which needs to be done using `.tolist()` instead of `.item()`) we may get either a list or a scalar value.

Test Plan:
# Test Quantized Resnet
From sandbox with GPU that supports quantized types (tested with V100)
`buck run mode/opt -c python.package_style=inplace caffe2:fx2trt_quantized_resnet_test`
Output
```
...
[TensorRT] INFO: [MemUsageSnapshot] Builder end: CPU 0 MiB, GPU 1548 MiB
[TensorRT] INFO: [MemUsageSnapshot] ExecutionContext creation begin: CPU 0 MiB, GPU 1548 MiB
[TensorRT] VERBOSE: Using cublasLt a tactic source
[TensorRT] WARNING: TensorRT was linked against cuBLAS/cuBLAS LT 11.5.1 but loaded cuBLAS/cuBLAS LT 11.1.0
[TensorRT] INFO: [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +8, now: CPU 0, GPU 1556 (MiB)
[TensorRT] VERBOSE: Using cuDNN as a tactic source
[TensorRT] INFO: [MemUsageChange] Init cuDNN: CPU +0, GPU +8, now: CPU 0, GPU 1564 (MiB)
[TensorRT] WARNING: TensorRT was linked against cuDNN 8.2.1 but loaded cuDNN 8.0.5
[TensorRT] VERBOSE: Total per-runner device memory is 23405056
[TensorRT] VERBOSE: Total per-runner host memory is 73760
[TensorRT] VERBOSE: Allocated activation device memory of size 154140672
[TensorRT] INFO: [MemUsageSnapshot] ExecutionContext creation end: CPU 0 MiB, GPU 1736 MiB
trt fp16 time (ms/iter) 1.252899169921875
trt int8 time (ms/iter) 1.3774776458740234
trt implicit int8 time (ms/iter) 1.3835883140563965
PyTorch time (CUDA) (ms/iter) 4.34483528137207
PyTorch time (CPU) (ms/iter) 55.687150955200195
[TensorRT] INFO: [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +0, now: CPU 0, GPU 1918 (MiB)
[TensorRT] INFO: [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +0, now: CPU 0, GPU 1866 (MiB)
[TensorRT] INFO: [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +0, now: CPU 0, GPU 1738 (MiB)
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1012 12:07:23.556475 711816 DynoConfigLoader.cpp:32] Failed to read config: No dyno config client
```

# Test shape inference
`buck test mode/opt glow/fb/fx/acc_tracer:test_acc_shape_inference`
Output
```
...
Summary
  Pass: 95
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/1407375092088240
```

Reviewed By: jfix71, jerryzh168

Differential Revision: D31457323

