### PR TITLE
[PyTorch] Call native `is_nonzero` instead of calling a tensor op

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -1,3 +1,4 @@
+#include <ATen/NativeFunctions.h>
 #include <ATen/core/ivalue.h>
 #include <ATen/core/Dict.h>
 #include <ATen/core/Formatting.h>
@@ -272,7 +273,7 @@ bool operator==(const IValue& lhs, const IValue& rhs) {
   // `bool()` is called on the return value of `__eq__` if the return value is
   // not a boolean. Mimic that behavior here.
   TORCH_INTERNAL_ASSERT(eq.isTensor());
-  return eq.toTensor().is_nonzero();
+  return at::native::is_nonzero(eq.toTensor());
 }
 
 bool IValue::ptrEqual(const IValue& lhs, const IValue& rhs) {

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -228,24 +228,6 @@ Tensor isfinite(const Tensor& self) {
   });
 }
 
-bool is_nonzero(const Tensor& self) {
-  auto n = self.numel();
-  TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");
-  TORCH_CHECK(n < 2, "Boolean value of Tensor with more than one value is ambiguous");
-
-  Scalar localScalar = self.item();
-  if (localScalar.isFloatingPoint()) {
-    return localScalar.to<double>() != 0;
-  } else if (localScalar.isComplex()) {
-     return localScalar.to<c10::complex<double>>() != c10::complex<double>(0.0, 0.0);
-  } else if (localScalar.isIntegral(false)){
-    return localScalar.to<int64_t>() != 0;
-  } else if (localScalar.isBoolean()) {
-    return localScalar.to<bool>();
-  }
-  TORCH_INTERNAL_ASSERT(false, "Expected non-Tensor backend scalar");
-}
-
 void _assert_async_cpu(const Tensor& self) {
   TORCH_CHECK(native::is_nonzero(self), "Expected Tensor with single nonzero value, but got zero");
 }

--- a/aten/src/ATen/native/prim_native_functions.cpp
+++ b/aten/src/ATen/native/prim_native_functions.cpp
@@ -1,0 +1,26 @@
+#include <ATen/ATen.h>
+
+namespace at {
+namespace meta {
+
+bool is_nonzero(const Tensor& self) {
+  auto n = self.numel();
+  TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");
+  TORCH_CHECK(
+      n < 2, "Boolean value of Tensor with more than one value is ambiguous");
+
+  Scalar localScalar = self.item();
+  if (localScalar.isFloatingPoint()) {
+    return localScalar.to<double>() != 0;
+  } else if (localScalar.isComplex()) {
+    return localScalar.to<c10::complex<double>>() !=
+        c10::complex<double>(0.0, 0.0);
+  } else if (localScalar.isIntegral(false)) {
+    return localScalar.to<int64_t>() != 0;
+  } else if (localScalar.isBoolean()) {
+    return localScalar.to<bool>();
+  }
+  TORCH_INTERNAL_ASSERT(false, "Expected non-Tensor backend scalar");
+}
+} // namespace meta
+} // namespace at

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -935,6 +935,7 @@ aten_cpu_source_non_codegen_list = [
     "aten/src/ATen/nnapi/nnapi_bind.cpp",
     "aten/src/ATen/nnapi/nnapi_wrapper.cpp",
     "aten/src/ATen/nnapi/nnapi_model_loader.cpp",
+    "aten/src/ATen/native/prim_native_functions.cpp",
 ]
 
 aten_cpu_source_codegen_list = [


### PR DESCRIPTION
Summary:
This diff is experimenting on whether we can call native function of `is_nonzero` directly, instead of calling aten operator which goes through dispatch. I'm not sure if there's implementation difference in `is_nonzero` for backends other than CPU, hoping CI can catch some issue here.

The purpose of this refactoring is to avoid the overhead of dispatching for `is_nonzero`.

Differential Revision: D31671923

