### PR TITLE
[Vulkan] Add vulkan_perf_test with google benchmark

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -145,6 +145,23 @@ void Context::flush() {
   command().pool.purge();
 }
 
+void Context::wait(const at::Tensor& src) {
+  // wait only if Vulkan tensor
+  if (at::kVulkan == src.device().type()) {
+    api::Command::Pool& command_pool = command().pool;
+    api::Command::Buffer& command_buffer = command_pool.stream();
+
+    using Future = ops::vTensor::Future<const void, ops::vTensor::Access::Read>;
+    const ops::vTensor& v_src = ops::convert(src);
+    const Future v_src_future = v_src.host<const void>(command_buffer);
+
+    // This wait() is a no-op if data is not out of sync.  More often than
+    // not though, waits here are expected as the GPU catches up with
+    // compute submitted from CPU.
+    v_src_future.wait();
+  }
+}
+
 bool available() {
   return context();
 }

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -56,6 +56,10 @@ class Context final {
 
   void flush();
 
+  // Use this function only for debugging and testing when you want to make sure
+  // all GPU operations get finished before calling flush(). Otherwise, it may crash.
+  void wait(const at::Tensor& src);
+
  private:
   VkDevice device();
   VkQueue queue();

--- a/aten/src/ATen/native/vulkan/api/Helper.cpp
+++ b/aten/src/ATen/native/vulkan/api/Helper.cpp
@@ -12,17 +12,23 @@ void copy_texture_to_texture(
     api::Command::Buffer& command_buffer,
     api::Resource::Image::Object& src_image,
     api::Resource::Image::Object& dst_image,
-    api::utils::uvec3 src_extents,
+    api::utils::uvec3 copy_extents,
+    api::utils::uvec3 src_offset,
     api::utils::uvec3 dst_offset) {
   VkImageCopy copy_info{};
   copy_info.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
   copy_info.srcSubresource.layerCount = 1;
   copy_info.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
   copy_info.dstSubresource.layerCount = 1;
-  copy_info.extent.width = src_extents.data[0u];
-  copy_info.extent.height = src_extents.data[1u];
-  copy_info.extent.depth = src_extents.data[2u];
+  copy_info.extent.width = copy_extents.data[0u];
+  copy_info.extent.height = copy_extents.data[1u];
+  copy_info.extent.depth = copy_extents.data[2u];
+  copy_info.srcOffset.x = src_offset.data[0u];
+  copy_info.srcOffset.y = src_offset.data[1u];
+  copy_info.srcOffset.z = src_offset.data[2u];
+  copy_info.dstOffset.x = dst_offset.data[0u];
   copy_info.dstOffset.y = dst_offset.data[1u];
+  copy_info.dstOffset.z = dst_offset.data[2u];
 
   // To use vkCmdCopyImage, the stage of src & dst image must be set to vTensor::Stage::Transfer.
   vkCmdCopyImage(

--- a/aten/src/ATen/native/vulkan/api/Helper.h
+++ b/aten/src/ATen/native/vulkan/api/Helper.h
@@ -18,7 +18,8 @@ void copy_texture_to_texture(
     api::Command::Buffer& command_buffer,
     api::Resource::Image::Object& src_image,
     api::Resource::Image::Object& dst_image,
-    api::utils::uvec3 src_extents,
+    api::utils::uvec3 copy_extents,
+    api::utils::uvec3 src_offset,
     api::utils::uvec3 dst_offset);
 
 } // namespace utils

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -96,6 +96,61 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
   return convert(v_output);
 }
 
+Tensor cat_feature_mult4ch(const TensorList tensors, vTensor& v_output) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  int64_t depth_size_allprior = 0;
+  int64_t ch_interval = 0;
+  for (const auto& tensor : tensors) {
+    ch_interval += tensor.sizes()[1];
+  }
+  const int64_t depth_interval = ch_interval / 4;
+
+  auto dst_image = v_output.image(
+    command_buffer,
+    vTensor::Stage::Transfer,
+    vTensor::Access::Write);
+  uvec3 src_offset{};
+  uvec3 dst_offset{};
+
+  for (const auto& tensor : tensors) {
+    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Transfer);
+
+      const uint32_t depth_slice = safe_downcast<uint32_t>(tensor.sizes()[1] / 4);
+      uvec3 copy_extents {v_self.extents().data[0u],
+        v_self.extents().data[1u],
+        depth_slice};
+
+      for (int b = 0; b < tensor.sizes()[0]; ++b) {
+        src_offset.data[2u] = safe_downcast<uint32_t>(depth_slice * b);
+        dst_offset.data[2u] = depth_size_allprior + safe_downcast<uint32_t>(depth_interval * b);
+        api::helper::copy_texture_to_texture(command_buffer,
+          src_image,
+          dst_image,
+          copy_extents,
+          src_offset,
+          dst_offset);
+      }
+
+      depth_size_allprior += depth_slice;
+    }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+
+  return convert(v_output);
+}
+
 Tensor cat_width(const TensorList tensors, vTensor& v_output) {
   TORCH_CHECK(false, "Vulkan cat not implemented for width dimension!");
 }
@@ -110,6 +165,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
     vTensor::Stage::Transfer,
     vTensor::Access::Write);
 
+  uvec3 src_offset{};
   uvec3 dst_offset{};
   for (const auto& tensor : tensors) {
     const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
@@ -123,6 +179,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
         src_image,
         dst_image,
         v_self.extents(),
+        src_offset,
         dst_offset);
 
       // Increment by height
@@ -148,10 +205,15 @@ Tensor cat(
 
   at::Tensor tensor = tensors[0];
   int64_t cat_dim_size = 0;
+  bool is_mult4ch = true;
 
   for (const auto & t : tensors) {
      TORCH_INTERNAL_ASSERT(
       t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
+
+    if (t.sizes()[1] % 4 != 0) {
+      is_mult4ch = false;
+    }
 
     for (int d = 0; d < 4; ++d) {
       if (d == dim) {
@@ -179,6 +241,9 @@ Tensor cat(
     return cat_height(tensors, v_output);
   }
   else if (dim == 1) {
+    if (is_mult4ch) {
+      return cat_feature_mult4ch(tensors, v_output);
+    }
     return cat_feature(tensors, v_output);
   }
   return cat_batch(tensors, v_output);

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1905,13 +1905,13 @@ TEST(VulkanAPITest, cat_dim1_twotensors_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_bat1_ch4multiple_success) {
+TEST(VulkanAPITest, cat_dim1_bat1_mult4ch_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
   }
 
-  // Arrange: batch=1 and channel (multiples of 4 <-> channel %4 == 0)
+  // Arrange: batch=1 and channel (a multiple of 4 <-> channel %4 == 0)
   const auto in_cpu1 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu2 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_cpu3 = at::rand({1, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
@@ -1919,6 +1919,79 @@ TEST(VulkanAPITest, cat_dim1_bat1_ch4multiple_success) {
   // Act
   const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
   const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_bat2_mult4ch_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: batch=2 and channel (a multiple of 4 <-> channel %4 == 0)
+  const auto in_cpu1 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_mult4ch_mixed_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: batch=1 and channel (different multiples of 4 <-> channel %4 == 0)
+  const auto in_cpu1 = at::rand({3, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 8, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({3, 12, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1); // dim=feature(channel)
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanAPITest, cat_dim1_mult4ch_nonmult4ch_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange: batch=1 and channel (a mixed set of multiples and non-multiples of 4)
+  const auto in_cpu1 = at::rand({3, 3, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({3, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({3, 7, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu4 = at::rand({3, 8, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::cat({in_cpu1, in_cpu2, in_cpu3, in_cpu4}, 1);
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan(), in_cpu4.vulkan()}, 1); // dim=feature(channel)
 
   // Assert
   const auto check = almostEqual(out_cpu, out_vulkan.cpu());

--- a/aten/src/ATen/test/vulkan_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_perf_test.cpp
@@ -1,0 +1,53 @@
+#ifdef USE_VULKAN_API
+
+#include <benchmark/benchmark.h>
+
+#include <ATen/ATen.h>
+#include <ATen/native/vulkan/api/api.h>
+
+namespace {
+
+static void cat_op_channel_perf(benchmark::State& state) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto batches = state.range(0);
+  const auto channels = state.range(1);
+  const auto height = state.range(2);
+  const auto width = state.range(3);
+  const auto in_cpu1 = at::rand({batches, channels, height, width}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({batches, channels, height, width}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({batches, channels, height, width}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan1 = in_cpu1.vulkan();
+  const auto in_vulkan2 = in_cpu2.vulkan();
+  const auto in_vulkan3 = in_cpu3.vulkan();
+
+  // Act
+  while (state.KeepRunning()) {
+    const auto out_vulkan = at::cat({in_vulkan1, in_vulkan2, in_vulkan3}, 1);
+
+    // to avoid out-of-memory issues, release resources by waiting and flushing all GPU operations
+    at::native::vulkan::api::context()->wait(out_vulkan);
+    at::native::vulkan::api::context()->flush();
+  }
+}
+
+static void CommonBenchmarkSettings(benchmark::internal::Benchmark* b) {
+  b->Threads(1);  // No multi-thread since Vulkan backend is not thread-safe.
+  b->Unit(benchmark::kMillisecond);
+  b->ArgNames({"N", "C", "H", "W"});
+}
+
+} // namespace
+
+BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Iterations(1000)->Args({3, 40, 221, 193}); // big multiple of 4 channels
+BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Iterations(1000)->Args({3, 20, 221, 193}); // big multiple of 4 channels
+BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Iterations(1000)->Args({3, 39, 221, 193}); // big non-multiple of 4 channels
+BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Iterations(5000)->Args({3, 4, 221, 193}); // small multiple of 4 channels
+BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Iterations(5000)->Args({3, 3, 221, 193}); // small non-multiple of 4 channels
+BENCHMARK_MAIN();
+
+#endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
Added a new test `vulkan_perf_test` for measuring performance with google benchmark.
**Summay:**
* `vulkan_perf_test` can be used to perform a quick benchmark test for Vulkan features to compare before and after performance when applying a new method and/or optimizing the existing implementation on your local machine.
* The **google benchmark** 3rd party library (https://github.com/google/benchmark) is already in the repo (`fbsource/third-party/benchmark`).
* The number of threads is set to 1 since Vulkan backend is not thread-safe.
* Added a new API `Context::wait()` to allow benchmark tests to wait for all GPU operations to be done before calling `Context::flush()` 
* Call `Context::wait()` for each output Vulkan tensor and then `Context::flush()` to avoid out-of-memory issues while running a number of iterations in the benchmark test code
* Use `Time` column (wall clock) as a total execution time for each iteration (instead of `CPU` column = CPU execution time only) from the benchmark result table
* The more iterations, the more reliable data. But, it will take much longer. 100-1,000 iterations for bigger tensors and 5,000-10,000 iterations for smaller ones would be sufficient.
* The benchmark data on MacOS is not reliable since there is an extra layer [MoltenVk](https://github.com/KhronosGroup/MoltenVK) that is running on top of `Metal`. And also running Vulkan models on MacOS instead of Metal ones is generally not a good idea.

**Next steps:**
* Add more benchmark tests as we optimize more Vulkan operators
* Consider using Vulkan own performance counter such as [uVkCompute](https://github.com/google/uVkCompute) in the near future. Each iteration time can be manually set by `benchmark::State::SetIterationTime()` and `Benchmark::UseManualTime()` APIs (see [UseManualTime API](https://github.com/google/benchmark/blob/365670e4328beb694d0a3adaf40a5974a616bb17/include/benchmark/benchmark.h#L1013))
* Consider this `vulkan_perf_test` as a performance BAT (Build Acceptance Test) on the CI pipeline. `gtest` and `google benchmark` can be written in the same place ([see](https://stackoverflow.com/questions/8565666/benchmarking-with-googletest)). And [swiftshader](https://github.com/google/swiftshader) can be used for Sandcastle devservers that don't support Vulkan. We may come up with a reasonable performance criteria for each test and it will fail if any significant performance degradation.
* 
Test Plan:
**Test build on Android**
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_perf_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_perf_test
adb shell "/data/local/tmp/vulkan_perf_test"
```
**Test build on MacOS**
```
cd ~/fbsource
buck build //xplat/caffe2:pt_vulkan_perf_test_binAppleMac
./buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAppleMac\#macosx-x86_64
```

**Test result on Google Pixel 5**
```
Running /data/local/tmp/vulkan_perf_test
Run on (8 X 1804.8 MHz CPU s)
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------------------
Benchmark (Without optimization for 4x channels)                            Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:1       60.4 ms         14.1 ms         1000
cat_op_channel_perf/N:3/C:20/H:221/W:193/iterations:1000/threads:1       24.1 ms        0.947 ms         1000
cat_op_channel_perf/N:3/C:39/H:221/W:193/iterations:1000/threads:1       59.6 ms         14.0 ms         1000
cat_op_channel_perf/N:3/C:4/H:221/W:193/iterations:5000/threads:1        5.98 ms        0.844 ms         5000
cat_op_channel_perf/N:3/C:3/H:221/W:193/iterations:5000/threads:1        6.02 ms        0.845 ms         5000
-------------------------------------------------------------------------------------------------------------
Benchmark (With optimization for 4x channels)                               Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:1       39.3 ms         13.3 ms         1000
cat_op_channel_perf/N:3/C:20/H:221/W:193/iterations:1000/threads:1       16.4 ms         3.49 ms         1000
cat_op_channel_perf/N:3/C:39/H:221/W:193/iterations:1000/threads:1       59.7 ms         14.1 ms         1000
cat_op_channel_perf/N:3/C:4/H:221/W:193/iterations:5000/threads:1        3.93 ms        0.855 ms         5000
cat_op_channel_perf/N:3/C:3/H:221/W:193/iterations:5000/threads:1        6.14 ms        0.852 ms         5000
```
Note that the smaller tensors (`3.93 ms` vs `6.14 ms` when comparing `{3,4,221,193}` with `{3,3,221,193}`) receive significant improvement on the Android builds. Because `vkCmdCopyImage` API is used for the bigger tensor `{3,4,22,193}` instead of shader operations.
* `{3,40,221,193}`: 60.4 ms -> 39.3 ms (34.93% faster)
* `{3,20,221,193}`: 24.1 ms -> 16.4 ms (31.95% faster)
* `{3,4,221,193}`: 5.98 ms -> 3.93 ms (34.28% faster)
![image](https://user-images.githubusercontent.com/88354936/138922878-00104b9e-a291-4886-8ca9-36e3953d21c4.png)

**Test result on MacOS**
```
Running ./buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAppleMac#macosx-x86_64
Run on (16 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 5.95, 5.02, 5.15
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------------------------------------------
Benchmark (Without optimization for 4x channels)                            Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:1       51.2 ms         35.5 ms         1000
cat_op_channel_perf/N:3/C:20/H:221/W:193/iterations:1000/threads:1       11.4 ms         4.76 ms         1000
cat_op_channel_perf/N:3/C:39/H:221/W:193/iterations:1000/threads:1       51.9 ms         35.0 ms         1000
cat_op_channel_perf/N:3/C:4/H:221/W:193/iterations:5000/threads:1        2.84 ms         1.36 ms         5000
cat_op_channel_perf/N:3/C:3/H:221/W:193/iterations:5000/threads:1        2.30 ms         1.13 ms         5000
-------------------------------------------------------------------------------------------------------------
Benchmark (With optimization for 4x channels)                               Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:1       70.1 ms         36.9 ms         1000
cat_op_channel_perf/N:3/C:20/H:221/W:193/iterations:1000/threads:1       11.8 ms         5.00 ms         1000
cat_op_channel_perf/N:3/C:39/H:221/W:193/iterations:1000/threads:1       69.3 ms         36.8 ms         1000
cat_op_channel_perf/N:3/C:4/H:221/W:193/iterations:5000/threads:1        4.60 ms         1.48 ms         5000
cat_op_channel_perf/N:3/C:3/H:221/W:193/iterations:5000/threads:1        3.65 ms         1.41 ms         5000
```
Note that `{3,40,221,193}` input tensors don't receive any performance improvement when we use `vkCmdCopyImage` API to directly copy textures when the number of channel is a multiple of 4 on MacOS. This is maybe due to an extra layer [MoltenVk](https://github.com/KhronosGroup/MoltenVK) that is running on top of `Metal`.

Differential Revision: D31906379

