### PR TITLE
[skip ci] Add test owners for a special hi-pri class of tests

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1,4 +1,4 @@
-# Owner(s): ["high priority"]
+# Owner(s): ["module: mta"]
 
 import itertools
 from numbers import Number

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import itertools
 from numbers import Number
 import random

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -1,4 +1,4 @@
-# Owner(s): ["high priority"]
+# Owner(s): ["module: autograd"]
 
 from torch.testing._internal.common_utils import TestCase, run_tests, slowTest, IS_WINDOWS
 

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 from torch.testing._internal.common_utils import TestCase, run_tests, slowTest, IS_WINDOWS
 
 import subprocess

--- a/test/test_module_init.py
+++ b/test/test_module_init.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import inspect
 import torch
 from unittest import mock

--- a/test/test_module_init.py
+++ b/test/test_module_init.py
@@ -1,4 +1,4 @@
-# Owner(s): ["high priority"]
+# Owner(s): ["module: nn"]
 
 import inspect
 import torch

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1,4 +1,4 @@
-# Owner(s): ["high priority"]
+# Owner(s): ["module: nn"]
 
 from itertools import product
 from inspect import signature, isgenerator

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 from itertools import product
 from inspect import signature, isgenerator
 from copy import deepcopy

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 from collections.abc import Sequence
 from functools import partial, wraps
 import warnings

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import torch
 import numpy as np
 import inspect

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.utils._pytree import tree_map

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten, TreeSpec, LeafSpec

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -1,4 +1,4 @@
-# Owner(s): ["high priority"]
+# Owner(s): ["module: nn"]
 
 import unittest
 

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import unittest
 
 import torch

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,3 +1,5 @@
+# Owner(s): ["high priority"]
+
 import sys
 import os
 import contextlib


### PR DESCRIPTION
Action following #66232 

This change does require some context: there were several suggestions regarding what to do about this group of tests: tests that are core and crucial to all of PyTorch and are too broad to be owned by one team.
1. Let's add a "module: core" and put people behind it! This idea sounds appealing unless you are one of the people backing the label. From talking to @albanD among others, this idea of putting all these core tests on the shoulder of a few people or one team isn't super fair and I have not yet found anyone willing to take on this job. 
2. Taking advantage of the fact that we already have a triaging oncall that takes turns triaging issues, we can leave these tests essentially unlabeled and allow the oncall to triage these tests. Since these tests are crucial to PyTorch, we'll add the "high priority" label to mark them different from other unowned tests (see #67552). 
3. I _could_ still create an unbacked label "module: core" and attribute these tests there, but I don't like the idea of creating a facade that the tests are "triaged" to a label when no one is actually taking a look.

Now we could potentially break these tests down into smaller files so that each piece _could_ be owned by a team, but 1. I don't know if this is currently feasible and 2. This approach does not prevent that from happening in the future.