### PR TITLE
[ROCm] Bump magma source to pickup memory leak fix

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -6,8 +6,8 @@ install_magma() {
     # "install" hipMAGMA into /opt/rocm/magma by copying after build
     git clone https://bitbucket.org/icl/magma.git
     pushd magma
-    # fix for Cholesky issue
-    git checkout 092253401778a2cd35a214b0436efacebe2e55cd
+    # fix for magma_queue memory leak issue
+    git checkout c62d700d880c7283b33fb1d615d62fc9c7f7ca21
     cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
     echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
     echo 'LIB += -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib -Wl,--rpath,$(MKLROOT)/lib -Wl,--rpath,/opt/rocm/magma/lib' >> make.inc


### PR DESCRIPTION
Magma's magma_queue was double allocating storage when creating
ptrArray for gemm operations.  A fix has been upstreamed and the build
needs to pick this up going forward.

Fixes #{issue number}


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH