### PR TITLE
fx quant: make reshape use dtype of first argument instead of qconfig

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2651,12 +2651,12 @@ class TestQuantizeFx(QuantizationTestCase):
         self.checkGraphModeFxOp(
             m1, data, QuantType.QAT,
             prepare_expected_node_occurrence={
-                ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 2,
+                ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 1,
             },
             expected_node_occurrence={
                 ns.call_function(torch.quantize_per_tensor): 1,
             },
-            prepare_custom_config_dict=prepare_custom_config_dict)
+            prepare_custom_config_dict=prepare_custom_config_dict, print_debug_info=True)
 
         # quantizeable node, quantized output
         class M2(torch.nn.Module):
@@ -3156,6 +3156,25 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # checking result match
         self.assertEqual(out_ref, out)
+
+    def test_general_tensor_shape_op_on_input(self):
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.add_module("c", torch.nn.Linear(1, 1, bias=False))
+
+            def forward(self, x):
+                output_shape = x.shape[:-1] + (self.c.out_features,)
+                x = x.reshape(output_shape)
+                return x
+
+        m = M().eval()
+        qconfig_dict = {'': torch.quantization.default_qconfig}
+        mp = prepare_fx(m, qconfig_dict)
+        print(mp)
+        mp(torch.randn(1, 1, 1, 1))
+
 
 
 @skipIfNoFBGEMM

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -244,6 +244,7 @@ def get_target_activation_dtype_for_node(
     qhandler: Optional[QuantizeHandler],
     modules: Dict[str, torch.nn.Module],
     cache_for_no_tensor_check: Dict[Node, bool],
+    node_name_to_target_dtype: Dict[str, Any],
 ) -> Optional[torch.dtype]:
     """
     Returns the expected dtype of the input and output of this node after
@@ -278,6 +279,11 @@ def get_target_activation_dtype_for_node(
 
         # get qconfig to determine the eventual dtype of this node
         if qconfig is not None:
+            if qhandler is not None and qhandler.is_general_tensor_shape_op():
+                first_arg = node.args[0]
+                if type(first_arg) is Node:
+                    first_arg_dtype = node_name_to_target_dtype[first_arg.name]  # type: ignore[union-attr]
+                    return first_arg_dtype
             if qhandler is not None and qhandler.input_output_observed() and qhandler.is_output_quantized(qconfig):
                 act_dtype, weight_dtype, act_compute_dtype = \
                     get_qconfig_dtypes(qconfig)
@@ -915,7 +921,7 @@ def insert_observers_for_model(
         node_name_to_target_dtype[node.name] = get_target_activation_dtype_for_node(
             node, qconfig, inputs_seen_counter, outputs_seen_counter,
             input_quantized_idxs, output_quantized_idxs, qhandler,
-            modules, cache_for_no_tensor_check)
+            modules, cache_for_no_tensor_check, node_name_to_target_dtype)
 
     # Second, for nodes with known input dtypes, propagate them throughout the
     # graph. For example, if there is a call such as


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67098

Summary:

Before this PR, ops like reshape used the dtype from qconfig.
It is more correct for them to use the dtype of the previous op.

This fixes an issue where an observer was incorrectly inserted
after such an op (see model in test case).

Test Plan:

Note: some tests with reference models are failing, need to be fixed before landing.

```
python test/test_quantization.py TestQuantizeFx.test_general_tensor_hape_op_on_input
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D31861393](https://our.internmc.facebook.com/intern/diff/D31861393)