### PR TITLE
[ONNX] Remove the argument use_external_data_format of export() method entirely.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -428,11 +428,11 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.tensor([2], dtype=torch.long)
         f = io.BytesIO()
-        with self.assertRaises(RuntimeError) as e:
+        err_msg = ("The serialized model is larger than the 2GiB limit imposed by the protobuf library. "
+                   "Therefore the output file must be a file path, so that the ONNX external data can be written to "
+                   "the same directory. Please specify the output file name.")
+        with self.assertRaisesRegex(RuntimeError, err_msg):
             torch.onnx.export(LargeModel(), x, f)
-
-        self.assertEqual("For large model export, f in torch.onnx.export must be a non-empty string " +
-                            "specifying the location of the model.", e.exception.args[0])
 
     def test_fuse_conv_bn1d(self):
         class Fuse(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -325,7 +325,7 @@ class TestONNXRuntime(unittest.TestCase):
     def run_model_test_with_external_data(self, model, input, rtol=0.001, atol=1e-7,
                                           do_constant_folding=True, dynamic_axes=None,
                                           input_names=None, output_names=None,
-                                          ort_optim_on=True, training=None, use_external_data_format=None):
+                                          ort_optim_on=True, training=None):
         import os
         import tempfile
 
@@ -353,8 +353,7 @@ class TestONNXRuntime(unittest.TestCase):
                                   do_constant_folding=do_constant_folding,
                                   keep_initializers_as_inputs=self.keep_initializers_as_inputs,
                                   dynamic_axes=dynamic_axes,
-                                  input_names=input_names, output_names=output_names,
-                                  use_external_data_format=use_external_data_format)
+                                  input_names=input_names, output_names=output_names)
                 # compute onnxruntime output prediction
                 ort_sess_opt = onnxruntime.SessionOptions()
                 ort_sess_opt.graph_optimization_level = \
@@ -391,26 +390,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_model_test_with_external_data(model, x)
 
     @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
-    def test_mobilenet_v2_with_external_data(self):
-        model = torchvision.models.mobilenet_v2(pretrained=False)
-        x = torch.randn(2, 3, 224, 224, requires_grad=True)
-        # We are turning off Onnx Runtime optimization off in this test,
-        # because external data format is not supported to in ORT optimizer.
-        # Once that support is added, we can set ort_optim_on=True (default).
-        self.run_model_test_with_external_data(model, x, rtol=1e-3, atol=1e-5,
-                                               ort_optim_on=False)
-
-    @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
-    def test_attribute_with_external_data(self):
-        class LargeModel(torch.nn.Module):
-            def forward(self, x):
-                return x + torch.ones(2, 1024)
-
-        x = torch.randn(2, 1)
-        self.run_model_test_with_external_data(LargeModel(), x, use_external_data_format=None)
-
-    @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
-    def test_largemodel_without_use_external_data_format_param(self):
+    def test_largemodel_with_external_data(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):
                 super(LargeModel, self).__init__()
@@ -426,36 +406,9 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, input):
                 return self.seq(input)
 
-        model = LargeModel()
         x = torch.tensor([2], dtype=torch.long)
-        self.run_model_test_with_external_data(LargeModel(), x, use_external_data_format=None)
-
-    @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
-    def test_largemodel_with_use_external_data_format_False(self):
-        class LargeModel(torch.nn.Module):
-            def __init__(self):
-                super(LargeModel, self).__init__()
-                dim = 5
-                n = 30 * 4 * 10 ** 6
-                self.emb = torch.nn.Embedding(n, dim)
-                self.lin1 = torch.nn.Linear(dim, 1)
-                self.seq = torch.nn.Sequential(
-                    self.emb,
-                    self.lin1,
-                )
-
-            def forward(self, input):
-                return self.seq(input)
-
-        model = LargeModel()
-        x = torch.tensor([3], dtype=torch.long)
-
-        with self.assertRaises(RuntimeError) as cm:
-            self.run_model_test_with_external_data(LargeModel(), x, use_external_data_format=False)
-
-            the_exception = cm.exception
-            self.assertEqual("RuntimeError: Exporting model exceed maximum protobuf size of 2GB. " +
-                             "Please call torch.onnx.export without setting use_external_data_format parameter.")
+        self.run_model_test_with_external_data(LargeModel(), x)
+        # self.run_test(LargeModel(), (x))
 
     def test_fuse_conv_bn1d(self):
         class Fuse(torch.nn.Module):

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -264,7 +264,7 @@ void initPythonIRBindings(PyObject* module_) {
             std::shared_ptr<::ONNX_NAMESPACE::ModelProto> model_proto;
             RawDataExportMap export_map;
             SymbolDimMap symbol_map;
-            bool val_use_external_data_format = false;
+            bool val_use_external_data_format;
             std::tie(
                 model_proto,
                 export_map,

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -257,14 +257,13 @@ void initPythonIRBindings(PyObject* module_) {
              bool keep_initializers_as_inputs,
              const std::map<std::string, int>& custom_opsets,
              bool add_node_names,
-             bool use_external_data_format,
              const std::string& onnx_file_path,
              const NodeAttrNameMap& node_attr_to_name) {
             std::string graph;
             std::shared_ptr<::ONNX_NAMESPACE::ModelProto> model_proto;
             RawDataExportMap export_map;
             SymbolDimMap symbol_map;
-            bool val_use_external_data_format;
+            bool val_use_external_data_format = false;
             std::tie(
                 model_proto,
                 export_map,
@@ -281,7 +280,7 @@ void initPythonIRBindings(PyObject* module_) {
                     keep_initializers_as_inputs,
                     custom_opsets,
                     add_node_names,
-                    use_external_data_format,
+                    val_use_external_data_format,
                     onnx_file_path,
                     node_attr_to_name);
             std::unordered_map<std::string, py::bytes>
@@ -311,7 +310,6 @@ void initPythonIRBindings(PyObject* module_) {
           py::arg("keep_initializers_as_inputs") = true,
           py::arg("custom_opsets"),
           py::arg("add_node_names") = true,
-          py::arg("use_external_data_format") = false,
           py::arg("onnx_file_path") = std::string(),
           py::arg("node_attr_to_name") = NodeAttrNameMap())
       .def(

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -445,7 +445,7 @@ GraphEncoder::GraphEncoder(
 
   // If graph proto size exceed maximum protobuf size of 2GB, set
   // use_external_data_format to true.
-  if (!use_external_data_format && !onnx_file_path.empty() &&
+  if (!use_external_data_format &&
       GetGraphProtoSize(model_proto_.mutable_graph(), graph, initializers) >
           INT_MAX) {
     GRAPH_DEBUG(
@@ -459,8 +459,8 @@ GraphEncoder::GraphEncoder(
   if (use_external_data_format) {
     TORCH_CHECK(
         !onnx_file_path.empty(),
-        "For large model export, f in torch.onnx.export must be a non-empty string "
-        "specifying the location of the model.");
+        "For large model export, f in torch.onnx.export must be a non-empty string. "
+        "Please specify the location of the model.");
   }
 
   auto* imp = model_proto_.add_opset_import();

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -338,9 +338,9 @@ class GraphEncoder {
   NodeAttrNameMap node_attr_to_name_;
   // For large models, the parameters can be stored in separate binary files.
   // This parameter sets a threshold on the number of elements in the parameter
-  // tensor, beyond which the parameter is stored in a separate file (if API
-  // argument use_external_data_format is set to True). This threshold is in
-  // place so as not to create too many external files.
+  // tensor, beyond which the parameter is stored in a separate file (if
+  // use_external_data_format_ is True). This threshold is in place
+  // so as not to create too many external files.
   const size_t ParamSizeThresholdForExternalStorage = 1024;
 };
 
@@ -1211,11 +1211,6 @@ export_onnx(
 
 std::string serialize_model_proto_to_string(
     const std::shared_ptr<::ONNX_NAMESPACE::ModelProto>& model_proto) {
-  const size_t proto_size = model_proto->ByteSizeLong();
-  TORCH_CHECK(
-      proto_size <= INT_MAX,
-      "Exporting model exceed maximum protobuf size of 2GB. "
-      "Please call torch.onnx.export without setting use_external_data_format parameter.");
   return model_proto->SerializeAsString();
 }
 

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -459,8 +459,9 @@ GraphEncoder::GraphEncoder(
   if (use_external_data_format) {
     TORCH_CHECK(
         !onnx_file_path.empty(),
-        "For large model export, f in torch.onnx.export must be a non-empty string. "
-        "Please specify the location of the model.");
+        "The serialized model is larger than the 2GiB limit imposed by the protobuf library. ",
+        "Therefore the output file must be a file path, so that the ONNX external data can ",
+        "be written to the same directory. Please specify the output file name.");
   }
 
   auto* imp = model_proto_.add_opset_import();

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -37,7 +37,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, do_constant_folding=True, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           use_external_data_format=None, export_modules_as_functions=False):
+           export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
@@ -287,9 +287,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             the opset version is set to 1. Only custom opset domain name and version should be
             indicated through this argument.
 
-        use_external_data_format (bool, default False): Deprecated and ignored. Will be removed in
-            next Pytorch release.
-        export_modules_as_functions (bool or set of type of nn.Module, default False): Flag to enable
+        export_modules_as_functions (bool or set of str, type or nn.Module, default False): Flag to enable
             exporting all ``nn.Module`` forward calls as local functions in ONNX. Or a set to indicate the
             particular modules to export as local functions in ONNX.
 
@@ -308,7 +306,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                         input_names, output_names, operator_export_type, opset_version,
                         do_constant_folding, dynamic_axes,
                         keep_initializers_as_inputs, custom_opsets,
-                        use_external_data_format, export_modules_as_functions)
+                        export_modules_as_functions)
 
 
 def export_to_pretty_string(*args, **kwargs) -> str:


### PR DESCRIPTION
This was deprecated in PyTorch 1.10: https://github.com/pytorch/pytorch/pull/62257.
There are no any issue request yet.

## BC-breaking note
### The signature of `torch.onnx.export()` changed: the argument `use_external_data_format` has been removed.
Setting `use_external_data_format` in a call to `torch.onnx.export()` will fail. Since version 1.9, the `export()` code automatically uses the external data format if the exported model size > 2GiB.


Below are examples of how to export a large model:

Version 1.9 and older:
```
torch.onnx.export(MyModel(), (x,), 'test_export_arg.onnx', use_external_data_format=True)

```


Version 1.11
```
torch.onnx.export(MyModel(), (x,), 'test_export_arg.onnx')

```