### PR TITLE
[deploy] Add pyyaml as a builtin library to torch::deploy 

### DIFF
--- a/torch/csrc/deploy/interpreter/register_pyyaml.cpp
+++ b/torch/csrc/deploy/interpreter/register_pyyaml.cpp
@@ -1,0 +1,6 @@
+#include <Python.h>
+#include <torch/csrc/deploy/interpreter/builtin_registry.h>
+
+extern "C" struct _frozen _PyImport_FrozenModules_pyyaml[];
+
+REGISTER_TORCH_DEPLOY_BUILTIN(frozen_pyyaml, _PyImport_FrozenModules_pyyaml);

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -445,3 +445,18 @@ TEST(TorchpyTest, TestNumpy) {
   EXPECT_EQ(8, mat38.attr("shape").attr("__getitem__")({1}).toIValue().toInt());
 }
 #endif
+
+#if HAS_PYYAML
+TEST(TorchpyTest, TestPyYAML) {
+  const std::string kDocument = "a: 1\n";
+
+  torch::deploy::InterpreterManager m(2);
+  auto I = m.acquireOne();
+
+  auto load = I.global("yaml", "load")({kDocument});
+  EXPECT_EQ(1, load.attr("__getitem__")({"a"}).toIValue().toInt());
+
+  auto dump = I.global("yaml", "dump")({load});
+  EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
+}
+#endif


### PR DESCRIPTION
Summary: add frozen_pyyaml as a builtin library to torch::deploy

Test Plan:
unittests pass

> buck test mode/dev-nosan caffe2/torch/csrc/deploy/... -- --regex ".*TestPyYAML.*"

predictor also works

> buck run mode/dev-nosan mode/inplace hpc/torchrec/models/examples:sparsenn_packager -- package_path=/tmp/sparsenn_example_zyan.zip

> buck run mode/dev-nosan mode/inplace hpc/predictor:server -- --package_path /tmp/sparsenn_example_zyan.zip --n_gpu 1

Differential Revision: D31852201

