### PR TITLE
[SR] Native implementation for aten::view

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1760,3 +1760,22 @@ TEST(StaticRuntime, IndividualOps_Where) {
   testStaticRuntime(where_script, args1_nnc);
   testStaticRuntime(where_script, args1_nnc, args2_nnc);
 }
+
+TEST(StaticRuntime, IndividualOps_View) {
+  // Note that clone is not technically necessary here since this is not
+  // an out variant, but it suppresses warnings about only have one op
+  // in testStaticRuntime
+  const auto src = R"IR(
+    graph(%input : Tensor, %shape : int[]):
+        %none : NoneType = prim::Constant()
+        %view : Tensor = aten::view(%input, %shape)
+        %res : Tensor = aten::clone(%view, %none)
+        return (%res)
+  )IR";
+
+  std::vector<IValue> args1{at::randn({2, 2}), c10::List<int64_t>(4)};
+  std::vector<IValue> args2{at::randn({2, 2, 2}), c10::List<int64_t>({4, 2})};
+
+  testStaticRuntime(src, args1);
+  testStaticRuntime(src, args1, args2);
+}

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -486,5 +486,22 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         }
       };
     });
+
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    aten::view,
+    aten_view,
+    [](Node* n) -> SROperator {
+      if (!n->matches(torch::schema(
+              "aten::view(Tensor(a) self, int[] size) -> (Tensor(a))"))) {
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+      return [](ProcessedNode* p_node) {
+        const auto& input = p_node->Input(0).toTensor();
+        const auto size = p_node->Input(1).toIntList();
+        p_node->Output(0) = at::native::view(input, size.vec());
+      };
+    });
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Native ops are faster than falling back to the JIT interpreter, sometimes significantly (we've previously seen this with ops like `TupleUnpack`). We should improve op coverage where possible.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D31962589

