### PR TITLE
[SR] Fix bug in FuseListUnpackV2

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -648,7 +648,9 @@ void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph) {
       // This captures a case of `y = fb::equally_split(x, 1, _)` where y
       // becomes just an alias of x.
       // If this case is found, replace y with x to avoid executing this op.
-      node->output(0)->replaceAllUsesWith(node->input(0));
+      list_unpack_node->output()->replaceAllUsesWith(node->input(0));
+      list_unpack_node->destroy();
+      to_remove.push_back(node);
       continue;
     }
 


### PR DESCRIPTION
Summary:
When applying the equally split optimization, we still need to delete the list unpack node.

I did an accuracy test yesterday but didn't catch this issue because my diffs were not properly synced between devservers (I use hlu1's devbig for testing and it had an old version of "Add FuseListUnpackV2"). But I did another test this morning and realized that there was an issue.

Differential Revision: D31827278

