### PR TITLE
[LTC] Add support for non-structured in-place operator variants

### DIFF
--- a/aten/src/ATen/templates/LazyIr.h
+++ b/aten/src/ATen/templates/LazyIr.h
@@ -7,7 +7,7 @@ ${lazy_ir_inc}
 
 ${external_backend_headers}
 
-namespace torch_lazy_tensors{
+namespace torch_lazy_tensors {
 namespace ir {
 
 static lazy_tensors::Shape convertShape(

--- a/aten/src/ATen/templates/ShapeDtype.h
+++ b/aten/src/ATen/templates/ShapeDtype.h
@@ -5,7 +5,7 @@ ${lazy_ir_sysinc}
 
 ${lazy_ir_inc}
 
-namespace torch_lazy_tensors{
+namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
@@ -46,7 +46,8 @@
 #include "lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.h"
 
 #include "torch/csrc/api/include/torch/enum.h"
-namespace torch_lazy_tensors{
+
+namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
@@ -134,6 +135,14 @@ std::vector<c10::ScalarType> compute_dtype_mv(const at::Tensor& self, const at::
   return {self.scalar_type()};
 }
 
+std::vector<std::vector<int64_t>> compute_shape_relu(const at::Tensor& self) {
+  return {self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_relu(const at::Tensor& self) {
+  return {self.scalar_type()};
+}
+
 std::vector<std::vector<int64_t>> compute_shape_bitwise_and(const at::Tensor& self, const at::Scalar& other) {
   return {self.sizes().vec()};
 }
@@ -161,11 +170,11 @@ std::vector<c10::ScalarType> compute_dtype_sum(
   ;
 }
 
-std::vector<std::vector<int64_t>> compute_shape_zero_(at::Tensor& self) {
+std::vector<std::vector<int64_t>> compute_shape_zero(at::Tensor& self) {
   return {self.sizes().vec()};
 }
 
-std::vector<c10::ScalarType> compute_dtype_zero_(at::Tensor& self) {
+std::vector<c10::ScalarType> compute_dtype_zero(at::Tensor& self) {
   return {self.scalar_type()};
 }
 
@@ -200,7 +209,7 @@ std::vector<std::vector<int64_t>> compute_shape_smooth_l1_loss_backward(
     const at::Tensor& grad_output, const at::Tensor& self,
     const at::Tensor& target, int64_t reduction, double beta) {
   // The `grad_output` tensor is really the input to this kernel, and while its
-  // shape may vary following the logic of the forward output, the outputs of
+  // shape may vary following the logic of the forward output, the output of
   // this kernel should have fixed shapes matching the inputs to the forward
   // kernel.
   return {self.sizes().vec(), target.sizes().vec()};

--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
@@ -161,6 +161,14 @@ std::vector<c10::ScalarType> compute_dtype_sum(
   ;
 }
 
+std::vector<std::vector<int64_t>> compute_shape_zero_(at::Tensor& self) {
+  return {self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_zero_(at::Tensor& self) {
+  return {self.scalar_type()};
+}
+
 std::vector<std::vector<int64_t>> compute_shape_trace(const at::Tensor& self) {
   return {{}};
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
@@ -79,13 +79,6 @@ NodePtr Abs(const torch::lazy::Value& input) {
   return GenericOp(OpKind(at::aten::abs), {input}, ir::GetShapeFromTsValue(input));
 }
 
-NodePtr ReluOp(const torch::lazy::Value& input) {
-  NodePtr node = GenericOp(OpKind(at::aten::relu), {input});
-  std::dynamic_pointer_cast<TsNode>(node)->SetShapeDeferred(
-      [&]() { return compiler::NodeLowering::Get()->Infer(node.get()); });
-  return node;
-}
-
 NodePtr HardSigmoid(const torch::lazy::Value& input) {
   return GenericOp(OpKind(at::aten::hardsigmoid), {input}, ir::GetShapeFromTsValue(input));
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
@@ -85,8 +85,6 @@ NodePtr SignOp(const torch::lazy::Value& input);
 
 NodePtr Abs(const torch::lazy::Value& input);
 
-NodePtr ReluOp(const torch::lazy::Value& input);
-
 NodePtr Min(const torch::lazy::Value& input, const torch::lazy::Value& other);
 
 NodePtr Max(const torch::lazy::Value& input, const torch::lazy::Value& other);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -2282,12 +2282,6 @@ std::tuple<LazyTensor, LazyTensor> var_mean(
                          input.CreateFrom(torch::lazy::Value(node, 1)));
 }
 
-void zero_(LazyTensor& input) {
-  torch::lazy::Value constant = LazyGraphExecutor::Get()->GetIrValueForScalar(
-      0.0, input.shape(), input.GetDevice());
-  input.SetInPlaceIrValue(std::move(constant));
-}
-
 LazyTensor where(const LazyTensor& condition, const LazyTensor& input,
                  const LazyTensor& other) {
   return input.CreateFrom(ir::ops::Where(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -1699,14 +1699,6 @@ LazyTensor reflection_pad2d_backward(const LazyTensor& grad_output,
       grad_output.GetIrValue(), input.GetIrValue(), std::move(padding)));
 }
 
-LazyTensor relu(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::ReluOp(input.GetIrValue()));
-}
-
-void relu_(LazyTensor& input) {
-  input.SetInPlaceIrValue(ir::ops::ReluOp(input.GetIrValue()));
-}
-
 LazyTensor remainder(const LazyTensor& input, const LazyTensor& other) {
   return input.CreateFrom(
       ir::ops::Remainder(input.GetIrValue(), other.GetIrValue()));

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -831,8 +831,6 @@ std::tuple<LazyTensor, LazyTensor> var_mean(
 LazyTensor view(const LazyTensor& input,
                 c10::ArrayRef<lazy_tensors::int64> output_size);
 
-void zero_(LazyTensor& input);
-
 LazyTensor where(const LazyTensor& condition, const LazyTensor& input,
                  const LazyTensor& other);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -604,9 +604,6 @@ LazyTensor reflection_pad2d_backward(const LazyTensor& grad_output,
                                      const LazyTensor& input,
                                      std::vector<lazy_tensors::int64> padding);
 
-LazyTensor relu(const LazyTensor& input);
-void relu_(LazyTensor& input);
-
 LazyTensor remainder(const LazyTensor& input, const LazyTensor& other);
 LazyTensor remainder(const LazyTensor& input, const at::Scalar& other);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -834,13 +834,6 @@ at::Tensor LazyNativeFunctions::view(const at::Tensor& self,
       lazy_tensor_aten_ops::view(self_tensor, Helpers::I64List(size)));
 }
 
-at::Tensor& LazyNativeFunctions::zero_(at::Tensor& self) {
-  LTC_FN_COUNTER("lazy::");
-  auto selfTensor = bridge::GetLtcTensor(self);
-  lazy_tensor_aten_ops::zero_(selfTensor);
-  return self;
-}
-
 void InitializeAtenBindings() {}
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -652,19 +652,6 @@ at::Tensor& LazyNativeFunctions::random_(at::Tensor& self,
   return self;
 }
 
-at::Tensor LazyNativeFunctions::relu(const at::Tensor& self) {
-  LTC_FN_COUNTER("lazy::");
-  return bridge::AtenFromLtcTensor(
-      lazy_tensor_aten_ops::relu(bridge::GetLtcTensor(self)));
-}
-
-at::Tensor& LazyNativeFunctions::relu_(at::Tensor& self) {
-  LTC_FN_COUNTER("lazy::");
-  LazyTensor self_tensor = bridge::GetLtcTensor(self);
-  lazy_tensor_aten_ops::relu_(self_tensor);
-  return self;
-}
-
 at::Tensor LazyNativeFunctions::repeat(const at::Tensor& self,
                                        at::IntArrayRef repeats) {
   LTC_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -127,8 +127,6 @@ class TSNodeLowering : public torch_lazy_tensors::compiler::TSNodeLoweringInterf
       // activation and unary op do not change shape
       case at::aten::leaky_relu:
       case at::aten::pow:
-      case at::aten::relu:
-      case at::aten::relu_:
       case at::aten::sqrt: {
         const torch::lazy::Output& argument = node->operand(0);
         return ir::GetShapeFromTsOutput(argument);

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -31,6 +31,8 @@ full_codegen:
   - native_layer_norm_backward
   - nll_loss_backward
   - nll_loss_forward
+  - relu
+  - relu_
   - rsqrt
   - sigmoid
   - smooth_l1_loss
@@ -70,8 +72,6 @@ supported:
   - max_pool3d_with_indices_backward
   - permute
   - random_
-  - relu
-  - relu_
   - repeat
   - select.int
   - slice.Tensor

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -5,11 +5,12 @@ full_codegen:
   - _log_softmax_backward_data
   - _softmax
   - _softmax_backward_data
+  - add.Tensor
   - addcdiv
   - addcmul
   - addmm
-  - bitwise_and.Tensor
   - baddbmm
+  - bitwise_and.Tensor
   - bmm
   - cos
   - clamp
@@ -41,7 +42,7 @@ full_codegen:
   - topk
   - trace
   - trunc
-  - add.Tensor
+  - zero_
 supported:
   - as_strided
   - as_strided_
@@ -107,7 +108,6 @@ supported:
   - index_select
   - alias
   - tanh_backward
-  - zero_
 autograd:
   - max_pool2d
   - max_pool3d

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -133,6 +133,10 @@ class LazyIrSchema:
     def aten_name(self) -> str:
         return f"{self.name.name}"
 
+    @property
+    def base_name(self) -> str:
+        return f"{self.name.name.base}"
+
     def filtered_types(self, positional: bool = True, keyword: bool = True,
                        values: bool = True, scalars: bool = True) -> List[NamedCType]:
         types: List[NamedCType] = []

--- a/tools/codegen/dest/__init__.py
+++ b/tools/codegen/dest/__init__.py
@@ -1,6 +1,6 @@
 from .lazy_ir import LazyIR as LazyIR
 from .lazy_ir import gen_lazy_shape_dtype_decl as gen_lazy_shape_dtype_decl
-from .lazy_ir import gen_lazy_nativefunc_definition as gen_lazy_nativefunc_definition
+from .lazy_ir import GenLazyNativeFuncDefinition as GenLazyNativeFuncDefinition
 from .register_dispatch_key import RegisterDispatchKey as RegisterDispatchKey
 from .register_dispatch_key import gen_registration_helpers as gen_registration_helpers
 from .native_functions import compute_native_function_declaration as compute_native_function_declaration

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 from dataclasses import dataclass
-from tools.codegen.context import method_with_native_function
+from tools.codegen.context import method_with_native_function, with_native_function_and_index
 from tools.codegen.model import (BackendIndex, NativeFunction,
                                  NativeFunctionsGroup)
 from tools.codegen.api.types import (BaseCType, OptionalCType, NamedCType,
@@ -183,10 +183,15 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
         lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(torch::lazy::Value(node, i), out_dtype[i]));
     }}
     auto result = bridge::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
+    # TODO(alanwaketan): What if the operator has both the tuple output and inplace variant.
+    if schema.name.name.inplace:
+        bridge_str = f"""lazy_{first_tensor.name}.SetInPlaceIrValue(node);
+    auto& result = {first_tensor.name};"""
+
 
     return [f"""\
 // TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
-{sig.decl(name=f"{class_method_name}::{schema.aten_name}")} {{
+{sig_decl(func, backend_index).format(f"{class_method_name}::{schema.aten_name}")} {{
     LTC_FN_COUNTER("lazy::");
     {get_device_str}
     {lazy_tensor_decls_str}
@@ -197,7 +202,11 @@ def gen_lazy_nativefunc_definition(func: NativeFunction, backend_index: BackendI
 }};\n
 """]
 
+@with_native_function_and_index
+def sig_decl(func: NativeFunction, backend_index: BackendIndex) -> str:
+    return kernel_signature(func, backend_index).decl("{}")
 
+@with_native_function_and_index
 def gen_lazy_shape_dtype_decl(f: NativeFunction, backend_index: BackendIndex) -> List[str]:
     sig = kernel_signature(f, backend_index)
 

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -81,6 +81,10 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     parsed_yaml = parse_native_yaml(native_yaml_path)
     native_functions, backend_indices = parsed_yaml.native_functions, parsed_yaml.backend_indices
     grouped_native_functions = get_grouped_native_functions(native_functions)
+    def sort_native_function(f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
+        func = f.functional.func if isinstance(f, NativeFunctionsGroup) else f.func
+        return str(func.name.name)
+    grouped_native_functions.sort(key=sort_native_function)
     parsed_backend_yaml = parse_backend_yaml(source_yaml, grouped_native_functions, backend_indices)
     backend_key = parsed_backend_yaml.backend_key
     autograd_key = parsed_backend_yaml.autograd_key
@@ -89,10 +93,21 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     full_codegen = parse_full_codegen_ops(source_yaml, grouped_native_functions)
 
     def concat_map_codegen(func: Callable[[NativeFunction], Sequence[str]],
-                           xs: Iterable[Union[NativeFunctionsGroup, NativeFunction]]) -> Iterator[str]:
+                           xs: Iterable[Union[NativeFunctionsGroup, NativeFunction]],
+                           *, codegenInplaceVariant: bool = False) -> Iterator[str]:
+        """
+        We code-gen for the functional variant, which is all we need for IR classes/lowerings/shape inferences, but we
+        only code-gen additional entries for the inplace variant for the native functions.
+        Note: If xs is not sorted, there maybe an edge case when generating IR classes. Considering relu and relu_, if
+        we encounter relu_ before relu. we will then generate an IR class with op = at::aten::relu_ for both relu and
+        relu_ which will cause problems for relu.
+        """
+        generated = set()
         for x in xs:
             f = x.functional if isinstance(x, NativeFunctionsGroup) else x
-            if f.func.name in full_codegen:
+            if f.func.name in full_codegen and \
+                (codegenInplaceVariant or not f.func.name.name.inplace or f.func.name.name.base not in generated):
+                generated.add(f.func.name.name.base)
                 for r in func(f):
                     yield r
 
@@ -140,7 +155,8 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
                     backend_indices[backend_dispatch_key],
                     class_method_name=f'{backend_dispatch_key}NativeFunctions',
                     node_base=node_base),
-                grouped_native_functions
+                grouped_native_functions,
+                codegenInplaceVariant=True
             )),
         })
 

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -81,9 +81,11 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     parsed_yaml = parse_native_yaml(native_yaml_path)
     native_functions, backend_indices = parsed_yaml.native_functions, parsed_yaml.backend_indices
     grouped_native_functions = get_grouped_native_functions(native_functions)
+
     def sort_native_function(f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
         func = f.functional.func if isinstance(f, NativeFunctionsGroup) else f.func
         return str(func.name.name)
+
     grouped_native_functions.sort(key=sort_native_function)
     parsed_backend_yaml = parse_backend_yaml(source_yaml, grouped_native_functions, backend_indices)
     backend_key = parsed_backend_yaml.backend_key
@@ -106,7 +108,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         for x in xs:
             f = x.functional if isinstance(x, NativeFunctionsGroup) else x
             if f.func.name in full_codegen and \
-                (codegenInplaceVariant or not f.func.name.name.inplace or f.func.name.name.base not in generated):
+               (codegenInplaceVariant or not f.func.name.name.inplace or f.func.name.name.base not in generated):
                 generated.add(f.func.name.name.base)
                 for r in func(f):
                     yield r


### PR DESCRIPTION
Summary:
This commit teached the LTC code-gen engine about in-place operator variants and generated zero_ for validation.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestZeroInPlace

Fixes #65576.
