### PR TITLE
Inserted check for PyObject_IsInstance in THPVariableCheck 

### DIFF
--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -6,6 +6,7 @@
 
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/THP_export.h>
+#include <torch/csrc/Exceptions.h>
 
 // Python object that backs torch.autograd.Variable
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
@@ -43,7 +44,10 @@ static inline bool THPVariable_CheckExact(PyObject *obj) {
 
 inline bool THPVariable_Check(PyObject *obj)
 {
-  return THPVariableClass && PyObject_IsInstance(obj, THPVariableClass);
+  const auto result = PyObject_IsInstance(obj, THPVariableClass);
+  if (result == -1)
+      throw python_error();
+  return THPVariableClass && result;
 }
 
 inline const at::Tensor& THPVariable_Unpack(THPVariable* var) {

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -44,10 +44,13 @@ static inline bool THPVariable_CheckExact(PyObject *obj) {
 
 inline bool THPVariable_Check(PyObject *obj)
 {
+  if (!THPVariableClass)
+      return false;
+
   const auto result = PyObject_IsInstance(obj, THPVariableClass);
   if (result == -1)
       throw python_error();
-  return THPVariableClass && result;
+  return result;
 }
 
 inline const at::Tensor& THPVariable_Unpack(THPVariable* var) {


### PR DESCRIPTION
Summary: Inserted check for the return of PyObject_IsInstance to capture the case in which it raises an exception and return -1. When this happen THPVariable_Check now throws a python_error to signal the exception.

Fixes #65084
