### PR TITLE
[static runtime][dper] multi_env tests for static runtime: selective enable

### DIFF
--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -18,10 +18,7 @@ class StaticModule:
             self.static_module = torch._C._jit_to_static_module(scripted.graph)
 
     def __call__(self, *args, **kwargs):
-        if not kwargs:
-            return self.static_module(args, {})
-        else:
-            return self.static_module(args, kwargs)
+        return self.static_module(*args, **kwargs)
 
     def benchmark(self, args, kwargs, warmup_runs, main_runs):
         self.static_module.benchmark(args, kwargs, warmup_runs, main_runs)

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -49,11 +49,18 @@ void initStaticModuleBindings(PyObject* module) {
       .def(
           "__call__",
           [](StaticModule& self,
-             const std::vector<at::Tensor>& args,
-             const std::unordered_map<std::string, at::Tensor>& kwargs) {
-            std::vector<c10::IValue> arg_ivalues{args.begin(), args.end()};
-            std::unordered_map<std::string, c10::IValue> kwarg_ivalues{
-                kwargs.begin(), kwargs.end()};
+             const py::args& args,
+             const py::kwargs& kwargs) {
+            std::vector<c10::IValue> arg_ivalues;
+            std::unordered_map<std::string, c10::IValue> kwarg_ivalues;
+            for (size_t i = 0; i < args.size(); ++i) {
+              auto ivalue = torch::jit::toIValue(args[i], c10::AnyType::get());
+              arg_ivalues.push_back(ivalue);
+            }
+            for (const auto& kv : kwargs) {
+              kwarg_ivalues[py::cast<std::string>(kv.first)] =
+                  torch::jit::toIValue(kv.second, c10::AnyType::get());
+            }
             c10::IValue ret = self(arg_ivalues, kwarg_ivalues);
             return toPyObject(ret);
           })


### PR DESCRIPTION
Summary:
Unit tests for static runtime in the dper multi-env tests for cpu and scripted (including fx-traced + scripted) models. Only turn it on for single_operators_tests that are in the inline_cvr local/local_ro/remote_ro model for now.

Will have another diff that turns this on by default and explicitly disables for certain tests.

Test Plan: buck test dper3/dper3/modules/low_level_modules/tests:single_operators_test

Differential Revision: D30870488

