### PR TITLE
[caffe2] Fix invalid vector accesses and polar() call

### DIFF
--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -587,7 +587,9 @@ C10_HOST_DEVICE complex<T> polar(const T& r, const T& theta = T()) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<complex<T>>(thrust::polar(r, theta));
 #else
-  return static_cast<complex<T>>(std::polar(r, theta));
+  // std::polar() requires r >= 0, so spell out the explicit implementation to
+  // avoid a branch.
+  return complex<T>(r * std::cos(theta), r * std::sin(theta));
 #endif
 }
 

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -641,8 +641,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           case INST(ISINSTANCE): {
             INST_GUARD;
             at::ArrayRef<TypePtr> types(
-                &(frame.function->type_table_[inst.X]),
-                &(frame.function->type_table_[inst.X + inst.N]));
+                &frame.function->type_table_[inst.X],
+                &frame.function->type_table_[inst.X] + inst.N);
             isinstance(stack, types);
           }
             INST_NEXT;
@@ -924,10 +924,13 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
   }
 
   void run(Stack& stack) {
+    // By the time the continuation completes the frame will be gone, so this
+    // must be done before calling runImpl().
+    TORCH_INTERNAL_ASSERT(!frames.empty());
+    const auto num_outputs = frames.front().function->n_outputs;
     if (runImpl(stack)) {
       future_->wait();
 
-      auto num_outputs = frames.front().function->n_outputs;
       if (num_outputs == 1) {
         push(stack, future_->value());
       } else {


### PR DESCRIPTION
Summary:
`InterpreterStateImpl::run()` gets the number of outputs from the current frame, but by the time the continuation completes, the frame is gone, so we're calling `front()` on an empty vector. This works out in practice (data is still there) but it is technically undefined behavior and could break in the future.

Also, `std::polar()` expects its argument to be non-negative, but `c10::polar()` does not, so implement it explicitly (implementation is the same as libstdc++).

Test Plan: JIT tests pass.

Differential Revision: D31715587

