### PR TITLE
Fixed deprection warnings with `.data<T>()` in SpectalOps.cpp

### DIFF
--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -210,12 +210,12 @@ inline shape_t shape_from_tensor(const Tensor& t) {
 
 template<typename T>
 inline std::complex<T> *tensor_cdata(Tensor& t) {
-  return reinterpret_cast<std::complex<T>*>(t.data<c10::complex<T>>());
+  return reinterpret_cast<std::complex<T>*>(t.data_ptr<c10::complex<T>>());
 }
 
 template<typename T>
 inline const std::complex<T> *tensor_cdata(const Tensor& t) {
-  return reinterpret_cast<const std::complex<T>*>(t.data<c10::complex<T>>());
+  return reinterpret_cast<const std::complex<T>*>(t.data_ptr<c10::complex<T>>());
 }
 
 template<typename T>
@@ -253,11 +253,11 @@ Tensor _fft_c2r_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, 
   if (self.scalar_type() == kComplexFloat) {
     pocketfft::c2r(shape_from_tensor(out), stride_from_tensor(self), stride_from_tensor(out), axes, false,
                    tensor_cdata<float>(self),
-                   out.data<float>(), compute_fct<float>(out, dim, normalization));
+                   out.data_ptr<float>(), compute_fct<float>(out, dim, normalization));
   } else {
     pocketfft::c2r(shape_from_tensor(out), stride_from_tensor(self), stride_from_tensor(out), axes, false,
                    tensor_cdata<double>(self),
-                   out.data<double>(), compute_fct<double>(out, dim, normalization));
+                   out.data_ptr<double>(), compute_fct<double>(out, dim, normalization));
     }
   return out;
 }
@@ -277,11 +277,11 @@ Tensor _fft_r2c_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, 
   pocketfft::shape_t axes(dim.begin(), dim.end());
   if (self.scalar_type() == kFloat) {
     pocketfft::r2c(shape_from_tensor(self), stride_from_tensor(self), stride_from_tensor(out), axes, true,
-                   self.data<float>(),
+                   self.data_ptr<float>(),
                    tensor_cdata<float>(out), compute_fct<float>(self, dim, normalization));
   } else {
     pocketfft::r2c(shape_from_tensor(self), stride_from_tensor(self), stride_from_tensor(out), axes, true,
-                   self.data<double>(),
+                   self.data_ptr<double>(),
                    tensor_cdata<double>(out), compute_fct<double>(self, dim, normalization));
   }
 


### PR DESCRIPTION
Description:
- Fixed deprection warnings `.data<T>()` -> `.data_ptr<T>()` in SpectralOps.cpp shown while building pytorch from source

```c++
../aten/src/ATen/native/mkl/SpectralOps.cpp:213:10: warning: ‘T* at::Tensor::data() const [with T = c10::complex<double>]’ is deprecated: Tensor.data<T>() is deprecated. Please use Tensor.
data_ptr<T>() instead. [-Wdeprecated-declarations]
  213 |   return reinterpret_cast<std::complex<T>*>(t.data<c10::complex<T>>());
```
