### PR TITLE
[doc] typo

### DIFF
--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -223,7 +223,7 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, FunctionCtx, _Hook
     r"""Base class to create custom `autograd.Function`
 
     To create a custom `autograd.Function`, subclass this class and implement
-    the :meth:`forward` and :meth`backward` static methods. Then, to use your custom
+    the :meth:`forward` and :meth:`backward` static methods. Then, to use your custom
     op in the forward pass, call the class method ``apply``. Do not call
     :meth:`forward` directly.
 


### PR DESCRIPTION
This PR fixes a typo in the `torch/autograd/function.py` doc

-----------------------

Additionally, the example at https://pytorch.org/docs/master/autograd.html#torch.autograd.Function doesn't quite compile:
```
'builtin_function_or_method' object has no attribute 'exp'
```
even though `i.exp()` is a valid function if `i` is a tensor.

I changed it to:
```
result = torch.exp(i)
```
but python doesn't like it either:
```
TypeError: exp(): argument 'input' (position 1) must be Tensor, not builtin_function_or_method
```