### PR TITLE
Fix tiny bug in fx/passes/graph_drawer.py that gobbles names of buffers

### DIFF
--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -223,9 +223,10 @@ if HAS_PYDOT:
                     ):
                         pname1 = node.name + "." + pname
                         label1 = (
-                            pname1 + "|op_code=get_" + ("parameter"
-                            if is_param
-                            else "buffer") + r"\l"
+                            pname1
+                            + "|op_code=get_"
+                            + ("parameter" if is_param else "buffer")
+                            + r"\l"
                         )
                         dot_w_node = pydot.Node(
                             pname1,

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -223,9 +223,9 @@ if HAS_PYDOT:
                     ):
                         pname1 = node.name + "." + pname
                         label1 = (
-                            pname1 + "|op_code=get_" + "parameter"
+                            pname1 + "|op_code=get_" + ("parameter"
                             if is_param
-                            else "buffer" + r"\l"
+                            else "buffer") + r"\l"
                         )
                         dot_w_node = pydot.Node(
                             pname1,


### PR DESCRIPTION
Fixes a tiny bug in `fx/passes/graph_drawer.py` that is gobbling names of buffers. Before and after images attached.

Before: 
![image](https://user-images.githubusercontent.com/19234106/140020923-b94d5524-35b5-4b15-8986-13bff87d27e5.png)

After: 
![image](https://user-images.githubusercontent.com/19234106/140020939-eb6a9937-d579-488e-99aa-3ad874812f64.png)

cc: @jamesr66a , @khabinov 
