### PR TITLE
[PyTorchEge] backport test

### DIFF
--- a/torch/csrc/jit/mobile/model_tracer/MobileModelRunner.h
+++ b/torch/csrc/jit/mobile/model_tracer/MobileModelRunner.h
@@ -34,6 +34,11 @@ class MobileModelRunner {
             module_load_options));
   }
 
+  MobileModelRunner(std::stringstream oss) {
+    module_ = std::make_shared<torch::jit::mobile::Module>(
+        torch::jit::_load_for_mobile(oss, at::Device(at::DeviceType::CPU, 0)));
+  }
+
   /**
    * Returns true if the list of operators passed in has a Metal GPU operator,
    * and false otherwise.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67824

Testing backport of all prod models using model test framework

Ref:
[Create tests at run-time (google test)](https://stackoverflow.com/questions/19160244/create-tests-at-run-time-google-test)

breaking the list of models into 20 chunks based on a simple hash (sum of all char values)

Differential Revision: [D32068955](https://our.internmc.facebook.com/intern/diff/D32068955/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D32068955/)!