### PR TITLE
[PyTorch] Avoid refcount bump in UnionType::canHoldType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -129,7 +129,7 @@ struct TORCH_API UnionType : public Type {
     return create(contained_types);
   }
 
-  bool canHoldType(TypePtr type) const;
+  bool canHoldType(const Type& type) const;
 
   bool hasFreeVariables() const override {
     return has_free_variables_;

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -188,7 +188,7 @@ NoneStatus canBeNone(Value* v) {
   }
   if (v->type()->kind() == OptionalType::Kind ||
       (v->type()->kind() == UnionType::Kind &&
-       v->type()->expect<UnionType>()->canHoldType(NoneType::get()))) {
+       v->type()->expect<UnionType>()->canHoldType(*NoneType::get()))) {
     return MAYBE;
   }
   return NEVER;
@@ -3354,7 +3354,7 @@ struct to_ir {
         // has the type Optional[T]
         if ((type->kind() == OptionalType::Kind ||
              (type->kind() == UnionType::Kind &&
-              type->expect<UnionType>()->canHoldType(NoneType::get()))) &&
+              type->expect<UnionType>()->canHoldType(*NoneType::get()))) &&
             expr->type()->isSubtypeOf(*NoneType::get())) {
           Node* none = graph->createNone();
           none->output()->setType(type);

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -789,7 +789,7 @@ bool Value::mustNotBeNone() const {
   return node_->kind() != prim::AutogradAdd && type() != NoneType::get() &&
       !type()->cast<OptionalType>() &&
       !(type()->cast<UnionType>() &&
-        type()->expect<UnionType>()->canHoldType(NoneType::get()));
+        type()->expect<UnionType>()->canHoldType(*NoneType::get()));
 }
 
 std::string Value::debugNameBase() const {

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -111,7 +111,7 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
       case UnionType::Kind: {
         auto t = w.static_type->expect<UnionType>();
         if (t->containedTypes().size() == 2 &&
-            t->canHoldType(NoneType::get())) {
+            t->canHoldType(*NoneType::get())) {
           if (!w.value.isNone()) {
             auto inner = t->containedTypes()[0] != NoneType::get()
                 ? t->containedTypes()[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66693

Passing a `TypePtr` by value causes an unnececssary refcount
bump. We don't need to take ownership, so `const Type&` is all we
need.

I considered providing a compatibility shim that takes `const
TypePtr&`, but doing so is dangerous because a
copy is required to convert from a more specific pointer like
`NoneTypePtr`.

Differential Revision: [D31691869](https://our.internmc.facebook.com/intern/diff/D31691869/)