### PR TITLE
Introduce version control for tensorrt converter decorator

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -480,7 +480,7 @@ def acc_ops_conv2d(network, target, args, kwargs, name):
     return layer.get_output(0)
 
 
-@tensorrt_converter(acc_ops.pad)
+@tensorrt_converter(acc_ops.pad, enabled=trt.__version__ < "8.2")
 def acc_ops_pad(network, target, args, kwargs, name):
     input_val = kwargs["input"]
     pad = kwargs["pad"]

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -257,7 +257,7 @@ NO_IMPLICIT_BATCH_DIM_SUPPORT = {}
 NO_EXPLICIT_BATCH_DIM_SUPPORT = {}
 
 
-def tensorrt_converter(key, no_implicit_batch_dim=False, no_explicit_batch_dim=False):
+def tensorrt_converter(key, no_implicit_batch_dim=False, no_explicit_batch_dim=False, enabled=True):
     def register_converter(converter):
         CONVERTERS[key] = converter
         if no_implicit_batch_dim:
@@ -266,7 +266,13 @@ def tensorrt_converter(key, no_implicit_batch_dim=False, no_explicit_batch_dim=F
             NO_EXPLICIT_BATCH_DIM_SUPPORT[key] = converter
         return converter
 
-    return register_converter
+    def pass_converter(converter):
+        return converter
+
+    if enabled:
+        return register_converter
+    else:
+        return pass_converter
 
 
 class InputTensorSpec(NamedTuple):


### PR DESCRIPTION
Summary: Similar to what we have in torch2trt tensorrt_converter, introduce version enablement for fx2trt converters. Upgrade to trt 8.2 will introduce new op converter as well as deprecate old op.

Test Plan: pass existing unit test

Differential Revision: D32183581

