### PR TITLE
Fix Wextra issues in Half.h

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -453,7 +453,9 @@ overflows(From f) {
     // allow for negative numbers to wrap using two's complement arithmetic.
     // For example, with uint8, this allows for `a - b` to be treated as
     // `a + 255 * b`.
-    return f > limit::max() ||
+    constexpr bool can_overflow =
+        std::numeric_limits<From>::digits > limit::digits;
+    return (can_overflow && f > limit::max()) ||
         (f < 0 && -static_cast<uint64_t>(f) > limit::max());
   } else {
     return f < limit::lowest() || f > limit::max();


### PR DESCRIPTION
Summary:
Fixes:
```
caffe2/c10/util/Half.h:456:14: error: comparison of integers of different signs: 'long' and 'unsigned long' [-Werror,-Wsign-compare]
    return f > limit::max() ||
           ~ ^ ~~~~~~~~~~~~
```

Differential Revision: D31656816

