### PR TITLE
[ROCm] enable test_distributed() in test.sh

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -535,7 +535,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *vulkan* ]]; then
   test_vulkan
 elif [[ "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then
   test_bazel
-elif [[ "${BUILD_ENVIRONMENT}" == *distributed* ]]; then
+elif [[ "${BUILD_ENVIRONMENT}" == *distributed* || "${JOB_BASE_NAME}" == *distributed* ]]; then
   test_distributed
   test_rpc
 elif [[ "${TEST_CONFIG}" = docs_test ]]; then


### PR DESCRIPTION
Restores tests for ROCm CI that used to run prior to #63147.

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport