### PR TITLE
[NNC] Adding more python bindings for missing operators

### DIFF
--- a/test/test_tensorexpr_pybind.py
+++ b/test/test_tensorexpr_pybind.py
@@ -10,19 +10,19 @@ LLVM_ENABLED = torch._C._llvm_enabled()
 
 
 def construct_adder(n: int, dtype=torch.float32):
-    A = te.BufHandle('A', [n], dtype)
-    B = te.BufHandle('B', [n], dtype)
+    A = te.BufHandle("A", [n], dtype)
+    B = te.BufHandle("B", [n], dtype)
 
     def compute(i):
         return A.load([i]) + B.load([i])
 
-    C = te.Compute('C', [n], compute)
+    C = te.Compute("C", [n], compute)
 
     loopnest = te.LoopNest([C])
     loopnest.prepare_for_codegen()
     stmt = te.simplify(loopnest.root_stmt())
 
-    return te.construct_codegen('ir_eval', stmt, [A, B, C])
+    return te.construct_codegen("ir_eval", stmt, [A, B, C])
 
 
 class TestTensorExprPyBind(JitTestCase):
@@ -49,15 +49,15 @@ class TestTensorExprPyBind(JitTestCase):
     def test_external_calls(self):
         dtype = torch.float32
 
-        A = te.BufHandle('A', [1, 4], dtype)
-        B = te.BufHandle('B', [4, 1], dtype)
-        C = te.BufHandle('C', [1, 1], dtype)
+        A = te.BufHandle("A", [1, 4], dtype)
+        B = te.BufHandle("B", [4, 1], dtype)
+        C = te.BufHandle("C", [1, 1], dtype)
 
         s = te.ExternalCall(C, "nnc_aten_matmul", [A, B], [])
 
         loopnest = te.LoopNest(s, [C])
         loopnest.prepare_for_codegen()
-        codegen = te.construct_codegen('ir_eval', s, [A, B, C])
+        codegen = te.construct_codegen("ir_eval", s, [A, B, C])
 
         tA = torch.ones(1, 4)
         tB = torch.ones(4, 1)
@@ -73,15 +73,12 @@ class TestTensorExprPyBind(JitTestCase):
         def compute(i):
             return A.load(i) - B.load(i)
 
-        C = te.Compute('C', [dN], compute)
+        C = te.Compute("C", [dN], compute)
 
         loopnest = te.LoopNest([C])
         loopnest.prepare_for_codegen()
 
-        cg = te.construct_codegen(
-            'ir_eval',
-            loopnest.simplify(),
-            [A, B, C, dN])
+        cg = te.construct_codegen("ir_eval", loopnest.simplify(), [A, B, C, dN])
 
         def test_with_shape(n):
             tA = torch.randn(n, dtype=torch.double)
@@ -94,15 +91,15 @@ class TestTensorExprPyBind(JitTestCase):
         test_with_shape(31)
 
     def test_dtype_error(self):
-        te.BufHandle('a', [1], torch.float32)  # ok
-        self.assertRaises(TypeError, lambda: te.BufHandle('a', [1], "float55"))
+        te.BufHandle("a", [1], torch.float32)  # ok
+        self.assertRaises(TypeError, lambda: te.BufHandle("a", [1], "float55"))
 
     @unittest.skipIf(not LLVM_ENABLED, "LLVM backend not enabled")
     def test_kernel_with_tensor_inputs(self):
         def f(a, b, c):
             return a + b + c
 
-        device, size = 'cpu', (4, 4)
+        device, size = "cpu", (4, 4)
         x = torch.rand(size, device=device)
         y = torch.rand(size, device=device)
         z = torch.rand(size, device=device)
@@ -130,9 +127,9 @@ graph(%a.1 : Float(4, 4, strides=[4, 1], requires_grad=0, device=cpu),
         def f(a, b, c):
             return a + b + c
 
-        x = torch.tensor(0.1, dtype=torch.float, device='cpu')
-        y = torch.tensor(0.6, dtype=torch.float, device='cpu')
-        z = torch.tensor(0.7, dtype=torch.float, device='cpu')
+        x = torch.tensor(0.1, dtype=torch.float, device="cpu")
+        y = torch.tensor(0.6, dtype=torch.float, device="cpu")
+        z = torch.tensor(0.7, dtype=torch.float, device="cpu")
 
         graph_str = """
 graph(%a.1 : Float(requires_grad=0, device=cpu),
@@ -154,7 +151,7 @@ graph(%a.1 : Float(requires_grad=0, device=cpu),
 
     @unittest.skipIf(not LLVM_ENABLED, "LLVM backend not enabled")
     def test_kernel_shape_prop(self):
-        device, size = 'cpu', (4, 4)
+        device, size = "cpu", (4, 4)
         x = torch.rand(size, device=device)
         y = torch.rand(size, device=device)
 
@@ -227,7 +224,7 @@ graph(%a : Tensor, %b : Tensor):
         # Now compilation should pass
         kernel = te.TensorExprKernel(graph)
 
-        device, size = 'cpu', (4, 4)
+        device, size = "cpu", (4, 4)
         x = torch.rand(size, device=device)
         y = torch.rand(size, device=device)
 
@@ -240,7 +237,7 @@ graph(%a : Tensor, %b : Tensor):
         def f(a):
             return a.t()
 
-        device, size = 'cpu', (3, 4)
+        device, size = "cpu", (3, 4)
         x = torch.rand(size, device=device)
 
         graph_str = """
@@ -262,7 +259,7 @@ graph(%a.1 : Float(3, 4, strides=[4, 1], requires_grad=0, device=cpu)):
         def f(a):
             return a.transpose(-1, -2)
 
-        device, size = 'cpu', (3, 4)
+        device, size = "cpu", (3, 4)
         x = torch.rand(size, device=device)
 
         graph_str = """
@@ -286,7 +283,7 @@ graph(%a.1 : Float(3, 4, strides=[4, 1], requires_grad=0, device=cpu)):
         def f(a):
             return a.permute([2, 1, 0])
 
-        device, size = 'cpu', (3, 4, 5)
+        device, size = "cpu", (3, 4, 5)
         x = torch.rand(size, device=device)
 
         graph_str = """
@@ -312,7 +309,7 @@ graph(%a.1 : Float(3, 4, 5, strides=[20, 5, 1], requires_grad=0, device=cpu)):
         def f(a):
             return a.nan_to_num()
 
-        device = 'cpu'
+        device = "cpu"
         x = torch.ones((2, 2), device=device)
         x[0, 0] = x[1, 1] = torch.nan
         graph_str = """
@@ -327,15 +324,18 @@ graph(%x : Float(2, 2, strides=[2, 1], requires_grad=0, device=cpu)):
             def get_dim_args(dims):
                 dim_args = []
                 for dim in dims:
-                    dim_args.append(te.DimArg(dim, 'i' + str(len(dim_args))))
+                    dim_args.append(te.DimArg(dim, "i" + str(len(dim_args))))
                 return dim_args
 
             def compute(idxs):
                 load = inputs[0].as_buf().load(idxs)
-                return te.ifThenElse(te.ExprHandle.isnan(load), te.ExprHandle.float(0.), load)
+                return te.ifThenElse(
+                    te.ExprHandle.isnan(load), te.ExprHandle.float(0.0), load
+                )
+
             return te.Compute2("custom_nan_to_num", get_dim_args(out_shape), compute)
 
-        kernel = te.TensorExprKernel(graph, {'aten::nan_to_num' : my_custom_lowering})
+        kernel = te.TensorExprKernel(graph, {"aten::nan_to_num": my_custom_lowering})
         res1 = kernel.run((x,))
         res2 = kernel.fallback((x,))
         correct = f(x)
@@ -347,7 +347,7 @@ graph(%x : Float(2, 2, strides=[2, 1], requires_grad=0, device=cpu)):
         def f(a):
             return a.expand((2, 3, 4))
 
-        device = 'cpu'
+        device = "cpu"
         x = torch.rand((1, 3, 1), device=device)
         graph_str = """
 graph(%a : Float(1, 3, 1, strides=[3, 1, 1], requires_grad=0, device=cpu)):
@@ -370,11 +370,10 @@ graph(%a : Float(1, 3, 1, strides=[3, 1, 1], requires_grad=0, device=cpu)):
 
     @unittest.skipIf(not LLVM_ENABLED, "LLVM backend not enabled")
     def test_alloc_in_loop(self):
-        a, tmp, b = [te.BufHandle(name, [1], torch.float32) for name in ["a", "tmp", "b"]]
-        body = te.Block([
-            tmp.store([0], a.load([0])),
-            b.store([0], tmp.load([0]))
-        ])
+        a, tmp, b = [
+            te.BufHandle(name, [1], torch.float32) for name in ["a", "tmp", "b"]
+        ]
+        body = te.Block([tmp.store([0], a.load([0])), b.store([0], tmp.load([0]))])
         for _ in range(4):
             i = te.VarHandle("i", torch.int32)
             body = te.For.make(i, 0, 100, body)
@@ -384,5 +383,64 @@ graph(%a : Float(1, 3, 1, strides=[3, 1, 1], requires_grad=0, device=cpu)):
         ta, tb = [torch.ones(1) for _ in range(2)]
         f.call([ta.data_ptr(), tb.data_ptr()])
 
-if __name__ == '__main__':
+
+class TestExprHandlePyBind(JitTestCase):
+    def test_unary_ops(self):
+        unary_operators = {
+            torch.sin: torch._C._te.sin,
+            torch.cos: torch._C._te.cos,
+            torch.tan: torch._C._te.tan,
+            torch.asin: torch._C._te.asin,
+            torch.acos: torch._C._te.acos,
+            torch.atan: torch._C._te.atan,
+            torch.sinh: torch._C._te.sinh,
+            torch.cosh: torch._C._te.cosh,
+            torch.tanh: torch._C._te.tanh,
+            torch.sigmoid: torch._C._te.sigmoid,
+            torch.exp: torch._C._te.exp,
+            torch.expm1: torch._C._te.expm1,
+            torch.abs: torch._C._te.abs,
+            torch.log: torch._C._te.log,
+            torch.log2: torch._C._te.log2,
+            torch.log10: torch._C._te.log10,
+            torch.log1p: torch._C._te.log1p,
+            torch.erf: torch._C._te.erf,
+            torch.erfc: torch._C._te.erfc,
+            torch.sqrt: torch._C._te.sqrt,
+            torch.rsqrt: torch._C._te.rsqrt,
+            torch.ceil: torch._C._te.ceil,
+            torch.floor: torch._C._te.floor,
+            torch.round: torch._C._te.round,
+            torch.trunc: torch._C._te.trunc,
+            torch.lgamma: torch._C._te.lgamma,
+            torch.frac: torch._C._te.frac,
+        }
+
+        def construct_te_fn(op, n: int, dtype=torch.float32):
+            A = torch._C._te.BufHandle("A", [n], dtype)
+
+            def compute(i):
+                return op(A.load([i]))
+
+            C = te.Compute("C", [n], compute)
+
+            loopnest = te.LoopNest([C])
+            loopnest.prepare_for_codegen()
+            stmt = te.simplify(loopnest.root_stmt())
+
+            return te.construct_codegen("ir_eval", stmt, [A, C])
+
+        n = 10
+        a = torch.rand(n)
+        for torch_op, te_op in unary_operators.items():
+            torch_fn = lambda x: torch_op(x)
+            ref = torch_fn(a)
+
+            te_fn = construct_te_fn(te_op, n, torch.float32)
+            res = torch.empty(n)
+            te_fn.call([a, res])
+            assert torch.allclose(ref, res, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
     run_tests()

--- a/test/test_tensorexpr_pybind.py
+++ b/test/test_tensorexpr_pybind.py
@@ -433,8 +433,7 @@ class TestExprHandlePyBind(JitTestCase):
         n = 10
         a = torch.rand(n)
         for torch_op, te_op in unary_operators.items():
-            torch_fn = lambda x: torch_op(x)
-            ref = torch_fn(a)
+            ref = torch_op(a)
 
             te_fn = construct_te_fn(te_op, n, torch.float32)
             res = torch.empty(n)

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -164,6 +164,36 @@ void initTensorExprBindings(PyObject* module) {
       [](const ExprHandle& c, const ExprHandle& t, const ExprHandle& f) {
         return ifThenElse(c, t, f);
       });
+
+  te.def("sin", [](const ExprHandle& v1) { return sin(v1); });
+  te.def("cos", [](const ExprHandle& v1) { return cos(v1); });
+  te.def("tan", [](const ExprHandle& v1) { return tan(v1); });
+  te.def("asin", [](const ExprHandle& v1) { return asin(v1); });
+  te.def("acos", [](const ExprHandle& v1) { return acos(v1); });
+  te.def("atan", [](const ExprHandle& v1) { return atan(v1); });
+  te.def("sinh", [](const ExprHandle& v1) { return sinh(v1); });
+  te.def("cosh", [](const ExprHandle& v1) { return cosh(v1); });
+  te.def("tanh", [](const ExprHandle& v1) { return tanh(v1); });
+  te.def("sigmoid", [](const ExprHandle& v1) { return sigmoid(v1); });
+  te.def("exp", [](const ExprHandle& v1) { return exp(v1); });
+  te.def("expm1", [](const ExprHandle& v1) { return expm1(v1); });
+  te.def("abs", [](const ExprHandle& v1) { return abs(v1); });
+  te.def("log", [](const ExprHandle& v1) { return log(v1); });
+  te.def("log2", [](const ExprHandle& v1) { return log2(v1); });
+  te.def("log10", [](const ExprHandle& v1) { return log10(v1); });
+  te.def("log1p", [](const ExprHandle& v1) { return log1p(v1); });
+  te.def("erf", [](const ExprHandle& v1) { return erf(v1); });
+  te.def("erfc", [](const ExprHandle& v1) { return erfc(v1); });
+  te.def("sqrt", [](const ExprHandle& v1) { return sqrt(v1); });
+  te.def("rsqrt", [](const ExprHandle& v1) { return rsqrt(v1); });
+  te.def("ceil", [](const ExprHandle& v1) { return ceil(v1); });
+  te.def("floor", [](const ExprHandle& v1) { return floor(v1); });
+  te.def("round", [](const ExprHandle& v1) { return round(v1); });
+  te.def("trunc", [](const ExprHandle& v1) { return trunc(v1); });
+  te.def("frac", [](const ExprHandle& v1) { return frac(v1); });
+  te.def("lgamma", [](const ExprHandle& v1) { return lgamma(v1); });
+  te.def("isnan", [](const ExprHandle& v1) { return isnan(v1); });
+
   te.def("atan2", [](const ExprHandle& v1, const ExprHandle& v2) {
     return atan2(v1, v2);
   });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66612

Summary: For op authoring project, we want to expose the python bindings
to create Expr. These are the missing bindings.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31667852](https://our.internmc.facebook.com/intern/diff/D31667852)