### PR TITLE
use irange for loops

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/irange.h>
 #include <cmath>
 #include <limits>
 
@@ -95,7 +96,7 @@ Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
       double step = static_cast<double>(scalar_end - scalar_start) / (steps - 1);
       const int64_t halfway = steps / 2;
       at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-        for (int64_t i=p_begin; i < p_end; i++) {
+        for (const auto i : c10::irange(p_begin, p_end)) {
           if (i < halfway) {
             data_ptr[i] = std::pow(scalar_base, scalar_start + step*i);
           } else {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -627,7 +627,7 @@ void cummax_cummin_helper(const T1* self_data, T1* values_data, T2* indices_data
       Operation op;
       T1 out = self_data[0];
       int idx = 0;
-      for(int i = 0; i < self_dim_size; i++) {
+      for (const auto i : c10::irange(self_dim_size)) {
         T1 curr_elem = self_data[i*self_stride];
         if(isnan_(curr_elem) || (!isnan_(out) && op(curr_elem, out))) {
             out = self_data[i*self_stride];
@@ -738,7 +738,7 @@ static inline void diff_check_compatible_shape(const Tensor& self, const c10::op
         other.value().dim() == self.dim(),
         "diff expects prepend or append to be the same dimension as input");
 
-    for (int i = 0; i < other.value().dim(); i++) {
+    for (const auto i : c10::irange(other.value().dim())) {
       TORCH_CHECK(
           other.value().size(i) == self.size(i) || i == wrapped_dim,
           "diff expects the shape of tensor to prepend or append to match that of"
@@ -1065,7 +1065,7 @@ Tensor trace_cpu(const Tensor& self) {
     t_stride_1 = self.stride(1);
 
     t_diag_size = std::min(self.size(0), self.size(1));
-    for (int64_t i = 0; i < t_diag_size; i++) {
+    for (const auto i : c10::irange(t_diag_size)) {
       sum += t_data[i * (t_stride_0 + t_stride_1)];
     }
 
@@ -1489,9 +1489,9 @@ static double std_var_all_cpu(const Tensor& self, int64_t correction, bool take_
         const int64_t outer_stride = strides[1];
 
         double local_sum = 0.0;
-        for (int64_t i = 0; i < size1; ++i) {
+        for (const auto i : c10::irange(size1)) {
           const char* row_ptr = data[0] + outer_stride * i;
-          for (int64_t j = 0; j < size0; ++j) {
+          for (const auto j : c10::irange(size0)) {
             const auto ptr = reinterpret_cast<const scalar_t*>(row_ptr + inner_stride * j);
             auto dx = (static_cast<double>(*ptr) - local_mean);
             local_sum += dx * dx;
@@ -1919,7 +1919,8 @@ bool cpu_equal(const Tensor& self, const Tensor& other) {
       }
       char* self_data = data[0];
       char* other_data = data[1];
-      for (int64_t i = 0; i < dim_size; ++i) {
+      for (const auto i : c10::irange(dim_size)) {
+        (void)i; //Suppress unused variable warning
         if (*((scalar_t*)self_data) != *((scalar_t*)other_data)) {
           result = false;
           return;

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -168,7 +168,7 @@ static Tensor review_reduce_result(const Tensor& result, int ndim, DimMask mask,
   }
   auto shape = DimVector(result.sizes());
   auto stride = DimVector(result.strides());
-  for (int dim = 0; dim < ndim; dim++) {
+  for (const auto dim : c10::irange(ndim)) {
     if (mask[dim]) {
       shape.insert(shape.begin() + dim, 1);
       stride.insert(stride.begin() + dim, 0);

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -226,8 +227,8 @@ static void reflection_pad1d_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x;
-    for (auto k = start; k < end; k++) {
-      for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto j : c10::irange(output_w)) {
         if (j < pad_l) {
           ip_x = pad_l * 2 - j;
         } else if (j >= pad_l && j < input_w + pad_l) {
@@ -252,7 +253,7 @@ inline void reflection_pad1d_out_loop(
     int64_t input_w, int64_t output_w,
     int64_t pad_l) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad1d_out_frame<scalar_t>(
         input_p + p * nplane * input_w,
         output_p + p * nplane * output_w,
@@ -352,8 +353,8 @@ static void reflection_pad1d_backward_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x;
-    for (auto k = start; k < end; k++) {
-      for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto j : c10::irange(output_w)) {
         if (j < pad_l) {
           ip_x = pad_l * 2 - j;
         } else if (j >= pad_l && j < input_w + pad_l) {
@@ -378,7 +379,7 @@ inline void reflection_pad1d_backward_out_loop(
     int64_t input_w, int64_t output_w,
     int64_t pad_l) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad1d_backward_out_frame<scalar_t>(
         grad_input + p * nplane * input_w,
         grad_output + p * nplane * output_w,
@@ -404,9 +405,9 @@ static void reflection_pad2d_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++) {
-      for (int64_t i = 0; i < output_h; i++) {
-        for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(output_h)) {
+        for (const auto j : c10::irange(output_w)) {
           if (j < pad_l) {
             ip_x = pad_l * 2 - j;
           } else if (j >= pad_l && j < input_w + pad_l) {
@@ -442,7 +443,7 @@ inline void reflection_pad2d_out_loop(
     int64_t output_w, int64_t output_h,
     int64_t pad_l, int64_t pad_t) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad2d_out_frame(
         input_p + p * nplane * input_w * input_h,
         output_p + p * nplane * output_w * output_h,
@@ -560,9 +561,9 @@ static void reflection_pad2d_backward_out_frame(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++) {
-      for (int64_t i = 0; i < output_h; i++) {
-        for (int64_t j = 0; j < output_w; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(output_h)) {
+        for (const auto j : c10::irange(output_w)) {
           if (j < pad_l) {
             ip_x = pad_l * 2 - j;
           } else if (j >= pad_l && j < input_w + pad_l) {
@@ -600,7 +601,7 @@ inline void reflection_pad2d_backward_out_loop(
     int64_t output_w, int64_t output_h,
     int64_t pad_l, int64_t pad_t) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad2d_backward_out_frame(
         grad_input + p * nplane * input_h * input_w,
         grad_output + p * nplane * output_h * output_w,
@@ -690,10 +691,10 @@ inline void parallel_reflection_pad3d(
   at::parallel_for(0, nplane, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y, ip_z;
-    for (int64_t k = start; k < end; k++) {
-      for (int64_t op_z = 0; op_z < output_d; op_z++) {
-        for (int64_t op_y = 0; op_y < output_h; op_y++) {
-          for (int64_t op_x = 0; op_x < output_w; op_x++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto op_z : c10::irange(output_d)) {
+        for (const auto op_y : c10::irange(output_h)) {
+          for (const auto op_x : c10::irange(output_w)) {
             if (op_x < pad_left) {
               ip_x = pad_left * 2 - op_x;
             } else if (op_x >= pad_left && op_x < input_w + pad_left) {
@@ -772,7 +773,7 @@ static void reflection_pad3d_out_loop(
     int64_t pad_left, int64_t pad_top, int64_t pad_front)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (int64_t p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad3d_out_frame(
           input_p + p * nplane * input_w * input_h * input_d,
           output_p + p * nplane * output_w * output_h * output_d,
@@ -833,7 +834,7 @@ static void reflection_pad3d_backward_out_loop(
     int64_t pad_left, int64_t pad_top, int64_t pad_front
 ) {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (int64_t p = start; p < end; p++) {
+    for (const auto p : c10::irange(start, end)) {
       reflection_pad3d_backward_out_frame<scalar_t>(
           grad_input + p * nplane * input_w * input_h * input_d,
           grad_output + p * nplane * output_w * output_h * output_d,

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/Repeat.h>
+#include <c10/util/irange.h>
 
 template <typename index_t>
 static void compute_cpu(
@@ -13,12 +14,12 @@ static void compute_cpu(
       (result_size == cumsum_ptr[size - 1]),
       "allocated size does not match required size");
   at::parallel_for(0, size, 1, [&](int64_t i_begin, int64_t i_end) {
-    for (int64_t i = i_begin; i < i_end; i++) {
+    for (const auto i : c10::irange(i_begin, i_end)) {
       int64_t end = cumsum_ptr[i];
       index_t size = repeat_ptr[i];
       TORCH_CHECK((size >= 0), "repeats can not be negative");
       int64_t start = end - size;
-      for (int64_t j = start; j < end; j++) {
+      for (const auto j : c10::irange(start, end)) {
         result_ptr[j] = i;
       }
     }

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 #include <algorithm>
 
 namespace at {
@@ -237,8 +238,7 @@ static void replication_pad1d_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     long ip_x;
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       for (long j = 0; j < owidth; j++) {
         if (j < pad_l) {
           ip_x = pad_l;
@@ -267,8 +267,7 @@ static void replication_pad1d_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data+p*nslices*iwidth;
       scalar_t *output_p = output_data+p*nslices*owidth;
       replication_pad1d_out_frame(input_p, output_p, nslices, iwidth, owidth, pad_l, pad_r);
@@ -290,8 +289,7 @@ static void replication_pad1d_backward_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     long ip_x;
-    for (auto k = start; k < end; k++)
-    {
+    for (const auto k : c10::irange(start, end)) {
       for (long j = 0; j < owidth; j++) {
         if (j < pad_l) {
           ip_x = pad_l;
@@ -320,8 +318,7 @@ static void replication_pad1d_backward_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *ginput_p = ginput_data + p * nslices * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * owidth;
       replication_pad1d_backward_out_frame(ginput_p, goutput_p,
@@ -347,10 +344,9 @@ static void replication_pad2d_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++)
-    {
-      for (int64_t i = 0; i < oheight; i++) {
-        for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(oheight)) {
+        for (const auto j : c10::irange(owidth)) {
           if (j < pad_l) {
             ip_x = pad_l;
           } else if (j >= pad_l && j < iwidth + pad_l) {
@@ -389,8 +385,7 @@ static void replication_pad2d_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data+p*nslices*iwidth*iheight;
       scalar_t *output_p = output_data+p*nslices*owidth*oheight;
       replication_pad2d_out_frame(input_p, output_p, nslices,
@@ -416,10 +411,9 @@ static void replication_pad2d_backward_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y;
-    for (auto k = start; k < end; k++)
-    {
-      for (int64_t i = 0; i < oheight; i++) {
-        for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto i : c10::irange(oheight)) {
+        for (const auto j : c10::irange(owidth)) {
           if (j < pad_l) {
             ip_x = pad_l;
           } else if (j >= pad_l && j < iwidth + pad_l) {
@@ -458,8 +452,7 @@ static void replication_pad2d_backward_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *ginput_p = ginput_data + p * nslices * iheight * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * oheight * owidth;
       replication_pad2d_backward_out_frame(ginput_p, goutput_p, nslices,
@@ -572,10 +565,10 @@ static void replication_pad3d_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y, ip_z;
-    for (auto k = start; k < end; k++) {
-      for (int64_t z = 0; z < odepth; z++) {
-        for (int64_t i = 0; i < oheight; i++) {
-          for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto z : c10::irange(odepth)) {
+        for (const auto i : c10::irange(oheight)) {
+          for (const auto j : c10::irange(owidth)) {
             if (j < pleft) {
               ip_x = pleft;
             } else if (j >= pleft && j < iwidth + pleft) {
@@ -627,8 +620,7 @@ static void replication_pad3d_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data + p * nslices * iwidth * iheight * idepth;
       scalar_t *output_p = output_data + p * nslices * owidth * oheight * odepth;
       replication_pad3d_out_frame(input_p, output_p, nslices,
@@ -658,10 +650,10 @@ static void replication_pad3d_backward_out_frame(
   at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ip_x, ip_y, ip_z;
-    for (auto k = start; k < end; k++) {
-      for (int64_t z = 0; z < odepth; z++) {
-        for (int64_t i = 0; i < oheight; i++) {
-          for (int64_t j = 0; j < owidth; j++) {
+    for (const auto k : c10::irange(start, end)) {
+      for (const auto z : c10::irange(odepth)) {
+        for (const auto i : c10::irange(oheight)) {
+          for (const auto j : c10::irange(owidth)) {
             if (j < pleft) {
               ip_x = pleft;
             } else if (j >= pleft && j < iwidth + pleft) {
@@ -713,8 +705,7 @@ static void replication_pad3d_backward_out_batch(
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++)
-    {
+    for (const auto p : c10::irange(start, end)) {
       scalar_t *ginput_p = ginput_data + p * nslices * idepth * iheight * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * odepth * oheight * owidth;
       replication_pad3d_backward_out_frame(ginput_p, goutput_p, nslices,

--- a/aten/src/ATen/native/ResizeCommon.h
+++ b/aten/src/ATen/native/ResizeCommon.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/NamedTensorUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -10,7 +11,7 @@ inline int64_t storage_size_for(IntArrayRef size, IntArrayRef stride) {
       "storage_size_for(size, stride) requires that size and stride ",
       "have the same size as a precondition.");
   int64_t storage_size = 1;
-  for (size_t dim = 0; dim < size.size(); ++dim) {
+  for (const auto dim : c10::irange(size.size())) {
     if (size[dim] == 0) {
       storage_size = 0;
       break;

--- a/aten/src/ATen/native/RowwisePrune.cpp
+++ b/aten/src/ATen/native/RowwisePrune.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 
 namespace at {
@@ -15,7 +16,7 @@ std::tuple<Tensor, Tensor> _rowwise_prune_helper(
   int num_non_masked_rows = 0;
   auto mask_contig = mask.contiguous();
   auto mask_data = mask_contig.data_ptr<bool>();
-  for (int i = 0; i < mask.numel(); ++i) {
+  for (const auto i : c10::irange(mask.numel())) {
     num_non_masked_rows += (((mask_data[i] == true)) ? 1 : 0);
   }
   int num_cols = weights.size(1);
@@ -32,7 +33,7 @@ std::tuple<Tensor, Tensor> _rowwise_prune_helper(
         compressed_indices_mapping.data_ptr<input_t>();
     auto weights_data = weights.data_ptr<scalar_t>();
     int last_row_kept = 0;
-    for (int i = 0; i < mask.numel(); i++) {
+    for (const auto i : c10::irange(mask.numel())) {
       if (mask_data[i]) {
         memcpy(pruned_2d_tensor_data + last_row_kept * num_cols,
               weights_data + i * num_cols,

--- a/aten/src/ATen/native/ScatterGatherChecks.h
+++ b/aten/src/ATen/native/ScatterGatherChecks.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <ATen/ATen.h>
 #include <ATen/native/ReduceOpsUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -45,7 +46,7 @@ static C10_UNUSED void gather_shape_check(const Tensor& self, int64_t dim,
     "Index tensor must have the same number of dimensions as input tensor"
   );
 
-  for (int64_t i = 0; i < self_dims; ++i) {
+  for (const auto i : c10::irange(self_dims)) {
     if (i != dim) {
       TORCH_CHECK(
         ensure_nonempty_size(index, i) <= ensure_nonempty_size(self, i),
@@ -77,7 +78,7 @@ static C10_UNUSED void scatter_shape_check(
   int64_t self_dims = ensure_nonempty_dim(self.dim());
 
   //  Check: index.size(d) <= self.size(d) for all d != dim
-  for (int64_t d = 0; d < self_dims; ++d) {
+  for (const auto d : c10::irange(self_dims)) {
     int64_t index_d_size = ensure_nonempty_size(index, d);
     if (d == dim) continue;
     if (index_d_size > ensure_nonempty_size(self, d)) {
@@ -89,7 +90,7 @@ static C10_UNUSED void scatter_shape_check(
   //  Check: index.size(d) <= src.size(d) for all d if src is Tensor
   if (!is_wrong_shape && src_opt.has_value()) {
     auto src = src_opt.value();
-    for (int64_t d = 0; d < self_dims; ++d) {
+    for (const auto d : c10::irange(self_dims)) {
       int64_t index_d_size = ensure_nonempty_size(index, d);
       if (index_d_size > ensure_nonempty_size(src, d)) {
         is_wrong_shape = true;

--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NumericUtils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -41,8 +42,8 @@ void _segment_reduce_cpu_kernel1(
         auto* output_data = output.data_ptr<scalar_t>();
         const auto* values_data = data.data_ptr<scalar_t>();
         int64_t lengths_cum_sum = 0;
-        for (int64_t i = 0; i < segment_count; ++i) {
-          for (int64_t l = 0; l < stride_count; ++l) {
+        for (const auto i : c10::irange(segment_count)) {
+          for (const auto l : c10::irange(stride_count)) {
             // ===== step1: initialize starting value
             scalar_t initial_value;
             if (initial.has_value()) {
@@ -141,12 +142,12 @@ void _segment_reduce_cpu_backward_kernel1(
         const auto* values_data = data_contig.data_ptr<scalar_t>();
 
         int64_t lengths_cum_sum = 0;
-        for (int64_t i = 0; i < segment_count; ++i) {
+        for (const auto i : c10::irange(segment_count)) {
           if (lengths_data[i] == 0) {
             continue;
           }
 
-          for (int64_t l = 0; l < stride_count; ++l) {
+          for (const auto l : c10::irange(stride_count)) {
             int64_t output_index = (i * stride_count) + l;
 
             if (reduction == SegmentReductionType::MAX ||

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -9,6 +9,7 @@
 #include <ATen/NamedTensorUtils.h>
 
 #include <c10/core/TensorOptions.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -129,10 +130,12 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
   int64_t outer_size = 1;
   int64_t dim_size = input.size(dim);
   int64_t inner_size = 1;
-  for (int64_t i = 0; i < dim; ++i)
+  for (const auto i : c10::irange(dim)) {
     outer_size *= input.size(i);
-  for (int64_t i = dim + 1; i < input.dim(); ++i)
+  }
+  for (int64_t i = dim + 1; i < input.dim(); ++i) {
     inner_size *= input.size(i);
+  }
   int64_t dim_stride = inner_size;
   int64_t outer_stride = dim_size * dim_stride;
   scalar_t* input_data_base = input.data_ptr<scalar_t>();
@@ -141,7 +144,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
   parallel_for(
       0, outer_size * inner_size, grain_size,
       [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* input_data =
@@ -149,11 +152,12 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
           scalar_t* output_data =
               output_data_base + outer_idx * outer_stride + inner_idx;
           scalar_t max_input = input_data[0];
-          for (int64_t d = 1; d < dim_size; d++)
+          for (const auto d : c10::irange(1, dim_size)) {
             max_input = std::max(max_input, input_data[d * dim_stride]);
+          }
 
           acc_type<scalar_t, false> tmpsum = 0;
-          for (int64_t d = 0; d < dim_size; d++) {
+          for (const auto d : c10::irange(dim_size)) {
             scalar_t z = std::exp(input_data[d * dim_stride] - max_input);
             if (!LogSoftMax) {
               output_data[d * dim_stride] = z;
@@ -161,17 +165,20 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
             tmpsum += z;
           }
 
-          if (LogSoftMax)
+          if (LogSoftMax) {
             tmpsum = std::log(tmpsum);
-          else
+          } else {
             tmpsum = 1 / tmpsum;
+          }
 
-          for (int64_t d = 0; d < dim_size; d++)
-            if (LogSoftMax)
+          for (const auto d : c10::irange(dim_size)) {
+            if (LogSoftMax) {
               output_data[d * dim_stride] =
                   input_data[d * dim_stride] - max_input - tmpsum;
-            else
+            } else {
               output_data[d * dim_stride] *= tmpsum;
+            }
+          }
         }
       });
 }
@@ -186,10 +193,12 @@ void host_softmax_backward(
   int64_t outer_size = 1;
   int64_t dim_size = grad.size(dim);
   int64_t inner_size = 1;
-  for (int64_t i = 0; i < dim; ++i)
+  for (const auto i : c10::irange(dim)) {
     outer_size *= grad.size(i);
-  for (int64_t i = dim + 1; i < grad.dim(); ++i)
+  }
+  for (int64_t i = dim + 1; i < grad.dim(); ++i) {
     inner_size *= grad.size(i);
+  }
   int64_t dim_stride = inner_size;
   int64_t outer_stride = dim_size * dim_stride;
   scalar_t* gradInput_data_base = gI.data_ptr<scalar_t>();
@@ -198,7 +207,7 @@ void host_softmax_backward(
   int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
   parallel_for(
       0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* gradInput_data =
@@ -209,14 +218,16 @@ void host_softmax_backward(
               gradOutput_data_base + outer_idx * outer_stride + inner_idx;
 
           acc_type<scalar_t, false> sum = 0;
-          for (int64_t d = 0; d < dim_size; d++)
-            if (LogSoftMax)
+          for (const auto d : c10::irange(dim_size)) {
+            if (LogSoftMax) {
               sum += gradOutput_data[d * dim_stride];
-            else
+            } else {
               sum +=
                   gradOutput_data[d * dim_stride] * output_data[d * dim_stride];
+            }
+          }
 
-          for (int64_t d = 0; d < dim_size; d++) {
+          for (const auto d : c10::irange(dim_size)) {
             if (LogSoftMax) {
               gradInput_data[d * dim_stride] = gradOutput_data[d * dim_stride] -
                   std::exp(output_data[d * dim_stride]) * sum;

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/Sorting.h>
 #include <ATen/native/SortingUtils.h>
 #include <ATen/native/ReduceOpsUtils.h>
+#include <c10/util/irange.h>
 
 #include <utility>
 
@@ -315,7 +316,7 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
 
   AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "kthvalue_cpu", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
-      for (int64_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         TensorAccessor<scalar_t, 1> tmp_values(
             reinterpret_cast<scalar_t*>(data[0] + i * strides[0]),
             &sizes[dim], &tmp_values_stride);
@@ -325,7 +326,7 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
         auto mode_value = reinterpret_cast<scalar_t*>(data[2] + i * strides[2]);
         auto mode_index = reinterpret_cast<int64_t*>(data[3] + i * strides[3]);
 
-        for (int64_t j = 0; j < tmp_indices.size(0); j++) {
+        for (const auto j : c10::irange(tmp_indices.size(0))) {
           tmp_indices[j] = j;
         }
 
@@ -411,7 +412,7 @@ std::tuple<Tensor&, Tensor&> median_with_indices_impl(
 
   AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, in.scalar_type(), "median_out", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
-      for (int64_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         auto valp = reinterpret_cast<scalar_t*>(data[0] + i * strides[0]);
         auto indp = reinterpret_cast<int64_t*>(data[1] + i * strides[1]);
         auto ip = reinterpret_cast<const scalar_t*>(data[2] + i * strides[2]);

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -2,6 +2,7 @@
 
 #include <ATen/NumericUtils.h>
 #include <ATen/native/Resize.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -97,7 +98,7 @@ void topk_impl_loop(
     const bool largest,
     const bool sorted,
     char** data, const int64_t* strides, const int64_t n) {
-  for (int64_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     TensorAccessor<scalar_t, 1> mode_values(
         reinterpret_cast<scalar_t*>(data[0] + i * strides[0]),
         &k, &mode_values_stride);
@@ -113,7 +114,7 @@ void topk_impl_loop(
 
     using elem_t = std::pair<accscalar_t, int64_t>;
     std::vector<elem_t> queue(n);
-    for (int64_t j = 0; j < n; j++) {
+    for (const auto j : c10::irange(n)) {
       queue[j].first = tmp_values[j];
       queue[j].second = j;
     }
@@ -157,7 +158,7 @@ void topk_impl_loop(
       }
     }
 
-    for (int64_t j = 0; j < k; j++) {
+    for (const auto j : c10::irange(k)) {
       mode_values[j] = queue[j].first;
       mode_indices[j] = queue[j].second;
     }

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -252,7 +252,7 @@ ShapeAndDims canonicalize_fft_shape_and_dim_args(
 
     // Translate shape of -1 to the default length
     ret.shape.resize(transform_ndim);
-    for (int64_t i = 0; i < transform_ndim; ++i) {
+    for (const auto i : c10::irange(transform_ndim)) {
       const auto n = (*shape)[i];
       ret.shape[i] = n == -1 ? input_sizes[ret.dim[i]] : n;
     }

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <c10/util/irange.h>
 
 #include <tuple>
 
@@ -45,13 +46,13 @@ Tensor _bincount_cpu_template(
         weights.options().pinned_memory_opt());
     weights_t* output_p = output.data_ptr<weights_t>();
     const weights_t* weights_p = weights.data_ptr<weights_t>();
-    for (int64_t i = 0; i < self_size; i++) {
+    for (const auto i : c10::irange(self_size)) {
       output_p[self_p[i]] += weights_p[i];
     }
   } else {
     output = native::zeros({nbins}, kLong);
     int64_t* output_p = output.data_ptr<int64_t>();
-    for (int64_t i = 0; i < self_size; i++) {
+    for (const auto i : c10::irange(self_size)) {
       output_p[self_p[i]] += 1L;
     }
   }

--- a/aten/src/ATen/native/TensorDimApply.h
+++ b/aten/src/ATen/native/TensorDimApply.h
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 namespace at {
   namespace native {
@@ -20,7 +21,7 @@ namespace at {
         func(self_data, values_data, indices_data, self_dim_size, self_stride, values_stride, indices_stride);
         if(ndims == 1)
            break;
-        for(int dim_i = 0; dim_i < ndims; dim_i++) {
+        for (const auto dim_i : c10::irange(ndims)) {
           if(dim_i == dim) {
             if(dim_i == (ndims - 1)) {
               tensor_dim_apply_has_finished = 1;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -14,6 +14,7 @@
 #include <c10/core/TensorOptions.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/native/UnaryOps.h>
 
@@ -423,8 +424,7 @@ Tensor& eye_out_cpu(int64_t n, int64_t m, Tensor& result) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::Bool, result.scalar_type(), "eye", [&]() -> void {
     scalar_t* result_data = result.data_ptr<scalar_t>();
     at::parallel_for(0, sz, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
-      for(int64_t i = p_begin; i < p_end; i++)
-        result_data[i*(result.strides()[0] + result.strides()[1])] = 1;
+      for (const auto i : c10::irange(p_begin, p_end))result_data[i*(result.strides()[0] + result.strides()[1])] = 1;
     });
   });
 
@@ -864,8 +864,9 @@ void randperm_cpu(Tensor& result, int64_t n, CPUGeneratorImpl* generator) {
 
   at::parallel_for(0, n, internal::GRAIN_SIZE,
                   [&r__data, &r__stride_0](int64_t p_begin, int64_t p_end) {
-    for(int64_t i = p_begin; i < p_end; i++)
+    for (const auto i : c10::irange(p_begin, p_end)) {
       r__data[i*r__stride_0] = static_cast<scalar_t>(i);
+    }
   });
 
   for(int64_t i = 0; i < n - 1; i++)

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -5,6 +5,7 @@
 #include <torch/library.h>
 
 #include <ATen/Config.h>
+#include <c10/util/irange.h>
 namespace at {
 namespace native {
 
@@ -72,7 +73,7 @@ bool is_set_to(const Tensor& self, const Tensor& src) {
   if (self.storage().unsafeGetStorageImpl() == src.storage().unsafeGetStorageImpl() &&
       self.storage_offset() == src.storage_offset() &&
       self.dim() == src.dim()) {
-    for (int64_t d = 0; d < self.dim(); ++d) {
+    for (const auto d : c10::irange(self.dim())) {
       if (self.size(d) != src.size(d) || self.stride(d) != src.stride(d)) {
         return false;
       }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1421,7 +1421,7 @@ static inline std::vector<Tensor> get_stack_inputs(TensorList tensors, int64_t d
   std::vector<Tensor> inputs(tensors.size());
   at::IntArrayRef entry_shape = tensors[0].sizes();
   inputs[0] = tensors[0].unsqueeze(dim);
-  for (size_t i = 1; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     TORCH_CHECK(tensors[i].sizes() == entry_shape,
       "stack expects each tensor to be equal size, but got ", entry_shape,
       " at entry 0 and ", tensors[i].sizes(), " at entry ", i);
@@ -1449,7 +1449,7 @@ bool inline can_use_native_serial_stack(Tensor& result, TensorList tensors, int6
   if (result.dtype() != firstTensor.dtype()) return false;
 
   // Inputs cannot alias the output tensor
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     auto lap = at::get_overlap_status(result, tensors[i]);
     TORCH_CHECK(lap != at::MemOverlapStatus::PARTIAL &&
         lap != at::MemOverlapStatus::FULL, 0,
@@ -1471,7 +1471,7 @@ bool inline can_use_native_serial_stack(Tensor& result, TensorList tensors, int6
 
   // check remainder of inputs
   auto const &first_tensor_shape = firstTensor.sizes();
-  for (size_t i = 1; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     auto const &tensor = tensors[i];
     TORCH_CHECK(tensors[i].sizes() == firstTensor.sizes(),
       "stack expects each tensor to be equal size, but got ", first_tensor_shape,

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -5,6 +5,7 @@
 #include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/core/DimVector.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <vector>
@@ -22,7 +23,7 @@ Tensor flip(const Tensor& self, IntArrayRef dims) {
   // Count dimensions in which we need to do work
   int n = 0;
   auto strides = DimVector(self.strides());
-  for(int64_t i = 0; i < total_dims; i++) {
+  for (const auto i : c10::irange(total_dims)) {
     if(flip_dims_b[i] && self.size(i) > 1 && self.stride(i) != 0) {
       n++;
       strides[i] = 0;
@@ -61,7 +62,7 @@ Tensor flip(const Tensor& self, IntArrayRef dims) {
   //   - We move the pointer to the opposite vertex of the cube
   //   - We iterate in the opposite direction (invert the strides)
 
-  for (int i=0; i<iter.ndim(); i++){
+  for (const auto i : c10::irange(iter.ndim())) {
     // We know that an dimension has a zero stride and self[i] does not, as we defined above
     // Note that it may be the case that strides_dummy[i] = 0 not because we set it, but because
     // strides_self[i] == 0. We do not want to do anything there

--- a/aten/src/ATen/native/TriangularOps.cpp
+++ b/aten/src/ATen/native/TriangularOps.cpp
@@ -6,6 +6,7 @@
 
 #include <ATen/Parallel.h>
 #include <ATen/native/TriangularOpsUtils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -23,7 +24,7 @@ static void apply_triu_tril_single(
 
   if (upper) {
     at::parallel_for(0, n, 0, [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         for (int64_t j = 0; j < std::min(m, i + k); j++) {
           result[i * res_row_stride + j * res_col_stride] = 0;
         }
@@ -36,7 +37,7 @@ static void apply_triu_tril_single(
     });
   } else {
     at::parallel_for(0, n, 0, [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
         for (int64_t j = std::max(zero, i + k + 1); j < m; j++) {
           result[i * res_row_stride + j * res_col_stride] = 0;
         }
@@ -74,7 +75,7 @@ void apply_triu_tril(Tensor& result, const Tensor& self, bool inplace, int64_t k
   }
 
   at::parallel_for(0, batchsize, 0, [&](int64_t start, int64_t end) {
-    for (auto b = start; b < end; b++) {
+    for (const auto b : c10::irange(start, end)) {
       scalar_t* self_batch = &self_data[b * self_stride];
       scalar_t* result_batch = &result_data[b * result_stride];
       apply_triu_tril_single<scalar_t, upper>(

--- a/aten/src/ATen/native/Unfold3d.cpp
+++ b/aten/src/ATen/native/Unfold3d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #if AT_MKL_ENABLED()
 #include <mkl.h>
@@ -17,7 +18,7 @@ bool IsAGeZeroAndALtB(int64_t a, int64_t b) {
 
 template <typename T>
 void MatCopy(int64_t M, int64_t N, int64_t lda, int64_t ldb, const T* A, T* B) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     std::memcpy(B + i * ldb, A + i * lda, N * sizeof(T));
   }
 }
@@ -32,10 +33,10 @@ void MatCopy(
     int64_t strideb,
     const T* A,
     T* B) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     const T* A_ptr = A + i * lda;
     T* B_ptr = B + i * ldb;
-    for (int64_t j = 0; j < N; ++j) {
+    for (const auto j : c10::irange(N)) {
       B_ptr[j * strideb] = A_ptr[j * stridea];
     }
   }
@@ -44,8 +45,8 @@ void MatCopy(
 // Y += X
 template <typename T>
 void MatAdd(int64_t M, int64_t N, int64_t ldx, int64_t ldy, const T* X, T* Y) {
-  for (int64_t i = 0; i < M; ++i) {
-    for (int64_t j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       Y[i * ldy + j] += X[i * ldx + j];
     }
   }
@@ -62,8 +63,8 @@ void MatAdd(
     int64_t stridey,
     const T* X,
     T* Y) {
-  for (int64_t i = 0; i < M; ++i) {
-    for (int64_t j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       Y[i * ldy + j * stridey] += X[i * ldx + j * stridex];
     }
   }
@@ -151,7 +152,7 @@ void MatAdd(
     int64_t stridey,
     const float* X,
     float* Y) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     cblas_saxpy(N, 1.0f, X + i * ldx, stridex, Y + i * ldy, stridey);
   }
 }
@@ -166,7 +167,7 @@ void MatAdd(
     int64_t stridey,
     const double* X,
     double* Y) {
-  for (int64_t i = 0; i < M; ++i) {
+  for (const auto i : c10::irange(M)) {
     cblas_daxpy(N, 1.0, X + i * ldx, stridex, Y + i * ldy, stridey);
   }
 }
@@ -194,7 +195,7 @@ void Unfold3dZeroPaddingCopyKernelImpl(
   const int64_t X_size = X_D * X_H * X_W;
   const int64_t Y_size = Y_D * Y_H * Y_W;
   at::parallel_for(0, n, 0, [=](int64_t begin, int64_t end) {
-    for (int64_t p = begin; p < end; ++p) {
+    for (const auto p : c10::irange(begin, end)) {
       int64_t c = p;
       const int64_t kw = c % kernel_w;
       c /= kernel_w;
@@ -202,7 +203,7 @@ void Unfold3dZeroPaddingCopyKernelImpl(
       c /= kernel_h;
       const int64_t kd = c % kernel_d;
       c /= kernel_d;
-      for (int64_t yd = 0; yd < Y_D; ++yd) {
+      for (const auto yd : c10::irange(Y_D)) {
         const int64_t xd = yd * stride_d + kd;
         const T* src_ptr = src + c * X_size + xd * X_H * X_W + kh * X_W + kw;
         T* dst_ptr = dst + p * Y_size + yd * Y_H * Y_W;
@@ -261,7 +262,7 @@ void Unfold3dCopyKernelImpl(
   const int64_t X_size = X_D * X_H * X_W;
   const int64_t Y_size = Y_D * Y_H * Y_W;
   at::parallel_for(0, n, 0, [=](int64_t begin, int64_t end) {
-    for (int64_t p = begin; p < end; ++p) {
+    for (const auto p : c10::irange(begin, end)) {
       int64_t c = p;
       const int64_t kw = c % kernel_w;
       c /= kernel_w;
@@ -271,20 +272,20 @@ void Unfold3dCopyKernelImpl(
       c /= kernel_d;
       const T* src_ptr = src + c * X_size;
       T* dst_ptr = dst + p * Y_size;
-      for (int64_t yd = 0; yd < Y_D; ++yd) {
+      for (const auto yd : c10::irange(Y_D)) {
         const int64_t xd = yd * stride_d - pad_d + kd;
         if (!IsAGeZeroAndALtB(xd, X_D)) {
           std::memset(dst_ptr + yd * Y_H * Y_W, 0, Y_H * Y_W * sizeof(T));
           continue;
         }
-        for (int64_t yh = 0; yh < Y_H; ++yh) {
+        for (const auto yh : c10::irange(Y_H)) {
           const int64_t xh = yh * stride_h - pad_h + kh;
           if (!IsAGeZeroAndALtB(xh, X_H)) {
             std::memset(
                 dst_ptr + yd * Y_H * Y_W + yh * Y_W, 0, Y_W * sizeof(T));
             continue;
           }
-          for (int64_t yw = 0; yw < Y_W; ++yw) {
+          for (const auto yw : c10::irange(Y_W)) {
             const int64_t xw = yw * stride_w - pad_w + kw;
             dst_ptr[yd * Y_H * Y_W + yh * Y_W + yw] = IsAGeZeroAndALtB(xw, X_W)
                 ? src_ptr[xd * X_H * X_W + xh * X_W + xw]
@@ -318,13 +319,13 @@ void Unfold3dZeroPaddingAccKernelImpl(
   const int64_t kernel_size = kernel_d * kernel_h * kernel_w;
   at::parallel_for(0, C, 0, [=](int64_t begin, int64_t end) {
     std::memset(dst + begin * X_size, 0, (end - begin) * X_size * sizeof(T));
-    for (int64_t c = begin; c < end; ++c) {
-      for (int64_t kd = 0; kd < kernel_d; ++kd) {
-        for (int64_t kh = 0; kh < kernel_h; ++kh) {
-          for (int64_t kw = 0; kw < kernel_w; ++kw) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto kd : c10::irange(kernel_d)) {
+        for (const auto kh : c10::irange(kernel_h)) {
+          for (const auto kw : c10::irange(kernel_w)) {
             const int64_t p =
                 c * kernel_size + kd * kernel_h * kernel_w + kh * kernel_w + kw;
-            for (int64_t yd = 0; yd < Y_D; ++yd) {
+            for (const auto yd : c10::irange(Y_D)) {
               const int64_t xd = yd * stride_d + kd;
               const T* src_ptr = src + p * Y_size + yd * Y_H * Y_W;
               T* dst_ptr = dst + c * X_size + xd * X_H * X_W + kh * X_W + kw;
@@ -393,25 +394,25 @@ void Unfold3dAccKernelImpl(
   const int64_t kernel_size = kernel_d * kernel_h * kernel_w;
   at::parallel_for(0, C, 0, [=](int64_t begin, int64_t end) {
     std::memset(dst + begin * X_size, 0, (end - begin) * X_size * sizeof(T));
-    for (int64_t c = begin; c < end; ++c) {
+    for (const auto c : c10::irange(begin, end)) {
       T* dst_ptr = dst + c * X_size;
-      for (int64_t kd = 0; kd < kernel_d; ++kd) {
-        for (int64_t kh = 0; kh < kernel_h; ++kh) {
-          for (int64_t kw = 0; kw < kernel_w; ++kw) {
+      for (const auto kd : c10::irange(kernel_d)) {
+        for (const auto kh : c10::irange(kernel_h)) {
+          for (const auto kw : c10::irange(kernel_w)) {
             const int64_t p =
                 c * kernel_size + kd * kernel_h * kernel_w + kh * kernel_w + kw;
             const T* src_ptr = src + p * Y_size;
-            for (int64_t yd = 0; yd < Y_D; ++yd) {
+            for (const auto yd : c10::irange(Y_D)) {
               const int64_t xd = yd * stride_d - pad_d + kd;
               if (!IsAGeZeroAndALtB(xd, X_D)) {
                 continue;
               }
-              for (int64_t yh = 0; yh < Y_H; ++yh) {
+              for (const auto yh : c10::irange(Y_H)) {
                 const int64_t xh = yh * stride_h - pad_h + kh;
                 if (!IsAGeZeroAndALtB(xh, X_H)) {
                   continue;
                 }
-                for (int64_t yw = 0; yw < Y_W; ++yw) {
+                for (const auto yw : c10::irange(Y_W)) {
                   const int64_t xw = yw * stride_w - pad_w + kw;
                   if (IsAGeZeroAndALtB(xw, X_W)) {
                     dst_ptr[xd * X_H * X_W + xh * X_W + xw] +=

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
+#include <c10/util/irange.h>
 
 #include <set>
 #include <tuple>
@@ -51,25 +52,25 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
     int64_t* inverse_indices_data = inverse_indices.data_ptr<int64_t>();
     std::unordered_map<scalar_t, int64_t> inverse_map;
     inverse_map.reserve(output.numel());
-    for (int64_t i = 0; i < output.numel(); ++i) {
+    for (const auto i : c10::irange(output.numel())) {
       inverse_map[output_data[i]] = i;
     }
-    for(int64_t i = 0; i < numel; ++i) {
+    for (const auto i : c10::irange(numel)) {
       inverse_indices_data[i] = inverse_map[input_data[i]];
     }
     if (return_counts) {
       std::unordered_map<scalar_t, int64_t> counts_map;
       counts_map.reserve(output.numel());
-      for (int64_t i = 0; i < output.numel(); ++i) {
+      for (const auto i : c10::irange(output.numel())) {
         counts_map[output_data[i]] = 0;
       }
-      for(int64_t i = 0; i < numel; i++) {
+      for (const auto i : c10::irange(numel)) {
         counts_map[input_data[i]] += 1;
       }
       counts.resize_(output.sizes());
       counts.fill_(0);
       int64_t *counts_data = counts.data_ptr<int64_t>();
-      for(int64_t i = 0; i < output.numel(); i++) {
+      for (const auto i : c10::irange(output.numel())) {
         counts_data[i] = counts_map[output_data[i]];
       }
     }
@@ -106,7 +107,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_consecutive_cpu_template(
     scalar_t *p = output_data;
     int64_t *q = counts_data;
     int64_t last = 0;
-    for (int64_t i = 0; i < numel; i++) {
+    for (const auto i : c10::irange(numel)) {
       if (input_data[i] != *p) {
         *(++p) = input_data[i];
         if (return_counts) {
@@ -202,7 +203,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
   if (!consecutive) {
     std::sort(indices.begin(), indices.end(),
       [&](int64_t a, int64_t b) -> bool {
-        for (int64_t i = 0; i < numel; ++i) {
+        for (const auto i : c10::irange(numel)) {
           scalar_t lhs = input_flat_ptr[i + a * numel];
           scalar_t rhs = input_flat_ptr[i + b * numel];
           if (lhs < rhs) {
@@ -218,7 +219,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
   Tensor input_sorted;
   if (!consecutive) {
     input_sorted = at::empty(input_flat.sizes(), input_flat.options());
-    for (size_t i = 0; i < indices.size(); ++i) {
+    for (const auto i : c10::irange(indices.size())) {
       input_sorted[i] = input_flat[indices[i]];
     }
   } else {

--- a/aten/src/ATen/native/UpSample.cpp
+++ b/aten/src/ATen/native/UpSample.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -20,7 +21,7 @@ TORCH_API c10::SmallVector<int64_t, 3> compute_output_size(
     TORCH_CHECK(!output_size, "Must specify exactly one of output_size and scale_factors");
     TORCH_CHECK(static_cast<int64_t>(scale_factors->size()) == spatial_dimensions);
     c10::SmallVector<int64_t, 3> ret;
-    for (int i = 0; i < spatial_dimensions; ++i) {
+    for (const auto i : c10::irange(spatial_dimensions)) {
       ret.push_back(static_cast<double>(input_size[i+2]) * scale_factors.value()[i]);
     }
     return ret;

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -33,7 +34,7 @@ TORCH_META_FUNC(upsample_bicubic2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",
@@ -65,11 +66,12 @@ static void upsample_bicubic2d_backward_out_frame(
 
   // Special case: input/output same size, just copy
   if (input_height == output_height && input_width == output_width) {
-    for (int64_t output_y = 0; output_y < output_height; output_y++) {
-      for (int64_t output_x = 0; output_x < output_width; output_x++) {
+    for (const auto output_y : c10::irange(output_height)) {
+      for (const auto output_x : c10::irange(output_width)) {
         scalar_t* in = &idata[output_y * input_width + output_x];
         scalar_t* out = &odata[output_y * output_width + output_x];
-        for (int64_t c = 0; c < channels; ++c) {
+        for (const auto c : c10::irange(channels)) {
+          (void)c; //Suppress unused variable warning
           in[0] = out[0];
           in += input_width * input_height;
           out += output_width * output_height;
@@ -84,8 +86,8 @@ static void upsample_bicubic2d_backward_out_frame(
   const scalar_t width_scale = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners, scales_w);
 
-  for (int64_t output_y = 0; output_y < output_height; output_y++) {
-    for (int64_t output_x = 0; output_x < output_width; output_x++) {
+  for (const auto output_y : c10::irange(output_height)) {
+    for (const auto output_x : c10::irange(output_width)) {
       scalar_t* in = idata;
       scalar_t* out = odata;
 
@@ -105,11 +107,12 @@ static void upsample_bicubic2d_backward_out_frame(
       get_cubic_upsample_coefficients<scalar_t>(x_coeffs, t_x);
       get_cubic_upsample_coefficients<scalar_t>(y_coeffs, t_y);
 
-      for (int64_t c = 0; c < channels; c++) {
+      for (const auto c : c10::irange(channels)) {
+        (void)c; //Suppress unused variable warning
         scalar_t out_value = out[output_y * output_width + output_x];
 
-        for (int64_t i = 0; i < 4; i++) {
-          for (int64_t j = 0; j < 4; j++) {
+        for (const auto i : c10::irange(4)) {
+          for (const auto j : c10::irange(4)) {
             upsample_increment_value_bounded<scalar_t>(
                 in,
                 input_width,

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -36,7 +37,7 @@ TORCH_META_FUNC(upsample_bilinear2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -33,7 +34,7 @@ TORCH_META_FUNC(upsample_nearest2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -37,7 +38,7 @@ TORCH_META_FUNC(upsample_nearest3d_backward) (
       grad_output.dim() == 5,
       "Expected grad_output to be a tensor of dimension 5 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 5; ++i) {
+  for (const auto i : c10::irange(5)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/UpSample.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace meta {
@@ -42,7 +43,7 @@ TORCH_META_FUNC(upsample_trilinear3d_backward) (
       grad_output.dim() == 5,
       "Expected grad_output to be a tensor of dimension 5 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 5; ++i) {
+  for (const auto i : c10::irange(5)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
@@ -5,6 +5,7 @@
 
 #include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+#include <c10/util/irange.h>
 
 namespace ao {
 namespace sparse {
@@ -64,7 +65,7 @@ at::Tensor PackedLinearWeight::apply_impl(
     // Process the per channel quantization.
     output_multiplier_float.resize(out_channels, 0.0);
     act_times_w_scale.resize(out_channels, 1.0f);
-    for (int i = 0; i < out_channels; ++i) {
+    for (const auto i : c10::irange(out_channels)) {
       act_times_w_scale[i] = (input_scale_float * w_scale[i]);
       output_multiplier_float[i] =
           act_times_w_scale[i] / static_cast<float>(output_scale);
@@ -126,7 +127,7 @@ at::Tensor PackedLinearWeight::apply_impl(
 
   int num_tasks = at::get_num_threads();
   at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
-    for (int task_id = begin; task_id < end; ++task_id) {
+    for (const auto task_id : c10::irange(begin, end)) {
       fbgemm::trRequantizationParams_t reqParams = {
           input_zero_point_int32,
           w_zp.data(),

--- a/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -34,16 +35,16 @@ void cpu_adaptive_max_pool(
 
   // parallel on dim of N, C
   at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t* input_ptr = input_data + c * input_height * input_width;
       scalar_t* output_ptr = output_data + c * output_height * output_width;
       int64_t* indices_ptr = indices_data + c * output_height * output_width;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
+      for (const auto oh : c10::irange(output_height)) {
         int64_t ih0 = start_index(oh, output_height, input_height);
         int64_t ih1 = end_index(oh, output_height, input_height);
 
-        for (int64_t ow = 0; ow < output_width; ow++) {
+        for (const auto ow : c10::irange(output_width)) {
           int64_t iw0 = start_index(ow, output_width, input_width);
           int64_t iw1 = end_index(ow, output_width, input_width);
 
@@ -121,7 +122,7 @@ void cpu_adaptive_max_pool_channels_last(
     // temp buffer holding index with integer_t
     std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = start_index(oh, output_height, input_height);
       int64_t ih1 = end_index(oh, output_height, input_height);
 
@@ -216,13 +217,13 @@ void cpu_adaptive_max_pool_backward(
 
   // parallel on dim of N, C
   at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
       scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
       int64_t* indices_ptr = indices_data + c * output_height * output_width;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           // retrieve position of max
           int64_t index = oh * output_width + ow;
           int64_t maxindex = indices_ptr[index];
@@ -264,17 +265,17 @@ void cpu_adaptive_max_pool_backward_channels_last(
 
   // parallel on dim N
   at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t n = begin; n < end; n++) {
+    for (const auto n : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
       scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
       int64_t* indices_ptr = indices_data + n * output_height * output_width * channels;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
           int64_t* ind = indices_ptr + oh * output_width * channels + ow * channels;
           // TODO: gcc vectorization
-          for (int64_t c = 0; c < channels; c++) {
+          for (const auto c : c10::irange(channels)) {
             int64_t maxindex = ind[c];
             grad_input_ptr[maxindex * channels + c] += gout[c];
           }

--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/cpu/CatKernel.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -33,8 +34,8 @@ void cat_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 
   using Vec = vec::Vectorized<scalar_t>;
   scalar_t* result_ptr = result_data;
-  for (int64_t i = 0; i < outer; ++i) {
-    for (int64_t j = 0; j < ninputs; j++) {
+  for (const auto i : c10::irange(outer)) {
+    for (const auto j : c10::irange(ninputs)) {
       int64_t local_inner = inputs[j].inner_size;
       scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
       int64_t d = 0;

--- a/aten/src/ATen/native/cpu/CrossKernel.cpp
+++ b/aten/src/ATen/native/cpu/CrossKernel.cpp
@@ -8,6 +8,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vml.h>
+#include <c10/util/irange.h>
 namespace at { namespace native { namespace {
 
 template<typename scalar_t>
@@ -28,7 +29,7 @@ static void apply_cross(Tensor& result, const Tensor& a, const Tensor& b, const 
     int64_t a_start = 0;
     int64_t b_start = 0;
     int64_t r_start = 0;
-    for (int64_t i = 0; i < a.dim(); i++) {
+    for (const auto i : c10::irange(a.dim())) {
       if (i == dim) continue;
       position_in_dims[i] = index_in_curr_dim % a.size(i);
       a_start += (index_in_curr_dim % a.size(i)) * a.stride(i);
@@ -43,7 +44,7 @@ static void apply_cross(Tensor& result, const Tensor& a, const Tensor& b, const 
       r_ptr[r_start+2*r_stride] = a_ptr[a_start+0*a_stride]*b_ptr[b_start+1*b_stride] - a_ptr[a_start+1*a_stride]*b_ptr[b_start+0*b_stride];
       s++;
 
-      for (int i = 0; i < a.dim(); i++) {
+      for (const auto i : c10::irange(a.dim())) {
         if (i == dim) {
           continue;
         }

--- a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+++ b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
@@ -1,6 +1,7 @@
 #include <ATen/native/cpu/DepthwiseConvKernel.h>
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
@@ -152,7 +153,7 @@ void convolution_depthwise3x3_winograd_impl(
       &input_tile.val[2],                                     \
       &input_tile.val[3]);                                    \
                                                               \
-  for (int64_t row = 0; row < 4; ++row) {                         \
+  for (const auto row : c10::irange(4)) {                         \
     input_tile.val[row] =                                     \
         vmulq_f32(input_tile.val[row], kernel_tile.val[row]); \
   }                                                           \
@@ -186,22 +187,22 @@ void convolution_depthwise3x3_winograd_impl(
                   2 * otw + 1 < args.out_cols
               )) {
         float32x4x4_t input_tile;
-        for (int64_t row = 0; row < 4; ++row) {
+        for (const auto row : c10::irange(4)) {
           input_tile.val[row] =
               vld1q_f32(input + (ih + row) * args.in_cols + iw);
         }
 
         TILE;
 
-        for (size_t row = 0; row < 2; ++row) {
+        for (const auto row : c10::irange(2)) {
           vst1_f32(
               output + (oth * 2 + row) * args.out_cols + otw * 2,
               vget_low_f32(input_tile.val[row]));
         }
       } else {
         float block[4][4];
-        for (int64_t row = 0; row < 4; ++row) {
-          for (int64_t col = 0; col < 4; ++col) {
+        for (const auto row : c10::irange(4)) {
+          for (const auto col : c10::irange(4)) {
             if (ih + row >= 0 && iw + col >= 0 && ih + row < args.in_rows &&
                 iw + col < args.in_cols) {
               block[row][col] = input[(ih + row) * args.in_cols + iw + col];
@@ -212,18 +213,18 @@ void convolution_depthwise3x3_winograd_impl(
         }
 
         float32x4x4_t input_tile;
-        for (int64_t row = 0; row < 4; ++row) {
+        for (const auto row : c10::irange(4)) {
           input_tile.val[row] = vld1q_f32(&block[row][0]);
         }
 
         TILE;
 
         float oblock[2][2];
-        for (int64_t row = 0; row < 2; ++row) {
+        for (const auto row : c10::irange(2)) {
           vst1_f32(&oblock[row][0], vget_low_f32(input_tile.val[row]));
         }
-        for (int64_t row = 0; row < 2; ++row) {
-          for (int64_t col = 0; col < 2; ++col) {
+        for (const auto row : c10::irange(2)) {
+          for (const auto col : c10::irange(2)) {
             if (2 * oth + row < args.out_rows &&
                 2 * otw + col < args.out_cols) {
               output[(2 * oth + row) * args.out_cols + 2 * otw + col] =
@@ -285,7 +286,7 @@ Tensor _convolution_depthwise3x3_winograd(
                       at::zeros({kernel_sizes[0]}, input.options());
 
   at::parallel_for(0, args.batch * args.out_channels, 0, [&](int64_t start, int64_t end) {
-    for (int64_t k = start; k < end; ++k) {
+    for (const auto k : c10::irange(start, end)) {
       const int64_t g = k % args.out_channels;
       const int64_t i = k / (args.out_channels / groups);
       convolution_depthwise3x3_winograd_impl(

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vml.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native { namespace {
 
@@ -227,7 +228,7 @@ struct Dist {
         const scalar_t * self_j = t2_start + size2 * l + j;
 
         scalar_t agg = 0;
-        for (int x = 0; x < m; x++) {
+        for (const auto x : c10::irange(m)) {
           scalar_t a = *(self_i + x);
           scalar_t b = *(self_j + x);
           agg = F::red(agg, F::map(std::abs(a-b), p));
@@ -392,7 +393,8 @@ struct Dist {
     const scalar_t * t1_end = t1 + l1_size;
     const scalar_t * t2_end = t2 + l2_size;
 
-    for (int64_t l = 0; l < d; l++) {
+    for (const auto l : c10::irange(d)) {
+      (void)l; //Suppress unused variable warning
       for (; t1 != t1_end; t1 += m, res += m) {
         const Vec vec_t1 = Vec::loadu(t1, count);
         Vec res_vec = Vec::loadu(res, count);

--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -10,6 +10,7 @@
 
 #ifdef CPU_CAPABILITY_AVX2
 #include <ATen/native/cpu/avx_mathfun.h>
+#include <c10/util/irange.h>
 #endif
 
 
@@ -108,7 +109,7 @@ void normal_fill_AVX2(Tensor& self, const float mean, const float std, RNG gener
   float *data = self.data_ptr<float>();
   auto size = self.numel();
   std::lock_guard<std::mutex> lock(generator->mutex_);
-  for (int64_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     at::uniform_real_distribution<float> uniform(0, 1);
     data[i] = uniform(generator);
   }
@@ -125,7 +126,7 @@ void normal_fill_AVX2(Tensor& self, const float mean, const float std, RNG gener
   if (size % 16 != 0) {
     // Recompute the last 16 values.
     data = data + size - 16;
-    for (int64_t i = 0; i < 16; ++i) {
+    for (const auto i : c10::irange(16)) {
       at::uniform_real_distribution<float> uniform(0, 1);
       data[i] = uniform(generator);
     }
@@ -136,7 +137,7 @@ void normal_fill_AVX2(Tensor& self, const float mean, const float std, RNG gener
 
 template <typename scalar_t>
 static void normal_fill_16(scalar_t *data, const scalar_t mean, const scalar_t std) {
-  for (int j = 0; j < 8; ++j) {
+  for (const auto j : c10::irange(8)) {
     const scalar_t u1 = 1 - data[j]; // [0, 1) -> (0, 1] for log.
     const scalar_t u2 = data[j + 8];
     const scalar_t radius = std::sqrt(-2 * std::log(u1));
@@ -151,7 +152,7 @@ void normal_fill(Tensor& self, const scalar_t mean, const scalar_t std, RNG gene
   scalar_t *data = self.data_ptr<scalar_t>();
   auto size = self.numel();
   std::lock_guard<std::mutex> lock(generator->mutex_);
-  for (int64_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     at::uniform_real_distribution<scalar_t> uniform(0, 1);
     data[i] = uniform(generator);
   }
@@ -162,7 +163,7 @@ void normal_fill(Tensor& self, const scalar_t mean, const scalar_t std, RNG gene
   if (size % 16 != 0) {
     // Recompute the last 16 values.
     data = data + size - 16;
-    for (int64_t i = 0; i < 16; ++i) {
+    for (const auto i : c10::irange(16)) {
       at::uniform_real_distribution<scalar_t> uniform(0, 1);
       data[i] = uniform(generator);
     }

--- a/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
+++ b/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
@@ -1,6 +1,7 @@
 #include <ATen/native/FunctionOfAMatrixUtils.h>
 
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 
 #if (defined(_WIN32) || defined(_WIN64))
 #define RESTRICT __restrict
@@ -27,14 +28,15 @@ void _compute_linear_combination_cpu_kernel(
         auto* RESTRICT in_ptr = data[1];
         auto* RESTRICT coeff_ptr = data[2];
 
-        for (int64_t elem = 0; elem < n; ++elem) {
+        for (const auto elem : c10::irange(n)) {
+          (void)elem; //Suppress unused variable warning
           auto* RESTRICT out_data = reinterpret_cast<scalar_t*>(out_ptr);
           auto* RESTRICT in_data = reinterpret_cast<scalar_t*>(in_ptr);
           using primitive_t = typename scalar_value_type<scalar_t>::type;
           auto* RESTRICT coeff_data = reinterpret_cast<primitive_t*>(coeff_ptr);
 
           // perform summation
-          for (int32_t i = 0; i < num_summations; ++i) {
+          for (const auto i : c10::irange(num_summations)) {
             *out_data += in_data[i * in_stride] * coeff_data[i * coeff_stride];
           }
 

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/cpu/GridSamplerKernel.h>
 #include <ATen/cpu/vml.h>
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <cstring>
@@ -50,7 +51,7 @@ namespace at { namespace native { namespace {
  *      //           from the beginning of this slice.
  *      //      iii. `len` as the number of valid locations in the vectors.
  *      //           (There might not be enough near boundary.)
- *      for (int n = 0; n < input_accessor.size(0); n++) {
+ *      for (const auto n : c10::irange(input_accessor.size(0))) {
  *        grid_sample_2d_grid_slice_iterator(
  *          grid_accessor[n],
  *          [&](const Vectorized<scalar_t>& grid_x,
@@ -443,7 +444,7 @@ mask_scatter_add(const scalar_t *src, scalar_t* base_addr,
   #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
   # pragma unroll
   #endif
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     if (mask[i] & 0x01) {
       base_addr[offsets[i]] += src[i];
     }
@@ -568,7 +569,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
 
       // mask_gather zeros out the mask, so we need to make copies
@@ -658,7 +659,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
       auto gOut = Vec::loadu(gOut_slice[c].data() + offset, len);
 
@@ -796,7 +797,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest,
       #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
       # pragma unroll
       #endif
-      for (int64_t c = 0; c < C; ++c) {
+      for (const auto c : c10::irange(C)) {
         mask_scatter_add(gOut_slice[c].data() + offset, (*gInp_slice_ptr)[c].data(),
                         gInp_offset_arr, mask_arr, len);
       }
@@ -930,13 +931,13 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
 
       // Interpolate the 4 values in the x direction
       // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
       Vec interp_x[4];
-      for (int64_t i = 0; i < 4; ++i) {
+      for (const auto i : c10::irange(4)) {
         interp_x[i] =
           coeff_x[0] * get_value_bounded(inp_slice_C_ptr, ix - Vec(1), iy + Vec(-1 + i)) +
           coeff_x[1] * get_value_bounded(inp_slice_C_ptr, ix + Vec(0), iy + Vec(-1 + i)) +
@@ -984,12 +985,12 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bicubic,
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t c = 0; c < C; ++c) {
+    for (const auto c : c10::irange(C)) {
       auto inp_slice_C_ptr = inp_slice[c].data();
       auto gOut = Vec::loadu(gOut_slice[c].data() + offset, len);
 
-      for (int64_t i = 0; i < 4; ++i) {
-        for (int64_t j = 0; j < 4; ++j) {
+      for (const auto i : c10::irange(4)) {
+        for (const auto j : c10::irange(4)) {
           auto xx = ix + Vec(-1 + i);
           auto yy = iy + Vec(-1 + j);
 
@@ -1099,7 +1100,7 @@ static inline void grid_sample_2d_grid_slice_iterator(
     } else {
       // If only [W] is contiguous, apply line_fn once for each h slice.
       auto grid_ptr_NH = grid_ptr;
-      for (int64_t h = 0; h < out_H; h++) {
+      for (const auto h : c10::irange(out_H)) {
         line_fn(grid_ptr_NH, grid_ptr_NH + grid_sCoor, h * out_W, out_W);
         grid_ptr_NH += grid_sH;
       }
@@ -1115,7 +1116,7 @@ static inline void grid_sample_2d_grid_slice_iterator(
     #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t h = 0; h < out_H; h++) {
+    for (const auto h : c10::irange(out_H)) {
       auto grid_ptr_x = grid_ptr + h * grid_sH;
       auto grid_ptr_y = grid_ptr_x + grid_sCoor;
       auto i_offsets = iVec::arange(0, grid_sW);
@@ -1161,7 +1162,7 @@ Tensor grid_sampler_2d_cpu_kernel_impl(const Tensor& input, const Tensor& grid,
     ApplyGridSample<scalar_t, 2, interp, padding, align_corners>               \
     grid_sample(inp_acc);                                                      \
     parallel_for(0, N, grain_size, [&](int64_t begin, int64_t end) {           \
-      for (int64_t n = begin; n < end; n++) {                                  \
+      for (const auto n : c10::irange(begin, end)) {                                  \
         auto out_slice = out_acc[n];                                           \
         auto inp_slice = inp_acc[n];                                           \
         grid_sample_2d_grid_slice_iterator(                                    \
@@ -1246,7 +1247,7 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
     ApplyGridSample<scalar_t, 2, interp, padding, align_corners>                 \
     grid_sample(inp_acc);                                                        \
     parallel_for(0, N, grain_size, [&](int64_t begin, int64_t end) {             \
-      for (int64_t n = begin; n < end; n++) {                                    \
+      for (const auto n : c10::irange(begin, end)) {                             \
         GINP_SLICE_PTR(input_requires_grad)                                      \
         auto gGrid_slice = gGrid_acc[n];                                         \
         auto gOut_slice = gOut_acc[n];                                           \

--- a/aten/src/ATen/native/cpu/HistogramKernel.cpp
+++ b/aten/src/ATen/native/cpu/HistogramKernel.cpp
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <mutex>
@@ -98,7 +99,7 @@ void histogram_cpu_contiguous(Tensor& hist, const Tensor& bin_edges,
         // Allocates a buffer for the thread's local results
         std::vector<input_t> data_out_local(numel_be - 1, input_t(0));
 
-        for (int64_t i = start; i < end; ++i) {
+        for (const auto i : c10::irange(start, end)) {
             const input_t elt = accessor_in[i];
 
             // Skips elements which fall outside the specified bins

--- a/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/cpu/Reduce.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native { namespace {
 
@@ -135,13 +136,14 @@ void unpack_pivots_cpu_kernel(
     auto* unpacked_pivots_ptr = data[0];
     const auto* pivots_ptr = data[1];
 
-    for (int64_t elem = 0; elem < nelems; ++elem) {
+    for (const auto elem : c10::irange(nelems)) {
+      (void)elem; //Suppress unused variable warning
       // WARNING: torch.lu returns int32 pivots,
       // this behavior could change in the future.
       auto* unpacked_pivots_data = reinterpret_cast<int32_t*>(unpacked_pivots_ptr);
       auto* pivots_data = reinterpret_cast<const int32_t*>(pivots_ptr);
 
-      for (int64_t i = 0; i < dim_size; ++i) {
+      for (const auto i : c10::irange(dim_size)) {
         std::swap(
           unpacked_pivots_data[i],
           unpacked_pivots_data[pivots_data[i]]

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/cpu/IsContiguous.h>
 #include <ATen/native/TensorIterator.h>
@@ -120,7 +121,7 @@ basic_loop(char* C10_RESTRICT data[], const int64_t* strides_, int64_t i, int64_
   // Copying strides to temporary array helps auto vectorization in older GCC
   // versions.
   int64_t strides[ntensors];
-  for (int arg = 0; arg < ntensors; arg++) {
+  for (const auto arg : c10::irange(ntensors)) {
     strides[arg] = strides_[arg];
   }
 
@@ -178,7 +179,7 @@ multiple_outputs_loop(char* C10_RESTRICT data[], const int64_t* strides_, int64_
   // Copying strides to temporary array helps auto vectorization in older GCC
   // versions.
   int64_t strides[ntensors];
-  for (int arg = 0; arg < ntensors; arg++) {
+  for (const auto arg : c10::irange(ntensors)) {
     strides[arg] = strides_[arg];
   }
 
@@ -204,7 +205,7 @@ vectorized_loop(char** C10_RESTRICT data_, int64_t n, int64_t S, func_t&& op, ve
   constexpr int ntensors = traits::arity + 1;
 
   char* C10_RESTRICT data[ntensors];
-  for (int arg = 0; arg < ntensors; arg++) {
+  for (const auto arg : c10::irange(ntensors)) {
     data[arg] = data_[arg];
   }
 
@@ -220,7 +221,7 @@ vectorized_loop(char** C10_RESTRICT data_, int64_t n, int64_t S, func_t&& op, ve
   }
   if (i < n) {
     int64_t strides[ntensors];
-    for (int arg = 0; arg < ntensors; arg++) {
+    for (const auto arg : c10::irange(ntensors)) {
       strides[arg] = (S > 0 && arg == S) ? 0 : sizeof(scalar_t);
     }
     basic_loop(data, strides, i, n, std::forward<func_t>(op));

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -43,7 +44,7 @@ void cpu_max_pool(
     int64_t ow = 0;
     data_index_init(begin, c, channels, oh, output_height, ow, output_width);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = oh * dH - padH;
       int64_t iw0 = ow * dW - padW;
       int64_t ih1 = std::min(ih0 + (kH - 1) * dilationH + 1, input_height);
@@ -133,7 +134,7 @@ void cpu_max_pool_channels_last(
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t ih0 = oh * dH - padH;
       int64_t iw0 = ow * dW - padW;
       int64_t ih1 = std::min(ih0 + (kH - 1) * dilationH + 1, input_height);
@@ -229,13 +230,13 @@ void cpu_max_pool_backward(
 
   // parallel on dim of N, C
   at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
       scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
       int64_t * indices_ptr = indices_data + c * output_height * output_width;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           // retrieve position of max
           int64_t index = oh * output_width + ow;
           int64_t maxindex = indices_ptr[index];
@@ -278,17 +279,17 @@ void cpu_max_pool_backward_channels_last(
 
   // parallel on dim N
   at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t n = begin; n < end; n++) {
+    for (const auto n : c10::irange(begin, end)) {
       scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
       scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
       int64_t* indices_ptr = indices_data + n * output_height * output_width * channels;
 
-      for (int64_t oh = 0; oh < output_height; oh++) {
-        for (int64_t ow = 0; ow < output_width; ow++) {
+      for (const auto oh : c10::irange(output_height)) {
+        for (const auto ow : c10::irange(output_width)) {
           scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
           int64_t* ind = indices_ptr + oh * output_width * channels + ow * channels;
           // TODO: gcc vectorization
-          for (int64_t c = 0; c < channels; c++) {
+          for (const auto c : c10::irange(channels)) {
             int64_t maxindex = ind[c];
             if (maxindex != -1) {
               grad_input_ptr[maxindex * channels + c] += gout[c];

--- a/aten/src/ATen/native/cpu/MaxPooling.cpp
+++ b/aten/src/ATen/native/cpu/MaxPooling.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/MaxPooling.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -13,7 +14,7 @@ inline void max_pool1d_kernel(
     scalar_t* C10_RESTRICT op,
     const scalar_t* C10_RESTRICT ip,
     const PoolingParams1D& p) {
-  for (int64_t kj = 0; kj < p.KW; ++kj) {
+  for (const auto kj : c10::irange(p.KW)) {
     int64_t oj = p.valid_output_start(kj);
     int64_t oe = p.valid_output_end(kj);
     int64_t ij = p.index(kj, oj);
@@ -40,7 +41,7 @@ void max_pool1d_impl(
         : std::numeric_limits<scalar_t>::lowest();
 
     at::parallel_for(0, p.NB * p.NC, 0, [&](int64_t begin, int64_t end) {
-      for (int64_t it = begin; it < end; ++it) {
+      for (const auto it : c10::irange(begin, end)) {
         scalar_t* op = OP + it * p.OW;
         const scalar_t* ip = IP + it * p.IW;
         std::fill_n(op, p.OW, FILL);

--- a/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 #include <c10/util/Optional.h>
 
@@ -60,7 +61,7 @@ void cpu_max_unpool(
     int64_t ip = 0;
     data_index_init(begin, c, channels, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* output_ptr = output_data + c * output_image_size;
 
       int64_t maxp = indices_data[i];
@@ -124,13 +125,13 @@ void cpu_max_unpool_channels_last(
     int64_t ip = 0;
     data_index_init(begin, n, nbatch, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* input_ptr = input_data + i * channels;
       int64_t* indices_ptr = indices_data + i * channels;
       scalar_t* output_ptr = output_data + n * output_image_size * channels;
 
       // can't do scatter on avx2 (only available on avx512)
-      for (int64_t c = 0; c < channels; c++) {
+      for (const auto c : c10::irange(channels)) {
         int64_t maxp = indices_ptr[c];
         if (maxp < 0 || maxp >= output_image_size) {
           optional_error_index = maxp;
@@ -197,7 +198,7 @@ void cpu_max_unpool_backward(
     int64_t ip = 0;
     data_index_init(begin, c, channels, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* grad_output_ptr = grad_output_data + c * output_image_size;
 
       int64_t maxp = indices_data[i];
@@ -262,12 +263,12 @@ void cpu_max_unpool_backward_channels_last(
     int64_t ip = 0;
     data_index_init(begin, n, nbatch, ip, input_image_size);
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       scalar_t* grad_output_ptr = grad_output_data + n * output_image_size * channels;
       scalar_t* grad_input_ptr = grad_input_data + i * channels;
       int64_t* indices_ptr = indices_data + i * channels;
 
-      for (int64_t c = 0; c < channels; c++) {
+      for (const auto c : c10::irange(channels)) {
         int64_t maxp = indices_ptr[c];
         if (maxp < 0 || maxp >= output_image_size) {
           optional_error_index = maxp;

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -4,6 +4,7 @@
 #include <ATen/Parallel.h>
 #include <c10/util/TypeList.h>
 #include <c10/core/Scalar.h>
+#include <c10/util/irange.h>
 
 #include <sstream>
 
@@ -38,10 +39,10 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
   VEC_LOOP_HEADER(func_t, data)
   const char* in1_ptr = data[1];
   Vec acc[4];
-  for  (int j = 0; j < 4; j++) {
+  for (const auto j : c10::irange(4)) {
     acc[j] = Vec::loadu(in1_ptr + j * Vec::size() * sizeof(scalar_t));
   }
-  for (int64_t i = 1; i < n; i++) {
+  for (const auto i : c10::irange(1, n)) {
     const char* ptr = in1_ptr + stride * i;
     acc[0] = vop(acc[0], Vec::loadu(ptr + (0 * Vec::size() * sizeof(scalar_t))));
     acc[1] = vop(acc[1], Vec::loadu(ptr + (1 * Vec::size() * sizeof(scalar_t))));
@@ -58,7 +59,7 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
     auto dst = (scalar_t*)out_ptr;
     *dst = op(*dst, buffer[0]);
   } else {
-    for (int j = 0; j < 4; j++) {
+    for (const auto j : c10::irange(4)) {
       auto dst = out_ptr + j * Vec::size() * sizeof(scalar_t);
       acc[j] = vop(acc[j], Vec::loadu(dst));
       acc[j].store(dst);
@@ -68,7 +69,8 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
 
 template <typename F>
 static inline void UNARY_OUTER_LOOP(char* data[2], const int64_t strides[2], int64_t n, F f) {
-  for (int j = 0; j < n; j++) {
+  for (const auto j : c10::irange(n)) {
+    (void)j; //Suppress unused variable warning
     f();
     data[0] += strides[0];
     data[1] += strides[1];
@@ -215,7 +217,7 @@ void binary_kernel_reduce(TensorIteratorBase& iter, ops_t ops, init_t init) {
         AT_ASSERT(ntensors - num_outputs == 1);
         char *in = data[ntensors - 1];
         int64_t stride = strides[ntensors - 1];
-        for (int64_t i = 0; i < size; ++i) {
+        for (const auto i : c10::irange(size)) {
           acc = ops.reduce(acc, *(data_t*)in, begin + i);
           in += stride;
         }
@@ -241,7 +243,7 @@ void binary_kernel_reduce(TensorIteratorBase& iter, ops_t ops, init_t init) {
           acc = reduction_body(acc, begin, end);
         }
       );
-      for (int i = 0; i < max_threads; ++i) {
+      for (const auto i : c10::irange(max_threads)) {
         total_acc = ops.combine(total_acc, buffer[i]);
       }
     }

--- a/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
@@ -11,6 +11,7 @@
 #include <ATen/native/cpu/zmath.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 namespace {
@@ -51,7 +52,7 @@ inline void reduce_all_impl(
   scalar_t result = at::parallel_reduce(0, input_numel, internal::GRAIN_SIZE, ident_v,
     [&](int64_t start, int64_t end, const scalar_t ident) -> scalar_t {
       scalar_t partial_out = ident;
-      for (int64_t i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
          partial_out = op(partial_out, input_data[i]);
       }
       return partial_out;
@@ -124,7 +125,7 @@ inline void reduce_all_impl_two_outputs(
   scalar_t_pair result = at::parallel_reduce(0, input_numel, internal::GRAIN_SIZE, ident_v,
     [&](int64_t start, int64_t end, const scalar_t_pair& ident) -> scalar_t_pair {
       scalar_t_pair partial_out(ident);
-      for (int64_t i = start; i < end; i++) {
+      for (const auto i : c10::irange(start, end)) {
          partial_out = reduce_chunk_func(partial_out, input_data[i]);
       }
       return partial_out;

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -13,6 +13,7 @@
 #include <ATen/native/cpu/Reduce.h>
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include <ATen/AccumulateType.h>
 
 namespace at { namespace native { namespace {
@@ -54,7 +55,8 @@ static inline void cpu_cum_base_kernel(const Tensor& result,
     auto* result_data_bytes = data[0];
     const auto* self_data_bytes = data[1];
 
-    for (int64_t i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
+      (void)i; //Suppress unused variable warning
       f(
         (scalar_t*)result_data_bytes, result_dim_stride,
         (scalar_t*)self_data_bytes, self_dim_stride, init_val
@@ -77,7 +79,7 @@ static void cumsum_cpu_kernel(const Tensor& result, const Tensor& self, int64_t 
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         // NOLINTNEXTLINE(bugprone-signed-char-misuse)
         auto cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
+        for (const auto i : c10::irange(self_dim_size)) {
           cum_number += self_data[i * self_dim_stride];
           result_data[i * result_dim_stride] = (scalar_t)cum_number;
         }
@@ -96,7 +98,7 @@ static void cumprod_cpu_kernel(const Tensor& result, const Tensor& self, int64_t
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         // NOLINTNEXTLINE(bugprone-signed-char-misuse)
         auto cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
+        for (const auto i : c10::irange(self_dim_size)) {
           cum_number *= self_data[i * self_dim_stride];
           result_data[i * result_dim_stride] = (scalar_t)cum_number;
         }
@@ -114,7 +116,7 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
       scalar_t* result_data, auto result_dim_stride,
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         scalar_t cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
+        for (const auto i : c10::irange(self_dim_size)) {
           scalar_t x = self_data[i * self_dim_stride];
 
           // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -52,7 +53,7 @@ struct _cpu_scatter_gather_dim_loop {
     func_t& f
   ) {
 
-    for (int64_t i = 0; i < index_dim_size; ++i) {
+    for (const auto i : c10::irange(index_dim_size)) {
       int64_t idx_dim = index_data[i * index_dim_stride];
       // we are not putting idx_dim in the error message because it disables
       // loop optimization in clang-7
@@ -79,7 +80,7 @@ struct _cpu_scatter_gather_dim_loop {
     func_t& f
   ) {
 
-    for (int64_t i = 0; i < index_dim_size; ++i) {
+    for (const auto i : c10::irange(index_dim_size)) {
       int64_t idx_dim = index_data[i * index_dim_stride];
       // we are not putting idx_dim in the error message because it disables
       // loop optimization in clang-7
@@ -146,7 +147,8 @@ struct cpu_scatter_gather_base_kernel {
           // whether `n` is smaller than `index_dim_size`
 
           if ((dim== self.dim() - 1) || (n < index_dim_size)) {
-            for (int64_t nelem = 0; nelem < n; ++nelem) {
+            for (const auto nelem : c10::irange(n)) {
+              (void)nelem; //Suppress unused variable warning
               // dim loop is a separate code block
               // for better performance
               _cpu_scatter_gather_dim_loop<is_scatter_like>()(
@@ -160,10 +162,11 @@ struct cpu_scatter_gather_base_kernel {
             }
           }
           else {
-            for (int64_t i = 0; i < index_dim_size; ++i) {
+            for (const auto i : c10::irange(index_dim_size)) {
               auto* self_data = self_data_bytes;
               auto* index_data = (char*)((int64_t*)index_data_bytes + i * index_dim_stride);
-              for (int64_t nelem = 0; nelem < n; ++nelem) {
+              for (const auto nelem : c10::irange(n)) {
+                (void)nelem; //Suppress unused variable warning
                 int64_t idx_dim = *(int64_t*)index_data;
                 // we are not putting idx_dim in the error message because it disables
                 // loop optimization in clang-7
@@ -227,7 +230,8 @@ struct cpu_scatter_gather_base_kernel {
           // whether dim is the last dimension and/or
           // whether `n` is smaller than `index_dim_size`
           if ((dim== self.dim() - 1) || (n < index_dim_size)) {
-            for (int64_t nelem = 0; nelem < n; ++nelem) {
+            for (const auto nelem : c10::irange(n)) {
+              (void)nelem; //Suppress unused variable warning
               // dim loop is a separate code block
               // for better performance
               _cpu_scatter_gather_dim_loop<is_scatter_like>()(
@@ -244,11 +248,12 @@ struct cpu_scatter_gather_base_kernel {
             }
           }
           else {
-            for (int64_t i = 0; i < index_dim_size; ++i) {
+            for (const auto i : c10::irange(index_dim_size)) {
               auto* self_data = self_data_bytes;
               auto* index_data = (char*)((int64_t*)index_data_bytes + i * index_dim_stride);
               auto* src_data = src_data_bytes;
-              for (int64_t nelem = 0; nelem < n; ++nelem) {
+              for (const auto nelem : c10::irange(n)) {
+                (void)nelem; //Suppress unused variable warning
                 int64_t idx_dim = *(int64_t*)index_data;
                 // we are not putting idx_dim in the error message because it disables
                 // loop optimization in clang-7

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/CompositeRandomAccessor.h>
 #include <ATen/native/Sorting.h>
 #include <ATen/native/SortingUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -55,7 +56,8 @@ void _dim_apply(
         auto* values_data_bytes = data[0];
         auto* indices_data_bytes = data[1];
 
-        for (int64_t i = 0; i < n; ++i) {
+        for (const auto i : c10::irange(n)) {
+          (void)i; //Suppress unused variable warning
           f(
             reinterpret_cast<scalar_t*>(values_data_bytes),
             values_dim_stride,

--- a/aten/src/ATen/native/cpu/StackKernel.cpp
+++ b/aten/src/ATen/native/cpu/StackKernel.cpp
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/StackKernel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -37,8 +38,8 @@ void stack_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 
   using Vec = vec::Vectorized<scalar_t>;
   scalar_t* result_ptr = result_data;
-  for (int64_t i = 0; i < outer; ++i) {
-    for (int64_t j = 0; j < ninputs; j++) {
+  for (const auto i : c10::irange(outer)) {
+    for (const auto j : c10::irange(ninputs)) {
       int64_t local_inner = inputs[j].inner_size;
       scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
 
@@ -46,7 +47,7 @@ void stack_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
 #pragma unroll
 #endif
-        for (int64_t k = 0; k < local_inner; k++) {
+        for (const auto k : c10::irange(local_inner)) {
           result_ptr[k] = input_ptr[k];
         }
       } else {

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Reduce.h>
 #include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 
@@ -26,7 +27,7 @@ Vectorized<acc_t> load_reduce_vec(const scalar_t* data, F reduce, acc_t ident) {
   constexpr int vstride = vec_t::size() / vacc_t::size();
   alignas(64) std::array<acc_t, vacc_t::size()> acc;
   acc.fill(ident);
-  for (int k = 0; k < vstride; ++k) {
+  for (const auto k : c10::irange(vstride)) {
     for (int i = 0; i < vacc_t::size(); ++i) {
       acc[i] = reduce(acc[i], values[i * vstride + k]);
     }
@@ -280,7 +281,7 @@ template <typename StorePolicy, typename scalar_t, size_t numel>
 static void store(char * C10_RESTRICT data, int64_t stride, int64_t index,
                   const std::array<scalar_t, numel> &values) {
   auto *base_ptr = data + stride * index;
-  for (size_t k = 0; k < numel; ++k) {
+  for (const auto k : c10::irange(numel)) {
     auto val = values[k];
     StorePolicy::store(base_ptr, stride, k, val);
   }
@@ -314,7 +315,7 @@ A simplified recursive implementation would look like this:
     scalar_t sum = 0;
     if (n <= min_chunk_size) {
       // Recursive base case, calculate a simple running sum
-      for (int64_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         sum += data[i];
       }
       return sum;
@@ -352,16 +353,16 @@ std::array<scalar_t, nrows> multi_row_sum(
       #if !defined(COMPILING_FOR_MIN_SIZE)
       # pragma unroll
       #endif
-      for (int64_t k = 0; k < nrows; ++k) {
+      for (const auto k : c10::irange(nrows)) {
         acc[0][k] += LoadPolicy::load(sum_base, col_stride, k);
       }
     }
 
-    for (int64_t j = 1; j < num_levels; ++j) {
+    for (const auto j : c10::irange(1, num_levels)) {
       #if !defined(COMPILING_FOR_MIN_SIZE)
       # pragma unroll
       #endif
-      for (int64_t k = 0; k < nrows; ++k) {
+      for (const auto k : c10::irange(nrows)) {
         acc[j][k] += acc[j-1][k];
         acc[j-1][k] = scalar_t(0);
       }
@@ -378,23 +379,23 @@ std::array<scalar_t, nrows> multi_row_sum(
     #if !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t k = 0; k < nrows; ++k) {
+    for (const auto k : c10::irange(nrows)) {
       acc[0][k] += LoadPolicy::load(sum_base, col_stride, k);
     }
   }
 
-  for (int64_t j = 1; j < num_levels; ++j) {
+  for (const auto j : c10::irange(1, num_levels)) {
     #if !defined(COMPILING_FOR_MIN_SIZE)
     # pragma unroll
     #endif
-    for (int64_t k = 0; k < nrows; ++k) {
+    for (const auto k : c10::irange(nrows)) {
       acc[0][k] += acc[j][k];
     }
   }
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   std::array<scalar_t, nrows> ret;
-  for (int64_t k = 0; k < nrows; ++k) {
+  for (const auto k : c10::irange(nrows)) {
     ret[k] = acc[0][k];
   }
   return ret;
@@ -414,7 +415,7 @@ scalar_t row_sum(const char * C10_RESTRICT in_data,
     partial_sums[0] += LoadPolicy::load(in_data, in_stride, i);
   }
 
-  for (int64_t k = 1; k < ilp_factor; ++k) {
+  for (const auto k : c10::irange(1, ilp_factor)) {
     partial_sums[0] += partial_sums[k];
   }
 
@@ -433,7 +434,7 @@ void vectorized_inner_sum(
   const int64_t vec_size = size0 / vec_numel;
 
   // Input is contiguous over the first (reduced) dimension
-  for (int64_t j = 0; j < size1; ++j) {
+  for (const auto j : c10::irange(size1)) {
     const auto *row_in = data[1] + j * outer_stride;
     auto vec_acc = row_sum<vacc_t, VecLoadPolicy>(row_in, vec_stride, vec_size);
 
@@ -444,7 +445,7 @@ void vectorized_inner_sum(
 
     alignas(64) std::array<acc_t, vacc_t::size()> partials{};
     vec_acc.store(partials.data());
-    for (size_t k = 0; k < partials.size(); ++k) {
+    for (const auto k : c10::irange(partials.size())) {
       final_acc += partials[k];
     }
     store<StorePolicy>(data[0], out_stride, j, final_acc);
@@ -456,7 +457,7 @@ void scalar_inner_sum(
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char * C10_RESTRICT data[2], int64_t in_strides[2], int64_t out_stride,
     int64_t size0, int64_t size1) {
-  for (int64_t j = 0; j < size1; ++j) {
+  for (const auto j : c10::irange(size1)) {
     const auto *row_in = data[1] + j * in_strides[1];
     auto ans = row_sum<acc_t, LoadPolicy>(row_in, in_strides[0], size0);
     store<StorePolicy>(data[0], out_stride, j, ans);
@@ -480,7 +481,7 @@ void vectorized_outer_sum(
     auto sums = multi_row_sum<vacc_t, nrows, VecLoadPolicy>(
         row_in, inner_stride, vec_stride, size0);
 
-    for (int64_t i = 0; i < nrows; ++i) {
+    for (const auto i : c10::irange(nrows)) {
       const int64_t base_idx = j + i * vacc_t::size();
       store<StorePolicy>(data[0], out_stride, base_idx, sums[i]);
     }

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -18,6 +18,7 @@
 
 #include <c10/util/MathConstants.h>
 #include <c10/core/Scalar.h>
+#include <c10/util/irange.h>
 
 #if AT_MKL_ENABLED()
 #include <mkl.h>
@@ -103,7 +104,7 @@ void LogitMKLKernel(T eps, TensorIteratorBase* it) {
   T* Y_data = static_cast<T*>(it->data_ptr(0));
   if (eps < T(0)) {
     at::parallel_for(0, N, K, [=](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; ++i) {
+      for (const auto i : c10::irange(begin, end)) {
         Y_data[i] = X_data[i] == T(1) ? std::numeric_limits<T>::infinity()
                                       : X_data[i] / (T(1) - X_data[i]);
       }
@@ -113,7 +114,7 @@ void LogitMKLKernel(T eps, TensorIteratorBase* it) {
     const T lo = eps;
     const T hi = T(1) - eps;
     at::parallel_for(0, N, K, [=](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; ++i) {
+      for (const auto i : c10::irange(begin, end)) {
         const T x = X_data[i] < lo ? lo : (X_data[i] > hi ? hi : X_data[i]);
         Y_data[i] =
             x == T(1) ? std::numeric_limits<T>::infinity() : (x / (T(1) - x));
@@ -552,10 +553,10 @@ static void erfcx_kernel(TensorIteratorBase& iter){
                 scalar_t buffer[WIDTH];                                       \
                 int64_t width = WIDTH;                                        \
                 width = std::min(width, n - i);                               \
-                for (int64_t j = 0; j < width; j++)                           \
+                for (const auto j : c10::irange(width))\
                   buffer[j] = in_data[in_stride * (i + j)];                   \
                 vml::v##op(buffer, buffer, width);                            \
-                for (int64_t j = 0; j < width; j++)                           \
+                for (const auto j : c10::irange(width))\
                   out_data[out_stride * (i + j)] = buffer[j];                 \
               }                                                               \
             }                                                                 \

--- a/aten/src/ATen/native/cpu/Unfold2d.cpp
+++ b/aten/src/ATen/native/cpu/Unfold2d.cpp
@@ -2,6 +2,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/Unfold2d.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 #include <cmath>
 
 namespace at {
@@ -46,7 +47,7 @@ static void unfolded2d_acc(
     int64_t output_height,
     int64_t output_width) {
   at::parallel_for(0, n_input_plane, 0, [&](int64_t start, int64_t end) {
-    for (auto nip = start; nip < end; nip++) {
+    for (const auto nip : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t kw, kh, y, x;
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -172,7 +173,7 @@ static void unfolded2d_copy(
     int64_t output_width) {
   at::parallel_for(
       0, (int64_t)n_input_plane * kH * kW, 0, [&](int64_t start, int64_t end) {
-        for (auto k = start; k < end; k++) {
+        for (const auto k : c10::irange(start, end)) {
           int64_t nip = k / (kH * kW);
           int64_t rest = k % (kH * kW);
           int64_t kh = rest / kW;

--- a/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
@@ -2,6 +2,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/UnfoldBackward.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/irange.h>
 
 #if (defined(_WIN32) || defined(_WIN64))
 #define RESTRICT __restrict
@@ -77,7 +78,8 @@ void _unfold_backward_internal_kernel(
     if (is_step_ge_size) {
       auto* RESTRICT idx_last_dim_ptr = data[3];
 
-      for (int64_t elem = 0; elem < nelems; ++elem) {
+      for (const auto elem : c10::irange(nelems)) {
+        (void)elem; //Suppress unused variable warning
         auto* RESTRICT grad_out_data = reinterpret_cast<scalar_t*>(grad_out_ptr);
         auto* RESTRICT grad_in_data = reinterpret_cast<scalar_t*>(grad_in_ptr);
 
@@ -94,7 +96,8 @@ void _unfold_backward_internal_kernel(
       }
     }
     else {
-      for (int64_t elem = 0; elem < nelems; ++elem) {
+      for (const auto elem : c10::irange(nelems)) {
+        (void)elem; //Suppress unused variable warning
         auto* RESTRICT grad_out_data = reinterpret_cast<scalar_t*>(grad_out_ptr);
         auto* RESTRICT grad_in_data = reinterpret_cast<scalar_t*>(grad_in_ptr);
 

--- a/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/UpSample.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -55,8 +56,8 @@ void cpu_upsample_linear_backward(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t iw0, iw1;
     scalar_t w0lambda, w1lambda;
-    for (int64_t c = begin; c < end; c++){
-      for (int64_t ow = 0; ow < output_width; ow++) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto ow : c10::irange(output_width)) {
         compute_source_index_and_lambda(
             iw0, iw1, w0lambda, w1lambda, width_scale, ow, input_width, output_width, align_corners);
         scalar_t grad_output_value = grad_output_data[c * output_slice_size + ow];
@@ -79,11 +80,11 @@ void cpu_upsample_linear_backward(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t ih0, ih1, iw0, iw1;
     scalar_t h0lambda, h1lambda, w0lambda, w1lambda;
-    for (int64_t c = begin; c < end; c++) {
-      for (int64_t oh = 0; oh < output_height; oh++) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto oh : c10::irange(output_height)) {
         compute_source_index_and_lambda(
             ih0, ih1, h0lambda, h1lambda, height_scale, oh, input_height, output_height, align_corners);
-        for (int64_t ow = 0; ow < output_width; ow++) {
+        for (const auto ow : c10::irange(output_width)) {
           compute_source_index_and_lambda(
               iw0, iw1, w0lambda, w1lambda, width_scale, ow, input_width, output_width, align_corners);
           scalar_t grad_output_value = grad_output_data[c * output_slice_size + oh * output_width + ow];
@@ -112,14 +113,14 @@ void cpu_upsample_linear_backward(
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t id0, id1, ih0, ih1, iw0, iw1;
     scalar_t d0lambda, d1lambda, h0lambda, h1lambda, w0lambda, w1lambda;
-    for (int64_t c = begin; c < end; c++) {
-      for (int64_t od = 0; od < output_depth; od++) {
+    for (const auto c : c10::irange(begin, end)) {
+      for (const auto od : c10::irange(output_depth)) {
         compute_source_index_and_lambda(
             id0, id1, d0lambda, d1lambda, depth_scale, od, input_depth, output_depth, align_corners);
-        for (int64_t oh = 0; oh < output_height; oh++) {
+        for (const auto oh : c10::irange(output_height)) {
           compute_source_index_and_lambda(
               ih0, ih1, h0lambda, h1lambda, height_scale, oh, input_height, output_height, align_corners);
-          for (int64_t ow = 0; ow < output_width; ow++) {
+          for (const auto ow : c10::irange(output_width)) {
             compute_source_index_and_lambda(
                 iw0, iw1, w0lambda, w1lambda, width_scale, ow, input_width, output_width, align_corners);
             scalar_t grad_output_value = grad_output_data[c * output_slice_size +

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 namespace {
@@ -42,7 +43,7 @@ void batch_norm_cpu_collect_linear_and_constant_terms(
   ///   the constant term beta(c) = bias(c) - mean(c) * inv_var(c) * weight(c)
   /// Note that this is only a good idea if (input_size >> c), in degenerate
   /// cases where image_size == 1 && batch_size == 1, it is slow.
-  for (int64_t c = 0; c < n_channel; c++) {
+  for (const auto c : c10::irange(n_channel)) {
     scalar_t mean, invstd;
     if (train) {
       mean = save_mean_a[c];
@@ -90,7 +91,7 @@ void batch_norm_cpu_contiguous_impl(Tensor& output, const Tensor& input,
       int64_t c = 0;
       data_index_init(begin, n, n_batch, c, n_channel);
 
-      for (int64_t i = begin; i < end; i++) {
+      for (const auto i : c10::irange(begin, end)) {
         const Vec alpha_vec(alpha_data[c]);
         const Vec beta_vec(beta_data[c]);
         int64_t offset = i * image_size;
@@ -113,7 +114,7 @@ void batch_norm_cpu_contiguous_impl(Tensor& output, const Tensor& input,
     // image_size == 1
     const int64_t loop_size = n_channel - (n_channel % Vec::size());
     at::parallel_for(0, n_batch, 1, [&](int64_t begin, int64_t end) {
-      for (int64_t n = begin; n < end; n++) {
+      for (const auto n : c10::irange(begin, end)) {
         int64_t offset = n * n_channel;
         int64_t d = 0;
         for (; d < loop_size; d += Vec::size()) {
@@ -161,7 +162,7 @@ void batch_norm_cpu_channels_last_impl(Tensor& output, const Tensor& input,
   // output(n, c, h, w) = input(n, c, h, w) * alpha(c) + beta(c)
   const int64_t loop_size = n_channel - (n_channel % Vec::size());
   at::parallel_for(0, n_batch * image_size, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t offset = i * n_channel;
       int64_t d = 0;
       // vectorize on channel dimension, for normal batch_norm input size,
@@ -200,11 +201,11 @@ void batch_norm_cpu_collect_stats_contiguous_impl(
 
   // parallel dim reduce on 'channel'
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       // compute mean per input
       accscalar_t sum = 0;
-      for (int64_t n = 0; n < n_batch; n++) {
-        for (int64_t i = 0; i < image_size; i++) {
+      for (const auto n : c10::irange(n_batch)) {
+        for (const auto i : c10::irange(image_size)) {
           auto offset = n * n_channel * image_size + c * image_size + i;
           sum += input_data[offset];
         }
@@ -214,8 +215,8 @@ void batch_norm_cpu_collect_stats_contiguous_impl(
 
       // compute variance per input
       accscalar_t _var_sum = 0;
-      for (int64_t n = 0; n < n_batch; n++) {
-        for (int64_t i = 0; i < image_size; i++) {
+      for (const auto n : c10::irange(n_batch)) {
+        for (const auto i : c10::irange(image_size)) {
           auto offset = n * n_channel * image_size + c * image_size + i;
           auto x = input_data[offset];
           _var_sum += (x - mean) * (x - mean);
@@ -259,7 +260,7 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
     TORCH_CHECK(tid < num_threads,
                 "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     scalar_t* buffer_ptr = buffer_data + tid * n_channel;
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       const scalar_t* x_ptr = input_data + i * n_channel;
       vec::map2<scalar_t>(
           [](Vec x, Vec y) { return x + y; },
@@ -271,9 +272,9 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
   });
 
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       accscalar_t sum = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         sum += buffer_data[t * n_channel + c];
       }
       scalar_t mean = sum / N;
@@ -287,7 +288,7 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
     int tid = at::get_thread_num();
     TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     scalar_t* buffer_ptr = buffer_data + tid * n_channel;
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       const scalar_t* x_ptr = input_data + i * n_channel;
       vec::map3<scalar_t>(
           [](Vec x, Vec y, Vec mean) { return y + (x - mean) * (x - mean); },
@@ -300,9 +301,9 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
   });
 
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       accscalar_t _var_sum = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         _var_sum += buffer_data[t * n_channel + c];
       }
       var_sum_data[c] = _var_sum;
@@ -341,7 +342,7 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
 
   // parallel dim reduce on 'channel'
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       scalar_t w = weight.defined() ? weight_a[c] : 1;
 
       scalar_t mean, invstd;
@@ -359,7 +360,7 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
       //
       accscalar_t sum = 0;
       accscalar_t dotp = 0;
-      for (int64_t n = 0; n < n_batch; n++) {
+      for (const auto n : c10::irange(n_batch)) {
         const scalar_t* x_ptr = input_data + n * n_channel * image_size + c * image_size;
         const scalar_t* dy_ptr = grad_output_data + n * n_channel * image_size + c * image_size;
 
@@ -381,13 +382,13 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
           scalar_t k = (scalar_t) dotp * invstd * invstd / N;
           scalar_t grad_mean = sum / N;
 
-          for (int64_t n = 0; n < n_batch; n++) {
+          for (const auto n : c10::irange(n_batch)) {
             const scalar_t* x_ptr = input_data + n * n_channel * image_size + c * image_size;
             scalar_t* dx_ptr = grad_input_data + n * n_channel * image_size + c * image_size;
             const scalar_t* dy_ptr = grad_output_data + n * n_channel * image_size + c * image_size;
 
             // Scalar math:
-            // for (int64_t j = 0; j < image_size; ++j) {
+            // for (const auto j : c10::irange(image_size)) {
             //   scalar_t dx = (x_ptr[j] - mean) * k;
             //   dx_ptr[j] = (dy_ptr[j] - grad_mean - dx) * invstd * w;
             // }
@@ -402,12 +403,12 @@ void batch_norm_cpu_backward_contiguous_impl(Tensor& grad_input, Tensor& grad_we
                 image_size);
           }
         } else { // evaluation mode
-          for (int64_t n = 0; n < n_batch; n++) {
+          for (const auto n : c10::irange(n_batch)) {
             scalar_t* dx_ptr = grad_input_data + n * n_channel * image_size + c * image_size;
             const scalar_t* dy_ptr = grad_output_data + n * n_channel * image_size + c * image_size;
 
             // Scalar math:
-            // for (int64_t j = 0; j < image_size; ++j) {
+            // for (const auto j : c10::irange(image_size)) {
             //   dx_ptr[j] = dy_ptr[j] * invstd * w;
             // }
             vec::map<scalar_t>(
@@ -467,7 +468,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
 
     invstd.resize_({n_channel});
     invstd_ptr = invstd.data_ptr<scalar_t>();
-    for (int64_t c = 0; c < n_channel; c++) {
+    for (const auto c : c10::irange(n_channel)) {
       invstd_ptr[c] = 1 / std::sqrt(running_var_data[c] + eps);
     }
   }
@@ -491,7 +492,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
     TORCH_CHECK(tid < num_threads, "expect thread id smaller than ", num_threads, ", got thread id ", tid);
     scalar_t* sum_ptr = sum_data + tid * n_channel;
     scalar_t* dotp_ptr = dotp_data + tid * n_channel;
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       const scalar_t* x_ptr = input_data + i * n_channel;
       const scalar_t* dy_ptr = grad_output_data + i * n_channel;
 
@@ -514,17 +515,17 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
   });
 
   at::parallel_for(0, n_channel, 1, [&](int64_t begin, int64_t end) {
-    for (int64_t c = begin; c < end; c++) {
+    for (const auto c : c10::irange(begin, end)) {
       // store the final result of sum and dotp in the 1st lane of immediate buffer,
       // so that we won't need to allocate anther buffer to store the temp values.
       accscalar_t _sum = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         _sum += sum_data[t * n_channel + c];
       }
       sum_data[/* 0 * n_channel + */c] = _sum;
 
       accscalar_t _dotp = 0;
-      for (int64_t t = 0; t < num_threads; t++) {
+      for (const auto t : c10::irange(num_threads)) {
         _dotp += dotp_data[t * n_channel + c];
       }
       dotp_data[/* 0 * n_channel + */c] = _dotp;
@@ -535,7 +536,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
   const int64_t loop_size = n_channel - (n_channel % Vec::size());
   if (grad_input.defined()) {
     at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; i++) {
+      for (const auto i : c10::irange(begin, end)) {
         scalar_t* dx_ptr = grad_input_data + i * n_channel;
         const scalar_t* x_ptr = input_data + i * n_channel;
         const scalar_t* dy_ptr = grad_output_data + i * n_channel;

--- a/aten/src/ATen/native/cpu/group_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/group_norm_kernel.cpp
@@ -9,6 +9,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/moments_utils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -44,7 +45,7 @@ void GroupNormKernelImplInternal(
   const int64_t inner_size = D * HxW;
 
   at::parallel_for(0, N * G, 1, [&](int64_t start, int64_t end) {
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* X_ptr = X_data + i * inner_size;
       T mean_val;
       T rstd_val;
@@ -52,18 +53,18 @@ void GroupNormKernelImplInternal(
       rstd_val = T(1) / std::sqrt(std::max(rstd_val, T(0)) + eps);
       if (gamma_null && beta_null) {
         T* Y_ptr = Y_data + i * inner_size;
-        for (int j = 0; j < inner_size; ++j) {
+        for (const auto j : c10::irange(inner_size)) {
           Y_ptr[j] = (X_ptr[j] - mean_val) * rstd_val;
         }
       } else {
         const int64_t g = i % G;
-        for (int64_t j = 0; j < D; ++j) {
+        for (const auto j : c10::irange(D)) {
           const int64_t c = g * D + j;
           const T scale = rstd_val * (gamma_null ? T(1) : gamma_data[c]);
           const T bias = -scale * mean_val + (beta_null ? T(0) : beta_data[c]);
           X_ptr = X_data + (i * D + j) * HxW;
           T* Y_ptr = Y_data + (i * D + j) * HxW;
-          for (int64_t k = 0; k < HxW; ++k) {
+          for (const auto k : c10::irange(HxW)) {
             Y_ptr[k] = scale * X_ptr[k] + bias;
           }
         }
@@ -110,10 +111,10 @@ void GroupNormKernelImplChannelsLastInternal(
   at::parallel_for(0, N, 1, [&](int64_t start, int64_t end) {
     constexpr int64_t K = Vec::size();
     const int64_t inner_size = C / K * K;
-    for (int64_t n = start; n < end; ++n) {
+    for (const auto n : c10::irange(start, end)) {
       T* mean_ptr = buffer_data + n * 2 * C;
       T* rstd_ptr = mean_ptr + C;
-      for (int64_t i = 0; i < HxW; ++i) {
+      for (const auto i : c10::irange(HxW)) {
         const T* X_ptr = X_data + n * HxW * C + i * C;
         for (int64_t j = 0; j < inner_size; j += K) {
           const Vec x_vec = Vec::loadu(X_ptr + j);
@@ -122,16 +123,16 @@ void GroupNormKernelImplChannelsLastInternal(
           mean_vec.store(mean_ptr + j);
           rstd_vec.store(rstd_ptr + j);
         }
-        for (int64_t j = inner_size; j < C; ++j) {
+        for (const auto j : c10::irange(inner_size, C)) {
           mean_ptr[j] += X_ptr[j];
           rstd_ptr[j] += X_ptr[j] * X_ptr[j];
         }
       }
 
-      for (int64_t g = 0; g < G; ++g) {
+      for (const auto g : c10::irange(G)) {
         T mean_val = T(0);
         T rstd_val = T(0);
-        for (int64_t d = 0; d < D; ++d) {
+        for (const auto d : c10::irange(D)) {
           mean_val += mean_ptr[g * D + d];
           rstd_val += rstd_ptr[g * D + d];
         }
@@ -141,7 +142,7 @@ void GroupNormKernelImplChannelsLastInternal(
 
         // continue to use the temp buffer for mean and rstd value,
         // so that we can vectorize the following math on entire C dimension.
-        for (int64_t d = 0; d < D; ++d) {
+        for (const auto d : c10::irange(D)) {
           mean_ptr[g * D + d] = mean_val;
           rstd_ptr[g * D + d] = rstd_val;
         }
@@ -152,7 +153,7 @@ void GroupNormKernelImplChannelsLastInternal(
 
       // expand gamma_null and beta_null to reduce if-else on critial path.
       if (!gamma_null && !beta_null) {
-        for (int64_t i = 0; i < HxW; ++i) {
+        for (const auto i : c10::irange(HxW)) {
           const T* X_ptr = X_data + n * HxW * C + i * C;
           T* Y_ptr = Y_data + n * HxW * C + i * C;
           for (int64_t j = 0; j < inner_size; j += K) {
@@ -161,14 +162,14 @@ void GroupNormKernelImplChannelsLastInternal(
             Vec y_vec = scale_vec * Vec::loadu(X_ptr + j) + bias_vec;
             y_vec.store(Y_ptr + j);
           }
-          for (int64_t j = inner_size; j < C; ++j) {
+          for (const auto j : c10::irange(inner_size, C)) {
             T scale = rstd_ptr[j] * gamma_data[j];
             T bias = -scale * mean_ptr[j] + beta_data[j];
             Y_ptr[j] = scale * X_ptr[j] + bias;
           }
         }
       } else if (gamma_null && beta_null) {
-        for (int64_t i = 0; i < HxW; ++i) {
+        for (const auto i : c10::irange(HxW)) {
           const T* X_ptr = X_data + n * HxW * C + i * C;
           T* Y_ptr = Y_data + n * HxW * C + i * C;
           for (int64_t j = 0; j < inner_size; j += K) {
@@ -176,13 +177,13 @@ void GroupNormKernelImplChannelsLastInternal(
             Vec y_vec = scale_vec * Vec::loadu(X_ptr + j) - scale_vec * Vec::loadu(mean_ptr + j);
             y_vec.store(Y_ptr + j);
           }
-          for (int64_t j = inner_size; j < C; ++j) {
+          for (const auto j : c10::irange(inner_size, C)) {
             T scale = rstd_ptr[j];
             Y_ptr[j] = scale * X_ptr[j] -scale * mean_ptr[j];
           }
         }
       } else {
-        for (int64_t i = 0; i < HxW; ++i) {
+        for (const auto i : c10::irange(HxW)) {
           const T* X_ptr = X_data + n * HxW * C + i * C;
           T* Y_ptr = Y_data + n * HxW * C + i * C;
           for (int64_t j = 0; j < inner_size; j += K) {
@@ -193,7 +194,7 @@ void GroupNormKernelImplChannelsLastInternal(
             Vec y_vec = scale_vec * Vec::loadu(X_ptr + j) + bias_vec;
             y_vec.store(Y_ptr + j);
           }
-          for (int64_t j = inner_size; j < C; ++j) {
+          for (const auto j : c10::irange(inner_size, C)) {
             T scale = rstd_ptr[j] * (gamma_null ? T(1) : gamma_data[j]);
             T bias = -scale * mean_ptr[j] + (beta_null ? T(0) : beta_data[j]);
             Y_ptr[j] = scale * X_ptr[j] + bias;
@@ -252,7 +253,7 @@ void ComputeInternalGradients(
     std::array<T, K> ds_arr;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     std::array<T, K> db_arr;
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* dY_ptr = dY + i * HxW;
       const T* X_ptr = X + i * HxW;
       vec::Vectorized<T> ds_vec(0);
@@ -267,7 +268,7 @@ void ComputeInternalGradients(
       db_vec.store(db_arr.data());
       T ds_val = std::accumulate(ds_arr.cbegin(), ds_arr.cend(), T(0));
       T db_val = std::accumulate(db_arr.cbegin(), db_arr.cend(), T(0));
-      for (int64_t j = inner_size; j < HxW; ++j) {
+      for (const auto j : c10::irange(inner_size, HxW)) {
         ds_val += dY_ptr[j] * X_ptr[j];
         db_val += dY_ptr[j];
       }
@@ -302,7 +303,7 @@ void GroupNormInputBackward(
     std::array<T, K> ds_arr;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     std::array<T, K> db_arr;
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const int64_t g = i % G;
       const T* ds_ptr = ds + i * D;
       const T* db_ptr = db + i * D;
@@ -319,7 +320,7 @@ void GroupNormInputBackward(
       db_vec.store(db_arr.data());
       T ds_val = std::accumulate(ds_arr.cbegin(), ds_arr.cend(), T(0));
       T db_val = std::accumulate(db_arr.cbegin(), db_arr.cend(), T(0));
-      for (int64_t j = d; j < D; ++j) {
+      for (const auto j : c10::irange(d, D)) {
         const T gamma_v = gamma_null ? T(1) : gamma[g * D + j];
         ds_val += ds_ptr[j] * gamma_v;
         db_val += db_ptr[j] * gamma_v;
@@ -327,13 +328,13 @@ void GroupNormInputBackward(
       const T c2 =
           (db_val * mean[i] - ds_val) * rstd[i] * rstd[i] * rstd[i] * s;
       const T c3 = -c2 * mean[i] - db_val * rstd[i] * s;
-      for (int64_t j = 0; j < D; ++j) {
+      for (const auto j : c10::irange(D)) {
         const int64_t c = g * D + j;
         const T* dY_ptr = dY + (i * D + j) * HxW;
         const T* X_ptr = X + (i * D + j) * HxW;
         T* dX_ptr = dX + (i * D + j) * HxW;
         const T c1 = rstd[i] * (gamma_null ? T(1) : gamma[c]);
-        for (int64_t k = 0; k < HxW; ++k) {
+        for (const auto k : c10::irange(HxW)) {
           dX_ptr[k] = c1 * dY_ptr[k] + c2 * X_ptr[k] + c3;
         }
       }
@@ -355,14 +356,14 @@ void GammaBackward(
   const int64_t D = C / G;
   constexpr int64_t K = vec::Vectorized<T>::size();
   at::parallel_for(0, D, K, [=](int64_t start, int64_t end) {
-    for (int64_t i = 0; i < G; ++i) {
+    for (const auto i : c10::irange(G)) {
       std::memset(dgamma + i * D + start, 0, (end - start) * sizeof(T));
     }
     for (int64_t i = 0; i < N * G; ++i) {
       const T* ds_ptr = ds + i * D;
       const T* db_ptr = db + i * D;
       const int64_t g = i % G;
-      for (int64_t j = start; j < end; ++j) {
+      for (const auto j : c10::irange(start, end)) {
         const int64_t c = g * D + j;
         dgamma[c] += (ds_ptr[j] - db_ptr[j] * mean[i]) * rstd[i];
       }
@@ -375,9 +376,9 @@ void BetaBackward(int64_t N, int64_t C, const T* db, T* dbeta) {
   constexpr int64_t K = vec::Vectorized<T>::size();
   at::parallel_for(0, C, K, [=](int64_t start, int64_t end) {
     std::memset(dbeta + start, 0, (end - start) * sizeof(T));
-    for (int64_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       const T* db_ptr = db + i * C;
-      for (int64_t j = start; j < end; ++j) {
+      for (const auto j : c10::irange(start, end)) {
         dbeta[j] += db_ptr[j];
       }
     }

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -9,6 +9,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/moments_utils.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -40,7 +41,7 @@ void LayerNormKernelImplInternal(
   const bool gamma_null = gamma_data == nullptr;
   const bool beta_null = beta_data == nullptr;
   at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* X_ptr = X_data + i * N;
       T* Y_ptr = Y_data + i * N;
       T mean_val;
@@ -50,7 +51,7 @@ void LayerNormKernelImplInternal(
       const T_ACC scale = rstd_val;
       const T_ACC bias = -rstd_val * mean_val;
       if (gamma_null || beta_null) {
-        for (int64_t j = 0; j < N; ++j) {
+        for (const auto j : c10::irange(N)) {
           const T gamma_v = gamma_null ? T(1) : gamma_data[j];
           const T beta_v = beta_null ? T(0) : beta_data[j];
           Y_ptr[j] = (X_ptr[j] * scale + bias) * gamma_v + beta_v;
@@ -153,14 +154,14 @@ void LayerNormBackwardKernelImplInternal(
     T* dgamma_buffer_ptr = dgamma_null ? nullptr : buffer_data + tid * N;
     T* dbeta_buffer_ptr =
         dbeta_null ? nullptr : buffer_data + num_threads * N + tid * N;
-    for (int64_t i = start; i < end; ++i) {
+    for (const auto i : c10::irange(start, end)) {
       const T* dY_ptr = dY_data + i * N;
       const T* X_ptr = X_data + i * N;
       if (!dgamma_null) {
         const T_ACC a = rstd_data[i];
         const T_ACC b = -a * mean_data[i];
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   dgamma_data[j] += dY_ptr[j] * (a * X_ptr[j] + b);
         // }
         vec::map3<T>(
@@ -175,7 +176,7 @@ void LayerNormBackwardKernelImplInternal(
       }
       if (!dbeta_null) {
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   dbeta_data[j] += dY_ptr[j];
         // }
         vec::map2<T>(
@@ -190,7 +191,7 @@ void LayerNormBackwardKernelImplInternal(
         T_ACC ds = T_ACC(0);
         T_ACC db = T_ACC(0);
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   const T gamma_v = gamma_null ? T(1) : gamma_data[j];
         //   ds += dY_ptr[j] * X_ptr[j] * gamma_v;
         //   db += dY_ptr[j] * gamma_v;
@@ -223,7 +224,7 @@ void LayerNormBackwardKernelImplInternal(
         const T_ACC b = (db * mean_data[i] - ds) * a * a * a * scale;
         const T_ACC c = -b * mean_data[i] - db * a * scale;
         // Scalar math:
-        // for (int64_t j = 0; j < N; ++j) {
+        // for (const auto j : c10::irange(N)) {
         //   const T gamma_v = gamma_null ? T(1) : gamma_data[j];
         //   dX_ptr[j] = a * dY_ptr[j] * gamma_v + b * X_ptr[j] + c;
         // }
@@ -254,10 +255,10 @@ void LayerNormBackwardKernelImplInternal(
   // Second path of dgamma/dbeta
   if (buffer_data != nullptr) {
     parallel_for(0, N, 1, [&](int64_t start, int64_t end) {
-      for (int64_t j = start; j < end; ++j) {
+      for (const auto j : c10::irange(start, end)) {
         T_ACC dgamma_v = T_ACC(0);
         T_ACC dbeta_v = T_ACC(0);
-        for (int64_t i = 0; i < num_threads; ++i) {
+        for (const auto i : c10::irange(num_threads)) {
           dgamma_v += buffer_data[i * N + j];
           dbeta_v += buffer_data[num_threads * N + i * N + j];
         }

--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -10,6 +10,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/SmallVector.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -69,12 +70,12 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
   c10::SmallVector<Vec, kMaxDepth> m1_stk(depth, kZeroVec);
   c10::SmallVector<Vec, kMaxDepth> m2_stk(depth, kZeroVec);
 
-  for (int64_t i = 0; i < m; ++i) {
+  for (const auto i : c10::irange(m)) {
     const T* X_ptr = X + i * kChunkSize * kVecSize;
     const int64_t m0 = std::min(kChunkSize, n - i * kChunkSize);
     Vec m1_vec(0);
     Vec m2_vec(0);
-    for (int64_t j = 0; j < m0; ++j) {
+    for (const auto j : c10::irange(m0)) {
       const Vec x_vec = Vec::loadu(X_ptr + j * kVecSize);
       const Vec delta_vec = x_vec - m1_vec;
       const Vec c_vec = Vec(T(1) / static_cast<T>(j + 1));
@@ -97,7 +98,7 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
       mask >>= 1;
     }
   }
-  for (int64_t i = 1; i < depth; ++i) {
+  for (const auto i : c10::irange(1, depth)) {
     AddMomentsVec(
         m0_stk[i], m1_stk[i], m2_stk[i], m0_stk[0], m1_stk[0], m2_stk[0]);
   }
@@ -116,7 +117,7 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
     m1 += delta / static_cast<T>(m0);
     m2 += delta * (X[i] - m1);
   }
-  for (int64_t i = 0; i < kVecSize; ++i) {
+  for (const auto i : c10::irange(kVecSize)) {
     AddMoments(n, m1_arr[i], m2_arr[i], m0, m1, m2);
   }
 

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -275,7 +275,7 @@ public:
                "cuFFT doesn't support signals of half type with compute "
                "capability less than SM_53, but the device containing input half "
                "tensor only has SM_", dev_prop->major, dev_prop->minor);
-      for (int64_t i = 0; i < signal_ndim; i++) {
+      for (const auto i : c10::irange(signal_ndim)) {
         TORCH_CHECK(is_pow_of_two(sizes[i + 1]),
             "cuFFT only supports dimensions whose sizes are powers of two when"
             " computing in half precision, but got a signal size of",

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/SpectralOpsUtils.h>
 #include <ATen/native/cuda/CuFFTUtils.h>
 #include <ATen/native/cuda/CuFFTPlanCache.h>
+#include <c10/util/irange.h>
 
 #include <cufft.h>
 #include <cufftXt.h>
@@ -229,7 +230,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
   const auto batch_size = input.sizes()[0];
   DimVector signal_size(signal_ndim + 1);
   signal_size[0] = batch_size;
-  for (int64_t i = 0; i < signal_ndim; ++i) {
+  for (const auto i : c10::irange(signal_ndim)) {
     auto in_size = input.sizes()[i + 1];
     auto out_size = out_sizes[dim[i]];
     signal_size[i + 1] = std::max(in_size, out_size);
@@ -241,7 +242,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
 
   batched_sizes[0] = batch_size;
   DimVector batched_out_sizes(batched_sizes.begin(), batched_sizes.end());
-  for (size_t i = 0; i < dim.size(); ++i) {
+  for (const auto i : c10::irange(dim.size())) {
     batched_out_sizes[i + 1] = out_sizes[dim[i]];
   }
   out.resize_(batched_out_sizes, MemoryFormat::Contiguous);
@@ -303,7 +304,7 @@ static const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_
     out_strides[dim_permute[i]] = batch_numel * out.strides()[0];
     batch_numel *= out_sizes[dim_permute[i]];
   }
-  for (int64_t i = batch_dims; i < ndim; ++i) {
+  for (const auto i : c10::irange(batch_dims, ndim)) {
     out_strides[dim_permute[i]] = out.strides()[1 + (i - batch_dims)];
   }
   return out.as_strided_(out_sizes, out_strides, out.storage_offset());

--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -20,6 +20,7 @@
 #include <ATen/native/utils/ParamsHash.h>
 
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 
 #include <functional>
 #include <iterator>
@@ -204,7 +205,7 @@ size_t getMaxWorkspaceSize(
   THCudaCheck(cudaGetDevice(&device));
   c10::cuda::CUDACachingAllocator::cacheInfo(device, &tmp_bytes, &max_block_size);
 
-  for (int i = 0; i < n_algo; i++) {
+  for (const auto i : c10::irange(n_algo)) {
     cudnnStatus_t err;
     size_t sz;
     err = getWorkspaceSize(args, algo[i], &sz);
@@ -229,7 +230,7 @@ std::vector<perf_t> getValidAlgorithms(perf_t *perfResults, const ConvolutionArg
 
   std::vector<perf_t> result;
   result.reserve(n_algo);
-  for (int i = 0; i < n_algo; i++) {
+  for (const auto i : c10::irange(n_algo)) {
     perf_t perf = perfResults[i];
 
     // TODO: Shouldn't all returned results be successful?
@@ -579,7 +580,7 @@ static inline void split_batch_dim_to_32bit_out(
   int64_t split_size = std::max<int64_t>(max_worksize / max_inner_size, 1L);
   int64_t num_splits = (n + split_size - 1) / split_size;
   if (split_size * max_inner_size < int_max) {
-    for (int64_t i = 0; i < num_splits; i++) {
+    for (const auto i : c10::irange(num_splits)) {
       int64_t start = split_size * i;
       int64_t split_size_ = std::min<int64_t>(split_size, n - start);
       Tensor input_ = input.narrow(0, start, split_size_);
@@ -805,7 +806,7 @@ void raw_cudnn_convolution_backward_weight_out(
   int64_t split_size = std::max<int64_t>(1024 * 1024 * 512 / max_inner_size, 1L);
   int64_t num_splits = (n + split_size - 1) / split_size;
   if (split_size * max_inner_size < int_max) {
-    for (int64_t i = 0; i < num_splits; i++) {
+    for (const auto i : c10::irange(num_splits)) {
       int64_t start = split_size * i;
       int64_t split_size_ = std::min<int64_t>(split_size, n - start);
       Tensor input_ = input.narrow(0, start, split_size_);

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -30,6 +30,7 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
 #include <ATen/cuda/Exceptions.h>
 
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 
 // TODO: descriptor checking
 
@@ -41,7 +42,7 @@ namespace {
 void setSamplerDescriptor(SpatialTransformerDescriptor& desc, cudnnDataType_t dataType, const at::Tensor& tensor)
 {
   int inputSize[4] = {0};
-  for (int i = 0; i < tensor.dim(); ++i) {
+  for (const auto i : c10::irange(tensor.dim())) {
     inputSize[i] = (int) tensor.size(i);
   }
   desc.set(dataType, 4, inputSize);

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -34,6 +34,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss(const Tensor& log_probs, const Tensor
 #include <ATen/cudnn/Utils.h>
 
 #include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -57,7 +58,7 @@ bool _use_cudnn_ctc_loss(
     for (const auto input_length : input_lengths) {
       use_cudnn &= ((input_length == max_input_length) ? 1 : 0);
     }
-    for (size_t b = 0; b < target_lengths.size(); b++) {
+    for (const auto b : c10::irange(target_lengths.size())) {
       // target length < 256 is documented, but we see illegal memory accesses
       // when target lengths > input lengths for CuDNN
       use_cudnn &=

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -11,6 +11,7 @@
 #include <ATen/TensorUtils.h>
 #include <c10/util/accumulate.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #if !AT_CUDNN_ENABLED()
 
@@ -191,7 +192,7 @@ namespace {
 
   std::vector<TensorDescriptor> rnn_descriptor(const Tensor& tensor, int64_t N) {
     std::vector<TensorDescriptor> descriptors(N);
-    for (int64_t i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       descriptors[i].set(tensor, 5);
     }
     return descriptors;
@@ -470,10 +471,10 @@ namespace {
     int64_t num_layers = rnn.num_directions() * rnn.num_layers;
     size_t cur_offset = 0;
     size_t global_layer_params_count = 0;
-    for (int64_t layer = 0; layer < num_layers; layer++) {
+    for (const auto layer : c10::irange(num_layers)) {
       size_t layer_params_count = 0;
       for (auto cudnn_method : cudnn_methods) {
-        for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
+        for (const auto linear_id : c10::irange(num_linear_layers)) {
           FilterDescriptor lin_layer_mat_desc;
           void* matrix_pointer;
           AT_CUDNN_CHECK(cudnn_method(
@@ -566,7 +567,7 @@ namespace {
     } else {
       data_ptrs.reserve(num_dir_layers * 2 * 2);
     }
-    for (int64_t layer = 0; layer < num_dir_layers; layer++) {
+    for (const auto layer : c10::irange(num_dir_layers)) {
       for (auto cudnn_method : cudnn_methods) {
         // This API returns a separate pointer for weight of every gate,
         // but we represent them as a single tensor, so we're only interested
@@ -629,7 +630,7 @@ namespace {
   void _viewOrCopyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to,
                          bool copy, bool allow_type_change=false) {
     TORCH_INTERNAL_ASSERT(params_from.size(0) == params_to.size(0), "number of layers mismatch");
-    for (size_t i = 0; i < params_from.size(0); i++) {
+    for (const auto i : c10::irange(params_from.size(0))) {
       auto layer_params_from = params_from[i];
       auto layer_params_to = params_to[i];
       // NOTE: these lists have all weights before all biases, so if the layer
@@ -845,7 +846,7 @@ copy_weights_to_flat_buf_views(
   _viewOrCopyParams(weight, params, /*copy=*/true, allow_type_change);
   if (set_orig_weights_to_flat_buf) {
     // Update the storage
-    for (size_t i = 0; i < weight.size(0); i++) {
+    for (const auto i : c10::irange(weight.size(0))) {
       // There is a special case for LSTM with projections and no bias,
       // where weight copy is done in 0->0, 1->1, 2->4 layout
       if (weight[i].size() == 3 && params[i].size() == 5) {
@@ -1525,7 +1526,7 @@ Tensor try_get_weight_buf(
     AT_ASSERT(num_ptrs % 5 == 0);
     if (has_biases) {
       AT_ASSERT(num_ptrs == num_parameters);
-      for (int64_t i = 0; i < num_parameters; i++) {
+      for (const auto i : c10::irange(num_parameters)) {
         if (expected_data_ptrs[i] != parameters[i].data_ptr()) return {};
       }
     } else {

--- a/aten/src/ATen/native/im2col.h
+++ b/aten/src/ATen/native/im2col.h
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 
@@ -30,15 +31,15 @@ static void im2col(
   const int64_t width_col = output_width;
   const int64_t channels_col = channels * kernel_h * kernel_w;
 
-  for (int64_t c_col = 0; c_col < channels_col; ++c_col) {
+  for (const auto c_col : c10::irange(channels_col)) {
     int64_t w_offset = c_col % kernel_w;
     int64_t h_offset = (c_col / kernel_w) % kernel_h;
     int64_t c_im = c_col / kernel_h / kernel_w;
 
-    for (int64_t h_col = 0; h_col < height_col; ++h_col) {
+    for (const auto h_col : c10::irange(height_col)) {
       int64_t h_im = h_col * stride_h - pad_h + h_offset * dilation_h;
 
-      for (int64_t w_col = 0; w_col < width_col; ++w_col) {
+      for (const auto w_col : c10::irange(width_col)) {
         int64_t w_im = w_col * stride_w - pad_w + w_offset * dilation_w;
         data_col[(c_col * height_col + h_col) * width_col + w_col] =
             (h_im >= 0 && w_im >= 0 && h_im < height && w_im < width)
@@ -72,15 +73,15 @@ static void col2im(
   const int64_t width_col = output_width;
   const int64_t channels_col = channels * kernel_h * kernel_w;
 
-  for (int64_t c_col = 0; c_col < channels_col; ++c_col) {
+  for (const auto c_col : c10::irange(channels_col)) {
     int64_t w_offset = c_col % kernel_w;
     int64_t h_offset = (c_col / kernel_w) % kernel_h;
     int64_t c_im = c_col / kernel_h / kernel_w;
 
-    for (int64_t h_col = 0; h_col < height_col; ++h_col) {
+    for (const auto h_col : c10::irange(height_col)) {
       int64_t h_im = h_col * stride_h - pad_h + h_offset * dilation_h;
 
-      for (int64_t w_col = 0; w_col < width_col; ++w_col) {
+      for (const auto w_col : c10::irange(width_col)) {
         int64_t w_im = w_col * stride_w - pad_w + w_offset * dilation_w;
 
         if (h_im >= 0 && h_im < height && w_im >= 0 && w_im < width)

--- a/aten/src/ATen/native/metal/MetalShaders.h
+++ b/aten/src/ATen/native/metal/MetalShaders.h
@@ -516,7 +516,7 @@ kernel void reshape(texture2d_array<half, access::read> in_arr[[texture(0), func
     const ushort n2 = gid.z / slices2; //image index
     const ushort s2 = gid.z - n2 * slices2; // slice offest
     half4 value;
-    for (int idx = 0; idx < 4; ++idx){
+    for (const auto idx : c10::irange(4)) {
         // we compute the "linear index" of the output element,
         // and convert it to the equivalent "linear index" of the input element.
         ushort offset = 4 * s2 + idx;
@@ -590,7 +590,7 @@ kernel void transpose(texture2d_array<half, access::read>in_arr[[texture(0),func
     half4 value;
     ushort4 threadIndexBufferLower{1, 1, 1, 1};
     ushort4 threadIndexBufferUpper{1, 1, 1 ,1};
-    for (int idx = 0; idx < 4; ++idx){
+    for (const auto idx : c10::irange(4)) {
         ushort offset = 4 * s2 + idx;
         size_t linear_idx2 = n2 * C2 * H2 * W2 + offset * H2 * W2 + gid.y * W2 + gid.x;
         if(linear_idx2 >= numel) {
@@ -810,8 +810,8 @@ kernel void roi_align(texture2d_array<half, access::sample> ina[[texture(0), fun
 
     constexpr sampler s2(coord::pixel, address::clamp_to_edge, filter::linear);
 
-    for (int iy = 0; iy < roi_bin_grid_h; iy++) {
-        for (int ix = 0; ix < roi_bin_grid_w; ix++) {
+    for (const auto iy : c10::irange(roi_bin_grid_h)) {
+        for (const auto ix : c10::irange(roi_bin_grid_w)) {
             // Shift the pixel by 0.5. This is critical to achieve high accuracy.
             const half y =
             roi_start_h + ph * bin_size_h + (iy+0.5) * bin_size_h / static_cast<half>(roi_bin_grid_h);

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -112,6 +112,7 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> miopen_depthwise_convolution_backwa
 
 #include <ATen/TensorUtils.h>
 #include <ATen/native/ConvUtils.h>
+#include <c10/util/irange.h>
 
 #include <c10/cuda/CUDACachingAllocator.h>
 
@@ -255,7 +256,7 @@ struct ParamsHash {
   std::size_t operator()(const ConvolutionParams& params) const {
     auto ptr = reinterpret_cast<const uint8_t*>(&params);
     uint32_t value = 0x811C9DC5;
-    for (int i = 0; i < (int)sizeof(ConvolutionParams); ++i) {
+    for (const auto i : c10::irange((int)sizeof(ConvolutionParams))) {
       value ^= ptr[i];
       value *= 0x01000193;
     }

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -8,6 +8,7 @@
 
 #include <ATen/cuda/CUDAConfig.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #if !AT_ROCM_ENABLED()
 
@@ -136,7 +137,7 @@ std::vector<TensorDescriptor> rnn_descriptor_sequence(const Tensor& tensor, IntA
 
 std::vector<TensorDescriptor> rnn_descriptor(const Tensor& tensor, int64_t N) {
     std::vector<TensorDescriptor> descriptors(N);
-    for (int64_t i = 0; i < N ; i++) {
+    for (const auto i : c10::irange(N)) {
         descriptors[i].set(tensor, 5);
     }
 
@@ -246,7 +247,7 @@ Tensor permute_wei_for_miopen(Tensor wei, int64_t mode)
 
 void _viewOrCopyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to, bool copy) {
     TORCH_CHECK(params_from.size(0) == params_to.size(0), "number of layers mismatch");
-    for (size_t i = 0; i < params_from.size(0); i++) {
+    for (const auto i : c10::irange(params_from.size(0))) {
         auto layer_params_from = params_from[i];
         auto layer_params_to = params_to[i];
         // NOTE: these lists have all weights before all biases, so if the layer
@@ -268,7 +269,7 @@ void _viewOrCopyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_t
 
 void _copyParams_and_permute(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to, int64_t mode) {
     TORCH_CHECK(params_from.size(0) == params_to.size(0), "number of layers mismatch");
-    for (size_t i = 0; i < params_from.size(0); i++) {
+    for (const auto i : c10::irange(params_from.size(0))) {
         auto layer_params_from = params_from[i];
         auto layer_params_to = params_to[i];
         for (auto a = layer_params_from.begin(), b = layer_params_to.begin();
@@ -327,11 +328,11 @@ std::pair<std::vector<Tensor>, size_t> get_parameters(miopenHandle_t handle, con
     auto elem_size = dataSize(getMiopenDataType(weight_buf));
     auto bias_mode = rnn.bias_mode;
 
-    for (int64_t layer = 0; layer < num_layers; layer++) {
+    for (const auto layer : c10::irange(num_layers)) {
         size_t layer_params_count = 0;
 
         // Get layer params
-        for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
+        for (const auto linear_id : c10::irange(num_linear_layers)) {
             FilterDescriptor lin_layer_mat_desc;
             size_t offset;
             MIOPEN_CHECK(miopenGetRNNLayerParamOffset(
@@ -366,7 +367,7 @@ std::pair<std::vector<Tensor>, size_t> get_parameters(miopenHandle_t handle, con
 
         // Get bias params
         if (bias_mode == miopenRNNwithBias) {
-            for (int64_t linear_id = 0; linear_id < num_linear_layers; linear_id++) {
+            for (const auto linear_id : c10::irange(num_linear_layers)) {
                 FilterDescriptor lin_layer_mat_desc;
                 size_t offset;
                 MIOPEN_CHECK(miopenGetRNNLayerBiasOffset(
@@ -776,7 +777,7 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> miopen_rnn_backward(
     if (output_mask[3]) {
         dw = at::native::miopen_rnn_backward_weight(input, weight, weight_stride0, weight_buf, hx, cx, output, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, ws);
         if (mode > 1) {
-            for (int i = 0; i < dw.size(); i++) {
+            for (const auto i : c10::irange(dw.size())) {
                 dw[i] = permute_wei_for_miopen(dw[i], mode);
             }
         }

--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -42,6 +42,7 @@ void mkl_gemm_batched(
 #else // AT_MKL_ENABLED
 
 #include <mkl.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -29,7 +29,7 @@ void _fft_fill_with_conjugate_symmetry_slice(
   // n-dimensions. This advances iter_index by one row, while updating in_ptr
   // and out_ptr to point to the new row of data.
   auto advance_index = [&] () __ubsan_ignore_undefined__ {
-    for (size_t i = 1; i < iter_index.size(); ++i) {
+    for (const auto i : c10::irange(1, iter_index.size())) {
       if (iter_index[i] + 1 < signal_half_sizes[i]) {
         ++iter_index[i];
         in_ptr += in_strides[i];
@@ -93,7 +93,7 @@ void _fft_fill_with_conjugate_symmetry_slice(
     while (numel_remaining > 0) {
       auto end = std::min(signal_half_sizes[0], numel_remaining);
       out_ptr[0] = std::conj(in_ptr[0]);
-      for (int64_t i = 1; i < end; ++i) {
+      for (const auto i : c10::irange(1, end)) {
         out_ptr[(signal_half_sizes[0] - i) * out_strides[0]] = std::conj(in_ptr[i * in_strides[0]]);
       }
       numel_remaining -= end;
@@ -448,7 +448,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
   const auto batch_size = input.sizes()[0];
   DimVector signal_size(signal_ndim + 1);
   signal_size[0] = batch_size;
-  for (int64_t i = 0; i < signal_ndim; ++i) {
+  for (const auto i : c10::irange(signal_ndim)) {
     auto in_size = input.sizes()[i + 1];
     auto out_size = out_sizes[dim[i]];
     signal_size[i + 1] = std::max(in_size, out_size);
@@ -460,7 +460,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
 
   batched_sizes[0] = batch_size;
   DimVector batched_out_sizes(batched_sizes.begin(), batched_sizes.end());
-  for (size_t i = 0; i < dim.size(); ++i) {
+  for (const auto i : c10::irange(dim.size())) {
     batched_out_sizes[i + 1] = out_sizes[dim[i]];
   }
 
@@ -485,7 +485,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
     out_strides[dim_permute[i]] = batch_numel * out.strides()[0];
     batch_numel *= out_sizes[dim_permute[i]];
   }
-  for (int64_t i = batch_dims; i < ndim; ++i) {
+  for (const auto i : c10::irange(batch_dims, ndim)) {
     out_strides[dim_permute[i]] = out.strides()[1 + (i - batch_dims)];
   }
   out.as_strided_(out_sizes, out_strides, out.storage_offset());

--- a/aten/src/ATen/native/mkldnn/Pooling.cpp
+++ b/aten/src/ATen/native/mkldnn/Pooling.cpp
@@ -229,7 +229,7 @@ static Tensor _mkldnn_pooling(
           false /*ceil_mode */);
 
       all_equal = true;
-      for (size_t i = 2; i < input.sizes().size(); ++i) {
+      for (const auto i : c10::irange(2, input.sizes().size())) {
         if (output_sizes[i] < output_sizes_ceil[i]) {
            padding_vec_r[i - 2]++;
            all_equal = false;
@@ -318,7 +318,7 @@ static Tensor _mkldnn_pooling_backward(
           false /*ceil_mode */);
 
       all_equal = true;
-      for (size_t i = 2; i < input.sizes().size(); ++i) {
+      for (const auto i : c10::irange(2, input.sizes().size())) {
         if (output_sizes[i] < output_sizes_ceil[i]) {
            padding_vec_r[i - 2]++;
            all_equal = false;
@@ -479,7 +479,7 @@ Tensor mkldnn_adaptive_avg_pool2d(
   auto output_size_vec =
       expand_param_if_needed(output_size, "output_size", input.dim() - 2);
   std::vector<int64_t> kernel_size(input.dim() - 2);
-  for (int64_t i = 2; i < input.dim(); ++i) {
+  for (const auto i : c10::irange(2, input.dim())) {
     auto s1 = input.size(i);
     auto s2 = output_size_vec[i - 2];
     TORCH_CHECK(s2 != 0, "output size can not be zero");

--- a/aten/src/ATen/native/mkldnn/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/Utils.cpp
@@ -1,5 +1,6 @@
 #include <ATen/native/mkldnn/Utils.h>
 #include <ATen/native/Pool.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -16,7 +17,7 @@ std::vector<int64_t> pool_output_sizes(
   output_size[0] = input_size[0];
   output_size[1] = input_size[1];
 
-  for (size_t i = 2; i < input_size.size(); ++i) {
+  for (const auto i : c10::irange(2, input_size.size())) {
     output_size[i] = pooling_output_shape_pad_lr<int64_t>(
       input_size[i],
       kernel_size[i - 2],

--- a/aten/src/ATen/native/quantized/Copy.cpp
+++ b/aten/src/ATen/native/quantized/Copy.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/quantized/affine_quantizer.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -23,7 +24,7 @@ Tensor& quantized_copy_from_float_cpu_(Tensor& self, const Tensor& src) {
   AT_DISPATCH_QINT_TYPES(self.scalar_type(), "Copy", [&]() {
     float* src_data = src.data_ptr<float>();
     scalar_t* self_data = self.data_ptr<scalar_t>();
-    for (int i = 0; i < self.numel(); ++i) {
+    for (const auto i : c10::irange(self.numel())) {
       self_data[i] = quantize_val<scalar_t>(
           self.q_scale(), self.q_zero_point(), src_data[i]);
     }

--- a/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/quantized/affine_quantizer_base.h>
+#include <c10/util/irange.h>
 #include <cfenv>
 #include <climits>
 
@@ -145,7 +146,7 @@ void quantize_vec(
     T* dst,
     size_t count) {
   checkZeroPoint<typename T::underlying>("quantize_vec", zero_point);
-  for (size_t i = 0; i < count; ++i) {
+  for (const auto i : c10::irange(count)) {
     dst[i] = quantize_val<T>(scale, zero_point, src[i]);
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -11,6 +11,7 @@
 #include <c10/core/QScheme.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 #include <torch/custom_class.h>
 
 torch::class_<LinearPackedParamsBase> register_linear_params();
@@ -47,9 +48,9 @@ void CopyToChannelsLast3dTensor(
     const T* src,
     T* dst) {
   const int64_t inner_size = D * H * W;
-  for (int64_t i = 0; i < N; ++i) {
-    for (int64_t j = 0; j < inner_size; ++j) {
-      for (int64_t k = 0; k < C; ++k) {
+  for (const auto i : c10::irange(N)) {
+    for (const auto j : c10::irange(inner_size)) {
+      for (const auto k : c10::irange(C)) {
         dst[(i * inner_size + j) * C + k] = src[(i * C + k) * inner_size + j];
       }
     }
@@ -69,8 +70,8 @@ void CopyICFirst3dTensorToChannelsLast3dTensor(
   // IC OC/G THW -> G OC/G THW IC/G
   const int64_t inner_size = D * H * W;
   for (int64_t i = 0; i < G * OC_G; ++i) {
-    for (int64_t j = 0; j < inner_size; ++j) {
-      for (int64_t ic = 0; ic < IC_G; ++ic) {
+    for (const auto j : c10::irange(inner_size)) {
+      for (const auto ic : c10::irange(IC_G)) {
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
         int g = i / OC_G;
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -5,6 +5,7 @@
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/embedding_packed_params.h>
 #include <c10/core/QScheme.h>
+#include <c10/util/irange.h>
 
 #ifdef USE_FBGEMM
 #include <fbgemm/Fbgemm.h>
@@ -240,7 +241,7 @@ inline void convert_uint8_int8(
     int len,
     const uint8_t* src_uint8,
     int8_t* dst_int8) {
-  for (int i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     dst_int8[i] = static_cast<int8_t>(static_cast<int32_t>(src_uint8[i]) - 128);
   }
 }
@@ -250,7 +251,7 @@ inline void convert_int8_uint8(
     int len,
     const int8_t* src_int8,
     uint8_t* dst_uint8) {
-  for (int i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     dst_uint8[i] =
         static_cast<uint8_t>(static_cast<int32_t>(src_int8[i]) + 128);
   }

--- a/aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/DispatchStub.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -22,7 +23,7 @@ Tensor int_repr_quantized_cpu(const Tensor& self) {
           self.options().dtype(UNDERLYING_TYPE),
           self.suggest_memory_format());
       const underlying_t* qdata = reinterpret_cast<underlying_t*>(self.data_ptr<scalar_t>());
-      for (int64_t i = 0; i < dst.numel(); ++i) {
+      for (const auto i : c10::irange(dst.numel())) {
         dst[i] = static_cast<underlying_t>(qdata[i]);
       }
     } else {

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -104,9 +104,9 @@ Tensor qcat_nhwc_kernel(
   // which causes an internal compiler error if they're not
   AT_DISPATCH_QINT_TYPES(output.scalar_type(), "qcat_nhwc", [&, N, H, W]() {
     using Vec = Vectorized<scalar_t>;
-    for (int64_t batch = 0; batch < N; ++batch) {
-      for (int64_t row = 0; row < H; ++row) {
-        for (int64_t col = 0; col < W; ++col) {
+    for (const auto batch : c10::irange(N)) {
+      for (const auto row : c10::irange(H)) {
+        for (const auto col : c10::irange(W)) {
           // loop over input tensors
           for (const auto tidx : c10::irange(Cs_in.size())) {
             scalar_t::underlying* optr =
@@ -1294,13 +1294,13 @@ void qmaxpool_2d_nhwc_kernel(
     scalar_t* odata = static_cast<scalar_t*>(qy.data_ptr());
 
     // Loop over N
-    for (int64_t b = 0; b < qx.size(0); ++b) {
+    for (const auto b : c10::irange(qx.size(0))) {
       // Loop over H
       auto* i_p =
           reinterpret_cast<scalar_t::underlying*>(idata + b * iW * iH * iC);
-      for (int64_t row = 0; row < oH; ++row) {
+      for (const auto row : c10::irange(oH)) {
         // Loop over W
-        for (int64_t col = 0; col < oW; ++col) {
+        for (const auto col : c10::irange(oW)) {
           // Pointer to output data for this specific N,H,W position
           auto* o_p = reinterpret_cast<scalar_t::underlying*>(
               odata + b * oH * oW * iC + row * oW * iC + col * iC);
@@ -1328,7 +1328,7 @@ void qmaxpool_2d_nhwc_kernel(
             int64_t x, y;
             for (y = h_start; y < h_end; y += dH) {
               for (x = w_start; x < w_end; x += dW) {
-                for (int i = 0; i < 4; ++i) {
+                for (const auto i : c10::irange(4)) {
                   tcntr = y * iW + x;
                   auto vals = Vectorized<scalar_t>::loadu(
                       i_p + tcntr * iC + c + Vectorized<scalar_t>::size() * i);
@@ -1336,7 +1336,7 @@ void qmaxpool_2d_nhwc_kernel(
                 }
               } // for x
             } // for y
-            for (int i = 0; i < 4; ++i) {
+            for (const auto i : c10::irange(4)) {
               accs[i].store(o_p + c + Vectorized<scalar_t>::size() * i);
             }
           } // for c
@@ -1417,18 +1417,18 @@ void do_avg_pool_nhwc_on_AVX_n(
     for (int c = c_start; c < csize; c += cb_step) {
       int cend = std::min(cb_size, (csize - c) / vec_width);
       // initialize loop
-      for (int ic = 0; ic < cend; ic++) {
+      for (const auto ic : c10::irange(cend)) {
         acc_buffer[ic] = Vectorized<int32_t>(input_zero_point_m_size);
       }
       // compute loop
-      for (int id = dstart; id < dend; id++) {
-        for (int ih = hstart; ih < hend; ih++) {
-          for (int iw = wstart; iw < wend; iw++) {
+      for (const auto id : c10::irange(dstart, dend)) {
+        for (const auto ih : c10::irange(hstart, hend)) {
+          for (const auto iw : c10::irange(wstart, wend)) {
             const int i_idx =
                 (id * wsize * hsize + ih * wsize + iw) *
                     csize +
                 c;
-            for (int ic = 0; ic < cend; ic++) {
+            for (const auto ic : c10::irange(cend)) {
               auto vals = vec::convert_to_int32<typename T::underlying>(
                   i_p + i_idx + ic * vec_width);
               acc_buffer[ic] = acc_buffer[ic] + vals;
@@ -1493,9 +1493,9 @@ void do_avg_pool_on_AVX_n(
       int64_t tcntr = 0;
 
       Vectorized<int32_t> acc(input_zero_point_m_size);
-      for (int64_t id = dstart; id < dend; id++) {
-        for (int64_t ih = hstart; ih < hend; ih++) {
-          for (int64_t iw = wstart; iw < wend; iw++) {
+      for (const auto id : c10::irange(dstart, dend)) {
+        for (const auto ih : c10::irange(hstart, hend)) {
+          for (const auto iw : c10::irange(wstart, wend)) {
             tcntr = id * stride_D + ih * stride_H + iw * stride_W;
             auto vals = vec::convert_to_int32<typename T::underlying>(
                 i_p + tcntr * channel_multiplier + c * stride_C);
@@ -1546,11 +1546,11 @@ void _qadaptive_avg_pool_kernel(
     int input_zero_point = qx.q_zero_point();
     int output_zero_point = qy.q_zero_point();
 
-    for (int64_t od = 0; od < osizeD; od++) {
+    for (const auto od : c10::irange(osizeD)) {
       int istartD = (int)std::floor((float)(od * isizeD) / osizeD);
       int iendD = (int)std::ceil((float)((od + 1) * isizeD) / osizeD);
       int kD = iendD - istartD;
-      for (int64_t oh = 0; oh < osizeH; oh++) {
+      for (const auto oh : c10::irange(osizeH)) {
         int istartH = (int)std::floor((float)(oh * isizeH) / osizeH);
         int iendH = (int)std::ceil((float)((oh + 1) * isizeH) / osizeH);
         int kH = iendH - istartH;
@@ -1603,9 +1603,9 @@ void _qadaptive_avg_pool_kernel(
           for (; c < sizeC; ++c) {
             int32_t acc_int32 = input_zero_point_m_size;
             int64_t tcntr = 0;
-            for (int64_t id = 0; id < kD; ++id) {
-              for (int64_t ih = 0; ih < kH; ++ih) {
-                for (int64_t iw = 0; iw < kW; ++iw) {
+            for (const auto id : c10::irange(kD)) {
+              for (const auto ih : c10::irange(kH)) {
+                for (const auto iw : c10::irange(kW)) {
                   tcntr = id * istrideD +
                           ih * istrideH +
                           iw * istrideW;
@@ -1945,7 +1945,7 @@ int64_t do_quantized_bilinear_on_AVX_n(
           pos1 + h1p * input_width * channels);
       pos1_int_v[3] = vec::convert_to_int32<typename T::underlying>(
           pos1 + (h1p * input_width + w1p) * channels);
-      for (int i = 0; i < 4; i++) {
+      for (const auto i : c10::irange(4)) {
         int32_t pos1_int[vec_width];
         float pos1_fp[vec_width];
         pos1_int_v[i].store(pos1_int);
@@ -1999,13 +1999,13 @@ void qupsample_bilinear2d_nhwc_kernel(
         const auto rwidth = area_pixel_compute_scale<float>(
             input_width, output_width, align_corners, scales_w);
 
-        for (int64_t b = 0; b < nbatch; ++b) {
+        for (const auto b : c10::irange(nbatch)) {
           auto* i_p = reinterpret_cast<typename scalar_t::underlying*>(
               idata + b * input_height * input_width * channels);
           auto* o_p = reinterpret_cast<typename scalar_t::underlying*>(
               odata + b * output_height * output_width * channels);
 
-          for (int64_t h2 = 0; h2 < output_height; ++h2) {
+          for (const auto h2 : c10::irange(output_height)) {
             const auto h1r = area_pixel_compute_source_index<float>(
                 rheight, h2, align_corners, /*cubic=*/false);
 
@@ -2014,7 +2014,7 @@ void qupsample_bilinear2d_nhwc_kernel(
             const float h1lambda = h1r - h1;
             const float h0lambda = static_cast<float>(1.) - h1lambda;
 
-            for (int64_t w2 = 0; w2 < output_width; ++w2) {
+            for (const auto w2 : c10::irange(output_width)) {
               const auto w1r = area_pixel_compute_source_index<float>(
                   rwidth, w2, align_corners, /*cubic=*/false);
               const int64_t w1 = w1r;
@@ -2250,7 +2250,7 @@ void _fake_quantize_tensor_helper(
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_type_handling", [&] {
     iter_combined.for_each([&](char** data, const int64_t* strides, int64_t n) {
-      for (int64_t i = 0; i < n; i++) {
+      for (const auto i : c10::irange(n)) {
         scalar_t* output_val = (scalar_t*)(data[0] + i * strides[0]);
         bool* mask_val = (bool*)(data[1] + i * strides[1]);
         scalar_t* input_val = (scalar_t*)(data[2] + i * strides[2]);
@@ -2319,7 +2319,7 @@ void fake_quantize_learnable_tensor_grad_kernel_cpu(
         (to move onto different elements), can allow accessing of the input and assignment
         to the right output.
     */
-    for (int64_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
       float* dXOutput = (float*)(data[0] + i * strides[0]);
       float* dScaleOutput = (float*)(data[1] + i * strides[1]);
       float* dZeroPointOutput = (float*)(data[2] + i * strides[2]);
@@ -2429,7 +2429,7 @@ void fake_quantize_learnable_channel_grad_kernel_cpu(
         please see the implemenetation of
         fake_quantize_learnable_tensor_grad_kernel_cpu.
     */
-    for (int64_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
       float* dx_output = (float*)(data[0] + i * strides[0]);
       float* dscale_output = (float*)(data[1] + i * strides[1]);
       float* dzero_point_output = (float*)(data[2] + i * strides[2]);
@@ -2516,7 +2516,7 @@ void quantized_normalize_kernel(
     int64_t kNonVecRemInChannel = NPerChannel % kIntVLen;
 
     at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-      for (int64_t i = start; i < end; ++i) {
+      for (const auto i : c10::irange(start, end)) {
 
         scalar_t* X_ptr = X_data + i * N;
         scalar_t* Y_ptr = Y_data + i * N;
@@ -2546,7 +2546,7 @@ void quantized_normalize_kernel(
 
           // if scaling per channel, scaling parameters can be pre-multiplied
           // with normalization parameters
-          for (int64_t chIdx = 0; chIdx < channels_per_group; chIdx++) {
+          for (const auto chIdx : c10::irange(channels_per_group)) {
             int scalingIdx = (i * channels_per_group + chIdx) % (num_channels);
             float gamma = gamma_null ? 1.0f : gamma_data[scalingIdx];
             // scale_x / layer_std * gamma
@@ -2558,7 +2558,7 @@ void quantized_normalize_kernel(
             int64_t chStartIdx = chIdx * NPerChannel;
             int64_t chEndIdx = chStartIdx + NPerChannel;
 
-            for (int64_t vecIdx = 0; vecIdx < kNumIntVecInChannel; vecIdx++) {
+            for (const auto vecIdx : c10::irange(kNumIntVecInChannel)) {
               int64_t vecStartIdx = chStartIdx + vecIdx * kIntVLen;
               auto qXVec = qVec::loadu(X_ptr + vecStartIdx);
               auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
@@ -2584,7 +2584,7 @@ void quantized_normalize_kernel(
 
         } else {
 
-          for (int64_t vecIdx = 0; vecIdx < kNumIntVecInLayer; vecIdx++) {
+          for (const auto vecIdx : c10::irange(kNumIntVecInLayer)) {
             int64_t vecStartIdx = vecIdx * kIntVLen;
             auto qXVec = qVec::loadu(X_ptr + vecStartIdx);
             auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
@@ -2638,7 +2638,7 @@ void quantize_tensor_per_tensor_affine_cpu(
         qparams.precision = CHAR_BIT * sizeof(underlying_t);
         int num_tasks = at::get_num_threads();
         at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
-          for (int task_id = begin; task_id < end; ++task_id) {
+          for (const auto task_id : c10::irange(begin, end)) {
             fbgemm::Quantize<underlying_t, false /*LEGACY*/>(
                 // NOLINTNEXTLINE(bugprone-argument-comment)
                 rd, /*src=*/
@@ -2672,7 +2672,7 @@ void dequantize_tensor_per_tensor_affine_cpu(
         float* rd = rtensor.data_ptr<float>();
         int num_tasks = at::get_num_threads();
         at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
-          for (int task_id = begin; task_id < end; ++task_id) {
+          for (const auto task_id : c10::irange(begin, end)) {
             fbgemm::Dequantize<underlying_t>(
                 // NOLINTNEXTLINE(bugprone-argument-comment)
                 qd, /*src=*/
@@ -2700,7 +2700,7 @@ void quantize_tensor_arm(
     const float scale,
     const int32_t zero_point) {
   auto out = qtensor.data_ptr<T>();
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     out[i] = at::native::quantize_val<T>(scale, zero_point, in[i]);
   }
 }
@@ -2802,7 +2802,7 @@ void quantize_tensor_per_tensor_affine_cpu(
         const float* const rdata = rtensor.data_ptr<float>();
         auto qdata = qtensor.data_ptr<scalar_t>();
         auto numel = rtensor.numel();
-        for (int i = 0; i < numel; ++i) {
+        for (const auto i : c10::irange(numel)) {
           qdata[i] = quantize_val<scalar_t>(scale, zero_point, rdata[i]);
         }
       });
@@ -2820,7 +2820,7 @@ void dequantize_tensor_per_tensor_affine_cpu(
         const auto* qd = qtensor.data_ptr<scalar_t>();
         float* rd = rtensor.data_ptr<float>();
         auto numel = qtensor.numel();
-        for (auto i = 0; i < numel; ++i) {
+        for (const auto i : c10::irange(numel)) {
           rd[i] = dequantize_val<scalar_t>(scale, zero_point, qd[i]);
         }
       });
@@ -2857,9 +2857,9 @@ void quantize_tensor_per_channel_impl(
     // channels_last contig.
     // If axis = 0 and channels_last contig, implementation for channels
     // first (NCHW) works.
-    for (auto b = 0; b < batches; ++b) {
-      for (auto e = 0; e < elements_per_channel; ++e) {
-        for (auto c = 0; c < channels; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
+        for (const auto c : c10::irange(channels)) {
           auto i = b * channels * elements_per_channel + e * channels + c;
           out[i] = at::native::quantize_val<T>(
               scales_data[c], zero_points_data[c], in[i]);
@@ -2867,9 +2867,9 @@ void quantize_tensor_per_channel_impl(
       }
     }
   } else {
-    for (auto b = 0; b < batches; ++b) {
-      for (auto c = 0; c < channels; ++c) {
-        for (auto e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channels)) {
+        for (const auto e : c10::irange(elements_per_channel)) {
           auto i = b * channels * elements_per_channel +
               c * elements_per_channel + e;
           out[i] = at::native::quantize_val<T>(
@@ -2919,7 +2919,7 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
   // Copy zero_points with magic int (int64_t) into int32_t array
   std::vector<float> inv_scales(channels);
   std::vector<int32_t> zero_points_int32t(channels);
-  for (int i = 0; i < channels; ++i) {
+  for (const auto i : c10::irange(channels)) {
     inv_scales[i] = 1.0f / (float)scales_data[i];
     zero_points_int32t[i] = (int32_t)(uint32_t)zero_points_data[i] - 0x4B400000;
   }
@@ -2930,8 +2930,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
     // channels_last contig.
     // If axis = 0 and channels_last contig, implementation for channels
     // first (NCHW) works.
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
         uint32_t c = 0;
         while (c + 8 < channels) {
           const int32x4_t voffset0123 = vld1q_s32(&zero_points_int32t[c]);
@@ -2965,8 +2965,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
       }
     }
   } else {
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t c = 0; c < channels; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channels)) {
         uint32_t e = 0;
         const int32x4_t voffset = vdupq_n_s32(zero_points_int32t[c]);
         const float32x4_t vinv_scale = vdupq_n_f32(inv_scales[c]);
@@ -3001,7 +3001,7 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
   // Copy zero_points (int64_t) into int16_t array
   std::vector<float> inv_scales(channels);
   std::vector<int16_t> zero_points_int16t(channels);
-  for (int i = 0; i < channels; ++i) {
+  for (const auto i : c10::irange(channels)) {
     inv_scales[i] = 1.0f / (float)scales_data[i];
     zero_points_int16t[i] = (int16_t)(uint16_t)zero_points_data[i];
   }
@@ -3012,8 +3012,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
     // channels_last contig.
     // If axis = 0 and channels_last contig, implementation for channels
     // first (NCHW) works.
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
         uint32_t c = 0;
         while (c + 8 < channels) {
           const int16x8_t vzero_point = vld1q_s16(&zero_points_int16t[c]);
@@ -3043,8 +3043,8 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
       }
     }
   } else {
-    for (uint32_t b = 0; b < batches; ++b) {
-      for (uint32_t c = 0; c < channels; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channels)) {
         uint32_t e = 0;
         const int16x8_t vzero_point = vdupq_n_s16(zero_points_int16t[c]);
         const float32x4_t vinv_scale = vdupq_n_f32(inv_scales[c]);
@@ -3123,9 +3123,9 @@ void dequantize_per_channel_affine_kernel(
   const auto elem_per_byte = 8 / bit_width;
   if (axis == 1 && (rtensor.is_contiguous(MemoryFormat::ChannelsLast) ||
       rtensor.is_contiguous(MemoryFormat::ChannelsLast3d))) {
-    for (auto b = 0; b < batches; ++b) {
-      for (auto e = 0; e < elements_per_channel; ++e) {
-        for (auto c = 0; c < channel; ++c) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto e : c10::irange(elements_per_channel)) {
+        for (const auto c : c10::irange(channel)) {
           auto i = b * channel * elements_per_channel + e * channel + c;
           // We need to convert the qint8 value to float to ensure the
           // subtraction subexpression returns a float
@@ -3139,9 +3139,9 @@ void dequantize_per_channel_affine_kernel(
       }
     }
   } else {
-    for (auto b = 0; b < batches; ++b) {
-      for (auto c = 0; c < channel; ++c) {
-        for (auto e = 0; e < elements_per_channel; ++e) {
+    for (const auto b : c10::irange(batches)) {
+      for (const auto c : c10::irange(channel)) {
+        for (const auto e : c10::irange(elements_per_channel)) {
           auto i = b * channel * elements_per_channel +
               c * elements_per_channel + e;
           // We need to convert the qint8 value to float to ensure the
@@ -3201,9 +3201,9 @@ void quantize_tensor_per_channel_float_qparams_cpu(
         int qvalue = 0;
         if (axis == 1 && (rtensor.is_contiguous(MemoryFormat::ChannelsLast) ||
             rtensor.is_contiguous(MemoryFormat::ChannelsLast3d))) {
-          for (auto b = 0; b < batches; ++b) {
-            for (auto e = 0; e < elements_per_channel; ++e) {
-              for (auto c = 0; c < channel; ++c) {
+          for (const auto b : c10::irange(batches)) {
+            for (const auto e : c10::irange(elements_per_channel)) {
+              for (const auto c : c10::irange(channel)) {
                 auto i = b * channel * elements_per_channel + e * channel + c;
                 qvalue = quantize_val_float_qparams(
                     scales_data[c], zero_points_data[c], rdata[i], quant_min, quant_max);
@@ -3217,9 +3217,9 @@ void quantize_tensor_per_channel_float_qparams_cpu(
             }
           }
         } else {
-          for (auto b = 0; b < batches; ++b) {
-            for (auto c = 0; c < channel; ++c) {
-              for (auto e = 0; e < elements_per_channel; ++e) {
+          for (const auto b : c10::irange(batches)) {
+            for (const auto c : c10::irange(channel)) {
+              for (const auto e : c10::irange(elements_per_channel)) {
                 auto i = b * channel * elements_per_channel +
                     c * elements_per_channel + e;
                 qvalue = quantize_val_float_qparams(
@@ -3263,7 +3263,7 @@ void quantize_tensor_per_tensor_affine_sub_byte_cpu(
       auto qdata = reinterpret_cast<underlying_t*>(qtensor.data_ptr<scalar_t>());
       auto numel = rtensor.numel();
       const auto elem_per_byte = CHAR_BIT / bit_width;
-      for (int i = 0; i < numel; ++i) {
+      for (const auto i : c10::irange(numel)) {
         float inv_scale = scale == 0 ? 1.0f : 1.0f / scale;
         int64_t qvalue = lrintf(std::nearbyint(rdata[i] * inv_scale) + zero_point);
         qvalue = std::max(quant_min, std::min(qvalue, quant_max));
@@ -3296,7 +3296,7 @@ void dequantize_tensor_per_tensor_affine_sub_byte_cpu(
       auto numel = rtensor.numel();
       const auto elem_per_byte = CHAR_BIT / bit_width;
 
-      for (int i = 0; i < numel; ++i) {
+      for (const auto i : c10::irange(numel)) {
         // NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
         underlying_t qvalue = qdata[i / elem_per_byte];
         qvalue >>= (i % elem_per_byte) * bit_width;

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -6,6 +6,8 @@
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/math_compat.h>
 
 #include <algorithm>
@@ -39,7 +41,7 @@ static void avg_pool2d_out_frame(
     bool count_include_pad,
     c10::optional<int64_t> divisor_override) {
   at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++) {
+    for (const auto k : c10::irange(start, end)) {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t xx, yy;
       /* For all output pixels... */
@@ -224,7 +226,7 @@ Tensor q_avg_pool2d(
           divisor_override);
     } else {
       at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++) {
+        for (const auto b : c10::irange(start, end)) {
           qavg_pool2d_nhwc_stub(
               input.device().type(),
               input,
@@ -270,7 +272,7 @@ Tensor q_avg_pool2d(
           divisor_override);
     } else {
       at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++) {
+        for (const auto b : c10::irange(start, end)) {
           avg_pool2d_out_frame<scalar_t>(
               input,
               output,

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool3d.cpp
@@ -5,6 +5,8 @@
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/math_compat.h>
 
 #include <algorithm>
@@ -154,7 +156,7 @@ Tensor q_avg_pool3d(
         divisor_override);
   } else {
     at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-      for (auto b = start; b < end; b++) {
+      for (const auto b : c10::irange(start, end)) {
         qavg_pool3d_nhwc_stub(
             input_nhwc.device().type(),
             input_nhwc,

--- a/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Parallel.h>
 #include <torch/library.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <vector>
@@ -30,7 +31,7 @@ void compute_fused_params(
   //     = (input(n, c, h, w) - mean(c)) / sqrt(var(c) + eps) * weight(c)
   //         + bias(c)
   // We factor out inv_sigma(c) = 1 / sqrt(var(c) + eps).
-  for (int64_t c = 0; c < channels; c++) {
+  for (const auto c : c10::irange(channels)) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     float inv_sigma = 1.0 / std::sqrt(var_data[c] + static_cast<float>(eps));
     float weight_v = weight_data ? weight_data[c] : 1;

--- a/aten/src/ATen/native/quantized/cpu/qclamp.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qclamp.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/quantized/Quantizer.h>
+#include <c10/util/irange.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 #include <algorithm>
@@ -29,7 +30,7 @@ Tensor qnnpack_clamp(Tensor input, const Scalar& min, const Scalar& max) {
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());
   size_t num_elems = 1;
-  for (int i = 1; i < input_contig.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, input_contig.ndimension())) {
     num_elems *= input_contig.size(i);
   }
 

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -95,7 +95,7 @@ at::SmallVector<int64_t, kSpatialDim + 2> MakeDeConvOutputShape(
   output_shape.resize(kSpatialDim + 2);
   output_shape[0] = N;  // Batch size
   output_shape[1] = M;  // Output channels
-  for (int64_t idx = 0; idx < kSpatialDim; ++idx) {
+  for (const auto idx : c10::irange(kSpatialDim)) {
     output_shape[idx + 2] = compute_deconv_shape(input_shape[idx],
                                                  kernel[idx],
                                                  stride[idx],
@@ -250,7 +250,7 @@ void PackedConvWeight<kSpatialDim>::GetQuantizationParams(
     const int M = w->outputChannels();
     output_multiplier_float->resize(M);
     act_times_w_scale->resize(M);
-    for (int i = 0; i < M; ++i) {
+    for (const auto i : c10::irange(M)) {
       act_times_w_scale->at(i) = (act_scale * w_scale[i]);
       output_multiplier_float->at(i) = act_times_w_scale->at(i) / out_scale;
     }
@@ -653,7 +653,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
         c10::nullopt);
     auto* qnnp_w_data = qnnp_weight.template data_ptr<c10::quint8>();
     auto wt_numel = weight_contig.numel();
-    for (int i = 0; i < wt_numel; ++i) {
+    for (const auto i : c10::irange(wt_numel)) {
       qnnp_w_data[i] = static_cast<c10::quint8>(w_data[i] + 128);
     }
     at::Tensor qbias;

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -91,7 +91,7 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
         !transpose,
         "Per Channel Quantization is currently disabled for transposed conv");
     zero_points.resize(output_channels);
-    for (int i = 0; i < output_channels; ++i) {
+    for (const auto i : c10::irange(output_channels)) {
       zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
     }
   } else {
@@ -120,11 +120,11 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
   const int inner_size =
       kernel_d * kernel_h * kernel_w * input_channels_per_group;
   for (const auto g : c10::irange(groups)) {
-    for (int i = 0; i < output_channels_per_group; ++i) {
+    for (const auto i : c10::irange(output_channels_per_group)) {
       // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
       const int c = g * output_channels_per_group + i;
       int32_t sum = 0;
-      for (int j = 0; j < inner_size; ++j) {
+      for (const auto j : c10::irange(inner_size)) {
         sum += static_cast<int32_t>(weight_data_int8[c * inner_size + j]);
       }
       if (qtype == c10::kPerTensorAffine) {
@@ -140,7 +140,7 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
     scales = {static_cast<float>(weight.q_scale())};
   } else if (qtype == c10::kPerChannelAffine) {
     scales.resize(output_channels);
-    for (int i = 0; i < output_channels; ++i) {
+    for (const auto i : c10::irange(output_channels)) {
       scales[i] = weight.q_per_channel_scales()[i].item<float>();
     }
   }
@@ -330,7 +330,8 @@ class QConvPackWeightInt8 final {
       int64_t groups) {
     torch::List<int64_t> output_padding;
     output_padding.reserve(kSpatialDim);
-    for (int idx = 0; idx < kSpatialDim; ++idx) {
+    for (const auto idx : c10::irange(kSpatialDim)) {
+      (void)idx; //Suppress unused variable warning
       output_padding.push_back((int64_t)0);
     }
     return _run(weight, bias, stride, padding, output_padding, dilation, groups,

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include <ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
 
@@ -44,7 +45,7 @@ at::Tensor& embedding_lookup_fallback_impl(
   std::vector<OffsetType> lengths_data;
 
   int64_t lower = accessor[0];
-  for (int64_t i = 1; i < offsets.numel(); ++i) {
+  for (const auto i : c10::irange(1, offsets.numel())) {
     lengths_data.push_back(accessor[i] - lower);
     lower = accessor[i];
   }
@@ -58,7 +59,7 @@ at::Tensor& embedding_lookup_fallback_impl(
   if (per_sample_weights_.has_value()) {
     per_sample_weights_data = per_sample_weights_.value().data_ptr<float>();
   }
-  for (int m = 0; m < output_size; ++m) {
+  for (const auto m : c10::irange(output_size)) {
     memset(output_data, 0, block_size * sizeof(float));
     TORCH_CHECK(
         current + lengths_data[m] <= index_size,
@@ -126,7 +127,7 @@ at::Tensor& embedding_lookup_fallback_impl(
         bias = weight_val * bias_val;
       }
 
-      for (int j = 0; j < block_size; ++j) {
+      for (const auto j : c10::irange(block_size)) {
         uint8_t quantized =
             weight_data[idx * weight_size + j / NUM_ELEM_PER_BYTE];
         quantized >>= (j % NUM_ELEM_PER_BYTE) * BIT_RATE;

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -67,7 +67,7 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
   weight_scales_tensor.copy_(qweight.q_per_channel_scales());
   weight_zero_points_tensor.copy_(qweight.q_per_channel_zero_points());
 
-  for (int64_t i = 0; i < embedding_rows; ++i) {
+  for (const auto i : c10::irange(embedding_rows)) {
     weight_bias[i] = weight_zero_points[i] * weight_scales[i] * -1;
   }
 
@@ -88,14 +88,14 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
   if (bit_width == 8) {
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             const uint8_t* input_row = weight_data + row * embedding_cols;
             std::uint8_t* output_row = output_data + row * output_columns;
             float* output_row_scale_bias =
                 reinterpret_cast<float*>(output_row + embedding_cols);
             output_row_scale_bias[0] = weight_scales[row];
             output_row_scale_bias[1] = weight_bias[row];
-            for (int64_t col = 0; col < embedding_cols; ++col) {
+            for (const auto col : c10::irange(embedding_cols)) {
               output_row[col] = input_row[col];
             }
           }
@@ -107,14 +107,14 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
         (embedding_cols + num_elem_per_byte - 1) / num_elem_per_byte;
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             const uint8_t* input_row = weight_data + row * embedding_cols;
             std::uint8_t* output_row = output_data + row * output_columns;
             at::Half* output_row_scale_bias =
                 reinterpret_cast<at::Half*>(output_row + embedding_cols);
             output_row_scale_bias[0] = weight_scales[row];
             output_row_scale_bias[1] = weight_bias[row];
-            for (int64_t col = 0; col < embedding_cols; ++col) {
+            for (const auto col : c10::irange(embedding_cols)) {
               // The weight values have already been packed, so here we just
               // store it in the output tensor.
               output_row[col] = input_row[col];
@@ -229,7 +229,7 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
     const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<fbgemm::float16>(
               weight_data + row * embedding_cols, 1,
                 embedding_cols, output_data + row * output_columns);
@@ -240,7 +240,7 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
     const auto weight_data = weight.data_ptr<float>();
     at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
               weight_data + row * embedding_cols, 1,
                 embedding_cols, output_data + row * output_columns);
@@ -344,7 +344,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
       const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
       at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<fbgemm::float16>(
               bit_width, weight_data + row * embedding_cols, 1,
               embedding_cols, output_data + row * output_shape[1]);
@@ -355,7 +355,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
       const auto weight_data = weight.data_ptr<float>();
       at::parallel_for(
         0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (int64_t row = start_idx; row < end_idx; ++row) {
+          for (const auto row : c10::irange(start_idx, end_idx)) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
               bit_width, weight_data + row * embedding_cols, 1,
               embedding_cols, output_data + row * output_shape[1]);
@@ -369,7 +369,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
         ? weight_contig.to(at::ScalarType::Float)
         : weight_contig;
     const auto weight_data = float_weight.data_ptr<float>();
-    for (int row = 0; row < embedding_rows; ++row) {
+    for (const auto row : c10::irange(embedding_rows)) {
       const float* input_row = weight_data + row * embedding_cols;
       std::uint8_t* output_row = output_data + row * output_columns;
 


### PR DESCRIPTION
Summary:
Modified loops in files under fbsource/fbcode/caffe2/ from the format

`for(TYPE var=x0;var<x_max;x++)`

to the format

`for(const auto var: irange(xmax))`

This was achieved by running r-barnes's loop upgrader script (D28874212) with some modification to exclude all files under /torch/jit and a number of reversions or unused variable suppression warnings added by hand.

Test Plan: Sandcastle

Differential Revision: D31705365

