### PR TITLE
[fx-acc] add optimize_noop graph opt

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -195,6 +195,7 @@ def unsqueeze(*, input, dim):
 
 
 @register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_method", "tile"))
 @register_acc_op_mapping(op_and_target=("call_function", torch.tile))
 @register_acc_op
 def tile(*, input, dims):


### PR DESCRIPTION
Summary:
Ports EliminateNoop to FX

Adds optimization for a few more ops and cases than the glow version
* `acc_ops.dequantize`
* `acc_ops.flatten`
* `acc_ops.(max|min)_full_reduce`
* `acc_ops.permute`
* `acc_ops.reshape`
* `acc_ops.squeeze`
* `acc_ops.to_dtype`

Already covered by either constant fold or custom mapper
* acc_ops.slice_tensor
* acc_ops.getitem

Bug fix
* If `-1` is used in reshape's `shape` argument, we would convert this inferred value to actual positive value but needed to use integer division, otherwise we get a float in the shape tuple. Existing unit tests didn't cover this because `unittest.TestCase.assertEqual(1, 1.0)` doesn't check types and returns `True`.

Test Plan:
# Graph Opt
`buck test mode/opt glow/fb/fx/graph_opts:test_fx_graph_opts -- TestEliminateNoOp`
```
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 95c17eb9-cd4d-463a-96c8-358ca3679d56
Trace available for this run at /tmp/tpx-20211105-144929.801413/trace.log
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/5629499609900775
    ✓ ListingSuccess: glow/fb/fx/graph_opts:test_fx_graph_opts - main (4.873)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_01_noop_dequantize (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.032)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_02_flatten (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.048)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_12_tile (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.081)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_15_to_dtype (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.022)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_20_cat (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.126)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_18_max_pool2d (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.183)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_08_reshape (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.034)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_16_avg_pool2d (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.183)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_10_squeeze (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.048)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_06_min_full_reduce (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.038)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_09_noop_reshape (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.055)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_00_identity (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.025)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_04_max_full_reduce (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.037)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_21_noop_cat (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.037)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_03_noop_flatten (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.040)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_19_noop_max_pool2d (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.135)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_11_noop_squeeze (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.036)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_14_to_dtype (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.024)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_17_noop_avg_pool2d (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.114)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_13_noop_tile (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.031)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_05_noop_max_full_reduce (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.026)
    ✓ Pass: glow/fb/fx/graph_opts:test_fx_graph_opts - test_eliminate_noop_07_noop_min_full_reduce (glow.fb.fx.graph_opts.tests.test_fx_graph_opts.TestEliminateNoOp) (0.030)
Summary
  Pass: 22
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/5629499609900775
```

# Shape Inference
`buck test mode/opt //glow/fb/fx/acc_tracer:test_acc_shape_inference`
```
Summary
  Pass: 99
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/4503599703156114
```

Reviewed By: jfix71

Differential Revision: D32081046

