### PR TITLE
[ONNX] Update value name copying logic for onnx (#66170)

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1093,6 +1093,35 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             self.assertNotEqual(node.kind(), "prim::Constant")
         self.assertEqual(len(list(graph.nodes())), 2)  # onnx::Sub and onnx::Add nodes only.
 
+    def test_onnx_value_name(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.in_weight = torch.nn.Parameter(torch.Tensor(3, 3))
+                self.in_bias = torch.nn.Parameter(torch.Tensor(3))
+
+            def forward(self, x):
+                start = 0
+                end = None
+                weight = self.in_weight
+                bias = self.in_bias
+                weight = weight[start:end, :]
+                if bias is not None:
+                    bias = bias[start:end]
+                return torch.nn.functional.linear(x, weight, bias)
+
+        model = MyModule()
+        x = torch.randn(3, 3)
+        f = io.BytesIO()
+
+        model.eval()
+        torch.onnx.export(model, (x,), f,
+                          opset_version=self.opset_version,
+                          keep_initializers_as_inputs=True)
+        graph = onnx.load(io.BytesIO(f.getvalue()))
+        self.assertEqual(graph.graph.input[1].name, "in_weight")
+        self.assertEqual(graph.graph.input[2].name, "in_bias")
+
     def test_duplicated_output_node(self):
         class DuplicatedOutputNet(torch.nn.Module):
             def __init__(self, input_size, num_classes):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67278 Remove the argument strip_doc_string of export() method entirely. (#66615)
* #67277 Deprecate the argument _retain_param_name of export() method entirely. (#66617)
* #67276 [ONNX] Remove the argument enable_onnx_checker of export() method entirely. (#66611)
* **#67275 [ONNX] Update value name copying logic for onnx (#66170)**
* #67274 [ONNX] Update onnx function export with comments and clean up (#66817)
* #67273 [ONNX] Relax check on Prim::PythonOp nodes for ONNX_FALLTHROUGH (#66172)
* #67272 [ONNX] Support conv-bn fusion in blocks (#66152)
* #67271 [ONNX] Use Reciprocal operator instead of Div(1, x). (#65382)
* #67270 [ONNX] Add dim argument to all symbolic (#66093)
* #67269 [ONNX] Update onnxruntime to 1.9 for CI (#65029)

Specifically targets the symbolic functions that directly returns input as output. The old logic will override the value name with output value name. But since the input is unmodified and unchanged, it is more logically to keep its original input name. Especially for cases where inputs are directly from model parameters.

Co-authored-by: BowenBao <bowbao@microsoft.com>

Differential Revision: [D31962517](https://our.internmc.facebook.com/intern/diff/D31962517)