### PR TITLE
.github: Switch 8xlarge to 4xlarge instance_type

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -22,8 +22,10 @@ runner_types:
     os: linux
     max_available: 500
     disk_size: 150
+  # TODO: Remove linux.8xlarge.nvidia.gpu after November 03, 2021
+  #       Ensure no queued jobs depend on this node type before removing
   linux.8xlarge.nvidia.gpu:
-    instance_type: g3.8xlarge
+    instance_type: g3.4xlarge
     os: linux
     max_available: 125
     disk_size: 150


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67299

Switches the linux.8xlarge.nvidia.gpu to the 4xlarge instance type to
help with queueing / capacity issues. This change is only meant to be a
bridge until everyone updates their PRs to use the new
linux.4xlarge.nvidia.gpu node type

NOTE: This node type will be removed so do not depend on it for any new
workflows.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D31945507](https://our.internmc.facebook.com/intern/diff/D31945507)