### PR TITLE
Fix DLPack CUDA stream convention

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7402,7 +7402,10 @@ else:
                 return self.tensor.__dlpack_device__()
 
             def __dlpack__(self, stream=None):
-                assert stream == 1
+                if torch.version.hip is None:
+                    assert stream == 1
+                else:
+                    assert stream == 0
                 capsule = self.tensor.__dlpack__(stream)
                 converted = True
                 return capsule

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -58,7 +58,14 @@ def from_dlpack(ext_tensor: Any) -> torch.Tensor:
             stream = torch.cuda.current_stream('cuda:{}'.format(device[1]))
             # cuda_stream is the pointer to the stream and it is a public
             # attribute, but it is not documented
-            dlpack = ext_tensor.__dlpack__(stream=stream.cuda_stream)
+            # The array API specify that the default legacy stream must be passed
+            # with a value of 1 for CUDA
+            # https://data-apis.org/array-api/latest/API_specification/array_object.html?dlpack-self-stream-none#dlpack-self-stream-none
+            is_cuda = device[0] == DLDeviceType.kDLGPU
+            # Since pytorch is not using PTDS by default, lets directly pass
+            # the legacy stream
+            stream_ptr = 1 if is_cuda and stream.cuda_stream == 0 else stream.cuda_stream
+            dlpack = ext_tensor.__dlpack__(stream=stream_ptr)
         else:
             dlpack = ext_tensor.__dlpack__()
     else:

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -60,7 +60,7 @@ def from_dlpack(ext_tensor: Any) -> torch.Tensor:
             # attribute, but it is not documented
             # The array API specify that the default legacy stream must be passed
             # with a value of 1 for CUDA
-            # https://data-apis.org/array-api/latest/API_specification/array_object.html?dlpack-self-stream-none#dlpack-self-stream-none
+            # https://data-apis.org/array-api/latest/API_specification/array_object.html?dlpack-self-stream-none#dlpack-self-stream-none  # NOQA
             is_cuda = device[0] == DLDeviceType.kDLGPU
             # Since pytorch is not using PTDS by default, lets directly pass
             # the legacy stream


### PR DESCRIPTION
Apparently for the array API, cuda default stream and per thread stream should be 1 and 2 instead of 0 and 1:

https://data-apis.org/array-api/latest/API_specification/array_object.html?dlpack-self-stream-none#dlpack-self-stream-none.

This caused a problem in the interop with CuPy https://github.com/cupy/cupy/pull/5970#discussion_r739912926.


cc @rgommers @leofang @mruberry