### PR TITLE
[static runtime] dequantize out variant

### DIFF
--- a/aten/src/ATen/core/QuantizerBase.h
+++ b/aten/src/ATen/core/QuantizerBase.h
@@ -70,6 +70,11 @@ struct TORCH_API Quantizer : public c10::intrusive_ptr_target {
   virtual Tensor dequantize(const Tensor& t) = 0;
 
   /**
+   * dequantize a quantized Tensor into a float Tensor, out= variant
+   */
+  virtual Tensor& dequantize_out(Tensor& out, const Tensor& t) = 0;
+
+  /**
    * Compare against `other` for equality.
    */
   virtual bool equalTo(QuantizerPtr other) = 0;

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -28,6 +28,7 @@ namespace {
         scales.numel() == zero_points.numel(),
         "number of elements in scales and zero_points must match");
   }
+
 } // anonymous namespace
 
 // Note: this is not a native function as Quantizer is not exposed to python yet
@@ -161,15 +162,38 @@ Tensor PerTensorAffineQuantizer::quantize(const Tensor& rtensor) {
   return qtensor;
 }
 
+void per_tensor_affine_dequantize_impl(
+    Tensor& rtensor, 
+    const Tensor& qtensor, 
+    const double scale, 
+    const int64_t zero_point) {
+  const auto qtensor_contig =
+    qtensor.expect_contiguous(qtensor.suggest_memory_format());
+  native::dequantize_tensor_per_tensor_affine(
+      *qtensor_contig, rtensor, scale, zero_point);
+}
+
+Tensor& PerTensorAffineQuantizer::dequantize_out(
+    Tensor& rtensor, const Tensor& qtensor) {
+  rtensor.resize_(qtensor.sizes());
+  TORCH_CHECK(
+      rtensor.is_contiguous(qtensor.suggest_memory_format()) &&
+      rtensor.scalar_type() == kFloat,
+      "Dequantize out should be a contiguous Float Tensor; instead got type ",
+      rtensor.scalar_type(),
+      ", and is_contiguous ",
+      rtensor.is_contiguous(qtensor.suggest_memory_format()));
+  per_tensor_affine_dequantize_impl(rtensor, qtensor, scale_, zero_point_);
+  return rtensor;
+}
+
 Tensor PerTensorAffineQuantizer::dequantize(const Tensor& qtensor) {
   Tensor rtensor = at::empty(
       qtensor.sizes(),
       qtensor.options()
           .dtype(at::kFloat)
           .memory_format(qtensor.suggest_memory_format()));
-  auto qtensor_contig = qtensor.expect_contiguous(qtensor.suggest_memory_format());
-  native::dequantize_tensor_per_tensor_affine(
-      *qtensor_contig, rtensor, scale_, zero_point_);
+  per_tensor_affine_dequantize_impl(rtensor, qtensor, scale_, zero_point_);
   return rtensor;
 }
 
@@ -188,15 +212,39 @@ Tensor PerChannelAffineQuantizer::quantize(const Tensor& rtensor) {
   return qtensor;
 }
 
+void per_channel_affine_dequantize_impl(
+    Tensor& rtensor, 
+    const Tensor& qtensor, 
+    const Tensor& scale, 
+    const Tensor& zero_point,
+    const int64_t axis) {
+  const auto qtensor_contig =
+    qtensor.expect_contiguous(qtensor.suggest_memory_format());
+  native::dequantize_tensor_per_channel_affine(
+      *qtensor_contig, rtensor, scale, zero_point, axis);
+}
+
 Tensor PerChannelAffineQuantizer::dequantize(const Tensor& qtensor) {
   Tensor rtensor = at::empty(
       qtensor.sizes(),
       qtensor.options()
           .dtype(at::kFloat)
           .memory_format(qtensor.suggest_memory_format()));
-  auto qtensor_contig = qtensor.expect_contiguous(qtensor.suggest_memory_format());
-  native::dequantize_tensor_per_channel_affine(
-      *qtensor_contig, rtensor, scales_, zero_points_, axis_);
+  per_channel_affine_dequantize_impl(rtensor, qtensor, scales_, zero_points_, axis_);
+  return rtensor;
+}
+
+Tensor& PerChannelAffineQuantizer::dequantize_out(
+    Tensor& rtensor, const Tensor& qtensor) {
+  rtensor.resize_(qtensor.sizes());
+  TORCH_CHECK(
+      rtensor.is_contiguous(qtensor.suggest_memory_format()) &&
+      rtensor.scalar_type() == kFloat,
+      "Dequantize out should be a contiguous Float Tensor; instead got type ",
+      rtensor.scalar_type(),
+      ", and is_contiguous ",
+      rtensor.is_contiguous(qtensor.suggest_memory_format()));
+  per_channel_affine_dequantize_impl(rtensor, qtensor, scales_, zero_points_, axis_);
   return rtensor;
 }
 
@@ -214,11 +262,37 @@ Tensor PerChannelAffineFloatQParamsQuantizer::quantize(const Tensor& rtensor) {
   return qtensor;
 }
 
+void per_channel_affine_float_q_params_dequantize_impl(
+    Tensor& rtensor, 
+    const Tensor& qtensor, 
+    const Tensor& scale, 
+    const Tensor& zero_point,
+    const int64_t axis) {
+  const auto qtensor_contig =
+    qtensor.expect_contiguous(qtensor.suggest_memory_format());
+  native::dequantize_tensor_per_channel_float_qparams(
+      *qtensor_contig, rtensor, scale, zero_point, axis);
+}
+
 Tensor PerChannelAffineFloatQParamsQuantizer::dequantize(const Tensor& qtensor) {
   Tensor rtensor = at::empty(qtensor.sizes(), qtensor.options().dtype(at::kFloat));
-  auto qtensor_contig = qtensor.expect_contiguous();
-  native::dequantize_tensor_per_channel_float_qparams(
-    *qtensor_contig, rtensor, scales_, zero_points_, axis_);
+  per_channel_affine_float_q_params_dequantize_impl(
+      rtensor, qtensor, scales_, zero_points_, axis_);
+  return rtensor;
+}
+
+Tensor& PerChannelAffineFloatQParamsQuantizer::dequantize_out(
+    Tensor& rtensor, const Tensor& qtensor) {
+  rtensor.resize_(qtensor.sizes());
+  TORCH_CHECK(
+      rtensor.is_contiguous(qtensor.suggest_memory_format()) &&
+      rtensor.scalar_type() == kFloat,
+      "Dequantize out should be a contiguous Float Tensor; instead got type ",
+      rtensor.scalar_type(),
+      ", and is_contiguous ",
+      rtensor.is_contiguous(qtensor.suggest_memory_format()));
+  per_channel_affine_float_q_params_dequantize_impl(
+      rtensor, qtensor, scales_, zero_points_, axis_);
   return rtensor;
 }
 

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -65,7 +65,8 @@ struct TORCH_API PerTensorAffineQuantizer : public AffineQuantizer {
         zero_point_(zero_point) {}
 
   Tensor quantize(const Tensor& tensor) override;
-  Tensor dequantize(const Tensor& tensor) override;
+  Tensor dequantize(const Tensor& qtensor) override;
+  Tensor& dequantize_out(Tensor& rtensor, const Tensor& qtensor) override;
 
   QScheme qscheme() const override {
     return kPerTensorAffine;
@@ -135,7 +136,8 @@ struct TORCH_API PerChannelAffineQuantizer : public AffineQuantizer {
   }
 
   Tensor quantize(const Tensor& tensor) override;
-  Tensor dequantize(const Tensor& tensor) override;
+  Tensor dequantize(const Tensor& qtensor) override;
+  Tensor& dequantize_out(Tensor& rtensor, const Tensor& qtensor) override;
 
   bool equalTo(QuantizerPtr other) override {
     if (!other.get() || other->qscheme() != kPerChannelAffine) {
@@ -185,7 +187,8 @@ struct TORCH_API PerChannelAffineFloatQParamsQuantizer : public PerChannelAffine
   }
 
   Tensor quantize(const Tensor& tensor) override;
-  Tensor dequantize(const Tensor& tensor) override;
+  Tensor dequantize(const Tensor& qtensor) override;
+  Tensor& dequantize_out(Tensor& rtensor, const Tensor& qtensor) override;
 
   bool equalTo(QuantizerPtr other) override {
     if (!other.get() || other->qscheme() != kPerChannelAffineFloatQParams) {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -15,6 +15,8 @@
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/qembeddingbag.h>
 #include <ATen/native/quantized/cpu/qembeddingbag_prepack.h>
+#include <ATen/quantized/QTensorImpl.h>
+#include <ATen/quantized/Quantizer.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -364,6 +366,14 @@ void where_out(
   });
 }
 
+at::Tensor& dequantize_copy_out(Tensor& out, const Tensor& self) {
+  if (!self.is_quantized()) {
+    // fallback to dequantize_cpu equivalent case: make sure out is at::kFloat
+    DCHECK(out.scalar_type() == kFloat);
+    return at::native::to_copy_out(out, self, false, false, c10::nullopt);
+  }
+  return get_qtensorimpl(self)->quantizer()->dequantize_out(out, self);
+}
 } // namespace native
 } // namespace at
 
@@ -1114,6 +1124,31 @@ REGISTER_OPERATOR_FUNCTOR(
         fastResizeToZero(out_t);
         at::native::to_copy_out(
             out_t, self, non_blocking, copy_strides, memory_format);
+      };
+    });
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+REGISTER_OPERATOR_FUNCTOR(
+    static_runtime::dequantize_copy,
+    aten_dequantize_copy,
+    [](Node* n) -> SROperator {
+      if (!n->matches(torch::schema(
+              "static_runtime::dequantize_copy.self(Tensor self) -> Tensor"))) {
+        // please implement static runtime support for aten::dequantize with
+        // TensorList
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+      return [](ProcessedNode* p_node) {
+        const auto& self = p_node->Input(0).toTensor();
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) =
+              create_empty_from(self, at::kFloat, self.suggest_memory_format());
+        }
+
+        auto& out_t = p_node->Output(0).toTensor();
+        fastResizeToZero(out_t);
+        at::native::dequantize_copy_out(out_t, self);
       };
     });
 

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -115,6 +115,14 @@ inline at::Tensor create_empty_from(
       memory_format);
 }
 
+inline at::Tensor create_empty_from(
+    const at::Tensor& t,
+    c10::ScalarType dtype,
+    c10::MemoryFormat memory_format) {
+  return at::detail::empty_cpu(
+      {0}, dtype, t.layout(), t.device(), c10::nullopt, memory_format);
+}
+
 inline bool checkResizedDataPtr(at::Tensor& t) {
   auto const prev_data_ptr = t.data_ptr();
   t.resize_({0});

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -351,6 +351,9 @@ TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
   m.def(torch::schema(
       "static_runtime::fused_equally_split(Tensor input, int num_split, int dim) -> ...",
       c10::AliasAnalysisKind::PURE_FUNCTION));
+  m.def(torch::schema(
+      "static_runtime::dequantize_copy.self(Tensor self) -> Tensor",
+      c10::AliasAnalysisKind::PURE_FUNCTION));
 }
 
 void FuseSignLog1P(std::shared_ptr<torch::jit::Graph>& graph) {
@@ -453,7 +456,9 @@ void ReplaceWithCopy(
        fromQualString("static_runtime::to_copy")},
       {torch::schema(
            "aten::to.other(Tensor(a) self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)"),
-       fromQualString("static_runtime::to_copy")}};
+       fromQualString("static_runtime::to_copy")},
+      {torch::schema("aten::dequantize.self(Tensor self) -> Tensor"),
+       fromQualString("static_runtime::dequantize_copy")}};
 
   auto match_schema = [&supported_schema](
                           const Node* node, c10::Symbol& out_matched_symbol) {


### PR DESCRIPTION
Summary: Add out variant for aten::dequantize

Test Plan:
Test on inline_cvr model
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --scripted_model=/data/users/ansha/tmp/adfinder/294738512/294738512_0.predictor.disagg.local --recordio_inputs=/data/users/ansha/tmp/adfinder/294738512/294738512_0_local.inputs.recordio --pt_enable_static_runtime=1 --compare_results=1 --iters=5 --warmup_iters=5 --num_threads=1 --do_profile=1 --method_name=local.forward --set_compatibility --do_benchmark=1 --recordio_use_ivalue_format=1
```

Before:
0.047472 ms.   0.409729%. aten::dequantize (9 nodes)

After
0.0307179 ms.   0.267204%. static_runtime::dequantize_copy (9 nodes, out variant)

Differential Revision: D32187063

