### PR TITLE
[PyTorch] Fix extra refcount bumps in matchTypeVariables

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1905,7 +1905,7 @@ struct MatchTypeReturn {
 // in the formal to still not be defined. In particular, None matches Optional[T]
 // but does not define the value of T.
 TORCH_API MatchTypeReturn
-matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env);
+matchTypeVariables(const TypePtr& formal, const TypePtr& actual, TypeEnv& type_env);
 
 // replace type variables appearing in `type` with the values in
 // `type_env`. Returns nullptr if a variable used in `type`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66720
* __->__ #66719
* #66718

Some cast that could be castRaw. Parameters did not need to force a refcount bump.

Differential Revision: [D31697455](https://our.internmc.facebook.com/intern/diff/D31697455/)