### PR TITLE
[PyTorch] Fix unnecessary shared_ptr copies in EnumType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1124,12 +1124,12 @@ struct TORCH_API EnumType : public NamedType {
     return str();
   }
 
-  TypePtr getValueType() const {
+  const TypePtr& getValueType() const {
     return value_type_;
   }
 
   bool operator==(const Type& rhs) const override {
-    if (auto enum_rhs = rhs.cast<EnumType>()) {
+    if (auto* enum_rhs = rhs.castRaw<EnumType>()) {
       return name().value() == enum_rhs->name().value() &&
           *getValueType() == *(enum_rhs->getValueType()) &&
           this->compilation_unit() == enum_rhs->compilation_unit();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66714

Forced copy in getValueType and unnecessary use of cast over castRaw.

Differential Revision: [D31696164](https://our.internmc.facebook.com/intern/diff/D31696164/)