### PR TITLE
[1/n] Use uint16_t for MesssageType enum

### DIFF
--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
@@ -27,7 +27,7 @@ RpcWithProfilingReq::RpcWithProfilingReq(
       messageType_ == rpc::MessageType::RUN_WITH_PROFILING_REQ,
       c10::str(
           "Incorrect message type, expected message type ",
-          rpc::MessageType::RUN_WITH_PROFILING_REQ));
+          uint16_t(rpc::MessageType::RUN_WITH_PROFILING_REQ)));
   wrappedMessageType_ = wrappedMessage_->type();
 }
 

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
@@ -27,7 +27,7 @@ RpcWithProfilingReq::RpcWithProfilingReq(
       messageType_ == rpc::MessageType::RUN_WITH_PROFILING_REQ,
       c10::str(
           "Incorrect message type, expected message type ",
-          uint16_t(rpc::MessageType::RUN_WITH_PROFILING_REQ)));
+          rpc::MessageType::RUN_WITH_PROFILING_REQ));
   wrappedMessageType_ = wrappedMessage_->type();
 }
 

--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -4,6 +4,10 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
+std::ostream& operator<<(std::ostream& os, MessageType const& type) {
+  return os << uint16_t(type);
+}
+
 Message::Message() = default;
 
 Message::Message(

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -18,75 +18,75 @@ enum RPCErrorType {
 // The enum values are bitwise ORed with MessageType
 // They are bit flags starting from 0x100 and should have
 // value such as 0x100, 0x200, 0x400, 0x800, 0xF00, etc.
-enum MessageTypeFlags {
-  REQUEST_TYPE = 0x100,
-  RESPONSE_TYPE = 0x200,
+enum MessageTypeFlags : uint16_t {
+  REQUEST_TYPE = 0x100u,
+  RESPONSE_TYPE = 0x200u,
 };
 
 // Message types must have values between 0x00 to 0xff
-enum MessageType {
+enum MessageType  : uint16_t  {
   // messages for dist.rpc on builtin operators
-  SCRIPT_CALL = 0x00 | MessageTypeFlags::REQUEST_TYPE,
-  SCRIPT_RET = 0x01 | MessageTypeFlags::RESPONSE_TYPE,
+  SCRIPT_CALL = 0x00u | MessageTypeFlags::REQUEST_TYPE,
+  SCRIPT_RET = 0x01u | MessageTypeFlags::RESPONSE_TYPE,
 
   // messages for dist.rpc on Python UDF
-  PYTHON_CALL = 0x02 | MessageTypeFlags::REQUEST_TYPE,
-  PYTHON_RET = 0x03 | MessageTypeFlags::RESPONSE_TYPE,
+  PYTHON_CALL = 0x02u | MessageTypeFlags::REQUEST_TYPE,
+  PYTHON_RET = 0x03u | MessageTypeFlags::RESPONSE_TYPE,
 
   // messages for dist.remote on builtin operators and Python UDF
-  SCRIPT_REMOTE_CALL = 0x04 |
+  SCRIPT_REMOTE_CALL = 0x04u |
       MessageTypeFlags::REQUEST_TYPE, // A remote call on a builtin operator
   PYTHON_REMOTE_CALL =
-      0x05 | MessageTypeFlags::REQUEST_TYPE, // A remote call on a Python UDF
+      0x05u | MessageTypeFlags::REQUEST_TYPE, // A remote call on a Python UDF
   REMOTE_RET =
-      0x06 | MessageTypeFlags::RESPONSE_TYPE, // Response for remote calls for
+      0x06u | MessageTypeFlags::RESPONSE_TYPE, // Response for remote calls for
                                               // UDF, builtin, or script
 
   // RRef related internal messages
   SCRIPT_RREF_FETCH_CALL =
-      0x07 | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<IValue> fetches value
+      0x07u | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<IValue> fetches value
                                              // from owner
   PYTHON_RREF_FETCH_CALL =
-      0x08 | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<py::object> fetches
+      0x08u | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<py::object> fetches
                                              // value from owner
-  SCRIPT_RREF_FETCH_RET = 0x09 |
+  SCRIPT_RREF_FETCH_RET = 0x09u |
       MessageTypeFlags::RESPONSE_TYPE, // An OwnerRRef sends ivalue to user
-  PYTHON_RREF_FETCH_RET = 0x0a |
+  PYTHON_RREF_FETCH_RET = 0x0au |
       MessageTypeFlags::RESPONSE_TYPE, // An OwnerRRef sends py::object to user
-  RREF_USER_DELETE = 0x0b |
+  RREF_USER_DELETE = 0x0bu |
       MessageTypeFlags::REQUEST_TYPE, // A UserRRef tells the owner to deref
   RREF_FORK_REQUEST =
-      0x0c | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells the owner
+      0x0cu | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells the owner
                                              // about itself
   RREF_CHILD_ACCEPT =
-      0x0d | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells parent
+      0x0du | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells parent
                                              // that owner knows it
   RREF_ACK =
-      0x0e | MessageTypeFlags::RESPONSE_TYPE, // ACK to internal RRef messages
+      0x0eu | MessageTypeFlags::RESPONSE_TYPE, // ACK to internal RRef messages
 
   // Messages with autograd info
-  FORWARD_AUTOGRAD_REQ = 0x0f | MessageTypeFlags::REQUEST_TYPE,
-  FORWARD_AUTOGRAD_RESP = 0x10 | MessageTypeFlags::RESPONSE_TYPE,
+  FORWARD_AUTOGRAD_REQ = 0x0fu | MessageTypeFlags::REQUEST_TYPE,
+  FORWARD_AUTOGRAD_RESP = 0x10u | MessageTypeFlags::RESPONSE_TYPE,
 
   // Messages to propagate gradients on the backward pass.
-  BACKWARD_AUTOGRAD_REQ = 0x11 | MessageTypeFlags::REQUEST_TYPE,
-  BACKWARD_AUTOGRAD_RESP = 0x12 | MessageTypeFlags::RESPONSE_TYPE,
+  BACKWARD_AUTOGRAD_REQ = 0x11u | MessageTypeFlags::REQUEST_TYPE,
+  BACKWARD_AUTOGRAD_RESP = 0x12u | MessageTypeFlags::RESPONSE_TYPE,
 
   // Messages to tell workers to clean up their autograd context.
-  CLEANUP_AUTOGRAD_CONTEXT_REQ = 0x13 | MessageTypeFlags::REQUEST_TYPE,
-  CLEANUP_AUTOGRAD_CONTEXT_RESP = 0x14 | MessageTypeFlags::RESPONSE_TYPE,
+  CLEANUP_AUTOGRAD_CONTEXT_REQ = 0x13u | MessageTypeFlags::REQUEST_TYPE,
+  CLEANUP_AUTOGRAD_CONTEXT_RESP = 0x14u | MessageTypeFlags::RESPONSE_TYPE,
 
   // Messages that tell workers to run requests with profiling enabled.
-  RUN_WITH_PROFILING_REQ = 0x15 | MessageTypeFlags::REQUEST_TYPE,
-  RUN_WITH_PROFILING_RESP = 0x16 | MessageTypeFlags::RESPONSE_TYPE,
+  RUN_WITH_PROFILING_REQ = 0x15u | MessageTypeFlags::REQUEST_TYPE,
+  RUN_WITH_PROFILING_RESP = 0x16u | MessageTypeFlags::RESPONSE_TYPE,
 
   // Messages to support RRef.backward().
-  RREF_BACKWARD_REQ = 0x17 | MessageTypeFlags::REQUEST_TYPE,
-  RREF_BACKWARD_RESP = 0x18 | MessageTypeFlags::RESPONSE_TYPE,
+  RREF_BACKWARD_REQ = 0x17u | MessageTypeFlags::REQUEST_TYPE,
+  RREF_BACKWARD_RESP = 0x18u | MessageTypeFlags::RESPONSE_TYPE,
 
   // Other internal message types
-  EXCEPTION = 0x37 | MessageTypeFlags::RESPONSE_TYPE,
-  UNKNOWN = 0x3c
+  EXCEPTION = 0x37u | MessageTypeFlags::RESPONSE_TYPE,
+  UNKNOWN = 0x3cu
 };
 
 // A message to be sent/received by an RpcAgent.

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -89,6 +89,10 @@ enum MessageType : uint16_t {
   UNKNOWN = 0x3cu
 };
 
+TORCH_API std::ostream& operator<<(
+    std::ostream& os,
+    const MessageType& type);
+
 // A message to be sent/received by an RpcAgent.
 //
 // A Message object contains 4 fields:

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -24,7 +24,7 @@ enum MessageTypeFlags : uint16_t {
 };
 
 // Message types must have values between 0x00 to 0xff
-enum MessageType  : uint16_t  {
+enum MessageType : uint16_t {
   // messages for dist.rpc on builtin operators
   SCRIPT_CALL = 0x00u | MessageTypeFlags::REQUEST_TYPE,
   SCRIPT_RET = 0x01u | MessageTypeFlags::RESPONSE_TYPE,
@@ -40,15 +40,15 @@ enum MessageType  : uint16_t  {
       0x05u | MessageTypeFlags::REQUEST_TYPE, // A remote call on a Python UDF
   REMOTE_RET =
       0x06u | MessageTypeFlags::RESPONSE_TYPE, // Response for remote calls for
-                                              // UDF, builtin, or script
+                                               // UDF, builtin, or script
 
   // RRef related internal messages
   SCRIPT_RREF_FETCH_CALL =
-      0x07u | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<IValue> fetches value
-                                             // from owner
+      0x07u | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<IValue> fetches
+                                              // value from owner
   PYTHON_RREF_FETCH_CALL =
       0x08u | MessageTypeFlags::REQUEST_TYPE, // A UserRRef<py::object> fetches
-                                             // value from owner
+                                              // value from owner
   SCRIPT_RREF_FETCH_RET = 0x09u |
       MessageTypeFlags::RESPONSE_TYPE, // An OwnerRRef sends ivalue to user
   PYTHON_RREF_FETCH_RET = 0x0au |
@@ -56,11 +56,11 @@ enum MessageType  : uint16_t  {
   RREF_USER_DELETE = 0x0bu |
       MessageTypeFlags::REQUEST_TYPE, // A UserRRef tells the owner to deref
   RREF_FORK_REQUEST =
-      0x0cu | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells the owner
-                                             // about itself
+      0x0cu | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells the
+                                              // owner about itself
   RREF_CHILD_ACCEPT =
       0x0du | MessageTypeFlags::REQUEST_TYPE, // A child UserRRef tells parent
-                                             // that owner knows it
+                                              // that owner knows it
   RREF_ACK =
       0x0eu | MessageTypeFlags::RESPONSE_TYPE, // ACK to internal RRef messages
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68089
* __->__ #68033

Context: to support custom messages, the `MessageType` field in RPC
Message can no longer be an enum. We plan to change that to an
`unint16_t` and allow users to register their own types.

This commit explicilty uses `uint16_t` as the integer type for the
enum.

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D32263167](https://our.internmc.facebook.com/intern/diff/D32263167)