### PR TITLE
[ONNX] Remove the argument example_outpus of export() method entirely.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -122,12 +122,11 @@ def ort_compare_with_pytorch(ort_outs, output, rtol, atol):
 
 def run_model_test(self, model, batch_size=2, state_dict=None,
                    input=None, use_gpu=True, rtol=0.001, atol=1e-7,
-                   example_outputs=None, do_constant_folding=True,
-                   dynamic_axes=None, test_with_inputs=None,
-                   input_names=None, output_names=None,
-                   fixed_batch_size=False, dict_check=True,
-                   training=None, remained_onnx_input_idx=None,
-                   flatten=True):
+                   do_constant_folding=True, dynamic_axes=None,
+                   test_with_inputs=None, input_names=None,
+                   output_names=None, fixed_batch_size=False,
+                   dict_check=True, training=None,
+                   remained_onnx_input_idx=None, flatten=True):
     if training is not None and training == torch.onnx.TrainingMode.TRAINING:
         model.train()
     elif training is None or training == torch.onnx.TrainingMode.EVAL:

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -17,7 +17,7 @@ import onnx
 import io
 import copy
 import unittest
-
+from typing import List
 
 skip = unittest.skip
 
@@ -128,8 +128,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_output_list(self):
         class PaddingLayer(torch.jit.ScriptModule):
             @torch.jit.script_method
-            def forward(self, input_t, n):
-                # type: (Tensor, int) -> List[Tensor]
+            def forward(self, input_t: torch.Tensor, n: int) -> List[torch.Tensor]:
                 for i in range(n):
                     input_t = input_t * 2
                 return [input_t]

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -129,22 +129,20 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         class PaddingLayer(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, input_t, n):
-                # type: (Tensor, int) -> Tensor
+                # type: (Tensor, int) -> List[Tensor]
                 for i in range(n):
                     input_t = input_t * 2
-                return input_t
+                return [input_t]
 
         input_t = torch.ones(size=[10], dtype=torch.long)
         n = 2
         model = torch.jit.script(PaddingLayer())
-        example_output = model(input_t, n)
 
         with self.assertRaises(RuntimeError):
             torch.onnx._export(model,
                                (input_t, n),
                                "test.onnx",
-                               opset_version=self.opset_version,
-                               example_outputs=[example_output])
+                               opset_version=self.opset_version)
 
     def test_constant_fold_transpose(self):
         class TransposeModule(torch.nn.Module):

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -226,7 +226,7 @@ class Errors(object):
             raise RuntimeError("ShortCircuit was raised, but no errors were recorded")
 
 def verify(model, args, backend, verbose=False, training=torch.onnx.TrainingMode.EVAL, rtol=1e-3, atol=1e-7,
-           test_args=2, do_constant_folding=True, example_outputs=None, opset_version=None,
+           test_args=2, do_constant_folding=True, opset_version=None,
            keep_initializers_as_inputs=True, add_node_names=False,
            operator_export_type=torch.onnx.OperatorExportTypes.ONNX,
            input_names=None, dynamic_axes=None,
@@ -354,7 +354,6 @@ def verify(model, args, backend, verbose=False, training=torch.onnx.TrainingMode
         proto_bytes = io.BytesIO()
         torch_out = torch.onnx._export(model, args, proto_bytes, verbose=verbose,
                                        do_constant_folding=do_constant_folding,
-                                       example_outputs=example_outputs,
                                        opset_version=opset_version,
                                        keep_initializers_as_inputs=keep_initializers_as_inputs,
                                        add_node_names=add_node_names,
@@ -370,7 +369,6 @@ def verify(model, args, backend, verbose=False, training=torch.onnx.TrainingMode
             alt_proto_bytes = io.BytesIO()
             torch_out = torch.onnx._export(model, args, alt_proto_bytes, verbose=verbose,
                                            do_constant_folding=do_constant_folding,
-                                           example_outputs=example_outputs,
                                            opset_version=opset_version,
                                            keep_initializers_as_inputs=keep_initializers_as_inputs,
                                            add_node_names=add_node_names,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -35,8 +35,8 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, do_constant_folding=True, example_outputs=None,
-           dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
+           opset_version=None, do_constant_folding=True, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None,
            use_external_data_format=None, export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
@@ -189,14 +189,11 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         do_constant_folding (bool, default False): Apply the constant-folding optimization.
             Constant-folding will replace some of the ops that have all constant inputs
             with pre-computed constant nodes.
-        example_outputs (T or a tuple of T, where T is Tensor or convertible to Tensor, default None):
-            Deprecated and ignored. Will be removed in next PyTorch release.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
 
             By default the exported model will have the shapes of all input and output tensors
-            set to exactly match those given in ``args`` (and ``example_outputs`` when that arg is
-            required). To specify axes of tensors as dynamic (i.e. known only at run-time), set
-            ``dynamic_axes`` to a dict with schema:
+            set to exactly match those given in ``args``. To specify axes of tensors as
+            dynamic (i.e. known only at run-time), set ``dynamic_axes`` to a dict with schema:
 
             * KEY (str): an input or output name. Each name must also be provided in ``input_names`` or
               ``output_names``.
@@ -309,7 +306,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
     from torch.onnx import utils
     return utils.export(model, args, f, export_params, verbose, training,
                         input_names, output_names, operator_export_type, opset_version,
-                        do_constant_folding, example_outputs, dynamic_axes,
+                        do_constant_folding, dynamic_axes,
                         keep_initializers_as_inputs, custom_opsets,
                         use_external_data_format, export_modules_as_functions)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -103,8 +103,8 @@ def exporter_context(model, mode):
 
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, do_constant_folding=True, example_outputs=None,
-           dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
+           opset_version=None, do_constant_folding=True, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None,
            use_external_data_format=None, export_modules_as_functions=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
@@ -112,9 +112,6 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
         else:
             operator_export_type = OperatorExportTypes.ONNX
 
-    if example_outputs is not None:
-        warnings.warn("`example_outputs' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release.")
     if use_external_data_format is not None:
         warnings.warn("`use_external_data_format' is deprecated and ignored. Will be removed in next "
                       "PyTorch release. The code will work as it is False if models are not larger than 2GB, "
@@ -122,8 +119,8 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
 
     _export(model, args, f, export_params, verbose, training, input_names, output_names,
             operator_export_type=operator_export_type, opset_version=opset_version,
-            do_constant_folding=do_constant_folding, example_outputs=example_outputs,
-            dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
+            do_constant_folding=do_constant_folding, dynamic_axes=dynamic_axes,
+            keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets, use_external_data_format=use_external_data_format,
             export_modules_as_functions=export_modules_as_functions)
 
@@ -493,7 +490,7 @@ def _get_example_outputs(model, args):
 def _model_to_graph(model, args, verbose=False,
                     input_names=None, output_names=None,
                     operator_export_type=OperatorExportTypes.ONNX,
-                    example_outputs=None, do_constant_folding=True,
+                    do_constant_folding=True,
                     _disable_torch_constant_prop=False, fixed_batch_size=False,
                     training=None, dynamic_axes=None):
     r"""Converts model into an ONNX graph.
@@ -523,16 +520,7 @@ def _model_to_graph(model, args, verbose=False,
                             module=module)
     from torch.onnx.symbolic_helper import _onnx_shape_inference
     if isinstance(model, torch.jit.ScriptModule) or isinstance(model, torch.jit.ScriptFunction):
-        if example_outputs is None:
-            example_outputs = _get_example_outputs(model, args)
-        else:
-            # example_outpus specified
-            if isinstance(example_outputs, (torch.Tensor, int, float, bool)):
-                example_outputs = (example_outputs,)
-
-            if isinstance(example_outputs, list):
-                example_outputs = [example_outputs]
-
+        example_outputs = _get_example_outputs(model, args)
         out_vars, desc = torch.jit._flatten(tuple(example_outputs))
         torch._C._jit_pass_onnx_assign_output_shape(graph, out_vars, desc, _onnx_shape_inference)
     else:
@@ -583,15 +571,15 @@ def _model_to_graph(model, args, verbose=False,
 
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
-                            export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                            google_printer=False, opset_version=None, keep_initializers_as_inputs=None,
-                            custom_opsets=None, add_node_names=True, do_constant_folding=True, dynamic_axes=None):
+                            export_type=ExportTypes.PROTOBUF_FILE, google_printer=False, opset_version=None,
+                            keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
+                            do_constant_folding=True, dynamic_axes=None):
     if f is not None:
         warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
-                                    export_type, example_outputs, google_printer,
-                                    opset_version, do_constant_folding=do_constant_folding,
+                                    export_type, google_printer, opset_version,
+                                    do_constant_folding=do_constant_folding,
                                     add_node_names=add_node_names,
                                     keep_initializers_as_inputs=keep_initializers_as_inputs,
                                     custom_opsets=custom_opsets, dynamic_axes=dynamic_axes)
@@ -599,8 +587,7 @@ def export_to_pretty_string(model, args, f, export_params=True, verbose=False, t
 
 def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                              input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
-                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                             google_printer=False, opset_version=None,
+                             export_type=ExportTypes.PROTOBUF_FILE, google_printer=False, opset_version=None,
                              do_constant_folding=True, keep_initializers_as_inputs=None,
                              fixed_batch_size=False, custom_opsets=None, add_node_names=True,
                              onnx_shape_inference=True, dynamic_axes=None):
@@ -623,7 +610,7 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
         args = _decide_input_format(model, args)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type,
-                                                        example_outputs, val_do_constant_folding,
+                                                        val_do_constant_folding,
                                                         fixed_batch_size=fixed_batch_size,
                                                         training=training, dynamic_axes=dynamic_axes)
 
@@ -696,9 +683,8 @@ def _reset_trace_module_map():
 
 def _export(model, args, f, export_params=True, verbose=False, training=None,
             input_names=None, output_names=None, operator_export_type=None,
-            export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-            opset_version=None, do_constant_folding=True,
-            dynamic_axes=None, keep_initializers_as_inputs=None,
+            export_type=ExportTypes.PROTOBUF_FILE, opset_version=None,
+            do_constant_folding=True, dynamic_axes=None, keep_initializers_as_inputs=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
             use_external_data_format=None, onnx_shape_inference=True,
             export_modules_as_functions=False):
@@ -752,7 +738,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             graph, params_dict, torch_out = \
                 _model_to_graph(model, args, verbose, input_names,
                                 output_names, operator_export_type,
-                                example_outputs, val_do_constant_folding,
+                                val_do_constant_folding,
                                 fixed_batch_size=fixed_batch_size,
                                 training=training,
                                 dynamic_axes=dynamic_axes)


### PR DESCRIPTION
This argument was deprecated in PyTorch 1.10: https://github.com/pytorch/pytorch/pull/62815.
Now we remove this argument entirely.

## BC-breaking note
### The signature of torch.onnx.export() function is changed: the argument `example_outpus ` has been removed.

In version 1.9 and older, `example_outputs` was required when the input was a `ScriptModule`.
In version 1.10, `example_outputs` was deprecated and never required.
In latest version, setting `example_outpus` will fail.

Example code:

Version 1.10 and older:

```python
model = torch.jit.script(MyModel())
example_outputs = model(x)
torch.onnx.export(model, (x,), "model.onnx", example_outputs=example_outputs)
```

Version 1.11:

```python
model = torch.jit.script(MyModel())
torch.onnx.export(model, (x,), "model.onnx")
```