### PR TITLE
Fix doc string for torch.acosh 

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -185,12 +185,12 @@ acosh(input, *, out=None) -> Tensor
 
 Returns a new tensor with the inverse hyperbolic cosine of the elements of :attr:`input`.
 
+.. math::
+    \text{out}_{i} = \cosh^{-1}(\text{input}_{i})
+
 Note:
     The domain of the inverse hyperbolic cosine is `[1, inf)` and values outside this range
     will be mapped to ``NaN``, except for `+ INF` for which the output is mapped to `+ INF`.
-
-.. math::
-    \text{out}_{i} = \cosh^{-1}(\text{input}_{i})
 """ + r"""
 Args:
     {input}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66814

Differential Revision: [D31742677](https://our.internmc.facebook.com/intern/diff/D31742677)

Addresses #65905 In preview docs built
https://docs-preview.pytorch.org/66814/generated/torch.acosh.html#torch.acosh equation is now above note

<img width="922" alt="Screen Shot 2021-10-18 at 5 12 13 PM" src="https://user-images.githubusercontent.com/35276741/137810849-18f0bfdd-71cb-444a-8785-82384870f07c.png">

