### PR TITLE
Upgrade and pin boto3 version to 1.19.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1292,7 +1292,7 @@ jobs:
           command: |
             set -ex
             source /Users/distiller/workspace/miniconda3/bin/activate
-            pip install boto3
+            python3 -m pip install boto3==1.19.12
 
             export IN_CI=1
             export JOB_BASE_NAME=$CIRCLE_JOB

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -213,7 +213,7 @@
           command: |
             set -ex
             source /Users/distiller/workspace/miniconda3/bin/activate
-            pip install boto3
+            python3 -m pip install boto3==1.19.12
 
             export IN_CI=1
             export JOB_BASE_NAME=$CIRCLE_JOB

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -57,7 +57,7 @@ concurrency:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 {%- endmacro -%}
 

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -292,7 +292,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -493,7 +493,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -491,7 +491,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7.yml
@@ -491,7 +491,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -300,7 +300,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Cleanup workspace
         if: always()

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -283,7 +283,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Cleanup workspace
         if: always()

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -302,7 +302,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
       - name: Cleanup workspace
         if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Ensure all test files have header containing ownership information
         if: always()
         run: |
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           .github/scripts/lint_test_ownership.py
 
   clang-format:

--- a/.github/workflows/update_pytorch_labels.yml
+++ b/.github/workflows/update_pytorch_labels.yml
@@ -20,5 +20,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_UPDATE_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_UPDATE_SECRET_ACCESS_KEY }}
         run: |
-          python3 -m pip install boto3==1.16.34
+          python3 -m pip install boto3==1.19.12
           .github/scripts/export_pytorch_labels.py


### PR DESCRIPTION
The new boto3 version could be causing the macos test reporting to fail. Pinning to version 1.19.12

example fail: https://app.circleci.com/pipelines/github/pytorch/pytorch/406385/workflows/f15ca6ba-e8af-45a3-b1b0-c0298ea3fe9d/jobs/16687920