### PR TITLE
[LTC] Add support for in-place operator variants

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -434,26 +434,6 @@ LazyTensor acosh(const LazyTensor& input) {
   return input.CreateFrom(ir::ops::Acosh(input.GetIrValue()));
 }
 
-LazyTensor add(const LazyTensor& input, const LazyTensor& other,
-               const at::Scalar& alpha,
-               c10::optional<at::ScalarType> logical_element_type) {
-  ir::Value constant = LazyTensor::GetIrValueForScalar(
-      alpha, other.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(input.GetIrValue() + other.GetIrValue() * constant,
-                          logical_element_type);
-}
-
-LazyTensor add(const LazyTensor& input, const at::Scalar& other,
-               const at::Scalar& alpha,
-               c10::optional<at::ScalarType> logical_element_type) {
-  ir::Value other_constant = LazyTensor::GetIrValueForScalar(
-      other, input.shape(), logical_element_type, input.GetDevice());
-  ir::Value alpha_constant = LazyTensor::GetIrValueForScalar(
-      alpha, input.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(input.GetIrValue() + other_constant * alpha_constant,
-                          logical_element_type);
-}
-
 LazyTensor addmm(const LazyTensor& input, const LazyTensor& weight,
                  const LazyTensor& bias) {
   return input.CreateFrom(ir::ops::AddMatMulOp(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -454,14 +454,6 @@ LazyTensor add(const LazyTensor& input, const at::Scalar& other,
                           logical_element_type);
 }
 
-void addcdiv_(LazyTensor& input, const at::Scalar& value,
-              const LazyTensor& tensor1, const LazyTensor& tensor2) {
-  ir::Value constant = LazyTensor::GetIrValueForScalar(
-      value, tensor1.shape().get().element_type(), input.GetDevice());
-  ir::Value div = tensor1.GetIrValue() / tensor2.GetIrValue();
-  input.SetInPlaceIrValue(input.GetIrValue() + div * constant);
-}
-
 LazyTensor addmm(const LazyTensor& input, const LazyTensor& weight,
                  const LazyTensor& bias) {
   return input.CreateFrom(ir::ops::AddMatMulOp(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
@@ -97,6 +97,14 @@ std::vector<c10::ScalarType> compute_dtype_bitwise_and(const at::Tensor& self, c
   return {self.scalar_type()};
 }
 
+std::vector<std::vector<int64_t>> compute_shape_bitwise_and_(at::Tensor& self, const at::Scalar& other) {
+  return {self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_bitwise_and_(at::Tensor& self, const at::Scalar& other) {
+  return {self.scalar_type()};
+}
+
 } // namespace ops
 } // namespace ir
 } // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
@@ -25,6 +25,25 @@ std::vector<c10::ScalarType> compute_dtype_dropout(const at::Tensor& input, doub
   return {input.scalar_type()};
 }
 
+std::vector<std::vector<int64_t>> compute_shape_add(const at::Tensor& self, const at::Scalar& other,
+    const at::Scalar& alpha) {
+  return {self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_add(const at::Tensor& self, const at::Scalar& other,
+    const at::Scalar& alpha) {
+  return {self.scalar_type()};
+}
+
+std::vector<std::vector<int64_t>> compute_shape_add_(at::Tensor & self, const at::Scalar & other,
+    const at::Scalar & alpha) {
+  return {self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_add_(at::Tensor & self, const at::Scalar & other, const at::Scalar & alpha) {
+  return {self.scalar_type()};
+}
+
 std::vector<std::vector<int64_t>> compute_shape_native_layer_norm(const at::Tensor & input,
     at::IntArrayRef normalized_shape, const c10::optional<at::Tensor> & weight, const c10::optional<at::Tensor> & bias,
     double eps) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -74,18 +74,6 @@ at::Tensor subtensor(const at::Tensor& tensor, int dim, int groups, int g) {
 
 }  // namespace
 
-at::Tensor LazyNativeFunctions::add(const at::Tensor& self,
-                                    const at::Tensor& other,
-                                    const at::Scalar& alpha) {
-  LTC_FN_COUNTER("lazy::");
-  at::native::alpha_check(at::result_type(self, other), alpha);
-  return DoBinaryOp(self, other,
-                    [&](const LazyTensor& xself, const LazyTensor& xother,
-                        at::ScalarType dtype) {
-                      return tensor_aten_ops::add(xself, xother, alpha, dtype);
-                    });
-}
-
 at::Tensor LazyNativeFunctions::addmm(const at::Tensor& self,
                                       const at::Tensor& mat1,
                                       const at::Tensor& mat2,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -86,17 +86,6 @@ at::Tensor LazyNativeFunctions::add(const at::Tensor& self,
                     });
 }
 
-at::Tensor& LazyNativeFunctions::addcdiv_(at::Tensor& self,
-                                         const at::Tensor& tensor1,
-                                         const at::Tensor& tensor2,
-                                         const at::Scalar& value) {
-  LTC_FN_COUNTER("lazy::");
-  LazyTensor self_tensor = bridge::GetLtcTensor(self);
-  tensor_aten_ops::addcdiv_(self_tensor, value, bridge::GetLtcTensor(tensor1),
-                            bridge::GetLtcTensor(tensor2));
-  return self;
-}
-
 at::Tensor LazyNativeFunctions::addmm(const at::Tensor& self,
                                       const at::Tensor& mat1,
                                       const at::Tensor& mat2,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -6,6 +6,7 @@ full_codegen:
   - _softmax
   - _softmax_backward_data
   - addcdiv
+  - addcdiv_
   - addcmul
   - bitwise_and.Scalar
   - bitwise_and.Tensor
@@ -24,7 +25,6 @@ full_codegen:
   - topk
 supported:
   - add.Tensor
-  - addcdiv_
   - as_strided
   - as_strided_
   - bernoulli

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -10,6 +10,8 @@ full_codegen:
   - addcmul
   - bitwise_and.Scalar
   - bitwise_and.Tensor
+  - bitwise_and_.Scalar
+  - bitwise_and_.Tensor
   - cos
   - clamp
   - dropout

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -5,6 +5,10 @@ full_codegen:
   - _log_softmax_backward_data
   - _softmax
   - _softmax_backward_data
+  - add.Scalar
+  - add.Tensor
+  - add_.Scalar
+  - add_.Tensor
   - addcdiv
   - addcdiv_
   - addcmul
@@ -26,7 +30,6 @@ full_codegen:
   - sigmoid
   - topk
 supported:
-  - add.Tensor
   - as_strided
   - as_strided_
   - bernoulli

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -94,7 +94,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
                            *, codegenInplaceVariant: bool = False) -> Iterator[str]:
         """
         We code-gen for the functional variant, which is all we need for IR classes/lowerings, but we only code-gen
-        additional entries for the inplace variant for the native function impl.
+        additional entries for the inplace variant for the native function and shape inference impl.
         """
         for x in xs:
             f = x.functional if isinstance(x, NativeFunctionsGroup) else x
@@ -174,7 +174,8 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
             'dispatch_namespace': backend_dispatch_key.lower(),
             'func_declarations': list(concat_map_codegen(
                 lambda f: dest.gen_lazy_shape_dtype_decl(f, backend_indices[backend_dispatch_key]),
-                grouped_native_functions
+                grouped_native_functions,
+                codegenInplaceVariant=True,
             )),
         })
 

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -98,13 +98,14 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         """
         for x in xs:
             f = x.functional if isinstance(x, NativeFunctionsGroup) else x
-            if f.func.name in full_codegen:
-                for r in func(f):
-                    yield r
+            if f.func.name in full_codegen and not f.func.name.name.inplace:
+                with local.parametrize(use_const_ref_for_mutable_tensors=f.use_const_ref_for_mutable_tensors):
+                    for r in func(f):
+                        yield r
 
             if codegenInplaceVariant:
-                inplace = x.inplace if isinstance(x, NativeFunctionsGroup) else None
-                if inplace and inplace.func.name in full_codegen:
+                inplace = x.inplace if isinstance(x, NativeFunctionsGroup) else x
+                if inplace and inplace.func.name in full_codegen and inplace.func.name.name.inplace:
                     with local.parametrize(use_const_ref_for_mutable_tensors=inplace.use_const_ref_for_mutable_tensors):
                         for r in func(inplace):
                             yield r

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -91,7 +91,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
 
     def concat_map_codegen(func: Callable[[NativeFunction], Sequence[str]],
                            xs: Iterable[Union[NativeFunctionsGroup, NativeFunction]],
-                           *, needsInplace:bool = False) -> Iterator[str]:
+                           *, needsInplace: bool = False) -> Iterator[str]:
         for x in xs:
             f = x.functional if isinstance(x, NativeFunctionsGroup) else x
             if f.func.name in full_codegen:
@@ -150,7 +150,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
                     class_method_name=f'{backend_dispatch_key}NativeFunctions',
                     node_base=node_base),
                 grouped_native_functions,
-                needsInplace = True,
+                needsInplace=True,
             )),
         })
 


### PR DESCRIPTION
Summary:
This commit teached the LTC code-gen engine about in-place operator variants and generated addcdiv_/bitwise_and_.Scalar/bitwise_and_.Tensor/add.Scalar/add.Tensor/add_.Scalar/add_.Tensor for validations.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestAddCDiv*:AtenLtcTsTensorTest.TestBitwiseAnd*:AtenLtcTsTensorTest.TestAdd*

Fixes #65576.
