### PR TITLE
[Pytorch Edge] Make some torchbind classes selective

### DIFF
--- a/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
+++ b/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
@@ -16,7 +16,7 @@ using internal::convolution2d::createConv2dClampPrePackOpContext;
 using internal::convolution2d::createConv2dTransposeClampPrePackOpContext;
 
 TORCH_LIBRARY(xnnpack, m) {
-  m.class_<LinearOpContext>("LinearOpContext")
+  m.class_<LinearOpContext>(TORCH_SELECTIVE_CLASS("LinearOpContext"))
     .def_pickle(
         [](const c10::intrusive_ptr<LinearOpContext>& op_context)
             -> SerializationTypeLinearPrePack { // __getstate__
@@ -33,7 +33,7 @@ TORCH_LIBRARY(xnnpack, m) {
               std::move(std::get<3>(state)));
         });
 
-  m.class_<Conv2dOpContext>("Conv2dOpContext")
+  m.class_<Conv2dOpContext>(TORCH_SELECTIVE_CLASS("Conv2dOpContext"))
     .def_pickle(
         [](const c10::intrusive_ptr<Conv2dOpContext>& op_context)
             -> SerializationTypeConv2dPrePack { // __getstate__
@@ -55,7 +55,7 @@ TORCH_LIBRARY(xnnpack, m) {
               std::move(std::get<7>(state)));
         });
 
-  m.class_<TransposeConv2dOpContext>("TransposeConv2dOpContext")
+  m.class_<TransposeConv2dOpContext>(TORCH_SELECTIVE_CLASS("TransposeConv2dOpContext"))
     .def_pickle(
         [](const c10::intrusive_ptr<TransposeConv2dOpContext>& op_context)
             -> SerializationTypeTransposeConv2dPrePack { // __getstate__

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -443,4 +443,20 @@ inline class_<CurClass> Library::class_(const std::string& className) {
 
 const std::unordered_set<std::string> getAllCustomClassesNames();
 
+template <class CurClass>
+inline class_<CurClass> Library::class_(detail::SelectiveStr<true> className) {
+  auto class_name = std::string(className.operator const char *());
+  TORCH_CHECK(kind_ == DEF || kind_ == FRAGMENT,
+    "class_(\"", class_name, "\"): Cannot define a class inside of a TORCH_LIBRARY_IMPL block.  "
+    "All class_()s should be placed in the (unique) TORCH_LIBRARY block for their namespace.  "
+    "(Error occurred at ", file_, ":", line_, ")");
+  TORCH_INTERNAL_ASSERT(ns_.has_value(), file_, ":", line_);
+  return torch::class_<CurClass>(*ns_, class_name);
+}
+
+template <class CurClass>
+inline detail::ClassNotSelected Library::class_(detail::SelectiveStr<false>) {
+  return detail::ClassNotSelected();
+}
+
 } // namespace torch

--- a/torch/library.h
+++ b/torch/library.h
@@ -408,6 +408,13 @@ namespace detail {
 
 namespace detail {
 
+  // dummy class for non selected custom torchbind classes
+  class ClassNotSelected {
+    public:
+      ClassNotSelected& def_pickle(...){ return *this;}
+      ClassNotSelected& def(...){ return *this;}
+  };
+
   // A SelectiveStr is like a const char*, except that it also comes
   // with a type brand that says whether or not the name is enabled or
   // not.  If the string is disabled, then (at compile time) we DON'T generate
@@ -417,12 +424,13 @@ namespace detail {
   template <bool enabled>
   class SelectiveStr {
   public:
-    constexpr SelectiveStr(const char* name) : name_(name) {}
+    constexpr explicit SelectiveStr(const char* name) : name_(name) {}
     constexpr operator const char*() { return name_; }
   private:
     const char* name_;
   };
 
+#define TORCH_SELECTIVE_CLASS(n) torch::detail::SelectiveStr<c10::impl::custom_class_allowlist_check(n)>(n)
 #define TORCH_SELECTIVE_NAME(n) torch::detail::SelectiveStr<c10::impl::op_allowlist_check(n)>(n)
 #define TORCH_SELECTIVE_SCHEMA(n) torch::detail::SelectiveStr<c10::impl::schema_allowlist_check(n)>(n)
 
@@ -680,6 +688,12 @@ public:
 
   template <class CurClass>
   inline torch::class_<CurClass> class_(const std::string& className);
+
+  template <class CurClass>
+  inline torch::class_<CurClass> class_(detail::SelectiveStr<true> className);
+
+  template <class CurClass>
+  inline detail::ClassNotSelected class_(detail::SelectiveStr<false> className);
 
 private:
   Kind kind_;

--- a/torch/library.h
+++ b/torch/library.h
@@ -689,6 +689,9 @@ public:
   template <class CurClass>
   inline torch::class_<CurClass> class_(const std::string& className);
 
+  // These overloads enable the use of selective build on classes registered within
+  // a library. The API is the same as before with 1 minor change. Instead of
+  // m.class_<foo>("foo") you instead do m.class_<foo>(TORCH_SELECTIVE_CLASS("foo"))
   template <class CurClass>
   inline torch::class_<CurClass> class_(detail::SelectiveStr<true> className);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67397
* __->__ #67340

Currently Torchbind classes arent selective. This makes is a rough granularity pass that will remove entire classes if they arent selected. If we need finer granularity in the future we can make individual methods within classes Selective though instrumenting that will be significantly more involved I think. On a linux build only __torch__.torch.classes._nnapi.Compilation remains unselective. I cant find where its registered :P (theres a couple Android only ones and presumably some metal only ones as well)


Many of the classes registered in functions returned a reference to the class that was created. I talked with @dreiss about it and we decided that this seemingly didnt serve any purpose, and leaving it like that would make the return value difficult (but possible) to create with selectivity. Since it seems useless anyway I just changed them to return an int so that they can still be called from a global scope, but not have any issues with the return type.

Differential Revision: [D31092564](https://our.internmc.facebook.com/intern/diff/D31092564/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D31092564/)!