### PR TITLE
[DataPipe] Unify mode for FileLoader

### DIFF
--- a/torch/utils/data/datapipes/iter/fileloader.py
+++ b/torch/utils/data/datapipes/iter/fileloader.py
@@ -14,9 +14,7 @@ class FileLoaderIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
     Args:
         datapipe: Iterable datapipe that provides pathnames
         mode: An optional string that specifies the mode in which
-            the file is opened by `open()`. It defaults to 'b' which
-            means open for reading in binary mode. Another option is
-            't' for text mode
+            the file is opened by Python `open` method ('r' by default)
         length: Nominal length of the datapipe
 
     Note:
@@ -26,14 +24,12 @@ class FileLoaderIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
 
     def __init__(
             self,
-            datapipe : Iterable[str],
-            mode: str = 'b',
-            length : int = -1):
+            datapipe: Iterable[str],
+            mode: str = 'r',
+            length: int = -1):
         super().__init__()
         self.datapipe: Iterable = datapipe
         self.mode: str = mode
-        if self.mode not in ('b', 't', 'rb', 'rt', 'r'):
-            raise ValueError("Invalid mode {}".format(mode))
         # TODO: enforce typing for each instance based on mode, otherwise
         #       `argument_validation` with this DataPipe may be potentially broken
         self.length: int = length

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -45,14 +45,12 @@ def get_file_binaries_from_pathnames(pathnames: Iterable, mode: str):
     if not isinstance(pathnames, Iterable):
         pathnames = [pathnames, ]
 
-    if mode in ('b', 't'):
-        mode = 'r' + mode
-
     for pathname in pathnames:
         if not isinstance(pathname, str):
             raise TypeError("Expected string type for pathname, but got {}"
                             .format(type(pathname)))
         yield pathname, StreamWrapper(open(pathname, mode))
+
 
 def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
     if not isinstance(data, tuple):
@@ -66,6 +64,7 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
             f"binary stream within the tuple should have IOBase or"
             f"its subclasses as type, but it is type {type(data[1])}"
         )
+
 
 # Warns user that the DataPipe has been moved to TorchData and will be removed from `torch`
 def deprecation_warning_torchdata(name):


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/issues/90

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#68082 [DataPipe] Unify mode for FileLoader**

As Python `open` has default mode as `r`. And, `IoPathFileLoader` is also using the mode `r` as default value. We should provide a unified API for the sake of interchangeability.

Differential Revision: [D32293648](https://our.internmc.facebook.com/intern/diff/D32293648)