### PR TITLE
Deprecate the argument _retain_param_name of export() method entirely. (#66617)

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -35,10 +35,9 @@ def _export(*args, **kwargs):
 
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None, use_external_data_format=None,
-           export_modules_as_functions=False):
+           opset_version=None, do_constant_folding=True, example_outputs=None,
+           strip_doc_string=None, dynamic_axes=None, keep_initializers_as_inputs=None,
+           custom_opsets=None, use_external_data_format=None, export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
@@ -187,8 +186,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         opset_version (int, default 9):
             Must be ``== _onnx_main_opset or in _onnx_stable_opsets``,
             defined in torch/onnx/symbolic_helper.py.
-        _retain_param_name (bool, default True): Deprecated and ignored. Will be removed in next PyTorch
-            release.
         do_constant_folding (bool, default False): Apply the constant-folding optimization.
             Constant-folding will replace some of the ops that have all constant inputs
             with pre-computed constant nodes.
@@ -313,9 +310,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
     from torch.onnx import utils
     return utils.export(model, args, f, export_params, verbose, training,
                         input_names, output_names, operator_export_type, opset_version,
-                        _retain_param_name, do_constant_folding, example_outputs,
-                        strip_doc_string, dynamic_axes, keep_initializers_as_inputs,
-                        custom_opsets, use_external_data_format, export_modules_as_functions)
+                        do_constant_folding, example_outputs, strip_doc_string,
+                        dynamic_axes, keep_initializers_as_inputs, custom_opsets,
+                        use_external_data_format, export_modules_as_functions)
 
 
 def export_to_pretty_string(*args, **kwargs) -> str:

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -103,19 +103,16 @@ def exporter_context(model, mode):
 
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
-           opset_version=None, _retain_param_name=None, do_constant_folding=True,
-           example_outputs=None, strip_doc_string=None, dynamic_axes=None,
-           keep_initializers_as_inputs=None, custom_opsets=None,
-           use_external_data_format=None, export_modules_as_functions=False):
+           opset_version=None, do_constant_folding=True, example_outputs=None,
+           strip_doc_string=None, dynamic_axes=None, keep_initializers_as_inputs=None,
+           custom_opsets=None, use_external_data_format=None,
+           export_modules_as_functions=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
 
-    if _retain_param_name is not None:
-        warnings.warn("'_retain_param_name' is deprecated and ignored. "
-                      "It will be removed in the next PyTorch release.")
     if strip_doc_string is not None:
         warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
                       "next PyTorch release. It's combined with `verbose' argument now. ")
@@ -591,14 +588,10 @@ def _model_to_graph(model, args, verbose=False,
 def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
                             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
-                            google_printer=False, opset_version=None, _retain_param_name=None,
-                            keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
-                            do_constant_folding=True, dynamic_axes=None):
+                            google_printer=False, opset_version=None, keep_initializers_as_inputs=None,
+                            custom_opsets=None, add_node_names=True, do_constant_folding=True, dynamic_axes=None):
     if f is not None:
         warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
-    if _retain_param_name is not None:
-        warnings.warn("'_retain_param_name' is deprecated and ignored. "
-                      "It will be removed in the next PyTorch release.")
     return _export_to_pretty_string(model, args, f, export_params, verbose, training,
                                     input_names, output_names, operator_export_type,
                                     export_type, example_outputs, google_printer,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67278 Remove the argument strip_doc_string of export() method entirely. (#66615)
* **#67277 Deprecate the argument _retain_param_name of export() method entirely. (#66617)**
* #67276 [ONNX] Remove the argument enable_onnx_checker of export() method entirely. (#66611)
* #67275 [ONNX] Update value name copying logic for onnx (#66170)
* #67274 [ONNX] Update onnx function export with comments and clean up (#66817)
* #67273 [ONNX] Relax check on Prim::PythonOp nodes for ONNX_FALLTHROUGH (#66172)
* #67272 [ONNX] Support conv-bn fusion in blocks (#66152)
* #67271 [ONNX] Use Reciprocal operator instead of Div(1, x). (#65382)
* #67270 [ONNX] Add dim argument to all symbolic (#66093)
* #67269 [ONNX] Update onnxruntime to 1.9 for CI (#65029)

Remove the argument _retain_param_name of export() method entirely.

Co-authored-by: fatcat-z <jiz@microsoft.com>

Differential Revision: [D31962514](https://our.internmc.facebook.com/intern/diff/D31962514)