### PR TITLE
[fbcode][static runtime] out-variant for quantized::linear_dynamic_fp16

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -2,8 +2,8 @@
 
 #include <ATen/Tensor.h>
 #include <ATen/native/quantized/cpu/conv_packed_params.h>
-#include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/embedding_packed_params.h>
+#include <ATen/native/quantized/cpu/packed_params.h>
 #include <c10/core/QScheme.h>
 #include <c10/util/irange.h>
 
@@ -63,8 +63,10 @@ struct TORCH_API PackedLinearWeight : public LinearPackedParamsBase {
       int64_t output_zero_point,
       at::Tensor& output) override;
 
-  at::Tensor apply_dynamic(at::Tensor input, bool reduce_range=false) override;
-  at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range=false) override;
+  at::Tensor apply_dynamic(at::Tensor input, bool reduce_range = false)
+      override;
+  at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range = false)
+      override;
 
   std::tuple<at::Tensor, c10::optional<at::Tensor>> unpack() override;
 
@@ -85,7 +87,7 @@ struct TORCH_API PackedLinearWeight : public LinearPackedParamsBase {
       at::Tensor& output);
 
   template <bool ReluFused>
-  at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range=false);
+  at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range = false);
 };
 
 struct TORCH_API PackedLinearWeightFp16 : public LinearPackedParamsBase {
@@ -110,8 +112,19 @@ struct TORCH_API PackedLinearWeightFp16 : public LinearPackedParamsBase {
     TORCH_INTERNAL_ASSERT(false);
   }
 
-  at::Tensor apply_dynamic(at::Tensor input, bool reduce_range=false) override;
-  at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range=false) override;
+  at::Tensor apply_dynamic(at::Tensor input, bool reduce_range = false)
+      override;
+  at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range = false)
+      override;
+
+  at::Tensor& apply_dynamic_out(
+      const at::Tensor& input,
+      at::Tensor& output,
+      bool reduce_range = false) override;
+  at::Tensor& apply_dynamic_relu_out(
+      const at::Tensor& input,
+      at::Tensor& output,
+      bool reduce_range = false) override;
 
   std::tuple<at::Tensor, c10::optional<at::Tensor>> unpack() override;
 
@@ -127,7 +140,7 @@ struct TORCH_API PackedLinearWeightFp16 : public LinearPackedParamsBase {
 
  private:
   template <bool ReluFused>
-  at::Tensor apply_dynamic_impl(at::Tensor input);
+  at::Tensor& apply_dynamic_impl(const at::Tensor& input, at::Tensor& output);
 };
 
 template <int kSpatialDim = 2>
@@ -146,19 +159,19 @@ struct TORCH_API PackedConvWeight : public ConvPackedParamsBase<kSpatialDim> {
       std::vector<float> w_scale,
       std::vector<int32_t> w_zp,
       c10::QScheme q_scheme)
-    : w(std::move(w)),
-    bias(std::move(bias)),
-    stride_(std::move(stride)),
-    padding_(std::move(padding)),
-    output_padding_(std::move(output_padding)),
-    dilation_(std::move(dilation)),
-    groups_(groups),
-    transpose_(transpose),
-    col_offsets(std::move(col_offsets)),
-    kernel(std::move(kernel)),
-    w_scale(std::move(w_scale)),
-    w_zp(std::move(w_zp)),
-    q_scheme(q_scheme) {}
+      : w(std::move(w)),
+        bias(std::move(bias)),
+        stride_(std::move(stride)),
+        padding_(std::move(padding)),
+        output_padding_(std::move(output_padding)),
+        dilation_(std::move(dilation)),
+        groups_(groups),
+        transpose_(transpose),
+        col_offsets(std::move(col_offsets)),
+        kernel(std::move(kernel)),
+        w_scale(std::move(w_scale)),
+        w_zp(std::move(w_zp)),
+        q_scheme(q_scheme) {}
 
   std::unique_ptr<fbgemm::PackWeightsForConv<kSpatialDim>> w;
   c10::optional<at::Tensor> bias;
@@ -305,9 +318,7 @@ Tensor MakeEmptyPerChannelAffineQuantizedChannelsLast3dTensor(
 Tensor ConvertToChannelsLast3dTensor(const Tensor& src);
 
 template <int kSpatialDim = 2>
-Tensor TransposeConvTensorUnpackConversion(
-    const Tensor& src,
-    int groups);
+Tensor TransposeConvTensorUnpackConversion(const Tensor& src, int groups);
 
 template <int kSpatialDim>
 Tensor ConvertConvWeightsToChannelLastTensor(
@@ -348,7 +359,8 @@ struct TORCH_API PackedEmbeddingBagWeight : public EmbeddingPackedParamsBase {
   int64_t version_;
 
   at::Tensor unpack() override;
-  static c10::intrusive_ptr<EmbeddingPackedParamsBase> prepack(at::Tensor weight);
+  static c10::intrusive_ptr<EmbeddingPackedParamsBase> prepack(
+      at::Tensor weight);
 
   int64_t bit_rate() const override {
     return bit_rate_;
@@ -359,19 +371,19 @@ struct TORCH_API PackedEmbeddingBagWeight : public EmbeddingPackedParamsBase {
   }
 
   at::Tensor embeddingbag_byte(
-    const at::Tensor& indices,
-    const c10::optional<at::Tensor>& offsets,
-    bool pruned_weights,
-    const c10::optional<at::Tensor>& per_sample_weights_,
-    const c10::optional<at::Tensor>& compressed_indices_mapping,
-    bool include_last_offset,
-    bool is_embedding_op) override;
+      const at::Tensor& indices,
+      const c10::optional<at::Tensor>& offsets,
+      bool pruned_weights,
+      const c10::optional<at::Tensor>& per_sample_weights_,
+      const c10::optional<at::Tensor>& compressed_indices_mapping,
+      bool include_last_offset,
+      bool is_embedding_op) override;
 
   at::Tensor embeddingbag_4bit(
-    const at::Tensor& indices,
-    const c10::optional<at::Tensor>& offsets,
-    bool pruned_weights,
-    const c10::optional<at::Tensor>& per_sample_weights_,
-    const c10::optional<at::Tensor>& compressed_indices_mapping,
-    bool include_last_offset) override;
+      const at::Tensor& indices,
+      const c10::optional<at::Tensor>& offsets,
+      bool pruned_weights,
+      const c10::optional<at::Tensor>& per_sample_weights_,
+      const c10::optional<at::Tensor>& compressed_indices_mapping,
+      bool include_last_offset) override;
 };

--- a/aten/src/ATen/native/quantized/cpu/packed_params.h
+++ b/aten/src/ATen/native/quantized/cpu/packed_params.h
@@ -35,8 +35,31 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
     return output;
   }
 
-  virtual at::Tensor apply_dynamic(at::Tensor input, bool reduce_range=false) = 0;
-  virtual at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range=false) = 0;
+  virtual at::Tensor apply_dynamic(
+      at::Tensor input,
+      bool reduce_range = false) = 0;
+  virtual at::Tensor apply_dynamic_relu(
+      at::Tensor input,
+      bool reduce_range = false) = 0;
+
+  virtual at::Tensor& apply_dynamic_out(
+      const at::Tensor& /* input */,
+      at::Tensor& output,
+      bool /* reduce_range */) {
+    throw std::runtime_error(
+        "apply_dynamic_out is not implemented for this packed "
+        "parameter type");
+    return output;
+  }
+  virtual at::Tensor& apply_dynamic_relu_out(
+      const at::Tensor& /* input */,
+      at::Tensor& output,
+      bool /* reduce_range */) {
+    throw std::runtime_error(
+        "apply_dynamic_relu_out is not implemented for this packed "
+        "parameter type");
+    return output;
+  }
 
   virtual std::tuple<at::Tensor, c10::optional<at::Tensor>> unpack() = 0;
 

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -19,7 +19,9 @@ int register_linear_params();
 
 #ifdef USE_FBGEMM
 template <bool ReluFused>
-at::Tensor PackedLinearWeight::apply_dynamic_impl(at::Tensor input, bool reduce_range) {
+at::Tensor PackedLinearWeight::apply_dynamic_impl(
+    at::Tensor input,
+    bool reduce_range) {
   using at::Tensor;
   // fp32 * int8 -> fp32 (with quantization on activation, and dequantization
   // on the result).
@@ -212,11 +214,16 @@ at::Tensor PackedLinearWeight::apply_dynamic_impl(at::Tensor input, bool reduce_
   return output;
 }
 
-at::Tensor PackedLinearWeight::apply_dynamic(at::Tensor input, bool reduce_range) {
-  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input), reduce_range);
+at::Tensor PackedLinearWeight::apply_dynamic(
+    at::Tensor input,
+    bool reduce_range) {
+  return apply_dynamic_impl</*ReluFused=*/false>(
+      std::move(input), reduce_range);
 }
 
-at::Tensor PackedLinearWeight::apply_dynamic_relu(at::Tensor input, bool reduce_range) {
+at::Tensor PackedLinearWeight::apply_dynamic_relu(
+    at::Tensor input,
+    bool reduce_range) {
   return apply_dynamic_impl</*ReluFused=*/true>(std::move(input), reduce_range);
 }
 
@@ -224,7 +231,8 @@ at::Tensor PackedLinearWeight::apply_dynamic_relu(at::Tensor input, bool reduce_
 
 #ifdef USE_PYTORCH_QNNPACK
 template <bool ReluFused>
-at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(at::Tensor input) {
+at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
+    at::Tensor input) {
   using at::Tensor;
   TORCH_CHECK(
       input.dim() >= 2,
@@ -272,16 +280,19 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(at::Tensor input) {
   if (!input_scale.has_value() || input_scale.value() != q_params.scale) {
     generate_requantization_scales(
         // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        w_scales, q_params.scale, 1.f, requantization_scales);
+        w_scales,
+        q_params.scale,
+        1.f,
+        requantization_scales);
   }
 
   if (!input_scale.has_value()) {
     // Get the original weight and adjust it to uint8 from int8
     auto weight_contig = orig_weight;
 
-    // TODO(kimishpatel), we are allocating affine_quantized regardless of per channel or not.
-    // This allocation is actually used only for packing weight and thus will be freed.
-    // Still we should be consistent. Fix this.
+    // TODO(kimishpatel), we are allocating affine_quantized regardless of per
+    // channel or not. This allocation is actually used only for packing weight
+    // and thus will be freed. Still we should be consistent. Fix this.
     Tensor qnnp_weight = at::_empty_affine_quantized(
         weight_contig.sizes(),
         at::device(c10::kCPU).dtype(c10::kQUInt8),
@@ -305,8 +316,8 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(at::Tensor input) {
         nullptr);
     packB = w.get();
     if (at::globalContext().releaseWeightsWhenPrepacking()) {
-      // On mobile, we release the original weight by resetting the intrusive_ptr.
-      // Calling unpack after this will throw an assertion.
+      // On mobile, we release the original weight by resetting the
+      // intrusive_ptr. Calling unpack after this will throw an assertion.
       orig_weight.reset();
     }
   }
@@ -361,11 +372,15 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(at::Tensor input) {
   return output;
 }
 
-at::Tensor PackedLinearWeightsQnnp::apply_dynamic(at::Tensor input, bool reduce_range) {
+at::Tensor PackedLinearWeightsQnnp::apply_dynamic(
+    at::Tensor input,
+    bool /* reduce_range */) {
   return apply_dynamic_impl</*ReluFused=*/false>(std::move(input));
 }
 
-at::Tensor PackedLinearWeightsQnnp::apply_dynamic_relu(at::Tensor input, bool reduce_range) {
+at::Tensor PackedLinearWeightsQnnp::apply_dynamic_relu(
+    at::Tensor input,
+    bool /* reduce_range */) {
   return apply_dynamic_impl</*ReluFused=*/true>(std::move(input));
 }
 
@@ -374,7 +389,9 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_relu(at::Tensor input, bool re
 #ifdef USE_FBGEMM
 
 template <bool ReluFused>
-at::Tensor PackedLinearWeightFp16::apply_dynamic_impl(at::Tensor input) {
+at::Tensor& PackedLinearWeightFp16::apply_dynamic_impl(
+    const at::Tensor& input,
+    at::Tensor& output) {
   const at::Tensor input_contig = input.contiguous();
   const float* input_ptr = input_contig.data_ptr<float>();
 
@@ -386,9 +403,11 @@ at::Tensor PackedLinearWeightFp16::apply_dynamic_impl(at::Tensor input) {
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   const int64_t M = size_to_dim_(input.dim() - 1, input.sizes());
   const int64_t N = packed_weight_fp16.numCols();
-  std::vector<int64_t> output_size = input.sizes().vec();
-  output_size.back() = N;
-  at::Tensor output = at::empty(output_size, input.options().dtype(at::kFloat));
+  std::vector<int64_t> output_sizes = input.sizes().vec();
+  TORCH_CHECK(!output_sizes.empty())
+  output_sizes.back() = N;
+  // Resize output Tensor
+  output.resize_(output_sizes);
 
   // Call the fp16 gemm interface
   fbgemm::cblas_gemm_compute(
@@ -408,12 +427,34 @@ at::Tensor PackedLinearWeightFp16::apply_dynamic_impl(at::Tensor input) {
   return output;
 }
 
-at::Tensor PackedLinearWeightFp16::apply_dynamic(at::Tensor input, bool reduce_range) {
-  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input));
+at::Tensor PackedLinearWeightFp16::apply_dynamic(
+    at::Tensor input,
+    bool /* reduce_range */) {
+  at::Tensor output = at::empty({0}, input.options().dtype(at::kFloat));
+  return apply_dynamic_impl</*ReluFused=*/false>(input, output);
 }
 
-at::Tensor PackedLinearWeightFp16::apply_dynamic_relu(at::Tensor input, bool reduce_range) {
-  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input));
+at::Tensor PackedLinearWeightFp16::apply_dynamic_relu(
+    at::Tensor input,
+    bool /* reduce_range */) {
+  at::Tensor output = at::empty({0}, input.options().dtype(at::kFloat));
+  return apply_dynamic_impl</*ReluFused=*/true>(input, output);
+}
+
+at::Tensor& PackedLinearWeightFp16::apply_dynamic_out(
+    const at::Tensor& input,
+    at::Tensor& output,
+    bool /* reduce_range */) {
+  TORCH_CHECK((output.device() == c10::kCPU) && (output.dtype() == at::kFloat));
+  return apply_dynamic_impl<false>(input, output);
+}
+
+at::Tensor& PackedLinearWeightFp16::apply_dynamic_relu_out(
+    const at::Tensor& input,
+    at::Tensor& output,
+    bool /* reduce_range */) {
+  TORCH_CHECK((output.device() == c10::kCPU) && (output.dtype() == at::kFloat));
+  return apply_dynamic_impl<true>(input, output);
 }
 
 void PackedLinearWeightFp16::set_bias(c10::optional<at::Tensor> bias) {
@@ -477,14 +518,24 @@ class QLinearDynamicFp16 final {
 };
 
 TORCH_LIBRARY_IMPL(quantized, CPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_dynamic"), TORCH_FN(QLinearDynamicInt8<false>::run));
-  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic"), TORCH_FN(QLinearDynamicInt8<true>::run));
-  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16"), TORCH_FN(QLinearDynamicFp16<false>::run));
-  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic_fp16"), TORCH_FN(QLinearDynamicFp16<true>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized::linear_dynamic"),
+      TORCH_FN(QLinearDynamicInt8<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic"),
+      TORCH_FN(QLinearDynamicInt8<true>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16"),
+      TORCH_FN(QLinearDynamicFp16<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic_fp16"),
+      TORCH_FN(QLinearDynamicFp16<true>::run));
 }
 
 TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_dynamic"), TORCH_FN(QLinearDynamicInt8<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("_quantized::linear_dynamic"),
+      TORCH_FN(QLinearDynamicInt8<false>::run));
 }
 
 } // namespace

--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -755,6 +755,14 @@ const std::string quantize_script = R"IR(
       return (%1249)
 )IR";
 
+const std::string quantized_linear_dynamic_fp16_script = R"IR(
+  graph(%input: Tensor, %weights: Tensor):
+      %bias: None = prim::Constant()
+      %packed_params = quantized::linear_prepack_fp16(%weights, %bias)
+      %output = quantized::linear_dynamic_fp16(%input, %packed_params)
+      return (%output)
+)IR";
+
 const auto fmod_tensor = R"JIT(
   def forward(self, a: Tensor, b: Tensor):
       return torch.fmod(a, b).clone()

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1519,6 +1519,19 @@ TEST(StaticRuntime, QuantizedLinear) {
   testStaticRuntime(quantize_script, {input, weight}, {input_2, weight_2});
 }
 
+TEST(StaticRuntime, QuantizedLinearDynamicFp16) {
+  at::Tensor weight = torch::randn({3, 2}, torch::kFloat);
+  at::Tensor input = torch::randn({3, 2}, torch::kFloat);
+
+  at::Tensor weight_2 = torch::randn({4, 3}, torch::kFloat);
+  at::Tensor input_2 = torch::randn({4, 3}, torch::kFloat);
+
+  testStaticRuntime(
+      quantized_linear_dynamic_fp16_script,
+      {input, weight},
+      {input_2, weight_2});
+}
+
 TEST(StaticRuntime, IndividualOps_VarStack) {
   // 2D tensors - stack dim = 0
   std::vector<IValue> args1 = {at::randn({6, 6}), at::randn({6, 6}), 0};

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1742,6 +1742,47 @@ REGISTER_OPERATOR_FUNCTOR(
       };
     });
 
+REGISTER_OPERATOR_FUNCTOR(
+    quantized::linear_dynamic_fp16,
+    quantized_linear_dynamic_fp16,
+    [](Node* n) -> SROperator {
+      if (!n->matches(torch::schema(
+              "quantized::linear_dynamic_fp16(Tensor X, __torch__.torch.classes."
+              "quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"))) {
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+      const auto weight = toIValue(n->inputs()[1]);
+      c10::intrusive_ptr<LinearPackedParamsBase> packed_weight;
+      if (weight) {
+        packed_weight = weight->toCustomClass<LinearPackedParamsBase>();
+      }
+      if (packed_weight) {
+        return [packed_weight](ProcessedNode* p_node) {
+          const auto& input = p_node->Input(0).toTensor();
+          if (p_node->Output(0).isNone()) {
+            p_node->Output(0) = create_empty_from(input, at::kFloat);
+          }
+          auto& out_t = p_node->Output(0).toTensor();
+          fastResizeToZero(out_t);
+          packed_weight->apply_dynamic_out(input, out_t, false);
+        };
+      } else {
+        return [](ProcessedNode* p_node) {
+          const auto& input = p_node->Input(0).toTensor();
+          if (p_node->Output(0).isNone()) {
+            p_node->Output(0) = create_empty_from(input, at::kFloat);
+          }
+          auto& out_t = p_node->Output(0).toTensor();
+          fastResizeToZero(out_t);
+          // Weights could be quantized on the fly
+          auto packed_weight_tmp =
+              p_node->Input(1).toCustomClass<LinearPackedParamsBase>();
+          packed_weight_tmp->apply_dynamic_out(input, out_t, false);
+        };
+      }
+    });
+
 REGISTER_OPERATOR_FUNCTOR(aten::full, aten_full, [](Node* n) -> SROperator {
   if (!n->matches(torch::schema(
           "aten::full(int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"))) {


### PR DESCRIPTION
Summary:
mostly follow the example of quantized::linear (D28428734 (https://github.com/pytorch/pytorch/commit/4d7abdbdadd440cb4b8412f1e309cae14a687b49)) to enable out-variant for quantized::linear_dynamic_fp16.

Reason being from MP tab ctr pytorch model migration, we observe quantized::linear_dynamic_fp16 operator has highest cost but not enable out-variant yet https://fburl.com/phabricator/b5juus2d

Test Plan:
buck build mode/opt caffe2/caffe2/fb/predictor:ptvsc2_predictor_bench

  sudo watch -n 20 /usr/local/fbprojects/dynamoserver/bin/turboDriver disable

  MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor:ptvsc2_predictor_bench -- --scripted_model=/home/bwen/models/991103061_4/991103061_4.predictor --pt_inputs=/home/bwen/models/991103061_4/pt_inputs --method_name=forward --pt_cleanup_activations=1 --pt_enable_out_variant=1 --pt_optimize_memory=1 --iters=1000 --warmup_iters=1000 --num_threads=1 --repetitions=3 --do_profile=1 --do_benchmark=1 --set_compatibility=1 --compare_results=1 --pt_enable_static_runtime 2>&1 | pastry

before: P465201159

  0.929067 ms.     31.808%. quantized::linear_dynamic_fp16 (16 nodes)
  0.921679 ms.    31.7324%. quantized::linear_dynamic_fp16 (16 nodes)
  0.919127 ms.    31.7404%. quantized::linear_dynamic_fp16 (16 nodes)

after: P465203015

  0.90898 ms.    31.0205%. quantized::linear_dynamic_fp16 (16 nodes, out variant)
  0.9127 ms.      30.62%. quantized::linear_dynamic_fp16 (16 nodes, out variant)
  0.879148 ms.    31.0161%. quantized::linear_dynamic_fp16 (16 nodes, out variant)

unit test logic refers https://fburl.com/code/vv0rry13

  buck run mode/opt caffe2/benchmarks/static_runtime:static_runtime_cpptest

Differential Revision: D32001168

