### PR TITLE
Enable warning tests for nondeterministic backward functions

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3888,7 +3888,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('avg_pool3d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('avg_pool3d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3900,7 +3900,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('adaptive_avg_pool2d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('adaptive_avg_pool2d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3912,7 +3912,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('adaptive_avg_pool3d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('adaptive_avg_pool3d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3924,7 +3924,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('max_pool3d_with_indices_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('max_pool3d_with_indices_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3936,7 +3936,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('adaptive_max_pool2d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('adaptive_max_pool2d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3948,7 +3948,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('fractional_max_pool2d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('fractional_max_pool2d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3960,7 +3960,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('fractional_max_pool3d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('fractional_max_pool3d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3975,7 +3975,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_linear1d_backward_out_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('upsample_linear1d_backward_out_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -3990,7 +3990,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_bilinear2d_backward_out_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('upsample_bilinear2d_backward_out_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4005,7 +4005,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_bicubic2d_backward_out_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('upsample_bicubic2d_backward_out_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4020,7 +4020,7 @@ else:
             align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('upsample_trilinear3d_backward_out_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('upsample_trilinear3d_backward_out_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4032,7 +4032,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('reflection_pad1d_backward_out_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('reflection_pad1d_backward_out_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4044,7 +4044,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('reflection_pad2d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('reflection_pad2d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4056,7 +4056,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('reflection_pad3d_backward_out_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('reflection_pad3d_backward_out_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4068,7 +4068,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('replication_pad1d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('replication_pad1d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4080,7 +4080,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('replication_pad2d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('replication_pad2d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4092,7 +4092,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('replication_pad3d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('replication_pad3d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4118,10 +4118,9 @@ else:
         res = module(input, target, input_lengths, target_lengths)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('ctc_loss_backward_gpu', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('ctc_loss_backward_gpu', ['cuda'])
         def backward_func(slf, device):
-            with warnings.catch_warnings(record=True) as w:
-                res.backward(grad)
+            res.backward(grad, retain_graph=True)
 
         backward_func(self, device)
 
@@ -4133,7 +4132,7 @@ else:
         res = module(input)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('embedding_bag_backward_cuda_max', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('embedding_bag_backward_cuda_max', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4245,7 +4244,7 @@ else:
             res = op_call(a, dim, index)
             grad = torch.ones_like(res)
 
-            @expectedAlertNondeterministic('scatter_add_cuda_kernel', ['cuda'], test_warning=False)
+            @expectedAlertNondeterministic('scatter_add_cuda_kernel', ['cuda'])
             def backward_func(slf, device):
                 res.backward(grad)
 
@@ -4260,7 +4259,7 @@ else:
         res = torch.nn.functional.grid_sample(input, grid, align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('grid_sampler_2d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('grid_sampler_2d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 
@@ -4272,7 +4271,7 @@ else:
         res = torch.nn.functional.grid_sample(input, grid, align_corners=False)
         grad = torch.ones_like(res)
 
-        @expectedAlertNondeterministic('grid_sampler_3d_backward_cuda', ['cuda'], test_warning=False)
+        @expectedAlertNondeterministic('grid_sampler_3d_backward_cuda', ['cuda'])
         def backward_func(slf, device):
             res.backward(grad)
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1071,24 +1071,13 @@ class expectedAlertNondeterministic:
     #       no others. If None, then the alert is expected to be triggered
     #       for all devices. Default: None
     #
-    # Keyword args:
-    #
-    #   test_warning (bool, optional): If True, tests warnings in addition
-    #       to errors. If False, only errors are tested. Default: True
-    #
-    # TODO: `test_warning=False` is only needed as a workaround for issue
-    #       https://github.com/pytorch/pytorch/issues/50209. Once CUDA
-    #       backward function warnings behave properly, we can remove this
-    #       argument and always test for warnings.
-    #
-    def __init__(self, caller_name, device_types=None, *, test_warning=True):
+    def __init__(self, caller_name, device_types=None):
         if device_types is not None:
             assert isinstance(device_types, list)
             for device_type in device_types:
                 assert isinstance(device_type, str)
         self.device_types = device_types
         self.error_message = caller_name + ' does not have a deterministic implementation, but you set'
-        self.test_warning = test_warning
 
     def __call__(self, fn):
         @wraps(fn)
@@ -1118,7 +1107,7 @@ class expectedAlertNondeterministic:
                         raise
 
             # Check that warnings are thrown correctly
-            if self.test_warning and should_alert:
+            if should_alert:
                 with DeterministicGuard(True, warn_only=True):
                     with slf.assertWarnsRegex(
                             UserWarning,


### PR DESCRIPTION
Followup from #66233

Since #50209 was fixed, we can enable these warning tests now

cc @mruberry @kurtamohler