### PR TITLE
Added TORCH_CHECK call for supported dtypes; arbitrarized the unit test function for dynamic qantization from 2nd to n-th order tensor

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -15,6 +15,7 @@ Tensor quantize_per_tensor_dynamic(
     const Tensor& self,
     ScalarType dtype,
     bool reduce_range) {
+  TORCH_CHECK( (dtype == ScalarType::QInt8 || dtype == ScalarType::QUInt8), "dtype ", dtype, "not supported");
   auto input_contig = self.contiguous();
   float x_min = input_contig.min().item<float>();
   float x_max = input_contig.max().item<float>();
@@ -31,8 +32,8 @@ Tensor quantize_per_tensor_dynamic(
     qmin = -128;
     qmax = 127;
   } else if (dtype == ScalarType::QUInt8) {
-  } else {
-    // dtype not supported
+    qmin = 0;
+    qmax = 255;
   }
 
   auto q_params = quant_utils::ChooseQuantizationParams(

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -150,7 +150,12 @@ class TestQuantizedTensor(TestCase):
         self._test_qtensor_dynamic(torch.device('cpu'))
 
     def _test_qtensor_dynamic(self, device):
-        mat2quant = torch.randn((4, 4), dtype=torch.float, device=device)
+        max_tensor_order = 4 # max number of tensor dimensions
+        max_dim_sz = 20 # max size for any tensor dimension
+
+        num_dim = np.random.randint(low=1, high=max_tensor_order)
+        dims = np.random.randint(low=1, high=max_dim_sz, size=num_dim)
+        mat2quant = torch.randn(*dims, dtype=torch.float, device=device)
         reduce_flag = False
 
         for dtype in [torch.qint8, torch.quint8]:
@@ -162,8 +167,7 @@ class TestQuantizedTensor(TestCase):
             print("Dynamically quantized tensor: \n", q_d)
             print("Statically quantized tensor: \n", q_s)
             print("Scale = ", scale, "Zero point = ", zero_pt)
-            # l2 = torch.norm(q_d - q_s)
-            # print("l2 norm between dynamically and statically quantized tensors: ", l2)
+            self.assertEqual(q_d, q_s)
 
     def _test_qtensor(self, device):
         device = str(device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68044
* #68004

