### PR TITLE
[LTC] Build in C++17 mode.

### DIFF
--- a/lazy_tensor_core/setup.py
+++ b/lazy_tensor_core/setup.py
@@ -251,7 +251,7 @@ def make_relative_rpath(path):
 
 
 extra_compile_args = [
-    '-std=c++14',
+    '-std=c++17',
     '-Wno-sign-compare',
     '-Wno-unknown-pragmas',
     '-Wno-deprecated-declarations',

--- a/lazy_tensor_core/test/cpp/run_tests.sh
+++ b/lazy_tensor_core/test/cpp/run_tests.sh
@@ -51,6 +51,7 @@ rm -rf "$BUILDDIR"
 mkdir "$BUILDDIR" 2>/dev/null
 pushd "$BUILDDIR"
 cmake "$RUNDIR" \
+  -DCMAKE_CXX_FLAGS="-std=c++17" \
   -DCMAKE_BUILD_TYPE=$BUILDTYPE \
   -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
   -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR') + '/' + sysconfig.get_config_var('LDLIBRARY'))")


### PR DESCRIPTION
We are using it in our code already in
`CreateComputationShapeFromMetaTensors`/`CreateDTypeFromMetaTensors`:

```
lazy_tensor_core/csrc/tensor_util.h:94:50: warning: pack fold expression is a C++17 extension [-Wc++17-extensions]
      ((shape.push_back(tensors.sizes().vec())), ...);
                                                 ^
lazy_tensor_core/csrc/tensor_util.h:103:51: warning: pack fold expression is a C++17 extension [-Wc++17-extensions]
      ((dtypes.push_back(tensors.scalar_type())), ...);
                                                  ^
```

