### PR TITLE
[skip-ci] .github: Set linux gpu instances to be non-ephemeral

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -15,6 +15,7 @@
 #     os: linux
 #     max_available: 20
 #     disk_size: 50
+#     is_ephemeral: true
 
 runner_types:
   linux.2xlarge:
@@ -27,16 +28,19 @@ runner_types:
     os: linux
     max_available: 125
     disk_size: 150
+    is_ephemeral: false
   linux.4xlarge.nvidia.gpu:
     instance_type: g3.4xlarge
     os: linux
     max_available: 125
     disk_size: 150
+    is_ephemeral: false
   linux.16xlarge.nvidia.gpu:
     instance_type: g3.16xlarge
     os: linux
     max_available: 10
     disk_size: 150
+    is_ephemeral: false
   windows.4xlarge:
     instance_type: c5d.4xlarge
     os: windows


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67345

Was hitting capacity issues, setting these to non-ephemeral would mean
keeping the current capacity at the expense of "unclean" nodes

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D31965477](https://our.internmc.facebook.com/intern/diff/D31965477)