### PR TITLE
Diff revealing missed memory overlapping problems from Static Runtime

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -55,7 +55,22 @@ MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b) {
   // similar situations (e.g., storage().data() == storage().data()+1)
   // which we will miss.
   auto a_storage = a->unsafe_storage();
+  auto b_storage = b->unsafe_storage();
   if (a_storage && a_storage.is_alias_of(b->unsafe_storage())) {
+    const auto a_begin = static_cast<char*>(a->data());
+    const auto a_end = a_begin + a->numel() * a->itemsize();
+    const auto b_begin = static_cast<char*>(b->data());
+    const auto b_end = b_begin + b->numel() * b->itemsize();
+
+    if (a_begin == b_begin && a_end == b_end) {
+      return (a->strides() == b->strides()) ?
+          MemOverlapStatus::FULL : MemOverlapStatus::PARTIAL;
+    }
+    if (a_begin < b_end && b_begin < a_end) {
+      return MemOverlapStatus::PARTIAL;
+    }
+  }
+  if (a_storage && b_storage) {
     const auto a_begin = static_cast<char*>(a->data());
     const auto a_end = a_begin + a->numel() * a->itemsize();
     const auto b_begin = static_cast<char*>(b->data());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

```
Confirmed that `%dp.1 : Tensor = static_runtime::flatten_copy(%dp_unflatten.1, %4, %8)` is causing this bug.


buck run //caffe2/benchmarks/static_runtime:static_runtime_cpptest -- --gtest_filter=StaticRuntime.DeepWide

Note: Google Test filter = StaticRuntime.DeepWide
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from StaticRuntime
[ RUN      ] StaticRuntime.DeepWide
F1011 17:39:23.986552 2074551 impl.cpp:1335] Check failed: verify_no_memory_overlap()
*** Check failure stack trace: ***
*** Aborted at 1633999163 (Unix time, try 'date -d @1633999163') ***
*** Signal 6 (SIGABRT) (0x2c322001fa7b7) received by PID 2074551 (pthread TID 0x7f5643e70140) (linux TID 2074551) (maybe from PID 2074551, UID 181026) (code: -6), stack trace: ***
    @ 0000000000018ffd folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*)
                       ./folly/experimental/symbolizer/SignalHandler.cpp:449
    @ 00000000000101eb folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*)
                       ./folly/experimental/symbolizer/SignalHandler.cpp:470
    @ 0000000000000000 (unknown)
    @ 000000000003e570 __GI_raise
    @ 00000000000254ec __GI_abort
    @ 000000000000dbac google::LogMessage::Fail()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:1519
    @ 00000000000109f2 google::LogMessage::SendToLog()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:1473
    @ 000000000000d7f2 google::LogMessage::Flush()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:1346
    @ 000000000000eaa8 google::LogMessageFatal::~LogMessageFatal()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:2013
    @ 00000000067547b3 torch::jit::ProcessedNode::run_impl()
                       ./caffe2/torch/csrc/jit/runtime/static/impl.cpp:1335
    @ 0000000006743063 torch::jit::ProcessedNode::run()
                       ./caffe2/torch/csrc/jit/runtime/static/impl.cpp:1376
    @ 000000000673a71e torch::jit::StaticRuntime::operator()(std::vector<c10::IValue, std::allocator<c10::IValue> > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, c10::IValue, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, c10::IValue> > > const&)
                       ./caffe2/torch/csrc/jit/runtime/static/impl.cpp:878
    @ 0000000006739dbf torch::jit::StaticRuntime::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> > const&)
                       ./caffe2/torch/csrc/jit/runtime/static/impl.cpp:806
    @ 000000000673942d torch::jit::StaticModule::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> > const&)
                       ./caffe2/torch/csrc/jit/runtime/static/impl.cpp:738
    @ 000000000040de2f StaticRuntime_DeepWide_Test::TestBody()
                       ./caffe2/benchmarks/static_runtime/test_static_runtime.cc:817
    @ 000000000005cd2f void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
                       /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest.cc:2605
                       -> /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest-all.cc
    @ 000000000004d6c5 testing::Test::Run()
                       /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest.cc:2680
                       -> /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest-all.cc
    @ 000000000004d834 testing::TestInfo::Run()
                       /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest.cc:2857
                       -> /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest-all.cc
    @ 000000000004dea1 testing::TestSuite::Run()
                       /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest.cc:3011
                       -> /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest-all.cc
    @ 000000000004e5de testing::internal::UnitTestImpl::RunAllTests()
                       /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest.cc:5722
                       -> /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest-all.cc
    @ 000000000004d8fc testing::UnitTest::Run()
                       /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest.cc:2605
                       -> /home/engshare/third-party2/googletest/20201023/src/googletest/googletest/src/gtest-all.cc
    @ 0000000000002680 RUN_ALL_TESTS()
                       ./third-party-buck/platform009/build/googletest/include/gtest/gtest.h:2486
                       -> ./common/gtest/LightMain.cpp
    @ 00000000000022a4 main
                       ./common/gtest/LightMain.cpp:20
    @ 0000000000025d94 __libc_start_main
    @ 000000000032b029 _start
                       /home/engshare/third-party2/glibc/2.30/src/glibc-2.30/csu/../sysdeps/x86_64/start.S:120
```

Differential Revision: [D31562712](https://our.internmc.facebook.com/intern/diff/D31562712/)