### PR TITLE
Replace lazy_tensors::Span with c10::ArrayRef

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -81,8 +81,7 @@ void ReplaceLtcTensor(const at::Tensor& tensor, LazyTensor new_ltc_tensor) {
   impl->set_tensor(std::move(new_ltc_tensor));
 }
 
-std::vector<LazyTensor> GetLtcTensors(
-    lazy_tensors::Span<const at::Tensor> tensors) {
+std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors) {
   std::vector<LazyTensor> ltc_tensors;
   ltc_tensors.reserve(tensors.size());
   for (const auto& tensor : tensors) {
@@ -166,9 +165,9 @@ std::vector<c10::optional<at::Tensor>> LtcCreateOptTensorList(
   return opt_aten_ltc_tensors;
 }
 
-void LtcUpdateTensors(lazy_tensors::Span<const at::Tensor> dest_ltc_tensors,
-                      lazy_tensors::Span<const at::Tensor> source_cpu_tensors,
-                      lazy_tensors::Span<const size_t> indices) {
+void LtcUpdateTensors(c10::ArrayRef<at::Tensor> dest_ltc_tensors,
+                      c10::ArrayRef<at::Tensor> source_cpu_tensors,
+                      c10::ArrayRef<size_t> indices) {
   for (auto index : indices) {
     at::Tensor dest = dest_ltc_tensors.at(index);
     at::Tensor source = source_cpu_tensors.at(index);
@@ -187,10 +186,9 @@ void LtcUpdateTensors(lazy_tensors::Span<const at::Tensor> dest_ltc_tensors,
   }
 }
 
-void LtcUpdateTensorsMeta(
-    lazy_tensors::Span<const at::Tensor> dest_ltc_tensors,
-    lazy_tensors::Span<const at::Tensor> source_cpu_tensors,
-    lazy_tensors::Span<const size_t> indices) {
+void LtcUpdateTensorsMeta(c10::ArrayRef<at::Tensor> dest_ltc_tensors,
+                          c10::ArrayRef<at::Tensor> source_cpu_tensors,
+                          c10::ArrayRef<size_t> indices) {
   for (auto index : indices) {
     at::Tensor dest = dest_ltc_tensors.at(index);
     at::Tensor source = source_cpu_tensors.at(index);
@@ -310,7 +308,7 @@ at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor) {
 }
 
 std::vector<at::Tensor> AtenFromLtcTensors(
-    lazy_tensors::Span<const LazyTensor> ltc_tensors) {
+    c10::ArrayRef<LazyTensor> ltc_tensors) {
   std::vector<at::Tensor> tensors;
   tensors.reserve(ltc_tensors.size());
   for (auto& tensor : ltc_tensors) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -8,7 +8,6 @@
 
 #include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensor_core/csrc/tensor.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace bridge {
@@ -25,8 +24,7 @@ LazyTensor GetLtcTensor(const at::Tensor& tensor);
 void ReplaceLtcTensor(const at::Tensor& tensor, LazyTensor new_ltc_tensor);
 
 // Same as above, applied to a list of tensors.
-std::vector<LazyTensor> GetLtcTensors(
-    lazy_tensors::Span<const at::Tensor> tensors);
+std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
 
 // If tensor is a lazy tensor type, returns the LazyTensor embedded within it,
 // otherwise creates a new lazy tensor type with tensor as data.
@@ -45,14 +43,13 @@ std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors);
 std::vector<c10::optional<at::Tensor>> LtcCreateOptTensorList(
     const std::vector<c10::optional<at::Tensor>>& tensors);
 
-void LtcUpdateTensors(lazy_tensors::Span<const at::Tensor> dest_ltc_tensors,
-                      lazy_tensors::Span<const at::Tensor> source_cpu_tensors,
-                      lazy_tensors::Span<const size_t> indices);
+void LtcUpdateTensors(c10::ArrayRef<at::Tensor> dest_ltc_tensors,
+                      c10::ArrayRef<at::Tensor> source_cpu_tensors,
+                      c10::ArrayRef<size_t> indices);
 
-void LtcUpdateTensorsMeta(
-    lazy_tensors::Span<const at::Tensor> dest_ltc_tensors,
-    lazy_tensors::Span<const at::Tensor> source_cpu_tensors,
-    lazy_tensors::Span<const size_t> indices);
+void LtcUpdateTensorsMeta(c10::ArrayRef<at::Tensor> dest_ltc_tensors,
+                          c10::ArrayRef<at::Tensor> source_cpu_tensors,
+                          c10::ArrayRef<size_t> indices);
 
 // Tries to extract the device out of the lazy tensor. Returns nullopt if the
 // input is not a lazy tensor.
@@ -99,7 +96,7 @@ at::Tensor LtcToAtenTensor(LazyTensor ltc_tensor,
 at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor);
 
 std::vector<at::Tensor> AtenFromLtcTensors(
-    lazy_tensors::Span<const LazyTensor> ltc_tensors);
+    c10::ArrayRef<LazyTensor> ltc_tensors);
 
 // Creates a lazy tensor holding the data in tensor, on the given device.
 at::Tensor CreateLtcTensor(at::Tensor tensor,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/backend_registrar.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/backend_registrar.cpp
@@ -24,7 +24,7 @@ namespace ir {
 
 std::unique_ptr<LoweringContext> LoweringContext::Create(
     const std::string& name, Device device,
-    lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+    c10::ArrayRef<torch::lazy::Node*> post_order,
     Util::EmissionMap emit_status) {
   return torch_lazy_tensors::compiler::getBackendRegistrar()
       ->CreateLoweringContext(name, device, post_order, emit_status);
@@ -52,7 +52,7 @@ ComputationClient* ComputationClient::GetIfInitialized() {
 }
 
 std::vector<std::string> ComputationClient::GetCompilationDevices(
-    const std::string& device, lazy_tensors::Span<const std::string> devices) {
+    const std::string& device, c10::ArrayRef<std::string> devices) {
   return torch_lazy_tensors::compiler::getBackendRegistrar()
       ->GetCompilationDevices(device, devices);
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/compiler/backend_impl_interface.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/compiler/backend_impl_interface.h
@@ -19,7 +19,7 @@ class BackendImplInterface {
 
   virtual std::unique_ptr<ir::LoweringContext> CreateLoweringContext(
       const std::string& name, Device device,
-      lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+      c10::ArrayRef<torch::lazy::Node*> post_order,
       ir::Util::EmissionMap emit_status) const = 0;
 
   virtual std::unique_ptr<ir::LoweringContext> CreateLoweringContext(
@@ -31,8 +31,7 @@ class BackendImplInterface {
       const = 0;
 
   virtual std::vector<std::string> GetCompilationDevices(
-      const std::string& device,
-      lazy_tensors::Span<const std::string> devices) const = 0;
+      const std::string& device, c10::ArrayRef<std::string> devices) const = 0;
 
   virtual at::Tensor MakeTensorFromComputationData(
       const lazy_tensors::ComputationClient::DataPtr data,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/cross_replica_reduces.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/cross_replica_reduces.h
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/data_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/data_ops.cpp
@@ -16,8 +16,8 @@
 namespace torch_lazy_tensors {
 
 std::vector<lazy_tensors::int64> GetCompleteShape(
-    lazy_tensors::Span<const lazy_tensors::int64> output_sizes,
-    lazy_tensors::Span<const lazy_tensors::int64> input_sizes) {
+    c10::ArrayRef<lazy_tensors::int64> output_sizes,
+    c10::ArrayRef<lazy_tensors::int64> input_sizes) {
   c10::optional<size_t> incomplete_dim;
   lazy_tensors::int64 incomplete_element_count = 1;
   for (size_t dim = 0; dim < output_sizes.size(); ++dim) {
@@ -56,7 +56,7 @@ std::vector<lazy_tensors::int64> GetCompleteShape(
 }
 
 std::vector<lazy_tensors::int64> BuildSqueezedDimensions(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
+    c10::ArrayRef<lazy_tensors::int64> dimensions,
     lazy_tensors::int64 squeeze_dim) {
   std::vector<lazy_tensors::int64> output_dimensions;
   for (lazy_tensors::int64 i = 0; i < dimensions.size(); ++i) {
@@ -69,8 +69,7 @@ std::vector<lazy_tensors::int64> BuildSqueezedDimensions(
 }
 
 std::vector<lazy_tensors::int64> BuildUnsqueezeDimensions(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    lazy_tensors::int64 dim) {
+    c10::ArrayRef<lazy_tensors::int64> dimensions, lazy_tensors::int64 dim) {
   LTC_CHECK_LE(dim, dimensions.size());
   auto unsqueeze_dimensions =
       lazy_tensors::util::ToVector<lazy_tensors::int64>(dimensions);
@@ -78,9 +77,8 @@ std::vector<lazy_tensors::int64> BuildUnsqueezeDimensions(
   return unsqueeze_dimensions;
 }
 
-size_t ComputeSplitCount(
-    lazy_tensors::int64 dim_size,
-    lazy_tensors::Span<const lazy_tensors::int64> split_sizes) {
+size_t ComputeSplitCount(lazy_tensors::int64 dim_size,
+                         c10::ArrayRef<lazy_tensors::int64> split_sizes) {
   size_t count = 0;
   for (auto size : split_sizes) {
     if (size > dim_size) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/data_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/data_ops.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "lazy_tensors/computation_client/types.h"
-#include "lazy_tensors/span.h"
 
 // Collection of lowerings for operations which only involve some form of data
 // movement and no computation.
@@ -16,20 +15,18 @@ namespace torch_lazy_tensors {
 // input_sizes and matches output_sizes in all dimensions except for at most
 // one, which can be inferred and stored as -1 in output_sizes.
 std::vector<lazy_tensors::int64> GetCompleteShape(
-    lazy_tensors::Span<const lazy_tensors::int64> output_sizes,
-    lazy_tensors::Span<const lazy_tensors::int64> input_sizes);
+    c10::ArrayRef<lazy_tensors::int64> output_sizes,
+    c10::ArrayRef<lazy_tensors::int64> input_sizes);
 
 std::vector<lazy_tensors::int64> BuildSqueezedDimensions(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
+    c10::ArrayRef<lazy_tensors::int64> dimensions,
     lazy_tensors::int64 squeeze_dim);
 
 std::vector<lazy_tensors::int64> BuildUnsqueezeDimensions(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    lazy_tensors::int64 dim);
+    c10::ArrayRef<lazy_tensors::int64> dimensions, lazy_tensors::int64 dim);
 
 // Computes the number of splits with a dimension size and the split sizes.
-size_t ComputeSplitCount(
-    lazy_tensors::int64 dim_size,
-    lazy_tensors::Span<const lazy_tensors::int64> split_sizes);
+size_t ComputeSplitCount(lazy_tensors::int64 dim_size,
+                         c10::ArrayRef<lazy_tensors::int64> split_sizes);
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/debug_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/debug_util.cpp
@@ -51,10 +51,10 @@ DebugUtil::GraphFormat DebugUtil::GetDefaultGraphFormat() {
   return format;
 }
 
-std::string DebugUtil::GetTensorsGraphInfo(
-    lazy_tensors::Span<const LazyTensor> tensors,
-    const std::vector<size_t>* indices, GraphFormat format) {
-  std::vector<const torch::lazy::Node*> root_nodes;
+std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<LazyTensor> tensors,
+                                           const std::vector<size_t>* indices,
+                                           GraphFormat format) {
+  std::vector<torch::lazy::Node*> root_nodes;
   std::vector<torch::lazy::Value> root_values;
   std::vector<torch::lazy::hash_t> root_hashes;
   lazy_tensors::util::Unique<Device> unique_device;
@@ -111,9 +111,10 @@ std::string DebugUtil::GetTensorsGraphInfo(
   return ss.str();
 }
 
-void DebugUtil::SaveTensorsGraphInfo(
-    const char* name, lazy_tensors::Span<const LazyTensor> tensors,
-    const std::vector<size_t>* indices, GraphFormat format) {
+void DebugUtil::SaveTensorsGraphInfo(const char* name,
+                                     c10::ArrayRef<LazyTensor> tensors,
+                                     const std::vector<size_t>* indices,
+                                     GraphFormat format) {
   static const std::string save_file =
       lazy_tensors::sys_util::GetEnvOrdinalPath("LTC_SAVE_TENSORS_FILE", "");
   if (!save_file.empty()) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/debug_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/debug_util.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "lazy_tensor_core/csrc/tensor.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 
@@ -23,15 +22,14 @@ class DebugUtil {
   // values held at the tensors. If indices is not nullptr, it selects the
   // indices of the tensors whose graph will be emitted.
   static std::string GetTensorsGraphInfo(
-      lazy_tensors::Span<const LazyTensor> tensors,
-      const std::vector<size_t>* indices,
+      c10::ArrayRef<LazyTensor> tensors, const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
 
   // If the environment variable LTC_SAVE_TENSORS_FILE is set to the proper
   // output path, an instance of the report returned by GetTensorsGraphInfo() is
   // saved.
   static void SaveTensorsGraphInfo(
-      const char* name, lazy_tensors::Span<const LazyTensor> tensors,
+      const char* name, c10::ArrayRef<LazyTensor> tensors,
       const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/helpers.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/helpers.cpp
@@ -13,8 +13,8 @@
 namespace torch_lazy_tensors {
 
 std::vector<lazy_tensors::int64> Helpers::DropDimensions(
-    lazy_tensors::Span<const lazy_tensors::int64> sizes,
-    lazy_tensors::Span<const lazy_tensors::int64> drop_dims) {
+    c10::ArrayRef<lazy_tensors::int64> sizes,
+    c10::ArrayRef<lazy_tensors::int64> drop_dims) {
   std::vector<lazy_tensors::int64> new_dims;
   size_t drop_index = 0;
   for (size_t i = 0; i < sizes.size(); ++i) {
@@ -42,8 +42,7 @@ lazy_tensors::int64 Helpers::GetCanonicalDimensionIndex(
 }
 
 std::vector<lazy_tensors::int64> Helpers::GetCanonicalDimensionIndices(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    lazy_tensors::int64 rank) {
+    c10::ArrayRef<lazy_tensors::int64> dimensions, lazy_tensors::int64 rank) {
   std::vector<lazy_tensors::int64> canonical_dim_indices;
   for (lazy_tensors::int64 dim : dimensions) {
     canonical_dim_indices.push_back(GetCanonicalDimensionIndex(dim, rank));
@@ -52,8 +51,8 @@ std::vector<lazy_tensors::int64> Helpers::GetCanonicalDimensionIndices(
 }
 
 lazy_tensors::int64 Helpers::GetCanonicalPosition(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    lazy_tensors::int64 dim, lazy_tensors::int64 pos) {
+    c10::ArrayRef<lazy_tensors::int64> dimensions, lazy_tensors::int64 dim,
+    lazy_tensors::int64 pos) {
   dim = GetCanonicalDimensionIndex(dim, dimensions.size());
   if (pos < 0) {
     pos = GetCanonicalDimensionIndex(pos, dimensions[dim]);
@@ -131,7 +130,7 @@ Helpers::MinMax Helpers::MinMaxValues(lazy_tensors::PrimitiveType type) {
 
 c10::optional<Helpers::DynamicReshapeInfo> Helpers::GetDynamicReshapeInfo(
     const lazy_tensors::Shape& input_shape,
-    lazy_tensors::Span<const lazy_tensors::int64> output_sizes) {
+    c10::ArrayRef<lazy_tensors::int64> output_sizes) {
   lazy_tensors::int64 input_dynamic_dimension =
       GetDynamicDimension(input_shape);
   if (input_dynamic_dimension < 0) {
@@ -169,7 +168,7 @@ c10::optional<Helpers::DynamicReshapeInfo> Helpers::GetDynamicReshapeInfo(
 
 lazy_tensors::Shape Helpers::GetDynamicReshape(
     const lazy_tensors::Shape& input_shape,
-    lazy_tensors::Span<const lazy_tensors::int64> output_sizes) {
+    c10::ArrayRef<lazy_tensors::int64> output_sizes) {
   auto info = GetDynamicReshapeInfo(input_shape, output_sizes);
   if (info) {
     return info->output_shape;
@@ -241,8 +240,8 @@ lazy_tensors::PrimitiveType Helpers::PromoteType(
 }
 
 std::vector<lazy_tensors::int64> Helpers::GetPromotedShape(
-    lazy_tensors::Span<const lazy_tensors::int64> shape1_dims,
-    lazy_tensors::Span<const lazy_tensors::int64> shape2_dims) {
+    c10::ArrayRef<lazy_tensors::int64> shape1_dims,
+    c10::ArrayRef<lazy_tensors::int64> shape2_dims) {
   std::vector<lazy_tensors::int64> dimensions;
   // If the rank of a shape is bigger than then other, fill up the first
   // dimensions with the ones of the bigger.

--- a/lazy_tensor_core/lazy_tensor_core/csrc/helpers.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/helpers.h
@@ -12,7 +12,6 @@
 #include "lazy_tensors/core/lib/bfloat16/bfloat16.h"
 #include "lazy_tensors/literal_util.h"
 #include "lazy_tensors/permutation_util.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/types.h"
 
 namespace torch_lazy_tensors {
@@ -93,11 +92,11 @@ class Helpers {
 
   static c10::optional<DynamicReshapeInfo> GetDynamicReshapeInfo(
       const lazy_tensors::Shape& input_shape,
-      lazy_tensors::Span<const lazy_tensors::int64> output_sizes);
+      c10::ArrayRef<lazy_tensors::int64> output_sizes);
 
   static lazy_tensors::Shape GetDynamicReshape(
       const lazy_tensors::Shape& input_shape,
-      lazy_tensors::Span<const lazy_tensors::int64> output_sizes);
+      c10::ArrayRef<lazy_tensors::int64> output_sizes);
 
   // Converts an iterable container to a vector of int64's.
   template <typename S>
@@ -112,8 +111,8 @@ class Helpers {
 
   // Creates a set of dimension by dropping the drop_dims ones.
   static std::vector<lazy_tensors::int64> DropDimensions(
-      lazy_tensors::Span<const lazy_tensors::int64> sizes,
-      lazy_tensors::Span<const lazy_tensors::int64> drop_dims);
+      c10::ArrayRef<lazy_tensors::int64> sizes,
+      c10::ArrayRef<lazy_tensors::int64> drop_dims);
 
   // Get the canonical dimension index in the [0, rank) interval. Negative
   // indices are interpreted as follows: -1 is rank-1, -2 is rank-2 etc.
@@ -122,14 +121,13 @@ class Helpers {
 
   // Same as above, for multiple dimensions.
   static std::vector<lazy_tensors::int64> GetCanonicalDimensionIndices(
-      lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-      lazy_tensors::int64 rank);
+      c10::ArrayRef<lazy_tensors::int64> dimensions, lazy_tensors::int64 rank);
 
   // Returns the canonical position in the dim dimension, handling negative
   // values for the position.
   static lazy_tensors::int64 GetCanonicalPosition(
-      lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-      lazy_tensors::int64 dim, lazy_tensors::int64 pos);
+      c10::ArrayRef<lazy_tensors::int64> dimensions, lazy_tensors::int64 dim,
+      lazy_tensors::int64 pos);
 
   // Retrieves the dynamic dimension of an input shape, or returns -1 if none.
   static lazy_tensors::int64 GetDynamicDimension(
@@ -143,8 +141,7 @@ class Helpers {
   // size as the input.
   template <typename Container>
   static std::vector<typename Container::value_type> Permute(
-      lazy_tensors::Span<const lazy_tensors::int64> permutation,
-      const Container& input) {
+      c10::ArrayRef<lazy_tensors::int64> permutation, const Container& input) {
     using T = typename Container::value_type;
     LTC_CHECK(input.size() == permutation.size() &&
               lazy_tensors::IsPermutation(permutation))
@@ -173,8 +170,8 @@ class Helpers {
   //   shape2       =       [6, 5, 2]
   //   result_shape = [9, 7, 6, 5, 2]
   static std::vector<lazy_tensors::int64> GetPromotedShape(
-      lazy_tensors::Span<const lazy_tensors::int64> shape1_dims,
-      lazy_tensors::Span<const lazy_tensors::int64> shape2_dims);
+      c10::ArrayRef<lazy_tensors::int64> shape1_dims,
+      c10::ArrayRef<lazy_tensors::int64> shape2_dims);
 
   static lazy_tensors::Shape GetPromotedShape(
       const lazy_tensors::Shape& shape1, const lazy_tensors::Shape& shape2);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -69,9 +69,9 @@ void PrepareToExit() {
 
 std::string GetTensorsDump(
     const std::vector<at::Tensor>& tensors,
-    const std::function<std::string(lazy_tensors::Span<const torch::lazy::Node* const>)>&
+    const std::function<std::string(c10::ArrayRef<torch::lazy::Node*>)>&
         coverter) {
-  std::vector<const torch::lazy::Node*> nodes;
+  std::vector<torch::lazy::Node*> nodes;
   std::vector<torch::lazy::Value> values;
   for (auto& tensor : tensors) {
     LazyTensor xtensor = bridge::GetLtcTensor(tensor);
@@ -275,7 +275,7 @@ std::string GetLiveTensorsReport(size_t nodes_threshold,
   for (auto& tensor : tensors) {
     torch::lazy::Value ir_value = tensor.CurrentIrValue();
     if (ir_value) {
-      std::vector<const torch::lazy::Node*> roots({ir_value.node.get()});
+      std::vector<torch::lazy::Node*> roots({ir_value.node.get()});
       auto post_order = ir::Util::ComputePostOrder(roots);
       if (post_order.size() > nodes_threshold) {
         ss << "Tensor: id=" << tensor.GetUniqueId()
@@ -412,14 +412,14 @@ void InitLtcModuleBindings(py::module m) {
   });
   m.def("_get_ltc_tensors_dot",
         [](const std::vector<at::Tensor>& tensors) -> std::string {
-          auto coverter = [](lazy_tensors::Span<const torch::lazy::Node* const> nodes) {
+          auto coverter = [](c10::ArrayRef<torch::lazy::Node*> nodes) {
             return ir::DumpUtil::ToDot(nodes);
           };
           return GetTensorsDump(tensors, coverter);
         });
   m.def("_get_ltc_tensors_text",
         [](const std::vector<at::Tensor>& tensors) -> std::string {
-          auto coverter = [](lazy_tensors::Span<const torch::lazy::Node* const> nodes) {
+          auto coverter = [](c10::ArrayRef<torch::lazy::Node*> nodes) {
             return ir::DumpUtil::ToText(nodes);
           };
           return GetTensorsDump(tensors, coverter);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.cpp
@@ -82,7 +82,7 @@ c10::optional<AttrTag> ParseAttrTag(const std::string& node_string,
   return tag;
 }
 
-NodeIdMap GenerateIdMap(lazy_tensors::Span<const torch::lazy::Node* const> post_order) {
+NodeIdMap GenerateIdMap(c10::ArrayRef<torch::lazy::Node*> post_order) {
   NodeIdMap id_map;
   for (auto node : post_order) {
     LTC_CHECK(id_map.emplace(node, id_map.size()).second) << node->ToString();
@@ -91,7 +91,7 @@ NodeIdMap GenerateIdMap(lazy_tensors::Span<const torch::lazy::Node* const> post_
 }
 
 std::unordered_map<const torch::lazy::Node*, size_t> GetRootsIds(
-    lazy_tensors::Span<const torch::lazy::Node* const> roots) {
+    c10::ArrayRef<torch::lazy::Node*> roots) {
   std::unordered_map<const torch::lazy::Node*, size_t> roots_ids;
   for (size_t i = 0; i < roots.size(); ++i) {
     roots_ids[roots[i]] = i;
@@ -190,14 +190,14 @@ std::string GenerateTextNodeSpec(const torch::lazy::Node* node, const NodeIdMap&
 
 }  // namespace
 
-std::string DumpUtil::ToDot(lazy_tensors::Span<const torch::lazy::Node* const> nodes) {
+std::string DumpUtil::ToDot(c10::ArrayRef<torch::lazy::Node*> nodes) {
   auto post_order = Util::ComputePostOrder(nodes);
   return PostOrderToDot(post_order, nodes);
 }
 
 std::string DumpUtil::PostOrderToDot(
-    lazy_tensors::Span<const torch::lazy::Node* const> post_order,
-    lazy_tensors::Span<const torch::lazy::Node* const> roots) {
+    c10::ArrayRef<torch::lazy::Node*> post_order,
+    c10::ArrayRef<torch::lazy::Node*> roots) {
   std::unordered_map<const torch::lazy::Node*, size_t> roots_ids = GetRootsIds(roots);
   NodeIdMap id_map = GenerateIdMap(post_order);
   std::stringstream ss;
@@ -230,14 +230,14 @@ std::string DumpUtil::PostOrderToDot(
   return ss.str();
 }
 
-std::string DumpUtil::ToText(lazy_tensors::Span<const torch::lazy::Node* const> nodes) {
+std::string DumpUtil::ToText(c10::ArrayRef<torch::lazy::Node*> nodes) {
   auto post_order = Util::ComputePostOrder(nodes);
   return PostOrderToText(post_order, nodes);
 }
 
 std::string DumpUtil::PostOrderToText(
-    lazy_tensors::Span<const torch::lazy::Node* const> post_order,
-    lazy_tensors::Span<const torch::lazy::Node* const> roots) {
+    c10::ArrayRef<torch::lazy::Node*> post_order,
+    c10::ArrayRef<torch::lazy::Node*> roots) {
   std::unordered_map<const torch::lazy::Node*, size_t> roots_ids = GetRootsIds(roots);
   NodeIdMap id_map = GenerateIdMap(post_order);
   std::stringstream ss;
@@ -255,7 +255,7 @@ std::string DumpUtil::PostOrderToText(
   return ss.str();
 }
 
-std::string DumpUtil::ToBackend(lazy_tensors::Span<const torch::lazy::Value> values,
+std::string DumpUtil::ToBackend(c10::ArrayRef<torch::lazy::Value> values,
                                 const Device& device) {
   auto lowering_ctx = ir::LoweringContext::Create("IrToBackend", device);
   for (auto& ir_value : values) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.h
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "lazy_tensor_core/csrc/device.h"
-#include "lazy_tensors/span.h"
 #include "torch/csrc/lazy/core/ir.h"
 
 namespace torch_lazy_tensors {
@@ -11,20 +10,20 @@ namespace ir {
 
 class DumpUtil {
  public:
-  static std::string ToDot(lazy_tensors::Span<const torch::lazy::Node* const> nodes);
+  static std::string ToDot(c10::ArrayRef<torch::lazy::Node *> nodes);
 
   static std::string PostOrderToDot(
-      lazy_tensors::Span<const torch::lazy::Node* const> post_order,
-      lazy_tensors::Span<const torch::lazy::Node* const> roots);
+      c10::ArrayRef<torch::lazy::Node *> post_order,
+      c10::ArrayRef<torch::lazy::Node *> roots);
 
-  static std::string ToText(lazy_tensors::Span<const torch::lazy::Node* const> nodes);
+  static std::string ToText(c10::ArrayRef<torch::lazy::Node *> nodes);
 
   static std::string PostOrderToText(
-      lazy_tensors::Span<const torch::lazy::Node* const> post_order,
-      lazy_tensors::Span<const torch::lazy::Node* const> roots);
+      c10::ArrayRef<torch::lazy::Node *> post_order,
+      c10::ArrayRef<torch::lazy::Node *> roots);
 
-  static std::string ToBackend(lazy_tensors::Span<const torch::lazy::Value> values,
-                               const Device& device);
+  static std::string ToBackend(c10::ArrayRef<torch::lazy::Value> values,
+                               const Device &device);
 };
 
 }  // namespace ir

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ir_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ir_util.h
@@ -3,7 +3,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "lazy_tensors/span.h"
 #include "torch/csrc/lazy/core/ir.h"
 
 namespace torch_lazy_tensors {
@@ -26,22 +25,20 @@ class Util {
   // this API. The returned post-order can be empty if the node has already been
   // emitted inside the emission map. An error is generated if a loop is
   // detected.
-  static std::vector<const torch::lazy::Node*> ComputePostOrder(
+  static std::vector<torch::lazy::Node*> ComputePostOrder(
       const torch::lazy::Node* node, EmissionMap* emap);
 
-  static std::vector<const torch::lazy::Node*> ComputePostOrder(
-      lazy_tensors::Span<const torch::lazy::Node* const> nodes,
-      EmissionMap* emap);
+  static std::vector<torch::lazy::Node*> ComputePostOrder(
+      c10::ArrayRef<torch::lazy::Node*> nodes, EmissionMap* emap);
 
   // Same as above, but computes the post order on the set of nodes specified as
   // argument.
-  static std::vector<const torch::lazy::Node*> ComputePostOrder(
-      lazy_tensors::Span<const torch::lazy::Node* const> nodes);
+  static std::vector<torch::lazy::Node*> ComputePostOrder(
+      c10::ArrayRef<torch::lazy::Node*> nodes);
 
   // Retrieves the number of nodes within the graph whose sink are passed in the
   // nodes argument.
-  static size_t GetGraphSize(
-      lazy_tensors::Span<const torch::lazy::Node* const> nodes);
+  static size_t GetGraphSize(c10::ArrayRef<torch::lazy::Node*> nodes);
 };
 
 }  // namespace ir

--- a/lazy_tensor_core/lazy_tensor_core/csrc/layout_manager.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/layout_manager.h
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensors/shape.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/types.h"
 
 namespace torch_lazy_tensors {
@@ -10,17 +9,16 @@ namespace torch_lazy_tensors {
 // Creates a minor-to-major layout from given dimensions. The dynamic_dimensions
 // slice should be either empty, or of the same size as dimensions.
 lazy_tensors::Shape MakeTorchTensorLayout(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    lazy_tensors::Span<const bool> dynamic_dimensions,
-    lazy_tensors::PrimitiveType type);
+    c10::ArrayRef<lazy_tensors::int64> dimensions,
+    c10::ArrayRef<bool> dynamic_dimensions, lazy_tensors::PrimitiveType type);
 
 // Create an shape with the given dimensions and type, suitable to be used in
 // the specified device type. The type of device can affect the choice of the
 // layout. The dynamic_dimensions slice should be either empty, or of the same
 // size as dimensions.
 lazy_tensors::Shape MakeArrayShapeFromDimensions(
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    lazy_tensors::Span<const bool> dynamic_dimensions,
-    lazy_tensors::PrimitiveType type, DeviceType device_type);
+    c10::ArrayRef<lazy_tensors::int64> dimensions,
+    c10::ArrayRef<bool> dynamic_dimensions, lazy_tensors::PrimitiveType type,
+    DeviceType device_type);
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
@@ -44,16 +44,15 @@ class LazyGraphExecutor {
   // run synchronously. The devices argument, if not empty, tells the devices
   // which should be partecipating into the replicated computation.
   void SyncLiveTensorsGraph(const Device* device,
-                            lazy_tensors::Span<const std::string> devices,
-                            bool wait);
+                            c10::ArrayRef<std::string> devices, bool wait);
 
   // Applies all the pending IR operations queued over the input tensors. All
   // the tensors must be on the same device. If wait is true, the sync operation
   // will be run synchronously. The devices argument, if not empty, tells the
   // devices which should be partecipating into the replicated computation.
   void SyncTensorsGraph(std::vector<LazyTensor>* tensors,
-                        lazy_tensors::Span<const std::string> devices,
-                        bool wait, bool sync_ltc_data);
+                        c10::ArrayRef<std::string> devices, bool wait,
+                        bool sync_ltc_data);
 
   // Marks an execution step, which allows the tensor framework to understand
   // the computation boundaries.
@@ -61,7 +60,7 @@ class LazyGraphExecutor {
 
   // Waits for all the outstanding operations on all the supplied devices.
   // If devices is empty, the wait will happen for all local devices.
-  void WaitDeviceOps(lazy_tensors::Span<const std::string> devices);
+  void WaitDeviceOps(c10::ArrayRef<std::string> devices);
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.
@@ -90,7 +89,7 @@ class LazyGraphExecutor {
   };
 
   struct PostOrderData {
-    std::vector<const torch::lazy::Node*> post_order;
+    std::vector<torch::lazy::Node*> post_order;
     ir::Util::EmissionMap emission_map;
     std::vector<lazy_tensors::ComputationClient::DataPtr> parameters_data;
     std::vector<size_t> parameter_sequence;
@@ -136,21 +135,21 @@ class LazyGraphExecutor {
   SyncTensorCollection CollectSyncTensors(
       const std::vector<LazyTensor>& tensors, const SyncTensorsConfig& config);
 
-  std::vector<torch::lazy::Value> CollectRoots(const std::vector<LazyTensor>& tensors,
-                                      lazy_tensors::Span<const size_t> indices);
+  std::vector<torch::lazy::Value> CollectRoots(
+      const std::vector<LazyTensor>& tensors, c10::ArrayRef<size_t> indices);
 
   std::vector<lazy_tensors::ComputationClient::DataPtr> FetchTensorData(
       std::vector<LazyTensor>* tensors, const SyncTensorsConfig& config,
-      lazy_tensors::Span<const size_t> indices);
+      c10::ArrayRef<size_t> indices);
 
   PostOrderData RunPostOrder(const std::vector<LazyTensor>& tensors,
-                             lazy_tensors::Span<const size_t> indices);
+                             c10::ArrayRef<size_t> indices);
   std::shared_ptr<Async> TryRunCachedSync(std::vector<LazyTensor>* tensors,
                                           SyncTensorCollection* coll,
                                           PostOrderData* po_data);
 
   CompilationResult Compile(const std::vector<LazyTensor>& tensors,
-                            lazy_tensors::Span<const std::string> devices,
+                            c10::ArrayRef<std::string> devices,
                             const SyncTensorCollection& coll,
                             PostOrderData* po_data);
 
@@ -160,19 +159,17 @@ class LazyGraphExecutor {
       const std::vector<LazyTensor>& tensors, const torch::lazy::hash_t& hash);
 
   void BuildInputOutputAliases(const std::vector<LazyTensor>& tensors,
-                               lazy_tensors::Span<const size_t> indices,
+                               c10::ArrayRef<size_t> indices,
                                ir::LoweringContext* lowering_ctx);
 
   // Runs an asynchronous syn operation using the op-by-op executor.
   using OpByOpAsync = lazy_tensors::util::AsyncTask<int>;
-  OpByOpAsync SyncTensorsGraphOpByOp(
-      std::vector<LazyTensor>* tensors,
-      lazy_tensors::Span<const std::string> devices,
-      const SyncTensorsConfig& config);
+  OpByOpAsync SyncTensorsGraphOpByOp(std::vector<LazyTensor>* tensors,
+                                     c10::ArrayRef<std::string> devices,
+                                     const SyncTensorsConfig& config);
 
   std::shared_ptr<Async> SyncTensorsGraphInternal(
-      std::vector<LazyTensor>* tensors,
-      lazy_tensors::Span<const std::string> devices,
+      std::vector<LazyTensor>* tensors, c10::ArrayRef<std::string> devices,
       const SyncTensorsConfig& config);
 
   // Schedules the execution of a sync tensors operation in background. The
@@ -195,17 +192,14 @@ class LazyGraphExecutor {
 
   std::vector<at::Tensor> FetchTensors(
       std::vector<LazyTensor>* tensors,
-      lazy_tensors::Span<const lazy_tensors::ComputationClient::DataPtr>
-          tensors_data,
+      c10::ArrayRef<lazy_tensors::ComputationClient::DataPtr> tensors_data,
       const std::vector<size_t>* indices);
 
   // Gathers the device data for all the input tensors, after an
   // asynchronous operation.
   std::vector<lazy_tensors::ComputationClient::DataPtr> GatherTensorsData(
-      const std::vector<LazyTensor>& tensors,
-      lazy_tensors::Span<const size_t> indices,
-      lazy_tensors::Span<const lazy_tensors::ComputationClient::DataPtr>
-          tensors_data);
+      const std::vector<LazyTensor>& tensors, c10::ArrayRef<size_t> indices,
+      c10::ArrayRef<lazy_tensors::ComputationClient::DataPtr> tensors_data);
 };
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lowering_context.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lowering_context.cpp
@@ -14,10 +14,9 @@ namespace ir {
 LoweringContext::LoweringContext(const std::string& name, Device device)
     : device_(std::move(device)) {}
 
-LoweringContext::LoweringContext(
-    const std::string& name, Device device,
-    lazy_tensors::Span<const torch::lazy::Node* const> post_order,
-    Util::EmissionMap emit_status)
+LoweringContext::LoweringContext(const std::string& name, Device device,
+                                 c10::ArrayRef<torch::lazy::Node*> post_order,
+                                 Util::EmissionMap emit_status)
     : device_(std::move(device)), emit_status_(std::move(emit_status)) {}
 
 const std::vector<lazy_tensors::ComputationClient::DataPtr>&

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lowering_context.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lowering_context.h
@@ -11,7 +11,6 @@
 #include "lazy_tensors/computation_client/computation_client.h"
 #include "lazy_tensors/core/platform/macros.h"
 #include "lazy_tensors/shape_util.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/types.h"
 #include "torch/csrc/lazy/core/ir.h"
 
@@ -23,14 +22,14 @@ class LoweringContext {
  public:
   LoweringContext(const std::string& name, Device device);
   LoweringContext(const std::string& name, Device device,
-                  lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+                  c10::ArrayRef<torch::lazy::Node*> post_order,
                   Util::EmissionMap emit_status);
 
   virtual ~LoweringContext() = default;
 
   static std::unique_ptr<LoweringContext> Create(
       const std::string& name, Device device,
-      lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+      c10::ArrayRef<torch::lazy::Node*> post_order,
       Util::EmissionMap emit_status);
 
   static std::unique_ptr<LoweringContext> Create(const std::string& name,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/op_by_op_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/op_by_op_executor.h
@@ -7,7 +7,6 @@
 #include "lazy_tensors/computation_client/cache.h"
 #include "lazy_tensors/computation_client/computation_client.h"
 #include "lazy_tensors/computation_client/util.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/types.h"
 #include "torch/csrc/lazy/core/ir.h"
 
@@ -25,16 +24,16 @@ class OpByOpExecutor {
   static OpByOpExecutor* Get();
 
   std::vector<lazy_tensors::ComputationClient::ExecuteChainedOp> BuildOps(
-      lazy_tensors::Span<const torch::lazy::Value> roots, const std::string& device,
-      lazy_tensors::Span<const std::string> devices);
+      c10::ArrayRef<torch::lazy::Value> roots, const std::string& device,
+      c10::ArrayRef<std::string> devices);
 
   std::vector<lazy_tensors::ComputationClient::DataPtr> Execute(
-      lazy_tensors::Span<const torch::lazy::Value> roots, const std::string& device,
-      lazy_tensors::Span<const std::string> devices);
+      c10::ArrayRef<torch::lazy::Value> roots, const std::string& device,
+      c10::ArrayRef<std::string> devices);
 
-  AsyncTask ExecuteAsync(lazy_tensors::Span<const torch::lazy::Value> roots,
+  AsyncTask ExecuteAsync(c10::ArrayRef<torch::lazy::Value> roots,
                          const std::string& device,
-                         lazy_tensors::Span<const std::string> devices);
+                         c10::ArrayRef<std::string> devices);
 
  private:
   using CompileCache =

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/adaptive_avg_pool2d.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/adaptive_avg_pool2d.h
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
 #include "lazy_tensors/primitive_types.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/adaptive_avg_pool3d.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/adaptive_avg_pool3d.h
@@ -4,7 +4,6 @@
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
 #include "lazy_tensors/primitive_types.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/as_strided.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/as_strided.cpp
@@ -38,19 +38,18 @@ NodePtr AsStrided::Clone(OpList operands) const {
   return torch::lazy::MakeNode<AsStrided>(operands.at(0), size_, stride_, storage_offset_);
 }
 
-bool AsStrided::StrideIsSupported(
-    const lazy_tensors::Shape& input_shape,
-    lazy_tensors::Span<const lazy_tensors::int64> size,
-    lazy_tensors::Span<const lazy_tensors::int64> stride,
-    lazy_tensors::int64 storage_offset) {
+bool AsStrided::StrideIsSupported(const lazy_tensors::Shape& input_shape,
+                                  c10::ArrayRef<lazy_tensors::int64> size,
+                                  c10::ArrayRef<lazy_tensors::int64> stride,
+                                  lazy_tensors::int64 storage_offset) {
   std::vector<lazy_tensors::int64> sorted_stride(stride.begin(), stride.end());
   std::sort(sorted_stride.begin(), sorted_stride.end());
   return stride.empty() || sorted_stride.front() == 1;
 }
 
 std::vector<lazy_tensors::int64> AsStrided::GetArrayStridePermutation(
-    lazy_tensors::Span<const lazy_tensors::int64> stride,
-    lazy_tensors::Span<const lazy_tensors::int64> size) {
+    c10::ArrayRef<lazy_tensors::int64> stride,
+    c10::ArrayRef<lazy_tensors::int64> size) {
   std::vector<lazy_tensors::int64> permutation =
       lazy_tensors::util::Iota<lazy_tensors::int64>(stride.size());
   std::sort(permutation.begin(), permutation.end(),

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/as_strided.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/as_strided.h
@@ -25,15 +25,14 @@ class AsStrided : public TsNode {
 
   lazy_tensors::int64 storage_offset() const { return storage_offset_; }
 
-  static bool StrideIsSupported(
-      const lazy_tensors::Shape& input_shape,
-      lazy_tensors::Span<const lazy_tensors::int64> size,
-      lazy_tensors::Span<const lazy_tensors::int64> stride,
-      lazy_tensors::int64 storage_offset);
+  static bool StrideIsSupported(const lazy_tensors::Shape& input_shape,
+                                c10::ArrayRef<lazy_tensors::int64> size,
+                                c10::ArrayRef<lazy_tensors::int64> stride,
+                                lazy_tensors::int64 storage_offset);
 
   static std::vector<lazy_tensors::int64> GetArrayStridePermutation(
-      lazy_tensors::Span<const lazy_tensors::int64> stride,
-      lazy_tensors::Span<const lazy_tensors::int64> size);
+      c10::ArrayRef<lazy_tensors::int64> stride,
+      c10::ArrayRef<lazy_tensors::int64> size);
 
  private:
   std::vector<lazy_tensors::int64> size_;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/binary_cross_entropy.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/binary_cross_entropy.cpp
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/compiler/node_lowering.h"
 #include "lazy_tensors/computation_client/util.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/cat.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/cat.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_backward_overrideable.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_backward_overrideable.h
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
 #include "lazy_tensors/primitive_types.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_overrideable.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/convolution_overrideable.h
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
 #include "lazy_tensors/primitive_types.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/flip.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/flip.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/generic_slice.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/generic_slice.cpp
@@ -7,12 +7,11 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-GenericSlice::GenericSlice(
-    const torch::lazy::Value& input,
-    lazy_tensors::Span<const lazy_tensors::int64> base_indices,
-    lazy_tensors::Span<const lazy_tensors::int64> sizes)
+GenericSlice::GenericSlice(const torch::lazy::Value& input,
+                           c10::ArrayRef<lazy_tensors::int64> base_indices,
+                           c10::ArrayRef<lazy_tensors::int64> sizes)
     : TsNode(ltc_generic_slice, {input},
-           /*num_outputs=*/1, torch::lazy::MHash(base_indices, sizes)),
+             /*num_outputs=*/1, torch::lazy::MHash(base_indices, sizes)),
       base_indices_(base_indices.begin(), base_indices.end()),
       sizes_(sizes.begin(), sizes.end()) {
   SetShapeDeferred(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/generic_slice.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/generic_slice.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -10,8 +9,8 @@ namespace ops {
 class GenericSlice : public TsNode {
  public:
   GenericSlice(const torch::lazy::Value& input,
-               lazy_tensors::Span<const lazy_tensors::int64> base_indices,
-               lazy_tensors::Span<const lazy_tensors::int64> sizes);
+               c10::ArrayRef<lazy_tensors::int64> base_indices,
+               c10::ArrayRef<lazy_tensors::int64> sizes);
 
   NodePtr Clone(OpList operands) const override;
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
@@ -129,9 +129,9 @@ CanonicalIndexInfo TransposeToFront(at::Tensor base, at::TensorList indices) {
 
 // Wraps index tensors once into the [0, dim_size) interval, where dim_size is
 // the size of the current indexed dimension.
-std::vector<LazyTensor> WrapIndicesOnce(
-    const LazyTensor& base, lazy_tensors::Span<const LazyTensor> indices,
-    int start_dim) {
+std::vector<LazyTensor> WrapIndicesOnce(const LazyTensor& base,
+                                        c10::ArrayRef<LazyTensor> indices,
+                                        int start_dim) {
   std::vector<LazyTensor> canonical_indices;
   auto base_shape_ref = base.shape();
   LTC_CHECK_LE(indices.size(), base_shape_ref.get().rank());
@@ -213,7 +213,7 @@ torch::lazy::Value EnsureRank1(const torch::lazy::Value& index) {
 }
 
 LazyTensor IndexByTensors(const LazyTensor& base,
-                          lazy_tensors::Span<const LazyTensor> indices,
+                          c10::ArrayRef<LazyTensor> indices,
                           lazy_tensors::int64 start_dim) {
   if (indices.empty()) {
     return base;
@@ -232,9 +232,9 @@ LazyTensor IndexByTensors(const LazyTensor& base,
 }
 
 torch::lazy::Value IndexPutByTensors(
-    const LazyTensor& base, lazy_tensors::Span<const LazyTensor> indices,
+    const LazyTensor& base, c10::ArrayRef<LazyTensor> indices,
     lazy_tensors::int64 start_dim, const LazyTensor& values, bool accumulate,
-    lazy_tensors::Span<const lazy_tensors::int64> result_permutation) {
+    c10::ArrayRef<lazy_tensors::int64> result_permutation) {
   if (indices.empty()) {
     return base.GetIrValue();
   }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.h
@@ -55,13 +55,13 @@ torch::lazy::Value EnsureRank1(const torch::lazy::Value& index);
 // Implements indexing by tensors of long according to the top-level
 // description.
 LazyTensor IndexByTensors(const LazyTensor& base,
-                          lazy_tensors::Span<const LazyTensor> indices,
+                          c10::ArrayRef<LazyTensor> indices,
                           lazy_tensors::int64 start_dim);
 
 torch::lazy::Value IndexPutByTensors(
-    const LazyTensor& base, lazy_tensors::Span<const LazyTensor> indices,
+    const LazyTensor& base, c10::ArrayRef<LazyTensor> indices,
     lazy_tensors::int64 start_dim, const LazyTensor& updates, bool accumulate,
-    lazy_tensors::Span<const lazy_tensors::int64> result_permutation);
+    c10::ArrayRef<lazy_tensors::int64> result_permutation);
 
 NodePtr IndexFill(const LazyTensor& base, lazy_tensors::int64 dim,
                       const LazyTensor& index, const at::Scalar& value);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss2d.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss2d.cpp
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/compiler/node_lowering.h"
 #include "lazy_tensors/computation_client/util.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss_forward.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/nll_loss_forward.cpp
@@ -2,7 +2,6 @@
 
 #include "lazy_tensor_core/csrc/compiler/node_lowering.h"
 #include "lazy_tensors/computation_client/util.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/permute.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/permute.cpp
@@ -29,7 +29,7 @@ std::string Permute::ToString() const {
 
 lazy_tensors::Shape Permute::MakePermuteShape(
     const lazy_tensors::Shape& source_shape,
-    lazy_tensors::Span<const lazy_tensors::int64> permutation) {
+    c10::ArrayRef<lazy_tensors::int64> permutation) {
   return Helpers::GetDynamicReshape(
       source_shape, Helpers::Permute(permutation, source_shape.dimensions()));
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/permute.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/permute.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -19,7 +18,7 @@ class Permute : public TsNode {
 
   static lazy_tensors::Shape MakePermuteShape(
       const lazy_tensors::Shape& source_shape,
-      lazy_tensors::Span<const lazy_tensors::int64> permutation);
+      c10::ArrayRef<lazy_tensors::int64> permutation);
 
  private:
   // The permutation of dimensions.

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/prod.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/prod.h
@@ -4,7 +4,6 @@
 #include <c10/util/Optional.h>
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/repeat.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/repeat.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/replication_pad.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/replication_pad.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/resize.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/resize.cpp
@@ -9,8 +9,8 @@ namespace ir {
 namespace ops {
 namespace {
 
-lazy_tensors::Shape NodeOutputShape(
-    const torch::lazy::Value& input, lazy_tensors::Span<const lazy_tensors::int64> size) {
+lazy_tensors::Shape NodeOutputShape(const torch::lazy::Value& input,
+                                    c10::ArrayRef<lazy_tensors::int64> size) {
   return lazy_tensors::ShapeUtil::MakeShape(ir::GetShapeFromTsValue(input).element_type(), size);
 }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/stack.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/stack.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/update_slice.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/update_slice.cpp
@@ -7,11 +7,11 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-UpdateSlice::UpdateSlice(
-    const torch::lazy::Value& input, const torch::lazy::Value& source,
-    lazy_tensors::Span<const lazy_tensors::int64> base_indices)
+UpdateSlice::UpdateSlice(const torch::lazy::Value& input,
+                         const torch::lazy::Value& source,
+                         c10::ArrayRef<lazy_tensors::int64> base_indices)
     : TsNode(ltc_update_slice, {input, source},
-           /*num_outputs=*/1, torch::lazy::MHash(base_indices)),
+             /*num_outputs=*/1, torch::lazy::MHash(base_indices)),
       base_indices_(base_indices.begin(), base_indices.end()) {
   SetShapeDeferred(
       [&]() { return compiler::NodeLowering::Get()->Infer(this); });

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/update_slice.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/update_slice.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -10,7 +9,7 @@ namespace ops {
 class UpdateSlice : public TsNode {
  public:
   UpdateSlice(const torch::lazy::Value& input, const torch::lazy::Value& source,
-              lazy_tensors::Span<const lazy_tensors::int64> base_indices);
+              c10::ArrayRef<lazy_tensors::int64> base_indices);
 
   NodePtr Clone(OpList operands) const override;
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/view.cpp
@@ -11,7 +11,7 @@ namespace {
 
 lazy_tensors::Shape NodeOutputShape(
     const torch::lazy::Value& input,
-    lazy_tensors::Span<const lazy_tensors::int64> output_sizes) {
+    c10::ArrayRef<lazy_tensors::int64> output_sizes) {
   const lazy_tensors::Shape& input_shape = ir::GetShapeFromTsValue(input);
   auto info = Helpers::GetDynamicReshapeInfo(input_shape, output_sizes);
   if (info) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/reduction.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/reduction.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "lazy_tensors/span.h"
 
 namespace torch_lazy_tensors {
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/shape_builder.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/shape_builder.cpp
@@ -10,9 +10,8 @@ ShapeBuilder& ShapeBuilder::Add(const lazy_tensors::Shape& shape,
   return *this;
 }
 
-ShapeBuilder& ShapeBuilder::Add(
-    const lazy_tensors::Shape& shape,
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions) {
+ShapeBuilder& ShapeBuilder::Add(const lazy_tensors::Shape& shape,
+                                c10::ArrayRef<lazy_tensors::int64> dimensions) {
   dims_.reserve(dimensions.size());
   for (auto dim : dimensions) {
     dims_.push_back({&shape, dim});

--- a/lazy_tensor_core/lazy_tensor_core/csrc/shape_builder.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/shape_builder.h
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "lazy_tensors/shape.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/types.h"
 
 namespace torch_lazy_tensors {
@@ -15,7 +14,7 @@ class ShapeBuilder {
   ShapeBuilder& Add(const lazy_tensors::Shape& shape, lazy_tensors::int64 dim);
 
   ShapeBuilder& Add(const lazy_tensors::Shape& shape,
-                    lazy_tensors::Span<const lazy_tensors::int64> dimensions);
+                    c10::ArrayRef<lazy_tensors::int64> dimensions);
 
   ShapeBuilder& Add(lazy_tensors::int64 size);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -374,8 +374,7 @@ torch::lazy::Value LazyTensor::GetIrValueForScalar(const at::Scalar& value,
 
 torch::lazy::Value LazyTensor::GetIrValueForScalar(
     const at::Scalar& value, lazy_tensors::PrimitiveType type,
-    lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-    const Device& device) {
+    c10::ArrayRef<lazy_tensors::int64> dimensions, const Device& device) {
   torch::lazy::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
     ir_value = torch::lazy::MakeNode<ir::ops::Expand>(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -176,8 +176,7 @@ class LazyTensor {
                                        const Device& device);
   static torch::lazy::Value GetIrValueForScalar(
       const at::Scalar& value, lazy_tensors::PrimitiveType type,
-      lazy_tensors::Span<const lazy_tensors::int64> dimensions,
-      const Device& device);
+      c10::ArrayRef<lazy_tensors::int64> dimensions, const Device& device);
   static torch::lazy::Value GetIrValueForScalar(const at::Scalar& value,
                                        const lazy_tensors::Shape& shape,
                                        const Device& device);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -159,11 +159,9 @@ void bitwise_xor_out(LazyTensor& out, const LazyTensor& input,
                      const LazyTensor& other);
 
 // Broadcasts the given tensors according to broadcasting semantics.
-std::vector<LazyTensor> broadcast_tensors(
-    lazy_tensors::Span<const LazyTensor> tensors);
+std::vector<LazyTensor> broadcast_tensors(c10::ArrayRef<LazyTensor> tensors);
 
-LazyTensor cat(lazy_tensors::Span<const LazyTensor> tensors,
-               lazy_tensors::int64 dim);
+LazyTensor cat(c10::ArrayRef<LazyTensor> tensors, lazy_tensors::int64 dim);
 
 LazyTensor ceil(const LazyTensor& input);
 
@@ -182,7 +180,7 @@ LazyTensor clone(const LazyTensor& input);
 // Pad with the given value and size specified by the given list of low and
 // high paddings.
 LazyTensor constant_pad_nd(const LazyTensor& input,
-                           lazy_tensors::Span<const lazy_tensors::int64> pad,
+                           c10::ArrayRef<lazy_tensors::int64> pad,
                            const at::Scalar& value);
 
 LazyTensor convolution_overrideable(
@@ -239,7 +237,7 @@ LazyTensor diagonal(const LazyTensor& input, lazy_tensors::int64 offset,
 // A generalized contraction between tensors of arbitrary dimension defined by
 // the given equation and applied to the input tensors.
 LazyTensor einsum(const std::string& equation,
-                  lazy_tensors::Span<const LazyTensor> tensors);
+                  c10::ArrayRef<LazyTensor> tensors);
 
 LazyTensor elu(const LazyTensor& input, const at::Scalar& alpha,
                const at::Scalar& scale, const at::Scalar& input_scale);
@@ -280,7 +278,7 @@ void fill_(LazyTensor& input, const at::Scalar& value);
 
 // Flips (reverses) the values in the dimensions of the input tensor.
 LazyTensor flip(const LazyTensor& input,
-                lazy_tensors::Span<const lazy_tensors::int64> dims);
+                c10::ArrayRef<lazy_tensors::int64> dims);
 
 LazyTensor fmod(
     const LazyTensor& input, const LazyTensor& other,
@@ -289,7 +287,7 @@ LazyTensor fmod(
     const LazyTensor& input, const at::Scalar& other,
     c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
 
-LazyTensor full(lazy_tensors::Span<const lazy_tensors::int64> size,
+LazyTensor full(c10::ArrayRef<lazy_tensors::int64> size,
                 const at::Scalar& fill_value, const Device& device,
                 at::ScalarType scalar_type);
 LazyTensor full_like(const LazyTensor& input, const at::Scalar& fill_value,
@@ -317,8 +315,7 @@ LazyTensor gt(const LazyTensor& input, const LazyTensor& other);
 // For input of shape d1 x d2 x ... x dn and p indices of shape i1 x i2 x ...
 // x ik, the output shape is d1 x ... x d(start_dim) x i1 x ... x ik x
 // d(start_dim+p+1) x ... x dn.
-LazyTensor index(const LazyTensor& input,
-                 lazy_tensors::Span<const LazyTensor> indices,
+LazyTensor index(const LazyTensor& input, c10::ArrayRef<LazyTensor> indices,
                  lazy_tensors::int64 start_dim);
 
 LazyTensor index_add(const LazyTensor& input, lazy_tensors::int64 dim,
@@ -351,16 +348,16 @@ void index_fill_(LazyTensor& input, lazy_tensors::int64 dim,
 
 // Puts values into the input tensor using the given indices (a tuple of
 // tensors) and returns the result.
-LazyTensor index_put(
-    const LazyTensor& input, lazy_tensors::Span<const LazyTensor> indices,
-    lazy_tensors::int64 start_dim, const LazyTensor& values, bool accumulate,
-    lazy_tensors::Span<const lazy_tensors::int64> result_permutation);
+LazyTensor index_put(const LazyTensor& input, c10::ArrayRef<LazyTensor> indices,
+                     lazy_tensors::int64 start_dim, const LazyTensor& values,
+                     bool accumulate,
+                     c10::ArrayRef<lazy_tensors::int64> result_permutation);
 
-void index_put_(
-    LazyTensor& input, const LazyTensor& canonical_base,
-    lazy_tensors::Span<const LazyTensor> indices, lazy_tensors::int64 start_dim,
-    const LazyTensor& values, bool accumulate,
-    lazy_tensors::Span<const lazy_tensors::int64> result_permutation);
+void index_put_(LazyTensor& input, const LazyTensor& canonical_base,
+                c10::ArrayRef<LazyTensor> indices,
+                lazy_tensors::int64 start_dim, const LazyTensor& values,
+                bool accumulate,
+                c10::ArrayRef<lazy_tensors::int64> result_permutation);
 
 LazyTensor index_select(const LazyTensor& input, lazy_tensors::int64 dim,
                         const LazyTensor& index);
@@ -537,7 +534,7 @@ std::tuple<LazyTensor, LazyTensor, LazyTensor> ts_native_batch_norm_backward(
     const LazyTensor& weight, const LazyTensor& running_mean,
     const LazyTensor& running_var, const LazyTensor& save_mean,
     const LazyTensor& save_invstd, bool training, double eps,
-    lazy_tensors::Span<const bool> output_mask);
+    c10::ArrayRef<bool> output_mask);
 
 LazyTensor ne(const LazyTensor& input, const at::Scalar& other);
 
@@ -587,7 +584,7 @@ LazyTensor not_supported(std::string description, lazy_tensors::Shape shape,
 
 // Permute the dimensions of this tensor according to the given permutation.
 LazyTensor permute(const LazyTensor& input,
-                   lazy_tensors::Span<const lazy_tensors::int64> dims);
+                   c10::ArrayRef<lazy_tensors::int64> dims);
 
 LazyTensor pow(const LazyTensor& input, const at::Scalar& exponent);
 LazyTensor pow(const LazyTensor& input, const LazyTensor& exponent);
@@ -729,8 +726,7 @@ LazyTensor squeeze(const LazyTensor& input, lazy_tensors::int64 dim);
 void squeeze_(LazyTensor& input);
 void squeeze_(LazyTensor& input, lazy_tensors::int64 dim);
 
-LazyTensor stack(lazy_tensors::Span<const LazyTensor> tensors,
-                 lazy_tensors::int64 dim);
+LazyTensor stack(c10::ArrayRef<LazyTensor> tensors, lazy_tensors::int64 dim);
 
 LazyTensor std(const LazyTensor& input,
                std::vector<lazy_tensors::int64> dimensions,
@@ -843,7 +839,7 @@ std::tuple<LazyTensor, LazyTensor> var_mean(
 
 // Like reshape, but it returns a view into the original tensor.
 LazyTensor view(const LazyTensor& input,
-                lazy_tensors::Span<const lazy_tensors::int64> output_size);
+                c10::ArrayRef<lazy_tensors::int64> output_size);
 
 void zero_(LazyTensor& input);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
@@ -17,15 +17,14 @@ std::vector<lazy_tensors::int64> ComputeShapeStrides(
     const lazy_tensors::Shape& shape);
 
 std::vector<lazy_tensors::int64> ComputeArrayStrides(
-    lazy_tensors::Span<const lazy_tensors::int64> sizes);
+    c10::ArrayRef<lazy_tensors::int64> sizes);
 
 // Converts a literal to an at::Tensor of the given element type.
 at::Tensor MakeTensorFromLiteral(const lazy_tensors::Literal& literal,
                                  at::ScalarType dest_element_type);
 
 std::vector<at::Tensor> DataHandlesToTensors(
-    lazy_tensors::Span<const lazy_tensors::ComputationClient::DataPtr>
-        data_handles,
+    c10::ArrayRef<lazy_tensors::ComputationClient::DataPtr> data_handles,
     at::ScalarType dest_element_type);
 
 bool TensorCompare(const at::Tensor& t1, const at::Tensor& t2);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
@@ -18,7 +18,7 @@ class TSBackendImpl : public BackendImplInterface {
 
   std::unique_ptr<ir::LoweringContext> CreateLoweringContext(
       const std::string& name, Device device,
-      lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+      c10::ArrayRef<torch::lazy::Node*> post_order,
       ir::Util::EmissionMap emit_status) const override {
     return std::make_unique<ts_backend::TSLoweringContext>(
         name, device, post_order, emit_status);
@@ -40,7 +40,7 @@ class TSBackendImpl : public BackendImplInterface {
 
   std::vector<std::string> GetCompilationDevices(
       const std::string& device,
-      lazy_tensors::Span<const std::string> devices) const override {
+      c10::ArrayRef<std::string> devices) const override {
     return std::vector<std::string>(devices.begin(), devices.end());
   }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
@@ -39,7 +39,7 @@ std::vector<ComputationClient::ComputationPtr> TSComputationClient::Compile(
 }
 
 std::vector<ComputationClient::DataPtr> TSComputationClient::ExecuteComputation(
-    const Computation& computation, lazy_tensors::Span<const DataPtr> arguments,
+    const Computation& computation, c10::ArrayRef<DataPtr> arguments,
     const std::string& device, const ExecuteComputationOptions& options) {
   torch::jit::GraphExecutor& graph_executor =
       static_cast<

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.h
@@ -37,12 +37,12 @@ class TSComputationClient : public ComputationClient {
   DataPtr CreateDataPlaceholder(std::string device, Shape shape) override;
 
   std::vector<DataPtr> TransferToServer(
-      lazy_tensors::Span<const TensorSource> tensors) override {
+      c10::ArrayRef<TensorSource> tensors) override {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 
   std::vector<Literal> TransferFromServer(
-      lazy_tensors::Span<const DataPtr> handles) override {
+      c10::ArrayRef<DataPtr> handles) override {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 
@@ -50,34 +50,33 @@ class TSComputationClient : public ComputationClient {
       std::vector<CompileInstance> instances) override;
 
   std::vector<DataPtr> ExecuteComputation(
-      const Computation& computation,
-      lazy_tensors::Span<const DataPtr> arguments, const std::string& device,
+      const Computation& computation, c10::ArrayRef<DataPtr> arguments,
+      const std::string& device,
       const ExecuteComputationOptions& options) override;
 
   std::vector<std::vector<DataPtr>> ExecuteReplicated(
       const Computation& computation,
       const std::vector<std::vector<DataPtr>>& arguments,
-      lazy_tensors::Span<const std::string> devices,
+      c10::ArrayRef<std::string> devices,
       const ExecuteReplicatedOptions& options) override {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 
   std::vector<std::vector<DataPtr>> ExecuteParallel(
-      lazy_tensors::Span<const Computation* const> computations,
+      c10::ArrayRef<Computation*> computations,
       const std::vector<std::vector<DataPtr>>& arguments,
-      lazy_tensors::Span<const std::string> devices,
+      c10::ArrayRef<std::string> devices,
       const ExecuteParallelOptions& options) override {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 
-  std::vector<DataPtr> ExecuteChained(
-      lazy_tensors::Span<const ExecuteChainedOp> ops,
-      const std::string& device) override {
+  std::vector<DataPtr> ExecuteChained(c10::ArrayRef<ExecuteChainedOp> ops,
+                                      const std::string& device) override {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 
   std::vector<std::vector<DataPtr>> DeconstructTuple(
-      lazy_tensors::Span<const DataPtr> tuples) override {
+      c10::ArrayRef<DataPtr> tuples) override {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
@@ -14,7 +14,7 @@ TSLoweringContext::TSLoweringContext(const std::string& name, Device device)
 
 TSLoweringContext::TSLoweringContext(
     const std::string& name, Device device,
-    lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+    c10::ArrayRef<torch::lazy::Node*> post_order,
     ir::Util::EmissionMap emit_status)
     : ir::LoweringContext(name, device, post_order, emit_status),
       graph_(std::make_shared<torch::jit::Graph>()) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.h
@@ -2,7 +2,6 @@
 
 #include <torch/jit.h>
 #include "lazy_tensor_core/csrc/lowering_context.h"
-#include "lazy_tensors/span.h"
 #include "torch/csrc/jit/runtime/graph_executor.h"
 
 namespace torch_lazy_tensors {
@@ -46,7 +45,7 @@ class TSLoweringContext : public ir::LoweringContext {
   TSLoweringContext(const std::string& name, Device device);
 
   TSLoweringContext(const std::string& name, Device device,
-                    lazy_tensors::Span<const torch::lazy::Node* const> post_order,
+                    c10::ArrayRef<torch::lazy::Node*> post_order,
                     ir::Util::EmissionMap emit_status);
 
   lazy_tensors::Shape GetResultShape(size_t index) const override;

--- a/lazy_tensor_core/lazy_tensors/layout.h
+++ b/lazy_tensor_core/lazy_tensors/layout.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/types.h"
 
 namespace lazy_tensors {
@@ -11,9 +10,7 @@ class Layout {
  public:
   int64 minor_to_major(int index) const { return minor_to_major_.at(index); }
 
-  lazy_tensors::Span<const int64> minor_to_major() const {
-    return minor_to_major_;
-  }
+  const std::vector<int64>& minor_to_major() const { return minor_to_major_; }
 
   std::vector<int64>* mutable_minor_to_major() { return &minor_to_major_; }
 

--- a/lazy_tensor_core/lazy_tensors/permutation_util.cc
+++ b/lazy_tensor_core/lazy_tensors/permutation_util.cc
@@ -5,8 +5,7 @@
 
 namespace lazy_tensors {
 
-std::vector<int64> InversePermutation(
-    lazy_tensors::Span<const int64> input_permutation) {
+std::vector<int64> InversePermutation(c10::ArrayRef<int64> input_permutation) {
   DCHECK(IsPermutation(input_permutation));
   std::vector<int64> output_permutation(input_permutation.size(), -1);
   for (size_t i = 0; i < input_permutation.size(); ++i) {
@@ -15,14 +14,14 @@ std::vector<int64> InversePermutation(
   return output_permutation;
 }
 
-bool IsPermutation(lazy_tensors::Span<const int64> permutation) {
+bool IsPermutation(c10::ArrayRef<int64> permutation) {
   std::vector<int64> trivial_permutation(permutation.size());
   std::iota(trivial_permutation.begin(), trivial_permutation.end(), 0);
   return std::is_permutation(permutation.begin(), permutation.end(),
                              trivial_permutation.begin());
 }
 
-bool IsIdentityPermutation(lazy_tensors::Span<const int64> permutation) {
+bool IsIdentityPermutation(c10::ArrayRef<int64> permutation) {
   for (int64 i = 0; i < permutation.size(); ++i) {
     if (permutation[i] != i) {
       return false;

--- a/lazy_tensor_core/lazy_tensors/permutation_util.h
+++ b/lazy_tensor_core/lazy_tensors/permutation_util.h
@@ -2,24 +2,22 @@
 
 #include <vector>
 
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/str_join.h"
 #include "lazy_tensors/types.h"
 
 namespace lazy_tensors {
 
-std::vector<int64> InversePermutation(
-    lazy_tensors::Span<const int64> input_permutation);
+std::vector<int64> InversePermutation(c10::ArrayRef<int64> input_permutation);
 
-bool IsPermutation(lazy_tensors::Span<const int64> permutation);
+bool IsPermutation(c10::ArrayRef<int64> permutation);
 
-bool IsIdentityPermutation(lazy_tensors::Span<const int64> permutation);
+bool IsIdentityPermutation(c10::ArrayRef<int64> permutation);
 
 template <typename Container>
 inline std::vector<typename Container::value_type> PermuteInverse(
-    const Container& input, lazy_tensors::Span<const int64> permutation) {
+    const Container& input, c10::ArrayRef<int64> permutation) {
   using T = typename Container::value_type;
-  lazy_tensors::Span<const T> data(input);
+  c10::ArrayRef<T> data(input);
   CHECK(IsPermutation(permutation));
   std::vector<T> output(data.size());
   for (size_t i = 0; i < permutation.size(); ++i) {

--- a/lazy_tensor_core/lazy_tensors/shape.cc
+++ b/lazy_tensor_core/lazy_tensors/shape.cc
@@ -2,10 +2,12 @@
 #include "lazy_tensor_core/csrc/tensor_util.h"
 namespace lazy_tensors {
 
-Shape::Shape(at::ScalarType element_type,
-             lazy_tensors::Span<const int64> dimensions)
+Shape::Shape(at::ScalarType element_type, c10::ArrayRef<int64> dimensions)
     : element_type_(torch_lazy_tensors::MakeLtcPrimitiveType(
-          element_type, /*device=*/nullptr)),    // TODO(whc) used what was available now, but want to move to using aten dtype not device-specific dtype
+          element_type,
+          /*device=*/nullptr)),  // TODO(whc) used what was available now, but
+                                 // want to move to using aten dtype not
+                                 // device-specific dtype
       dimensions_(dimensions.begin(), dimensions.end()),
       dynamic_dimensions_(dimensions.size(), false) {}
 

--- a/lazy_tensor_core/lazy_tensors/shape.h
+++ b/lazy_tensor_core/lazy_tensors/shape.h
@@ -9,7 +9,6 @@
 #include "lazy_tensors/computation_client/debug_macros.h"
 #include "lazy_tensors/layout.h"
 #include "lazy_tensors/primitive_util.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/str_cat.h"
 #include "lazy_tensors/str_join.h"
 #include "lazy_tensors/types.h"
@@ -20,14 +19,14 @@ class Shape {
  public:
   Shape() : element_type_(PrimitiveType::INVALID) {}
 
-  Shape(at::ScalarType element_type, lazy_tensors::Span<const int64> dimensions);
+  Shape(at::ScalarType element_type, c10::ArrayRef<int64> dimensions);
 
-  Shape(PrimitiveType element_type, lazy_tensors::Span<const int64> dimensions)
+  Shape(PrimitiveType element_type, c10::ArrayRef<int64> dimensions)
       : element_type_(element_type),
         dimensions_(dimensions.begin(), dimensions.end()),
         dynamic_dimensions_(dimensions.size(), false) {}
 
-  Shape(lazy_tensors::Span<const Shape> element_shapes)
+  Shape(c10::ArrayRef<Shape> element_shapes)
       : element_type_(PrimitiveType::TUPLE),
         element_shapes_(element_shapes.begin(), element_shapes.end()) {}
 
@@ -62,7 +61,7 @@ class Shape {
     dynamic_dimensions_[dimension] = is_dynamic;
   }
 
-  lazy_tensors::Span<const bool> dynamic_dimensions() const {
+  c10::ArrayRef<bool> dynamic_dimensions() const {
     LTC_LOG(FATAL) << "Not implemented yet.";
   }
 
@@ -88,11 +87,11 @@ class Shape {
     dimensions_[index] = value;
   }
 
-  lazy_tensors::Span<const int64> dimensions() const {
+  c10::ArrayRef<int64> dimensions() const {
     if (dynamic_mode_.load()) {
       throw std::runtime_error("Exact shape not known");
     }
-    return MakeSpan(dimensions_);
+    return dimensions_;
   }
 
   int tuple_shapes_size() const { return element_shapes_.size(); }

--- a/lazy_tensor_core/lazy_tensors/shape_util.h
+++ b/lazy_tensor_core/lazy_tensors/shape_util.h
@@ -4,7 +4,6 @@
 
 #include "lazy_tensors/primitive_types.h"
 #include "lazy_tensors/shape.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/util.h"
 #include "torch/csrc/jit/tensorexpr/types.h"
 #include "torch/csrc/lazy/core/hash.h"
@@ -101,20 +100,21 @@ class ShapeUtil {
     }
   }
 
-  static Shape MakeTupleShape(lazy_tensors::Span<const Shape> shapes) {
+  static Shape MakeTupleShape(c10::ArrayRef<Shape> shapes) {
     return Shape(shapes);
   }
 
   static Shape MakeShape(PrimitiveType element_type,
-                         lazy_tensors::Span<const int64> dimensions) {
+                         c10::ArrayRef<int64> dimensions) {
     return MakeShapeWithDescendingLayout(element_type, dimensions);
   }
 
-  static Shape MakeShapeWithLayout(
-      PrimitiveType element_type, lazy_tensors::Span<const int64> dimensions,
-      lazy_tensors::Span<const int64> minor_to_major,
-      lazy_tensors::Span<const Tile> tiles = {}, int64 element_size_in_bits = 0,
-      int64 memory_space = 0) {
+  static Shape MakeShapeWithLayout(PrimitiveType element_type,
+                                   c10::ArrayRef<int64> dimensions,
+                                   c10::ArrayRef<int64> minor_to_major,
+                                   c10::ArrayRef<Tile> tiles = {},
+                                   int64 element_size_in_bits = 0,
+                                   int64 memory_space = 0) {
     LTC_CHECK(tiles.empty());
     LTC_CHECK_EQ(element_size_in_bits, 0);
     LTC_CHECK_EQ(memory_space, 0);
@@ -130,8 +130,8 @@ class ShapeUtil {
     return shape;
   }
 
-  static Shape MakeShapeWithDescendingLayout(
-      PrimitiveType element_type, lazy_tensors::Span<const int64> dimensions) {
+  static Shape MakeShapeWithDescendingLayout(PrimitiveType element_type,
+                                             c10::ArrayRef<int64> dimensions) {
     std::vector<int64> layout(dimensions.size());
     std::iota(layout.rbegin(), layout.rend(), static_cast<int64>(0));
     return MakeShapeWithLayout(element_type, dimensions, layout);

--- a/lazy_tensor_core/lazy_tensors/span.h
+++ b/lazy_tensor_core/lazy_tensors/span.h
@@ -205,7 +205,7 @@ constexpr Span<T> MakeSpan(T (&array)[N]) noexcept {
 //
 // Examples:
 //
-//   void ProcessInts(lazy_tensors::Span<const int> some_ints);
+//   void ProcessInts(c10::ArrayRef<int> some_ints);
 //
 //   // Call with a pointer and size.
 //   int array[3] = { 0, 0, 0 };

--- a/lazy_tensor_core/lazy_tensors/util.h
+++ b/lazy_tensor_core/lazy_tensors/util.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "lazy_tensors/span.h"
 
 namespace lazy_tensors {
 
-inline lazy_tensors::Span<const int64> AsInt64Slice(
-    lazy_tensors::Span<const int64> slice) {
+inline c10::ArrayRef<int64> AsInt64Slice(c10::ArrayRef<int64> slice) {
   return slice;
 }
 

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -132,7 +132,7 @@ bool EqualValuesNoElementTypeCheck(at::Tensor tensor1, at::Tensor tensor2) {
   return equal;
 }
 
-void ForEachDevice(lazy_tensors::Span<const DeviceType> device_types,
+void ForEachDevice(c10::ArrayRef<DeviceType> device_types,
                    const std::function<void(const Device&)>& devfn) {
   const Device* device = GetDefaultDevice();
   if (device_types.empty() ||
@@ -145,7 +145,7 @@ void ForEachDevice(lazy_tensors::Span<const DeviceType> device_types,
   }
 }
 
-void ForEachDevice(lazy_tensors::Span<const DeviceType> device_types,
+void ForEachDevice(c10::ArrayRef<DeviceType> device_types,
                    const std::function<void(const torch::Device&)>& devfn) {
   const Device* device = GetDefaultDevice();
   if (device_types.empty() ||
@@ -193,7 +193,7 @@ bool CloseValues(at::Tensor tensor1, at::Tensor tensor2, double rtol,
 }
 
 void WithAllDevices(
-    lazy_tensors::Span<const DeviceType> device_types,
+    c10::ArrayRef<DeviceType> device_types,
     const std::function<void(const std::vector<Device>&,
                              const std::vector<Device>&)>& devfn) {
   for (auto device_type : device_types) {

--- a/lazy_tensor_core/test/cpp/cpp_test_util.h
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.h
@@ -11,7 +11,6 @@
 #include "lazy_tensor_core/csrc/debug_util.h"
 #include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensor_core/csrc/tensor.h"
-#include "lazy_tensors/span.h"
 #include "torch/csrc/lazy/core/ir.h"
 
 #define XLA_CPP_TEST_ENABLED(name)                          \
@@ -59,10 +58,10 @@ static inline void AllEqual(at::Tensor tensor, at::Tensor xla_tensor) {
   EXPECT_TRUE(EqualValues(tensor, xla_tensor));
 }
 
-void ForEachDevice(lazy_tensors::Span<const DeviceType> device_types,
+void ForEachDevice(c10::ArrayRef<DeviceType> device_types,
                    const std::function<void(const Device&)>& devfn);
 
-void ForEachDevice(lazy_tensors::Span<const DeviceType> device_types,
+void ForEachDevice(c10::ArrayRef<DeviceType> device_types,
                    const std::function<void(const torch::Device&)>& devfn);
 
 void ForEachDevice(const std::function<void(const Device&)>& devfn);
@@ -70,7 +69,7 @@ void ForEachDevice(const std::function<void(const Device&)>& devfn);
 void ForEachDevice(const std::function<void(const torch::Device&)>& devfn);
 
 void WithAllDevices(
-    lazy_tensors::Span<const DeviceType> device_types,
+    c10::ArrayRef<DeviceType> device_types,
     const std::function<void(const std::vector<Device>&,
                              const std::vector<Device>&)>& devfn);
 

--- a/lazy_tensor_core/third_party/computation_client/computation_client.h
+++ b/lazy_tensor_core/third_party/computation_client/computation_client.h
@@ -14,7 +14,6 @@
 #include "lazy_tensors/computation_client/metrics.h"
 #include "lazy_tensors/computation_client/types.h"
 #include "lazy_tensors/literal_util.h"
-#include "lazy_tensors/span.h"
 #include "lazy_tensors/status.h"
 #include "lazy_tensors/types.h"
 
@@ -124,12 +123,12 @@ class ComputationClient {
 
   // Transfers local tensor values to the TPU servers and fetches the handles.
   virtual std::vector<DataPtr> TransferToServer(
-      lazy_tensors::Span<const TensorSource> tensors) = 0;
+      c10::ArrayRef<TensorSource> tensors) = 0;
 
   // Reads the tensor literal values stored at TPU server sites, behind the
   // supplied handles.
   virtual std::vector<Literal> TransferFromServer(
-      lazy_tensors::Span<const DataPtr> handles) = 0;
+      c10::ArrayRef<DataPtr> handles) = 0;
 
   // Compiles a set of computations.
   virtual std::vector<ComputationPtr> Compile(
@@ -140,9 +139,8 @@ class ComputationClient {
   // If options.explode_tuple is true, the output tuple will be decomposed into
   // its single elements.
   virtual std::vector<DataPtr> ExecuteComputation(
-      const Computation& computation,
-      lazy_tensors::Span<const DataPtr> arguments, const std::string& device,
-      const ExecuteComputationOptions& options) = 0;
+      const Computation& computation, c10::ArrayRef<DataPtr> arguments,
+      const std::string& device, const ExecuteComputationOptions& options) = 0;
 
   // Executes the computation in replicated mode.
   // The size of the arguments vector is the number of replicas to execute,
@@ -158,7 +156,7 @@ class ComputationClient {
   virtual std::vector<std::vector<DataPtr>> ExecuteReplicated(
       const Computation& computation,
       const std::vector<std::vector<DataPtr>>& arguments,
-      lazy_tensors::Span<const std::string> devices,
+      c10::ArrayRef<std::string> devices,
       const ExecuteReplicatedOptions& options) = 0;
 
   // Executes the computations in parallel. Each computation must target a
@@ -169,9 +167,9 @@ class ComputationClient {
   // being the return value of computations[i]. If options.explode_tuple is
   // true, the output tuples will be decomposed into their single elements.
   virtual std::vector<std::vector<DataPtr>> ExecuteParallel(
-      lazy_tensors::Span<const Computation* const> computations,
+      c10::ArrayRef<Computation*> computations,
       const std::vector<std::vector<DataPtr>>& arguments,
-      lazy_tensors::Span<const std::string> devices,
+      c10::ArrayRef<std::string> devices,
       const ExecuteParallelOptions& options) = 0;
 
   // Executes a serie of operations, whose results are input of other
@@ -181,11 +179,10 @@ class ComputationClient {
   // every ExecuteChainedOp marked with is_result=true, in the order they appear
   // within the ops post-order.
   virtual std::vector<DataPtr> ExecuteChained(
-      lazy_tensors::Span<const ExecuteChainedOp> ops,
-      const std::string& device) = 0;
+      c10::ArrayRef<ExecuteChainedOp> ops, const std::string& device) = 0;
 
   virtual std::vector<std::vector<DataPtr>> DeconstructTuple(
-      lazy_tensors::Span<const DataPtr> tuples) = 0;
+      c10::ArrayRef<DataPtr> tuples) = 0;
 
   // Returns a unique string which identifies the resource domain of a given
   // device. Within a resource domain, handles to device memory or compiled
@@ -218,7 +215,7 @@ class ComputationClient {
   // device will be returned. Otherwise a vector with the devices content will
   // be returned.
   std::vector<std::string> GetCompilationDevices(
-      const std::string& device, lazy_tensors::Span<const std::string> devices);
+      const std::string& device, c10::ArrayRef<std::string> devices);
 
   // Retrieves the ordinal number out of a device string. This is the number
   // after the last ':' character of the device string.

--- a/lazy_tensor_core/third_party/computation_client/util.h
+++ b/lazy_tensor_core/third_party/computation_client/util.h
@@ -22,14 +22,14 @@ namespace lazy {
 // Adapters that provide torch::lazy Hash functions for xla types
 
 template <typename T>
-torch::lazy::hash_t Hash(lazy_tensors::Span<const T> values) {
+torch::lazy::hash_t Hash(c10::ArrayRef<T> values) {
   return torch::lazy::ContainerHash(values);
 }
 
 // When specializing Hash(T) also specialize MHash(T, ...) since
 // torch::lazy::MHash template won't be aware of the Hash(T) here
 template <typename T, typename... Targs>
-hash_t MHash(lazy_tensors::Span<const T> value, Targs... Fargs) {
+hash_t MHash(c10::ArrayRef<T> value, Targs... Fargs) {
   return HashCombine(Hash(value), MHash(Fargs...));
 }
 
@@ -191,8 +191,8 @@ std::vector<T> ToVector(const S& input) {
 
 template <typename T>
 std::vector<T> GetValuesVector(
-    lazy_tensors::Span<const T> values,
-    lazy_tensors::Span<const c10::optional<T>* const> opt_values) {
+    const std::vector<T>& values,
+    const std::vector<const c10::optional<T>*>& opt_values) {
   std::vector<T> result(values.begin(), values.end());
   for (auto opt : opt_values) {
     if (*opt) {


### PR DESCRIPTION
Summary: This is a preparation step for landing on master. Because
c10::ArrayRef does not take const qualifier, we need to drop them in
this rewrite, which should be safe since ArrayRef only provides const iterator.

TODO: There is still use of Span in class Literal, where the Span needs to be
mutable indeed. Let's revisit this when working on the Literal class.