### PR TITLE
Add retry logic for test_multitenancy and documentation for find_free_port

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -171,6 +171,7 @@ class TCPStoreTest(TestCase, StoreTestBase):
             store1 = dist.TCPStore(addr, port, 1, True)  # noqa: F841
             store2 = dist.TCPStore(addr, port, 1, True)  # noqa: F841
 
+    @retry_on_connect_failures
     def test_multitenancy(self):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2233,9 +2233,9 @@ def download_file(url, binary=True):
 
 def find_free_port():
     """
-    Binds to an available port then returns that port number.
+    Finds an available port and returns that port number.
 
-    NOTE: If this function is being used to allocate a port to Store (or 
+    NOTE: If this function is being used to allocate a port to Store (or
     indirectly via init_process_group or init_rpc), it should be used
     in conjuction with the `retry_on_connect_failures` decorator as there is a potential
     race condition where the allocated port may become unavailable before it can be used

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2232,6 +2232,14 @@ def download_file(url, binary=True):
         raise unittest.SkipTest(msg) from e
 
 def find_free_port():
+    """
+    Binds to an available port then returns that port number.
+
+    NOTE: If this function is being used to allocate a port to Store (or 
+    indirectly via init_process_group or init_rpc), it should be used
+    in conjuction with the `retry_on_connect_failures` decorator as there is a potential
+    race condition where the allocated port may become unavailable before it can be used
+    """
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind(('localhost', 0))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#67775 Add retry logic for test_multitenancy and documentation for find_free_port**
* #67638 Fix test_init_pg_and_rpc_with_same_socket by retrying on addr in use error

Add retry logic to another test for reasons related to #67638

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D32142749](https://our.internmc.facebook.com/intern/diff/D32142749)