### PR TITLE
Implement padding with slice layer

### DIFF
--- a/test/fx2trt/converters/acc_op/test_pad.py
+++ b/test/fx2trt/converters/acc_op/test_pad.py
@@ -4,7 +4,9 @@ import torch
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
 import torch.nn as nn
 from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase
-from parameterized import parameterized
+from parameterized import param, parameterized
+import unittest
+import tensorrt as trt
 
 
 class TestPadConverter(AccTestCase):
@@ -15,6 +17,46 @@ class TestPadConverter(AccTestCase):
         ]
     )
     def test_pad(self, _, pad):
+        class Pad(nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.pad(x, pad)
+
+        inputs = [torch.randn(1, 2, 3, 4)]
+        self.run_test(
+            Pad(),
+            inputs,
+            expected_ops={acc_ops.pad},
+        )
+
+
+    @parameterized.expand(
+        [
+            param("value", pad=(2, 0, 0, 1), value=1),
+        ]
+    )
+    def test_pad_fail(self, _, pad, mode='constant', value=0):
+        class Pad(nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.pad(x, pad, mode, value)
+
+        inputs = [torch.randn(1, 2, 3, 4)]
+        self.run_test_with_assert_error(
+            Pad(),
+            inputs,
+            expect_error=RuntimeError,
+        )
+
+
+    @parameterized.expand(
+        [
+            ("3d", (2, 2, 3, 1, 2, 2)),
+        ]
+    )
+    @unittest.skipIf(
+        trt.__version__ < "8.2",
+        "Padding 3d only supported in TensorRT 8.2 and later",
+    )
+    def test_pad_3d(self, _, pad):
         class Pad(nn.Module):
             def forward(self, x):
                 return torch.nn.functional.pad(x, pad)


### PR DESCRIPTION
Summary:
Implement padding with slice layer, work step is:
reverse slice and pad 0
[1, 2] => [2, 1, 0 ... 0]
transpose, reverse tensor back to original order, finish pre-pad
[2, 1, 0 ... 0] => [0 ... 0, 1, 2]
continue post-pad
[0 ... 0, 1, 2] => [0 ... 0, 1, 2, 0 ... 0]

Test Plan: buck test mode/dev-nosan caffe2/test/fx2trt/converters:test_pad

Reviewed By: 842974287

Differential Revision: D32160739

