### PR TITLE
[ONNX] Suppress ort warnings in onnx related test (#67054)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -93,7 +93,11 @@ def convert_to_onnx(model, input=None, opset_version=9, do_constant_folding=True
                        onnx_shape_inference=onnx_shape_inference)
 
     # compute onnxruntime output prediction
-    ort_sess = onnxruntime.InferenceSession(f.getvalue())
+    so = onnxruntime.SessionOptions()
+    # suppress ort warnings.
+    # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
+    so.log_severity_level = 3
+    ort_sess = onnxruntime.InferenceSession(f.getvalue(), so)
     return ort_sess
 
 
@@ -359,6 +363,9 @@ class TestONNXRuntime(unittest.TestCase):
                 ort_sess_opt.graph_optimization_level = \
                     onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED if ort_optim_on else \
                     onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+                # suppress ort warnings.
+                # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
+                ort_sess_opt.log_severity_level = 3
                 ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt)
                 input_copy = copy.deepcopy(input)
                 ort_outs = run_ort(ort_sess, input_copy)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67812 [ONNX] ConstantMap setters to update existing value instead of emplace (#67630)
* #67811 [ONNX] Remove the argument use_external_data_format of export() method entirely. (#67080)
* #67810 [ONNX] Allow registration of custom symbolics for aten namespace (#66481)
* #67809 [ONNX] Remove the argument example_outpus of export() method entirely. (#67082)
* #67808 [ONNX] Fix reciprocal when input is not floating point (#67471)
* #67807 [ONNX] Use human readable enum for dtype scalars (#66822)
* #67806 [ONNX] Fix new_full and full_like for Python 3.9 (#67124)
* #67805 [ONNX] Support opset 15 (#67121)
* **#67804 [ONNX] Suppress ort warnings in onnx related test (#67054)**
* #67803 [ONNX] Update onnx function export with comments and clean up (#66817)

Improve readability of test logs by suppressing ort warnings logging for onnx related test.

Reducing ONNX CI test log binary size:
linux-xenial-py3.6-clang7-onnx-test1: 12443 KB -> 6958 KB
linux-xenial-py3.6-clang7-onnx-test2: 16884 KB -> 5778 KB

Co-authored-by: BowenBao<bowbao@microsoft.com>

Differential Revision: [D32181308](https://our.internmc.facebook.com/intern/diff/D32181308)