### PR TITLE
[LTC] Code-gen addcdiv_

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -454,14 +454,6 @@ LazyTensor add(const LazyTensor& input, const at::Scalar& other,
                           logical_element_type);
 }
 
-void addcdiv_(LazyTensor& input, const at::Scalar& value,
-              const LazyTensor& tensor1, const LazyTensor& tensor2) {
-  ir::Value constant = LazyTensor::GetIrValueForScalar(
-      value, tensor1.shape().get().element_type(), input.GetDevice());
-  ir::Value div = tensor1.GetIrValue() / tensor2.GetIrValue();
-  input.SetInPlaceIrValue(input.GetIrValue() + div * constant);
-}
-
 LazyTensor addmm(const LazyTensor& input, const LazyTensor& weight,
                  const LazyTensor& bias) {
   return input.CreateFrom(ir::ops::AddMatMulOp(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -63,9 +63,6 @@ LazyTensor add(
     const LazyTensor& input, const at::Scalar& other, const at::Scalar& alpha,
     c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
-void addcdiv_(LazyTensor& input, const at::Scalar& value,
-              const LazyTensor& tensor1, const LazyTensor& tensor2);
-
 LazyTensor addmm(const LazyTensor& input, const LazyTensor& weight,
                  const LazyTensor& bias);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -86,17 +86,6 @@ at::Tensor LazyNativeFunctions::add(const at::Tensor& self,
                     });
 }
 
-at::Tensor& LazyNativeFunctions::addcdiv_(at::Tensor& self,
-                                         const at::Tensor& tensor1,
-                                         const at::Tensor& tensor2,
-                                         const at::Scalar& value) {
-  LTC_FN_COUNTER("lazy::");
-  LazyTensor self_tensor = bridge::GetLtcTensor(self);
-  tensor_aten_ops::addcdiv_(self_tensor, value, bridge::GetLtcTensor(tensor1),
-                            bridge::GetLtcTensor(tensor2));
-  return self;
-}
-
 at::Tensor LazyNativeFunctions::addmm(const at::Tensor& self,
                                       const at::Tensor& mat1,
                                       const at::Tensor& mat2,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -24,7 +24,6 @@ full_codegen:
   - topk
 supported:
   - add.Tensor
-  - addcdiv_
   - as_strided
   - as_strided_
   - bernoulli


### PR DESCRIPTION
Summary:
This patch code-generated addcdiv_. In-place op variants for structured ops are supported via auto-generated wrappers in the RegisterLazy.cpp. Hence, we just need to remove addcdiv_ in the list.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestAddCDiv*

Fixes #65576.
