### PR TITLE
[fbcode] Fix operator_benchmark with jit mode

### DIFF
--- a/benchmarks/operator_benchmark/pt/bmm_test.py
+++ b/benchmarks/operator_benchmark/pt/bmm_test.py
@@ -4,15 +4,16 @@ import torch
 """Microbenchmarks for add_ operator. Supports both Caffe2/PyTorch."""
 
 class BmmBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, B, M, N, K, device):
+    def init(self, B, M, N, K, device, op):
         self.inputs = {
             "batch1": torch.rand((B, M, K), device=device, requires_grad=self.auto_set()),
             "batch2": torch.rand((B, K, N,), device=device, requires_grad=self.auto_set())
         }
-        self.set_module_name("bmm")
+        self.set_module_name(f"bmm (actual {op=}")
+        self.op = torch.bmm if op == "bmm" else torch.matmul
 
     def forward(self, batch1, batch2):
-        return torch.bmm(batch1, batch2)
+        return self.op(batch1, batch2)
 
 bmm_configs = op_bench.cross_product_configs(
     B=[2, 100],
@@ -21,6 +22,7 @@ bmm_configs = op_bench.cross_product_configs(
     K=[16, 32],
     device=['cpu'],
     tags=["short"],
+    op=["bmm", "matmul"],
 )
 
 op_bench.generate_pt_test(bmm_configs, BmmBenchmark)


### PR DESCRIPTION
Summary:
two simple updates:

* fix running benchmark with --use_jit. Previously will fail with error

  torch.jit.frontend.UnsupportedNodeError: import statements aren't supported:
  File "/proc/self/fd/3/bmm_test.py", line 9
  def __invoke_main():
    import ctypes
    ~~~~~~ <--- HERE
    import ctypes.util
    import errno

* add matmul to bmm benchmark as D31837588

Test Plan:
buck run mode/opt caffe2/benchmarks/operator_benchmark/pt:bmm_test --  --forward_only=True --mkl_num_threads=1 --omp_num_threads=1
 --use_jit=True

Differential Revision: D31960528

