### PR TITLE
Fix failing test due to a bug in NumPy when using OpenBLAS

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1640,7 +1640,7 @@ class TestLinalg(TestCase):
         for p in norm_types:
             try:
                 run_test_case(a, p)
-            except numpy.linalg.LinAlgError:
+            except np.linalg.LinAlgError:
                 # Numpy may fail to converge for some BLAS backends (although this is very rare)
                 # See the discussion in https://github.com/pytorch/pytorch/issues/67675
                 pass

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1638,7 +1638,12 @@ class TestLinalg(TestCase):
         a = torch.eye(3, dtype=dtype, device=device)
         a[-1, -1] = 0  # make 'a' singular
         for p in norm_types:
-            run_test_case(a, p)
+            try:
+                run_test_case(a, p)
+            except numpy.linalg.LinAlgError:
+                # Numpy may fail to converge for some BLAS backends (although this is very rare)
+                # See the discussion in #67675
+                pass
 
         # test for 0x0 matrices. NumPy doesn't work for such input, we return 0
         input_sizes = [(0, 0), (2, 5, 0, 0)]

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1642,7 +1642,7 @@ class TestLinalg(TestCase):
                 run_test_case(a, p)
             except numpy.linalg.LinAlgError:
                 # Numpy may fail to converge for some BLAS backends (although this is very rare)
-                # See the discussion in #67675
+                # See the discussion in https://github.com/pytorch/pytorch/issues/67675
                 pass
 
         # test for 0x0 matrices. NumPy doesn't work for such input, we return 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67679

implementations

Fixes https://github.com/pytorch/pytorch/issues/67675

cc @mruberry

Differential Revision: [D32368698](https://our.internmc.facebook.com/intern/diff/D32368698)