### PR TITLE
Use storagemethods to load storages for zip file serialization

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import torch
+
+x = torch.ones(2, 2, 2)
+
+torch.save(x, "out.zip")
+
+print(torch.load("out.zip"))

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -97,11 +97,19 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage, uint64_t el
   }
 #endif
 
+  // Todo: make this a param with default = false, only set it to true for zipfile serialization
+  bool skipSize = true;
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   scalar_t *data;
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int64_t size;
-  doRead(file, &size, sizeof(int64_t));
+  if (skipSize) {
+    size = element_size;
+  } else {
+    doRead(file, &size, sizeof(int64_t));
+  }
+  // size = 4;
+  std::cout << "size " << size << "   el: " << element_size << "\n";
   int64_t nbytes = element_size * size;
   if (torch::utils::THP_nativeByteOrder() ==
       torch::utils::THPByteOrder::THP_BIG_ENDIAN) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1087,6 +1087,15 @@ void initJITBindings(PyObject* module) {
             return self.writeRecord(
                 name, reinterpret_cast<const char*>(data), size);
           })
+      .def(
+          "write_bytes",
+          [](PyTorchStreamWriter& self,
+             const std::string& name,
+             char* data,
+             size_t size) {
+            return self.writeRecord(
+                name, reinterpret_cast<const char*>(data), size);
+          })
       .def("archive_name", &PyTorchStreamWriter::archiveName)
       .def(
           "get_all_written_records",

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -112,6 +112,7 @@ static ssize_t doPartialPythonWrite(PyObject* fildes, void* buf, size_t nbytes) 
 // Requires that we read EXACTLY nbytes; fails if we don't.
 template <typename io>
 void doRead(io fildes, void* raw_buf, size_t nbytes) {
+  std::cout << "Reading " << nbytes << " bytes\n";
   char* buf = static_cast<char*>(raw_buf);
   while (nbytes > 0) {
     errno = 0; // doPartialRead may not set errno


### PR DESCRIPTION
Fixes #{issue number}
