### PR TITLE
[ONNX] Remove the argument use_external_data_format of export() method entirely. (#67080)

### DIFF
--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -231,7 +231,6 @@ void initPythonIRBindings(PyObject* module_) {
              bool keep_initializers_as_inputs,
              const std::map<std::string, int>& custom_opsets,
              bool add_node_names,
-             bool use_external_data_format,
              const std::string& onnx_file_path,
              const NodeAttrNameMap& node_attr_to_name) {
             std::string graph;
@@ -255,7 +254,7 @@ void initPythonIRBindings(PyObject* module_) {
                     keep_initializers_as_inputs,
                     custom_opsets,
                     add_node_names,
-                    use_external_data_format,
+                    val_use_external_data_format,
                     onnx_file_path,
                     node_attr_to_name);
             std::unordered_map<std::string, py::bytes>
@@ -285,7 +284,6 @@ void initPythonIRBindings(PyObject* module_) {
           py::arg("keep_initializers_as_inputs") = true,
           py::arg("custom_opsets"),
           py::arg("add_node_names") = true,
-          py::arg("use_external_data_format") = false,
           py::arg("onnx_file_path") = std::string(),
           py::arg("node_attr_to_name") = NodeAttrNameMap())
       .def(

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -33,7 +33,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
            input_names=None, output_names=None, operator_export_type=None,
            opset_version=None, do_constant_folding=True, dynamic_axes=None,
            keep_initializers_as_inputs=None, custom_opsets=None,
-           use_external_data_format=None, export_modules_as_functions=False):
+           export_modules_as_functions=False):
     r"""
     Exports a model into ONNX format. If ``model`` is not a
     :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
@@ -283,9 +283,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             the opset version is set to 1. Only custom opset domain name and version should be
             indicated through this argument.
 
-        use_external_data_format (bool, default False): Deprecated and ignored. Will be removed in
-            next Pytorch release.
-        export_modules_as_functions (bool or set of type of nn.Module, default False): Flag to enable
+        export_modules_as_functions (bool or set of str, type or nn.Module, default False): Flag to enable
             exporting all ``nn.Module`` forward calls as local functions in ONNX. Or a set to indicate the
             particular modules to export as local functions in ONNX.
 
@@ -304,7 +302,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                         input_names, output_names, operator_export_type, opset_version,
                         do_constant_folding, dynamic_axes,
                         keep_initializers_as_inputs, custom_opsets,
-                        use_external_data_format, export_modules_as_functions)
+                        export_modules_as_functions)
 
 
 def export_to_pretty_string(*args, **kwargs) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67812 [ONNX] ConstantMap setters to update existing value instead of emplace (#67630)
* **#67811 [ONNX] Remove the argument use_external_data_format of export() method entirely. (#67080)**
* #67810 [ONNX] Allow registration of custom symbolics for aten namespace (#66481)
* #67809 [ONNX] Remove the argument example_outpus of export() method entirely. (#67082)
* #67808 [ONNX] Fix reciprocal when input is not floating point (#67471)
* #67807 [ONNX] Use human readable enum for dtype scalars (#66822)
* #67806 [ONNX] Fix new_full and full_like for Python 3.9 (#67124)
* #67805 [ONNX] Support opset 15 (#67121)
* #67804 [ONNX] Suppress ort warnings in onnx related test (#67054)
* #67803 [ONNX] Update onnx function export with comments and clean up (#66817)

* remove the argument use_external_data_format of export() method entirely

Co-authored-by: hwangdeyu <dejack953@outlook.com>

Differential Revision: [D32181302](https://our.internmc.facebook.com/intern/diff/D32181302)