### PR TITLE
[DDP] Fix some issues with code example in DDP docstring

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -323,8 +323,10 @@ class DistributedDataParallel(Module, Joinable):
 
             >>> import torch.distributed.autograd as dist_autograd
             >>> from torch.nn.parallel import DistributedDataParallel as DDP
+            >>> import torch
             >>> from torch import optim
             >>> from torch.distributed.optim import DistributedOptimizer
+            >>> import torch.distributed.rpc as rpc
             >>> from torch.distributed.rpc import RRef
             >>>
             >>> t1 = torch.rand((3, 3), requires_grad=True)
@@ -345,9 +347,9 @@ class DistributedDataParallel(Module, Joinable):
             >>>
             >>> with dist_autograd.context() as context_id:
             >>>     pred = ddp_model(rref.to_here())
-            >>>     loss = loss_func(pred, loss)
-            >>>     dist_autograd.backward(context_id, loss)
-            >>>     dist_optim.step()
+            >>>     loss = loss_func(pred, target)
+            >>>     dist_autograd.backward(context_id, [loss])
+            >>>     dist_optim.step(context_id)
 
     .. note::
         To let a non-DDP model load a state dict from a DDP model,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67885
* __->__ #67883
* #67882

I copy-pasted this code to write my own script and ran into a few issues:

* Use of the base `torch` namespace, which wasn't imported
* Use of the base `rpc` namespace, which wasn't imported
* The `loss_func` taking in `loss`, but in a real script it should take in the targets. I switched that to `target` (even though we're not defining either `loss_func` or `target` in the script, it should still guide the user to do the right thing)
* `dist_autograd.backward()` should take a list of tensor for 2nd argument
* `dist_optim.step()` should take `context_id` as argument

Another thing to note is that the code example is missing initialization code for the RPC framework and process group, but I assume those were omitted for brevity

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D32190946](https://our.internmc.facebook.com/intern/diff/D32190946)