### PR TITLE
Add an option to disable reduced precision reductions for FP16 GEMM

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -147,6 +147,14 @@ void Context::setAllowTF32CuBLAS(bool b) {
   allow_tf32_cublas = b;
 }
 
+bool Context::allowFP16ReductionCuBLAS() const {
+  return allow_fp16_reduction_cublas;
+}
+
+void Context::setAllowFP16ReductionCuBLAS(bool b) {
+  allow_fp16_reduction_cublas = b;
+}
+
 bool Context::hasMKL() {
 #if AT_MKL_ENABLED()
   return true;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -241,7 +241,7 @@ class TORCH_API Context {
   bool benchmark_cudnn = false;
   bool allow_tf32_cudnn = true;
   bool allow_tf32_cublas = true;
-  bool allow_fp16_reduction_cublas = false;
+  bool allow_fp16_reduction_cublas = true;
   bool enabled_mkldnn = true;
   #ifdef C10_MOBILE
   bool release_original_weights = true;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -202,6 +202,8 @@ class TORCH_API Context {
   void setAllowTF32CuDNN(bool);
   bool allowTF32CuBLAS() const;
   void setAllowTF32CuBLAS(bool);
+  bool allowFP16ReductionCuBLAS() const;
+  void setAllowFP16ReductionCuBLAS(bool);
   at::QEngine qEngine() const;
   void setQEngine(at::QEngine e);
   static const std::vector<at::QEngine>& supportedQEngines() ;
@@ -239,6 +241,7 @@ class TORCH_API Context {
   bool benchmark_cudnn = false;
   bool allow_tf32_cudnn = true;
   bool allow_tf32_cublas = true;
+  bool allow_fp16_reduction_cublas = false;
   bool enabled_mkldnn = true;
   #ifdef C10_MOBILE
   bool release_original_weights = true;

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -25,6 +25,10 @@ torch.backends.cuda
     A :class:`bool` that controls whether TensorFloat-32 tensor cores may be used in matrix
     multiplications on Ampere or newer GPUs. See :ref:`tf32_on_ampere`.
 
+.. attribute::  torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
+
+    A :class:`bool` that controls whether reduced precision reductions (e.g., with fp16 accumulation type) are allowed with fp16 GEMMs.
+
 .. attribute::  torch.backends.cuda.cufft_plan_cache
 
     ``cufft_plan_cache`` caches the cuFFT plans

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -131,6 +131,8 @@ For more information about TF32, see:
 .. _CUDA 11: https://devblogs.nvidia.com/cuda-11-features-revealed/
 .. _Ampere architecture: https://devblogs.nvidia.com/nvidia-ampere-architecture-in-depth/
 
+.. _FP16ReducedPrecision:
+
 Reduced Precision Reduction in FP16 GEMMs
 -----------------------------------------
 
@@ -153,6 +155,7 @@ Some example benchmark data on V100::
         [4096, 5120, 4096]    |           2142.8        |           2631.0
         [4096, 9728, 4096]    |           3875.1        |           5779.8
         [4096, 16384, 4096]   |           6182.9        |           9656.5
+
 (times in microseconds).
 
 If full precision reductions are needed, users can disable reduced precision reductions in fp16 GEMMs with:

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -139,7 +139,7 @@ Reduced Precision Reduction in FP16 GEMMs
 fp16 GEMMs are potentially done with reduced precision reductions (e.g., in fp16 rather than fp32). This reduction in precision can allow for higher performance on certain workloads (particularly those with a large `k` dimension) and GPU architectures at the cost of numerical precision and potential for overflow.
 
 Some example benchmark data on V100
-::
+.. code::
   [--------------------------- bench_gemm_transformer --------------------------]
         [  m ,  k  ,  n  ]    |  allow_fp16_reduc=True  |  allow_fp16_reduc=False
   1 threads: --------------------------------------------------------------------

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -140,6 +140,7 @@ fp16 GEMMs are potentially done with reduced precision reductions (e.g., in fp16
 
 Some example benchmark data on V100
 .. code::
+
   [--------------------------- bench_gemm_transformer --------------------------]
         [  m ,  k  ,  n  ]    |  allow_fp16_reduc=True  |  allow_fp16_reduc=False
   1 threads: --------------------------------------------------------------------

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -138,7 +138,8 @@ Reduced Precision Reduction in FP16 GEMMs
 
 fp16 GEMMs are potentially done with reduced precision reductions (e.g., in fp16 rather than fp32). This reduction in precision can allow for higher performance on certain workloads (particularly those with a large `k` dimension) and GPU architectures at the cost of numerical precision and potential for overflow.
 
-Some example benchmark data on V100::
+Some example benchmark data on V100
+::
   [--------------------------- bench_gemm_transformer --------------------------]
         [  m ,  k  ,  n  ]    |  allow_fp16_reduc=True  |  allow_fp16_reduc=False
   1 threads: --------------------------------------------------------------------

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -136,7 +136,7 @@ For more information about TF32, see:
 Reduced Precision Reduction in FP16 GEMMs
 -----------------------------------------
 
-fp16 GEMMs are potentially done with reduced precision reductions (e.g., in fp16 rather than fp32). This reduction in precision can allow for higher performance on certain workloads (particularly those with a large `k` dimension) and GPU architectures at the cost of numerical precision and potential for overflow.
+fp16 GEMMs are potentially done with some intermediate reduced precision reductions (e.g., in fp16 rather than fp32). These selective reductions in precision can allow for higher performance on certain workloads (particularly those with a large `k` dimension) and GPU architectures at the cost of numerical precision and potential for overflow.
 
 Some example benchmark data on V100
 .. code::
@@ -157,8 +157,7 @@ Some example benchmark data on V100
         [4096, 5120, 4096]    |           2142.8        |           2631.0
         [4096, 9728, 4096]    |           3875.1        |           5779.8
         [4096, 16384, 4096]   |           6182.9        |           9656.5
-
-(times in microseconds).
+  (times in microseconds).
 
 If full precision reductions are needed, users can disable reduced precision reductions in fp16 GEMMs with:
 

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -138,7 +138,8 @@ Reduced Precision Reduction in FP16 GEMMs
 
 fp16 GEMMs are potentially done with some intermediate reduced precision reductions (e.g., in fp16 rather than fp32). These selective reductions in precision can allow for higher performance on certain workloads (particularly those with a large `k` dimension) and GPU architectures at the cost of numerical precision and potential for overflow.
 
-Some example benchmark data on V100
+Some example benchmark data on V100:
+
 .. code::
 
   [--------------------------- bench_gemm_transformer --------------------------]

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -131,7 +131,7 @@ For more information about TF32, see:
 .. _CUDA 11: https://devblogs.nvidia.com/cuda-11-features-revealed/
 .. _Ampere architecture: https://devblogs.nvidia.com/nvidia-ampere-architecture-in-depth/
 
-.. _FP16ReducedPrecision:
+.. _fp16reducedprecision:
 
 Reduced Precision Reduction in FP16 GEMMs
 -----------------------------------------

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -147,6 +147,12 @@ Some example benchmark data on V100::
         [4096, 4104, 4096]    |           1677.4        |           1674.9
         [4096, 4128, 4096]    |           1655.7        |           1646.0
         [4096, 4144, 4096]    |           1796.8        |           2519.6
+        [4096, 5096, 4096]    |           2094.6        |           3190.0
+        [4096, 5104, 4096]    |           2144.0        |           2663.5
+        [4096, 5112, 4096]    |           2149.1        |           2766.9
+        [4096, 5120, 4096]    |           2142.8        |           2631.0
+        [4096, 9728, 4096]    |           3875.1        |           5779.8
+        [4096, 16384, 4096]   |           6182.9        |           9656.5
 (times in microseconds).
 
 If full precision reductions are needed, users can disable reduced precision reductions in fp16 GEMMs with:

--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -71,4 +71,4 @@ Half-precision GEMM operations are typically done with intermediate accumulation
 If reduced-precision reductions are problematic, they can be turned off with
 ``torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False``
 
-For more information see :ref:`allow_fp16_reduced_precision_reduction<_FP16ReducedPrecision>`
+For more information see :ref:`allow_fp16_reduced_precision_reduction<_fp16reducedprecision>`

--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -67,7 +67,7 @@ For more information see :ref:`TensorFloat32<tf32_on_ampere>`
 
 Reduced Precision Reduction for FP16 GEMMs
 ------------------------------------------
-Half-precision GEMM operations are typically done with intermediate accumulations (reduction) in single-precision for numerical accuracy and improved resilience to overflow. For performance, certain GPU architectures, especially more recent ones, enable reductions in reduced precision (e.g., half-precision). This change is often benign from the perspective of model convergence, though it may lead to unexpected results (e.g., ``inf`` values when the final result should be be representable in half-precision).
+Half-precision GEMM operations are typically done with intermediate accumulations (reduction) in single-precision for numerical accuracy and improved resilience to overflow. For performance, certain GPU architectures, especially more recent ones, allow a few truncations of the intermediate accumulation results to the reduced precision (e.g., half-precision). This change is often benign from the perspective of model convergence, though it may lead to unexpected results (e.g., ``inf`` values when the final result should be be representable in half-precision).
 If reduced-precision reductions are problematic, they can be turned off with
 ``torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False``
 

--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -64,3 +64,12 @@ with fp32, however, if better accuracy is desired, TF32 can be turned off with
 ``torch.backends.cuda.matmul.allow_tf32 = False``
 
 For more information see :ref:`TensorFloat32<tf32_on_ampere>`
+
+Reduced Precision Reduction for FP16 GEMMs
+------------------------------------------
+Half-precision GEMM operations are typically done with intermediate accumulations (reduction) in single-precision for numerical accuracy and improved resilience to overflow. For performance, certain GPU architectures, especially more recent ones, enable reductions in reduced precision (e.g., half-precision). This change is often benign from the perspective of model convergence, though it may leed to unexpected results (e.g., ``inf`` values when the final result should be be representable in half-precision).
+If reduced-precision reductions are problematic, they can be turned off with
+``torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False``
+
+For more information see :ref:`allow_fp16_reduced_precision_reduction<_FP16ReducedPrecision>`
+

--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -72,4 +72,3 @@ If reduced-precision reductions are problematic, they can be turned off with
 ``torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False``
 
 For more information see :ref:`allow_fp16_reduced_precision_reduction<_FP16ReducedPrecision>`
-

--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -71,4 +71,4 @@ Half-precision GEMM operations are typically done with intermediate accumulation
 If reduced-precision reductions are problematic, they can be turned off with
 ``torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False``
 
-For more information see :ref:`allow_fp16_reduced_precision_reduction<_fp16reducedprecision>`
+For more information see :ref:`allow_fp16_reduced_precision_reduction<fp16reducedprecision>`

--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -67,7 +67,7 @@ For more information see :ref:`TensorFloat32<tf32_on_ampere>`
 
 Reduced Precision Reduction for FP16 GEMMs
 ------------------------------------------
-Half-precision GEMM operations are typically done with intermediate accumulations (reduction) in single-precision for numerical accuracy and improved resilience to overflow. For performance, certain GPU architectures, especially more recent ones, enable reductions in reduced precision (e.g., half-precision). This change is often benign from the perspective of model convergence, though it may leed to unexpected results (e.g., ``inf`` values when the final result should be be representable in half-precision).
+Half-precision GEMM operations are typically done with intermediate accumulations (reduction) in single-precision for numerical accuracy and improved resilience to overflow. For performance, certain GPU architectures, especially more recent ones, enable reductions in reduced precision (e.g., half-precision). This change is often benign from the perspective of model convergence, though it may lead to unexpected results (e.g., ``inf`` values when the final result should be be representable in half-precision).
 If reduced-precision reductions are problematic, they can be turned off with
 ``torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False``
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -584,6 +584,13 @@ class TestCuda(TestCase):
         self.assertEqual(torch._C._get_cublas_allow_tf32(), not orig)
         torch.backends.cuda.matmul.allow_tf32 = orig
 
+    def test_cublas_allow_fp16_reduced_precision_reduction_get_set(self):
+        orig = torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
+        self.assertEqual(torch._C._get_cublas_allow_fp16_reduced_precision_reduction(), orig)
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = not orig
+        self.assertEqual(torch._C._get_cublas_allow_fp16_reduced_precision_reduction(), not orig)
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = orig
+
     def test_cudnn_allow_tf32_get_set(self):
         with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False):
             self.assertFalse(torch.backends.cudnn.allow_tf32)

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -596,6 +596,8 @@ def _get_cudnn_allow_tf32() -> _bool: ...  # THPModule_allowTF32CuDNN
 def _set_cudnn_allow_tf32(arg: _bool) -> None: ...  # THPModule_setAllowTF32CuDNN
 def _get_cublas_allow_tf32() -> _bool: ...  # THPModule_allowTF32CuBLAS
 def _set_cublas_allow_tf32(arg: _bool) -> None: ...  # THPModule_setAllowTF32CuBLAS
+def _get_cublas_allow_fp16_reduced_precision_reduction() -> _bool: ... #THPModule_allowFP16ReductionCuBLAS
+def _set_cublas_allow_fp16_reduced_precision_reduction(arg: _bool) -> None: ... #THPModule_setAllowFP16ReductionCuBLAS
 # NB: There is no Capsule type in typing, see
 # https://code.activestate.com/lists/python-dev/139675/
 def _to_dlpack(data: Tensor) -> Any: ...  # THPModule_toDLPack

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -85,12 +85,18 @@ class cuFFTPlanCacheManager(object):
 
 class cuBLASModule:
     def __getattr__(self, name):
-        assert name == "allow_tf32", "Unknown attribute " + name
-        return torch._C._get_cublas_allow_tf32()
+        assert name == "allow_tf32" or name == "allow_fp16_reduced_precision_reduction", "Unknown attribute " + name
+        if name == "allow_tf32":
+            return torch._C._get_cublas_allow_tf32()
+        else:
+            return torch._C._get_cublas_allow_fp16_reduced_precision_reduction()
 
     def __setattr__(self, name, value):
-        assert name == "allow_tf32", "Unknown attribute " + name
-        return torch._C._set_cublas_allow_tf32(value)
+        assert name == "allow_tf32" or name == "allow_fp16_reduced_precision_reduction", "Unknown attribute " + name
+        if name == "allow_tf32":
+            return torch._C._set_cublas_allow_tf32(value)
+        else:
+            return torch._C._set_cublas_allow_fp16_reduced_precision_reduction(value)
 
 
 cufft_plan_cache = cuFFTPlanCacheManager()

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -85,18 +85,18 @@ class cuFFTPlanCacheManager(object):
 
 class cuBLASModule:
     def __getattr__(self, name):
-        assert name == "allow_tf32" or name == "allow_fp16_reduced_precision_reduction", "Unknown attribute " + name
+        assert False, "Unknown attribute " + name
         if name == "allow_tf32":
             return torch._C._get_cublas_allow_tf32()
-        else:
+        elif name == "allow_fp16_reduced_precision_reduction":
             return torch._C._get_cublas_allow_fp16_reduced_precision_reduction()
 
     def __setattr__(self, name, value):
-        assert name == "allow_tf32" or name == "allow_fp16_reduced_precision_reduction", "Unknown attribute " + name
         if name == "allow_tf32":
             return torch._C._set_cublas_allow_tf32(value)
-        else:
+        elif name == "allow_fp16_reduced_precision_reduction":
             return torch._C._set_cublas_allow_fp16_reduced_precision_reduction(value)
+        assert False, "Unknown attribute " + name
 
 
 cufft_plan_cache = cuFFTPlanCacheManager()

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -85,18 +85,18 @@ class cuFFTPlanCacheManager(object):
 
 class cuBLASModule:
     def __getattr__(self, name):
-        assert False, "Unknown attribute " + name
         if name == "allow_tf32":
             return torch._C._get_cublas_allow_tf32()
         elif name == "allow_fp16_reduced_precision_reduction":
             return torch._C._get_cublas_allow_fp16_reduced_precision_reduction()
+        raise AssertionError("Unknown attribute " + name)
 
     def __setattr__(self, name, value):
         if name == "allow_tf32":
             return torch._C._set_cublas_allow_tf32(value)
         elif name == "allow_fp16_reduced_precision_reduction":
             return torch._C._set_cublas_allow_fp16_reduced_precision_reduction(value)
-        assert False, "Unknown attribute " + name
+        raise AssertionError("Unknown attribute " + name)
 
 
 cufft_plan_cache = cuFFTPlanCacheManager()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -522,6 +522,22 @@ PyObject *THPModule_allowTF32CuBLAS(PyObject *_unused, PyObject *noargs)
   Py_RETURN_FALSE;
 }
 
+PyObject *THPModule_setAllowFP16ReductionCuBLAS(PyObject *_unused, PyObject *arg)
+{
+  THPUtils_assert(PyBool_Check(arg), "set_allow_fp16_reduction_cublas expects a bool, "
+          "but got %s", THPUtils_typename(arg));
+  at::globalContext().setAllowFP16ReductionCuBLAS(arg == Py_True);
+  Py_RETURN_NONE;
+}
+
+PyObject *THPModule_allowFP16ReductionCuBLAS(PyObject *_unused, PyObject *noargs)
+{
+  if (at::globalContext().allowFP16ReductionCuBLAS()) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+}
+
 PyObject *THPModule_setFlushDenormal(PyObject *_unused, PyObject *arg) {
   THPUtils_assert(PyBool_Check(arg), "flush_denormal expects a bool, "
           "but got %s", THPUtils_typename(arg));
@@ -676,6 +692,8 @@ static PyMethodDef TorchMethods[] = {
   {"_set_warnAlways", THPModule_setWarnAlways, METH_O,  nullptr},
   {"_get_cublas_allow_tf32", THPModule_allowTF32CuBLAS, METH_NOARGS,     nullptr},
   {"_set_cublas_allow_tf32", THPModule_setAllowTF32CuBLAS, METH_O,  nullptr},
+  {"_get_cublas_allow_fp16_reduced_precision_reduction", THPModule_allowFP16ReductionCuBLAS, METH_NOARGS, nullptr},
+  {"_set_cublas_allow_fp16_reduced_precision_reduction", THPModule_setAllowFP16ReductionCuBLAS, METH_O, nullptr},
   {"_vmapmode_increment_nesting", THPModule_vmapmode_increment_nesting, METH_NOARGS, nullptr},
   {"_vmapmode_decrement_nesting", THPModule_vmapmode_decrement_nesting, METH_NOARGS, nullptr},
   {"_debug_only_display_vmap_fallback_warnings", THPModule_set_display_vmap_fallback_warnings_mode, METH_O, nullptr},


### PR DESCRIPTION
#67578 disabled reduced precision reductions for FP16 GEMMs. After benchmarking, we've found that this has substantial performance impacts for common GEMM shapes (e.g., those found in popular instantiations of multiheaded-attention) on architectures such as Volta. As these performance regressions may come as a surprise to current users, this PR adds a toggle to disable reduced precision reductions
`torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = `
rather than making it the default behavior.

CC @ngimel @ptrblck
@stas00 Note that the behavior after the previous PR can be replicated with
`torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False`