### PR TITLE
[PyTorch][easy] Fix missing move in UnionType::createWithContained

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -126,7 +126,7 @@ struct TORCH_API UnionType : public Type {
   }
 
   TypePtr createWithContained(std::vector<TypePtr> contained_types) const override {
-    return create(contained_types);
+    return create(std::move(contained_types));
   }
 
   bool canHoldType(TypePtr type) const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66691

Does what it says on the tin.

Differential Revision: [D31691627](https://our.internmc.facebook.com/intern/diff/D31691627/)