### PR TITLE
[ONNX] Remove the argument _retain_param_name of export() method entirely.

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -35,9 +35,9 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, enable_onnx_checker=None,
+           opset_version=None, do_constant_folding=True, example_outputs=None,
+           strip_doc_string=None, dynamic_axes=None, keep_initializers_as_inputs=None,
+           custom_opsets=None, enable_onnx_checker=None,
            use_external_data_format=None, export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
@@ -187,8 +187,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         opset_version (int, default 9):
             Must be ``== _onnx_main_opset or in _onnx_stable_opsets``,
             defined in torch/onnx/symbolic_helper.py.
-        _retain_param_name (bool, default True): Deprecated and ignored. Will be removed in next PyTorch
-            release.
         do_constant_folding (bool, default False): Apply the constant-folding optimization.
             Constant-folding will replace some of the ops that have all constant inputs
             with pre-computed constant nodes.
@@ -315,9 +313,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
     from torch.onnx import utils
     return utils.export(model, args, f, export_params, verbose, training,
                         input_names, output_names, operator_export_type, opset_version,
-                        _retain_param_name, do_constant_folding, example_outputs,
-                        strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, enable_onnx_checker, use_external_data_format,
+                        do_constant_folding, example_outputs, strip_doc_string,
+                        dynamic_axes, keep_initializers_as_inputs, custom_opsets,
+                        enable_onnx_checker, use_external_data_format,
                         export_modules_as_functions)
 
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -103,10 +103,9 @@ def exporter_context(model, mode):
 
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None,
-           enable_onnx_checker=None, use_external_data_format=None,
+           opset_version=None, do_constant_folding=True, example_outputs=None,
+           strip_doc_string=None, dynamic_axes=None, keep_initializers_as_inputs=None,
+           custom_opsets=None, enable_onnx_checker=None, use_external_data_format=None,
            export_modules_as_functions=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
@@ -596,14 +595,10 @@ def _model_to_graph(model, args, verbose=False,
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                            google_printer=False, opset_version=None, _retain_param_name=None,
-                            keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
-                            do_constant_folding=True, dynamic_axes=None):
+                            google_printer=False, opset_version=None, keep_initializers_as_inputs=None,
+                            custom_opsets=None, add_node_names=True, do_constant_folding=True, dynamic_axes=None):
     if f is not None:
         warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
-    if _retain_param_name is not None:
-        warnings.warn("'_retain_param_name' is deprecated and ignored. "
-                      "It will be removed in the next PyTorch release.")
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, google_printer,


### PR DESCRIPTION
This was deprecated in PyTorch 1.10: https://github.com/pytorch/pytorch/pull/61702.

In the latest release, we should remove this argument entirely.

## BC-breaking note
### The signature of torch.onnx.export() function is changed because the argument "_retain_param_name" has been removed entirely.
In latest version, if we specified the value of "_retain_param_name" in a call to torch.onnx.export() function, the call will fail. Those parameter names are now always kept.

Below are examples of how to retain parameter names in final onnx file different versions:

Version 1.10 and older:
```
torch.onnx.export(MyModel(), (x,), 'test_export_arg.onnx', _retain_param_name=True)

```


Version 1.11
```
torch.onnx.export(MyModel(), (x,), 'test_export_arg.onnx')

```
