### PR TITLE
Added schedule build for LTS branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,6 @@
 version: 2.1
 
 parameters:
-  run_binary_tests:
-    type: boolean
-    default: false
   run_build:
     type: boolean
     default: true
@@ -6640,7 +6637,13 @@ workflows:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           package_type: libtorch
           upload_subfolder: cu111
-    when: << pipeline.parameters.run_binary_tests >>
+    triggers:
+      - schedule:
+          cron: "30 1 1,15 * *"
+          filters:
+            branches:
+              only:
+                - lts/release/1.8
   build:
     jobs:
       - docker_build_job:

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -106,10 +106,28 @@ def gen_build_workflows_tree():
         binary_build_definitions.get_nightly_uploads,
     ]
 
+    # Schedule LTS branch to build every 2 weeks
+    # (on the 1st and 15th of every month at 1:30AM)
+    # on workflow "binary_builds".
+    lts_binary_builds_schedule = [
+        {
+            "schedule": {
+                "cron": "\"30 1 1,15 * *\"",
+                "filters": {
+                    "branches": {
+                        "only": [
+                            "lts/release/1.8"
+                        ]
+                    }
+                }
+            },
+        }
+    ]
+
     return {
         "workflows": {
             "binary_builds": {
-                "when": r"<< pipeline.parameters.run_binary_tests >>",
+                "triggers": lts_binary_builds_schedule,
                 "jobs": [f() for f in binary_build_functions],
             },
             "build": {

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -8,9 +8,6 @@
 version: 2.1
 
 parameters:
-  run_binary_tests:
-    type: boolean
-    default: false
   run_build:
     type: boolean
     default: true


### PR DESCRIPTION
This PR adds the logic for scheduling PyTorch LTS wheels to be built and published once every 2 weeks (on the 1st and 15th of every month, at 1:30 AM). This triggers the ["binary_builds" CircleCI workflow](https://app.circleci.com/pipelines/github/pytorch/pytorch/370495/workflows/7c927b03-fdb5-4acc-b2e8-570b8e6a7a90), which updates published wheels at https://download.pytorch.org/whl/lts/1.8/torch_lts.html.