### PR TITLE
[PyTorch] Pass c10::optional<bool> to Stride ctor by value

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -243,7 +243,7 @@ struct TORCH_API Stride {
   Stride() {}
   Stride(
       const c10::optional<size_t>& stride_index,
-      const c10::optional<bool>& contiguous,
+      c10::optional<bool> contiguous,
       const c10::optional<size_t>& stride)
       : stride_index_(stride_index), contiguous_(contiguous), stride_(stride) {}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66698

this type should fit in a register; no need to pass by reference.

Differential Revision: [D31693291](https://our.internmc.facebook.com/intern/diff/D31693291/)