### PR TITLE
Test repository dispatch from pytorch/builder for CircleCI Binary Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ parameters:
   run_slow_gradcheck_build:
     type: boolean
     default: false
+  builder_circle_sha1:
+    type: string
+    default: ""
 
 executors:
   windows-with-nvidia-gpu:
@@ -407,6 +410,7 @@ binary_linux_build_params: &binary_linux_build_params
     BUILD_ENVIRONMENT: << parameters.build_environment >>
     LIBTORCH_VARIANT: << parameters.libtorch_variant >>
     ANACONDA_USER: pytorch
+    BUILDER_CIRCLE_SHA1: << pipeline.parameters.builder_circle_sha1 >>
   resource_class: << parameters.resource_class >>
   docker:
     - image: << parameters.docker_image >>

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -63,6 +63,11 @@ popd
 # Clone the Builder master repo
 retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
+if [[ -n "${BUILDER_CIRCLE_SHA1:-}" ]]; then
+  # Check out a specific commit (typically the latest) from pytorch/builder
+  git reset --hard "${BUILDER_CIRCLE_SHA1}"
+  git checkout -q -B main
+fi
 echo "Using builder from "
 git --no-pager log --max-count 1
 popd

--- a/.circleci/verbatim-sources/build-parameters/binary-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/binary-build-params.yml
@@ -16,6 +16,7 @@ binary_linux_build_params: &binary_linux_build_params
     BUILD_ENVIRONMENT: << parameters.build_environment >>
     LIBTORCH_VARIANT: << parameters.libtorch_variant >>
     ANACONDA_USER: pytorch
+    BUILDER_CIRCLE_SHA1: << pipeline.parameters.builder_circle_sha1 >>
   resource_class: << parameters.resource_class >>
   docker:
     - image: << parameters.docker_image >>

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -20,6 +20,9 @@ parameters:
   run_slow_gradcheck_build:
     type: boolean
     default: false
+  builder_circle_sha1:
+    type: string
+    default: ""
 
 executors:
   windows-with-nvidia-gpu:


### PR DESCRIPTION
Test if CircleCI workflow can be triggered by a PR from`pytorch/builder`
Fix issue: https://github.com/pytorch/builder/issues/865