### PR TITLE
[LTC] Bug fix in lazy_ir.py + code-gen softplus, softplus_backward

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -2129,19 +2129,6 @@ LazyTensor smooth_l1_loss_backward(const LazyTensor& grad_output,
                                           GetReductionMode(reduction), beta);
 }
 
-LazyTensor softplus(const LazyTensor& input, const at::Scalar& beta,
-                    const at::Scalar& threshold) {
-  return tensor_ops::Softplus(input, beta, threshold);
-}
-
-LazyTensor softplus_backward(const LazyTensor& grad_output,
-                             const LazyTensor& input, const at::Scalar& beta,
-                             const at::Scalar& threshold,
-                             const LazyTensor& output) {
-  return tensor_ops::SoftplusBackward(grad_output, input, beta, threshold,
-                                      output);
-}
-
 LazyTensor softshrink(const LazyTensor& input, const at::Scalar& lambda) {
   return input.CreateFrom(
       ir::MakeNode<ir::ops::Softshrink>(input.GetIrValue(), lambda));

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -770,13 +770,6 @@ LazyTensor softmax(const LazyTensor& input, lazy_tensors::int64 dim,
 LazyTensor softmax_backward(const LazyTensor& grad_output,
                             const LazyTensor& output, lazy_tensors::int64 dim);
 
-LazyTensor softplus(const LazyTensor& input, const at::Scalar& beta,
-                    const at::Scalar& threshold);
-LazyTensor softplus_backward(const LazyTensor& grad_output,
-                             const LazyTensor& input, const at::Scalar& beta,
-                             const at::Scalar& threshold,
-                             const LazyTensor& output);
-
 LazyTensor softshrink(const LazyTensor& input, const at::Scalar& lambda);
 LazyTensor softshrink_backward(const LazyTensor& grad_out,
                                const LazyTensor& input,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
@@ -196,27 +196,6 @@ LazyTensor SmoothL1LossBackward(const LazyTensor& grad_output,
   }
 }
 
-LazyTensor Softplus(const LazyTensor& input, const at::Scalar& beta,
-                    const at::Scalar& threshold) {
-  return tensor_aten_ops::where(
-      tensor_aten_ops::gt(tensor_aten_ops::mul(input, beta), threshold), input,
-      tensor_aten_ops::div(tensor_aten_ops::log1p(tensor_aten_ops::exp(
-                               tensor_aten_ops::mul(input, beta))),
-                           beta));
-}
-
-LazyTensor SoftplusBackward(const LazyTensor& grad_output,
-                            const LazyTensor& input, const at::Scalar& beta,
-                            const at::Scalar& threshold,
-                            const LazyTensor& output) {
-  LazyTensor scaled_input = tensor_aten_ops::mul(input, beta);
-  LazyTensor z = tensor_aten_ops::exp(tensor_aten_ops::mul(output, beta));
-  return tensor_aten_ops::where(
-      tensor_aten_ops::gt(scaled_input, threshold), grad_output,
-      tensor_aten_ops::mul(
-          grad_output, tensor_aten_ops::div(tensor_aten_ops::sub(z, 1, 1), z)));
-}
-
 LazyTensor Select(const LazyTensor& input, lazy_tensors::int64 dim,
                   lazy_tensors::int64 index) {
   auto shape = input.shape();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.h
@@ -28,14 +28,6 @@ LazyTensor SmoothL1LossBackward(const LazyTensor& grad_output,
                                 const LazyTensor& target,
                                 ReductionMode reduction, double beta);
 
-LazyTensor Softplus(const LazyTensor& input, const at::Scalar& beta,
-                    const at::Scalar& threshold);
-
-LazyTensor SoftplusBackward(const LazyTensor& grad_output,
-                            const LazyTensor& input, const at::Scalar& beta,
-                            const at::Scalar& threshold,
-                            const LazyTensor& output);
-
 LazyTensor Select(const LazyTensor& input, lazy_tensors::int64 dim,
                   lazy_tensors::int64 index);
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -22,6 +22,8 @@ full_codegen:
   - native_layer_norm_backward
   - rsqrt
   - sigmoid
+  - softplus
+  - softplus_backward
   - topk
 supported:
   - add.Tensor

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -169,8 +169,11 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
             meta_out = """auto out_shape = CreateComputationShapeFromMetaTensors(out_meta);
     auto out_dtype = CreateDTypeFromMetaTensors(out_meta);"""
 
-        meta_args = ", ".join([f"{t.name}.to(c10::kMeta)" for t in value_types] +
-                              [f"{t.name}" for t in scalar_types])
+        meta_args_list = []
+        for t in all_types:
+            meta_arg = f"{t.name}.to(c10::kMeta)" if t in value_types else f"{t.name}"
+            meta_args_list.append(meta_arg)
+        meta_args = ", ".join(meta_args_list)
         meta_str = f"""auto out_meta = at::meta::{schema.aten_name}({meta_args});
     {meta_out}"""
     else:


### PR DESCRIPTION
Summary:
This commit fixes a bug in the codegen that was not preserving the
order of arguments when generating part of the body of the functions
in `LazyNativeFunctions.cpp`. This commit also adds codegen for
`softplus` and `softplus_backward` to test the implementation.

Test Plan:
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestSoftplus*

Change in code-gen in `LazyNativeFunctions.cpp`:

```diff
// TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
at::Tensor LazyNativeFunctions::softplus_backward(const at::Tensor & grad_output, const at::Tensor & self, const at::Scalar & beta, const at::Scalar & threshold, const at::Tensor & output) {
    LTC_FN_COUNTER("lazy::");
    LazyTensor l_grad_output = bridge::GetLtcTensor(grad_output);
    LazyTensor l_self = bridge::GetLtcTensor(self);
    LazyTensor l_output = bridge::GetLtcTensor(output);
-   auto out_meta = at::meta::softplus_backward(grad_output.to(c10::kMeta), self.to(c10::kMeta), output.to(c10::kMeta), beta, threshold);
+   auto out_meta = at::meta::softplus_backward(grad_output.to(c10::kMeta), self.to(c10::kMeta), beta, threshold, output.to(c10::kMeta));
    std::vector<std::vector<int64_t>> out_shape{out_meta.sizes().vec()};
    std::vector<c10::ScalarType> out_dtype{out_meta.scalar_type()};
    auto node = ir::MakeNode<ir::ops::SoftplusBackward>(l_grad_output.GetIrValue(),
                              l_self.GetIrValue(),
                              beta,
                              threshold,
                              l_output.GetIrValue(), out_dtype, out_shape);
    auto result = bridge::AtenFromLtcTensor(l_grad_output.CreateFrom(node,
        // TODO (@wconstab): experiment on dtype
        // try always overriding output dtype to match the one ATen says our op should produce.
        // this diverges from most of the handwritten methods, which often do not override and
        // rely on other behavior in the lowering or copy process to make this correct.
        // (1) evaluate design goal: to always pick the IR's dtype in one place (here)
        // (2) rationalize this with Google's design, it may be a problem
        // (3) evaluate perf impact: make sure we're not actually doing casts becuase of this override
        out_dtype.front()));
    return result;
};
```
