### PR TITLE
[SR] Fix aten::split schema

### DIFF
--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -541,23 +541,20 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       };
     });
 
-REGISTER_NATIVE_OPERATOR_FUNCTOR(
-    aten::split,
-    aten_split,
-    [](Node* n) -> SROperator {
-      if (!n->matches(torch::schema(
-              "aten::split(Tensor self, int split_size, int dim=0) -> Tensor[]"))) {
-        LogAndDumpSchema(n);
-        return nullptr;
-      }
+REGISTER_NATIVE_OPERATOR_FUNCTOR(aten::split, aten_split, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::split(Tensor(a -> *) self, int split_size, int dim=0) -> Tensor(a)[]"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
 
-      return [](ProcessedNode* p_node) {
-        const auto& self = p_node->Input(0).toTensor();
-        const auto split_size = p_node->Input(1).toInt();
-        const auto dim = p_node->Input(2).toInt();
-        p_node->Output(0) = at::native::split(self, split_size, dim);
-      };
-    });
+  return [](ProcessedNode* p_node) {
+    const auto& self = p_node->Input(0).toTensor();
+    const auto split_size = p_node->Input(1).toInt();
+    const auto dim = p_node->Input(2).toInt();
+    p_node->Output(0) = at::native::split(self, split_size, dim);
+  };
+});
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Update the schema to reflect the changes in  D31935573 (https://github.com/pytorch/pytorch/commit/6b44e75f6bccca7acc8ec31a635f1175c265ac54).

Test Plan:
`buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Confirmed native implementation is used.

Differential Revision: D32326865

