### PR TITLE
[Static Runtime] Cache managed tensor Storages

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -55,7 +55,22 @@ MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b) {
   // similar situations (e.g., storage().data() == storage().data()+1)
   // which we will miss.
   auto a_storage = a->unsafe_storage();
+  auto b_storage = b->unsafe_storage();
   if (a_storage && a_storage.is_alias_of(b->unsafe_storage())) {
+    const auto a_begin = static_cast<char*>(a->data());
+    const auto a_end = a_begin + a->numel() * a->itemsize();
+    const auto b_begin = static_cast<char*>(b->data());
+    const auto b_end = b_begin + b->numel() * b->itemsize();
+
+    if (a_begin == b_begin && a_end == b_end) {
+      return (a->strides() == b->strides()) ?
+          MemOverlapStatus::FULL : MemOverlapStatus::PARTIAL;
+    }
+    if (a_begin < b_end && b_begin < a_end) {
+      return MemOverlapStatus::PARTIAL;
+    }
+  }
+  if (a_storage && b_storage) {
     const auto a_begin = static_cast<char*>(a->data());
     const auto a_end = a_begin + a->numel() * a->itemsize();
     const auto b_begin = static_cast<char*>(b->data());

--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -43,7 +43,7 @@ TEST(StaticModule, ValueGroup) {
 
   std::vector<const Value*> expected_input_aliases{graph.inputs()[0], graph.inputs()[1], nodes[0]->output()};
   for (auto* value : expected_input_aliases) {
-    EXPECT_TRUE(value_group.isInputAlias(value));
+    EXPECT_TRUE(value_group.isExternalAlias(value));
   }
 
   std::vector<const Value*> expected_output_aliases{graph.outputs()[0], nodes[2]->output()};

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -20,6 +20,7 @@
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
 #include <torch/csrc/jit/runtime/vararg_functions.h>
+#include <sstream>
 #include <stdexcept>
 
 #ifdef FBCODE_CAFFE2
@@ -58,6 +59,18 @@ bool canEnableStaticRuntime(const std::shared_ptr<torch::jit::Graph>& graph) {
     can_support = false;
   }
   return can_support;
+}
+
+std::string dumpValueSet(
+    const FastSet<const Value*>& value_set,
+    const char* set_name) {
+  std::ostringstream oss;
+  oss << set_name << ": {";
+  for (const auto* val : value_set) {
+    oss << "%" << val->debugName() << ", ";
+  }
+  oss << "}";
+  return oss.str();
 }
 
 namespace {
@@ -525,7 +538,6 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
   Method method = module.get_method("forward");
   auto graph = module.get_method("forward").graph();
 
-  // graph->dump();
   PrepareGraphForStaticModule(graph, opts);
 
   return std::make_pair(graph, module);
@@ -543,17 +555,16 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
 void ValueGroup::init(
     const std::shared_ptr<torch::jit::Graph>& graph,
     AliasDb& db) {
-  input_or_constant_aliases_.clear();
+  external_aliases_.clear();
   output_aliases_.clear();
   // Build `input_or_constant_aliases` as we look through nodes forwardly from
   // the graph's inputs and add aliases of the inputs being created by the
   // nodes.
-  input_or_constant_aliases_.insert(
-      graph->inputs().begin(), graph->inputs().end());
+  external_aliases_.insert(graph->inputs().begin(), graph->inputs().end());
   for (const auto* node : graph->nodes()) {
     if (node->kind() == prim::Constant) {
       for (const auto* output : node->outputs()) {
-        input_or_constant_aliases_.insert(output);
+        external_aliases_.insert(output);
       }
     }
   }
@@ -563,8 +574,8 @@ void ValueGroup::init(
       continue;
     }
     for (const auto* v : node->outputs()) {
-      if (mayContainAlias(db, {v}, input_or_constant_aliases_)) {
-        input_or_constant_aliases_.insert(v);
+      if (mayContainAlias(db, {v}, external_aliases_)) {
+        external_aliases_.insert(v);
       }
     }
   }
@@ -578,8 +589,14 @@ void ValueGroup::init(
       continue;
     }
     for (const auto* v : node->outputs()) {
-      if (mayContainAlias(db, {v}, output_aliases_) &&
-          !mayContainAlias(db, {v}, input_or_constant_aliases_)) {
+      // Add values that can aliase input/constant values. Note some output
+      // aliases may end up in this category  via collection objects (e.g.,
+      // Tuple).
+      if (mayContainAlias(db, {v}, external_aliases_)) {
+        external_aliases_.insert(v);
+        continue;
+      }
+      if (mayContainAlias(db, {v}, output_aliases_)) {
         output_aliases_.insert(v);
       }
     }
@@ -705,6 +722,7 @@ StaticModule::StaticModule(
   AliasDb alias_db(
       graph_, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
   value_group_.init(graph_, alias_db);
+  GRAPH_DEBUG("ValueGroup: ", value_group_.toString());
 
   if (opts_.optimize_memory) {
     auto lm = GetLivenessMap(graph_, value_group_, alias_db);

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -433,6 +433,10 @@ class TORCH_API ProcessedNode {
  private:
   void run_impl();
 
+  bool verify_outputs_dont_overlap_each_other() const;
+
+  bool verify_inputs_dont_overlap_outputs() const;
+
   Node* node_;
   using OutVariant = std::function<void(ProcessedNode*)>;
   using NativeFunction = std::function<void(ProcessedNode*)>;

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 
 namespace torch {
@@ -135,6 +136,8 @@ MemoryPlanner::MemoryPlanner(
   for (IValue* output : runtime->outputs()) {
     unmanaged_ivalues.erase(output);
   }
+
+  GRAPH_DEBUG("managed_tensor_values:", dumpValueSet(managed_tensor_values));
 
   // copy to unmanaged_ivalues_
   unmanaged_ivalues_.reserve(unmanaged_ivalues.size());

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -181,30 +181,45 @@ void MemoryPlanner::allocateManagedTensors() {
   if (managed_bytes_ == 0) {
     return;
   }
+  DCHECK(!managed_tensor_storages_.empty());
   buffer_ = allocate_buffer(managed_bytes_);
 
   size_t offset = 0;
   uint8_t* start = static_cast<uint8_t*>(buffer_.get());
 
   reused_tensors_ = 0;
-  for (const auto& ms : managed_tensors_) {
+#ifndef NDEBUG
+  auto group_idx = 0;
+#endif
+  for (const auto& ms : managed_tensor_storages_) {
     auto tensor_size = ms.first;
     if (tensor_size == 0) {
+#ifndef NDEBUG
+      group_idx++;
+#endif
       continue;
     }
-    const auto& tensors = ms.second;
+    const auto& storages = ms.second;
     DCHECK_LE(offset + tensor_size, managed_bytes_);
     void* src = static_cast<void*>(start + offset);
 
-    for (auto* tensor : tensors) {
-      tensor->storage().set_data_ptr_noswap(
-          at::DataPtr(src, src, nullptr, tensor->device()));
-      tensor->storage().set_nbytes(tensor_size);
+#ifndef NDEBUG
+    auto storage_idx = 0;
+#endif
+    DCHECK_EQ(storages.size(), managed_tensors_[group_idx].second.size());
+    DCHECK_EQ(tensor_size, managed_tensors_[group_idx].first);
+   for (auto* storage : storages) {
+      DCHECK_EQ(storage->device().type(), c10::DeviceType::CPU);
+      DCHECK_EQ(storage, &managed_tensors_[group_idx].second[storage_idx++]->storage());
+      storage->set_data_ptr_noswap(
+          at::DataPtr(src, src, nullptr, c10::Device(c10::DeviceType::CPU)));
+      storage->set_nbytes(tensor_size);
       reused_tensors_++;
     }
     reused_tensors_--;
 
     offset += tensor_size;
+    group_idx++;
   }
   DCHECK_EQ(offset, managed_bytes_);
 }
@@ -246,14 +261,27 @@ void MemoryPlanner::allocate() {
 void MemoryPlanner::deallocate() {
   managed_bytes_ = 0;
   // free memory used by outputs of ops in out variants
-  // but keep the TensorImpl and StorageImpl around
+  // but keep the TensorImpl and StorageImpl around.
+
+  // We don't have any guarantee that the model doesn't change the
+  // Storage for managed tensors out from under us during execution,
+  // so we have to grab the Storages each time we deallocate.
+  auto group_idx = 0;
+  const bool first_time = managed_tensor_storages_.empty();
   for (auto& ms : managed_tensors_) {
     const auto& tensors = ms.second;
     size_t max = ms.first;
+    if (C10_UNLIKELY(first_time)) {
+      managed_tensor_storages_.emplace_back(std::piecewise_construct, std::make_tuple(ms.first), std::make_tuple(tensors.size()));
+    }
+    auto& mss = managed_tensor_storages_[group_idx++];
+    auto& storages = mss.second;
+    auto tensor_idx = 0;
     for (auto& tensor : tensors) {
-      size_t current_size =
-          compute_aligned_tensor_size(tensor->storage().nbytes());
-      tensor->storage().unsafeGetStorageImpl()->reset();
+      const auto& storage = tensor->storage();
+      size_t current_size = compute_aligned_tensor_size(storage.nbytes());
+      storage.unsafeGetStorageImpl()->reset();
+      storages[tensor_idx++] = &storage;
       max = std::max(max, current_size);
     }
     // Static runtime does not know the size of tensors statically, so we use
@@ -261,7 +289,7 @@ void MemoryPlanner::deallocate() {
     // run (following C2 tradition), exploiting the fact that tensor storage
     // size does not have to match that of real tensor size. The following logic
     // records the tensor storage size for the next run.
-    ms.first = max;
+    mss.first = ms.first = max;
     managed_bytes_ += max;
   }
 

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -103,8 +103,18 @@ class MemoryPlanner {
   std::vector<IValue*> unmanaged_ivalues_;
 
   // each pair contains the size (in bytes) of data to be allocated
-  // and a vector of Tensors that should be backed by that same data.
-  // Thus, if memonger is disabled, all vectors are of size 1.
+  // and a vector of Tensors' storages that should be backed by that
+  // same data.  Thus, if memonger is disabled, all vectors are of
+  // size 1.
+
+  // We cache the storage pointers directly rather than caching Tensor
+  // objects so that we don't have to do an extra load from memory
+  // (which will likely miss in CPU data cache) per Tensor reading
+  // the Storage pointerfrom the TensorImpl object.
+  std::vector<std::pair<size_t, std::vector<const at::Storage*>>> managed_tensor_storages_;
+  // We don't have any guarantee that the model doesn't change the
+  // Storage for managed tensors out from under us during execution,
+  // so we have to grab the Storages each time we deallocate.
   std::vector<std::pair<size_t, std::vector<at::Tensor*>>> managed_tensors_;
   at::DataPtr buffer_; // allocated each time we call Run()
   size_t num_managed_tensors_{0};

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -319,17 +319,24 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 }
 
 TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
-  m.def("static_runtime::permute_copy(Tensor self, int[] dims) -> Tensor");
-  m.def(
-      "static_runtime::reshape_copy(Tensor(a) self, int[] shape) -> Tensor(a)");
-  m.def(
-      "static_runtime::flatten_copy.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)");
-  m.def(
-      "static_runtime::to_copy.prim_dtype(Tensor self, int? dtype=None, bool non_blocking=False, bool copy=False) -> Tensor");
-  m.def(
-      "static_runtime::to_copy.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor");
-  m.def(
-      "static_runtime::to_copy.other(Tensor self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor");
+  m.def(torch::schema(
+      "static_runtime::permute_copy(Tensor self, int[] dims) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
+  m.def(torch::schema(
+      "static_runtime::reshape_copy(Tensor self, int[] shape) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
+  m.def(torch::schema(
+      "static_runtime::flatten_copy.using_ints(Tensor self, int start_dim=0, int end_dim=-1) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
+  m.def(torch::schema(
+      "static_runtime::to_copy.prim_dtype(Tensor self, int? dtype=None, bool non_blocking=False, bool copy=False) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
+  m.def(torch::schema(
+      "static_runtime::to_copy.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
+  m.def(torch::schema(
+      "static_runtime::to_copy.other(Tensor self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
   m.def(torch::schema(
       "static_runtime::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> (Tensor, Tensor, Tensor)",
       c10::AliasAnalysisKind::PURE_FUNCTION));


### PR DESCRIPTION
Summary: See comments in code explaining what we're doing here.

Test Plan:
Ran ptvsc2_predictor_bench on ctr_mobile_feed local and local_ro net before/after this change on a devserver with turbo off.

Results:

```
Before, local:
I1004 16:07:44.167793 849834 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.87211. Iters per second: 145.516
I1004 16:08:05.637187 849834 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.91276. Iters per second: 144.66
I1004 16:08:26.886401 849834 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.85547. Iters per second: 145.869
I1004 16:08:48.382458 849834 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.93404. Iters per second: 144.216
I1004 16:09:09.816869 849834 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.91091. Iters per second: 144.699

mean: 6.897
std: 0.0288

Before, local_ro:
I1004 16:05:25.324666 838180 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.73789. Iters per second: 365.245
I1004 16:05:33.824411 838180 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.74206. Iters per second: 364.689
I1004 16:05:42.285459 838180 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.72766. Iters per second: 366.615
I1004 16:05:50.746560 838180 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.73016. Iters per second: 366.279
I1004 16:05:59.200126 838180 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.72728. Iters per second: 366.665

mean: 2.733, std: 0.00592

This diff, local:
I1004 16:53:45.928027 1107208 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.83543. Iters per second: 146.297
I1004 16:54:07.112851 1107208 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.83417. Iters per second: 146.324
I1004 16:54:28.449077 1107208 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.88387. Iters per second: 145.267
I1004 16:54:49.692930 1107208 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.85258. Iters per second: 145.93
I1004 16:55:10.942575 1107208 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 6.8559. Iters per second: 145.86

mean: 6.85239, std: 0.01801

This diff, local_ro
I1004 16:56:16.379674 1119229 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.67988. Iters per second: 373.152
I1004 16:56:24.663563 1119229 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.67254. Iters per second: 374.176
I1004 16:56:32.939530 1119229 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.66991. Iters per second: 374.545
I1004 16:56:41.216761 1119229 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.66951. Iters per second: 374.6
I1004 16:56:49.500725 1119229 PyTorchPredictorBenchLib.cpp:343] PyTorch run finished. Milliseconds per iter: 2.67151. Iters per second: 374.321

mean: 2.673, std: 0.00377

Difference in means for local is 0.0446 (0.65%), which is outside 1 standard deviation.
For local_ro it is 0.0600 (2.2%), which is way outside 1 standard deviation.

Differential Revision: D31326711

