### PR TITLE
QNNPACK: Update to use pytorch/cpuinfo.git repo as a third party dependency

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadCpuinfo.cmake
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadCpuinfo.cmake
@@ -10,7 +10,7 @@ project(cpuinfo-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(cpuinfo
-  GIT_REPOSITORY https://github.com/Maratyszcza/cpuinfo.git
+  GIT_REPOSITORY https://github.com/pytorch/cpuinfo.git
   GIT_TAG master
   SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/cpuinfo"
   BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/cpuinfo"


### PR DESCRIPTION
Test Plan: Recloned cpuinfo, rebuilt, and ran all the tests locally

Differential Revision: D31782317

