### PR TITLE
[ROCm] Add sparse mappings for CUDA->HIP translation

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -7760,6 +7760,8 @@ CUDA_SPARSE_MAP = collections.OrderedDict(
     [
         ("cusparseStatus_t", ("hipsparseStatus_t", CONV_MATH_FUNC, API_SPARSE)),
         ("cusparseHandle_t", ("hipsparseHandle_t", CONV_MATH_FUNC, API_SPARSE)),
+        ("cuComplex", ("hipComplex", CONV_TYPE, API_SPARSE)),
+        ("cuDoubleComplex", ("hipDoubleComplex", CONV_TYPE, API_SPARSE)),
         (
             "CUSPARSE_POINTER_MODE_HOST",
             ("HIPSPARSE_POINTER_MODE_HOST", CONV_NUMERIC_LITERAL, API_SPARSE),
@@ -7798,6 +7800,15 @@ CUDA_SPARSE_MAP = collections.OrderedDict(
         ("cusparseDcsrgemm2", ("hipsparseDcsrgemm2", CONV_MATH_FUNC, API_SPARSE)),
         ("cusparseScsrgemm2", ("hipsparseScsrgemm2", CONV_MATH_FUNC, API_SPARSE)),
         ("cusparseSetPointerMode", ("hipsparseSetPointerMode", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseXcsrgeam2Nnz", ("hipsparseXcsrgeam2Nnz", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseScsrgeam2_bufferSizeExt", ("hipsparseScsrgeam2_bufferSizeExt", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseDcsrgeam2_bufferSizeExt", ("hipsparseDcsrgeam2_bufferSizeExt", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseCcsrgeam2_bufferSizeExt", ("hipsparseCcsrgeam2_bufferSizeExt", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseZcsrgeam2_bufferSizeExt", ("hipsparseZcsrgeam2_bufferSizeExt", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseScsrgeam2", ("hipsparseScsrgeam2", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseDcsrgeam2", ("hipsparseDcsrgeam2", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseCcsrgeam2", ("hipsparseCcsrgeam2", CONV_MATH_FUNC, API_SPARSE)),
+        ("cusparseZcsrgeam2", ("hipsparseZcsrgeam2", CONV_MATH_FUNC, API_SPARSE)),
         ("cusparseXcsrsort", ("hipsparseXcsrsort", CONV_MATH_FUNC, API_SPARSE)),
         (
             "cusparseXcoosort_bufferSizeExt",

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -750,7 +750,7 @@ def preprocessor(
         return PYTORCH_MAP[m.group(0)]
 
     def pt_sparse_repl(m):
-        # checks SPARSE map first, and if a miss occurs, falls back to pytorch mappings.
+        # checks SPARSE map first, and if a miss occurs, falls back to pytorch mappings
         return PYTORCH_SPARSE_MAP.get(m.group(0), pt_repl(m))
 
     if is_pytorch_extension:

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -600,6 +600,11 @@ def is_pytorch_file(filepath):
     return False
 
 
+def is_cusparse_file(filepath):
+    if is_pytorch_file(filepath):
+        return "sparse" in filepath.lower()
+    return False
+
 def is_caffe2_gpu_file(filepath):
     if filepath.startswith("c10/cuda"):
         return True
@@ -673,7 +678,17 @@ class Trie():
 CAFFE2_TRIE = Trie()
 CAFFE2_MAP = {}
 PYTORCH_TRIE = Trie()
-PYTORCH_MAP = {}
+PYTORCH_MAP: Dict[str, object] = {}
+
+# In PyTorch, we map cuBLAS->rocBLAS and cuSPARSE->hipSPARSE. Note the prefix, roc versus hip.
+# The 'hip' APIs offer a more direct CUDA-friendly mapping, but calling rocBLAS directly has better performance.
+# Unfortunately, the roc* types and hip* types differ, i.e., rocblas_float_complex versus hipComplex.
+# In the case of SPARSE, we must use the hip types for complex instead of the roc types,
+# but the pytorch mappings assume roc. Therefore, we create a new SPARSE mapping that has a higher priority.
+# Its mappings will trigger first, and only when a miss occurs will the lower-priority pytorch mapping take place.
+# When a file contains "sparse" in the filename, a mapping marked with API_SPARSE is preferred over other choices.
+PYTORCH_SPARSE_MAP = {}
+
 for mapping in CUDA_TO_HIP_MAPPINGS:
     assert isinstance(mapping, Mapping)
     for src, value in mapping.items():
@@ -681,7 +696,12 @@ for mapping in CUDA_TO_HIP_MAPPINGS:
         meta_data = value[1:]
         if constants.API_CAFFE2 not in meta_data:
             PYTORCH_TRIE.add(src)
-            PYTORCH_MAP[src] = dst
+            # if src is already in PYTORCH_MAP and dst belongs to API_SPARSE
+            # do not overwrite PYTORCH_MAP, store dst separately
+            if constants.API_SPARSE in meta_data and PYTORCH_MAP.get(src, ""):
+                PYTORCH_SPARSE_MAP[src] = dst
+            else:
+                PYTORCH_MAP[src] = dst
         if constants.API_PYTORCH not in meta_data:
             CAFFE2_TRIE.add(src)
             CAFFE2_MAP[src] = dst
@@ -729,10 +749,16 @@ def preprocessor(
     def pt_repl(m):
         return PYTORCH_MAP[m.group(0)]
 
+    def pt_sparse_repl(m):
+        # checks SPARSE map first, and if a miss occurs, falls back to pytorch mappings.
+        return PYTORCH_SPARSE_MAP.get(m.group(0), pt_repl(m))
+
     if is_pytorch_extension:
         output_source = RE_PYTORCH_PREPROCESSOR.sub(pt_repl, output_source)
     else:
-        if is_pytorch_file(filepath):
+        if is_cusparse_file(filepath):
+            output_source = RE_PYTORCH_PREPROCESSOR.sub(pt_sparse_repl, output_source)
+        elif is_pytorch_file(filepath):
             output_source = RE_PYTORCH_PREPROCESSOR.sub(pt_repl, output_source)
         else:
             def c2_repl(m):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #66401
* #62180
* #65606
* #64391
* #61536
* #63948
* __->__ #67323
* #61858

Applied patch proposed by Jeff https://github.com/pytorch/pytorch/pull/63948#issuecomment-952166982.
In PyTorch, we map cuBLAS->rocBLAS and cuSPARSE->hipSPARSE. Note the prefix, roc versus hip.
The 'hip' APIs offer a more direct CUDA-friendly mapping, but calling rocBLAS directly has better performance.
Unfortunately, the `roc*` types and `hip*` types differ, i.e., `rocblas_float_complex` versus `hipComplex`.
In the case of SPARSE, we must use the hip types for complex instead of the roc types,
but the pytorch mappings assume roc. Therefore, we create a new SPARSE mapping that has a higher priority.
Its mappings will trigger first, and only when a miss occurs will the lower-priority pytorch mapping take place.
When a file contains "sparse" in the filename, a mapping marked with API_SPARSE is preferred over other choices.

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH

Differential Revision: [D31969246](https://our.internmc.facebook.com/intern/diff/D31969246)