### PR TITLE
Fast cuda layer norm

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -11,9 +11,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
-#include <iostream>
-//#include <ATen/native/cuda/Loops.cuh> // needed for thread_work_size
-//#include <ATen/native/cuda/MemoryAccess.cuh>
+//#include <iostream>
 
 #include <c10/cuda/CUDAMathCompat.h>
 
@@ -461,7 +459,7 @@ void launch_vectorized_layer_norm_kernel(
     const dim3 blocks(M);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(threads.y % 2 == 0 || threads.y == 1);
     int nshared = threads.y > 1 ? threads.y * 3/2 *sizeof(T_ACC) : 0;
-    vectorized_layer_norm_kernel<T, acc_type<T, true>><<<blocks, threads, nshared, stream>>>(N, eps, X_data,
+    vectorized_layer_norm_kernel<<<blocks, threads, nshared, stream>>>(N, eps, X_data,
     gamma_data, beta_data, mean_data, rstd_data, Y_data);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -456,7 +456,7 @@ void launch_vectorized_layer_norm_kernel(
   T_ACC* mean_data,
   T_ACC* rstd_data
 ) {
-    constexpr int alignment = 16; //currently unused to make sure float and half results are bw accurate
+    //constexpr int alignment = 16; //currently unused to make sure float and half results are bw accurate
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     const dim3 threads(32,4,1);
     const dim3 blocks(M);
@@ -465,6 +465,8 @@ void launch_vectorized_layer_norm_kernel(
 	    threads.y * 3/2 *sizeof(T_ACC) : 0;
 	  vectorized_layer_norm_kernel<T, acc_type<T, true>><<<blocks, threads, nshared, stream>>>(N, eps, X_data,
     gamma_data, beta_data, mean_data, rstd_data, Y_data);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
 
 
 }

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -11,6 +11,9 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
+#include <iostream>
+//#include <ATen/native/cuda/Loops.cuh> // needed for thread_work_size
+//#include <ATen/native/cuda/MemoryAccess.cuh>
 
 #include <c10/cuda/CUDAMathCompat.h>
 
@@ -21,6 +24,13 @@ namespace {
 
 constexpr int kCUDANumThreads = 256;
 constexpr int kColwiseReduceTileSize = 32;
+
+// aligned vector generates vectorized load/store on CUDA (copy-pasted from MemoryAccess.cuh)
+template<typename scalar_t, int vec_size>
+struct alignas(sizeof(scalar_t) * vec_size) aligned_vector {
+  scalar_t val[vec_size];
+};
+
 
 template <typename T, typename T_ACC>
 __global__ void RowwiseMomentsCUDAKernel(
@@ -81,6 +91,162 @@ __global__ void LayerNormForwardCUDAKernel(
             static_cast<T_ACC>(rstd[i]) * gamma_v +
         beta_v;
   }
+}
+
+struct WelfordData{
+  float mean;
+  float sigma2;
+  float count;
+  C10_HOST_DEVICE WelfordData(): mean(0.f), sigma2(0.f), count(0.f){}
+  C10_HOST_DEVICE WelfordData(float mean, float sigma2, float count): mean(mean), sigma2(sigma2), count(count) {}
+};
+
+template<typename U> __device__
+WelfordData cuWelfordOnlineSum(
+  const U val,
+  const WelfordData& curr_sum)
+{
+  U delta = val - curr_sum.mean;
+  U new_count = curr_sum.count + 1.f;
+  U new_mean = curr_sum.mean + delta/new_count;
+  return {new_mean, curr_sum.sigma2 + delta * (val - new_mean), new_count};
+}
+
+__device__
+WelfordData cuWelfordCombine(
+  const WelfordData dataB,
+  const WelfordData dataA
+) {
+  using U = decltype(dataB.count);
+  U delta = dataB.mean - dataA.mean;
+  U count = dataA.count + dataB.count;
+  U mean, sigma2;
+  if (count > decltype(dataB.count){0}) {
+    auto nA = dataA.count / count;
+    auto nB = dataB.count / count;
+    mean = nA*dataA.mean + nB*dataB.mean;
+    sigma2 = dataA.sigma2 + dataB.sigma2 + delta * delta * dataA.count * nB;
+  } else {
+    mean = U(0);
+    sigma2 = U(0);
+  }
+  return {mean, sigma2, count};
+}
+
+template<typename T, int alignment=16>
+__device__ WelfordData compute_stats(
+  const T*  __restrict__ X,
+  const int N,
+  float * buf
+  ) {
+    //X points to the row to read
+    constexpr int vec_size = alignment / sizeof(T);
+    using vec_t = aligned_vector<T, vec_size>;
+    using acc_t = acc_type<T, true>;
+    const vec_t * X_vec = reinterpret_cast<const vec_t*>(X);
+    const int numx = blockDim.x * blockDim.y;
+    const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
+    const int n_vec_to_read = N/vec_size;
+    WelfordData wd(0.f, 0.f, 0.f);
+    //no tail, we check that N is multiple of vec_size
+    for (int i = thrx; i < n_vec_to_read; i += numx) {
+      vec_t data = X_vec[i];
+      #pragma unroll
+      for (int ii=0; ii < vec_size; ii++){
+        wd = cuWelfordOnlineSum(static_cast<acc_t>(data.val[ii]), wd);
+      }
+    }
+//    intra-warp reduction
+    for (int l = 0;  l <= 4;  ++l) {
+      int srcLaneB = (threadIdx.x+(1<<l))&31;
+      WelfordData wdB{WARP_SHFL(wd.mean, srcLaneB),
+      WARP_SHFL(wd.count, srcLaneB),WARP_SHFL(wd.sigma2, srcLaneB)};
+      //WelfordData wdB{meanB, sigma2B, countB};
+      wd = cuWelfordCombine(wd, wdB);
+    }
+    // threadIdx.x == 0 has correct values for each warp
+    // inter-warp reductions
+    if (blockDim.y > 1) {
+      float * meansigmabuf = buf;
+      float * countbuf = buf + blockDim.y;
+      for (int offset = blockDim.y/2;  offset > 0;  offset /= 2) {
+        // upper half of warps write to shared
+        if (threadIdx.x == 0 && threadIdx.y >= offset && threadIdx.y < 2*offset) {
+          const int wrt_y = threadIdx.y - offset;
+          meansigmabuf[2*wrt_y] = wd.mean;
+          meansigmabuf[2*wrt_y+1] = wd.sigma2;
+          countbuf[wrt_y] = wd.count;
+        }
+        __syncthreads();
+        // lower half merges
+        if (threadIdx.x == 0 && threadIdx.y < offset) {
+          WelfordData wdB{meansigmabuf[2*threadIdx.y],
+                          meansigmabuf[2*threadIdx.y+1],
+                          countbuf[threadIdx.y]};
+          wd = cuWelfordCombine(wd, wdB);
+        }
+        __syncthreads();
+      }
+      if (threadIdx.x == 0 && threadIdx.y == 0) {
+        meansigmabuf[0] = wd.mean;
+        meansigmabuf[1] = wd.sigma2/float(N);
+      }
+      __syncthreads();
+      return WelfordData{meansigmabuf[0], meansigmabuf[1],0.f};
+
+    } else {
+      return WelfordData{WARP_SHFL(wd.mean,0), WARP_SHFL(wd.sigma2,0)/float(N), 0.f};
+    }
+}
+
+
+template <typename T, typename T_ACC, int alignment>
+__global__ void vectorized_layer_norm_kernel(
+  const int N,
+  T_ACC eps,
+  const  T* __restrict__ X,
+  const  T* gamma,
+  const  T* beta,
+  T_ACC* mean,
+  T_ACC* rstd,
+  T* Y){
+    extern __shared__ float s_data[]; //if we made smem WelfordData, there would be bank conflicts,
+    //as one thread would have to write 3 consecutive floats
+    auto i1 = blockIdx.x;
+    const T * block_row = X + i1 * N;
+    WelfordData wd = compute_stats(block_row, N, s_data);
+    constexpr int vec_size = alignment / sizeof(T);
+    using vec_t = aligned_vector<T, vec_size>;
+    const vec_t * X_vec = reinterpret_cast<const vec_t*>(block_row);
+    vec_t * Y_vec = reinterpret_cast<vec_t*>(Y + i1 * N);
+    const int numx = blockDim.x * blockDim.y;
+    const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
+    const int n_vec_to_read = N/vec_size;
+    T_ACC rstd_val = c10::cuda::compat::rsqrt(wd.sigma2 + eps);
+    //no tail, N is guaranteed to be multiple of vec size
+    for (int i = thrx; i < n_vec_to_read; i += numx) {
+      vec_t data = X_vec[i];
+      vec_t out;
+      //computation is performed in T_ACC, X is cast to T_ACC and result is implicitly cast to T
+      if (gamma != nullptr && beta != nullptr) {
+        #pragma unroll
+        for (int ii=0; ii < vec_size; ii++){
+          out.val[ii] = static_cast<T_ACC>(gamma[i*vec_size + ii]) * (rstd_val * (static_cast<T_ACC>(data.val[ii]) - wd.mean))
+          + static_cast<T_ACC>(beta[i*vec_size + ii]);
+        }
+      } else {
+        #pragma unroll
+        for (int ii=0; ii < vec_size; ii++){
+          out.val[ii] = rstd_val * (static_cast<T_ACC>(data.val[ii]) - wd.mean);
+        }
+
+      }
+      Y_vec[i] = out;
+    }
+    if (thrx == 0) {
+      mean[i1] = wd.mean;
+      rstd[i1] = rstd_val;
+    }
 }
 
 template <typename T>
@@ -263,6 +429,32 @@ __global__ void GammaBetaBackwardCUDAKernel(
 }
 
 template <typename T, typename T_ACC>
+//typename std::enable_if<!std::is_same<>::type* = nullptr>
+void launch_vectorized_layer_norm_kernel(
+  int N,
+  int64_t M,
+  T_ACC eps,
+  const T* X_data,
+  const T* gamma_data,
+  const T* beta_data,
+  T* Y_data,
+  T_ACC* mean_data,
+  T_ACC* rstd_data
+) {
+    constexpr int alignment = 16;
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    const dim3 threads(32,4,1);
+    const dim3 blocks(M);
+    int nshared =
+        threads.y > 1 ?
+	    threads.y * 3/2 *sizeof(T_ACC) : 0;
+	  vectorized_layer_norm_kernel<T, acc_type<T, true>, alignment><<<blocks, threads, nshared, stream>>>(N, eps, X_data,
+    gamma_data, beta_data, mean_data, rstd_data, Y_data);
+
+
+}
+
+template <typename T, typename T_ACC>
 void LayerNormKernelImplInternal(
     const Tensor& X,
     const Tensor& gamma,
@@ -273,15 +465,24 @@ void LayerNormKernelImplInternal(
     Tensor* Y,
     Tensor* mean,
     Tensor* rstd) {
-  DCHECK_EQ(X.numel(), M * N);
-  DCHECK(!gamma.defined() || gamma.numel() == N);
-  DCHECK(!beta.defined() || beta.numel() == N);
+  // assumes input, gamma and beta are of proper shape, this was checked in _check_layer_norm_inputs
+  // assumes all tensors are contiguous
   const T* X_data = X.data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
   const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
   T* Y_data = Y->data_ptr<T>();
   T_ACC* mean_data = mean->data_ptr<T_ACC>();
   T_ACC* rstd_data = rstd->data_ptr<T_ACC>();
+  // check if can take fast path - all tensors are properly aligned, N is less than 2^24 (to use float count),
+  // N is multiple of vec_size (so that all rows are aligned if tensor is aligned)
+  auto can_vectorize = [&](const T * ptr, int alignment){uint64_t addr = reinterpret_cast<uint64_t>(ptr); return addr % alignment == 0;};
+  constexpr int vec_size = 16;
+  constexpr int num_vec_elems = vec_size / sizeof(T);
+  if ((std::is_same<T, float>::value || std::is_same<T, at::Half>::value) &&
+  N <= 1ULL << std::numeric_limits<float>::digits && N % num_vec_elems == 0 &&
+  can_vectorize(X_data, vec_size) && can_vectorize(Y_data, vec_size)) {
+    launch_vectorized_layer_norm_kernel(static_cast<int>(N), M, eps, X_data, gamma_data, beta_data, Y_data, mean_data, rstd_data);
+  } else {
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
   RowwiseMomentsCUDAKernel<T, T_ACC>
       <<<M, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
@@ -290,6 +491,8 @@ void LayerNormKernelImplInternal(
   LayerNormForwardCUDAKernel<T, T_ACC><<<M, kCUDANumThreads, 0, cuda_stream>>>(
       N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  //std::cout << *mean << *rstd << "\n";
 }
 
 void LayerNormKernelImpl(
@@ -568,8 +771,8 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cuda(
   return std::make_tuple(std::move(dX), std::move(dgamma), std::move(dbeta));
 }
 
-REGISTER_DISPATCH(LayerNormKernel, &LayerNormKernelImpl);
-REGISTER_DISPATCH(LayerNormBackwardKernel, &LayerNormBackwardKernelImpl);
+//REGISTER_DISPATCH(LayerNormKernel, &LayerNormKernelImpl);
+//REGISTER_DISPATCH(LayerNormBackwardKernel, &LayerNormBackwardKernelImpl);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -201,7 +201,8 @@ __device__ WelfordData compute_stats(
 }
 
 
-template <typename T, typename T_ACC>
+template <typename T, typename T_ACC,
+typename std::enable_if<!std::is_same<T, double>::value, int>::type = 0>
 __global__ void vectorized_layer_norm_kernel(
   const int N,
   T_ACC eps,
@@ -248,6 +249,20 @@ __global__ void vectorized_layer_norm_kernel(
       rstd[i1] = rstd_val;
     }
 }
+
+template <typename T, typename T_ACC,
+typename std::enable_if<std::is_same<T, double>::value, int>::type = 0>
+__global__ void vectorized_layer_norm_kernel(
+  const int N,
+  T_ACC eps,
+  const  T* __restrict__ X,
+  const  T* gamma,
+  const  T* beta,
+  T_ACC* mean,
+  T_ACC* rstd,
+  T* Y){
+    CUDA_KERNEL_ASSERT("doesn't work with double");
+  }
 
 template <typename T>
 __global__ void ComputeInternalGradientsCUDAKernel(

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -11,7 +11,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
-//#include <iostream>
 
 #include <c10/cuda/CUDAMathCompat.h>
 
@@ -516,7 +515,6 @@ void LayerNormKernelImplInternal(
       N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
-  //std::cout << *mean << *rstd << "\n";
 }
 
 void LayerNormKernelImpl(


### PR DESCRIPTION
This adds apex-inspired fast layer norm forward kernel to pytorch (it is a significant rewrite though). 
It's much faster than current implementation, for a typical transformer size (32*196, 1024) time goes down from ~180us to ~49 us on Volta. Compared to apex, it also produces bitwise accurate results between float inputs representable in fp16, and fp16 inputs. It produces slightly different results compared to current implementation though, because welford summation is implemented differently. 
It is slower than lightSeq (~37 us), but lightseq uses inaccurate variance approximation, and doesn't guarantee float - fp16 bitwise accuracy. 

