### PR TITLE
[TensorExpr] Add missing schema for aten::where and aten::pow lowerings.

### DIFF
--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -712,7 +712,8 @@ RegisterNNCLoweringsFunction aten_type_as(
 
 RegisterNNCLoweringsFunction aten_pow(
     {"aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> (Tensor)",
-     "aten::pow.Tensor_Tensor(Tensor self, Tensor exponent) -> (Tensor)"},
+     "aten::pow.Tensor_Tensor(Tensor self, Tensor exponent) -> (Tensor)",
+     "aten::pow.Scalar(Scalar self, Tensor exponent) -> Tensor"},
     [](const std::vector<ArgValue>& inputs,
        const std::vector<ExprHandle>& outputShape,
        const c10::optional<ScalarType>& outputType,

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -1230,7 +1230,8 @@ RegisterNNCLoweringsFunction aten_threshold(
 RegisterNNCLoweringsFunction aten_where(
     {"aten::where.ScalarOther(Tensor condition, Tensor self, Scalar other) -> (Tensor)",
      "aten::where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> (Tensor)",
-     "aten::where.self(Tensor condition, Tensor self, Tensor other) -> (Tensor)"},
+     "aten::where.self(Tensor condition, Tensor self, Tensor other) -> (Tensor)",
+     "aten::where.Scalar(Tensor condition, Scalar self, Scalar other) -> Tensor"},
     [](const std::vector<ArgValue>& inputs,
        const std::vector<ExprHandle>& outputShape,
        const c10::optional<ScalarType>& outputType,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66688



Differential Revision: [D31689431](https://our.internmc.facebook.com/intern/diff/D31689431)