### PR TITLE
keep flat_param as parameter attribute only

### DIFF
--- a/torch/distributed/_fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/_fsdp/fully_sharded_data_parallel.py
@@ -139,7 +139,7 @@ class FullyShardedDataParallel(nn.Module):
             module, param_list=params
         )
         del module  # free original module in case it helps garbage collection
-        if self._fsdp_wrapped_module.flat_param is not None:
+        if hasattr(self._fsdp_wrapped_module, "flat_param"):
             self.params = [self._fsdp_wrapped_module.flat_param]
         else:
             self.params = []

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -44,7 +44,7 @@ def get_full_params(model, recurse=True):
     else:
         torch.cuda.synchronize()
         model._rebuild_full_params()
-        if model.module.flat_param is not None:
+        if hasattr(model.module, "flat_param"):
             model.module._unflatten_params()
 
 def _maybe_cuda(model, move_to_cuda):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #67951
* #67950

right now, flat_param is defined as regular attribute of FlattenParamWrapper first, and then it is registered as parameter attributed. It is redundant to define flat_param as regular attribute, keep it as parameter attribute only

Differential Revision: [D32228527](https://our.internmc.facebook.com/intern/diff/D32228527/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang