### PR TITLE
[Core ML] Assign Core ML computationUnit to executor

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -227,6 +227,7 @@ class API_AVAILABLE(ios(11.0), macos(10.13)) CoreMLBackend
     const std::string& model = modelDict.at("model").toStringRef();
     const std::string& sha256 = modelDict.at("hash").toStringRef();
     PTMCoreMLExecutor* executor = [PTMCoreMLExecutor new];
+    executor.backend = config.backend();
     bool result = [executor compileMLModel:model identifier:sha256];
     TORCH_CHECK(result, "Compiling MLModel failed!");
     auto executorWrapper = c10::make_intrusive<CoreMLExecutorWrapper>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67412
* __->__ #67411
* #67410

This was overlooked before.

Differential Revision: [D31977097](https://our.internmc.facebook.com/intern/diff/D31977097/)