### PR TITLE
[SR] Introduce StaticMethod

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -657,11 +657,10 @@ StaticModule::StaticModule(
   // handle schema
   if (module_.has_value()) {
     Method method = module_->get_method("forward");
-    schema_ = method.function().getSchema();
     if (RemoveSelfFromGraphInput(graph_)) {
       schema_ = RemoveSelfFromSchema(method.function().getSchema());
+      module_ = c10::nullopt;
     } else {
-      first_input_is_self_ = true;
       schema_ = method.function().getSchema();
     }
   }

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -182,6 +182,7 @@ class TORCH_API StaticModule {
   }
 
   const Module& module() const {
+    DCHECK(module_.has_value());
     return *module_;
   }
 
@@ -229,14 +230,13 @@ class TORCH_API StaticModule {
   }
 
   bool first_input_is_self() const {
-    return first_input_is_self_;
+    return module_.has_value();
   }
 
   StaticRuntime& runtime();
 
  private:
   StaticModuleOptions opts_;
-  bool first_input_is_self_{false};
   std::shared_ptr<torch::jit::Graph> graph_;
   c10::optional<torch::jit::Module> module_;
   c10::optional<c10::FunctionSchema> schema_;

--- a/torch/csrc/jit/runtime/static/static_method.h
+++ b/torch/csrc/jit/runtime/static/static_method.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <torch/csrc/api/include/torch/imethod.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
+
+namespace torch {
+namespace jit {
+
+class StaticMethod : public torch::IMethod {
+ public:
+  StaticMethod(
+      std::shared_ptr<StaticModule> static_module,
+      std::string method_name)
+      : static_module_(std::move(static_module)),
+        method_name_(std::move(method_name)) {
+    TORCH_CHECK(static_module_);
+  }
+
+  c10::IValue operator()(
+      std::vector<IValue> args,
+      const IValueMap& kwargs = IValueMap()) const override {
+    return (*static_module_)(std::move(args), kwargs);
+  }
+
+  const std::string& name() const override {
+    return method_name_;
+  }
+
+ protected:
+  void setArgumentNames(
+      std::vector<std::string>& argument_names_out) const override {
+    const auto& schema = static_module_->schema();
+    CAFFE_ENFORCE(schema.has_value());
+    const auto& arguments = schema->arguments();
+    argument_names_out.clear();
+    argument_names_out.reserve(arguments.size());
+    std::transform(
+        arguments.begin(),
+        arguments.end(),
+        std::back_inserter(argument_names_out),
+        [](const c10::Argument& arg) -> std::string { return arg.name(); });
+  }
+
+ private:
+  std::shared_ptr<StaticModule> static_module_;
+  std::string method_name_;
+};
+
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Summary:
To save on memory, various internal classes need to release all references to their `torch::jit::Module` after constructing their `StaticModule`. Unfortunately, many of these classes currently instantiate a `torch::jit::Method` attribute, which holds a reference to the `ivalue` backing its owning module.

To avoid this, I've introduced a new subclass of `IMethod` to represent scripted functions backed by static runtime.

Test Plan: CI

Differential Revision: D32232039

