### PR TITLE
don't include label in ci: sev issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-sev.md
+++ b/.github/ISSUE_TEMPLATE/ci-sev.md
@@ -1,9 +1,9 @@
 ---
 name: "⚠️CI SEV"
 about: Tracking incidents for PyTorch's CI infra.
-labels: "ci: sev"
 ---
 
+> NOTE: Remember to label this issue with "`ci: sev`"
 
 ## Current Status
 *Status could be: preemptive, ongoing, mitigated, closed. Also tell people if they need to take action to fix it (i.e. rebase)*.
@@ -16,6 +16,7 @@ labels: "ci: sev"
 
 <details>
 <summary> Click for example </summary>
+
 e.g.
 - 10/30 7:27a incident began
 - 10/30 8:30a detected by <method>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68093

We don't want regular users without write access to be able to file an
actual issue with the `ci: sev` label since that issue will
automatically show up on hud.pytorch.org

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D32299553](https://our.internmc.facebook.com/intern/diff/D32299553)