### PR TITLE
Extend autograd functional benchmarking to run jacfwd, jacrev, hessian_fwdrev, and hessian_revrev

### DIFF
--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -12,6 +12,30 @@ import audio_text_models
 
 from utils import to_markdown_table, TimingResultType, InputsType, GetterType, VType
 
+def get_task_func(task: str) -> Callable:
+    def hessian_fwdrev(model, inp, strict=None):
+        return functional.hessian(model, inp, strict=False, vectorize=True, forward_ad=True)
+
+    def hessian_revrev(model, inp, strict=None):
+        return functional.hessian(model, inp, strict=False, vectorize=True)
+
+    def jacfwd(model, inp, strict=None):
+        return functional.jacobian(model, inp, strict=False, vectorize=True, forward_ad=True)
+
+    def jacrev(model, inp, strict=None):
+        return functional.jacobian(model, inp, strict=False, vectorize=True)
+
+    if task == "hessian_fwdrev":
+        return hessian_fwdrev
+    elif task == "hessian_revrev":
+        return hessian_revrev
+    elif task == "jacfwd":
+        return jacfwd
+    elif task == "jacrev":
+        return jacrev
+    else:
+        return getattr(functional, task)
+
 # Listing of the different tasks
 FAST_TASKS_NO_DOUBLE_BACK = [
     "vjp",
@@ -22,13 +46,17 @@ FAST_TASKS = FAST_TASKS_NO_DOUBLE_BACK + [
     "jvp",
 ]
 
-ALL_TASKS = FAST_TASKS + [
+ALL_TASKS_NON_VECTORIZED = FAST_TASKS + [
     "hvp",
     "jacobian",
     "hessian"
 ]
 
 DOUBLE_BACKWARD_TASKS = ["jvp", "hvp", "vhp", "hessian"]
+
+VECTORIZED_TASKS = ["hessian_fwdrev", "hessian_revrev", "jacfwd", "jacrev"]
+
+ALL_TASKS = ALL_TASKS_NON_VECTORIZED + VECTORIZED_TASKS
 
 # Model definition which contains:
 # - name: a string with the model name.
@@ -47,7 +75,7 @@ MODELS = [
     ModelDef("resnet18", vision_models.get_resnet18, FAST_TASKS, []),
     ModelDef("fcn_resnet", vision_models.get_fcn_resnet, FAST_TASKS, []),
     ModelDef("detr", vision_models.get_detr, FAST_TASKS, []),
-    ModelDef("ppl_simple_reg", ppl_models.get_simple_regression, ALL_TASKS, []),
+    ModelDef("ppl_simple_reg", ppl_models.get_simple_regression, ["jacfwd", "jacrev"], []),
     ModelDef("ppl_robust_reg", ppl_models.get_robust_regression, ALL_TASKS, []),
     ModelDef("wav2letter", audio_text_models.get_wav2letter, FAST_TASKS, []),
     ModelDef("deepspeech", audio_text_models.get_deepspeech, FAST_TASKS_NO_DOUBLE_BACK, DOUBLE_BACKWARD_TASKS),
@@ -72,7 +100,7 @@ def get_v_for(model: Callable, inp: InputsType, task: str) -> VType:
     return v
 
 def run_once(model: Callable, inp: InputsType, task: str, v: VType) -> None:
-    func = getattr(functional, task)
+    func = get_task_func(task)
 
     if v is not None:
         res = func(model, inp, v=v, strict=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67042
* #67041
* #67040
* #66294
* #66293
* #66292
* #66291

