### PR TITLE
[ONNX] Relax check on Prim::PythonOp nodes for ONNX_FALLTHROUGH (#66172)

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -915,6 +915,33 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         iter = graph.nodes()
         self.assertEqual(next(iter).kind(), "CustomNamespace::Custom")
 
+    def test_autograd_onnx_fallthrough(self):
+        class CustomFunction(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input):
+                ctx.save_for_backward(input)
+                return input.clamp(min=0)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                input, = ctx.saved_tensors
+                grad_input = grad_output.clone()
+                grad_input[input < 0] = 0
+                return grad_input
+
+        class Custom(torch.nn.Module):
+            def forward(self, input):
+                return CustomFunction.apply(input)
+
+        model = Custom()
+        batch = torch.FloatTensor(1, 3)
+
+        graph, _, _ = self._model_to_graph(model, batch,
+                                           operator_export_type=OperatorExportTypes.ONNX_FALLTHROUGH,
+                                           input_names=["batch"], dynamic_axes={"batch": [0, 1]})
+        iter = graph.nodes()
+        self.assertEqual(next(iter).kind(), "prim::PythonOp")
+
     def test_unused_initializers(self):
         class Model(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -71,10 +71,13 @@ void validateBlock(
       "\n\nGraph we tried to export:\n" + b->owningGraph()->toString());
     // Special error messages for certain types of operators
     if (node->kind() == prim::PythonOp) {
-      auto py_node = static_cast<PythonOp*>(node);
-      FAIL_EXPORT(
-          "Couldn't export Python operator " + py_node->name() +
-          "\n\nDefined at:\n" + getNodeStackTraceString(node))
+      if (operator_export_type !=
+          onnx_torch::OperatorExportTypes::ONNX_FALLTHROUGH) {
+        auto py_node = static_cast<PythonOp*>(node);
+        FAIL_EXPORT(
+            "Couldn't export Python operator " + py_node->name() +
+            "\n\nDefined at:\n" + getNodeStackTraceString(node))
+      }
     } else {
       if (node->kind() == aten::expand) {
         if (operator_export_type ==


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67278 Remove the argument strip_doc_string of export() method entirely. (#66615)
* #67277 Deprecate the argument _retain_param_name of export() method entirely. (#66617)
* #67276 [ONNX] Remove the argument enable_onnx_checker of export() method entirely. (#66611)
* #67275 [ONNX] Update value name copying logic for onnx (#66170)
* #67274 [ONNX] Update onnx function export with comments and clean up (#66817)
* **#67273 [ONNX] Relax check on Prim::PythonOp nodes for ONNX_FALLTHROUGH (#66172)**
* #67272 [ONNX] Support conv-bn fusion in blocks (#66152)
* #67271 [ONNX] Use Reciprocal operator instead of Div(1, x). (#65382)
* #67270 [ONNX] Add dim argument to all symbolic (#66093)
* #67269 [ONNX] Update onnxruntime to 1.9 for CI (#65029)

* Relax check on Prim::PythonOp nodes for Onnx_fallthrough

* Add tests

Differential Revision: [D31962521](https://our.internmc.facebook.com/intern/diff/D31962521)