### PR TITLE
ATen | Fix potential crash if `MTLCreateSystemDefaultDevice` return nil

### DIFF
--- a/aten/src/ATen/native/metal/MetalDevice.h
+++ b/aten/src/ATen/native/metal/MetalDevice.h
@@ -16,7 +16,9 @@ struct MetalDeviceInfo {
 
 static inline MetalDeviceInfo createDeviceInfo(id<MTLDevice> device) {
   MetalDeviceInfo device_info;
-  device_info.name = device.name.UTF8String;
+  if (device.name != nil) {
+    device_info.name = device.name.UTF8String;
+  }
   if (@available(macOS 11.0, iOS 14.0, *)) {
     device_info.languageVersion = MTLLanguageVersion2_3;
   } else if (@available(macOS 10.15, iOS 13.0, *)) {


### PR DESCRIPTION
Summary:
`MTLCreateSystemDefaultDevice` can return `nil`. If that happens then inside `createDeviceInfo`, we'll crash trying to convert the `nullptr` from `device.name.UTF8String` into a `std::string`.

Let's fix it by returning early in setup if there's no Metal device. But also make `createDeviceInfo` safe if we do pass in `nil`.

Test Plan: * CircleCI

Differential Revision: D31759690

