### PR TITLE
[ROCm] Enable frexp support for ROCm builds

### DIFF
--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -154,12 +154,6 @@ void nan_to_num_kernel_cuda(
 }
 
 void frexp_kernel_cuda(TensorIteratorBase& iter) {
-#if defined(USE_ROCM)
-  // Reference: https://rocmdocs.amd.com/en/latest/ROCm_API_References/HIP-MATH.html
-  //            https://github.com/ROCm-Developer-Tools/HIP/issues/2169
-  // ROCm does not support frexp function yet
-  TORCH_CHECK(false, "torch.frexp() is not implemented on ROCm platform.");
-#else
   AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::Half,
     // The iter.dtype() here is the dtype of mantissa output.
     // It's a floating point type and must be the same as the input's dtype.
@@ -171,7 +165,6 @@ void frexp_kernel_cuda(TensorIteratorBase& iter) {
         return {mantissa, exponent};
       });
   });
-#endif
 }
 
 REGISTER_DISPATCH(bitwise_not_stub, &bitwise_not_kernel_cuda);

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7694,7 +7694,7 @@ op_db: List[OpInfo] = [
                    dtypes=floating_types_and(torch.half),
                    dtypesIfCPU=floating_types_and(torch.half, torch.bfloat16),
                    # skip testing torch.frexp as it is not supported by ROCm platform yet
-                   decorators=[skipCUDAIfRocm],
+                   decorators=[],
                    supports_out=False,
                    supports_forward_ad=True,
                    skips=(

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -37,6 +37,7 @@ MATH_TRANSPILATIONS = collections.OrderedDict(
         ("std::fabs", ("::fabs")),
         ("std::fmod", ("::fmod")),
         ("std::remainder", ("::remainder")),
+        ("std::frexp", ("::frexp")),
     ]
 )
 


### PR DESCRIPTION
The frexp function has been enabled in ROCm code.  Updating PyTorch
to enable this functionality.


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH