### PR TITLE
[predictor][trt] Expose more CUDA/CuDNN info to at::Context and BC stage 1

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -67,6 +67,12 @@ class TORCH_API Context {
   static long versionCUDART() {
     return detail::getCUDAHooks().versionCUDART();
   }
+  static bool hasCuDNN() {
+    return detail::getCUDAHooks().hasCuDNN();
+  }
+  static long versionCuDNN() {
+    return detail::getCUDAHooks().versionCuDNN();
+  }
   static bool hasHIP() {
     return detail::getHIPHooks().hasHIP();
   }


### PR DESCRIPTION
Summary: Expose more CUDA/CuDNN info to at::Context

Test Plan: CI; lint;

Differential Revision: D32264935

