### PR TITLE
Fixed C++ BatchNorm pretty_print() with optional momentum

### DIFF
--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -23,13 +23,13 @@ void BatchNormImplBase<D, Derived>::pretty_print(std::ostream& stream) const {
          << this->options.num_features() << ", "
          << "eps=" << this->options.eps() << ", "
          << "momentum=";
-         
+
   if (this->options.momentum().has_value()) {
       stream << this->options.momentum().value();
   } else {
       stream << "None";
   }
-         
+ 
   stream << ", "
          << "affine=" << this->options.affine() << ", "
          << "track_running_stats=" << this->options.track_running_stats() << ")";

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -29,8 +29,8 @@ void BatchNormImplBase<D, Derived>::pretty_print(std::ostream& stream) const {
   } else {
       stream << "None";
   }
- 
-  stream << ", "
+
+   stream << ", "
          << "affine=" << this->options.affine() << ", "
          << "track_running_stats=" << this->options.track_running_stats() << ")";
 }

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -22,7 +22,15 @@ void BatchNormImplBase<D, Derived>::pretty_print(std::ostream& stream) const {
          << "torch::nn::BatchNorm" << D << "d("
          << this->options.num_features() << ", "
          << "eps=" << this->options.eps() << ", "
-         << "momentum=" << this->options.momentum().value() << ", "
+         << "momentum=";
+         
+  if (this->options.momentum().has_value()) {
+      stream << this->options.momentum().value();
+  } else {
+      stream << "None";
+  }
+         
+  stream << ", "
          << "affine=" << this->options.affine() << ", "
          << "track_running_stats=" << this->options.track_running_stats() << ")";
 }


### PR DESCRIPTION
Summary : Inserted a check for the momentum and print  "None" in case is not defined. See  #65143

Test: The code below now prints `torch::nn::BatchNorm2d(128, eps=1e-05, momentum=None, affine=true, track_running_stats=true)` without generating errors.
```
torch::nn::BatchNorm2d m(torch::nn::BatchNormOptions(128).momentum(c10::nullopt));
std::cerr << *m << "\n";
```
Fixes #65143