### PR TITLE
[ONNX] Remove the argument strip_doc_string of export() method entirely.

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -36,9 +36,9 @@ def _export(*args, **kwargs):
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=None,
-           use_external_data_format=None, export_modules_as_functions=False):
+           example_outputs=None, dynamic_axes=None, keep_initializers_as_inputs=None,
+           custom_opsets=None, enable_onnx_checker=None, use_external_data_format=None,
+           export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
@@ -194,7 +194,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             with pre-computed constant nodes.
         example_outputs (T or a tuple of T, where T is Tensor or convertible to Tensor, default None):
             Deprecated and ignored. Will be removed in next PyTorch release.
-        strip_doc_string (bool, default True): Deprecated and ignored. Will be removed in next PyTorch release.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
 
             By default the exported model will have the shapes of all input and output tensors
@@ -316,8 +315,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
     return utils.export(model, args, f, export_params, verbose, training,
                         input_names, output_names, operator_export_type, opset_version,
                         _retain_param_name, do_constant_folding, example_outputs,
-                        strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, enable_onnx_checker, use_external_data_format,
+                        dynamic_axes, keep_initializers_as_inputs, custom_opsets,
+                        enable_onnx_checker, use_external_data_format,
                         export_modules_as_functions)
 
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -104,9 +104,8 @@ def exporter_context(model, mode):
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=None, use_external_data_format=None,
+           example_outputs=None, dynamic_axes=None, keep_initializers_as_inputs=None,
+           custom_opsets=None, enable_onnx_checker=None, use_external_data_format=None,
            export_modules_as_functions=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
@@ -121,9 +120,6 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
     if _retain_param_name is not None:
         warnings.warn("'_retain_param_name' is deprecated and ignored. "
                       "It will be removed in the next PyTorch release.")
-    if strip_doc_string is not None:
-        warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release. It's combined with `verbose' argument now. ")
     if example_outputs is not None:
         warnings.warn("`example_outputs' is deprecated and ignored. Will be removed in "
                       "next PyTorch release.")


### PR DESCRIPTION
This was deprecated in PyTorch 1.10: https://github.com/pytorch/pytorch/pull/61712.

In the latest release, we should remove this argument entirely.

## BC-breaking note
### The signature of torch.onnx.export() function is changed because the argument "strip_doc_string" has been removed entirely.
In latest version, if we specified the value of "strip_doc_string" in a call to torch.onnx.export() function, the call will fail. We now leverage "verbose" argument to control if the field "doc_string" will be included in the final onnx file or not.

Below are examples of how to include "doc_string" field for debug in different versions:

Version 1.10 and older:
```
torch.onnx.export(MyModel(), (x,), 'test_export_arg.onnx', strip_doc_string=False)

```


Version 1.11
```
torch.onnx.export(MyModel(), (x,), 'test_export_arg.onnx', verbose=True)

```
