### PR TITLE
Docs module check

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+from os import path
 # import sys
+import pkgutil
 
 # source code directory, relative to this file, for sphinx-autobuild
 # sys.path.insert(0, os.path.abspath('../..'))
@@ -192,6 +194,107 @@ coverage_ignore_classes = [
     "ExportTypes",
 ]
 
+# List of modules that do not have automodule/py:module in the doc yet
+# We should NOT add anything to this list, see the CI failure message
+# on how to solve missing automodule issues
+coverage_missing_automodule = [
+    # "torch",  # temporarily removed to see how this failure looks in CI
+    "torch.ao",
+    "torch.ao.nn",
+    "torch.ao.nn.sparse",
+    "torch.ao.nn.sparse.quantized",
+    "torch.ao.nn.sparse.quantized.dynamic",
+    "torch.ao.ns",
+    "torch.ao.ns.fx",
+    "torch.ao.quantization",
+    "torch.ao.quantization.fx",
+    "torch.ao.quantization.fx.backend_config_dict",
+    "torch.ao.sparsity",
+    "torch.ao.sparsity.experimental",
+    "torch.ao.sparsity.experimental.pruner",
+    "torch.ao.sparsity.scheduler",
+    "torch.ao.sparsity.sparsifier",
+    "torch.backends",
+    "torch.backends.cuda",
+    "torch.backends.cudnn",
+    "torch.backends.mkl",
+    "torch.backends.mkldnn",
+    "torch.backends.openmp",
+    "torch.backends.quantized",
+    "torch.backends.xnnpack",
+    "torch.contrib",
+    "torch.cpu",
+    "torch.cpu.amp",
+    "torch.distributed.algorithms",
+    "torch.distributed.algorithms.ddp_comm_hooks",
+    "torch.distributed.algorithms.model_averaging",
+    "torch.distributed.elastic",
+    "torch.distributed.elastic.utils",
+    "torch.distributed.elastic.utils.data",
+    "torch.distributed.launcher",
+    "torch.distributed.nn",
+    "torch.distributed.nn.api",
+    "torch.distributed.nn.jit",
+    "torch.distributed.nn.jit.templates",
+    "torch.distributed.pipeline",
+    "torch.distributed.pipeline.sync",
+    "torch.distributed.pipeline.sync.skip",
+    "torch.fft",
+    "torch.for_onnx",
+    "torch.fx.experimental",
+    "torch.fx.experimental.fx2trt",
+    "torch.fx.experimental.fx_acc",
+    "torch.fx.experimental.unification",
+    "torch.fx.experimental.unification.multipledispatch",
+    "torch.fx.passes",
+    "torch.jit.mobile",
+    "torch.nn",
+    "torch.nn.backends",
+    "torch.nn.intrinsic",
+    "torch.nn.intrinsic.modules",
+    "torch.nn.intrinsic.qat",
+    "torch.nn.intrinsic.qat.modules",
+    "torch.nn.intrinsic.quantized",
+    "torch.nn.intrinsic.quantized.dynamic",
+    "torch.nn.intrinsic.quantized.dynamic.modules",
+    "torch.nn.intrinsic.quantized.modules",
+    "torch.nn.modules",
+    "torch.nn.parallel",
+    "torch.nn.qat",
+    "torch.nn.qat.modules",
+    "torch.nn.quantizable",
+    "torch.nn.quantizable.modules",
+    "torch.nn.quantized",
+    "torch.nn.quantized.dynamic",
+    "torch.nn.quantized.dynamic.modules",
+    "torch.nn.quantized.modules",
+    "torch.nn.utils",
+    "torch.package",
+    "torch.package.analyze",
+    "torch.quantization",
+    "torch.quantization.fx",
+    "torch.sparse",
+    "torch.special",
+    "torch.utils",
+    "torch.utils.backcompat",
+    "torch.utils.benchmark.examples",
+    "torch.utils.benchmark.op_fuzzers",
+    "torch.utils.benchmark.utils",
+    "torch.utils.benchmark.utils.valgrind_wrapper",
+    "torch.utils.bottleneck",
+    "torch.utils.data.communication",
+    "torch.utils.data.datapipes",
+    "torch.utils.data.datapipes.dataframe",
+    "torch.utils.data.datapipes.iter",
+    "torch.utils.data.datapipes.map",
+    "torch.utils.data.datapipes.utils",
+    "torch.utils.ffi",
+    "torch.utils.hipify",
+    "torch.utils.model_dump",
+    "torch.utils.tensorboard",
+]
+
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
@@ -302,6 +405,70 @@ html_css_files = [
     'css/jit.css',
 ]
 
+from sphinx.ext.coverage import CoverageBuilder
+
+def coverage_post_process(app, exception):
+    if exception is not None:
+        return
+
+    # Only run this test for the coverage build
+    if not isinstance(app.builder, CoverageBuilder):
+        return
+
+    # These are all the modules that have "automodule" in an rst file
+    # These modules are the ones for which coverage is checked
+    # Here, we make sure that no module is missing from that list
+    modules = app.env.domaindata['py']['modules']
+
+    # We go through all the torch submodules and make sure they are
+    # properly tested
+    missing = set()
+    def is_not_internal(modname):
+        split_name = modname.split(".")
+        for name in split_name:
+            if name[0] == "_":
+                return False
+        return True
+
+    # The walk function does not return the top module
+    if "torch" not in modules:
+        missing.add("torch")
+
+    for _, modname, ispkg in pkgutil.walk_packages(path=torch.__path__,
+                                                   prefix=torch.__name__ + '.'):
+        if ispkg and is_not_internal(modname):
+            if not modname in modules:
+                missing.add(modname)
+
+    expected = set(coverage_missing_automodule)
+
+    output = []
+
+    unexpected_missing = missing - expected
+    if unexpected_missing:
+        mods = ", ".join(unexpected_missing)
+        output.append(f"\nYou added the following module(s) to the PyTorch namespace '{mods}' "
+                      "but they have no corresponding entry in a doc .rst file. You should "
+                      "either make sure that the .rst file that contains its documentations "
+                      "properly contains either '.. automodule:: mod_name' (if you do not want "
+                      "the paragraph added by the automodule, you can simply use py:module) or "
+                      "make the module private (by appending an '_' at the beginning of its name.")
+
+    unexpected_not_missing = expected - missing
+    if unexpected_not_missing:
+        mods = ", ".join(unexpected_not_missing)
+        output.append(f"\nThank you for adding the missing .rst entries for '{mods}', please update "
+                      "the 'coverage_missing_automodule' in 'torch/docs/source/conf.py' to remove "
+                      "the module(s) you fixed and make sure we do not regress on this in the future.")
+
+    # The output file is hard-coded by the coverage tool
+    # Our CI is setup to fail if any line is added to this file
+    output_file = path.join(app.outdir, 'python.txt')
+
+    if output:
+        with open(output_file, "a") as f:
+            for o in output:
+                f.write(o)
 
 # Called automatically by Sphinx, making this `conf.py` an "extension".
 def setup(app):
@@ -317,6 +484,8 @@ def setup(app):
     add_css = getattr(app, 'add_css_file', app.add_stylesheet)
     for css_file in html_css_files:
         add_css(css_file)
+
+    app.connect("build-finished", coverage_post_process)
 
 # From PyTorch 1.5, we now use autogenerated files to document classes and
 # functions. This breaks older references since

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -198,7 +198,7 @@ coverage_ignore_classes = [
 # We should NOT add anything to this list, see the CI failure message
 # on how to solve missing automodule issues
 coverage_missing_automodule = [
-    # "torch",  # temporarily removed to see how this failure looks in CI
+    "torch",
     "torch.ao",
     "torch.ao.nn",
     "torch.ao.nn.sparse",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -450,7 +450,7 @@ def coverage_post_process(app, exception):
         mods = ", ".join(unexpected_missing)
         output.append(f"\nYou added the following module(s) to the PyTorch namespace '{mods}' "
                       "but they have no corresponding entry in a doc .rst file. You should "
-                      "either make sure that the .rst file that contains its documentations "
+                      "either make sure that the .rst file that contains the module's documentation "
                       "properly contains either '.. automodule:: mod_name' (if you do not want "
                       "the paragraph added by the automodule, you can simply use py:module) or "
                       "make the module private (by appending an '_' at the beginning of its name.")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -423,6 +423,7 @@ def coverage_post_process(app, exception):
     # We go through all the torch submodules and make sure they are
     # properly tested
     missing = set()
+
     def is_not_internal(modname):
         split_name = modname.split(".")
         for name in split_name:
@@ -437,7 +438,7 @@ def coverage_post_process(app, exception):
     for _, modname, ispkg in pkgutil.walk_packages(path=torch.__path__,
                                                    prefix=torch.__name__ + '.'):
         if ispkg and is_not_internal(modname):
-            if not modname in modules:
+            if modname not in modules:
                 missing.add(modname)
 
     expected = set(coverage_missing_automodule)


### PR DESCRIPTION
Add check to make sure we do not add new submodules without documenting them in an rst file.
This is especially important because our doc coverage only runs for modules that are properly listed.

temporarily removed "torch" from the list to make sure the failure in CI looks as expected. EDIT: fixed now

This is what a CI failure looks like for the top level torch module as an example:
![image](https://user-images.githubusercontent.com/6359743/139264690-01af48b3-cb2f-4cfc-a50f-975fca0a8140.png)
