### PR TITLE
Fix sign warnings in CUDA kernels

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -4,9 +4,10 @@
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/cuda/Loops.cuh>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <ATen/native/cuda/Loops.cuh>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <type_traits>
 
@@ -98,7 +99,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   } else if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        if (!std::is_unsigned<scalar_t>::value && (a < 0) != (b < 0)) {
+        if (c10::signs_differ(a, b)) {
           // Subtracts one from the results of truncation division if the
           // divisor and dividend have different sign(bit)s and the remainder of
           // the division is nonzero

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <type_traits>
 
@@ -17,7 +18,7 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         scalar_t r = a % b;
-        if (!std::is_unsigned<scalar_t>::value && (r != 0) && ((r < 0) != (b < 0))) {
+        if (r != 0 && c10::signs_differ(r, b)) {
           r += b;
         }
         return r;
@@ -28,7 +29,7 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
           auto mod = ::fmod(a, b);
-          if (!std::is_unsigned<scalar_t>::value && (mod != 0) && ((b < 0) != (mod < 0))) {
+          if (mod != 0 && c10::signs_differ(b, mod)) {
             mod += b;
           }
           return mod;

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -6,6 +6,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <type_traits>
 
@@ -38,8 +39,7 @@ void sign_kernel_cuda(TensorIteratorBase& iter){
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "sign_cuda", [&]() {
         gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-            scalar_t zero = scalar_t(0);
-            return (zero < a) - (a < zero);
+            return c10::signum(a);
         });
     });
   }
@@ -47,7 +47,7 @@ void sign_kernel_cuda(TensorIteratorBase& iter){
 
 void signbit_kernel_cuda(TensorIteratorBase& iter){
   AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return !std::is_unsigned<scalar_t>::value && a < 0; });
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return is_negative(a); });
   });
 }
 

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -11,7 +11,9 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/C++17.h>
+#include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/complex.h>
+#include <type_traits>
 
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
 #include <cmath>
@@ -49,6 +51,8 @@
 #else
 #define C10_DEVICE_HOST_FUNCTION
 #endif
+
+#include <typeinfo> // operator typeid
 
 namespace c10 {
 
@@ -256,9 +260,9 @@ inline float fp16_ieee_to_fp32_value(uint16_t h) {
    * exponent == 0). However, they also do not operate on denormal inputs, and
    * do not produce denormal results.
    */
-  const uint32_t exp_offset = UINT32_C(0xE0) << 23;
+  constexpr uint32_t exp_offset = UINT32_C(0xE0) << 23;
   // const float exp_scale = 0x1.0p-112f;
-  uint32_t scale_bits = (uint32_t)15 << 23;
+  constexpr uint32_t scale_bits = (uint32_t)15 << 23;
   float exp_scale_val;
   std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
   const float exp_scale = exp_scale_val;
@@ -296,8 +300,8 @@ inline float fp16_ieee_to_fp32_value(uint16_t h) {
    * single-precision number to get the numerical equivalent of the input
    * half-precision number.
    */
-  const uint32_t magic_mask = UINT32_C(126) << 23;
-  const float magic_bias = 0.5f;
+  constexpr uint32_t magic_mask = UINT32_C(126) << 23;
+  constexpr float magic_bias = 0.5f;
   const float denormalized_value =
       fp32_from_bits((two_w >> 17) | magic_mask) - magic_bias;
 
@@ -309,7 +313,7 @@ inline float fp16_ieee_to_fp32_value(uint16_t h) {
    * - Combine the result of conversion of exponent and mantissa with the sign
    * of the input number.
    */
-  const uint32_t denormalized_cutoff = UINT32_C(1) << 27;
+  constexpr uint32_t denormalized_cutoff = UINT32_C(1) << 27;
   const uint32_t result = sign |
       (two_w < denormalized_cutoff ? fp32_to_bits(denormalized_value)
                                    : fp32_to_bits(normalized_value));
@@ -328,8 +332,8 @@ inline float fp16_ieee_to_fp32_value(uint16_t h) {
 inline uint16_t fp16_ieee_from_fp32_value(float f) {
   // const float scale_to_inf = 0x1.0p+112f;
   // const float scale_to_zero = 0x1.0p-110f;
-  uint32_t scale_to_inf_bits = (uint32_t)239 << 23;
-  uint32_t scale_to_zero_bits = (uint32_t)17 << 23;
+  constexpr uint32_t scale_to_inf_bits = (uint32_t)239 << 23;
+  constexpr uint32_t scale_to_zero_bits = (uint32_t)17 << 23;
   float scale_to_inf_val, scale_to_zero_val;
   std::memcpy(&scale_to_inf_val, &scale_to_inf_bits, sizeof(scale_to_inf_val));
   std::memcpy(
@@ -453,12 +457,10 @@ overflows(From f) {
     // allow for negative numbers to wrap using two's complement arithmetic.
     // For example, with uint8, this allows for `a - b` to be treated as
     // `a + 255 * b`.
-    constexpr bool can_overflow =
-        std::numeric_limits<From>::digits > limit::digits;
-    return (can_overflow && f > limit::max()) ||
-        (f < 0 && -static_cast<uint64_t>(f) > limit::max());
+    return greater_than_max<To>(f) ||
+        (c10::is_negative(f) && -static_cast<uint64_t>(f) > limit::max());
   } else {
-    return f < limit::lowest() || f > limit::max();
+    return f < limit::lowest() || greater_than_max<To>(f);
   }
 }
 

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <limits>
+#include <type_traits>
+
+namespace c10 {
+
+/// Returns false since we cannot have x < 0 if x is unsigned.
+template <typename T>
+static inline constexpr bool is_negative(
+    const T& x,
+    std::true_type is_unsigned) {
+  return false;
+}
+
+/// Returns true if a signed variable x < 0
+template <typename T>
+static inline constexpr bool is_negative(
+    const T& x,
+    std::false_type is_unsigned) {
+  return x < T(0);
+}
+
+/// Returns true if x < 0
+/// NOTE: Will fail on an unsigned custom type
+///       For the most part it's possible to fix this if
+///       the custom type has a constexpr constructor.
+///       However, notably, c10::Half does not :-(
+template <typename T>
+inline constexpr bool is_negative(const T& x) {
+  return is_negative(x, std::is_unsigned<T>());
+}
+
+/// Returns the sign of an unsigned variable x as 0, 1
+template <typename T>
+static inline constexpr int signum(const T& x, std::true_type is_unsigned) {
+  return T(0) < x;
+}
+
+/// Returns the sign of a signed variable x as -1, 0, 1
+template <typename T>
+static inline constexpr int signum(const T& x, std::false_type is_unsigned) {
+  return (T(0) < x) - (x < T(0));
+}
+
+/// Returns the sign of x as -1, 0, 1
+/// NOTE: Will fail on an unsigned custom type
+///       For the most part it's possible to fix this if
+///       the custom type has a constexpr constructor.
+///       However, notably, c10::Half does not :-(
+template <typename T>
+inline constexpr int signum(const T& x) {
+  return signum(x, std::is_unsigned<T>());
+}
+
+/// Returns true if a and b are not both negative
+template <typename T, typename U>
+inline constexpr bool signs_differ(const T& a, const U& b) {
+  return is_negative(a) != is_negative(b);
+}
+
+/// Returns true if x is greater than the greatest value of the type Limit
+template <typename Limit, typename T>
+inline constexpr bool greater_than_max(const T& x) {
+  constexpr bool can_overflow =
+      std::numeric_limits<T>::digits > std::numeric_limits<Limit>::digits;
+  return can_overflow && x > std::numeric_limits<Limit>::max();
+}
+
+} // namespace c10


### PR DESCRIPTION
Summary:
Fixes:
```
stderr: caffe2/aten/src/ATen/native/cuda/UnarySignKernels.cu: In lambda function:
caffe2/aten/src/ATen/native/cuda/UnarySignKernels.cu:49:72: error: comparison is always false due to limited range of data type [-Werror=type-limits]
   49 |   AT_DISPATCH_ALL_TYPES_AND2 (https://github.com/pytorch/pytorch/commit/b60050e96a44e6d068bbfa0c3f61000eaf460404)(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
      |                                                                      ~~^~~
stderr: caffe2/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu: In lambda function:
caffe2/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu:99:86: error: comparison is always false due to limited range of data type [-Werror=type-limits]
   99 |     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
      |                                                                                      ^
caffe2/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu:99:97: error: comparison is always false due to limited range of data type [-Werror=type-limits]
   99 |     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
      |                                                                                                 ^
```
I thought I'd fixed this previously using `std::is_unsigned`, but apparently not.

Differential Revision: D31708173

