### PR TITLE
[fx-acc] PassManager

### DIFF
--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -1,0 +1,121 @@
+from typing import Any, Callable, List, Protocol, Type, TypeVar
+import torch.nn as nn
+
+T1 = TypeVar('T1', bound=nn.Module)
+T2 = TypeVar('T2', bound=nn.Module)
+
+class Pass(Protocol[T1, T2]):
+    def __call__(self, g: T1) -> T2:
+        ...
+
+
+# for callables which modify object inplace and return something other than
+# the object on which they act
+def inplace_wrapper(fn: Callable[[T1], Any]) -> Pass:
+    def wrapped_fn(gm: T1) -> T1:
+        fn(gm)
+        return gm
+
+    return wrapped_fn
+
+
+class LoopPass(Pass):
+    def __init__(self, _pass: Pass, n_iter: int = None, predicate: Callable = None):
+        self._pass = _pass
+        self._n_iter = n_iter
+        self._predicate = predicate
+        assert n_iter is None or predicate is None
+
+    def __call__(self, source):
+        if self._n_iter:
+            for _ in range(self._n_iter):
+                self._pass(source)
+        else:
+            while self._predicate(self._pass(source)):
+                continue
+        return source
+
+
+# Constraints are implemented as 'less than' operators. A constraint is
+# satisfied iff a list has a valid partial ordering according to this
+# comparison operator.
+class PassScheduleConstraint:
+    def lt(self, a, b):
+        raise NotImplementedError()
+
+    def validate(self, passes: List[Pass]):
+        for i, a in enumerate(passes):
+            for j, b in enumerate(passes[i + 1 :]):
+                if self.lt(a, b):
+                    continue
+                raise RuntimeError(
+                    f"PassScheduleConstraint {self} violated. Expected {a} before {b}"
+                    f" but found {a} at index {i} and {b} at index{j} in pass"
+                    f" list."
+                )
+
+
+class ThisBeforeThatConstraint(PassScheduleConstraint):
+    def __init__(self, this: Pass, that: Pass):
+        self._this = this
+        self._that = that
+
+    def lt(self, a, b):
+        if a == self._that and b == self._this:
+            return False
+        return True
+
+
+class TheseBeforeThoseConstraint(PassScheduleConstraint):
+    def __init__(self, these: Type[Pass], those: Type[Pass]):
+        self._these = these
+        self._those = those
+
+    def lt(self, a, b):
+        if isinstance(a, self._those) and isinstance(b, self._these):
+            return False
+        return True
+
+
+class PassManager(Pass):
+    def __init__(self, passes: List[Pass] = None, constraints: List[Callable] = None):
+        self._passes = passes or []
+        self._constraints = constraints or []
+        self._validated = False
+
+    def add_pass(self, _pass: Pass):
+        self._passes.append(_pass)
+        self._validated = False
+
+    def add_constraint(self, constraint):
+        self._constraints.append(constraint)
+        self._validated = False
+
+    def validate(self):
+        if self._validated:
+            return
+        for constraint in self._constraints:
+            constraint.validate(self._passes)
+        self._validated = True
+
+    def __call__(self, source):
+        self.validate()
+        out = source
+        for _pass in self._passes:
+            out = _pass(out)
+        return out
+
+
+class PassManagerBuilder:
+    @classmethod
+    def build_from_passlist(cls, passes: List[Pass]) -> PassManager:
+        pm = PassManager()
+
+        # Add passes
+        for _pass in passes:
+            pm.add_pass(_pass)
+
+        # TODO(@alexbeloi): Add constraints to preserve given order
+        # TODO(@alexbeloi): Add validation
+
+        return pm

--- a/torch/fx/passes/tests/test_pass_manager.py
+++ b/torch/fx/passes/tests/test_pass_manager.py
@@ -1,0 +1,16 @@
+import unittest
+
+from caffe2.torch.fx.passes.pass_manager import PassManagerBuilder, ThisBeforeThatConstraint
+
+class TestPassManager(unittest.TestCase):
+    def test_pass_manager_builder(self):
+        passes = [
+            lambda x: 2 * x for _ in range(10)
+        ]
+        pm = PassManagerBuilder.build_from_passlist(passes)
+        pm.validate()
+
+        # add unfulfillable constraint
+        pm.add_constraint(ThisBeforeThatConstraint(passes[-1], passes[0]))
+
+        self.assertRaises(RuntimeError, pm.validate)


### PR DESCRIPTION
Summary:
Adds a `Pass`, `PassManager`, `PassConstraint`, `PassManagerBuilder`.

The idea is that a `Pass` modifies an IR in-place. `PassConstraint`s define a partial ordering on `Pass`s with a `lt` (less than) method. `PassManager` manages the collection of `Pass`s, `PassConstraint`s and ensures validation before execution. `PassManagerBuilder` creates `PassManager`s (example usage in follow-up diff).

These are very loosely typed, so could be applied to different IRs as well as transformation between IRs.

Test Plan:
```
buck test mode/opt //caffe2/torch/fx/passes:test_pass_manager
```
```
Invalidating internal cached state: Buck configuration options changed between invocations. This may cause slower builds.
  Changed value //project.buck_out='buck-out/opt' (was 'buck-out/dev')
  ... and 277 more. See logs for all changes
Parsing buck files: finished in 1.4 sec
Downloaded 7/22 artifacts, 24.06 Kbytes, 58.8% cache miss (for updated rules)
Building: finished in 3.2 sec (100%) 264/264 jobs, 264/264 updated
  Total time: 4.8 sec
More details at https://www.internalfb.com/intern/buck/build/e41d6cf9-f561-4454-99c4-57e294965eee
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 035b0bee-14f1-41b9-aec2-6ccfdc8eb994
Trace available for this run at /tmp/tpx-20211021-001311.235202/trace.log
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/3940649747763055
    ✓ ListingSuccess: caffe2/torch/fx/passes:test_pass_manager - main (0.290)
    ✓ Pass: caffe2/torch/fx/passes:test_pass_manager - test_pass_manager_builder (caffe2.torch.fx.passes.tests.test_pass_manager.TestPassManager) (0.207)
Summary
  Pass: 1
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/3940649747763055
```

Reviewed By: jfix71

Differential Revision: D31316086

