### PR TITLE
[2/n] Put native message types into BuiltinMessageType enum

### DIFF
--- a/test/cpp/rpc/e2e_test_base.h
+++ b/test/cpp/rpc/e2e_test_base.h
@@ -107,7 +107,7 @@ class TestE2EBase : public ::testing::Test {
         std::move(scriptCall).toMessage());
     response->waitAndThrow();
 
-    MessageType messageType = MessageType::FORWARD_AUTOGRAD_RESP;
+    MessageType messageType = BuiltinMessageType::FORWARD_AUTOGRAD_RESP;
     auto wrappedResponse = deserializeResponse(
         std::move(*response->value().toCustomClass<Message>()), messageType);
     return static_cast<ScriptResp&>(*wrappedResponse).value().toTensor();

--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -18,7 +18,7 @@ TEST(TensorpipeSerialize, Base) {
   std::vector<char> payload = {'1', '2', '3'};
   std::vector<char> payloadCopy = payload; // for testing
   torch::distributed::rpc::MessageType mtype =
-      torch::distributed::rpc::MessageType::UNKNOWN;
+      torch::distributed::rpc::BuiltinMessageType::UNKNOWN;
   int64_t mId = 100;
   auto sendingRpcMessage = c10::make_intrusive<torch::distributed::rpc::Message>(
       std::move(payload), std::move(tensors), mtype);
@@ -112,7 +112,7 @@ TEST(TensorpipeSerialize, RecopySparseTensors) {
   std::vector<at::Tensor> tensors{main, tiny};
   std::vector<char> payload = {'1', '2', '3'};
   torch::distributed::rpc::MessageType mtype =
-      torch::distributed::rpc::MessageType::UNKNOWN;
+      torch::distributed::rpc::BuiltinMessageType::UNKNOWN;
   auto sendingRpcMessage = c10::make_intrusive<torch::distributed::rpc::Message>(
       std::move(payload), std::move(tensors), mtype);
 
@@ -144,7 +144,7 @@ TEST(TensorpipeSerialize, NoDeleterTensors) {
   std::vector<at::Tensor> tensors{t1, t2};
   std::vector<char> payload = {'1', '2', '3'};
   torch::distributed::rpc::MessageType mtype =
-      torch::distributed::rpc::MessageType::UNKNOWN;
+      torch::distributed::rpc::BuiltinMessageType::UNKNOWN;
   auto sendingRpcMessage = c10::make_intrusive<torch::distributed::rpc::Message>(
       std::move(payload), std::move(tensors), mtype);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
@@ -21,7 +21,7 @@ c10::intrusive_ptr<rpc::Message> CleanupAutogradContextReq::toMessageImpl() && {
   return c10::make_intrusive<rpc::Message>(
       std::move(payload),
       std::move(tensorTable),
-      rpc::MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ);
+      rpc::BuiltinMessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ);
 }
 
 std::unique_ptr<CleanupAutogradContextReq> CleanupAutogradContextReq::

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.cpp
@@ -10,7 +10,7 @@ c10::intrusive_ptr<rpc::Message> CleanupAutogradContextResp::toMessageImpl() && 
   return c10::make_intrusive<rpc::Message>(
       std::move(payload),
       std::move(tensors),
-      rpc::MessageType::CLEANUP_AUTOGRAD_CONTEXT_RESP);
+      rpc::BuiltinMessageType::CLEANUP_AUTOGRAD_CONTEXT_RESP);
 }
 
 std::unique_ptr<CleanupAutogradContextResp> CleanupAutogradContextResp::

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -9,7 +9,7 @@ namespace distributed {
 namespace autograd {
 
 using rpc::Message;
-using rpc::MessageType;
+using rpc::BuiltinMessageType;
 using torch::autograd::Variable;
 
 PropagateGradientsReq::PropagateGradientsReq(
@@ -42,7 +42,7 @@ c10::intrusive_ptr<Message> PropagateGradientsReq::toMessageImpl() && {
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensorTable),
-      MessageType::BACKWARD_AUTOGRAD_REQ);
+      BuiltinMessageType::BACKWARD_AUTOGRAD_REQ);
 }
 
 std::unique_ptr<PropagateGradientsReq> PropagateGradientsReq::fromMessage(

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.cpp
@@ -8,7 +8,7 @@ c10::intrusive_ptr<rpc::Message> PropagateGradientsResp::toMessageImpl() && {
   return c10::make_intrusive<rpc::Message>(
       std::vector<char>{},
       std::vector<torch::Tensor>{},
-      rpc::MessageType::BACKWARD_AUTOGRAD_RESP);
+      rpc::BuiltinMessageType::BACKWARD_AUTOGRAD_RESP);
 }
 
 std::unique_ptr<PropagateGradientsResp> PropagateGradientsResp::fromMessage(

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.cpp
@@ -9,6 +9,7 @@ namespace torch {
 namespace distributed {
 namespace autograd {
 
+using rpc::BuiltinMessageType;
 using rpc::Message;
 using rpc::MessageType;
 using rpc::RpcCommandBase;
@@ -26,8 +27,8 @@ RpcWithAutograd::RpcWithAutograd(
       wrappedMessage_(std::move(wrappedMessage)),
       deviceMap_(std::move(deviceMap)) {
   TORCH_INTERNAL_ASSERT(
-      messageType_ == MessageType::FORWARD_AUTOGRAD_REQ ||
-      messageType_ == MessageType::FORWARD_AUTOGRAD_RESP);
+      messageType_ == BuiltinMessageType::FORWARD_AUTOGRAD_REQ ||
+      messageType_ == BuiltinMessageType::FORWARD_AUTOGRAD_RESP);
   tensors_ = wrappedMessage_->tensors();
   wrappedMessageType_ = wrappedMessage_->type();
 }
@@ -49,8 +50,8 @@ RpcWithAutograd::RpcWithAutograd(
       deviceMap_(std::move(deviceMap)) {
   TORCH_INTERNAL_ASSERT(wrappedRpc_ != nullptr, "wrappedRpc cannot be null!");
   TORCH_INTERNAL_ASSERT(
-      messageType_ == MessageType::FORWARD_AUTOGRAD_REQ ||
-      messageType_ == MessageType::FORWARD_AUTOGRAD_RESP);
+      messageType_ == BuiltinMessageType::FORWARD_AUTOGRAD_REQ ||
+      messageType_ == BuiltinMessageType::FORWARD_AUTOGRAD_RESP);
 }
 
 c10::intrusive_ptr<Message> RpcWithAutograd::toMessageImpl() && {
@@ -92,8 +93,8 @@ std::unique_ptr<RpcWithAutograd> RpcWithAutograd::fromMessage(
     const Message& message) {
   MessageType originalMessageType = message.type();
   TORCH_INTERNAL_ASSERT(
-      MessageType::FORWARD_AUTOGRAD_REQ == originalMessageType ||
-      MessageType::FORWARD_AUTOGRAD_RESP == originalMessageType);
+      BuiltinMessageType::FORWARD_AUTOGRAD_REQ == originalMessageType ||
+      BuiltinMessageType::FORWARD_AUTOGRAD_RESP == originalMessageType);
 
   std::vector<torch::Tensor> tensors = message.tensors();
   int64_t messageId = message.id();
@@ -122,7 +123,7 @@ std::unique_ptr<RpcWithAutograd> RpcWithAutograd::fromMessage(
       std::move(payload), std::move(tensors), wrappedMessageType, messageId);
 
   std::unique_ptr<RpcCommandBase> wrappedRpc;
-  if (originalMessageType == MessageType::FORWARD_AUTOGRAD_REQ) {
+  if (originalMessageType == BuiltinMessageType::FORWARD_AUTOGRAD_REQ) {
     wrappedRpc = deserializeRequest(*wrappedMessage);
   } else {
     wrappedRpc = deserializeResponse(*wrappedMessage, wrappedMessageType);

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
@@ -24,10 +24,10 @@ RpcWithProfilingReq::RpcWithProfilingReq(
       profilingKeyId_(profilingKeyId) {
   tensors_ = wrappedMessage_->tensors();
   TORCH_INTERNAL_ASSERT(
-      messageType_ == rpc::MessageType::RUN_WITH_PROFILING_REQ,
+      messageType_ == rpc::BuiltinMessageType::RUN_WITH_PROFILING_REQ,
       c10::str(
           "Incorrect message type, expected message type ",
-          rpc::MessageType::RUN_WITH_PROFILING_REQ));
+          rpc::BuiltinMessageType::RUN_WITH_PROFILING_REQ));
   wrappedMessageType_ = wrappedMessage_->type();
 }
 

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.cpp
@@ -21,7 +21,7 @@ RpcWithProfilingResp::RpcWithProfilingResp(
       profilingId_(profilingId) {
   tensors_ = wrappedMessage_->tensors();
   TORCH_INTERNAL_ASSERT(
-      messageType_ == rpc::MessageType::RUN_WITH_PROFILING_RESP,
+      messageType_ == rpc::BuiltinMessageType::RUN_WITH_PROFILING_RESP,
       "Incorrect Message type");
   wrappedMessageType_ = wrappedMessage_->type();
 }

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
@@ -7,7 +7,7 @@ namespace distributed {
 namespace autograd {
 
 using rpc::Message;
-using rpc::MessageType;
+using rpc::BuiltinMessageType;
 
 RRefBackwardReq::RRefBackwardReq(
     const rpc::RRefId& rrefId,
@@ -33,7 +33,7 @@ c10::intrusive_ptr<Message> RRefBackwardReq::toMessageImpl() && {
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensorTable),
-      MessageType::RREF_BACKWARD_REQ);
+      BuiltinMessageType::RREF_BACKWARD_REQ);
 }
 
 std::unique_ptr<RRefBackwardReq> RRefBackwardReq::fromMessage(

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.cpp
@@ -8,12 +8,12 @@ c10::intrusive_ptr<rpc::Message> RRefBackwardResp::toMessageImpl() && {
   return c10::make_intrusive<rpc::Message>(
       std::vector<char>{},
       std::vector<torch::Tensor>{},
-      rpc::MessageType::RREF_BACKWARD_RESP);
+      rpc::BuiltinMessageType::RREF_BACKWARD_RESP);
 }
 
 std::unique_ptr<RRefBackwardResp> RRefBackwardResp::fromMessage(
     const rpc::Message& message) {
-  TORCH_INTERNAL_ASSERT(message.type() == rpc::MessageType::RREF_BACKWARD_RESP);
+  TORCH_INTERNAL_ASSERT(message.type() == rpc::BuiltinMessageType::RREF_BACKWARD_RESP);
   return std::unique_ptr<RRefBackwardResp>();
 }
 

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -16,6 +16,7 @@ namespace autograd {
 
 using torch::distributed::autograd::AutogradMetadata;
 using torch::distributed::autograd::RpcWithAutograd;
+using torch::distributed::rpc::BuiltinMessageType;
 using torch::distributed::rpc::JitFuture;
 using torch::distributed::rpc::Message;
 using torch::distributed::rpc::MessageType;
@@ -152,7 +153,7 @@ c10::intrusive_ptr<JitFuture> sendMessageWithAutograd(
   auto msg = getMessageWithAutograd(
       dst.id_,
       std::move(wrappedRpcMsg),
-      MessageType::FORWARD_AUTOGRAD_REQ,
+      BuiltinMessageType::FORWARD_AUTOGRAD_REQ,
       forceGradRecording,
       agent.getDeviceMap(dst));
 
@@ -163,7 +164,7 @@ c10::intrusive_ptr<JitFuture> sendMessageWithAutograd(
     auto profilerConfig = torch::autograd::profiler::getProfilerConfig();
     auto msgWithProfiling = getMessageWithProfiling(
         std::move(msg),
-        rpc::MessageType::RUN_WITH_PROFILING_REQ,
+        rpc::BuiltinMessageType::RUN_WITH_PROFILING_REQ,
         // NOLINTNEXTLINE(performance-move-const-arg)
         std::move(profilerConfig));
     fut = agent.send(dst, std::move(msgWithProfiling), rpcTimeoutSeconds);

--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -4,7 +4,7 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-std::ostream& operator<<(std::ostream& os, MessageType const& type) {
+std::ostream& operator<<(std::ostream& os, BuiltinMessageType const& type) {
   return os << uint16_t(type);
 }
 
@@ -100,7 +100,7 @@ c10::intrusive_ptr<Message> createExceptionResponse(
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::vector<torch::Tensor>(),
-      MessageType::EXCEPTION,
+      BuiltinMessageType::EXCEPTION,
       id);
 }
 

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -24,7 +24,7 @@ enum MessageTypeFlags : uint16_t {
 };
 
 // Message types must have values between 0x00 to 0xff
-enum MessageType : uint16_t {
+enum BuiltinMessageType : uint16_t {
   // messages for dist.rpc on builtin operators
   SCRIPT_CALL = 0x00u | MessageTypeFlags::REQUEST_TYPE,
   SCRIPT_RET = 0x01u | MessageTypeFlags::RESPONSE_TYPE,
@@ -91,7 +91,9 @@ enum MessageType : uint16_t {
 
 TORCH_API std::ostream& operator<<(
     std::ostream& os,
-    const MessageType& type);
+    const BuiltinMessageType& type);
+
+using MessageType = uint16_t;
 
 // A message to be sent/received by an RpcAgent.
 //
@@ -162,7 +164,7 @@ class TORCH_API Message final : public torch::CustomClassHolder {
  private:
   std::vector<char> payload_;
   std::vector<torch::Tensor> tensors_;
-  MessageType type_ = MessageType::UNKNOWN;
+  MessageType type_ = BuiltinMessageType::UNKNOWN;
   int64_t id_ = -1;
 };
 

--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -22,7 +22,7 @@ c10::intrusive_ptr<Message> PythonCall::toMessageImpl() && {
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(serializedPyObj_.tensors_),
-      MessageType::PYTHON_CALL);
+      BuiltinMessageType::PYTHON_CALL);
 }
 
 std::unique_ptr<PythonCall> PythonCall::fromMessage(const Message& message) {

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -29,7 +29,7 @@ IValue toPyIValue(const Message& message) {
   MessageType msgType = message.type();
   auto response = deserializeResponse(message, msgType);
   switch (msgType) {
-    case MessageType::SCRIPT_RET: {
+    case BuiltinMessageType::SCRIPT_RET: {
       auto& ret = static_cast<ScriptResp&>(*response);
       Stack stack;
       stack.push_back(ret.value());
@@ -40,7 +40,7 @@ IValue toPyIValue(const Message& message) {
           torch::jit::createPyObjectForStack(std::move(stack)),
           PyObjectType::get());
     }
-    case MessageType::PYTHON_RET: {
+    case BuiltinMessageType::PYTHON_RET: {
       // TODO: Try to avoid a copy here.
       auto& resp = static_cast<PythonResp&>(*response);
       auto& pythonRpcHandler = PythonRpcHandler::getInstance();

--- a/torch/csrc/distributed/rpc/python_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/python_remote_call.cpp
@@ -29,7 +29,7 @@ c10::intrusive_ptr<Message> PythonRemoteCall::toMessageImpl() && {
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensor_table),
-      MessageType::PYTHON_REMOTE_CALL);
+      BuiltinMessageType::PYTHON_REMOTE_CALL);
 }
 
 std::unique_ptr<PythonRemoteCall> PythonRemoteCall::fromMessage(

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -15,7 +15,7 @@ c10::intrusive_ptr<Message> PythonResp::toMessageImpl() && {
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(serializedPyObj_.tensors_),
-      MessageType::PYTHON_RET);
+      BuiltinMessageType::PYTHON_RET);
 }
 
 std::unique_ptr<PythonResp> PythonResp::fromMessage(const Message& message) {

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -45,12 +45,12 @@ std::unique_ptr<RpcCommandBase> deserializePythonRpcCommandReference(
     RpcCommandBase& rpc,
     const MessageType& messageType) {
   switch (messageType) {
-    case MessageType::PYTHON_CALL: {
+    case BuiltinMessageType::PYTHON_CALL: {
       auto& pc = static_cast<PythonCall&>(rpc);
       return std::make_unique<UnpickledPythonCall>(
           pc.serializedPyObj(), pc.isAsyncExecution());
     }
-    case MessageType::PYTHON_REMOTE_CALL: {
+    case BuiltinMessageType::PYTHON_REMOTE_CALL: {
       auto& prc = static_cast<PythonRemoteCall&>(rpc);
       return std::make_unique<UnpickledPythonRemoteCall>(
           prc.serializedPyObj(),
@@ -58,7 +58,7 @@ std::unique_ptr<RpcCommandBase> deserializePythonRpcCommandReference(
           prc.retForkId(),
           prc.isAsyncExecution());
     }
-    case MessageType::FORWARD_AUTOGRAD_REQ: {
+    case BuiltinMessageType::FORWARD_AUTOGRAD_REQ: {
       // Deserialize the wrapped RPC if it contains Python UDF
       auto& rwa = static_cast<RpcWithAutograd&>(rpc);
       auto& wrappedRpc = rwa.wrappedRpc();
@@ -69,7 +69,7 @@ std::unique_ptr<RpcCommandBase> deserializePythonRpcCommandReference(
       }
       return nullptr;
     }
-    case MessageType::RUN_WITH_PROFILING_REQ: {
+    case BuiltinMessageType::RUN_WITH_PROFILING_REQ: {
       // Deserialize wrapped RPC if it contains python call
       auto& rpcWithProfilingReq = static_cast<RpcWithProfilingReq&>(rpc);
       auto& wrappedRpc = rpcWithProfilingReq.wrappedRpc();

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -45,8 +45,8 @@ std::unique_ptr<RpcCommandBase> RequestCallbackNoPython::
         std::unique_ptr<RpcCommandBase> rpc,
         const MessageType& messageType) const {
   TORCH_CHECK(
-      messageType != MessageType::PYTHON_CALL &&
-          messageType != MessageType::PYTHON_REMOTE_CALL,
+      messageType != BuiltinMessageType::PYTHON_CALL &&
+          messageType != BuiltinMessageType::PYTHON_REMOTE_CALL,
       "Python calls are not supported!");
   return rpc;
 }
@@ -344,7 +344,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
           auto msg = getMessageWithAutograd(
               fromWorkerId,
               wrappedRpcResponseFuture.value().toCustomClass<Message>(),
-              MessageType::FORWARD_AUTOGRAD_RESP);
+              BuiltinMessageType::FORWARD_AUTOGRAD_RESP);
           return withStorages(std::move(msg));
         }
       },
@@ -472,7 +472,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
             populateRemoteProfiledEvents(
                 profiledEvents, profilingConfig, event_lists);
             auto rpcWithProfilingResp = std::make_unique<RpcWithProfilingResp>(
-                MessageType::RUN_WITH_PROFILING_RESP,
+                BuiltinMessageType::RUN_WITH_PROFILING_RESP,
                 wrappedRpcResponseFuture.value().toCustomClass<Message>(),
                 profiledEvents,
                 profilingKeyId);
@@ -503,46 +503,46 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::processRpc(
   // we can call here. RpcResponse could have an abstract method to convert it
   // to a python object.
   switch (messageType) {
-    case MessageType::SCRIPT_CALL: {
+    case BuiltinMessageType::SCRIPT_CALL: {
       return processScriptCall(rpc, std::move(streams));
     }
-    case MessageType::PYTHON_CALL: {
+    case BuiltinMessageType::PYTHON_CALL: {
       return processPythonCall(rpc, std::move(streams));
     }
-    case MessageType::SCRIPT_REMOTE_CALL: {
+    case BuiltinMessageType::SCRIPT_REMOTE_CALL: {
       return processScriptRemoteCall(rpc, std::move(streams));
     }
-    case MessageType::PYTHON_REMOTE_CALL: {
+    case BuiltinMessageType::PYTHON_REMOTE_CALL: {
       return processPythonRemoteCall(rpc, std::move(streams));
     }
-    case MessageType::SCRIPT_RREF_FETCH_CALL: {
+    case BuiltinMessageType::SCRIPT_RREF_FETCH_CALL: {
       return processScriptRRefFetchCall(rpc);
     }
-    case MessageType::PYTHON_RREF_FETCH_CALL: {
+    case BuiltinMessageType::PYTHON_RREF_FETCH_CALL: {
       return processPythonRRefFetchCall(rpc);
     }
-    case MessageType::RREF_USER_DELETE: {
+    case BuiltinMessageType::RREF_USER_DELETE: {
       return processRRefUserDelete(rpc);
     }
-    case MessageType::RREF_CHILD_ACCEPT: {
+    case BuiltinMessageType::RREF_CHILD_ACCEPT: {
       return processRRefChildAccept(rpc);
     }
-    case MessageType::RREF_FORK_REQUEST: {
+    case BuiltinMessageType::RREF_FORK_REQUEST: {
       return processRRefForkRequest(rpc);
     }
-    case MessageType::FORWARD_AUTOGRAD_REQ: {
+    case BuiltinMessageType::FORWARD_AUTOGRAD_REQ: {
       return processForwardAutogradReq(rpc, std::move(streams));
     }
-    case MessageType::BACKWARD_AUTOGRAD_REQ: {
+    case BuiltinMessageType::BACKWARD_AUTOGRAD_REQ: {
       return processBackwardAutogradReq(rpc, std::move(streams));
     };
-    case MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ: {
+    case BuiltinMessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ: {
       return processCleanupAutogradContextReq(rpc);
     }
-    case MessageType::RUN_WITH_PROFILING_REQ: {
+    case BuiltinMessageType::RUN_WITH_PROFILING_REQ: {
       return processRunWithProfilingReq(rpc);
     }
-    case MessageType::RREF_BACKWARD_REQ: {
+    case BuiltinMessageType::RREF_BACKWARD_REQ: {
       return processRRefBackward(rpc);
     }
     default: {

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -187,8 +187,8 @@ IValue UserRRef::toHere(const float timeoutSeconds) const {
   MessageType msgType = messagePtr->type();
   auto response = deserializeResponse(*messagePtr, msgType);
   TORCH_INTERNAL_ASSERT(
-      msgType == MessageType::SCRIPT_RREF_FETCH_RET ||
-          msgType == MessageType::PYTHON_RREF_FETCH_RET,
+      msgType == BuiltinMessageType::SCRIPT_RREF_FETCH_RET ||
+          msgType == BuiltinMessageType::PYTHON_RREF_FETCH_RET,
       "Message type should either be SCRIPT_RREF_FETCH_RET "
       "or PYTHON_RREF_FETCH_RET");
   RpcCommandBase& rpc = *response;

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -75,12 +75,12 @@ c10::intrusive_ptr<Message> ScriptRRefFetchCall::toMessageImpl() && {
   ivalues.reserve(2);
   ivalues.emplace_back(rrefId_.toIValue());
   ivalues.emplace_back(fromWorkerId_);
-  return fromIValues(std::move(ivalues), MessageType::SCRIPT_RREF_FETCH_CALL);
+  return fromIValues(std::move(ivalues), BuiltinMessageType::SCRIPT_RREF_FETCH_CALL);
 }
 
 std::unique_ptr<ScriptRRefFetchCall> ScriptRRefFetchCall::fromMessage(
     const Message& message) {
-  auto values = toIValues(message, MessageType::SCRIPT_RREF_FETCH_CALL);
+  auto values = toIValues(message, BuiltinMessageType::SCRIPT_RREF_FETCH_CALL);
   TORCH_INTERNAL_ASSERT(
       values.size() == 2, "ScriptRRefFetchCall expects 2 IValues from message");
   auto id = values[1].toInt();
@@ -97,12 +97,12 @@ c10::intrusive_ptr<Message> PythonRRefFetchCall::toMessageImpl() && {
   ivalues.reserve(2);
   ivalues.emplace_back(rrefId_.toIValue());
   ivalues.emplace_back(fromWorkerId_);
-  return fromIValues(std::move(ivalues), MessageType::PYTHON_RREF_FETCH_CALL);
+  return fromIValues(std::move(ivalues), BuiltinMessageType::PYTHON_RREF_FETCH_CALL);
 }
 
 std::unique_ptr<PythonRRefFetchCall> PythonRRefFetchCall::fromMessage(
     const Message& message) {
-  auto values = toIValues(message, MessageType::PYTHON_RREF_FETCH_CALL);
+  auto values = toIValues(message, BuiltinMessageType::PYTHON_RREF_FETCH_CALL);
   TORCH_INTERNAL_ASSERT(
       values.size() == 2, "PythonRRefFetchCall expects 2 IValues from message");
   auto id = values[1].toInt();
@@ -124,7 +124,7 @@ c10::intrusive_ptr<Message> RRefFetchRet::toMessageImpl() && {
 
 std::unique_ptr<ScriptRRefFetchRet> ScriptRRefFetchRet::fromMessage(
     const Message& message) {
-  auto values = toIValues(message, MessageType::SCRIPT_RREF_FETCH_RET);
+  auto values = toIValues(message, BuiltinMessageType::SCRIPT_RREF_FETCH_RET);
   TORCH_INTERNAL_ASSERT(
       values.size() == 1,
       "RRef of IValue should contain a single IValue, but got ",
@@ -135,19 +135,19 @@ std::unique_ptr<ScriptRRefFetchRet> ScriptRRefFetchRet::fromMessage(
 std::unique_ptr<PythonRRefFetchRet> PythonRRefFetchRet::fromMessage(
     const Message& message) {
   return std::make_unique<PythonRRefFetchRet>(
-      toIValues(message, MessageType::PYTHON_RREF_FETCH_RET).vec());
+      toIValues(message, BuiltinMessageType::PYTHON_RREF_FETCH_RET).vec());
 }
 
 std::unique_ptr<RRefUserDelete> RRefUserDelete::fromMessage(
     const Message& message) {
   auto pair =
-      ForkMessageBase::fromMessage(message, MessageType::RREF_USER_DELETE);
+      ForkMessageBase::fromMessage(message, BuiltinMessageType::RREF_USER_DELETE);
   return std::make_unique<RRefUserDelete>(
       RRefUserDelete(pair.first, pair.second));
 }
 
 std::unique_ptr<RemoteRet> RemoteRet::fromMessage(const Message& message) {
-  auto pair = ForkMessageBase::fromMessage(message, MessageType::REMOTE_RET);
+  auto pair = ForkMessageBase::fromMessage(message, BuiltinMessageType::REMOTE_RET);
   return std::make_unique<RemoteRet>(pair.first, pair.second);
 }
 
@@ -156,12 +156,12 @@ const ForkId& RRefChildAccept::forkId() const {
 }
 
 c10::intrusive_ptr<Message> RRefChildAccept::toMessageImpl() && {
-  return fromIValues({forkId_.toIValue()}, MessageType::RREF_CHILD_ACCEPT);
+  return fromIValues({forkId_.toIValue()}, BuiltinMessageType::RREF_CHILD_ACCEPT);
 }
 
 std::unique_ptr<RRefChildAccept> RRefChildAccept::fromMessage(
     const Message& message) {
-  auto values = toIValues(message, MessageType::RREF_CHILD_ACCEPT);
+  auto values = toIValues(message, BuiltinMessageType::RREF_CHILD_ACCEPT);
   TORCH_INTERNAL_ASSERT(values.size() == 1, "Expect 1 IValues from message.");
 
   return std::make_unique<RRefChildAccept>(ForkId::fromIValue(values.back()));
@@ -170,20 +170,20 @@ std::unique_ptr<RRefChildAccept> RRefChildAccept::fromMessage(
 std::unique_ptr<RRefForkRequest> RRefForkRequest::fromMessage(
     const Message& message) {
   auto pair =
-      ForkMessageBase::fromMessage(message, MessageType::RREF_FORK_REQUEST);
+      ForkMessageBase::fromMessage(message, BuiltinMessageType::RREF_FORK_REQUEST);
   return std::make_unique<RRefForkRequest>(pair.first, pair.second);
 }
 
 c10::intrusive_ptr<Message> RRefAck::toMessageImpl() && {
   return c10::make_intrusive<Message>(
-      std::vector<char>{}, std::vector<torch::Tensor>{}, MessageType::RREF_ACK);
+      std::vector<char>{}, std::vector<torch::Tensor>{}, BuiltinMessageType::RREF_ACK);
 }
 
 std::unique_ptr<RRefAck> RRefAck::fromMessage(const Message& message) {
   TORCH_INTERNAL_ASSERT(
-      message.type() == MessageType::RREF_ACK,
+      message.type() == BuiltinMessageType::RREF_ACK,
       "Message type miss match, expect ",
-      MessageType::RREF_ACK,
+      BuiltinMessageType::RREF_ACK,
       ", but got ",
       message.type());
   return std::make_unique<RRefAck>();

--- a/torch/csrc/distributed/rpc/rref_proto.h
+++ b/torch/csrc/distributed/rpc/rref_proto.h
@@ -50,7 +50,7 @@ class TORCH_API ForkMessageBase : public RRefMessageBase {
 class TORCH_API ScriptRRefFetchCall final : public RRefMessageBase {
  public:
   ScriptRRefFetchCall(worker_id_t fromWorkerId, const RRefId& rrefId)
-      : RRefMessageBase(rrefId, MessageType::SCRIPT_RREF_FETCH_CALL),
+      : RRefMessageBase(rrefId, BuiltinMessageType::SCRIPT_RREF_FETCH_CALL),
         fromWorkerId_(fromWorkerId) {}
 
   inline worker_id_t fromWorkerId() const {
@@ -68,7 +68,7 @@ class TORCH_API ScriptRRefFetchCall final : public RRefMessageBase {
 class TORCH_API PythonRRefFetchCall final : public RRefMessageBase {
  public:
   PythonRRefFetchCall(worker_id_t fromWorkerId, const RRefId& rrefId)
-      : RRefMessageBase(rrefId, MessageType::PYTHON_RREF_FETCH_CALL),
+      : RRefMessageBase(rrefId, BuiltinMessageType::PYTHON_RREF_FETCH_CALL),
         fromWorkerId_(fromWorkerId) {}
 
   c10::intrusive_ptr<Message> toMessageImpl() && override;
@@ -96,7 +96,7 @@ class TORCH_API RRefFetchRet : public RpcCommandBase {
 class TORCH_API ScriptRRefFetchRet final : public RRefFetchRet {
  public:
   explicit ScriptRRefFetchRet(std::vector<at::IValue> values)
-      : RRefFetchRet(std::move(values), MessageType::SCRIPT_RREF_FETCH_RET) {}
+      : RRefFetchRet(std::move(values), BuiltinMessageType::SCRIPT_RREF_FETCH_RET) {}
 
   static std::unique_ptr<ScriptRRefFetchRet> fromMessage(
       const Message& message);
@@ -105,7 +105,7 @@ class TORCH_API ScriptRRefFetchRet final : public RRefFetchRet {
 class TORCH_API PythonRRefFetchRet final : public RRefFetchRet {
  public:
   explicit PythonRRefFetchRet(std::vector<at::IValue> values)
-      : RRefFetchRet(std::move(values), MessageType::PYTHON_RREF_FETCH_RET) {}
+      : RRefFetchRet(std::move(values), BuiltinMessageType::PYTHON_RREF_FETCH_RET) {}
 
   static std::unique_ptr<PythonRRefFetchRet> fromMessage(
       const Message& message);
@@ -116,7 +116,7 @@ class TORCH_API PythonRRefFetchRet final : public RRefFetchRet {
 class TORCH_API RRefUserDelete final : public ForkMessageBase {
  public:
   RRefUserDelete(const RRefId& rrefId, const ForkId& forkId)
-      : ForkMessageBase(rrefId, forkId, MessageType::RREF_USER_DELETE) {}
+      : ForkMessageBase(rrefId, forkId, BuiltinMessageType::RREF_USER_DELETE) {}
 
   static std::unique_ptr<RRefUserDelete> fromMessage(const Message& message);
 };
@@ -124,7 +124,7 @@ class TORCH_API RRefUserDelete final : public ForkMessageBase {
 class TORCH_API RemoteRet final : public ForkMessageBase {
  public:
   RemoteRet(const RRefId& rrefId, const ForkId& forkId)
-      : ForkMessageBase(rrefId, forkId, MessageType::REMOTE_RET) {}
+      : ForkMessageBase(rrefId, forkId, BuiltinMessageType::REMOTE_RET) {}
 
   static std::unique_ptr<RemoteRet> fromMessage(const Message& message);
 };
@@ -148,7 +148,7 @@ class TORCH_API RRefChildAccept final : public RpcCommandBase {
 class TORCH_API RRefForkRequest final : public ForkMessageBase {
  public:
   RRefForkRequest(const RRefId& rrefId, const ForkId& forkId)
-      : ForkMessageBase(rrefId, forkId, MessageType::RREF_FORK_REQUEST) {}
+      : ForkMessageBase(rrefId, forkId, BuiltinMessageType::RREF_FORK_REQUEST) {}
 
   static std::unique_ptr<RRefForkRequest> fromMessage(const Message& message);
 };

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -117,7 +117,7 @@ c10::intrusive_ptr<Message> ScriptCall::toMessageImpl() && {
       c10::ivalue::Tuple::create(std::move(ivalues)), &tensor_table);
 
   return c10::make_intrusive<Message>(
-      std::move(payload), std::move(tensor_table), MessageType::SCRIPT_CALL);
+      std::move(payload), std::move(tensor_table), BuiltinMessageType::SCRIPT_CALL);
 }
 
 std::unique_ptr<ScriptCall> ScriptCall::fromMessage(const Message& message) {

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -63,7 +63,7 @@ c10::intrusive_ptr<Message> ScriptRemoteCall::toMessageImpl() && {
   return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensor_table),
-      MessageType::SCRIPT_REMOTE_CALL);
+      BuiltinMessageType::SCRIPT_REMOTE_CALL);
 }
 
 std::unique_ptr<ScriptRemoteCall> ScriptRemoteCall::fromMessage(

--- a/torch/csrc/distributed/rpc/script_resp.cpp
+++ b/torch/csrc/distributed/rpc/script_resp.cpp
@@ -26,7 +26,7 @@ c10::intrusive_ptr<Message> ScriptResp::toMessageImpl() && {
   std::vector<torch::Tensor> tensor_table;
   auto payload = jit::pickle(value_, &tensor_table);
   return c10::make_intrusive<Message>(
-      std::move(payload), std::move(tensor_table), MessageType::SCRIPT_RET);
+      std::move(payload), std::move(tensor_table), BuiltinMessageType::SCRIPT_RET);
 }
 
 std::unique_ptr<ScriptResp> ScriptResp::fromMessage(const Message& message) {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -921,7 +921,7 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
               // Remove entry from timeoutMap_.
               removeFromTimeoutMap(messageId);
 
-              if (responseMessage->type() == MessageType::EXCEPTION) {
+              if (responseMessage->type() == BuiltinMessageType::EXCEPTION) {
                 markFutureWithError(
                     std::move(futureResponseMessage),
                     std::string(

--- a/torch/csrc/distributed/rpc/testing/faulty_tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/testing/faulty_tensorpipe_agent.cpp
@@ -129,17 +129,17 @@ MessageType FaultyTensorPipeAgent::messageStringToType(
     const std::string& messageString) const {
   // Lazily constructed map that returns string to message type mapping
   static std::unordered_map<std::string, MessageType> msgMap = {
-      {"RREF_FORK_REQUEST", MessageType::RREF_FORK_REQUEST},
-      {"RREF_CHILD_ACCEPT", MessageType::RREF_CHILD_ACCEPT},
-      {"RREF_USER_DELETE", MessageType::RREF_USER_DELETE},
+      {"RREF_FORK_REQUEST", BuiltinMessageType::RREF_FORK_REQUEST},
+      {"RREF_CHILD_ACCEPT", BuiltinMessageType::RREF_CHILD_ACCEPT},
+      {"RREF_USER_DELETE", BuiltinMessageType::RREF_USER_DELETE},
       {"CLEANUP_AUTOGRAD_CONTEXT_REQ",
-       MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ},
-      {"PYTHON_REMOTE_CALL", MessageType::PYTHON_REMOTE_CALL},
-      {"SCRIPT_REMOTE_CALL", MessageType::SCRIPT_REMOTE_CALL},
-      {"PYTHON_CALL", MessageType::PYTHON_CALL},
-      {"SCRIPT_CALL", MessageType::SCRIPT_CALL},
-      {"PYTHON_RREF_FETCH_CALL", MessageType::PYTHON_RREF_FETCH_CALL},
-      {"SCRIPT_RREF_FETCH_CALL", MessageType::SCRIPT_RREF_FETCH_CALL}};
+       BuiltinMessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ},
+      {"PYTHON_REMOTE_CALL", BuiltinMessageType::PYTHON_REMOTE_CALL},
+      {"SCRIPT_REMOTE_CALL", BuiltinMessageType::SCRIPT_REMOTE_CALL},
+      {"PYTHON_CALL", BuiltinMessageType::PYTHON_CALL},
+      {"SCRIPT_CALL", BuiltinMessageType::SCRIPT_CALL},
+      {"PYTHON_RREF_FETCH_CALL", BuiltinMessageType::PYTHON_RREF_FETCH_CALL},
+      {"SCRIPT_RREF_FETCH_CALL", BuiltinMessageType::SCRIPT_RREF_FETCH_CALL}};
   const auto& it = msgMap.find(messageString);
   TORCH_CHECK(
       it != msgMap.end(),

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -98,46 +98,46 @@ std::string makeRPCError(
 
 std::unique_ptr<RpcCommandBase> deserializeRequest(const Message& request) {
   switch (request.type()) {
-    case MessageType::SCRIPT_CALL: {
+    case BuiltinMessageType::SCRIPT_CALL: {
       return ScriptCall::fromMessage(request);
     }
-    case MessageType::PYTHON_CALL: {
+    case BuiltinMessageType::PYTHON_CALL: {
       return PythonCall::fromMessage(request);
     }
-    case MessageType::SCRIPT_REMOTE_CALL: {
+    case BuiltinMessageType::SCRIPT_REMOTE_CALL: {
       return ScriptRemoteCall::fromMessage(request);
     }
-    case MessageType::PYTHON_REMOTE_CALL: {
+    case BuiltinMessageType::PYTHON_REMOTE_CALL: {
       return PythonRemoteCall::fromMessage(request);
     }
-    case MessageType::SCRIPT_RREF_FETCH_CALL: {
+    case BuiltinMessageType::SCRIPT_RREF_FETCH_CALL: {
       return ScriptRRefFetchCall::fromMessage(request);
     }
-    case MessageType::PYTHON_RREF_FETCH_CALL: {
+    case BuiltinMessageType::PYTHON_RREF_FETCH_CALL: {
       return PythonRRefFetchCall::fromMessage(request);
     }
-    case MessageType::RREF_USER_DELETE: {
+    case BuiltinMessageType::RREF_USER_DELETE: {
       return RRefUserDelete::fromMessage(request);
     }
-    case MessageType::RREF_CHILD_ACCEPT: {
+    case BuiltinMessageType::RREF_CHILD_ACCEPT: {
       return RRefChildAccept::fromMessage(request);
     }
-    case MessageType::RREF_FORK_REQUEST: {
+    case BuiltinMessageType::RREF_FORK_REQUEST: {
       return RRefForkRequest::fromMessage(request);
     }
-    case MessageType::FORWARD_AUTOGRAD_REQ: {
+    case BuiltinMessageType::FORWARD_AUTOGRAD_REQ: {
       return autograd::RpcWithAutograd::fromMessage(request);
     }
-    case MessageType::BACKWARD_AUTOGRAD_REQ: {
+    case BuiltinMessageType::BACKWARD_AUTOGRAD_REQ: {
       return autograd::PropagateGradientsReq::fromMessage(request);
     }
-    case MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ: {
+    case BuiltinMessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ: {
       return autograd::CleanupAutogradContextReq::fromMessage(request);
     }
-    case MessageType::RUN_WITH_PROFILING_REQ: {
+    case BuiltinMessageType::RUN_WITH_PROFILING_REQ: {
       return autograd::RpcWithProfilingReq::fromMessage(request);
     }
-    case MessageType::RREF_BACKWARD_REQ: {
+    case BuiltinMessageType::RREF_BACKWARD_REQ: {
       return autograd::RRefBackwardReq::fromMessage(request);
     }
     default: {
@@ -151,25 +151,25 @@ std::unique_ptr<RpcCommandBase> deserializeResponse(
     const Message& response,
     MessageType& wrappedMsgType) {
   switch (response.type()) {
-    case MessageType::SCRIPT_RET: {
+    case BuiltinMessageType::SCRIPT_RET: {
       return ScriptResp::fromMessage(response);
     }
-    case MessageType::PYTHON_RET: {
+    case BuiltinMessageType::PYTHON_RET: {
       return PythonResp::fromMessage(response);
     }
-    case MessageType::REMOTE_RET: {
+    case BuiltinMessageType::REMOTE_RET: {
       return RemoteRet::fromMessage(response);
     }
-    case MessageType::SCRIPT_RREF_FETCH_RET: {
+    case BuiltinMessageType::SCRIPT_RREF_FETCH_RET: {
       return ScriptRRefFetchRet::fromMessage(response);
     }
-    case MessageType::PYTHON_RREF_FETCH_RET: {
+    case BuiltinMessageType::PYTHON_RREF_FETCH_RET: {
       return PythonRRefFetchRet::fromMessage(response);
     }
-    case MessageType::RREF_ACK: {
+    case BuiltinMessageType::RREF_ACK: {
       return RRefAck::fromMessage(response);
     }
-    case MessageType::FORWARD_AUTOGRAD_RESP: {
+    case BuiltinMessageType::FORWARD_AUTOGRAD_RESP: {
       std::unique_ptr<RpcCommandBase> rpcPtr =
           autograd::RpcWithAutograd::fromMessage(response);
       RpcCommandBase& rpc = *rpcPtr;
@@ -193,13 +193,13 @@ std::unique_ptr<RpcCommandBase> deserializeResponse(
 
       return std::move(rpcWithAutograd).moveWrappedRpc();
     }
-    case MessageType::BACKWARD_AUTOGRAD_RESP: {
+    case BuiltinMessageType::BACKWARD_AUTOGRAD_RESP: {
       return autograd::PropagateGradientsResp::fromMessage(response);
     }
-    case MessageType::CLEANUP_AUTOGRAD_CONTEXT_RESP: {
+    case BuiltinMessageType::CLEANUP_AUTOGRAD_CONTEXT_RESP: {
       return autograd::CleanupAutogradContextResp::fromMessage(response);
     }
-    case MessageType::RUN_WITH_PROFILING_RESP: {
+    case BuiltinMessageType::RUN_WITH_PROFILING_RESP: {
       std::unique_ptr<RpcCommandBase> rpcPtr =
           autograd::RpcWithProfilingResp::fromMessage(response);
       RpcCommandBase& rpc = *rpcPtr;
@@ -212,7 +212,7 @@ std::unique_ptr<RpcCommandBase> deserializeResponse(
       auto wrappedRPC = std::move(rpcWithProfilingResp).moveWrappedRpc();
       return wrappedRPC;
     }
-    case MessageType::RREF_BACKWARD_RESP: {
+    case BuiltinMessageType::RREF_BACKWARD_RESP: {
       return autograd::RRefBackwardResp::fromMessage(response);
     }
     default: {
@@ -226,7 +226,7 @@ IValue deserializeResptoIValueInternal(
     RpcCommandBase& rpc,
     MessageType messageType) {
   switch (messageType) {
-    case MessageType::SCRIPT_RET: {
+    case BuiltinMessageType::SCRIPT_RET: {
       auto& ret = static_cast<ScriptResp&>(rpc);
       return ret.value();
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68089
* #68033

Context: to support custom messages, the `MessageType` field in RPC
Message can no longer be an enum. We plan to change that to an
`unint16_t` and allow users to register their own types.

This commit makes `MessageType` as a alias of `uint16_t`, and
rename existing `MessageType` to `BuiltinMessageType`.

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang