### PR TITLE
[distributed][docs] Delete distributed optimimzer section from RPC and add reference to namespace docs page

### DIFF
--- a/docs/source/distributed.optim.rst
+++ b/docs/source/distributed.optim.rst
@@ -4,11 +4,8 @@
 Distributed Optimizers
 ======================
 
-.. autoclass:: torch.distributed.optim.DistributedOptimizer
-    :members:
+.. warning ::
+    Distributed optimizer is not currently supported when using CUDA tensors
 
-.. autoclass:: torch.distributed.optim.PostLocalSGDOptimizer
-    :members:
-
-.. autoclass:: torch.distributed.optim.ZeroRedundancyOptimizer
-    :members:
+.. automodule:: torch.distributed.optim
+    :members: DistributedOptimizer, PostLocalSGDOptimizer, ZeroRedundancyOptimizer

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -261,11 +261,7 @@ using RPC. For more details see :ref:`distributed-autograd-design`.
 Distributed Optimizer
 ---------------------
 
-.. warning ::
-    Distributed optimizer is not currently supported when using CUDA tensors
-
-.. automodule:: torch.distributed.optim
-    :members: DistributedOptimizer
+See the `torch.distributed.optim <https://pytorch.org/docs/master/distributed.optim.html>`__ page for documentation on distributed optimizers.
 
 Design Notes
 ------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68068


Follow-up to https://github.com/pytorch/pytorch/pull/67885. This removes the `automodule` documentation for distributed optimizer from the RPC page and instead references the module-level `torch.distributed.optim` page. RPC page section now looks like this:

![image](https://user-images.githubusercontent.com/4685384/140978883-692fd78d-b424-4e51-b0ad-cb6fa8696cde.png)

And `torch.distributed.optim` page has been updated to include the module-level docs, so looks like this:

![image](https://user-images.githubusercontent.com/4685384/140978937-43862aee-129a-4a40-b477-b67827ac301e.png)



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D32286554](https://our.internmc.facebook.com/intern/diff/D32286554)