### PR TITLE
`torch.lobpcg.backward`: do not save non-Variable types with `ctx.save_for_backward`.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2707,7 +2707,7 @@ class TestAutograd(TestCase):
             if A.dim() > 2:
                 X = X.expand(X_shape)
 
-            D, U = torch.lobpcg(A=A, k=k, B=B, X=X)
+            D, U = torch.lobpcg(A=A, k=k, B=B, X=X, largest=largest)
 
             # LOBPCG uses a random initial eigenspace approximation
             # if parameter `X` is not provided.
@@ -2745,8 +2745,6 @@ class TestAutograd(TestCase):
             (D.sum() + U.sum()).backward()
             self.assertEqual(A.grad, A.grad.mT)
 
-        # the tests below take about 1-2 minutes to finish,
-        # but we want to be extra sure that the backward is correct.
         for largest in [True, False]:
             run_symeig_test(1, (6, 6), largest=largest)
             run_symeig_test(1, (2, 6, 6), largest=largest)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2697,7 +2697,6 @@ class TestAutograd(TestCase):
         torch.autograd.backward(r2, grad)
         self.assertEqual(input1.grad, input2.grad, rtol=0.01, atol=0.0)
 
-    @slowTest
     @skipIfNoLapack
     def test_lobpcg(self):
 

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -291,7 +291,8 @@ class LOBPCGAutogradFunction(torch.autograd.Function):
             ortho_iparams, ortho_fparams, ortho_bparams
         )
 
-        ctx.save_for_backward(A, B, D, U, largest)
+        ctx.save_for_backward(A, B, D, U)
+        ctx.largest = largest
 
         return D, U
 
@@ -300,7 +301,8 @@ class LOBPCGAutogradFunction(torch.autograd.Function):
         A_grad = B_grad = None
         grads = [None] * 14
 
-        A, B, D, U, largest = ctx.saved_tensors
+        A, B, D, U = ctx.saved_tensors
+        largest = ctx.largest
 
         # lobpcg.backward has some limitations. Checks for unsupported input
         if A.is_sparse or (B is not None and B.is_sparse and ctx.needs_input_grad[2]):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/67827

cc @ezyang @albanD @zou3519 @gqchen @pearu @nikitaved @soulitzer @Lezcano @Varal7