### PR TITLE
[Static Runtime] Add a comment on clients taking ownership of managed output tensors

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -344,8 +344,10 @@ class TORCH_API StaticRuntime {
     return static_module_.is_optimizable_container_type(n);
   }
 
-  // Deallocate managed output tensors. This should be called only when all the
-  // references to the output from Static Runtime are gone.
+  // WARNING: Deallocate managed output tensors.  A client receiving Static
+  // Runtime-managed Tensors needs to be very careful to call
+  // `StaticRuntime::deallocateOutputTensors` after all references of output
+  // Tensors are gone.
   void deallocateOutputTensors();
 
   bool checkOutputTensorMemoryLeaks();


### PR DESCRIPTION
Summary: This change adds a comment on clients taking ownership of managed output tensor to remind SR developers of  how and why that matters.

Test Plan: N/A

Reviewed By: swolchok

Differential Revision: D32013468

