### PR TITLE
[Quant] Add dynamic QAT Linear module

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -262,6 +262,8 @@ coverage_missing_automodule = [
     "torch.nn.parallel",
     "torch.nn.qat",
     "torch.nn.qat.modules",
+    "torch.nn.qat.dynamic",
+    "torch.nn.qat.dynamic.modules",
     "torch.nn.quantizable",
     "torch.nn.quantizable.modules",
     "torch.nn.quantized",

--- a/docs/source/quantization-support.rst
+++ b/docs/source/quantization-support.rst
@@ -321,6 +321,22 @@ effect of INT8 quantization.
     Conv3d
     Linear
 
+torch.nn.qat.dynamic
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module implements versions of the key nn modules such as **Linear()**
+which run in FP32 but with rounding applied to simulate the effect of INT8
+quantization and will be dynamically quantized during inference.
+
+.. currentmodule:: torch.nn.qat.dynamic
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    Linear
+
 torch.nn.quantized
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/torch/ao/ns/fx/mappings.py
+++ b/torch/ao/ns/fx/mappings.py
@@ -12,6 +12,7 @@ import torch.nn.intrinsic.quantized.dynamic as nniqd
 import torch.nn.intrinsic.qat as nniqat
 import torch.nn.intrinsic as nni
 import torch.nn.qat as nnqat
+import torch.nn.qat.dynamic as nnqatd
 
 from .ns_types import NSNodeTargetType
 
@@ -73,6 +74,7 @@ def get_base_name_to_sets_of_related_ops() -> Dict[str, Set[NSNodeTargetType]]:
             nniq.LinearReLU,
             nniqd.LinearReLU,
             nnqat.Linear,
+            nnqatd.Linear,
             nnqd.Linear,
             nniqat.LinearReLU,
             nn.modules.linear.NonDynamicallyQuantizableLinear,
@@ -488,6 +490,7 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
     MODS_IO_TYPE_FP32: Set[NSNodeTargetType] = set([
         nn.Linear,
         nnqat.Linear,
+        nnqatd.Linear,
         nnqd.Linear,
         torch.nn.modules.linear.NonDynamicallyQuantizableLinear,
         nn.Conv1d,

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -6,6 +6,7 @@ during QAT.
 import torch
 from torch.nn import Module
 from torch.ao.quantization.observer import (
+    MinMaxObserver,
     MovingAverageMinMaxObserver,
     HistogramObserver,
     MovingAveragePerChannelMinMaxObserver,
@@ -344,6 +345,12 @@ default_weight_fake_quant = FakeQuantize.with_args(observer=MovingAverageMinMaxO
                                                    dtype=torch.qint8, qscheme=torch.per_tensor_symmetric, reduce_range=False)
 """
 Default fake_quant for weights.
+"""
+
+default_dynamic_fake_quant = FakeQuantize.with_args(observer=MinMaxObserver, quant_min=0, quant_max=255,
+                                                    dtype=torch.quint8, memoryless=True)
+"""
+Default dynamic fake_quant for activations.
 """
 
 # TODO(future PR): remove these defaults and enforce activation functions

--- a/torch/ao/quantization/quantization_mappings.py
+++ b/torch/ao/quantization/quantization_mappings.py
@@ -12,6 +12,7 @@ import torch.nn.quantized as nnq
 import torch.nn.quantized._reference as nnqr
 import torch.nn.quantized.dynamic as nnqd
 import torch.nn.qat as nnqat
+import torch.nn.qat.dynamic as nnqatd
 
 from typing import Optional, Union, Dict, Set, Callable, Any
 
@@ -102,6 +103,7 @@ DEFAULT_QAT_MODULE_MAPPINGS : Dict[Callable, Any] = {
 DEFAULT_DYNAMIC_QUANT_MODULE_MAPPINGS : Dict[Callable, Any] = {
     nn.GRUCell: nnqd.GRUCell,
     nn.Linear: nnqd.Linear,
+    nnqatd.Linear: nnqd.Linear,
     nn.modules.linear.NonDynamicallyQuantizableLinear: nnqd.Linear,
     nn.LSTM: nnqd.LSTM,
     nn.GRU: nnqd.GRU,

--- a/torch/nn/qat/dynamic/__init__.py
+++ b/torch/nn/qat/dynamic/__init__.py
@@ -1,0 +1,1 @@
+from .modules import *  # noqa: F403

--- a/torch/nn/qat/dynamic/modules/__init__.py
+++ b/torch/nn/qat/dynamic/modules/__init__.py
@@ -1,0 +1,3 @@
+from .linear import Linear
+
+__all__ = ["Linear"]

--- a/torch/nn/qat/dynamic/modules/linear.py
+++ b/torch/nn/qat/dynamic/modules/linear.py
@@ -1,0 +1,20 @@
+import torch
+from torch.ao.quantization import activation_is_memoryless
+
+class Linear(torch.nn.qat.Linear):
+    r"""
+    A linear module attached with FakeQuantize modules for weight,
+    used for dynamic quantization aware training.
+
+    We adopt the same interface as `torch.nn.Linear`, please see
+    https://pytorch.org/docs/stable/nn.html#torch.nn.Linear
+    for documentation.
+
+    Similar to `torch.nn.Linear`, with FakeQuantize modules initialized to
+    default.
+    """
+    def __init__(self, in_features, out_features, bias=True,
+                 qconfig=None, device=None, dtype=None) -> None:
+        super().__init__(in_features, out_features, bias, qconfig, device, dtype)
+        if not activation_is_memoryless(qconfig):
+            raise ValueError("Dynamic QAT requires a memoryless observer")

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -81,7 +81,7 @@ class Linear(nnq.Linear):
                           utilities or provided by the user
         """
         float_modules = [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear,
-                         torch.nn.intrinsic.modules.fused.LinearReLU]
+                         torch.nn.intrinsic.modules.fused.LinearReLU, torch.nn.qat.dynamic.Linear]
 
         assert type(mod) in float_modules, \
             'nn.quantized.dynamic.Linear.from_float only works for one of' + \

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -14,6 +14,7 @@ import torch.distributed as dist
 from torch.testing._internal.common_utils import TestCase
 from torch.ao.quantization import (
     QuantType,
+    default_dynamic_qat_qconfig,
     default_embedding_qat_qconfig,
 )
 from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, \
@@ -1647,6 +1648,20 @@ class ManualLinearQATModel(torch.nn.Module):
         x = self.fc1(x)
         x = self.fc2(x)
         return self.dequant(x)
+
+class ManualLinearDynamicQATModel(torch.nn.Module):
+    r"""A Module that uses a dynamic QAT by default.
+    """
+    def __init__(self, qconfig=None):
+        super().__init__()
+        self.qconfig = qconfig or default_dynamic_qat_qconfig
+        self.fc1 = torch.nn.Linear(5, 1).to(dtype=torch.float)
+        self.fc2 = torch.nn.Linear(1, 10).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return x
 
 class ManualConvLinearQATModel(torch.nn.Module):
     r"""A module with manually inserted `QuantStub` and `DeQuantStub`


### PR DESCRIPTION
**Summary:** This commit adds the `torch.nn.qat.dynamic.modules.Linear`
module, the dynamic counterpart to `torch.nn.qat.modules.Linear`.
Functionally these are very similar, except the dynamic version
expects a memoryless observer and is converted into a dynamically
quantized module before inference.

**Test Plan:** `python3 test/test_quantization.py TestQuantizationAwareTraining.test_dynamic_qat_linear`

**Reviewers:** Charles David Hernandez, Jerry Zhang

**Subscribers:** Charles David Hernandez, Supriya Rao, Yining Lu

**Tasks:** T99696812, T99699094, T99702853

**Tags:** pytorch