### PR TITLE
Clean up the View class

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/helpers.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/helpers.h
@@ -64,23 +64,6 @@ class Helpers {
   static int64_t GetCanonicalPosition(c10::ArrayRef<int64_t> dimensions,
                                       int64_t dim, int64_t pos);
 
-  // Gathers the input using the order specified by the permutation. For each i,
-  // output[i] = input[permutation[i]]. The given permutation must be the same
-  // size as the input.
-  template <typename Container>
-  static std::vector<typename Container::value_type> Permute(
-      c10::ArrayRef<int64_t> permutation, const Container& input) {
-    using T = typename Container::value_type;
-    CHECK(input.size() == permutation.size() &&
-          lazy_tensors::IsPermutation(permutation))
-        << "Invalid permutation specified";
-    std::vector<T> output(input.size());
-    for (size_t i = 0; i < permutation.size(); ++i) {
-      output[i] = input[permutation[i]];
-    }
-    return output;
-  }
-
   // Creates a transposition from the given input and dimensions.
   static std::vector<int64_t> MakeTransposePermutation(int64_t dim0,
                                                        int64_t dim1,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/permute.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/permute.cpp
@@ -28,7 +28,7 @@ lazy_tensors::Shape Permute::MakePermuteShape(
     c10::ArrayRef<int64_t> permutation) {
   return lazy_tensors::ShapeUtil::MakeShape(
       source_shape.scalar_type(),
-      Helpers::Permute(permutation, source_shape.sizes()));
+      lazy_tensors::Permute(permutation, source_shape.sizes()));
 }
 
 }  // namespace ops

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -171,7 +171,8 @@ class LazyTensor {
   torch::lazy::Value CreateTensorNode(compiler::BackendDataPtr data,
                                       bool read_only) const;
 
-  View::IrNode GetViewUpdate(const std::shared_ptr<View>& view) const;
+  std::tuple<torch::lazy::Value, bool> GetViewUpdate(
+      const std::shared_ptr<View>& view) const;
 
   std::shared_ptr<View> UpdateView(std::shared_ptr<View> view,
                                    torch::lazy::Value ir_value) const;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view.cpp
@@ -16,9 +16,7 @@
 #include "lazy_tensor_core/csrc/ops/unselect.h"
 #include "lazy_tensor_core/csrc/ops/update_slice.h"
 #include "lazy_tensor_core/csrc/ops/view.h"
-#include "lazy_tensors/computation_client/util.h"
 #include "lazy_tensors/permutation_util.h"
-#include "lazy_tensors/shape_util.h"
 
 namespace torch_lazy_tensors {
 namespace {
@@ -177,10 +175,10 @@ void Alias::Update(torch::lazy::Value ir_value, std::vector<ViewInfo> view_infos
 
 torch::lazy::Value Alias::SyncUpdateOperations() {
   for (auto& update_data : updates_) {
-    ir_value_ = ApplyUpdate(ir_value_, update_data);
+    root_ir_value_ = ApplyUpdate(root_ir_value_, update_data);
   }
   updates_.clear();
-  return ir_value_;
+  return root_ir_value_;
 }
 
 View::View(lazy_tensors::Shape shape, std::shared_ptr<Alias> alias,
@@ -207,7 +205,7 @@ std::shared_ptr<View> View::CreateSubView(lazy_tensors::Shape shape,
                                 std::move(view_infos));
 }
 
-View::IrNode View::GetViewIrNode() {
+std::tuple<torch::lazy::Value, bool> View::GetViewIrNode() {
   if (IsUpToDate()) {
     return {ir_value_, false};
   }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view.h
@@ -101,11 +101,8 @@ class Alias {
     std::vector<ViewInfo> view_infos;
   };
 
-  explicit Alias(torch::lazy::Value ir_value) : ir_value_(std::move(ir_value)) {}
-
-  const torch::lazy::Value& ir_value() const { return ir_value_; }
-
-  const std::vector<UpdateData>& updates() const { return updates_; }
+  explicit Alias(torch::lazy::Value ir_value)
+      : root_ir_value_(std::move(ir_value)) {}
 
   size_t generation() const { return generation_; }
 
@@ -118,7 +115,7 @@ class Alias {
 
  private:
   // The IR value which is the root at which the view was created.
-  torch::lazy::Value ir_value_;
+  torch::lazy::Value root_ir_value_;
   // The stacked updates on the view. Orders matter, as most recent updates
   // might overwrite older ones.
   std::vector<UpdateData> updates_;
@@ -129,11 +126,6 @@ class Alias {
 
 class View {
  public:
-  struct IrNode {
-    torch::lazy::Value ir_value;
-    bool updated;
-  };
-
   View(lazy_tensors::Shape shape, std::shared_ptr<Alias> alias,
        ViewInfo view_info);
   View(lazy_tensors::Shape shape, std::shared_ptr<Alias> alias,
@@ -151,7 +143,7 @@ class View {
   // Extracts the current IrNode out of a view, into a IrNode structure
   // where the updated fields tells whether a new IR value has been created, or
   // the cached one returned.
-  IrNode GetViewIrNode();
+  std::tuple<torch::lazy::Value, bool> GetViewIrNode();
 
   bool IsUpToDate() const {
     return ir_value_ && generation_ == alias_->generation();

--- a/lazy_tensor_core/lazy_tensors/permutation_util.cc
+++ b/lazy_tensor_core/lazy_tensors/permutation_util.cc
@@ -7,7 +7,7 @@ namespace lazy_tensors {
 
 std::vector<int64_t> InversePermutation(
     c10::ArrayRef<int64_t> input_permutation) {
-  CHECK(IsPermutation(input_permutation));
+  TORCH_CHECK(IsPermutation(input_permutation));
   std::vector<int64_t> output_permutation(input_permutation.size(), -1);
   for (size_t i = 0; i < input_permutation.size(); ++i) {
     output_permutation.at(input_permutation.at(i)) = i;
@@ -20,15 +20,6 @@ bool IsPermutation(c10::ArrayRef<int64_t> permutation) {
   std::iota(trivial_permutation.begin(), trivial_permutation.end(), 0);
   return std::is_permutation(permutation.begin(), permutation.end(),
                              trivial_permutation.begin());
-}
-
-bool IsIdentityPermutation(c10::ArrayRef<int64_t> permutation) {
-  for (int64_t i = 0; i < permutation.size(); ++i) {
-    if (permutation[i] != i) {
-      return false;
-    }
-  }
-  return true;
 }
 
 }  // namespace lazy_tensors

--- a/lazy_tensor_core/lazy_tensors/permutation_util.h
+++ b/lazy_tensor_core/lazy_tensors/permutation_util.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <c10/util/Logging.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/Exception.h>
 
 #include <vector>
-
-#include "lazy_tensors/str_join.h"
 
 namespace lazy_tensors {
 
@@ -13,17 +12,18 @@ std::vector<int64_t> InversePermutation(
 
 bool IsPermutation(c10::ArrayRef<int64_t> permutation);
 
-bool IsIdentityPermutation(c10::ArrayRef<int64_t> permutation);
-
+// Gathers the input using the order specified by the permutation. For each i,
+// output[i] = input[permutation[i]]. The given permutation must be the same
+// size as the input.
 template <typename Container>
-inline std::vector<typename Container::value_type> PermuteInverse(
-    const Container& input, c10::ArrayRef<int64_t> permutation) {
+std::vector<typename Container::value_type> Permute(
+    c10::ArrayRef<int64_t> permutation, const Container& input) {
   using T = typename Container::value_type;
-  c10::ArrayRef<T> data(input);
-  CHECK(IsPermutation(permutation));
-  std::vector<T> output(data.size());
+  TORCH_CHECK(input.size() == permutation.size() && IsPermutation(permutation),
+              "Invalid permutation specified");
+  std::vector<T> output(input.size());
   for (size_t i = 0; i < permutation.size(); ++i) {
-    output[permutation[i]] = data[i];
+    output[i] = input[permutation[i]];
   }
   return output;
 }

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -200,6 +200,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
                 "torch/csrc/lazy/core/ir.h",
                 "lazy_tensor_core/csrc/ts_backend/ts_node_lowering.h",
                 "torch/csrc/lazy/core/hash.h",
+                "lazy_tensors/str_join.h",
                 node_base_hdr if node_base_hdr is not None else None
             ] if path is not None],
             'external_backend_headers': f'#include "{output_dir}/{backend_key}NativeFunctions.h"',


### PR DESCRIPTION
Summary:
- Remove used header files
- Remove unused functions
- Replace View::IrNode with std::tuple to avoid name confusion