### PR TITLE
[ONNX] Support conv-bn fusion in blocks (#66152)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -313,7 +313,7 @@ class TestONNXRuntime(unittest.TestCase):
             scripting_remained_onnx_input_idx = remained_onnx_input_idx
             tracing_remained_onnx_input_idx = remained_onnx_input_idx
 
-        if self.is_script_test_enabled:
+        if self.is_script_test_enabled and not isinstance(model, torch.jit.ScriptModule):
             script_model = torch.jit.script(model)
             _run_test(script_model, scripting_remained_onnx_input_idx, flatten=False)
 
@@ -495,6 +495,38 @@ class TestONNXRuntime(unittest.TestCase):
         model = Fuse()
         x = torch.randn(2, 3, 10, 50, 100, requires_grad=True)
         self.run_test(model, (x,), rtol=1e-3, atol=1e-6)
+
+    def test_fuse_conv_in_block(self):
+        class Fuse(torch.nn.Module):
+            def __init__(self):
+                super(Fuse, self).__init__()
+                self.conv = torch.nn.Conv1d(
+                    in_channels=5,
+                    out_channels=5,
+                    kernel_size=3,
+                    stride=1,
+                    padding=2,
+                    dilation=1
+                )
+                self.bn = torch.nn.BatchNorm1d(5)
+
+            def forward(self, x):
+                results_available = True
+
+                if x.sum() > -1:
+                    results_available = False
+
+                if results_available:
+                    x = self.conv(x)
+                    x = self.bn(x)
+
+                return x
+
+        model = Fuse()
+        x = torch.randn(2, 5, 9, requires_grad=True)
+        self.run_test(torch.jit.script(model), (x,),
+                      input_names=['x'], dynamic_axes={'x': [0, 2]},
+                      rtol=1e-3, atol=1e-6)
 
     def test_conv_tbc(self):
         from torch.nn.modules.utils import _single

--- a/torch/csrc/jit/passes/onnx/eval_peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/eval_peephole.cpp
@@ -129,7 +129,7 @@ static void fuseConvBatchNorm(Block* b, ValueToParamPairMap& valsToParamsMap) {
       newConvW->inferTypeFrom(convW);
       newConv->addInput(newConvW);
 
-      auto newConvB = b->addInput();
+      auto newConvB = b->owningGraph()->addInput();
       valsToParamsMap.insert(
           {newConvB, std::make_pair(newConvB->debugName(), convB)});
       newConvB->inferTypeFrom(convB);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67278 Remove the argument strip_doc_string of export() method entirely. (#66615)
* #67277 Deprecate the argument _retain_param_name of export() method entirely. (#66617)
* #67276 [ONNX] Remove the argument enable_onnx_checker of export() method entirely. (#66611)
* #67275 [ONNX] Update value name copying logic for onnx (#66170)
* #67274 [ONNX] Update onnx function export with comments and clean up (#66817)
* #67273 [ONNX] Relax check on Prim::PythonOp nodes for ONNX_FALLTHROUGH (#66172)
* **#67272 [ONNX] Support conv-bn fusion in blocks (#66152)**
* #67271 [ONNX] Use Reciprocal operator instead of Div(1, x). (#65382)
* #67270 [ONNX] Add dim argument to all symbolic (#66093)
* #67269 [ONNX] Update onnxruntime to 1.9 for CI (#65029)

* Support conv-bn fusion in nested blocks

* avoid running script tests twice

Differential Revision: [D31962513](https://our.internmc.facebook.com/intern/diff/D31962513)