### PR TITLE
graceful failure for draw_graph() in acc_utils.py

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_utils.py
+++ b/torch/fx/experimental/fx_acc/acc_utils.py
@@ -90,7 +90,10 @@ def draw_graph(traced: torch.fx.GraphModule, fname: str, figname: str = "fx_grap
     print(f"Writing FX graph to file: {base}{ext}")
     g = graph_drawer.FxGraphDrawer(traced, figname)
     x = g.get_main_dot_graph()
-    getattr(x, "write_" + ext.lstrip("."))(fname)
+    try:
+        getattr(x, "write_" + ext.lstrip("."))(fname)
+    except OSError as e:
+        print(f"Failed to write the FX graph due to: {e}")
 
 
 def get_model_info_str(gm: torch.fx.GraphModule, header: Optional[str] = None):


### PR DESCRIPTION
Summary: writing to the current directory is causing issues in CI. we might also consider writing the ".dot" files to some temporary location.

Test Plan: CI

Differential Revision: D31657078

