### PR TITLE
Codegen arange.start_out 

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -76,6 +76,25 @@ std::vector<int64_t> expand_param_if_needed(
   }
 }
 
+std::vector<Shape> compute_shape_arange_out(const at::Scalar & start, const at::Scalar & end, const at::Scalar & step, at::Tensor & out) {
+  //Returns a 1-D tensor of size
+  // ceil ( (end - start) / step )
+  // ceil (a/b) = (a + b - 1) / b;
+  assert(step.toFloat() != 0);
+  int64_t size = (end.toFloat() - start.toFloat()) / step.toFloat();
+  assert (size > 0);
+
+  // From torch.arange docs:
+  // dtype (torch.dtype, optional) – the desired data type of returned tensor.
+  // Default: if None, uses a global default (see torch.set_default_tensor_type()).
+  // If dtype is not given, infer the data type from the other input arguments.
+  // If any of start, end, or stop are floating-point, the dtype is inferred to be the default dtype, see get_default_dtype().
+  // Otherwise, the dtype is inferred to be torch.int64.
+
+  // Since out tensor is specified, its dtype should always be used?
+  return {Shape(out.scalar_type(), {size})};
+}
+
 std::vector<Shape> compute_shape_binary_cross_entropy(const at::Tensor & self, const at::Tensor & target, const c10::optional<at::Tensor> & weight, int64_t reduction) {
   if(reduction == at::Reduction::None) {
     return {Shape(self.scalar_type(), self.sizes().vec())};
@@ -151,11 +170,11 @@ std::vector<Shape> compute_shape_convolution(const at::Tensor & input, const at:
   }
 }
 
-std::vector<Shape> compute_shape_masked_fill(at::Tensor & self, const at::Tensor & mask, const at::Scalar & value) {
+std::vector<Shape> compute_shape_masked_fill_(at::Tensor & self, const at::Tensor & mask, const at::Scalar & value) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
-std::vector<Shape> compute_shape_masked_fill(at::Tensor & self, const at::Tensor & mask, const at::Tensor & value) {
+std::vector<Shape> compute_shape_masked_fill_(at::Tensor & self, const at::Tensor & mask, const at::Tensor & value) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
@@ -276,6 +295,10 @@ std::vector<Shape> compute_shape_relu(const at::Tensor& self) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
+std::vector<Shape> compute_shape_relu_(at::Tensor& self) {
+  return compute_shape_relu(self);
+}
+
 std::vector<Shape> compute_shape_bitwise_and(const at::Tensor& self, const at::Scalar& other) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
@@ -293,7 +316,7 @@ std::vector<Shape> compute_shape_sum(
   return {Shape(self.scalar_type(), {})};;
 }
 
-std::vector<Shape> compute_shape_zero(at::Tensor& self) {
+std::vector<Shape> compute_shape_zero_(at::Tensor& self) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -9,6 +9,7 @@ full_codegen:
   - addcdiv
   - addcmul
   - addmm
+  - arange.start_out
   - avg_pool2d
   - avg_pool2d_backward
   - baddbmm

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -231,7 +231,9 @@ class GenLazyNativeFuncDefinition:
             lazy_tensors.push_back(torch::lazy::LazyTensor::Create(torch::lazy::Value(node, i), *common_device));
         }}
         auto result = torch::lazy::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
-        if schema.name.name.inplace:
+
+        if schema.name.name.inplace or "out" in func.func.name.overload_name:
+            # TODO(whc) ensure a clean way to match kernels that are out= variants and need same handling as inplace
             assert returns_length == 1, "We assumed there was no such case where an op is an in-place variant " \
                                         "and has tuple outputs."
             bridge_str = f"""lazy_{first_tensor_name}.SetInPlaceIrValue(node);

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -232,8 +232,7 @@ class GenLazyNativeFuncDefinition:
         }}
         auto result = torch::lazy::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
 
-        if schema.name.name.inplace or "out" in func.func.name.overload_name:
-            # TODO(whc) ensure a clean way to match kernels that are out= variants and need same handling as inplace
+        if schema.name.name.inplace or func.func.is_out_fn():
             assert returns_length == 1, "We assumed there was no such case where an op is an in-place variant " \
                                         "and has tuple outputs."
             bridge_str = f"""lazy_{first_tensor_name}.SetInPlaceIrValue(node);

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -198,7 +198,8 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         'func_declarations': list(concat_map_codegen(
             dest.GenLazyShapeInferenceDefinition(backend_indices[backend_key],
                                                  tensor_class),
-            grouped_native_functions
+            grouped_native_functions,
+            codegenInplaceVariant=True,
         )),
     })
     # Generate IR node classes


### PR DESCRIPTION
- does not add full support for factory functions (with TensorOption
  style args), but does add codegen support for handling expanding
  TensorOption args into their components.  Needs more work in order
  to support ops like `arange`
- supports arange.start_out: changes to how shape inference
  functions are named, to accomodate having out variants vs functional variants

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc