### PR TITLE
Re-enable using the << operator for at::Scalar

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.cpp
@@ -31,10 +31,6 @@ torch::lazy::hash_t ScalarHash(const at::Scalar& s) {
                              : torch::lazy::Hash(s.toLong());
 }
 
-std::ostream& operator<<(std::ostream& ostrm, at::Scalar s) {
-  return ostrm << (s.isFloatingPoint() ? s.toDouble() : s.toLong());
-}
-
 }  // namespace ops
 }  // namespace ir
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/scalar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/Scalar.h>
+#include <ATen/core/Formatting.h>
 
 #include <iostream>
 
@@ -30,7 +31,7 @@ class Scalar : public TsNode {
 
 torch::lazy::hash_t ScalarHash(const at::Scalar& s);
 
-std::ostream& operator<<(std::ostream& ostrm, at::Scalar s);
+using at::operator<<;
 
 }  // namespace ops
 }  // namespace ir


### PR DESCRIPTION
This reverts commit b70bfa6bf4de35998bf47ce60308425951f822bf by
changing "using namespace at" into more specific "using at::operator<<".
