### PR TITLE
[qnnpack] Remove redundant fp16 dependency (#67281)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/pytorch_qnnpack.h
@@ -14,7 +14,6 @@
 
 #include <pthreadpool.h>
 #include <qnnpack/log.h>
-#include <qnnpack/operator.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/qnnpack_func.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/qnnpack_func.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <qnnpack/operator.h>
 
 namespace qnnpack {
 class PrePackConvWeights final {

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-prepack.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-prepack.cc
@@ -1,5 +1,6 @@
 #include <pytorch_qnnpack.h>
 #include <qnnpack/log.h>
+#include <qnnpack/operator.h>
 #include <qnnpack/pack.h>
 #include <qnnpack_func.h>
 #include <cstring>


### PR DESCRIPTION
Summary:
`qnnpack/operator.h` introduces a dependency on an external library fp16 via `qnnpack/requantization.h`.
Including `qnnpack/operator.h` in `pytorch_qnnpack.h` will make objects who really don't require fp16 depend on it indirectly because they include `pytorch_qnnpack.h`.
This was causing some test and bench targets to fail building for local and android/arm64 (only two tried) using cmake.

This diff moves `qnnpack/operator.h` from `pytorch_qnnpack.h` to `qnnpack_func.h`, and explicitly add `qnnpack/operator.h` in `src/conv-prepack.cc`.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/67281

Test Plan: Ran all the tests for local on my devserver, and arm64 on Pixel3a.

Reviewed By: kimishpatel

Differential Revision: D32250984

Pulled By: digantdesai

