### PR TITLE
Skip meta conversion before running shape inference

### DIFF
--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -163,12 +163,7 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
             meta_out = """auto out_shape = CreateComputationShapeFromMetaTensors(out_meta);
     auto out_dtype = CreateDTypeFromMetaTensors(out_meta);"""
 
-        meta_args_list = []
-        for t in all_types:
-            meta_arg = f"{t.name}.to(c10::kMeta)" if t in value_types else f"{t.name}"
-            meta_args_list.append(meta_arg)
-        meta_args = ", ".join(meta_args_list)
-        meta_str = f"""auto out_meta = at::meta::{schema.aten_name}({meta_args});
+        meta_str = f"""auto out_meta = at::meta::{schema.aten_name}({', '.join(str(t.name) for t in all_types)});
     {meta_out}"""
     else:
         meta_args = ", ".join([f"{t.name}" for t in all_types])

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -163,12 +163,7 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
             meta_out = """auto out_shape = CreateComputationShapeFromMetaTensors(out_meta);
     auto out_dtype = CreateDTypeFromMetaTensors(out_meta);"""
 
-        meta_args_list = []
-        for t in all_types:
-            meta_arg = f"{t.name}.to(c10::kMeta)" if t in value_types else f"{t.name}"
-            meta_args_list.append(meta_arg)
-        meta_args = ", ".join(meta_args_list)
-        meta_str = f"""auto out_meta = at::meta::{schema.aten_name}({meta_args});
+        meta_str = f"""auto out_meta = at::meta::{schema.aten_name}({', '.join(t.name for t in all_types)});
     {meta_out}"""
     else:
         meta_args = ", ".join([f"{t.name}" for t in all_types])


### PR DESCRIPTION
It turns out that the `at::meta::` API doesn't require the inputs be meta tensors in order to work; this should actually reduce overhead a fair amount (since .to() required going through the dispatcher).

Separately, this fixes a really awful bug in shape/dtype inference for LazyTensor: see the comment [thread here](https://github.com/pytorch/pytorch/pull/67044/files#r734018083).

The error shows up in this code:
```
a = at::ones({2}, at::TensorOptions().dtype(at::kByte));
b = at::div(a, 1.0);  // final dtype is "float" (???)
```

PyTorch core has some interesting type promotion logic, that ends up giving the result type a dtype of `float`. Part of that logic involves the fact that the `1.0` gets turned into a "wrapped scalar tensor" that core knows how to treat specially.

However, in the LTC code we're running shape inference like this:
```
auto out_meta = at::meta::div(self.to(c10::kMeta), other.to(c10::kMeta));
```

The `other.to(...)` call ends up getting rid of the "wrapped-scalar-tensor"-ness of `other`, which affects the type promotion logic: `other.to(c10::kMeta)` is now a legitimate `dtype=double` tensor, and type promotion gives the output a dtype of `double`.

So the simple fix is just to pass the tensors directly into `at::meta::{op}` without converting them to meta tensors first.

If for whatever reason that fails, we could still fix the behavior by manually setting `is_wrapped_number(...)` after the fact. I'm testing this fix on top of https://github.com/pytorch/pytorch/pull/67044 first to confirm.
