### PR TITLE
[LTC] Code-gen exp, elu*, and log_sigmoid*

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeDtype.cpp
@@ -204,6 +204,26 @@ std::vector<c10::ScalarType> compute_dtype_smooth_l1_loss_backward(
   return {self.scalar_type(), target.scalar_type()};
 }
 
+std::vector<std::vector<int64_t>> compute_shape_log_sigmoid_forward(const at::Tensor& self) {
+  // Based on definition of aten/src/ATen/native/Activation.cpp::log_sigmoid_forward_out_cpu.
+  return {self.sizes().vec(), self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_log_sigmoid_forward(const at::Tensor& self) {
+  // Based on definition of aten/src/ATen/native/Activation.cpp::log_sigmoid_forward_out_cpu.
+  return {self.scalar_type(), self.scalar_type()};
+}
+
+std::vector<std::vector<int64_t>> compute_shape_log_sigmoid_backward(const at::Tensor& grad_output, const at::Tensor& self, const at::Tensor& buffer) {
+  // Based on definition of aten/src/ATen/native/Activation.cpp::log_sigmoid_backward_cpu*.
+  return {grad_output.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_log_sigmoid_backward(const at::Tensor& grad_output, const at::Tensor& self, const at::Tensor& buffer) {
+  // Based on definition of aten/src/ATen/native/Activation.cpp::log_sigmoid_backward_cpu*.
+  return {grad_output.scalar_type()};
+}
+
 } // namespace ops
 } // namespace ir
 } // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.h
@@ -121,11 +121,6 @@ NodePtr HardSigmoid(const torch::lazy::Value& input);
 
 NodePtr HardSigmoidBackward(const torch::lazy::Value& grad_output, const torch::lazy::Value& input);
 
-std::tuple<NodePtr, NodePtr> LogSigmoid(const torch::lazy::Value& input);
-
-NodePtr LogSigmoidBackward(const torch::lazy::Value& grad_output, const torch::lazy::Value& input,
-                           const torch::lazy::Value& buffer);
-
 NodePtr Sigmoid(const torch::lazy::Value& input);
 
 NodePtr SiLU(const torch::lazy::Value& input);
@@ -167,13 +162,6 @@ NodePtr BroadcastTensors(OpList tensors);
 
 NodePtr Identity(lazy_tensors::int64 lines, lazy_tensors::int64 cols,
                  lazy_tensors::PrimitiveType element_type);
-
-NodePtr Elu(const torch::lazy::Value& input, const at::Scalar& alpha,
-            const at::Scalar& scale, const at::Scalar& input_scale);
-
-NodePtr EluBackward(const torch::lazy::Value& grad_output, const torch::lazy::Value& output,
-                    const at::Scalar& alpha, const at::Scalar& scale,
-                    const at::Scalar& input_scale);
 
 NodePtr Lshift(const torch::lazy::Value& input, const at::Scalar& other);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -854,26 +854,6 @@ LazyTensor eq(const LazyTensor& input, const LazyTensor& other) {
   return DispatchComparisonOp(at::aten::eq, input, other);
 }
 
-LazyTensor elu(const LazyTensor& input, const at::Scalar& alpha,
-               const at::Scalar& scale, const at::Scalar& input_scale) {
-  return input.CreateFrom(
-      ir::ops::Elu(input.GetIrValue(), alpha, scale, input_scale));
-}
-
-void elu_(LazyTensor& input, const at::Scalar& alpha, const at::Scalar& scale,
-          const at::Scalar& input_scale) {
-  input.SetInPlaceIrValue(
-      ir::ops::Elu(input.GetIrValue(), alpha, scale, input_scale));
-}
-
-LazyTensor elu_backward(const LazyTensor& grad_output, const at::Scalar& alpha,
-                        const at::Scalar& scale, const at::Scalar& input_scale,
-                        const LazyTensor& output) {
-  return grad_output.CreateFrom(ir::ops::EluBackward(grad_output.GetIrValue(),
-                                                     output.GetIrValue(), alpha,
-                                                     scale, input_scale));
-}
-
 LazyTensor erf(const LazyTensor& input) {
   return input.CreateFrom(ir::ops::Erf(input.GetIrValue()));
 }
@@ -884,10 +864,6 @@ LazyTensor erfc(const LazyTensor& input) {
 
 LazyTensor erfinv(const LazyTensor& input) {
   return input.CreateFrom(ir::ops::Erfinv(input.GetIrValue()));
-}
-
-LazyTensor exp(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::Exp(input.GetIrValue()));
 }
 
 LazyTensor expand(const LazyTensor& input,
@@ -1209,24 +1185,6 @@ LazyTensor log(const LazyTensor& input) {
 LazyTensor log_base(const LazyTensor& input, torch::lazy::OpKind op, double base) {
   return input.CreateFrom(
       torch::lazy::MakeNode<ir::ops::LogBase>(input.GetIrValue(), op, base));
-}
-
-LazyTensor log_sigmoid(const LazyTensor& input) {
-  return input.CreateFrom(std::get<0>(ir::ops::LogSigmoid(input.GetIrValue())));
-}
-
-std::tuple<LazyTensor, LazyTensor> log_sigmoid_forward(
-    const LazyTensor& input) {
-  auto output_and_buffer = ir::ops::LogSigmoid(input.GetIrValue());
-  return std::make_tuple(input.CreateFrom(std::get<0>(output_and_buffer)),
-                         input.CreateFrom(std::get<1>(output_and_buffer)));
-}
-
-LazyTensor log_sigmoid_backward(const LazyTensor& grad_output,
-                                const LazyTensor& input,
-                                const LazyTensor& buffer) {
-  return grad_output.CreateFrom(ir::ops::LogSigmoidBackward(
-      grad_output.GetIrValue(), input.GetIrValue(), buffer.GetIrValue()));
 }
 
 LazyTensor log1p(const LazyTensor& input) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -241,14 +241,6 @@ LazyTensor diagonal(const LazyTensor& input, lazy_tensors::int64 offset,
 LazyTensor einsum(const std::string& equation,
                   lazy_tensors::Span<const LazyTensor> tensors);
 
-LazyTensor elu(const LazyTensor& input, const at::Scalar& alpha,
-               const at::Scalar& scale, const at::Scalar& input_scale);
-void elu_(LazyTensor& input, const at::Scalar& alpha, const at::Scalar& scale,
-          const at::Scalar& input_scale);
-LazyTensor elu_backward(const LazyTensor& grad_output, const at::Scalar& alpha,
-                        const at::Scalar& scale, const at::Scalar& input_scale,
-                        const LazyTensor& output);
-
 LazyTensor eq(const LazyTensor& input, const at::Scalar& other);
 
 LazyTensor eq(const LazyTensor& input, const LazyTensor& other);
@@ -258,8 +250,6 @@ LazyTensor erf(const LazyTensor& input);
 LazyTensor erfc(const LazyTensor& input);
 
 LazyTensor erfinv(const LazyTensor& input);
-
-LazyTensor exp(const LazyTensor& input);
 
 LazyTensor expand(const LazyTensor& input,
                   std::vector<lazy_tensors::int64> size);
@@ -411,12 +401,6 @@ LazyTensor lerp(const LazyTensor& input, const LazyTensor& end,
 LazyTensor log(const LazyTensor& input);
 
 LazyTensor log_base(const LazyTensor& input, torch::lazy::OpKind op, double base);
-
-LazyTensor log_sigmoid(const LazyTensor& input);
-std::tuple<LazyTensor, LazyTensor> log_sigmoid_forward(const LazyTensor& input);
-LazyTensor log_sigmoid_backward(const LazyTensor& grad_output,
-                                const LazyTensor& input,
-                                const LazyTensor& buffer);
 
 LazyTensor log_softmax_backward(const LazyTensor& grad_output,
                                 const LazyTensor& output,

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -3089,12 +3089,27 @@ TEST_F(AtenLtcTsTensorTest, TestHannWindow) {
 }
 
 TEST_F(AtenLtcTsTensorTest, TestLogSigmoid) {
-  torch::Tensor a = torch::rand({2, 2}, torch::TensorOptions(torch::kFloat));
+  torch::Tensor a = torch::empty({2, 2}, torch::TensorOptions(torch::kFloat));
+  a.uniform_(-1.0, 1.0);
   torch::Tensor b = torch::log_sigmoid(a);
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor xla_a = CopyToDevice(a, device);
     torch::Tensor xla_b = torch::log_sigmoid(xla_a);
     AllClose(b, xla_b, /*rtol=*/1e-3, /*atol=*/1e-5);
+  });
+}
+
+TEST_F(AtenLtcTsTensorTest, TestLogSigmoidForward) {
+  torch::Tensor a = torch::empty({2, 2}, torch::TensorOptions(torch::kFloat));
+  a.uniform_(-1.0, 1.0);
+  auto tuple = torch::log_sigmoid_forward(a);
+  ForEachDevice([&](const torch::Device& device) {
+    torch::Tensor xla_a = CopyToDevice(a, device);
+    auto xla_tuple = torch::log_sigmoid_forward(xla_a);
+    AllClose(std::get<0>(tuple), std::get<0>(xla_tuple),
+             /*rtol=*/1e-3, /*atol=*/1e-5);
+    AllClose(std::get<1>(tuple), std::get<1>(xla_tuple),
+             /*rtol=*/1e-3, /*atol=*/1e-5);
   });
 }
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -15,13 +15,18 @@ full_codegen:
   - clamp
   - div.Tensor
   - div.Tensor_mode
+  - elu
+  - elu_backward
   - embedding_dense_backward
+  - exp
   - floor
   - frac
   - gelu
   - gelu_backward
   - kl_div_backward
   - log2
+  - log_sigmoid_backward
+  - log_sigmoid_forward
   - mean
   - mean.dim
   - mm


### PR DESCRIPTION
Summary:
This commit adds code-gen support for the following ops:
- `exp`
- `elu`
- `elu_backward`
- `log_sigmoid_forward` (`log_sigmoid` is just a special case of this function)
- `log_sigmoid_backward`

## Unit Tests

This commit improves the unit test `AtenLtcTsTensorTest.TestLogSigmoid` by
expanding the range of values used to generate the random tensor to include 
negative numbers. This is important because some definitions of `log_sigmoid` treat
positive and negative values differently, for example,

https://github.com/pytorch/pytorch/blob/e91f510d2d4736344ab54dcb66f3aa3f0561a675/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp#L98

which could result in an error that is not caught by the testing suite.

This commit also adds unit test `AtenLtcTsTensorTest.LogSigmoidForward`.

Test Plan:
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestExp:AtenLtcTsTensorTest.TestElu*:AtenLtcTsTensorTest.TestLogSigmoid*

