### PR TITLE
[LTC] Code-gen `log2`

### DIFF
--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -14,6 +14,7 @@ full_codegen:
   - dropout
   - gelu
   - gelu_backward
+  - log2
   - mean
   - mm
   - mv


### PR DESCRIPTION
Summary:
This commit adds code-gen support for the log2 op.

Test Plan:
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestLog2

