### PR TITLE
[SR] Out variant for prim::NumToTensor

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1859,3 +1859,45 @@ TEST(StaticRuntime, IndividuaOps_Squeeze) {
   testStaticRuntime(src, {a, 1});
   testStaticRuntime(src, {a, -1}, {b, 2});
 }
+
+TEST(StaticRuntime, IndividualOps_NumToTensorScalar) {
+  const auto num_to_tensor_ir = R"IR(
+    graph(%1 : int):
+      %2 : NoneType = prim::Constant()
+      %3 : Tensor = prim::NumToTensor(%1)
+      %4 : Tensor = aten::clone(%3, %2)
+      return (%4)
+  )IR";
+
+  IValue arg{5};
+  std::vector<IValue> args = {arg};
+  testStaticRuntime(num_to_tensor_ir, args);
+}
+
+TEST(StaticRuntime, IndividualOps_NumToTensorFalse) {
+  const auto num_to_tensor_ir = R"IR(
+    graph(%1 : bool):
+      %2 : NoneType = prim::Constant()
+      %3 : Tensor = prim::NumToTensor(%1)
+      %4 : Tensor = aten::clone(%3, %2)
+      return (%4)
+  )IR";
+
+  IValue arg{false};
+  std::vector<IValue> args = {arg};
+  testStaticRuntime(num_to_tensor_ir, args);
+}
+
+TEST(StaticRuntime, IndividualOps_NumToTensorTrue) {
+  const auto num_to_tensor_ir = R"IR(
+    graph(%1 : bool):
+      %2 : NoneType = prim::Constant()
+      %3 : Tensor = prim::NumToTensor(%1)
+      %4 : Tensor = aten::clone(%3, %2)
+      return (%4)
+  )IR";
+
+  IValue arg{true};
+  std::vector<IValue> args = {arg};
+  testStaticRuntime(num_to_tensor_ir, args);
+}

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -2148,5 +2148,29 @@ REGISTER_OPERATOR_FUNCTOR(aten::where, aten_where, [](Node* n) -> SROperator {
   return nullptr;
 });
 
+REGISTER_OPERATOR_FUNCTOR(
+    prim::NumToTensor,
+    prim_NumToTensor,
+    [](Node* n) -> SROperator {
+      if (n->matches(
+              torch::schema("prim::NumToTensor.Scalar(Scalar s) -> Tensor")) ||
+          n->matches(
+              torch::schema("prim::NumToTensor.bool(bool a) -> Tensor"))) {
+        return [](ProcessedNode* pnode) {
+          const auto scalar = pnode->Input(0).toScalar();
+          if (pnode->Output(0).isNone()) {
+            pnode->Output(0) = at::scalar_to_tensor(scalar);
+            return;
+          }
+          auto& out = pnode->Output(0).toTensor();
+          fastResizeToZero(out);
+          at::native::resize_(out, {}, c10::nullopt);
+          at::detail::scalar_fill(out, scalar);
+        };
+      }
+      LogAndDumpSchema(n);
+      return nullptr;
+    });
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Returns a tensor constructed from scalar input

Test Plan:
```
buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest
```

Differential Revision: D32014194

