### PR TITLE
[SR] Native implementation for aten::split

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -2082,3 +2082,17 @@ TEST(StaticRuntime, NumToTensorTrue) {
   std::vector<IValue> args = {arg};
   testStaticRuntime(num_to_tensor_ir, args);
 }
+
+TEST(StaticRuntime, Split) {
+  const auto src = R"JIT(
+    def forward(self, inp, split_size: int, dim: int):
+        return inp.split(split_size, dim)
+  )JIT";
+
+  const auto a = at::randn({2, 2});
+  const auto b = at::randn({2, 2, 2});
+
+  testStaticRuntime(src, {a, 1, 0});
+  testStaticRuntime(src, {a, 1, 1});
+  testStaticRuntime(src, {a, 2, -1}, {b, 2, 2});
+}

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -541,5 +541,23 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       };
     });
 
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    aten::split,
+    aten_split,
+    [](Node* n) -> SROperator {
+      if (!n->matches(torch::schema(
+              "aten::split(Tensor self, int split_size, int dim=0) -> Tensor[]"))) {
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+
+      return [](ProcessedNode* p_node) {
+        const auto& self = p_node->Input(0).toTensor();
+        const auto split_size = p_node->Input(1).toInt();
+        const auto dim = p_node->Input(2).toInt();
+        p_node->Output(0) = at::native::split(self, split_size, dim);
+      };
+    });
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Native ops are faster than falling back to the JIT interpreter, sometimes significantly (we've previously seen this with ops like TupleUnpack). We should improve op coverage where possible.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D31994040

