### PR TITLE
[Pytorch Edge] Make some torchbind classes selective

### DIFF
--- a/aten/src/ATen/core/custom_class.cpp
+++ b/aten/src/ATen/core/custom_class.cpp
@@ -1,5 +1,5 @@
 #include <torch/custom_class.h>
-
+#include <ATen/record_function.h>
 #include <ATen/core/jit_type.h>
 #include <ATen/core/function_schema.h>
 #include <ATen/core/functional.h>
@@ -8,6 +8,14 @@
 #include <unordered_map>
 
 namespace torch {
+
+namespace detail {
+
+void record_custom_class(std::string name) {
+  RECORD_FUNCTION_WITH_SCOPE(at::RecordScope::CUSTOM_CLASS, name, {});
+}
+
+} // namespace detail
 
 std::unordered_map<std::string, at::ClassTypePtr>& customClasses() {
   static std::unordered_map<std::string, at::ClassTypePtr> customClasses;
@@ -25,8 +33,12 @@ void registerCustomClass(at::ClassTypePtr class_type) {
   customClasses()[name] = std::move(class_type);
 }
 
-at::ClassTypePtr getCustomClass(const std::string& name) {
-  return customClasses().count(name) ? customClasses()[name] : nullptr;
+at::ClassTypePtr getCustomClass(const std::string& class_name) {
+  auto ret = customClasses().count(class_name) ? customClasses()[class_name] : nullptr;
+  if (ret) {
+    RECORD_CUSTOM_CLASS(class_name);
+  }
+  return ret;
 }
 
 const std::unordered_set<std::string> getAllCustomClassesNames() {

--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -91,6 +91,21 @@ constexpr bool schema_allowlist_check(string_view schema) {
 #endif
 }
 
+// Returns true iff the given custom class name is on the allowlist
+// and should be registered
+constexpr bool custom_class_allowlist_check(string_view custom_class_name) {
+#if !defined(TORCH_CUSTOM_CLASS_ALLOWLIST)
+  // If the TORCH_CUSTOM_CLASS_ALLOWLIST parameter is not defined,
+  // all custom classes are to be registered
+  (void)custom_class_name;
+  return true;
+#else
+  return op_allowlist_contains(
+    C10_STRINGIZE(TORCH_CUSTOM_CLASS_ALLOWLIST),
+    custom_class_name);
+#endif
+}
+
 // schema_allowlist_check() implicitly depends on a macro, TORCH_OPERATOR_WHITELIST.
 // Add this API to pass arbitrary allowlist.
 constexpr bool op_allowlist_contains_name_in_schema(string_view allowlist, string_view schema) {

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -11,7 +11,7 @@
 #include <torch/custom_class.h>
 #include <torch/library.h>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/ao_sparse/library.cpp
+++ b/aten/src/ATen/native/ao_sparse/library.cpp
@@ -5,7 +5,7 @@
 
 namespace ao {
 namespace sparse {
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 }}
 
 // Register operators

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
@@ -8,10 +8,11 @@
 
 namespace ao {
 namespace sparse {
-torch::class_<LinearPackedParamsBase> register_linear_params() {
+
+int register_linear_params() {
   static auto register_linear_params =
-      torch::class_<LinearPackedParamsBase>(
-          "sparse", "LinearPackedParamsBase")
+      torch::selective_class::class_<LinearPackedParamsBase>(
+          "sparse", TORCH_SELECTIVE_CLASS("LinearPackedParamsBase"))
           .def_pickle(
               [](const c10::intrusive_ptr<LinearPackedParamsBase>& params)
                   -> LinearPackedSerializationType { // __getstate__
@@ -65,7 +66,7 @@ torch::class_<LinearPackedParamsBase> register_linear_params() {
 #endif // USE_FBGEMM
                 TORCH_CHECK(false, "Unknown qengine");
               });
-  return register_linear_params;
+  return 0;
 }
 
 namespace {

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
@@ -10,7 +10,7 @@
 namespace ao {
 namespace sparse {
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_dynamic.cpp
@@ -13,7 +13,7 @@
 namespace ao {
 namespace sparse {
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_PYTORCH_QNNPACK
 template <>

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_prepack.cpp
@@ -13,7 +13,7 @@
 namespace ao {
 namespace sparse {
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 namespace {

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_unpack.cpp
@@ -8,7 +8,7 @@
 
 namespace ao {
 namespace sparse {
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -14,8 +14,8 @@
 #include <c10/util/irange.h>
 #include <torch/custom_class.h>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
-torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
+int register_linear_params();
+int register_embedding_params();
 
 #ifdef USE_FBGEMM
 
@@ -358,15 +358,27 @@ Tensor ConvertConvWeightsToChannelLastTensor<3>(
 } // namespace native
 } // namespace at
 
-
 #endif // USE_FBGEMM
 
-    template <int kSpatialDim = 2>
-    TORCH_API torch::class_<ConvPackedParamsBase<kSpatialDim>>
-    register_conv_params() {
+namespace {
+  constexpr const char* _hack_int_to_class_name(int x) {
+    switch(x) {
+      case 2:
+        return "Conv2dPackedParamsBase";
+      case 3:
+        return "Conv3dPackedParamsBase";
+      default:
+        assert(false);
+        return "NotAValidDimension";
+    }
+  }
+}
+
+template <int kSpatialDim = 2>
+int register_conv_params() {
   static auto register_conv_params =
-    torch::class_<ConvPackedParamsBase<kSpatialDim>>(
-        "quantized", "Conv" + c10::to_string(kSpatialDim) + "dPackedParamsBase")
+    torch::selective_class::class_<ConvPackedParamsBase<kSpatialDim>>(
+        "quantized", TORCH_SELECTIVE_CLASS(_hack_int_to_class_name(kSpatialDim)))
     .def_pickle(
         [](const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& params)
         -> ConvParamsSerializationType { // __getstate__
@@ -398,19 +410,14 @@ Tensor ConvertConvWeightsToChannelLastTensor<3>(
     .def("dilation", &ConvPackedParamsBase<kSpatialDim>::dilation)
     .def("groups", &ConvPackedParamsBase<kSpatialDim>::groups)
     .def("transpose", &ConvPackedParamsBase<kSpatialDim>::transpose);
-  return register_conv_params;
+  return 0;
 }
 
-template
-TORCH_API torch::class_<ConvPackedParamsBase<2>> register_conv_params<2>();
-template
-TORCH_API torch::class_<ConvPackedParamsBase<3>> register_conv_params<3>();
-
-torch::class_<LinearPackedParamsBase> register_linear_params() {
+int register_linear_params() {
   using SerializationType = std::tuple<at::Tensor, c10::optional<at::Tensor>>;
   static auto register_linear_params =
-      torch::class_<LinearPackedParamsBase>(
-          "quantized", "LinearPackedParamsBase")
+      torch::selective_class::class_<LinearPackedParamsBase>(
+          "quantized", TORCH_SELECTIVE_CLASS("LinearPackedParamsBase"))
           .def_pickle(
               [](const c10::intrusive_ptr<LinearPackedParamsBase>& params)
                   -> SerializationType { // __getstate__
@@ -464,11 +471,14 @@ torch::class_<LinearPackedParamsBase> register_linear_params() {
                    return bias;
                  })
               .def("unpack", &LinearPackedParamsBase::unpack);
-  return register_linear_params;
+  // its convenient to call this function from a global scope in this file to ensure
+  // registration occurs. However, we dont need to keep the reference to this class
+  // after registration so returning a dummy value is fine.
+  return 0;
 }
 
 
-torch::class_<EmbeddingPackedParamsBase> register_embedding_params() {
+int register_embedding_params() {
   // Type for __getstate__/__setstate__ serialization
   //
   // Element 0 is the version of the PackedParam structure
@@ -483,8 +493,8 @@ torch::class_<EmbeddingPackedParamsBase> register_embedding_params() {
     std::vector<int64_t>>;
 
   static auto register_embedding_params =
-    torch::class_<EmbeddingPackedParamsBase>(
-      "quantized", "EmbeddingPackedParamsBase")
+    torch::selective_class::class_<EmbeddingPackedParamsBase>(
+      "quantized", TORCH_SELECTIVE_CLASS("EmbeddingPackedParamsBase"))
       .def_pickle(
           [](const c10::intrusive_ptr<EmbeddingPackedParamsBase>& params)
               -> EmbeddingParamsSerializationType { // __getstate__ call
@@ -520,14 +530,14 @@ torch::class_<EmbeddingPackedParamsBase> register_embedding_params() {
       .def("bit_rate", &EmbeddingPackedParamsBase::bit_rate)
       .def("version", &EmbeddingPackedParamsBase::version);
 
-  return register_embedding_params;
+  return 0;
 }
 
 namespace {
 
+static auto linear_params = register_linear_params();
 static auto conv2d_params = register_conv_params<2>();
 static auto conv3d_params = register_conv_params<3>();
-static auto linear_params = register_linear_params();
 static auto embedding_params = register_embedding_params();
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -11,7 +11,7 @@
 #include <ATen/Parallel.h>
 #include <c10/util/irange.h>
 
-torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
+int register_embedding_params();
 
 namespace {
 

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -9,7 +9,7 @@
 
 #include <c10/util/irange.h>
 
-torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
+int register_embedding_params();
 
 /*
  * Prepack function for embedding_bag weights.

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
@@ -5,7 +5,7 @@
 #include <c10/util/irange.h>
 #include <torch/library.h>
 
-torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
+int register_embedding_params();
 
 at::Tensor PackedEmbeddingBagWeight::unpack() {
   auto packed_weight = packed_w;

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -13,7 +13,7 @@
 #include <algorithm>
 #include <string>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 template <bool ReluFused>

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <string>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 template <bool ReluFused>

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <vector>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 namespace {

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -6,7 +6,7 @@
 #include <torch/custom_class.h>
 #include <torch/library.h>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 #ifdef USE_FBGEMM
 std::tuple<at::Tensor, c10::optional<at::Tensor>> PackedLinearWeight::unpack() {

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -5,14 +5,12 @@
 #include <ATen/native/quantized/cpu/embedding_packed_params.h>
 #include <torch/custom_class.h>
 
-torch::class_<LinearPackedParamsBase> register_linear_params();
+int register_linear_params();
 
 template <int kSpatialDim = 2>
-torch::class_<ConvPackedParamsBase<kSpatialDim>> register_conv_params();
+int register_conv_params();
 
-extern template torch::class_<ConvPackedParamsBase<2>> register_conv_params<2>();
-extern template torch::class_<ConvPackedParamsBase<3>> register_conv_params<3>();
-torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
+int register_embedding_params();
 
 TORCH_LIBRARY(quantized, m) {
   register_linear_params();

--- a/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
+++ b/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
@@ -16,7 +16,7 @@ using internal::convolution2d::createConv2dClampPrePackOpContext;
 using internal::convolution2d::createConv2dTransposeClampPrePackOpContext;
 
 TORCH_LIBRARY(xnnpack, m) {
-  m.class_<LinearOpContext>("LinearOpContext")
+  m.class_<LinearOpContext>(TORCH_SELECTIVE_CLASS("LinearOpContext"))
     .def_pickle(
         [](const c10::intrusive_ptr<LinearOpContext>& op_context)
             -> SerializationTypeLinearPrePack { // __getstate__
@@ -33,7 +33,7 @@ TORCH_LIBRARY(xnnpack, m) {
               std::move(std::get<3>(state)));
         });
 
-  m.class_<Conv2dOpContext>("Conv2dOpContext")
+  m.class_<Conv2dOpContext>(TORCH_SELECTIVE_CLASS("Conv2dOpContext"))
     .def_pickle(
         [](const c10::intrusive_ptr<Conv2dOpContext>& op_context)
             -> SerializationTypeConv2dPrePack { // __getstate__
@@ -55,7 +55,7 @@ TORCH_LIBRARY(xnnpack, m) {
               std::move(std::get<7>(state)));
         });
 
-  m.class_<TransposeConv2dOpContext>("TransposeConv2dOpContext")
+  m.class_<TransposeConv2dOpContext>(TORCH_SELECTIVE_CLASS("TransposeConv2dOpContext"))
     .def_pickle(
         [](const c10::intrusive_ptr<TransposeConv2dOpContext>& op_context)
             -> SerializationTypeTransposeConv2dPrePack { // __getstate__

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -27,6 +27,8 @@ enum class C10_API_ENUM RecordScope : uint8_t {
   TORCHSCRIPT_FUNCTION,
   // Kernel Function dtype Tag
   KERNEL_FUNCTION_DTYPE,
+  // Torchbind custom class,
+  CUSTOM_CLASS,
   // Kernel Function dtype Tag
   LITE_INTERPRETER,
   // User defined scope (e.g. with record_function())

--- a/tools/codegen/selective_build/selector.py
+++ b/tools/codegen/selective_build/selector.py
@@ -36,11 +36,16 @@ class SelectiveBuilder:
     # of the kernel function implementation itself.
     kernel_metadata: Dict[str, List[str]]
 
+    # A set of all the custom torch bind classes used by the selected models
+    # Stored as a set internally to remove duplicates proactively, but written
+    # as a list to yamls
+    custom_classes: Set[str]
+
     # If true, then fragments for all dtypes for all kernel functions
-    # are included. This is typically set when any one of the
+    # are included as well as all custom classes. This is typically set when any one of the
     # operator lists is generated from a mechanism other than
     # tracing based selective build.
-    include_all_kernel_dtypes: bool
+    include_all_non_op_selectives: bool
 
     @staticmethod
     def get_nop_selector() -> 'SelectiveBuilder':
@@ -49,11 +54,12 @@ class SelectiveBuilder:
     @staticmethod
     def from_yaml_dict(data: Dict[str, object]) -> 'SelectiveBuilder':
         valid_top_level_keys = {
-            'include_all_kernel_dtypes',
+            'include_all_non_op_selectives',
             'include_all_operators',
             'debug_info',
             'operators',
             'kernel_metadata',
+            'custom_classes',
         }
         top_level_keys = set(data.keys())
         if len(top_level_keys - valid_top_level_keys) > 0:
@@ -84,15 +90,19 @@ class SelectiveBuilder:
         for (k, v) in kernel_metadata_dict.items():
             kernel_metadata[str(k)] = list(map(lambda dtype: str(dtype), v))
 
-        include_all_kernel_dtypes = data.get('include_all_kernel_dtypes', False)
-        assert isinstance(include_all_kernel_dtypes, bool)
+        custom_classes = data.get('custom_classes', [])
+        custom_classes = set(custom_classes)  # type: ignore[arg-type]
+
+        include_all_non_op_selectives = data.get('include_all_non_op_selectives', False)
+        assert isinstance(include_all_non_op_selectives, bool)
 
         return SelectiveBuilder(
             include_all_operators,
             debug_info,
             operators,
             kernel_metadata,
-            include_all_kernel_dtypes,
+            custom_classes,  # type: ignore[arg-type]
+            include_all_non_op_selectives,
         )
 
     @staticmethod
@@ -121,7 +131,7 @@ class SelectiveBuilder:
             }
         return SelectiveBuilder.from_yaml_dict({
             'operators': operators,
-            'include_all_kernel_dtypes': True,
+            'include_all_non_op_selectives': True,
         })
 
     def is_operator_selected(self, name: str) -> bool:
@@ -184,14 +194,14 @@ class SelectiveBuilder:
         return base_op.include_all_overloads and base_op.is_root_operator
 
     def is_kernel_dtype_selected(self, kernel_tag: str, dtype: str) -> bool:
-        if self.include_all_operators or self.include_all_kernel_dtypes:
+        if self.include_all_operators or self.include_all_non_op_selectives:
             return True
 
         return kernel_tag in self.kernel_metadata and dtype in self.kernel_metadata[kernel_tag]
 
     def to_dict(self) -> Dict[str, object]:
         ret: Dict[str, object] = {
-            'include_all_kernel_dtypes': self.include_all_kernel_dtypes,
+            'include_all_non_op_selectives': self.include_all_non_op_selectives,
             'include_all_operators': self.include_all_operators,
         }
         operators = {}
@@ -203,6 +213,8 @@ class SelectiveBuilder:
             ret['debug_info'] = sorted(self._debug_info)
 
         ret['kernel_metadata'] = {k: sorted(list(v)) for (k, v) in self.kernel_metadata.items()}
+
+        ret['custom_classes'] = sorted(self.custom_classes)
 
         return ret
 
@@ -226,13 +238,15 @@ def combine_selective_builders(lhs: SelectiveBuilder, rhs: SelectiveBuilder) -> 
     debug_info = merge_debug_info(lhs._debug_info, rhs._debug_info)
     operators = merge_operator_dicts(lhs.operators, rhs.operators)
     kernel_metadata = merge_kernel_metadata(lhs.kernel_metadata, rhs.kernel_metadata)
-    include_all_kernel_dtypes = lhs.include_all_kernel_dtypes or rhs.include_all_kernel_dtypes
+    include_all_non_op_selectives = lhs.include_all_non_op_selectives or rhs.include_all_non_op_selectives
+    custom_classes = lhs.custom_classes.union(rhs.custom_classes)
     return SelectiveBuilder(
         include_all_operators,
         debug_info,
         operators,
         kernel_metadata,
-        include_all_kernel_dtypes,
+        custom_classes,
+        include_all_non_op_selectives,
     )
 
 

--- a/tools/lite_interpreter/gen_selected_mobile_ops_header.py
+++ b/tools/lite_interpreter/gen_selected_mobile_ops_header.py
@@ -52,7 +52,7 @@ def get_selected_kernel_dtypes_code(
     # dtypes are selected (i.e. both cases).
     #
     body = "return true;"
-    if selective_builder.include_all_operators is False and selective_builder.include_all_kernel_dtypes is False:
+    if selective_builder.include_all_operators is False and selective_builder.include_all_non_op_selectives is False:
         body_parts = []
         for kernel_tag, dtypes in selective_builder.kernel_metadata.items():
             conditions = list(map(lambda x: 'scalar_type == at::ScalarType::' + x, dtypes))
@@ -76,10 +76,16 @@ def write_selected_mobile_ops(
         selective_builder: SelectiveBuilder,
 ) -> None:
     root_ops = extract_root_operators(selective_builder)
+    custom_classes = selective_builder.custom_classes
     with open(output_file_path, "wb") as out_file:
         body_parts = [selected_mobile_ops_preamble]
+        # This condition checks if we are in selective build.
+        # if these lists are not defined the corresponding selective build macros trivially return the item in question was selected
         if not selective_builder.include_all_operators:
             body_parts.append("#define TORCH_OPERATOR_WHITELIST " + (";".join(sorted(root_ops))) + ";\n\n")
+            # This condition checks if we are in tracing based selective build
+            if selective_builder.include_all_non_op_selectives is False:
+                body_parts.append("#define TORCH_CUSTOM_CLASS_ALLOWLIST " + (";".join(sorted(custom_classes))) + ";\n\n")
 
         body_parts.append(get_selected_kernel_dtypes_code(selective_builder))
         header_contents = "".join(body_parts)

--- a/torch/csrc/jit/mobile/model_tracer/CustomClassTracer.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/CustomClassTracer.cpp
@@ -1,0 +1,13 @@
+#include <torch/csrc/jit/mobile/model_tracer/CustomClassTracer.h>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+CustomClassTracer::custom_classes_type& CustomClassTracer::getLoadedClasses() {
+  static custom_classes_type loaded_classes;
+  return loaded_classes;
+}
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/model_tracer/CustomClassTracer.h
+++ b/torch/csrc/jit/mobile/model_tracer/CustomClassTracer.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <ATen/record_function.h>
+#include <map>
+#include <set>
+#include <string>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+/* The CustomClassTracer class handles the attachment and removal of a recording
+ * callback that traces the invocation of code that handles loading custom
+ * classes on mobile.
+ *
+ * You can get the set of used custom classes using
+ * getLoadedClasses().
+ *
+ * Note: This class is not thread safe or re-entrant, and should not be used
+ * across multiple threads of execution.
+ *
+ */
+struct CustomClassTracer final {
+  at::CallbackHandle handle_;
+  /* These are the custom class names (constant
+   * character string) which shows up in code.
+   */
+  typedef std::set<std::string> custom_classes_type;
+
+  CustomClassTracer() {
+    auto recorder_cb = [](const at::RecordFunction& fn)
+        -> std::unique_ptr<at::ObserverContext> {
+      std::string name = fn.name().str();
+      getLoadedClasses().insert(name);
+      return nullptr;
+    };
+
+    handle_ =
+        at::addGlobalCallback(at::RecordFunctionCallback(recorder_cb)
+                                  .scopes({at::RecordScope::CUSTOM_CLASS}));
+  }
+
+  static custom_classes_type& getLoadedClasses();
+
+  ~CustomClassTracer() {
+    at::removeCallback(handle_);
+  }
+};
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <torch/csrc/jit/mobile/model_tracer/CustomClassTracer.h>
 #include <torch/csrc/jit/mobile/model_tracer/KernelDTypeTracer.h>
 
 namespace torch {
@@ -17,6 +18,7 @@ struct TracerResult {
   std::set<std::string> root_ops;
   std::set<std::string> traced_operators;
   KernelDTypeTracer::kernel_tags_type called_kernel_tags;
+  CustomClassTracer::custom_classes_type loaded_classes;
   std::set<std::string> enabled_backends;
 };
 

--- a/torch/csrc/jit/mobile/model_tracer/tracer.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/tracer.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  yaml_out << "include_all_kernel_dtypes: true" << std::endl;
+  yaml_out << "include_all_non_op_selectives: true" << std::endl;
   yaml_out << "operators:" << std::endl;
   printOpsYAML(
       yaml_out,

--- a/torch/custom_class_detail.h
+++ b/torch/custom_class_detail.h
@@ -8,6 +8,29 @@
 
 namespace torch {
 
+namespace detail {
+/**
+ * In the Facebook internal build (using BUCK), this macro is enabled by
+ * passing in -c pt.enable_record_kernel_dtype=1 when building the tracer
+ * binary.
+ */
+#if defined ENABLE_RECORD_KERNEL_FUNCTION_DTYPE
+TORCH_API void record_custom_class(std::string name);
+
+/**
+ * Record an instance of a custom class being loaded
+ * grab portion of string after final '.' from qualified name
+ * as this seemingly aligns with how users name their custom classes
+ * example: __torch__.torch.classes.xnnpack.Conv2dOpContext
+ */
+#define RECORD_CUSTOM_CLASS(NAME) \
+  auto name = std::string(NAME);  \
+  detail::record_custom_class(name.substr(name.find_last_of(".") + 1));
+#else
+#define RECORD_CUSTOM_CLASS(NAME)
+#endif
+} // namespace detail
+
 /// This struct is used to represent default values for arguments
 /// when registering methods for custom classes.
 ///     static auto register_foo = torch::class_<Foo>("myclasses", "Foo")

--- a/torch/library.h
+++ b/torch/library.h
@@ -408,6 +408,13 @@ namespace detail {
 
 namespace detail {
 
+  // dummy class for non selected custom torchbind classes
+  class ClassNotSelected {
+    public:
+      ClassNotSelected& def_pickle(...){ return *this;}
+      ClassNotSelected& def(...){ return *this;}
+  };
+
   // A SelectiveStr is like a const char*, except that it also comes
   // with a type brand that says whether or not the name is enabled or
   // not.  If the string is disabled, then (at compile time) we DON'T generate
@@ -417,12 +424,13 @@ namespace detail {
   template <bool enabled>
   class SelectiveStr {
   public:
-    constexpr SelectiveStr(const char* name) : name_(name) {}
+    constexpr explicit SelectiveStr(const char* name) : name_(name) {}
     constexpr operator const char*() { return name_; }
   private:
     const char* name_;
   };
 
+#define TORCH_SELECTIVE_CLASS(n) torch::detail::SelectiveStr<c10::impl::custom_class_allowlist_check(n)>(n)
 #define TORCH_SELECTIVE_NAME(n) torch::detail::SelectiveStr<c10::impl::op_allowlist_check(n)>(n)
 #define TORCH_SELECTIVE_SCHEMA(n) torch::detail::SelectiveStr<c10::impl::schema_allowlist_check(n)>(n)
 
@@ -680,6 +688,12 @@ public:
 
   template <class CurClass>
   inline torch::class_<CurClass> class_(const std::string& className);
+
+  template <class CurClass>
+  inline torch::class_<CurClass> class_(detail::SelectiveStr<true> className);
+
+  template <class CurClass>
+  inline detail::ClassNotSelected class_(detail::SelectiveStr<false> className);
 
 private:
   Kind kind_;


### PR DESCRIPTION
Summary: Currently Torchbind classes arent selective. This makes is a rough granularity pass that will remove entire classes if they arent selected. If we need finer granularity in the future we can make individual methods within classes Selective. Theres also more classes that can be marked selective. Current linux list of all custom classes is {P463389669}

Test Plan: CI, model unit tests, test models in prod apps

Differential Revision: D31092564

