### PR TITLE
Avoid inlining error reporting in checked_convert

### DIFF
--- a/c10/util/TypeCast.cpp
+++ b/c10/util/TypeCast.cpp
@@ -1,0 +1,11 @@
+#include <c10/util/TypeCast.h>
+
+namespace c10 {
+
+void report_overflow(const char* name) {
+  std::ostringstream oss;
+  oss << "value cannot be converted to type " << name << " without overflow";
+  throw std::runtime_error(oss.str()); // rather than domain_error (issue 33562)
+}
+
+} // namespace c10

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -173,15 +173,14 @@ To convert(From f) {
   return static_cast_with_inter_type<To, From>::apply(f);
 }
 
+// Define separately to avoid being inlined and prevent code-size bloat
+C10_API void report_overflow(const char* name);
+
 template <typename To, typename From>
 To checked_convert(From f, const char* name) {
   // Converting to bool can't overflow so we exclude this case from checking.
   if (!std::is_same<To, bool>::value && overflows<To, From>(f)) {
-    std::ostringstream oss;
-    oss << "value cannot be converted to type " << name
-        << " without overflow: " << f;
-    throw std::runtime_error(
-        oss.str()); // rather than domain_error (issue 33562)
+    report_overflow(name);
   }
   return convert<To, From>(f);
 }


### PR DESCRIPTION
**Summary:** Move the error reporting part to the cpp file to avoid callers inlining it, which inflates the generated code size. See https://github.com/pytorch/pytorch/issues/65830.

**Test Plan:** Compiling the simple program below now generates ~150 lines of assembly, compared to 700+ lines before.

```
#include <c10/core/Scalar.h>

void g(float) {}

void f(const c10::Scalar& scalar) {
    auto x = scalar.to<float>();
    g(x);
}
```

**Reviewers:** Edward Yang

**Subscribers:** Edward Yang, Yining Lu

**Tasks:** T103384490

**Tags:** pytorch

Fixes https://github.com/pytorch/pytorch/issues/65830