### PR TITLE
fixed type checking errors in fuse.py

### DIFF
--- a/torch/ao/quantization/fx/fuse.py
+++ b/torch/ao/quantization/fx/fuse.py
@@ -28,7 +28,7 @@ from .quantization_types import Pattern
 class Fuser:
     def fuse(
         self, model: GraphModule, fuse_custom_config_dict: Optional[Dict[str, Any]] = None
-    ) -> GraphModule: 
+    ) -> GraphModule:
         if fuse_custom_config_dict is None:
             fuse_custom_config_dict = {}
 

--- a/torch/ao/quantization/fx/fuse.py
+++ b/torch/ao/quantization/fx/fuse.py
@@ -5,33 +5,30 @@ from torch.fx import (
     Node,
     map_arg
 )
-
 from torch.fx.graph import Graph
-
 from ..utils import (
     get_combined_dict
 )
-
+from .graph_module import (
+    FusedGraphModule
+)
+from .match_utils import is_match
 from .pattern_utils import (
     get_default_fusion_patterns,
 )
 
-from .match_utils import is_match
-
-from .graph_module import (
-    FusedGraphModule
-)
-
 from .fusion_patterns import *  # noqa: F401,F403
+
+from typing import Callable, Tuple
+from typing import Optional
 
 from .quantization_types import Pattern
 
-from typing import Callable, Tuple
-
 
 class Fuser:
-    def fuse(self, model: GraphModule,
-             fuse_custom_config_dict: Dict[str, Any] = None) -> GraphModule:
+    def fuse(
+        self, model: GraphModule, fuse_custom_config_dict: Optional[Dict[str, Any]] = None
+    ) -> GraphModule: 
         if fuse_custom_config_dict is None:
             fuse_custom_config_dict = {}
 


### PR DESCRIPTION
Fixes [Issue#70](https://github.com/MLH-Fellowship/pyre-check/issues/70)
This PR fixes the type checking error that was found in fuse.py as follows:

torch/quantization/fx/fuse.py:34:13 Incompatible variable type [9]: fuse_custom_config_dict is declared to have type `Dict[str, typing.Any]` but is used as type `None`.


Signed-off-by: Onyemowo Agbo
