### PR TITLE
[DO NOT MERGE] Move Concat Linear out of Optimize Numerics and add LinearTranspose

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1934,30 +1934,6 @@ class TestFrozenOptimizations(JitTestCase):
                 self.assertEqual(mod(inp), scripted_mod(inp))
                 self.assertEqual(mod(inp), scripted_mod(inp))
 
-    @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
-    def test_linear_to_mkldnn(self):
-
-        with set_default_dtype(torch.float):
-            # make sure mkldnn handles broadcast rules
-            inp_shapes = [[20], [20, 20], [1, 20, 20]]
-            for inp_shape in inp_shapes:
-                mod = nn.Linear(20, 30).eval()
-                scripted_mod = torch.jit.script(mod)
-                inp = torch.rand(inp_shape)
-
-                self.run_pass("inline", scripted_mod.graph)
-                FileCheck().check("aten::linear").run(scripted_mod.graph)
-                # successfully no-ops with non-const inputs
-                self.run_pass("convert_frozen_ops_to_mkldnn", scripted_mod.graph)
-                FileCheck().check_not("ConvertToMKLDNN").run(scripted_mod.graph)
-
-                scripted_mod = torch.jit.freeze(scripted_mod)
-                self.run_pass("convert_frozen_ops_to_mkldnn", scripted_mod.graph)
-                FileCheck().check("to_mkldnn").check("aten::linear").check("to_dense").run(scripted_mod.graph)
-
-                self.assertEqual(mod(inp), scripted_mod(inp))
-                self.assertEqual(mod(inp), scripted_mod(inp))
-
     def test_linear_transpose(self):
         class ModLinear(torch.nn.Module):
             def __init__(self):
@@ -2006,42 +1982,25 @@ class TestFrozenOptimizations(JitTestCase):
 
         self.assertEqual(mod_to_device(*test_vals_to_device), script_mod(*test_vals_to_device))
 
+    @staticmethod
+    def conv():
+        # Generic composable conv for testing purposes
+        return nn.Conv2d(8, 8, 1)
+
     @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
     def test_collapse_adjacent_conversions(self):
 
         with set_default_dtype(torch.float):
-            mod = nn.Sequential(nn.Linear(20, 20), nn.Linear(20, 20)).eval()
+            mod = nn.Sequential(self.conv(), self.conv()).eval()
             scripted_mod = torch.jit.script(mod)
             scripted_mod = torch.jit.freeze(scripted_mod)
             self.run_pass("convert_frozen_ops_to_mkldnn", scripted_mod.graph)
-            FileCheck().check("to_mkldnn").check("aten::linear").check("aten::linear").check("to_dense").run(scripted_mod.graph)
+            FileCheck().check("to_mkldnn").check("prim::mkldnn_convolution").check("prim::mkldnn_convolution").check("to_dense").run(scripted_mod.graph)
             FileCheck().check_count("to_mkldnn", 1, exactly=True).run(scripted_mod.graph)
 
-            inp = torch.rand([20, 20])
+            inp = torch.rand([1, 8, 8, 8])
             self.assertEqual(scripted_mod(inp), mod(inp))
             self.assertEqual(scripted_mod(inp), mod(inp))
-
-            # testing unsupported behavior
-            class Add(nn.Module):
-                def __init__(self, tensor):
-                    super().__init__()
-                    self.tensor = tensor
-
-                def forward(self, x):
-                    return x + self.tensor
-
-            def test_unsupported(module, preserved_attrs=None):
-                mod = torch.jit.freeze(torch.jit.script(module.eval()), preserved_attrs)
-                self.run_pass("convert_frozen_ops_to_mkldnn", mod.graph)
-                FileCheck().check("to_mkldnn").check("linear").check("to_dense").check("add").run(mod.graph)
-
-            lin = nn.Linear(20, 20)
-            # Scalar-Tensor not supported
-            test_unsupported(nn.Sequential(lin, Add(.5)))
-            # # 0-dim not supported
-            test_unsupported(nn.Sequential(lin, Add(torch.tensor(.5))))
-            # tensor of unknown dtype (getAttr node here) not supported
-            test_unsupported(nn.Sequential(lin, Add(torch.tensor([20]))), ['1'])
 
     @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
     def test_mkldnn_fuser_broadcasting(self):
@@ -2054,20 +2013,20 @@ class TestFrozenOptimizations(JitTestCase):
                 return x + self.tensor
 
         with set_default_dtype(torch.float):
-            for add_inp in [20], [20, 20, 1]:
-                mod = nn.Sequential(nn.Linear(20, 20), Add(torch.rand(add_inp))).eval()
+            for add_inp in [8], [8, 8, 1]:
+                mod = nn.Sequential(self.conv(), Add(torch.rand(add_inp))).eval()
                 scripted_mod = torch.jit.script(mod)
                 scripted_mod = torch.jit.freeze(scripted_mod)
                 self.run_pass("convert_frozen_ops_to_mkldnn", scripted_mod.graph)
                 FileCheck().check("prim::BroadcastMKLDNNTensors").run(scripted_mod.graph)
-                inp = torch.rand([20, 20])
+                inp = torch.rand([1, 8, 8, 8])
                 self.assertEqual(scripted_mod(inp), mod(inp))
                 self.assertEqual(scripted_mod(inp), mod(inp))
 
                 # for good measure, check that broadcasting does not work without this op
                 # so we can remove the op if it ever gets supported
                 with self.assertRaisesRegex(RuntimeError, ""):
-                    torch.rand([20, 20]).to_mkldnn() + torch.rand(add_inp).to_mkldnn()
+                    torch.rand([1, 8, 8, 8]).to_mkldnn() + torch.rand(add_inp).to_mkldnn()
 
     @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
     def test_mkldnn_inplace_removal(self):
@@ -2080,13 +2039,13 @@ class TestFrozenOptimizations(JitTestCase):
                 return x.add_(self.tensor).div_(self.tensor) - 4
 
         with set_default_dtype(torch.float):
-            mod = nn.Sequential(nn.Linear(20, 20), AddMul(torch.rand([20]))).eval()
+            mod = nn.Sequential(self.conv(), AddMul(torch.rand([8]))).eval()
             scripted_mod = torch.jit.script(mod)
             scripted_mod = torch.jit.freeze(scripted_mod)
             self.run_pass("convert_frozen_ops_to_mkldnn", scripted_mod.graph)
             # add gets uninplaced and reinplaced
             FileCheck().check("aten::to_mkldnn").check("aten::add_").check("aten::div_").run(scripted_mod.graph)
-            inp = torch.rand([20, 20])
+            inp = torch.rand([1, 8, 8, 8])
             self.assertEqual(scripted_mod(inp), mod(inp))
             self.assertEqual(scripted_mod(inp), mod(inp))
 
@@ -2226,44 +2185,6 @@ class TestFrozenOptimizations(JitTestCase):
                 FileCheck().check("aten::to_dense").check_next("return").run(mod.graph)
                 self.assertEqual(sub_model(inp), mod(inp))
 
-    @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
-    @skipIfNoTorchVision
-    def test_layernorm(self):
-        with set_default_dtype(torch.float):
-
-            class ResidualLayernorm(torch.nn.Module):
-                def __init__(self, op, layernorm, **kwargs):
-                    super(ResidualLayernorm, self).__init__()
-                    self.op = op
-                    self.layernorm = layernorm
-
-                def forward(self, x):
-                    y = self.op(x)
-                    return self.layernorm(y) + y
-
-            model = torchvision.models.resnet18()
-            N, C, H, W, = 10, 3, 224, 224
-            for param in ((model.conv1, [W // 2], torch.randn(N, C, H, W)),
-                          (model.conv1, [H // 2, W // 2], torch.randn(N, C, H, W)),
-                          (torch.nn.Linear(H, W), [W], torch.randn(N, C, W)),):
-
-                for layernorm in (torch.nn.LayerNorm(param[1]),
-                                  torch.nn.LayerNorm(param[1], elementwise_affine=False)):
-                    # to generate non inplace tests we extend the use of layernorm's input
-                    for inplace in (True, False):
-                        sub_model = torch.nn.Sequential(param[0], layernorm) if inplace else ResidualLayernorm(param[0], layernorm)
-                        sub_model.eval()
-                        mod = torch.jit.freeze(torch.jit.script(sub_model))
-                        self.run_pass("convert_frozen_ops_to_mkldnn", mod.graph)
-                        # if weight and bias are present and shape is the last dimension
-                        # we should convert `aten::layer_norm` to `prim::MKLDNNLayerNorm`
-                        if layernorm.elementwise_affine and len(param[1]) == 1:
-                            inplace_suffix = "_" if inplace else ""
-                            (FileCheck().check("prim::MKLDNNLayerNorm" + inplace_suffix).
-                                check_count("aten::to_dense", 1, exactly=True).run(mod.graph))
-                        else:
-                            FileCheck().check_count("aten::to_dense", 1, exactly=True).check("aten::layer_norm").run(mod.graph)
-                        self.assertEqual(sub_model(param[2]), mod(param[2]), rtol=1e-04, atol=1e-04)
 
     @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
     @skipIfNoTorchVision
@@ -2337,7 +2258,7 @@ class TestFrozenOptimizations(JitTestCase):
             class Mod(nn.Module):
                 def __init__(self):
                     super().__init__()
-                    self.mod = nn.Linear(20, 20)
+                    self.mod = nn.Conv2d(8, 8, 1, padding=1)
 
                 def forward(self, x):
                     a1 = self.mod(x) * 4
@@ -2346,23 +2267,10 @@ class TestFrozenOptimizations(JitTestCase):
             mod = Mod().eval()
             scripted = torch.jit.freeze(torch.jit.script(mod))
             optimized = torch.jit.optimize_for_inference(scripted)
-            inp = torch.rand([20, 20])
+            inp = torch.rand([1, 8, 8, 8])
             # a1 cant be inplaced for first use, can for second
-            FileCheck().check("ScalarMul_").check("ScalarMul(").check("ScalarMul_").run(optimized.graph)
+            FileCheck().check("ScalarMul(").check("ScalarMul_").run(optimized.graph)
             self.assertEqual(optimized(inp), mod(inp))
-
-    @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
-    def test_optimize_for_inference(self):
-        with set_default_dtype(torch.float):
-            mod = nn.Linear(20, 30).eval()
-            scripted_mod = torch.jit.script(mod)
-
-            optimized = torch.jit.optimize_for_inference(scripted_mod)
-            FileCheck().check("to_mkldnn").run(optimized.graph)
-
-            frozen_mod = torch.jit.freeze(torch.jit.script(mod.eval()))
-            optimized = torch.jit.optimize_for_inference(scripted_mod)
-            FileCheck().check("to_mkldnn").run(optimized.graph)
 
 @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
 class TestMKLDNNReinplacing(JitTestCase):

--- a/torch/csrc/jit/passes/frozen_graph_optimizations.cpp
+++ b/torch/csrc/jit/passes/frozen_graph_optimizations.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir_views.h>
 #include <torch/csrc/jit/passes/frozen_concat_linear.h>
+#include <torch/csrc/jit/passes/frozen_linear_transpose.h>
 #include <torch/csrc/jit/passes/frozen_conv_folding.h>
 #include <torch/csrc/jit/passes/frozen_graph_optimizations.h>
 #include <torch/csrc/jit/passes/remove_dropout.h>
@@ -15,15 +16,16 @@ void OptimizeFrozenGraph(
     std::shared_ptr<Graph>& graph,
     bool optimize_numerics) {
   removeDropout(graph);
+  FrozenConcatLinear(graph);
   // run a couple times to capture Conv -> Mul -> Add etc
   if (optimize_numerics) {
+    FrozenLinearTranspose(graph);
     for (const auto i : c10::irange(2)) {
       (void)i; // Suppress unused variable warning
       FoldFrozenConvBatchnorm(graph);
       FoldFrozenConvAddOrSub(graph);
       FoldFrozenConvMulOrDiv(graph);
     }
-    FrozenConcatLinear(graph);
   }
 }
 

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -936,8 +936,7 @@ class MKLDNNSubgraphSlicer {
       return true;
     }
     // see [mkldnn perf strategy]
-    return frozenMkldnnCompatibleLinearNode(node) ||
-        frozenMkldnnCompatibleConvNode(node);
+    return frozenMkldnnCompatibleConvNode(node);
   }
 
  private:

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -121,8 +121,10 @@ def freeze(mod, preserved_attrs: Optional[List[str]] = None, optimize_numerics: 
 def run_frozen_optimizations(mod, optimize_numerics: bool = True):
     r"""
     Runs a series of optimizations looking for patterns that occur in frozen graphs.
-    The current set of optimizations is:
+    The current set of optimizations includes:
         - Dropout Removal
+        - Pretranspose Linear Layers
+        - Concat Linear Layers with same input Tensor
         - Conv -> Batchnorm folding
         - Conv -> Add/Sub folding
         - Conv -> Mul/Div folding
@@ -157,15 +159,7 @@ def run_frozen_optimizations(mod, optimize_numerics: bool = True):
         assert "batch_norm" not in str(frozen_mod.graph)
 
     """
-    # xxx: keep in sync with frozen_graph_optimization.cpp
-    # intentionally duplicated to make to make it easier to create custom optimization sequence
-    torch._C._jit_pass_remove_dropout(mod._c)
-    if optimize_numerics:
-        # run a couple times to capture Conv -> Mul -> Add etc
-        for _ in range(2):
-            torch._C._jit_pass_fold_frozen_conv_bn(mod.graph)
-            torch._C._jit_pass_fold_frozen_conv_add_or_sub(mod.graph)
-            torch._C._jit_pass_fold_frozen_conv_mul_or_div(mod.graph)
+    torch._C._jit_pass_optimize_frozen_graph(mod.graph, optimize_numerics)
 
 def optimize_for_inference(mod: ScriptModule) -> ScriptModule:
     """


### PR DESCRIPTION
Test @Gamrix' Linear Concat 

RUN_TORCHBENCH: alexnet,Background_Matting,BERT_pytorch,demucs,densenet121,dlrm,drq,fastNLP,hf_Albert,hf_Bart,hf_Bert,hf_BigBird,hf_DistilBert,hf_GPT2,hf_Longformer,hf_Reformer,hf_T5,LearningToPaint,maml,maml_omniglot,mnasnet1_0,mobilenet_v2,mobilenet_v2_quantized_qat,mobilenet_v3_large,moco,opacus_cifar10,pyhpc_equation_of_state,pyhpc_isoneutral_mixing,pytorch_CycleGAN_and_pix2pix,pytorch_stargan,resnet18,resnet50,resnext50_32x4d,shufflenet_v2_x1_0,soft_actor_critic,speech_transformer,squeezenet1_1,Super_SloMo,tacotron2,vgg16,yolov3
