### PR TITLE
Mark mv as CompositeExplicitAutograd

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3126,7 +3126,7 @@
 - func: mv(Tensor self, Tensor vec) -> Tensor
   variants: function, method
   dispatch:
-    CPU, CUDA, SparseCsrCUDA: mv
+    CompositeExplicitAutograd: mv
     SparseCPU, SparseCUDA, SparseCsrCPU: mv_sparse
 
 - func: mv.out(Tensor self, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67373

Summary:
From the implementation of mv, it's decomposed into addmv. So it should
be a CompositeExplicitAutograd op.

Test Plan:
It shouldn't change any behaviors. So, CI.

Differential Revision: [D31973265](https://our.internmc.facebook.com/intern/diff/D31973265)