### PR TITLE
[fx2trt] Add torch.nn.function.pad support for fx2trt

### DIFF
--- a/test/fx2trt/converters/acc_op/test_pad.py
+++ b/test/fx2trt/converters/acc_op/test_pad.py
@@ -1,0 +1,27 @@
+# Owner(s): ["oncall: fx"]
+
+import torch
+import torch.fx.experimental.fx_acc.acc_ops as acc_ops
+import torch.nn as nn
+from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase
+from parameterized import parameterized
+
+
+class TestPadConverter(AccTestCase):
+    @parameterized.expand(
+        [
+            ("1d", (1, 2)),
+            ("2d", (2, 0, 0, 1)),
+        ]
+    )
+    def test_pad(self, _, pad):
+        class Pad(nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.pad(x, pad)
+
+        inputs = [torch.randn(1, 2, 3, 4)]
+        self.run_test(
+            Pad(),
+            inputs,
+            expected_ops={acc_ops.pad},
+        )

--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -111,6 +111,9 @@ class AccTracerTest(unittest.TestCase):
         self._make_acc_op_function_test(acc_ops.sum, torch_sum)
         self._make_acc_op_function_test(acc_ops.sum, torch_sum, dim=(1,), keepdim=True)
 
+    def test_pad(self):
+        self._make_acc_op_function_test(acc_ops.pad, torch.nn.functional.pad, pad=(2, 0))
+
     def test_max(self):
         def torch_max(x, *args, **kwargs):
             return x.max(*args, **kwargs)
@@ -1922,6 +1925,7 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.embedding_bag_byte_rowwise_offsets,
                 acc_ops.embedding_bag_4bit_rowwise_offsets,
                 acc_ops.contiguous,
+                acc_ops.pad,
                 acc_ops.sin,
                 acc_ops.cos,
                 acc_ops.tan,

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -480,6 +480,52 @@ def acc_ops_conv2d(network, target, args, kwargs, name):
     return layer.get_output(0)
 
 
+@tensorrt_converter(acc_ops.pad)
+def acc_ops_pad(network, target, args, kwargs, name):
+    input_val = kwargs["input"]
+    pad = kwargs["pad"]
+    mode = kwargs["mode"]
+    value = kwargs["value"]
+    rank = len(input_val.shape)
+
+    if not isinstance(input_val, trt.tensorrt.ITensor):
+        raise RuntimeError(
+            f"pad received input {input_val} that is not part "
+            "of the TensorRT region!"
+        )
+
+    if mode != "constant":
+        raise RuntimeError(
+            f"Currently we only support constant mode for pad, got {mode}."
+        )
+
+    if len(pad) / 2 > rank:
+        raise RuntimeError(
+            f"Trying to pad last {len(pad) / 2} dimension but the input only has {rank} dimension."
+        )
+
+    # TODO: Padding layer is deprecating starting on 8.2. We need to convert acc_ops.pad
+    # to Slice layer instead. Slice layer also allows more modes, filling value other
+    # than 0, and more dimensions.
+    if value != 0:
+        raise RuntimeError(
+            f"Currently we only support padding value of 0, got {value}."
+        )
+    if len(pad) > 4:
+        raise RuntimeError("Currently we only support padding last two dimensions.")
+
+    pre_padding = tuple(pad[len(pad) - i - 2] for i in range(0, len(pad), 2))
+    post_padding = tuple(pad[len(pad) - i - 1] for i in range(0, len(pad), 2))
+
+    layer = network.add_padding(
+        input_val,
+        pre_padding if len(pre_padding) == 2 else (0,) + pre_padding,
+        post_padding if len(post_padding) == 2 else (0,) + post_padding
+    )
+    set_layer_name(layer, target, name)
+    return layer.get_output(0)
+
+
 @tensorrt_converter(acc_ops.flatten)
 def acc_ops_flatten(network, target, args, kwargs, name):
     input_val = kwargs["input"]

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -933,6 +933,12 @@ def ceil(*, input):
     return torch.ceil(**locals())
 
 
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.pad))
+@register_acc_op
+def pad(*, input, pad, mode, value):
+    return torch.nn.functional.pad(**locals())
+
+
 @register_acc_op_mapping(op_and_target=("call_function", torch.conv2d))
 @register_acc_op
 def conv2d(*, input, weight, bias, stride, padding, dilation, groups):


### PR DESCRIPTION
Summary:
Add acc_ops.pad and a converter for it. We want to try padding convolution channel dimension to get better int8 performance.

This one only support padding the last two dimension though. Starting from 8.2, it's suggested to use Slice layer to do padding but this might be nice to have for old version support.

Test Plan: buck test mode/dev-nosan caffe2/test/fx2trt/converters:test_pad

Differential Revision: D32006072

