### PR TITLE
[quant][embedding qat] Support non-partial functions in qconfig comparison

### DIFF
--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -20,9 +20,11 @@ from torch.ao.quantization import (
     DeQuantStub,
     default_qconfig,
     default_qat_qconfig,
+    default_embedding_qat_qconfig,
     get_default_qat_qconfig,
     FixedQParamsFakeQuantize,
 )
+from torch.ao.quantization.qconfig import qconfig_equals
 from torch.testing._internal.common_utils import TestCase
 
 from torch.testing._internal.common_quantization import (
@@ -911,6 +913,16 @@ class TestEmbeddingBagQATModule(TestCase):
                                     "torch.per_channel_affine_float_qparams"):
             nnqat.EmbeddingBag.from_float(embed_bag)
 
+    def test_embedding_qat_qconfig_equal(self):
+        # Embedding QAT uses a NoopObserver class for activation,
+        # and a FakeQuant for weight, make sure that qconfig comparison
+        # functions properly for a mix of partial function and class in
+        # qconfig.
+        model = ManualEmbeddingBagLinear().train()
+        model = prepare_qat(model)
+
+        self.assertTrue(qconfig_equals(model.emb.qconfig,
+                                       default_embedding_qat_qconfig))
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -328,7 +328,19 @@ def qconfig_equals(q1: QConfigAny, q2: QConfigAny):
     else:
         assert q1 is not None and q2 is not None
         try:
-            return partial_equals(q1.activation.p, q2.activation.p) and partial_equals(q1.weight.p, q2.weight.p)
+            # Qconfig weight and activation can be either a partial wrapper,
+            # or an observer class. Special handling is required (above) for
+            # comparing partial wrappers.
+            if(isinstance(q1.activation, torch.ao.quantization.observer._PartialWrapper)):
+                activation_same = partial_equals(q1.activation.p, q2.activation.p)
+            else:
+                activation_same = q1.activation == q2.activation
+            if(isinstance(q1.weight, torch.ao.quantization.observer._PartialWrapper)):
+                weight_same = partial_equals(q1.weight.p, q2.weight.p)
+            else:
+                weight_same = q1.weight == q2.weight
+
+            return activation_same and weight_same
         except AttributeError:
             return q1 == q2
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68121
* __->__ #68067

Summary:

Embedding QAT uses a NoopObserver class for activation,
and a FakeQuant for weight, make sure that qconfig comparison
functions properly for a mix of partial function and class in
qconfig.

Test Plan:

`pytest test/quantization/eager/test_quantize_eager_qat.py  -v -k "test_embedding_qat_qconfig_equal"`

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D32318434](https://our.internmc.facebook.com/intern/diff/D32318434)