### PR TITLE
Add register_frozenpython.cpp to the torch::deploy interpreter library in the OSS build

### DIFF
--- a/torch/csrc/deploy/interpreter/CMakeLists.txt
+++ b/torch/csrc/deploy/interpreter/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(torch_python_static STATIC $<TARGET_OBJECTS:torch_python_obj>)
 set(INTERPRETER_LIB_SOURCES
   ${INTERPRETER_DIR}/interpreter_impl.cpp
   ${INTERPRETER_DIR}/builtin_registry.cpp
+  ${INTERPRETER_DIR}/register_frozenpython.cpp
   ${INTERPRETER_DIR}/import_find_sharedfuncptr.cpp
   ${FROZEN_FILES}
   ${LINKER_SCRIPT}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67286
* __->__ #67280

PR #67085 split the python builtin registration to register_frozonpython.cpp but didn't add the file to OSS build. This causes segfault when running torch::deploy in OSS build. This PR is a quick fix.

Differential Revision: [D31935958](https://our.internmc.facebook.com/intern/diff/D31935958)