### PR TITLE
Fixed bug in ListType subtype checking

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -1350,7 +1350,7 @@ bool ListType::isSubtypeOfExt(const Type& rhs_, std::ostream* why_not) const {
   if (rhs_.kind() == AnyListType::Kind) {
     return true;
   }
-  auto rhs = rhs_->cast<ListType>();
+  auto rhs = rhs_.cast<ListType>();
   if (!rhs) {
     return false;
   }

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -1350,7 +1350,11 @@ bool ListType::isSubtypeOfExt(const Type& rhs_, std::ostream* why_not) const {
   if (rhs_.kind() == AnyListType::Kind) {
     return true;
   }
-  return false;
+  auto rhs = rhs_->cast<ListType>();
+  if (!rhs) {
+    return false;
+  }
+  return containedTypes()[0]->isSubtypeOfExt(rhs->containedTypes()[0], why_not);
 }
 
  bool TupleType::operator==(const Type& rhs) const {


### PR DESCRIPTION
When list with specialized contained type is checked against general type the subtype check will fail. (For example List of Tensors with dimensions is not reckognized as List of Tensors)
The fix check if type contained in the list is subtype of general contained type of the ListType.
