### PR TITLE
DispatchStub: Improve type mismatch errors

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -33,11 +33,11 @@ DEFINE_DISPATCH(mkldnn_convolution_backward_stub);
 DEFINE_DISPATCH(slow_conv_dilated2d_backward_stub);
 DEFINE_DISPATCH(slow_conv_dilated3d_backward_stub);
 DEFINE_DISPATCH(slow_conv_transpose2d_backward_stub);
-REGISTER_NO_CPU_DISPATCH(cudnn_convolution_backward_stub, cudnn_convolution_backward_fn);
-REGISTER_NO_CPU_DISPATCH(cudnn_convolution_transpose_backward_stub, cudnn_convolution_transpose_backward_fn);
-REGISTER_NO_CPU_DISPATCH(miopen_convolution_backward_stub, miopen_convolution_backward_fn);
-REGISTER_NO_CPU_DISPATCH(miopen_convolution_transpose_backward_stub, miopen_convolution_transpose_backward_fn);
-REGISTER_NO_CPU_DISPATCH(miopen_depthwise_convolution_backward_stub, miopen_depthwise_convolution_backward_fn);
+REGISTER_NO_CPU_DISPATCH(cudnn_convolution_backward_stub);
+REGISTER_NO_CPU_DISPATCH(cudnn_convolution_transpose_backward_stub);
+REGISTER_NO_CPU_DISPATCH(miopen_convolution_backward_stub);
+REGISTER_NO_CPU_DISPATCH(miopen_convolution_transpose_backward_stub);
+REGISTER_NO_CPU_DISPATCH(miopen_depthwise_convolution_backward_stub);
 
 std::ostream& operator<<(std::ostream & out, const ConvParams& params) {
   out << "ConvParams {"

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -169,16 +169,16 @@ private:
 };
 
 namespace {
-template <typename FnPtr, typename T>
+template <typename DispatchStub>
 struct RegisterCUDADispatch {
-  RegisterCUDADispatch(DispatchStub<FnPtr, T>& stub, FnPtr value) {
+  RegisterCUDADispatch(DispatchStub &stub, typename DispatchStub::FnPtr value) {
     stub.set_cuda_dispatch_ptr(value);
   }
 };
 
-template <typename FnPtr, typename T>
+template <typename DispatchStub>
 struct RegisterHIPDispatch {
-  RegisterHIPDispatch(DispatchStub<FnPtr, T>& stub, FnPtr value) {
+  RegisterHIPDispatch(DispatchStub &stub, typename DispatchStub::FnPtr value) {
     // TODO: make this point at hip_dispatch_ptr
     stub.set_cuda_dispatch_ptr(value);
   }
@@ -201,7 +201,7 @@ struct RegisterHIPDispatch {
 #define DEFINE_DISPATCH(name) struct name name
 
 #define REGISTER_ARCH_DISPATCH(name, arch, fn) \
-  template <> decltype(fn) DispatchStub<decltype(fn), struct name>::arch = fn;
+  template <> name::FnPtr DispatchStub<name::FnPtr, struct name>::arch = fn;
 
 #ifdef HAVE_AVX512_CPU_DEFINITION
 #define REGISTER_AVX512_DISPATCH(name, fn) REGISTER_ARCH_DISPATCH(name, AVX512, fn)
@@ -229,14 +229,14 @@ struct RegisterHIPDispatch {
   REGISTER_AVX2_DISPATCH(name, fn)                                             \
   REGISTER_VSX_DISPATCH(name, fn)
 
-#define REGISTER_NO_CPU_DISPATCH(name, fn_type)                                \
-  REGISTER_ALL_CPU_DISPATCH(name, static_cast<fn_type>(nullptr))
+#define REGISTER_NO_CPU_DISPATCH(name)                                         \
+  REGISTER_ALL_CPU_DISPATCH(name, nullptr)
 
 #define REGISTER_CUDA_DISPATCH(name, fn) \
-  static RegisterCUDADispatch<decltype(fn), struct name> name ## __register(name, fn);
+  static RegisterCUDADispatch<struct name> name ## __register(name, fn);
 
 #define REGISTER_HIP_DISPATCH(name, fn) \
-  static RegisterHIPDispatch<decltype(fn), struct name> name ## __register(name, fn);
+  static RegisterHIPDispatch<struct name> name ## __register(name, fn);
 
 // NB: This macro must be used in an actual 'cu' file; if you try using
 // it from a 'cpp' file it will not work!
@@ -249,8 +249,8 @@ struct RegisterHIPDispatch {
 // #define REGISTER_DISPATCH(name, fn) REGISTER_HIP_DISPATCH(name, fn)
 #elif defined(CPU_CAPABILITY)
 #define REGISTER_DISPATCH(name, fn) REGISTER_ARCH_DISPATCH(name, CPU_CAPABILITY, fn)
-#define REGISTER_NO_AVX512_DISPATCH(name, fn_type)                             \
-  REGISTER_AVX512_DISPATCH(name, static_cast<fn_type>(nullptr))
+#define REGISTER_NO_AVX512_DISPATCH(name)       \
+  REGISTER_AVX512_DISPATCH(name, nullptr)
 #endif
 
 

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1210,10 +1210,10 @@ bool _use_cudnn_rnn_flatten_weight() {
   DEFINE_DISPATCH(NAME##_miopen_stub);                                      \
   DEFINE_DISPATCH(NAME##_packed_cudnn_stub);                                \
   DEFINE_DISPATCH(NAME##_packed_miopen_stub);                               \
-  REGISTER_NO_CPU_DISPATCH(NAME##_cudnn_stub, rnn_fn);                      \
-  REGISTER_NO_CPU_DISPATCH(NAME##_miopen_stub, rnn_fn);                     \
-  REGISTER_NO_CPU_DISPATCH(NAME##_packed_cudnn_stub, rnn_packed_fn);        \
-  REGISTER_NO_CPU_DISPATCH(NAME##_packed_miopen_stub, rnn_packed_fn);       \
+  REGISTER_NO_CPU_DISPATCH(NAME##_cudnn_stub);                              \
+  REGISTER_NO_CPU_DISPATCH(NAME##_miopen_stub);                             \
+  REGISTER_NO_CPU_DISPATCH(NAME##_packed_cudnn_stub);                       \
+  REGISTER_NO_CPU_DISPATCH(NAME##_packed_miopen_stub);                      \
                                                                             \
   std::tuple<Tensor, Tensor> NAME(                                          \
       const Tensor& _input,                                                 \
@@ -1464,10 +1464,10 @@ DEFINE_DISPATCH(lstm_cudnn_stub);
 DEFINE_DISPATCH(lstm_packed_cudnn_stub);
 DEFINE_DISPATCH(lstm_miopen_stub);
 DEFINE_DISPATCH(lstm_packed_miopen_stub);
-REGISTER_NO_CPU_DISPATCH(lstm_cudnn_stub, lstm_fn);
-REGISTER_NO_CPU_DISPATCH(lstm_packed_cudnn_stub, lstm_packed_fn);
-REGISTER_NO_CPU_DISPATCH(lstm_miopen_stub, lstm_fn);
-REGISTER_NO_CPU_DISPATCH(lstm_packed_miopen_stub, lstm_packed_fn);
+REGISTER_NO_CPU_DISPATCH(lstm_cudnn_stub);
+REGISTER_NO_CPU_DISPATCH(lstm_packed_cudnn_stub);
+REGISTER_NO_CPU_DISPATCH(lstm_miopen_stub);
+REGISTER_NO_CPU_DISPATCH(lstm_packed_miopen_stub);
 
 std::tuple<Tensor, Tensor, Tensor> lstm(
       const Tensor& _input, TensorList hx,

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -1,8 +1,8 @@
+#include <ATen/native/RangeFactories.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Parallel.h>
 #include <ATen/Dispatch.h>
-#include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/util/irange.h>
 #include <cmath>
@@ -10,8 +10,6 @@
 
 namespace at { namespace native {
 
-DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, const Scalar&), arange_stub);
-DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, int64_t), linspace_stub);
 
 Tensor& linspace_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
   const auto steps = optional_steps.value_or(100);

--- a/aten/src/ATen/native/RangeFactories.h
+++ b/aten/src/ATen/native/RangeFactories.h
@@ -1,0 +1,12 @@
+#include <ATen/native/DispatchStub.h>
+#include <c10/core/Scalar.h>
+
+namespace at {
+struct TensorIterator;
+
+namespace native {
+
+DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, const Scalar&), arange_stub);
+DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, int64_t), linspace_stub);
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -248,7 +248,7 @@ DEFINE_DISPATCH(index_put_with_sort_stub);
 DEFINE_DISPATCH(put_stub);
 DEFINE_DISPATCH(take_stub);
 DEFINE_DISPATCH(masked_fill_stub);
-REGISTER_NO_CPU_DISPATCH(index_put_with_sort_stub, index_put_with_sort_fn);
+REGISTER_NO_CPU_DISPATCH(index_put_with_sort_stub);
 DEFINE_DISPATCH(masked_select_serial_stub);
 DEFINE_DISPATCH(masked_select_stub);
 DEFINE_DISPATCH(masked_scatter_stub);

--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -151,7 +151,7 @@ REGISTER_DISPATCH(log_normal_stub, &log_normal_kernel);
 #ifdef CPU_CAPABILITY_AVX512
 // normal_stub isn't being dispatched to AVX512 because it exposes
 // flakiness in test_sgd of test/test_optim.py
-REGISTER_NO_AVX512_DISPATCH(normal_stub, void(*)(Tensor&, const double, const double, c10::optional<Generator>));
+REGISTER_NO_AVX512_DISPATCH(normal_stub);
 #else
 REGISTER_DISPATCH(normal_stub, &normal_kernel);
 #endif

--- a/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/cpu/MaxUnpoolKernel.h>
 #include <ATen/ATen.h>
 
 #include <ATen/Dispatch.h>

--- a/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
+++ b/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
@@ -1,4 +1,5 @@
 #define TORCH_ASSERT_NO_OPERATORS
+#include <ATen/native/RangeFactories.h>
 #include <cmath>
 #include <ATen/Config.h>
 #include <ATen/Dispatch.h>

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -639,7 +639,7 @@ REGISTER_DISPATCH(sum_stub, &sum_kernel_impl);
 #ifndef CPU_CAPABILITY_AVX512
 REGISTER_DISPATCH(nansum_stub, &nansum_kernel_impl);
 #else
-REGISTER_NO_AVX512_DISPATCH(nansum_stub, reduce_fn);
+REGISTER_NO_AVX512_DISPATCH(nansum_stub);
 #endif
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -560,7 +560,7 @@ Tensor _fft_c2c_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, 
 #else
 
 namespace at { namespace native {
-REGISTER_NO_CPU_DISPATCH(fft_fill_with_conjugate_symmetry_stub, fft_fill_with_conjugate_symmetry_fn);
+REGISTER_NO_CPU_DISPATCH(fft_fill_with_conjugate_symmetry_stub);
 
 Tensor _fft_c2r_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
   AT_ERROR("fft: ATen not compiled with FFT support");

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -31,7 +31,7 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_convolution_backward(
   TORCH_CHECK(false, "mkldnn_convolution_backward: ATen not compiled with MKLDNN support");
 }
 
-REGISTER_NO_CPU_DISPATCH(mkldnn_convolution_backward_stub, mkldnn_convolution_backward_fn);
+REGISTER_NO_CPU_DISPATCH(mkldnn_convolution_backward_stub);
 
 }}
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -3437,63 +3437,48 @@ void dequantize_tensor_per_tensor_affine_sub_byte_cpu(
 // So, until Quantization support for Windows is fixed for AVX512,
 // AVX2 kernels would be used instead. Ref: GH 56992.
 #if defined(CPU_CAPABILITY_AVX512) && defined(_WIN32)
-REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_channel_affine_stub,
-                            dequantize_tensor_per_channel_affine_fn);
-REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_tensor_affine_stub,
-                            dequantize_tensor_per_tensor_affine_fn);
-REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_channel_float_qparams_stub,
-                            dequantize_tensor_per_channel_float_qparams_fn);
-REGISTER_NO_AVX512_DISPATCH(fake_quant_grad_learnable_tensor_stub,
-                            fake_quant_learnable_grad_tensor_fn);
-REGISTER_NO_AVX512_DISPATCH(fake_quant_per_channel_cachemask_stub,
-                            fake_quant_per_channel_cachemask_fn);
-REGISTER_NO_AVX512_DISPATCH(fake_quant_tensor_cachemask_stub,
-                            fake_quant_tensor_cachemask_fn);
-REGISTER_NO_AVX512_DISPATCH(fake_quant_tensor_cachemask_tensor_qparams_stub,
-                            fake_quant_tensor_cachemask_tensor_qparams_fn);
-REGISTER_NO_AVX512_DISPATCH(qadaptive_avg_pool2d_nhwc_stub,
-                            qadaptive_avg_pool2d_fn);
-REGISTER_NO_AVX512_DISPATCH(qadaptive_avg_pool3d_ndhwc_stub,
-                            qadaptive_avg_pool3d_fn);
-REGISTER_NO_AVX512_DISPATCH(qadd_relu_stub, qbinary_fn);
-REGISTER_NO_AVX512_DISPATCH(qadd_scalar_relu_stub, qadd_scalar_fn);
-REGISTER_NO_AVX512_DISPATCH(qadd_scalar_stub, qadd_scalar_fn);
-REGISTER_NO_AVX512_DISPATCH(qadd_stub, qbinary_fn);
-REGISTER_NO_AVX512_DISPATCH(qavg_pool2d_nhwc_stub, qavg_pool2d_fn);
-REGISTER_NO_AVX512_DISPATCH(qavg_pool3d_nhwc_stub, qavg_pool3d_fn);
-REGISTER_NO_AVX512_DISPATCH(qbatch_norm_relu_stub, qbatch_norm_fn);
-REGISTER_NO_AVX512_DISPATCH(qbatch_norm_stub, qbatch_norm_fn);
-REGISTER_NO_AVX512_DISPATCH(qcat_nhwc_stub, qcat_nhwc_fn);
-REGISTER_NO_AVX512_DISPATCH(qcat_relu_nhwc_stub, qcat_nhwc_fn);
-REGISTER_NO_AVX512_DISPATCH(qclamp_stub, qclamp_fn);
-REGISTER_NO_AVX512_DISPATCH(qclamp_min_stub, qclamp_minmax_fn);
-REGISTER_NO_AVX512_DISPATCH(qclamp_max_stub, qclamp_minmax_fn);
-REGISTER_NO_AVX512_DISPATCH(qelu_stub, qelu_fn);
-REGISTER_NO_AVX512_DISPATCH(qhardsigmoid_stub, qhardsigmoid_fn);
-REGISTER_NO_AVX512_DISPATCH(qhardswish_stub, qhardswish_fn);
-REGISTER_NO_AVX512_DISPATCH(qmaxpool_2d_nhwc_stub, qmaxpool_2d_fn);
-REGISTER_NO_AVX512_DISPATCH(qmul_relu_stub, qbinary_fn);
-REGISTER_NO_AVX512_DISPATCH(qmul_stub, qbinary_fn);
-REGISTER_NO_AVX512_DISPATCH(qrelu_leaky_stub, qrelu_leaky_fn);
-REGISTER_NO_AVX512_DISPATCH(qrelu_stub, qrelu_fn);
-REGISTER_NO_AVX512_DISPATCH(qsigmoid_stub, qsigmoid_fn);
-REGISTER_NO_AVX512_DISPATCH(qtanh_stub, qtanh_fn);
-REGISTER_NO_AVX512_DISPATCH(qthreshold_stub, qthreshold_fn);
-REGISTER_NO_AVX512_DISPATCH(qtopk_stub, qtopk_fn);
-REGISTER_NO_AVX512_DISPATCH(fake_quant_grad_learnable_channel_stub,
-                            fake_quant_learnable_per_channel_fn);
-REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_tensor_affine_stub,
-                            quantize_tensor_per_tensor_affine_fn);
-REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_channel_affine_stub,
-                            quantize_tensor_per_channel_affine_fn);
-REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_channel_float_qparams_stub,
-                            quantize_tensor_per_channel_float_qparams_fn);
-REGISTER_NO_AVX512_DISPATCH(quantized_normalize_stub, qnormalize_fn);
-REGISTER_NO_AVX512_DISPATCH(qupsample_bilinear2d_nhwc_stub, qupsample_bilinear2d_fn);
-REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_tensor_affine_sub_byte_stub,
-                            quantize_tensor_per_tensor_affine_sub_byte_fn);
-REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_tensor_affine_sub_byte_stub,
-                            dequantize_tensor_per_tensor_affine_sub_byte_fn);
+REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_channel_affine_stub);
+REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_tensor_affine_stub);
+REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_channel_float_qparams_stub);
+REGISTER_NO_AVX512_DISPATCH(fake_quant_grad_learnable_tensor_stub);
+REGISTER_NO_AVX512_DISPATCH(fake_quant_per_channel_cachemask_stub);
+REGISTER_NO_AVX512_DISPATCH(fake_quant_tensor_cachemask_stub);
+REGISTER_NO_AVX512_DISPATCH(fake_quant_tensor_cachemask_tensor_qparams_stub);
+REGISTER_NO_AVX512_DISPATCH(qadaptive_avg_pool2d_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qadaptive_avg_pool3d_ndhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qadd_relu_stub);
+REGISTER_NO_AVX512_DISPATCH(qadd_scalar_relu_stub);
+REGISTER_NO_AVX512_DISPATCH(qadd_scalar_stub);
+REGISTER_NO_AVX512_DISPATCH(qadd_stub);
+REGISTER_NO_AVX512_DISPATCH(qavg_pool2d_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qavg_pool3d_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qbatch_norm_relu_stub);
+REGISTER_NO_AVX512_DISPATCH(qbatch_norm_stub);
+REGISTER_NO_AVX512_DISPATCH(qcat_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qcat_relu_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qclamp_stub);
+REGISTER_NO_AVX512_DISPATCH(qclamp_min_stub);
+REGISTER_NO_AVX512_DISPATCH(qclamp_max_stub);
+REGISTER_NO_AVX512_DISPATCH(qelu_stub);
+REGISTER_NO_AVX512_DISPATCH(qhardsigmoid_stub);
+REGISTER_NO_AVX512_DISPATCH(qhardswish_stub);
+REGISTER_NO_AVX512_DISPATCH(qmaxpool_2d_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(qmul_relu_stub);
+REGISTER_NO_AVX512_DISPATCH(qmul_stub);
+REGISTER_NO_AVX512_DISPATCH(qrelu_leaky_stub);
+REGISTER_NO_AVX512_DISPATCH(qrelu_stub);
+REGISTER_NO_AVX512_DISPATCH(qsigmoid_stub);
+REGISTER_NO_AVX512_DISPATCH(qtanh_stub);
+REGISTER_NO_AVX512_DISPATCH(qthreshold_stub);
+REGISTER_NO_AVX512_DISPATCH(qtopk_stub);
+REGISTER_NO_AVX512_DISPATCH(fake_quant_grad_learnable_channel_stub);
+REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_tensor_affine_stub);
+REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_channel_affine_stub);
+REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_channel_float_qparams_stub);
+REGISTER_NO_AVX512_DISPATCH(quantized_normalize_stub);
+REGISTER_NO_AVX512_DISPATCH(qupsample_bilinear2d_nhwc_stub);
+REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_tensor_affine_sub_byte_stub);
+REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_tensor_affine_sub_byte_stub);
 #else
 REGISTER_DISPATCH(dequantize_tensor_per_channel_affine_stub,
                   &dequantize_tensor_per_channel_affine_cpu);


### PR DESCRIPTION
Currently when you register a kernel implementation to a dispatch stub,
it takes the function signature from the function pointer you pass in.
That means if you get the signature wrong, it fails at runtime with a
link error instead of failing during the compilation. This also means
that when registering nullptr you need to manually specify the type.

Instead, taking the type from `DispatchStub::FnPtr` means quicker time
to signal on failure and better error messages. The only downside is
you need to actually include the DispatchStub declaration which for
some CPU kernels was missing, so I've had to add them here.
