### PR TITLE
Wextra fix for NamedTensor.cpp

### DIFF
--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -221,7 +221,7 @@ Tensor align_to(const Tensor& tensor, DimnameList order, int64_t ellipsis_idx) {
   };
 
   // Fill in the non-ellipsis dimensions
-  for (const auto order_idx : c10::irange(0U, order.size())) {
+  for (const auto order_idx : c10::irange(static_cast<int64_t>(order.size()))) {
     auto out_idx = order_idx;
     if (order_idx >= ellipsis_idx) {
       out_idx = order_idx + num_ellipsis_names;

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -4,9 +4,10 @@
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/cuda/Loops.cuh>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
-#include <ATen/native/cuda/Loops.cuh>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <type_traits>
 
@@ -98,7 +99,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   } else if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        if (!std::is_unsigned<scalar_t>::value && (a < 0) != (b < 0)) {
+        if (c10::signs_differ(a, b)) {
           // Subtracts one from the results of truncation division if the
           // divisor and dividend have different sign(bit)s and the remainder of
           // the division is nonzero

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <type_traits>
 
@@ -17,7 +18,7 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         scalar_t r = a % b;
-        if (!std::is_unsigned<scalar_t>::value && (r != 0) && ((r < 0) != (b < 0))) {
+        if (r != 0 && c10::signs_differ(r, b)) {
           r += b;
         }
         return r;
@@ -28,7 +29,7 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
           auto mod = ::fmod(a, b);
-          if (!std::is_unsigned<scalar_t>::value && (mod != 0) && ((b < 0) != (mod < 0))) {
+          if (mod != 0 && c10::signs_differ(b, mod)) {
             mod += b;
           }
           return mod;

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -6,6 +6,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
+#include <c10/util/TypeSafeSignMath.h>
 
 #include <type_traits>
 
@@ -38,8 +39,7 @@ void sign_kernel_cuda(TensorIteratorBase& iter){
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "sign_cuda", [&]() {
         gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-            scalar_t zero = scalar_t(0);
-            return (zero < a) - (a < zero);
+            return c10::signum(a);
         });
     });
   }
@@ -47,7 +47,7 @@ void sign_kernel_cuda(TensorIteratorBase& iter){
 
 void signbit_kernel_cuda(TensorIteratorBase& iter){
   AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return !std::is_unsigned<scalar_t>::value && a < 0; });
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return is_negative(a); });
   });
 }
 

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <limits>
+#include <type_traits>
+
+namespace c10 {
+
+/// Returns false since we cannot have x < 0 if x is unsigned.
+template <typename T>
+static inline constexpr bool is_negative(
+    const T& x,
+    std::false_type is_signed) {
+  return false;
+}
+
+/// Returns true if a signed variable x < 0
+template <typename T>
+static inline constexpr bool is_negative(const T& x, std::true_type is_signed) {
+  return x < T(0);
+}
+
+/// Returns true if x < 0
+template <typename T>
+inline constexpr bool is_negative(const T& x) {
+  return is_negative(x, std::is_signed<T>());
+}
+
+/// Returns the sign of an unsigned variable x as 0, 1
+template <typename T>
+static inline constexpr int signum(const T& x, std::false_type is_signed) {
+  return T(0) < x;
+}
+
+/// Returns the sign of a signed variable x as -1, 0, 1
+template <typename T>
+static inline constexpr int signum(const T& x, std::true_type is_signed) {
+  return (T(0) < x) - (x < T(0));
+}
+
+/// Returns the sign of x as -1, 0, 1
+template <typename T>
+inline constexpr int signum(const T& x) {
+  return signum(x, std::is_signed<T>());
+}
+
+/// Returns true if a and b are not both negative
+template <typename T, typename U>
+inline constexpr int signs_differ(const T& a, const U& b) {
+  return is_negative(a) != is_negative(b);
+}
+
+/// Returns true if x is greater than the greatest value of the type Limit
+template <typename Limit, typename T>
+inline constexpr bool greater_than_max(const T& x) {
+  constexpr bool can_overflow =
+      std::numeric_limits<T>::digits > std::numeric_limits<Limit>::digits;
+  return can_overflow && x > std::numeric_limits<Limit>::max();
+}
+
+} // namespace c10


### PR DESCRIPTION
Summary:
Fixes:
```
stderr: caffe2/aten/src/ATen/native/NamedTensor.cpp:226:19: error: comparison of integers of different signs: 'const unsigned long' and 'int64_t' (aka 'long') [-Werror,-Wsign-compare]
    if (order_idx >= ellipsis_idx) {
        ~~~~~~~~~ ^  ~~~~~~~~~~~~
stderr: caffe2/aten/src/ATen/native/NamedTensor.cpp:226:19: error: comparison of integers of different signs: 'const unsigned long' and 'int64_t' (aka 'long') [-Werror,-Wsign-compare]
    if (order_idx >= ellipsis_idx) {
        ~~~~~~~~~ ^  ~~~~~~~~~~~~
```

Test Plan: Sandcastle

Differential Revision: D31774623

