### PR TITLE
trt engine inspector demo

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -148,6 +148,7 @@ class TRTInterpreter(torch.fx.Interpreter):
         strict_type_constraints=False,
         algorithm_selector=None,
         timing_cache=None,
+        profiling_verbosity=None,
     ) -> TRTInterpreterResult:
         # For float outputs, we set their dtype to fp16 only if fp16_mode=True and
         # force_fp32_output=False.
@@ -174,6 +175,7 @@ class TRTInterpreter(torch.fx.Interpreter):
             cache = builder_config.create_timing_cache(b"")
         builder_config.set_timing_cache(cache, False)
 
+        builder_config.profiling_verbosity = profiling_verbosity if profiling_verbosity else trt.ProfilingVerbosity.LAYER_NAMES_ONLY
         if fp16_mode:
             builder_config.set_flag(trt.BuilderFlag.FP16)
 


### PR DESCRIPTION
Summary: Starting from TensorRT 8.2, we have this nice engine inspector which gives you much details of trt layer.

Test Plan:
```
buck run  mode/opt -c python.package_style=inplace scripts/yinghai/test:trt_engine_inspector
```
And you will see something like
```
{"Layers": [{
  "Name": "PWN(PWN(relu_1), add_1)",
  "LayerType": "PointWiseV2",
  "Inputs": [
  {
    "Name": "x",
    "Dimensions": [10,2],
    "Format/Datatype": "Row major linear FP16 format"
  }],
  "Outputs": [
  {
    "Name": "(Unnamed Layer* 1) [ElementWise]_output",
    "Dimensions": [10,2],
    "Format/Datatype": "Row major linear FP16 format"
  }],
  "ParameterType": "PointWise",
  "ParameterSubType": "PointWiseExpression",
  "NbInputArgs": 1,
  "InputArgs": ["arg0"],
  "NbOutputVars": 1,
  "OutputVars": ["var1"],
  "NbParams": 0,
  "Params": [],
  "NbLiterals": 4,
  "Literals": ["0.000000e+00f", "1.000000e+00f", "0.000000e+00f", "0.000000e+00f"],
  "NbOperations": 2,
  "Operations": ["const auto var0 = pwgen::iMax(arg0, literal0);", "const auto var1 = pwgen::iPlus(arg0, var0);"],
  "TacticValue": "0x0"
},{
  "Name": "matmul_1",
  "LayerType": "MatrixMultiply",
  "Inputs": [
  {
    "Name": "(Unnamed Layer* 1) [ElementWise]_output",
    "Dimensions": [10,2],
    "Format/Datatype": "Row major linear FP16 format"
  },
  {
    "Name": "y",
    "Dimensions": [10,2],
    "Format/Datatype": "Row major linear FP16 format"
  }],
  "Outputs": [
  {
    "Name": "output0",
    "Dimensions": [10],
    "Format/Datatype": "Row major linear FP16 format"
  }],
  "ParameterType": "MatrixMultiply",
  "MatrixOpA": "VECTOR",
  "MatrixOpB": "VECTOR",
  "Alpha": 1,
  "Beta": 0,
  "TacticValue": "0x1"
}],
"Bindings": ["x"
,"y"
,"output0"
]}
```

Differential Revision: D31681405

