### PR TITLE
quantization docs: remove erroneous rebase artifact

### DIFF
--- a/docs/source/quantization-support.rst
+++ b/docs/source/quantization-support.rst
@@ -86,9 +86,6 @@ This describes the quantization related functions of the `torch` namespace.
 
 torch.Tensor (quantization related methods)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
->>>>>>> 76f04ad385 (Quantization docs: rewrite API reference to be more automated)
->>>>>>> 37fe4f87ce (Quantization docs: rewrite API reference to be more automated)
->>>>>>> af26f377de (Quantization docs: rewrite API reference to be more automated)
 
 Quantized Tensors support a limited subset of data manipulation methods of the
 regular full-precision tensor.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66577

Summary:

There was a rebase artifact erroneously landed to quantization docs,
this PR removes it.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31651350](https://our.internmc.facebook.com/intern/diff/D31651350)