### PR TITLE
[SmartCompose][OnDevice]fix function name bug in mobile export & Script to convert mobile model

### DIFF
--- a/torch/utils/bundled_inputs.py
+++ b/torch/utils/bundled_inputs.py
@@ -250,10 +250,15 @@ def augment_many_model_functions_with_bundled_inputs(
     get_bundled_inputs_functions_and_info_template = ""
 
     for function, input_list in inputs.items():
-        if not hasattr(function, "__name__"):
-            raise Exception(
-                'At least one of your functions has no attribute __name__ please ensure all have one. m.foo.__name__ = "foo"')
-        function_name = function.__name__
+        if hasattr(function, "__name__"):
+            function_name = function.__name__
+        else:
+            if hasattr(function, "name"):
+                function_name = function.name  # type: ignore[attr-defined]
+            else:
+                raise Exception(
+                    'At least one of your functions has no attribute name please ensure all have one. m.foo.name = "foo"')
+
 
         if input_list is not None and not isinstance(input_list, Sequence):
             raise TypeError("Error inputs for function {0} is not a Sequence".format(function_name))


### PR DESCRIPTION
Summary: fix function name bug in mobile export

Test Plan: buck run pytext/fb/assistant/smart_compose:mobile_converter -- --model_input=pytext_training/tree/teams/assistant/smart_compose/300555761/model.ts --model_output=pytext_training/tree/teams/assistant/smart_compose/300555761/mobile_model_test.ts

Differential Revision: D31782983

