### PR TITLE
Remove the argument strip_doc_string of export() method entirely. (#66615)

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -36,8 +36,8 @@ def _export(*args, **kwargs):
 def export(model, args, f, export_params=True, verbose=False, training=TrainingMode.EVAL,
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, do_constant_folding=True, example_outputs=None,
-           strip_doc_string=None, dynamic_axes=None, keep_initializers_as_inputs=None,
-           custom_opsets=None, use_external_data_format=None, export_modules_as_functions=False):
+           dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
+           use_external_data_format=None, export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
@@ -191,7 +191,6 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             with pre-computed constant nodes.
         example_outputs (T or a tuple of T, where T is Tensor or convertible to Tensor, default None):
             Deprecated and ignored. Will be removed in next PyTorch release.
-        strip_doc_string (bool, default True): Deprecated and ignored. Will be removed in next PyTorch release.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
 
             By default the exported model will have the shapes of all input and output tensors
@@ -310,8 +309,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
     from torch.onnx import utils
     return utils.export(model, args, f, export_params, verbose, training,
                         input_names, output_names, operator_export_type, opset_version,
-                        do_constant_folding, example_outputs, strip_doc_string,
-                        dynamic_axes, keep_initializers_as_inputs, custom_opsets,
+                        do_constant_folding, example_outputs, dynamic_axes,
+                        keep_initializers_as_inputs, custom_opsets,
                         use_external_data_format, export_modules_as_functions)
 
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -104,18 +104,14 @@ def exporter_context(model, mode):
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, do_constant_folding=True, example_outputs=None,
-           strip_doc_string=None, dynamic_axes=None, keep_initializers_as_inputs=None,
-           custom_opsets=None, use_external_data_format=None,
-           export_modules_as_functions=False):
+           dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
+           use_external_data_format=None, export_modules_as_functions=False):
     if operator_export_type is None:
         if torch.onnx.PYTORCH_ONNX_CAFFE2_BUNDLE:
             operator_export_type = OperatorExportTypes.ONNX_ATEN_FALLBACK
         else:
             operator_export_type = OperatorExportTypes.ONNX
 
-    if strip_doc_string is not None:
-        warnings.warn("`strip_doc_string' is deprecated and ignored. Will be removed in "
-                      "next PyTorch release. It's combined with `verbose' argument now. ")
     if example_outputs is not None:
         warnings.warn("`example_outputs' is deprecated and ignored. Will be removed in "
                       "next PyTorch release.")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#67278 Remove the argument strip_doc_string of export() method entirely. (#66615)**
* #67277 Deprecate the argument _retain_param_name of export() method entirely. (#66617)
* #67276 [ONNX] Remove the argument enable_onnx_checker of export() method entirely. (#66611)
* #67275 [ONNX] Update value name copying logic for onnx (#66170)
* #67274 [ONNX] Update onnx function export with comments and clean up (#66817)
* #67273 [ONNX] Relax check on Prim::PythonOp nodes for ONNX_FALLTHROUGH (#66172)
* #67272 [ONNX] Support conv-bn fusion in blocks (#66152)
* #67271 [ONNX] Use Reciprocal operator instead of Div(1, x). (#65382)
* #67270 [ONNX] Add dim argument to all symbolic (#66093)
* #67269 [ONNX] Update onnxruntime to 1.9 for CI (#65029)

Remove the argument strip_doc_string of export() method entirely.

Co-authored-by: fatcat-z <jiz@microsoft.com>

Differential Revision: [D31962512](https://our.internmc.facebook.com/intern/diff/D31962512)