### PR TITLE
[PyTorch] Fix missing moves in ListType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -793,7 +793,7 @@ struct TORCH_API ListType
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
-    return create(contained_types.at(0));
+    return create(std::move(contained_types.at(0)));
   }
 
   bool isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const override;

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -808,7 +808,7 @@ struct TORCH_API ListType
   static ListTypePtr ofStrings();
 
  private:
-  ListType(TypePtr elem) : SingleElementType(elem) {}
+  ListType(TypePtr elem) : SingleElementType(std::move(elem)) {}
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
     std::stringstream ss;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66701

We own the argument vector.

Differential Revision: [D31693645](https://our.internmc.facebook.com/intern/diff/D31693645/)