### PR TITLE
[nnc] Use given kernel function name while emitting code (#66216)

### DIFF
--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -1794,6 +1794,28 @@ TEST(LLVM, CustomTarget) {
       ->run(ss.str());
 }
 
+TEST(LLVM, CodeGenKernelFuncName) {
+  BufHandle a("A", {1}, kInt);
+  BufHandle b("B", {1}, kInt);
+  std::vector<int32_t> a_buffer = {42};
+  std::vector<int32_t> b_buffer = {-11};
+  auto store = b.store({0}, a.load(0));
+
+  {
+    LLVMCodeGen cg(store, {a, b});
+    // Check that the kernel function name used by LLVMCodeGen
+    // is not empty.
+    ASSERT_NE(cg.kernel_func_name(), "");
+  }
+
+  {
+    LLVMCodeGen cg(store, {a, b}, at::kCPU, "new_func");
+    // Check that the kernel function name used by LLVMCodeGen
+    // is the one that was given above.
+    ASSERT_EQ(cg.kernel_func_name(), "new_func");
+  }
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -202,6 +202,7 @@ class LLVMCodeGenImpl : public IRVisitor {
   llvm::BasicBlock* bb_;
   llvm::Value* value_{nullptr};
   llvm::JITTargetAddress kernelAddress_;
+  std::string kernel_func_name_;
 
 #define LLVM_TYPE_DECLARE(_1, Name) llvm::Type* Name##Ty_;
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, LLVM_TYPE_DECLARE);
@@ -251,6 +252,7 @@ class LLVMCodeGenImpl : public IRVisitor {
       const std::vector<CodeGen::BufferArg>& args,
       at::Device device,
       Dtype dtype,
+      std::string kernel_func_name,
       c10::optional<std::string> triple,
       c10::optional<std::string> cpu,
       c10::optional<std::string> attrs);
@@ -338,7 +340,14 @@ LLVMCodeGen::LLVMCodeGen(
     c10::optional<std::string> attrs)
     : CodeGen(stmt, args, device, kernel_func_name) {
   impl_ = std::make_unique<LLVMCodeGenImpl>(
-      this->stmt(), args, device, dtype, triple, cpu, attrs);
+      this->stmt(),
+      args,
+      device,
+      dtype,
+      this->kernel_func_name(),
+      triple,
+      cpu,
+      attrs);
   callee_ = std::make_unique<LLVMCodeGenCallee>(
       impl_->releaseJIT(), (void*)impl_->getKernelAddress());
 }
@@ -417,10 +426,13 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
     const std::vector<CodeGen::BufferArg>& args,
     at::Device device,
     Dtype dtype,
+    std::string kernel_func_name,
     c10::optional<std::string> triple,
     c10::optional<std::string> cpu,
     c10::optional<std::string> attrs)
-    : context_(std::make_unique<llvm::LLVMContext>()), irb_(getContext()) {
+    : context_(std::make_unique<llvm::LLVMContext>()),
+      irb_(getContext()),
+      kernel_func_name_(std::move(kernel_func_name)) {
   if (!triple) {
     triple = LLVMTargetTriple();
   }
@@ -487,7 +499,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
 
   jit_->addModule(std::move(module_), std::move(context_));
   if (!LLVMAOTWorkflow()) {
-    auto sym = jit_->findSymbol("wrapper");
+    auto sym = jit_->findSymbol(kernel_func_name_);
     kernelAddress_ = assertSuccess(sym.getAddress());
   }
 }
@@ -529,7 +541,7 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
   auto wrapper = llvm::Function::Create(
       llvm::FunctionType::get(IntTy_, {voidPtrPtrTy}, false),
       llvm::Function::ExternalLinkage,
-      "wrapper",
+      kernel_func_name_,
       module_.get());
   auto wrapBB = llvm::BasicBlock::Create(getContext(), "wrapBB", wrapper);
   irb_.SetInsertPoint(wrapBB);


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/66216

Test Plan: Imported from OSS

Differential Revision: D32145958

Pulled By: navahgar

