### PR TITLE
[JIT] Eliminate trivial concats

### DIFF
--- a/torch/csrc/jit/passes/concat_opt.h
+++ b/torch/csrc/jit/passes/concat_opt.h
@@ -13,5 +13,8 @@ TORCH_API bool EliminateConcatCommonInputs(const std::shared_ptr<Graph>& graph);
 TORCH_API void ExpandConcatAndEliminateRedundancy(
     const std::shared_ptr<Graph>& graph);
 
+// Remove `aten::cat` and `prim::VarConcat` nodes with a single input.
+TORCH_API bool EliminateTrivialConcat(const std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
Added a pass to eliminate `aten::cat` and `prim::VarCat` nodes with only one input.

Related task: https://github.com/pytorch/pytorch/issues/66654

Test Plan: `buck test caffe2/test/cpp/jit:jit -- ConcatOpt`

Differential Revision: D31818771

