### PR TITLE
[SR] Eliminate no-ops

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -303,12 +303,6 @@ const auto to_script_alias = R"JIT(
       return (c)
 )JIT";
 
-const auto detach_script = R"JIT(
-  def forward(self, input: Tensor):
-      a = input.detach()
-      return a.clone()
-)JIT";
-
 const std::string embedding_bag_default = R"JIT(
   def forward(self, a: Tensor, b: Tensor, c: Tensor):
       return torch.embedding_bag(a, b, c)

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -714,15 +714,6 @@ TEST(StaticRuntime, IndividualOps_to) {
   }
 }
 
-TEST(StaticRuntime, IndividualOps_Detach) {
-  auto a = at::randn({4, 3, 1, 2});
-  auto b = at::randn({3, 2, 2});
-  std::vector<IValue> args{a};
-  std::vector<IValue> args2{b};
-  testStaticRuntime(detach_script, args);
-  testStaticRuntime(detach_script, args, args2);
-}
-
 TEST(StaticRuntime, IndividualOps_ExpandAs) {
   auto a = at::randn({3, 1});
   auto b = at::randn({3, 2});

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -2364,6 +2364,36 @@ class TestFrozenOptimizations(JitTestCase):
             optimized = torch.jit.optimize_for_inference(scripted_mod)
             FileCheck().check("to_mkldnn").run(optimized.graph)
 
+    def test_remove_detach(self):
+        class Mod(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                y = x.detach()
+                return y * y
+
+        mod = Mod().eval()
+        frozen_mod = torch.jit.freeze(torch.jit.script(mod))
+        inp = torch.randn((2, 2))
+        FileCheck().check_not("aten::detach").run(frozen_mod.graph)
+        self.assertEqual(frozen_mod(inp), mod(inp))
+
+    def test_remove_detach_not_applied(self):
+        class Mod(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                y = x.detach()
+                return x is y
+
+        mod = Mod().eval()
+        frozen_mod = torch.jit.freeze(torch.jit.script(mod))
+        inp = torch.randn((2, 2))
+        FileCheck().check("aten::detach").run(frozen_mod.graph)
+        self.assertEqual(frozen_mod(inp), mod(inp))
+
 @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
 class TestMKLDNNReinplacing(JitTestCase):
     def setUp(self):

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -210,6 +210,7 @@ core_sources_full_mobile_no_backend_interface = [
     "torch/csrc/jit/passes/restore_mutation.cpp",
     "torch/csrc/jit/passes/create_autodiff_subgraphs.cpp",
     "torch/csrc/jit/passes/dead_code_elimination.cpp",
+    "torch/csrc/jit/passes/eliminate_no_ops.cpp",
     "torch/csrc/jit/passes/remove_redundant_profiles.cpp",
     "torch/csrc/jit/passes/remove_exceptions.cpp",
     "torch/csrc/jit/passes/decompose_ops.cpp",

--- a/torch/csrc/jit/passes/eliminate_no_ops.cpp
+++ b/torch/csrc/jit/passes/eliminate_no_ops.cpp
@@ -1,0 +1,80 @@
+#include <torch/csrc/jit/passes/eliminate_no_ops.h>
+
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/runtime/graph_iterator.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+bool allInputsAreTensors(Node* node) {
+  for (const auto* value : node->inputs()) {
+    const auto& type = value->type();
+    if (!type->castRaw<TensorType>()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool cannotOptimize(Node* node) {
+  const auto kind = node->kind();
+  if (kind == aten::__is__ || kind == aten::__isnot__) {
+    return allInputsAreTensors(node);
+  }
+  return false;
+}
+
+// Certain ops can make this optimization unsound. For example,
+// consider the following graph:
+//   %y : Tensor = aten::detach(%x)
+//   %b : bool = aten::__is__(%y, %x) (= False)
+// After remove detach, we would get
+//   %b : bool = aten::__is__(%x, %x) (= True!)
+bool containsInvalidOp(std::shared_ptr<Graph>& graph) {
+  for (auto* node : graph->nodes()) {
+    if (cannotOptimize(node)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+bool EliminateNoOps(
+    std::shared_ptr<Graph>& graph,
+    std::unordered_set<c10::Symbol> custom_ops) {
+  GRAPH_DUMP("Before EliminateNoOps: ", graph);
+  if (containsInvalidOp(graph)) {
+    return false;
+  }
+  // Ops here should be of the form x = f(x, ...)
+  std::unordered_set<c10::Symbol> no_ops{aten::detach};
+  no_ops.insert(custom_ops.begin(), custom_ops.end());
+
+  bool changed = false;
+
+  auto graph_it = DepthFirstGraphNodeIterator(graph);
+  for (auto* node = graph_it.next(); node != nullptr; node = graph_it.next()) {
+    auto it = no_ops.find(node->kind());
+    if (it == no_ops.end()) {
+      continue;
+    }
+
+    changed = true;
+    node->output()->replaceAllUsesWith(node->input(0));
+  }
+
+  if (changed) {
+    EliminateDeadCode(graph);
+  }
+
+  GRAPH_DUMP("After EliminateNoOps: ", graph);
+  return changed;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/eliminate_no_ops.h
+++ b/torch/csrc/jit/passes/eliminate_no_ops.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+// Remove ops that do nothing on the forward pass (like aten::detach).
+// This pass is invoked as a part of freeze_module.
+// This function also takes a set of custom ops to eliminate. All ops in this
+// set must take their output as their first input, i.e. x = f(x, ...)
+TORCH_API bool EliminateNoOps(
+    std::shared_ptr<Graph>& graph,
+    std::unordered_set<c10::Symbol> custom_ops = {});
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/passes/clear_profiling.h>
+#include <torch/csrc/jit/passes/eliminate_no_ops.h>
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/passes/lower_tuples.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
@@ -104,6 +105,7 @@ class AttributePropagator {
           subgraph,
           /* unroll_non_constant_loops? */ false,
           /* const_prop_user_classes? */ false);
+      EliminateNoOps(subgraph);
       LowerSimpleTuples(subgraph);
     };
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/eliminate_no_ops.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
@@ -121,6 +122,8 @@ void OptimizeGraph(
   RemoveImmutableInputDictLookups(graph);
   UseVariadicTupleUnpack(graph);
   UseVariadicGroupedAccessor(graph);
+  EliminateNoOps(
+      graph, /* custom_ops */ {fromQualString("fb::scale_gradient")});
   GRAPH_DUMP("Final graph after optimizations: ", graph);
 }
 


### PR DESCRIPTION
Summary: Certain ops do nothing on the forward pass and can be discarded after training: `aten::detach` and `fb::scale_gradient` are examples of this.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Reviewed By: hlu1

Differential Revision: D31980843

