### PR TITLE
[quant] Fix comparison against reference for test_qat_functional_linear

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5780,7 +5780,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             converted_ref = convert_fx(prepared_ref)
             inp = torch.rand(5, 5)
             out = converted(inp)
-            out_ref = converted(inp)
+            out_ref = converted_ref(inp)
 
             torch.testing.assert_allclose(out, out_ref)
 if __name__ == '__main__':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68061

Summary:

Test had a typo that didn't compare test value against reference value, fixed typo.

Test Plan:

`pytest test/quantization/fx/test_quantize_fx.py  -v -k "test_qat_functional_linear"`

Reviewers:

Supriya Rao

Subscribers:

Tasks:

Tags:

Differential Revision: [D32280803](https://our.internmc.facebook.com/intern/diff/D32280803)