### PR TITLE
[PyTorch][easy] Don't copy string in TensorType::repr_str unnecessarily

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -591,7 +591,11 @@ struct TORCH_API TensorType : public Type {
   std::string str() const override;
 
   std::string repr_str() const override {
-    return str() + (isInferredType() ? " (inferred)" : "");
+    if (isInferredType()) {
+      return str() + " (inferred)";
+    } else {
+      return str();
+    }
   }
 
   c10::optional<size_t> numel() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66699

std::string::operator+ will copy the string an extra time even if the argument is `""`. See https://godbolt.org/z/3sM5h1qTo

Differential Revision: [D31693522](https://our.internmc.facebook.com/intern/diff/D31693522/)