### PR TITLE
use irange for loops

### DIFF
--- a/test/cpp/api/operations.cpp
+++ b/test/cpp/api/operations.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -11,7 +12,7 @@ struct OperationTest : torch::test::SeedingFixture {
 };
 
 TEST_F(OperationTest, Lerp) {
-  for (auto i = 0; i < TEST_AMOUNT; i++) {
+  for (const auto i : c10::irange(TEST_AMOUNT)) {
     // test lerp_kernel_scalar
     auto start = torch::rand({3, 5});
     auto end = torch::rand({3, 5});
@@ -35,13 +36,13 @@ TEST_F(OperationTest, Lerp) {
 }
 
 TEST_F(OperationTest, Cross) {
-  for (auto i = 0; i < TEST_AMOUNT; i++) {
+  for (const auto i : c10::irange(TEST_AMOUNT)) {
     // input
     auto a = torch::rand({10, 3});
     auto b = torch::rand({10, 3});
     // expected
     auto exp = torch::empty({10, 3});
-    for (int j = 0; j < 10; j++) {
+    for (const auto j : c10::irange(10)) {
       auto u1 = a[j][0], u2 = a[j][1], u3 = a[j][2];
       auto v1 = b[j][0], v2 = b[j][1], v3 = b[j][2];
       exp[j][0] = u2 * v3 - v2 * u3;

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/optim_baseline.h>
@@ -36,7 +37,7 @@ bool test_optimizer_xor(Options options) {
   while (running_loss > 0.1) {
     auto inputs = torch::empty({kBatchSize, 2});
     auto labels = torch::empty({kBatchSize});
-    for (size_t i = 0; i < kBatchSize; i++) {
+    for (const auto i : c10::irange(kBatchSize)) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
@@ -112,7 +113,7 @@ void check_exact_values(
   torch::Tensor input =
       torch::tensor({0.1, 0.2, 0.3, 0.4, 0.5, 0.6}, torch::kFloat64).reshape({3, 2});
 
-  for (size_t i = 0; i < kIterations; ++i) {
+  for (const auto i : c10::irange(kIterations)) {
     optimizer.zero_grad();
     auto output = model->forward(input);
     auto loss = output.sum();
@@ -124,7 +125,7 @@ void check_exact_values(
     if (i % kSampleEvery == 0) {
       ASSERT_TRUE(
           expected_parameters.at(i / kSampleEvery).size() == parameters.size());
-      for (size_t p = 0; p < parameters.size(); ++p) {
+      for (const auto p : c10::irange(parameters.size())) {
         ASSERT_TRUE(parameters[p]->defined());
         // Always compare using double dtype, regardless of the original dtype of the tensors
         auto computed = parameters[p]->flatten().to(torch::kFloat64);
@@ -143,7 +144,7 @@ void check_exact_values(
 TEST(OptimTest, OptimizerAccessors) {
   auto options = AdagradOptions(1.0);
   std::vector<torch::Tensor> params;
-  for (size_t i = 0; i < 3; i++) {
+  for (const auto i : c10::irange(3)) {
     params.push_back(torch::randn(10));
   }
   auto optimizer = Adagrad(params, options);
@@ -155,7 +156,7 @@ TEST(OptimTest, OptimizerAccessors) {
   // NOLINTNEXTLINE(modernize-use-emplace)
   params_groups.push_back(OptimizerParamGroup(params));
   auto& params_1 = params_groups[1].params();
-  for (size_t i = 0; i < params_1.size(); i++) {
+  for (const auto i : c10::irange(params_1.size())) {
     torch::equal(params[i], params_1[i]);
   }
 
@@ -225,7 +226,7 @@ TEST(OptimTest, OldInterface) {
 
     std::vector<torch::Tensor> params_;
     OLD_INTERFACE_WARNING_CHECK(params_ = optimizer.parameters());
-    for (size_t p = 0; p < size; ++p) {
+    for (const auto p : c10::irange(size)) {
       ASSERT_TRUE(params_[p].allclose(parameters[p]));
     }
   }

--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/functions/comm.h>
 #include <torch/nn/module.h>
 #include <torch/nn/modules/conv.h>
@@ -86,7 +87,7 @@ TEST_F(ParallelTest, Replicate_MultiCUDA) {
   }
   replicas[0]->to(torch::kCPU);
   ASSERT_EQ(replica1_parameters.size(), original_parameters.size());
-  for (size_t i = 0; i < original_parameters.size(); ++i) {
+  for (const auto i : c10::irange(original_parameters.size())) {
     ASSERT_TRUE(replica1_parameters[i].allclose(original_parameters[i]));
     ASSERT_TRUE(
         replica1_parameters[i].data_ptr<float>() !=
@@ -99,7 +100,7 @@ TEST_F(ParallelTest, Replicate_MultiCUDA) {
   }
   replicas[1]->to(torch::kCPU);
   ASSERT_EQ(replica2_parameters.size(), original_parameters.size());
-  for (size_t i = 0; i < original_parameters.size(); ++i) {
+  for (const auto i : c10::irange(original_parameters.size())) {
     ASSERT_TRUE(replica2_parameters[i].allclose(original_parameters[i]));
     ASSERT_TRUE(
         replica2_parameters[i].data_ptr<float>() !=
@@ -222,7 +223,7 @@ TEST_F(ParallelTest, DataParallelUsesAllAvailableCUDADevices_CUDA) {
   auto output = parallel::data_parallel(m, input);
 
   ASSERT_EQ(output.numel(), device_count);
-  for (size_t i = 0; i < device_count; ++i) {
+  for (const auto i : c10::irange(device_count)) {
     ASSERT_EQ(output[i].item<int32_t>(), i);
   }
 }
@@ -258,7 +259,7 @@ TEST_F(ParallelTest, DataParallelNumericalEquivalence_MultiCUDA) {
     auto model_dp = std::dynamic_pointer_cast<M>(model->clone());
 
     // run 3 training iterations
-    for (int i = 0; i < 3; ++i) {
+    for (const auto i : c10::irange(3)) {
       input += i;
       input_dp += i;
 

--- a/test/cpp/api/parameterlist.cpp
+++ b/test/cpp/api/parameterlist.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <algorithm>
@@ -78,11 +79,11 @@ TEST_F(ParameterListTest, AccessWithAt) {
   ASSERT_EQ(list->size(), 4);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < params.size(); ++i) {
+  for (const auto i : c10::irange(params.size())) {
     ASSERT_TRUE(torch::all(torch::eq(list->at(i), params[i])).item<bool>());
   }
 
-  for (size_t i = 0; i < params.size(); ++i) {
+  for (const auto i : c10::irange(params.size())) {
     ASSERT_TRUE(torch::all(torch::eq(list[i], params[i])).item<bool>());
   }
 

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <algorithm>
@@ -172,7 +173,7 @@ TEST_F(SequentialTest, AccessWithAt) {
   ASSERT_EQ(sequential->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(&sequential->at<M>(i), modules[i].get());
   }
 
@@ -201,7 +202,7 @@ TEST_F(SequentialTest, AccessWithPtr) {
   ASSERT_EQ(sequential->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(sequential->ptr(i).get(), modules[i].get());
     ASSERT_EQ(sequential[i].get(), modules[i].get());
     ASSERT_EQ(sequential->ptr<M>(i).get(), modules[i].get());

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/util/tempfile.h>
 #include <c10/util/flat_hash_map.h>
+#include <c10/util/irange.h>
 
 #include <torch/torch.h>
 
@@ -41,7 +42,7 @@ void is_optimizer_param_group_equal(const OptimizerParamGroup& lhs, const Optimi
   const auto& rhs_params = rhs.params();
 
   ASSERT_TRUE(lhs_params.size() == rhs_params.size());
-  for (size_t j = 0; j < lhs_params.size(); j++) {
+  for (const auto j : c10::irange(lhs_params.size())) {
     ASSERT_TRUE(torch::equal(lhs_params[j], rhs_params[j]));
   }
   ASSERT_TRUE(static_cast<const DerivedOptions&>(lhs.options()) == static_cast<const DerivedOptions&>(rhs.options()));
@@ -136,7 +137,7 @@ void test_serialize_optimizer(DerivedOptimizerOptions options, bool only_has_glo
   ASSERT_TRUE(optim3_2_state.size() == optim3_state.size());
 
   // checking correctness of serialization logic for optimizer.param_groups_ and optimizer.state_
-  for (int i = 0; i < optim3_2_param_groups.size(); i++) {
+  for (const auto i : c10::irange(optim3_2_param_groups.size())) {
     is_optimizer_param_group_equal<DerivedOptimizerOptions>(
       optim3_2_param_groups[i], optim3_param_groups[i]);
     is_optimizer_state_equal<DerivedOptimizerParamState>(optim3_2_state, optim3_state);
@@ -173,7 +174,7 @@ void write_tensors_to_archive(
     const BufferContainer& buffers) {
   archive.write(
       key + "/size", torch::tensor(static_cast<int64_t>(buffers.size())));
-  for (size_t index = 0; index < buffers.size(); ++index) {
+  for (const auto index : c10::irange(buffers.size())) {
     archive.write(
         key + "/" + c10::to_string(index), buffers[index], /*is_buffer=*/true);
   }
@@ -203,7 +204,7 @@ void write_step_buffers(
 TEST(SerializeTest, KeysFunc) {
   auto tempfile = c10::make_tempfile();
   torch::serialize::OutputArchive output_archive;
-  for (size_t i = 0; i < 3; i++) {
+  for (const auto i : c10::irange(3)) {
     output_archive.write("element/" + c10::to_string(i), c10::IValue(static_cast<int64_t>(i)));
   }
   output_archive.save_to(tempfile.name);
@@ -211,7 +212,7 @@ TEST(SerializeTest, KeysFunc) {
   input_archive.load_from(tempfile.name);
   std::vector<std::string> keys = input_archive.keys();
   ASSERT_EQ(keys.size(), 3);
-  for (size_t i = 0; i < keys.size(); i++) {
+  for (const auto i : c10::irange(keys.size())) {
     ASSERT_EQ(keys[i], "element/" + c10::to_string(i));
   }
 }
@@ -219,7 +220,7 @@ TEST(SerializeTest, KeysFunc) {
 TEST(SerializeTest, TryReadFunc) {
   auto tempfile = c10::make_tempfile();
   torch::serialize::OutputArchive output_archive;
-  for (size_t i = 0; i < 3; i++) {
+  for (const auto i : c10::irange(3)) {
     output_archive.write("element/" + c10::to_string(i), c10::IValue(static_cast<int64_t>(i)));
   }
   output_archive.save_to(tempfile.name);
@@ -363,7 +364,7 @@ TEST(SerializeTest, XOR) {
   auto getLoss = [](Sequential model, uint32_t batch_size) {
     auto inputs = torch::empty({batch_size, 2});
     auto labels = torch::empty({batch_size});
-    for (size_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
@@ -533,7 +534,7 @@ TEST(SerializeTest, Optim_SGD) {
   int64_t iteration_{0};
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const SGDParamState& curr_state_ = static_cast<const SGDParamState&>(*(optim1_state.at(key_).get()));
@@ -577,7 +578,7 @@ TEST(SerializeTest, Optim_Adam) {
   std::vector<at::Tensor> max_exp_average_sq_buffers;
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const AdamParamState& curr_state_ = static_cast<const AdamParamState&>(*(optim1_state.at(key_).get()));
@@ -627,7 +628,7 @@ TEST(SerializeTest, Optim_AdamW) {
   std::vector<at::Tensor> max_exp_average_sq_buffers;
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const AdamWParamState& curr_state_ = static_cast<const AdamWParamState&>(*(optim1_state.at(key_).get()));
@@ -678,7 +679,7 @@ TEST(SerializeTest, Optim_RMSprop) {
   std::vector<at::Tensor> grad_average_buffers;
   const auto& params_ = optim1.param_groups()[0].params();
   const auto& optim1_state = optim1.state();
-  for (size_t i = 0; i < params_.size(); i++) {
+  for (const auto i : c10::irange(params_.size())) {
     if(i != (params_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       const RMSpropParamState& curr_state_ = static_cast<const RMSpropParamState&>(*(optim1_state.at(key_).get()));
@@ -703,7 +704,7 @@ TEST(SerializeTest, Optim_RMSprop) {
   const auto& params1_2_ = optim1_2.param_groups()[0].params();
   auto& optim1_2_state = optim1_2.state();
   // old RMSprop didn't track step value
-  for (size_t i = 0; i < params1_2_.size(); i++) {
+  for (const auto i : c10::irange(params1_2_.size())) {
     if(i != (params1_2_.size() - 1)) {
       auto key_ = c10::guts::to_string(params_[i].unsafeGetTensorImpl());
       auto key1_2_ = c10::guts::to_string(params1_2_[i].unsafeGetTensorImpl());
@@ -788,7 +789,7 @@ TEST(SerializeTest, XOR_CUDA) {
       inputs = inputs.cuda();
       labels = labels.cuda();
     }
-    for (size_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       inputs[i] = torch::randint(2, {2}, torch::kInt64);
       labels[i] = inputs[i][0].item<int64_t>() ^ inputs[i][1].item<int64_t>();
     }
@@ -879,7 +880,7 @@ TEST(SerializeTest, VectorOfTensors) {
   std::vector<torch::Tensor> y_vec;
   torch::load(y_vec, stream);
 
-  for (int64_t i = 0; i < x_vec.size(); i++) {
+  for (const auto i : c10::irange(x_vec.size())) {
     auto& x = x_vec[i];
     auto& y = y_vec[i];
     ASSERT_TRUE(y.defined());

--- a/test/cpp/api/static.cpp
+++ b/test/cpp/api/static.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/detail/static.h>
 #include <torch/csrc/utils/variadic.h>
 #include <torch/torch.h>
@@ -95,7 +96,7 @@ TEST(TestStatic, Apply) {
   std::vector<int> v;
   torch::apply([&v](int x) { v.push_back(x); }, 1, 2, 3, 4, 5);
   ASSERT_EQ(v.size(), 5);
-  for (size_t i = 0; i < v.size(); ++i) {
+  for (const auto i : c10::irange(v.size())) {
     ASSERT_EQ(v.at(i), i + 1);
   }
 }

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <test/cpp/api/support.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <cmath>
@@ -263,7 +264,7 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   tensor = at::tensor(v);
   ASSERT_EQ(tensor.numel(), v.size());
   ASSERT_EQ(tensor.dtype(), at::kInt);
-  for (size_t i = 0; i < v.size(); ++i) {
+  for (const auto i : c10::irange(v.size())) {
     ASSERT_TRUE(exactly_equal(tensor[i], v.at(i)));
   }
 
@@ -271,7 +272,7 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   tensor = at::tensor(w);
   ASSERT_EQ(tensor.numel(), w.size());
   ASSERT_EQ(tensor.dtype(), at::kDouble);
-  for (size_t i = 0; i < w.size(); ++i) {
+  for (const auto i : c10::irange(w.size())) {
     ASSERT_TRUE(almost_equal(tensor[i], w.at(i)));
   }
 
@@ -282,7 +283,7 @@ TEST(TensorTest, AtTensorCtorSingleDim) {
   tensor = at::tensor(x);
   ASSERT_EQ(tensor.numel(), x.size());
   ASSERT_EQ(tensor.dtype(), at::kComplexDouble);
-  for (size_t i = 0; i < x.size(); ++i) {
+  for (const auto i : c10::irange(x.size())) {
     ASSERT_TRUE(almost_equal(tensor[i], x.at(i)));
   }
 }
@@ -913,8 +914,8 @@ TEST(TensorTest, FromBlobWithStrides) {
   ASSERT_EQ(tensor.numel(), 9);
   const std::vector<int64_t> expected_strides = {1, 3};
   ASSERT_EQ(tensor.strides(), expected_strides);
-  for (int64_t i = 0; i < tensor.size(0); ++i) {
-    for (int64_t j = 0; j < tensor.size(1); ++j) {
+  for (const auto i : c10::irange(tensor.size(0))) {
+    for (const auto j : c10::irange(tensor.size(1))) {
       // NOTE: This is column major because the strides are swapped.
       EXPECT_EQ(tensor[i][j].item<int32_t>(), 1 + (j * tensor.size(1)) + i);
     }

--- a/test/cpp/c10d/ProcessGroupGlooTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooTest.cpp
@@ -242,7 +242,7 @@ void checkProfiledEvents(
       auto match = !strcmp(evt.name(), expected_profile_str);
       if (verify_shapes && match) {
         auto shapesVec = evt.shapes();
-        for (int i = 0; i < expected_count; i++) {
+        for (const auto i : c10::irange(expected_count)) {
           // Assumptions: no two expected shapes are the same
           if (shapesVec[0] == expected_shapes[i]) {
             matched_shapes[i] = true;

--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -312,8 +312,7 @@ class ReduceScatterBaseNCCLTest : public NCCLTest {
       : NCCLTest(path, worldSize) {
         output_tensor_ = at::empty({1}, at::kCUDA);
         input_tensor_ = at::empty({worldSize}, at::kCUDA);
-        for(int i = 0; i < worldSize; i++)
-        {
+        for (const auto i : c10::irange(worldSize)) {
           input_tensor_[i] = i;
         }
       }

--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -2,6 +2,7 @@
 
 #include <tensorpipe/common/cpu_buffer.h>
 #include <tensorpipe/core/message.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/distributed/rpc/tensorpipe_utils.h>
 #include <torch/torch.h>
 
@@ -64,7 +65,7 @@ TEST(TensorpipeSerialize, Base) {
   // Mimic tensorpipe data transfer
   EXPECT_EQ(
       recvingTpAllocation.payloads.size(), sendingTpMessage.payloads.size());
-  for (int i = 0; i < recvingTpAllocation.payloads.size(); i++) {
+  for (const auto i : c10::irange(recvingTpAllocation.payloads.size())) {
     tensorpipe::Message::Payload& srcPayload = sendingTpMessage.payloads[i];
     tensorpipe::Allocation::Payload& dstPayload =
         recvingTpAllocation.payloads[i];
@@ -76,7 +77,7 @@ TEST(TensorpipeSerialize, Base) {
   }
   EXPECT_EQ(
       recvingTpAllocation.tensors.size(), sendingTpMessage.tensors.size());
-  for (int i = 0; i < recvingTpAllocation.tensors.size(); i++) {
+  for (const auto i : c10::irange(recvingTpAllocation.tensors.size())) {
     tensorpipe::Message::Tensor& srcTensor = sendingTpMessage.tensors[i];
     tensorpipe::Allocation::Tensor& dstTensor = recvingTpAllocation.tensors[i];
     memcpy(

--- a/test/cpp/rpc/test_wire_serialization.cpp
+++ b/test/cpp/rpc/test_wire_serialization.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 #include <torch/torch.h>
 
@@ -27,7 +28,7 @@ TEST(WireSerialize, Base) {
       EXPECT_TRUE(
           memcmp(deser.first.data(), payload.data(), payload.size()) == 0);
     }
-    for (size_t i = 0; i < tensors.size(); ++i) {
+    for (const auto i : c10::irange(tensors.size())) {
       EXPECT_TRUE(torch::equal(tensors[i], deser.second[i]));
     }
   };

--- a/test/cpp/tensorexpr/padded_buffer.cpp
+++ b/test/cpp/tensorexpr/padded_buffer.cpp
@@ -1,6 +1,7 @@
 #include "test/cpp/tensorexpr/padded_buffer.h"
 
 #include <c10/util/Logging.h>
+#include <c10/util/irange.h>
 #include <sstream>
 
 namespace torch {
@@ -10,7 +11,7 @@ namespace tensorexpr {
 int PaddedBufferBase::Index(const std::vector<int>& indices) const {
   DCHECK_EQ(dims_.size(), indices.size());
   int total_index = 0;
-  for (size_t i = 0; i < dims_.size(); i++) {
+  for (const auto i : c10::irange(dims_.size())) {
     total_index += indices[i] * strides_[i];
   }
   return total_index;

--- a/test/cpp/tensorexpr/padded_buffer.h
+++ b/test/cpp/tensorexpr/padded_buffer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include <c10/util/irange.h>
 #include "torch/csrc/jit/tensorexpr/eval.h"
 
 namespace torch {
@@ -168,7 +169,7 @@ class PaddedBuffer : public PaddedBufferBase {
 
   // Verify the watermarks in the paddings are intact.
   void ValidateWatermark() const {
-    for (int i = 0; i < kPaddingSize; i++) {
+    for (const auto i : c10::irange(kPaddingSize)) {
       ASSERT_EQ(data_[i], kPaddingValue);
       ASSERT_EQ(data_[i + total_size_ + kPaddingSize], kPaddingValue);
     }
@@ -178,7 +179,7 @@ class PaddedBuffer : public PaddedBufferBase {
     ValidateWatermark();
     DCHECK(backup_data_.size() == data_.size())
         << "Please make sure you have call Backup() before calling CheckBackup()";
-    for (int i = 0; i < total_size_; i++) {
+    for (const auto i : c10::irange(total_size_)) {
       ASSERT_EQ(data_[i + kPaddingSize], backup_data_[i + kPaddingSize]);
     }
   }
@@ -214,7 +215,7 @@ void ExpectAllEqual(const PaddedBuffer<T>& f1, const PaddedBuffer<T>& f2) {
   ASSERT_EQ(v1.size(), v2.size());
   f1.ValidateWatermark();
   f2.ValidateWatermark();
-  for (int i = 0; i < total_size; i++) {
+  for (const auto i : c10::irange(total_size)) {
     ASSERT_EQ(v1[kPaddingSize + i], v2[kPaddingSize + i]);
   }
 }
@@ -231,7 +232,7 @@ void ExpectAllNear(
   ASSERT_EQ(v1.size(), v2.size());
   f1.ValidateWatermark();
   f2.ValidateWatermark();
-  for (int i = 0; i < total_size; i++) {
+  for (const auto i : c10::irange(total_size)) {
     ASSERT_NEAR(v1[kPaddingSize + i], v2[kPaddingSize + i], abs_error);
   }
 }

--- a/test/cpp/tensorexpr/test_aten.cpp
+++ b/test/cpp/tensorexpr/test_aten.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 #include "test/cpp/tensorexpr/padded_buffer.h"
 #include "test/cpp/tensorexpr/test_base.h"
 #include "torch/csrc/jit/tensorexpr/ir_printer.h"
@@ -28,14 +29,14 @@ TEST(ATen, _cast_Float) {
   PaddedBuffer<int> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), static_cast<float>(i));
   }
@@ -55,14 +56,14 @@ TEST(ATen, negInt) {
   PaddedBuffer<int> a_v(kTotalSize);
   PaddedBuffer<int> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), -static_cast<float>(i));
   }
@@ -82,14 +83,14 @@ TEST(ATen, negFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), -i);
   }
@@ -114,7 +115,7 @@ TEST(ATen, addInt) {
   PaddedBuffer<int> c_v(kTotalSize);
   PaddedBuffer<int> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -123,7 +124,7 @@ TEST(ATen, addInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -150,7 +151,7 @@ TEST(ATen, addFloat) {
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -159,7 +160,7 @@ TEST(ATen, addFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -186,7 +187,7 @@ TEST(ATen, subInt) {
   PaddedBuffer<int> c_v(kTotalSize);
   PaddedBuffer<int> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -195,7 +196,7 @@ TEST(ATen, subInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -222,7 +223,7 @@ TEST(ATen, subFloat) {
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -231,7 +232,7 @@ TEST(ATen, subFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -258,7 +259,7 @@ TEST(ATen, lerp) {
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> d_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -267,7 +268,7 @@ TEST(ATen, lerp) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf});
   ir_eval(a_v, b_v, c_v, d_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -297,7 +298,7 @@ TEST(ATen, addcmulInt) {
   PaddedBuffer<int> d_v(kTotalSize);
   PaddedBuffer<int> e_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -307,7 +308,7 @@ TEST(ATen, addcmulInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf, e_buf});
   ir_eval(a_v, b_v, c_v, d_v, e_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -338,7 +339,7 @@ TEST(ATen, addcmulFloat) {
   PaddedBuffer<float> d_v(kTotalSize);
   PaddedBuffer<float> e_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
     c_v(i) = 3 * i + 2;
@@ -348,7 +349,7 @@ TEST(ATen, addcmulFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf, d_buf, e_buf});
   ir_eval(a_v, b_v, c_v, d_v, e_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), 3 * i + 2);
@@ -373,7 +374,7 @@ TEST(ATen, mulInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -381,7 +382,7 @@ TEST(ATen, mulInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), a_v(i) * b_v(i));
@@ -404,7 +405,7 @@ TEST(ATen, mulFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -412,7 +413,7 @@ TEST(ATen, mulFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), a_v(i) * b_v(i));
@@ -435,7 +436,7 @@ TEST(ATen, divInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = 2 * i + 1;
     b_v(i) = i + 1;
   }
@@ -443,7 +444,7 @@ TEST(ATen, divInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), 2 * i + 1);
     ASSERT_EQ(b_v(i), i + 1);
     ASSERT_EQ(c_v(i), a_v(i) / b_v(i));
@@ -466,7 +467,7 @@ TEST(ATen, divFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = 2 * i + 1;
     b_v(i) = i + 1;
   }
@@ -474,7 +475,7 @@ TEST(ATen, divFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), 2 * i + 1);
     ASSERT_EQ(b_v(i), i + 1);
     ASSERT_EQ(c_v(i), a_v(i) / b_v(i));
@@ -497,7 +498,7 @@ TEST(ATen, maxInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -505,7 +506,7 @@ TEST(ATen, maxInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::max(a_v(i), b_v(i)));
@@ -528,7 +529,7 @@ TEST(ATen, maxFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -536,7 +537,7 @@ TEST(ATen, maxFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::fmax(a_v(i), b_v(i)));
@@ -559,7 +560,7 @@ TEST(ATen, minInt) {
   PaddedBuffer<int> b_v(kTotalSize);
   PaddedBuffer<int> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -567,7 +568,7 @@ TEST(ATen, minInt) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::min(a_v(i), b_v(i)));
@@ -590,7 +591,7 @@ TEST(ATen, minFloat) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
     b_v(i) = 2 * i + 1;
   }
@@ -598,7 +599,7 @@ TEST(ATen, minFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf, c_buf});
   ir_eval(a_v, b_v, c_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 2 * i + 1);
     ASSERT_EQ(c_v(i), std::fmin(a_v(i), b_v(i)));
@@ -618,14 +619,14 @@ void __ubsan_ignore_float_divide_by_zero__ testATenreciprocal() {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i);
     ASSERT_EQ(b_v(i), 1.0f / i);
   }
@@ -644,14 +645,14 @@ TEST(ATen, reluInt) {
   PaddedBuffer<int> a_v(kTotalSize);
   PaddedBuffer<int> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i - 64;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i - 64);
     ASSERT_EQ(b_v(i), std::max(a_v(i), 0));
   }
@@ -672,14 +673,14 @@ TEST(ATen, reluFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i - 64;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i - 64);
     ASSERT_EQ(b_v(i), std::fmax(a_v(i), 0));
   }
@@ -698,14 +699,14 @@ TEST(ATen, logFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i + 10;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i + 10);
     ASSERT_EQ(b_v(i), std::log(a_v(i)));
   }
@@ -724,14 +725,14 @@ TEST(ATen, fastLogFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = at::randn({1}).item().to<float>();
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     auto test = b_v(i);
     auto ref = std::log(a_v(i));
     if (std::isnan(ref)) {
@@ -755,14 +756,14 @@ TEST(ATen, fastTanhFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = at::randn({1}).item().to<float>();
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     auto test = b_v(i);
     auto ref = std::tanh(a_v(i));
     if (std::isnan(ref)) {
@@ -786,14 +787,14 @@ TEST(ATen, fastSigmoidFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = at::randn({1}).item().to<float>();
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     auto test = b_v(i);
     at::Tensor t = at::ones({1}) * a_v(i);
     float ref = at::sigmoid(t).item().to<float>();
@@ -818,14 +819,14 @@ TEST(ATen, log10Float) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i + 10;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i + 10);
     ASSERT_EQ(b_v(i), std::log10(a_v(i)));
   }
@@ -844,14 +845,14 @@ TEST(ATen, log2Float) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i + 10;
   }
 
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i + 10);
     ASSERT_EQ(b_v(i), std::log2(a_v(i)));
   }
@@ -870,7 +871,7 @@ TEST(ATen, expFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     a_v(i) = i / 10.0f;
   }
@@ -878,7 +879,7 @@ TEST(ATen, expFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i / 10.0f);
     ASSERT_EQ(b_v(i), std::exp(a_v(i)));
   }
@@ -897,7 +898,7 @@ TEST(ATen, erfFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     a_v(i) = i / 10.0f;
   }
@@ -905,7 +906,7 @@ TEST(ATen, erfFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i / 10.0f);
     ASSERT_EQ(b_v(i), std::erf(a_v(i)));
   }
@@ -924,7 +925,7 @@ TEST(ATen, cosFloat) {
   PaddedBuffer<float> a_v(kTotalSize);
   PaddedBuffer<float> b_v(kTotalSize);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     a_v(i) = i / 10.0f;
   }
@@ -932,7 +933,7 @@ TEST(ATen, cosFloat) {
   SimpleIREvaluator ir_eval(stmt, {a_buf, b_buf});
   ir_eval(a_v, b_v);
 
-  for (int i = 0; i < kTotalSize; ++i) {
+  for (const auto i : c10::irange(kTotalSize)) {
     ASSERT_EQ(a_v(i), i / 10.0f);
     ASSERT_EQ(b_v(i), std::cos(a_v(i)));
   }

--- a/test/cpp/tensorexpr/test_cpp_codegen.cpp
+++ b/test/cpp/tensorexpr/test_cpp_codegen.cpp
@@ -2,6 +2,7 @@
 
 #include "test/cpp/tensorexpr/test_base.h"
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/cpp_codegen.h>
 #include <torch/csrc/jit/tensorexpr/fwd_decls.h>
 #include <torch/csrc/jit/tensorexpr/stmt.h>
@@ -207,7 +208,7 @@ TEST(CppPrinter, Cond) {
 TEST(CppPrinter, Intrinsics) {
   const std::unordered_set<IntrinsicsOp, std::hash<int>> unsupported_ops{
       kRand, kSigmoid};
-  for (int i = 0; i < kMaxIntrinsicsOp; i++) {
+  for (const auto i : c10::irange(static_cast<uint32_t>(kMaxIntrinsicsOp))) {
     IntrinsicsOp op = static_cast<IntrinsicsOp>(i);
     if (unsupported_ops.count(op)) {
       continue;

--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -2,6 +2,7 @@
 
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/padded_buffer.h>
 #include <test/cpp/tensorexpr/test_utils.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
@@ -163,7 +164,7 @@ TEST(Expr, VectorAdd01) {
 
   /*
   Build the following:
-    for (int index = 0; index < kVectorCount; index++) {
+    for (const auto index : c10::irange(kVectorCount)) {
       store(c_buf, ramp(index * 8, 1, 8),
             load(a_buf, ramp(index * 8, 1, 8) +
             load(b_buf, ramp(index * 8, 1, 8))))
@@ -187,7 +188,7 @@ TEST(Expr, VectorAdd01) {
   PaddedBuffer<float> b_v(kTotalSize);
   PaddedBuffer<float> c_v(kTotalSize);
   PaddedBuffer<float> c_ref(kTotalSize);
-  for (int i = 0; i < kTotalSize; i++) {
+  for (const auto i : c10::irange(kTotalSize)) {
     a_v(i) = i * i;
     b_v(i) = i * i * 4;
     c_ref(i) = a_v(i) + b_v(i);
@@ -568,7 +569,7 @@ void testCond01() {
   SimpleIREvaluator(for_stmt, {a_buf})(a_v);
 
   PaddedBuffer<float> a_ref(N);
-  for (int i = 0; i < N; i++) {
+  for (const auto i : c10::irange(N)) {
     if (i % 2 == 0) {
       a_ref(i) = i * 2;
     } else {

--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/test_base.h>
 #include <torch/csrc/jit/frontend/code_template.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -416,13 +417,13 @@ TEST_F(Kernel, DISABLED_Shape_Inference) {
     // Check sizes
     CHECK_EQ(o.sizes().size(), ref.sizes().size());
     size_t num_el = 1;
-    for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+    for (const auto idx : c10::irange(ref.sizes().size())) {
       CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
       num_el *= ref.sizes()[idx];
     }
 
     // Check the contents
-    for (size_t i = 0; i < num_el; i++) {
+    for (const auto i : c10::irange(num_el)) {
       CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
     }
   }
@@ -469,13 +470,13 @@ TEST_F(Kernel, DISABLED_Shape_Inference) {
     // Check sizes
     CHECK_EQ(o.sizes().size(), ref.sizes().size());
     size_t num_el = 1;
-    for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+    for (const auto idx : c10::irange(ref.sizes().size())) {
       CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
       num_el *= ref.sizes()[idx];
     }
 
     // Check the contents
-    for (size_t i = 0; i < num_el; i++) {
+    for (const auto i : c10::irange(num_el)) {
       CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
     }
   }
@@ -569,13 +570,13 @@ TEST_F(Kernel, CatInputTypesPromotion) {
     CHECK_EQ(o.sizes().size(), ref.sizes().size());
     CHECK_EQ(o.dtype(), ref.dtype());
     size_t num_el = 1;
-    for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+    for (const auto idx : c10::irange(ref.sizes().size())) {
       CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
       num_el *= ref.sizes()[idx];
     }
 
     // Check the contents
-    for (size_t i = 0; i < num_el; i++) {
+    for (const auto i : c10::irange(num_el)) {
       CHECK_EQ(((double*)o.data_ptr())[i], ((double*)ref.data_ptr())[i]);
     }
   }
@@ -658,13 +659,13 @@ TEST_F(Kernel, CatWoConditionals) {
   CHECK_EQ(o.sizes().size(), ref.sizes().size());
   CHECK_EQ(o.dtype(), ref.dtype());
   size_t num_el = 1;
-  for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+  for (const auto idx : c10::irange(ref.sizes().size())) {
     CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
     num_el *= ref.sizes()[idx];
   }
 
   // Check the contents
-  for (size_t i = 0; i < num_el; i++) {
+  for (const auto i : c10::irange(num_el)) {
     CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
   }
   getCatWoConditionals() = false;
@@ -723,13 +724,13 @@ TEST_F(Kernel, OptimizeConditionals) {
   CHECK_EQ(o.sizes().size(), ref.sizes().size());
   CHECK_EQ(o.dtype(), ref.dtype());
   size_t num_el = 1;
-  for (size_t idx = 0; idx < ref.sizes().size(); idx++) {
+  for (const auto idx : c10::irange(ref.sizes().size())) {
     CHECK_EQ(o.sizes()[idx], ref.sizes()[idx]);
     num_el *= ref.sizes()[idx];
   }
 
   // Check the contents
-  for (size_t i = 0; i < num_el; i++) {
+  for (const auto i : c10::irange(num_el)) {
     CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
   }
   getOptConditionals() = old_opt_conditionals;
@@ -904,7 +905,7 @@ TEST_F(Kernel, SumMultipleAxes) {
 
   // Only iterate over positive values of axes to keep the running time
   // reasonable, since the number of pairs is quadratic.
-  for (int dim1 = 0; dim1 < a.dim(); ++dim1) {
+  for (const auto dim1 : c10::irange(a.dim())) {
     for (int dim2 = dim1 + 1; dim2 < a.dim(); ++dim2) {
       for (bool keepdim : {false, true}) {
         TemplateEnv env;
@@ -977,7 +978,7 @@ TEST_F(Kernel, Softmax2D) {
         # CHECK-NEXT: aten_softmax)IR";
 
   for (auto log_softmax : {false, true}) {
-    for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
+    for (const auto softmax_dim : c10::irange(a.dim())) {
       auto softmax_dim_size = a.sizes()[softmax_dim];
       auto other_dim = (softmax_dim + 1) % a.dim();
       auto ref =
@@ -1046,10 +1047,10 @@ TEST_F(Kernel, Softmax3D) {
         # CHECK-NEXT: aten_softmax)IR";
 
   for (auto log_softmax : {false, true}) {
-    for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
+    for (const auto softmax_dim : c10::irange(a.dim())) {
       auto softmax_dim_size = a.sizes()[softmax_dim];
       std::vector<int> other_dims;
-      for (int i = 0; i < a.dim(); ++i) {
+      for (const auto i : c10::irange(a.dim())) {
         if (i != softmax_dim) {
           other_dims.push_back(i);
         }
@@ -1127,10 +1128,10 @@ TEST_F(Kernel, Softmax4D) {
         # CHECK-NEXT: aten_softmax)IR";
 
   for (auto log_softmax : {false, true}) {
-    for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
+    for (const auto softmax_dim : c10::irange(a.dim())) {
       auto softmax_dim_size = a.sizes()[softmax_dim];
       std::vector<int> other_dims;
-      for (int i = 0; i < a.dim(); ++i) {
+      for (const auto i : c10::irange(a.dim())) {
         if (i != softmax_dim) {
           other_dims.push_back(i);
         }

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -8,6 +8,7 @@
 
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/padded_buffer.h>
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
@@ -28,7 +29,7 @@ TEST(Reductions, ReduceSum0D_1) {
 
   BufHandle b("b", {M}, kFloat);
   std::vector<float> in(M);
-  for (int j = 0; j < M; ++j) {
+  for (const auto j : c10::irange(M)) {
     in[j] = j;
   }
 
@@ -43,7 +44,7 @@ TEST(Reductions, ReduceSum0D_1) {
   SimpleIREvaluator cg(s, {b, c});
 
   cg.call({in, out});
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[i], in[i]);
   }
 }
@@ -73,7 +74,7 @@ TEST(Reductions, ReduceSum0D_2) {
 TEST(Reductions, ReduceSum1D) {
   BufHandle b("b", {10}, kFloat);
   std::vector<float> in(10);
-  for (int j = 0; j < 10; ++j) {
+  for (const auto j : c10::irange(10)) {
     in[j] = j;
   }
 
@@ -100,8 +101,8 @@ TEST(Reductions, ReduceSum2D) {
 
   BufHandle b("b", {m, n}, kFloat);
   std::vector<float> in(M * N);
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       in[i * N + j] = j;
     }
   }
@@ -119,12 +120,12 @@ TEST(Reductions, ReduceSum2D) {
   cg.call({in, out, 5, 7});
 
   float expected = 0;
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected += i;
   }
 
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[i], expected);
   }
 }
@@ -151,14 +152,14 @@ TEST(Reductions, ReduceSum3D) {
   std::vector<float> eData(2, 1.0f);
 
   for (int i = 0; i < 2 * 3; ++i) {
-    for (int j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       bData[i * M + j] = j;
     }
   }
 
   cg.call({bData, cData, M});
   float expected = 0;
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected += i;
   }
@@ -179,7 +180,7 @@ TEST(Reductions, ReduceSum3D) {
   // We're combining an additional dimension of 3, so the sum is 3x.
   expected = expected * 3;
 
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(dData[i], expected);
   }
 
@@ -194,7 +195,7 @@ TEST(Reductions, ReduceSum3D) {
   SimpleIREvaluator cg3(s3, {c, e});
   cg3.call({cData, eData});
 
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(eData[i], expected);
   }
 }
@@ -226,7 +227,7 @@ TEST(Reductions, ReduceSum10D) {
 
   // NOLINTNEXTLINE(bugprone-integer-division)
   float expected = InputSize / OutputSize;
-  for (int i = 0; i < OutputSize; ++i) {
+  for (const auto i : c10::irange(OutputSize)) {
     ASSERT_EQ(out[i], expected);
   }
 }
@@ -238,8 +239,8 @@ TEST(Reductions, ReduceProduct) {
 
   BufHandle b("b", {M, N}, kFloat);
   std::vector<float> in(M * N);
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       in[i * N + j] = 2 + j;
     }
   }
@@ -260,12 +261,12 @@ TEST(Reductions, ReduceProduct) {
   cg.call({in, out});
 
   float expected = 1;
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected *= 2 + i;
   }
 
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[i], expected);
   }
 }
@@ -276,7 +277,7 @@ TEST(Reductions, ReduceMax) {
 
   std::vector<float> in(10);
   std::vector<float> out(1, -1.f);
-  for (int j = 0; j < 10; ++j) {
+  for (const auto j : c10::irange(10)) {
     in[j] = j;
   }
 
@@ -316,7 +317,7 @@ TEST(Reductions, ReduceMinCustomInitializer) {
 
   std::vector<float> in(10);
   std::vector<float> out(1, -1.f);
-  for (int j = 0; j < 10; ++j) {
+  for (const auto j : c10::irange(10)) {
     in[j] = 10 + j;
   }
 
@@ -374,7 +375,7 @@ TEST(Reductions, ReduceAnyAll) {
   std::vector<int> out(4, 0);
 
   // input has 0-39 in 4 rows.
-  for (int i = 0; i < 40; ++i) {
+  for (const auto i : c10::irange(40)) {
     in[i] = i;
   }
   cg.call({in, out, 1});
@@ -438,8 +439,8 @@ TEST(Reductions, ReduceMatmul2D) {
   std::vector<float> tB_(6);
 
   std::vector<float> out(9, -1.f);
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 2; ++j) {
+  for (const auto i : c10::irange(3)) {
+    for (const auto j : c10::irange(2)) {
       tA_[i * 2 + j] = i * 2 + j;
       tB_[j * 3 + i] = i * 2 + j;
     }
@@ -465,7 +466,7 @@ TEST(Reductions, ReduceMatmul2D) {
   std::vector<float> expected(
       {1.f, 3.f, 5.f, 3.f, 13.f, 23.f, 5.f, 23.f, 41.f});
 
-  for (int i = 0; i < 9; ++i) {
+  for (const auto i : c10::irange(9)) {
     ASSERT_EQ(out[i], expected[i]);
   }
 }
@@ -473,7 +474,7 @@ TEST(Reductions, ReduceMatmul2D) {
 TEST(Reductions, ReduceRfactorLike) {
   BufHandle in("in", {10, 10}, kFloat);
   std::vector<float> in_(100);
-  for (int i = 0; i < 100; ++i) {
+  for (const auto i : c10::irange(100)) {
     in_[i] = i;
   }
   std::vector<float> in_rf_(10, -2.f);
@@ -522,14 +523,14 @@ TEST(Reductions, ReduceAsProducer) {
 
   for (int i = 0; i < 2 * 3; ++i) {
     aData[i] = 6 - i;
-    for (int j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       bData[i * M + j] = j;
     }
   }
 
   cg.call({aData, bData, dData, M});
   float expected = 0;
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     expected += i;
   }
@@ -564,7 +565,7 @@ TEST(Reductions, ReduceAsConsumer) {
   std::vector<float> dData(2, 6.0f);
 
   for (int i = 0; i < 2 * 3; ++i) {
-    for (int j = 0; j < M; ++j) {
+    for (const auto j : c10::irange(M)) {
       bData[i * M + j] = j + 1;
       aData[i * M + j] = 6 - i;
     }
@@ -573,16 +574,16 @@ TEST(Reductions, ReduceAsConsumer) {
   cg.call({aData, bData, dData, M});
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   float expected[2] = {0, 0};
-  for (int i = 0; i < 2; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      for (int k = 0; k < M; ++k) {
+  for (const auto i : c10::irange(2)) {
+    for (const auto j : c10::irange(3)) {
+      for (const auto k : c10::irange(M)) {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         expected[i] += (k + 1) * (6 - (i * 3 + j));
       }
     }
   }
 
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(dData[i], expected[i]);
   }
 }
@@ -591,8 +592,8 @@ TEST(Reductions, SplitReduceAxis) {
   BufHandle in("in", {16, 8}, kFloat);
 
   std::vector<float> in_(16 * 8);
-  for (int i = 0; i < 16; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(16)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }
@@ -611,7 +612,7 @@ TEST(Reductions, SplitReduceAxis) {
   SimpleIREvaluator cg(s, {in, tensor});
   cg.call({in_, out});
 
-  for (int i = 0; i < 16; ++i) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(out[i], i * 8);
   }
 }
@@ -620,8 +621,8 @@ TEST(Reductions, SplitNonReduceAxis) {
   BufHandle in("in", {16, 8}, kFloat);
 
   std::vector<float> in_(16 * 8);
-  for (int i = 0; i < 16; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(16)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }
@@ -640,7 +641,7 @@ TEST(Reductions, SplitNonReduceAxis) {
   SimpleIREvaluator cg(s, {in, tensor});
   cg.call({in_, out});
 
-  for (int i = 0; i < 16; ++i) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(out[i], i * 8);
   }
 }
@@ -689,7 +690,7 @@ TEST(Reductions, ReorderedReductionInitializer) {
   SimpleIREvaluator cg2(s, {in, tensor});
   cg2.call({in_, out2});
 
-  for (int i = 0; i < 16; ++i) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_EQ(out1[i], out2[i]);
   }
 }
@@ -807,7 +808,7 @@ TEST(Reductions, ReduceRepeatedInternalRfactor) {
   LoopNest orig_loop({c});
 
   // Try rfactoring N outer loops
-  for (int rfac_number = 1; rfac_number < 5; rfac_number++) {
+  for (const auto rfac_number : c10::irange(1, 5)) {
     LoopNest refloop(orig_loop);
     LoopNest loop(orig_loop);
     refloop.prepareForCodegen();
@@ -817,7 +818,7 @@ TEST(Reductions, ReduceRepeatedInternalRfactor) {
 
     BufPtr tmp_buf = c.buf();
 
-    for (int idx = 0; idx < rfac_number; idx++) {
+    for (const auto idx : c10::irange(rfac_number)) {
       auto reduce = loop.getAllWritesToBuf(tmp_buf)[1];
       ASSERT_TRUE(loop.rfactor(
           reduce, loop.getLoopStmtsFor(tmp_buf).at(idx), &tmp_buf));
@@ -846,7 +847,7 @@ TEST(Reductions, ReduceSplitTail) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -876,7 +877,7 @@ TEST(Reductions, ReduceSplitNoTail) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -908,7 +909,7 @@ TEST(Reductions, ReduceOverSplitTail) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -939,7 +940,7 @@ TEST(Reductions, ReduceSplitMask) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -969,7 +970,7 @@ TEST(Reductions, ReduceSplitNoMask) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -1000,7 +1001,7 @@ TEST(Reductions, ReduceOverSplitMask) {
     in[j] = j;
   }
 
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     std::vector<float> out(M, -1.f);
 
     Tensor c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}, {K, "k"}});
@@ -1029,7 +1030,7 @@ TEST(Reductions, ReduceSplitRfactor) {
 
   BufHandle b("b", {M, N, K}, kFloat);
   std::vector<float> in(M * N * K);
-  for (int m = 0; m < M; ++m) {
+  for (const auto m : c10::irange(M)) {
     for (int j = 0; j < N * K; ++j) {
       in[m * N * K + j] = j;
     }
@@ -1056,7 +1057,7 @@ TEST(Reductions, ReduceSplitRfactor) {
   SimpleIREvaluator cg(s, {b, c});
 
   cg.call({in, out});
-  for (int i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     ASSERT_EQ(out[0], 4950);
   }
 }
@@ -1134,12 +1135,12 @@ TEST(Reductions, ReduceInlineReduction) {
   PaddedBuffer<float> a_v(M);
   PaddedBuffer<float> b_v(M, N, K);
 
-  for (int i = 0; i < M; i++) {
+  for (const auto i : c10::irange(M)) {
     a_v(i) = i * i;
   }
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      for (int k = 0; k < K; k++) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
+      for (const auto k : c10::irange(K)) {
         b_v(i, j, k) = j * j * k;
       }
     }
@@ -1169,9 +1170,9 @@ TEST(Reductions, ReduceInlineConsumer) {
   PaddedBuffer<float> a_v(M, N, K);
   PaddedBuffer<float> b_v(M, N, K);
 
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      for (int k = 0; k < K; k++) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
+      for (const auto k : c10::irange(K)) {
         a_v(i, j, k) = i * i + k;
         b_v(i, j, k) = j * j + k;
       }
@@ -1226,9 +1227,9 @@ TEST(Reductions, ReduceInlineReducerInternal) {
   PaddedBuffer<float> a_v(M, N, K);
   PaddedBuffer<float> b_v(M, N, K);
 
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      for (int k = 0; k < K; k++) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
+      for (const auto k : c10::irange(K)) {
         a_v(i, j, k) = i * i + k;
         b_v(i, j, k) = j * j + k;
       }
@@ -1319,9 +1320,9 @@ TEST(Reductions, ReductionCacheAccessesOperatorAxis) {
   PaddedBuffer<float> e_before(L, "e_before");
   PaddedBuffer<float> e_after(L, "e_after");
 
-  for (int l = 0; l < L; l++) {
-    for (int m = 0; m < M; m++) {
-      for (int n = 0; n < N; n++) {
+  for (const auto l : c10::irange(L)) {
+    for (const auto m : c10::irange(M)) {
+      for (const auto n : c10::irange(N)) {
         a_v(l, m, n) = at::randn({1}).item().to<float>();
         b_v(l, m, n) = at::randn({1}).item().to<float>();
       }
@@ -1392,9 +1393,9 @@ TEST(Reductions, ReductionCacheAccessesOuterReduceAxis) {
   PaddedBuffer<float> e_before(L, "e_before");
   PaddedBuffer<float> e_after(L, "e_after");
 
-  for (int l = 0; l < L; l++) {
-    for (int m = 0; m < M; m++) {
-      for (int n = 0; n < N; n++) {
+  for (const auto l : c10::irange(L)) {
+    for (const auto m : c10::irange(M)) {
+      for (const auto n : c10::irange(N)) {
         a_v(l, m, n) = at::randn({1}).item().to<float>();
         b_v(l, m, n) = at::randn({1}).item().to<float>();
       }
@@ -1465,9 +1466,9 @@ TEST(Reductions, ReductionCacheAccessesInnerReduceAxis) {
   PaddedBuffer<float> e_before(L, "e_before");
   PaddedBuffer<float> e_after(L, "e_after");
 
-  for (int l = 0; l < L; l++) {
-    for (int m = 0; m < M; m++) {
-      for (int n = 0; n < N; n++) {
+  for (const auto l : c10::irange(L)) {
+    for (const auto m : c10::irange(M)) {
+      for (const auto n : c10::irange(N)) {
         a_v(l, m, n) = at::randn({1}).item().to<float>();
         b_v(l, m, n) = at::randn({1}).item().to<float>();
       }
@@ -1782,8 +1783,8 @@ TEST(Reductions, ReductionRfactorCacheTempInner) {
 
 TEST(Reductions, ReductionVectorize) {
   std::vector<float> in_(8 * 8);
-  for (int i = 0; i < 8; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(8)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }
@@ -1820,7 +1821,7 @@ TEST(Reductions, ReductionVectorize) {
   s = IRSimplifier::simplify(l.root_stmt());
   SimpleIREvaluator cg_after(s, {in, tensor});
   cg_after.call({in_, out_after});
-  for (int i = 0; i < 8; ++i) {
+  for (const auto i : c10::irange(8)) {
     ASSERT_EQ(out_before[i], out_after[i]);
   }
 }
@@ -1836,8 +1837,8 @@ TEST(Reductions, ReductionVectorizeInner) {
 
 TEST(Reductions, ReductionVectorizeRfactor) {
   std::vector<float> in_(8 * 8);
-  for (int i = 0; i < 8; ++i) {
-    for (int j = 0; j < 8; ++j) {
+  for (const auto i : c10::irange(8)) {
+    for (const auto j : c10::irange(8)) {
       in_[i * 8 + j] = i;
     }
   }

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/test_utils.h>
 #include <torch/csrc/jit/tensorexpr/hash_provider.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
@@ -1132,7 +1133,7 @@ TEST(Simplify, SimplifyDivWithLoopContext0) {
 
 TEST(Simplify, SimplifyDivWithLoopContext1) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) / 6;
   //}
   VarHandle i("i", kInt);
@@ -1153,7 +1154,7 @@ TEST(Simplify, SimplifyDivWithLoopContext1) {
 
 TEST(Simplify, SimplifyDivWithLoopContext2) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i + 25) / 6;
   //}
   VarHandle i("i", kInt);
@@ -1174,7 +1175,7 @@ TEST(Simplify, SimplifyDivWithLoopContext2) {
 
 TEST(Simplify, SimplifyDivWithLoopContext3) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) / (-6);
   //}
   VarHandle i("i", kInt);
@@ -1195,7 +1196,7 @@ TEST(Simplify, SimplifyDivWithLoopContext3) {
 
 TEST(Simplify, SimplifyDivWithLoopContext4) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i - 5) / 6;
   //}
   VarHandle i("i", kInt);
@@ -1216,8 +1217,8 @@ TEST(Simplify, SimplifyDivWithLoopContext4) {
 
 TEST(Simplify, SimplifyDivWithLoopContext5) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) / 6;
   //  }
   //}
@@ -1242,7 +1243,7 @@ TEST(Simplify, SimplifyDivWithLoopContext5) {
 
 TEST(Simplify, SimplifyDivWithLoopContext6) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  for (int j = -1; j < 9; j++) {
   //    A[i, j+1] = (i + 6*j) / 6;
   //  }
@@ -1269,8 +1270,8 @@ TEST(Simplify, SimplifyDivWithLoopContext6) {
 
 TEST(Simplify, SimplifyDivWithLoopContext7) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) / (-6);
   //  }
   //}
@@ -1296,7 +1297,7 @@ TEST(Simplify, SimplifyDivWithLoopContext7) {
 
 TEST(Simplify, SimplifyModWithLoopContext0) {
   // Stmt to simplify:
-  // for (int i = 0; i < 100; i++) {
+  // for (const auto i : c10::irange(100)) {
   //  A[i] = i % 100;
   //}
   VarHandle i("i", kInt);
@@ -1317,7 +1318,7 @@ TEST(Simplify, SimplifyModWithLoopContext0) {
 
 TEST(Simplify, SimplifyModWithLoopContext1) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) % 6;
   //}
   VarHandle i("i", kInt);
@@ -1338,7 +1339,7 @@ TEST(Simplify, SimplifyModWithLoopContext1) {
 
 TEST(Simplify, SimplifyModWithLoopContext2) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i + 25) % 6;
   //}
   VarHandle i("i", kInt);
@@ -1359,7 +1360,7 @@ TEST(Simplify, SimplifyModWithLoopContext2) {
 
 TEST(Simplify, SimplifyModWithLoopContext3) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  A[i] = (i + 24) % (-6);
   //}
   VarHandle i("i", kInt);
@@ -1380,7 +1381,7 @@ TEST(Simplify, SimplifyModWithLoopContext3) {
 
 TEST(Simplify, SimplifyModWithLoopContext4) {
   // Stmt to simplify:
-  // for (int i = 0; i < 5; i++) {
+  // for (const auto i : c10::irange(5)) {
   //  A[i] = (i - 5) % 6;
   //}
   VarHandle i("i", kInt);
@@ -1401,8 +1402,8 @@ TEST(Simplify, SimplifyModWithLoopContext4) {
 
 TEST(Simplify, SimplifyModWithLoopContext5) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) % 6;
   //  }
   //}
@@ -1427,7 +1428,7 @@ TEST(Simplify, SimplifyModWithLoopContext5) {
 
 TEST(Simplify, SimplifyModWithLoopContext6) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
+  // for (const auto i : c10::irange(6)) {
   //  for (int j = -1; j < 9; j++) {
   //    A[i, j+1] = (i + 6*j) % 6;
   //  }
@@ -1454,8 +1455,8 @@ TEST(Simplify, SimplifyModWithLoopContext6) {
 
 TEST(Simplify, SimplifyModWithLoopContext7) {
   // Stmt to simplify:
-  // for (int i = 0; i < 6; i++) {
-  //  for (int j = 0; j < 10; j++) {
+  // for (const auto i : c10::irange(6)) {
+  //  for (const auto j : c10::irange(10)) {
   //    A[i, j] = (i + 6*j) % (-6);
   //  }
   //}
@@ -3884,7 +3885,7 @@ TEST(Simplify, SimplifyEliminateEmptyFor) {
   {
     // Flatten many layers around an empty block to an empty block.
     StmtPtr last = alloc<Block>(std::vector<StmtPtr>({}));
-    for (int i = 0; i < 11; ++i) {
+    for (const auto i : c10::irange(11)) {
       VarHandle loopVar("loopVar", kInt);
       last = For::make(loopVar, 0, 10, last);
     }
@@ -3968,7 +3969,7 @@ TEST(Simplify, SimplifyFlattenBlock) {
   {
     // Flatten many layers around an empty block to an empty block.
     StmtPtr last = alloc<Block>(std::vector<StmtPtr>({}));
-    for (int i = 0; i < 11; ++i) {
+    for (const auto i : c10::irange(11)) {
       last = alloc<Block>(std::vector<StmtPtr>({last}));
     }
 
@@ -4817,18 +4818,18 @@ TEST(Simplify, SimplifyBroadcastTermExpander) {
   SimpleIREvaluator eval(store, {buf});
   std::vector<int> output(num_lanes);
   eval(output);
-  for (int i = 0; i < num_lanes; ++i) {
+  for (const auto i : c10::irange(num_lanes)) {
     ASSERT_EQ(output[i], 2);
   }
 }
 
 TEST(Simplify, DISABLED_CompareSelectCondAlwaysInLoopBounds) {
   // Before:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = n < 1 ? 0.f : 1.f;
   //   }
   // After:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = 1.f;
   //   }
   constexpr int N = 8;
@@ -4848,11 +4849,11 @@ TEST(Simplify, DISABLED_CompareSelectCondAlwaysInLoopBounds) {
 
 TEST(Simplify, DISABLED_IfThenCondAlwaysInLoopBounds) {
   // Before:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = IfThenElse(n < 1 ? 1 : 0, 0.f, 1.f);
   //   }
   // After:
-  //   for (int n = 1; n < N; n++) {
+  //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = 1.f;
   //   }
   constexpr int N = 8;
@@ -4875,13 +4876,13 @@ TEST(Simplify, DISABLED_MultiClauseCondAlwaysInLoopBounds) {
   // conditional that is provably satisfied (or unsatisfied) by the entire loop
   // range.
   // Before:
-  //   for (int i = 1; i < 7; i++) {
-  //     for (int j = 1; j < 7; j++) {
+  //   for (const auto i : c10::irange(1, 7)) {
+  //     for (const auto j : c10::irange(1, 7)) {
   //       b[i, j] = IfThenElse(
   //         j>=7 ? 1 : (i>=7 ? 1 : (j<1 ? 1 : (i<1 ? 1 : 0))), 0.f, 1.f);
   // After:
-  //   for (int i = 1; i < 7; i++) {
-  //     for (int j = 1; j < 7; j++) {
+  //   for (const auto i : c10::irange(1, 7)) {
+  //     for (const auto j : c10::irange(1, 7)) {
   //       b[i, j] = 1.f;
   constexpr int N = 8;
   BufHandle b("b", {N, N}, kFloat);
@@ -4910,13 +4911,13 @@ TEST(Simplify, DISABLED_SimplifyLoopBounds) {
   // could be solved by peeling, and applying the range-based conditional
   // simplification in the previous tests.
   // Before:
-  //   for (int i = 0; i < 3; i++) {
-  //     for (int j = 0; j < 3; j++) {
+  //   for (const auto i : c10::irange(3)) {
+  //     for (const auto j : c10::irange(3)) {
   //       b[i, j] = (b[i, j]) + (IfThenElse(
   //         j>=7 ? 1 : (i>=7 ? 1 : (j<1 ? 1 : (i<1 ? 1 : 0))), 0.f, a[i, j]));
   // After:
-  //   for (int i = 1; i < 3; i++) {
-  //     for (int j = 1; j < 3; j++) {
+  //   for (const auto i : c10::irange(1, 3)) {
+  //     for (const auto j : c10::irange(1, 3)) {
   //       b[i, j] = (b[i, j]) + 1.f;
   constexpr int N = 8;
   constexpr int K = 3;
@@ -4937,8 +4938,8 @@ TEST(Simplify, DISABLED_SimplifyLoopBounds) {
   oss << *s;
   torch::jit::testing::FileCheck().run(
       R"IR(
-# CHECK: for (int i = 1; i < 3; i++) {
-# CHECK: for (int j = 1; j < 3; j++) {
+# CHECK: for (const auto i : c10::irange(1, 3)) {
+# CHECK: for (const auto j : c10::irange(1, 3)) {
 # CHECK-NOT: IfThenElse
 )IR",
       oss.str());

--- a/test/cpp/tensorexpr/tutorial.cpp
+++ b/test/cpp/tensorexpr/tutorial.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <string>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
@@ -146,8 +147,8 @@ int main(int argc, char* argv[]) {
     std::cout << "Nested for loops: " << std::endl << *loop_i_a << std::endl;
     // Prints:
     // Nested for loops:
-    // for (int i = 0; i < 64; i++) {
-    //   for (int j = 0; j < 32; j++) {
+    // for (const auto i : c10::irange(64)) {
+    //   for (const auto j : c10::irange(32)) {
     //     A[i, j] = i + j;
     //   }
     // }
@@ -166,13 +167,13 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Compound Block statement:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       A[i, j] = i + j;
     //     }
     //   }
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       B[i, j] = A[i, j];
     //     }
     //   }
@@ -193,8 +194,8 @@ int main(int argc, char* argv[]) {
               << *C.stmt() << std::endl;
     // Prints:
     // Stmt produced by 'Compute' API:
-    // for (int i = 0; i < 64; i++) {
-    //   for (int j = 0; j < 32; j++) {
+    // for (const auto i : c10::irange(64)) {
+    //   for (const auto j : c10::irange(32)) {
     //     C[i, j] = i * j;
     //   }
     // }
@@ -239,13 +240,13 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt produced by 'Compute' API:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       C[i, j] = i * (j + 1);
     //     }
     //   }
-    //   for (int i_1 = 0; i_1 < 64; i_1++) {
-    //     for (int j_1 = 0; j_1 < 32; j_1++) {
+    //   for (const auto i_1 : c10::irange(64)) {
+    //     for (const auto j_1 : c10::irange(32)) {
     //       D[i_1, j_1] = (C[i_1, j_1]) - i_1;
     //     }
     //   }
@@ -265,13 +266,13 @@ int main(int argc, char* argv[]) {
     // Prints:
     // LoopNest root stmt:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       C[i, j] = i * (j + 1);
     //     }
     //   }
-    //   for (int i_1 = 0; i_1 < 64; i_1++) {
-    //     for (int j_1 = 0; j_1 < 32; j_1++) {
+    //   for (const auto i_1 : c10::irange(64)) {
+    //     for (const auto j_1 : c10::irange(32)) {
     //       D[i_1, j_1] = (C[i_1, j_1]) - i_1;
     //     }
     //   }
@@ -284,8 +285,8 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt after inlining:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       D[i, j] = i * (j + 1) - i;
     //     }
     //   }
@@ -298,8 +299,8 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt after simplification:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       D[i, j] = i * j;
     //     }
     //   }
@@ -319,15 +320,15 @@ int main(int argc, char* argv[]) {
     // Prints:
     // Stmt after splitWithTail:
     // {
-    //   for (int i_outer = 0; i_outer < 4; i_outer++) {
-    //     for (int i_inner = 0; i_inner < 13; i_inner++) {
-    //       for (int j = 0; j < 32; j++) {
+    //   for (const auto i_outer : c10::irange(4)) {
+    //     for (const auto i_inner : c10::irange(13)) {
+    //       for (const auto j : c10::irange(32)) {
     //         D[i_inner + 13 * i_outer, j] = i_inner * j + 13 * (i_outer * j);
     //       }
     //     }
     //   }
-    //   for (int i_tail = 0; i_tail < 12; i_tail++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i_tail : c10::irange(12)) {
+    //     for (const auto j : c10::irange(32)) {
     //       D[i_tail + 52, j] = i_tail * j + 52 * j;
     //     }
     //   }
@@ -365,8 +366,8 @@ int main(int argc, char* argv[]) {
     std::cout << *loopnest.root_stmt() << std::endl;
     // Prints:
     // {
-    //   for (int i = 0; i < 64; i++) {
-    //     for (int j = 0; j < 32; j++) {
+    //   for (const auto i : c10::irange(64)) {
+    //     for (const auto j : c10::irange(32)) {
     //       X[i, j] = (A[i, j]) + (B[i, j]);
     //     }
     //   }
@@ -469,8 +470,8 @@ int main(int argc, char* argv[]) {
     // Prints:
     // TE Stmt constructed from TorchScript:
     // {
-    //   for (int v = 0; v < 5; v++) {
-    //     for (int _tail_tail = 0; _tail_tail < 3; _tail_tail++) {
+    //   for (const auto v : c10::irange(5)) {
+    //     for (const auto _tail_tail : c10::irange(3)) {
     //       aten_add[_tail_tail + 3 * v] = (tA[_tail_tail + 3 * v]) *
     //       ((tA[_tail_tail + 3 * v]) * (tB[_tail_tail + 3 * v])) +
     //       (tB[_tail_tail + 3 * v]);

--- a/test/custom_operator/op.cpp
+++ b/test/custom_operator/op.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/script.h>
 
 #include "op.h"
@@ -11,7 +12,7 @@ torch::List<torch::Tensor> custom_op(
     int64_t repeat) {
   torch::List<torch::Tensor> output;
   output.reserve(repeat);
-  for (int64_t i = 0; i < repeat; ++i) {
+  for (const auto i : c10::irange(repeat)) {
     output.push_back(tensor * scalar);
   }
   return output;

--- a/test/custom_operator/test_custom_ops.cpp
+++ b/test/custom_operator/test_custom_ops.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/script.h>
 #include <torch/cuda.h>
 
@@ -44,7 +45,7 @@ void get_operator_from_registry_and_execute() {
   const auto manual = custom_op(torch::ones(5), 2.0, 3);
 
   TORCH_INTERNAL_ASSERT(output.size() == 3);
-  for (size_t i = 0; i < output.size(); ++i) {
+  for (const auto i : c10::irange(output.size())) {
     TORCH_INTERNAL_ASSERT(output[i].allclose(torch::ones(5) * 2));
     TORCH_INTERNAL_ASSERT(output[i].allclose(manual[i]));
   }

--- a/test/mobile/custom_build/predictor.cpp
+++ b/test/mobile/custom_build/predictor.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <string>
+#include <c10/util/irange.h>
 #include <torch/script.h>
 
 using namespace std;
@@ -40,7 +41,7 @@ int main(int argc, const char* argv[]) {
   }();
 
   std::cout << std::setprecision(3) << std::fixed;
-  for (int i = 0; i < 5; i++) {
+  for (const auto i : c10::irange(5)) {
     std::cout << output.data_ptr<float>()[i] << std::endl;
   }
   return 0;

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -4,8 +4,6 @@
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
 
-#include <c10/util/irange.h>
-
 #include <memory>
 #include <string>
 #include <vector>

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -589,7 +589,7 @@ static void _trace_post_record(
   // to the original tuple type.
   if (!unpack_output) {
     std::vector<TypePtr> new_tuple_values;
-    for (int i = 0; i < num_outputs; ++i) {
+    for (const auto i : c10::irange(num_outputs)) {
       TypePtr ptr = node->outputs()[i]->type();
       new_tuple_values.push_back(ptr);
     }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1706,7 +1706,7 @@ void concrete_dispatch_fn(
   }
 
   // Find overloaded tensors
-  for (int64_t idx = 0; idx < arguments.size(); idx++) {
+  for (const auto idx : c10::irange(arguments.size())) {
     const auto& ivalue = arguments[idx];
     if (ivalue.isTensor()) {
       const auto& tensor = ivalue.toTensor();
@@ -1728,12 +1728,12 @@ void concrete_dispatch_fn(
   }
 
   // Populate positional arguments
-  for (int64_t idx = 0; idx < positional_default_start; idx++) {
+  for (const auto idx : c10::irange(positional_default_start)) {
     PyTuple_SET_ITEM(args.ptr(), idx, torch::jit::toPyObject(std::move(arguments[idx])).release().ptr());
   }
 
   // Populate keyword arguments
-  for (int64_t idx = kwarg_only_start; idx < arguments.size(); idx++) {
+  for (const auto idx : c10::irange(kwarg_only_start, arguments.size())) {
     // But don't populate default keyword arguments
     if (is_default(idx)) continue;
     const auto& arg = schema.arguments()[idx];

--- a/torch/csrc/deploy/loader.cpp
+++ b/torch/csrc/deploy/loader.cpp
@@ -54,6 +54,7 @@
 #include <sys/user.h>
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <fmt/format.h>
 #include <torch/csrc/deploy/loader.h>
@@ -152,7 +153,7 @@ size_t phdr_table_get_load_size(
   Elf64_Addr max_vaddr = 0;
 
   bool found_pt_load = false;
-  for (size_t i = 0; i < phdr_count; ++i) {
+  for (const auto i : c10::irange(phdr_count)) {
     const Elf64_Phdr* phdr = &phdr_table[i];
 
     if (phdr->p_type != PT_LOAD) {
@@ -383,7 +384,7 @@ std::pair<const char*, std::vector<const char*>> load_needed_from_elf_file(
   auto program_headers = (Elf64_Phdr*)(data + header_->e_phoff);
   auto n_program_headers = header_->e_phnum;
   const Elf64_Dyn* dynamic = nullptr;
-  for (size_t i = 0; i < n_program_headers; ++i) {
+  for (const auto i : c10::irange(n_program_headers)) {
     const Elf64_Phdr* phdr = &program_headers[i];
     if (phdr->p_type == PT_DYNAMIC) {
       dynamic = reinterpret_cast<const Elf64_Dyn*>(data + phdr->p_offset);
@@ -405,7 +406,7 @@ std::pair<const char*, std::vector<const char*>> load_needed_from_elf_file(
   const char* segment_string_table =
       data + segment_headers[header_->e_shstrndx].sh_offset;
 
-  for (size_t i = 0; i < n_segments; ++i) {
+  for (const auto i : c10::irange(n_segments)) {
     const Elf64_Shdr* shdr = &segment_headers[i];
     if (shdr->sh_type == SHT_STRTAB &&
         strcmp(".dynstr", segment_string_table + shdr->sh_name) == 0) {
@@ -641,7 +642,7 @@ struct AlreadyLoadedSymTable {
       const Elf64_Phdr* program_headers,
       size_t n_program_headers) {
     Elf64_Dyn* dynamic = nullptr;
-    for (size_t i = 0; i < n_program_headers; ++i) {
+    for (const auto i : c10::irange(n_program_headers)) {
       const Elf64_Phdr* phdr = &program_headers[i];
 
       // Segment addresses in memory.
@@ -871,7 +872,7 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
 
   void load_segments() {
     // from bionic
-    for (size_t i = 0; i < n_program_headers_; ++i) {
+    for (const auto i : c10::irange(n_program_headers_)) {
       const Elf64_Phdr* phdr = &program_headers_[i];
 
       // Segment addresses in memory.
@@ -1141,17 +1142,17 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
   }
 
   void relocate() {
-    for (size_t i = 0; i < dyninfo_.n_rela_; ++i) {
+    for (const auto i : c10::irange(dyninfo_.n_rela_)) {
       relocate_one(dyninfo_.rela_[i]);
     }
-    for (size_t i = 0; i < dyninfo_.n_plt_rela_; ++i) {
+    for (const auto i : c10::irange(dyninfo_.n_plt_rela_)) {
       relocate_one(dyninfo_.plt_rela_[i]);
     }
   }
 
   void initialize() {
     call_function(dyninfo_.init_func_);
-    for (size_t i = 0; i < dyninfo_.n_init_array_; ++i) {
+    for (const auto i : c10::irange(dyninfo_.n_init_array_)) {
       call_function(dyninfo_.init_array_[i]);
     }
     initialized_ = true;


### PR DESCRIPTION
Summary:
Modified loops in files under fbsource/fbcode/caffe2/ from the format

`for(TYPE var=x0;var<x_max;x++)`

to the format

`for(const auto var: irange(xmax))`

This was achieved by running r-barnes's loop upgrader script (D28874212) with some modification to exclude all files under /torch/jit and a number of reversions or unused variable suppression warnings added by hand.

Test Plan: Sandcastle

Differential Revision: D31705358



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang