### PR TITLE
enable channels last 1d support

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -244,7 +244,13 @@ class TORCH_API TensorBase {
     // Setting channels_last_strides_exact_match to true forces function to
     // check 0,1 - sized dimension strides.
     if (!is_mkldnn() && !is_sparse()) {
-      if (impl_->is_strides_like_channels_last()) {
+      if (impl_->is_strides_like_channels_last_1d()) {
+        if (!channels_last_strides_exact_match ||
+            get_channels_last_strides_1d(sizes()) == strides()) {
+          return at::MemoryFormat::ChannelsLast1d;
+        }
+      }
+      else if (impl_->is_strides_like_channels_last()) {
         if (!channels_last_strides_exact_match ||
             get_channels_last_strides_2d(sizes()) == strides()) {
           return at::MemoryFormat::ChannelsLast;

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -80,6 +80,9 @@ Tensor TensorMaker::make_tensor() {
    static std::int64_t zeros[5] = {0, 0, 0, 0, 0};
    if (opts_.has_memory_format()) {
      MemoryFormat format = *opts_.memory_format_opt();
+     if (format == MemoryFormat::ChannelsLast1d) {
+       return IntArrayRef(zeros, 3);
+     }
      if (format == MemoryFormat::ChannelsLast) {
        return IntArrayRef(zeros, 4);
      }

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -134,10 +134,12 @@ inline std::vector<int64_t> get_channels_last_strides_3d(IntArrayRef sizes) {
 // input
 // 3. All helper functions have similar comments, only 1st helper function is
 // commented here.
-inline bool is_channels_last_strides_1d_s3(const IntArrayRef sizes, const IntArrayRef strides) {
+inline bool is_channels_last_strides_1d_s3(
+    const IntArrayRef sizes,
+    const IntArrayRef strides) {
   int64_t min = 0;
   // special case for trivial C dimension. default to NCL
-  if (strides[1]==0) {
+  if (strides[1] == 0) {
     return false;
   }
   // loop strides indices
@@ -154,7 +156,7 @@ inline bool is_channels_last_strides_1d_s3(const IntArrayRef sizes, const IntArr
     // Two cases could lead us here:
     // a. N11 contiguous Tensor ([N,1,1]@[1,1,1])
     // b. N1L contiguous Tensor sliced on the L-dimension. ([N,1,1]@[L,L,L])
-    if (d==0 && min==strides[1]) {
+    if (d == 0 && min == strides[1]) {
       return false;
     }
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -597,13 +597,10 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   dest_impl->key_set_ = src_impl->key_set_.remove(DispatchKey::Python);
   dest_impl->is_contiguous_ = src_impl->is_contiguous_;
   dest_impl->has_contiguity_ = src_impl->has_contiguity_;
-  dest_impl->is_channels_last_1d_contiguous_ =
-      src_impl->is_channels_last_1d_contiguous_;
   dest_impl->is_channels_last_contiguous_ =
       src_impl->is_channels_last_contiguous_;
   dest_impl->is_channels_last_3d_contiguous_ =
       src_impl->is_channels_last_3d_contiguous_;
-  dest_impl->is_channels_last_1d_ = src_impl->is_channels_last_1d_;
   dest_impl->is_channels_last_ = src_impl->is_channels_last_;
   dest_impl->is_channels_last_3d_ = src_impl->is_channels_last_3d_;
   dest_impl->is_non_overlapping_and_dense_ =

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -271,17 +271,17 @@ bool TensorImpl::compute_channels_last_contiguous_1d() const {
   // compiler fully unroll the loop to get better performance
   switch (sizes_and_strides_.size()) {
     case 3: {
-        int64_t expected = 1;
-        for (auto& d : {1, 2, 0}) {
-          const auto size_d = sizes_and_strides_.size_at_unchecked(d);
-          if (size_d != 1) {
-            if (sizes_and_strides_.stride_at_unchecked(d) != expected) {
-              return false;
-            }
-            expected *= size_d;
+      int64_t expected = 1;
+      for (auto& d : {1, 2, 0}) {
+        const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+        if (size_d != 1) {
+          if (sizes_and_strides_.stride_at_unchecked(d) != expected) {
+            return false;
           }
+          expected *= size_d;
         }
-        return true;
+      }
+      return true;
     }
     // NOLINTNEXTLINE(bugprone-branch-clone)
     case 2:

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -791,7 +791,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     }
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
     if (memory_format == at::MemoryFormat::ChannelsLast1d) {
-      return is_channels_last_1d_contiguous_;
+      return compute_channels_last_contiguous_1d();
     } else if (memory_format == at::MemoryFormat::ChannelsLast) {
       return is_channels_last_contiguous_;
     } else if (memory_format == at::MemoryFormat::ChannelsLast3d) {
@@ -2121,7 +2121,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_strides_like_channels_last_1d() const {
-    return is_channels_last_1d_;
+    return compute_strides_like_channels_last_1d();
   }
 
   bool is_strides_like_channels_last() const {
@@ -2277,66 +2277,41 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   void refresh_contiguous() {
     is_contiguous_ = compute_contiguous();
     // Note:
-    // Dim 0, 1  will never be a channels last 1d/2d/3d format
-    // Dim 2+ is possibly be a channels last 1d format (Dim 3 only at this
-    // point) Dim 3+ is possibly be a channels last 2d format (Dim 4 only at
+    // Dim 0, 1, 2  will never be a channels last 2d/3d format
+    // Dim 3+ is possibly be a channels last 2d format (Dim 4 only at
     // this point) Dim 4+ is possibly be a channels last 3d format (Dim 5 only
     // at this point)
     switch (dim()) {
-      case 3:
-        is_channels_last_1d_contiguous_ = compute_channels_last_contiguous_1d();
-        is_channels_last_contiguous_ = false;
-        is_channels_last_3d_contiguous_ = false;
-        is_channels_last_1d_ = compute_strides_like_channels_last_1d();
-        is_channels_last_ = false;
-        is_channels_last_3d_ = false;
-        is_non_overlapping_and_dense_ = is_contiguous_ ||
-            is_channels_last_1d_contiguous_ ||
-            compute_non_overlapping_and_dense();
-        break;
       case 4:
-        is_channels_last_1d_contiguous_ = compute_channels_last_contiguous_1d();
-        is_channels_last_contiguous_ = !is_channels_last_1d_contiguous_ &&
-            compute_channels_last_contiguous_2d();
+        is_channels_last_contiguous_ = compute_channels_last_contiguous_2d();
         is_channels_last_3d_contiguous_ = false;
-        is_channels_last_1d_ = !is_channels_last_contiguous_ &&
-            compute_strides_like_channels_last_1d();
-        is_channels_last_ =
-            !is_channels_last_1d_ && compute_strides_like_channels_last_2d();
+        is_channels_last_ = compute_strides_like_channels_last_2d();
         is_channels_last_3d_ = false;
         is_non_overlapping_and_dense_ = is_contiguous_ ||
-            is_channels_last_1d_contiguous_ || is_channels_last_contiguous_ ||
+            is_channels_last_contiguous_ ||
             compute_non_overlapping_and_dense();
         break;
       case 5:
-        is_channels_last_1d_contiguous_ = compute_channels_last_contiguous_1d();
-        is_channels_last_contiguous_ = !is_channels_last_1d_contiguous_ &&
-            compute_channels_last_contiguous_2d();
-        is_channels_last_3d_contiguous_ = !is_channels_last_1d_contiguous_ &&
-            !is_channels_last_contiguous_ &&
+        is_channels_last_contiguous_ = compute_channels_last_contiguous_2d();
+        is_channels_last_3d_contiguous_ = !is_channels_last_contiguous_ &&
             compute_channels_last_contiguous_3d();
-        is_channels_last_1d_ = !is_channels_last_contiguous_ &&
-            !is_channels_last_3d_contiguous_ &&
-            compute_strides_like_channels_last_1d();
         is_channels_last_ = !is_channels_last_3d_contiguous_ &&
             compute_strides_like_channels_last_2d();
-        is_channels_last_3d_ = !is_channels_last_1d_ && !is_channels_last_ &&
+        is_channels_last_3d_ = !is_channels_last_ &&
             compute_strides_like_channels_last_3d();
         is_non_overlapping_and_dense_ = is_contiguous_ ||
-            is_channels_last_1d_contiguous_ || is_channels_last_contiguous_ ||
+            is_channels_last_contiguous_ ||
             is_channels_last_3d_contiguous_ ||
             compute_non_overlapping_and_dense();
         break;
       default:
-        is_channels_last_1d_contiguous_ = false;
         is_channels_last_contiguous_ = false;
         is_channels_last_3d_contiguous_ = false;
-        // is_channels_last_1d_, is_channels_last_ and is_channels_last_3d_ are
+        // is_channels_last_ and is_channels_last_3d_ are
         // suggested memory_format. memory_format. Being
         // channels_last_contiguous doesn't necessarily mean the tensor is
         // strided like channels_last: for strides on channel dimension could
         // suggest desired memory_layout, but it doesn't affect memory storage
-        is_channels_last_1d_ = false;
         is_channels_last_ = false;
         is_channels_last_3d_ = false;
         is_non_overlapping_and_dense_ =
@@ -2527,8 +2502,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     is_contiguous_ = true;
     has_contiguity_ = static_cast<uint8_t>(HasContiguityPolicy::Default);
 
-    is_channels_last_1d_ = false;
-    is_channels_last_1d_contiguous_ = false;
     is_channels_last_ = false;
     is_channels_last_contiguous_ = false;
     is_channels_last_3d_ = false;
@@ -2540,16 +2513,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     owns_pyobj_ = false;
     storage_access_should_throw_ = false;
   }
-
-  // Tensor is stored in the channels last 1d memory format, when dimensions
-  // order is (N)CW and C-strides < W-strides (< N-strides)
-  // (If size of any dimension is equal to 1, this dimension strides value
-  // is not taken into account).
-  bool is_channels_last_1d_ : 1;
-
-  // Channels last 1d contiguous tensor is channel last tensor which occupies
-  // contiguous memory block.
-  bool is_channels_last_1d_contiguous_ : 1;
 
   // Tensor is stored in the channels last 2d memory format, when dimensions
   // order is (N)CHW and C-strides < W-strides < H-strides (< N-strides)

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2278,12 +2278,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     is_contiguous_ = compute_contiguous();
     // Note:
     // Dim 0, 1  will never be a channels last 1d/2d/3d format
-    // Dim 2+ is possibly be a channels last 1d format (Dim 3 only at this point)
-    // Dim 3+ is possibly be a channels last 2d format (Dim 4 only at this
-    // point) Dim 4+ is possibly be a channels last 3d format (Dim 5 only at
-    // this point)
+    // Dim 2+ is possibly be a channels last 1d format (Dim 3 only at this
+    // point) Dim 3+ is possibly be a channels last 2d format (Dim 4 only at
+    // this point) Dim 4+ is possibly be a channels last 3d format (Dim 5 only
+    // at this point)
     switch (dim()) {
-       case 3:
+      case 3:
         is_channels_last_1d_contiguous_ = compute_channels_last_contiguous_1d();
         is_channels_last_contiguous_ = false;
         is_channels_last_3d_contiguous_ = false;
@@ -2301,12 +2301,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         is_channels_last_3d_contiguous_ = false;
         is_channels_last_1d_ = !is_channels_last_contiguous_ &&
             compute_strides_like_channels_last_1d();
-        is_channels_last_ = !is_channels_last_1d_ &&
-            compute_strides_like_channels_last_2d();
+        is_channels_last_ =
+            !is_channels_last_1d_ && compute_strides_like_channels_last_2d();
         is_channels_last_3d_ = false;
         is_non_overlapping_and_dense_ = is_contiguous_ ||
-            is_channels_last_1d_contiguous_ ||
-            is_channels_last_contiguous_ ||
+            is_channels_last_1d_contiguous_ || is_channels_last_contiguous_ ||
             compute_non_overlapping_and_dense();
         break;
       case 5:
@@ -2321,24 +2320,22 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             compute_strides_like_channels_last_1d();
         is_channels_last_ = !is_channels_last_3d_contiguous_ &&
             compute_strides_like_channels_last_2d();
-        is_channels_last_3d_ = !is_channels_last_1d_ &&
-            !is_channels_last_ &&
+        is_channels_last_3d_ = !is_channels_last_1d_ && !is_channels_last_ &&
             compute_strides_like_channels_last_3d();
         is_non_overlapping_and_dense_ = is_contiguous_ ||
-            is_channels_last_1d_contiguous_ ||
-            is_channels_last_contiguous_ ||
-            is_channels_last_3d_contiguous_||
+            is_channels_last_1d_contiguous_ || is_channels_last_contiguous_ ||
+            is_channels_last_3d_contiguous_ ||
             compute_non_overlapping_and_dense();
         break;
       default:
         is_channels_last_1d_contiguous_ = false;
         is_channels_last_contiguous_ = false;
         is_channels_last_3d_contiguous_ = false;
-        // is_channels_last_1d_, is_channels_last_ and is_channels_last_3d_ are suggested memory_format.
-        // memory_format. Being channels_last_contiguous doesn't necessarily
-        // mean the tensor is strided like channels_last: for strides on channel
-        // dimension could suggest desired memory_layout, but it doesn't affect
-        // memory storage
+        // is_channels_last_1d_, is_channels_last_ and is_channels_last_3d_ are
+        // suggested memory_format. memory_format. Being
+        // channels_last_contiguous doesn't necessarily mean the tensor is
+        // strided like channels_last: for strides on channel dimension could
+        // suggest desired memory_layout, but it doesn't affect memory storage
         is_channels_last_1d_ = false;
         is_channels_last_ = false;
         is_channels_last_3d_ = false;

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1821,8 +1821,10 @@ class TestSparse(TestCase):
         test_shape([2, 3, 4], [0, 4, 5, 6], [9, 12])
 
         sparse_tensor, _, _ = self._gen_sparse(len([2, 3]), 9, [2, 3] + [5, 6], dtype, device, coalesced)
-        data = (sparse_tensor, sparse_tensor, sparse_tensor, sparse_tensor.unsqueeze(0))
-        mem_formats = [torch.channels_last, torch.contiguous_format, torch.preserve_format, torch.channels_last_3d]
+        data = (sparse_tensor, sparse_tensor, sparse_tensor,
+                sparse_tensor.to_dense().reshape([2 * 3, 5, 6]).to_sparse(), sparse_tensor.unsqueeze(0))
+        mem_formats = [torch.channels_last, torch.contiguous_format, torch.preserve_format,
+                       torch.channels_last_1d, torch.channels_last_3d]
         for x, mem_format in zip(data, mem_formats):
 
             with self.assertRaisesRegex(RuntimeError, "memory format option is only supported by strided tensors"):
@@ -1858,8 +1860,10 @@ class TestSparse(TestCase):
         self.assertEqual(result.dense_dim(), sparse_tensor.dense_dim())
 
         sparse_tensor, _, _ = self._gen_sparse(len([2, 3]), 9, [2, 3] + [5, 6], dtype, device, coalesced)
-        data = (sparse_tensor, sparse_tensor, sparse_tensor, sparse_tensor.unsqueeze(0))
-        mem_formats = [torch.channels_last, torch.contiguous_format, torch.preserve_format, torch.channels_last_3d]
+        data = (sparse_tensor, sparse_tensor, sparse_tensor,
+                sparse_tensor.to_dense().reshape([2 * 3, 5, 6]).to_sparse(), sparse_tensor.unsqueeze(0))
+        mem_formats = [torch.channels_last, torch.contiguous_format, torch.preserve_format,
+                       torch.channels_last_1d, torch.channels_last_3d]
         for x, mem_format in zip(data, mem_formats):
 
             with self.assertRaisesRegex(RuntimeError, "memory format option is only supported by strided tensors"):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7521,7 +7521,7 @@ else:
     def _test_memory_format_transformations(self, device, input_generator_fn, transformation_fn,
                                             memory_format, compare_data=True, default_is_preserve=False):
 
-        assert(memory_format == torch.channels_last_1d or 
+        assert(memory_format == torch.channels_last_1d or
                memory_format == torch.channels_last or
                memory_format == torch.channels_last_3d)
 

--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -30,6 +30,7 @@ void initializeMemoryFormats() {
 
   _ADD_MEMORY_FORMAT(at::MemoryFormat::Preserve, "preserve_format");
   _ADD_MEMORY_FORMAT(at::MemoryFormat::Contiguous, "contiguous_format");
+  _ADD_MEMORY_FORMAT(at::MemoryFormat::ChannelsLast1d, "channels_last_1d");
   _ADD_MEMORY_FORMAT(at::MemoryFormat::ChannelsLast, "channels_last");
   _ADD_MEMORY_FORMAT(at::MemoryFormat::ChannelsLast3d, "channels_last_3d");
 


### PR DESCRIPTION
1. enable channels last 1d support
2. example:
>>> import torch
>>> N, C, L = 10, 3, 32
>>> x = torch.empty(N, C, L)
>>> cl_x = x.to(memory_format=torch.channels_last)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: required rank 4 tensor to use channels_last format
>>> cl_x = x.to(memory_format=torch.channels_last_1d)
>>> print(cl_x.is_contiguous(memory_format=torch.channels_last_1d))
True
>>> print(cl_x.shape)
torch.Size([10, 3, 32])
>>> print(cl_x.stride())
(96, 1, 3)
>>>