### PR TITLE
When loading model on a big-endian platform, do byteswap

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -522,7 +522,10 @@ def _save(obj, zip_file, pickle_module, pickle_protocol):
                 storage_type_str = obj.pickle_storage_type()
                 storage_type = getattr(torch, storage_type_str)
                 storage_numel = obj.size()
-
+                if sys.byteorder == 'big':
+                    storage = storage.clone()
+                    for i in range(storage_numel):
+                        storage[i] = storage[i].to_bytes(obj.element_size(), byteorder='little')
             else:
                 storage = obj
                 storage_type = normalize_storage_type(type(obj))


### PR DESCRIPTION
When loading models that are saved on a little-endian system and that
use zip file serialization, the byte order is not restored. This patch
assumes that we will always save models on little-endian system and
partially fixes this issue by swapping byte order on the loading side.
The function `get_storage_from_record` is called from:

https://github.com/pytorch/pytorch/blob/facff2ec6562d61eab2ccd9f1c16872e54eec92d/torch/serialization.py#L845

Fix #65300

---

This is not a complete fix (yet) because the saving side must also swap
byte order on a big-endian platform. I'm sending this patch in this
shape just to confirm this is the right direction to go.

cc @driazati @ezyang @andrewsi-z