### PR TITLE
fx: Update fx.rst

### DIFF
--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -617,28 +617,31 @@ examine our traced module:
     # The generated `forward` function is:
     """
     def forward(self, x, y):
-        add_1 = x + y;  x = y = None
-        return add_1
+        add = x + y;  x = y = None
+        return add
     """
 
     # Print the internal Graph.
     print(traced.graph)
     # This print-out returns:
     """
-    graph(x, y):
-        %add_1 : [#users=1] = call_function[target=<built-in function add>](args = (%x, %y), kwargs = {})
-        return add_1
+    graph():
+        %x : [#users=1] = placeholder[target=x]
+        %y : [#users=1] = placeholder[target=y]
+        %add : [#users=1] = call_function[target=operator.add](args = (%x, %y), kwargs = {})
+        return add
     """
 
     # Print a tabular representation of the internal Graph.
     traced.graph.print_tabular()
     # This gives us:
     """
-    opcode         name    target                   args      kwargs
-    -------------  ------  -----------------------  --------  --------
-    placeholder    x       x                        ()        {}
-    placeholder    y       y                        ()        {}
-    call_function  add_1   <built-in function add>  (x, y)    {}
+    opcode         name    target                   args    kwargs
+    -------------  ------  -----------------------  ------  --------
+    placeholder    x       x                        ()      {}
+    placeholder    y       y                        ()      {}
+    call_function  add     <built-in function add>  (x, y)  {}
+    output         output  output                   (add,)  {}
     """
 
 Using the utility functions above, we can compare our traced Module


### PR DESCRIPTION
When I run this part of the code on the document with PyTorch version 1.10.0, I found some differences between the output and the document, as follows: 


```python
import torch
import torch.fx as fx

class M(torch.nn.Module):
    def forward(self, x, y):
        return x + y

# Create an instance of `M`
m = M()

traced = fx.symbolic_trace(m)
print(traced)
print(traced.graph)
traced.graph.print_tabular()
```

I get the result：

```shell
def forward(self, x, y):
    add = x + y;  x = y = None
    return add
    
graph():
    %x : [#users=1] = placeholder[target=x]
    %y : [#users=1] = placeholder[target=y]
    %add : [#users=1] = call_function[target=operator.add](args = (%x, %y), kwargs = {})
    return add
opcode         name    target                   args    kwargs
-------------  ------  -----------------------  ------  --------
placeholder    x       x                        ()      {}
placeholder    y       y                        ()      {}
call_function  add     <built-in function add>  (x, y)  {}
output         output  output                   (add,)  {}
```

This pr modified the document。