### PR TITLE
[distributed] Render `torch.distributed.optim` members in docs

### DIFF
--- a/docs/source/distributed.optim.rst
+++ b/docs/source/distributed.optim.rst
@@ -4,5 +4,11 @@
 Distributed Optimizers
 ======================
 
+.. autoclass:: torch.distributed.optim.DistributedOptimizer
+    :members:
+
+.. autoclass:: torch.distributed.optim.PostLocalSGDOptimizer
+    :members:
+
 .. autoclass:: torch.distributed.optim.ZeroRedundancyOptimizer
     :members:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67885
* #67883
* #67882

I noticed that `optim.DistributedOptimizer` was missing from the docs, so I added that to the sphinx RST source. Also, I added `PostLocalSGDOptimizer` because it is also a public member of `optim`. The docs page looks like this now:

![image](https://user-images.githubusercontent.com/4685384/140433295-699c9b66-220c-41c5-aa65-b0dc93c17f31.png)
![image](https://user-images.githubusercontent.com/4685384/140433303-16319ab2-1ab3-44fe-bb9b-7f3d89da2510.png)
![image](https://user-images.githubusercontent.com/4685384/140433312-43b9219e-1031-4c2c-907d-7ec051881323.png)
![image](https://user-images.githubusercontent.com/4685384/140433316-62bded39-9777-48b2-8c17-93c97a47e686.png)
![image](https://user-images.githubusercontent.com/4685384/140433326-cb8378f8-56c5-4876-b0e4-bb74857923c1.png)


cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D32191952](https://our.internmc.facebook.com/intern/diff/D32191952)