### PR TITLE
[GHA] Hardcode doc build target to `master`

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -310,8 +310,8 @@ jobs:
           set -ex
           time docker pull "${DOCKER_IMAGE}" > /dev/null
           echo "${GITHUB_REF}"
-          ref=${GITHUB_REF##*/}
-          target=${ref//v}
+          # TODO: Set it correctly when workflows are scheduled on tags
+          target="master"
           # detached container should get cleaned up by teardown_ec2_linux
           container_name=$(docker run \
             -e BUILD_ENVIRONMENT \
@@ -344,7 +344,7 @@ jobs:
           retention-days: 14
           s3-bucket: doc-previews
           if-no-files-found: error
-          path: pytorch.github.io/docs/merge/
+          path: pytorch.github.io/docs/master/
           s3-prefix: pytorch/${{ github.event.pull_request.number }}
       - uses: !{{ common.upload_artifact_s3_action }}
         name: Upload C++ Docs Preview

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -590,8 +590,8 @@ jobs:
           set -ex
           time docker pull "${DOCKER_IMAGE}" > /dev/null
           echo "${GITHUB_REF}"
-          ref=${GITHUB_REF##*/}
-          target=${ref//v}
+          # TODO: Set it correctly when workflows are scheduled on tags
+          target="master"
           # detached container should get cleaned up by teardown_ec2_linux
           container_name=$(docker run \
             -e BUILD_ENVIRONMENT \
@@ -624,7 +624,7 @@ jobs:
           retention-days: 14
           s3-bucket: doc-previews
           if-no-files-found: error
-          path: pytorch.github.io/docs/merge/
+          path: pytorch.github.io/docs/master/
           s3-prefix: pytorch/${{ github.event.pull_request.number }}
       - uses: seemethere/upload-artifact-s3@v3
         name: Upload C++ Docs Preview


### PR DESCRIPTION
According to https://github.com/pytorch/pytorch/blob/f48f20e154f0295cdfd5e1461781f1023287e9eb/.circleci/verbatim-sources/job-specs/job-specs-custom.yml#L46-L48
target should always be master (even on release branches) unless it is a
tagged build

Fixes https://github.com/pytorch/pytorch/issues/66466
