### PR TITLE
[DataPipe] Traverse DataPipe graph excluding primitive variables and callable

### DIFF
--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -151,6 +151,9 @@ class MapperIterDataPipe(IterDataPipe[T_co]):
         )
 
     def __getstate__(self):
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(self)
+
         if DILL_AVAILABLE:
             dill_function = dill.dumps(self.fn)
         else:

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -118,6 +118,9 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
         return r
 
     def __getstate__(self):
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(self)
+
         if DILL_AVAILABLE:
             dill_function = dill.dumps(self.filter_fn)
         else:

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -208,6 +208,7 @@ class IterableDataset(Dataset[T_co], metaclass=_DataPipeMeta):
     """
     functions: Dict[str, Callable] = {}
     reduce_ex_hook : Optional[Callable] = None
+    getstate_hook: Optional[Callable] = None
 
     def __iter__(self) -> Iterator[T_co]:
         raise NotImplementedError
@@ -225,6 +226,11 @@ class IterableDataset(Dataset[T_co], metaclass=_DataPipeMeta):
         else:
             raise AttributeError
 
+    def __getstate__(self):
+        if IterableDataset.getstate_hook is not None:
+            return IterableDataset.getstate_hook(self)
+        return self.__dict__
+
     def __reduce_ex__(self, *args, **kwargs):
         if IterableDataset.reduce_ex_hook is not None:
             try:
@@ -232,6 +238,12 @@ class IterableDataset(Dataset[T_co], metaclass=_DataPipeMeta):
             except NotImplementedError:
                 pass
         return super().__reduce_ex__(*args, **kwargs)
+
+    @classmethod
+    def set_getstate_hook(cls, hook_fn):
+        if IterableDataset.getstate_hook is not None and hook_fn is not None:
+            raise Exception("Attempt to override existing getstate_hook")
+        IterableDataset.getstate_hook = hook_fn
 
     @classmethod
     def set_reduce_ex_hook(cls, hook_fn):

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -12,7 +12,7 @@ def stub_unpickler():
     return "STUB"
 
 # TODO(VitalyFedyunin): Make sure it works without dill module installed
-def list_connected_datapipes(scan_obj):
+def list_connected_datapipes(scan_obj, only_datapipe):
 
     f = io.BytesIO()
     p = pickle.Pickler(f)  # Not going to work for lambdas, but dill infinite loops on typing and can't be used as is
@@ -21,6 +21,13 @@ def list_connected_datapipes(scan_obj):
         return stub_unpickler, ()
 
     captured_connections = []
+
+    def getstate_hook(obj):
+        state = {}
+        for k, v in obj.__dict__.items():
+            if isinstance(v, IterableDataset):
+                state[k] = v
+        return state
 
     def reduce_hook(obj):
         if obj == scan_obj:
@@ -31,14 +38,18 @@ def list_connected_datapipes(scan_obj):
 
     # TODO(VitalyFedyunin):  Better do it as `with` context for safety
     IterableDataset.set_reduce_ex_hook(reduce_hook)
+    if only_datapipe:
+        IterableDataset.set_getstate_hook(getstate_hook)
     p.dump(scan_obj)
     IterableDataset.set_reduce_ex_hook(None)
+    if only_datapipe:
+        IterableDataset.set_getstate_hook(None)
     return captured_connections
 
 
-def traverse(datapipe):
-    items = list_connected_datapipes(datapipe)
+def traverse(datapipe, only_datapipe=False):
+    items = list_connected_datapipes(datapipe, only_datapipe)
     d: Dict[Any, Any] = {datapipe: {}}
     for item in items:
-        d[datapipe].update(traverse(item))
+        d[datapipe].update(traverse(item, only_datapipe))
     return d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#67692 [DataPipe] Traverse DataPipe graph excluding primitive variables and callable**

Add `getstate_hook` to enable optionally serialize objects other than `IterDataPipe`
`traverse` has an optional argument to turn on/off the feature to only traverse `IterDataPipe`

This is going to be used by `OnDiskCacheHolder` to trace the DataPipe Graph.

Differential Revision: [D32106346](https://our.internmc.facebook.com/intern/diff/D32106346)