### PR TITLE
Only set sccache_epilogue to run on build job exits

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -101,7 +101,10 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
       sccache --show-stats
       sccache --stop-server || true
     }
-    trap_add sccache_epilogue EXIT
+
+    if [[ "${JOB_BASE_NAME}" == *-build ]]; then
+      trap_add sccache_epilogue EXIT
+    fi
   fi
 
   if which ccache > /dev/null; then


### PR DESCRIPTION
Fixes:
* https://github.com/pytorch/pytorch/issues/65431
