### PR TITLE
Add host-side memory requirement for `test_softmax_64bit_indexing`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15126,7 +15126,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypesIfCUDA(torch.float, torch.half)
     @largeTensorTest("20GB")
-    @largeTensorTest("64GB", "cpu")
+    @largeTensorTest("90GB", "cpu")
     @precisionOverride({torch.half: 0.001})
     def test_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15126,6 +15126,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypesIfCUDA(torch.float, torch.half)
     @largeTensorTest("20GB")
+    @largeTensorTest("36GB", "cpu")
     @precisionOverride({torch.half: 0.001})
     def test_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15126,7 +15126,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypesIfCUDA(torch.float, torch.half)
     @largeTensorTest("20GB")
-    @largeTensorTest("40GB", "cpu")
+    @largeTensorTest("64GB", "cpu")
     @precisionOverride({torch.half: 0.001})
     def test_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15126,7 +15126,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     @dtypesIfCUDA(torch.float, torch.half)
     @largeTensorTest("20GB")
-    @largeTensorTest("36GB", "cpu")
+    @largeTensorTest("40GB", "cpu")
     @precisionOverride({torch.half: 0.001})
     def test_softmax_64bit_indexing(self, device, dtype):
         def run_test(*shape):


### PR DESCRIPTION
#67910
The original `largeTensorTest` decorator didn't account for the additional host-side memory requirements.
Thanks @crcrpar for raising the issue, CC @ptrblck 