### PR TITLE
[Pytorch][Bootcamp] Add fix and testing for non-vectorized Adadelta optimizer to handle complex numbers

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -246,7 +246,7 @@ class TestOptim(TestCase):
     def _test_complex_optimizer(self, optimizer_constructor):
         complex_param = torch.randn(5, 5, dtype=torch.complex64, requires_grad=True)
         complex_opt = optimizer_constructor(complex_param)
-        real_param = torch.view_as_real(complex_param).detach().requires_grad_()
+        real_param = torch.view_as_real(complex_param).detach().clone().requires_grad_()
         real_opt = optimizer_constructor(real_param)
 
         for i in range(3):
@@ -563,6 +563,18 @@ class TestOptim(TestCase):
             )
             with self.assertRaisesRegex(ValueError, "Invalid rho value: 1.1"):
                 optimizer(None, lr=1e-2, rho=1.1)
+
+    def test_adadelta_complex(self):
+        for optimizer in [optim.Adadelta]:
+            self._test_complex_optimizer(
+                lambda weight: optimizer([weight])
+            )
+            self._test_complex_optimizer(
+                lambda weight: optimizer([weight], rho=0.95)
+            )
+            self._test_complex_optimizer(
+                lambda weight: optimizer([weight], rho=0.95, weight_decay=1)
+            )
 
     def test_nadam(self):
         for optimizer in [optim.NAdam, optim_mt.NAdam]:

--- a/torch/optim/_functional.py
+++ b/torch/optim/_functional.py
@@ -198,12 +198,20 @@ def adadelta(params: List[Tensor],
         if weight_decay != 0:
             grad = grad.add(param, alpha=weight_decay)
 
+        if torch.is_complex(param):
+            square_avg = torch.view_as_real(square_avg)
+            acc_delta = torch.view_as_real(acc_delta)
+            grad = torch.view_as_real(grad)
+
         square_avg.mul_(rho).addcmul_(grad, grad, value=1 - rho)
         std = square_avg.add(eps).sqrt_()
         delta = acc_delta.add(eps).sqrt_().div_(std).mul_(grad)
-        param.add_(delta, alpha=-lr)
         acc_delta.mul_(rho).addcmul_(delta, delta, value=1 - rho)
-
+        if torch.is_complex(param):
+            delta = torch.view_as_complex(delta)
+            square_avg = torch.view_as_complex(square_avg)
+            acc_delta = torch.view_as_complex(acc_delta)
+        param.add_(delta, alpha=-lr)
 
 def rmsprop(params: List[Tensor],
             grads: List[Tensor],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66586

Made some changes in the step function of the non-vectorized Adadelta optimizer to handle complex numbers as two real numbers as per Pytorch github issue #65711

Differential Revision: [D31630069](https://our.internmc.facebook.com/intern/diff/D31630069/)