### PR TITLE
[ONNX] ConstantMap setters to update existing value instead of emplace (#67630)

### DIFF
--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -23,8 +23,8 @@ ConstantValueMap& ConstantValueMap::getInstance() {
 void ConstantValueMap::SetRank(
     const std::string& tensorName,
     size_t rankValue) {
-  ConstantValueMap::getInstance().rankMap.emplace(tensorName, rankValue);
-  ConstantValueMap::getInstance().useInferredTypeMap.emplace(tensorName, true);
+  ConstantValueMap::getInstance().rankMap[tensorName] = rankValue;
+  ConstantValueMap::getInstance().useInferredTypeMap[tensorName] = true;
 }
 
 bool ConstantValueMap::HasRank(const std::string& tensorName) {
@@ -42,8 +42,8 @@ c10::optional<size_t> ConstantValueMap::GetRank(const std::string& tensorName) {
 void ConstantValueMap::SetShape(
     const std::string& tensorName,
     const c10::SymbolicShape& shapeValue) {
-  ConstantValueMap::getInstance().shapeMap.emplace(tensorName, shapeValue);
-  ConstantValueMap::getInstance().useInferredTypeMap.emplace(tensorName, true);
+  ConstantValueMap::getInstance().shapeMap[tensorName] = shapeValue;
+  ConstantValueMap::getInstance().useInferredTypeMap[tensorName] = true;
 }
 
 bool ConstantValueMap::HasShape(const std::string& tensorName) {
@@ -62,7 +62,7 @@ c10::optional<c10::SymbolicShape> ConstantValueMap::GetShape(
 void ConstantValueMap::SetValue(
     const std::string& tensorName,
     const at::Tensor& value) {
-  ConstantValueMap::getInstance().tensorValueMap.emplace(tensorName, value);
+  ConstantValueMap::getInstance().tensorValueMap[tensorName] = value;
 }
 
 bool ConstantValueMap::HasValue(const std::string& tensorName) {
@@ -151,7 +151,7 @@ std::vector<int64_t> ConstantValueMap::GetValueInto1DInt64Vector(
 void ConstantValueMap::SetTypeReliable(
     const std::string& tensorName,
     bool value) {
-  ConstantValueMap::getInstance().typeReliableMap.emplace(tensorName, value);
+  ConstantValueMap::getInstance().typeReliableMap[tensorName] = value;
 }
 
 bool ConstantValueMap::HasTypeReliable(const std::string& tensorName) {
@@ -170,7 +170,7 @@ c10::optional<bool> ConstantValueMap::GetTypeReliable(
 void ConstantValueMap::SetUseInferredType(
     const std::string& tensorName,
     bool value) {
-  ConstantValueMap::getInstance().useInferredTypeMap.emplace(tensorName, value);
+  ConstantValueMap::getInstance().useInferredTypeMap[tensorName] = value;
 }
 
 bool ConstantValueMap::HasUseInferredType(const std::string& tensorName) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -820,7 +820,8 @@ void ProcessReduceNode(Node* n) {
         axes_vector[idx] += rank_0;
       }
     }
-    int64_t keepdims = 0;
+    // ONNX keepdims defaults to 1 when not set.
+    int64_t keepdims = 1;
     if (n->hasAttributeS("keepdims")) {
       keepdims = n->i(attr::keepdims);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#67812 [ONNX] ConstantMap setters to update existing value instead of emplace (#67630)**
* #67811 [ONNX] Remove the argument use_external_data_format of export() method entirely. (#67080)
* #67810 [ONNX] Allow registration of custom symbolics for aten namespace (#66481)
* #67809 [ONNX] Remove the argument example_outpus of export() method entirely. (#67082)
* #67808 [ONNX] Fix reciprocal when input is not floating point (#67471)
* #67807 [ONNX] Use human readable enum for dtype scalars (#66822)
* #67806 [ONNX] Fix new_full and full_like for Python 3.9 (#67124)
* #67805 [ONNX] Support opset 15 (#67121)
* #67804 [ONNX] Suppress ort warnings in onnx related test (#67054)
* #67803 [ONNX] Update onnx function export with comments and clean up (#66817)

`UpdateShape` uses `.emplace(tensorName, shapeValue)`. This will not update `shapeValue` for `tensorName`, if such name already exist in the map. Hence our code is not able to correct the shape inference error, even if we inferred the shape correctly later.

Co-authored-by: BowenBao <bowbao@microsoft.com>

Differential Revision: [D32181300](https://our.internmc.facebook.com/intern/diff/D32181300)