### PR TITLE
Increase sleep time for test_nccl_timeout

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2378,6 +2378,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
                     raise e
             time.sleep(1)
 
+    @skip_if_rocm
     @with_nccl_blocking_wait
     @requires_nccl()
     @skip_if_lt_x_gpu(3)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2378,7 +2378,6 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
                     raise e
             time.sleep(1)
 
-    @skip_if_rocm
     @with_nccl_blocking_wait
     @requires_nccl()
     @skip_if_lt_x_gpu(3)
@@ -2398,7 +2397,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
                 process_group.allreduce(torch.rand(10).cuda(self.rank)).wait(timeout=timedelta(seconds=1))
         else:
             # Sleep to ensure timeout.
-            time.sleep(10)
+            time.sleep(15)
 
             self._wait_for_comm_abort(process_group)
 


### PR DESCRIPTION
Increase sleep time for test_nccl_timeout (__main__.NcclErrorHandlingTest) to fix flakiness on the ROCm test branch. The test sometimes will terminate before timeout which causes issues.

Signed-off-by: Kyle Chen <kylechen@amd.com>

@jeffdaily 

Increasing the sleep time will fix the following issue:
```
======================================================================
ERROR [14.854s]: test_nccl_timeout (__main__.NcclErrorHandlingTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 424, in wrapper
    self._join_processes(fn)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 643, in _join_processes
    self._check_return_codes(elapsed_time)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 688, in _check_return_codes
    raise RuntimeError(error)
RuntimeError: Process 0 exited with error code 10 and exception:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 542, in run_test
    getattr(self, test_name)()
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 426, in wrapper
    fn()
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 176, in wrapper
    ret = func(*args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_utils.py", line 2898, in wrapper
    return func(*args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_distributed.py", line 112, in wrapper
    return func(*args, **kwargs)
  File "/var/lib/jenkins/workspace/test/distributed/test_c10d_nccl.py", line 2397, in test_nccl_timeout
    process_group.allreduce(torch.rand(10).cuda(self.rank)).wait(timeout=timedelta(seconds=1))
  File "/opt/conda/lib/python3.6/unittest/case.py", line 203, in __exit__
    self._raiseFailure("{} not raised".format(exc_name))
  File "/opt/conda/lib/python3.6/unittest/case.py", line 135, in _raiseFailure
    raise self.test_case.failureException(msg)
AssertionError: RuntimeError not raised
```

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport