### PR TITLE
Add remote_module logging to the __new__ method.

### DIFF
--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -109,6 +109,12 @@ def _raise_not_supported(name: str) -> None:
 
 
 class _RemoteModule(nn.Module):
+
+    def __new__(cls, *args, **kwargs):
+        # Use __new__ for logging purposes.
+        torch._C._log_api_usage_once("torch.distributed.nn.api.remote_module")
+        return super(_RemoteModule, cls).__new__(cls)
+
     def __init__(
         self,
         remote_device: str,
@@ -208,7 +214,6 @@ class _RemoteModule(nn.Module):
             >>> rpc.shutdown()
         """
         super().__init__()
-        torch._C._log_api_usage_once("torch.distributed.nn.api.remote_module")
 
         enable_moving_cpu_tensors_to_cuda = self._prepare_init(remote_device)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68035

RemoteModule is sometimes created using object.__new__ (ex:
init_from_module_rref), in this case the logging in the __init__ method would
not pick this up.

As a result, adding a `__new__` method to RemoteModule to log all usages
appropriately.

Differential Revision: [D32263978](https://our.internmc.facebook.com/intern/diff/D32263978/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang