### PR TITLE
[ONNX] Allow registration of custom symbolics for aten namespace (#66481)

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -4,8 +4,14 @@ from test_pytorch_common import TestCase, run_tests
 
 import torch
 import torch.onnx
-from torch.onnx import utils, OperatorExportTypes, TrainingMode, register_custom_op_symbolic
-from torch.onnx.symbolic_helper import _set_opset_version, _set_operator_export_type, _set_onnx_shape_inference
+from torch.onnx import (utils,
+                        OperatorExportTypes,
+                        TrainingMode,
+                        register_custom_op_symbolic,
+                        unregister_custom_op_symbolic)
+from torch.onnx.symbolic_helper import (_set_opset_version,
+                                        _set_operator_export_type,
+                                        _set_onnx_shape_inference)
 import torch.utils.cpp_extension
 from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion,
                                  skipIfUnsupportedMaxOpsetVersion)
@@ -795,6 +801,8 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertEqual(next(iter).kind(), "custom_namespace::custom_op")
 
     def test_custom_opsets_gelu(self):
+        self.addCleanup(unregister_custom_op_symbolic, "::gelu", 1)
+
         def gelu(g, self):
             return g.op("com.microsoft::Gelu", self).setType(self.type())
 
@@ -810,6 +818,23 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertEqual(graph.opset_import[0].version, self.opset_version)
         self.assertEqual(graph.opset_import[1].domain, "com.microsoft")
         self.assertEqual(graph.opset_import[1].version, 1)
+
+
+    def test_register_aten_custom_op_symbolic(self):
+        self.addCleanup(unregister_custom_op_symbolic, "aten::gelu", 1)
+
+        def gelu(g, self):
+            return g.op("com.microsoft::Gelu", self).setType(self.type())
+
+        register_custom_op_symbolic("aten::gelu", gelu, 1)
+        model = torch.nn.GELU()
+        x = torch.randn(3, 3)
+        f = io.BytesIO()
+        torch.onnx.export(model, (x, ), f, opset_version=self.opset_version)
+        graph = onnx.load(io.BytesIO(f.getvalue()))
+
+        self.assertEqual(graph.graph.node[0].op_type, "Gelu")
+        self.assertEqual(graph.opset_import[1].domain, "com.microsoft")
 
     def test_custom_opsets_inverse(self):
         class CustomInverse(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67812 [ONNX] ConstantMap setters to update existing value instead of emplace (#67630)
* #67811 [ONNX] Remove the argument use_external_data_format of export() method entirely. (#67080)
* **#67810 [ONNX] Allow registration of custom symbolics for aten namespace (#66481)**
* #67809 [ONNX] Remove the argument example_outpus of export() method entirely. (#67082)
* #67808 [ONNX] Fix reciprocal when input is not floating point (#67471)
* #67807 [ONNX] Use human readable enum for dtype scalars (#66822)
* #67806 [ONNX] Fix new_full and full_like for Python 3.9 (#67124)
* #67805 [ONNX] Support opset 15 (#67121)
* #67804 [ONNX] Suppress ort warnings in onnx related test (#67054)
* #67803 [ONNX] Update onnx function export with comments and clean up (#66817)

Differential Revision: [D32181303](https://our.internmc.facebook.com/intern/diff/D32181303)