### PR TITLE
Disable reduced precision reductions for fp16 GEMMs

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -451,6 +451,9 @@ void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
     // On CUDA versions prior to 11, users are required to set the math mode to CUBLAS_TENSOR_OP_MATH
     // manually to be able to use tensor cores for FP16. On CUDA 11, this is no longer required.
     TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
+#else
+    // Disallow fp16 reductions that could lead to unexpected overflow issues.
+    TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, static_cast<cublasMath_t>(CUBLAS_DEFAULT_MATH | CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION)));
 #endif  // defined(CUDA_VERSION) && CUDA_VERSION < 11000
     TORCH_CUDABLAS_CHECK(cublasGemmEx(
         handle,
@@ -472,11 +475,7 @@ void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
         ldc,
         CUDA_R_32F,
         CUBLAS_GEMM_DFALT_TENSOR_OP));
-#if defined(CUDA_VERSION) && CUDA_VERSION < 11000
-    // On CUDA versions prior to 11, users are required to set the math mode to CUBLAS_TENSOR_OP_MATH
-    // manually to be able to use tensor cores for FP16. On CUDA 11, this is no longer required.
     TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
-#endif  // defined(CUDA_VERSION) && CUDA_VERSION < 11000
   } else {
     TORCH_CUDABLAS_CHECK(cublasSgemmEx(
         handle,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6125,6 +6125,20 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
                     self.assertRaisesRegex(RuntimeError, f"{n}x{k + 1}.*{k}x{m}", lambda: torch.addmm(M, m1, m2))
                     self.assertRaisesRegex(RuntimeError, f"{n}x{k + 1}.*{k}x{m}", lambda: torch.mm(m1, m2))
 
+    @dtypes(torch.half)
+    @onlyCUDA
+    def test_addmm_addbmm_overflow(self, device, dtype):
+        inp = torch.zeros(128, 128, dtype=torch.half, device=device)
+        mat1 = torch.ones(128, 1000, dtype=torch.half, device=device)*100
+        mat2 = torch.ones(1000, 128, dtype=torch.half, device=device)*100
+        out = torch.addmm(inp, mat1, mat2, alpha=0.001, beta=0.)
+        self.assertFalse(out.isinf().any())
+
+        mat1 = torch.ones(3, 128, 1000, dtype=torch.half, device=device)*100
+        mat2 = torch.ones(3, 1000, 128, dtype=torch.half, device=device)*100
+        out = torch.addbmm(inp, mat1, mat2, alpha=0.001, beta=0.)
+        self.assertFalse(out.isinf().any())
+        
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @onlyCUDA
     def test_matmul_45724(self, device):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6138,7 +6138,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         mat2 = torch.ones(3, 1000, 128, dtype=torch.half, device=device)*100
         out = torch.addbmm(inp, mat1, mat2, alpha=0.001, beta=0.)
         self.assertFalse(out.isinf().any())
-        
+
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @onlyCUDA
     def test_matmul_45724(self, device):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6129,13 +6129,13 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @onlyCUDA
     def test_addmm_addbmm_overflow(self, device, dtype):
         inp = torch.zeros(128, 128, dtype=torch.half, device=device)
-        mat1 = torch.ones(128, 1000, dtype=torch.half, device=device)*100
-        mat2 = torch.ones(1000, 128, dtype=torch.half, device=device)*100
+        mat1 = torch.ones(128, 1000, dtype=torch.half, device=device) * 100
+        mat2 = torch.ones(1000, 128, dtype=torch.half, device=device) * 100
         out = torch.addmm(inp, mat1, mat2, alpha=0.001, beta=0.)
         self.assertFalse(out.isinf().any())
 
-        mat1 = torch.ones(3, 128, 1000, dtype=torch.half, device=device)*100
-        mat2 = torch.ones(3, 1000, 128, dtype=torch.half, device=device)*100
+        mat1 = torch.ones(3, 128, 1000, dtype=torch.half, device=device) * 100
+        mat2 = torch.ones(3, 1000, 128, dtype=torch.half, device=device) * 100
         out = torch.addbmm(inp, mat1, mat2, alpha=0.001, beta=0.)
         self.assertFalse(out.isinf().any())
 


### PR DESCRIPTION
It appears that most NVIDIA architectures (well, at least there haven't been many reports of this issue) don't do reduced precision reductions (e.g., reducing in fp16 given fp16 inputs), but this change attempts to ensure that a reduced precision reduction is never done. The included test case currently fails on Volta but passes on Pascal and Ampere; setting this flag causes the test to pass on all three.

CC @stas00 @ngimel @ptrblck 