### PR TITLE
[PyTorch] Fix unnecessary shared_ptr copies in FutureType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -919,7 +919,7 @@ struct TORCH_API FutureType
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
-    return create(contained_types.at(0));
+    return create(std::move(contained_types.at(0)));
   }
 
   bool isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const override {
@@ -933,7 +933,7 @@ struct TORCH_API FutureType
   }
 
  private:
-  FutureType(TypePtr elem) : SingleElementType(elem) {}
+  FutureType(TypePtr elem) : SingleElementType(std::move(elem)) {}
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
     std::stringstream ss;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66704

Missing moves in the construction path.

Differential Revision: [D31694296](https://our.internmc.facebook.com/intern/diff/D31694296/)