### PR TITLE
[ONNX] remove torch::onnx::PRODUCER_VERSION

### DIFF
--- a/docs/cpp/source/notes/versioning.rst
+++ b/docs/cpp/source/notes/versioning.rst
@@ -10,16 +10,18 @@ Example usage:
   #include <iostream>
 
   int main() {
-    std::cout << "PyTorch version: "
+    std::cout << "PyTorch version from parts: "
       << TORCH_VERSION_MAJOR << "."
       << TORCH_VERSION_MINOR << "."
       << TORCH_VERSION_PATCH << std::endl;
+    std::cout << "PyTorch version: " << TORCH_VERSION << std::endl;
   }
 
 This will output something like:
 
 .. code-block:: text
 
+  PyTorch version from parts: 1.8.0
   PyTorch version: 1.8.0
 
 .. note::

--- a/torch/csrc/api/include/torch/version.h.in
+++ b/torch/csrc/api/include/torch/version.h.in
@@ -8,3 +8,7 @@
 
 /// Indicates the patch version of LibTorch.
 #define TORCH_VERSION_PATCH @TORCH_VERSION_PATCH@
+
+/// Indicates the version of LibTorch.
+#define TORCH_VERSION \
+  "@TORCH_VERSION_MAJOR@.@TORCH_VERSION_MINOR@.@TORCH_VERSION_PATCH@"

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -7,6 +7,7 @@
 #include <c10/util/Optional.h>
 #include <c10/util/accumulate.h>
 #include <c10/util/irange.h>
+#include <torch/csrc/api/include/torch/version.h>
 #include <torch/csrc/autograd/symbolic.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
@@ -438,8 +439,7 @@ GraphEncoder::GraphEncoder(
   // onnx::IR_VERSION. with this change, the test_operators.py will be more
   // stable. only bump it when it's necessary
   model_proto_.set_ir_version(onnx_torch::IR_VERSION);
-  // TODO: set the producer version using appropriate function call
-  model_proto_.set_producer_version(onnx_torch::PRODUCER_VERSION);
+  model_proto_.set_producer_version(TORCH_VERSION);
 
   validateGraph(graph, operator_export_type);
 

--- a/torch/csrc/onnx/init.cpp
+++ b/torch/csrc/onnx/init.cpp
@@ -1,8 +1,10 @@
+#include <onnx/onnx_pb.h>
+#include <torch/csrc/api/include/torch/version.h>
 #include <torch/csrc/onnx/init.h>
 #include <torch/csrc/onnx/onnx.h>
-#include <onnx/onnx_pb.h>
 
-namespace torch { namespace onnx {
+namespace torch {
+namespace onnx {
 void initONNXBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   auto onnx = m.def_submodule("_onnx");
@@ -25,18 +27,18 @@ void initONNXBindings(PyObject* module) {
       .value("COMPLEX128", ::ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128);
 
   py::enum_<OperatorExportTypes>(onnx, "OperatorExportTypes")
-    .value("ONNX", OperatorExportTypes::ONNX)
-    .value("ONNX_ATEN", OperatorExportTypes::ONNX_ATEN)
-    .value("ONNX_ATEN_FALLBACK", OperatorExportTypes::ONNX_ATEN_FALLBACK)
-    .value("ONNX_FALLTHROUGH", OperatorExportTypes::ONNX_FALLTHROUGH);
+      .value("ONNX", OperatorExportTypes::ONNX)
+      .value("ONNX_ATEN", OperatorExportTypes::ONNX_ATEN)
+      .value("ONNX_ATEN_FALLBACK", OperatorExportTypes::ONNX_ATEN_FALLBACK)
+      .value("ONNX_FALLTHROUGH", OperatorExportTypes::ONNX_FALLTHROUGH);
 
   py::enum_<TrainingMode>(onnx, "TrainingMode")
-    .value("EVAL", TrainingMode::EVAL)
-    .value("PRESERVE", TrainingMode::PRESERVE)
-    .value("TRAINING", TrainingMode::TRAINING);
+      .value("EVAL", TrainingMode::EVAL)
+      .value("PRESERVE", TrainingMode::PRESERVE)
+      .value("TRAINING", TrainingMode::TRAINING);
 
   onnx.attr("IR_VERSION") = IR_VERSION;
-  onnx.attr("PRODUCER_VERSION") = py::str(PRODUCER_VERSION);
+  onnx.attr("PRODUCER_VERSION") = py::str(TORCH_VERSION);
 
 #ifdef PYTORCH_ONNX_CAFFE2_BUNDLE
   onnx.attr("PYTORCH_ONNX_CAFFE2_BUNDLE") = true;
@@ -44,4 +46,5 @@ void initONNXBindings(PyObject* module) {
   onnx.attr("PYTORCH_ONNX_CAFFE2_BUNDLE") = false;
 #endif
 }
-}} // namespace torch::onnx
+} // namespace onnx
+} // namespace torch

--- a/torch/csrc/onnx/onnx.h
+++ b/torch/csrc/onnx/onnx.h
@@ -20,6 +20,5 @@ enum class TrainingMode {
 // test_operators.py will be more stable. Only bump it when
 // necessary.
 constexpr size_t IR_VERSION = 8;
-constexpr const char* PRODUCER_VERSION = "1.11";
 } // namespace onnx
 } // namespace torch


### PR DESCRIPTION
Use constants from version.h instead.
This simplifies things since we no longer have to update
PRODUCER_VERSION for each release.

Also add TORCH_VERSION to version.h so that a string is available for
this purpose.

Fixes #{issue number}
