### PR TITLE
Remove duplicate check in distributions arg validation

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -59,8 +59,6 @@ class Distribution(object):
                         f"to satisfy the constraint {repr(constraint)}, "
                         f"but found invalid values:\n{value}"
                     )
-                if not constraint.check(getattr(self, param)).all():
-                    raise ValueError("The parameter {} has invalid values".format(param))
         super(Distribution, self).__init__()
 
     def expand(self, batch_shape, _instance=None):


### PR DESCRIPTION
Partial fix for #66800. (Duplicate of #67725 against pytorch/pytorch so as to trigger TorchBench)

#61056 added a more verbose error message for distributions failing argument validation. However, it did not replace the earlier error check as was originally intended and was flagged by @xuzhao9 as being the potential cause of a perf regression in `test_eval[soft_actor_critic-cuda-eager]`. 

@xuzhao9: Is there a way for me to check if this resolves the perf issue you mentioned?

cc @VitalyFedyunin @ngimel

Note that existing tests already check for the error message and should verify that the removed lines are redundant. 

RUN_TORCHBENCH: soft_actor_critic
