### PR TITLE
[Autocast] Handle CallMethod in JIT autocast.

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -142,7 +142,7 @@ Tensor _autocast_to_reduced_precision(const Tensor& self, bool cuda_enabled, boo
 // If input tensor is fp16, cast it to fp32, otherwise leave it alone.
 // (this is intended to be used internally by the JIT autocast implementation)
 Tensor _autocast_to_full_precision(const Tensor& self, bool cuda_enabled, bool cpu_enabled) {
-  if (self.dtype() == at::ScalarType::Half &&
+  if ((self.dtype() == at::ScalarType::Half || self.dtype() == at::ScalarType::BFloat16) &&
       ((self.device().is_cuda() && cuda_enabled) ||
       (self.device().is_cpu() && cpu_enabled))
       ) {

--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -249,22 +249,9 @@ void handleBlock(Block* block, AutocastContext initial_state) {
         break;
 
       case prim::CallMethod:
-        // TODO: limit it only to amp related node;
-        if (auto class_type = node->input(0)->type()->cast<ClassType>()) {
-          const auto& name = node->s(attr::name);
-          const auto& function = class_type->getMethod(name);
-          if (!function.isGraphFunction()) {
-            TORCH_INTERNAL_ASSERT(
-                !incompatible_amp.has_value() || incompatible_amp.value(),
-                "Calls are not expected with AMP & JIT");
-            incompatible_amp = true;
-          }
-        } else {
-          TORCH_INTERNAL_ASSERT(
-              !incompatible_amp.has_value() || incompatible_amp.value(),
-              "Unexpected prim::CallMethod form with AMP & JIT");
-          incompatible_amp = true;
-        }
+        // Assume all CallMethod should be run in full precision now.
+        castTensorInputs(
+            node, aten::_autocast_to_full_precision, current_state());
         break;
 
       case prim::Enter:


### PR DESCRIPTION
Summary:
Some models have CallMethod and it will cause an exception in JIT autocast pass.

Handle it by assuming all CallMethod are using full precision.

Test Plan: Unit tests passing

Differential Revision: D32144841

