### PR TITLE
[SR] Add rvalue overload for operator()

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -17,10 +17,8 @@ StaticModule makeStaticModuleFromScript(const std::string& script) {
 
 } // namespace
 
-/**
- * Test that StaticModule::value_group groups values of the graph into
- * 1) Inputs/Constants and their aliases 2) Outputs and their aliases.
- */
+// Test that StaticModule::value_group groups values of the graph into
+// 1) Inputs/Constants and their aliases 2) Outputs and their aliases.
 TEST(StaticModule, ValueGroup) {
   const std::string src = R"IR(
     graph(%input0 : Tensor, %input1 : Tensor):
@@ -114,4 +112,23 @@ TEST(StaticModule, IsOptimizableContainerType_CanUseOutVariant) {
       EXPECT_FALSE(sm.is_optimizable_container_type(n));
     }
   }
+}
+
+// Test operator() with rvalue inputs
+TEST(StaticModule, RValueInputs) {
+  const std::string src = R"JIT(
+    def forward(self, x):
+        y = torch.relu(x)
+        return y.clone()
+  )JIT";
+  auto sm = makeStaticModuleFromScript(src);
+
+  std::vector<IValue> input{at::randn({1})};
+
+  auto expected = sm(input, {});
+  auto actual = sm(std::move(input), {});
+
+  EXPECT_TRUE(expected.isTensor());
+  EXPECT_TRUE(actual.isTensor());
+  EXPECT_TRUE(expected.toTensor().equal(actual.toTensor()));
 }

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -883,7 +883,7 @@ TEST(StaticRuntime, KWargsAPI_2) {
              {"wide", wide}});
 
         // run static runtime
-        c10::IValue output_ivalue = smod({}, kwargs);
+        c10::IValue output_ivalue = smod(std::vector<IValue>{}, kwargs);
         smod.runtime().check_for_memory_leak();
 
         at::Tensor output_2 = getTensor(output_ivalue);

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -20,6 +20,7 @@
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
 #include <torch/csrc/jit/runtime/vararg_functions.h>
+#include <iterator>
 #include <sstream>
 #include <stdexcept>
 
@@ -769,9 +770,15 @@ std::vector<at::Tensor> StaticModule::operator()(
 }
 
 c10::IValue StaticModule::operator()(
-    c10::ArrayRef<c10::IValue> args,
+    const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
   return runtime()(args, kwargs);
+}
+
+c10::IValue StaticModule::operator()(
+    std::vector<c10::IValue>&& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  return runtime()(std::move(args), kwargs);
 }
 
 StaticRuntime::StaticRuntime(const StaticModule& sm) : static_module_(sm) {
@@ -850,7 +857,7 @@ std::vector<at::Tensor> StaticRuntime::operator()(
 }
 
 void StaticRuntime::set_inputs(
-    c10::ArrayRef<c10::IValue> args,
+    const std::vector<IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
   if (!kwargs.empty()) {
     // This is not ideal
@@ -886,8 +893,49 @@ void StaticRuntime::set_inputs(
   }
 }
 
+void StaticRuntime::set_inputs(
+    std::vector<IValue>&& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  if (!kwargs.empty()) {
+    // This is not ideal
+    TORCH_CHECK(
+        static_module_.schema(),
+        "Schema is not available. Consider creating the Static Runtime "
+        "with StaticModule(const torch::jit::Module& m) instead.");
+    std::vector<c10::IValue> stack;
+    stack.reserve(inputs_.size());
+    if (static_module_.first_input_is_self()) {
+      stack.emplace_back(static_module_.module()._ivalue());
+    }
+    stack.insert(
+        stack.end(),
+        std::make_move_iterator(args.begin()),
+        std::make_move_iterator(args.end()));
+
+    static_module_.schema()->checkAndNormalizeInputs(stack, kwargs);
+    DCHECK_EQ(inputs_.size(), stack.size());
+    for (const auto i : c10::irange(stack.size())) {
+      Input(i) = std::move(stack[i]);
+    }
+  } else {
+    if (static_module_.first_input_is_self()) {
+      Input(0) = static_module_.module()._ivalue();
+      DCHECK_EQ(inputs_.size(), args.size() + 1);
+      for (const auto i : c10::irange(args.size())) {
+        Input(i + 1) = std::move(args[i]);
+      }
+    } else {
+      DCHECK_EQ(inputs_.size(), args.size());
+      for (const auto i : c10::irange(args.size())) {
+        Input(i) = std::move(args[i]);
+      }
+    }
+  }
+}
+
+template <typename IValueList>
 c10::IValue StaticRuntime::operator()(
-    c10::ArrayRef<c10::IValue> args,
+    IValueList&& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
   // We assume inference workloads, so we do not need
   // autograd. Enabling this is a significant win on dispatcher
@@ -902,7 +950,7 @@ c10::IValue StaticRuntime::operator()(
     planner_->allocate();
   }
 
-  set_inputs(args, kwargs);
+  set_inputs(std::forward<IValueList>(args), kwargs);
 
   // NB: before optimizing the order of execution, ensure that the
   // memory optimization pass (LivenessMap) is
@@ -950,6 +998,14 @@ c10::IValue StaticRuntime::operator()(
   return std::move(*outputs_[0]);
 }
 
+template c10::IValue StaticRuntime::operator()<const std::vector<c10::IValue>&>(
+    const std::vector<c10::IValue>& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs);
+
+template c10::IValue StaticRuntime::operator()<std::vector<c10::IValue>&&>(
+    std::vector<c10::IValue>&& args,
+    const std::unordered_map<std::string, c10::IValue>& kwargs);
+
 namespace {
 
 std::string generate_latency_json(const std::string& label, double millis) {
@@ -968,7 +1024,7 @@ std::string generate_latency_json(const std::string& label, double millis) {
 } // namespace
 
 void StaticRuntime::benchmark(
-    c10::ArrayRef<c10::IValue> args,
+    const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
     const int main_runs,
@@ -1061,7 +1117,7 @@ void StaticRuntime::benchmark(
 }
 
 float StaticRuntime::benchmark_model(
-    c10::ArrayRef<c10::IValue> args,
+    const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
     const int main_runs) {
@@ -1132,7 +1188,7 @@ void display_pnode_info(const ProcessedNode& pnode) {
 }
 
 void StaticRuntime::display_nodes(
-    c10::ArrayRef<c10::IValue> args,
+    const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
   c10::InferenceMode mode;
   if (planner_) {
@@ -1164,7 +1220,7 @@ void StaticRuntime::display_nodes(
 }
 
 StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
-    c10::ArrayRef<c10::IValue> args,
+    const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
     const int main_runs) {

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -175,7 +175,10 @@ class TORCH_API StaticModule {
   // This interface only works if StaticModule was initialized
   // with a TorchScript module, otherwise use the above interface
   c10::IValue operator()(
-      c10::ArrayRef<c10::IValue> args,
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs);
+  c10::IValue operator()(
+      std::vector<c10::IValue>&& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   const Graph& graph() const {
@@ -275,16 +278,18 @@ class TORCH_API StaticRuntime {
 
   // This interface only works if StaticModule was initialized
   // with a TorchScript module, otherwise use the above interface
+  // IValueList should be a std::vector<IValue> (lvalue or rvalue)
+  template <class IValueList>
   c10::IValue operator()(
-      c10::ArrayRef<c10::IValue> args,
+      IValueList&& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   void display_nodes(
-      c10::ArrayRef<c10::IValue> args,
+      const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   void benchmark(
-      c10::ArrayRef<c10::IValue> args,
+      const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,
       const int warmup_runs,
       const int main_runs,
@@ -292,7 +297,7 @@ class TORCH_API StaticRuntime {
       bool generate_ai_pep_output = false);
 
   float benchmark_model(
-      c10::ArrayRef<c10::IValue> args,
+      const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,
       const int warmup_runs,
       const int main_runs);
@@ -315,7 +320,7 @@ class TORCH_API StaticRuntime {
   };
 
   IndividualMetrics benchmark_individual_ops(
-      c10::ArrayRef<c10::IValue> args,
+      const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,
       const int warmup_runs,
       const int main_runs);
@@ -365,7 +370,10 @@ class TORCH_API StaticRuntime {
  private:
   // helper method for copying input args/kwargs into inputs_
   void set_inputs(
-      c10::ArrayRef<c10::IValue> args,
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs);
+  void set_inputs(
+      std::vector<c10::IValue>&& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   // clean up owning refs of input IValues


### PR DESCRIPTION
Summary:
Currently, SR shallow-copies its `IValue` inputs when running inferences. We can avoid refcount bumps by `std::move`-ing the inputs into their slots. To achieve this, I've made the following changes:

1. Add an overload for `set_inputs` that takes a `std::vector<IValue>&&`.
2. Change the signatures of `StaticModule::operator()` and `StaticRuntime::operator()`.
Old:
```
operator()(const std::vector<IValue>& args, const std::unordered_map<std::string, IValue>& kwargs)
```
New:
```
template <class IValueList>
operator()(IValueList&& args, const std::unordered_map<std::string, IValue>& kwargs)
```

The implementations use perfect forwarding to invoke the correct overload of `set_inputs`.

Test Plan: Added a short new unit test to exercise the new code path. All other unit tests still pass.

Differential Revision: D31659973

