### PR TITLE
Fixed type checking errors in Pytorch - torch/distributed/rpc/options.py

### DIFF
--- a/torch/ao/quantization/fx/fuse.py
+++ b/torch/ao/quantization/fx/fuse.py
@@ -28,7 +28,7 @@ from .quantization_types import Pattern
 class Fuser:
     def fuse(
         self, model: GraphModule, fuse_custom_config_dict: Optional[Dict[str, Any]] = None
-    ) -> GraphModule: 
+    ) -> GraphModule:
         if fuse_custom_config_dict is None:
             fuse_custom_config_dict = {}
 

--- a/torch/ao/quantization/fx/fuse.py
+++ b/torch/ao/quantization/fx/fuse.py
@@ -5,33 +5,30 @@ from torch.fx import (
     Node,
     map_arg
 )
-
 from torch.fx.graph import Graph
-
 from ..utils import (
     get_combined_dict
 )
-
+from .graph_module import (
+    FusedGraphModule
+)
+from .match_utils import is_match
 from .pattern_utils import (
     get_default_fusion_patterns,
 )
 
-from .match_utils import is_match
-
-from .graph_module import (
-    FusedGraphModule
-)
-
 from .fusion_patterns import *  # noqa: F401,F403
+
+from typing import Callable, Tuple
+from typing import Optional
 
 from .quantization_types import Pattern
 
-from typing import Callable, Tuple
-
 
 class Fuser:
-    def fuse(self, model: GraphModule,
-             fuse_custom_config_dict: Dict[str, Any] = None) -> GraphModule:
+    def fuse(
+        self, model: GraphModule, fuse_custom_config_dict: Optional[Dict[str, Any]] = None
+    ) -> GraphModule: 
         if fuse_custom_config_dict is None:
             fuse_custom_config_dict = {}
 

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -19,9 +19,11 @@ def _to_device(device: DeviceType) -> torch.device:
     return device
 
 
-def _to_device_map(device_map: Dict[DeviceType, DeviceType]) -> Dict[torch.device, torch.device]:
-    full_device_map : Dict[torch.device, torch.device] = {}
-    reverse_map : Dict[torch.device, torch.device] = {}
+def _to_device_map(
+    device_map: Dict[DeviceType, DeviceType]
+) -> Dict[torch.device, torch.device]:
+    full_device_map: Dict[torch.device, torch.device] = {}
+    reverse_map: Dict[torch.device, torch.device] = {}
     for k in device_map:
         v = device_map[k]
         k, v = torch.device(k), torch.device(v)
@@ -37,7 +39,6 @@ def _to_device_map(device_map: Dict[DeviceType, DeviceType]) -> Dict[torch.devic
 
 def _to_device_list(devices: List[DeviceType]) -> List[torch.device]:
     return list(map(_to_device, devices))
-
 
 
 class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
@@ -73,6 +74,7 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
             requests, the agent will properly synchronize CUDA streams for
             all devices in this ``List``.
     """
+
     def __init__(
         self,
         *,
@@ -81,17 +83,15 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
         init_method: str = rpc_contants.DEFAULT_INIT_METHOD,
         device_maps: Optional[Dict[str, Dict[DeviceType, DeviceType]]] = None,
         devices: Optional[List[DeviceType]] = None,
-        _transports: List = None,
-        _channels: List = None,
+        _transports: Optional[List] = None,
+        _channels: Optional[List] = None,
     ):
         full_device_maps = (
-            {} if device_maps is None else
-            {k : _to_device_map(v) for k, v in device_maps.items()}
+            {}
+            if device_maps is None
+            else {k: _to_device_map(v) for k, v in device_maps.items()}
         )
-        full_device_list = (
-            [] if devices is None else
-            _to_device_list(devices)
-        )
+        full_device_list = [] if devices is None else _to_device_list(devices)
         super().__init__(
             num_worker_threads,
             _transports,


### PR DESCRIPTION
Fixes #{64}
This PR fixes the type checking errors in torch/distributed/rpc/options.py. 
The variable types in 84:8 and 85:8 were  declared to have type `List`  but were sometimes assigned a value of  `None`. This caused an incompatitble variable type error. Therefore, I changed the type from `List` to `Optional[List]` . Hence, this fixes the incompatitble variable type error. 





cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang