### PR TITLE
[Vulkan] cat operator for channel dimension

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Helper.cpp
+++ b/aten/src/ATen/native/vulkan/api/Helper.cpp
@@ -24,9 +24,10 @@ void copy_texture_to_texture(
   copy_info.extent.depth = src_extents.data[2u];
   copy_info.dstOffset.y = dst_offset.data[1u];
 
+  // To use vkCmdCopyImage, the stage of src & dst image must be set to vTensor::Stage::Transfer.
   vkCmdCopyImage(
     command_buffer.handle(),
-    src_image.handle, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+    src_image.handle, VK_IMAGE_LAYOUT_GENERAL,
     dst_image.handle, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
     1,
     &copy_info);

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -111,7 +111,7 @@ VkInstance create_instance(const Runtime::Type type) {
     VK_API_VERSION_1_0,
   };
 
-  const VkInstanceCreateInfo instance_create_info{
+const VkInstanceCreateInfo instance_create_info{
     VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
     nullptr,
     0u,

--- a/aten/src/ATen/native/vulkan/glsl/cat_feature.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/cat_feature.glsl
@@ -1,0 +1,46 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba16f) uniform PRECISION           image3D uOutput;
+layout(set = 0, binding = 1)          uniform PRECISION           sampler3D uInput;
+layout(set = 0, binding = 2)          uniform PRECISION restrict  Block {
+  ivec4 size;            // output texture size (x=width,y=height,z=depth,w=unused)
+  ivec4 isize;           // input texture size (x=width,y=height,z=depth,w=unused)
+  uint batch_size;       // input tensor's batch size
+  uint ch_size;          // input tensor's channel size
+  uint ch_interval;      // channel interval (total # of channels for all tensors)
+  uint ch_size_allprior; // # of channels for tensor 0 to i-1 at ith tensor
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 posIn = ivec3(gl_GlobalInvocationID);
+  const uint max_src_index = uBlock.ch_size * uBlock.batch_size;
+
+  if (all(lessThan(posIn, uBlock.isize.xyz))) {
+    ivec3 posOut = posIn; // x and y don't change. only z and index matter
+    const vec4 inval = texelFetch(uInput, posIn, 0);
+
+    for (uint i = 0; i < 4; ++i)
+    {
+      uint src_index = posIn.z * 4 + i;
+      if (src_index >= max_src_index) {
+        // out of range
+        break;
+      }
+
+      uint dst_index = uint(src_index / uBlock.ch_size) * uBlock.ch_interval + (src_index % uBlock.ch_size) + uBlock.ch_size_allprior;
+      posOut.z = int(dst_index / 4);
+      uint j = (dst_index % 4);
+
+      vec4 outval = imageLoad(uOutput, posOut);
+      outval[j] = inval[i];
+      imageStore(uOutput, posOut, outval);
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -1,5 +1,5 @@
-#include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/api/Helper.h>
+#include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
 
 namespace at {
@@ -21,7 +21,79 @@ Tensor cat_batch(const TensorList tensors, vTensor& v_output) {
 }
 
 Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
-  TORCH_CHECK(false, "Vulkan cat not implemented for feature dimension!");
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  int64_t ch_size_allprior = 0;
+  int64_t ch_interval = 0;
+  for (const auto& tensor : tensors) {
+    ch_interval += tensor.sizes()[1];
+  }
+
+  auto dst_image = v_output.image(
+    command_buffer,
+    vTensor::Stage::Compute,
+    vTensor::Access::Read | vTensor::Access::Write);
+
+  for (const auto& tensor : tensors) {
+    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Compute);
+
+      const struct Block final {
+        uvec3 size;                // output texture size
+        uint32_t fill_0;           // dummy
+        uvec3 isize;               // input texture size
+        uint32_t fill_1;           // dummy
+        uint32_t batch_size;       // input tensor's batch size
+        uint32_t ch_size;          // input tensor's channel size
+        uint32_t ch_interval;      // channel interval (total # of channels for all tensors)
+        uint32_t ch_size_allprior; // # of channels for tensor 0 to i-1 at ith tensor
+      } block {
+        v_output.extents(),
+        0u,
+        v_self.extents(),
+        0u,
+        safe_downcast<uint32_t>(v_self.sizes()[0]),
+        safe_downcast<uint32_t>(v_self.sizes()[1]),
+        safe_downcast<uint32_t>(ch_interval),
+        safe_downcast<uint32_t>(ch_size_allprior),
+      };
+
+      ch_size_allprior += v_self.sizes()[1];
+
+      context->dispatch(
+          command_buffer,
+          {
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          },
+          VK_KERNEL(cat_feature),
+          v_self.extents(),
+          context->gpu().adapter->local_work_group_size(),
+          // Read/Write access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
+          dst_image,
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
+          src_image,
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
+    }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+
+  return convert(v_output);
 }
 
 Tensor cat_width(const TensorList tensors, vTensor& v_output) {
@@ -35,7 +107,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
 
   auto dst_image = v_output.image(
     command_buffer,
-    vTensor::Stage::Compute,
+    vTensor::Stage::Transfer,
     vTensor::Access::Write);
 
   uvec3 dst_offset{};
@@ -45,7 +117,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
     if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
       auto src_image = v_self.image(
               command_buffer,
-              vTensor::Stage::Compute);
+              vTensor::Stage::Transfer);
 
       api::helper::copy_texture_to_texture(command_buffer,
         src_image,
@@ -77,9 +149,8 @@ Tensor cat(
   at::Tensor tensor = tensors[0];
   int64_t cat_dim_size = 0;
 
-  for (int i = 0; i < tensors.size(); ++i) {
-    const auto& t = tensors[i];
-    TORCH_INTERNAL_ASSERT(
+  for (const auto & t : tensors) {
+     TORCH_INTERNAL_ASSERT(
       t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
 
     for (int d = 0; d < 4; ++d) {

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -279,7 +279,9 @@ vTensor::Image allocate_image(
       // Usage
       {
         VK_IMAGE_USAGE_SAMPLED_BIT |
-            VK_IMAGE_USAGE_STORAGE_BIT,
+            VK_IMAGE_USAGE_STORAGE_BIT |
+            VK_IMAGE_USAGE_TRANSFER_SRC_BIT | // for vkCmdCopyImage
+            VK_IMAGE_USAGE_TRANSFER_DST_BIT,  // for vkCmdCopyImage
         {
           VMA_MEMORY_USAGE_GPU_ONLY,
           0u,

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1682,6 +1682,173 @@ TEST(VulkanAPITest, upsample_nearest2d) {
   ASSERT_TRUE(check);
 }
 
+#if !defined(__APPLE__)
+TEST(VulkanAPITest, cat_dim1_samefeature_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_difffeature_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu1 = at::rand({3, 3, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 8, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({3, 11, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_texture2d_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: 2D Texture (VK_IMAGE_VIEW_TYPE_2D)
+  const auto in_cpu1 = at::rand({2, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({2, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({2, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+#endif /* !defined(__APPLE__) */
+
+TEST(VulkanAPITest, cat_dim1_singledepth_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: batch x channel (1x1) = single depth texture
+  const auto in_cpu1 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_singletensor_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: single input tensor
+  const auto in_cpu1 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1}, 1);
+  const auto out_vulkan = at::cat({in_cpu1}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_twotensors_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: two input tensors
+  const auto in_cpu1 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_bat1_ch4multiple_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: batch=1 and channel (multiples of 4 <-> channel %4 == 0)
+  const auto in_cpu1 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST(VulkanAPITest, cat_dim2_sameheight_success) {
   // Guard
   if (!at::is_vulkan_available()) {
@@ -1716,6 +1883,30 @@ TEST(VulkanAPITest, cat_dim2_diffheight_success) {
   const auto in_cpu1 = at::rand({3, 9, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({3, 9, 112, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu3 = at::rand({3, 9, 331, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 2);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 2);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim2_singledepth_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: batch x channel (1x1) = single depth texture
+  const auto in_cpu1 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({1, 1, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
 
   // Act
   const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 2);


### PR DESCRIPTION
Summary:
Implemented `cat` operator for channel dimension

**Facts:**
* texture coordinate: x(width), y(height), z(depth)
* input x, y, z -> no change
* out x, y -> no change
* out z and index i, j only matter

**Equations:**
batch_size = bt0 (or bt1 or bt2 or ...) = # of batch for tensor i
ch_size = ch0 (or ch1 or ch2 or ...) = # of channels for tensor i
ch_interval = ch0 + ch1 + ch2 + ... = total # of channels for all tensors
ch_size_allprior = ch0 (or ch0+ch1 or ch0+ch1+ch2 or ...) = # of channels for tensor 0 to i-1 where pos.z = d (input)
i = index of input texel = vec4[i] of texel at posIn(x,y,z) on input texture
j = index of output texel = vec4[j] of texel at posOut(x',y',z') on input texture

posIn[i] = {x,y,z} at ith index of vec4
src_index = posIn.z * 4 + i
dst_index = int(src_index / ch_size) * ch_interval + (src_index % ch_size) + ch_size_allprior
d = posOut.z = int(dst_index / 4)
j = (dst_index % 4)
posOut[j] = {posIn.x, posIn.y, d} at jth index of vec4

**Shader pseudo code:**
posOut = posIn;
for (i = 0; i < 4; ++i) {
	src_index = posIn.z * 4 + i;
	if (src_index >= ch_size * batch_size) break; // out of range
	dst_index = int(src_index / ch_size) * ch_interval + (src_index % ch_size) + ch_size_allprior;
	posOut.z = int(dst_index / 4);
	j = (dst_index % 4);
	uOutput[j] = uInput[i]
}

Test Plan:
Test build on Android:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```

Test result:
```
[ RUN      ] VulkanAPITest.cat_dim1_samefeature_success
[       OK ] VulkanAPITest.cat_dim1_samefeature_success (101 ms)
[ RUN      ] VulkanAPITest.cat_dim1_difffeature_success
[       OK ] VulkanAPITest.cat_dim1_difffeature_success (81 ms)
[ RUN      ] VulkanAPITest.cat_dim1_texture2d_success
[       OK ] VulkanAPITest.cat_dim1_texture2d_success (2 ms)
[ RUN      ] VulkanAPITest.cat_dim1_singledepth_success
[       OK ] VulkanAPITest.cat_dim1_singledepth_success (6 ms)
[ RUN      ] VulkanAPITest.cat_dim1_singletensor_success
[       OK ] VulkanAPITest.cat_dim1_singletensor_success (21 ms)
[ RUN      ] VulkanAPITest.cat_dim1_twotensors_success
[       OK ] VulkanAPITest.cat_dim1_twotensors_success (53 ms)
[ RUN      ] VulkanAPITest.cat_dim1_bat1_ch4multiple_success
[       OK ] VulkanAPITest.cat_dim1_bat1_ch4multiple_success (17 ms)
[ RUN      ] VulkanAPITest.cat_dim2_sameheight_success
[       OK ] VulkanAPITest.cat_dim2_sameheight_success (83 ms)
[ RUN      ] VulkanAPITest.cat_dim2_diffheight_success
[       OK ] VulkanAPITest.cat_dim2_diffheight_success (86 ms)
[ RUN      ] VulkanAPITest.cat_dim2_singledepth_success
[       OK ] VulkanAPITest.cat_dim2_singledepth_success (5 ms)
[ RUN      ] VulkanAPITest.cat_dim2_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_dim2_invalidinputs_exceptions (82 ms)
```

Differential Revision: D31593623

