### PR TITLE
Overload TestCase not vanilla TestCase for some elastic tests

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     TEST_WITH_TSAN,
+    TestCase
 )
 
 
@@ -39,7 +40,7 @@ if IS_WINDOWS or IS_MACOS:
     sys.exit(0)
 
 
-class DistributedUtilTest(unittest.TestCase):
+class DistributedUtilTest(TestCase):
     def test_create_store_single_server(self):
         store = create_c10d_store(is_server=True, server_addr=socket.gethostname())
         self.assertIsNotNone(store)

--- a/test/distributed/elastic/utils/logging_test.py
+++ b/test/distributed/elastic/utils/logging_test.py
@@ -6,16 +6,15 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import unittest
-
 import torch.distributed.elastic.utils.logging as logging
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 log = logging.get_logger()
 
 
-class LoggingTest(unittest.TestCase):
+class LoggingTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.clazz_log = logging.get_logger()
 
     def test_logger_name(self):

--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -7,8 +7,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
 import torch.distributed.elastic.utils.store as store_util
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.testing._internal.common_utils import run_tests, TestCase

--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -11,7 +11,7 @@ import unittest
 
 import torch.distributed.elastic.utils.store as store_util
 from torch.distributed.elastic.utils.logging import get_logger
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestStore:
@@ -19,7 +19,7 @@ class TestStore:
         return f"retrieved:{key}"
 
 
-class StoreUtilTest(unittest.TestCase):
+class StoreUtilTest(TestCase):
     def test_get_data(self):
         store = TestStore()
         data = store_util.get_all(store, "test/store", 10)
@@ -53,7 +53,7 @@ class StoreUtilTest(unittest.TestCase):
             self.assertEqual(f"data{idx}", actual_str)
 
 
-class UtilTest(unittest.TestCase):
+class UtilTest(TestCase):
     def test_get_logger_different(self):
         logger1 = get_logger("name1")
         logger2 = get_logger("name2")


### PR DESCRIPTION
Addresses a bit of https://github.com/pytorch/pytorch/issues/66903

Fixes it so that https://github.com/pytorch/pytorch/issues/66207 can be properly disabled

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang