### PR TITLE
Binaries without AVX512 kernels shouldn't report CPU Capability as AVX512 on machines with AVX512 support

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -20,8 +20,8 @@ static CPUCapability compute_cpu_capability() {
     // If PyTorch wasn't built with AVX512 support, setting ATEN_CPU_CAPABILITY
     // as AVX512 shouldn't result in the CPU capability being set as AVX512.
     if (strcmp(envar, "avx512") == 0) {
-    // If an Intel KNL user sets ATEN_CPU_CAPABILITY as AVX512, it shouldn't be
-    // set as KNL doesn't support all AVX512 instruction sets.
+      // If an Intel KNL user sets ATEN_CPU_CAPABILITY as AVX512, it shouldn't
+      // be set as KNL doesn't support all AVX512 instruction sets.
       if (cpuinfo_initialize()) {
         if (cpuinfo_has_x86_avx512vl() && cpuinfo_has_x86_avx512bw() &&  \
             cpuinfo_has_x86_avx512dq() && cpuinfo_has_x86_fma3()) {

--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -17,17 +17,8 @@ static CPUCapability compute_cpu_capability() {
     }
 #else
 #ifdef HAVE_AVX512_CPU_DEFINITION
-    // If PyTorch wasn't built with AVX512 support, setting ATEN_CPU_CAPABILITY
-    // as AVX512 shouldn't result in the CPU capability being set as AVX512.
     if (strcmp(envar, "avx512") == 0) {
-      // If an Intel KNL user sets ATEN_CPU_CAPABILITY as AVX512, it shouldn't
-      // be set as KNL doesn't support all AVX512 instruction sets.
-      if (cpuinfo_initialize()) {
-        if (cpuinfo_has_x86_avx512vl() && cpuinfo_has_x86_avx512bw() &&  \
-            cpuinfo_has_x86_avx512dq() && cpuinfo_has_x86_fma3()) {
-          return CPUCapability::AVX512;
-        }
-      }
+      return CPUCapability::AVX512;
     }
 #endif
 #ifdef HAVE_AVX2_CPU_DEFINITION

--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -30,9 +30,11 @@ static CPUCapability compute_cpu_capability() {
       }
     }
 #endif
+#ifdef HAVE_AVX2_CPU_DEFINITION
     if (strcmp(envar, "avx2") == 0) {
       return CPUCapability::AVX2;
     }
+#endif
 #endif
     if (strcmp(envar, "default") == 0) {
       return CPUCapability::DEFAULT;

--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -54,9 +54,11 @@ static CPUCapability compute_cpu_capability() {
       return CPUCapability::AVX512;
     }
 #endif
+#ifdef HAVE_AVX2_CPU_DEFINITION
     if (cpuinfo_has_x86_avx2() && cpuinfo_has_x86_fma3()) {
       return CPUCapability::AVX2;
     }
+#endif
   }
 #endif
 #ifdef HAVE_VSX_CPU_DEFINITION


### PR DESCRIPTION
### BUG 
If a PyTorch binary is built with a compiler that doesn't support all the AVX512 intrinsics in the codebase, then it won't have ATen AVX512 kernels, but at runtime, CPU capability would still be incorrectly returned as AVX512 on a machine that supports AVX512. It seems that PyTorch Linux releases are done on CentOS with `gcc 7.3`, so this bug would manifest in the 1.10 release, unless a fix such as this one is added. gcc versions below 9.0 don't support all the AVX512 intrinsics in the codebase, such as `_mm512_set_epi16`.

### FIX 
CPU Capability would be returned as AVX512 at runtime only if the binary was built with a compiler that supports all the AVX512 intrinsics in the codebase, and if the hardware the binary is being run on supports all the required AVX512 instruction sets.