### PR TITLE
[SR] Remove unused operator() overload

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -82,11 +82,11 @@ static void BM_deep_wide_static(benchmark::State& state) {
   auto user_emb = torch::randn({batch_size, 1, embedding_size});
   auto wide = torch::randn({batch_size, num_features});
 
-  std::vector<at::Tensor> inputs({ad_emb_packed, user_emb, wide});
+  std::vector<c10::IValue> inputs({ad_emb_packed, user_emb, wide});
 
-  smod(inputs);
+  smod(inputs, {});
   for (auto _ : state) {
-    smod(inputs);
+    smod(inputs, {});
   }
 }
 
@@ -104,11 +104,11 @@ static void BM_deep_wide_static_threaded(benchmark::State& state) {
   auto user_emb = torch::randn({batch_size, 1, embedding_size});
   auto wide = torch::randn({batch_size, num_features});
 
-  std::vector<at::Tensor> inputs({ad_emb_packed, user_emb, wide});
+  std::vector<c10::IValue> inputs({ad_emb_packed, user_emb, wide});
 
-  sr(inputs);
+  sr(inputs, {});
   for (auto _ : state) {
-    sr(inputs);
+    sr(inputs, {});
   }
 }
 
@@ -118,11 +118,11 @@ static void BM_leaky_relu_const(benchmark::State& state) {
 
   const int batch_size = state.range(0);
   auto data = torch::randn({batch_size, num_features});
-  std::vector<at::Tensor> inputs({data});
+  std::vector<c10::IValue> inputs({data});
 
-  smod(inputs);
+  smod(inputs, {});
   for (auto _ : state) {
-    smod(inputs);
+    smod(inputs, {});
   }
 }
 
@@ -133,11 +133,11 @@ static void BM_leaky_relu(benchmark::State& state) {
   const int batch_size = state.range(0);
   auto neg_slope = torch::randn(1);
   auto data = torch::randn({batch_size, num_features});
-  std::vector<at::Tensor> inputs({data, neg_slope[0]});
+  std::vector<c10::IValue> inputs({data, neg_slope[0]});
 
-  smod(inputs);
+  smod(inputs, {});
   for (auto _ : state) {
-    smod(inputs);
+    smod(inputs, {});
   }
 }
 
@@ -150,11 +150,11 @@ static void BM_signed_log1p(benchmark::State& state) {
 
   const int num_elements = state.range(0);
   auto data = torch::randn({num_elements});
-  std::vector<at::Tensor> inputs({data});
+  std::vector<c10::IValue> inputs({data});
 
-  smod(inputs);
+  smod(inputs, {});
   for (auto _ : state) {
-    smod(inputs);
+    smod(inputs, {});
   }
 }
 
@@ -170,11 +170,11 @@ static void BM_long_static_memory_optimization(benchmark::State& state) {
   auto a = torch::randn({N, N});
   auto b = torch::randn({N, N});
   auto c = torch::randn({N, N});
-  std::vector<at::Tensor> inputs({a, b, c});
+  std::vector<c10::IValue> inputs({a, b, c});
 
-  smod(inputs);
+  smod(inputs, {});
   for (auto _ : state) {
-    smod(inputs);
+    smod(inputs, {});
   }
 }
 

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -755,9 +755,9 @@ TEST(StaticRuntime, LongModel) {
   at::Tensor output_1 = mod.forward(input_ivalues).toTensor();
 
   // run static runtime
-  std::vector<at::Tensor> input_tensors({a, b, c});
+  std::vector<c10::IValue> input_tensors({a, b, c});
   torch::jit::StaticModule smod(mod);
-  at::Tensor output_2 = smod(input_tensors)[0];
+  at::Tensor output_2 = smod(input_tensors, {}).toTensor();
   smod.runtime().check_for_memory_leak();
   EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
@@ -773,9 +773,9 @@ TEST(StaticRuntime, TrivialModel) {
   at::Tensor output_1 = mod.forward(input_ivalues).toTensor();
 
   // run static runtime
-  std::vector<at::Tensor> input_tensors({a, b, c});
+  std::vector<c10::IValue> input_tensors({a, b, c});
   torch::jit::StaticModule smod(mod);
-  at::Tensor output_2 = smod(input_tensors)[0];
+  at::Tensor output_2 = smod(input_tensors, {}).toTensor();
   smod.runtime().check_for_memory_leak();
   EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
@@ -789,9 +789,9 @@ TEST(StaticRuntime, LeakyReLU) {
   at::Tensor output_1 = mod.forward(input_ivalues).toTensor();
 
   // run static runtime
-  std::vector<at::Tensor> input_tensors({inputs});
+  std::vector<c10::IValue> input_tensors({inputs});
   torch::jit::StaticModule smod(mod);
-  at::Tensor output_2 = smod(input_tensors)[0];
+  at::Tensor output_2 = smod(input_tensors, {}).toTensor();
   smod.runtime().check_for_memory_leak();
   EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
@@ -813,8 +813,10 @@ TEST(StaticRuntime, DeepWide) {
       auto output_1 = getTensor(mod.forward(inputs));
 
       // run static runtime
-      std::vector<at::Tensor> input_tensors({ad_emb_packed, user_emb, wide});
-      at::Tensor output_2 = smod(input_tensors)[0];
+      std::vector<c10::IValue> input_tensors({ad_emb_packed, user_emb, wide});
+      auto outputs = smod(input_tensors, {}).toTuple()->elements();
+      ASSERT_TRUE(outputs.size() > 0);
+      at::Tensor output_2 = outputs[0].toTensor();
       smod.runtime().check_for_memory_leak();
       EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
     }
@@ -947,9 +949,11 @@ TEST(StaticRuntime, CleanUpMemory) {
               auto output_1 = getTensor(mod.forward(inputs));
 
               // run static runtime
-              std::vector<at::Tensor> input_tensors(
+              std::vector<c10::IValue> input_tensors(
                   {ad_emb_packed, user_emb, wide});
-              at::Tensor output_2 = runtime(input_tensors)[0];
+              auto outputs = runtime(input_tensors, {}).toTuple()->elements();
+              ASSERT_TRUE(outputs.size() > 0);
+              auto output_2 = outputs[0].toTensor();
               runtime.check_for_memory_leak();
               EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
               if (manage_output_tensors) {
@@ -1053,9 +1057,9 @@ TEST(StaticRuntime, ManageOutputTensorsWithDeallocateOutputTensors) {
       torch::randn({batch_size, 1, embedding_size});
     auto user_emb = torch::randn({batch_size, 1, embedding_size});
     auto wide = torch::randn({batch_size, num_features});
-    std::vector<at::Tensor> input_tensors(
+    std::vector<c10::IValue> input_tensors(
         {ad_emb_packed, user_emb, wide});
-    runtime(input_tensors)[0];
+    runtime(input_tensors, {});
     runtime.check_for_memory_leak();
     runtime.deallocateOutputTensors();
     runtime.checkOutputTensorMemoryLeaks();
@@ -1079,21 +1083,21 @@ TEST(StaticRuntime, ManageOutputTensorsWithoutDeallocateOutputTensors) {
     torch::randn({batch_size, 1, embedding_size});
   auto user_emb = torch::randn({batch_size, 1, embedding_size});
   auto wide = torch::randn({batch_size, num_features});
-  std::vector<at::Tensor> input_tensors(
+  std::vector<c10::IValue> input_tensors(
       {ad_emb_packed, user_emb, wide});
   // Profile run.
-  runtime(input_tensors)[0];
+  runtime(input_tensors, {});
   runtime.deallocateOutputTensors();
   // Run again to allocate output Tensors without deallocating them.
-  runtime(input_tensors)[0];
+  runtime(input_tensors, {});
   // Memory leak checking fails.
   EXPECT_THROW(runtime.checkOutputTensorMemoryLeaks(), std::exception);
   // Calling the runtime without deallocation fails too.
-  EXPECT_THROW(runtime(input_tensors)[0], std::exception);
+  EXPECT_THROW(runtime(input_tensors, {}), std::exception);
   // After deallocation, everything works fine.
   runtime.deallocateOutputTensors();
   runtime.checkOutputTensorMemoryLeaks();
-  runtime(input_tensors)[0];
+  runtime(input_tensors, {});
 }
 
 TEST(StaticRuntime, FusionPass) {

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -17,7 +17,7 @@ class StaticModule:
 
     def __call__(self, *args, **kwargs):
         if not kwargs:
-            return self.static_module(args)
+            return self.static_module(args, {})
         else:
             return self.static_module(args, kwargs)
 
@@ -227,20 +227,20 @@ class TestStaticModule(TestCase):
             bot_inp = torch.randn(2048, 512)  # torch.Size([2048, 512])
             top_inp = torch.randn(2048, 100)  # torch.Size([2048, 100])
         ref_bot = bot_l(bot_inp)
-        acc_bot = bot_l_acc(bot_inp)[0]
+        acc_bot = bot_l_acc(bot_inp)
         torch.testing.assert_close(acc_bot, ref_bot)
         ref_top = top_l(top_inp)
-        acc_top = top_l_acc(top_inp)[0]
+        acc_top = top_l_acc(top_inp)
         torch.testing.assert_close(acc_top, ref_top)
         for _ in range(5):
             with torch.no_grad():
                 bot_inp = torch.randn(2048, 512)  # torch.Size([2048, 512])
                 top_inp = torch.randn(2048, 100)  # torch.Size([2048, 100])
             ref_bot = bot_l(bot_inp)
-            acc_bot = bot_l_acc(bot_inp)[0]
+            acc_bot = bot_l_acc(bot_inp)
             torch.testing.assert_close(acc_bot, ref_bot)
             ref_top = top_l(top_inp)
-            acc_top = top_l_acc(top_inp)[0]
+            acc_top = top_l_acc(top_inp)
             torch.testing.assert_close(acc_top, ref_top)
 
     def test_trivial_graph(self):
@@ -248,7 +248,7 @@ class TestStaticModule(TestCase):
         tg = torch.jit.script(trivial_graph)
         o_ref = tg(s, s, s)
         tg_a = StaticModule(tg)
-        o_test = tg_a(s, s, s)[0]
+        o_test = tg_a(s, s, s)
         torch.testing.assert_close(o_ref, o_test)
 
     def test_leaky_relu(self):
@@ -256,7 +256,7 @@ class TestStaticModule(TestCase):
         tg = torch.jit.script(nn.LeakyReLU(0.1))
         o_ref = tg(s)
         tg_a = StaticModule(tg)
-        o_test = tg_a(s)[0]
+        o_test = tg_a(s)
         torch.testing.assert_close(o_ref, o_test)
 
     def test_attr(self):
@@ -292,7 +292,7 @@ class TestStaticModule(TestCase):
 
         ms = torch.jit.script(m)
         sm = StaticModule(ms)
-        output_sm = sm(input)[0]
+        output_sm = sm(input)
         torch.testing.assert_close(output_s, output_sm)
         sm.benchmark([input], {}, 2, 2)
         sm.benchmark_individual_ops([input], {}, 2, 2)

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -933,7 +933,7 @@ void StaticRuntime::set_inputs(
 }
 
 template <typename IValueList>
-c10::IValue StaticRuntime::operator()(
+c10::IValue StaticRuntime::run_impl(
     IValueList&& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
   // We assume inference workloads, so we do not need
@@ -997,13 +997,17 @@ c10::IValue StaticRuntime::operator()(
   return std::move(*outputs_[0]);
 }
 
-template c10::IValue StaticRuntime::operator()<const std::vector<c10::IValue>&>(
+c10::IValue StaticRuntime::operator()(
     const std::vector<c10::IValue>& args,
-    const std::unordered_map<std::string, c10::IValue>& kwargs);
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  return run_impl(args, kwargs);
+}
 
-template c10::IValue StaticRuntime::operator()<std::vector<c10::IValue>&&>(
+c10::IValue StaticRuntime::operator()(
     std::vector<c10::IValue>&& args,
-    const std::unordered_map<std::string, c10::IValue>& kwargs);
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  return run_impl(std::move(args), kwargs);
+}
 
 namespace {
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -763,11 +763,6 @@ StaticRuntime& StaticModule::runtime() {
   return *cached_runtime_;
 }
 
-std::vector<at::Tensor> StaticModule::operator()(
-    const std::vector<at::Tensor>& inps) {
-  return runtime()(inps);
-}
-
 c10::IValue StaticModule::operator()(
     const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
@@ -830,30 +825,6 @@ StaticRuntime::StaticRuntime(const StaticModule& sm) : static_module_(sm) {
 }
 
 StaticRuntime::~StaticRuntime() = default;
-
-std::vector<at::Tensor> StaticRuntime::operator()(
-    const std::vector<at::Tensor>& inps) {
-  std::vector<c10::IValue> stack;
-  stack.resize(inps.size());
-  for (const auto i : c10::irange(inps.size())) {
-    stack[i] = inps[i];
-  }
-
-  c10::IValue v =
-      (*this)(stack, std::unordered_map<std::string, c10::IValue>());
-
-  std::vector<at::Tensor> out;
-
-  if (v.isTuple()) {
-    auto t = v.toTuple();
-    for (const auto& el : t->elements()) {
-      out.emplace_back(el.toTensor());
-    }
-  } else {
-    out.emplace_back(v.toTensor());
-  }
-  return out;
-}
 
 void StaticRuntime::set_inputs(
     const std::vector<IValue>& args,

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -279,9 +279,11 @@ class TORCH_API StaticRuntime {
   // This interface only works if StaticModule was initialized
   // with a TorchScript module, otherwise use the above interface
   // IValueList should be a std::vector<IValue> (lvalue or rvalue)
-  template <class IValueList>
   c10::IValue operator()(
-      IValueList&& args,
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs);
+  c10::IValue operator()(
+      std::vector<c10::IValue>&& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   void display_nodes(
@@ -368,6 +370,11 @@ class TORCH_API StaticRuntime {
   bool isManagedOutputTensor(const IValue& ivalue);
 
  private:
+  template <typename IValueList>
+  c10::IValue run_impl(
+      IValueList&& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs);
+
   // helper method for copying input args/kwargs into inputs_
   void set_inputs(
       const std::vector<c10::IValue>& args,

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -170,10 +170,6 @@ class TORCH_API StaticModule {
   using DefInfo = std::pair<int, int>;
 
  public:
-  std::vector<at::Tensor> operator()(const std::vector<at::Tensor>& inps);
-
-  // This interface only works if StaticModule was initialized
-  // with a TorchScript module, otherwise use the above interface
   c10::IValue operator()(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
@@ -274,11 +270,6 @@ class TORCH_API StaticRuntime {
 
   C10_DISABLE_COPY_AND_ASSIGN(StaticRuntime);
 
-  std::vector<at::Tensor> operator()(const std::vector<at::Tensor>& inps);
-
-  // This interface only works if StaticModule was initialized
-  // with a TorchScript module, otherwise use the above interface
-  // IValueList should be a std::vector<IValue> (lvalue or rvalue)
   c10::IValue operator()(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -48,10 +48,6 @@ void initStaticModuleBindings(PyObject* module) {
   static_module
       .def(
           "__call__",
-          py::overload_cast<const std::vector<at::Tensor>&>(
-              &StaticModule::operator()))
-      .def(
-          "__call__",
           [](StaticModule& self,
              const std::vector<at::Tensor>& args,
              const std::unordered_map<std::string, at::Tensor>& kwargs) {


### PR DESCRIPTION
Summary:
The overload of `operator()` taking `std::vector<at::Tensor>` was only used for testing. In a diff following this one, I will add a new overload that takes `std::vector<c10::IValue> args` and no `kwargs` so we can avoid default-constructing `kwargs` everywhere.

This new overload will probably take a forwarding reference, so to avoid problems with overloading on forwarding reference and simplify the interface, it's best to remove this unused one.

Test Plan:
`buck test caffe2/benchmarks/static_runtime/...`

`buck test caffe2/test:static_runtime`

Differential Revision: D31821990

