### PR TITLE
Fix dropout backward by not tracing it

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
@@ -50,14 +50,6 @@ namespace torch_lazy_tensors{
 namespace ir {
 namespace ops {
 
-std::vector<std::vector<int64_t>> compute_shape_dropout(const at::Tensor& input, double p, bool train) {
-  return {input.sizes().vec()};
-}
-
-std::vector<c10::ScalarType> compute_dtype_dropout(const at::Tensor& input, double p, bool train) {
-  return {input.scalar_type()};
-}
-
 std::vector<std::vector<int64_t>> compute_shape_native_layer_norm(const at::Tensor & input,
     at::IntArrayRef normalized_shape, const c10::optional<at::Tensor> & weight, const c10::optional<at::Tensor> & bias,
     double eps) {

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -13,7 +13,6 @@ full_codegen:
   - bmm
   - cos
   - clamp
-  - dropout
   - gelu
   - gelu_backward
   - log2


### PR DESCRIPTION
- dropout is a CompositeImplicitAutograd op, which means in order for Autograd to implicitly materialize its backward ops, Autograd has to trace through the 'dropout' kernel on CPU (which in turn just executes other ATen ops, which have explicit backwards implementations).
- Lazy tracing of CompositeImplicitAutograd ops breaks backwards; it can't be done unless you also provide an override of the Autograd kernel for the op such as is currently done for maxpool
- See this https://github.com/pytorch/pytorch/pull/67090 for an updated safety check we're adding to prevent this in the future