### PR TITLE
[LTC] Code-gen mean.dim

### DIFF
--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -1315,6 +1315,21 @@ TEST_F(AtenLtcTsTensorTest, TestMeanInDimsKeepCast) {
   }
 }
 
+TEST_F(AtenLtcTsTensorTest, TestMeanInDimOut) {
+  torch::Tensor a = torch::rand({4, 4, 4}, torch::TensorOptions(torch::kFloat));
+  int rank = a.dim();
+  for (int dim = -rank; dim < rank; ++dim) {
+    torch::Tensor b = torch::empty({4, 4}, torch::TensorOptions(torch::kFloat));
+    torch::mean_out(b, a, {dim});
+    ForEachDevice([&](const torch::Device& device) {
+      torch::Tensor xla_a = CopyToDevice(a, device);
+      torch::Tensor xla_b = torch::empty({4, 4}, xla_a.options());
+      torch::mean_out(xla_b, xla_a, {dim});
+      AllClose(b, xla_b);
+    });
+  }
+}
+
 TEST_F(AtenLtcTsTensorTest, TestStd) {
   torch::Tensor a = torch::rand({4, 3, 4}, torch::TensorOptions(torch::kFloat));
   for (auto unbiased : {true, false}) {

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -17,6 +17,7 @@ full_codegen:
   - gelu_backward
   - log2
   - mean
+  - mean.dim
   - mm
   - mv
   - native_layer_norm


### PR DESCRIPTION
Summary:
Code-generated mean.dim and mean.out which is the out variant.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestMean*

Fixes #65576.
