### PR TITLE
[ONNX] Add module name as PythonOp attribute

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -482,6 +482,7 @@ namespace c10 {
   _(attr, transA)                    \
   _(attr, transB)                    \
   _(attr, name)                      \
+  _(attr, module)                    \
   _(attr, a)                         \
   _(attr, b)                         \
   _(attr, beg)                       \

--- a/test/onnx/autograd_helper.py
+++ b/test/onnx/autograd_helper.py
@@ -1,0 +1,18 @@
+# Owner(s): ["module: onnx"]
+
+import torch
+
+# Autograd funtion that is a replica of the autograd funtion in
+# test_utility_funs.py (test_autograd_module_name)
+class CustomFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input):
+        ctx.save_for_backward(input)
+        return input.clamp(min=0)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, = ctx.saved_tensors
+        grad_input = grad_output.clone()
+        grad_input[input < 0] = 0
+        return grad_input

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -559,14 +559,9 @@ static void _trace_post_record(
   }
 
   node->i_(jit::attr::inplace, is_inplace);
-  if (node) {
-    auto module_name = PyDict_GetItemString(((PyTypeObject*)op_obj)->tp_dict, "__module__");
-    if (module_name) {
-      const char *ptr = PyUnicode_AsUTF8(module_name);
-      if (ptr) {
-          auto modname = std::string(ptr);
-          node->s_(jit::attr::module, modname);
-      }
+  if (auto module_name = PyDict_GetItemString(((PyTypeObject*)op_obj)->tp_dict, "__module__")) {
+    if (auto ptr = PyUnicode_AsUTF8(module_name)) {
+        node->s_(jit::attr::module, std::string(ptr));
     }
   }
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -621,6 +621,20 @@ PyObject* process_outputs(PyObject *op_obj, const std::shared_ptr<PyNode>& cdata
     }
   }
 
+  auto module_name = PyDict_GetItemString(((PyTypeObject*)op_obj)->tp_dict, "__module__");
+  if (!module_name) {
+    return NULL;
+  }
+  Py_ssize_t size;
+  const char *ptr = PyUnicode_AsUTF8AndSize(module_name, &size);
+  if (!ptr) {
+      return NULL;
+  }
+  auto modname = std::string(ptr);
+  if (node) {
+    node->s_(jit::attr::module, modname);
+  }
+
   bool is_inplace = static_cast<bool>(grad_fn->dirty_tensors);
   _wrap_outputs(cdata, grad_fn, unpacked.input_vars, raw_output, outputs, is_executable);
   _trace_post_record(node, op_obj, unpacked.input_vars, outputs, is_inplace, unpack_output);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -562,8 +562,7 @@ static void _trace_post_record(
   if (node) {
     auto module_name = PyDict_GetItemString(((PyTypeObject*)op_obj)->tp_dict, "__module__");
     if (module_name) {
-      Py_ssize_t size;
-      const char *ptr = PyUnicode_AsUTF8AndSize(module_name, &size);
+      const char *ptr = PyUnicode_AsUTF8(module_name);
       if (ptr) {
           auto modname = std::string(ptr);
           node->s_(jit::attr::module, modname);


### PR DESCRIPTION
Stores the module name of the autograd function as attribute for a PythonOp node in the IR graph.

Before this modification:
```
graph(%input : Float(1, strides=[1], requires_grad=0, device=cpu)):
  %3 : Float(1, strides=[1], requires_grad=0, device=cpu) = ^MyExp[inplace=0]()(%input)]
  %6 : Float(1, strides=[1], requires_grad=0, device=cpu) = ^MyExp[inplace=0]()(%input)]
  %7 : int = prim::Constant[value=1]()
  %8 : Float(1, strides=[1], requires_grad=0, device=cpu) = aten::add(%3, %6, %7)
  return (%8)
```
After this modification:
```
graph(%input : Float(1, strides=[1], requires_grad=0, device=cpu)):
  %3 : Float(1, strides=[1], requires_grad=0, device=cpu) = ^MyExp[module="autograd1", inplace=0]()(%input)]
  %6 : Float(1, strides=[1], requires_grad=0, device=cpu) = ^MyExp[module="autograd2", inplace=0]()(%input)]
  %7 : int = prim::Constant[value=1]()
  %8 : Float(1, strides=[1], requires_grad=0, device=cpu) = aten::add(%3, %6, %7)
  return (%8)
```
