### PR TITLE
Unsqueeze bug fix

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1147,6 +1147,10 @@ def acc_ops_unsqueeze(network, target, args, kwargs, name):
                            "of the TensorRT region!")
 
     dim = kwargs["dim"]
+    input_shape = input_val.shape
+    input_shape_size = len(input_val.shape) + 1 if network.has_implicit_batch_dimension else len(input_val.shape)
+    if dim < 0:
+        dim = dim % (input_shape_size + 1)
     if network.has_implicit_batch_dimension:
         assert dim != 0
         dim -= 1


### PR DESCRIPTION
Summary: Added support for negative dims and modified unit test.

Test Plan: buck test mode/dev-nosan caffe2/test/fx2trt/converters:test_unsqueeze

Differential Revision: D31769393

