### PR TITLE
[qnnpack] fix benchmarks after an API update

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/average-pooling.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/average-pooling.cc
@@ -55,8 +55,6 @@ static void average_pooling_q8(benchmark::State& state, const char* net) {
   status = pytorch_qnnp_create_average_pooling2d_nhwc_q8(
       paddingSize,
       paddingSize,
-      paddingSize,
-      paddingSize,
       poolingSize,
       poolingSize,
       stride,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/max-pooling.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/max-pooling.cc
@@ -55,8 +55,6 @@ static void max_pooling_u8(benchmark::State& state, const char* net) {
   status = pytorch_qnnp_create_max_pooling2d_nhwc_u8(
       paddingSize,
       paddingSize,
-      paddingSize,
-      paddingSize,
       poolingSize,
       poolingSize,
       stride,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
@@ -14,7 +14,6 @@
 
 #include <pthreadpool.h>
 #include <qnnpack/log.h>
-#include <qnnpack/operator.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/qnnpack_func.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/qnnpack_func.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <qnnpack/operator.h>
 
 namespace qnnpack {
 class PrePackConvWeights final {

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-prepack.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-prepack.cc
@@ -1,5 +1,6 @@
 #include <pytorch_qnnpack.h>
 #include <qnnpack/log.h>
+#include <qnnpack/operator.h>
 #include <qnnpack/pack.h>
 #include <qnnpack_func.h>
 #include <cstring>


### PR DESCRIPTION
Summary: We don't need to pass so many padding args after removing support for asymm padding from qnnpack

Test Plan: it builds

Reviewed By: jshen

Differential Revision: D32082204

