### PR TITLE
[ATen] Make sure at::native::resize_ calls the native version

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -861,7 +861,7 @@ Tensor& narrow_copy_dense_cpu_out(
   // resize output
   auto output_sizes = self_sizes.vec();
   output_sizes[dim] = length;
-  at::native::resize_(output, output_sizes);
+  at::native::resize_(output, output_sizes, c10::nullopt);
 
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   const int64_t unit = c10::size_from_dim_(dim + 1, self_sizes);


### PR DESCRIPTION
Summary: Without the last arg, `at::native::resize_` has to go through the dispatcher.

Test Plan: CI

Differential Revision: D32272030

