### PR TITLE
[ONNX] Support opset 15 (#67121)

### DIFF
--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -80,7 +80,7 @@ fi
 
 if [[ "$BUILD_ENVIRONMENT" == *ort_test2* || "${SHARD_NUMBER}" == "2" ]]; then
   # Update the loop for new opsets
-  for i in $(seq 10 14); do
+  for i in $(seq 10 15); do
     pytest "${args[@]}" \
       "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset$i"
   done

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10324,5 +10324,13 @@ TestONNXRuntime_opset14 = type(str("TestONNXRuntime_opset14"),
                                     keep_initializers_as_inputs=False,
                                     onnx_shape_inference=True))
 
+# opset 15 tests
+TestONNXRuntime_opset15 = type(str("TestONNXRuntime_opset15"),
+                               (unittest.TestCase,),
+                               dict(TestONNXRuntime.__dict__, opset_version=15,
+                                    keep_initializers_as_inputs=False,
+                                    onnx_shape_inference=True))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -842,8 +842,8 @@ def _handle_reduce_dim_none(g, self, op_name):
 
 
 _default_onnx_opset_version = 9
-_onnx_main_opset = 14
-_onnx_stable_opsets = [7, 8, 9, 10, 11, 12, 13]
+_onnx_main_opset = 15
+_onnx_stable_opsets = [7, 8, 9, 10, 11, 12, 13, 14]
 _export_onnx_opset_version = _default_onnx_opset_version
 
 

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -119,9 +119,9 @@ def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduc
     if reduction == 0:
         return output
     elif reduction == 1:
-        return g.op("ReduceMean", output)
+        return g.op("ReduceMean", output, keepdims_i=0)
     elif reduction == 2:
-        return g.op("ReduceSum", output)
+        return g.op("ReduceSum", output, keepdims_i=0)
     else:
         return sym_help._onnx_unsupported("binary_cross_entropy_with_logits with reduction other than none, mean, or sum")
 

--- a/torch/onnx/symbolic_opset15.py
+++ b/torch/onnx/symbolic_opset15.py
@@ -1,0 +1,25 @@
+# EDITING THIS FILE? READ THIS FIRST!
+# see Note [Edit Symbolic Files] in symbolic_helper.py
+
+# This file exports ONNX ops for opset 15
+
+# Note [ONNX operators that are added/updated in opset 15]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# https://github.com/onnx/onnx/blob/master/docs/Changelog.md#version-15-of-the-default-onnx-operator-set
+# New operators:
+#   Bernoulli
+#   CastLike
+#   Optional
+#   OptionalGetElement
+#   OptionalHasElement
+#
+# Updated operators:
+#    BatchNormalization https://github.com/onnx/onnx/pull/3545
+#                       Backwards compatible
+#                       TODO: test coverage for mixed types inputs.
+#    Pow                https://github.com/onnx/onnx/pull/3412
+#                       Backwards compatible
+#                       TODO: bfloat16 support.
+#    Shape              https://github.com/onnx/onnx/pull/3580
+#                       Backwards compatible
+#                       TODO: optional start/end attribute.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67812 [ONNX] ConstantMap setters to update existing value instead of emplace (#67630)
* #67811 [ONNX] Remove the argument use_external_data_format of export() method entirely. (#67080)
* #67810 [ONNX] Allow registration of custom symbolics for aten namespace (#66481)
* #67809 [ONNX] Remove the argument example_outpus of export() method entirely. (#67082)
* #67808 [ONNX] Fix reciprocal when input is not floating point (#67471)
* #67807 [ONNX] Use human readable enum for dtype scalars (#66822)
* #67806 [ONNX] Fix new_full and full_like for Python 3.9 (#67124)
* **#67805 [ONNX] Support opset 15 (#67121)**
* #67804 [ONNX] Suppress ort warnings in onnx related test (#67054)
* #67803 [ONNX] Update onnx function export with comments and clean up (#66817)

Also fix Reduce ops on binary_cross_entropy_with_logits

The graph says the output is a scalar but with `keepdims=1`
(the default), the output should be a tensor of rank 1. We set keep
`keepdims=0` to make it clear that we want a scalar output.

This previously went unnoticed because ONNX Runtime does not strictly
enforce shape inference mismatches if the model is not using the latest
opset version.

Co-authored-by: Bowen Bao <bowbao@microsoft.com>

Differential Revision: [D32181304](https://our.internmc.facebook.com/intern/diff/D32181304)