### PR TITLE
CppSignature: Compare types by their mangled names

### DIFF
--- a/aten/src/ATen/core/dispatch/CppSignature.h
+++ b/aten/src/ATen/core/dispatch/CppSignature.h
@@ -45,7 +45,7 @@ public:
         // linking libraries of different compilers together, they might have
         // different ways to serialize a type name. That, together with a missing
         // RTLD_GLOBAL, would still fail this.
-        if (lhs.name() == rhs.name()) {
+        if (0 == strcmp(lhs.signature_.name(), rhs.signature_.name())) {
             return true;
         }
 


### PR DESCRIPTION
`.name()` has to call `__cxa_demangle` and allocate a new string, both of which can be avoided by just comparing the mangled names directly.