### PR TITLE
[PyTorch] Fix extra refcount bumps in tryEvalTypeVariables

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1910,7 +1910,7 @@ matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env);
 // replace type variables appearing in `type` with the values in
 // `type_env`. Returns nullptr if a variable used in `type`
 // does not appear in `type_env`
-TORCH_API TypePtr tryEvalTypeVariables(TypePtr type, TypeEnv& type_env);
+TORCH_API TypePtr tryEvalTypeVariables(const TypePtr& type, TypeEnv& type_env);
 
 TORCH_API bool elementTypeCanBeInferredFromMembers(const TypePtr& elem_type);
 

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -545,12 +545,12 @@ MatchTypeReturn matchTypeVariables(
 }
 
 // change return types like List[List[t]] into List[List[int]]
-TORCH_API TypePtr tryEvalTypeVariables(TypePtr type, std::unordered_map<std::string, TypePtr>& type_env) {
+TORCH_API TypePtr tryEvalTypeVariables(const TypePtr& type, std::unordered_map<std::string, TypePtr>& type_env) {
   if (!type->hasFreeVariables()) {
     return type;
   }
 
-  if (auto vt = type->cast<VarType>()) {
+  if (auto vt = type->castRaw<VarType>()) {
     auto it = type_env.find(vt->name());
     if (it == type_env.end()) {
       return nullptr;
@@ -564,7 +564,7 @@ TORCH_API TypePtr tryEvalTypeVariables(TypePtr type, std::unordered_map<std::str
       if (!r) {
         return nullptr;
       }
-      new_contained.push_back(r);
+      new_contained.push_back(std::move(r));
     }
     return type->withContained(std::move(new_contained));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66722

Missing move, s/cast/castRaw/, and take TypePtr arg by const ref because we only sometimes need to take ownership.

Differential Revision: [D31697631](https://our.internmc.facebook.com/intern/diff/D31697631/)