### PR TITLE
[ONNX] Support exporting with Apex O2 (#65374)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -65,6 +65,24 @@ class TestONNXRuntime_cuda(unittest.TestCase):
         target[target == 1] = -100
         self.run_test(FusionModel(), (input, target))
 
+    @skipIfNoCuda
+    @disableScriptTest()
+    def test_apex_o2(self):
+        class LinearModel(torch.nn.Module):
+            def __init__(self):
+                super(LinearModel, self).__init__()
+                self.linear = torch.nn.Linear(3, 5)
+
+            def forward(self, x):
+                return self.linear(x)
+        try:
+            from apex import amp
+        except Exception:
+            raise unittest.SkipTest("Apex is not available")
+        input = torch.randn(3, 3, device=torch.device("cuda"))
+        model = amp.initialize(LinearModel(), opt_level="O2")
+        self.run_test(model, input)
+
 TestONNXRuntime_cuda.setUp = TestONNXRuntime.setUp
 TestONNXRuntime_cuda.run_test = TestONNXRuntime.run_test
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -70,6 +70,36 @@ def select_model_mode_for_export(model, mode):
         if not isinstance(model, torch.jit.ScriptFunction):
             model.train(is_originally_training)
 
+@contextlib.contextmanager
+def disable_apex_o2_state_dict_hook(model):
+    # Apex O2 hook state_dict to return fp16 weights as fp32.
+    # Exporter cannot identify them as same tensors.
+    # Since this hook is only used by optimizer, it is safe to
+    # remove this hook while exporting.
+    if not isinstance(model, torch.jit.ScriptFunction):
+        tmp_map = {}  # type: ignore[var-annotated]
+        for module in model.modules():
+            for k, v in module._state_dict_hooks.items():
+                if type(v).__name__ == 'O2StateDictHook':
+                    if module not in tmp_map:
+                        tmp_map[module] = {}
+                    tmp_map[module][k] = v
+            if module in tmp_map:
+                for k in tmp_map[module].keys():
+                    module._state_dict_hooks.pop(k)
+    try:
+        yield
+    finally:
+        if not isinstance(model, torch.jit.ScriptFunction):
+            for module, m_map in tmp_map.items():
+                for k, v in m_map.items():
+                    module._state_dict_hooks[k] = v
+
+@contextlib.contextmanager
+def exporter_context(model, mode):
+    with select_model_mode_for_export(model, mode) as mode_ctx, \
+            disable_apex_o2_state_dict_hook(model) as apex_ctx:
+        yield (mode_ctx, apex_ctx)
 
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
@@ -593,7 +623,7 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
     _set_operator_export_type(operator_export_type)
     from torch.onnx.symbolic_helper import _set_onnx_shape_inference
     _set_onnx_shape_inference(onnx_shape_inference)
-    with select_model_mode_for_export(model, training):
+    with exporter_context(model, training):
         val_keep_init_as_ip = _decide_keep_init_as_input(keep_initializers_as_inputs,
                                                          operator_export_type,
                                                          opset_version)
@@ -649,7 +679,7 @@ def _find_missing_ops_onnx_export(model, args, f, verbose=False, training=Traini
     # operator_export_type is set ro ONNX_FALLTHROUGH by default so that if an op is not supported
     # in ONNX, fall through will occur and export the operator as is, as a custom ONNX op.
     operator_export_type = OperatorExportTypes.ONNX_FALLTHROUGH
-    with select_model_mode_for_export(model, training):
+    with exporter_context(model, training):
         args = _decide_input_format(model, args)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type)
@@ -698,7 +728,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
         # (to preserve whatever the original training mode was.)
         _set_opset_version(opset_version)
         _set_operator_export_type(operator_export_type)
-        with select_model_mode_for_export(model, training):
+        with exporter_context(model, training):
             val_keep_init_as_ip = _decide_keep_init_as_input(keep_initializers_as_inputs,
                                                              operator_export_type,
                                                              opset_version)


### PR DESCRIPTION
Apex O2 hook state_dict to return fp16 weights as fp32. Exporter cannot identify them as same tensors.
Since this hook is only used by optimizer, it is safe to remove this hook while exporting.
