### PR TITLE
[ONNX] Set `ir_version` based on opset_version.

### DIFF
--- a/test/onnx/expect/TestOperators.test_acos.expect
+++ b/test/onnx/expect/TestOperators.test_acos.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_add_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_broadcast.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_addconstant.expect
+++ b/test/onnx/expect/TestOperators.test_addconstant.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_addmm.expect
+++ b/test/onnx/expect/TestOperators.test_addmm.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_arange_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_arange_dynamic.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_argmax.expect
+++ b/test/onnx/expect/TestOperators.test_argmax.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_asin.expect
+++ b/test/onnx/expect/TestOperators.test_asin.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_at_op.expect
+++ b/test/onnx/expect/TestOperators.test_at_op.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_atan.expect
+++ b/test/onnx/expect/TestOperators.test_atan.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_aten_embedding_2.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_2.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_avg_pool2d.expect
+++ b/test/onnx/expect/TestOperators.test_avg_pool2d.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_baddbmm.expect
+++ b/test/onnx/expect/TestOperators.test_baddbmm.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_basic.expect
+++ b/test/onnx/expect/TestOperators.test_basic.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_batchnorm.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_batchnorm_onnx_irv4.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_onnx_irv4.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_batchnorm_training.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_training.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_bitshift.expect
+++ b/test/onnx/expect/TestOperators.test_bitshift.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_c2_op.expect
+++ b/test/onnx/expect/TestOperators.test_c2_op.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_chunk.expect
+++ b/test/onnx/expect/TestOperators.test_chunk.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_clip.expect
+++ b/test/onnx/expect/TestOperators.test_clip.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_concat2.expect
+++ b/test/onnx/expect/TestOperators.test_concat2.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_conv.expect
+++ b/test/onnx/expect/TestOperators.test_conv.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_conv_onnx_irv4.expect
+++ b/test/onnx/expect/TestOperators.test_conv_onnx_irv4.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_conv_onnx_irv4_opset8.expect
+++ b/test/onnx/expect/TestOperators.test_conv_onnx_irv4_opset8.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 3
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_convtranspose.expect
+++ b/test/onnx/expect/TestOperators.test_convtranspose.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_cos.expect
+++ b/test/onnx/expect/TestOperators.test_cos.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_cumsum.expect
+++ b/test/onnx/expect/TestOperators.test_cumsum.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_det.expect
+++ b/test/onnx/expect/TestOperators.test_det.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dict.expect
+++ b/test/onnx/expect/TestOperators.test_dict.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dict_str.expect
+++ b/test/onnx/expect/TestOperators.test_dict_str.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dim.expect
+++ b/test/onnx/expect/TestOperators.test_dim.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dropout.expect
+++ b/test/onnx/expect/TestOperators.test_dropout.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dropout_default.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_default.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dropout_opset12.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_opset12.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dropout_training.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_training.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dropout_training_opset12.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_training_opset12.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_add.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_add.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_matmul.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_matmul.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_reduce_mean.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_reduce_mean.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_unchange.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_unchange.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_elu.expect
+++ b/test/onnx/expect/TestOperators.test_elu.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_empty_like.expect
+++ b/test/onnx/expect/TestOperators.test_empty_like.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_empty_like_opset7.expect
+++ b/test/onnx/expect/TestOperators.test_empty_like_opset7.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 3
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_equal.expect
+++ b/test/onnx/expect/TestOperators.test_equal.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_erf.expect
+++ b/test/onnx/expect/TestOperators.test_erf.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_exp.expect
+++ b/test/onnx/expect/TestOperators.test_exp.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_flatten2D.expect
+++ b/test/onnx/expect/TestOperators.test_flatten2D.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_fmod.expect
+++ b/test/onnx/expect/TestOperators.test_fmod.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 5
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_frobenius_norm.expect
+++ b/test/onnx/expect/TestOperators.test_frobenius_norm.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_full.expect
+++ b/test/onnx/expect/TestOperators.test_full.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_full_like.expect
+++ b/test/onnx/expect/TestOperators.test_full_like.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_gather.expect
+++ b/test/onnx/expect/TestOperators.test_gather.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_gather_opset11.expect
+++ b/test/onnx/expect/TestOperators.test_gather_opset11.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_ge.expect
+++ b/test/onnx/expect/TestOperators.test_ge.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_gelu.expect
+++ b/test/onnx/expect/TestOperators.test_gelu.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_gt.expect
+++ b/test/onnx/expect/TestOperators.test_gt.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_hardtanh.expect
+++ b/test/onnx/expect/TestOperators.test_hardtanh.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_implicit_expand.expect
+++ b/test/onnx/expect/TestOperators.test_implicit_expand.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_index.expect
+++ b/test/onnx/expect/TestOperators.test_index.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_isnan.expect
+++ b/test/onnx/expect/TestOperators.test_isnan.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
+++ b/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_le.expect
+++ b/test/onnx/expect/TestOperators.test_le.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_linear.expect
+++ b/test/onnx/expect/TestOperators.test_linear.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_log_sigmoid.expect
+++ b/test/onnx/expect/TestOperators.test_log_sigmoid.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_logsoftmax.expect
+++ b/test/onnx/expect/TestOperators.test_logsoftmax.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
+++ b/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_lt.expect
+++ b/test/onnx/expect/TestOperators.test_lt.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_master_opset.expect
+++ b/test/onnx/expect/TestOperators.test_master_opset.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 5
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_max.expect
+++ b/test/onnx/expect/TestOperators.test_max.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_maxpool.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_maxpool_dilations.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool_dilations.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 5
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_maxpool_indices.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool_indices.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_mean.expect
+++ b/test/onnx/expect/TestOperators.test_mean.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_mean_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_mean_dtype.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_meshgrid.expect
+++ b/test/onnx/expect/TestOperators.test_meshgrid.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_min.expect
+++ b/test/onnx/expect/TestOperators.test_min.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_mm.expect
+++ b/test/onnx/expect/TestOperators.test_mm.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_narrow.expect
+++ b/test/onnx/expect/TestOperators.test_narrow.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_ne.expect
+++ b/test/onnx/expect/TestOperators.test_ne.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_nonzero.expect
+++ b/test/onnx/expect/TestOperators.test_nonzero.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_norm_p1.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p1.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_norm_p2.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p2.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_ones_like.expect
+++ b/test/onnx/expect/TestOperators.test_ones_like.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_pad.expect
+++ b/test/onnx/expect/TestOperators.test_pad.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_params.expect
+++ b/test/onnx/expect/TestOperators.test_params.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_params_onnx_irv4.expect
+++ b/test/onnx/expect/TestOperators.test_params_onnx_irv4.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_permute2.expect
+++ b/test/onnx/expect/TestOperators.test_permute2.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_pixel_shuffle.expect
+++ b/test/onnx/expect/TestOperators.test_pixel_shuffle.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_pow.expect
+++ b/test/onnx/expect/TestOperators.test_pow.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_prelu.expect
+++ b/test/onnx/expect/TestOperators.test_prelu.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_prod.expect
+++ b/test/onnx/expect/TestOperators.test_prod.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_prod_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_prod_dtype.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_rand.expect
+++ b/test/onnx/expect/TestOperators.test_rand.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_randn.expect
+++ b/test/onnx/expect/TestOperators.test_randn.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
+++ b/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_mean.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_mean_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_dtype.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_prod.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_prod_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod_dtype.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_sum.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_sum_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_dtype.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reducemax.expect
+++ b/test/onnx/expect/TestOperators.test_reducemax.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_reducemin.expect
+++ b/test/onnx/expect/TestOperators.test_reducemin.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_remainder.expect
+++ b/test/onnx/expect/TestOperators.test_remainder.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_repeat.expect
+++ b/test/onnx/expect/TestOperators.test_repeat.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
+++ b/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_round.expect
+++ b/test/onnx/expect/TestOperators.test_round.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_rrelu.expect
+++ b/test/onnx/expect/TestOperators.test_rrelu.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_rsqrt.expect
+++ b/test/onnx/expect/TestOperators.test_rsqrt.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_rsub.expect
+++ b/test/onnx/expect/TestOperators.test_rsub.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_scatter_add.expect
+++ b/test/onnx/expect/TestOperators.test_scatter_add.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_scatter_add_opset11.expect
+++ b/test/onnx/expect/TestOperators.test_scatter_add_opset11.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_selu.expect
+++ b/test/onnx/expect/TestOperators.test_selu.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_sign.expect
+++ b/test/onnx/expect/TestOperators.test_sign.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_sin.expect
+++ b/test/onnx/expect/TestOperators.test_sin.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_slice.expect
+++ b/test/onnx/expect/TestOperators.test_slice.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_slice_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_slice_dynamic.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 5
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d_none.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d_none.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_4d.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_4d.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_ignore_index.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_ignore_index.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_weights.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_weights.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 7
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_split.expect
+++ b/test/onnx/expect/TestOperators.test_split.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_split_with_sizes.expect
+++ b/test/onnx/expect/TestOperators.test_split_with_sizes.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_sqrt.expect
+++ b/test/onnx/expect/TestOperators.test_sqrt.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_std.expect
+++ b/test/onnx/expect/TestOperators.test_std.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_sum.expect
+++ b/test/onnx/expect/TestOperators.test_sum.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_sum_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_sum_dtype.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_tan.expect
+++ b/test/onnx/expect/TestOperators.test_tan.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_topk.expect
+++ b/test/onnx/expect/TestOperators.test_topk.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 5
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_topk_smallest_unsorted.expect
+++ b/test/onnx/expect/TestOperators.test_topk_smallest_unsorted.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_transpose.expect
+++ b/test/onnx/expect/TestOperators.test_transpose.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_type_as.expect
+++ b/test/onnx/expect/TestOperators.test_type_as.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_unfold.expect
+++ b/test/onnx/expect/TestOperators.test_unfold.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_unique.expect
+++ b/test/onnx/expect/TestOperators.test_unique.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_unsqueeze.expect
+++ b/test/onnx/expect/TestOperators.test_unsqueeze.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_view.expect
+++ b/test/onnx/expect/TestOperators.test_view.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/expect/TestOperators.test_zeros_like.expect
+++ b/test/onnx/expect/TestOperators.test_zeros_like.expect
@@ -1,4 +1,4 @@
-ir_version: 8
+ir_version: 4
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -9,15 +9,15 @@ import onnx
 import io
 
 from torch.onnx.symbolic_helper import _export_onnx_opset_version
-from torch.onnx import ir_version, producer_name, producer_version
+from torch.onnx import producer_name, producer_version
 
 
 def check_onnx_opset_operator(model, ops, opset_version=_export_onnx_opset_version):
     # check_onnx_components
-    assert model.ir_version == ir_version and \
-        model.producer_name == producer_name and \
-        model.producer_version == producer_version and \
-        model.opset_import[0].version == opset_version
+    assert (
+        model.producer_name == producer_name and
+        model.producer_version == producer_version and
+        model.opset_import[0].version == opset_version)
 
     # check the schema with the onnx checker
     onnx.checker.check_model(model)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -16,6 +16,7 @@ import inspect
 import glob
 import os
 import shutil
+import tempfile
 import torch.testing._internal.common_utils as common
 
 '''Usage: python test/onnx/test_operators.py [--no-onnx] [--produce-onnx-test-data]
@@ -281,12 +282,12 @@ class TestOperators(TestCase):
         model = torch.nn.Conv2d(3, 2, 3)
 
         dynamic_axes = {"input_1": [0, 2, 3], "output_1": {0: "output_1_variable_dim_0", 1: "output_1_variable_dim_1"}}
-        model_proto_name = "conv2d.onnx"
-        torch.onnx.export(model, x, model_proto_name, verbose=True, input_names=["input_1"], output_names=["output_1"],
+        model_proto_file = tempfile.NamedTemporaryFile()
+        torch.onnx.export(model, x, model_proto_file.name, verbose=True, input_names=["input_1"], output_names=["output_1"],
                           dynamic_axes=dynamic_axes)
 
         import onnx
-        onnx_model = onnx.load(model_proto_name)
+        onnx_model = onnx.load(model_proto_file.name)
         onnx.checker.check_model(onnx_model)
 
         # Asserting the default dynamic axes names are generated when custom names are not provided

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1689,6 +1689,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(ArithmeticModule(), x, remained_onnx_input_idx=[])
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_arithmetic_prim_bool(self):
         class ArithmeticModule(torch.nn.Module):
             def forward(self, x, y: int, z: bool, t: float):
@@ -2760,6 +2761,7 @@ class TestONNXRuntime(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             self._interpolate(x, "area", False, True)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_groupnorm(self):
         model = torch.nn.GroupNorm(3, 6, 0.002)
         x = torch.randn(4, 6, 180, 180, 180)
@@ -2773,6 +2775,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(4, 6, 180, 180)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_groupnorm_noaffine(self):
         model = torch.nn.GroupNorm(4, 8, 0.002, affine=False)
         x = torch.randn(3, 8, 224, 224)
@@ -3469,6 +3472,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(10, 10, 128)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_batchnorm1d_norunningstats(self):
         x = torch.randn(10, 10)
         model = torch.nn.BatchNorm1d(10, track_running_stats=False)
@@ -3487,6 +3491,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.BatchNorm2d(3, affine=False)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_batchnorm2d_norunningstats(self):
         x = torch.randn(10, 3, 128, 128)
         model = torch.nn.BatchNorm2d(3, track_running_stats=False)
@@ -3511,6 +3516,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm1d(5, affine=False, track_running_stats=True)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_instancenorm1d_norunningstats(self):
         x = torch.randn(10, 5, 128)
         model = torch.nn.InstanceNorm1d(5, affine=True, track_running_stats=False)
@@ -3528,6 +3534,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm2d(3, affine=False, track_running_stats=True)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_instancenorm2d_norunningstats(self):
         x = torch.randn(10, 3, 128, 128)
         model = torch.nn.InstanceNorm2d(3, affine=True, track_running_stats=False)
@@ -3545,6 +3552,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.InstanceNorm3d(3, affine=False, track_running_stats=True)
         self.run_test(model, x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_instancenorm3d_norunningstats(self):
         x = torch.randn(10, 3, 128, 128, 128)
         model = torch.nn.InstanceNorm3d(3, affine=True, track_running_stats=False)
@@ -8196,6 +8204,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(6, 4, 3, 3)
         self.run_test(FakeQuantizePerChannelModel(), (x))
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_batchnorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -8220,6 +8229,7 @@ class TestONNXRuntime(unittest.TestCase):
         model_export.train()
         self.run_test(model_export, (x, ), training=torch.onnx.TrainingMode.PRESERVE, rtol=1e-3, atol=1e-5)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_batchnorm_training_mode_fix_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -8270,6 +8280,7 @@ class TestONNXRuntime(unittest.TestCase):
         model_export.eval()
         self.run_test(model_export, (x,), training=torch.onnx.TrainingMode.PRESERVE, rtol=1e-3, atol=1e-5)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_instancenorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -8294,6 +8305,7 @@ class TestONNXRuntime(unittest.TestCase):
         model_export.train()
         self.run_test(model_export, (x, ), training=torch.onnx.TrainingMode.PRESERVE, rtol=1e-3, atol=1e-5)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_instancenorm_training_mode_fix_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -8319,6 +8331,7 @@ class TestONNXRuntime(unittest.TestCase):
         model_export.train()
         self.run_test(model_export, (x,), training=torch.onnx.TrainingMode.PRESERVE, rtol=1e-3, atol=1e-5)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_instancenorm_eval_mode_train_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -8420,6 +8433,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         np.testing.assert_allclose(ratio_pytorch, ratio_ort, rtol=0.01, atol=0.01)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -8437,6 +8451,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model_export, (x,), training=torch.onnx.TrainingMode.EVAL)
         self.run_test(model_export, (x,), training=torch.onnx.TrainingMode.TRAINING, rtol=1e-3, atol=1e-5)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_multiple_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -10124,6 +10139,7 @@ class TestONNXRuntime(unittest.TestCase):
         loaded_model = onnx.load_from_string(f.getvalue())
 
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # https://github.com/microsoft/onnxruntime/issues/9663
     def test_tuple_output_from_if_with_raised_exception(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/torch/_C/_onnx.pyi
+++ b/torch/_C/_onnx.pyi
@@ -3,7 +3,6 @@
 from enum import Enum
 
 PYTORCH_ONNX_CAFFE2_BUNDLE: bool
-IR_VERSION: int
 PRODUCER_VERSION: str
 
 class TensorProtoDataType(Enum):

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -460,7 +460,8 @@ GraphEncoder::GraphEncoder(
       onnx_opset_version > 0 &&
           onnx_opset_version < kOpsetVersionToIRVersion.size() &&
           kOpsetVersionToIRVersion[onnx_opset_version] != kInvalidOpsetVersion,
-      "Unsupported onnx_opset_version.");
+      "Unsupported onnx_opset_version: ",
+      onnx_opset_version);
 
   model_proto_.set_ir_version(kOpsetVersionToIRVersion[onnx_opset_version]);
   model_proto_.set_producer_version(TORCH_VERSION);

--- a/torch/csrc/onnx/init.cpp
+++ b/torch/csrc/onnx/init.cpp
@@ -37,7 +37,6 @@ void initONNXBindings(PyObject* module) {
       .value("PRESERVE", TrainingMode::PRESERVE)
       .value("TRAINING", TrainingMode::TRAINING);
 
-  onnx.attr("IR_VERSION") = IR_VERSION;
   onnx.attr("PRODUCER_VERSION") = py::str(TORCH_VERSION);
 
 #ifdef PYTORCH_ONNX_CAFFE2_BUNDLE

--- a/torch/csrc/onnx/onnx.h
+++ b/torch/csrc/onnx/onnx.h
@@ -16,9 +16,5 @@ enum class TrainingMode {
   TRAINING, // Training mode
 };
 
-// We pin IR version instead of using onnx::IR_VERSION so that the
-// test_operators.py will be more stable. Only bump it when
-// necessary.
-constexpr size_t IR_VERSION = 8;
 } // namespace onnx
 } // namespace torch

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -7,10 +7,6 @@ PYTORCH_ONNX_CAFFE2_BUNDLE = _C._onnx.PYTORCH_ONNX_CAFFE2_BUNDLE
 
 ONNX_ARCHIVE_MODEL_PROTO_NAME = "__MODEL_PROTO"
 
-# TODO: Update these variables when there
-# is a new ir_version and producer_version
-# and use these values in the exporter
-ir_version = _C._onnx.IR_VERSION
 producer_name = "pytorch"
 producer_version = _C._onnx.PRODUCER_VERSION
 constant_folding_opset_versions = [9, 10, 11, 12, 13, 14]

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2099,7 +2099,7 @@ class TestCase(expecttest.TestCase):
             with open(expected_file, 'w') as f:
                 # Adjust for producer_version, leave s unmodified
                 s_tag = re.sub(r'(producer_version): "[0-9.]*"',
-                               r'\1producer_version: "CURRENT_VERSION"', s)
+                               r'\1: "CURRENT_VERSION"', s)
                 f.write(s_tag)
 
         try:


### PR DESCRIPTION
This increases the odds that the exported ONNX model will be usable.
Before this change, we were setting the IR version to a value which may
be higher than what the model consumer supports.

Also some minor clean-up in the test code:
* Fix string replacement.
* Use a temporary file so as to not leave files around in the test
  current working directory.

