### PR TITLE
[PyTorch] Fix unnecessary shared_ptr copies in RRefType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -961,11 +961,11 @@ struct TORCH_API RRefType
   }
   TypePtr createWithContained(
       std::vector<TypePtr> contained_types) const override {
-    return create(contained_types.at(0));
+    return create(std::move(contained_types.at(0)));
   }
 
  private:
-  RRefType(TypePtr elem) : SingleElementType(elem) {}
+  RRefType(TypePtr elem) : SingleElementType(std::move(elem)) {}
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
     std::stringstream ss;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66706

Missing moves in the construction path.

Differential Revision: [D31694356](https://our.internmc.facebook.com/intern/diff/D31694356/)