### PR TITLE
[SR] Native implementation for aten::squeeze

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1794,3 +1794,19 @@ TEST(StaticRuntime, IndividualOps_Size) {
   testStaticRuntime(src, args2);
   testStaticRuntime(src, args1, args3);
 }
+
+TEST(StaticRuntime, IndividuaOps_Squeeze) {
+  // Note: this is a native op, not an out variant, but clone anyways
+  // to silence warnings in testStaticRuntime
+  const auto src = R"JIT(
+    def forward(self, inp, dim: int):
+        return inp.squeeze(dim).clone()
+  )JIT";
+
+  const auto a = at::randn({2, 2});
+  const auto b = at::randn({2, 2, 2});
+
+  testStaticRuntime(src, {a, 0});
+  testStaticRuntime(src, {a, 1});
+  testStaticRuntime(src, {a, -1}, {b, 2});
+}

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -524,5 +524,22 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       };
     });
 
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    aten::squeeze,
+    aten_squeeze,
+    [](Node* n) -> SROperator {
+      if (!n->matches(torch::schema(
+              "aten::squeeze.dim(Tensor(a) self, int dim) -> Tensor(a)"))) {
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+
+      return [](ProcessedNode* p_node) {
+        const auto& self = p_node->Input(0).toTensor();
+        const auto dim = p_node->Input(1).toInt();
+        p_node->Output(0) = at::native::squeeze(self, dim);
+      };
+    });
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Native ops are faster than falling back to the JIT interpreter, sometimes significantly (we've previously seen this with ops like TupleUnpack). We should improve op coverage where possible.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D31992093

