### PR TITLE
Remove meta from device test cases

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -40,7 +40,7 @@ from torch.testing._internal.common_methods_invocations import mask_not_all_zero
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests, skipCUDAIfRocm,
                                                         onlyCPU, onlyCUDA, onlyOnCPUAndCUDA, dtypes, dtypesIfCUDA,
                                                         deviceCountAtLeast, skipCUDAIfCudnnVersionLessThan,
-                                                        skipCUDAIf, skipMeta)
+                                                        skipCUDAIf)
 from torch.testing._internal.common_dtype import get_all_dtypes
 
 import pickle
@@ -7875,7 +7875,6 @@ class TestAutogradDeviceType(TestCase):
             nnz = 0 if empty_nnz else 5
             _test(sparse_size + dense_size, len(sparse_size), nnz, device)
 
-    @skipMeta
     @dtypes(torch.double, torch.cdouble)
     def test_sparse_backward(self, device, dtype):
         class FixedGradientFunction(Function):
@@ -8328,7 +8327,6 @@ class TestAutogradDeviceType(TestCase):
                     param.grad = None
                 inp.grad = None
 
-    @skipMeta  # LSTM cell reuses output which was resized
     def test_LSTM_grad_and_gradgrad(self, device):
         hsize = 4
         inp = torch.rand(1, 3, hsize, device=device, dtype=torch.float64, requires_grad=True)
@@ -8336,7 +8334,6 @@ class TestAutogradDeviceType(TestCase):
             mod = torch.nn.LSTM(hsize, hsize, bias=bias).to(device).to(torch.float64)
             self._test_rnn_mod(mod, inp)
 
-    @skipMeta  # GRU cell reuses output which was resized
     def test_GRU_grad_and_gradgrad(self, device):
         hsize = 4
         inp = torch.rand(1, 3, hsize, device=device, dtype=torch.float64, requires_grad=True)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -8,7 +8,7 @@ import unittest
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, TEST_WITH_SLOW
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, dtypes, onlyCUDA, skipCUDAIfRocm, skipMeta, ops)
+    (instantiate_device_type_tests, dtypes, onlyCUDA, skipCUDAIfRocm, ops)
 from torch.testing._internal.common_methods_invocations import \
     (foreach_unary_op_db, foreach_binary_op_db, foreach_pointwise_op_db, foreach_minmax_op_db)
 from torch.testing._internal.common_dtype import (
@@ -169,7 +169,6 @@ class TestForeach(TestCase):
     # are expected to return the same outputs, however, the outputs look unstable for torch.bfloat16 and torch.half.
     # log: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-bionic-rocm4.2-py3.6-test1/2741/console
     @skipCUDAIfRocm
-    @skipMeta
     @ops(foreach_binary_op_db)
     def test_binary_op_tensorlists_fastpath(self, device, dtype, op):
         for N in N_values:
@@ -191,7 +190,6 @@ class TestForeach(TestCase):
         self._binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True)
 
     @skipCUDAIfRocm
-    @skipMeta
     @ops(foreach_binary_op_db)
     def test_binary_op_scalar_fastpath(self, device, dtype, op):
         for N, scalar in itertools.product(N_values, Scalars):
@@ -230,7 +228,6 @@ class TestForeach(TestCase):
     # separating mixed scalarlist tests. By setting the first element of scalarlist to bool,
     # they are expected to throw bool sub error even in inplace test.
     @skipCUDAIfRocm
-    @skipMeta
     @ops(foreach_binary_op_db)
     def test_binary_op_scalarlist_fastpath(self, device, dtype, op):
         for N in N_values:
@@ -298,7 +295,6 @@ class TestForeach(TestCase):
         self._pointwise_test(
             dtype, inplace_op, inplace_ref, inputs, is_fastpath and disable_fastpath, is_inplace=True, values=values)
 
-    @skipMeta
     @ops(foreach_pointwise_op_db)
     def test_pointwise_op_fastpath(self, device, dtype, op):
         disable_fastpath = dtype in get_all_int_dtypes() + [torch.bool]
@@ -364,7 +360,6 @@ class TestForeach(TestCase):
         self._regular_unary_test(dtype, op, ref, inputs, is_fastpath)
         self._inplace_unary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath)
 
-    @skipMeta
     @ops(foreach_unary_op_db)
     def test_unary_fastpath(self, device, dtype, op):
         for N in N_values:
@@ -446,7 +441,6 @@ class TestForeach(TestCase):
     # note(mkozuki): this test case fails with Meta at least in my local environment.
     # The message was
     # `AssertionError: NotImplementedError("Could not run 'aten::_foreach_add.Scalar' with arguments from the 'Meta' backend.`
-    @skipMeta
     @dtypes(torch.float)
     @ops(foreach_binary_op_db)
     def test_binary_op_scalar_with_different_tensor_dtypes(self, device, dtype, op):
@@ -523,7 +517,6 @@ class TestForeach(TestCase):
                 with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                     foreach_op_([tensor1], [tensor2])
 
-    @skipMeta
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not found")
     @dtypes(*get_all_dtypes())
     @ops(foreach_binary_op_db)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -22,7 +22,7 @@ from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes,
      onlyCPU, skipCUDAIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
      skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, onlyOnCPUAndCUDA, dtypesIfCUDA,
-     onlyCUDA, skipCUDAVersionIn, skipMeta, skipCUDAIfNoCusolver)
+     onlyCUDA, skipCUDAVersionIn, skipCUDAIfNoCusolver)
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import (
     all_types, floating_types, floating_and_complex_types, get_all_dtypes, get_all_int_dtypes, get_all_complex_dtypes,
@@ -1530,7 +1530,6 @@ class TestLinalg(TestCase):
 
     # This test compares torch.linalg.norm, torch.linalg.matrix_norm and numpy.linalg.norm to
     # ensure that their matrix norm results match.
-    @skipMeta  # https://github.com/pytorch/pytorch/issues/54082
     @skipCUDAIfNoMagma
     @dtypes(torch.float, torch.double)
     @precisionOverride({torch.float32: 2e-5})
@@ -1595,7 +1594,6 @@ class TestLinalg(TestCase):
                                       ("aten::norm", "aten::linalg_vector_norm")):
             profile_and_check(f, x, kwargs, fn_name)
 
-    @skipMeta  # https://github.com/pytorch/pytorch/issues/53739
     @skipCPUIfNoLapack
     @skipCUDAIfNoMagma
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
@@ -1650,7 +1648,6 @@ class TestLinalg(TestCase):
                 actual = torch.linalg.cond(input, p)
                 self.assertEqual(actual, expected)
 
-    @skipMeta  # https://github.com/pytorch/pytorch/issues/53739
     @skipCPUIfNoLapack
     @skipCUDAIfNoMagma
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
@@ -1820,7 +1817,6 @@ class TestLinalg(TestCase):
                 result_n = np.linalg.norm(x_n, ord=ord)
                 self.assertEqual(result, result_n, msg=msg)
 
-    @skipMeta  # https://github.com/pytorch/pytorch/issues/54082
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double)
@@ -3929,7 +3925,6 @@ class TestLinalg(TestCase):
         run_test_skipped_elements((12, 3, 2), ind=1)
         run_test_skipped_elements((18, 3, 3, 1), ind=1)
 
-    @skipMeta  # See https://github.com/pytorch/pytorch/issues/53739
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
@@ -3940,7 +3935,6 @@ class TestLinalg(TestCase):
             a_inv = torch.linalg.tensorinv(a, ind=ind)
             self.assertEqual(a_inv.shape, a.shape[ind:] + a.shape[:ind])
 
-    @skipMeta  # See https://github.com/pytorch/pytorch/issues/53739
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)

--- a/test/test_module_init.py
+++ b/test/test_module_init.py
@@ -431,7 +431,7 @@ def generate_tests(test_cls, constructor_arg_db):
 
 
 class TestModuleInit(TestCase):
-    _ignore_not_implemented_error = False
+    ...
 
 
 generate_tests(TestModuleInit, build_constructor_arg_db())

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -46,7 +46,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
     skipCUDAIfRocm, skipCUDAIf, skipCUDAIfNotRocm, skipCUDAIfRocmVersionLessThan, skipCUDAIfNotMiopenSuggestNHWC, \
-    onlyOnCPUAndCUDA, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, skipMeta, get_all_device_types
+    onlyOnCPUAndCUDA, deviceCountAtLeast, largeTensorTest, get_all_device_types
 from torch.nn import MultiheadAttention
 
 from hypothesis import given
@@ -17741,7 +17741,6 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.elu_(x)
 
-    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_hardswish_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
@@ -17883,7 +17882,6 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue("Complex modules are a new feature" in str(w[-1].message))
 
-    @skipMeta
     @dtypes(torch.float32, torch.float64)
     def test_module_to_empty(self, device, dtype):
         class MyModule(nn.Module):
@@ -17911,7 +17909,6 @@ class TestNNDeviceType(NNTestCase):
         m.to_empty(device='meta')
         m(input)
 
-    @skipMeta
     def test_skip_init(self, device):
         torch.manual_seed(1)
         m_initialized = torch.nn.Linear(5, 1)

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import \
     (IS_MACOS, IS_WINDOWS, TestCase, run_tests, load_tests, coalescedonoff)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, dtypesIfCUDA, onlyCPU, onlyCUDA, skipCUDAIfNoCusparseGeneric,
-     precisionOverride, skipMeta)
+     precisionOverride)
 from torch.testing._internal.common_dtype import floating_types, get_all_dtypes
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
@@ -106,7 +106,6 @@ class TestSparseCSR(TestCase):
             self.assertEqual(torch.tensor([0, 1, 0, 1], dtype=torch.int64, device=device), sparse.col_indices())
             self.assertEqual(torch.tensor([1, 2, 3, 4], dtype=dtype, device=device), sparse.values())
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_empty(self, device, dtype):
         ns = [5, 2, 0]
@@ -127,7 +126,6 @@ class TestSparseCSR(TestCase):
             self.assertEqual(result.col_indices().dtype, torch.int64)
             self.assertEqual(result.values().dtype, dtype)
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_empty_errors(self, device, dtype):
         with self.assertRaisesRegex(RuntimeError, "torch.empty: Only 2D sparse CSR tensors are supported."):
@@ -136,7 +134,6 @@ class TestSparseCSR(TestCase):
         with self.assertRaisesRegex(RuntimeError, "torch.empty: Only 2D sparse CSR tensors are supported."):
             torch.empty((2, 3, 4), dtype=dtype, device=device, layout=torch.sparse_csr)
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_copy(self, device, dtype):
 
@@ -155,7 +152,6 @@ class TestSparseCSR(TestCase):
             run_test(shape, 0, index_dtype)
             run_test(shape, shape[0] * shape[1], index_dtype)
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_copy_errors(self, device, dtype):
         for index_dtype in [torch.int32, torch.int64]:
@@ -174,7 +170,6 @@ class TestSparseCSR(TestCase):
             with self.assertRaisesRegex(RuntimeError, "only tensors with the same number of specified elements are supported."):
                 a.copy_(b)
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_resize(self, device, dtype):
         for index_dtype in [torch.int32, torch.int64]:
@@ -196,7 +191,6 @@ class TestSparseCSR(TestCase):
             # resize to smaller shape trims specified elements
             self.assertEqual(a._nnz(), 5)
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_resize_errors(self, device, dtype):
         for index_dtype in [torch.int32, torch.int64]:

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -18,7 +18,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests, deviceCountAtLeast, onlyOnCPUAndCUDA,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
-    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, get_all_device_types)
+    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, get_all_device_types)
 from torch.testing._internal.common_dtype import (
     get_all_dtypes, get_all_math_dtypes, get_all_int_dtypes, get_all_fp_dtypes, get_all_complex_dtypes
 )
@@ -1525,7 +1525,6 @@ class TestTensorCreation(TestCase):
         self.assertTrue(grid_b.equal(grid_b2))
         self.assertTrue(grid_c.equal(grid_c2))
 
-    @skipMeta
     def test_meshgrid_vs_numpy(self, device):
         # Shapes to the random tensors. Each line is a test case, and
         # each list within that line is the shape of a single
@@ -2587,8 +2586,6 @@ class TestTensorCreation(TestCase):
                                    torch.tensor(1, dtype=torch.int16)).dtype)
         torch.set_default_dtype(saved_dtype)
 
-    # cannot call storage() on meta tensor
-    @skipMeta
     def test_empty_strided(self, device):
         for shape in [(2, 3, 4), (0, 2, 0)]:
             # some of these cases are pretty strange, just verifying that if as_strided
@@ -3864,10 +3861,6 @@ class TestAsArray(TestCase):
         check(device=device, dtype=dtype)
         check(device=device, dtype=dtype, copy=False)
 
-    # Skipping 'meta' devices, since there's no point in comparing their
-    # data pointer (which is basically the point here), since they all
-    # return 0.
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_alias_from_tensor(self, device, dtype):
         self._test_alias_with_cvt(identity, device, dtype)
@@ -3877,8 +3870,6 @@ class TestAsArray(TestCase):
     def test_alias_from_numpy(self, device, dtype):
         self._test_alias_with_cvt(to_numpy, device, dtype)
 
-    # Skipping 'meta', since 'to_dlpack' does not work for them.
-    @skipMeta
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_alias_from_dlpack(self, device, dtype):
         self._test_alias_with_cvt(to_dlpack, device, dtype)
@@ -3916,7 +3907,6 @@ class TestAsArray(TestCase):
                     check(same_dtype=False, dtype=other)
                     check(same_dtype=False, dtype=other, copy=True)
 
-    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_copy_tensor(self, device, dtype):
         self._test_copy_with_cvt(identity, device, dtype)
@@ -3926,7 +3916,6 @@ class TestAsArray(TestCase):
     def test_copy_from_numpy(self, device, dtype):
         self._test_copy_with_cvt(to_numpy, device, dtype)
 
-    @skipMeta
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_copy_from_dlpack(self, device, dtype):
         self._test_copy_with_cvt(to_dlpack, device, dtype)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -44,7 +44,6 @@ from torch.testing._internal.common_device_type import (
     skipCUDAVersionIn,
     onlyCUDA, onlyCPU,
     dtypes, dtypesIfCUDA, dtypesIfCPU, deviceCountAtLeast,
-    skipMeta,
     PYTORCH_CUDA_MEMCHECK, largeTensorTest, onlyOnCPUAndCUDA,
     expectedAlertNondeterministic, get_all_device_types)
 from typing import Dict, List, Tuple
@@ -7238,7 +7237,6 @@ else:
             for x in xs:
                 _test_helper(x, op, unary=True)
 
-    @skipMeta
     @onlyOnCPUAndCUDA
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_dlpack_capsule_conversion(self, device, dtype):
@@ -7247,7 +7245,6 @@ else:
         z = from_dlpack(to_dlpack(x))
         self.assertEqual(z, x)
 
-    @skipMeta
     @onlyOnCPUAndCUDA
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_dlpack_protocol_conversion(self, device, dtype):
@@ -7255,7 +7252,6 @@ else:
         z = from_dlpack(x)
         self.assertEqual(z, x)
 
-    @skipMeta
     @onlyOnCPUAndCUDA
     def test_dlpack_shared_storage(self, device):
         x = make_tensor((5,), device, torch.float64)
@@ -7263,7 +7259,6 @@ else:
         z[0] = z[0] + 20.0
         self.assertEqual(z, x)
 
-    @skipMeta
     @onlyCUDA
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_dlpack_conversion_with_streams(self, device, dtype):
@@ -7282,7 +7277,6 @@ else:
         stream.synchronize()
         self.assertEqual(z, x)
 
-    @skipMeta
     @onlyCUDA
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_dlpack_conversion_with_diff_streams(self, device, dtype):
@@ -7300,7 +7294,6 @@ else:
         stream_b.synchronize()
         self.assertEqual(z, x)
 
-    @skipMeta
     @onlyOnCPUAndCUDA
     @dtypes(*get_all_dtypes(include_bool=False))
     def test_dlpack_tensor_invalid_stream(self, device, dtype):
@@ -7308,7 +7301,6 @@ else:
             x = make_tensor((5,), device, dtype)
             x.__dlpack__(stream=object())
 
-    @skipMeta
     def test_dlpack_error_on_bool_tensor(self):
         x = torch.tensor([True], dtype=torch.bool)
         with self.assertRaises(RuntimeError):
@@ -7316,20 +7308,17 @@ else:
 
     # TODO: increase tests once NumPy supports the `__dlpack__` protocol
 
-    @skipMeta
     def test_dlpack_export_requires_grad(self):
         x = torch.zeros(10, dtype=torch.float32, requires_grad=True)
         with self.assertRaisesRegex(RuntimeError, r"require gradient"):
             x.__dlpack__()
 
-    @skipMeta
     def test_dlpack_export_is_conj(self):
         x = torch.tensor([-1 + 1j, -2 + 2j, 3 - 3j])
         y = torch.conj(x)
         with self.assertRaisesRegex(RuntimeError, r"conjugate bit"):
             y.__dlpack__()
 
-    @skipMeta
     def test_dlpack_export_non_strided(self):
         x = torch.sparse_coo_tensor([[0]], [1], size=(1,))
         y = torch.conj(x)

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -9,7 +9,7 @@ import torch
 from torch.testing._internal.common_utils import (TestCase, run_tests, load_tests,
                                                   TEST_NUMPY, torch_to_numpy_dtype_dict)
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyOnCPUAndCUDA,
-                                                        dtypes, dtypesIfCUDA, onlyCPU, expectedFailureMeta)
+                                                        dtypes, dtypesIfCUDA, onlyCPU)
 from torch.testing._internal.common_dtype import (
     get_all_dtypes, get_all_math_dtypes, get_all_int_dtypes, get_all_fp_dtypes
 )
@@ -561,7 +561,6 @@ class TestTypePromotion(TestCase):
         for dtype in get_all_dtypes():
             self.assertEqual(torch.promote_types(dtype, dtype), dtype)
 
-    @expectedFailureMeta
     @float_double_default_dtype
     def test_indexing_fail(self, device):
         # https://github.com/pytorch/pytorch/issues/28010

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -754,7 +754,7 @@ class TestAssert(TestCase):
         # data can be passed without errors
         x = torch.randn(4, 4).fill_(1.0)
         ms(x)
-        with self.assertRaisesRegex(torch.jit.Error, "foo"):
+        with self.assertRaisesRegex(torch.jit.Error, "foo"):  # type: ignore[type-var]
             ms(torch.tensor([False], dtype=torch.bool))
 
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -38,7 +38,7 @@ except ImportError:
 #   compatible test classes and optionally doing the following:
 #
 #     - instantiating a version of the test class for each available device type
-#         (often the CPU, CUDA, and META device types)
+#         (often the CPU, and CUDA device types)
 #     - further instantiating a version of each test that's always specialized
 #         on the test class's device type, and optionally specialized further
 #         on datatypes or operators
@@ -421,15 +421,6 @@ class CPUTestBase(DeviceTypeTestBase):
     def _should_stop_test_suite(self):
         return False
 
-# The meta device represents tensors that don't have any storage; they have
-# all metadata (size, dtype, strides) but they don't actually do any compute
-class MetaTestBase(DeviceTypeTestBase):
-    device_type = 'meta'
-    _ignore_not_implemented_error = True
-
-    def _should_stop_test_suite(self):
-        return False
-
 class CUDATestBase(DeviceTypeTestBase):
     device_type = 'cuda'
     _do_cuda_memory_leak_check = True
@@ -483,11 +474,8 @@ def get_device_type_test_bases():
                 test_bases.append(CUDATestBase)
         else:
             test_bases.append(CPUTestBase)
-            test_bases.append(MetaTestBase)
     else:
         test_bases.append(CPUTestBase)
-        if not TEST_SKIP_NOARCH:
-            test_bases.append(MetaTestBase)
         if torch.cuda.is_available():
             test_bases.append(CUDATestBase)
 
@@ -785,12 +773,6 @@ class skipCUDAIf(skipIf):
 
     def __init__(self, dep, reason):
         super().__init__(dep, reason, device_type='cuda')
-
-# Skips a test on Meta if the condition is true.
-class skipMetaIf(skipIf):
-
-    def __init__(self, dep, reason):
-        super().__init__(dep, reason, device_type='meta')
 
 def _has_sufficient_memory(device, size):
     if torch.device(device).type == 'cuda':
@@ -1227,6 +1209,3 @@ def skipCUDAIfNoCusparseGeneric(fn):
 
 def skipCUDAIfNoCudnn(fn):
     return skipCUDAIfCudnnVersionLessThan(0)(fn)
-
-def skipMeta(fn):
-    return skipMetaIf(True, "test doesn't work with meta tensors")(fn)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -12,7 +12,7 @@ import os
 import torch
 from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
     skipCUDANonDefaultStreamIf, TEST_WITH_ASAN, TEST_WITH_UBSAN, TEST_WITH_TSAN, \
-    IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, DeterministicGuard, TEST_SKIP_NOARCH, \
+    IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, DeterministicGuard, \
     _TestParametrizer, dtype_name, TEST_WITH_MIOPEN_SUGGEST_NHWC
 from torch.testing._internal.common_cuda import _get_torch_cuda_version, TEST_CUSPARSE_GENERIC
 from torch.testing._internal.common_dtype import get_all_dtypes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67190

This PR removes the meta device from the device type test bases. There are 5 issues with treating meta as a regular device in unit and integration tests:

1. The default behavior of `MetaTestBase` is to skip tests that raise a `NotImplementedError`. This means tests can be unintentionally skipped if the error was raised by a code path that was not part of the assertion (i.e. the author wants to test a legitimate meta behavior, but another auxiliary operator raises `NotImplementedError`).

2. Looking at the source code of a test one can not find out whether it is intended to work with the meta device or is expected to be skipped.

3. With the increasing number of operators that support the meta device (i.e. out-of-the-box support with structured kernels), majority of the test cases will start to fail since they won't raise a `NotImplementedError` anymore. The mitigation right now is to annotate such test cases with `skipMeta`; however this approach will become quite redundant once the majority of the operators have meta device support.

4. Deciding whether to skip a test or not should be the responsibility of the test author, not the test framework. Overall swallowing `NotImplementedError` and skipping test cases is a fragile and error-prone approach.

5. Nit: Skipped meta tests generate a lot of noise in the test outputs with long stack trace logs.

Here I recommend the following idiom for meta device testing:

```
from torch.testing._internal.common_utils import TestCase
from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU

# Tests included in `TestMyTensorOperators` should assert the actual
# logic of the operators assuming they are run on a real device.
#
# As of today practically all our device-specific test cases behave
# similar to this class.
class TestMyTensorOperators(TestCase):
    def test_my_operator(self, device):
        ...

    @onlyCPU
    def test_my_other_operator(self, device):
        ...

# Instantiates tests of `TestMyTensorOperators` to be run on real
# devices (i.e. CPU, CUDA), note that this function does NOT instantiates
# tests for the meta backend anymore.
instantiate_device_type_tests(TestMyTensorOperators, globals())

# Since the semantics of a meta tensor is very different than a regular
# tensor, any operator logic that is specific to the meta backend
# should be tested in a separate `TestCase`.
class TestMyTensorOperatorsOnMeta(TestCase):
    ...
```

Although it is tricky to determine which tests will be "ignored" after this change (see issue #2 above), my initial observation is that as of today we have no device-specific tests in our code base that we specifically expect to pass on the meta device. They are either skipped due to raising a `NotImplementedError` or pass solely (and unintentionally) as a side effect of explicit meta backend support.

Differential Revision: [D31898006](https://our.internmc.facebook.com/intern/diff/D31898006/)