### PR TITLE
Add meta support to tensor range factories

### DIFF
--- a/aten/src/ATen/native/Histogram.cpp
+++ b/aten/src/ATen/native/Histogram.cpp
@@ -177,7 +177,7 @@ histogram_out_cpu(const Tensor& self, int64_t bin_ct, c10::optional<c10::ArrayRe
         Tensor& hist, Tensor& bin_edges) {
     histogram_prepare_out(self, bin_ct, hist, bin_edges);
     auto outer_bin_edges = select_outer_bin_edges(self, range);
-    linspace_cpu_out(outer_bin_edges.first, outer_bin_edges.second, bin_ct + 1, bin_edges);
+    linspace_out(outer_bin_edges.first, outer_bin_edges.second, bin_ct + 1, bin_edges);
     histogram_check_inputs(self, bin_edges, weight);
 
     histogram_linear_stub(self.device().type(), self, weight, density, hist, bin_edges, true);
@@ -198,7 +198,7 @@ Tensor& histogram_histc_cpu_out(const Tensor& self, int64_t bin_ct,
     Tensor bin_edges = at::empty({0}, self.options());
     histogram_prepare_out(self, bin_ct, hist, bin_edges);
     auto outer_bin_edges = histc_select_outer_bin_edges(self, min, max);
-    linspace_cpu_out(outer_bin_edges.first, outer_bin_edges.second, bin_ct + 1, bin_edges);
+    linspace_out(outer_bin_edges.first, outer_bin_edges.second, bin_ct + 1, bin_edges);
     histogram_check_inputs(self, bin_edges, {});
 
     histogram_linear_stub(self.device().type(), self,

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -12,7 +12,7 @@ namespace at { namespace native {
 DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, const Scalar&), arange_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, int64_t), linspace_stub);
 
-Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
+Tensor& linspace_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
   const auto steps = optional_steps.value_or(100);
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
 
@@ -25,6 +25,10 @@ Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
 
   if (result.numel() != steps) {
     result.resize_({steps});
+  }
+
+  if (result.device() == kMeta) {
+    return result;
   }
 
   if (steps == 0) {
@@ -43,7 +47,7 @@ Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
   return result;
 }
 
-Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, double base, Tensor& result) {
+Tensor& logspace_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, double base, Tensor& result) {
   const auto steps = optional_steps.value_or(100);
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
 
@@ -57,6 +61,11 @@ Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
   if (result.numel() != steps) {
     result.resize_({steps});
   }
+
+  if (result.device() == kMeta) {
+    return result;
+  }
+
   Tensor r = result.is_contiguous() ? result : result.contiguous();
 
   if (steps == 0) {
@@ -112,7 +121,7 @@ Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
   return result;
 }
 
-Tensor& range_cpu_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
+Tensor& range_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
   AT_DISPATCH_ALL_TYPES_AND(kBFloat16, result.scalar_type(), "range_cpu", [&]() {
     using accscalar_t = at::acc_type<scalar_t, false>;
     auto xstart = start.to<accscalar_t>();
@@ -129,6 +138,11 @@ Tensor& range_cpu_out(const Scalar& start, const Scalar& end, const Scalar& step
     if (result.numel() != size) {
       result.resize_({size});
     }
+
+    if (result.device() == kMeta) {
+      return;
+    }
+
     Tensor r = result.is_contiguous() ? result : result.contiguous();
     scalar_t *data_ptr = r.data_ptr<scalar_t>();
 
@@ -146,7 +160,7 @@ Tensor& range_cpu_out(const Scalar& start, const Scalar& end, const Scalar& step
   return result;
 }
 
-Tensor& arange_cpu_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
+Tensor& arange_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
   AT_DISPATCH_ALL_TYPES_AND(kBFloat16, result.scalar_type(), "arange_cpu", [&]() {
     using accscalar_t = at::acc_type<scalar_t, false>;
     auto xstart = start.to<accscalar_t>();
@@ -191,6 +205,10 @@ Tensor& arange_cpu_out(const Scalar& start, const Scalar& end, const Scalar& ste
                     "The out tensor will be resized to a tensor of shape (", size, ",).");
       }
       result.resize_({size});
+    }
+
+    if (result.device() == kMeta) {
+      return;
     }
 
     Tensor r = result.is_contiguous() ? result : result.contiguous();

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -533,7 +533,7 @@
 
 - func: arange.start_out(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: arange_cpu_out
+    CPU, Meta: arange_out
     CUDA: arange_cuda_out
 
 # This function is a temporary hack to allow tracing of arange like constructs with dynamic
@@ -2482,7 +2482,7 @@
 
 - func: linspace.out(Scalar start, Scalar end, int? steps=None, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: linspace_cpu_out
+    CPU, Meta: linspace_out
     CUDA: linspace_cuda_out
 
 - func: log(Tensor self) -> Tensor
@@ -2641,7 +2641,7 @@
 
 - func: logspace.out(Scalar start, Scalar end, int? steps=None, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: logspace_cpu_out
+    CPU, Meta: logspace_out
     CUDA: logspace_cuda_out
 
 # log_softmax allows positional dtype, unlike most operators, because kwonly is BC-breaking when loading jit models.
@@ -3450,7 +3450,7 @@
 
 - func: range.out(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: range_cpu_out
+    CPU, Meta: range_out
     CUDA: range_cuda_out
 
 - func: ravel(Tensor(a) self) -> Tensor(a)

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1622,6 +1622,7 @@ class TestTensorCreation(TestCase):
         self.assertEqual(c1, expected)
         self.assertEqual(c2, expected)
 
+    @skipMeta
     def test_linlogspace_mem_overlap(self, device):
         x = torch.rand(1, device=device).expand(10)
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
@@ -2422,6 +2423,20 @@ class TestTensorCreation(TestCase):
         torch.range(1, 1, 1, device=device, out=res2)
         self.assertEqual(res1, res2, atol=0, rtol=0)
 
+        # Test on the meta device
+        e1 = torch.range(2, 5)
+        r1 = torch.range(2, 5, device='meta')
+        e2 = torch.range(3, 6, dtype=torch.float32)
+        r2 = torch.range(3, 6, dtype=torch.float32, device='meta')
+        self.assertEqual(r1.device, torch.device('meta'))
+        self.assertEqual(r2.device, torch.device('meta'))
+        self.assertEqual(r1.size(), e1.size())
+        self.assertEqual(r2.size(), e2.size())
+        self.assertEqual(r1.stride(), e1.stride())
+        self.assertEqual(r2.stride(), e2.stride())
+        self.assertEqual(r1.dtype, e1.dtype)
+        self.assertEqual(r2.dtype, e2.dtype)
+
     # TODO: this test should be updated
     def test_range_warning(self, device):
         with warnings.catch_warnings(record=True) as w:
@@ -2529,6 +2544,20 @@ class TestTensorCreation(TestCase):
         msg = "unsupported range"
         self.assertRaisesRegex(RuntimeError, msg, lambda: torch.arange(0, float('inf')))
         self.assertRaisesRegex(RuntimeError, msg, lambda: torch.arange(float('inf')))
+
+        # Test on the meta device
+        e1 = torch.arange(10)
+        r1 = torch.arange(10, device='meta')
+        e2 = torch.arange(20, dtype=torch.float32)
+        r2 = torch.arange(20, dtype=torch.float32, device='meta')
+        self.assertEqual(r1.device, torch.device('meta'))
+        self.assertEqual(r2.device, torch.device('meta'))
+        self.assertEqual(r1.size(), e1.size())
+        self.assertEqual(r2.size(), e2.size())
+        self.assertEqual(r1.stride(), e1.stride())
+        self.assertEqual(r2.stride(), e2.stride())
+        self.assertEqual(r1.dtype, e1.dtype)
+        self.assertEqual(r2.dtype, e2.dtype)
 
         for device in get_all_device_types():
             self.assertRaisesRegex(RuntimeError, msg, lambda: torch.arange(-5, float('nan'), device=device))
@@ -2982,6 +3011,20 @@ class TestTensorCreation(TestCase):
         y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2), dtype=dtype)
         self.assertEqual(x, torch.tensor(((0, 0, 1), (0, 2, 3)), device=device, dtype=dtype), atol=0, rtol=0)
 
+        # Test on the meta device
+        e1 = torch.linspace(2, 8, 2)
+        r1 = torch.linspace(2, 8, 2, device='meta')
+        e2 = torch.linspace(3, 6, 1, dtype=torch.float32)
+        r2 = torch.linspace(3, 6, 1, dtype=torch.float32, device='meta')
+        self.assertEqual(r1.device, torch.device('meta'))
+        self.assertEqual(r2.device, torch.device('meta'))
+        self.assertEqual(r1.size(), e1.size())
+        self.assertEqual(r2.size(), e2.size())
+        self.assertEqual(r1.stride(), e1.stride())
+        self.assertEqual(r2.stride(), e2.stride())
+        self.assertEqual(r1.dtype, e1.dtype)
+        self.assertEqual(r2.dtype, e2.dtype)
+
     def _test_linspace_logspace_deduction_helper(self, fn, device):
         for start, end in [(1, 2), (1., 2), (1., -2.), (1j, 2j), (0., 2j), (1j, 2)]:
             dtype = torch.float32
@@ -3115,6 +3158,20 @@ class TestTensorCreation(TestCase):
         x = torch.zeros(2, 3, device=device, dtype=dtype)
         y = torch.logspace(0, 3, 4, base=2, device=device, dtype=dtype, out=x.narrow(1, 1, 2))
         self.assertEqual(x, torch.tensor(((0, 1, 2), (0, 4, 8)), device=device, dtype=dtype), atol=0, rtol=0)
+
+        # Test on the meta device
+        e1 = torch.logspace(2, 8, 2)
+        r1 = torch.logspace(2, 8, 2, device='meta')
+        e2 = torch.logspace(3, 6, 1, dtype=torch.float32)
+        r2 = torch.logspace(3, 6, 1, dtype=torch.float32, device='meta')
+        self.assertEqual(r1.device, torch.device('meta'))
+        self.assertEqual(r2.device, torch.device('meta'))
+        self.assertEqual(r1.size(), e1.size())
+        self.assertEqual(r2.size(), e2.size())
+        self.assertEqual(r1.stride(), e1.stride())
+        self.assertEqual(r2.stride(), e2.stride())
+        self.assertEqual(r1.dtype, e1.dtype)
+        self.assertEqual(r2.dtype, e2.dtype)
 
     @onlyOnCPUAndCUDA
     @dtypes(torch.half, torch.float, torch.double)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66630

This PR adds meta backend support to the `range`, `arange`, `linspace`, and `logspace` operators.

Differential Revision: [D31656999](https://our.internmc.facebook.com/intern/diff/D31656999/)