### PR TITLE
Add feature: zeros_like() from a dense tensor to a sparse tensor

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1833,6 +1833,10 @@ class TestSparse(TestCase):
             result = torch.zeros_like(x, layout=torch.strided, memory_format=mem_format)
             self.assertTrue(result.layout == torch.strided)
 
+        dense_tensor = sparse_tensor.to_dense()
+        result = torch.zeros_like(dense_tensor, layout=torch.sparse_coo)
+        self.assertTrue(dense_tensor.shape, result.shape)
+
     def _assert_sparse_invars(self, t):
         # SparseTensor has the following invariants:
         # - sparse_dim + dense_dim = len(SparseTensor.shape)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1833,12 +1833,6 @@ class TestSparse(TestCase):
             result = torch.zeros_like(x, layout=torch.strided, memory_format=mem_format)
             self.assertTrue(result.layout == torch.strided)
 
-        with self.assertRaisesRegex(
-            RuntimeError, r"Could not run 'aten::empty_strided' with arguments from the 'Sparse(CPU|CUDA)' backend"
-        ):
-            dense_tensor = sparse_tensor.to_dense()
-            result = torch.zeros_like(dense_tensor, layout=torch.sparse_coo)
-
     def _assert_sparse_invars(self, t):
         # SparseTensor has the following invariants:
         # - sparse_dim + dense_dim = len(SparseTensor.shape)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1835,7 +1835,12 @@ class TestSparse(TestCase):
 
         dense_tensor = sparse_tensor.to_dense()
         result = torch.zeros_like(dense_tensor, layout=torch.sparse_coo)
-        self.assertTrue(dense_tensor.shape, result.shape)
+        self.assertEqual(dense_tensor.shape, result.shape)
+        self.assertEqual(result.layout, torch.sparse_coo)
+
+        sparse_zeros = torch.zeros(dense_tensor.shape, layout=torch.sparse_coo)
+        self.assertEqual(result._indices().shape, sparse_zeros._indices().shape)
+        self.assertEqual(result._values().shape, sparse_zeros._values().shape)
 
     def _assert_sparse_invars(self, t):
         # SparseTensor has the following invariants:


### PR DESCRIPTION
Fixes #67904.
 - Create a sparse tensor when the sparse layout is given even if the input tensor is not sparse.

cc @nikitaved @pearu @cpuhrsch @IvanYashchuk