### PR TITLE
[numpy] Alias `arctan2` to `atan2`

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -191,6 +191,7 @@ _(aten, argmin) \
 _(aten, amax) \
 _(aten, amin) \
 _(aten, aminmax) \
+_(aten, arctan2) \
 _(aten, as_strided) \
 _(aten, as_tensor) \
 _(aten, atan2) \

--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -191,10 +191,8 @@ _(aten, argmin) \
 _(aten, amax) \
 _(aten, amin) \
 _(aten, aminmax) \
-_(aten, arctan2) \
 _(aten, as_strided) \
 _(aten, as_tensor) \
-_(aten, atan2) \
 _(aten, atleast_1d) \
 _(aten, atleast_2d) \
 _(aten, atleast_3d) \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -199,6 +199,7 @@ namespace c10 {
   _(aten, atan2)                     \
   _(aten, atan2_)                    \
   _(aten, arctan2)                   \
+  _(aten, arctan2_)                  \
   _(aten, atanh)                     \
   _(aten, atanh_)                    \
   _(aten, arctanh)                   \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -196,6 +196,9 @@ namespace c10 {
   _(aten, atan_)                     \
   _(aten, arctan)                    \
   _(aten, arctan_)                   \
+  _(aten, atan2)                     \
+  _(aten, atan2_)                    \
+  _(aten, arctan2)                   \
   _(aten, atanh)                     \
   _(aten, atanh_)                    \
   _(aten, arctanh)                   \

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -415,6 +415,10 @@ TORCH_IMPL_FUNC(atan2_out) (const Tensor& self, const Tensor& other, const Tenso
   atan2_stub(device_type(), *this);
 }
 
+Tensor arctan2(const Tensor& self, const Tensor& other) {
+  return at::atan2(self, other);
+}
+
 Tensor& add_relu_impl(
     Tensor& result, const Tensor& self, const Tensor& other, const Scalar& alpha) {
   auto iter = TensorIterator::binary_op(result, self, other);

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -420,7 +420,7 @@ Tensor arctan2(const Tensor& self, const Tensor& other) {
 }
 
 Tensor& arctan2_(Tensor& self, const Tensor& other) {
-  return at::atan2_(self, other);
+  return self.atan2_(other);
 }
 
 Tensor& arctan2_out(const Tensor& self, const Tensor& other, Tensor& result) {

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -419,6 +419,14 @@ Tensor arctan2(const Tensor& self, const Tensor& other) {
   return at::atan2(self, other);
 }
 
+Tensor& arctan2_(Tensor& self, const Tensor& other) {
+  return at::atan2_(self, other);
+}
+
+Tensor& arctan2_out(const Tensor& self, const Tensor& other, Tensor& result) {
+  return at::atan2_out(result, self, other);
+}
+
 Tensor& add_relu_impl(
     Tensor& result, const Tensor& self, const Tensor& other, const Scalar& alpha) {
   auto iter = TensorIterator::binary_op(result, self, other);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7038,6 +7038,10 @@
   structured_delegate: atan2.out
   variants: method, function
 
+# arctan2, alias of atan2
+- func: arctan2(Tensor self, Tensor other) -> Tensor
+  variants: method, function
+
 - func: lerp.Scalar_out(Tensor self, Tensor end, Scalar weight, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7042,6 +7042,12 @@
 - func: arctan2(Tensor self, Tensor other) -> Tensor
   variants: method, function
 
+- func: arctan2.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+
+- func: arctan2_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  variants: method
+
 - func: lerp.Scalar_out(Tensor self, Tensor end, Scalar weight, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -244,6 +244,7 @@ Tensor class reference
     Tensor.arctan_
     Tensor.atan2
     Tensor.atan2_
+    Tensor.arctan2
     Tensor.all
     Tensor.any
     Tensor.backward

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -245,6 +245,7 @@ Tensor class reference
     Tensor.atan2
     Tensor.atan2_
     Tensor.arctan2
+    Tensor.arctan2_
     Tensor.all
     Tensor.any
     Tensor.backward

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -292,6 +292,7 @@ Pointwise Ops
     atanh
     arctanh
     atan2
+    arctan2
     bitwise_not
     bitwise_and
     bitwise_or

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -563,6 +563,12 @@ atan2_(other) -> Tensor
 In-place version of :meth:`~Tensor.atan2`
 """)
 
+add_docstr_all('arctan2', r"""
+arctan2(other) -> Tensor
+
+See :func:`torch.arctan2`
+""")
+
 add_docstr_all('atanh', r"""
 atanh() -> Tensor
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -569,6 +569,12 @@ arctan2(other) -> Tensor
 See :func:`torch.arctan2`
 """)
 
+add_docstr_all('arctan2_', r"""
+atan2_(other) -> Tensor
+
+In-place version of :meth:`~Tensor.arctan2`
+""")
+
 add_docstr_all('atanh', r"""
 atanh() -> Tensor
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -927,6 +927,12 @@ Example::
     tensor([ 0.9833,  0.0811, -1.9743, -1.4151])
 """.format(**common_args))
 
+add_docstr(torch.arctan2,
+           r"""
+arctan2(input, other, *, out=None) -> Tensor
+Alias for :func:`torch.atan2`.
+""")
+
 add_docstr(torch.atanh, r"""
 atanh(input, *, out=None) -> Tensor
 

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -96,6 +96,8 @@ const std::unordered_map<Symbol, Symbol>& getOperatorAliasMap() {
       {aten::arcsin_, aten::asin_},
       {aten::arctan, aten::atan},
       {aten::arctan_, aten::atan_},
+      {aten::arctan2, aten::atan2},
+      {aten::arctan2_, aten::atan2_},
       {aten::arccosh, aten::acosh},
       {aten::arccosh_, aten::acosh_},
       {aten::arcsinh, aten::asinh},

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -332,6 +332,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.atan: lambda input, out=None: -1,
         torch.arctan: lambda input, out=None: -1,
         torch.atan2: lambda input, other, out=None: -1,
+        torch.arctan2: lambda input, other, out=None: -1,
         torch.atanh: lambda input, out=None: -1,
         torch.arctanh: lambda input, out=None: -1,
         torch.atleast_1d: lambda *tensors: -1,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6840,6 +6840,7 @@ op_db: List[OpInfo] = [
                                     active_if=IS_WINDOWS),
                    )),
     OpInfo('atan2',
+           aliases=('arctan2',),
            dtypes=all_types_and(torch.bool),
            dtypesIfCPU=all_types_and(torch.bool),
            dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),


### PR DESCRIPTION
Fixes #65906 

Adds an alias `arctan2` to improve numpy compatibility

cc @mruberry @rgommers