### PR TITLE
Setup c10d extension Backend class attr the same way as builtin ones

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -760,6 +760,17 @@ class PythonProcessGroupTest(MultiProcessTestCase):
         dpg = DummyProcessGroup(0, 1)
         self.assertEqual("Dummy", dpg.name())
 
+    def test_backend_class_attr(self):
+        dist.Backend.register_backend(
+            "dummy",
+            PythonProcessGroupTest.create_dummy
+        )
+        self.assertEqual(dist.Backend.DUMMY, "DUMMY")
+        self.assertEqual(
+            dist.Backend._plugins["DUMMY"],
+            PythonProcessGroupTest.create_dummy
+        )
+
     @staticmethod
     def create_dummy(store, rank, size, timeout):
         return DummyProcessGroup(rank, size)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -107,6 +107,7 @@ class Backend(object):
     NCCL = "nccl"
     MPI = "mpi"
     TCP = "tcp"
+    _plugins = {}
 
     def __new__(cls, name: str):
         if not isinstance(name, string_classes):
@@ -142,7 +143,15 @@ class Backend(object):
         .. note:: This support of 3rd party backend is experimental and subject to change.
 
         """
-        setattr(Backend, name.upper(), func)
+        assert not hasattr(Backend, name.upper()), (
+            f"{name.upper()} c10d backend already exist"
+        )
+        assert name.upper() not in Backend._plugins, (
+            f"{name.upper()} c10d backend creator function already exist"
+        )
+
+        setattr(Backend, name.upper(), name.upper())
+        Backend._plugins[name.upper()] = func
 
 
 # `_backend`, `dist_backend`, and `reduce_op` are here to maintain backward
@@ -739,7 +748,10 @@ def _new_process_group_helper(
             _pg_map[pg] = (Backend.NCCL, store)
             _pg_names[pg] = group_name
         else:
-            pg = getattr(Backend, backend.upper())(
+            assert backend.upper() in Backend._plugins, (
+                f"unknown c10d backend type {backend.upper()}"
+            )
+            pg = Backend._plugins[backend.upper()](
                 prefix_store, rank, world_size, timeout
             )
             _pg_map[pg] = (backend, store)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6,7 +6,7 @@ import pickle
 import time
 import warnings
 from datetime import timedelta
-from typing import Dict, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import torch
 from torch._C._distributed_c10d import (
@@ -107,7 +107,7 @@ class Backend(object):
     NCCL = "nccl"
     MPI = "mpi"
     TCP = "tcp"
-    _plugins = {}
+    _plugins: Dict[str, Callable] = {}
 
     def __new__(cls, name: str):
         if not isinstance(name, string_classes):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #66991

Currently, c10d extensions uses Backend.NAME to store the creator
function. However, builtin ones use that same field to store the
name. This commit makes c10d extensions comply with builtin ones,
and uses a dedicated `_plugins` field to store creator functions.

Thanks @bryanmr for pointing this out.

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D31820307](https://our.internmc.facebook.com/intern/diff/D31820307)