### PR TITLE
[LTC] Teach code-gen about composite ops with wrapped numbers

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -109,6 +109,11 @@ LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
   return xtensor ? *xtensor : LazyTensor::Create(*tensor, device);
 }
 
+LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const Device& device) {
+  return tensor.unsafeGetTensorImpl()->is_wrapped_number() ?
+      GetOrCreateLtcTensor(tensor, device) : GetLtcTensor(tensor);
+}
+
 std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors) {
   std::vector<at::Tensor> aten_ltc_tensors(tensors.size());
   std::vector<LazyTensor> ltc_tensors;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -35,6 +35,8 @@ LazyTensor GetOrCreateLtcTensor(const at::Tensor& tensor, const Device& device);
 LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
                                 const Device& device);
 
+LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const Device& device);
+
 // Creates a vector of at::Tensor objects extracted from a list of lazy tensors.
 std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors);
 
@@ -66,6 +68,15 @@ c10::optional<Device> GetLtcDevice(const c10::Device& device);
 
 c10::optional<Device> GetLtcDevice(
     const c10::optional<c10::Device>& device = c10::nullopt);
+
+template<typename T, typename... Args>
+c10::optional<Device> GetLtcDevice(const T& tensor, const Args&... forward_tensors) {
+    auto optional_device = GetLtcDevice(tensor);
+    if (optional_device) {
+        return optional_device;
+    }
+    return GetLtcDevice(forward_tensors...);
+}
 
 Device AtenDeviceToLtcDevice(const c10::Device& device);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -434,26 +434,6 @@ LazyTensor acosh(const LazyTensor& input) {
   return input.CreateFrom(ir::ops::Acosh(input.GetIrValue()));
 }
 
-LazyTensor add(const LazyTensor& input, const LazyTensor& other,
-               const at::Scalar& alpha,
-               c10::optional<at::ScalarType> logical_element_type) {
-  ir::Value constant = LazyTensor::GetIrValueForScalar(
-      alpha, other.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(input.GetIrValue() + other.GetIrValue() * constant,
-                          logical_element_type);
-}
-
-LazyTensor add(const LazyTensor& input, const at::Scalar& other,
-               const at::Scalar& alpha,
-               c10::optional<at::ScalarType> logical_element_type) {
-  ir::Value other_constant = LazyTensor::GetIrValueForScalar(
-      other, input.shape(), logical_element_type, input.GetDevice());
-  ir::Value alpha_constant = LazyTensor::GetIrValueForScalar(
-      alpha, input.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(input.GetIrValue() + other_constant * alpha_constant,
-                          logical_element_type);
-}
-
 LazyTensor addmm(const LazyTensor& input, const LazyTensor& weight,
                  const LazyTensor& bias) {
   return input.CreateFrom(ir::ops::AddMatMulOp(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -56,13 +56,6 @@ LazyTensor acos(const LazyTensor& input);
 
 LazyTensor acosh(const LazyTensor& input);
 
-LazyTensor add(
-    const LazyTensor& input, const LazyTensor& other, const at::Scalar& alpha,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-LazyTensor add(
-    const LazyTensor& input, const at::Scalar& other, const at::Scalar& alpha,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-
 LazyTensor addmm(const LazyTensor& input, const LazyTensor& weight,
                  const LazyTensor& bias);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -74,18 +74,6 @@ at::Tensor subtensor(const at::Tensor& tensor, int dim, int groups, int g) {
 
 }  // namespace
 
-at::Tensor LazyNativeFunctions::add(const at::Tensor& self,
-                                    const at::Tensor& other,
-                                    const at::Scalar& alpha) {
-  LTC_FN_COUNTER("lazy::");
-  at::native::alpha_check(at::result_type(self, other), alpha);
-  return DoBinaryOp(self, other,
-                    [&](const LazyTensor& xself, const LazyTensor& xother,
-                        at::ScalarType dtype) {
-                      return tensor_aten_ops::add(xself, xother, alpha, dtype);
-                    });
-}
-
 at::Tensor LazyNativeFunctions::addmm(const at::Tensor& self,
                                       const at::Tensor& mat1,
                                       const at::Tensor& mat2,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -7,7 +7,6 @@ full_codegen:
   - _softmax_backward_data
   - addcdiv
   - addcmul
-  - bitwise_and.Scalar
   - bitwise_and.Tensor
   - cos
   - clamp
@@ -25,8 +24,8 @@ full_codegen:
   - softplus
   - softplus_backward
   - topk
-supported:
   - add.Tensor
+supported:
   - as_strided
   - as_strided_
   - bernoulli

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -151,8 +151,7 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
     scalar_types = schema.filtered_types(values=False, scalars=True)
     returns_length = len(schema.returns)
 
-    get_device_str = f"""auto device = bridge::GetLtcDevice({", ".join([f"{t.name}" for t in value_types])});
-    LTC_CHECK(!!device) << "None of the input tensors is a lazy tensor.";"""
+    get_device_str = f"""auto device = bridge::GetLtcDevice({", ".join([f"{t.name}" for t in value_types])});"""
     lazy_tensor_decls_str = lazy_tensor_decls(value_types)
     node_ctor_input_str = node_ctor_inputs(schema)
 

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -18,11 +18,11 @@ def node_ctor_inputs(func: LazyIrSchema) -> str:
     for arg in func.filtered_types():
         if isValueType(arg.type):
             if isinstance(arg.type, BaseCType):
-                node_ctor_values.append(f"l_{arg.name}.GetIrValue()")
+                node_ctor_values.append(f"lazy_{arg.name}.GetIrValue()")
             elif isinstance(arg.type, OptionalCType):
                 node_ctor_values.append(
-                    f"l_{arg.name} ? "
-                    f"c10::make_optional(l_{arg.name}->GetIrValue()) : "
+                    f"lazy_{arg.name} ? "
+                    f"c10::make_optional(lazy_{arg.name}->GetIrValue()) : "
                     "c10::nullopt")
             else:
                 raise AssertionError("TODO not sure if there are other valid types to handle here")
@@ -124,10 +124,14 @@ def lazy_tensor_decls(value_types: List[NamedCType]) -> str:
     lazy_tensor_decls: List[str] = []
     for t in value_types:
         if isinstance(t.type, BaseCType):
-            lazy_tensor_decls.append(f"LazyTensor l_{t.name} = bridge::GetLtcTensor({t.name});")
-        elif isinstance(t.type, OptionalCType):
             lazy_tensor_decls.append(
-                f"c10::optional<LazyTensor> l_{t.name} =  "
+                f"LazyTensor lazy_{t.name} = "
+                f"bridge::GetLtcTensorOrCreateForWrappedNumber({t.name}, *device);")
+        elif isinstance(t.type, OptionalCType):
+            # TODO(alanwaketan): Maybe we want to apply GetLtcTensorOrCreateForWrappedNumber here, but hold it
+            # until we encounter a real world example.
+            lazy_tensor_decls.append(
+                f"c10::optional<LazyTensor> lazy_{t.name} =  "
                 f"{t.name} ? "
                 f"bridge::TryGetLtcTensor(*{t.name}) : "
                 f"c10::nullopt;")
@@ -145,9 +149,12 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
     all_types = schema.filtered_types()
     value_types = schema.filtered_types(values=True, scalars=False)
     scalar_types = schema.filtered_types(values=False, scalars=True)
+    returns_length = len(schema.returns)
+
+    get_device_str = f"""auto device = bridge::GetLtcDevice({", ".join([f"{t.name}" for t in value_types])});
+    LTC_CHECK(!!device) << "None of the input tensors is a lazy tensor.";"""
     lazy_tensor_decls_str = lazy_tensor_decls(value_types)
     node_ctor_input_str = node_ctor_inputs(schema)
-    returns_length = len(schema.returns)
 
     # call the meta kernel if it exists, to compute output shape/dtype for our IR
     if func.structured or func.structured_delegate is not None:
@@ -174,7 +181,7 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
 
     assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
     first_tensor = value_types[0]
-    bridge_str = f"""auto result = bridge::AtenFromLtcTensor(l_{first_tensor.name}.CreateFrom(node,
+    bridge_str = f"""auto result = bridge::AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node,
         // TODO (@wconstab): experiment on dtype
         // try always overriding output dtype to match the one ATen says our op should produce.
         // this diverges from most of the handwritten methods, which often do not override and
@@ -186,7 +193,7 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
     if returns_length > 1:
         bridge_str = f"""std::vector<LazyTensor> lazy_tensors;
     for (int i = 0; i < {returns_length}; i++) {{
-        lazy_tensors.push_back(l_{first_tensor.name}.CreateFrom(ir::Value(node, i), out_dtype[i]));
+        lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(ir::Value(node, i), out_dtype[i]));
     }}
     auto result = bridge::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
 
@@ -194,6 +201,7 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
 // TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
 {sig.decl(name=f"{class_method_name}::{schema.aten_name}")} {{
     LTC_FN_COUNTER("lazy::");
+    {get_device_str}
     {lazy_tensor_decls_str}
     {meta_str}
     {node_str}

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -182,13 +182,6 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
     assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
     first_tensor = value_types[0]
     bridge_str = f"""auto result = bridge::AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node,
-        // TODO (@wconstab): experiment on dtype
-        // try always overriding output dtype to match the one ATen says our op should produce.
-        // this diverges from most of the handwritten methods, which often do not override and
-        // rely on other behavior in the lowering or copy process to make this correct.
-        // (1) evaluate design goal: to always pick the IR's dtype in one place (here)
-        // (2) rationalize this with Google's design, it may be a problem
-        // (3) evaluate perf impact: make sure we're not actually doing casts becuase of this override
         out_dtype.front()));"""
     if returns_length > 1:
         bridge_str = f"""std::vector<LazyTensor> lazy_tensors;


### PR DESCRIPTION
Summary:
This patch adds support to code-generate composite ops with wrapped numbers. For composite ops, we should only need to generate the base ops that compose them. However, in the case of .Scalar ops where the scalar will be promoted to a tensor, we have an issue. The promoted tensor is not on the lazy device by default.

Here, we add guards to first determine if a given tensor is a promoted wrapped number. If so, we create a LazyTensor out of it. Otherwise, we fallback to the normal path.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestAdd*;AtenLtcTsTensorTest.TestBitwiseAnd*

Fixes #65576.

P.S. An internal design doc is [here](https://fb.quip.com/voahAjCTfSsu).