### PR TITLE
[Static Runtime][DI] Fuse list unpack and grouped_accessor_op

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -592,7 +592,12 @@ void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph) {
       {fromQualString("fb::equally_split"),
        fromQualString("static_runtime::fused_equally_split")},
       {fromQualString("fb::sigrid_transforms"),
-       fromQualString("static_runtime::fused_sigrid_transforms")}};
+       fromQualString("static_runtime::fused_sigrid_transforms")},
+      {fromQualString("static_runtime::variadic_grouped_accessor_op"),
+       fromQualString("static_runtime::fused_variadic_grouped_accessor_op")},
+      {fromQualString("static_runtime::variadic_grouped_accessor_op_v2"),
+       fromQualString(
+           "static_runtime::fused_variadic_grouped_accessor_op_v2")}};
 
   AliasDb alias_db(
       graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
@@ -779,14 +784,12 @@ void UseVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph) {
   // both versions of this op.
   UseVariadicOp(
       graph,
-      c10::Symbol::fromQualString("grouped_accessor::grouped_accessor_op"),
-      c10::Symbol::fromQualString(
-          "static_runtime::variadic_grouped_accessor_op"));
+      fromQualString("grouped_accessor::grouped_accessor_op"),
+      fromQualString("static_runtime::variadic_grouped_accessor_op"));
   UseVariadicOp(
       graph,
-      c10::Symbol::fromQualString("grouped_accessor::grouped_accessor_op_v2"),
-      c10::Symbol::fromQualString(
-          "static_runtime::variadic_grouped_accessor_op_v2"));
+      fromQualString("grouped_accessor::grouped_accessor_op_v2"),
+      fromQualString("static_runtime::variadic_grouped_accessor_op_v2"));
 }
 
 } // namespace jit


### PR DESCRIPTION
Summary: Add a new op `static_runtime::fused_variadic_grouped_accessor_op` that outputs many tensors rather than a single tensor list. Incorporated this new op into `FuseListUnpack`. This eliminates `ListUnpack` overhead and tensor refcount bumps.

Test Plan:
**Accuracy Test**

Model 294738512_40 (manually confirmed that fusion happens)
```
get 2861 prediction values
get 2861 prediction values
max_error:  0  total:  0
```

**Performance**
TODO

Differential Revision: D31620408

