### PR TITLE
Adds an optimizer instance variable to ChainedScheduler

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2109,16 +2109,9 @@ class TestLRScheduler(TestCase):
         if isinstance(schedulers, _LRScheduler):
             schedulers = [schedulers]
 
-        def get_optimizer(scheduler):
-            if hasattr(scheduler, "optimizer"):
-                return scheduler.optimizer
-            else:
-                assert isinstance(scheduler, ChainedScheduler), \
-                    f"Error: scheduler={scheduler} does not have an optimizer and is not a chained scheduler."
-                return get_optimizer(scheduler._schedulers[0])
         optimizers = set()
         for scheduler in schedulers:
-            optimizers.add(get_optimizer(scheduler))
+            optimizers.add(scheduler.optimizer)
         for epoch in range(epochs):
             for param_group, target in zip(self.opt.param_groups, targets):
                 self.assertEqual(target[epoch], param_group['lr'],

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -25,6 +25,7 @@ class _LRScheduler(object):
 
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
+            import ipdb; ipdb.set_trace()
             raise TypeError('{} is not an Optimizer'.format(
                 type(optimizer).__name__))
         self.optimizer = optimizer
@@ -765,6 +766,7 @@ class ChainedScheduler(_LRScheduler):
                     "got schedulers at index {} and {} to be different".format(0, scheduler_idx)
                 )
         self._schedulers = list(schedulers)
+        self.optimizer = schedulers[0].optimizer
 
     def step(self):
         for scheduler in self._schedulers:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -25,7 +25,6 @@ class _LRScheduler(object):
 
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
-            import ipdb; ipdb.set_trace()
             raise TypeError('{} is not an Optimizer'.format(
                 type(optimizer).__name__))
         self.optimizer = optimizer


### PR DESCRIPTION
Fixes #67601.

As simple a fix as I could make it. I even managed to delete some testing code!

I checked calling `super()` and, as I had feared, it doesn't work out the box, so perhaps that ought to be revisited later.

As it stands,  #20124, still applies to the chained scheduler, but I think this change is still an improvement.
