### PR TITLE
[RFC] Added logging for rank statuses: stuck, not stuck and timed out

### DIFF
--- a/test/test_multiprocessing_spawn.py
+++ b/test/test_multiprocessing_spawn.py
@@ -111,14 +111,14 @@ class _TestMultiProcessing(object):
         for i in range(nprocs):
             with self.assertRaisesRegex(
                 Exception,
-                "\nValueError: legitimate exception from process %d$" % i,
+                "\nValueError: legitimate exception from process %d" % i,
             ):
                 mp.start_processes(test_exception_single_func, args=(i,), nprocs=nprocs, start_method=self.start_method)
 
     def test_exception_all(self):
         with self.assertRaisesRegex(
             Exception,
-            "\nValueError: legitimate exception from process (0|1)$",
+            "\nValueError: legitimate exception from process (0|1)",
         ):
             mp.start_processes(test_exception_all_func, nprocs=2, start_method=self.start_method)
 

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -449,6 +449,7 @@ class MultiprocessContext(PContext):
             join=False,
             daemon=False,
             start_method=self.start_method,
+            envs=self.envs,
         )
 
     def _is_done(self) -> bool:


### PR DESCRIPTION
Summary:
We maintain a memory-mapped file per node. The memory-mapped files will initial have `n bytes` set to `0xFF`, where n is the # of ranks on a node. Every rank within that node will set a byte in memory-mapped files when it enters a collective and resets it upon exiting the collective. If more than one collective can be entered simultaneously, we can do a +1 on enter and -1 on exit instead. When the process terminates, each rank can be in one of the following states: 1) byte=0x01 (or non-zero), stuck: Rank entered a collective but never exited it, 2) byte=0x00, not stuck: Rank exited all collectives it entered, 3) timedout: Ranks that also timed out by reaching here: https://github.com/pytorch/pytorch/blob/master/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L437 This is just a special case of 2) as timed out ranks are also "not stuck" ranks.

Before the parent process is terminated, we will log an event, one per node. This event would contains the state information explained above for each rank on that node. For example, if you had 4 nodes and 8 ranks/node, each memory-mapped file would contain 8 bytes and we would have 4 such memory-mapped files. Also, we would log 4 events to our datastore per retry.

Test Plan:
```
> rg 'ProcessExitedException|ProcessRaisedException|rank =' run.log
337:    raise ProcessExitedException(
338:torch.multiprocessing.spawn.ProcessExitedException: process 0 terminated with signal SIGABRT
340:failed rank = 0
342:(rank = 0, status = Timed out)
343:(rank = 1, status = Not stuck)
344:(rank = 2, status = Timed out)
546:    raise ProcessExitedException(
547:torch.multiprocessing.spawn.ProcessExitedException: process 0 terminated with signal SIGABRT
549:failed rank = 0
551:(rank = 0, status = Timed out)
552:(rank = 1, status = Not stuck)
553:(rank = 2, status = Timed out)
```

Differential Revision: D32083277



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang