### PR TITLE
[PyTorchEdge] Make aten function common to aten and torch_common

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -228,24 +228,6 @@ Tensor isfinite(const Tensor& self) {
   });
 }
 
-bool is_nonzero(const Tensor& self) {
-  auto n = self.numel();
-  TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");
-  TORCH_CHECK(n < 2, "Boolean value of Tensor with more than one value is ambiguous");
-
-  Scalar localScalar = self.item();
-  if (localScalar.isFloatingPoint()) {
-    return localScalar.to<double>() != 0;
-  } else if (localScalar.isComplex()) {
-     return localScalar.to<c10::complex<double>>() != c10::complex<double>(0.0, 0.0);
-  } else if (localScalar.isIntegral(false)){
-    return localScalar.to<int64_t>() != 0;
-  } else if (localScalar.isBoolean()) {
-    return localScalar.to<bool>();
-  }
-  TORCH_INTERNAL_ASSERT(false, "Expected non-Tensor backend scalar");
-}
-
 void _assert_async_cpu(const Tensor& self) {
   TORCH_CHECK(native::is_nonzero(self), "Expected Tensor with single nonzero value, but got zero");
 }

--- a/aten/src/ATen/native/prim_native_functions.cpp
+++ b/aten/src/ATen/native/prim_native_functions.cpp
@@ -1,0 +1,26 @@
+#include <ATen/ATen.h>
+
+namespace at {
+namespace native {
+
+bool is_nonzero(const Tensor& self) {
+  auto n = self.numel();
+  TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");
+  TORCH_CHECK(
+      n < 2, "Boolean value of Tensor with more than one value is ambiguous");
+
+  Scalar localScalar = self.item();
+  if (localScalar.isFloatingPoint()) {
+    return localScalar.to<double>() != 0;
+  } else if (localScalar.isComplex()) {
+    return localScalar.to<c10::complex<double>>() !=
+        c10::complex<double>(0.0, 0.0);
+  } else if (localScalar.isIntegral(false)) {
+    return localScalar.to<int64_t>() != 0;
+  } else if (localScalar.isBoolean()) {
+    return localScalar.to<bool>();
+  }
+  TORCH_INTERNAL_ASSERT(false, "Expected non-Tensor backend scalar");
+}
+} // namespace meta
+} // namespace at

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -939,6 +939,7 @@ aten_cpu_source_non_codegen_list = [
     "aten/src/ATen/nnapi/nnapi_bind.cpp",
     "aten/src/ATen/nnapi/nnapi_wrapper.cpp",
     "aten/src/ATen/nnapi/nnapi_model_loader.cpp",
+    "aten/src/ATen/native/prim_native_functions.cpp",
 ]
 
 aten_cpu_source_codegen_list = [


### PR DESCRIPTION
Summary:
fb: TensorCompare.cpp is in per-app, a target higher than torch_mobile

Create a filed called "prim_native_functions.cpp" in ATen, add it to aten_cpu, and cut-paste native::is_nonzero() to prim_native_functions.cpp.
By doing this we move the function to lower layer which is more visible to all targets depending on it.


Differential Revision: D31669536

