### PR TITLE
Fix typo in LinearLR docs

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -509,7 +509,7 @@ class LinearLR(_LRScheduler):
         >>> # lr = 0.03125  if epoch == 1
         >>> # lr = 0.0375   if epoch == 2
         >>> # lr = 0.04375  if epoch == 3
-        >>> # lr = 0.005    if epoch >= 4
+        >>> # lr = 0.05    if epoch >= 4
         >>> scheduler = LinearLR(self.opt, start_factor=0.5, total_iters=4)
         >>> for epoch in range(100):
         >>>     train(...)


### PR DESCRIPTION
The final learning rate should be 0.05 like the lr used as the argument for the optimizer and not 0.005.
