### PR TITLE
`scatter_reduce`

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -173,7 +173,7 @@ TORCH_META_FUNC(scatter_add)
   scatter_meta_impl(*this, self, dim, index, src, "add");
 }
 
-TORCH_META_FUNC(scatter_reduce2)
+TORCH_META_FUNC(_scatter_reduce)
 (const Tensor& self,
  int64_t dim,
  const Tensor& index,
@@ -1283,7 +1283,7 @@ TORCH_IMPL_FUNC(scatter_add)
   }
 }
 
-TORCH_IMPL_FUNC(scatter_reduce2_structured_cpu)
+TORCH_IMPL_FUNC(_scatter_reduce_structured_cpu)
 (const Tensor& self,
  int64_t dim,
  const Tensor& index,
@@ -1304,7 +1304,7 @@ TORCH_IMPL_FUNC(scatter_reduce2_structured_cpu)
 
   out.zero_();
 
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, self.scalar_type(), "scatter_reduce2", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, self.scalar_type(), "_scatter_reduce", [&] {
     auto self_data = self.data_ptr<scalar_t>();
     auto index_data = index.data_ptr<int64_t>();
     auto out_data = out.data_ptr<scalar_t>();

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -175,7 +175,7 @@ TORCH_META_FUNC(scatter_add)
 
 TORCH_META_FUNC(scatter_reduce2)
 (const Tensor& self,
- const int64_t dim,
+ int64_t dim,
  const Tensor& index,
  const c10::string_view reduce,
  const c10::optional<int64_t> output_size) {
@@ -184,6 +184,8 @@ TORCH_META_FUNC(scatter_reduce2)
       "Expected `dim` to be in range ", -self.dim(), " to ", self.dim() - 1, " (got ", dim, ")");
 
   auto sizes = self.sizes().vec();
+
+  dim = dim < 0 ? dim + self.dim() : dim;
 
   if (output_size.has_value())
     sizes[dim] = output_size.value();

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1291,6 +1291,8 @@ TORCH_IMPL_FUNC(_scatter_reduce_structured_cpu)
  const c10::optional<int64_t> output_size,
  const Tensor& out) {
 
+  // TODO: Add documentation.
+
   TORCH_CHECK(self.dim() == index.dim(),
       "Shape mismatch between `self` (got ", self.sizes(), ") and `index` (got ", index.sizes(), ")");
   for (int64_t i = 0; i < self.dim(); i++) {
@@ -1317,6 +1319,7 @@ TORCH_IMPL_FUNC(_scatter_reduce_structured_cpu)
 
     scalar_t value;
     int64_t dim_index;
+    // TODO: We currently expect contiguous memory layout.
     for (int64_t i = 0; i < offset1; i++) {
       for (int64_t j = 0; j < self.size(dim); j++) {
         for (int64_t k = 0; k < offset2; k++) {

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1302,6 +1302,11 @@ TORCH_IMPL_FUNC(_scatter_reduce_structured_cpu)
 
   TORCH_CHECK(reduce == "sum", "`reduce` argument must be 'sum'");
 
+  // TODO: We currently expect contiguous memory layout.
+  TORCH_CHECK(self.is_contiguous(), "`self` needs to be contiguous");
+  TORCH_CHECK(index.is_contiguous(), "`index` needs to be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "`out` needs to be contiguous");
+
   dim = dim < 0 ? dim + self.dim() : dim;
 
   out.zero_();
@@ -1319,7 +1324,6 @@ TORCH_IMPL_FUNC(_scatter_reduce_structured_cpu)
 
     scalar_t value;
     int64_t dim_index;
-    // TODO: We currently expect contiguous memory layout.
     for (int64_t i = 0; i < offset1; i++) {
       for (int64_t j = 0; j < self.size(dim); j++) {
         for (int64_t k = 0; k < offset2; k++) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5850,15 +5850,15 @@
 - func: scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method
 
-- func: scatter_reduce2(Tensor self, int dim, Tensor index, str reduce, *, int? output_size=None) -> Tensor
-  structured_delegate: scatter_reduce2.out
+- func: _scatter_reduce(Tensor self, int dim, Tensor index, str reduce, *, int? output_size=None) -> Tensor
+  structured_delegate: _scatter_reduce.out
   variants: function, method
 
-- func: scatter_reduce2.out(Tensor self, int dim, Tensor index, str reduce, *, int? output_size=None, Tensor(a!) out) -> Tensor(a!)
+- func: _scatter_reduce.out(Tensor self, int dim, Tensor index, str reduce, *, int? output_size=None, Tensor(a!) out) -> Tensor(a!)
   structured: True
   variants: function
   dispatch:
-    CPU: scatter_reduce2_structured_cpu
+    CPU: _scatter_reduce_structured_cpu
 
 - func: eq_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   structured_delegate: eq.Scalar_out

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5850,6 +5850,16 @@
 - func: scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method
 
+- func: scatter_reduce2(Tensor self, int dim, Tensor index, str reduce, *, int? output_size=None) -> Tensor
+  structured_delegate: scatter_reduce2.out
+  variants: function, method
+
+- func: scatter_reduce2.out(Tensor self, int dim, Tensor index, str reduce, *, int? output_size=None, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  variants: function
+  dispatch:
+    CPU: scatter_reduce2_structured_cpu
+
 - func: eq_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   structured_delegate: eq.Scalar_out
   device_check: NoCheck   # TensorIterator

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1271,7 +1271,7 @@ class AbstractTestCases:
                 self._test_scatter_base(self, lambda t: t, 'scatter_', reduction=method)
                 self._test_scatter_base(self, lambda t: t, 'scatter_', True, reduction=method)
 
-        def test_scatter_reduce2(self):
+        def test_scatter_reduce(self):
             dtype = device = None
 
             output_size = 10
@@ -1281,7 +1281,7 @@ class AbstractTestCases:
             input = torch.randn(shape, dtype=dtype, device=device)
 
             for dim in range(len(shape)):
-                output = input.scatter_reduce2(dim, index, "sum", output_size=output_size)
+                output = input._scatter_reduce(dim, index, "sum", output_size=output_size)
 
                 output_shape = copy.copy(shape)
                 output_shape[dim] = output_size
@@ -1303,23 +1303,23 @@ class AbstractTestCases:
 
                 self.assertTrue(torch.allclose(output, expected))
 
-                torch.scatter_reduce2(input, dim, index, "sum", out=output)
+                torch._scatter_reduce(input, dim, index, "sum", out=output)
                 self.assertTrue(torch.allclose(output, expected))
 
             with self.assertRaisesRegex(RuntimeError, "Expected `dim` to be in range -3 to 2"):
-                torch.scatter_reduce2(input, 4, index, "sum")
+                torch._scatter_reduce(input, 4, index, "sum")
 
             with self.assertRaisesRegex(RuntimeError, "Shape mismatch"):
                 index2 = torch.randint(0, output_size, (10, ), dtype=torch.long, device=device)
-                torch.scatter_reduce2(input, 0, index2, "sum")
+                torch._scatter_reduce(input, 0, index2, "sum")
 
             with self.assertRaisesRegex(RuntimeError, "`reduce` argument must be 'sum'"):
-                torch.scatter_reduce2(input, 2, index, "mean")
+                torch._scatter_reduce(input, 2, index, "mean")
 
             with self.assertRaisesRegex(RuntimeError, "Expected `index` values to be in range 0 to 2"):
                 input2 = torch.randn(10, dtype=dtype, device=device)
                 index2 = torch.tensor([0, 1, 0, 1, 2, 3, 3, 4, 4, 3])
-                torch.scatter_reduce2(input2, 0, index2, "sum", output_size=2)
+                torch._scatter_reduce(input2, 0, index2, "sum", output_size=2)
 
         def test_structseq_repr(self):
             a = torch.arange(250).reshape(5, 5, 10)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1306,7 +1306,7 @@ class AbstractTestCases:
                 torch.scatter_reduce2(input, dim, index, "sum", out=output)
                 self.assertTrue(torch.allclose(output, expected))
 
-            with self.assertRaisesRegex(RuntimeError, "Expected `dim` to be in range -3 and 2"):
+            with self.assertRaisesRegex(RuntimeError, "Expected `dim` to be in range -3 to 2"):
                 torch.scatter_reduce2(input, 4, index, "sum")
 
             with self.assertRaisesRegex(RuntimeError, "Shape mismatch"):
@@ -1315,6 +1315,11 @@ class AbstractTestCases:
 
             with self.assertRaisesRegex(RuntimeError, "`reduce` argument must be 'sum'"):
                 torch.scatter_reduce2(input, 2, index, "mean")
+
+            with self.assertRaisesRegex(RuntimeError, "Expected `index` values to be in range 0 to 2"):
+                input2 = torch.randn(10, dtype=dtype, device=device)
+                index2 = torch.tensor([0, 1, 0, 1, 2, 3, 3, 4, 4, 3])
+                torch.scatter_reduce2(input2, 0, index2, "sum", output_size=2)
 
         def test_structseq_repr(self):
             a = torch.arange(250).reshape(5, 5, 10)

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -890,6 +890,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.saddmm: lambda input, mat1, mat2, beta=1, alpha=1, out=None: -1,
         torch.scatter: lambda input, dim, index, src: -1,
         torch.scatter_add: lambda input, dim, index, src: -1,
+        torch._scatter_reduce: lambda input, dim, index, reduce, output_size=None, out=None: -1,
         torch.searchsorted: lambda sorted_sequence, input, out_int32=False, right=False, out=None: -1,
         torch.segment_reduce: lambda data, reduce="max", lengths=None, indices=None, axis=0, unsafe=False: -1,
         torch.select: lambda input, dim, index: -1,


### PR DESCRIPTION
Fixes #63780

Basic functionality of a `scatter_reduce` algorithm with `reduce="sum"`:

* `scatter_reduce` is named as `scatter_reduce2` due to compiling issues
* It currently re-uses functionality from `scatter_add`
* Tests are missing: WIP

The error when the `scatter_reduce` naming is used:
```
In file included from aten/src/ATen/core/TensorBody.h:3,
                 from ../aten/src/ATen/core/Tensor.h:3,
                 from ../aten/src/ATen/DeviceGuard.h:4,
                 from ../aten/src/ATen/ATen.h:11,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Operators.h:13949:18: error: redefinition of ‘struct at::_ops::scatter_reduce’
13949 | struct TORCH_API scatter_reduce {
      |                  ^~~~~~~~~~~~~~
aten/src/ATen/Operators.h:13817:18: note: previous definition of ‘struct at::_ops::scatter_reduce’
13817 | struct TORCH_API scatter_reduce {
      |                  ^~~~~~~~~~~~~~
aten/src/ATen/Operators.h:13960:18: error: redefinition of ‘struct at::_ops::scatter_reduce_out’
13960 | struct TORCH_API scatter_reduce_out {
      |                  ^~~~~~~~~~~~~~~~~~
aten/src/ATen/Operators.h:13839:18: note: previous definition of ‘struct at::_ops::scatter_reduce_out’
13839 | struct TORCH_API scatter_reduce_out {
      |                  ^~~~~~~~~~~~~~~~~~
In file included from ../aten/src/ATen/core/Tensor.h:3,
                 from ../aten/src/ATen/DeviceGuard.h:4,
                 from ../aten/src/ATen/ATen.h:11,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/core/TensorBody.h: In member function ‘at::Tensor at::Tensor::scatter_reduce(int64_t, const at::Tensor&, c10::string_view, c10::optional<long int>) const’:
aten/src/ATen/core/TensorBody.h:3976:83: error: cannot convert ‘c10::string_view’ {aka ‘c10::basic_string_view<char>’} to ‘const at::Tensor&’
 3976 |     return at::_ops::scatter_reduce::call(const_cast<Tensor&>(*this), dim, index, reduce, output_size);
      |                                                                                   ^~~~~~
      |                                                                                   |
      |                                                                                   c10::string_view {aka c10::basic_string_view<char>}
In file included from aten/src/ATen/core/TensorBody.h:3,
                 from ../aten/src/ATen/core/Tensor.h:3,
                 from ../aten/src/ATen/DeviceGuard.h:4,
                 from ../aten/src/ATen/ATen.h:11,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Operators.h:13824:109: note:   initializing argument 4 of ‘static at::Tensor at::_ops::scatter_reduce::call(const at::Tensor&, int64_t, const at::Tensor&, const at::Tensor&, c10::string_view)’
13824 |   static at::Tensor call(const at::Tensor & self, int64_t dim, const at::Tensor & index, const at::Tensor & src, c10::string_view reduce);
      |                                                                                          ~~~~~~~~~~~~~~~~~~~^~~
In file included from ../aten/src/ATen/ATen.h:15,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Functions.h: In function ‘at::Tensor at::scatter_reduce(const at::Tensor&, int64_t, const at::Tensor&, c10::string_view, c10::optional<long int>)’:
aten/src/ATen/Functions.h:7119:61: error: cannot convert ‘c10::string_view’ {aka ‘c10::basic_string_view<char>’} to ‘const at::Tensor&’
 7119 |     return at::_ops::scatter_reduce::call(self, dim, index, reduce, output_size);
      |                                                             ^~~~~~
      |                                                             |
      |                                                             c10::string_view {aka c10::basic_string_view<char>}
In file included from aten/src/ATen/core/TensorBody.h:3,
                 from ../aten/src/ATen/core/Tensor.h:3,
                 from ../aten/src/ATen/DeviceGuard.h:4,
                 from ../aten/src/ATen/ATen.h:11,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Operators.h:13824:109: note:   initializing argument 4 of ‘static at::Tensor at::_ops::scatter_reduce::call(const at::Tensor&, int64_t, const at::Tensor&, const at::Tensor&, c10::string_view)’
13824 |   static at::Tensor call(const at::Tensor & self, int64_t dim, const at::Tensor & index, const at::Tensor & src, c10::string_view reduce);
      |                                                                                          ~~~~~~~~~~~~~~~~~~~^~~
In file included from ../aten/src/ATen/ATen.h:15,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Functions.h: In function ‘at::Tensor& at::scatter_reduce_out(at::Tensor&, const at::Tensor&, int64_t, const at::Tensor&, c10::string_view, c10::optional<long int>)’:
aten/src/ATen/Functions.h:7124:65: error: cannot convert ‘c10::string_view’ {aka ‘c10::basic_string_view<char>’} to ‘const at::Tensor&’
 7124 |     return at::_ops::scatter_reduce_out::call(self, dim, index, reduce, output_size, out);
      |                                                                 ^~~~~~
      |                                                                 |
      |                                                                 c10::string_view {aka c10::basic_string_view<char>}
In file included from aten/src/ATen/core/TensorBody.h:3,
                 from ../aten/src/ATen/core/Tensor.h:3,
                 from ../aten/src/ATen/DeviceGuard.h:4,
                 from ../aten/src/ATen/ATen.h:11,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Operators.h:13846:111: note:   initializing argument 4 of ‘static at::Tensor& at::_ops::scatter_reduce_out::call(const at::Tensor&, int64_t, const at::Tensor&, const at::Tensor&, c10::string_view, at::Tensor&)’
13846 |   static at::Tensor & call(const at::Tensor & self, int64_t dim, const at::Tensor & index, const at::Tensor & src, c10::string_view reduce, at::Tensor & out);
      |                                                                                            ~~~~~~~~~~~~~~~~~~~^~~
In file included from ../aten/src/ATen/ATen.h:15,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Functions.h: In function ‘at::Tensor& at::scatter_reduce_outf(const at::Tensor&, int64_t, const at::Tensor&, c10::string_view, c10::optional<long int>, at::Tensor&)’:
aten/src/ATen/Functions.h:7129:65: error: cannot convert ‘c10::string_view’ {aka ‘c10::basic_string_view<char>’} to ‘const at::Tensor&’
 7129 |     return at::_ops::scatter_reduce_out::call(self, dim, index, reduce, output_size, out);
      |                                                                 ^~~~~~
      |                                                                 |
      |                                                                 c10::string_view {aka c10::basic_string_view<char>}
In file included from aten/src/ATen/core/TensorBody.h:3,
                 from ../aten/src/ATen/core/Tensor.h:3,
                 from ../aten/src/ATen/DeviceGuard.h:4,
                 from ../aten/src/ATen/ATen.h:11,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/Operators.h:13846:111: note:   initializing argument 4 of ‘static at::Tensor& at::_ops::scatter_reduce_out::call(const at::Tensor&, int64_t, const at::Tensor&, const at::Tensor&, c10::string_view, at::Tensor&)’
13846 |   static at::Tensor & call(const at::Tensor & self, int64_t dim, const at::Tensor & index, const at::Tensor & src, c10::string_view reduce, at::Tensor & out);
      |                                                                                            ~~~~~~~~~~~~~~~~~~~^~~
In file included from aten/src/ATen/NativeFunctions.h:6,
                 from ../aten/src/ATen/TensorIndexing.h:12,
                 from ../aten/src/ATen/ATen.h:20,
                 from aten/src/ATen/native/cpu/CopyKernel.cpp.DEFAULT.cpp:1:
aten/src/ATen/NativeMetaFunctions.h: At global scope:
aten/src/ATen/NativeMetaFunctions.h:496:18: error: redefinition of ‘struct at::meta::structured_scatter_reduce’
  496 | struct TORCH_API structured_scatter_reduce : public at::impl::MetaBase {
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~
aten/src/ATen/NativeMetaFunctions.h:481:18: note: previous definition of ‘struct at::meta::structured_scatter_reduce’
  481 | struct TORCH_API structured_scatter_reduce : public at::impl::MetaBase {
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```