### PR TITLE
[PyTorch Edge] Better error message when training attribute is not found

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -51,7 +51,10 @@ void set_train_recurse(
   if (auto slot = obj->type()->findAttributeSlot("training")) {
     obj->setSlot(*slot, on);
   } else {
-    TORCH_INTERNAL_ASSERT(false, "'training' attribute not found");
+    TORCH_INTERNAL_ASSERT(
+      false,
+      "'training' attribute not found. Did you accidentally "
+      "call .eval() before saving your model?");
   }
   for (const auto& slot : obj->slots()) {
     if (slot.isObject()) {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -52,9 +52,9 @@ void set_train_recurse(
     obj->setSlot(*slot, on);
   } else {
     TORCH_INTERNAL_ASSERT(
-      false,
-      "'training' attribute not found. Did you accidentally "
-      "call .eval() before saving your model?");
+        false,
+        "'training' attribute not found. Did you accidentally "
+        "call .eval() before saving your model?");
   }
   for (const auto& slot : obj->slots()) {
     if (slot.isObject()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68103

The error message `'training' attribute not found.` in itself isn't particularly actionable. Anyone running into this tends to be clueless regarding why they are getting this message.

For example, see [this post](https://fb.workplace.com/groups/pytorch.edge.users/posts/965868874283406/) asking for help when seeing this specific error message.

The most common reason for this error is that users call `.eval()` in the model instance before saving it. This change tries to draw attention to that oversight and allows them to proactively investigate and correct that mis-action if necessary.

This saves valuable time for our users and effort from the team tp provide support. Overall, I believe this is a Developer Experience win.

#accept2ship

Differential Revision: [D32304477](https://our.internmc.facebook.com/intern/diff/D32304477/)