### PR TITLE
[fx-acc] add automated graph opt testing using AccOpProperty

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_op_properties.py
+++ b/torch/fx/experimental/fx_acc/acc_op_properties.py
@@ -8,6 +8,7 @@ import torch.fx
 class AccOpProperty(Flag):
     pointwise = auto()
     quantized = auto()
+    unary = auto()
 
 acc_op_properties: DefaultDict[Callable, Set[AccOpProperty]] = defaultdict(set)
 acc_ops_with_property: DefaultDict[AccOpProperty, Set[Callable]] = defaultdict(set)

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -11,7 +11,10 @@ from torch.fx.experimental.fx_acc.acc_normalizer import (
     register_acc_op_mapping,
     register_custom_acc_mapper_fn,
 )
-from torch.fx.experimental.fx_acc.acc_op_properties import AccOpProperty, register_acc_op_properties
+from torch.fx.experimental.fx_acc.acc_op_properties import (
+    AccOpProperty,
+    register_acc_op_properties,
+)
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 
 this_arg_is_optional = True
@@ -27,8 +30,7 @@ def linear(*, input, weight, bias):
 
 @register_acc_op_properties(AccOpProperty.quantized)
 @register_acc_op
-def quantized_linear(*, input, weight, bias, acc_out_ty=None):
-    assert acc_out_ty is not None
+def quantized_linear(*, input, weight, bias, acc_out_ty):
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     return nn.quantized.functional.linear(
         input,
@@ -39,6 +41,7 @@ def quantized_linear(*, input, weight, bias, acc_out_ty=None):
     )
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(
     op_and_target=("call_method", "flatten"),
     arg_replacement_tuples=[
@@ -53,6 +56,7 @@ def flatten(*, input, start_dim=0, end_dim=-1):
     return torch.flatten(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(
     op_and_target=("call_method", "squeeze"),
     arg_replacement_tuples=[
@@ -105,12 +109,14 @@ def avg_pool2d(
     return nn.functional.avg_pool2d(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.sign))
 @register_acc_op
 def sign(*, input):
     return torch.sign(input)
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def size(*, input):
     return input.size()
@@ -180,16 +186,20 @@ def add(*, input, other):
     return input + other
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_method", "unsqueeze"))
 @register_acc_op_mapping(op_and_target=("call_function", torch.unsqueeze))
 @register_acc_op
 def unsqueeze(*, input, dim):
     return torch.unsqueeze(**locals())
 
+
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.tile))
 @register_acc_op
 def tile(*, input, dims):
     return torch.tile(**locals())
+
 
 @register_custom_acc_mapper_fn(
     op_and_target=("call_function", torch.stack),
@@ -224,14 +234,15 @@ def stack_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
         return cat_node
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.clamp))
 @register_acc_op_mapping(op_and_target=("call_method", "clamp"))
 @register_acc_op
-def clamp(*, input, min, max):
+def clamp(*, input, min=None, max=None):
     return torch.clamp(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.cat))
 @register_acc_op
 def cat(*, tensors, dim):
@@ -281,12 +292,14 @@ def transpose_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
     return permute_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_method", "contiguous"))
 @register_acc_op
 def contiguous(*, input):
     return input.contiguous()
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.softmax))
 @register_acc_op
 def softmax(*, input, dim, dtype):
@@ -369,6 +382,7 @@ def t_mapper(node: torch.fx.Node, _: nn.Module):
         return new_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(
     op_and_target=("call_method", "permute"),
     arg_replacement_tuples=[
@@ -415,15 +429,16 @@ def matmul(*, input, other):
     arg_replacement_tuples=[("input", "input")],
 )
 @register_custom_acc_mapper_fn(
-    op_and_target=("call_method", "detach"),
-    arg_replacement_tuples=[("input", "input")])
+    op_and_target=("call_method", "detach"), arg_replacement_tuples=[("input", "input")]
+)
 def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
     """
     Remove dropout node and directly map its input to output.
     """
     return node.kwargs["input"]
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(
     op_and_target=("call_function", nn.functional.hardtanh),
     arg_replacement_tuples=[
@@ -433,17 +448,17 @@ def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
     ],
 )
 @register_acc_op
-def hardtanh(*, input, left, right):
+def hardtanh(*, input, left=-1.0, right=1.0):
     return nn.functional.hardtanh(input, min_val=left, max_val=right)
 
-@register_acc_op_properties(AccOpProperty.pointwise)
-@register_acc_op_mapping(
-    op_and_target=("call_function", nn.functional.hardsigmoid))
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.hardsigmoid))
 @register_acc_op
 def hardsigmoid(*, input):
     return nn.functional.hardsigmoid(input)
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+
 @register_custom_acc_mapper_fn(
     op_and_target=("call_function", nn.functional.hardswish),
     arg_replacement_tuples=[
@@ -463,6 +478,7 @@ def hardswish_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
         new_node.meta = node.meta.copy()
         return new_node
 
+
 @register_acc_op_properties(AccOpProperty.quantized)
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.ops.quantized.add),
@@ -478,8 +494,7 @@ def hardswish_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
     ],
 )
 @register_acc_op
-def quantized_add(*, input, other, acc_out_ty=None):
-    assert acc_out_ty is not None
+def quantized_add(*, input, other, acc_out_ty):
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     return torch.ops.quantized.add(
         input,
@@ -504,8 +519,7 @@ def quantized_add(*, input, other, acc_out_ty=None):
     ],
 )
 @register_acc_op
-def quantized_mul(*, input, other, acc_out_ty=None):
-    assert acc_out_ty is not None
+def quantized_mul(*, input, other, acc_out_ty):
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     return torch.ops.quantized.mul(
         input,
@@ -515,6 +529,7 @@ def quantized_mul(*, input, other, acc_out_ty=None):
     )
 
 
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_properties(AccOpProperty.quantized)
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.quantize_per_tensor),
@@ -522,7 +537,7 @@ def quantized_mul(*, input, other, acc_out_ty=None):
         ("input", "input"),
         ("scale", "scale"),
         ("zero_point", "zero_point"),
-        ("dtype", "dtype")
+        ("dtype", "dtype"),
     ],
     kwargs_to_move_to_acc_out_ty=[
         ("scale", "scale", move_to_qparams),
@@ -531,18 +546,15 @@ def quantized_mul(*, input, other, acc_out_ty=None):
     ],
 )
 @register_acc_op
-def quantize_per_tensor(*, input, acc_out_ty=None):
-    assert acc_out_ty is not None
+def quantize_per_tensor(*, input, acc_out_ty):
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     dtype = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "dtype")
     return torch.quantize_per_tensor(
-        input,
-        qparams["scale"],
-        qparams["zero_point"],
-        dtype
+        input, qparams["scale"], qparams["zero_point"], dtype
     )
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.quantize_per_channel),
     arg_replacement_tuples=[
@@ -550,7 +562,7 @@ def quantize_per_tensor(*, input, acc_out_ty=None):
         ("scales", "scales"),
         ("zero_points", "zero_points"),
         ("axis", "axis"),
-        ("dtype", "dtype")
+        ("dtype", "dtype"),
     ],
     kwargs_to_move_to_acc_out_ty=[
         ("scales", "scale", move_to_qparams),
@@ -560,8 +572,7 @@ def quantize_per_tensor(*, input, acc_out_ty=None):
     ],
 )
 @register_acc_op
-def quantize_per_channel(*, input, acc_out_ty=None):
-    assert acc_out_ty is not None
+def quantize_per_channel(*, input, acc_out_ty):
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     dtype = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "dtype")
     return torch.quantize_per_channel(
@@ -569,9 +580,11 @@ def quantize_per_channel(*, input, acc_out_ty=None):
         torch.tensor(qparams["scale"]),
         torch.tensor(qparams["zero_point"]),
         qparams["axis"],
-        dtype)  # type: ignore[call-overload]
+        dtype,
+    )  # type: ignore[call-overload]
 
 
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_method", "dequantize"))
 @register_acc_op_mapping(op_and_target=("call_function", torch.dequantize))
 @register_acc_op
@@ -579,18 +592,20 @@ def dequantize(*, input):
     return torch.dequantize(input)
 
 
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary, AccOpProperty.quantized)
 @register_acc_op
-def rescale_quantize_per_tensor(*, input, acc_out_ty=None):
+def rescale_quantize_per_tensor(*, input, acc_out_ty):
     d = dequantize(input=input)
     return quantize_per_tensor(input=d, acc_out_ty=acc_out_ty)
 
-
+@register_acc_op_properties(AccOpProperty.unary, AccOpProperty.quantized)
 @register_acc_op
-def rescale_quantize_per_channel(*, input, acc_out_ty=None):
+def rescale_quantize_per_channel(*, input, acc_out_ty):
     d = dequantize(input=input)
     return quantize_per_channel(input=d, acc_out_ty=acc_out_ty)
 
 
+@register_acc_op_properties(AccOpProperty.pointwise)
 @register_acc_op_mapping(op_and_target=("call_function", operator.sub))
 @register_acc_op
 def sub(*, input, other):
@@ -613,13 +628,14 @@ def div(*, input, other):
     return input / other
 
 
+@register_acc_op_properties(AccOpProperty.pointwise)
 @register_acc_op_mapping(op_and_target=("call_function", torch.pow))
 @register_acc_op
 def pow(*, input, exponent):
     return torch.pow(input, exponent)
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", nn.functional.relu))
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.relu),
@@ -651,6 +667,7 @@ def torch_log1p_mapper(node: torch.fx.Node, _: torch.nn.Module) -> torch.fx.Node
         return log_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_custom_acc_mapper_fn(
     op_and_target=("call_method", "sum"),
     arg_replacement_tuples=[
@@ -679,6 +696,7 @@ def add_sum_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.N
         return sum_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def sum(*, input, dim=None, keepdim=False, dtype=None):
     if dim is not None:
@@ -768,16 +786,19 @@ def add_maximum_minimum_mapper(
         return max_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def max_full_reduce(*, input):
     return torch.max(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def max_dim_reduce(*, input, dim=None, keepdim=False):
     return torch.max(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.pointwise)
 @register_acc_op_mapping(op_and_target=("call_function", torch.maximum))
 @register_acc_op_mapping(op_and_target=("call_method", "maximum"))
 @register_acc_op
@@ -785,16 +806,19 @@ def maximum(*, input, other):
     return torch.maximum(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def min_full_reduce(*, input):
     return torch.min(input)
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def min_dim_reduce(*, input, dim=None, keepdim=False):
     return torch.min(input, dim=dim, keepdim=keepdim)
 
 
+@register_acc_op_properties(AccOpProperty.pointwise)
 @register_acc_op_mapping(op_and_target=("call_function", torch.minimum))
 @register_acc_op_mapping(op_and_target=("call_method", "minimum"))
 @register_acc_op
@@ -802,7 +826,7 @@ def minimum(*, input, other):
     return torch.minimum(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.sigmoid))
 @register_acc_op_mapping(op_and_target=("call_method", "sigmoid"))
 @register_acc_op
@@ -810,21 +834,21 @@ def sigmoid(*, input):
     return torch.sigmoid(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.sinh))
 @register_acc_op
 def sinh(*, input):
     return torch.sinh(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.cosh))
 @register_acc_op
 def cosh(*, input):
     return torch.cosh(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.tanh))
 @register_acc_op_mapping(op_and_target=("call_method", "tanh"))
 @register_acc_op
@@ -832,77 +856,77 @@ def tanh(*, input):
     return torch.tanh(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.asin))
 @register_acc_op
 def asin(*, input):
     return torch.asin(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.acos))
 @register_acc_op
 def acos(*, input):
     return torch.acos(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.atan))
 @register_acc_op
 def atan(*, input):
     return torch.atan(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.exp))
 @register_acc_op
 def exp(*, input):
     return torch.exp(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.log))
 @register_acc_op
 def log(*, input):
     return torch.log(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.sqrt))
 @register_acc_op
 def sqrt(*, input):
     return torch.sqrt(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.reciprocal))
 @register_acc_op
 def reciprocal(*, input):
     return torch.reciprocal(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.abs))
 @register_acc_op
 def abs(*, input):
     return torch.abs(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.neg))
 @register_acc_op
 def neg(*, input):
     return torch.neg(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.floor))
 @register_acc_op
 def floor(*, input):
     return torch.floor(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.ceil))
 @register_acc_op
 def ceil(*, input):
@@ -927,9 +951,8 @@ def quantized_conv2d(
     dilation,
     groups,
     padding_mode,
-    acc_out_ty=None,
+    acc_out_ty,
 ):
-    assert acc_out_ty is not None
     qparams = acc_utils.get_field_from_acc_out_ty(acc_out_ty, "qparams")
     return torch.nn.quantized.functional.conv2d(
         input,
@@ -1089,6 +1112,7 @@ def torch_split_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
         return new_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def split(*, input, split_size, dim):
     return torch.split(input, split_size, dim)
@@ -1197,27 +1221,28 @@ def embedding_bag_4bit_rowwise_offsets(
     return torch.ops.quantized.embedding_bag_4bit_rowwise_offsets(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.sin))
 @register_acc_op
 def sin(*, input):
     return torch.sin(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.cos))
 @register_acc_op
 def cos(*, input):
     return torch.cos(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.tan))
 @register_acc_op
 def tan(*, input):
     return torch.tan(**locals())
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.topk))
 @register_acc_op
 def topk(*, input, k, dim, largest, sorted):
@@ -1230,6 +1255,7 @@ def getitem(*, input, idx):
     return input[idx]
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
 def slice_tensor(*, input, dims, starts, stops, steps):
     slices: List[Optional[slice]] = [None for _ in range(input.dim())]
@@ -1281,6 +1307,7 @@ def custom_narrow_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
     return new_node
 
 
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.reshape),
     arg_replacement_tuples=[
@@ -1298,8 +1325,7 @@ def custom_narrow_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
     kwargs_to_move_to_acc_out_ty=[("shape", "shape")],
 )
 @register_acc_op
-def reshape(*, input, acc_out_ty=None):
-    assert acc_out_ty is not None
+def reshape(*, input, acc_out_ty):
     return torch.reshape(
         input, tuple(acc_utils.get_field_from_acc_out_ty(acc_out_ty, "shape"))
     )
@@ -1338,9 +1364,9 @@ def custom_tensor_reshape_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.
         return new_node
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op
-def to_dtype(input, acc_out_ty=None):
+def to_dtype(input, acc_out_ty):
     assert acc_out_ty is not None, "valid acc_out_ty needed"
     return input.to(dtype=acc_utils.get_field_from_acc_out_ty(acc_out_ty, "dtype"))
 
@@ -1416,7 +1442,6 @@ def custom_torch_add_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Nod
         return new_node
 
 
-@register_acc_op_properties(AccOpProperty.quantized)
 @register_custom_acc_mapper_fn(
     op_and_target=("call_module", nn.quantized.Linear),
     arg_replacement_tuples=[
@@ -1455,18 +1480,13 @@ def packed_quantized_linear_mapper(
                 linear_module.bias()
             )
 
-        qparams = {
-            "scale": linear_module.scale,
-            "zero_point": linear_module.zero_point
-        }
+        qparams = {"scale": linear_module.scale, "zero_point": linear_module.zero_point}
         # Create kwargs for acc_op.quantized_linear
         kwargs = {
             "input": node.kwargs["input"],
             "weight": get_weight,
             "bias": get_bias,
-            "acc_out_ty": acc_utils.build_raw_tensor_meta(
-                qparams=qparams
-            ),
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(qparams=qparams),
         }
 
         new_node = node.graph.call_function(quantized_linear, kwargs=kwargs)
@@ -1474,7 +1494,6 @@ def packed_quantized_linear_mapper(
         return new_node
 
 
-@register_acc_op_properties(AccOpProperty.quantized)
 @register_custom_acc_mapper_fn(
     op_and_target=("call_module", nn.quantized.Conv2d),
     arg_replacement_tuples=[
@@ -1509,10 +1528,7 @@ def packed_quantized_conv2d_mapper(
             get_bias = node.graph.get_attr(bias_name)
             get_bias.meta["tensor_meta"] = _extract_tensor_metadata(conv_module.bias())
 
-        qparams = {
-            "scale": conv_module.scale,
-            "zero_point": conv_module.zero_point
-        }
+        qparams = {"scale": conv_module.scale, "zero_point": conv_module.zero_point}
 
         # Create kwargs for acc_op.conv
         kwargs = {
@@ -1524,9 +1540,7 @@ def packed_quantized_conv2d_mapper(
             "dilation": conv_module.dilation,
             "groups": conv_module.groups,
             "padding_mode": conv_module.padding_mode,
-            "acc_out_ty": acc_utils.build_raw_tensor_meta(
-                qparams=qparams
-            ),
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(qparams=qparams),
         }
 
         new_node = node.graph.call_function(quantized_conv2d, kwargs=kwargs)
@@ -1534,7 +1548,6 @@ def packed_quantized_conv2d_mapper(
         return new_node
 
 
-@register_acc_op_properties(AccOpProperty.quantized)
 @register_custom_acc_mapper_fn(
     op_and_target=("call_function", torch.ops.quantized.add_relu),
     arg_replacement_tuples=[
@@ -1550,14 +1563,12 @@ def add_relu_unfuse_mapper(
     with node.graph.inserting_before(node):
         qparams = {
             "scale": node.kwargs["scale"],
-            "zero_point": node.kwargs["zero_point"]
+            "zero_point": node.kwargs["zero_point"],
         }
         add_kwargs = {
             "input": node.kwargs["input"],
             "other": node.kwargs["other"],
-            "acc_out_ty": acc_utils.build_raw_tensor_meta(
-                qparams=qparams
-            ),
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(qparams=qparams),
         }
         add_node = node.graph.call_function(quantized_add, kwargs=add_kwargs)
         add_node.meta = node.meta.copy()
@@ -1569,7 +1580,6 @@ def add_relu_unfuse_mapper(
         return relu_node
 
 
-@register_acc_op_properties(AccOpProperty.quantized)
 @register_custom_acc_mapper_fn(
     op_and_target=("call_module", nn.intrinsic.quantized.ConvReLU2d),
     arg_replacement_tuples=[
@@ -1596,18 +1606,23 @@ def packed_quantized_convrelu2d_mapper(
         return relu_node
 
 
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.gelu))
 @register_acc_op_mapping(op_and_target=("call_method", "gelu"))
 @register_acc_op
 def gelu(*, input):
     return torch.nn.functional.gelu(**locals())
 
+
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.cumsum))
 @register_acc_op_mapping(op_and_target=("call_method", "cumsum"))
 @register_acc_op
 def cumsum(*, input, dim, dtype=None):
     return torch.cumsum(**locals())
 
+
+@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.chunk))
 @register_acc_op_mapping(op_and_target=("call_method", "chunk"))
 @register_acc_op


### PR DESCRIPTION
Summary:
We added `AccOpProperty` for easy enablement of graph opts for new acc ops based on general properties. This diff adds
1. `AccOpProperty.unary`
2. Automated testing for acc ops with both `AccOpProperty.unary` and `AccOpProperty.pointwise` with `sink_reshape_ops` graph opt. [Adds coverage for 30 more acc_ops]
3. Refactors `graph_opts/TARGETS` to collect all graph optimizations into a common library
4. replaces `def foo(*, input, acc_out_ty=None): assert acc_out_ty is not None` with just `def foo(*, input, acc_out_ty)`. Let me know if there is some hidden purpose to the other implementation.
5. adds `AccOpProperty.*` flags to appropriate ops.

Test Plan:
`buck test mode/dev glow/fb/fx/graph_opts:test_fx_sink`

```
...
Summary
  Pass: 31
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/4222124724581304
```

Also ran
```
`buck test mode/dev glow/fb/fx/acc_tracer:`
```
```
...
Summary
  Pass: 136
  ListingSuccess: 4
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/5910974582823618
```

Reviewed By: jfix71

Differential Revision: D31671833

