### PR TITLE
Have test classes extend from common_utils.TestCase, not unittest.TestCase

### DIFF
--- a/test/distributed/nn/jit/test_instantiator.py
+++ b/test/distributed/nn/jit/test_instantiator.py
@@ -3,7 +3,6 @@
 
 import pathlib
 import sys
-import unittest
 from typing import Tuple
 
 import torch
@@ -15,7 +14,7 @@ if not dist.is_available():
     sys.exit(0)
 
 from torch.distributed.nn.jit import instantiator
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 
 @torch.jit.interface
@@ -34,7 +33,7 @@ def create_module():
     return MyModule()
 
 
-class TestInstantiator(unittest.TestCase):
+class TestInstantiator(TestCase):
     def test_get_arg_return_types_from_interface(self):
         (
             args_str,

--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -1,17 +1,16 @@
 # Owner(s): ["module: ci"]
 
 import os
-import unittest
 
 import run_test
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 
 class DummyOptions(object):
     verbose = False
 
 
-class DeterminationTest(unittest.TestCase):
+class DeterminationTest(TestCase):
     # Test determination on a subset of tests
     TESTS = [
         "test_nn",

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -86,7 +86,7 @@ import torch.nn.functional as F
 from torch.testing._internal import jit_utils
 from torch.testing._internal.common_jit import check_against_reference
 from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, TEST_WITH_UBSAN, \
-    suppress_warnings, IS_SANDCASTLE, GRAPH_EXECUTOR, ProfilingMode, \
+    suppress_warnings, IS_SANDCASTLE, GRAPH_EXECUTOR, ProfilingMode, TestCase, \
     freeze_rng_state, slowTest, TemporaryFileName, skipIfCompiledWithoutNumpy, \
     enable_profiling_mode_for_profiling_tests, TEST_MKL, set_default_dtype, num_profiled_runs
 from torch.testing._internal.jit_utils import JitTestCase, enable_cpu_fuser, disable_autodiff_subgraph_inlining, \
@@ -16337,7 +16337,7 @@ def normalize_check_ad(check_ad, name):
     return check_ad
 
 
-class TestProducerVersion(unittest.TestCase):
+class TestProducerVersion(TestCase):
 
     def test_version(self):
         # issue gh-32561

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -1,11 +1,10 @@
 # Owner(s): ["module: autograd"]
 
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 import torch
-import unittest
 
-class TestPublicBindings(unittest.TestCase):
+class TestPublicBindings(TestCase):
     def test_no_new_bindings(self):
         """
         This test aims to stop the introduction of new JIT bindings into torch._C


### PR DESCRIPTION
This causes some functionality to not work, such as the disabling issues e.g., https://github.com/pytorch/pytorch/issues/66641

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang