### PR TITLE
use irange for loops

### DIFF
--- a/caffe2/ideep/operators/conv_pool_base_op.h
+++ b/caffe2/ideep/operators/conv_pool_base_op.h
@@ -53,7 +53,7 @@ class IDEEPConvPoolOpBase : public ConvPoolOpBase<IDEEPContext> {
 
   bool RunOnDevice() override {
     if (!global_pooling_) {
-      for (int dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE_GT(kernel_[dim], 0);
       }
     }

--- a/caffe2/ideep/operators/conv_transpose_unpool_base_op.h
+++ b/caffe2/ideep/operators/conv_transpose_unpool_base_op.h
@@ -109,7 +109,7 @@ class IDEEPConvTransposeUnpoolBase : public IDEEPOperator {
       CAFFE_ENFORCE_EQ(pads_.size(), 2 * kernel_.size());
     }
 
-    for (int dim = 0; dim < kernel_.size(); ++dim) {
+    for (const auto dim : c10::irange(kernel_.size())) {
       CAFFE_ENFORCE_GT(kernel_[dim], 0);
       CAFFE_ENFORCE_GT(stride_[dim], 0);
       CAFFE_ENFORCE_GE(adj_[dim], 0);
@@ -143,7 +143,7 @@ class IDEEPConvTransposeUnpoolBase : public IDEEPOperator {
     auto input_dims = input.get_dims();
     itensor::dims dims;
     dims.assign(input_dims.begin() + 2, input_dims.end());
-    for (int dim = 0; dim < dims.size(); ++dim) {
+    for (const auto dim : c10::irange(dims.size())) {
       int dim_size = 0;
       ComputeSizeAndPad(
           dims[dim],

--- a/caffe2/ideep/operators/operator_fallback_ideep.h
+++ b/caffe2/ideep/operators/operator_fallback_ideep.h
@@ -52,7 +52,7 @@ class IDEEPFallbackOp final : public IDEEPOperator {
     // Create output blobs in parent workspace,
     // then forward output blobs to local workspace.
     std::unordered_map<string, string> forwarded_output_blobs;
-    for (int i = 0; i < base_def_.output_size(); i++) {
+    for (const auto i : c10::irange(base_def_.output_size())) {
       // For in-place case, the in/output tensor for local_ws must be
       // re-created, instead of forwarding from current workspace.
       string parent_name(base_def_.output(i));
@@ -81,7 +81,7 @@ class IDEEPFallbackOp final : public IDEEPOperator {
   }
 
   bool RunOnDevice() override {
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       if (InputIsType<itensor>(i)
           && (Input(i).has_scale()
             || Input(i).get_data_type() == idtype::f32)) {
@@ -128,7 +128,7 @@ class IDEEPFallbackOp final : public IDEEPOperator {
       return false;
     }
 
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       if (SkipOutputCopy::Contains(i)) {
         VLOG(1) << "Copy output: index " << i << " skipped.";
         continue;

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -83,7 +83,7 @@ class IDEEPContext final : public BaseContext {
           static_cast<const void*>(src),
           static_cast<void*>(dst));
     } else {
-      for (size_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         dst[i] = src[i];
       }
     }

--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn_kernels.h
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn_kernels.h
@@ -523,7 +523,7 @@ kernel void col2im(
                 }
             } else {
                 half4 components(0, 0, 0, 0);
-                for (auto i = 0; i < 4; ++i) {
+                for (const auto i : c10::irange(4)) {
                     ushort c_col_i = n * divRoundUp(kernel_h * kernel_w * C, 4) * 4 + h_k * kernel_w * C +
                     w_k * C + c * 4 + i;
                     ushort c_col_i_z = c_col_i / 4;
@@ -826,7 +826,7 @@ kernel void concat(
   ushort2 gid_ = ushort2(gid.x, gid.y);
   half4 value;
   
-  for (int off = 0; off < 4; ++off) {
+  for (const auto off : c10::irange(4)) {
     ushort cur_channel = c * 4 + off;
     ushort cur_idx = 0;
     if (cur_channel >= C) {
@@ -1013,8 +1013,8 @@ kernel void roi_warp(texture2d_array<half, access::sample> ina[[texture(0), func
   const RoIT count = iy_upper * ix_upper;
 
   RoIT4 output_val = 0.0;
-  for (int iy = 0; iy < iy_upper; iy++) {
-    for (int ix = 0; ix < ix_upper; ix++) {
+  for (const auto iy : c10::irange(iy_upper)) {
+    for (const auto ix : c10::irange(ix_upper)) {
       const RoIT y =
           roi_start_h + ph * bin_size_h + iy * bin_size_h / static_cast<RoIT>(roi_bin_grid_h);
       const RoIT x =
@@ -1141,7 +1141,7 @@ kernel void channel_shuffle(
   const ushort c = gid.z - n * divRoundUp(C, 4);
   half4 value;
   ushort2 gid_ = gid.xy;
-  for (int off = 0; off < 4; ++off) {
+  for (const auto off : c10::irange(4)) {
     ushort cur_channel = c * 4 + off;
     if (cur_channel >= C) {
       break;

--- a/caffe2/mobile/contrib/libopencl-stub/include/CL/cl.hpp
+++ b/caffe2/mobile/contrib/libopencl-stub/include/CL/cl.hpp
@@ -1196,7 +1196,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, size_t<N>* param, long)
         return err;
     }
 
-    for(int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
         (*param)[i] = value[i];
     }
 

--- a/caffe2/operators/arg_ops.h
+++ b/caffe2/operators/arg_ops.h
@@ -1,13 +1,14 @@
 #ifndef CAFFE2_OPERATORS_ARG_OPS_H_
 #define CAFFE2_OPERATORS_ARG_OPS_H_
 
-#include <algorithm>
-#include <iterator>
-#include <vector>
-
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
+#include <c10/util/irange.h>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
 
 namespace caffe2 {
 
@@ -43,7 +44,7 @@ class ArgOp final : public Operator<Context> {
     Y_dims.reserve(ndim);
     int prev_size = 1;
     int next_size = 1;
-    for (int i = 0; i < axis_; ++i) {
+    for (const auto i : c10::irange(axis_)) {
       Y_dims.push_back(X_dims[i]);
       prev_size *= X_dims[i];
     }

--- a/caffe2/operators/assert_op.h
+++ b/caffe2/operators/assert_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -21,9 +22,9 @@ class AssertOp final : public Operator<Context> {
   bool DoRunWithType() {
     // Copy into CPU context for comparison
     cmp_tensor_.CopyFrom(Input(0));
-    auto* cmp_data = cmp_tensor_.template data<T>();
+    auto *const cmp_data = cmp_tensor_.template data<T>();
 
-    for (int64_t i = 0; i < cmp_tensor_.numel(); ++i) {
+    for (const auto i : c10::irange(cmp_tensor_.numel())) {
       CAFFE_ENFORCE((bool)cmp_data[i], [&]() {
         std::stringstream ss;
         ss << "Assert failed for element " << i

--- a/caffe2/operators/batch_gather_ops.h
+++ b/caffe2/operators/batch_gather_ops.h
@@ -80,7 +80,7 @@ class BatchGatherGradientOp final : public Operator<Context> {
     CAFFE_ENFORCE_GE(data.dim(), 2, "DATA should be at least 2-D");
     // Outer dimensions of input data and gradient should be the same
     // because they are preserved for gathers with axis > 0.
-    for (int acheck = 0; acheck < axis; acheck++) {
+    for (const auto acheck : c10::irange(axis)) {
       CAFFE_ENFORCE_EQ(
           data.size(acheck),
           grad.size(acheck),
@@ -105,7 +105,7 @@ class BatchGatherGradientOp final : public Operator<Context> {
     auto idx_inner_dims_product = indices.size_from_dim(axis);
     if (match_outer) {
       CAFFE_ENFORCE_GE(axis, 1, "Axis should be at least 1");
-      for (auto i = 0; i < axis; i++) {
+      for (const auto i : c10::irange(axis)) {
         CAFFE_ENFORCE_EQ(
             data.size(i),
             indices.size(i),
@@ -120,11 +120,11 @@ class BatchGatherGradientOp final : public Operator<Context> {
     gather_helper::check_indexarray_range<TInd>(
         idxs, N, src_indexing_axis_dim, false);
 
-    for (auto batch = 0; batch < outer_dims_product; ++batch) {
+    for (const auto batch : c10::irange(outer_dims_product)) {
       auto grad_batch_base = grad_data + batch * gathered_grad_batch_size;
       auto out_batch_base = out_data + batch * batch_size;
 
-      for (auto i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         auto idx = idxs[i];
         if (match_outer) {
           idx = idxs[batch * idx_inner_dims_product + i];

--- a/caffe2/operators/bisect_percentile_op.h
+++ b/caffe2/operators/bisect_percentile_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -74,11 +75,12 @@ class BisectPercentileOp final : public Operator<Context> {
     int feature_length = 0;
     int cur_index = 0;
 
-    for (int i = 0; i < num_features; ++i) {
+    for (const auto i : c10::irange(num_features)) {
       cur_index = i;
       feature_start_index = index[i];
       feature_length = pct_lens_[i];
-      for (int j = 0; j < batch_size; ++j) {
+      for (const auto j : c10::irange(batch_size)) {
+        (void)j; // Suppress unused variable warning
         pct_output[cur_index] = compute_percentile(
             pct_raw_.begin() + feature_start_index,
             pct_mapping_.begin() + feature_start_index,

--- a/caffe2/operators/byte_weight_dequant_op.h
+++ b/caffe2/operators/byte_weight_dequant_op.h
@@ -25,7 +25,7 @@ class ByteWeightDequantOp : public Operator<Context> {
     auto* Y = Output(0, shape_, at::dtype<float>());
     float bin_interval = (max_ - min_) / 255.0;
     int total = 1;
-    for (auto i = 0U; i < shape_.size(); i++) {
+    for (const auto i : c10::irange(0U, shape_.size())) {
       total *= Y->size(i);
     }
     const uint8_t* Xdata;

--- a/caffe2/operators/cast_op.h
+++ b/caffe2/operators/cast_op.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -41,7 +42,7 @@ class CastOp : public Operator<Context> {
     const auto* data = input.template data<SrcType>();
     auto* out = output->template mutable_data<DstType>();
     auto N = input.size();
-    for (int64_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       out[i] = static_cast<DstType>(data[i]);
     }
     return true;

--- a/caffe2/operators/ceil_op.h
+++ b/caffe2/operators/ceil_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -17,11 +18,11 @@ class CeilOp final : public Operator<Context> {
   bool RunOnDevice() override {
     auto& X = Input(0);
 
-    auto* Y = Output(0, X.sizes(), at::dtype<float>());
+    auto *const Y = Output(0, X.sizes(), at::dtype<float>());
 
-    const float* Xdata = X.template data<float>();
-    float* Ydata = Y->template mutable_data<float>();
-    for (int i = 0; i < X.numel(); ++i) {
+    const float *const Xdata = X.template data<float>();
+    float *const Ydata = Y->template mutable_data<float>();
+    for (const auto i : c10::irange(X.numel())) {
       Ydata[i] = std::ceil(Xdata[i]);
     }
     return true;

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -1,15 +1,16 @@
 #ifndef CAFFE2_OPERATORS_CONV_POOL_OP_BASE_H_
 #define CAFFE2_OPERATORS_CONV_POOL_OP_BASE_H_
 
-#include <algorithm>
-#include <vector>
-
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
 #include "caffe2/proto/caffe2_legacy.pb.h"
 #include "caffe2/utils/math.h"
+
+#include <algorithm>
+#include <vector>
 
 // This macro is here just to allow us to experiment with padding values that
 // determines, when we have an odd number of pads, which side gets the one
@@ -139,7 +140,7 @@ class ConvPoolOpBase : public Operator<Context> {
     }
 
     if (global_pooling_) {
-      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE(
             pads_[2 * dim] == 0 && pads_[2 * dim + 1] == 0 &&
                 dilation_[dim] == 1 && stride_[dim] == 1,
@@ -152,7 +153,7 @@ class ConvPoolOpBase : public Operator<Context> {
     // need to clean this up.
     if (operator_def.name().find("Conv") == 0 ||
         operator_def.name().find("Pool") != std::string::npos) {
-      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE_GE(pads_[dim], 0);
         CAFFE_ENFORCE_GE(pads_[kernel_.size() + dim], 0);
         CAFFE_ENFORCE(
@@ -162,7 +163,7 @@ class ConvPoolOpBase : public Operator<Context> {
       }
     }
 
-    for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+    for (const auto dim : c10::irange(kernel_.size())) {
       CAFFE_ENFORCE_GE(kernel_[dim], 0);
       CAFFE_ENFORCE_GE(dilation_[dim], 0);
       CAFFE_ENFORCE_GE(stride_[dim], 0);
@@ -281,7 +282,7 @@ class ConvPoolOpBase : public Operator<Context> {
       std::copy_n(input_dims.cbegin() + offset, ndim, kernel->begin());
       std::fill_n(output_dims->begin() + offset, ndim, 1LL);
     } else {
-      for (int i = 0; i < ndim; ++i) {
+      for (const auto i : c10::irange(ndim)) {
         ComputeSizeAndPad(
             input_dims[i + offset],
             stride[i],
@@ -320,7 +321,7 @@ class ConvPoolOpBase : public Operator<Context> {
       std::copy_n(input_dims.cbegin() + offset, ndim, kernel->begin());
       std::fill_n(output_dims->begin() + offset, ndim, 1LL);
     } else {
-      for (int i = 0; i < ndim; ++i) {
+      for (const auto i : c10::irange(ndim)) {
         ComputeSizeAndPad64(
             input_dims[i + offset],
             stride[i],
@@ -342,7 +343,7 @@ class ConvPoolOpBase : public Operator<Context> {
     } else if (legacy_pad_ != LegacyPadding::NOTSET) {
       int output_unused;
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (int dim = 0; dim < dims.size(); ++dim) {
+      for (const auto dim : c10::irange(dims.size())) {
         ComputeSizeAndPad(
             dims[dim],
             stride_[dim],
@@ -381,7 +382,7 @@ class ConvPoolOpBase : public Operator<Context> {
       reset_tensor_device_ = true;
     } else {
       const int* tensor_data = tensor->template data<int>();
-      for (int d_i = 0; d_i < data.size(); ++d_i) {
+      for (const auto d_i : c10::irange(data.size())) {
         if (tensor_data[d_i] != data[d_i]) {
           reset_tensor_device_ = true;
           break;
@@ -411,7 +412,7 @@ class ConvPoolOpBase : public Operator<Context> {
 
   bool RunOnDevice() override {
     if (!global_pooling_) {
-      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
+      for (const auto dim : c10::irange(kernel_.size())) {
         CAFFE_ENFORCE_GT(kernel_[dim], 0);
       }
     }

--- a/caffe2/operators/conv_transpose_op_impl.h
+++ b/caffe2/operators/conv_transpose_op_impl.h
@@ -78,7 +78,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
         buffer_shape,
         at::dtype<T>().device(Context::GetDeviceType()));
     T* col_buffer_data = col_buffer->template mutable_data<T>();
-    for (int image_id = 0; image_id < N; ++image_id) {
+    for (const auto image_id : c10::irange(N)) {
       // Weight term
       if (G == 1) {
         math::Gemm<T, Context>(
@@ -231,7 +231,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
         buffer_shape,
         at::dtype<T>().device(Context::GetDeviceType()));
     T* col_buffer_data = col_buffer_.template mutable_data<T>();
-    for (int image_id = 0; image_id < N; ++image_id) {
+    for (const auto image_id : c10::irange(N)) {
       // Weight term
       if (G == 1) {
         math::Gemm<T, Context>(
@@ -247,7 +247,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
             col_buffer_data,
             &context_);
       } else {
-        for (int group_id = 0; group_id < G; ++group_id) {
+        for (const auto group_id : c10::irange(G)) {
           math::GemmEx<T, Context>(
               CblasNoTrans,
               CblasNoTrans,
@@ -374,7 +374,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       at::dtype<T>().device(Context::GetDeviceType()));
   T* col_buffer_data = col_buffer_.template mutable_data<T>();
 
-  for (int image_id = 0; image_id < N; ++image_id) {
+  for (const auto image_id : c10::irange(N)) {
     // gradient w.r.t. filters. Im2Col followed by Gemm
     // Im2Col.
     math::Im2Col<T, Context, StorageOrder::NCHW>(
@@ -539,7 +539,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
       at::dtype<T>().device(Context::GetDeviceType()));
   T* col_buffer_data = col_buffer_.template mutable_data<T>();
 
-  for (int image_id = 0; image_id < N; ++image_id) {
+  for (const auto image_id : c10::irange(N)) {
     // gradient w.r.t. filters. Im2Col followed by Gemm
     // Im2Col.
     math::Im2Col<T, Context, StorageOrder::NHWC>(
@@ -575,7 +575,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
           dfilter_data,
           &context_);
     } else {
-      for (int group_id = 0; group_id < G; ++group_id) {
+      for (const auto group_id : c10::irange(G)) {
         math::GemmEx<T, Context>(
             CblasTrans,
             CblasNoTrans,
@@ -610,7 +610,7 @@ bool ConvTransposeGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
             dX_data + image_id * M * X_HxW,
             &context_);
       } else {
-        for (int group_id = 0; group_id < G; ++group_id) {
+        for (const auto group_id : c10::irange(G)) {
           math::GemmEx<T, Context>(
               CblasNoTrans,
               CblasTrans,

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -76,7 +76,7 @@ void runTileContiguous(
   int colBlockSize = (W + kernelW / strideW);
   int numColBlocks = strideW;
 
-  for (int c = 0; c < kernelDataSize; ++c) {
+  for (const auto c : c10::irange(kernelDataSize)) {
     int w_offset = c % kernelW;
     int h_offset = (c / kernelW) % kernelH;
     int c_im = c / kernelH / kernelW;
@@ -276,13 +276,13 @@ void reinterleaveRows(
     float32x4_t v0[kStrideW];
     float32x4_t v1[kStrideW];
 
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v0[i] = vld1q_f32(src + i * colBlockSize);
       v1[i] = vld1q_f32(src + i * colBlockSize + 4);
     }
 
     // add per-channel bias
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v0[i] = vaddq_f32(v0[i], biasV);
       v1[i] = vaddq_f32(v1[i], biasV);
     }
@@ -300,12 +300,12 @@ void reinterleaveRows(
   for (; w < inputW - 1; ++w) {
     float v[kStrideW];
 
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v[i] = src[i * colBlockSize];
     }
 
     // add per-channel bias
-    for (int i = 0; i < kStrideW; ++i) {
+    for (const auto i : c10::irange(kStrideW)) {
       v[i] += b;
     }
 
@@ -614,12 +614,12 @@ bool ConvTransposeMobileOp<T, Context>::RunOnDeviceWithOrderNCHW() {
         numThreads * threadColBufferSize);
     // Group together thread buffers for accumulation
     std::vector<T*> toSum(numThreads - 1);
-    for (int i = 1; i < numThreads; ++i) {
+    for (const auto i : c10::irange(1, numThreads)) {
       toSum[i - 1] = threadBuffer->template mutable_data<T>() +
           i * threadYBufferSizeAligned;
     }
 
-    for (auto image_id = 0; image_id < N; ++image_id) {
+    for (const auto image_id : c10::irange(N)) {
       // Each time through, we have to reset all per-thread output
       // buffers, since the output buffer is only per-batch element
       // The column buffers are overwritten by the matrix multiplication

--- a/caffe2/operators/conv_transpose_unpool_op_base.h
+++ b/caffe2/operators/conv_transpose_unpool_op_base.h
@@ -121,7 +121,7 @@ class ConvTransposeUnpoolBase : public Operator<Context> {
     }
 
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int dim = 0; dim < kernel_.size(); ++dim) {
+    for (const auto dim : c10::irange(kernel_.size())) {
       CAFFE_ENFORCE_GT(kernel_[dim], 0);
       CAFFE_ENFORCE_GT(stride_[dim], 0);
       CAFFE_ENFORCE_GE(adj_[dim], 0);

--- a/caffe2/operators/deform_conv_op_impl.h
+++ b/caffe2/operators/deform_conv_op_impl.h
@@ -77,7 +77,7 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
           1);
 
   int kernel_dims_size = 1;
-  for (int i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE(filter.dim32(i + 2) == kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
@@ -155,8 +155,8 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     col_buffer->Resize(buffer_shape);
     T* col_buffer_data = col_buffer->template mutable_data<T>();
     // Im2col, followed by gemm.
-    for (int image_id = 0; image_id < N; ++image_id) {
-      for (int group_id = 0; group_id < group_; ++group_id) {
+    for (const auto image_id : c10::irange(N)) {
+      for (const auto group_id : c10::irange(group_)) {
         DeformableIm2col(
             Xdata + group_id * input_offset,
             offset_data,
@@ -271,7 +271,7 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
           1);
 
   int kernel_dims_size = 1;
-  for (int i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE(filter.dim32(i + 2) == kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
@@ -342,8 +342,8 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     math::Set<T, Context>(dX->numel(), 0, dXdata, &context_);
   }
 
-  for (int image_id = 0; image_id < N; ++image_id) {
-    for (int group_id = 0; group_id < group_; ++group_id) {
+  for (const auto image_id : c10::irange(N)) {
+    for (const auto group_id : c10::irange(group_)) {
       math::Gemm<T, Context>(
           CblasTrans,
           CblasNoTrans,
@@ -378,7 +378,7 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     DeformableIm2col(
         Xdata, offset_data, X.sizes(), col_buffer_shape, col_buffer_data);
 
-    for (int group_id = 0; group_id < group_; ++group_id) {
+    for (const auto group_id : c10::irange(group_)) {
       math::Gemm<T, Context>(
           CblasNoTrans,
           CblasTrans,

--- a/caffe2/operators/dense_vector_to_id_list_op.h
+++ b/caffe2/operators/dense_vector_to_id_list_op.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -33,9 +34,9 @@ class DenseVectorToIdListOp : public Operator<Context> {
 
     auto v_pos = 0;
     auto l_pos = 0;
-    for (auto i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       auto length = 0;
-      for (int j = 0; j < col_num; j++) {
+      for (const auto j : c10::irange(col_num)) {
         if ((int)(input_data[i * col_num + j] + 0.5) != 0) {
           out_values_data[v_pos++] = j;
           length++;

--- a/caffe2/operators/distance_op.h
+++ b/caffe2/operators/distance_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -37,7 +38,7 @@ class SquaredL2DistanceGradientOp final : public Operator<Context> {
     int N = X.dim() > 0 ? X.dim32(0) : 1;
     int D = N > 0 ? X.numel() / N : 0;
     CAFFE_ENFORCE(X.dim() == Y.dim());
-    for (int i = 0; i < X.dim(); ++i) {
+    for (const auto i : c10::irange(X.dim())) {
       CAFFE_ENFORCE(X.dim32(i) == Y.dim32(i));
     }
     CAFFE_ENFORCE(dDistance.dim() == 1);
@@ -50,7 +51,7 @@ class SquaredL2DistanceGradientOp final : public Operator<Context> {
         Y.template data<T>(),
         dX->template mutable_data<T>(),
         &context_);
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       math::Scale<T, T, Context>(
           D,
           dDistance.template data<T>() + i,
@@ -227,7 +228,7 @@ class DotProductWithPaddingGradientOp final : public Operator<Context> {
     const auto* dDot_data = dDot.template data<T>();
     auto* dX_data = dX->template mutable_data<T>();
     auto* dY_data = dY->template mutable_data<T>();
-    for (int i = 0; i < N; ++i) { // TODO: multithreading
+    for (const auto i : c10::irange(N)) { // TODO: multithreading
       auto offsetX = i * DX;
       auto offsetY = i * DY;
       if (replicate_) {

--- a/caffe2/operators/do_op.h
+++ b/caffe2/operators/do_op.h
@@ -11,6 +11,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/create_scope_op.h"
 #include "caffe2/proto/caffe2_pb.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -46,7 +47,7 @@ class DoOp final : public Operator<Context> {
 
     const auto& outer_blob_names = checkAndGetOuterNames(operator_def);
     std::unordered_set<std::string> used_outer_names;
-    for (size_t blob_idx = 0; blob_idx < inner_blobs.size(); ++blob_idx) {
+    for (const auto blob_idx : c10::irange(inner_blobs.size())) {
       CAFFE_ENFORCE(
           !blob_bindings_.count(inner_blobs[blob_idx]),
           "Invalid blob bindings: redefinition of inner blob " +
@@ -154,7 +155,7 @@ class DoOp final : public Operator<Context> {
       const OperatorDef& operator_def) const {
     std::vector<std::string> names;
     names.reserve(operator_def.input_size());
-    for (auto idx = 0; idx < operator_def.input_size(); ++idx) {
+    for (const auto idx : c10::irange(operator_def.input_size())) {
       names.push_back(operator_def.input(idx));
     }
     return names;
@@ -164,7 +165,7 @@ class DoOp final : public Operator<Context> {
       const OperatorDef& operator_def) const {
     std::vector<std::string> names;
     names.reserve(operator_def.output_size());
-    for (auto idx = 0; idx < operator_def.output_size(); ++idx) {
+    for (const auto idx : c10::irange(operator_def.output_size())) {
       names.push_back(operator_def.output(idx));
     }
     return names;

--- a/caffe2/operators/elementwise_logical_ops.h
+++ b/caffe2/operators/elementwise_logical_ops.h
@@ -51,7 +51,7 @@ class WhereOp final : public Operator<Context> {
 
     if (enable_broadcast_) {
       size_t block_size = left.size_from_dim(1);
-      for (int i = 0; i < select.numel(); i++) {
+      for (const auto i : c10::irange(select.numel())) {
         size_t offset = i * block_size;
         if (select_data[i]) {
           context_.CopyItemsSameDevice(
@@ -68,7 +68,7 @@ class WhereOp final : public Operator<Context> {
         }
       }
     } else {
-      for (int i = 0; i < select.numel(); ++i) {
+      for (const auto i : c10::irange(select.numel())) {
         output_data[i] = select_data[i] ? left_data[i] : right_data[i];
       }
     }
@@ -159,7 +159,7 @@ class IsMemberOfOp final : public Operator<Context> {
 
     const T* input_data = input.template data<T>();
     bool* output_data = output->template mutable_data<bool>();
-    for (int i = 0; i < input.numel(); ++i) {
+    for (const auto i : c10::irange(input.numel())) {
       output_data[i] = values.find(input_data[i]) != values.end();
     }
     return true;

--- a/caffe2/operators/elementwise_op_test.h
+++ b/caffe2/operators/elementwise_op_test.h
@@ -62,7 +62,7 @@ void elementwiseAnd() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{true, false, false, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -83,7 +83,7 @@ void elementwiseAnd() {
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{
         true, false, false, false, true, false, false, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -108,7 +108,7 @@ void elementwiseOr() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{true, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -128,7 +128,7 @@ void elementwiseOr() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{true, true, true, false, true, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -153,7 +153,7 @@ void elementwiseXor() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{false, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -174,7 +174,7 @@ void elementwiseXor() {
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{
         false, true, true, false, false, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -198,7 +198,7 @@ void elementwiseNot() {
   caffe2::Tensor Y(blob->Get<caffe2::Tensor>(), caffe2::CPU);
   EXPECT_EQ(Y.numel(), N);
   std::vector<bool> result{false, true};
-  for (size_t i = 0; i < Y.numel(); ++i) {
+  for (const auto i : c10::irange(Y.numel())) {
     EXPECT_EQ(Y.template data<bool>()[i], result[i]);
   }
 }
@@ -220,7 +220,7 @@ void elementwiseEQ() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{false, true, false, true};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -237,7 +237,7 @@ void elementwiseEQ() {
     caffe2::Tensor Z(blob->Get<caffe2::Tensor>(), caffe2::CPU);
     EXPECT_EQ(Z.numel(), N);
     std::vector<bool> result{true, true, false, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }
@@ -257,7 +257,7 @@ void elementwiseEQ() {
     EXPECT_EQ(Z.numel(), M * N);
     std::vector<bool> result{
         true, false, false, true, false, true, true, false};
-    for (size_t i = 0; i < Z.numel(); ++i) {
+    for (const auto i : c10::irange(Z.numel())) {
       EXPECT_EQ(Z.template data<bool>()[i], result[i]);
     }
   }

--- a/caffe2/operators/enforce_finite_op.h
+++ b/caffe2/operators/enforce_finite_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -32,7 +33,7 @@ class EnforceFiniteOp final : public Operator<Context> {
     const T* input_data = input.template data<T>();
     auto size = input.numel();
 
-    for (auto i = 0; i < size; i++) {
+    for (const auto i : c10::irange(size)) {
       auto isfinite = std::isfinite(input_data[i]);
       if (!isfinite) {
         LogBlobFiniteness();

--- a/caffe2/operators/expand_op.h
+++ b/caffe2/operators/expand_op.h
@@ -7,6 +7,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -95,7 +96,7 @@ class ExpandGradientOp final : public Operator<Context> {
     auto* dX = Output(0, X.sizes(), at::dtype<T>());
     std::vector<int> axes;
     const int offset = ndim - X.dim();
-    for (int i = 0; i < ndim; i++) {
+    for (const auto i : c10::irange(ndim)) {
       if (i < offset || dX_dims[i - offset] == 1) {
         axes.push_back(i);
       }

--- a/caffe2/operators/expand_squeeze_dims_op.h
+++ b/caffe2/operators/expand_squeeze_dims_op.h
@@ -1,6 +1,7 @@
 #ifndef CAFFE2_OPERATORS_EXPAND_SQUEEZE_DIMS_OP_H_
 #define CAFFE2_OPERATORS_EXPAND_SQUEEZE_DIMS_OP_H_
 
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 
@@ -91,8 +92,7 @@ class SqueezeOp : public Operator<Context> {
       const std::vector<int>& dims) {
     size_t j = 0;
     std::vector<int> newDims;
-    for (size_t i = 0; i < inputDims.size(); ++i) {
-      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
+    for (const auto i : c10::irange(inputDims.size())) {
       if (j < dims.size() && dims[j] == i) {
         CAFFE_ENFORCE_EQ(
             inputDims[i],

--- a/caffe2/operators/filler_op.h
+++ b/caffe2/operators/filler_op.h
@@ -1,6 +1,7 @@
 #ifndef CAFFE2_OPERATORS_FILLER_OP_H_
 #define CAFFE2_OPERATORS_FILLER_OP_H_
 
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -536,7 +537,7 @@ class LengthsRangeFillOp : public Operator<Context> {
     auto* output_data = output->template mutable_data<int32_t>();
 
     int32_t offset = 0;
-    for (int i = 0; i < input.numel(); ++i) {
+    for (const auto i : c10::irange(input.numel())) {
       auto len = input_data[i];
       auto start = output_data + offset;
       std::iota(

--- a/caffe2/operators/find_duplicate_elements_op.h
+++ b/caffe2/operators/find_duplicate_elements_op.h
@@ -1,12 +1,13 @@
 #ifndef CAFFE2_OPERATORS_FIND_DUPLICATE_ELEMENTS_OP_H
 #define CAFFE2_OPERATORS_FIND_DUPLICATE_ELEMENTS_OP_H
 
-#include <unordered_map>
-#include <vector>
-
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
+#include "c10/util/irange.h"
+
+#include <unordered_map>
+#include <vector>
 
 namespace caffe2 {
 
@@ -44,7 +45,7 @@ class FindDuplicateElementsOp final : public Operator<Context> {
     auto* output =
         Output(0, {static_cast<int64_t>(dupSize)}, at::dtype<int64_t>());
     auto* out_ptr = output->template mutable_data<int64_t>();
-    for (size_t i = 0; i < dupSize; ++i) {
+    for (const auto i : c10::irange(dupSize)) {
       out_ptr[i] = dupIndices[i];
     }
 

--- a/caffe2/operators/find_op.h
+++ b/caffe2/operators/find_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 #include <unordered_map>
 
@@ -42,7 +43,7 @@ class FindOp final : public Operator<Context> {
     // index into a map
     if (needles.numel() < 16) {
       // Brute force O(nm)
-      for (int i = 0; i < needles.numel(); i++) {
+      for (const auto i : c10::irange(needles.numel())) {
         T x = needles_data[i];
         T res = static_cast<T>(missing_value_);
         for (int j = idx_size - 1; j >= 0; j--) {
@@ -56,10 +57,10 @@ class FindOp final : public Operator<Context> {
     } else {
       // O(n + m)
       std::unordered_map<T, int> idx_map;
-      for (int j = 0; j < idx_size; j++) {
+      for (const auto j : c10::irange(idx_size)) {
         idx_map[idx_data[j]] = j;
       }
-      for (int i = 0; i < needles.numel(); i++) {
+      for (const auto i : c10::irange(needles.numel())) {
         T x = needles_data[i];
         auto it = idx_map.find(x);
         res_data[i] = (it == idx_map.end() ? missing_value_ : it->second);

--- a/caffe2/operators/floor_op.h
+++ b/caffe2/operators/floor_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -21,7 +22,7 @@ class FloorOp final : public Operator<Context> {
 
     const float* Xdata = X.template data<float>();
     float* Ydata = Y->template mutable_data<float>();
-    for (int i = 0; i < X.numel(); ++i) {
+    for (const auto i : c10::irange(X.numel())) {
       Ydata[i] = std::floor(Xdata[i]);
     }
     return true;

--- a/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_8bit_conversion_ops.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/reducer_functors.h"
@@ -82,7 +83,7 @@ class FloatToFused8BitRowwiseQuantizedOp : public Operator<Context> {
 
       vector<float> tmp(input_columns);
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t row = 0; row < input_rows; ++row) {
+      for (const auto row : c10::irange(input_rows)) {
         convert(tmp.data(), input_data + row * input_columns, input_columns);
         if (out_sb_half) {
           FloatToFusedNBitRowwiseQuantizedSBHalf(
@@ -163,7 +164,7 @@ class Fused8BitRowwiseQuantizedToFloatOp : public Operator<Context> {
 
       vector<float> tmp(input_columns);
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t row = 0; row < input_rows; ++row) {
+      for (const auto row : c10::irange(input_rows)) {
         if (in_sb_half) {
           FusedNBitRowwiseQuantizedSBHalfToFloat(
               8,

--- a/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbit_conversion_ops.h
@@ -131,7 +131,7 @@ class FloatToFusedNBitRowwiseQuantizedOp final : public Operator<CPUContext> {
         *output_row_scale = scale;
         *output_row_bias = Xmin;
 
-        for (int col = 0; col < input_columns; ++col) {
+        for (const auto col : c10::irange(input_columns)) {
           float X = tmp[col];
           std::uint8_t quantized = std::max(
               0,
@@ -206,7 +206,7 @@ class FusedNBitRowwiseQuantizedToFloatOp final : public Operator<CPUContext> {
       std::vector<float> tmp(output_columns);
 
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t row = 0; row < input_rows; ++row) {
+      for (const auto row : c10::irange(input_rows)) {
         const std::uint8_t* input_row = input_data + row * input_columns;
         float scale = *reinterpret_cast<const at::Half*>(
             input_row +
@@ -216,7 +216,7 @@ class FusedNBitRowwiseQuantizedToFloatOp final : public Operator<CPUContext> {
             (output_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE +
             sizeof(at::Half));
 
-        for (int col = 0; col < output_columns; ++col) {
+        for (const auto col : c10::irange(output_columns)) {
           std::uint8_t quantized = input_row[col / NUM_ELEM_PER_BYTE];
           quantized >>= (col % NUM_ELEM_PER_BYTE) * BIT_RATE;
           quantized &= (1 << BIT_RATE) - 1;

--- a/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h
+++ b/caffe2/operators/fused_rowwise_nbitfake_conversion_ops.h
@@ -118,7 +118,7 @@ class FloatToFusedNBitFakeRowwiseQuantizedOp final
       output_row_scale_bias[1] = minimum_element;
 
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (size_t col = 0; col < input_columns; ++col) {
+      for (const auto col : c10::irange(input_columns)) {
         output_row[col] = std::max(
             0,
             std::min<int>(

--- a/caffe2/operators/gather_fused_8bit_rowwise_op.h
+++ b/caffe2/operators/gather_fused_8bit_rowwise_op.h
@@ -37,7 +37,7 @@ class GatherFused8BitRowwiseOp : public Operator<Context> {
     const Index* idxs = indices.template data<Index>();
     auto out = output->template mutable_data<float>();
 
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       auto idx = idxs[i];
       CAFFE_ENFORCE(
           0 <= idx && idx < data.size(0),

--- a/caffe2/operators/gather_ranges_to_dense_op.h
+++ b/caffe2/operators/gather_ranges_to_dense_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/common_omp.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
@@ -42,7 +43,8 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     CAFFE_ENFORCE_GT(
         minObservation_, 0, "The number of observations is at least 1");
     // Initialize the empty and mismatch counter.
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
+      (void)i; // Suppress unused variable warning
       emptyRanges_.push_back(0);
       mismatchedRanges_.push_back(0);
       mismatchedLengths_.push_back(set<int>());
@@ -105,7 +107,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     auto batchSize = ranges.size(0);
     vector<int64_t> outputDims{batchSize, 0};
     vector<char*> outputRawData;
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       auto* output = Output(i);
       outputDims[1] = lengths_[i];
       output->Resize(outputDims);
@@ -114,8 +116,8 @@ class GatherRangesToDenseOp final : public Operator<Context> {
       outputRawData.push_back(ptr);
     }
 
-    for (int i = 0; i < batchSize; ++i) {
-      for (int j = 0; j < OutputSize(); ++j) {
+    for (const auto i : c10::irange(batchSize)) {
+      for (const auto j : c10::irange(OutputSize())) {
         auto rangeStart = rangesData[rangesDataOffset++];
         auto rangeLength = rangesData[rangesDataOffset++];
 
@@ -143,7 +145,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
           auto& key = Input(KEY);
           auto* key_data = key.template data<int64_t>();
           vector<std::pair<int64_t, const char*>> buffer;
-          for (int b_i = 0; b_i < rangeLength; ++b_i) {
+          for (const auto b_i : c10::irange(rangeLength)) {
             int64_t one_key_item = key_data[rangeStart + b_i];
             auto* one_data_item = rawData + (rangeStart + b_i) * itemsize;
             buffer.emplace_back(one_key_item, one_data_item);
@@ -155,7 +157,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
                  const std::pair<int64_t, const char*>& right) {
                 return left.first < right.first;
               });
-          for (int b_i = 0; b_i < rangeLength; ++b_i) {
+          for (const auto b_i : c10::irange(rangeLength)) {
             // Since this CPU only, directly copy to the destination.
             std::memcpy(
                 outputRawData[j] + (i * lengths_[j] + b_i) * itemsize,
@@ -170,7 +172,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
 
     // Check whether the empty and mismatch ratio exceeded the threshold.
     totalRanges_ += batchSize;
-    for (int j = 0; j < OutputSize(); ++j) {
+    for (const auto j : c10::irange(OutputSize())) {
       // Only check when the ratio is not set to allow all mismatches.
       if (maxMismatchedRatio_ < 1.0) {
         CAFFE_ENFORCE_GE(

--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -294,7 +294,7 @@ EArrXXt<typename Derived::Scalar> clip_boxes_rotated(
 
   EArrXXt<typename Derived::Scalar> ret(boxes.rows(), boxes.cols());
   ret = boxes;
-  for (int i = 0; i < upright_boxes.rows(); ++i) {
+  for (const auto i : c10::irange(upright_boxes.rows())) {
     ret.row(indices[i]) = upright_boxes.row(i);
   }
   return ret;

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -247,7 +247,7 @@ int rotated_rect_intersection_pts(
   // Specical case of rect1 == rect2
   bool same = true;
 
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     if (fabs(pts1[i].x() - pts2[i].x()) > samePointEps ||
         (fabs(pts1[i].y() - pts2[i].y()) > samePointEps)) {
       same = false;
@@ -256,7 +256,7 @@ int rotated_rect_intersection_pts(
   }
 
   if (same) {
-    for (int i = 0; i < 4; i++) {
+    for (const auto i : c10::irange(4)) {
       intersections[i] = pts1[i];
     }
     num = 4;
@@ -265,14 +265,14 @@ int rotated_rect_intersection_pts(
 
   // Line vector
   // A line from p1 to p2 is: p1 + (p2-p1)*t, t=[0,1]
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     vec1[i] = pts1[(i + 1) % 4] - pts1[i];
     vec2[i] = pts2[(i + 1) % 4] - pts2[i];
   }
 
   // Line test - test all line combos for intersection
-  for (int i = 0; i < 4; i++) {
-    for (int j = 0; j < 4; j++) {
+  for (const auto i : c10::irange(4)) {
+    for (const auto j : c10::irange(4)) {
       // Solve for 2x2 Ax=b
 
       // This takes care of parallel lines
@@ -298,7 +298,7 @@ int rotated_rect_intersection_pts(
     const auto& DA = vec2[3];
     auto ABdotAB = AB.squaredNorm();
     auto ADdotAD = DA.squaredNorm();
-    for (int i = 0; i < 4; i++) {
+    for (const auto i : c10::irange(4)) {
       // assume ABCD is the rectangle, and P is the point to be judged
       // P is inside ABCD iff. P's projection on AB lies within AB
       // and P's projection on AD lies within AD
@@ -321,7 +321,7 @@ int rotated_rect_intersection_pts(
     const auto& DA = vec1[3];
     auto ABdotAB = AB.squaredNorm();
     auto ADdotAD = DA.squaredNorm();
-    for (int i = 0; i < 4; i++) {
+    for (const auto i : c10::irange(4)) {
       auto AP = pts2[i] - pts1[0];
 
       auto APdotAB = AP.dot(AB);
@@ -351,7 +351,7 @@ int convex_hull_graham(
   // if more than 1 points have the same minimum y,
   // pick the one with the mimimum x.
   int t = 0;
-  for (int i = 1; i < num_in; i++) {
+  for (const auto i : c10::irange(1, num_in)) {
     if (p[i].y() < p[t].y() || (p[i].y() == p[t].y() && p[i].x() < p[t].x())) {
       t = i;
     }
@@ -360,7 +360,7 @@ int convex_hull_graham(
 
   // Step 2:
   // Subtract starting point from every points (for sorting in the next step)
-  for (int i = 0; i < num_in; i++) {
+  for (const auto i : c10::irange(num_in)) {
     q[i] = p[i] - s;
   }
 
@@ -415,8 +415,7 @@ int convex_hull_graham(
   // But if we're only interested in getting the area/perimeter of the shape
   // We can simply return.
   if (!shift_to_zero) {
-    for (int i = 0; i < m; i++)
-      q[i] += s;
+    for (const auto i : c10::irange(m))q[i] += s;
   }
 
   return m;
@@ -518,8 +517,8 @@ Eigen::ArrayXXf bbox_overlaps_rotated(
   const auto& query_boxes_areas = query_boxes.col(2) * query_boxes.col(3);
 
   Eigen::ArrayXXf overlaps(boxes.rows(), query_boxes.rows());
-  for (int i = 0; i < boxes.rows(); ++i) {
-    for (int j = 0; j < query_boxes.rows(); ++j) {
+  for (const auto i : c10::irange(boxes.rows())) {
+    for (const auto j : c10::irange(query_boxes.rows())) {
       auto inter = bbox_intersection_rotated(boxes.row(i), query_boxes.row(j));
       overlaps(i, j) = (inter == 0.0)
           ? 0.0
@@ -554,7 +553,7 @@ std::vector<int> nms_cpu_rotated(
   EArrX areas = widths * heights;
 
   std::vector<RotatedRect> rotated_rects(proposals.rows());
-  for (int i = 0; i < proposals.rows(); ++i) {
+  for (const auto i : c10::irange(proposals.rows())) {
     rotated_rects[i] = bbox_to_rotated_rect(proposals.row(i));
   }
 
@@ -616,7 +615,7 @@ std::vector<int> soft_nms_cpu_rotated(
   EArrX areas = widths * heights;
 
   std::vector<RotatedRect> rotated_rects(proposals.rows());
-  for (int i = 0; i < proposals.rows(); ++i) {
+  for (const auto i : c10::irange(proposals.rows())) {
     rotated_rects[i] = bbox_to_rotated_rect(proposals.row(i));
   }
 

--- a/caffe2/operators/given_tensor_byte_string_to_uint8_fill_op.h
+++ b/caffe2/operators/given_tensor_byte_string_to_uint8_fill_op.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -60,8 +61,7 @@ class GivenTensorByteStringToUInt8FillOp final : public FillerOp<Context> {
         {static_cast<int64_t>(str.size())},
         at::dtype<uint8_t>().device(CPU));
     uint8_t* values_data = values_.template mutable_data<uint8_t>();
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < str.size(); i++) {
+    for (const auto i : c10::irange(str.size())) {
       values_data[i] = static_cast<uint8_t>(str[i]);
     }
   }

--- a/caffe2/operators/given_tensor_fill_op.h
+++ b/caffe2/operators/given_tensor_fill_op.h
@@ -68,7 +68,7 @@ class GivenTensorFillOp final : public FillerOp<Context> {
         at::dtype<Type>().device(CPU));
     Type* values_data = values_.template mutable_data<Type>();
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < source_values.size(); i++) {
+    for (const auto i : c10::irange(source_values.size())) {
       values_data[i] = static_cast<Type>(source_values[i]);
     }
     body_ = &GivenTensorFillOp::FillWithType<Type>;

--- a/caffe2/operators/gru_unit_op.h
+++ b/caffe2/operators/gru_unit_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 namespace detail {
@@ -29,10 +30,10 @@ void GRUUnit(
     bool drop_states,
     T* H,
     Context* /*context*/) {
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
 
-    for (int d = 0; d < D; ++d) {
+    for (const auto d : c10::irange(D)) {
       if (!valid) {
         if (drop_states) {
           H[d] = 0;
@@ -68,10 +69,10 @@ void GRUUnitGradient(
     T* H_prev_diff,
     T* X_diff,
     Context* /*context*/) {
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
 
-    for (int d = 0; d < D; ++d) {
+    for (const auto d : c10::irange(D)) {
       T* h_prev_diff = H_prev_diff + d;
       T* reset_diff = X_diff + 0 * D + d;
       T* update_diff = X_diff + 1 * D + d;

--- a/caffe2/operators/h_softmax_op.h
+++ b/caffe2/operators/h_softmax_op.h
@@ -2,6 +2,7 @@
 #define CAFFE2_OPERATORS_H_SOFTMAX_OP_H_
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -51,7 +52,7 @@ class HSoftmaxOpBase : public Operator<Context> {
       int M,
       std::unordered_map<int, PathProto>& hierarchy) const {
     int size = 0;
-    for (int label = 0; label < M; ++label) {
+    for (const auto label : c10::irange(M)) {
       int word_id = labels[label];
       const auto& path = hierarchy[word_id];
       size += std::accumulate(

--- a/caffe2/operators/histogram_op.h
+++ b/caffe2/operators/histogram_op.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
+
 #include <cmath>
 #include <limits>
-#include "caffe2/core/operator.h"
 
 namespace caffe2 {
 
@@ -19,7 +21,7 @@ class HistogramOp final : public Operator<Context> {
         2,
         "Number of bin edges must be greater than or equal to 2.");
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 1; i < bin_edges_.size(); i++) {
+    for (const auto i : c10::irange(1, bin_edges_.size())) {
       CAFFE_ENFORCE_GT(
           bin_edges_[i],
           bin_edges_[i - 1],
@@ -41,11 +43,11 @@ class HistogramOp final : public Operator<Context> {
     math::Set<int64_t, Context>(
         bin_edges_.size() - 1, 0, histogram_data, &context_);
 
-    for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+    for (const auto input_idx : c10::irange(InputSize())) {
       const auto& x = Input(input_idx);
       const int64_t N = x.numel();
       const auto* x_data = x.template data<T>();
-      for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+      for (const auto data_idx : c10::irange(N)) {
         const auto bisection_it = std::upper_bound(
             bin_edges_.begin(), bin_edges_.end(), x_data[data_idx]);
         const int bisection_idx = bisection_it - bin_edges_.begin();
@@ -67,7 +69,7 @@ class HistogramOp final : public Operator<Context> {
 
   void CheckInputs() {
     const auto& input_zero = Input(0);
-    for (int i = 1; i < InputSize(); i++) {
+    for (const auto i : c10::irange(1, InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).dtype(),
           input_zero.dtype(),

--- a/caffe2/operators/im2col_op.h
+++ b/caffe2/operators/im2col_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -84,7 +85,7 @@ class Im2ColOp final : public Operator<Context> {
 
         const size_t dx = X.numel() / N;
         const size_t dy = Y->numel() / N;
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Im2Col<T, Context, StorageOrder::NCHW>(
@@ -114,7 +115,7 @@ class Im2ColOp final : public Operator<Context> {
 
         const size_t dx = X.numel() / N;
         const size_t dy = Y->numel() / N;
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Im2Col<T, Context, StorageOrder::NHWC>(
@@ -230,7 +231,7 @@ class Col2ImOp final : public Operator<Context> {
     // could template-specialize this, but it's test code...
     switch (order_) {
       case StorageOrder::NCHW: {
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Col2Im<T, Context, StorageOrder::NCHW>(
@@ -253,7 +254,7 @@ class Col2ImOp final : public Operator<Context> {
         }
       }; break;
       case StorageOrder::NHWC: {
-        for (int n = 0; n < N; ++n) {
+        for (const auto n : c10::irange(N)) {
           const auto* xdata = X.template data<T>() + (n * dx);
           auto* ydata = Y->template mutable_data<T>() + (n * dy);
           math::Col2Im<T, Context, StorageOrder::NHWC>(

--- a/caffe2/operators/index_hash_ops.h
+++ b/caffe2/operators/index_hash_ops.h
@@ -2,6 +2,7 @@
 #define CAFFE2_OPERATORS_INDEX_HASH_OPS_H_
 
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 
@@ -42,7 +43,7 @@ class IndexHashOp : public Operator<Context> {
     auto* indices_data = indices.template data<T>();
     auto* hashed_indices_data = hashed_indices->template mutable_data<T>();
 
-    for (auto i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       hashed_indices_data[i] = hash(indices_data[i]);
     }
 

--- a/caffe2/operators/index_ops.h
+++ b/caffe2/operators/index_ops.h
@@ -9,6 +9,7 @@
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 namespace {
@@ -64,7 +65,7 @@ struct Index : IndexBase {
     }
     std::lock_guard<std::mutex> lock(dictMutex_);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < numKeys; ++i) {
+    for (const auto i : c10::irange(numKeys)) {
       auto it = dict_.find(keys[i]);
       if (it != dict_.end()) {
         values[i] = it->second;
@@ -84,7 +85,7 @@ struct Index : IndexBase {
         numKeys <= maxElements_,
         "Cannot load index: Tensor is larger than max_elements.");
     decltype(dict_) dict;
-    for (auto i = 0U; i < numKeys; ++i) {
+    for (const auto i : c10::irange(0U, numKeys)) {
       CAFFE_ENFORCE(
           dict.insert({keys[i], i + 1}).second,
           "Repeated elements found: cannot load into dictionary.");
@@ -111,7 +112,7 @@ struct Index : IndexBase {
 
  private:
   void FrozenGet(const T* keys, int64_tValue* values, size_t numKeys) {
-    for (auto i = 0U; i < numKeys; ++i) {
+    for (const auto i : c10::irange(0U, numKeys)) {
       auto it = dict_.find(keys[i]);
       values[i] = it != dict_.end() ? it->second : 0;
     }

--- a/caffe2/operators/key_split_ops.h
+++ b/caffe2/operators/key_split_ops.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
-
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+
+#include <vector>
 
 namespace caffe2 {
 template <typename T, class Context>
@@ -22,26 +23,26 @@ class KeySplitOp : public Operator<Context> {
 
   bool RunOnDevice() override {
     auto& keys = Input(0);
-    int N = keys.numel();
-    const T* keys_data = keys.template data<T>();
+    const auto N = keys.numel();
+    const T *const keys_data = keys.template data<T>();
     std::vector<int> counts(categorical_limit_);
     std::vector<int*> eids(categorical_limit_);
-    for (int k = 0; k < categorical_limit_; k++) {
+    for (const auto k : c10::irange(categorical_limit_)) {
       counts[k] = 0;
     }
-    for (int i = 0; i < N; i++) {
-      int k = keys_data[i];
+    for (const auto i : c10::irange(N)) {
+      const auto k = keys_data[i];
       CAFFE_ENFORCE_GT(categorical_limit_, k);
       CAFFE_ENFORCE_GE(k, 0);
       counts[k]++;
     }
-    for (int k = 0; k < categorical_limit_; k++) {
-      auto* eid = Output(k, {counts[k]}, at::dtype<int>());
+    for (const auto k : c10::irange(categorical_limit_)) {
+      auto *const eid = Output(k, {counts[k]}, at::dtype<int>());
       eids[k] = eid->template mutable_data<int>();
       counts[k] = 0;
     }
-    for (int i = 0; i < N; i++) {
-      int k = keys_data[i];
+    for (const auto i : c10::irange(N)) {
+      const auto k = keys_data[i];
       eids[k][counts[k]++] = i;
     }
     return true;

--- a/caffe2/operators/length_split_op.h
+++ b/caffe2/operators/length_split_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -55,11 +56,11 @@ class LengthsSplitOp final : public Operator<Context> {
     const int32_t* Ldata = L.template data<int32_t>();
     int32_t* Ydata = Y->template mutable_data<int32_t>();
 
-    for (int i = 0; i < M; i++) {
+    for (const auto i : c10::irange(M)) {
       int32_t mod = Ldata[i] % n_split_;
       int32_t res =
           mod != 0 ? math::DivUp(Ldata[i], n_split_) : Ldata[i] / n_split_ + 1;
-      for (int j = 0; j < n_split_; j++) {
+      for (const auto j : c10::irange(n_split_)) {
         Ydata[(i * n_split_) + j] = mod-- > 0 ? res : res - 1;
       }
     }

--- a/caffe2/operators/lengths_pad_op.h
+++ b/caffe2/operators/lengths_pad_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -56,7 +57,7 @@ class LengthsPadOp : public Operator<Context> {
 
     math::Set(
         output->numel(), static_cast<T>(padding_value_), out_data, &context_);
-    for (int64_t i = 0; i < lengths_size; ++i) {
+    for (const auto i : c10::irange(lengths_size)) {
       auto length = lengths_data[i];
       CAFFE_ENFORCE_GE(length, 0);
       CAFFE_ENFORCE_GE(

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -121,7 +121,7 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
     auto indices_data = indices.template data<IndexType>();
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       for (int i = 0; i < lengths_data[m]; ++i) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -137,7 +137,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
 
     // Error handling
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       for (int i = 0; i < lengths_data[m]; ++i) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
@@ -164,7 +164,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
         << "Running slow path because FBGEMM is not available";
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       memset(output_data, 0, block_size * sizeof(float));
       if (current + lengths_data[m] > index_size) {
         return false;
@@ -185,7 +185,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
         const float scale = weight * scale_bias[0];
         const float bias = weight * scale_bias[1];
 
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           uint8_t quantized =
               input_data[idx * data.size(1) + j / NUM_ELEM_PER_BYTE];
           quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;
@@ -196,7 +196,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
       } // for each i
       if (is_mean && lengths_data[m]) {
         float scale = 1.0f / lengths_data[m];
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           output_data[j] *= scale;
         }
       }
@@ -284,13 +284,14 @@ class SparseLengthsSumSparseLookupOp final : public Operator<CPUContext> {
     const IndexType compressed_data_size = compressed_indices_mapping.size(0);
     IndexType current = 0;
     IndexType current_output = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       const auto current_length = lengths_data[m];
       if (current + current_length > index_size) {
         return false;
       }
       int32_t skipped = 0;
-      for (int i = 0; i < current_length; ++i) {
+      for (const auto i : c10::irange(current_length)) {
+        (void)i; // Suppress unused variable warning
         IndexType compressed_idx = indices_data[current];
         if (compressed_idx < 0 || compressed_idx >= compressed_data_size) {
           return false;
@@ -554,7 +555,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
 
     // Error handling
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       for (int i = 0; i < lengths_data[m]; ++i) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
@@ -592,7 +593,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
         << "Running slow path because FBGEMM is not available";
 
     int64_t current = 0;
-    for (int m = 0; m < output_size; ++m) {
+    for (const auto m : c10::irange(output_size)) {
       memset(output_data, 0, block_size * sizeof(float));
       if (current + lengths_data[m] > index_size) {
         return false;
@@ -632,7 +633,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
           bias = weight * reinterpret_cast<const at::Half*>(scale_bias)[1];
         }
 
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           uint8_t quantized =
               input_data[idx * data.size(1) + j / NUM_ELEM_PER_BYTE];
           quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;
@@ -643,7 +644,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
       } // for each i
       if (is_mean && lengths_data[m]) {
         float scale = 1.0f / lengths_data[m];
-        for (int j = 0; j < block_size; ++j) {
+        for (const auto j : c10::irange(block_size)) {
           output_data[j] *= scale;
         }
       }

--- a/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
+++ b/caffe2/operators/lengths_reducer_rowwise_8bit_ops.h
@@ -110,7 +110,7 @@ class FloatToRowwiseQuantized8BitsOp : public Operator<Context> {
     float* scale_bias_data = scale_bias->template mutable_data<float>();
     size_t n_blocks = input.size(0);
     size_t block_size = input.size_from_dim(1);
-    for (size_t i = 0; i < n_blocks; ++i) {
+    for (const auto i : c10::irange(n_blocks)) {
       ConstEigenVectorArrayMap<float> input_row(
           input_data + i * block_size, block_size);
       EigenVectorArrayMap<uint8_t> output_row(
@@ -164,7 +164,7 @@ class Rowwise8BitQuantizedToFloatOp : public Operator<Context> {
     size_t block_size = input.size_from_dim(1);
     size_t n_blocks = input.size(0);
 
-    for (size_t i = 0; i < n_blocks; ++i) {
+    for (const auto i : c10::irange(n_blocks)) {
       ConstEigenVectorArrayMap<uint8_t> input_row(
           input_data + i * block_size, block_size);
       EigenVectorArrayMap<float> output_row(

--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -5,6 +5,8 @@
 #include <map>
 #include <unordered_set>
 
+
+#include <c10/util/irange.h>
 #include <c10/util/string_view.h>
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/core/context.h"
@@ -129,13 +131,13 @@ class LoadOp final : public Operator<Context> {
     int total_loaded_blobs = 0;
     std::unordered_map<string, load_save_op_util::BlobState> blob_states;
     if (InputSize() > 0) {
-      for (int i = 0; i < InputSize(); ++i) {
+      for (const auto i : c10::irange(InputSize())) {
         const db::DBReader& reader = this->template Input<db::DBReader>(i);
         extract(i, reader.cursor(), &blob_states, &total_loaded_blobs);
       }
     } else {
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (int i = 0; i < db_names_.size(); ++i) {
+      for (const auto i : c10::irange(db_names_.size())) {
         string full_db_name = absolute_path_
             ? db_names_[i]
             : (ws_->RootFolder() + "/" + db_names_[i]);

--- a/caffe2/operators/locally_connected_op_impl.h
+++ b/caffe2/operators/locally_connected_op_impl.h
@@ -45,7 +45,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(*Y);
   const std::vector<int> output_image_dims = GetDims(*Y);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
 
@@ -82,7 +82,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   if (InputSize() == 3) {
     const auto& bias = Input(BIAS);
     CAFFE_ENFORCE_EQ(bias.dim(), image_ndim + 1);
-    for (int i = 0; i < image_ndim; ++i) {
+    for (const auto i : c10::irange(image_ndim)) {
       CAFFE_ENFORCE_EQ(bias.dim32(i), output_image_dims[i]);
     }
     CAFFE_ENFORCE_EQ(bias.dim32(image_ndim), shape.M);
@@ -129,7 +129,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(*Y);
   const std::vector<int> output_image_dims = GetDims(*Y);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
 
@@ -159,7 +159,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   if (InputSize() == 3) {
     const auto& bias = Input(BIAS);
     CAFFE_ENFORCE_EQ(bias.dim(), image_ndim + 1);
-    for (int i = 0; i < image_ndim; ++i) {
+    for (const auto i : c10::irange(image_ndim)) {
       CAFFE_ENFORCE_EQ(bias.dim32(i), output_image_dims[i]);
     }
     CAFFE_ENFORCE_EQ(bias.dim32(image_ndim), shape.M);
@@ -200,8 +200,9 @@ void LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHWImpl(
   T* column_buffer_data = column_buffer->template mutable_data<T>();
   T* Y_transposed_buffer_data = Y_transposed_buffer->template mutable_data<T>();
 
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
-    for (int group_id = 0; group_id < group_; ++group_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
+    (void)image_id; // Suppress unused variable warning
+    for (const auto group_id : c10::irange(group_)) {
       if (kernel_.size() == 2) {
         math::Im2Col<T, Context, StorageOrder::NCHW>(
             shape.C / group_,
@@ -302,7 +303,7 @@ void LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWCImpl(
   Y_transposed_buffer->Resize(shape.Y_transposed_dims);
   T* column_buffer_data = column_buffer->template mutable_data<T>();
   T* Y_transposed_buffer_data = Y_transposed_buffer->template mutable_data<T>();
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
     math::Im2Col<T, Context, StorageOrder::NHWC>(
         shape.C,
         shape.X_dims[0],
@@ -387,7 +388,7 @@ bool LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   shape.input_image_size = GetDimsSize(X);
   const std::vector<int> output_image_dims = GetDims(dY);
   shape.output_image_size = GetDimsSize(dY);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
   ConvPoolOpBase<Context>::ComputePads(input_image_dims);
@@ -484,7 +485,7 @@ bool LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(dY);
   const std::vector<int> output_image_dims = GetDims(dY);
-  for (int i = 0; i < image_ndim; ++i) {
+  for (const auto i : c10::irange(image_ndim)) {
     CAFFE_ENFORCE_EQ(output_image_dims[i], filter.dim32(i));
   }
 
@@ -568,8 +569,9 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHWImpl(
   T* dY_transposed_buffer_data =
       dY_transposed_buffer->template mutable_data<T>();
 
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
-    for (int group_id = 0; group_id < group_; ++group_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
+    (void)image_id; // Suppress unused variable warning
+    for (const auto group_id : c10::irange(group_)) {
       if (kernel_.size() == 2) {
         math::Im2Col<T, Context, StorageOrder::NCHW>(
             shape.C / group_,
@@ -681,8 +683,9 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHWImpl(
         column_buffer->template mutable_data<T>(),
         &context_);
     const T* const_column_buffer_data = column_buffer->template data<T>();
-    for (int image_id = 0; image_id < shape.N; ++image_id) {
-      for (int group_id = 0; group_id < group_; ++group_id) {
+    for (const auto image_id : c10::irange(shape.N)) {
+      (void)image_id; // Suppress unused variable warning
+      for (const auto group_id : c10::irange(group_)) {
         if (kernel_.size() == 2) {
           math::Col2Im<T, Context, StorageOrder::NCHW>(
               shape.C / group_,
@@ -743,7 +746,7 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNHWCImpl(
   T* column_buffer_data = column_buffer->template mutable_data<T>();
   T* dY_transposed_buffer_data =
       dY_transposed_buffer->template mutable_data<T>();
-  for (int image_id = 0; image_id < shape.N; ++image_id) {
+  for (const auto image_id : c10::irange(shape.N)) {
     math::Im2Col<T, Context, StorageOrder::NHWC>(
         shape.C,
         shape.X_dims[0],
@@ -835,7 +838,8 @@ void LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNHWCImpl(
         column_buffer->template mutable_data<T>(),
         &context_);
     const T* const_column_buffer_data = column_buffer->template data<T>();
-    for (int image_id = 0; image_id < shape.N; ++image_id) {
+    for (const auto image_id : c10::irange(shape.N)) {
+      (void)image_id; // Suppress unused variable warning
       math::Col2Im<T, Context, StorageOrder::NHWC>(
           shape.C,
           shape.X_dims[0],

--- a/caffe2/operators/lstm_utils.h
+++ b/caffe2/operators/lstm_utils.h
@@ -78,7 +78,7 @@ template <typename T>
 static std::vector<T> unpair_vec(std::vector<std::pair<T, T>>&& vals) {
   std::vector<T> result;
   result.reserve(vals.size() * 2);
-  for (int64_t i = 0; i < vals.size(); i++) {
+  for (const auto i : c10::irange(vals.size())) {
     result.push_back(std::move(vals[i].first));
     result.push_back(std::move(vals[i].second));
   }
@@ -150,7 +150,7 @@ chunk(const Tensor& input, int chunks, int axis, CPUContext* context) {
   auto split_size = input_channels / chunks;
   vector<int64_t> output_dims(input.sizes().vec());
   int before = 1, after = 1;
-  for (int i = 0; i < canonical_axis; ++i) {
+  for (const auto i : c10::irange(canonical_axis)) {
     before *= input.dim32(i);
   }
   for (int i = canonical_axis + 1; i < input.dim(); ++i) {
@@ -158,7 +158,8 @@ chunk(const Tensor& input, int chunks, int axis, CPUContext* context) {
   }
   size_t input_offset = 0;
   std::vector<Tensor> outputs;
-  for (int i = 0; i < chunks; ++i) {
+  for (const auto i : c10::irange(chunks)) {
+    (void)i; // Suppress unused variable warning
     auto axis_dim = split_size;
     output_dims[canonical_axis] = split_size;
     Tensor output(output_dims, CPU);
@@ -187,7 +188,7 @@ std::vector<Tensor> unbind(const Tensor& input, int axis, CPUContext* context) {
   newDims.erase(newDims.begin() + axis);
 
   // 3 - Reshape chunks to drop the extra dimension
-  for (int i = 0; i < chunks.size(); i++) {
+  for (const auto i : c10::irange(chunks.size())) {
     CAFFE_ENFORCE_EQ(
         chunks[i].sizes()[axis], 1, "Got an unexpected chunk size");
     chunks[i].Reshape(newDims);
@@ -201,14 +202,14 @@ cat(const std::vector<Tensor>& tensorList, int axis, CPUContext* context) {
   auto input_zero = copy_ctor(tensorList.at(0));
   vector<int64_t> outputDims(input_zero.sizes().vec());
   CAFFE_ENFORCE(outputDims.size() > 0);
-  for (int i = 1; i < tensorList.size(); i++) {
+  for (const auto i : c10::irange(1, tensorList.size())) {
     CAFFE_ENFORCE(input_zero.dtype() == tensorList.at(i).dtype());
     outputDims[axis] += tensorList.at(i).sizes()[axis];
   }
   auto output_channels = outputDims[axis];
   Tensor output(outputDims, CPU);
   int before = 1, after = 1;
-  for (int i = 0; i < tensorList.at(0).dim(); ++i) {
+  for (const auto i : c10::irange(tensorList.at(0).dim())) {
     if (i == axis) {
       continue;
     }
@@ -245,7 +246,7 @@ stack(const std::vector<Tensor>& tensorList, int axis, CPUContext* context) {
   std::vector<int64_t> newDims(tensorList[0].sizes().vec());
   std::vector<Tensor> expandedTensorList;
   newDims.insert(newDims.begin() + axis, 1);
-  for (int i = 0; i < tensorList.size(); i++) {
+  for (const auto i : c10::irange(tensorList.size())) {
     expandedTensorList.emplace_back(tensorList[i].Clone());
     expandedTensorList.at(i).Reshape(newDims);
   }
@@ -301,7 +302,7 @@ Tensor transpose(const Tensor& X, int dim0, int dim1, CPUContext* context) {
   std::swap(axes[dim0], axes[dim1]);
   const std::vector<std::int64_t> X_dims = X.sizes().vec();
   std::vector<std::int64_t> Y_dims(ndim);
-  for (int i = 0; i < ndim; ++i) {
+  for (const auto i : c10::irange(ndim)) {
     Y_dims[i] = X_dims[axes[i]];
   }
   Tensor Y(Y_dims, CPU);

--- a/caffe2/operators/map_ops.h
+++ b/caffe2/operators/map_ops.h
@@ -1,6 +1,11 @@
 #ifndef CAFFE2_OPERATORS_MAP_OPS_H_
 #define CAFFE2_OPERATORS_MAP_OPS_H_
 
+#include "caffe2/core/blob_serialization.h"
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include <c10/util/irange.h>
+
 #include <algorithm>
 #include <iterator>
 #include <string>
@@ -8,10 +13,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include "caffe2/core/blob_serialization.h"
-#include "caffe2/core/context.h"
-#include "caffe2/core/operator.h"
 
 namespace caffe2 {
 
@@ -130,7 +131,7 @@ class KeyValueToMapOp final : public Operator<Context> {
 
     auto* map_data = this->template Output<MapType>(MAP);
 
-    for (int i = 0; i < key_input.numel(); ++i) {
+    for (const auto i : c10::irange(key_input.numel())) {
       map_data->emplace(key_data[i], value_data[i]);
     }
 
@@ -257,7 +258,7 @@ class MapDeserializer : public BlobDeserializerBase {
     auto* value_data = value_tensor.data<VALUE_T>();
 
     auto* map_ptr = blob->template GetMutable<MapType>();
-    for (int i = 0; i < key_tensor.numel(); ++i) {
+    for (const auto i : c10::irange(key_tensor.numel())) {
       map_ptr->emplace(key_data[i], value_data[i]);
     }
   }

--- a/caffe2/operators/mean_op.h
+++ b/caffe2/operators/mean_op.h
@@ -8,6 +8,7 @@
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
 #include "caffe2/utils/proto_utils.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -29,7 +30,7 @@ class MeanOp final : public Operator<Context> {
     }
 
     // Dimension checking
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       if (output->sizes() != Input(i).sizes()) {
         CAFFE_THROW(
             "Check failed: output->sizes() == Input(i).sizes().",
@@ -43,7 +44,7 @@ class MeanOp final : public Operator<Context> {
     }
 
     T* output_data = output->template mutable_data<T>();
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       math::Add(
           output->numel(),
           output_data,
@@ -101,7 +102,7 @@ class MeanGradientOp : public Operator<Context> {
         size, scale, dY_data, dX0->template mutable_data<T>(), &context_);
 
     // Copy the rest dX
-    for (int i = 1; i < num_inputs; i++) {
+    for (const auto i : c10::irange(1, num_inputs)) {
       auto* cur_dX = Output(i);
       cur_dX->ResizeLike(dY);
       cur_dX->CopyFrom(*dX0, true /*async*/);

--- a/caffe2/operators/merge_id_lists_op.h
+++ b/caffe2/operators/merge_id_lists_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 
 C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(MergeIdLists);
 
@@ -50,7 +51,7 @@ class MergeIdListsOp : public Operator<Context> {
     // TODO(badri): Use unordered_set if performance is an issue
     std::set<T> deduped;
     std::vector<int> offsets(InputSize(), 0);
-    for (auto sample = 0; sample < batch_size; sample++) {
+    for (const auto sample : c10::irange(batch_size)) {
       for (size_t i = 0; i < InputSize(); i += 2) {
         auto& lengths = Input(i);
         const auto* lengths_data = lengths.template data<int32_t>();

--- a/caffe2/operators/minmax_ops.h
+++ b/caffe2/operators/minmax_ops.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -39,7 +40,7 @@ class MaxOp final : public Operator<Context> {
         Y->sizes());
     const T* X1_data = X1.template data<T>();
     math::Max<T, Context>(N, X0_data, X1_data, Y_data, &context_);
-    for (int i = 2; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(2, InputSize())) {
       const auto& Xi = Input(i);
       CAFFE_ENFORCE_EQ(
           Xi.sizes(),
@@ -87,7 +88,7 @@ class MinOp final : public Operator<Context> {
         Y->sizes());
     const T* X1_data = X1.template data<T>();
     math::Min<T, Context>(N, X0_data, X1_data, Y_data, &context_);
-    for (int i = 2; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(2, InputSize())) {
       const auto& Xi = Input(i);
       CAFFE_ENFORCE_EQ(
           Xi.sizes(),

--- a/caffe2/operators/moments_op.h
+++ b/caffe2/operators/moments_op.h
@@ -1,12 +1,13 @@
 #ifndef CAFFE2_OPERATORS_MOMENTS_OP_H_
 #define CAFFE2_OPERATORS_MOMENTS_OP_H_
 
-#include <algorithm>
-#include <vector>
-
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include <c10/util/irange.h>
+
+#include <algorithm>
+#include <vector>
 
 namespace caffe2 {
 
@@ -45,7 +46,7 @@ class MomentsOp final : public Operator<Context> {
     std::vector<std::int64_t> output_dims;
     output_dims.reserve(ndim);
     std::size_t cur_axis = 0;
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       if (cur_axis < axes_.size() && i == axes_[cur_axis]) {
         if (keep_dims_) {
           output_dims.push_back(1);

--- a/caffe2/operators/ngram_ops.h
+++ b/caffe2/operators/ngram_ops.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
-
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
+
+#include <vector>
 
 namespace caffe2 {
 template <typename F, typename T, class Context>
@@ -35,9 +36,9 @@ class NGramFromCategoricalOp : public Operator<Context> {
     }
     int base = 1;
     int idx = 0;
-    for (int k = 0; k < col_num_; k++) {
+    for (const auto k : c10::irange(col_num_)) {
       int l = categorical_limits_[k];
-      for (int m = 0; m < l; m++) {
+      for (const auto m : c10::irange(l)) {
         int v = vals_[idx++];
         ngram_maps_[k][v] = m * base;
       }
@@ -56,8 +57,8 @@ class NGramFromCategoricalOp : public Operator<Context> {
     math::Set<T, Context>(output->numel(), 0, output_data, &context_);
 
     CAFFE_ENFORCE_GT(D, max_col_id_);
-    for (int i = 0; i < N; i++) {
-      for (int k = 0; k < col_num_; k++) {
+    for (const auto i : c10::irange(N)) {
+      for (const auto k : c10::irange(col_num_)) {
         int j = col_ids_[k];
         int v = round(floats_data[i * D + j]);
         // for out-of-vocabulary values, we always treat them the same as the

--- a/caffe2/operators/normalize_op.h
+++ b/caffe2/operators/normalize_op.h
@@ -48,7 +48,7 @@ class NormalizeOp final : public Operator<Context> {
     using ConstStridedVec =
         Eigen::Map<const Eigen::Matrix<T, 1, Eigen::Dynamic>, 0, InnerStride>;
 
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto base = (i / sf) * sf * m + (i % sf);
       ConstStridedVec xVec(xData + base, 1, m, InnerStride(sf));
       auto norm = xVec.template lpNorm<2>();

--- a/caffe2/operators/numpy_tile_op.h
+++ b/caffe2/operators/numpy_tile_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -33,7 +34,7 @@ class NumpyTileOp : public Operator<Context> {
         " number of elements as `inputs` has dimensions.");
     const int64_t* repeats_data = repeats.template data<int64_t>();
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < repeats.numel(); ++i) {
+    for (const auto i : c10::irange(repeats.numel())) {
       CAFFE_ENFORCE_GE(repeats_data[i], 0);
     }
 
@@ -45,7 +46,7 @@ class NumpyTileOp : public Operator<Context> {
     Tensor *src = &buffer, *dst = output;
     src->CopyFrom(input);
     vector<int64_t> output_dims(input.sizes().vec());
-    for (size_t i = 0; i < repeats.numel(); ++i) {
+    for (const auto i : c10::irange(repeats.numel())) {
       if (repeats_data[i] == 1) {
         continue;
       }
@@ -100,8 +101,10 @@ class NumpyTileOp : public Operator<Context> {
       int64_t num_tiles,
       const char* input_data,
       char* output_data) {
-    for (auto i = 0; i < outer_dim; ++i) {
-      for (auto t = 0; t < num_tiles; ++t) {
+    for (const auto i : c10::irange(outer_dim)) {
+      (void)i; // Suppress unused variable warning
+      for (const auto t : c10::irange(num_tiles)) {
+        (void)t; // Suppress unused variable warning
         context_.CopyItemsSameDevice(meta, inner_dim, input_data, output_data);
         output_data += inner_dim * item_size;
       }

--- a/caffe2/operators/onnx_while_op.h
+++ b/caffe2/operators/onnx_while_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/operators/create_scope_op.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -94,7 +95,7 @@ class ONNXWhileOp final : public Operator<Context> {
         "outputs");
 
     // Copy initial loop-carried dependencies
-    for (int i = 0; i < num_loop_carried_deps; ++i) {
+    for (const auto i : c10::irange(num_loop_carried_deps)) {
       scope_->lcd_tensor(i)->CopyFrom(Input(i + num_inputs_before_lcds));
     }
 
@@ -126,7 +127,7 @@ class ONNXWhileOp final : public Operator<Context> {
     };
 
     // Allocate scan_outputs for zero-iteration case
-    for (int i = 0; i < num_scan_outputs; ++i) {
+    for (const auto i : c10::irange(num_scan_outputs)) {
       Output(i + num_loop_carried_deps)->Resize(0);
       Output(i + num_loop_carried_deps)->template mutable_data<int32_t>();
     }
@@ -154,13 +155,13 @@ class ONNXWhileOp final : public Operator<Context> {
         }
 
         // Copy forward loop-carried dependencies
-        for (int i = 0; i < num_loop_carried_deps; ++i) {
+        for (const auto i : c10::irange(num_loop_carried_deps)) {
           Blob* b = cur_ws->GetBlob(scope_->net()->external_output()[i + 1]);
           const Tensor& t = b->template Get<Tensor>();
           scope_->lcd_tensor(i)->CopyFrom(t);
         }
         // Copy out scan_outputs
-        for (int i = 0; i < num_scan_outputs; ++i) {
+        for (const auto i : c10::irange(num_scan_outputs)) {
           int net_output_idx = i + 1 + num_loop_carried_deps;
           const Tensor& scan_output =
               cur_ws->GetBlob(scope_->net()->external_output()[net_output_idx])
@@ -202,7 +203,7 @@ class ONNXWhileOp final : public Operator<Context> {
     }
 
     // Copy out final loop-carried dependencies
-    for (int i = 0; i < num_loop_carried_deps; ++i) {
+    for (const auto i : c10::irange(num_loop_carried_deps)) {
       Output(i)->CopyFrom(*scope_->lcd_tensor(i));
     }
 

--- a/caffe2/operators/op_utils_cudnn.h
+++ b/caffe2/operators/op_utils_cudnn.h
@@ -36,7 +36,7 @@ inline void LogCuDNNPerfStats(
     const ArrayOfcudnnConvolutionAlgoPerf_t& perf_stat,
     int returned_algo_count) {
   VLOG(1) << "Perf result: (algo: stat, time, memory)";
-  for (int i = 0; i < returned_algo_count; ++i) {
+  for (const auto i : c10::irange(returned_algo_count)) {
     const auto& stat = perf_stat[i];
     VLOG(1) << stat.algo << ": " << stat.status << " " << stat.time << " "
             << stat.memory;

--- a/caffe2/operators/operator_fallback_gpu.h
+++ b/caffe2/operators/operator_fallback_gpu.h
@@ -62,7 +62,7 @@ class GPUFallbackOpEx final : public Operator<CUDAContext> {
   }
 
   bool RunOnDevice() override {
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       if (this->InputIsTensorType(i, CUDA)) {
         // use sync copy
         BlobGetMutableTensor(local_input_blobs_[i], CPU)->CopyFrom(Input(i));
@@ -82,7 +82,7 @@ class GPUFallbackOpEx final : public Operator<CUDAContext> {
                  << ProtoDebugString(this->debug_def());
       return false;
     }
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       if (SkipOutputCopy::Contains(i)) {
         VLOG(1) << "Copy output: index " << i << " skipped.";
         continue;

--- a/caffe2/operators/order_switch_ops.h
+++ b/caffe2/operators/order_switch_ops.h
@@ -1,10 +1,11 @@
 #ifndef CAFFE2_OPERATORS_ORDER_SWITCH_OPS_H_
 #define CAFFE2_OPERATORS_ORDER_SWITCH_OPS_H_
 
-#include <vector>
-
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include <c10/util/irange.h>
+
+#include <vector>
 
 namespace caffe2 {
 
@@ -30,7 +31,7 @@ class NHWC2NCHWOp final : public Operator<Context> {
     Y_dims[0] = N;
     Y_dims[1] = C;
     int HxW = 1;
-    for (int i = 2; i < ndim; ++i) {
+    for (const auto i : c10::irange(2, ndim)) {
       Y_dims[i] = X.dim32(i - 1);
       HxW *= Y_dims[i];
     }

--- a/caffe2/operators/pack_rnn_sequence_op.h
+++ b/caffe2/operators/pack_rnn_sequence_op.h
@@ -1,11 +1,13 @@
 #ifndef CAFFE2_OPERATORS_PACK_RNN_SEQUENCE_OP_H_
 #define CAFFE2_OPERATORS_PACK_RNN_SEQUENCE_OP_H_
 
-#include <algorithm>
-#include <vector>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
+
+#include <algorithm>
+#include <vector>
 
 namespace caffe2 {
 
@@ -69,7 +71,7 @@ class PackRNNSequenceOpBase : public Operator<Context> {
     math::Set<ValT, Context>(output->numel(), 0, output_data, &context_);
 
     int32_t offset = 0;
-    for (int c = 0; c < cols; c++) {
+    for (const auto c : c10::irange(cols)) {
       for (int r = 0; r < lengths_vec[c]; r++) {
         auto input_offset = Forward ? (offset + r) : (r * cols + c);
         auto output_offset = Forward ? (r * cols + c) : (offset + r);

--- a/caffe2/operators/piecewise_linear_transform_op.h
+++ b/caffe2/operators/piecewise_linear_transform_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/operator.h"
 
 C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(PiecewiseLinearTransform);
@@ -61,7 +62,7 @@ class PiecewiseLinearTransformOp final : public Operator<Context> {
       const int64_t num_bounds_per_group,
       const int64_t num_group) {
     const T* start = bounds;
-    for (int64_t i = 0; i < num_group; i++) {
+    for (const auto i : c10::irange(num_group)) {
       if (!std::is_sorted(start, start + num_bounds_per_group)) {
         return false;
       }
@@ -153,11 +154,11 @@ class PiecewiseLinearTransformOp final : public Operator<Context> {
         &bounds, &slopes, &intercepts, &num_func_per_group, &num_group);
     CAFFE_ENFORCE_EQ(num_group, M);
 
-    for (int64_t j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       const T* bounds_group = bounds + j * (num_func_per_group + 1);
       const T* slopes_group = slopes + j * num_func_per_group;
       const T* intercepts_group = intercepts + j * num_func_per_group;
-      for (int64_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         Ydata[i * M + j] = PiecewiseLinearTransform(
             Xdata[i * M + j],
             bounds_group,
@@ -192,12 +193,12 @@ class PiecewiseLinearTransformOp final : public Operator<Context> {
     CAFFE_ENFORCE_EQ(num_group, 1);
 
     if (M == 1) {
-      for (int64_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         Ydata[i] = PiecewiseLinearTransform(
             Xdata[i], bounds, slopes, intercepts, num_func_per_group);
       }
     } else {
-      for (int64_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         Ydata[i * M + 1] = PiecewiseLinearTransform(
             Xdata[i * M + 1], bounds, slopes, intercepts, num_func_per_group);
         Ydata[i * M] = 1.0f - Ydata[i * M + 1];

--- a/caffe2/operators/pool_op.h
+++ b/caffe2/operators/pool_op.h
@@ -20,12 +20,12 @@ class PoolOp final : public ConvPoolOpBase<Context> {
   explicit PoolOp(Args&&... args)
       : ConvPoolOpBase<Context>(std::forward<Args>(args)...), functor_(*this) {
     const int kernel_size = kernel_.size();
-    for (int i = 0; i < kernel_size; ++i) {
+    for (const auto i : c10::irange(kernel_size)) {
       CAFFE_ENFORCE_EQ(
           dilation_[i], 1, "Pooling op does not support dilation right now.");
     }
     if (!global_pooling_) {
-      for (int i = 0; i < kernel_size; ++i) {
+      for (const auto i : c10::irange(kernel_size)) {
         CAFFE_ENFORCE(
             pads_[i] < kernel_[i] && pads_[i + kernel_size] < kernel_[i],
             "Pad should be smaller than kernel.");

--- a/caffe2/operators/prepend_dim_op.h
+++ b/caffe2/operators/prepend_dim_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -35,7 +36,7 @@ class PrependDimOp : public Operator<Context> {
     actual_new_shape[0] = dim_size_;
     actual_new_shape[1] = input.size(0) / dim_size_;
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 1; i < input.sizes().size(); ++i) {
+    for (const auto i : c10::irange(1, input.sizes().size())) {
       actual_new_shape[i + 1] = input.size(i);
     }
     output->Resize(actual_new_shape);

--- a/caffe2/operators/quant_decode_op.h
+++ b/caffe2/operators/quant_decode_op.h
@@ -1,6 +1,8 @@
 #ifndef QUANT_DECODE_OP_H_
 #define QUANT_DECODE_OP_H_
 
+
+#include <c10/util/irange.h>
 #include <c10/util/typeid.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
@@ -34,7 +36,7 @@ void Decode(
     }
 
     int sz = output->numel();
-    for (int i = 0; i < sz; i++) {
+    for (const auto i : c10::irange(sz)) {
       DCHECK_LE(*code_ptr, cb_size);
       *out_ptr++ = cb_ptr[*code_ptr++];
     }
@@ -116,7 +118,7 @@ class QuantDecodeOp final : public Operator<CPUContext> {
     const auto& codebook = Input(0);
     CAFFE_ENFORCE(codebook.template IsType<float>(), codebook.dtype().name());
 
-    for (int i = 0; i < OutputSize(); i++) {
+    for (const auto i : c10::irange(OutputSize())) {
       auto& ci = Input(i + 1);
       auto* co = Output(i);
 
@@ -157,7 +159,7 @@ class QuantDecodeGradientOp final : public Operator<CPUContext> {
     auto* gradient_ptr = gradient->template mutable_data<float>();
     std::fill(gradient_ptr, gradient_ptr + gradient->numel(), 0);
 
-    for (int i = 0; i < num_code_tensors; i++) {
+    for (const auto i : c10::irange(num_code_tensors)) {
       auto& codes_i = Input(i + 1);
       auto& output_gradient_i = Input(i + num_code_tensors + 1);
       DecodeGeneral(codebook, codes_i, &output_gradient_i, gradient, false);

--- a/caffe2/operators/quantile_op.h
+++ b/caffe2/operators/quantile_op.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
+
 #include <cmath>
 #include <limits>
-#include "caffe2/core/operator.h"
 
 namespace caffe2 {
 
@@ -42,7 +44,7 @@ class QuantileOp final : public Operator<Context> {
 
     auto& input_zero = Input(0);
     int64_t numel = input_zero.numel();
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).dtype(),
           input_zero.dtype(),
@@ -116,9 +118,9 @@ class QuantileOp final : public Operator<Context> {
   void GetRangeFromInputs(T* lo, T* hi) {
     *hi = std::numeric_limits<T>::lowest();
     *lo = std::numeric_limits<T>::max();
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto* input = Input(i).template data<T>();
-      for (int j = 0; j < Input(i).numel(); j++) {
+      for (const auto j : c10::irange(Input(i).numel())) {
         const T val = abs_ ? std::abs(input[j]) : input[j];
         if (*hi < val) {
           *hi = val;
@@ -133,9 +135,9 @@ class QuantileOp final : public Operator<Context> {
   template <typename T>
   int64_t CountLowerEq(const T& thd) {
     int64_t count = 0;
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto* input = Input(i).template data<T>();
-      for (int j = 0; j < Input(i).numel(); j++) {
+      for (const auto j : c10::irange(Input(i).numel())) {
         const T val = abs_ ? std::abs(input[j]) : input[j];
         if (val <= thd) {
           count++;

--- a/caffe2/operators/quantized/int8_concat_op.h
+++ b/caffe2/operators/quantized/int8_concat_op.h
@@ -1,6 +1,7 @@
 #ifndef CAFFE2_OPERATORS_INT8_CONCAT_OP_H_
 #define CAFFE2_OPERATORS_INT8_CONCAT_OP_H_
 
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor_int8.h"
@@ -46,10 +47,10 @@ class Int8ConcatOp final : public Operator<CPUContext> {
     if (this->template GetSingleArgument<string>("order", "") == "NHWC") {
       CHECK_EQ(Y_dims.size(), 4);
     }
-    for (auto i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       const auto& Xi = Inputs()[i]->template Get<Int8TensorCPU>();
       CHECK_EQ(Xi.t.dim(), Y_dims.size());
-      for (auto j = 0; j < Y_dims.size(); ++j) {
+      for (const auto j : c10::irange(Y_dims.size())) {
         if (j != axis_) {
           CHECK_EQ(Xi.t.size(j), Y_dims[j]);
         }
@@ -61,7 +62,7 @@ class Int8ConcatOp final : public Operator<CPUContext> {
     int after = X0.t.size_from_dim(axis_ + 1);
     const auto C_total = Y_dims[axis_];
     size_t C_offset = 0;
-    for (auto i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto& Xi = Inputs()[i]->template Get<Int8TensorCPU>();
       // Copy the NxHxWxC input slice to NxHxWx[C_offset:C_offset + C].
       const auto Ci = Xi.t.size(axis_);

--- a/caffe2/operators/quantized/int8_dequantize_op.h
+++ b/caffe2/operators/quantized/int8_dequantize_op.h
@@ -5,6 +5,8 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor_int8.h"
 #include "caffe2/operators/quantized/int8_utils.h"
+#include <c10/util/irange.h>
+
 
 namespace caffe2 {
 
@@ -18,7 +20,7 @@ void Int8Dequantize(
     const int64_t N,
     const float X_scale,
     const int32_t X_offset) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     out[i] = (static_cast<int32_t>(in[i]) - X_offset) * X_scale;
   }
 }

--- a/caffe2/operators/quantized/int8_given_tensor_fill_op.h
+++ b/caffe2/operators/quantized/int8_given_tensor_fill_op.h
@@ -40,7 +40,7 @@ class Int8GivenTensorFillOp final : public Operator<CPUContext> {
         {static_cast<int64_t>(source_values.size())},
         at::dtype<uint8_t>().device(CPU));
     uint8_t* values_data = values_.template mutable_data<uint8_t>();
-    for (int i = 0; i < source_values.size(); i++) {
+    for (const auto i : c10::irange(source_values.size())) {
       values_data[i] = static_cast<uint8_t>(source_values[i]);
     }
   }
@@ -92,7 +92,7 @@ class Int8GivenIntTensorFillOp final : public Operator<CPUContext> {
         {static_cast<int64_t>(source_values.size())},
         at::dtype<int32_t>().device(CPU));
     auto* values_data = values_.template mutable_data<int32_t>();
-    for (int i = 0; i < source_values.size(); i++) {
+    for (const auto i : c10::irange(source_values.size())) {
       values_data[i] = static_cast<int32_t>(source_values[i]);
     }
   }

--- a/caffe2/operators/quantized/int8_resize_nearest_op.h
+++ b/caffe2/operators/quantized/int8_resize_nearest_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor_int8.h"
 #include "caffe2/operators/quantized/int8_utils.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -54,10 +55,10 @@ class Int8ResizeNearestOp final : public Operator<CPUContext> {
     const uint8_t* Xdata = X.t.data<uint8_t>();
     uint8_t* Ydata = Y->t.mutable_data<uint8_t>();
 
-    for (int n = 0; n < N; ++n) {
-      for (int y = 0; y < OH; ++y) {
+    for (const auto n : c10::irange(N)) {
+      for (const auto y : c10::irange(OH)) {
         const int in_y = std::min((int)(y / height_scale_), (IH - 1));
-        for (int x = 0; x < OW; ++x) {
+        for (const auto x : c10::irange(OW)) {
           const int in_x = std::min((int)(x / width_scale_), (IW - 1));
           std::memcpy(
               &Ydata[C * x + C * OW * y + C * OW * OH * n],

--- a/caffe2/operators/quantized/int8_roi_align_op.h
+++ b/caffe2/operators/quantized/int8_roi_align_op.h
@@ -9,6 +9,7 @@
 #include "caffe2/core/tensor_int8.h"
 #include "caffe2/operators/quantized/int8_utils.h"
 #include "caffe2/utils/math.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -44,13 +45,13 @@ void pre_calc_for_bilinear_interpolate(
   int pre_calc_index = 0;
   // boltnn use a smaller multiplier here. Sometimes w will shrink to 0.
   const float w_multiplier = 255.0;
-  for (int ph = 0; ph < pooled_height; ph++) {
-    for (int pw = 0; pw < pooled_width; pw++) {
-      for (int iy = 0; iy < iy_upper; iy++) {
+  for (const auto ph : c10::irange(pooled_height)) {
+    for (const auto pw : c10::irange(pooled_width)) {
+      for (const auto iy : c10::irange(iy_upper)) {
         const float yy = roi_start_h + ph * bin_size_h +
             static_cast<float>(iy + .5f) * bin_size_h /
                 static_cast<float>(roi_bin_grid_h); // e.g., 0.5, 1.5
-        for (int ix = 0; ix < ix_upper; ix++) {
+        for (const auto ix : c10::irange(ix_upper)) {
           const float xx = roi_start_w + pw * bin_size_w +
               static_cast<float>(ix + .5f) * bin_size_w /
                   static_cast<float>(roi_bin_grid_w);
@@ -152,7 +153,7 @@ void ROIAlignForward(
 
   int n_rois = nthreads / channels / pooled_width / pooled_height;
 
-  for (int n = 0; n < n_rois; n++) {
+  for (const auto n : c10::irange(n_rois)) {
     int index_n = n * channels * pooled_width * pooled_height;
 
     // roi could have 4 or 5 columns
@@ -224,19 +225,19 @@ void ROIAlignForward(
     const uint8_t* offset_bottom_data =
         bottom_data + roi_batch_ind * channels * height * width;
     int pre_calc_index = 0;
-    for (int ph = 0; ph < pooled_height; ph++) {
-      for (int pw = 0; pw < pooled_width; pw++) {
+    for (const auto ph : c10::irange(pooled_height)) {
+      for (const auto pw : c10::irange(pooled_width)) {
         vector<int32_t> acc_buffer(channels, 0);
 
-        for (int iy = 0; iy < roi_bin_grid_h; iy++) {
-          for (int ix = 0; ix < roi_bin_grid_w; ix++) {
+        for (const auto iy : c10::irange(roi_bin_grid_h)) {
+          for (const auto ix : c10::irange(roi_bin_grid_w)) {
             PreCalc pc = pre_calc[pre_calc_index];
 
             const uint8_t* data_1 = offset_bottom_data + channels * pc.pos1;
             const uint8_t* data_2 = offset_bottom_data + channels * pc.pos2;
             const uint8_t* data_3 = offset_bottom_data + channels * pc.pos3;
             const uint8_t* data_4 = offset_bottom_data + channels * pc.pos4;
-            for (int c = 0; c < channels; ++c) {
+            for (const auto c : c10::irange(channels)) {
               acc_buffer[c] += (uint32_t)(pc.w1) * (uint32_t)(data_1[c]);
               acc_buffer[c] += (uint32_t)(pc.w2) * (uint32_t)(data_2[c]);
               acc_buffer[c] += (uint32_t)(pc.w3) * (uint32_t)(data_3[c]);
@@ -251,7 +252,7 @@ void ROIAlignForward(
         }
         int index_nhw = index_n + (ph * pooled_width + pw) * channels;
         uint8_t* out_ptr = top_data + index_nhw;
-        for (int c = 0; c < channels; ++c) {
+        for (const auto c : c10::irange(channels)) {
           int32_t a_mul = MultiplyByQuantizedMultiplierSmallerThanOne(
                               acc_buffer[c], Y_multiplier, Y_shift) +
               y_offset;

--- a/caffe2/operators/quantized/int8_roi_align_op_test.cc
+++ b/caffe2/operators/quantized/int8_roi_align_op_test.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/quantized/int8_test_utils.h"
 #include "caffe2/operators/quantized/int8_utils.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 

--- a/caffe2/operators/quantized/int8_test_utils.h
+++ b/caffe2/operators/quantized/int8_test_utils.h
@@ -77,7 +77,7 @@ inline std::unique_ptr<TensorCPU> biasdq(const int8::Int8TensorCPU& XQ) {
 #define EXPECT_TENSOR_EQ(_YA, _YE)                                     \
   do {                                                                 \
     EXPECT_TRUE((_YA).sizes() == (_YE).sizes());                       \
-    for (auto i = 0; i < (_YA).numel(); ++i) {                         \
+    for (const auto i : c10::irange((_YA).numel())) {                         \
       EXPECT_FLOAT_EQ((_YA).data<float>()[i], (_YE).data<float>()[i]); \
     }                                                                  \
   } while (0);
@@ -85,7 +85,7 @@ inline std::unique_ptr<TensorCPU> biasdq(const int8::Int8TensorCPU& XQ) {
 #define EXPECT_TENSOR_APPROX_EQ(_YA, _YE, _tol)                            \
   do {                                                                     \
     EXPECT_TRUE((_YA).sizes() == (_YE).sizes());                           \
-    for (auto i = 0; i < (_YA).numel(); ++i) {                             \
+    for (const auto i : c10::irange((_YA).numel())) {                             \
       EXPECT_NEAR((_YA).data<float>()[i], (_YE).data<float>()[i], (_tol)); \
     }                                                                      \
   } while (0);

--- a/caffe2/operators/reduce_front_back_max_ops.h
+++ b/caffe2/operators/reduce_front_back_max_ops.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -35,7 +36,7 @@ class MaxReduceDimsOp final : public Operator<Context> {
     int start_index = FIRSTDIMS ? num_reduce_dims_ : 0;
     int end_index = FIRSTDIMS ? X.dim() : X.dim() - num_reduce_dims_;
 
-    for (int i = start_index; i < end_index; ++i) {
+    for (const auto i : c10::irange(start_index, end_index)) {
       output_shape.push_back(X.sizes()[i]);
     }
     auto* Y = Output(0, output_shape, at::dtype<float>());

--- a/caffe2/operators/reduce_front_back_sum_mean_ops.h
+++ b/caffe2/operators/reduce_front_back_sum_mean_ops.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -35,7 +36,7 @@ class SumReduceDimsOp final : public Operator<Context> {
     vector<int64_t> output_shape;
     int start_index = FIRSTDIMS ? num_reduce_dims_ : 0;
     int end_index = FIRSTDIMS ? X.dim() : X.dim() - num_reduce_dims_;
-    for (int i = start_index; i < end_index; ++i) {
+    for (const auto i : c10::irange(start_index, end_index)) {
       output_shape.push_back(X.sizes()[i]);
     }
     auto* Y = Output(0, output_shape, at::dtype<T>());

--- a/caffe2/operators/reduce_ops.h
+++ b/caffe2/operators/reduce_ops.h
@@ -1,14 +1,15 @@
 #ifndef CAFFE2_OPERATORS_REDUCE_OPS_H_
 #define CAFFE2_OPERATORS_REDUCE_OPS_H_
 
-#include <algorithm>
-#include <functional>
-#include <vector>
-
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
+#include <c10/util/irange.h>
+
+#include <algorithm>
+#include <functional>
+#include <vector>
 
 namespace caffe2 {
 
@@ -50,7 +51,7 @@ class ReduceOp final : public Operator<Context> {
     std::vector<int64_t> output_dims;
     output_dims.reserve(ndim);
     std::size_t cur_axis = 0;
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       if (cur_axis < axes_.size() && i == axes_[cur_axis]) {
         if (keep_dims_) {
           output_dims.push_back(1);

--- a/caffe2/operators/reducer_functors.h
+++ b/caffe2/operators/reducer_functors.h
@@ -50,7 +50,7 @@ class SumRangeReducerGradient {
       const T* /*data_out*/, // unused
       Context* context) {
     // do we have some op that does it smartly with minimum number of memcpy?
-    for (int64_t i = 0; i < blocks; ++i) {
+    for (const auto i : c10::irange(blocks)) {
       context->template CopySameDevice<T>(
           block_size, segment_grad, data_grad + block_size * i);
     }
@@ -83,13 +83,13 @@ class LogSumExpRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T max_value = std::numeric_limits<T>::lowest();
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         max_value = std::max(max_value, in[i * block_size + j]);
       }
       T scaled_exp_sum = 0;
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         scaled_exp_sum += std::exp(in[i * block_size + j] - max_value);
       }
       *(out++) = std::log(scaled_exp_sum) + max_value;
@@ -109,10 +109,10 @@ class LogSumExpRangeReducerGradient {
       const T* data_in, // I
       const T* data_out, // O
       Context* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
       const T offset = *(data_out++);
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         data_grad[idx] = out_grad * std::exp(data_in[idx] - offset);
       }
@@ -145,13 +145,13 @@ class LogMeanExpRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T max_value = std::numeric_limits<T>::lowest();
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         max_value = std::max(max_value, in[i * block_size + j]);
       }
       T scaled_exp_sum = 0;
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         scaled_exp_sum += std::exp(in[i * block_size + j] - max_value);
       }
       scaled_exp_sum /= blocks;
@@ -171,10 +171,10 @@ class LogMeanExpRangeReducerGradient {
       const T* data_in, // I
       const T* data_out, // O
       Context* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
       const T offset = *(data_out++);
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         data_grad[idx] = out_grad * std::exp(data_in[idx] - offset) / blocks;
       }
@@ -207,9 +207,9 @@ class MeanRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T avg_value = 0;
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         avg_value += in[i * block_size + j] / blocks;
       }
       *(out++) = avg_value;
@@ -229,9 +229,9 @@ class MeanRangeReducerGradient {
       const T* /*data_out*/, // O
       Context* /*context*/) {
     const auto in_grad = 1.0 / blocks;
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         data_grad[idx] = out_grad * in_grad;
       }
@@ -266,9 +266,9 @@ class MaxRangeReducer<T, CPUContext> {
       const T* in,
       T* out,
       CPUContext* /*context*/) {
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       T max_value = std::numeric_limits<T>::lowest();
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         max_value = std::max(max_value, in[i * block_size + j]);
       }
       *(out++) = max_value;
@@ -289,10 +289,10 @@ class MaxRangeReducerGradient {
       Context* /*context*/) {
     std::memset(
         static_cast<void*>(data_grad), 0, blocks * block_size * sizeof(T));
-    for (int j = 0; j < block_size; ++j) {
+    for (const auto j : c10::irange(block_size)) {
       const T out_grad = *(segment_grad++);
       const T out = data_out[j];
-      for (int i = 0; i < blocks; ++i) {
+      for (const auto i : c10::irange(blocks)) {
         auto idx = i * block_size + j;
         if (out == data_in[idx]) {
           data_grad[idx] = out_grad;
@@ -813,7 +813,7 @@ class MaxReducerGradient : public BaseReducerGradient {
       int64_t /*offset*/,
       Context* /*context*/,
       const int /*length*/) {
-    for (int64_t i = 0; i < meta.block_size; ++i) {
+    for (const auto i : c10::irange(meta.block_size)) {
       data_grad[i] = data[i] == forward_output[i] ? s_grad_[i] : 0;
     }
   }

--- a/caffe2/operators/reduction_ops.h
+++ b/caffe2/operators/reduction_ops.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -164,7 +165,7 @@ class MaxReductionOp : public Operator<Context> {
           &context_);
     } else {
       const int input_size = N * M;
-      for (int i = 0; i < batch_size; ++i) {
+      for (const auto i : c10::irange(batch_size)) {
         math::ColwiseMax<T, Context>(
             M,
             N,

--- a/caffe2/operators/remove_data_blocks_op.h
+++ b/caffe2/operators/remove_data_blocks_op.h
@@ -6,6 +6,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -40,7 +41,7 @@ class RemoveDataBlocksOp final : public Operator<Context> {
     const auto* ind_ptr = indices.template data<T>();
 
     std::vector<T> ind_vec;
-    for (int64_t i = 0; i < indices_size; i++) {
+    for (const auto i : c10::irange(indices_size)) {
       ind_vec.push_back(ind_ptr[i]);
     }
     std::sort(ind_vec.begin(), ind_vec.end());
@@ -60,7 +61,7 @@ class RemoveDataBlocksOp final : public Operator<Context> {
 
     ind_vec.insert(ind_vec.begin(), -1);
     int64_t ind_vec_size = ind_vec.size();
-    for (auto i = 0; i < ind_vec_size; i++) {
+    for (const auto i : c10::irange(ind_vec_size)) {
       int64_t interval_start = ind_vec[i] + 1;
       int64_t interval_end =
           (i == ind_vec_size - 1) ? outer_size : ind_vec[i + 1];


### PR DESCRIPTION
Summary:
Modified loops in files under fbsource/fbcode/caffe2/ from the format

`for(TYPE var=x0;var<x_max;x++)`

to the format

`for(const auto var: irange(xmax))`

This was achieved by running r-barnes's loop upgrader script (D28874212) with some modification to exclude all files under /torch/jit and a number of reversions or unused variable suppression warnings added by hand.

Test Plan: Sandcastle

Differential Revision: D31705366

