### PR TITLE
Add static_runtime::fused_equally_split

### DIFF
--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -277,6 +277,18 @@ void testStaticRuntime(
   compareTensorLists(args_tensors, args_copy, use_allclose, use_equalnan);
 }
 
+bool hasProcessedNodeWithName(
+    torch::jit::StaticModule& smodule,
+    const char* name) {
+  for (torch::jit::ProcessedNode& pnode : smodule.runtime().nodes()) {
+    auto op_name = pnode.node()->kind().toQualString();
+    if (strcmp(op_name, name) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace test
 } // namespace jit
 } // namespace torch

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
 
 namespace c10 {
 struct IValue;
@@ -29,6 +30,8 @@ void testStaticRuntime(
     const bool use_equalnan = false);
 
 std::shared_ptr<Graph> getGraphFromIR(const std::string& ir);
+
+bool hasProcessedNodeWithName(torch::jit::StaticModule& smodule, const char *name);
 
 } // namespace test
 } // namespace jit


### PR DESCRIPTION
Summary: Adds `static_runtime::fused_equally_split` operator and removes `is_fused` logic from original operator. Modifies `FuseUnpackListV2` to map `fb::equally_split` to this new operator.

Test Plan:
```
adityapillai@5960 /data/sandcastle/boxes/fbsource/fbcode 1m 13s
❯ buck test //caffe2/benchmarks/static_runtime/fb:test_fb_operators
```
and sandcastle
strange_what_could_go_wrong

Differential Revision: D31742293

