### PR TITLE
Update rpc testing to include USE_TENSORPIPE directive

### DIFF
--- a/torch/csrc/distributed/rpc/testing/init.cpp
+++ b/torch/csrc/distributed/rpc/testing/init.cpp
@@ -34,6 +34,7 @@ PyObject* faulty_agent_init(PyObject* _unused, PyObject* noargs) {
   // Import the rpc_module so we can subclass TensorPipeAgent
   py::module rpc_module = py::module::import("torch.distributed.rpc");
 
+#ifdef USE_TENSORPIPE
   shared_ptr_class_<FaultyTensorPipeRpcBackendOptions>(
       module,
       "FaultyTensorPipeRpcBackendOptions",
@@ -125,6 +126,7 @@ PyObject* faulty_agent_init(PyObject* _unused, PyObject* noargs) {
           (std::vector<WorkerInfo>(TensorPipeAgent::*)() const) &
               TensorPipeAgent::getWorkerInfos,
           py::call_guard<py::gil_scoped_release>());
+#endif // USE_TENSORPIPE
 
   Py_RETURN_TRUE;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#68080 Update rpc testing to include USE_TENSORPIPE directive**

Fixes #68002

After FaultyProcessGroupAgent was replaced with FaultyTensorpipeAgent there is now a dependency on Tensorpipe for rpc testing. However, if user does not have USE_TENSORPIPE enabled they will hit an issue such `undeclared identifier 'FaultyTensorPipeRpcBackendOptions'`. This is for testing the faulty agent method so it should not block compilation. Update to wrap the Tensorpipe specific code in a directive.

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D32292861](https://our.internmc.facebook.com/intern/diff/D32292861)