### PR TITLE
generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit migrated to GHA

### DIFF
--- a/.circleci/cimodel/data/simple/android_definitions.py
+++ b/.circleci/cimodel/data/simple/android_definitions.py
@@ -2,7 +2,6 @@ import cimodel.data.simple.util.branch_filters as branch_filters
 from cimodel.data.simple.util.docker_constants import (
     DOCKER_IMAGE_NDK, DOCKER_REQUIREMENT_NDK
 )
-import cimodel.lib.miniutils as miniutils
 
 
 class AndroidJob:
@@ -90,15 +89,6 @@ WORKFLOW_DATA = [
         ["pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build"],
         is_master_only=False,
         is_pr_only=True),
-    AndroidGradleJob(
-        "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
-        "pytorch_android_gradle_custom_build_single",
-        [DOCKER_REQUIREMENT_NDK],
-        is_master_only=False,
-        is_pr_only=True,
-        extra_props=tuple({
-            "lite_interpreter": miniutils.quote(str(int(False)))
-        }.items())),
     AndroidGradleJob(
         "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build",
         "pytorch_android_gradle_build",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,24 +294,6 @@ pytorch_params: &pytorch_params
     CI_MASTER: << pipeline.parameters.run_master_build >>
   resource_class: << parameters.resource_class >>
 
-pytorch_android_params: &pytorch_android_params
-  parameters:
-    build_environment:
-      type: string
-      default: ""
-    op_list:
-      type: string
-      default: ""
-    lite_interpreter:
-      type: string
-      default: "1"
-  environment:
-    BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
-    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c"
-    PYTHON_VERSION: "3.6"
-    SELECTED_OP_LIST: << parameters.op_list >>
-    BUILD_LITE_INTERPRETER: << parameters.lite_interpreter >>
-
 pytorch_ios_params: &pytorch_ios_params
   parameters:
     build_environment:
@@ -1512,43 +1494,6 @@ jobs:
     - store_artifacts:
         path: ~/workspace/build_android_x86_32_artifacts/artifacts.tgz
         destination: artifacts.tgz
-
-  pytorch_android_gradle_custom_build_single:
-    <<: *pytorch_android_params
-    resource_class: large
-    machine:
-      image: ubuntu-2004:202104-01
-    steps:
-    - checkout
-    - calculate_docker_image_tag
-    - setup_linux_system_environment
-    - checkout
-    - calculate_docker_image_tag
-    - setup_ci_environment
-    - run:
-        name: pytorch android gradle custom build single architecture (for PR)
-        no_output_timeout: "1h"
-        command: |
-          set -e
-          # Unlike other gradle jobs, it's not worth building libtorch in a separate CI job and share via docker, because:
-          # 1) Not shareable: it's custom selective build, which is different from default libtorch mobile build;
-          # 2) Not parallelizable by architecture: it only builds libtorch for one architecture;
-
-          echo "DOCKER_IMAGE: ${DOCKER_IMAGE}:${DOCKER_TAG}"
-          time docker pull ${DOCKER_IMAGE}:${DOCKER_TAG} >/dev/null
-
-          git submodule sync && git submodule update -q --init --recursive --depth 1 --jobs 0
-          VOLUME_MOUNTS="-v /home/circleci/project/:/var/lib/jenkins/workspace"
-          export id=$(docker run --env-file "${BASH_ENV}" ${VOLUME_MOUNTS} --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE}:${DOCKER_TAG})
-
-          export COMMAND='((echo "export GRADLE_OFFLINE=1" && echo "export BUILD_LITE_INTERPRETER=${BUILD_LITE_INTERPRETER}" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
-
-          # Skip docker push as this job is purely for size analysis purpose.
-          # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
-
-    - upload_binary_size_for_android_build:
-        build_type: custom-build-single
 
   pytorch_ios_build:
     <<: *pytorch_ios_params
@@ -6662,16 +6607,6 @@ workflows:
           name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-x86_32
           requires:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
-      - pytorch_android_gradle_custom_build_single:
-          filters:
-            branches:
-              only:
-                - /gh\/.*\/head/
-                - /pull\/.*/
-          lite_interpreter: "0"
-          name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
-          requires:
-            - docker-pytorch-linux-xenial-py3-clang5-android-ndk-r19c
       - pytorch_android_gradle_build:
           filters:
             branches:

--- a/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
@@ -26,24 +26,6 @@ pytorch_params: &pytorch_params
     CI_MASTER: << pipeline.parameters.run_master_build >>
   resource_class: << parameters.resource_class >>
 
-pytorch_android_params: &pytorch_android_params
-  parameters:
-    build_environment:
-      type: string
-      default: ""
-    op_list:
-      type: string
-      default: ""
-    lite_interpreter:
-      type: string
-      default: "1"
-  environment:
-    BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
-    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c"
-    PYTHON_VERSION: "3.6"
-    SELECTED_OP_LIST: << parameters.op_list >>
-    BUILD_LITE_INTERPRETER: << parameters.lite_interpreter >>
-
 pytorch_ios_params: &pytorch_ios_params
   parameters:
     build_environment:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -416,43 +416,6 @@
         path: ~/workspace/build_android_x86_32_artifacts/artifacts.tgz
         destination: artifacts.tgz
 
-  pytorch_android_gradle_custom_build_single:
-    <<: *pytorch_android_params
-    resource_class: large
-    machine:
-      image: ubuntu-2004:202104-01
-    steps:
-    - checkout
-    - calculate_docker_image_tag
-    - setup_linux_system_environment
-    - checkout
-    - calculate_docker_image_tag
-    - setup_ci_environment
-    - run:
-        name: pytorch android gradle custom build single architecture (for PR)
-        no_output_timeout: "1h"
-        command: |
-          set -e
-          # Unlike other gradle jobs, it's not worth building libtorch in a separate CI job and share via docker, because:
-          # 1) Not shareable: it's custom selective build, which is different from default libtorch mobile build;
-          # 2) Not parallelizable by architecture: it only builds libtorch for one architecture;
-
-          echo "DOCKER_IMAGE: ${DOCKER_IMAGE}:${DOCKER_TAG}"
-          time docker pull ${DOCKER_IMAGE}:${DOCKER_TAG} >/dev/null
-
-          git submodule sync && git submodule update -q --init --recursive --depth 1 --jobs 0
-          VOLUME_MOUNTS="-v /home/circleci/project/:/var/lib/jenkins/workspace"
-          export id=$(docker run --env-file "${BASH_ENV}" ${VOLUME_MOUNTS} --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE}:${DOCKER_TAG})
-
-          export COMMAND='((echo "export GRADLE_OFFLINE=1" && echo "export BUILD_LITE_INTERPRETER=${BUILD_LITE_INTERPRETER}" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
-          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
-
-          # Skip docker push as this job is purely for size analysis purpose.
-          # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
-
-    - upload_binary_size_for_android_build:
-        build_type: custom-build-single
-
   pytorch_ios_build:
     <<: *pytorch_ios_params
     macos:

--- a/.github/generated-ciflow-ruleset.json
+++ b/.github/generated-ciflow-ruleset.json
@@ -25,11 +25,13 @@
       "periodic-linux-xenial-cuda11.1-py3.6-gcc7",
       "periodic-win-vs2019-cuda11.1-py3",
       "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
       "win-vs2019-cpu-py3",
       "win-vs2019-cuda11.3-py3"
     ],
     "ciflow/android": [
-      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single"
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit"
     ],
     "ciflow/bazel": [
       "linux-xenial-py3.6-gcc7-bazel-test"
@@ -45,6 +47,7 @@
       "linux-xenial-py3.6-gcc7-bazel-test",
       "parallelnative-linux-xenial-py3.6-gcc5.4",
       "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
       "win-vs2019-cpu-py3"
     ],
     "ciflow/cuda": [
@@ -71,6 +74,7 @@
       "linux-xenial-py3.6-gcc7",
       "linux-xenial-py3.6-gcc7-bazel-test",
       "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
       "win-vs2019-cpu-py3",
       "win-vs2019-cuda11.3-py3"
     ],
@@ -100,7 +104,8 @@
       "periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
       "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
       "periodic-linux-xenial-cuda11.1-py3.6-gcc7",
-      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single"
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit"
     ],
     "ciflow/mobile": [
       "linux-xenial-py3-clang5-mobile-build",

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -530,6 +530,16 @@ ANDROID_WORKFLOWS = [
             labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_ANDROID, LABEL_CIFLOW_DEFAULT},
         ),
     ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_ANDROID, LABEL_CIFLOW_DEFAULT},
+        ),
+    ),
 ]
 
 BAZEL_WORKFLOWS = [

--- a/.github/templates/android_ci_workflow.yml.j2
+++ b/.github/templates/android_ci_workflow.yml.j2
@@ -53,6 +53,12 @@ on:
           echo "DOCKER_IMAGE: ${DOCKER_IMAGE}"
           time docker pull "${DOCKER_IMAGE}" >/dev/null
 
+          export BUILD_LITE_INTERPRETER
+          BUILD_LITE_INTERPRETER="1"
+          if [[ "${BUILD_ENVIRONMENT}" == *"full-jit" ]]; then
+            BUILD_LITE_INTERPRETER="0"
+          fi
+
           git submodule sync && git submodule update -q --init --recursive --depth 1 --jobs 0
           # shellcheck disable=SC2016
           export id
@@ -64,6 +70,7 @@ on:
             -e PR_LABELS \
             -e SKIP_SCCACHE_INITIALIZATION=1 \
             -e TORCH_CUDA_ARCH_LIST \
+            -e BUILD_LITE_INTERPRETER \
             -e http_proxy="!{{ common.squid_proxy }}" -e https_proxy="!{{ common.squid_proxy }}" -e no_proxy="!{{ common.squid_no_proxy }}" \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --security-opt seccomp=unconfined \
@@ -81,7 +88,7 @@ on:
           # shellcheck disable=SC2016
           export COMMAND
           # shellcheck disable=SC2016
-          COMMAND='((echo "export GRADLE_OFFLINE=1" && echo "export BUILD_LITE_INTERPRETER=1" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          COMMAND='((echo "export GRADLE_OFFLINE=1" && echo "export BUILD_LITE_INTERPRETER=${BUILD_LITE_INTERPRETER}" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
           echo "${COMMAND}" > ./command.sh && bash ./command.sh
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
@@ -100,6 +107,8 @@ on:
         run: |
           COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
           export COMMIT_TIME
+          ANDROID_BUILD_TYPE="custom-build-single"
+          export ANDROID_BUILD_TYPE
           pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba "android" || exit 0
       !{{ common.teardown_ec2_linux() }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/android_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
+name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
+  BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
   DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c
   SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
   XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
@@ -31,7 +31,7 @@ env:
   CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}
   CIRCLE_SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
 concurrency:
-  group: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
     runs-on: linux.2xlarge
     needs: [ciflow_should_run]
     env:
-      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-build-and-test
+      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit-build-and-test
       NUM_TEST_SHARDS: 1
     steps:
       - name: Display EC2 information


### PR DESCRIPTION
Summary:
in scope of: #67301. Main changes:
* generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit deleted from circle
* pytorch_android_gradle_custom_build_single removed since it is no longer used
* generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit added to GHA