### PR TITLE
Sort Tensor? ahead of Scalar? variance

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -809,6 +809,7 @@ def sort_overloads(
 
     def is_arg_smaller(t1: Type, t2: Type) -> bool:
         return (str(t1) == 'Scalar' and str(t2) == 'Tensor' or
+                str(t1) == 'Scalar?' and str(t2) == 'Tensor?' or
                 'Dimname' in str(t1) and 'Dimname' not in str(t2) or
                 # In the discussion https://github.com/pytorch/pytorch/issues/54555 it has been
                 # discussed why it is important to prioritize int/int? over int[]


### PR DESCRIPTION
Sort Tensor? ahead of Scalar? variance similar to Tensor and Scalar argument

Fixes #67428
