### PR TITLE
Wrap TRTInterpreter result with wrapper

### DIFF
--- a/torch/fx/experimental/fx2trt/example/quantized_resnet_test.py
+++ b/torch/fx/experimental/fx2trt/example/quantized_resnet_test.py
@@ -15,8 +15,8 @@ def build_fp16_trt(rn18):
     rn18 = acc_tracer.trace(rn18, [torch.randn(1, 3, 224, 224)])
     interp = TRTInterpreter(
         rn18, [InputTensorSpec(torch.Size([3, 224, 224]), torch.float, has_batch_dim=False)])
-    engine, input_names, output_names = interp.run(fp16_mode=True)
-    return TRTModule(engine, input_names, output_names)
+    interpreter_result = interp.run(fp16_mode=True)
+    return TRTModule(interpreter_result.engine, interpreter_result.input_names, interpreter_result.output_names)
 
 @torch.no_grad()
 def build_int8_trt(rn18):

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -8,7 +8,10 @@ from torch.fx.node import _get_qualified_name
 from torch.fx.passes.shape_prop import TensorMetadata
 
 
-TRTInterpreterResult = Tuple[Any, Sequence[str], Sequence[str]]
+class TRTInterpreterResult(NamedTuple):
+    engine: Any
+    input_names: Sequence[str]
+    output_names: Sequence[str]
 
 
 # Borrowed from torch2trt
@@ -453,7 +456,7 @@ class TRTInterpreter(torch.fx.Interpreter):
 
         engine = self.builder.build_engine(self.network, builder_config)
         assert engine
-        return engine, self._input_names, self._output_names
+        return TRTInterpreterResult(engine, self._input_names, self._output_names)
 
     def run_node(self, n):
         self._cur_node_name = str(n)

--- a/torch/fx/experimental/fx2trt/tools/trt_minimizer.py
+++ b/torch/fx/experimental/fx2trt/tools/trt_minimizer.py
@@ -16,7 +16,8 @@ def lower_mod_default(
     interp = TRTInterpreter(
         mod, InputTensorSpec.from_tensors(inputs), explicit_batch_dimension=True
     )
-    res_mod = TRTModule(*interp.run(max_batch_size=batch_size))
+    interpreter_result = interp.run(max_batch_size=batch_size)
+    res_mod = TRTModule(interpreter_result.engine, interpreter_result.input_names, interpreter_result.output_names)
     return res_mod
 
 

--- a/torch/fx/experimental/fx2trt/tools/trt_splitter.py
+++ b/torch/fx/experimental/fx2trt/tools/trt_splitter.py
@@ -58,8 +58,8 @@ class TRTSplitter(splitter_base._SplitterBase):
         # Current code for lowering is place-holder, subject to future change
         # based on feeds model's actual status
         interp = TRTInterpreter(mod, InputTensorSpec.from_tensors(inputs))
-        engine, input_names, output_names = interp.run(*inputs)
-        return TRTModule(engine, input_names, output_names)
+        interpreter_result = interp.run(*inputs)
+        return TRTModule(interpreter_result.engine, interpreter_result.input_names, interpreter_result.output_names)
 
     def _find_culprit(self, mod: torch.fx.GraphModule, inputs: Tensors):
         """

--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -49,8 +49,8 @@ class TRTTestCase(unittest.TestCase):
             if len(expected_ops):
                 self.assert_has_op(mod, expected_ops)
 
-            engine, input_names, output_names = interpreter.run(fp16_mode=False)
-            trt_mod = TRTModule(engine, input_names, output_names)
+            interpreter_result = interpreter.run(fp16_mode=False)
+            trt_mod = TRTModule(interpreter_result.engine, interpreter_result.input_names, interpreter_result.output_names)
 
             ref_outputs = mod(*inputs)
             outputs = trt_mod(*cuda_inputs)
@@ -91,8 +91,8 @@ class TRTTestCase(unittest.TestCase):
             if len(expected_ops):
                 self.assert_has_op(mod, expected_ops)
 
-            engine, input_names, output_names = interpreter.run(fp16_mode=False)
-            trt_mod = TRTModule(engine, input_names, output_names)
+            interpreter_result = interpreter.run(fp16_mode=False)
+            trt_mod = TRTModule(interpreter_result.engine, interpreter_result.input_names, interpreter_result.output_names)
             res_trt = trt_mod(*cuda_inputs).cpu()
             res_cpu = mod(*inputs)
             assert len(res_trt) == len(res_cpu)


### PR DESCRIPTION
Summary: Wrap TRTInterpreter result so that any future change to output params is less likely to break existing use cases.

Test Plan: Run test with all touched file

Differential Revision: D31945634

