### PR TITLE
[Torch] Default to IPv6 on listen (#49124)

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -181,7 +181,7 @@ class RendezvousEnvTest(TestCase):
     @retry_on_connect_failures
     def test_logging_init(self):
         os.environ["WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["MASTER_PORT"] = str(common.find_free_port())
         os.environ["RANK"] = "0"
 
@@ -559,7 +559,9 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             opts = c10d.AllreduceCoalescedOptions()
             pg.allreduce_coalesced([], opts)
 
-        with self.assertRaisesRegex(RuntimeError, "tensors must all have the same type"):
+        with self.assertRaisesRegex(
+            RuntimeError, "tensors must all have the same type"
+        ):
             opts = c10d.AllreduceCoalescedOptions()
             pg.allreduce_coalesced([t1, t2], opts)
 
@@ -676,7 +678,9 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
         # Sparse allreduce only works with c10d.ReduceOp.SUM.
         for op in [c10d.ReduceOp.PRODUCT, c10d.ReduceOp.MIN, c10d.ReduceOp.MAX]:
-            with self.assertRaisesRegex(RuntimeError, "unsupported reduction operation"):
+            with self.assertRaisesRegex(
+                RuntimeError, "unsupported reduction operation"
+            ):
                 opts = c10d.AllreduceOptions()
                 opts.reduceOp = op
                 pg.allreduce([t3], opts)
@@ -744,12 +748,16 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             opts.rootRank = 0
             pg.scatter([t1, t1], [], opts)
 
-        with self.assertRaisesRegex(RuntimeError, "requires a single-element input list"):
+        with self.assertRaisesRegex(
+            RuntimeError, "requires a single-element input list"
+        ):
             opts = c10d.ScatterOptions()
             opts.rootRank = self.rank
             pg.scatter([t1], [], opts)
 
-        with self.assertRaisesRegex(RuntimeError, "requires a single-element input list"):
+        with self.assertRaisesRegex(
+            RuntimeError, "requires a single-element input list"
+        ):
             opts = c10d.ScatterOptions()
             opts.rootRank = self.rank
             pg.scatter([t1], [[t1] * self.world_size, [t1] * self.world_size], opts)
@@ -1054,7 +1062,9 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         t2 = torch.zeros([1], dtype=torch.float64)
         t3 = torch.zeros([2], dtype=torch.float32)
 
-        with self.assertRaisesRegex(RuntimeError, "requires non-empty input tensor list"):
+        with self.assertRaisesRegex(
+            RuntimeError, "requires non-empty input tensor list"
+        ):
             pg.allgather([], [])
 
         with self.assertRaisesRegex(
@@ -1208,11 +1218,19 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         )
 
         xxs = [2 * [torch.tensor([i + self.rank])] for i in range(2)]
-        yys = [[[torch.zeros_like(x) for x in xx] for _ in range(self.world_size)] for xx in xxs]
-        futs = [c10d.all_gather_coalesced(yy, xx, async_op=True) for xx, yy in zip(xxs, yys)]
+        yys = [
+            [[torch.zeros_like(x) for x in xx] for _ in range(self.world_size)]
+            for xx in xxs
+        ]
+        futs = [
+            c10d.all_gather_coalesced(yy, xx, async_op=True) for xx, yy in zip(xxs, yys)
+        ]
 
         # expected outputs
-        zzs = [[2 * [torch.tensor([i + r])] for r in range(self.world_size)] for i in range(2)]
+        zzs = [
+            [2 * [torch.tensor([i + r])] for r in range(self.world_size)]
+            for i in range(2)
+        ]
 
         torch.futures.wait_all(futs)
         for yy, zz in zip(yys, zzs):
@@ -1988,7 +2006,9 @@ class DistributedDataParallelTest(
             ModuleForDdpCommHook(), process_group=process_group
         )
 
-        expected_err = "Communication hook: return annotation should be torch.futures.Future"
+        expected_err = (
+            "Communication hook: return annotation should be torch.futures.Future"
+        )
         with self.assertRaisesRegex(
             ValueError,
             expected_err,
@@ -2104,7 +2124,9 @@ class ReducerTest(TestCase):
         model = ReducerModule()
         parameters = list(model.parameters())
         buckets = [list(range(len(parameters)))]
-        dist.Reducer(parameters, buckets, [dist._DEFAULT_FIRST_BUCKET_BYTES], self.process_group)
+        dist.Reducer(
+            parameters, buckets, [dist._DEFAULT_FIRST_BUCKET_BYTES], self.process_group
+        )
 
     def _create_mixed_precision_model(self):
         model = ReducerModule()
@@ -2125,7 +2147,7 @@ class ReducerTest(TestCase):
                 parameters,
                 buckets,
                 [dist._DEFAULT_FIRST_BUCKET_BYTES],
-                self.process_group
+                self.process_group,
             )
 
     @requires_gloo()
@@ -2140,7 +2162,7 @@ class ReducerTest(TestCase):
             parameters,
             buckets,
             [dist._DEFAULT_FIRST_BUCKET_BYTES for _ in buckets],
-            self.process_group
+            self.process_group,
         )
 
     def _create_reducer_for_models(self, models, find_unused_parameters=False):

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -18,10 +18,7 @@ if not dist.is_available():
 
 import torch.testing._internal.common_utils as common
 from torch._six import string_classes
-from torch.testing._internal.common_distributed import (
-    skip_if_win32,
-    create_tcp_store
-)
+from torch.testing._internal.common_distributed import skip_if_win32, create_tcp_store
 from torch.testing._internal.common_utils import (
     TestCase,
     load_tests,
@@ -56,7 +53,7 @@ def gpus_for_rank(world_size):
     gpus_for_rank = []
     for rank in range(world_size):
         gpus_for_rank.append(
-            visible_devices[rank * gpus_per_process: (rank + 1) * gpus_per_process]
+            visible_devices[rank * gpus_per_process : (rank + 1) * gpus_per_process]
         )
     return gpus_for_rank
 
@@ -89,7 +86,9 @@ class StoreTestBase(object):
         self._test_set_get(self._create_store())
 
     def _test_compare_set(self, store):
-        missing_key_result = store.compare_set("cs_key0", "wrong_old_value", "new_value0")
+        missing_key_result = store.compare_set(
+            "cs_key0", "wrong_old_value", "new_value0"
+        )
         self.assertEqual(b"wrong_old_value", missing_key_result)
 
         store.set("cs_key0", "value0")
@@ -246,11 +245,17 @@ class TCPStoreTest(TestCase, StoreTestBase):
         self._test_numkeys_delkeys(self._create_store())
 
     def _create_client(self, index, addr, port, world_size):
-        client_store = dist.TCPStore(addr, port, world_size, timeout=timedelta(seconds=10))
+        client_store = dist.TCPStore(
+            addr, port, world_size, timeout=timedelta(seconds=10)
+        )
         self.assertEqual("value".encode(), client_store.get("key"))
         client_store.set(f"new_key{index}", f"new_value{index}")
-        self.assertEqual(f"next_value{index}".encode(),
-                         client_store.compare_set(f"new_key{index}", f"new_value{index}", f"next_value{index}"))
+        self.assertEqual(
+            f"next_value{index}".encode(),
+            client_store.compare_set(
+                f"new_key{index}", f"new_value{index}", f"next_value{index}"
+            ),
+        )
 
     def _multi_worker_helper(self, world_size):
         addr = DEFAULT_HOSTNAME
@@ -266,6 +271,7 @@ class TCPStoreTest(TestCase, StoreTestBase):
 
     def test_multi_worker_with_nonfixed_world_size(self):
         self._multi_worker_helper(-1)
+
 
 class PrefixTCPStoreTest(TestCase, StoreTestBase):
     def setUp(self):
@@ -334,7 +340,7 @@ class RendezvousEnvTest(TestCase):
     @retry_on_connect_failures
     def test_nominal(self):
         os.environ["WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_ADDR"] = DEFAULT_HOSTNAME
         os.environ["MASTER_PORT"] = str(common.find_free_port())
 
         # Single rank

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -50,7 +50,8 @@ TORCH_API std::string parse_env(const char* env_var_name);
 TORCH_API DistributedDebugLevel parseDistDebugLevel();
 
 // Retrieve tensor shapes from a given tensor.
-TORCH_API std::vector<at::Tensor> getTensorShapes(const std::vector<at::Tensor>& tensors);
+TORCH_API std::vector<at::Tensor> getTensorShapes(
+    const std::vector<at::Tensor>& tensors);
 
 // Turns at::IntArrayRef into "(1, 2, 3, 4)".
 inline std::string toString(at::IntArrayRef l) {
@@ -92,7 +93,8 @@ inline bool parseEnvVarFlag(const char* envVarName) {
     try {
       val = std::stoi(stringValue);
     } catch (std::exception& e) {
-      TORCH_CHECK(false,
+      TORCH_CHECK(
+          false,
           "Invalid value for environment variable: " + std::string(envVarName));
     }
     if (val == 1) {
@@ -100,7 +102,8 @@ inline bool parseEnvVarFlag(const char* envVarName) {
     } else if (val == 0) {
       return false;
     } else {
-      TORCH_CHECK(false,
+      TORCH_CHECK(
+          false,
           "Invalid value for environment variable: " + std::string(envVarName));
     }
   }
@@ -448,7 +451,7 @@ size_t computeLengthsAndOffsets(
     equal_splits = true;
     split_size = tensor.size(0) / group_size;
   }
-  for(const auto i : c10::irange(group_size)) {
+  for (const auto i : c10::irange(group_size)) {
     size_t length = row_size * (equal_splits ? split_size : split_sizes[i]);
     TORCH_INTERNAL_ASSERT(
         length <= std::numeric_limits<int>::max() &&
@@ -468,7 +471,7 @@ size_t computeLengthsAndOffsets(
     std::vector<T>* offsets) {
   size_t group_size = lengths->size();
   size_t offset = 0;
-  for(const auto i : c10::irange(group_size)) {
+  for (const auto i : c10::irange(group_size)) {
     size_t length = tensors[i].numel();
     TORCH_INTERNAL_ASSERT(
         length <= std::numeric_limits<int>::max() &&
@@ -504,7 +507,7 @@ using SizeType = uint64_t;
         continue;                                                         \
       } else if (                                                         \
           errno_local == WSAETIMEDOUT || errno_local == WSAEWOULDBLOCK) { \
-        TORCH_CHECK(false, "Socket Timeout");                       \
+        TORCH_CHECK(false, "Socket Timeout");                             \
       } else {                                                            \
         throw std::system_error(errno_local, std::system_category());     \
       }                                                                   \
@@ -521,7 +524,7 @@ using SizeType = uint64_t;
       if (errno == EINTR) {                                     \
         continue;                                               \
       } else if (errno == EAGAIN || errno == EWOULDBLOCK) {     \
-        TORCH_CHECK(false, "Socket Timeout");             \
+        TORCH_CHECK(false, "Socket Timeout");                   \
       } else {                                                  \
         throw std::system_error(errno, std::system_category()); \
       }                                                         \

--- a/torch/csrc/distributed/c10d/WinSockUtils.hpp
+++ b/torch/csrc/distributed/c10d/WinSockUtils.hpp
@@ -5,7 +5,6 @@
 namespace c10d {
 namespace tcputil {
 
-#define AF_SELECTED AF_INET
 #define CONNECT_SOCKET_OFFSET 1
 
 inline void closeSocket(int socket) { ::closesocket(socket); }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/49124

At Facebook, most of our hosts are IPv6-only, but sometimes we do clowny things to make them dual-stacked.
As we do not expect them to be dual-stacked, they end up with an IPv4 IP address which is not in the DNS, and we do not have any `/etc/gai.conf` to order them.
So by default, if we try to bind anything to such a host, we'll get the IPv4 address.
But... if we try to connect to that host, the DNS will only ever resolve to IPv6, so we'll try to connect over v6, which won't work as the socket listens only on v4.

This will make the first try to use only IPv6. It should work in 99% of the cases, as long as the IPv6 stack is enabled.
Even if the host only has an IPv4 address, it will listen over v6 and use the compatibility layer (so `::ffff:` addresses)

And if the host has disabled IPv6 (using something like `ipv6.disable=1` on the kernel command line), we'll fallback to the old code, so it should be fully backwards compatible.

The main change is that IPv4 users might see "weird" addresses like `::ffff:127.0.0.1` instead of `127.0.0.1`, but otherwise, it should just work

Reviewed By: malfet

Differential Revision: D24969149



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang