### PR TITLE
[PyTorch] Fix missing move in OptionalType::createWithContained

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -190,7 +190,7 @@ struct TORCH_API OptionalType : public UnionType {
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
     AT_ASSERT(contained_types.size() == 1);
-    return create(contained_types[0]);
+    return create(std::move(contained_types[0]));
   }
 
   bool isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const override;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66697

We own this vector, so we can move from it.

Differential Revision: [D31693230](https://our.internmc.facebook.com/intern/diff/D31693230/)