### PR TITLE
Run sparse tests only for TensorPipe agent.

### DIFF
--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -267,142 +267,6 @@ class CommonDistAutogradTest(RpcAgentTestFixture):
 
         self.assertEqual(ngrads, len(grads))
 
-
-class DistAutogradTest(CommonDistAutogradTest):
-    @dist_init
-    def test_autograd_context(self):
-        # Verify max possible id.
-        max_auto_increment = 281474976710655
-        self.assertEqual(
-            max_auto_increment + (self.worker_id << 48), dist_autograd._get_max_id()
-        )
-
-        context_ids = []
-        for i in range(200):
-            with dist_autograd.context() as context_id:
-                self.assertEqual(
-                    context_id,
-                    dist_autograd._retrieve_context(context_id)._context_id(),
-                )
-                # First 16 bits should be worker_id.
-                self.assertEqual(self.worker_id, context_id >> 48)
-                context_ids.append(context_id)
-
-        for context_id in context_ids:
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Could not find autograd context with id: {}".format(context_id),
-            ):
-                dist_autograd._retrieve_context(context_id)
-
-    @dist_init
-    def test_nested_context(self):
-        with dist_autograd.context() as context_id:
-            # Nested contexts not supported.
-            with self.assertRaisesRegex(
-                RuntimeError, "Already have an autograd context id for this thread"
-            ):
-                with dist_autograd.context() as context_id:
-                    pass
-
-    # For current context, this rank sends t1 and t2 tensors to dst_rank,
-    # then get t3 = torch.add(t1, t2) result tensor.
-    # For the current context in this rank, it expects graph like this:
-    #  send function:
-    #              rpcSendBackward
-    #                  /          \
-    #  t1.AccumulateGrad         t2.AccumulateGrad
-    #
-    #  recv function:
-    #
-    #            |
-    #          t3.rpcRecvBackward
-    #
-    def _verify_graph_for_first_rpc_call(
-        self, send_function, recv_function, t1, t2, ret
-    ):
-        # Retrieve the next functions in the graph.
-        next_funcs = send_function.next_functions
-        self.assertEqual(2, len(next_funcs))
-
-        # We should now hit t1 and t2 in the autograd graph.
-        self.assertEqual("torch::autograd::AccumulateGrad", next_funcs[0][0].name())
-        self.assertEqual(t1, next_funcs[0][0].variable)
-        self.assertEqual(0, next_funcs[0][1])
-        self.assertEqual("torch::autograd::AccumulateGrad", next_funcs[1][0].name())
-        self.assertEqual(t2, next_funcs[1][0].variable)
-        self.assertEqual(0, next_funcs[1][1])
-
-        # Test recv functions.
-        self.assertEqual(ret.grad_fn, recv_function)
-
-    # For a context passed from previous nested chain calls, this rank
-    # receives two tensors t1 and t2, executes torch.add(t1, t2) and sends
-    # result tensor t3 back.
-    # For this context in this rank, it expects graph like this:
-    #  send and recv functions:
-    #       rpcSendBackward
-    #           |
-    #          t3.AddBackward0
-    #          /             \
-    # t1.recvRpcBackward    t2.recvRpcBackward
-    def _verify_graph_for_rpc_call_exec(self, send_function):
-        # Verify next function is AddBackward0
-        next_funcs = send_function.next_functions
-        self.assertEqual(1, len(next_funcs))
-        add_backward_fn = next_funcs[0][0]
-        self.assertEqual("AddBackward0", add_backward_fn.name())
-
-        # Verify the next two functions are the same recv backward function.
-        next_funcs = add_backward_fn.next_functions
-        self.assertEqual(2, len(next_funcs))
-        self.assertEqual(
-            "torch::distributed::autograd::RecvRpcBackward", next_funcs[0][0].name()
-        )
-        self.assertEqual(
-            "torch::distributed::autograd::RecvRpcBackward", next_funcs[1][0].name()
-        )
-        self.assertEqual(next_funcs[0][0], next_funcs[1][0])
-
-    # For a context passed from previous nested chain calls, this rank
-    # receives two tensors t1 and t2, forwards t1 and t2 tensors using
-    # nested rpc call to next dst. In return route, receive result tensor t3
-    # from next dst and forwarding t3 back to previous calls.
-    # For this context in this rank, it expects graph like this:
-    #  send and recv functions for receiving and forwarding t1 and t2:
-    #       rpcSendBackward
-    #          /          \
-    # t1.recvRpcBackward    t2.recvRpcBackward
-    #  send and recv functions for receiving and forwarding t3:
-    #       rpcSendBackward
-    #             |
-    #           t3.recvRpcBackward
-    def _verify_graph_for_nested_rpc_call(self, ctx):
-        send_functions = ctx._send_functions()
-        self.assertEqual(2, len(send_functions))
-
-        # For send function when making nest rpc call,
-        # next functions of the send function are two recv functions
-        # for received two tensors from previous call
-        next_funcs = list(send_functions.values())[0].next_functions
-        self.assertEqual(2, len(next_funcs))
-        self.assertEqual(
-            "torch::distributed::autograd::RecvRpcBackward", next_funcs[0][0].name()
-        )
-        self.assertEqual(
-            "torch::distributed::autograd::RecvRpcBackward", next_funcs[1][0].name()
-        )
-        self.assertEqual(next_funcs[0][0], next_funcs[1][0])
-
-        # For send function when returning resonpose to previous call
-        # next function of the send function is the recv function
-        # for received tensor result returned from nested call
-        next_funcs = list(send_functions.values())[1].next_functions
-        self.assertEqual(1, len(next_funcs))
-        self.assertEqual(
-            "torch::distributed::autograd::RecvRpcBackward", next_funcs[0][0].name()
-        )
-
     def _test_graph(self, fn, exec_mode, sparse):
         dst_rank = (self.rank + 1) % self.world_size
 
@@ -461,38 +325,6 @@ class DistAutogradTest(CommonDistAutogradTest):
         # No autograd context available.
         with self.assertRaises(RuntimeError):
             ctx = dist_autograd._current_context()
-
-    @dist_init
-    def test_graph_for_builtin_call(self):
-        self._test_graph(torch.add, ExecMode.RPC_SYNC, False)
-
-    @dist_init
-    def test_graph_for_builtin_call_sparse(self):
-        self._test_graph(torch.add, ExecMode.RPC_SYNC, True)
-
-    @dist_init
-    def test_graph_for_python_call(self):
-        self._test_graph(my_py_add, ExecMode.RPC_SYNC, False)
-
-    @dist_init
-    def test_graph_for_python_call_sparse(self):
-        self._test_graph(my_py_add, ExecMode.RPC_SYNC, True)
-
-    @dist_init
-    def test_graph_for_builtin_remote_call(self):
-        self._test_graph(torch.add, ExecMode.REMOTE, False)
-
-    @dist_init
-    def test_graph_for_builtin_remote_call_sparse(self):
-        self._test_graph(torch.add, ExecMode.REMOTE, True)
-
-    @dist_init
-    def test_graph_for_python_remote_call(self):
-        self._test_graph(my_py_add, ExecMode.REMOTE, False)
-
-    @dist_init
-    def test_graph_for_python_remote_call_sparse(self):
-        self._test_graph(my_py_add, ExecMode.REMOTE, True)
 
     # 3-layer nested calls
     def _test_graph_for_py_nested_call(self, exec_mode, sparse):
@@ -577,22 +409,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             # autograd context before another worker tries to access it.
             dist.barrier()
 
-    @dist_init
-    def test_graph_for_py_nested_call(self):
-        self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC, False)
-
-    @dist_init
-    def test_graph_for_py_nested_call_sparse(self):
-        self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC, True)
-
-    @dist_init
-    def test_graph_for_py_nested_remote_call(self):
-        self._test_graph_for_py_nested_call(ExecMode.REMOTE, False)
-
-    @dist_init
-    def test_graph_for_py_nested_remote_call_sparse(self):
-        self._test_graph_for_py_nested_call(ExecMode.REMOTE, True)
-
     # Rank0->Rank1->Rank0
     def _test_graph_for_py_nested_call_itself(self, exec_mode, sparse):
         dst_rank = (self.rank + 1) % self.world_size
@@ -668,22 +484,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             # autograd context before another worker tries to access it.
             dist.barrier()
 
-    @dist_init
-    def test_graph_for_py_nested_call_itself(self):
-        self._test_graph_for_py_nested_call_itself(ExecMode.RPC_SYNC, False)
-
-    @dist_init
-    def test_graph_for_py_nested_call_itself_sparse(self):
-        self._test_graph_for_py_nested_call_itself(ExecMode.RPC_SYNC, True)
-
-    @dist_init
-    def test_graph_for_py_nested_remote_call_itself(self):
-        self._test_graph_for_py_nested_call_itself(ExecMode.REMOTE, False)
-
-    @dist_init
-    def test_graph_for_py_nested_remote_call_itself_sparse(self):
-        self._test_graph_for_py_nested_call_itself(ExecMode.REMOTE, True)
-
     def _test_no_graph_with_tensors_not_require_grad(self, exec_mode, sparse):
         initialize_pg(self.file_init_method, self.rank, self.world_size)
         dst_rank = (self.rank + 1) % self.world_size
@@ -726,59 +526,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             self.assertNotEqual(-1, dist_autograd._retrieve_context(ctx_ids[1]))
             dist.barrier()
 
-    @dist_init
-    def test_no_graph_with_tensors_not_require_grad(self):
-        self._test_no_graph_with_tensors_not_require_grad(ExecMode.RPC_SYNC, False)
-
-    @dist_init
-    def test_no_graph_with_tensors_not_require_grad_sparse(self):
-        self._test_no_graph_with_tensors_not_require_grad(ExecMode.RPC_SYNC, True)
-
-    @dist_init
-    def test_no_graph_with_tensors_not_require_grad_remote(self):
-        self._test_no_graph_with_tensors_not_require_grad(ExecMode.REMOTE, False)
-
-    @dist_init
-    def test_no_graph_with_tensors_not_require_grad_remote_sparse(self):
-        self._test_no_graph_with_tensors_not_require_grad(ExecMode.REMOTE, True)
-
-    def _test_grad_only_on_return_value(self, exec_mode):
-        initialize_pg(self.file_init_method, self.rank, self.world_size)
-        dst_rank = (self.rank + 1) % self.world_size
-        with dist_autograd.context() as context_id:
-            if ExecMode.RPC_SYNC == exec_mode:
-                ret = rpc.rpc_sync(worker_name(dst_rank), ret_requires_grad)
-            elif ExecMode.REMOTE == exec_mode:
-                ret = rpc.remote(
-                    worker_name(dst_rank), ret_requires_grad
-                ).to_here()
-            else:
-                raise ValueError("Unrecognized ExecMode {}".format(exec_mode))
-
-            dist_autograd.backward(context_id, [ret.sum()])
-
-            rpc.rpc_sync(
-                worker_name(dst_rank), _set_rpc_done, args=(context_id, 1)
-            )
-
-            # Wait for the prev rank to be done with rpc.
-            self._check_rpc_done(1)
-            grads = dist_autograd.get_gradients(ctx_ids[1])
-            self.assertEqual(1, len(grads))
-            self.assertIn(requires_grad_tensor, grads)
-            self.assertEqual(torch.ones_like(ret), grads[requires_grad_tensor])
-            # due to the above get_gradients call, ensure that dist autograd
-            # contexts aren't cleaned up until all workers exit context managers
-            dist.barrier()
-
-    @dist_init
-    def test_grad_only_on_return_value(self):
-        self._test_grad_only_on_return_value(ExecMode.RPC_SYNC)
-
-    @dist_init
-    def test_grad_only_on_return_value_remote(self):
-        self._test_grad_only_on_return_value(ExecMode.REMOTE)
-
     def _test_rpc_complex_args(self, exec_mode, sparse):
         with dist_autograd.context() as context_id:
             num_tensors = 10
@@ -820,22 +567,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             self.assertEqual(len(worker_ids), 1)
             self.assertEqual(worker_ids, {dst_rank})
 
-    @dist_init
-    def test_rpc_complex_args(self):
-        self._test_rpc_complex_args(ExecMode.RPC_SYNC, False)
-
-    @dist_init
-    def test_rpc_complex_args_sparse(self):
-        self._test_rpc_complex_args(ExecMode.RPC_SYNC, True)
-
-    @dist_init
-    def test_remote_complex_args(self):
-        self._test_rpc_complex_args(ExecMode.REMOTE, False)
-
-    @dist_init
-    def test_remote_complex_args_sparse(self):
-        self._test_rpc_complex_args(ExecMode.REMOTE, True)
-
     def context_cleanup_test_helper(self, rpc_args, func, nested=False):
         initialize_pg(self.file_init_method, self.rank, self.world_size)
 
@@ -873,11 +604,459 @@ class DistAutogradTest(CommonDistAutogradTest):
         success = _all_contexts_cleaned_up()
         self.assertTrue(success)
 
+    def _backward_no_grad_on_tensor(self, t1, t2, sparse):
+        with dist_autograd.context() as context_id:
+            loss = rpc.rpc_sync(
+                worker_name(self._next_rank()),
+                torch.add,
+                args=(t1, t2))
+            if sparse:
+                loss = torch.sparse.sum(loss)
+            else:
+                loss = loss.sum()
+            dist_autograd.backward(context_id, [loss], retain_graph=True)
+            self.assertIsNone(t1.grad)
+            self.assertIsNone(t2.grad)
+
+            # Now populate .grad with local autograd engine and
+            # verify dist autograd doesn't mess with it.
+            loss_local = torch.add(t1, t2)
+            if sparse:
+                loss_local = torch.sparse.sum(loss_local)
+            else:
+                loss_local = loss_local.sum()
+            loss_local.backward()
+            self.assertIsNotNone(t1.grad)
+            self.assertIsNotNone(t2.grad)
+
+            t1_grad_before = t1.grad
+            t2_grad_before = t2.grad
+            dist_autograd.backward(context_id, [loss])
+            self.assertEqual(t1_grad_before, t1.grad)
+            self.assertEqual(t2_grad_before, t2.grad)
+
+    # The current rank first creates a tensor on the rref_owner, and then passes
+    # the rref with another tensor to the callee to run either my_rref_add or
+    # my_nested_rref_add, depending on whether the callee is the rref owner.
+    # The grad of tensor lives on the current rank, and the grad of the rref
+    # tensor lives on the rref owner.
+    def _backward_rref(self, callee, rref_owner, t1, t2, local_grads, sparse):
+        local_ret = torch.add(t1, t2)
+        if sparse:
+            local_ret = torch.sparse.sum(local_ret)
+        else:
+            local_ret = local_ret.sum()
+        local_ret.backward()
+        with dist_autograd.context() as context_id:
+            if sparse:
+                rref_t1 = rpc.remote(
+                    rref_owner, build_sparse_tensor, args=(False, True,)
+                )
+            else:
+                rref_t1 = rpc.remote(
+                    rref_owner, _torch_ones, args=((3, 3),), kwargs={"requires_grad": True}
+                )
+            if callee == rref_owner:
+                rref = rpc.remote(callee, my_rref_add, args=(rref_t1, t2))
+            else:
+                rref = rpc.remote(
+                    callee, my_nested_rref_add, args=(rref_owner, rref_t1, t2)
+                )
+            ret = rref.to_here()
+            if sparse:
+                ret = torch.sparse.sum(ret)
+            else:
+                ret = ret.sum()
+            dist_autograd.backward(context_id, [ret])
+
+            # verify grads on caller
+            grads = dist_autograd.get_gradients(context_id)
+            self.assertIn(t2, grads)
+            self.assertEqual(grads[t2], t2.grad)
+
+            # verify grads on rref owner
+            self.assertTrue(
+                rpc.rpc_sync(
+                    rref_owner,
+                    _compare_owner_value,
+                    args=(context_id, rref_t1, t1.grad),
+                )
+            )
+
+    # In this test, every rank will serve as a parameter server (ps) and a
+    # driver, and then kicks off trainers on the other three ranks. So, we have:
+    # ps = rank0 with trainers = rank1/2/3
+    # ps = rank2 with trainers = rank2/3/0
+    # ps = rank3 with trainers = rank3/0/1
+    # ps = rank4 with trainers = rank0/1/2
+    #
+    # These four test ps-trainer groups run on completely separate autograd
+    # graphs, but they share the same set of underlying RpcAgents.
+    def _test_trainer_ps(self, create_ref_fn, trainer_fn, sparse):
+        if sparse:
+            t1 = build_sparse_tensor(requires_grad=True)
+            t2 = build_sparse_tensor(requires_grad=True)
+        else:
+            t1 = torch.ones((3, 3), requires_grad=True)
+            t2 = torch.zeros((3, 3), requires_grad=True)
+
+        local_ret = torch.add(t1, t2)
+        if sparse:
+            torch.sparse.sum(local_ret).backward()
+        else:
+            local_ret.sum().backward()
+
+        # create rref on self
+        rref_t1 = rpc.remote(
+            worker_name(self.rank),
+            create_ref_fn,
+            args=())
+
+        # kick off forward and backward pass on three other workers (trainers)
+        rank_diffs = [1, 2, 3]
+        futures = []
+        for rank_diff in rank_diffs:
+            futures.append(
+                rpc.rpc_async(
+                    worker_name((self.rank + rank_diff) % self.world_size),
+                    trainer_fn,
+                    args=(rref_t1, t2, worker_name(self.rank), rank_diff, sparse),
+                )
+            )
+
+        # check if the trainers have done with their backward pass
+        for rank_diff in rank_diffs:
+            self._check_rpc_done(rank_diff)
+
+        # trainers are done and holding the context for verification
+        accumulate_grad_func = None
+        for rank_diff in rank_diffs:
+            # make sure grads are accumulated for the same tensors and values
+            # are all correct
+            ctx_id = ctx_ids[rank_diff]
+            grads = dist_autograd.get_gradients(ctx_id)
+            local_t1 = rref_t1.to_here()
+            self.assertIn(local_t1, grads)
+            self.assertEqual(grads[local_t1], t1.grad)
+
+        # unblock trainers
+        _set_rpc_done(None, 0)
+
+        # wait until all trainers are done
+        torch.futures.wait_all(futures)
+
+    def _backward_multiple_round_trips(self, t1, t2, t3, t4, t5, local_grads, sparse):
+        for exec_mode in [ExecMode.LOCAL, ExecMode.RPC_SYNC, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                # Multiple RPCs between different nodes.
+                val = self._exec_func(exec_mode, torch.add, t1, t2)
+                val = self._exec_func(exec_mode, torch.mul, t3, val)
+                s1 = self._exec_func(exec_mode, torch.stack, (t4, val))
+                s2 = self._exec_func(exec_mode, torch.stack, (t5, val))
+                if sparse:
+                    val = self._exec_func(exec_mode, torch.mul, s1, s2)
+                    val = self._exec_func(exec_mode, torch.mul, val, val)
+                    loss = torch.sparse.sum(val)
+                else:
+                    val = self._exec_func(exec_mode, torch.bmm, s1, s2)
+                    val = self._exec_func(exec_mode, torch.matmul, val, val)
+                    loss = val.sum()
+
+                ret = self._verify_backwards(
+                    exec_mode, [loss], context_id, local_grads, t1, t2, t3, t4, t5
+                )
+                local_grads = ret if ret else local_grads
+
+    def _backward_different_dtypes(self, t1, t2, sparse):
+        local_grads = None
+        for exec_mode in [ExecMode.LOCAL, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                loss = self._exec_func(exec_mode, torch.add, t1, t2)
+                if sparse:
+                    loss = torch.sparse.sum(loss)
+                else:
+                    loss = loss.sum()
+                local_grads = self._verify_backwards(
+                    exec_mode, [loss], context_id, local_grads, t1, t2
+                )
+
+    # Run the same code locally and with dist autograd and verify gradients
+    # are same.
+    def _backward_simple_python_udf(self, t1, t2, sparse):
+        local_grads = None
+        for exec_mode in [ExecMode.LOCAL, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                ret = self._exec_func(exec_mode, my_py_add, t1, t2)
+                if sparse:
+                    loss = torch.sparse.sum(ret)
+                else:
+                    loss = ret.sum()
+                local_grads = self._verify_backwards(
+                    exec_mode, [loss], context_id, local_grads, t1, t2
+                )
+
+    # Run the same code locally and with dist autograd and verify gradients
+    # are same.
+    def _backward_simple_script_call(self, t1, t2, sparse):
+        local_grads = None
+        for exec_mode in [
+            ExecMode.LOCAL,
+            ExecMode.RPC_SYNC,
+            ExecMode.RPC_ASYNC,
+            ExecMode.REMOTE,
+        ]:
+            with dist_autograd.context() as context_id:
+                forward_ret = self._exec_func(exec_mode, my_script_add, t1, t2)
+                if sparse:
+                    loss = torch.sparse.sum(forward_ret)
+                else:
+                    loss = forward_ret.sum()
+                ret = self._verify_backwards(
+                    exec_mode, [loss], context_id, local_grads, t1, t2
+                )
+                local_grads = ret if ret else local_grads
+
+    def _nested_backward_accumulate_grads(self, t1, t2, sparse):
+        with dist_autograd.context() as context_id:
+            ret = rpc.rpc_sync(
+                worker_name(self._next_rank()),
+                DistAutogradTest._test_nested_backward_accumulate_grads,
+                args=(t1, t2, self._next_rank()),
+            )
+            if sparse:
+                loss = torch.sparse.sum(ret)
+            else:
+                loss = ret.sum()
+            # Run backward twice.
+            dist_autograd.backward(context_id, [loss], retain_graph=True)
+            dist_autograd.backward(context_id, [loss])
+
+    def _backwards_nested_python_udf(self, t1, t2, sparse):
+        t3 = t1 * t2
+        t4 = t1 + t2
+        res = t3 + t4
+        loss = t1 * t2 * t3 * t4 * res
+        if sparse:
+            loss = torch.sparse.sum(loss)
+        else:
+            loss = loss.sum()
+        torch.autograd.backward([loss])
+
+        # Now run distributed autograd.
+        with dist_autograd.context() as context_id:
+            loss = rpc.rpc_sync(
+                worker_name(self._next_rank()),
+                DistAutogradTest._nested_python_udf,
+                args=(t1, t2, self._next_rank()),
+            )
+            if sparse:
+                loss = torch.sparse.sum(loss)
+            else:
+                loss = loss.sum()
+            dist_autograd.backward(context_id, [loss])
+            grads = dist_autograd.get_gradients(context_id)
+            self.assertEqual(t1.grad, grads[t1])
+            self.assertEqual(t2.grad, grads[t2])
+
+    def _mixed_requires_grad(self, t1, t2, sparse):
+        for exec_mode in [ExecMode.RPC_SYNC, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                ret = self._exec_func(
+                    exec_mode, DistAutogradTest._mixed_requires_grad_operaton, t1, t2
+                )
+                self.assertEqual(t1 * t2, ret)
+                if sparse:
+                    loss = torch.sparse.sum(ret)
+                else:
+                    loss = ret.sum()
+                dist_autograd.backward(context_id, [loss])
+                self.assertTrue(t1.requires_grad)
+                self.assertFalse(t2.requires_grad)
+                grads = dist_autograd.get_gradients(context_id)
+                self.assertIn(t1, grads)
+                self.assertNotIn(t2, grads)
+                self.assertEqual(t2, grads[t1])
+
+    def _multiple_backward(self, t1, t2, sparse):
+        with dist_autograd.context() as context_id:
+            loss = rpc.rpc_sync(
+                worker_name(self._next_rank()),
+                torch.add,
+                args=(t1, t2))
+            if sparse:
+                loss = torch.sparse.sum(loss)
+            else:
+                loss = loss.sum()
+            # Run backward in a loop multiple times.
+            for i in range(1000):
+                dist_autograd.backward(context_id, [loss], retain_graph=True)
+
+    # For current context, this rank sends t1 and t2 tensors to dst_rank,
+    # then get t3 = torch.add(t1, t2) result tensor.
+    # For the current context in this rank, it expects graph like this:
+    #  send function:
+    #              rpcSendBackward
+    #                  /          \
+    #  t1.AccumulateGrad         t2.AccumulateGrad
+    #
+    #  recv function:
+    #
+    #            |
+    #          t3.rpcRecvBackward
+    #
+    def _verify_graph_for_first_rpc_call(
+        self, send_function, recv_function, t1, t2, ret
+    ):
+        # Retrieve the next functions in the graph.
+        next_funcs = send_function.next_functions
+        self.assertEqual(2, len(next_funcs))
+
+        # We should now hit t1 and t2 in the autograd graph.
+        self.assertEqual("torch::autograd::AccumulateGrad", next_funcs[0][0].name())
+        self.assertEqual(t1, next_funcs[0][0].variable)
+        self.assertEqual(0, next_funcs[0][1])
+        self.assertEqual("torch::autograd::AccumulateGrad", next_funcs[1][0].name())
+        self.assertEqual(t2, next_funcs[1][0].variable)
+        self.assertEqual(0, next_funcs[1][1])
+
+        # Test recv functions.
+        self.assertEqual(ret.grad_fn, recv_function)
+
+    # Run the same code locally and with dist autograd and verify gradients
+    # are same.
+    def _backward_simple(self, dst, t1, t2, local_grads, sparse):
+        for exec_mode in [ExecMode.LOCAL, ExecMode.RPC_SYNC, ExecMode.REMOTE]:
+            with dist_autograd.context() as context_id:
+                ret = self._exec_func_with_dst(
+                    dst, exec_mode, torch.add, t1, t2
+                )
+                if sparse:
+                    loss = torch.sparse.sum(ret)
+                else:
+                    loss = ret.sum()
+                ret = self._verify_backwards(
+                    exec_mode, [loss], context_id, local_grads, t1, t2
+                )
+                local_grads = ret if ret else local_grads
+
+    # For a context passed from previous nested chain calls, this rank
+    # receives two tensors t1 and t2, executes torch.add(t1, t2) and sends
+    # result tensor t3 back.
+    # For this context in this rank, it expects graph like this:
+    #  send and recv functions:
+    #       rpcSendBackward
+    #           |
+    #          t3.AddBackward0
+    #          /             \
+    # t1.recvRpcBackward    t2.recvRpcBackward
+    def _verify_graph_for_rpc_call_exec(self, send_function):
+        # Verify next function is AddBackward0
+        next_funcs = send_function.next_functions
+        self.assertEqual(1, len(next_funcs))
+        add_backward_fn = next_funcs[0][0]
+        self.assertEqual("AddBackward0", add_backward_fn.name())
+
+        # Verify the next two functions are the same recv backward function.
+        next_funcs = add_backward_fn.next_functions
+        self.assertEqual(2, len(next_funcs))
+        self.assertEqual(
+            "torch::distributed::autograd::RecvRpcBackward", next_funcs[0][0].name()
+        )
+        self.assertEqual(
+            "torch::distributed::autograd::RecvRpcBackward", next_funcs[1][0].name()
+        )
+        self.assertEqual(next_funcs[0][0], next_funcs[1][0])
+
+    # For a context passed from previous nested chain calls, this rank
+    # receives two tensors t1 and t2, forwards t1 and t2 tensors using
+    # nested rpc call to next dst. In return route, receive result tensor t3
+    # from next dst and forwarding t3 back to previous calls.
+    # For this context in this rank, it expects graph like this:
+    #  send and recv functions for receiving and forwarding t1 and t2:
+    #       rpcSendBackward
+    #          /          \
+    # t1.recvRpcBackward    t2.recvRpcBackward
+    #  send and recv functions for receiving and forwarding t3:
+    #       rpcSendBackward
+    #             |
+    #           t3.recvRpcBackward
+    def _verify_graph_for_nested_rpc_call(self, ctx):
+        send_functions = ctx._send_functions()
+        self.assertEqual(2, len(send_functions))
+
+        # For send function when making nest rpc call,
+        # next functions of the send function are two recv functions
+        # for received two tensors from previous call
+        next_funcs = list(send_functions.values())[0].next_functions
+        self.assertEqual(2, len(next_funcs))
+        self.assertEqual(
+            "torch::distributed::autograd::RecvRpcBackward", next_funcs[0][0].name()
+        )
+        self.assertEqual(
+            "torch::distributed::autograd::RecvRpcBackward", next_funcs[1][0].name()
+        )
+        self.assertEqual(next_funcs[0][0], next_funcs[1][0])
+
+        # For send function when returning resonpose to previous call
+        # next function of the send function is the recv function
+        # for received tensor result returned from nested call
+        next_funcs = list(send_functions.values())[1].next_functions
+        self.assertEqual(1, len(next_funcs))
+        self.assertEqual(
+            "torch::distributed::autograd::RecvRpcBackward", next_funcs[0][0].name()
+        )
+
+
+class TensorPipeAgentDistAutogradTest(CommonDistAutogradTest):
+
+    # Sparse tests only work with TensorPipeAgent.
     @dist_init
-    def test_context_cleanup_tensor_with_grad(self):
-        t1 = torch.ones(3, 3, requires_grad=True)
-        t2 = torch.zeros(3, 3, requires_grad=True)
-        self.context_cleanup_test_helper(rpc_args=(t1, t2), func=torch.add)
+    def test_graph_for_builtin_call_sparse(self):
+        self._test_graph(torch.add, ExecMode.RPC_SYNC, True)
+
+    @dist_init
+    def test_graph_for_python_call_sparse(self):
+        self._test_graph(my_py_add, ExecMode.RPC_SYNC, True)
+
+    @dist_init
+    def test_graph_for_builtin_remote_call_sparse(self):
+        self._test_graph(torch.add, ExecMode.REMOTE, True)
+
+    @dist_init
+    def test_graph_for_python_remote_call_sparse(self):
+        self._test_graph(my_py_add, ExecMode.REMOTE, True)
+
+    @dist_init
+    def test_graph_for_py_nested_call_sparse(self):
+        self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC, True)
+
+    @dist_init
+    def test_graph_for_py_nested_remote_call_sparse(self):
+        self._test_graph_for_py_nested_call(ExecMode.REMOTE, True)
+
+    @dist_init
+    def test_graph_for_py_nested_call_itself_sparse(self):
+        self._test_graph_for_py_nested_call_itself(ExecMode.RPC_SYNC, True)
+
+    @dist_init
+    def test_graph_for_py_nested_remote_call_itself_sparse(self):
+        self._test_graph_for_py_nested_call_itself(ExecMode.REMOTE, True)
+
+    @dist_init
+    def test_no_graph_with_tensors_not_require_grad_sparse(self):
+        self._test_no_graph_with_tensors_not_require_grad(ExecMode.RPC_SYNC, True)
+
+    @dist_init
+    def test_no_graph_with_tensors_not_require_grad_remote_sparse(self):
+        self._test_no_graph_with_tensors_not_require_grad(ExecMode.REMOTE, True)
+
+    @dist_init
+    def test_rpc_complex_args_sparse(self):
+        self._test_rpc_complex_args(ExecMode.RPC_SYNC, True)
+
+    @dist_init
+    def test_remote_complex_args_sparse(self):
+        self._test_rpc_complex_args(ExecMode.REMOTE, True)
 
     @dist_init
     def test_context_cleanup_tensor_with_grad_sparse(self):
@@ -886,13 +1065,297 @@ class DistAutogradTest(CommonDistAutogradTest):
         self.context_cleanup_test_helper(rpc_args=(t1, t2), func=torch.add)
 
     @dist_init
-    def test_context_cleanup_tensor_no_grad(self):
-        t1 = torch.ones(3, 3, requires_grad=False)
+    def test_context_cleanup_tensor_no_grad_sparse(self):
+        t1 = build_sparse_tensor(requires_grad=False)
         self.context_cleanup_test_helper(rpc_args=(t1, t1), func=torch.add)
 
     @dist_init
-    def test_context_cleanup_tensor_no_grad_sparse(self):
-        t1 = build_sparse_tensor(requires_grad=False)
+    def test_context_cleanup_nested_rpc_sparse(self):
+        t1 = build_sparse_tensor(requires_grad=True)
+        t2 = build_sparse_tensor(requires_grad=True)
+        dst_rank = (self.rank + 1) % self.world_size
+        args = (t1, t2, dst_rank, self.world_size, 0)
+        self.context_cleanup_test_helper(
+            rpc_args=args, func=my_py_nested_call, nested=True
+        )
+
+    @dist_init
+    def test_backward_no_grad_on_tensor_sparse(self):
+        self._backward_no_grad_on_tensor(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            True
+        )
+
+    @dist_init
+    def test_backward_simple_sparse(self):
+        self._backward_simple(
+            self._next_rank(),
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            None,
+            True
+        )
+
+    @dist_init
+    def test_backward_simple_self_sparse(self):
+        self._backward_simple(
+            self.rank,
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            None,
+            True
+        )
+
+    @dist_init
+    def test_backward_rref_multi_sparse(self):
+        if self.rank > 0:
+            callee = "worker0"
+            rref_owner = callee
+            self._backward_rref(
+                callee,
+                rref_owner,
+                build_sparse_tensor(requires_grad=True),
+                build_sparse_tensor(requires_grad=True),
+                None,
+                True
+            )
+
+    @dist_init
+    def test_backward_rref_sparse(self):
+        callee = worker_name(self._next_rank())
+        rref_owner = callee
+        self._backward_rref(
+            callee,
+            rref_owner,
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            None,
+            True
+        )
+
+    @dist_init
+    def test_backward_rref_nested_sparse(self):
+        callee = worker_name((self.rank + 1) % self.world_size)
+        rref_owner = worker_name((self.rank + 2) % self.world_size)
+        self._backward_rref(
+            callee,
+            rref_owner,
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            None,
+            True
+        )
+
+    @dist_init
+    def test_trainer_ps_sparse(self):
+        self._test_trainer_ps(
+            build_sparse_tensor,
+            _run_trainer,
+            True
+        )
+
+    @dist_init
+    def test_backward_multiple_round_trips_sparse(self):
+        self._backward_multiple_round_trips(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=False),
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=False),
+            build_sparse_tensor(requires_grad=True),
+            None,
+            True
+        )
+
+    @dist_init
+    def test_backward_different_dtypes_sparse(self):
+        self._backward_different_dtypes(
+            build_sparse_tensor(requires_grad=True, dtype=torch.float32),
+            build_sparse_tensor(requires_grad=True, dtype=torch.float64),
+            True
+        )
+
+    @dist_init
+    def test_backward_simple_python_udf_sparse(self):
+        self._backward_simple_python_udf(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            True
+        )
+
+    @dist_init
+    def test_backward_simple_script_call_sparse(self):
+        self._backward_simple_script_call(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            True
+        )
+
+    @dist_init
+    def test_nested_backward_accumulate_grads_sparse(self):
+        self._nested_backward_accumulate_grads(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            True
+        )
+
+    @dist_init
+    def test_backwards_nested_python_udf_sparse(self):
+        # Run equivalent of _nested_python_udf locally.
+        self._backwards_nested_python_udf(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            True
+        )
+
+    @dist_init
+    def test_mixed_requires_grad_sparse(self):
+        self._mixed_requires_grad(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=False),
+            True
+        )
+
+    @dist_init
+    def test_multiple_backward_sparse(self):
+        self._multiple_backward(
+            build_sparse_tensor(requires_grad=True),
+            build_sparse_tensor(requires_grad=True),
+            True
+        )
+
+
+class DistAutogradTest(CommonDistAutogradTest):
+    @dist_init
+    def test_autograd_context(self):
+        # Verify max possible id.
+        max_auto_increment = 281474976710655
+        self.assertEqual(
+            max_auto_increment + (self.worker_id << 48), dist_autograd._get_max_id()
+        )
+
+        context_ids = []
+        for i in range(200):
+            with dist_autograd.context() as context_id:
+                self.assertEqual(
+                    context_id,
+                    dist_autograd._retrieve_context(context_id)._context_id(),
+                )
+                # First 16 bits should be worker_id.
+                self.assertEqual(self.worker_id, context_id >> 48)
+                context_ids.append(context_id)
+
+        for context_id in context_ids:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Could not find autograd context with id: {}".format(context_id),
+            ):
+                dist_autograd._retrieve_context(context_id)
+
+    @dist_init
+    def test_nested_context(self):
+        with dist_autograd.context() as context_id:
+            # Nested contexts not supported.
+            with self.assertRaisesRegex(
+                RuntimeError, "Already have an autograd context id for this thread"
+            ):
+                with dist_autograd.context() as context_id:
+                    pass
+
+    @dist_init
+    def test_graph_for_builtin_call(self):
+        self._test_graph(torch.add, ExecMode.RPC_SYNC, False)
+
+    @dist_init
+    def test_graph_for_python_call(self):
+        self._test_graph(my_py_add, ExecMode.RPC_SYNC, False)
+
+    @dist_init
+    def test_graph_for_builtin_remote_call(self):
+        self._test_graph(torch.add, ExecMode.REMOTE, False)
+
+    @dist_init
+    def test_graph_for_python_remote_call(self):
+        self._test_graph(my_py_add, ExecMode.REMOTE, False)
+
+    @dist_init
+    def test_graph_for_py_nested_call(self):
+        self._test_graph_for_py_nested_call(ExecMode.RPC_SYNC, False)
+
+    @dist_init
+    def test_graph_for_py_nested_remote_call(self):
+        self._test_graph_for_py_nested_call(ExecMode.REMOTE, False)
+
+    @dist_init
+    def test_graph_for_py_nested_call_itself(self):
+        self._test_graph_for_py_nested_call_itself(ExecMode.RPC_SYNC, False)
+
+    @dist_init
+    def test_graph_for_py_nested_remote_call_itself(self):
+        self._test_graph_for_py_nested_call_itself(ExecMode.REMOTE, False)
+
+    @dist_init
+    def test_no_graph_with_tensors_not_require_grad(self):
+        self._test_no_graph_with_tensors_not_require_grad(ExecMode.RPC_SYNC, False)
+
+    @dist_init
+    def test_no_graph_with_tensors_not_require_grad_remote(self):
+        self._test_no_graph_with_tensors_not_require_grad(ExecMode.REMOTE, False)
+
+    def _test_grad_only_on_return_value(self, exec_mode):
+        initialize_pg(self.file_init_method, self.rank, self.world_size)
+        dst_rank = (self.rank + 1) % self.world_size
+        with dist_autograd.context() as context_id:
+            if ExecMode.RPC_SYNC == exec_mode:
+                ret = rpc.rpc_sync(worker_name(dst_rank), ret_requires_grad)
+            elif ExecMode.REMOTE == exec_mode:
+                ret = rpc.remote(
+                    worker_name(dst_rank), ret_requires_grad
+                ).to_here()
+            else:
+                raise ValueError("Unrecognized ExecMode {}".format(exec_mode))
+
+            dist_autograd.backward(context_id, [ret.sum()])
+
+            rpc.rpc_sync(
+                worker_name(dst_rank), _set_rpc_done, args=(context_id, 1)
+            )
+
+            # Wait for the prev rank to be done with rpc.
+            self._check_rpc_done(1)
+            grads = dist_autograd.get_gradients(ctx_ids[1])
+            self.assertEqual(1, len(grads))
+            self.assertIn(requires_grad_tensor, grads)
+            self.assertEqual(torch.ones_like(ret), grads[requires_grad_tensor])
+            # due to the above get_gradients call, ensure that dist autograd
+            # contexts aren't cleaned up until all workers exit context managers
+            dist.barrier()
+
+    @dist_init
+    def test_grad_only_on_return_value(self):
+        self._test_grad_only_on_return_value(ExecMode.RPC_SYNC)
+
+    @dist_init
+    def test_grad_only_on_return_value_remote(self):
+        self._test_grad_only_on_return_value(ExecMode.REMOTE)
+
+    @dist_init
+    def test_rpc_complex_args(self):
+        self._test_rpc_complex_args(ExecMode.RPC_SYNC, False)
+
+    @dist_init
+    def test_remote_complex_args(self):
+        self._test_rpc_complex_args(ExecMode.REMOTE, False)
+
+    @dist_init
+    def test_context_cleanup_tensor_with_grad(self):
+        t1 = torch.ones(3, 3, requires_grad=True)
+        t2 = torch.zeros(3, 3, requires_grad=True)
+        self.context_cleanup_test_helper(rpc_args=(t1, t2), func=torch.add)
+
+    @dist_init
+    def test_context_cleanup_tensor_no_grad(self):
+        t1 = torch.ones(3, 3, requires_grad=False)
         self.context_cleanup_test_helper(rpc_args=(t1, t1), func=torch.add)
 
     @dist_init
@@ -903,16 +1366,6 @@ class DistAutogradTest(CommonDistAutogradTest):
     def test_context_cleanup_nested_rpc(self):
         t1 = torch.ones(3, 3, requires_grad=True)
         t2 = torch.zeros(3, 3, requires_grad=True)
-        dst_rank = (self.rank + 1) % self.world_size
-        args = (t1, t2, dst_rank, self.world_size, 0)
-        self.context_cleanup_test_helper(
-            rpc_args=args, func=my_py_nested_call, nested=True
-        )
-
-    @dist_init
-    def test_context_cleanup_nested_rpc_sparse(self):
-        t1 = build_sparse_tensor(requires_grad=True)
-        t2 = build_sparse_tensor(requires_grad=True)
         dst_rank = (self.rank + 1) % self.world_size
         args = (t1, t2, dst_rank, self.world_size, 0)
         self.context_cleanup_test_helper(
@@ -988,37 +1441,6 @@ class DistAutogradTest(CommonDistAutogradTest):
                     worker_name(self._next_rank()), torch.matmul, args=(t1, t2)
                 )
 
-    def _backward_no_grad_on_tensor(self, t1, t2, sparse):
-        with dist_autograd.context() as context_id:
-            loss = rpc.rpc_sync(
-                worker_name(self._next_rank()),
-                torch.add,
-                args=(t1, t2))
-            if sparse:
-                loss = torch.sparse.sum(loss)
-            else:
-                loss = loss.sum()
-            dist_autograd.backward(context_id, [loss], retain_graph=True)
-            self.assertIsNone(t1.grad)
-            self.assertIsNone(t2.grad)
-
-            # Now populate .grad with local autograd engine and
-            # verify dist autograd doesn't mess with it.
-            loss_local = torch.add(t1, t2)
-            if sparse:
-                loss_local = torch.sparse.sum(loss_local)
-            else:
-                loss_local = loss_local.sum()
-            loss_local.backward()
-            self.assertIsNotNone(t1.grad)
-            self.assertIsNotNone(t2.grad)
-
-            t1_grad_before = t1.grad
-            t2_grad_before = t2.grad
-            dist_autograd.backward(context_id, [loss])
-            self.assertEqual(t1_grad_before, t1.grad)
-            self.assertEqual(t2_grad_before, t2.grad)
-
     @dist_init
     def test_backward_no_grad_on_tensor(self):
         self._backward_no_grad_on_tensor(
@@ -1028,31 +1450,6 @@ class DistAutogradTest(CommonDistAutogradTest):
         )
 
     @dist_init
-    def test_backward_no_grad_on_tensor_sparse(self):
-        self._backward_no_grad_on_tensor(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            True
-        )
-
-    # Run the same code locally and with dist autograd and verify gradients
-    # are same.
-    def _backward_simple(self, dst, t1, t2, local_grads, sparse):
-        for exec_mode in [ExecMode.LOCAL, ExecMode.RPC_SYNC, ExecMode.REMOTE]:
-            with dist_autograd.context() as context_id:
-                ret = self._exec_func_with_dst(
-                    dst, exec_mode, torch.add, t1, t2
-                )
-                if sparse:
-                    loss = torch.sparse.sum(ret)
-                else:
-                    loss = ret.sum()
-                ret = self._verify_backwards(
-                    exec_mode, [loss], context_id, local_grads, t1, t2
-                )
-                local_grads = ret if ret else local_grads
-
-    @dist_init
     def test_backward_simple(self):
         self._backward_simple(
             self._next_rank(),
@@ -1060,16 +1457,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             torch.rand((3, 3), requires_grad=True),
             None,
             False
-        )
-
-    @dist_init
-    def test_backward_simple_sparse(self):
-        self._backward_simple(
-            self._next_rank(),
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            None,
-            True
         )
 
     @dist_init
@@ -1083,64 +1470,6 @@ class DistAutogradTest(CommonDistAutogradTest):
         )
 
     @dist_init
-    def test_backward_simple_self_sparse(self):
-        self._backward_simple(
-            self.rank,
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            None,
-            True
-        )
-
-    # The current rank first creates a tensor on the rref_owner, and then passes
-    # the rref with another tensor to the callee to run either my_rref_add or
-    # my_nested_rref_add, depending on whether the callee is the rref owner.
-    # The grad of tensor lives on the current rank, and the grad of the rref
-    # tensor lives on the rref owner.
-    def _backward_rref(self, callee, rref_owner, t1, t2, local_grads, sparse):
-        local_ret = torch.add(t1, t2)
-        if sparse:
-            local_ret = torch.sparse.sum(local_ret)
-        else:
-            local_ret = local_ret.sum()
-        local_ret.backward()
-        with dist_autograd.context() as context_id:
-            if sparse:
-                rref_t1 = rpc.remote(
-                    rref_owner, build_sparse_tensor, args=(False, True,)
-                )
-            else:
-                rref_t1 = rpc.remote(
-                    rref_owner, _torch_ones, args=((3, 3),), kwargs={"requires_grad": True}
-                )
-            if callee == rref_owner:
-                rref = rpc.remote(callee, my_rref_add, args=(rref_t1, t2))
-            else:
-                rref = rpc.remote(
-                    callee, my_nested_rref_add, args=(rref_owner, rref_t1, t2)
-                )
-            ret = rref.to_here()
-            if sparse:
-                ret = torch.sparse.sum(ret)
-            else:
-                ret = ret.sum()
-            dist_autograd.backward(context_id, [ret])
-
-            # verify grads on caller
-            grads = dist_autograd.get_gradients(context_id)
-            self.assertIn(t2, grads)
-            self.assertEqual(grads[t2], t2.grad)
-
-            # verify grads on rref owner
-            self.assertTrue(
-                rpc.rpc_sync(
-                    rref_owner,
-                    _compare_owner_value,
-                    args=(context_id, rref_t1, t1.grad),
-                )
-            )
-
-    @dist_init
     def test_backward_rref(self):
         callee = worker_name(self._next_rank())
         rref_owner = callee
@@ -1151,19 +1480,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             torch.rand((3, 3), requires_grad=True),
             None,
             False
-        )
-
-    @dist_init
-    def test_backward_rref_sparse(self):
-        callee = worker_name(self._next_rank())
-        rref_owner = callee
-        self._backward_rref(
-            callee,
-            rref_owner,
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            None,
-            True
         )
 
     @dist_init
@@ -1181,20 +1497,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             )
 
     @dist_init
-    def test_backward_rref_multi_sparse(self):
-        if self.rank > 0:
-            callee = "worker0"
-            rref_owner = callee
-            self._backward_rref(
-                callee,
-                rref_owner,
-                build_sparse_tensor(requires_grad=True),
-                build_sparse_tensor(requires_grad=True),
-                None,
-                True
-            )
-
-    @dist_init
     def test_backward_rref_nested(self):
         callee = worker_name((self.rank + 1) % self.world_size)
         rref_owner = worker_name((self.rank + 2) % self.world_size)
@@ -1208,94 +1510,11 @@ class DistAutogradTest(CommonDistAutogradTest):
         )
 
     @dist_init
-    def test_backward_rref_nested_sparse(self):
-        callee = worker_name((self.rank + 1) % self.world_size)
-        rref_owner = worker_name((self.rank + 2) % self.world_size)
-        self._backward_rref(
-            callee,
-            rref_owner,
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            None,
-            True
-        )
-
-    # In this test, every rank will serve as a parameter server (ps) and a
-    # driver, and then kicks off trainers on the other three ranks. So, we have:
-    # ps = rank0 with trainers = rank1/2/3
-    # ps = rank2 with trainers = rank2/3/0
-    # ps = rank3 with trainers = rank3/0/1
-    # ps = rank4 with trainers = rank0/1/2
-    #
-    # These four test ps-trainer groups run on completely separate autograd
-    # graphs, but they share the same set of underlying RpcAgents.
-    def _test_trainer_ps(self, create_ref_fn, trainer_fn, sparse):
-        if sparse:
-            t1 = build_sparse_tensor(requires_grad=True)
-            t2 = build_sparse_tensor(requires_grad=True)
-        else:
-            t1 = torch.ones((3, 3), requires_grad=True)
-            t2 = torch.zeros((3, 3), requires_grad=True)
-
-        local_ret = torch.add(t1, t2)
-        if sparse:
-            torch.sparse.sum(local_ret).backward()
-        else:
-            local_ret.sum().backward()
-
-        # create rref on self
-        rref_t1 = rpc.remote(
-            worker_name(self.rank),
-            create_ref_fn,
-            args=())
-
-        # kick off forward and backward pass on three other workers (trainers)
-        rank_diffs = [1, 2, 3]
-        futures = []
-        for rank_diff in rank_diffs:
-            futures.append(
-                rpc.rpc_async(
-                    worker_name((self.rank + rank_diff) % self.world_size),
-                    trainer_fn,
-                    args=(rref_t1, t2, worker_name(self.rank), rank_diff, sparse),
-                )
-            )
-
-        # check if the trainers have done with their backward pass
-        for rank_diff in rank_diffs:
-            self._check_rpc_done(rank_diff)
-
-        # trainers are done and holding the context for verification
-        accumulate_grad_func = None
-        for rank_diff in rank_diffs:
-            # make sure grads are accumulated for the same tensors and values
-            # are all correct
-            ctx_id = ctx_ids[rank_diff]
-            grads = dist_autograd.get_gradients(ctx_id)
-            local_t1 = rref_t1.to_here()
-            self.assertIn(local_t1, grads)
-            self.assertEqual(grads[local_t1], t1.grad)
-
-        # unblock trainers
-        _set_rpc_done(None, 0)
-
-        # wait until all trainers are done
-        torch.futures.wait_all(futures)
-
-    @dist_init
     def test_trainer_ps(self):
         self._test_trainer_ps(
             create_tensor,
             _run_trainer,
             False
-        )
-
-    @dist_init
-    def test_trainer_ps_sparse(self):
-        self._test_trainer_ps(
-            build_sparse_tensor,
-            _run_trainer,
-            True
         )
 
     @dist_init
@@ -1309,28 +1528,6 @@ class DistAutogradTest(CommonDistAutogradTest):
 
         self._test_trainer_ps(create_torchscript_tensor, _run_trainer_torchscript, False)
 
-    def _backward_multiple_round_trips(self, t1, t2, t3, t4, t5, local_grads, sparse):
-        for exec_mode in [ExecMode.LOCAL, ExecMode.RPC_SYNC, ExecMode.REMOTE]:
-            with dist_autograd.context() as context_id:
-                # Multiple RPCs between different nodes.
-                val = self._exec_func(exec_mode, torch.add, t1, t2)
-                val = self._exec_func(exec_mode, torch.mul, t3, val)
-                s1 = self._exec_func(exec_mode, torch.stack, (t4, val))
-                s2 = self._exec_func(exec_mode, torch.stack, (t5, val))
-                if sparse:
-                    val = self._exec_func(exec_mode, torch.mul, s1, s2)
-                    val = self._exec_func(exec_mode, torch.mul, val, val)
-                    loss = torch.sparse.sum(val)
-                else:
-                    val = self._exec_func(exec_mode, torch.bmm, s1, s2)
-                    val = self._exec_func(exec_mode, torch.matmul, val, val)
-                    loss = val.sum()
-
-                ret = self._verify_backwards(
-                    exec_mode, [loss], context_id, local_grads, t1, t2, t3, t4, t5
-                )
-                local_grads = ret if ret else local_grads
-
     @dist_init
     def test_backward_multiple_round_trips(self):
         self._backward_multiple_round_trips(
@@ -1341,18 +1538,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             torch.rand((3, 3), requires_grad=True),
             None,
             False
-        )
-
-    @dist_init
-    def test_backward_multiple_round_trips_sparse(self):
-        self._backward_multiple_round_trips(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=False),
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=False),
-            build_sparse_tensor(requires_grad=True),
-            None,
-            True
         )
 
     @dist_init
@@ -1589,19 +1774,6 @@ class DistAutogradTest(CommonDistAutogradTest):
                     exec_mode, [r1, r2, r3, r4], context_id, local_grads, t1, t2
                 )
 
-    def _backward_different_dtypes(self, t1, t2, sparse):
-        local_grads = None
-        for exec_mode in [ExecMode.LOCAL, ExecMode.REMOTE]:
-            with dist_autograd.context() as context_id:
-                loss = self._exec_func(exec_mode, torch.add, t1, t2)
-                if sparse:
-                    loss = torch.sparse.sum(loss)
-                else:
-                    loss = loss.sum()
-                local_grads = self._verify_backwards(
-                    exec_mode, [loss], context_id, local_grads, t1, t2
-                )
-
     @dist_init
     def test_backward_different_dtypes(self):
         self._backward_different_dtypes(
@@ -1609,29 +1781,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             torch.rand((3, 3), requires_grad=True, dtype=torch.float64),
             False
         )
-
-    @dist_init
-    def test_backward_different_dtypes_sparse(self):
-        self._backward_different_dtypes(
-            build_sparse_tensor(requires_grad=True, dtype=torch.float32),
-            build_sparse_tensor(requires_grad=True, dtype=torch.float64),
-            True
-        )
-
-    # Run the same code locally and with dist autograd and verify gradients
-    # are same.
-    def _backward_simple_python_udf(self, t1, t2, sparse):
-        local_grads = None
-        for exec_mode in [ExecMode.LOCAL, ExecMode.REMOTE]:
-            with dist_autograd.context() as context_id:
-                ret = self._exec_func(exec_mode, my_py_add, t1, t2)
-                if sparse:
-                    loss = torch.sparse.sum(ret)
-                else:
-                    loss = ret.sum()
-                local_grads = self._verify_backwards(
-                    exec_mode, [loss], context_id, local_grads, t1, t2
-                )
 
     @dist_init
     def test_backward_simple_python_udf(self):
@@ -1642,48 +1791,11 @@ class DistAutogradTest(CommonDistAutogradTest):
         )
 
     @dist_init
-    def test_backward_simple_python_udf_sparse(self):
-        self._backward_simple_python_udf(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            True
-        )
-
-    # Run the same code locally and with dist autograd and verify gradients
-    # are same.
-    def _backward_simple_script_call(self, t1, t2, sparse):
-        local_grads = None
-        for exec_mode in [
-            ExecMode.LOCAL,
-            ExecMode.RPC_SYNC,
-            ExecMode.RPC_ASYNC,
-            ExecMode.REMOTE,
-        ]:
-            with dist_autograd.context() as context_id:
-                forward_ret = self._exec_func(exec_mode, my_script_add, t1, t2)
-                if sparse:
-                    loss = torch.sparse.sum(forward_ret)
-                else:
-                    loss = forward_ret.sum()
-                ret = self._verify_backwards(
-                    exec_mode, [loss], context_id, local_grads, t1, t2
-                )
-                local_grads = ret if ret else local_grads
-
-    @dist_init
     def test_backward_simple_script_call(self):
         self._backward_simple_script_call(
             torch.rand(3, 3, requires_grad=True),
             torch.rand(3, 3, requires_grad=True),
             False
-        )
-
-    @dist_init
-    def test_backward_simple_script_call_sparse(self):
-        self._backward_simple_script_call(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            True
         )
 
     @staticmethod
@@ -1796,33 +1908,6 @@ class DistAutogradTest(CommonDistAutogradTest):
         res = rpc.rpc_sync(worker_name(dst), my_py_add, args=(t3, t4))
         return t1 * t2 * t3 * t4 * res
 
-    def _backwards_nested_python_udf(self, t1, t2, sparse):
-        t3 = t1 * t2
-        t4 = t1 + t2
-        res = t3 + t4
-        loss = t1 * t2 * t3 * t4 * res
-        if sparse:
-            loss = torch.sparse.sum(loss)
-        else:
-            loss = loss.sum()
-        torch.autograd.backward([loss])
-
-        # Now run distributed autograd.
-        with dist_autograd.context() as context_id:
-            loss = rpc.rpc_sync(
-                worker_name(self._next_rank()),
-                DistAutogradTest._nested_python_udf,
-                args=(t1, t2, self._next_rank()),
-            )
-            if sparse:
-                loss = torch.sparse.sum(loss)
-            else:
-                loss = loss.sum()
-            dist_autograd.backward(context_id, [loss])
-            grads = dist_autograd.get_gradients(context_id)
-            self.assertEqual(t1.grad, grads[t1])
-            self.assertEqual(t2.grad, grads[t2])
-
     @dist_init
     def test_backwards_nested_python_udf(self):
         # Run equivalent of _nested_python_udf locally.
@@ -1830,15 +1915,6 @@ class DistAutogradTest(CommonDistAutogradTest):
             torch.rand(3, 3, requires_grad=True),
             torch.rand(3, 3, requires_grad=True),
             False
-        )
-
-    @dist_init
-    def test_backwards_nested_python_udf_sparse(self):
-        # Run equivalent of _nested_python_udf locally.
-        self._backwards_nested_python_udf(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            True
         )
 
     _test_clean_context_backward_context_id = None
@@ -1986,39 +2062,12 @@ class DistAutogradTest(CommonDistAutogradTest):
         else:
             return t1 * t2
 
-    def _mixed_requires_grad(self, t1, t2, sparse):
-        for exec_mode in [ExecMode.RPC_SYNC, ExecMode.REMOTE]:
-            with dist_autograd.context() as context_id:
-                ret = self._exec_func(
-                    exec_mode, DistAutogradTest._mixed_requires_grad_operaton, t1, t2
-                )
-                self.assertEqual(t1 * t2, ret)
-                if sparse:
-                    loss = torch.sparse.sum(ret)
-                else:
-                    loss = ret.sum()
-                dist_autograd.backward(context_id, [loss])
-                self.assertTrue(t1.requires_grad)
-                self.assertFalse(t2.requires_grad)
-                grads = dist_autograd.get_gradients(context_id)
-                self.assertIn(t1, grads)
-                self.assertNotIn(t2, grads)
-                self.assertEqual(t2, grads[t1])
-
     @dist_init
     def test_mixed_requires_grad(self):
         self._mixed_requires_grad(
             torch.rand(3, 3, requires_grad=True),
             torch.rand(3, 3, requires_grad=False),
             False
-        )
-
-    @dist_init
-    def test_mixed_requires_grad_sparse(self):
-        self._mixed_requires_grad(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=False),
-            True
         )
 
     class TestDebugInfoFunc(Function):
@@ -2160,21 +2209,6 @@ class DistAutogradTest(CommonDistAutogradTest):
     def _test_nested_backward_accumulate_grads(t1, t2, dst_rank):
         return rpc.rpc_sync(worker_name(dst_rank), torch.add, args=(t1, t2))
 
-    def _nested_backward_accumulate_grads(self, t1, t2, sparse):
-        with dist_autograd.context() as context_id:
-            ret = rpc.rpc_sync(
-                worker_name(self._next_rank()),
-                DistAutogradTest._test_nested_backward_accumulate_grads,
-                args=(t1, t2, self._next_rank()),
-            )
-            if sparse:
-                loss = torch.sparse.sum(ret)
-            else:
-                loss = ret.sum()
-            # Run backward twice.
-            dist_autograd.backward(context_id, [loss], retain_graph=True)
-            dist_autograd.backward(context_id, [loss])
-
     @dist_init
     def test_nested_backward_accumulate_grads(self):
         self._nested_backward_accumulate_grads(
@@ -2184,41 +2218,11 @@ class DistAutogradTest(CommonDistAutogradTest):
         )
 
     @dist_init
-    def test_nested_backward_accumulate_grads_sparse(self):
-        self._nested_backward_accumulate_grads(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            True
-        )
-
-    def _multiple_backward(self, t1, t2, sparse):
-        with dist_autograd.context() as context_id:
-            loss = rpc.rpc_sync(
-                worker_name(self._next_rank()),
-                torch.add,
-                args=(t1, t2))
-            if sparse:
-                loss = torch.sparse.sum(loss)
-            else:
-                loss = loss.sum()
-            # Run backward in a loop multiple times.
-            for i in range(1000):
-                dist_autograd.backward(context_id, [loss], retain_graph=True)
-
-    @dist_init
     def test_multiple_backward(self):
         self._multiple_backward(
             torch.rand(3, 3, requires_grad=True),
             torch.rand(3, 3, requires_grad=True),
             False
-        )
-
-    @dist_init
-    def test_multiple_backward_sparse(self):
-        self._multiple_backward(
-            build_sparse_tensor(requires_grad=True),
-            build_sparse_tensor(requires_grad=True),
-            True
         )
 
     @dist_init(clean_shutdown=False)

--- a/torch/testing/_internal/distributed/rpc_utils.py
+++ b/torch/testing/_internal/distributed/rpc_utils.py
@@ -27,6 +27,7 @@ from torch.testing._internal.distributed.rpc.dist_autograd_test import (
     DistAutogradTest,
     CudaDistAutogradTest,
     FaultyAgentDistAutogradTest,
+    TensorPipeAgentDistAutogradTest,
     TensorPipeCudaDistAutogradTest
 )
 from torch.testing._internal.distributed.rpc.dist_optimizer_test import (
@@ -126,6 +127,7 @@ GENERIC_CUDA_TESTS = [
 # list (not subclasses of those!).
 TENSORPIPE_TESTS = [
     TensorPipeAgentRpcTest,
+    TensorPipeAgentDistAutogradTest,
 ]
 TENSORPIPE_CUDA_TESTS = [
     TensorPipeAgentCudaRpcTest,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Sparse RPC functionality added in
https://github.com/pytorch/pytorch/pull/62794 works only for TensorPipe and is
broken for other agent types.

Moving these tests to a TensorPipe only class.

Differential Revision: [D31633305](https://our.internmc.facebook.com/intern/diff/D31633305/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang