### PR TITLE
[fx]Early return if a node tries prepend self

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1908,6 +1908,16 @@ class TestFX(JitTestCase):
         input = torch.randn(33, 44)
         self.assertEqual(gm(input), torch.relu(torch.neg(input)))
 
+    def test_prepend_self(self):
+        graph : torch.fx.Graph = torch.fx.Graph()
+        x : torch.fx.Node = graph.create_node('placeholder', 'x')
+        b : torch.fx.Node = graph.create_node('call_function', target=torch.relu, args=(x,))
+        output : torch.fx.Node = graph.output(b)
+
+        b.prepend(b)
+        x.append(b)
+        self.assertEqual(len(graph.nodes), 3)
+
     def test_erase_node_error(self):
         st = SimpleTest()
         traced = symbolic_trace(st)

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -5,6 +5,7 @@ from .immutable_collections import immutable_dict, immutable_list
 import torch
 import builtins
 import types
+import warnings
 from torch.fx.operator_schemas import normalize_function, normalize_module, ArgsKwargsPair
 
 if TYPE_CHECKING:
@@ -233,6 +234,9 @@ class Node:
             x (Node): The node to put before this node. Must be a member of the same graph.
         """
         assert self.graph == x.graph, "Attempting to move a Node into a different Graph"
+        if self == x:
+            warnings.warn("Trying to prepend a node to itself. This behavior has no effect on the graph.")
+            return
         x._remove_from_list()
         p = self._prev
         p._next, x._prev = x, p


### PR DESCRIPTION
Summary:
Prepending a node to itself will result in the node gets removed from the graph.

Usually people won't prepend a node with itself. But people would accidentally try to append a node that's already next to `self` node, which will be prepending `self` to `self`.

Test Plan: Added a unit test

Differential Revision: D31849030

