### PR TITLE
[Static Runtime] Determine function for `ProcessedNode::run()` statically

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -472,11 +472,11 @@ class TORCH_API ProcessedNode {
   std::vector<IValue> clone_inputs() const;
 
   bool has_out_variant() const {
-    return fn_.index() == 0;
+    return function_kind_ == FunctionKind::kOutVariant;
   }
 
   bool has_native() const {
-    return fn_.index() == 1;
+    return function_kind_ == FunctionKind::kNativeFunction;
   }
 
   bool verify_no_memory_overlap() const;
@@ -486,12 +486,14 @@ class TORCH_API ProcessedNode {
   }
 
  private:
-  void run_impl();
-
   Node* node_;
-  using OutVariant = std::function<void(ProcessedNode*)>;
-  using NativeFunction = std::function<void(ProcessedNode*)>;
-  c10::variant<OutVariant, NativeFunction, Operation> fn_;
+  enum class FunctionKind {
+    kOutVariant,
+    kNativeFunction,
+    kInterpreterFallback,
+  };
+  FunctionKind function_kind_;
+  std::function<void(ProcessedNode*)> fn_;
   std::unique_ptr<const IValue*[]> inputs_; // unowned
   std::unique_ptr<IValue[]> outputs_;
   size_t inputs_size_;


### PR DESCRIPTION
Summary:
Currently `ProcessedNode::run()` performs 2 dynamic dispatches to decide which function implementation to execute depending on if the function is an out variant / native / or interpreter fallback. Note that this is happening every time an operation is executed by Static Runtime dynamically.

This change makes *that* same decision during module loading time once so that we can remove 1 dynamic dispatch cost at runtime.

**size reduction**

Saving 4 bytes per `ProcessedNode`.

- Before: sizeof(c10::variant<OutVariant, NativeFunction, Operation>):40

- After: sizeof(std::function<void(ProcessedNode*)>): 32 + sizeof(FunctionKind):4 = 36

**latency optimization**

Expected to remove 2 memory loads & 1 conditional jump per `ProcessedNode::run()` execution (needs to be confirmed from compiled binary code).

Ran `ptvsc2_predictor_bench` with `inline_cvr` with 1000 iterations:
- local : 7.56026 -> 7.24794
- local_ro: 1.5799. -> 1.55504.
- remote_ro: 10.6464 -> 10.3017

Test Plan: Ran existing unittests

Reviewed By: swolchok

Differential Revision: D31591785

