### PR TITLE
Add SiLU backward Aten symbol

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -638,6 +638,7 @@ _(aten, set) \
 _(aten, sign) \
 _(aten, signbit) \
 _(aten, silu) \
+_(aten, silu_backward) \
 _(aten, sgn) \
 _(aten, sin) \
 _(aten, sinh) \


### PR DESCRIPTION
This is related to https://github.com/pytorch/xla/issues/3192. @bdhirsh 