### PR TITLE
[SR][easy] Alias for c10::Symbol::fromQualString

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -94,9 +94,8 @@ void OptimizeGraph(
   if (opts.enable_out_variant) {
     UseVariadicOp(
         graph,
-        c10::Symbol::fromQualString("fb::sigrid_transforms_torch_bind"),
-        c10::Symbol::fromQualString(
-            "fb::variadic_sigrid_transforms_torch_bind"));
+        fromQualString("fb::sigrid_transforms_torch_bind"),
+        fromQualString("fb::variadic_sigrid_transforms_torch_bind"));
     FuseSignLog1P(graph);
 
     // TODO: we can avoid this guard by moving operations

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -400,7 +400,7 @@ void FuseTupleUnpackBlock(const TupleUnpackBlock& nodes) {
   TORCH_CHECK(nodes.size() > 0);
   auto graph = nodes[0]->owningGraph();
   auto var_unpack = graph->create(
-      c10::Symbol::fromQualString("static_runtime::VarTupleUnpack"),
+      fromQualString("static_runtime::VarTupleUnpack"),
       /* num_outputs */ 0);
   var_unpack->insertAfter(nodes[nodes.size() - 1]);
   for (Node* node : nodes) {
@@ -432,27 +432,26 @@ void ReplaceWithCopy(
 
   const std::map<c10::Symbol, c10::Symbol> supported = {
 #ifdef FBCODE_CAFFE2
-      {c10::Symbol::fromQualString("aten::permute"),
-       c10::Symbol::fromQualString("static_runtime::permute_copy")},
+      {fromQualString("aten::permute"),
+       fromQualString("static_runtime::permute_copy")},
 #endif
-      {c10::Symbol::fromQualString("aten::narrow"),
-       c10::Symbol::fromQualString("aten::narrow_copy")},
-      {c10::Symbol::fromQualString("aten::reshape"),
-       c10::Symbol::fromQualString("static_runtime::reshape_copy")},
-      {c10::Symbol::fromQualString("aten::flatten"),
-       c10::Symbol::fromQualString("static_runtime::flatten_copy")}};
+      {fromQualString("aten::narrow"), fromQualString("aten::narrow_copy")},
+      {fromQualString("aten::reshape"),
+       fromQualString("static_runtime::reshape_copy")},
+      {fromQualString("aten::flatten"),
+       fromQualString("static_runtime::flatten_copy")}};
 
   // for ops that have overloads, match the schema
   const std::vector<std::pair<c10::FunctionSchema, c10::Symbol>> supported_schema = {
       {torch::schema(
            "aten::to.prim_dtype(Tensor(a) self, int? dtype=None, bool non_blocking=False, bool copy=False) -> Tensor(a|b)"),
-       c10::Symbol::fromQualString("static_runtime::to_copy")},
+       fromQualString("static_runtime::to_copy")},
       {torch::schema(
            "aten::to.dtype(Tensor(a) self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)"),
-       c10::Symbol::fromQualString("static_runtime::to_copy")},
+       fromQualString("static_runtime::to_copy")},
       {torch::schema(
            "aten::to.other(Tensor(a) self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)"),
-       c10::Symbol::fromQualString("static_runtime::to_copy")}};
+       fromQualString("static_runtime::to_copy")}};
 
   auto match_schema = [&supported_schema](
                           const Node* node, c10::Symbol& out_matched_symbol) {
@@ -589,10 +588,10 @@ void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
 
 void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph) {
   const FastMap<c10::Symbol, c10::Symbol> unfused_to_fused = {
-      {c10::Symbol::fromQualString("fb::equally_split"),
-       c10::Symbol::fromQualString("static_runtime::fused_equally_split")},
-      {c10::Symbol::fromQualString("fb::sigrid_transforms"),
-       c10::Symbol::fromQualString("static_runtime::fused_sigrid_transforms")}};
+      {fromQualString("fb::equally_split"),
+       fromQualString("static_runtime::fused_equally_split")},
+      {fromQualString("fb::sigrid_transforms"),
+       fromQualString("static_runtime::fused_sigrid_transforms")}};
 
   AliasDb alias_db(
       graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
@@ -622,7 +621,7 @@ void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph) {
     }
 
     const bool is_equally_split =
-        node->kind() == c10::Symbol::fromQualString("fb::equally_split");
+        node->kind() == fromQualString("fb::equally_split");
     if (!is_equally_split) {
       // If any output of the ListUnpack node is unmanaged, disable fusion
       // since the fused op assumes all outputs are either managed or not.
@@ -675,7 +674,7 @@ void FuseListUnpackV2(std::shared_ptr<torch::jit::Graph>& graph) {
 
 void EnableStaticRuntimeLayerNorm(std::shared_ptr<torch::jit::Graph>& graph) {
   const c10::Symbol static_runtime_layer_norm_symbol =
-      c10::Symbol::fromQualString("static_runtime::layer_norm");
+      fromQualString("static_runtime::layer_norm");
   auto nodes = graph->nodes();
   std::vector<std::pair<Node*, Node*>> replacement;
   for (auto it = nodes.begin(); it != nodes.end(); ++it) {
@@ -752,7 +751,7 @@ void RemoveImmutableInputDictLookups(
     key->moveBefore(marker);
   }
   const c10::Symbol static_runtime_dict_unpack_symbol =
-      c10::Symbol::fromQualString("static_runtime::dict_unpack");
+      fromQualString("static_runtime::dict_unpack");
   for (auto& it : dict_to_getitems) {
     Value* dict = it.first;
     std::vector<Node*>& getitems = it.second;

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -30,5 +30,11 @@ TORCH_API void FuseSignLog1P(std::shared_ptr<Graph>& graph);
 
 TORCH_API void UseVariadicTupleUnpack(const std::shared_ptr<Graph>& graph);
 
+// c10::Symbol::fromQualString is a bit long to type everywhere, and
+// we can't use a `using` statement since it's a static class function.
+inline c10::Symbol fromQualString(const std::string& qual_string) {
+  return c10::Symbol::fromQualString(qual_string);
+}
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: It's a bit annoying/ugly to type `c10::Symbol::fromQualString` everywhere, and we can't do `using c10::Symbol::fromQualString` since it's a static class function.

Test Plan: CI

Differential Revision: D31887042

