### PR TITLE
Modify decorator for acc op converters

### DIFF
--- a/test/fx2trt/passes/trt_operator_supported_test.py
+++ b/test/fx2trt/passes/trt_operator_supported_test.py
@@ -1,0 +1,62 @@
+# Owner(s): ["oncall: fx"]
+
+import unittest
+import torch.fx.experimental.fx_acc.acc_ops  # noqa: F401
+import torch
+import torch.fx
+from torch.fx.experimental.fx2trt.tools.trt_splitter import create_trt_operator_support
+import torch.nn as nn
+from torch.fx.experimental.fx_acc import acc_ops, acc_tracer
+
+
+class TestTRTOperatorSupport(unittest.TestCase):
+    def test_supported_node_target(self):
+        class TestModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(1, 1)
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = x + 1
+                return torch.add(input=x, other=x)
+
+        mod = TestModule()
+        traced_mod = acc_tracer.trace(mod, torch.randn(1, 2, 1, 1))
+        op_support = create_trt_operator_support()
+        for node in traced_mod.graph.nodes:
+            self.assertTrue(op_support.is_node_supported(mod, node))
+
+
+    def test_unsupport_node_explicit_batch_dim(self):
+        class TestModule(nn.Module):
+            def forward(self, x):
+                y = torch.add(input=x, other=x)
+                return torch.split(y, 2)
+
+        mod = TestModule()
+        traced_mod = acc_tracer.trace(mod, torch.randn(5, 2))
+        op_support = create_trt_operator_support(use_implicit_batch_dim=False)
+
+        for node in traced_mod.graph.nodes:
+            if node.target == acc_ops.add:
+                self.assertTrue(op_support.is_node_supported(mod, node))
+            elif node.target == acc_ops.split:
+                self.assertFalse(op_support.is_node_supported(mod, node))
+
+
+    def test_unsupport_node_implicit_batch_dim(self):
+        class TestModule(nn.Module):
+            def forward(self, x):
+                y = torch.add(input=x, other=x)
+                return nn.functional.gelu(y)
+
+        mod = TestModule()
+        traced_mod = acc_tracer.trace(mod, torch.randn(5, 2))
+        op_support = create_trt_operator_support(use_implicit_batch_dim=True)
+
+        for node in traced_mod.graph.nodes:
+            if node.target == acc_ops.add:
+                self.assertTrue(op_support.is_node_supported(mod, node))
+            elif node.target == acc_ops.gelu:
+                self.assertFalse(op_support.is_node_supported(mod, node))

--- a/test/fx2trt/passes/trt_splitter_test.py
+++ b/test/fx2trt/passes/trt_splitter_test.py
@@ -1,3 +1,5 @@
+# Owner(s): ["oncall: fx"]
+
 import operator
 import unittest
 

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1029,12 +1029,12 @@ def add_acc_ops_dim_reduce(network, target, args, kwargs, name, reduce_op):
     return (shuffle_layer0.get_output(0), shuffle_layer1.get_output(0))
 
 
-@tensorrt_converter(acc_ops.max_full_reduce)
+@tensorrt_converter(acc_ops.max_full_reduce, no_implicit_batch_dim=True)
 def acc_ops_max_full_reduce(network, target, args, kwargs, name):
     return add_acc_ops_full_reduce(network, target, args, kwargs, name, trt.ReduceOperation.MAX)
 
 
-@tensorrt_converter(acc_ops.min_full_reduce)
+@tensorrt_converter(acc_ops.min_full_reduce, no_implicit_batch_dim=True)
 def acc_ops_min_full_reduce(network, target, args, kwargs, name):
     return add_acc_ops_full_reduce(network, target, args, kwargs, name, trt.ReduceOperation.MIN)
 
@@ -1368,7 +1368,7 @@ def acc_ops_slice_tensor(network, target, args, kwargs, name):
     return layer.get_output(0)
 
 
-@tensorrt_converter(acc_ops.split)
+@tensorrt_converter(acc_ops.split, no_explicit_batch_dim=True)
 def acc_ops_split(network, target, args, kwargs, name):
     input_val = kwargs["input"]
 
@@ -1828,7 +1828,7 @@ def acc_ops_dequantize(network, target, args, kwargs, name):
     return layer.get_output(0)
 
 
-@tensorrt_converter(acc_ops.gelu)
+@tensorrt_converter(acc_ops.gelu, no_implicit_batch_dim=True)
 def acc_ops_gelu(network, target, args, kwargs, name):
     input_val = kwargs["input"]
     if not isinstance(input_val, trt.tensorrt.ITensor):
@@ -1897,7 +1897,7 @@ def acc_ops_chunk(network, target, args, kwargs, name):
         output.append(layer.get_output(0))
     return output
 
-@tensorrt_converter(acc_ops.cumsum)
+@tensorrt_converter(acc_ops.cumsum, no_implicit_batch_dim=True)
 def acc_ops_cumsum(network, target, args, kwargs, name):
     input_val = kwargs["input"]
     dim = kwargs["dim"]

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -253,11 +253,17 @@ class TRTModule(torch.nn.Module):
 
 
 CONVERTERS = {}
+NO_IMPLICIT_BATCH_DIM_SUPPORT = {}
+NO_EXPLICIT_BATCH_DIM_SUPPORT = {}
 
 
-def tensorrt_converter(key):
+def tensorrt_converter(key, no_implicit_batch_dim=False, no_explicit_batch_dim=False):
     def register_converter(converter):
         CONVERTERS[key] = converter
+        if no_implicit_batch_dim:
+            NO_IMPLICIT_BATCH_DIM_SUPPORT[key] = converter
+        if no_explicit_batch_dim:
+            NO_EXPLICIT_BATCH_DIM_SUPPORT[key] = converter
         return converter
 
     return register_converter


### PR DESCRIPTION
Summary:
Modify decorator to denote whether a acc op converter is able to support explicit/implicit batch dim. This info will be used by trt_splitter when determine whether a node can be split into acc graph.
This is can prevent us from split node to acc module and later found no proper converter exist for the node and fail the lower process.

Test Plan: unit test

Differential Revision: D31998477

