### PR TITLE
[LTC] Fix a few build issues in my environment

### DIFF
--- a/lazy_tensor_core/test/cpp/CMakeLists.txt
+++ b/lazy_tensor_core/test/cpp/CMakeLists.txt
@@ -36,7 +36,7 @@ ExternalProject_Add(
   LOG_CONFIGURE ON
   LOG_BUILD ON
   CMAKE_ARGS
-    "-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=${PT_CXX_ABI} -Wno-error=maybe-uninitialized")
+    "-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=${PT_CXX_ABI} -Wno-error")
 
 ExternalProject_Get_Property(googletest SOURCE_DIR)
 

--- a/lazy_tensor_core/test/cpp/run_tests.sh
+++ b/lazy_tensor_core/test/cpp/run_tests.sh
@@ -54,7 +54,9 @@ cmake "$RUNDIR" \
   -DCMAKE_BUILD_TYPE=$BUILDTYPE \
   -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
   -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/' + sysconfig.get_config_var('LDLIBRARY'))")
-make -j $VERB
+# Ninja needs a separate build invocation for googletest.
+cmake --build . --target googletest
+cmake --build . --target all
 
 if [ $BUILD_ONLY -eq 0 ]; then
   if [ "$LOGFILE" != "" ]; then


### PR DESCRIPTION
- clang 11 doesn't support `-Wno-error=maybe-uninitialized`. Just
  replace it with `-Wno-error` (I don't think we care that much about
  googletest's warnings -- we could silence all warnings with `-w`
  potentially as well).
- Use `cmake --build` instead of hardcoding `make` in `run_tests.sh`.
  This makes it more portable across cmake generators (I have been using
  ninja)
- Add a separate `cmake --build` invocation for `googletest` to appease
  the CMake Ninja generator. I'm not sure why it requires this.
