### PR TITLE
[LTC] Code-gen `sort`

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
@@ -208,6 +208,14 @@ std::vector<c10::ScalarType> compute_dtype_trace(const at::Tensor& self) {
   return {self.scalar_type()};
 }
 
+std::vector<std::vector<int64_t>> compute_shape_sort(const at::Tensor & self, int64_t dim, bool descending) {
+  return {self.sizes().vec(), self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_sort(const at::Tensor & self, int64_t dim, bool descending) {
+  return {self.scalar_type(), c10::ScalarType::Long};
+}
+
 std::vector<std::vector<int64_t>> compute_shape_smooth_l1_loss(
     const at::Tensor& self, const at::Tensor& target, int64_t reduction,
     double beta) {
@@ -234,13 +242,13 @@ std::vector<std::vector<int64_t>> compute_shape_smooth_l1_loss_backward(
   // shape may vary following the logic of the forward output, the output of
   // this kernel should have fixed shapes matching the inputs to the forward
   // kernel.
-  return {self.sizes().vec(), target.sizes().vec()};
+  return {self.sizes().vec()};
 }
 
 std::vector<c10::ScalarType> compute_dtype_smooth_l1_loss_backward(
     const at::Tensor& grad_output, const at::Tensor& self,
     const at::Tensor& target, int64_t reduction, double beta) {
-  return {self.scalar_type(), target.scalar_type()};
+  return {self.scalar_type()};
 }
 
 std::vector<std::vector<int64_t>> compute_shape_log_sigmoid_forward(const at::Tensor& self) {

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -44,6 +44,7 @@ full_codegen:
   - smooth_l1_loss_backward
   - softplus
   - softplus_backward
+  - sort
   - sum
   - sum.dim_IntList
   - topk

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -174,6 +174,9 @@ class GenLazyNativeFuncDefinition:
             meta_str = f"""
         auto out_shape = {shape_sig.shape_call};
         auto out_dtype = {shape_sig.dtype_call};"""
+        meta_str += f"""
+        TORCH_INTERNAL_ASSERT(out_shape.size() == {returns_length});
+        TORCH_INTERNAL_ASSERT(out_dtype.size() == {returns_length});"""
 
         node_str = f"""auto node = torch::lazy::MakeNode<ir::ops::{schema.node_name}>({node_ctor_input_str},
                                                                                       out_dtype, out_shape);"""


### PR DESCRIPTION
- Code-gen `sort`.
- Teach `gen_lazy_nativefunc_definition` to emit assertions that the
  number of shapes/dtypes computed is as expected.
  - Fix bug in `smooth_l1_loss_backward` uncovered by the assertion.

Test Plan:
```
test/cpp/build/test_ptltc
```
