### PR TITLE
Add missing bicubic mode in GridSampleFuncOptions

### DIFF
--- a/torch/csrc/api/include/torch/nn/options/vision.h
+++ b/torch/csrc/api/include/torch/nn/options/vision.h
@@ -17,7 +17,7 @@ namespace functional {
 /// F::grid_sample(input, grid, F::GridSampleFuncOptions().mode(torch::kBilinear).padding_mode(torch::kZeros).align_corners(true));
 /// ```
 struct TORCH_API GridSampleFuncOptions {
-  typedef c10::variant<enumtype::kBilinear, enumtype::kNearest> mode_t;
+  typedef c10::variant<enumtype::kBilinear, enumtype::kNearest, enumtype::kBicubic> mode_t;
   typedef c10::variant<enumtype::kZeros, enumtype::kBorder, enumtype::kReflection> padding_mode_t;
 
   /// interpolation mode to calculate output values. Default: Bilinear


### PR DESCRIPTION
We don't handle for this mode in
https://github.com/pytorch/pytorch/blob/3a66a1cb99d7e1c1fe7abf8f390e177b9183a436/torch/csrc/api/include/torch/nn/functional/vision.h#L67 and https://github.com/pytorch/pytorch/blob/d3bcba5f85f97ef273109924c695f33bf739e115/test/cpp/api/functional.cpp#L497-L498