### PR TITLE
[fx2trt] Better trt layer name

### DIFF
--- a/torch/fx/experimental/fx2trt/example/fx2trt_example.py
+++ b/torch/fx/experimental/fx2trt/example/fx2trt_example.py
@@ -101,7 +101,17 @@ cuda_inputs = [input.cuda() for input in inputs]
 split_mod.cuda()
 lowered_model_output = split_mod(*cuda_inputs)
 
-# we make sure the results match
+# Make sure the results match
 model.cuda()
 regular_model_output = model(*cuda_inputs)
 torch.testing.assert_close(lowered_model_output, regular_model_output.to(torch.float16), atol=3e-3, rtol=1e-2)
+
+# We can utilize the trt profiler to print out the time spend on each layer.
+trt_mod.enable_profiling()
+trt_mod(*cuda_inputs)
+'''
+Reformatting CopyNode for Input Tensor 0 to LayerType.FULLY_CONNECTED_acc_ops.linear_linear_1: 0.027392ms
+LayerType.FULLY_CONNECTED_acc_ops.linear_linear_1: 0.023072ms
+PWN(ActivationType.RELU_acc_ops.relu_relu_1): 0.008928ms
+'''
+trt_mod.disable_profiling()

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -205,6 +205,16 @@ class TRTModule(torch.nn.Module):
         if not self.context.profiler:
             self.context.profiler = trt.Profiler()
 
+    def disable_profiling(self):
+        """
+        Disable TensorRT profiling.
+        """
+        self._check_initialized()
+
+        torch.cuda.synchronize()
+        del self.context
+        self.context = self.engine.create_execution_context()
+
 
 CONVERTERS = {}
 


### PR DESCRIPTION
Summary:
We want to put more information on the tensorrt layer name. Mainly we want to be able to tell the original op that a TensorRT layer is mapped from.

The layer format is `[TensorRT Layer Type]-[Original Op Code]-[FX Node Name]`
```
Reformatting CopyNode for Input Tensor 0 to [FULLY_CONNECTED]-[acc_ops.linear]-[linear_1]: 0.0328ms
[FULLY_CONNECTED]-[acc_ops.linear]-[linear_1]: 0.027712ms
PWN([RELU]-[acc_ops.relu]-[relu_1]): 0.008672ms
```

Test Plan:
CI

```
buck run mode/dev-nosan -c python.package_style=inplace caffe2:fx2trt_example
```

Differential Revision: D31627274

