### PR TITLE
[PyTorch][JIT] Add AliasDb::mayTransitivelyContainOrPointTo

### DIFF
--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -699,7 +699,7 @@ TEST(WriteTrackingTest, HasWriters) {
 #define EXPECT_MAY_TRANSITIVELY_CONTAIN_OR_POINT_TO_ASYMMETRIC(aliasDb, a, b) \
   do {                                                                        \
     EXPECT_TRUE((aliasDb).mayContainAlias((a), (b)));                         \
-    EXPECT_TRUE((aliasDb).mayContainAlias((b), (a)));                   \
+    EXPECT_TRUE((aliasDb).mayContainAlias((b), (a)));                         \
     EXPECT_TRUE((aliasDb).mayTransitivelyContainOrPointTo((a), (b)));         \
     EXPECT_FALSE((aliasDb).mayTransitivelyContainOrPointTo((b), (a)));        \
   } while (0)
@@ -752,7 +752,8 @@ TEST(ContainerAliasingTest, MayContainAlias) {
 
   EXPECT_DOES_NOT_CONTAIN_OR_ALIAS(aliasDb, local_var, graph->inputs());
 
-  EXPECT_MAY_CONTAIN_ALIAS(aliasDb, c10::ArrayRef<Value*>({ten_output}), graph->outputs());
+  EXPECT_MAY_CONTAIN_ALIAS(
+      aliasDb, c10::ArrayRef<Value*>({ten_output}), graph->outputs());
 
   EXPECT_DOES_NOT_CONTAIN_OR_ALIAS(aliasDb, str_output, graph->outputs());
 }
@@ -789,7 +790,8 @@ TEST(ContainerAliasingTest, MayContainAlias_cast) {
 
   EXPECT_DOES_NOT_CONTAIN_OR_ALIAS(aliasDb, b, graph->inputs());
 
-  EXPECT_MAY_CONTAIN_ALIAS(aliasDb, (c10::ArrayRef<Value*>{c}), graph->outputs());
+  EXPECT_MAY_CONTAIN_ALIAS(
+      aliasDb, (c10::ArrayRef<Value*>{c}), graph->outputs());
 
   EXPECT_DOES_NOT_CONTAIN_OR_ALIAS(aliasDb, b, graph->outputs());
 }
@@ -1506,8 +1508,10 @@ TEST(
       graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
 
   EXPECT_TRUE(!aliasDb.mayAlias(vmap["x"], vmap["y"]));
-  EXPECT_MAY_TRANSITIVELY_CONTAIN_OR_POINT_TO_ASYMMETRIC(aliasDb, vmap["z"], vmap["x"]);
-  EXPECT_MAY_TRANSITIVELY_CONTAIN_OR_POINT_TO_ASYMMETRIC(aliasDb, vmap["z"], vmap["y"]);
+  EXPECT_MAY_TRANSITIVELY_CONTAIN_OR_POINT_TO_ASYMMETRIC(
+      aliasDb, vmap["z"], vmap["x"]);
+  EXPECT_MAY_TRANSITIVELY_CONTAIN_OR_POINT_TO_ASYMMETRIC(
+      aliasDb, vmap["z"], vmap["y"]);
 }
 
 TEST(

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -73,6 +73,21 @@ class AliasDb {
       const at::ArrayRef<Value*> a,
       const at::ArrayRef<Value*> b) const;
 
+  // Might there be any path from `a` to `b` in the contains-or-points-to graph?
+  // Compare to mayContainAlias, except the relationship is not symmetric.
+  TORCH_API bool mayTransitivelyContainOrPointTo(Value* a, Value* b) const;
+
+  // Might there be any path from `a` to any element in `b` in the
+  // contains-or-points-to graph? Compare to mayContainAlias, except the
+  // relationship is not symmetric.
+  TORCH_API bool mayTransitivelyContainOrPointTo(
+      Value* a,
+      const at::ArrayRef<Value*> b) const;
+
+  TORCH_API bool mayTransitivelyContainOrPointTo(
+      const at::ArrayRef<Value*> a,
+      const at::ArrayRef<Value*> b) const;
+
   // Do `a` and `b` potentially share a memory location?
   TORCH_API bool mayAlias(const Value* a, const Value* b) const;
   // Do any values in group `a` potentially share a memory location with any
@@ -268,6 +283,7 @@ class AliasDb {
       Element* container_elem,
       const AliasTypeSet& mut_types);
 
+  bool mayTransitivelyContainOrPointToImpl(Element* a, Element* b) const;
   std::vector<Element*> getElements(at::ArrayRef<Value*> vs) const;
   bool mayAliasWildcard(const Value* v) const;
   bool mayAliasWildcard(const at::ArrayRef<Value*> vs) const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67217
* #66994
* #66966
* #67075
* #66996
* #66965

Just exposing the MemoryDAG functionality from the previous diff.

Differential Revision: [D31833293](https://our.internmc.facebook.com/intern/diff/D31833293/)