### PR TITLE
Move some cub templates out of the header file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -417,6 +417,7 @@ filegroup(
 filegroup(
     name = "aten_srcs_cu",
     srcs = [
+        "aten/src/ATen/cuda/cub.cu.cc",
         "aten/src/ATen/cuda/detail/IndexUtils.cu.cc",
         "aten/src/ATen/cuda/detail/CUDAGraphsUtils.cu.cc",
         "aten/src/ATen/native/cuda/Activation.cu.cc",

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/CUDAConfig.h>
 
 namespace at {
 namespace cuda {
@@ -54,7 +55,12 @@ AT_INSTANTIATE_SORT_PAIRS(int64_t, 4)
 #define AT_INSTANTIATE_SORT_PAIRS_8(scalar_t, ScalarType)   \
   AT_INSTANTIATE_SORT_PAIRS(scalar_t, 8)
 
-AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, AT_INSTANTIATE_SORT_PAIRS_8)
+AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, AT_INSTANTIATE_SORT_PAIRS_8)
+
+// BFloat16 is not supported by ROCm's radix sort
+#if !AT_ROCM_ENABLED()
+AT_INSTANTIATE_SORT_PAIRS(c10::BFloat16, 8)
+#endif
 
 }  // namespace detail
 

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -1,0 +1,145 @@
+#define TORCH_ASSERT_NO_OPERATORS
+#include <ATen/cuda/cub.cuh>
+
+namespace at {
+namespace cuda {
+namespace cub {
+namespace detail {
+
+template<typename key_t, int value_size>
+void radix_sort_pairs_impl(
+    const key_t *keys_in, key_t *keys_out,
+    const OpaqueType<value_size> *values_in, OpaqueType<value_size> *values_out,
+    int64_t n, bool descending, int64_t begin_bit, int64_t end_bit) {
+  TORCH_CHECK(n <= std::numeric_limits<int>::max(),
+    "cub sort does not support sorting more than INT_MAX elements");
+  using key_t_ = typename detail::cuda_type<key_t>::type;
+
+  auto allocator = c10::cuda::CUDACachingAllocator::get();
+  c10::DataPtr keys_out_owner;
+
+  if (keys_out == nullptr) {
+    keys_out_owner = allocator->allocate(n * sizeof(key_t));
+    keys_out = reinterpret_cast<key_t *>(keys_out_owner.get());
+  }
+
+  const key_t_ *keys_in_ = reinterpret_cast<const key_t_*>(keys_in);
+  key_t_ *keys_out_ = reinterpret_cast<key_t_*>(keys_out);
+
+  if (descending) {
+    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortPairsDescending,
+      keys_in_, keys_out_, values_in, values_out, n,
+      begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
+  } else {
+    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortPairs,
+      keys_in_, keys_out_, values_in, values_out, n,
+      begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
+  }
+}
+
+#define AT_INSTANTIATE_SORT_PAIRS(key_t, value_size)                    \
+  template void radix_sort_pairs_impl(                                  \
+      const key_t *keys_in, key_t *keys_out,                            \
+      const OpaqueType<value_size> *values_in,                          \
+      OpaqueType<value_size> *values_out,                               \
+      int64_t n, bool descending, int64_t begin_bit, int64_t end_bit);
+
+AT_INSTANTIATE_SORT_PAIRS(int32_t, 1)
+AT_INSTANTIATE_SORT_PAIRS(int32_t, 2)
+AT_INSTANTIATE_SORT_PAIRS(int32_t, 4)
+AT_INSTANTIATE_SORT_PAIRS(int64_t, 1)
+AT_INSTANTIATE_SORT_PAIRS(int64_t, 2)
+AT_INSTANTIATE_SORT_PAIRS(int64_t, 4)
+
+#define AT_INSTANTIATE_SORT_PAIRS_8(scalar_t, ScalarType)   \
+  AT_INSTANTIATE_SORT_PAIRS(scalar_t, 8)
+
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, AT_INSTANTIATE_SORT_PAIRS_8)
+
+}  // namespace detail
+
+template<typename key_t>
+void radix_sort_keys(
+    const key_t *keys_in, key_t *keys_out,
+    int64_t n, bool descending, int64_t begin_bit, int64_t end_bit) {
+  TORCH_CHECK(n <= std::numeric_limits<int>::max(),
+              "cub sort does not support sorting more than INT_MAX elements");
+  using key_t_ = typename detail::cuda_type<key_t>::type;
+
+  const key_t_ *keys_in_ = reinterpret_cast<const key_t_*>(keys_in);
+  key_t_ *keys_out_ = reinterpret_cast<key_t_*>(keys_out);
+
+  if (descending) {
+    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortKeysDescending,
+                keys_in_, keys_out_, n,
+                begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
+  } else {
+    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortKeys,
+                keys_in_, keys_out_, n,
+                begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
+  }
+}
+
+template<typename scalar_t>
+void unique(const scalar_t *input, scalar_t *output, int64_t *num_selected_out, int64_t num_items) {
+  TORCH_CHECK(num_items <= std::numeric_limits<int>::max(),
+              "cub unique does not support more than INT_MAX elements");
+  CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceSelect::Unique,
+              input, output, num_selected_out, num_items, at::cuda::getCurrentCUDAStream());
+}
+
+template <typename scalar_t>
+void run_length_encode(const scalar_t *input, scalar_t *output, int64_t *counts_out,
+                       int64_t *length_out, int64_t num_items) {
+  TORCH_CHECK(num_items <= std::numeric_limits<int>::max(),
+              "cub run_length_encode does not support more than INT_MAX elements");
+  CUB_WRAPPER(
+      NO_ROCM(at_cuda_detail)::cub::DeviceRunLengthEncode::Encode,
+      input, output, counts_out, length_out, num_items,
+      at::cuda::getCurrentCUDAStream());
+}
+
+#define AT_INSTATIATE_CUB_TEMPLATES(scalar_t, ScalarType)           \
+  template void radix_sort_keys(                                    \
+      const scalar_t *keys_in, scalar_t *keys_out, int64_t n,       \
+      bool descending, int64_t begin_bit, int64_t end_bit);         \
+  template void unique(                                             \
+      const scalar_t *input, scalar_t *output,                      \
+      int64_t *num_selected_out, int64_t num_items);                \
+  template void run_length_encode(                                  \
+      const scalar_t *input, scalar_t *output, int64_t *counts_out, \
+      int64_t *length_out, int64_t n);
+
+AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, AT_INSTATIATE_CUB_TEMPLATES)
+
+namespace {
+template <typename scalar_t>
+struct SumOp {
+  __device__ scalar_t operator () (scalar_t a, scalar_t b) const {
+    return a + b;
+  }
+};
+}
+
+template <typename input_t, typename output_t>
+void inclusive_sum(const input_t *input, output_t *output, int64_t num_items) {
+  using scalar_t = std::common_type_t<input_t, output_t>;
+  inclusive_scan(input, output, SumOp<scalar_t>{}, num_items);
+}
+
+template void inclusive_sum(const int32_t *input, int32_t *output, int64_t num_items);
+template void inclusive_sum(const int64_t *input, int64_t *output, int64_t num_items);
+template void inclusive_sum(const int32_t *input, int64_t *output, int64_t num_items);
+
+template <typename input_t, typename output_t>
+void exclusive_sum(const input_t *input, output_t *output, int64_t num_items) {
+  using scalar_t = std::common_type_t<input_t, output_t>;
+  exclusive_scan(input, output, SumOp<scalar_t>{}, scalar_t(0), num_items);
+}
+
+template void exclusive_sum(const int32_t *input, int32_t *output, int64_t num_items);
+template void exclusive_sum(const int64_t *input, int64_t *output, int64_t num_items);
+template void exclusive_sum(const bool *input, int64_t *output, int64_t num_items);
+template void exclusive_sum(const uint8_t *input, int64_t *output, int64_t num_items);
+
+}}}  // namespace at::cuda::cub

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -128,24 +128,24 @@ struct SumOp {
 }
 
 template <typename input_t, typename output_t>
-void inclusive_sum(const input_t *input, output_t *output, int64_t num_items) {
+void inclusive_sum_truncating(const input_t *input, output_t *output, int64_t num_items) {
   using scalar_t = std::common_type_t<input_t, output_t>;
   inclusive_scan(input, output, SumOp<scalar_t>{}, num_items);
 }
 
-template void inclusive_sum(const int32_t *input, int32_t *output, int64_t num_items);
-template void inclusive_sum(const int64_t *input, int64_t *output, int64_t num_items);
-template void inclusive_sum(const int32_t *input, int64_t *output, int64_t num_items);
+template void inclusive_sum_truncating(const int32_t *input, int32_t *output, int64_t num_items);
+template void inclusive_sum_truncating(const int64_t *input, int64_t *output, int64_t num_items);
+template void inclusive_sum_truncating(const int32_t *input, int64_t *output, int64_t num_items);
 
 template <typename input_t, typename output_t>
-void exclusive_sum(const input_t *input, output_t *output, int64_t num_items) {
+void exclusive_sum_in_common_type(const input_t *input, output_t *output, int64_t num_items) {
   using scalar_t = std::common_type_t<input_t, output_t>;
   exclusive_scan(input, output, SumOp<scalar_t>{}, scalar_t(0), num_items);
 }
 
-template void exclusive_sum(const int32_t *input, int32_t *output, int64_t num_items);
-template void exclusive_sum(const int64_t *input, int64_t *output, int64_t num_items);
-template void exclusive_sum(const bool *input, int64_t *output, int64_t num_items);
-template void exclusive_sum(const uint8_t *input, int64_t *output, int64_t num_items);
+template void exclusive_sum_in_common_type(const int32_t *input, int32_t *output, int64_t num_items);
+template void exclusive_sum_in_common_type(const int64_t *input, int64_t *output, int64_t num_items);
+template void exclusive_sum_in_common_type(const bool *input, int64_t *output, int64_t num_items);
+template void exclusive_sum_in_common_type(const uint8_t *input, int64_t *output, int64_t num_items);
 
 }}}  // namespace at::cuda::cub

--- a/aten/src/ATen/cuda/cub.cu
+++ b/aten/src/ATen/cuda/cub.cu
@@ -129,8 +129,8 @@ struct SumOp {
 
 template <typename input_t, typename output_t>
 void inclusive_sum_truncating(const input_t *input, output_t *output, int64_t num_items) {
-  using scalar_t = std::common_type_t<input_t, output_t>;
-  inclusive_scan(input, output, SumOp<scalar_t>{}, num_items);
+  using NO_ROCM(at_cuda_detail)::cub::Sum;
+  inclusive_scan(input, output, Sum{}, num_items);
 }
 
 template void inclusive_sum_truncating(const int32_t *input, int32_t *output, int64_t num_items);

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -147,7 +147,9 @@ namespace impl {
 template<typename InputIteratorT1, typename InputIteratorT2, typename OutputIteratorT, class ScanOpT>
 C10_LAUNCH_BOUNDS_1(1)
 __global__ void transform_vals(InputIteratorT1 a, InputIteratorT2 b, OutputIteratorT out, ScanOpT scan_op){
-  *out = scan_op(*a, *b);
+  // NOTE: out here not the final scan output, but an intermediate of the accumulation type.
+  using acc_t = typename std::iterator_traits<OutputIteratorT>::value_type;
+  *out = scan_op(static_cast<acc_t>(*a), static_cast<acc_t>(*b));
 }
 
 template<typename ValueT, typename InputIteratorT>

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include <ATen/cuda/cub.h>
 
 #include <cstddef>
 #include <type_traits>
@@ -103,72 +104,8 @@ struct cuda_type<c10::BFloat16> {
 
 }  // namespace detail
 
-inline int get_num_bits(uint64_t max_key) {
-  int num_bits = 1;
-  while (max_key > 1) {
-    max_key >>= 1;
-    num_bits++;
-  }
-  return num_bits;
-}
-
-template<typename key_t>
-static inline void radix_sort_keys(
-    const key_t *keys_in, key_t *keys_out,
-    int64_t n, bool descending=false, int64_t begin_bit=0, int64_t end_bit=sizeof(key_t)*8
-) {
-  TORCH_CHECK(n <= std::numeric_limits<int>::max(),
-    "cub sort does not support sorting more than INT_MAX elements");
-  using key_t_ = typename detail::cuda_type<key_t>::type;
-
-  const key_t_ *keys_in_ = reinterpret_cast<const key_t_*>(keys_in);
-  key_t_ *keys_out_ = reinterpret_cast<key_t_*>(keys_out);
-
-  if (descending) {
-    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortKeysDescending,
-      keys_in_, keys_out_, n,
-      begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
-  } else {
-    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortKeys,
-      keys_in_, keys_out_, n,
-      begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
-  }
-}
-
-template<typename key_t, typename value_t>
-static inline void radix_sort_pairs(
-    const key_t *keys_in, key_t *keys_out,
-    const value_t *values_in, value_t *values_out,
-    int64_t n, bool descending=false, int64_t begin_bit=0, int64_t end_bit=sizeof(key_t)*8
-) {
-  TORCH_CHECK(n <= std::numeric_limits<int>::max(),
-    "cub sort does not support sorting more than INT_MAX elements");
-  using key_t_ = typename detail::cuda_type<key_t>::type;
-
-  auto allocator = c10::cuda::CUDACachingAllocator::get();
-  c10::DataPtr keys_out_owner;
-
-  if (keys_out == nullptr) {
-    keys_out_owner = allocator->allocate(n * sizeof(key_t));
-    keys_out = reinterpret_cast<key_t *>(keys_out_owner.get());
-  }
-
-  const key_t_ *keys_in_ = reinterpret_cast<const key_t_*>(keys_in);
-  key_t_ *keys_out_ = reinterpret_cast<key_t_*>(keys_out);
-
-  if (descending) {
-    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortPairsDescending,
-      keys_in_, keys_out_, values_in, values_out, n,
-      begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
-  } else {
-    CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceRadixSort::SortPairs,
-      keys_in_, keys_out_, values_in, values_out, n,
-      begin_bit, end_bit, c10::cuda::getCurrentCUDAStream());
-  }
-}
-
 template<typename key_t, typename value_t, typename OffsetIteratorT>
-static inline void segmented_sort_pairs(
+inline void segmented_sort_pairs(
     const key_t *keys_in, key_t *keys_out,
     const value_t *values_in, value_t *values_out,
     int64_t num_elements, int64_t num_segments,
@@ -257,7 +194,7 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
       size_cub,
       at::cuda::getCurrentCUDAStream());
   C10_CUDA_KERNEL_LAUNCH_CHECK();
-  using input_t = std::remove_reference_t<decltype(*input)>;
+  using input_t = std::remove_cv_t<std::remove_reference_t<decltype(*input)>>;
   for (int64_t i = max_cub_size; i < num_items; i += max_cub_size) {
     auto allocator = c10::cuda::CUDACachingAllocator::get();
     c10::DataPtr first_elem = allocator->allocate(sizeof(input_t));
@@ -326,14 +263,6 @@ inline void exclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         size_cub,
         at::cuda::getCurrentCUDAStream());
   }
-}
-
-template<typename InputIteratorT , typename OutputIteratorT , typename NumSelectedIteratorT >
-inline void unique(InputIteratorT input, OutputIteratorT output, NumSelectedIteratorT num_selected_out, int64_t num_items) {
-  TORCH_CHECK(num_items <= std::numeric_limits<int>::max(),
-    "cub unique does not support more than INT_MAX elements");
-  CUB_WRAPPER(NO_ROCM(at_cuda_detail)::cub::DeviceSelect::Unique,
-    input, output, num_selected_out, num_items, at::cuda::getCurrentCUDAStream());
 }
 
 }}}  // namespace at::cuda::cub

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -194,7 +194,7 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
       size_cub,
       at::cuda::getCurrentCUDAStream());
   C10_CUDA_KERNEL_LAUNCH_CHECK();
-  using input_t = std::remove_cv_t<std::remove_reference_t<decltype(*input)>>;
+  using input_t = typename std::iterator_traits<InputIteratorT>::value_type;
   for (int64_t i = max_cub_size; i < num_items; i += max_cub_size) {
     auto allocator = c10::cuda::CUDACachingAllocator::get();
     c10::DataPtr first_elem = allocator->allocate(sizeof(input_t));

--- a/aten/src/ATen/cuda/cub.h
+++ b/aten/src/ATen/cuda/cub.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <cstdint>
+#include <c10/core/ScalarType.h>
+
+// NOTE: These templates are intentionally not defined in this header,
+// which aviods re-compiling them for each translation unit. If you get
+// a link error, you need to add an explicit instantiation for your
+// types in cub.cu
+
+namespace at {
+namespace cuda {
+namespace cub {
+
+inline int get_num_bits(uint64_t max_key) {
+  int num_bits = 1;
+  while (max_key > 1) {
+    max_key >>= 1;
+    num_bits++;
+  }
+  return num_bits;
+}
+
+namespace detail {
+
+// radix_sort_pairs doesn't interact with value_t other than to copy
+// the data, so we can save template instantiations by reinterpreting
+// it as an opaque type.
+template <int N> struct alignas(N) OpaqueType { char data[N]; };
+
+template<typename key_t, int value_size>
+void radix_sort_pairs_impl(
+    const key_t *keys_in, key_t *keys_out,
+    const OpaqueType<value_size> *values_in, OpaqueType<value_size> *values_out,
+    int64_t n, bool descending, int64_t begin_bit, int64_t end_bit);
+
+}  // namespace detail
+
+template<typename key_t, typename value_t>
+void radix_sort_pairs(
+    const key_t *keys_in, key_t *keys_out,
+    const value_t *values_in, value_t *values_out,
+    int64_t n, bool descending=false, int64_t begin_bit=0, int64_t end_bit=sizeof(key_t)*8) {
+  static_assert(std::is_trivially_copyable<value_t>::value, "Value must be trivially copyable");
+  // Make key type opaque, so all inputs of a certain size use the same template instantiation
+  using opaque_t = detail::OpaqueType<sizeof(value_t)>;
+  static_assert(sizeof(value_t) <= 8 && (sizeof(value_t) & (sizeof(value_t) - 1)) == 0, "");
+  detail::radix_sort_pairs_impl(
+      keys_in, keys_out,
+      reinterpret_cast<const opaque_t*>(values_in),
+      reinterpret_cast<opaque_t*>(values_out),
+      n, descending, begin_bit, end_bit);
+}
+
+template<typename key_t>
+void radix_sort_keys(
+    const key_t *keys_in, key_t *keys_out,
+    int64_t n, bool descending=false, int64_t begin_bit=0, int64_t end_bit=sizeof(key_t)*8);
+
+template <typename scalar_t>
+void unique(const scalar_t *input, scalar_t *output,
+            int64_t *num_selected_out, int64_t num_items);
+
+template <typename scalar_t>
+void run_length_encode(const scalar_t *input, scalar_t *output, int64_t *counts_out,
+                       int64_t *length_out, int64_t n);
+
+template <typename input_t, typename output_t>
+void inclusive_sum(const input_t *input, output_t *output, int64_t n);
+
+template <typename input_t, typename output_t>
+void exclusive_sum(const input_t *input, output_t *output, int64_t n);
+
+}}}  // namespace at::cuda::cub

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -6,7 +6,7 @@
 #include <c10/util/Exception.h>
 #include <c10/macros/Macros.h>
 
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 
 #include <ATen/native/cuda/EmbeddingBackwardKernel.cuh>
 #include <ATen/native/cuda/SortingCommon.cuh>

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/cuda/SortingCommon.cuh>
@@ -222,12 +222,10 @@ Tensor embedding_backward_cuda_kernel(
     // start position of each _segment_ in `partial_segment_offset`.
     // Unit: index in `partial_segment_offset`
     auto partials_per_segment_offset = at::empty({num_of_segments}, orig_indices.options());
-    cuda::cub::exclusive_scan(
-      partials_per_segment.data_ptr<index_t>(),
-      partials_per_segment_offset.data_ptr<index_t>(),
-      cub::Sum(),
-      index_t(0),
-      num_of_segments);
+    cuda::cub::exclusive_sum(
+        partials_per_segment.data_ptr<index_t>(),
+        partials_per_segment_offset.data_ptr<index_t>(),
+        num_of_segments);
 
     // The total number of partial-segments is the sum of `partials_per_segment_offset`
     const int num_of_partial_segments = partials_per_segment[num_of_segments-1].item<index_t>() +

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -8,7 +8,7 @@
 
 #include <ATen/AccumulateType.h>
 
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/native/cuda/EmbeddingBackwardKernel.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -389,7 +389,7 @@ void masked_scatter_cuda_impl(Tensor& self, const Tensor& mask, const Tensor& so
   auto maskPrefixSum_data = maskPrefixSum.data_ptr<int64_t>();
   auto mask_data = mask_cont.data_ptr<mask_t>();
 
-  at::cuda::cub::exclusive_sum(
+  at::cuda::cub::exclusive_sum_in_common_type(
       mask_data, maskPrefixSum_data, mask_numel);
 
   // Asynchronously check that the number of `1` elements present in the mask

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -9,7 +9,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/ExpandUtils.h>
@@ -389,10 +389,8 @@ void masked_scatter_cuda_impl(Tensor& self, const Tensor& mask, const Tensor& so
   auto maskPrefixSum_data = maskPrefixSum.data_ptr<int64_t>();
   auto mask_data = mask_cont.data_ptr<mask_t>();
 
-  at::cuda::cub::exclusive_scan(
-    mask_data, maskPrefixSum_data,
-    []__device__(int64_t a, int64_t b) { return a + b; },
-    int64_t(0), mask_numel);
+  at::cuda::cub::exclusive_sum(
+      mask_data, maskPrefixSum_data, mask_numel);
 
   // Asynchronously check that the number of `1` elements present in the mask
   // must be <= the number of elements available in `src`.

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -15,7 +15,7 @@
 #include <ATen/cuda/CUDAUtils.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 #include <c10/util/irange.h>
 #include <c10/core/QScheme.h>
 

--- a/aten/src/ATen/native/cuda/Randperm.cu
+++ b/aten/src/ATen/native/cuda/Randperm.cu
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/native/TensorFactories.h>
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 #include <ATen/native/cuda/Randperm.cuh>
 
 #include <limits>

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -55,12 +55,10 @@ Tensor _get_complete_sum(const Tensor& lengths) {
       lengths.type(), "_segment_reduce_cuda_backward_kernel1", ([&] {
         auto* lengths_data_ptr = lengths.data_ptr<index_t>();
         auto* offsets_data_ptr = offsets.data_ptr<index_t>();
-        CUB_WRAPPER(
-            cub::DeviceScan::InclusiveSum,
+        at::cuda::cub::inclusive_sum(
             lengths_data_ptr,
             offsets_data_ptr + 1,
-            segment_count,
-            at::cuda::getCurrentCUDAStream());
+            segment_count);
       }));
   return offsets;
 }

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -3,7 +3,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/KernelUtils.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
-#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/cub.h>
 
 namespace at {
 namespace native {
@@ -68,12 +68,10 @@ std::tuple<Tensor, Tensor, Tensor, int64_t> compute_unique(
 
     Tensor inv_loc_out =
         consecutive ? inverse_indices : at::empty({num_inp}, options);
-    CUB_WRAPPER(
-        cub::DeviceScan::InclusiveSum,
+    at::cuda::cub::inclusive_sum(
         inv_loc_ptr,
         inv_loc_out.data_ptr<int64_t>(),
-        num_inp,
-        stream);
+        num_inp);
 
     if (!consecutive) {
       TORCH_INTERNAL_ASSERT(
@@ -98,14 +96,12 @@ std::tuple<Tensor, Tensor, Tensor, int64_t> compute_unique(
     num_out = length.item<int64_t>();
   } else {
     counts.resize_(num_inp);
-    CUB_WRAPPER(
-        cub::DeviceRunLengthEncode::Encode,
+    at::cuda::cub::run_length_encode(
         data,
         data_out.data_ptr<scalar_t>(),
         counts.data_ptr<int64_t>(),
         length.data_ptr<int64_t>(),
-        num_inp,
-        stream);
+        num_inp);
     num_out = length.item<int64_t>();
     counts.resize_(num_out);
   }

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -68,7 +68,7 @@ std::tuple<Tensor, Tensor, Tensor, int64_t> compute_unique(
 
     Tensor inv_loc_out =
         consecutive ? inverse_indices : at::empty({num_inp}, options);
-    at::cuda::cub::inclusive_sum(
+    at::cuda::cub::inclusive_sum_truncating(
         inv_loc_ptr,
         inv_loc_out.data_ptr<int64_t>(),
         num_inp);


### PR DESCRIPTION
Cub routines are both expensive to compile and used in multiple
different operators throughout the cuda folder. So, it makes sense to
compile them in one centralized place where possible (i.e. when
custom operators aren't involved).
