### PR TITLE
[TensorExpr] Add missing schemas for lshift/rshift lowerings.

### DIFF
--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -151,7 +151,8 @@ RegisterNNCLoweringsFunction aten___xor__(
     });
 
 RegisterNNCLoweringsFunction aten___lshift__(
-    {"aten::__lshift__.Tensor(Tensor self, Tensor other) -> (Tensor)"},
+    {"aten::__lshift__.Scalar(Tensor self, Scalar other) -> (Tensor)",
+     "aten::__lshift__.Tensor(Tensor self, Tensor other) -> (Tensor)"},
     [](const std::vector<ArgValue>& inputs,
        const std::vector<ExprHandle>& outputShape,
        const c10::optional<ScalarType>& outputType,
@@ -167,7 +168,8 @@ RegisterNNCLoweringsFunction aten___lshift__(
     });
 
 RegisterNNCLoweringsFunction aten___rshift__(
-    {"aten::__rshift__.Tensor(Tensor self, Tensor other) -> (Tensor)"},
+    {"aten::__rshift__.Scalar(Tensor self, Scalar other) -> (Tensor)",
+     "aten::__rshift__.Tensor(Tensor self, Tensor other) -> (Tensor)"},
     [](const std::vector<ArgValue>& inputs,
        const std::vector<ExprHandle>& outputShape,
        const c10::optional<ScalarType>& outputType,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66653

Differential Revision: [D31664748](https://our.internmc.facebook.com/intern/diff/D31664748)