### PR TITLE
Avoid convert trt.Dims to tuple in hot path

### DIFF
--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -96,10 +96,19 @@ class TRTModule(torch.nn.Module):
             torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
             for idx in self.output_binding_indices_in_order
         ]
+        self.output_shapes = [
+            tuple(self.engine.get_binding_shape(idx)) if self.engine.has_implicit_batch_dimension else tuple()
+            for idx in self.output_binding_indices_in_order
+        ]
         self.hidden_output_dtypes: Sequence[torch.dtype] = [
             torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
             for idx in self.hidden_output_binding_indices_in_order
         ]
+        self.hidden_output_shapes = [
+            tuple(self.engine.get_binding_shape(idx)) if self.engine.has_implicit_batch_dimension else tuple()
+            for idx in self.hidden_output_binding_indices_in_order
+        ]
+
 
     def _check_initialized(self):
         if not self.initialized:
@@ -186,11 +195,10 @@ class TRTModule(torch.nn.Module):
             with torch.autograd.profiler.record_function("TRTModule:ProcessOutputs"):
                 # create output tensors
                 outputs: List[torch.Tensor] = []
+
                 for i, idx in enumerate(self.output_binding_indices_in_order):
                     if self.engine.has_implicit_batch_dimension:
-                        shape = (batch_size,) + tuple(
-                            self.engine.get_binding_shape(idx)
-                        )
+                        shape = (batch_size,) + self.output_shapes[i]
                     else:
                         shape = tuple(self.context.get_binding_shape(idx))
 
@@ -201,11 +209,10 @@ class TRTModule(torch.nn.Module):
                     )
                     outputs.append(output)
                     bindings[idx] = output.data_ptr()
+
                 for i, idx in enumerate(self.hidden_output_binding_indices_in_order):
                     if self.engine.has_implicit_batch_dimension:
-                        shape = (batch_size,) + tuple(
-                            self.engine.get_binding_shape(idx)
-                        )
+                        shape = (batch_size,) + self.hidden_output_shapes[i]
                     else:
                         shape = tuple(self.context.get_binding_shape(idx))
 


### PR DESCRIPTION
Summary:
For some reason, we are throwing py::index_error when converting a trt.Dims to tuple. This staying in the hot path of trt inference in not good, especially when we register a bunch of pybind11 exception translator where they repeatedly rethrow the exception. Since shape is static information, we save it once to avoid such repeated conversion.

TODO: follow up on why `tuple(trt.Dims)` induces an exception.

Differential Revision: D32232065

