### PR TITLE
[LTC] Get rid of current device concept

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -247,16 +247,9 @@ c10::optional<Device> GetLtcDevice(const c10::optional<c10::Device>& device) {
 
 Device AtenDeviceToLtcDevice(const c10::Device& device) {
   CHECK_EQ(device.type(), at::kLazy) << device;
-  int ordinal = device.has_index() ? device.index() : -1;
-  if (ordinal < 0) {
-    c10::Device current_device = GetCurrentAtenDevice();
-    if (current_device.has_index()) {
-      ordinal = current_device.index();
-    }
-  }
-  if (ordinal < 0) {
-    return GetCurrentDevice();
-  }
+  // Ordinal doesn't make any sense now given
+  // distributed training is not supported.
+  int ordinal = device.has_index() ? device.index() : 0;
   return AtenLtcDeviceMapper::Get()->GetDeviceFromOrdinal(ordinal);
 }
 
@@ -267,24 +260,6 @@ c10::Device LtcDeviceToAtenDevice(const Device& device) {
 
 std::string ToLtcString(const c10::Device& device) {
   return c10::str("lazy:", device.index());
-}
-
-c10::Device AtenDefaultDevice() {
-  return LtcDeviceToAtenDevice(*GetDefaultDevice());
-}
-
-c10::Device SetCurrentDevice(const c10::Device& device) {
-  Device prev_device =
-      torch_lazy_tensors::SetCurrentDevice(AtenDeviceToLtcDevice(device));
-  return LtcDeviceToAtenDevice(prev_device);
-}
-
-Device SetCurrentDevice(const Device& device) {
-  return torch_lazy_tensors::SetCurrentDevice(device);
-}
-
-c10::Device GetCurrentAtenDevice() {
-  return LtcDeviceToAtenDevice(torch_lazy_tensors::GetCurrentDevice());
 }
 
 at::Tensor LtcToAtenTensor(LazyTensor ltc_tensor,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -247,8 +247,8 @@ c10::optional<Device> GetLtcDevice(const c10::optional<c10::Device>& device) {
 
 Device AtenDeviceToLtcDevice(const c10::Device& device) {
   CHECK_EQ(device.type(), at::kLazy) << device;
-  // Ordinal doesn't make any sense now given
-  // distributed training is not supported.
+  // Ordinal doesn't make any sense currently given
+  // distributed training/multi-device is not supported.
   int ordinal = device.has_index() ? device.index() : 0;
   return AtenLtcDeviceMapper::Get()->GetDeviceFromOrdinal(ordinal);
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -81,14 +81,6 @@ c10::Device LtcDeviceToAtenDevice(const Device& device);
 
 std::string ToLtcString(const c10::Device& device);
 
-c10::Device AtenDefaultDevice();
-
-c10::Device SetCurrentDevice(const c10::Device& device);
-
-Device SetCurrentDevice(const Device& device);
-
-c10::Device GetCurrentAtenDevice();
-
 at::Tensor LtcToAtenTensor(LazyTensor ltc_tensor,
                            const at::TensorOptions& tensor_options);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/debug_util.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/debug_util.cpp
@@ -102,7 +102,7 @@ std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<LazyTensor> tensors,
     graph_str = ir::DumpUtil::ToDot(root_nodes);
   } else if (format == GraphFormat::kBackend) {
     graph_str = ir::DumpUtil::ToBackend(
-        root_values, unique_device ? *unique_device : GetCurrentDevice());
+        root_values, unique_device ? *unique_device : Device());
   } else {
     LOG(ERROR) << "Invalid graph format: " << format;
   }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
@@ -4,12 +4,8 @@
 #include <c10/util/Optional.h>
 
 namespace torch_lazy_tensors {
-namespace {
 
-thread_local c10::optional<Device> g_current_device;
-
-}  // namespace
-
+// TODO(alanwaketan): Use the backend API to get the default device type.
 Device::Device()
   : type_(std::make_shared<BackendDeviceType>()) {}
 
@@ -17,7 +13,7 @@ Device::Device(std::shared_ptr<BackendDeviceType>&& type, int ordinal)
   : type_(std::move(type)), ordinal_(ordinal) {}
 
 Device::Device(const std::string& device_spec)
-  : type_(std::make_shared<BackendDeviceType>()) {}
+  : Device() {}
 
 int8_t Device::type() const {
   TORCH_INTERNAL_ASSERT(type_);
@@ -39,25 +35,6 @@ int Device::compare(const Device& rhs) const {
 std::ostream& operator<<(std::ostream& os, const Device& device) {
   os << device.toString();
   return os;
-}
-
-const Device* GetDefaultDevice() {
-  static const Device* default_device = new Device();
-  return default_device;
-}
-
-Device GetCurrentDevice() {
-  if (!g_current_device) {
-    g_current_device = *GetDefaultDevice();
-  }
-  return *g_current_device;
-}
-
-Device SetCurrentDevice(const Device& device) {
-  Device current = GetCurrentDevice();
-  g_current_device = device;
-  VLOG(2) << "New current device: " << device;
-  return current;
 }
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.cpp
@@ -6,6 +6,7 @@
 namespace torch_lazy_tensors {
 
 // TODO(alanwaketan): Use the backend API to get the default device type.
+// In the future, we should also get the default device ordinal.
 Device::Device()
   : type_(std::make_shared<BackendDeviceType>()) {}
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.h
@@ -42,14 +42,4 @@ class Device {
 
 std::ostream& operator<<(std::ostream& os, const Device& device);
 
-const Device* GetDefaultDevice();
-
-Device GetCurrentDevice();
-
-Device SetCurrentDevice(const Device& device);
-
-static inline Device GetDeviceOrCurrent(const Device* device) {
-  return device != nullptr ? *device : GetCurrentDevice();
-}
-
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/device.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/device.h
@@ -17,6 +17,8 @@ struct BackendDeviceType {
 // TODO(alanwaketan): Rename it to BackendDevice.
 class Device {
  public:
+  // The default constructor will set both the device type and ordinal
+  // to backend specific defaults.
   Device();
   Device(std::shared_ptr<BackendDeviceType>&& type, int ordinal);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -572,14 +572,16 @@ void InitLtcModuleBindings(py::module m) {
     // i) It makes sense to set default device type to CPU, GPU or TPU,
     // but not lazy given that would just use whatever default hardware type.
     // ii) Setting ordinal like lazy:0 doesn't make any sense now as distributed
-    // training is still under development.
+    // training/multi-device support is still under development.
     LOG(ERROR) << "Setting the default device is deprecated. Use "
                   "_ltc_set_default_device_type to set the default "
                   "device type instead.";
     return;
   });
   m.def("_ltc_get_default_device", []() {
-    // It's always lazy:0 given distributed training is not supported yet.
+    // TODO: Call the backend API to get the default ordinal as well. For xla, the
+    // default is lazy:1.
+    // It's always lazy:X given distributed training/multi-device is not supported yet.
     return "lazy:0";
   });
   m.def(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -54,7 +54,7 @@ c10::optional<Device> GetOptionalDevice(const std::string& device_str) {
 
 Device GetDeviceOrCurrent(const std::string& device_str) {
   if (device_str.empty()) {
-    return GetCurrentDevice();
+    return Device();
   }
   return bridge::AtenDeviceToLtcDevice(c10::Device(device_str));
 }
@@ -78,17 +78,6 @@ std::string GetTensorsDump(
     nodes.push_back(values.back().node.get());
   }
   return coverter(nodes);
-}
-
-std::string SetCurrentThreadDevice(const std::string& device_str) {
-  c10::Device prev_device = bridge::SetCurrentDevice(c10::Device(device_str));
-  std::stringstream ss;
-  ss << prev_device;
-  return ss.str();
-}
-
-std::string GetCurrentThreadDevice() {
-  return bridge::GetCurrentAtenDevice().str();
 }
 
 std::vector<std::string> GetLtcDeviceStrings(
@@ -578,9 +567,21 @@ void InitLtcModuleBindings(py::module m) {
           return result_tuple;
         });
   m.def("_ltc_set_default_device", [](const std::string& device) {
-    return SetCurrentThreadDevice(device);
+    // TODO: Replace this API with _ltc_set_default_device_type.
+    // The reasons why deprecating this API are that:
+    // i) It makes sense to set default device type to CPU, GPU or TPU,
+    // but not lazy given that would just use whatever default hardware type.
+    // ii) Setting ordinal like lazy:0 doesn't make any sense now as distributed
+    // training is still under development.
+    LOG(ERROR) << "Setting the default device is deprecated. Use "
+                  "_ltc_set_default_device_type to set the default "
+                  "device type instead.";
+    return;
   });
-  m.def("_ltc_get_default_device", []() { return GetCurrentThreadDevice(); });
+  m.def("_ltc_get_default_device", []() {
+    // It's always lazy:0 given distributed training is not supported yet.
+    return "lazy:0";
+  });
   m.def(
       "_ltc_set_rng_seed",
       [](uint64_t seed, const std::string& device) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -472,7 +472,7 @@ std::string LazyGraphExecutor::DumpBackendComputation(
     }
   }
   return !ir_values.empty()
-             ? ir::DumpUtil::ToBackend(ir_values, GetCurrentDevice())
+             ? ir::DumpUtil::ToBackend(ir_values, Device())
              : std::string();
 }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
@@ -4,6 +4,7 @@
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/macros/Macros.h>
 
+#include "c10/util/Exception.h"
 #include "lazy_tensor_core/csrc/aten_ltc_bridge.h"
 #include "lazy_tensor_core/csrc/tensor_util.h"
 
@@ -21,6 +22,7 @@ struct LTCGuardImpl : public c10::impl::DeviceGuardImplInterface {
   at::DeviceType type() const override { return at::DeviceType::Lazy; }
 
   c10::Device exchangeDevice(c10::Device device) const override {
+    TORCH_INTERNAL_ASSERT(device.type() == c10::DeviceType::Lazy);
     auto old_device = g_device;
     g_device = device;
     return old_device;
@@ -31,14 +33,17 @@ struct LTCGuardImpl : public c10::impl::DeviceGuardImplInterface {
   }
 
   void setDevice(c10::Device device) const override {
+    TORCH_INTERNAL_ASSERT(device.type() == c10::DeviceType::Lazy);
     g_device = device;
   }
 
   void uncheckedSetDevice(c10::Device device) const noexcept override {
+    TORCH_INTERNAL_ASSERT(device.type() == c10::DeviceType::Lazy);
     g_device = device;
   }
 
   c10::Stream getStream(c10::Device device) const noexcept override {
+    TORCH_INTERNAL_ASSERT(device.type() == c10::DeviceType::Lazy);
     return c10::Stream(c10::Stream::DEFAULT, device);
   }
 

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -131,16 +131,12 @@ bool EqualValuesNoElementTypeCheck(at::Tensor tensor1, at::Tensor tensor2) {
   return equal;
 }
 
-void ForEachDevice(const std::function<void(const Device&)>& devfn) {
-  const Device* device = GetDefaultDevice();
-  bridge::SetCurrentDevice(*device);
-  devfn(*device);
-}
-
 void ForEachDevice(const std::function<void(const torch::Device&)>& devfn) {
-  const Device* device = GetDefaultDevice();
-  torch::Device torch_device = bridge::LtcDeviceToAtenDevice(*device);
-  bridge::SetCurrentDevice(torch_device);
+  // Currently TorchScript backend only supports one type of hardware per process,
+  // which is set by env. And the ordinal is always 0 given distributed training
+  // is not supported yet.
+  auto device = Device();
+  torch::Device torch_device = bridge::LtcDeviceToAtenDevice(device);
   devfn(torch_device);
 }
 

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -133,8 +133,8 @@ bool EqualValuesNoElementTypeCheck(at::Tensor tensor1, at::Tensor tensor2) {
 
 void ForEachDevice(const std::function<void(const torch::Device&)>& devfn) {
   // Currently TorchScript backend only supports one type of hardware per process,
-  // which is set by env. And the ordinal is always 0 given distributed training
-  // is not supported yet.
+  // which is set by env. And the ordinal is always 0 given distributed training/
+  // multi-device is not supported yet.
   auto device = Device();
   torch::Device torch_device = bridge::LtcDeviceToAtenDevice(device);
   devfn(torch_device);

--- a/lazy_tensor_core/test/cpp/cpp_test_util.h
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.h
@@ -58,8 +58,6 @@ static inline void AllEqual(at::Tensor tensor, at::Tensor xla_tensor) {
   EXPECT_TRUE(EqualValues(tensor, xla_tensor));
 }
 
-void ForEachDevice(const std::function<void(const Device&)>& devfn);
-
 void ForEachDevice(const std::function<void(const torch::Device&)>& devfn);
 
 std::string GetTensorTextGraph(at::Tensor tensor);

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -1627,9 +1627,9 @@ TEST_F(AtenLtcTsTensorTest, TestNormInDimsKeep) {
 TEST_F(AtenLtcTsTensorTest, TestNormalTwoTensor) {
   at::Tensor mean = at::zeros({10, 10, 10}, at::dtype(at::kFloat));
   at::Tensor std = at::ones({10, 10, 10}, at::dtype(at::kFloat));
-  ForEachDevice([&](const Device& device) {
-    at::Tensor xla_mean = bridge::CreateLtcTensor(mean, device);
-    at::Tensor xla_std = bridge::CreateLtcTensor(std, device);
+  ForEachDevice([&](const torch::Device& device) {
+    at::Tensor xla_mean = CopyToDevice(mean, device);
+    at::Tensor xla_std = CopyToDevice(std, device);
     at::Tensor xla_normal = at::normal(xla_mean, xla_std);
     double res_mean = xla_normal.mean().item().toDouble();
     double res_std = xla_normal.std().item().toDouble();
@@ -1642,8 +1642,8 @@ TEST_F(AtenLtcTsTensorTest, TestNormalTwoTensor) {
 
 TEST_F(AtenLtcTsTensorTest, TestNormalDoubleMean) {
   at::Tensor std = at::ones({10, 10, 10}, at::dtype(at::kFloat));
-  ForEachDevice([&](const Device& device) {
-    at::Tensor xla_std = bridge::CreateLtcTensor(std, device);
+  ForEachDevice([&](const torch::Device& device) {
+    at::Tensor xla_std = CopyToDevice(std, device);
     at::Tensor xla_normal = at::normal(0, xla_std);
     double res_mean = xla_normal.mean().item().toDouble();
     double res_std = xla_normal.std().item().toDouble();
@@ -1656,8 +1656,8 @@ TEST_F(AtenLtcTsTensorTest, TestNormalDoubleMean) {
 
 TEST_F(AtenLtcTsTensorTest, TestNormalDoubleStd) {
   at::Tensor mean = at::zeros({10, 10, 10}, at::dtype(at::kFloat));
-  ForEachDevice([&](const Device& device) {
-    at::Tensor xla_mean = bridge::CreateLtcTensor(mean, device);
+  ForEachDevice([&](const torch::Device& device) {
+    at::Tensor xla_mean = CopyToDevice(mean, device);
     at::Tensor xla_normal = at::normal(xla_mean, 1);
     double res_mean = xla_normal.mean().item().toDouble();
     double res_std = xla_normal.std().item().toDouble();
@@ -1670,8 +1670,8 @@ TEST_F(AtenLtcTsTensorTest, TestNormalDoubleStd) {
 
 TEST_F(AtenLtcTsTensorTest, TestNormalInPlace) {
   at::Tensor a = at::zeros({10, 10, 10}, at::dtype(at::kFloat));
-  ForEachDevice([&](const Device& device) {
-    at::Tensor xla_a = bridge::CreateLtcTensor(a, device);
+  ForEachDevice([&](const torch::Device& device) {
+    at::Tensor xla_a = CopyToDevice(a, device);
     xla_a.normal_(/*mean=*/0, /*std=*/1);
     double res_mean = xla_a.mean().item().toDouble();
     double res_std = xla_a.std().item().toDouble();
@@ -1685,8 +1685,8 @@ TEST_F(AtenLtcTsTensorTest, TestNormalInPlace) {
 TEST_F(AtenLtcTsTensorTest, TestUniformInPlace) {
   const double eps = 1e-3;
   at::Tensor a = at::zeros({10, 10, 10}, at::dtype(at::kFloat));
-  ForEachDevice([&](const Device& device) {
-    at::Tensor xla_a = bridge::CreateLtcTensor(a, device);
+  ForEachDevice([&](const torch::Device& device) {
+    at::Tensor xla_a = CopyToDevice(a, device);
     xla_a.uniform_(/*from=*/0, /*to=*/1);
     at::Tensor cpu_a = ToCpuTensor(xla_a);
     double res_min = cpu_a.min().item().toDouble();

--- a/lazy_tensor_core/test/cpp/torch_ltc_ts_test.cpp
+++ b/lazy_tensor_core/test/cpp/torch_ltc_ts_test.cpp
@@ -10,7 +10,7 @@ namespace cpp_test {
 
 void LtcTsTest::SetUp() {
   at::manual_seed(42);
-  LazyGraphExecutor::Get()->SetRngSeed(GetCurrentDevice(), 42);
+  LazyGraphExecutor::Get()->SetRngSeed(Device(), 42);
 }
 
 void LtcTsTest::TearDown() {}


### PR DESCRIPTION
Summary:
The current device concept is used in three scenarios, and each either now
has a better replacement or is not applicable. Here they are:
1) Used by UAPI _ltc_set_default_device/_ltc_get_default_device: these APIs
are available for users before but actually make no senses. It makes sense
to set default device type to CPU, GPU or TPU, but not lazy given that would
just use whatever default hardware type. Setting ordinal like lazy:0 doesn't
make any sense now as distributed training is still under development.
2) Used by LTCGuardImpl: it only needs to know c10 device but not backend
device. Replaced the g_device with c10 one.
3) Used as the default device: replaced with Device(), which later will
be enhanced with the default device type backend API.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc
