### PR TITLE
[SR] Drop support for aten::__is__ and aten::__isnot__

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -303,13 +303,7 @@ const auto to_script_alias = R"JIT(
       return (c)
 )JIT";
 
-const auto detach_script_0 = R"JIT(
-  def forward(self, input: Tensor):
-      a = input.detach()
-      return input is a
-)JIT";
-
-const auto detach_script_1 = R"JIT(
+const auto detach_script = R"JIT(
   def forward(self, input: Tensor):
       a = input.detach()
       return a.clone()
@@ -584,20 +578,6 @@ const auto bmm_script = R"JIT(
 const auto addmm_script = R"JIT(
   def forward(self, inp: Tensor, mat1: Tensor, mat2: Tensor, beta: float, alpha: float):
    return torch.addmm(inp, mat1, mat2, alpha=alpha, beta=beta).clone()
-)JIT";
-
-const auto if_script = R"JIT(
-  def forward(self, a: Tensor, b: Tensor, x: bool):
-    c = (a + b).relu().half().float()
-    d = b * c
-    if x:
-      e = a.flatten().half() * b.flatten().half()
-    else:
-      e = a.flatten().half() + b.flatten().half()
-    f = e.float().relu()
-    g = {"d": d, "b": b}
-    h = {"e": e, "f": f}
-    return [g, h]
 )JIT";
 
 const auto var_cat_script = R"JIT(


### PR DESCRIPTION
Summary:
`aten::__is__` and `aten::__isnot__` are extremely problematic for a large number of SR graph optimizations.

Some examples:

- Removing ops that are no-ops in the forward pass like `aten::detach`. This would normally be trivial, but `is` introduces corner cases like this:
```
def forward(x):
    y = x.detach()
    return x is y
```
We get `False` before optimizations. But after optimizations, the test becomes `x is x`, and we get `True`.

- `ReplaceWithCopy`: the pass that replaces ops like `aten::to` with an out variant that copies its input. The following graph returns `True` before optimizations, but `False` afterwards
```
def forward(x):
    y = x.to(x.dtype)
    return x is y
```

- And many more, `FuseListUnpack` can break too

Since the ops are not used by 99.99% of users, rejecting them so we don't have to think about this is not a big deal.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D32022584

