### PR TITLE
Add OpInfo for `nn.functional.cosine_embedding_loss`

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6089,6 +6089,25 @@ def sample_inputs_grid_sample(op_info, device, dtype, requires_grad, **kwargs):
 
     return sample_inputs
 
+def sample_inputs_cosine_embedding_loss(op_info, device, dtype, requires_grad, **kwargs):
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    def make_target(shape):
+        shape = () if len(shape) == 1 else (shape[0], )
+        t = torch.randint(0, 2, shape, device=device, dtype=torch.long)
+        # Label with -1 or 1
+        t = t * 2 - 1
+        target = t.to(dtype=dtype).detach()
+        return target
+
+    def gen_inputs():
+        shapes = ((S, S), (S,))
+        reductions = ('none', 'mean', 'sum')
+        for s, r in product(shapes, reductions):
+            yield SampleInput(make_input(s), args=(make_input(s), make_target(s)), kwargs=dict(reduction=r, margin=random.uniform(-1, 1)))
+
+    return list(gen_inputs())
+
 def sample_inputs_ctc_loss(op_info, device, dtype, requires_grad, **kwargs):
     input_length = 50
     batch = 16
@@ -11296,6 +11315,19 @@ op_db: List[OpInfo] = [
                 "test_variant_consistency_jit",
                 dtypes=(torch.float32,),
             ),
+        ),
+    ),
+    OpInfo(
+        "nn.functional.cosine_embedding_loss",
+        ref=_NOTHING,
+        dtypesIfCPU=all_types_and(torch.bfloat16, torch.bool),
+        dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
+        supports_out=False,
+        sample_inputs_func=sample_inputs_cosine_embedding_loss,
+        skips=(
+            # https://github.com/pytorch/pytorch/issues/67463
+            # test_forward_mode_AD hangs forever
+            DecorateInfo(unittest.skip("Skipped!"), "TestGradients", "test_forward_mode_AD", dtypes=(torch.float64,),),
         ),
     ),
     OpInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#67465 Add OpInfo for `nn.functional.cosine_embedding_loss`**
* #67464 Add OpInfor for `nn.functional.ctc_loss`
* #67371 Add OpInfo for `nn.functional.poisson_nll_loss`
* #67376 Add OpInfo for `nn.functional.huber_loss`
* #67381 Add OpInfo for `nn.functional.hinge_embedding_loss`
* #67356 Add OpInfo for `torch.nn.functional.gaussian_nll_loss`

Differential Revision: [D32001920](https://our.internmc.facebook.com/intern/diff/D32001920)