### PR TITLE
[Pytorch Edge] Expose runtime operators versioning

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -467,10 +467,12 @@ TEST(LiteInterpreterTest, GetRuntimeByteCodeVersion) {
 }
 
 TEST(LiteInterpreterTest, GetRuntimeOperatorsVersion) {
-  auto runtime_operators_version = _get_runtime_operators_version();
+  auto runtime_operators_version = _get_runtime_operators_min_max_versions();
   AT_ASSERT(
-      runtime_operators_version ==
-      caffe2::serialize::kProducedFileFormatVersion);
+      runtime_operators_version.first ==
+          caffe2::serialize::kMinSupportedFileFormatVersion &&
+      runtime_operators_version.second ==
+          caffe2::serialize::kMaxSupportedFileFormatVersion);
 }
 
 /**

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -466,6 +466,13 @@ TEST(LiteInterpreterTest, GetRuntimeByteCodeVersion) {
       caffe2::serialize::kMaxSupportedBytecodeVersion);
 }
 
+TEST(LiteInterpreterTest, GetRuntimeOperatorsVersion) {
+  auto runtime_operators_version = _get_runtime_operators_version();
+  AT_ASSERT(
+      runtime_operators_version ==
+      caffe2::serialize::kProducedFileFormatVersion);
+}
+
 /**
  * The test below is disarmed for FB internal xplat builds since
  * BUCK requires us to pass in the script_module_v4.ptl file in

--- a/torch/csrc/jit/mobile/runtime_compatibility.cpp
+++ b/torch/csrc/jit/mobile/runtime_compatibility.cpp
@@ -18,8 +18,10 @@ uint64_t _get_runtime_bytecode_version() {
   return caffe2::serialize::kMaxSupportedBytecodeVersion;
 }
 
-uint64_t _get_runtime_operators_version() {
-  return caffe2::serialize::kProducedFileFormatVersion;
+std::pair<uint64_t, uint64_t> _get_runtime_operators_min_max_versions() {
+  return std::pair<uint64_t, uint64_t>(
+      caffe2::serialize::kMinSupportedFileFormatVersion,
+      caffe2::serialize::kMaxSupportedFileFormatVersion);
 }
 
 /*

--- a/torch/csrc/jit/mobile/runtime_compatibility.cpp
+++ b/torch/csrc/jit/mobile/runtime_compatibility.cpp
@@ -18,6 +18,10 @@ uint64_t _get_runtime_bytecode_version() {
   return caffe2::serialize::kMaxSupportedBytecodeVersion;
 }
 
+uint64_t _get_runtime_operators_version() {
+  return caffe2::serialize::kProducedFileFormatVersion;
+}
+
 /*
  * Returns all registered PyTorch ops and their versioning
  */

--- a/torch/csrc/jit/mobile/runtime_compatibility.h
+++ b/torch/csrc/jit/mobile/runtime_compatibility.h
@@ -27,6 +27,8 @@ struct RuntimeCompatibilityInfo {
 
 TORCH_API uint64_t _get_runtime_bytecode_version();
 
+TORCH_API uint64_t _get_runtime_operators_version();
+
 TORCH_API std::unordered_map<std::string, OperatorInfo>
 _get_runtime_ops_and_info();
 

--- a/torch/csrc/jit/mobile/runtime_compatibility.h
+++ b/torch/csrc/jit/mobile/runtime_compatibility.h
@@ -27,7 +27,8 @@ struct RuntimeCompatibilityInfo {
 
 TORCH_API uint64_t _get_runtime_bytecode_version();
 
-TORCH_API uint64_t _get_runtime_operators_version();
+TORCH_API std::pair<uint64_t, uint64_t>
+_get_runtime_operators_min_max_versions();
 
 TORCH_API std::unordered_map<std::string, OperatorInfo>
 _get_runtime_ops_and_info();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67385

As part of the expanded operator versioning effort we are going to start looking at this variable and whats stored locally in the model file.

Differential Revision: [D31976654](https://our.internmc.facebook.com/intern/diff/D31976654/)