### PR TITLE
[LTC] Refactor torch_lazy_tensors::Device

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -13,6 +13,7 @@ namespace torch_lazy_tensors {
 namespace bridge {
 namespace {
 
+// TODO(alanwaketan): Move it to the backend interface.
 class AtenLtcDeviceMapper {
  public:
   static AtenLtcDeviceMapper* Get();
@@ -31,7 +32,8 @@ class AtenLtcDeviceMapper {
   AtenLtcDeviceMapper() {
     for (auto& device_str :
          compiler::getBackend()->GetLocalDevices()) {
-      devices_.emplace_back(device_str);
+      // TODO(alanwaketan): The backend should do the mapping themselves, and construct the device accordingly.
+      devices_.emplace_back();
       devices_ordinals_[devices_.back()] = devices_.size() - 1;
     }
   }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/backend_registrar.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/backend_registrar.cpp
@@ -23,13 +23,6 @@ at::Tensor MakeTensorFromComputationData(
       ->MakeTensorFromComputationData(data, logical_scalar_type);
 }
 
-torch_lazy_tensors::compiler::BackendDataPtr MakeComputationDataFromTensor(
-    const at::Tensor& tensor, const lazy_tensors::Shape& shape,
-    const std::string& device) {
-  return compiler::getBackend()
-      ->MakeComputationDataFromTensor(tensor, shape, device);
-}
-
 }  // namespace compiler
 
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/compiler/backend_impl_interface.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/compiler/backend_impl_interface.h
@@ -34,10 +34,10 @@ class BackendImplInterface {
 
   virtual BackendDataPtr MakeComputationDataFromTensor(
       const at::Tensor& tensor, const lazy_tensors::Shape& shape,
-      const std::string& device) const = 0;
+      const Device& device) const = 0;
 
-  virtual BackendDataPtr CreateDataPlaceholder(std::string device,
-                                        lazy_tensors::Shape shape) const = 0;
+  virtual BackendDataPtr CreateDataPlaceholder(const Device& device,
+      const lazy_tensors::Shape& shape) const = 0;
 
   virtual at::Tensor MakeTensorFromComputationData(
       const BackendDataPtr data,
@@ -64,7 +64,7 @@ class BackendImplInterface {
 
   virtual std::vector<BackendDataPtr> ExecuteComputation(
       Computation& computation, c10::ArrayRef<BackendDataPtr> arguments,
-      const std::string& device) const = 0;
+      const Device& device) const = 0;
 
   /**
    * Device Configuration
@@ -74,6 +74,7 @@ class BackendImplInterface {
 
   virtual size_t GetNumDevices() const = 0;
 
+  // TODO: Return std::vector<Device> instead.
   virtual std::vector<std::string> GetLocalDevices() const = 0;
 
   virtual std::vector<std::string> GetAllDevices() const = 0;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/compiler/data.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/compiler/data.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string.h>
+#include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensors/shape.h"
 
 namespace torch_lazy_tensors {
@@ -20,12 +21,12 @@ class BackendData {
    * */
   using Handle = int64_t;
 
-  BackendData(std::string device, lazy_tensors::Shape shape)
-      : device_(std::move(device)), shape_(std::move(shape)) {}
+  BackendData(const Device& device, const lazy_tensors::Shape& shape)
+      : device_(device), shape_(shape) {}
 
   virtual ~BackendData() {}
 
-  const std::string& device() const { return device_; }
+  const Device& device() const { return device_; }
 
   const lazy_tensors::Shape& shape() const { return shape_; }
 
@@ -43,7 +44,7 @@ class BackendData {
   virtual bool HasValue() const = 0;
 
  private:
-  std::string device_;
+  Device device_;
   lazy_tensors::Shape shape_;
   std::shared_ptr<Info> info_;
 };

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
@@ -30,7 +30,7 @@ std::ostream& operator<<(std::ostream& os, const Device& device) {
 }
 
 const Device* GetDefaultDevice() {
-  static const Device* default_device = new Device("");
+  static const Device* default_device = new Device();
   return default_device;
 }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
@@ -13,8 +13,20 @@ thread_local c10::optional<Device> g_current_device;
 
 Device::Device(const std::string& device_spec) {}
 
-std::string Device::ToString() const {
-  return c10::str("Default:", ordinal);
+std::string Device::toString() const {
+  return c10::str("Default:", ordinal_);
+}
+
+int Device::compare(const Device& rhs) const {
+  if (type_ != rhs.type_) {
+    return type_ < rhs.type_ ? -1 : +1;
+  }
+  return ordinal_ < rhs.ordinal_ ? -1 : (ordinal_ > rhs.ordinal_ ? +1 : 0);
+}
+
+std::ostream& operator<<(std::ostream& os, const Device& device) {
+  os << device.toString();
+  return os;
 }
 
 const Device* GetDefaultDevice() {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
@@ -9,58 +9,12 @@ namespace {
 
 thread_local c10::optional<Device> g_current_device;
 
-std::string DeviceTypeToString(DeviceType hw_type) {
-  switch (hw_type) {
-    case DeviceType::CPU:
-      return "CPU";
-    case DeviceType::GPU:
-      return "GPU";
-    case DeviceType::TPU:
-      return "TPU";
-  }
-  LOG(ERROR) << "Invalid device type";
-}
-
-void ParseDevice(const std::string& device_spec, Device* device) {
-  if (device_spec.empty()) {
-    std::string default_device_spec =
-        compiler::getBackend()->GetDefaultDevice();
-    CHECK(!default_device_spec.empty());
-    return ParseDevice(default_device_spec, device);
-  }
-  if (device_spec[0] == ':') {
-    std::string default_device_spec =
-        compiler::getBackend()->GetDefaultDevice();
-    auto pos = default_device_spec.find(':');
-    CHECK_NE(pos, std::string::npos) << default_device_spec;
-    return ParseDevice(default_device_spec.substr(0, pos) + device_spec,
-                       device);
-  }
-  std::vector<std::string> device_spec_parts =
-      lazy_tensors::StrSplit(device_spec, ':');
-  CHECK_EQ(device_spec_parts.size(), 2)
-      << "Invalid device specification: " << device_spec;
-
-  device->ordinal = std::stoi(device_spec_parts[1]);
-  if (device_spec_parts[0] == "TPU") {
-    device->hw_type = DeviceType::TPU;
-  } else if (device_spec_parts[0] == "CPU") {
-    device->hw_type = DeviceType::CPU;
-  } else if (device_spec_parts[0] == "GPU") {
-    device->hw_type = DeviceType::GPU;
-  } else {
-    LOG(ERROR) << "Invalid device specification: " << device_spec;
-  }
-}
-
 }  // namespace
 
-Device::Device(const std::string& device_spec) {
-  ParseDevice(device_spec, this);
-}
+Device::Device(const std::string& device_spec) {}
 
 std::string Device::ToString() const {
-  return c10::str(DeviceTypeToString(hw_type), ":", ordinal);
+  return c10::str("Default:", ordinal);
 }
 
 const Device* GetDefaultDevice() {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.h
@@ -1,20 +1,27 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include <c10/util/Deprecated.h>
 
 namespace torch_lazy_tensors {
 
-// Backend can define their own enum and mandate that in their implementations.
-using HardwareType = uint8_t;
+// Backend can extend it and define their own supported hardware types.
+struct BackendDeviceType {
+  int8_t type {0};
+  virtual std::string toString() const { return "Unknown"; }
+};
 
+// TODO(alanwaketan): Rename it to BackendDevice.
 class Device {
  public:
-  Device() = default;
-  Device(HardwareType type, int ordinal)
-      : type_(type), ordinal_(ordinal) {}
+  Device();
+  Device(std::shared_ptr<BackendDeviceType>&& type, int ordinal);
+
+  int8_t type() const;
+  int64_t ordinal() const { return ordinal_;  }
 
   bool operator==(const Device& other) const { return compare(other) == 0; }
   bool operator!=(const Device& other) const { return compare(other) != 0; }
@@ -28,8 +35,9 @@ class Device {
  private:
   int compare(const Device& rhs) const;
 
-  HardwareType type_ {0};
-  int ordinal_ {0};
+  // Use shared_ptr instead of unique_ptr so that Device can be copied.
+  std::shared_ptr<BackendDeviceType> type_;
+  int64_t ordinal_ {0};
 };
 
 std::ostream& operator<<(std::ostream& os, const Device& device);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.h
@@ -3,40 +3,35 @@
 #include <iostream>
 #include <string>
 
+#include <c10/util/Deprecated.h>
+
 namespace torch_lazy_tensors {
 
 // Backend can define their own enum and mandate that in their implementations.
 using HardwareType = uint8_t;
 
-struct Device {
+class Device {
+ public:
   Device() = default;
-  explicit Device(const std::string& device_spec);
-  Device(HardwareType hw_type, int ordinal)
-      : hw_type(hw_type), ordinal(ordinal) {}
+  Device(HardwareType type, int ordinal)
+      : type_(type), ordinal_(ordinal) {}
 
   bool operator==(const Device& other) const { return compare(other) == 0; }
-
   bool operator!=(const Device& other) const { return compare(other) != 0; }
-
   bool operator<(const Device& rhs) const { return compare(rhs) < 0; }
 
-  int compare(const Device& rhs) const {
-    if (hw_type != rhs.hw_type) {
-      return hw_type < rhs.hw_type ? -1 : +1;
-    }
-    return ordinal < rhs.ordinal ? -1 : (ordinal > rhs.ordinal ? +1 : 0);
-  }
+  std::string toString() const;
 
-  std::string ToString() const;
+  C10_DEPRECATED explicit Device(const std::string& device_spec);
 
-  friend std::ostream& operator<<(std::ostream& os, const Device& device) {
-    os << device.ToString();
-    return os;
-  }
+ private:
+  int compare(const Device& rhs) const;
 
-  HardwareType hw_type {0};
-  int ordinal {0};
+  HardwareType type_ {0};
+  int ordinal_ {0};
 };
+
+std::ostream& operator<<(std::ostream& os, const Device& device);
 
 const Device* GetDefaultDevice();
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.h
@@ -3,17 +3,15 @@
 #include <iostream>
 #include <string>
 
-#include "lazy_tensors/computation_client/util.h"
-#include "torch/csrc/lazy/core/hash.h"
-
 namespace torch_lazy_tensors {
 
-enum class DeviceType { CPU, GPU, TPU };
+// Backend can define their own enum and mandate that in their implementations.
+using HardwareType = uint8_t;
 
 struct Device {
   Device() = default;
   explicit Device(const std::string& device_spec);
-  Device(DeviceType hw_type, int ordinal)
+  Device(HardwareType hw_type, int ordinal)
       : hw_type(hw_type), ordinal(ordinal) {}
 
   bool operator==(const Device& other) const { return compare(other) == 0; }
@@ -36,13 +34,8 @@ struct Device {
     return os;
   }
 
-  size_t hash() const {
-    return torch::lazy::StdHashCombine(
-        lazy_tensors::util::GetEnumValue(hw_type), ordinal + 1);
-  }
-
-  DeviceType hw_type = DeviceType::CPU;
-  int ordinal = 0;
+  HardwareType hw_type {0};
+  int ordinal {0};
 };
 
 const Device* GetDefaultDevice();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.h
@@ -22,6 +22,7 @@ class Device {
 
   std::string toString() const;
 
+  // The string -> Device conversion should be handled by the backend interface.
   C10_DEPRECATED explicit Device(const std::string& device_spec);
 
  private:

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -97,7 +97,7 @@ std::vector<std::string> GetLtcDevices(
   ltc_devices.reserve(devices.size());
   for (auto& device_str : devices) {
     Device device = bridge::AtenDeviceToLtcDevice(c10::Device(device_str));
-    ltc_devices.emplace_back(device.ToString());
+    ltc_devices.emplace_back(device.toString());
   }
   return ltc_devices;
 }
@@ -389,7 +389,7 @@ py::object LtcNms(const at::Tensor& boxes, const at::Tensor& scores,
 //     NoGilSection nogil;
 //     Device device = GetDeviceOrCurrent(device_str);
 //     mem_info = compiler::getBackend()->GetMemoryInfo(
-//         device.ToString());
+//         device.toString());
 //   }
 //   auto py_dict = py::dict();
 //   py_dict["kb_free"] = mem_info.kb_free;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -63,7 +63,7 @@ void PrepareToExit() {
   //TODO(whc) should we hook this interface up? It does nothing currently
   compiler::getBackend()->PrepareToExit();
   //TODO(whc) can I call this unconditionally?
-  LazyGraphExecutor::Get()->WaitDeviceOps();
+  LazyGraphExecutor::Get()->WaitDeviceOps({});
 }
 
 std::string GetTensorsDump(
@@ -621,10 +621,11 @@ void InitLtcModuleBindings(py::module m) {
       "_ltc_wait_device_ops",
       [](const std::vector<std::string>& devices) {
         NoGilSection nogil;
+        // TODO: Add support of non-empty devices.
         if (!devices.empty()) {
           LOG(ERROR) << "Non-empty devices are not supported.";
         }
-        LazyGraphExecutor::Get()->WaitDeviceOps();
+        LazyGraphExecutor::Get()->WaitDeviceOps({});
       },
       py::arg("devices"));
   m.def("_ltc_counter_names",

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.h
@@ -2,10 +2,12 @@
 
 #include <string>
 
-#include "lazy_tensor_core/csrc/device.h"
 #include "torch/csrc/lazy/core/ir.h"
 
 namespace torch_lazy_tensors {
+
+struct Device;
+
 namespace ir {
 
 class DumpUtil {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ir_dump_util.h
@@ -6,7 +6,7 @@
 
 namespace torch_lazy_tensors {
 
-struct Device;
+class Device;
 
 namespace ir {
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -701,8 +701,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
   VLOG(5) << "TensorsGraphSize=" << po_data->post_order.size();
 
   return ScheduleSyncTensorsGraph(
-      tensors, coll, std::move(po_data->parameters_data),
-      coll->device.toString(), std::move(cached_computation));
+      tensors, coll, std::move(po_data->parameters_data), std::move(cached_computation));
 }
 
 LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
@@ -854,8 +853,7 @@ LazyGraphExecutor::SyncTensorsGraphInternal(std::vector<LazyTensor>* tensors,
   GetComputationCache()->Add(coll.hash, cached_computation);
 
   return ScheduleSyncTensorsGraph(
-      tensors, &coll, std::move(compile_result.parameters_data),
-      compile_result.device.toString(), std::move(cached_computation));
+      tensors, &coll, std::move(compile_result.parameters_data), std::move(cached_computation));
 }
 
 std::shared_ptr<LazyGraphExecutor::Async>
@@ -911,7 +909,7 @@ LazyGraphExecutor::ScheduleSyncTensorsGraph(
 std::shared_ptr<LazyGraphExecutor::Async>
 LazyGraphExecutor::ScheduleSyncTensorsGraph(
     std::vector<LazyTensor>* tensors, SyncTensorCollection* coll,
-    std::vector<compiler::BackendDataPtr> parameters_data, std::string device,
+    std::vector<compiler::BackendDataPtr> parameters_data,
     ComputationCache::TypePtr cached_computation) {
   auto tensors_data = FetchTensorData(tensors, coll->config, coll->indices);
   return ScheduleSyncTensorsGraph(coll, std::move(parameters_data),

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -532,7 +532,7 @@ LazyGraphExecutor::Async::Async(SyncTensorCollection* coll,
       indices(std::move(coll->indices)),
       unlocker(std::move(coll->unlocker)),
       parameters_data(std::move(parameters_data)),
-      device(coll->device.ToString()),
+      device(coll->device.toString()),
       cached_computation(std::move(cached_computation)),
       tensors_data(std::move(tensors_data)) {}
 
@@ -605,12 +605,11 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
         c10::optional<at::Tensor> tensor_data = tensors[i].CurrentTensorData();
         CHECK(tensor_data);
         at_tensors.push_back(*tensor_data);
-        devices.push_back(tensors[i].GetDevice().ToString());
+        devices.push_back(tensors[i].GetDevice().toString());
         at_tensor_index.push_back(i);
       }
     }
   }
-
   if (!at_tensors.empty()) {
     LTC_COUNTER("SyncTensorsToData", at_tensors.size());
     std::vector<compiler::BackendDataPtr> handles =
@@ -658,7 +657,7 @@ std::vector<compiler::BackendDataPtr> LazyGraphExecutor::FetchTensorData(
     if (handle == nullptr && config.force_ltc_data) {
       const Device& tensor_device = tensor.GetDevice();
       handle = compiler::getBackend()
-                   ->CreateDataPlaceholder(tensor_device.ToString(),
+                   ->CreateDataPlaceholder(tensor_device.toString(),
                                            std::move(tensor.shape()));
       tensor.SetDataHandle(handle, config.sync_ltc_data);
     }
@@ -709,7 +708,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
 
   return ScheduleSyncTensorsGraph(
       tensors, coll, std::move(po_data->parameters_data),
-      coll->device.ToString(), std::move(cached_computation));
+      coll->device.toString(), std::move(cached_computation));
 }
 
 LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
@@ -862,7 +861,7 @@ LazyGraphExecutor::SyncTensorsGraphInternal(std::vector<LazyTensor>* tensors,
 
   return ScheduleSyncTensorsGraph(
       tensors, &coll, std::move(compile_result.parameters_data),
-      compile_result.device.ToString(), std::move(cached_computation));
+      compile_result.device.toString(), std::move(cached_computation));
 }
 
 std::shared_ptr<LazyGraphExecutor::Async>

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -436,11 +436,17 @@ void LazyGraphExecutor::MarkStep(const Device& device) {
   g_tls_data.Reset();
 }
 
-void LazyGraphExecutor::WaitDeviceOps() {
+void LazyGraphExecutor::WaitDeviceOps(c10::ArrayRef<Device> devices) {
   std::set<Device> wait_devices;
-  for (auto& device_str : compiler::getBackend()->GetLocalDevices()) {
-    // TODO: Remove the last use of Device(const std::string& device_spec).
-    wait_devices.insert(Device(device_str));
+  if (!devices.empty()) {
+    for (auto& device : devices) {
+      wait_devices.insert(device);
+    }
+  } else {
+    for (auto& device_str : compiler::getBackend()->GetLocalDevices()) {
+      // TODO: Remove the last use of Device(const std::string& device_spec).
+      wait_devices.insert(Device(device_str));
+    }
   }
   // The LockDevices() API returns a vector of
   // lazy_tensors::util::ExceptionCleanup object, which is going to be freed

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
@@ -205,7 +205,7 @@ class LazyGraphExecutor {
   std::shared_ptr<Async> ScheduleSyncTensorsGraph(
       std::vector<LazyTensor>* tensors, SyncTensorCollection* coll,
       std::vector<compiler::BackendDataPtr> parameters_data,
-      std::string device, ComputationCache::TypePtr cached_computation);
+      ComputationCache::TypePtr cached_computation);
 
   std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/ArrayRef.h>
 #include "lazy_tensor_core/csrc/ir_util.h"
 #include "lazy_tensor_core/csrc/lowering_context.h"
 #include "lazy_tensor_core/csrc/tensor.h"
@@ -64,8 +65,9 @@ class LazyGraphExecutor {
   // the computation boundaries.
   void MarkStep(const Device& device);
 
-  // Waits for all the outstanding operations on all local devices.
-  void WaitDeviceOps();
+  // Waits for all the outstanding operations on all the supplied devices.
+  // If devices is empty, the wait will happen for all local devices.
+  void WaitDeviceOps(c10::ArrayRef<Device> devices);
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
@@ -64,9 +64,8 @@ class LazyGraphExecutor {
   // the computation boundaries.
   void MarkStep(const Device& device);
 
-  // Waits for all the outstanding operations on all the supplied devices.
-  // If devices is empty, the wait will happen for all local devices.
-  void WaitDeviceOps(c10::ArrayRef<std::string> devices);
+  // Waits for all the outstanding operations on all local devices.
+  void WaitDeviceOps();
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.
@@ -155,7 +154,7 @@ class LazyGraphExecutor {
     std::vector<size_t> indices;
     std::vector<lazy_tensors::util::ExceptionCleanup> unlocker;
     std::vector<compiler::BackendDataPtr> parameters_data;
-    std::string device;
+    Device device;
     ComputationCache::TypePtr cached_computation;
     std::vector<compiler::BackendDataPtr> tensors_data;
   };

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/generic_slice.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/generic_slice.cpp
@@ -2,6 +2,7 @@
 
 #include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
+#include "lazy_tensors/computation_client/util.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.cpp
@@ -31,6 +31,10 @@ torch::lazy::hash_t ScalarHash(const at::Scalar& s) {
                              : torch::lazy::Hash(s.toLong());
 }
 
+std::ostream& operator<<(std::ostream& ostrm, at::Scalar s) {
+  return ostrm << (s.isFloatingPoint() ? s.toDouble() : s.toLong());
+}
+
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.h
@@ -1,14 +1,11 @@
 #pragma once
 
 #include <c10/core/Scalar.h>
-#include <ATen/core/Formatting.h>
 
 #include <iostream>
 
 #include "lazy_tensor_core/csrc/ts_backend/TsNode.h"
 #include "lazy_tensors/computation_client/types.h"
-
-using namespace at;
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -32,6 +29,8 @@ class Scalar : public TsNode {
 };
 
 torch::lazy::hash_t ScalarHash(const at::Scalar& s);
+
+std::ostream& operator<<(std::ostream& ostrm, at::Scalar s);
 
 }  // namespace ops
 }  // namespace ir

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/update_slice.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/update_slice.cpp
@@ -2,6 +2,7 @@
 
 #include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
+#include "lazy_tensors/computation_client/util.h"
 
 namespace torch_lazy_tensors {
 namespace ir {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -3,6 +3,7 @@
 #include "lazy_tensor_core/csrc/compiler/backend_impl_interface.h"
 #include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensor_core/csrc/view.h"
+#include "lazy_tensors/computation_client/util.h"
 #include "torch/csrc/lazy/core/ir.h"
 
 namespace torch_lazy_tensors {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
@@ -5,7 +5,6 @@
 #include <c10/macros/Macros.h>
 
 #include "lazy_tensor_core/csrc/aten_ltc_bridge.h"
-#include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensor_core/csrc/tensor_util.h"
 
 namespace torch_lazy_tensors {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
@@ -325,17 +325,16 @@ compiler::BackendDataPtr TensorToDataHandle(const at::Tensor& tensor,
   return compiler::getBackend()
       ->MakeComputationDataFromTensor(
           tensor, lazy_tensors::Shape(tensor.scalar_type(), tensor.sizes()),
-          device.toString());
+          device);
 }
 
 std::vector<compiler::BackendDataPtr> CreateTensorsData(
     const std::vector<at::Tensor>& tensors,
-    const std::vector<std::string>& devices) {
+    const std::vector<Device>& devices) {
   CHECK_EQ(tensors.size(), devices.size());
   std::vector<compiler::BackendDataPtr> result;
   result.reserve(tensors.size());
   for (size_t i = 0; i < tensors.size(); ++i) {
-    Device device(devices[i]);
     lazy_tensors::Shape shape(tensors[i].scalar_type(), tensors[i].sizes());
     result.push_back(
         compiler::getBackend()

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 
 #include "lazy_tensor_core/csrc/compiler/backend_impl_interface.h"
+#include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensor_core/csrc/helpers.h"
 #include "lazy_tensors/computation_client/multi_wait.h"
 #include "lazy_tensors/computation_client/sys_util.h"

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.cpp
@@ -325,7 +325,7 @@ compiler::BackendDataPtr TensorToDataHandle(const at::Tensor& tensor,
   return compiler::getBackend()
       ->MakeComputationDataFromTensor(
           tensor, lazy_tensors::Shape(tensor.scalar_type(), tensor.sizes()),
-          device.ToString());
+          device.toString());
 }
 
 std::vector<compiler::BackendDataPtr> CreateTensorsData(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "lazy_tensor_core/csrc/compiler/backend_impl_interface.h"
-#include "lazy_tensor_core/csrc/device.h"
 #include "lazy_tensors/literal.h"
 #include "lazy_tensors/shape.h"
 #include "lazy_tensors/span.h"

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_util.h
@@ -30,7 +30,7 @@ torch::lazy::hash_t TensorHash(const at::Tensor& tensor);
 // corresponding devices.
 std::vector<compiler::BackendDataPtr> CreateTensorsData(
     const std::vector<at::Tensor>& tensors,
-    const std::vector<std::string>& devices);
+    const std::vector<Device>& devices);
 
 template<typename... TupleType>
 std::vector<std::vector<int64_t>> CreateComputationShapeFromMetaTensors(const std::tuple<TupleType...>& tensors) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
@@ -38,7 +38,7 @@ class TSBackendImpl : public BackendImplInterface {
 
   BackendDataPtr MakeComputationDataFromTensor(
       const at::Tensor& tensor, const lazy_tensors::Shape& shape,
-      const std::string& device) const override {
+      const Device& device) const override {
     at::TensorOptions options = tensor.options().device(HardwareDeviceType());
     return std::make_shared<TSData>(tensor.to(options), shape, device);
   }
@@ -56,11 +56,11 @@ class TSBackendImpl : public BackendImplInterface {
  public:
   class TSData : public BackendData {
    public:
-    TSData(const at::Tensor& data, lazy_tensors::Shape shape,
-           std::string device)
+    TSData(const at::Tensor& data, const lazy_tensors::Shape& shape,
+           const Device& device)
         : BackendData(device, shape), data_(data) {}
 
-    TSData(lazy_tensors::Shape shape, std::string device)
+    TSData(const lazy_tensors::Shape& shape, const Device& device)
         : BackendData(device, shape) {}
 
     Handle GetOpaqueHandle() override {
@@ -79,15 +79,15 @@ class TSBackendImpl : public BackendImplInterface {
     at::Tensor data_;
   };
 
-  BackendDataPtr CreateDataPlaceholder(std::string device,
-                                lazy_tensors::Shape shape) const override;
+  BackendDataPtr CreateDataPlaceholder(const Device& device,
+      const lazy_tensors::Shape& shape) const override;
 
   std::vector<ComputationPtr> Compile(
       std::vector<ComputationPtr> instances) const override;
 
   std::vector<BackendDataPtr> ExecuteComputation(
       Computation& computation, c10::ArrayRef<BackendDataPtr> arguments,
-      const std::string& device) const override;
+      const Device& device) const override;
 
   std::string GetDefaultDevice() const override;
 
@@ -118,9 +118,9 @@ class TSBackendImpl : public BackendImplInterface {
   at::DeviceType HardwareDeviceType() const override;
 };
 
-BackendDataPtr TSBackendImpl::CreateDataPlaceholder(std::string device,
-                                             lazy_tensors::Shape shape) const {
-  return std::make_shared<TSBackendImpl::TSData>(shape, std::move(device));
+BackendDataPtr TSBackendImpl::CreateDataPlaceholder(const Device& device,
+      const lazy_tensors::Shape& shape) const {
+  return std::make_shared<TSBackendImpl::TSData>(shape, device);
 }
 
 std::vector<ComputationPtr> TSBackendImpl::Compile(
@@ -134,7 +134,7 @@ std::vector<ComputationPtr> TSBackendImpl::Compile(
 
 std::vector<BackendDataPtr> TSBackendImpl::ExecuteComputation(
     Computation& computation, c10::ArrayRef<BackendDataPtr> arguments,
-    const std::string& device) const {
+    const Device& device) const {
   torch::jit::GraphExecutor& graph_executor =
       static_cast<compiler::ts_backend::TSComputation&>(computation)
           .graph_executor();

--- a/lazy_tensor_core/lazy_tensors/shape_util.h
+++ b/lazy_tensor_core/lazy_tensors/shape_util.h
@@ -5,7 +5,7 @@
 
 #include <complex>
 
-#include "lazy_tensor_core/csrc/device.h"
+#include "lazy_tensors/computation_client/util.h"
 #include "lazy_tensors/shape.h"
 #include "torch/csrc/jit/tensorexpr/types.h"
 #include "torch/csrc/lazy/core/hash.h"

--- a/lazy_tensor_core/test/cpp/cpp_test_util.h
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.h
@@ -58,20 +58,9 @@ static inline void AllEqual(at::Tensor tensor, at::Tensor xla_tensor) {
   EXPECT_TRUE(EqualValues(tensor, xla_tensor));
 }
 
-void ForEachDevice(c10::ArrayRef<DeviceType> device_types,
-                   const std::function<void(const Device&)>& devfn);
-
-void ForEachDevice(c10::ArrayRef<DeviceType> device_types,
-                   const std::function<void(const torch::Device&)>& devfn);
-
 void ForEachDevice(const std::function<void(const Device&)>& devfn);
 
 void ForEachDevice(const std::function<void(const torch::Device&)>& devfn);
-
-void WithAllDevices(
-    c10::ArrayRef<DeviceType> device_types,
-    const std::function<void(const std::vector<Device>&,
-                             const std::vector<Device>&)>& devfn);
 
 std::string GetTensorTextGraph(at::Tensor tensor);
 

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -4270,8 +4270,7 @@ TEST_F(AtenLtcTsTensorTest, TestNonzero) {
     torch::Tensor xla_b = torch::nonzero(xla_a);
     AllClose(b, xla_b);
 
-    if (DebugUtil::ExperimentEnabled("nonzero") &&
-        bridge::AtenDeviceToLtcDevice(device).hw_type == DeviceType::TPU) {
+    if (DebugUtil::ExperimentEnabled("nonzero")) {
       // If the nonzero support is enabled, we must not see any aten:: calls.
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
     }
@@ -4290,8 +4289,7 @@ TEST_F(AtenLtcTsTensorTest, TestMaskedSelect) {
     torch::Tensor xla_c = torch::masked_select(xla_a, xla_b);
     AllClose(c, xla_c);
 
-    if (DebugUtil::ExperimentEnabled("masked_select") &&
-        bridge::AtenDeviceToLtcDevice(device).hw_type == DeviceType::TPU) {
+    if (DebugUtil::ExperimentEnabled("masked_select")) {
       // If the masked_select support is enabled, we must not see any aten::
       // calls.
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
@@ -4313,8 +4311,7 @@ TEST_F(AtenLtcTsTensorTest, TestMaskedScatter) {
     torch::Tensor xla_d = torch::masked_scatter(xla_a, xla_b, xla_c);
     AllClose(d, xla_d);
 
-    if (DebugUtil::ExperimentEnabled("masked_scatter") &&
-        bridge::AtenDeviceToLtcDevice(device).hw_type == DeviceType::TPU) {
+    if (DebugUtil::ExperimentEnabled("masked_scatter")) {
       // If the masked_select support is enabled, we must not see any aten::
       // calls.
       ExpectCounterNotChanged("aten::.*", cpp_test::GetIgnoredCounters());
@@ -9658,10 +9655,6 @@ TEST_F(AtenLtcTsTensorTest, TestEmbeddingBackward) {
 }
 
 TEST_F(AtenLtcTsTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
-  DeviceType hw_type = GetDefaultDevice()->hw_type;
-  if (hw_type != DeviceType::GPU && hw_type != DeviceType::CPU) {
-    return;
-  }
   torch::Tensor grads0 =
       torch::tensor({1, 2, 3, 4}, torch::TensorOptions(torch::kFloat));
   torch::Tensor grads1 = torch::tensor({1.0, 2.0, std::nan("1"), 4.0},
@@ -9695,10 +9688,6 @@ TEST_F(AtenLtcTsTensorTest, TestAmpForeachNonFiniteCheckAndUnscale) {
 }
 
 TEST_F(AtenLtcTsTensorTest, TestAmpUpdateScale) {
-  DeviceType hw_type = GetDefaultDevice()->hw_type;
-  if (hw_type != DeviceType::GPU && hw_type != DeviceType::CPU) {
-    return;
-  }
   torch::Tensor growth_tracker =
       torch::scalar_tensor(0, torch::TensorOptions(torch::kInt32));
   torch::Tensor current_scale =


### PR DESCRIPTION
Summary:
This pull request will keep track of the progress of refactoring torch_lazy_tensors::Device.
1. The first commit removed torch_lazy_tensors::DeviceType from all places and added a HardwareType type as an extension point for backends that need this type of information.
2. Clean up class Device interface.
3. Remove most use cases of string devices.
4. Introduce BackendDeviceType to class Device.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc

To be noted:
It's easier to review it commit by commit.
