### PR TITLE
Splitter: Transformer_encoder

### DIFF
--- a/test/fx2trt/converters/acc_op/test_unsqueeze.py
+++ b/test/fx2trt/converters/acc_op/test_unsqueeze.py
@@ -5,21 +5,42 @@ import torch.fx
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
 import torch.nn as nn
 from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase, InputTensorSpec
+from parameterized import parameterized
 
 
 class TestUnsqueeze(AccTestCase):
-    def test_unsqueeze(self):
+    @parameterized.expand(
+        [
+            ("negative_dim", -2),
+            ("positive_dim", 2),
+        ]
+    )
+    def test_unsqueeze(self, _, dim):
         class Unsqueeze(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.dim = dim
+
             def forward(self, x):
-                return torch.unsqueeze(x, 1)
+                return torch.unsqueeze(x, self.dim)
 
         inputs = [torch.randn(1, 2, 3)]
-        self.run_test(Unsqueeze(), inputs, expected_ops={acc_ops.unsqueeze})
+        self.run_test(Unsqueeze(dim), inputs, expected_ops={acc_ops.unsqueeze})
 
-    def test_unsqueeze_with_dynamic_shape(self):
+    @parameterized.expand(
+        [
+            ("negative_dim_dynamic", -2),
+            ("positive_dim_dynamic", 1),
+        ]
+    )
+    def test_unsqueeze_with_dynamic_shape(self, _, dim):
         class Unsqueeze(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.dim = dim
+
             def forward(self, x):
-                return torch.unsqueeze(x, 1)
+                return torch.unsqueeze(x, self.dim)
 
         input_specs = [
             InputTensorSpec(
@@ -29,5 +50,5 @@ class TestUnsqueeze(AccTestCase):
             ),
         ]
         self.run_test_with_dynamic_shape(
-            Unsqueeze(), input_specs, expected_ops={acc_ops.unsqueeze}
+            Unsqueeze(dim), input_specs, expected_ops={acc_ops.unsqueeze}
         )

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1147,9 +1147,14 @@ def acc_ops_unsqueeze(network, target, args, kwargs, name):
                            "of the TensorRT region!")
 
     dim = kwargs["dim"]
+    input_shape = input_val.shape
+    input_shape_size = len(input_val.shape)
+    if dim < 0:
+        dim = dim % (input_shape_size + 1)
     if network.has_implicit_batch_dimension:
         assert dim != 0
-        dim -= 1
+        if kwargs["dim"] > 0:
+            dim -= 1
 
     assert len(get_dynamic_dims(input_val.shape)) <= 1, "Currently we don't support unsqueeze with more than one dynamic dims."
     layer = network.add_shuffle(input_val)

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -150,7 +150,7 @@ class TRTModule(torch.nn.Module):
 
                     idx = self.input_binding_indices_in_order[i]
                     bindings[idx] = contiguous_inputs[i].data_ptr()
-
+                    # print(contiguous_inputs[i].shape)
                     if not self.engine.has_implicit_batch_dimension:
                         self.context.set_binding_shape(
                             idx, tuple(contiguous_inputs[i].shape)


### PR DESCRIPTION
Summary:
Added splitter to lower parts of the transformer model
Program now supports arg input

Test Plan:
Performance on non-lowered model:
0.19662559509277344
Performance on semi-lowered model:
0.19131642150878905

Differential Revision: D31541325

