### PR TITLE
[LTC] A quick fix to Device(const std::string& device_spec)

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
@@ -14,9 +14,10 @@ Device::Device()
   : type_(std::make_shared<BackendDeviceType>()) {}
 
 Device::Device(std::shared_ptr<BackendDeviceType>&& type, int ordinal)
-      : type_(std::move(type)), ordinal_(ordinal) {}
+  : type_(std::move(type)), ordinal_(ordinal) {}
 
-Device::Device(const std::string& device_spec) {}
+Device::Device(const std::string& device_spec)
+  : type_(std::make_shared<BackendDeviceType>()) {}
 
 int8_t Device::type() const {
   TORCH_INTERNAL_ASSERT(type_);


### PR DESCRIPTION
Summary:
This commit adds initialization of type_ in the constructor
Device(const std::string& device_spec).

Test Plan:
python lazy_tensor_core/example.py