### PR TITLE
[skip ci] Change pretrained to false for quantization tests

### DIFF
--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -2044,7 +2044,7 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
     @unittest.skip("TODO: broken by https://github.com/pytorch/pytorch/pull/61687, will enable later")
     def test_resnet18(self):
         import torchvision
-        m = torchvision.models.quantization.resnet18(pretrained=True, quantize=False).eval()
+        m = torchvision.models.quantization.resnet18(pretrained=False, quantize=False).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         self._test_match_shadow_activations(
             m, (torch.randn(1, 3, 224, 224),),
@@ -2056,7 +2056,7 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
     @unittest.skip("TODO: broken by https://github.com/pytorch/pytorch/pull/61687, will enable later")
     def test_mobilenet_v2(self):
         import torchvision
-        m = torchvision.models.quantization.mobilenet_v2(pretrained=True, quantize=False).eval()
+        m = torchvision.models.quantization.mobilenet_v2(pretrained=False, quantize=False).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         self._test_match_shadow_activations(
             m, (torch.randn(1, 3, 224, 224),),

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5356,7 +5356,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
                 kwargs["transform_input"] = False
             eager_quantizable_model = None
             if name in quantized_model_list:
-                eager_quantizable_model = quantized_models.__dict__[name](pretrained=True, quantize=False, **kwargs).eval().float()
+                eager_quantizable_model = quantized_models.__dict__[name](pretrained=False, quantize=False, **kwargs).eval().float()
             # compare with eager mode quantized model when it is available
             pretrained = eager_quantizable_model is not None
             model = models.__dict__[name](pretrained=pretrained, **kwargs).eval().float()
@@ -5395,8 +5395,8 @@ class TestQuantizeFxModels(QuantizationTestCase):
     def test_resnet18_ddp(self):
         from torchvision import models
         from torchvision.models import quantization as quantized_models
-        eager_quantizable_model = quantized_models.__dict__[name](pretrained=True, quantize=False).eval().float()
-        model = models.__dict__[name](pretrained=True).eval().float()
+        eager_quantizable_model = quantized_models.__dict__[name](pretrained=False, quantize=False).eval().float()
+        model = models.__dict__[name](pretrained=False).eval().float()
         self._test_model_impl(
             'ddp', 'resnet18', model, eager_quantizable_model)
 


### PR DESCRIPTION
Helps resolve a bit of https://github.com/pytorch/pytorch/issues/65439 

skipping ci as all tests this change affects are skipped.