### PR TITLE
[Doc] [ONNX]Fix a broken url for ONNXRuntime custom op

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -516,7 +516,7 @@ When exporting a custom operator, you can specify the custom domain version usin
 ``custom_opsets`` dictionary at export. If not specified, the custom opset version defaults to 1.
 The runtime that consumes the model needs to support the custom op. See
 `Caffe2 custom ops <https://caffe2.ai/docs/custom-operators.html>`_,
-`ONNX Runtime custom ops <https://github.com/microsoft/onnxruntime/blob/master/docs/AddingCustomOp.md>`_,
+`ONNX Runtime custom ops <https://onnxruntime.ai/docs/reference/operators/add-custom-op.html>`_,
 or your runtime of choice's documentation.
 
 


### PR DESCRIPTION
**Description**
Update the broken url by a valid link https://onnxruntime.ai/docs/reference/operators/add-custom-op.html.

**Motivation**
Closes #67849. The url is broken.