### PR TITLE
[TS] Return early if device doesn't match

### DIFF
--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -23,6 +23,10 @@ bool tensorEqual(const at::Tensor& lhs, const at::Tensor& rhs) {
   if (lhs.is_mkldnn() || rhs.is_mkldnn()) {
     return false;
   }
+  // If device is not equal, lhs.equal(rhs) would throw an error.
+  if (lhs.device() != rhs.device()) {
+    return false;
+  }
   return lhs.options().type_equal(rhs.options()) && lhs.equal(rhs);
 }
 


### PR DESCRIPTION
Summary: `lhs.equal(rhs)` would throw if the device doesn't match. To avoid that we return early if the device doesn't match.

Test Plan: CI

Differential Revision: D31691608

