### PR TITLE
[Pytorch Delegated Backend] Add macro to define sentinel value of debug handle.

### DIFF
--- a/torch/csrc/jit/backends/backend_exception.h
+++ b/torch/csrc/jit/backends/backend_exception.h
@@ -50,3 +50,5 @@ class TORCH_API BackendRuntimeException : public c10::Error {
     e.pushDebugHandle(debug_handle);                     \
     throw;                                               \
   } while (false)
+
+#define DEBUG_HANDLE_UNKNOWN -1


### PR DESCRIPTION
Summary:
This will help avoid "-1"s in different places in our and backend codebase when
debug handle is not known.

Test Plan: CI

Differential Revision: D31614478

