### PR TITLE
[SR] Add runtime check to correct bad schema alias info

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1183,7 +1183,7 @@ TEST(
   std::unique_ptr<const IValue*[]> ivalue_inputs =
       std::make_unique<const IValue*[]>(1);
   ivalue_inputs[0] = &a;
-  ProcessedNode pnode(sigmoid_node, std::move(ivalue_inputs), 1, true);
+  ProcessedNode pnode(sigmoid_node, std::move(ivalue_inputs), 1, true, false);
 
   pnode.Output(0) = b;
   EXPECT_TRUE(pnode.verify_no_memory_overlap());
@@ -1205,7 +1205,7 @@ TEST(
   std::unique_ptr<const IValue*[]> ivalue_inputs =
       std::make_unique<const IValue*[]>(1);
   ivalue_inputs[0] = &a;
-  ProcessedNode pnode(sigmoid_node, std::move(ivalue_inputs), 1, true);
+  ProcessedNode pnode(sigmoid_node, std::move(ivalue_inputs), 1, true, false);
 
   pnode.Output(0) = b;
   EXPECT_TRUE(pnode.verify_no_memory_overlap());
@@ -1231,7 +1231,11 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
         std::make_unique<const IValue*[]>(1);
     inputs[0] = &ivalue;
     ProcessedNode list_unpack_pnode(
-        list_unpack_node, std::move(inputs), 1, /*enable_out_variant=*/true);
+        list_unpack_node,
+        std::move(inputs),
+        1,
+        /*enable_out_variant=*/true,
+        /* check_memory_overlap */ false);
     ASSERT_EQ(list_unpack_pnode.outputs().size(), 2);
     EXPECT_TRUE(list_unpack_pnode.verify_no_memory_overlap());
   }
@@ -1242,7 +1246,11 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
         std::make_unique<const IValue*[]>(1);
     inputs[0] = &ivalue;
     ProcessedNode list_unpack_pnode(
-        list_unpack_node, std::move(inputs), 1, /*enable_out_variant=*/true);
+        list_unpack_node,
+        std::move(inputs),
+        1,
+        /*enable_out_variant=*/true,
+        /* check_memory_overlap */ false);
     auto b = at::randn({2, 3});
     list_unpack_pnode.Output(0) = b;
     list_unpack_pnode.Output(1) = b;
@@ -1891,4 +1899,74 @@ TEST(StaticRuntime, NumToTensorTrue) {
   IValue arg{true};
   std::vector<IValue> args = {arg};
   testStaticRuntime(num_to_tensor_ir, args);
+}
+
+namespace test {
+at::Tensor bad_add(const at::Tensor& self, int64_t b) {
+  if (b == 0) {
+    return self;
+  }
+  return at::native::add(self, b);
+}
+
+at::Tensor good_add(const at::Tensor& self, int64_t b) {
+  if (b == 0) {
+    return self;
+  }
+  return at::native::add(self, b);
+}
+} // namespace test
+
+// test::bad_add has the schema with incorrect alias annotation.
+// test::good_add has the correct alias annotation.
+TORCH_LIBRARY_FRAGMENT(test, m) {
+  m.def("bad_add(Tensor self, int b=0) -> Tensor");
+  m.def("good_add(Tensor(a) self, int b=0) -> Tensor(a)");
+}
+TORCH_LIBRARY_IMPL(test, CPU, m) {
+  m.impl("bad_add", ::test::bad_add);
+  m.impl("good_add", ::test::good_add);
+}
+
+TEST(StaticRuntime, BadSchemaAliasInfo) {
+  const std::string src = R"IR(
+      graph(%x: Tensor, %s: int):
+          %c0 : int = prim::Constant[value=0]()
+          %c1 : int = prim::Constant[value=1]()
+          %a = aten::add(%x, %x, %c1)
+          %b1 = test::bad_add(%a, %s) # b1 aliases a
+          %t : (Tensor) = prim::TupleConstruct(%b1)
+          return (%t)
+  )IR";
+
+  const auto x1 = at::randn({2, 2});
+  // big enough to trigger resize of the internal buffer
+  const auto x2 = at::randn({3, 6});
+  testStaticRuntime(src, {x1, 0}, {x2, 10});
+  // This test doesn't pass yet. This is the corner case mentioned in Step 2 of
+  // [Check and correct bad schema alias info at runtime]
+  // testStaticRuntime(src, {x1, 10}, {x2, 0});
+}
+
+// This test repeats the last test, but with the correct schema alias
+// annotations
+TEST(StaticRuntime, GoodSchemaAliasInfo) {
+  // comment out the prim::TupleConstruct repro the failure of
+  // DCHECK(!isManagedOutputTensor(*outputs_[0]));
+  const std::string src = R"IR(
+      graph(%x: Tensor, %s: int):
+          %c0 : int = prim::Constant[value=0]()
+          %c1 : int = prim::Constant[value=1]()
+          %a = aten::add(%x, %x, %c1)
+          %b1 = test::good_add(%a, %s) # b1 aliases a
+          # return (%b1)
+          %t : (Tensor) = prim::TupleConstruct(%b1)
+          return (%t)
+  )IR";
+
+  const auto x1 = at::randn({2, 2});
+  // big enough to trigger resize of the internal buffer
+  const auto x2 = at::randn({3, 6});
+  testStaticRuntime(src, {x1, 0}, {x2, 10});
+  testStaticRuntime(src, {x1, 10}, {x2, 0});
 }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -624,6 +624,13 @@ void ValueGroup::init(
   }
 }
 
+bool containTensorsOnly(at::ArrayRef<Value*> values) {
+  // return true only if all outputs are tensors
+  return std::all_of(values.begin(), values.end(), [](const Value* value) {
+    return value->type()->castRaw<TensorType>() != nullptr;
+  });
+}
+
 StaticModule::StaticModule(
     std::shared_ptr<torch::jit::Graph> g,
     const StaticModuleOptions& opts)
@@ -705,6 +712,9 @@ StaticModule::StaticModule(
     }
   }
 
+  AliasDb alias_db(
+      graph_, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
+
   // construct SSA definition for non-constant nodes
   int node_idx = 0;
   FastMap<Node*, bool> node_has_out_variant;
@@ -717,12 +727,23 @@ StaticModule::StaticModule(
     std::vector<DefInfo> input_ssa_defs;
     size_t idx = 0;
     for (Value* input : node->inputs()) {
-      ivalue_inputs[idx++] = value_to_ivalue.at(input);
-      input_ssa_defs.emplace_back(value_to_ssa_def.at(input));
+      ivalue_inputs[idx++] = value_to_ivalue[input];
+      input_ssa_defs.emplace_back(value_to_ssa_def[input]);
     }
     node_inputs_ssa_def_map_[node_idx] = input_ssa_defs;
+
+    // create a new ProcessedNode
+    // see [Check and correct bad schema alias info at runtime]
+    bool check_outputs_for_overlap =
+        !alias_db.mayContainAlias(node->inputs(), node->outputs()) &&
+        containTensorsOnly(node->outputs());
     nodes_.emplace_back(
-        node, std::move(ivalue_inputs), idx, opts.enable_out_variant);
+        node,
+        std::move(ivalue_inputs),
+        idx,
+        opts.enable_out_variant,
+        check_outputs_for_overlap);
+
     node_has_out_variant.emplace(node, nodes_.back().has_out_variant());
     for (const auto i : c10::irange(node->outputs().size())) {
       value_to_ivalue[node->outputs()[i]] = nullptr;
@@ -741,8 +762,6 @@ StaticModule::StaticModule(
   }
 
   // Prepare for memory planning
-  AliasDb alias_db(
-      graph_, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
   value_group_.init(graph_, alias_db);
   GRAPH_DEBUG(value_group_.toString());
 
@@ -954,6 +973,108 @@ c10::IValue StaticRuntime::move_outputs_to_tuple(size_t num_outputs) {
   }
 }
 
+/// [Check and correct bad schema alias info at runtime]
+/// Static runtime relies on the operator schema's alias info to be correct for
+/// memory planning. Because it's hard to enforce the alias info to be correct,
+/// we need to do runtime detection for accidental aliases that do not comply
+/// with the schema. Only aliases of managed tensors are problematic. To avoid
+/// runtime crashes, we can add runtime detection and force the op to comply
+/// with its schema by cloning the alias. Because all managed tensors' data_ptrs
+/// are part of the internal buffer that the MemoryPlanner allocates, we can
+/// check aliases by checking the memory overlap with this internal buffer. But
+/// a tensor's storage can be resized during inferenceso we need another way to
+/// handle the resized case.
+///
+/// There are two ways for incorrect schema to break memory planning. Let's look
+/// at two examples:
+///
+/// Example 1:
+/// @code
+///   def forward(x):
+///     a = x + x
+///     b = bad_op(a)  # b ends up aliasing a incorrectly
+///     return (b)
+/// @endcode
+/// bad_op: its schema says it returns a new Tensor, but it actually returns an
+/// alias. In this case, the memory planner would recognize `a` as a managed
+/// tensor and clean up its memory before returning `b`. But `b` is actually an
+/// alias of `a`, when `a`'s data_ptr get reset, `b`'s data_ptr gets reset too.
+///
+/// Example 2:
+/// @code
+///   def forward(x):
+///     a = x + x
+///     a2 = bad_op(a) # a2 ends up alias a incorrectly
+///     b = a + a
+///     c = b * b # c shares storage with a
+///     d = c + 2 # d shares storage with b
+///     e = a2 * a2
+///     return (d, e)
+/// @endcode
+/// With the memory reuse algorithm, `c` could end up sharing storage with `a`,
+/// but because of bad_op, `a2` now aliases `a`. `c` overwrites `a` and
+/// therefore `a2`, leading to the wrong results. We solve this problem with two
+/// steps. Note this doesn't happen with the current memory reuse algorithm
+/// because of the way it's implemented. Things could change with a different
+/// implementation.
+///
+/// Step 1, annotate the ProcessedNodes with a flag `check_memory_overlap_` set
+/// to true if its outputs do not alias its inputs as indicated by the AliasDb
+/// and all of its outputs are Tensors. Then at runtime, we check that the
+/// nodes' output tensors do not overlap with the internal buffer that the
+/// MemoryPlanner allocates. For latency concerns, we only run this check for
+/// fallback ops. The schemas of native ops and out variants are vetted and
+/// enforced with static runtime unit tests. For the first iteration, we do a
+/// full memory overlap check with
+/// ProcessedNode::verify_and_correct_memory_overlap() because the internal
+/// buffer doesn't exist yet.
+///
+/// Step 2, if a managed tensor gets resized during inference, it gets a new
+/// data_ptr which is not from the buffer. We can tackle this corner case by
+/// delaying the deallocation of the managed tensors to after the outputs are no
+/// longer used (essentially merging the internal/output buffers into one).
+/// Before the merging is implemented, we add another flag `overlap_detected_`
+/// to flag any node with overlap detected in Step 1 and do a full memory
+/// overlap check if the fast check (by checking memory overlap with internal
+/// buffer) fails. There is still a corner case that fails with the added flag.
+/// If a resize is triggered at the same time as the op creating an alias at the
+/// same time, the current checks would fail to detect the alias.
+///
+/// There is another case of failure that step 2 can prevent. With
+/// StaticModule::opts().cleanup_activations = false, the returned Static
+/// Runtime instance in the instance pool can be re-entered while an unintended
+/// output tensor's alias is still being used by the client (in the multi-threaded
+/// setting). This can only be prevented by delaying the deallocation and
+/// returning the Static Runtime instance after the client is done with the
+/// outputs.
+
+void StaticRuntime::verify_and_correct_memory_overlap(ProcessedNode& n) {
+  // The slow check can be removed once the internal/output buffers are merged
+  if (C10_UNLIKELY(n.check_outputs_for_memory_overlap())) {
+    if (C10_UNLIKELY(!planner_ && static_module_.opts().cleanup_activations)) {
+      // slow check, for first iter only with cleanup_activations = true
+      n.verify_and_correct_memory_overlap();
+    } else if (planner_) {
+      bool overlap_detected_with_fast_check = false;
+      for (size_t i = 0; i < n.outputs().size(); i++) {
+        at::Tensor& t = n.Output(i).toTensor();
+        if (planner_->overlapWithInternalBuffer(t.data_ptr())) {
+          VLOG(1) << "Detected alias for node: " << PrintNode(n.node());
+          n.Output(i) = at::native::clone(t, c10::nullopt);
+          // set flag if overlap detected
+          overlap_detected_with_fast_check = true;
+          n.set_outputs_memory_overlap_detected();
+        }
+      }
+      if (n.outputs_memory_overlap_detected() &&
+          !overlap_detected_with_fast_check) {
+        // slow check. Only run when the fast check fails.
+        n.verify_and_correct_memory_overlap();
+      }
+    }
+  }
+}
+
 template <typename IValueList>
 c10::IValue StaticRuntime::run_impl(
     IValueList&& args,
@@ -979,6 +1100,8 @@ c10::IValue StaticRuntime::run_impl(
   for (auto& n : nodes_) {
     // LOG(INFO) << "Running node: " << PrintNode(n.node());
     n.run();
+    // Check for incorrect schema alias info.
+    verify_and_correct_memory_overlap(n);
   }
 
   if (static_module_.opts().cleanup_activations) {
@@ -1482,7 +1605,8 @@ ProcessedNode::ProcessedNode(
     Node* node,
     std::unique_ptr<const IValue*[]> inputs,
     size_t inputsSize,
-    bool enable_out_variant)
+    bool enable_out_variant,
+    bool check_memory_overlap)
     : node_(node),
       inputs_(std::move(inputs)),
       inputs_size_(inputsSize),
@@ -1530,7 +1654,7 @@ ProcessedNode::ProcessedNode(
             pnode->Output(i) = std::move(stack[i]);
           }
         };
-    fn_ = {f, FunctionKind::kInterpreterFallback};
+    fn_ = {f, FunctionKind::kInterpreterFallback, check_memory_overlap};
     VLOG(1) << "Fallback interpreter for node: " << PrintNode(node);
   }
 }
@@ -1635,6 +1759,24 @@ bool ProcessedNode::verify_inputs_dont_overlap_outputs() const {
     }
   }
   return true;
+}
+
+void ProcessedNode::verify_and_correct_memory_overlap() {
+  for (const auto i : c10::irange(inputs_size_)) {
+    const IValue& in = Input(i);
+    if (!in.isTensor()) {
+      continue;
+    }
+    const auto& in_t = in.toTensor();
+    for (const auto j : c10::irange(outputs_size_)) {
+      const auto& out_t = Output(j).toTensor();
+      if (!checkNoMemoryOverlap(in_t, out_t)) {
+        VLOG(1) << "Detected alias for node: " << PrintNode(node());
+        Output(i) = at::native::clone(out_t, c10::nullopt);
+        set_outputs_memory_overlap_detected();
+      }
+    }
+  }
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -368,12 +368,16 @@ class TORCH_API StaticRuntime {
       std::vector<c10::IValue>&& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
+  void verify_and_correct_memory_overlap(ProcessedNode& n);
+
   // clean up owning refs of input IValues
   void clean_up_input_ivalues() {
     for (IValue& ival : inputs_) {
       ival = IValue();
     }
   }
+
+  IValue move_outputs_to_tuple(size_t num_outputs);
 
   void create_memory_planner();
 
@@ -387,8 +391,6 @@ class TORCH_API StaticRuntime {
   void display_nodes(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
-
-  IValue move_outputs_to_tuple(size_t num_outputs);
 
   // Memory planning is only enabled if sm->opts().cleanup_activations is true.
   // Otherwise, the memory used by activations is cached inside the static
@@ -409,7 +411,8 @@ class TORCH_API ProcessedNode {
       Node* n,
       std::unique_ptr<const IValue*[]> inputs,
       size_t inputsSize,
-      bool enable_out_variant);
+      bool enable_out_variant,
+      bool check_memory_overlap);
 
   ProcessedNode(const ProcessedNode& rhs)
       : node_(rhs.node_),
@@ -501,11 +504,25 @@ class TORCH_API ProcessedNode {
     return fn_.kind == FunctionKind::kNativeFunction;
   }
 
-  bool verify_no_memory_overlap() const;
-
   const char* get_op_name() const {
     return op_name_;
   }
+
+  bool verify_no_memory_overlap() const;
+
+  bool check_outputs_for_memory_overlap() const {
+    return fn_.check_memory_overlap_;
+  }
+
+  void set_outputs_memory_overlap_detected() {
+    fn_.overlap_detected_ = true;
+  }
+
+  bool outputs_memory_overlap_detected() {
+    return fn_.overlap_detected_;
+  }
+
+  void verify_and_correct_memory_overlap();
 
  private:
   C10_NODISCARD bool verify_outputs_dont_overlap_each_other() const;
@@ -513,7 +530,7 @@ class TORCH_API ProcessedNode {
   C10_NODISCARD bool verify_inputs_dont_overlap_outputs() const;
 
   Node* node_;
-  enum class FunctionKind {
+  enum class FunctionKind : uint8_t {
     kOutVariant,
     kNativeFunction,
     kInterpreterFallback,
@@ -521,6 +538,8 @@ class TORCH_API ProcessedNode {
   struct Function {
     std::function<void(ProcessedNode*)> f;
     FunctionKind kind = FunctionKind::kOutVariant;
+    bool check_memory_overlap_{false};
+    bool overlap_detected_{false};
   };
   Function fn_;
   std::unique_ptr<const IValue*[]> inputs_; // unowned

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -138,6 +138,9 @@ MemoryPlanner::MemoryPlanner(
   }
 
   GRAPH_DEBUG("managed_tensor_values: ", dumpValueSet(managed_tensor_values));
+  GRAPH_DEBUG(
+      "managed_output_tensor_values_: ",
+      dumpValueSet(managed_output_tensor_values_));
 
   // copy to unmanaged_ivalues_
   unmanaged_ivalues_.reserve(unmanaged_ivalues.size());
@@ -186,6 +189,8 @@ void MemoryPlanner::allocateManagedTensors() {
 
   size_t offset = 0;
   uint8_t* start = static_cast<uint8_t*>(buffer_.get());
+  buffer_start_ = start;
+  buffer_end_ = start + managed_bytes_;
 
   reused_tensors_ = 0;
   auto group_idx = 0;
@@ -342,6 +347,7 @@ void MemoryPlanner::deallocate() {
   }
 
   DCHECK_EQ(managed_tensor_storage_impls_.size(), managed_tensors_.size());
+  VLOG(1) << "managed_bytes: " << managed_bytes_;
 
   // for unmanaged ivalues (either tensor or non-tensor), we reset the *iv so
   // that the objects pointed to by *iv may be reclaimed by reference counting

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -113,6 +113,10 @@ class MemoryPlanner {
     return impl_p >= start && impl_p < end;
   }
 
+  bool overlapWithInternalBuffer(void* data_ptr) {
+    return buffer_start_ <= data_ptr && data_ptr < buffer_end_;
+  }
+
  private:
   // ivalues created in one run but not managed by MemoryPlanner
   std::vector<IValue*> unmanaged_ivalues_;
@@ -134,6 +138,8 @@ class MemoryPlanner {
   // so we have to check the StorageImpls each time we deallocate.
   std::vector<std::pair<size_t, std::vector<at::Tensor*>>> managed_tensors_;
   at::DataPtr buffer_; // allocated each time we call Run()
+  uint8_t* buffer_start_{nullptr};
+  uint8_t* buffer_end_{nullptr};
   size_t num_managed_tensors_{0};
   size_t managed_bytes_{0};
   size_t reused_tensors_{0};


### PR DESCRIPTION
Summary: The comment explains how it works.

Test Plan:
A small regression to local and local_ro if we only enable it for fallback ops.
```
## local_ro
# before
I1103 21:25:05.250440 2636751 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.22213. Iters per second: 818.247
I1103 21:25:08.629221 2636751 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.22351. Iters per second: 817.319
I1103 21:25:12.005179 2636751 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.22285. Iters per second: 817.759
I1103 21:25:12.005236 2636751 PyTorchPredictorBenchLib.cpp:285] Mean milliseconds per iter: 1.22283, standard deviation: 0.000693619

# after
# # only enable for fall back ops: 0.7%
I1103 21:26:40.190436 2644597 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.22928. Iters per second: 813.481
I1103 21:26:43.590443 2644597 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.23265. Iters per second: 811.262
I1103 21:26:46.992928 2644597 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.23379. Iters per second: 810.51
I1103 21:26:46.992980 2644597 PyTorchPredictorBenchLib.cpp:285] Mean milliseconds per iter: 1.23191, standard deviation: 0.0023424

# enable for all (no clone): 4.7%
I1103 21:27:55.291216 2649780 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.28204. Iters per second: 780.005
I1103 21:27:58.822347 2649780 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.27854. Iters per second: 782.14
I1103 21:28:02.354184 2649780 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 1.27958. Iters per second: 781.506
I1103 21:28:02.354240 2649780 PyTorchPredictorBenchLib.cpp:285] Mean milliseconds per iter: 1.28006, standard deviation: 0.00179765

# local
# before
I1103 21:52:00.784718 2765168 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.676. Iters per second: 50.8233
I1103 21:52:28.985873 2765168 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.699. Iters per second: 50.7641
I1103 21:52:57.200223 2765168 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.6953. Iters per second: 50.7735
I1103 21:52:57.200273 2765168 PyTorchPredictorBenchLib.cpp:285] Mean milliseconds per iter: 19.6901, standard deviation: 0.0123206
# after
# # only enable for fall back ops: 0.1%
I1103 21:45:25.514535 2734440 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.7103. Iters per second: 50.7349
I1103 21:45:53.773594 2734440 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.7005. Iters per second: 50.7601
I1103 21:46:21.955680 2734440 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.7398. Iters per second: 50.659
I1103 21:46:21.955729 2734440 PyTorchPredictorBenchLib.cpp:285] Mean milliseconds per iter: 19.7169, standard deviation: 0.0204658

# enable for all (no clone): 0.9%
I1103 21:43:22.162272 2723868 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.8893. Iters per second: 50.2783
I1103 21:43:50.651847 2723868 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.8566. Iters per second: 50.3611
I1103 21:44:19.068519 2723868 PyTorchPredictorBenchLib.cpp:274] PyTorch run finished. Milliseconds per iter: 19.8793. Iters per second: 50.3037
I1103 21:44:19.068570 2723868 PyTorchPredictorBenchLib.cpp:285] Mean milliseconds per iter: 19.875, standard deviation: 0.0167498
```

Differential Revision: D32124812

