### PR TITLE
[PyTorch Distributed][Fix] Sync the change to init local shards API to weight sharding

### DIFF
--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -489,19 +489,8 @@ def shard_parameter(
             metadata=local_metadata,  # type: ignore[arg-type]
         )
     ]
-    sharded_tensor_metadata = ShardedTensorMetadata(
-        shards_metadata=shards_metadata,
-        size=tensor.size(),
-        tensor_properties=TensorProperties(
-            dtype=local_shard.dtype,
-            layout=local_shard.layout,
-            requires_grad=local_shard.requires_grad,
-            memory_format=torch.contiguous_format,
-            pin_memory=local_shard.is_pinned(),
-        )
-    )
 
-    st = ShardedTensor._init_from_local_shards(local_shards, sharded_tensor_metadata, process_group=pg)
+    st = ShardedTensor._init_from_local_shards(local_shards, tensor.size(), process_group=pg)
 
     # Manually set sharding_spec
     st._sharding_spec = sharding_spec


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67574
* #67188
* __->__ #67534

https://github.com/pytorch/pytorch/pull/64481(D30748504) has simplified the way we initiate the local shards. But this breaks all sharding primitive ops test because we are still using the old API.

Differential Revision: [D32014421](https://our.internmc.facebook.com/intern/diff/D32014421/)