### PR TITLE
add frozen_numpy to :builtin_registry_cuda target

### DIFF
--- a/torch/csrc/deploy/test_deploy_gpu.cpp
+++ b/torch/csrc/deploy/test_deploy_gpu.cpp
@@ -84,3 +84,34 @@ TEST(TorchDeployGPUTest, TensorRT) {
         output.allclose(model(at::IValue{input}).toIValue().toTensor()));
   }
 }
+
+// OSS build does not have bultin numpy support yet. Use this flag to guard the
+// test case.
+#if HAS_NUMPY
+TEST(TorchpyTest, TestNumpy) {
+  torch::deploy::InterpreterManager m(2);
+  auto noArgs = at::ArrayRef<torch::deploy::Obj>();
+  auto I = m.acquireOne();
+  auto mat35 = I.global("numpy", "random").attr("rand")({3, 5});
+  auto mat58 = I.global("numpy", "random").attr("rand")({5, 8});
+  auto mat38 = I.global("numpy", "matmul")({mat35, mat58});
+  EXPECT_EQ(2, mat38.attr("shape").attr("__len__")(noArgs).toIValue().toInt());
+  EXPECT_EQ(3, mat38.attr("shape").attr("__getitem__")({0}).toIValue().toInt());
+  EXPECT_EQ(8, mat38.attr("shape").attr("__getitem__")({1}).toIValue().toInt());
+}
+#endif
+
+#if HAS_PYYAML
+TEST(TorchpyTest, TestPyYAML) {
+  const std::string kDocument = "a: 1\n";
+
+  torch::deploy::InterpreterManager m(2);
+  auto I = m.acquireOne();
+
+  auto load = I.global("yaml", "load")({kDocument});
+  EXPECT_EQ(1, load.attr("__getitem__")({"a"}).toIValue().toInt());
+
+  auto dump = I.global("yaml", "dump")({load});
+  EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
+}
+#endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67396

frozen_numpy did not work on GPU since we didn't added register_frozennumpy to the :builtin_registry_cuda target.

This was not found earlier since the unit test we added to test_deploy.cpp is only run on CPU. On GPU, we run test_deploy_gpu.cpp which does not contains the added unit tests for numpy.
In this diff, I just duplidate the unit tests for numpy (and pyyaml) across test_deploy.cpp and test_deploy_gpu.cpp.
I think ideally we should consolidate there 2 files to a single one. So we can add unit test in a single place while run them in both hardward platforms.
Tracking task: T104399180

Differential Revision: [D31978156](https://our.internmc.facebook.com/intern/diff/D31978156/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D31978156/)!