### PR TITLE
__getitem__: Ensure Tensor subclasses are not treated as tuples

### DIFF
--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -212,6 +212,9 @@ static inline bool treatSequenceAsTuple(PyObject* index) {
   if (PyTuple_Check(index)) {
     return true;
   }
+  if (THPVariable_Check(index)) {
+    return false;
+  }
   if (!PySequence_Check(index)) {
     return false;
   }


### PR DESCRIPTION
Fixes #50710, fixes #67027

`torch.Tensor` is considered a Mapping, but not a Sequence in Python
because it uses `tp_as_mapping` instead of defining `__getitem__` in
Python. However, If you try to overwrite `__getitem__` from Python
it is considered a `Sequence` and so the tensor is treated like a
tuple for indexing purposes.
