### PR TITLE
.github: Add 4xlarge nvidia gpu to scale-config

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -27,6 +27,11 @@ runner_types:
     os: linux
     max_available: 125
     disk_size: 150
+  linux.4xlarge.nvidia.gpu:
+    instance_type: g3.4xlarge
+    os: linux
+    max_available: 125
+    disk_size: 150
   linux.16xlarge.nvidia.gpu:
     instance_type: g3.16xlarge
     os: linux


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67262

Adds a 4xlarge nvidia gpu variant to our scale-config.yml

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D31931941](https://our.internmc.facebook.com/intern/diff/D31931941)