### PR TITLE
Specialize torch::make_variable to _unique

### DIFF
--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -75,6 +75,6 @@ def process_function(f: NativeFunction) -> Optional[str]:
     return f"""\
 inline at::Tensor {name}({', '.join(formals)}) {{
   at::AutoDispatchBelowADInplaceOrView guard;
-  return autograd::make_variable(at::{name}({', '.join(exprs)}), /*requires_grad=*/{requires_grad});
+  return autograd::make_variable_unique(at::{name}({', '.join(exprs)}), /*requires_grad=*/{requires_grad});
 }}
 """

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -38,7 +38,7 @@ namespace torch {
 /// - `unsigned long long int`
 /// - `long long int`
 inline at::Tensor tensor(detail::TensorDataContainer tensor_data_container, const at::TensorOptions& options = {}) {
-  return autograd::make_variable(
+  return autograd::make_variable_unique(
     // note: we remove the requires_grad setting from the TensorOptions because
     // it is ignored anyways (and we actually have an assertion that it isn't set
     // which would fail otherwise). We handle requires_grad explicitly here
@@ -69,7 +69,7 @@ inline at::Tensor from_blob(
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     return at::from_blob(data, sizes, strides, deleter, options.requires_grad(c10::nullopt));
   })();
-  return autograd::make_variable(tensor, options.requires_grad());
+  return autograd::make_variable_unique(std::move(tensor), options.requires_grad());
 }
 
 /// Exposes the given `data` as a `Tensor` without taking ownership of the
@@ -87,7 +87,7 @@ inline at::Tensor from_blob(
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     return at::from_blob(data, sizes, strides, options.requires_grad(c10::nullopt));
   })();
-  return autograd::make_variable(tensor, options.requires_grad());
+  return autograd::make_variable_unique(std::move(tensor), options.requires_grad());
 }
 
 /// Exposes the given `data` as a `Tensor` without taking ownership of the
@@ -106,7 +106,7 @@ inline at::Tensor from_blob(
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     return at::from_blob(data, sizes, deleter, options.requires_grad(c10::nullopt));
   })();
-  return autograd::make_variable(tensor, options.requires_grad());
+  return autograd::make_variable_unique(std::move(tensor), options.requires_grad());
 }
 
 /// Exposes the given `data` as a `Tensor` without taking ownership of the
@@ -122,7 +122,7 @@ inline at::Tensor from_blob(
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     return at::from_blob(data, sizes, options.requires_grad(c10::nullopt));
   })();
-  return autograd::make_variable(tensor, options.requires_grad());
+  return autograd::make_variable_unique(std::move(tensor), options.requires_grad());
 }
 
 ${function_definitions}


### PR DESCRIPTION
Used when the input tensor is guaranteed to be unique, e.g., when called with the result of tensor factories. Those are guaranteed to have no copies laying around.
Plus micro-optimization & code size shrinking on make_variable

@wconstab This is useful for lazy tensors when dealing with structured kernels. For example, zero() creates a new tensor and then calls zero_. This call to zero_ is delayed and added to the trace, thus bumping the reference counter on the new tensor.
When zero() returns, the reference counter is now 2 and make_variable won't go to the fast path anymore.
This patch assumes that all "tensor factory" ops return fresh tensors without further references and exploits that to skip copying them. (c.f. https://github.com/nunoplopes/torchy/issues/10)