### PR TITLE
[JIT] Combine concat nodes where possible

### DIFF
--- a/torch/csrc/jit/passes/concat_opt.h
+++ b/torch/csrc/jit/passes/concat_opt.h
@@ -13,5 +13,7 @@ TORCH_API bool EliminateConcatCommonInputs(const std::shared_ptr<Graph>& graph);
 TORCH_API void ExpandConcatAndEliminateRedundancy(
     const std::shared_ptr<Graph>& graph);
 
+TORCH_API bool CombineConcats(const std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir_views.h>
 #include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/peephole_alias_sensitive.h>
 #include <torch/csrc/jit/passes/peephole_dict_idioms.h>
@@ -36,6 +37,7 @@ struct PeepholeOptimizeImpl {
     changed |= PeepholeOptimizeDictIdioms(graph_);
     changed |= PeepholeOptimizeAliasSensitive(graph_, shape_peepholes_);
     changed |= PeepholeOptimizeNonTensor(graph_);
+    changed |= CombineConcats(graph_);
     return changed;
   }
 


### PR DESCRIPTION
Summary:
See the [related issue](https://github.com/pytorch/pytorch/issues/66654) for a description of the pattern that this pass optimizes.

Enabled the new pass in SR since we've seen cases where it is useful.

Test Plan: `buck test caffe2/test/cpp/jit:jit -- ConcatOpt`

Differential Revision: D31819491

