### PR TITLE
Add reporting for flaky tests in CI

### DIFF
--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -26,7 +26,6 @@ class TestAsync(JitTestCase):
         fut = torch.jit.fork(foo, x)
         y_hat = foo(x)
         y = torch.jit.wait(fut)
-
         # assert nothing; only to make sure the fake python path works
 
     def test_async_future_type_python(self):

--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -27,7 +27,6 @@ class TestAsync(JitTestCase):
         y_hat = foo(x)
         y = torch.jit.wait(fut)
 
-        self.assertTrue(False)
         # assert nothing; only to make sure the fake python path works
 
     def test_async_future_type_python(self):
@@ -41,9 +40,6 @@ class TestAsync(JitTestCase):
             return all_outputs
 
         # assert nothing, just to make sure python type parsing works
-        import random
-        if random.randint(0, 4) < 2:
-            self.assertTrue(False)
         foo(torch.randn(3, 4))
 
     def test_async_parsing(self):
@@ -116,11 +112,7 @@ class TestAsync(JitTestCase):
         with torch.jit.optimized_execution(False):
             y, y_hat = m.forward(x1, x2)
 
-        import random
-        if random.randint(0, 4) < 2:
-            self.assertEqual(y, y_hat)
-        else:
-            self.assertTrue(False)
+        self.assertEqual(y, y_hat)
 
     def test_async_script_nested(self):
         @torch.jit.script

--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -26,6 +26,8 @@ class TestAsync(JitTestCase):
         fut = torch.jit.fork(foo, x)
         y_hat = foo(x)
         y = torch.jit.wait(fut)
+
+        self.assertTrue(False)
         # assert nothing; only to make sure the fake python path works
 
     def test_async_future_type_python(self):
@@ -39,6 +41,9 @@ class TestAsync(JitTestCase):
             return all_outputs
 
         # assert nothing, just to make sure python type parsing works
+        import random
+        if random.randint(0, 4) < 2:
+            self.assertTrue(False)
         foo(torch.randn(3, 4))
 
     def test_async_parsing(self):
@@ -111,7 +116,11 @@ class TestAsync(JitTestCase):
         with torch.jit.optimized_execution(False):
             y, y_hat = m.forward(x1, x2)
 
-        self.assertEqual(y, y_hat)
+        import random
+        if random.randint(0, 4) < 2:
+            self.assertEqual(y, y_hat)
+        else:
+            self.assertTrue(False)
 
     def test_async_script_nested(self):
         @torch.jit.script

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -1058,7 +1058,6 @@ if __name__ == '__main__':
     reports_by_file, duplicated_tests_by_file = parse_reports(args.folder)
     assemble_flaky_test_stats(duplicated_tests_by_file)
 
-    sys.exit(0)
     upload_failures_to_rds(reports_by_file)
     if reports_has_no_tests(reports_by_file):
         print(f"No tests in reports found in {args.folder}")

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -642,7 +642,9 @@ class TestSuite:
         test_count = len(sorted_tests)
         print(f"class {self.name}:")
         print(
-            f"    tests: {test_count} failed: {self.failed_count} skipped: {self.skipped_count} errored: {self.errored_count} unexpected_success: {self.unexpected_success_count} expected_failure: {self.expected_failure_count}")
+            f"    tests: {test_count} failed: {self.failed_count} skipped: {self.skipped_count} "
+            f"errored: {self.errored_count} unexpected_success: {self.unexpected_success_count} "
+            f"expected_failure: {self.expected_failure_count}")
         print(f"    run_time: {self.total_time:.2f} seconds")
         print(f"    avg_time: {self.total_time/test_count:.2f} seconds")
         if test_count >= 2:
@@ -714,7 +716,7 @@ def get_recursive_files(folder: str, extension: str) -> Iterable[str]:
 
 def parse_reports(folder: str) -> Tuple[Dict[str, TestFile], Dict[str, DuplicatedDict]]:
     tests_by_file = dict()
-    duplicated_tests_by_file = dict()
+    duplicated_tests_by_file : Dict[str, DuplicatedDict] = dict()
     for report in get_recursive_files(folder, ".xml"):
         report_path = Path(report)
         # basename of the directory of test-report is the test filename

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -570,10 +570,32 @@ class TestCase:
         self.class_name = str(dom.attributes['classname'].value)
         self.name = str(dom.attributes['name'].value)
         self.time = float(dom.attributes['time'].value)
-        self.errored = len(dom.getElementsByTagName('error')) > 0
+        error_elements = dom.getElementsByTagName('error')
+        # DISCLAIMER: unexpected successes and expected failures are currently not reported in assemble_s3_object
+        self.expected_failure = False
+        self.skipped = False
+        self.errored = False
+        self.unexpected_success = False
+        if len(error_elements) > 0:
+            # We are only expecting 1 element here
+            error_element = error_elements[0]
+            self.unexpected_success = error_element.attributes['type'].value == 'UnexpectedSuccess'
+            self.errored = not self.unexpected_success
+        skipped_elements = dom.getElementsByTagName('skipped')
+        if len(skipped_elements) > 0:
+            # We are only expecting 1 element here
+            skipped_element = skipped_elements[0]
+            self.expected_failure = skipped_element.attributes['type'].value == 'XFAIL'
+            self.skipped = not self.expected_failure
         self.failed = len(dom.getElementsByTagName('failure')) > 0
-        self.skipped = len(dom.getElementsByTagName('skipped')) > 0
 
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __str__(self) -> str:
+        return f'[TestCase name: {self.name} | class_name: {self.class_name} | time: {self.time} | ' \
+            f'expected_failure: {self.expected_failure} | skipped: {self.skipped} | errored: {self.errored} | ' \
+            f'unexpected_success: {self.unexpected_success} | failed: {self.failed}]'
 
 class TestSuite:
     def __init__(self, name: str) -> None:
@@ -583,6 +605,9 @@ class TestSuite:
         self.skipped_count = 0
         self.errored_count = 0
         self.total_time = 0.0
+        # The below are currently not included in test reports
+        self.unexpected_success_count = 0
+        self.expected_failure_count = 0
 
     def __repr__(self) -> str:
         rc = f'{self.name} run_time: {self.total_time:.2f} tests: {len(self.test_cases)}'
@@ -596,21 +621,26 @@ class TestSuite:
         self.failed_count += 1 if test_case.failed else 0
         self.skipped_count += 1 if test_case.skipped else 0
         self.errored_count += 1 if test_case.errored else 0
+        self.unexpected_success_count += 1 if test_case.unexpected_success else 0
+        self.expected_failure_count += 1 if test_case.expected_failure else 0
 
     def update(self, test_case: TestCase) -> None:
         name = test_case.name
         assert name in self.test_cases, f'Error: attempting to replace nonexistent test case {name}'
+        # Note that time for unexpected successes and expected failures are reported as 0s
         self.test_cases[name].time += test_case.time
         self.test_cases[name].failed |= test_case.failed
         self.test_cases[name].errored |= test_case.errored
         self.test_cases[name].skipped |= test_case.skipped
+        self.test_cases[name].unexpected_success |= test_case.unexpected_success
+        self.test_cases[name].expected_failure |= test_case.expected_failure
 
     def print_report(self, num_longest: int = 3) -> None:
         sorted_tests = sorted(self.test_cases.values(), key=lambda x: x.time)
         test_count = len(sorted_tests)
         print(f"class {self.name}:")
         print(
-            f"    tests: {test_count} failed: {self.failed_count} skipped: {self.skipped_count} errored: {self.errored_count}")
+            f"    tests: {test_count} failed: {self.failed_count} skipped: {self.skipped_count} errored: {self.errored_count} unexpected_success: {self.unexpected_success_count} expected_failure: {self.expected_failure_count}")
         print(f"    run_time: {self.total_time:.2f} seconds")
         print(f"    avg_time: {self.total_time/test_count:.2f} seconds")
         if test_count >= 2:
@@ -621,6 +651,7 @@ class TestSuite:
             print(f"        {test.name} time: {test.time:.2f} seconds")
         print("")
 
+DuplicatedDict = Dict[str, Dict[str, List[TestCase]]]
 
 class TestFile:
     def __init__(self, name: str) -> None:
@@ -628,7 +659,7 @@ class TestFile:
         self.total_time = 0.0
         self.test_suites: Dict[str, TestSuite] = dict()
 
-    def append(self, test_case: TestCase, test_type: str) -> None:
+    def append(self, test_case: TestCase, test_type: str, duplicated_tests_dict: DuplicatedDict) -> None:
         is_multi_test = self.name == 'test_cpp_extensions_aot' or \
             self.name == 'distributed/test_distributed_spawn' or \
             self.name == 'distributed/test_c10d_gloo' or \
@@ -644,8 +675,12 @@ class TestFile:
                 self.test_suites[suite_name].update(test_case)
                 self.total_time += test_case.time
             else:
-                raise RuntimeWarning(
-                    f'Duplicate test case {test_case.name} in suite {suite_name} called from {self.name}')
+                # Gather up duplicated test cases
+                if suite_name not in duplicated_tests_dict:
+                    duplicated_tests_dict[suite_name] = dict()
+                if test_case.name not in duplicated_tests_dict[suite_name]:
+                    duplicated_tests_dict[suite_name][test_case.name] = [self.test_suites[suite_name].test_cases[test_case.name]]
+                duplicated_tests_dict[suite_name][test_case.name].append(test_case)
         else:
             self.test_suites[suite_name].append(test_case)
             self.total_time += test_case.time
@@ -675,8 +710,9 @@ def get_recursive_files(folder: str, extension: str) -> Iterable[str]:
                 yield os.path.join(root, fname)
 
 
-def parse_reports(folder: str) -> Dict[str, TestFile]:
+def parse_reports(folder: str) -> Tuple[Dict[str, TestFile], Dict[str, DuplicatedDict]]:
     tests_by_file = dict()
+    duplicated_tests_by_file = dict()
     for report in get_recursive_files(folder, ".xml"):
         report_path = Path(report)
         # basename of the directory of test-report is the test filename
@@ -684,11 +720,69 @@ def parse_reports(folder: str) -> Dict[str, TestFile]:
         # test type is the parent directory (only applies to dist-*)
         # See: CUSTOM_HANDLERS in test/run_test.py
         test_type = report_path.parent.parent.name
+        if test_filename not in duplicated_tests_by_file:
+            duplicated_tests_by_file[test_filename] = dict()
         if test_filename not in tests_by_file:
             tests_by_file[test_filename] = TestFile(test_filename)
         for test_case in parse_report(report):
-            tests_by_file[test_filename].append(test_case, test_type)
-    return tests_by_file
+            tests_by_file[test_filename].append(test_case, test_type, duplicated_tests_by_file[test_filename])
+    return tests_by_file, duplicated_tests_by_file
+
+
+def process_intentional_test_runs(runs: List[TestCase]) -> Tuple[int, int]:
+    num_fail = 0
+    num_expected_fail = 0
+    num_pass = 0
+    num_unexpected_success = 0
+    num_errored = 0
+    num_skipped = 0
+    for test_run in runs:
+        if test_run.failed:
+            num_fail += 1
+        elif test_run.expected_failure:
+            num_expected_fail += 1
+        elif test_run.unexpected_success:
+            num_unexpected_success += 1
+        elif test_run.errored:
+            num_errored += 1
+        elif test_run.skipped:
+            num_skipped += 1
+        else:
+            num_pass += 1
+    # err_msg = f'Warning: unintentional test case duplicates found for {test_run.name} in suite  {test_run.class_name}.'
+    # THE BELOW ARE ONLY APPLICABLE WHEN REPORT_ONLY IS TRUE
+    # if num_fail + num_errored + num_unexpected_success < 1:
+    #     raise RuntimeWarning(f'{err_msg} Intentional reruns are only triggered when the first run fails or errors, but'
+    #                          ' we found no failures nor errors.')
+    # if num_unexpected_success + num_expected_fail < 1:
+    #     raise RuntimeWarning(f'{err_msg} Intentional reruns should raise at least one unexpected success or expected '
+    #                          'failure, but none have been found.')
+    # if num_pass != num_unexpected_success:
+    #     raise RuntimeWarning(f'{err_msg} Every success in an intentional rerun is shadowed by one unexpected success.'
+    #                          f'However, successes = {num_pass} and unexpected successes = {num_unexpected_success}')
+    # if num_skipped > 0:
+    #     raise RuntimeWarning(f'{err_msg} No skips should occur in intentional reruns, but skips = {num_skipped}')
+    return max(num_unexpected_success, num_pass), num_fail + num_expected_fail + num_errored
+
+
+def assemble_flaky_test_stats(duplicated_tests_by_file: Dict[str, DuplicatedDict]) -> Any:
+    flaky_tests = []
+    for file_name, suite_to_dict in duplicated_tests_by_file.items():
+        for suite_name, testcase_to_runs in suite_to_dict.items():
+            for testcase_name, list_of_runs in testcase_to_runs.items():
+                num_green, num_red = process_intentional_test_runs(list_of_runs)
+                if num_green > 0:   # Otherwise, it's likely just a failing test
+                    flaky_tests.append({
+                        "name": testcase_name,
+                        "suite": suite_name,
+                        "file": file_name,
+                        "num_green": num_green,
+                        "num_red": num_red
+                    })
+    print(flaky_tests)
+    if len(flaky_tests) > 0:
+        register_rds_schema("flaky_tests", schema_from_sample(flaky_tests[0]))
+        rds_write("flaky_tests", flaky_tests, only_on_master=False)
 
 
 def build_info() -> ReportMetaMeta:
@@ -957,8 +1051,10 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    reports_by_file = parse_reports(args.folder)
+    reports_by_file, duplicated_tests_by_file = parse_reports(args.folder)
+    assemble_flaky_test_stats(duplicated_tests_by_file)
 
+    sys.exit(0)
     upload_failures_to_rds(reports_by_file)
     if reports_has_no_tests(reports_by_file):
         print(f"No tests in reports found in {args.folder}")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1097,7 +1097,7 @@ def get_function_arglist(func):
 
 def set_rng_seed(seed):
     torch.manual_seed(seed)
-    # random.seed(seed)
+    random.seed(seed)
     if TEST_NUMPY:
         np.random.seed(seed)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1454,12 +1454,12 @@ class TestCase(expecttest.TestCase):
         return self.wrap_method_with_policy(method, self.assertLeaksNoCudaTensors)
 
     # Recursive function that incorporates retry logic when PYTORCH_RETRY_TEST_CASES=1 and adds early test termination
-    def _run(self, result=None, num_runs_left=0):
+    def _run_with_retry(self, result=None, num_runs_left=0):
         if num_runs_left == 0:
             return
 
-        failures_before = 0 if result == None else len(result.failures)  # num tests marked as failed before starting
-        errors_before = 0 if result == None else len(result.errors)  # num tests marked as errored before starting
+        failures_before = 0 if result is None else len(result.failures)  # num tests marked as failed before starting
+        errors_before = 0 if result is None else len(result.errors)  # num tests marked as errored before starting
 
         super().run(result=result)
         # Early terminate test if necessary.
@@ -1476,17 +1476,17 @@ class TestCase(expecttest.TestCase):
             if num_retries_left > 0:
                 result.failures.pop(-1)
                 result.addExpectedFailure(self, err)
-                self._run(result=result, num_runs_left=num_retries_left)
+                self._run_with_retry(result=result, num_runs_left=num_retries_left)
         elif errors_before < len(result.errors):
             print(f" {self._testMethodName} errored - num_retries_left: {num_retries_left}")
             if num_retries_left > 0:
                 result.errors.pop(-1)
                 result.addExpectedFailure(self, err)
-                self._run(result=result, num_runs_left=num_retries_left)
+                self._run_with_retry(result=result, num_runs_left=num_retries_left)
 
     def run(self, result=None):
         num_runs = MAX_NUM_RETRIES + 1 if RETRY_TEST_CASES else 1
-        self._run(result=result, num_runs_left=num_runs)
+        self._run_with_retry(result=result, num_runs_left=num_runs)
 
     def setUp(self):
         check_if_enable(self)


### PR DESCRIPTION
This PR does NOT change how signal is displayed in CI but rather just reports stats of flaky tests to RDS. **None of the below will be enabled after landing this PR--it will be done in a separate PR with environment variables.**

We report flaky tests stats when a test first fails, and when we rerun it MAX_NUM_RETRIES times, we get at least one success. 
For tests that fail all the reruns, we assume it is because it is a real test failure.
For tests that succeed the first time, we do not rerun the test, even if it was previously noted as flaky.

## Test plan:
First, I modified:
test_async_python to always fail (will be our "failing test")
test_async_future_type_python to fail 40% of the time
test_async_script_capture to fail 60% of the time 

Then, running `python test/test_jit.py -v -k test_async` while setting IN_CI to 1:
```
(pytorch) janeyx@janeyx-mbp pytorch % python test/test_jit.py -v -k test_async                                         
...

Running tests...
----------------------------------------------------------------------
  test_async_future_type_python (jit.test_async.TestAsync) ... ok (0.004s)
  test_async_grad_guard_no_grad (jit.test_async.TestAsync) ... ok (0.020s)
  test_async_grad_guard_with_grad (jit.test_async.TestAsync) ... ok (0.008s)
  test_async_kwargs (jit.test_async.TestAsync) ... ok (0.045s)
  test_async_parsing (jit.test_async.TestAsync) ... ok (0.010s)
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 3
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 2
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 1
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 0
  test_async_script (jit.test_async.TestAsync) ... ok (0.008s)
  test_async_script_capture (jit.test_async.TestAsync) ... FAIL (0.010s)
    test_async_script_capture failed - num_retries_left: 3
  test_async_script_capture (jit.test_async.TestAsync) ... FAIL (0.010s)
    test_async_script_capture failed - num_retries_left: 2
  test_async_script_capture (jit.test_async.TestAsync) ... ok (0.011s)
    test_async_script_capture succeeded - num_retries_left: 1
  test_async_script_capture (jit.test_async.TestAsync) ... FAIL (0.010s)
    test_async_script_capture failed - num_retries_left: 0
  test_async_script_error (jit.test_async.TestAsync) ... ok (0.040s)
  test_async_script_multi_forks (jit.test_async.TestAsync) ... ok (0.025s)
  test_async_script_multi_waits (jit.test_async.TestAsync) ... ok (0.009s)
...

======================================================================
FAIL [0.003s]: test_async_python (jit.test_async.TestAsync)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/janeyx/pytorch/test/jit/test_async.py", line 30, in test_async_python
    self.assertTrue(False)
AssertionError: False is not true

======================================================================
FAIL [0.010s]: test_async_script_capture (jit.test_async.TestAsync)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/janeyx/pytorch/test/jit/test_async.py", line 123, in test_async_script_capture
    self.assertTrue(False)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 28 tests in 0.399s

FAILED (failures=2, expected failures=5, unexpected successes=1)
```
Yielding this as the test report (I changed the extension from xml to txt so it uploads here): 
[TEST-jit.test_async.TestAsync-20211110222055.txt](https://github.com/pytorch/pytorch/files/7517532/TEST-jit.test_async.TestAsync-20211110222055.txt)

And then running print_test_stats correctly excludes the all failing test `test_async_python` and calculates red and green appropriately: 
```
(pytorch) janeyx@janeyx-mbp pytorch % python tools/stats/print_test_stats.py test-reports/python-unittest/test.test_jit
[scribe] Not invoking RDS lambda outside GitHub Actions:
[{'create_table': {'table_name': 'flaky_tests', 'fields': {'name': 'string', 'suite': 'string', 'file': 'string', 'num_green': 'int', 'num_red': 'int', 'pr': 'string', 'ref': 'string', 'branch': 'string', 'workflow_id': 'string', 'build_environment': 'string'}}}]
[scribe] Writing for None
[scribe] Wrote stats for flaky_tests
[scribe] Not invoking RDS lambda outside GitHub Actions:
[{'write': {'table_name': 'flaky_tests', 'values': {'name': 'test_async_script_capture', 'suite': 'jit.test_async.TestAsync', 'file': 'test/test_jit', 'num_green': 1, 'num_red': 3, 'pr': None, 'ref': None, 'branch': None, 'workflow_id': None, 'build_environment': 'linux-xenial-gcc5.4-py3'}}}]
(pytorch) janeyx@janeyx-mbp pytorch % 
```

-------------------
If you're curious, I also included the code for when we would like to override the report_only feature and also hide flaky signal in CI. The results for the same test command correctly still fail the test suite, but mark the flaky test_async_future_type_python as passed:
```
(pytorch) janeyx@janeyx-mbp pytorch % python test/test_jit.py -v -k test_async
...

Running tests...
----------------------------------------------------------------------
  test_async_future_type_python (jit.test_async.TestAsync) ... FAIL (0.004s)
    test_async_future_type_python failed - num_retries_left: 3
  test_async_future_type_python (jit.test_async.TestAsync) ... ok (0.001s)
  test_async_grad_guard_no_grad (jit.test_async.TestAsync) ... ok (0.017s)
  test_async_grad_guard_with_grad (jit.test_async.TestAsync) ... ok (0.008s)
  test_async_kwargs (jit.test_async.TestAsync) ... ok (0.091s)
  test_async_parsing (jit.test_async.TestAsync) ... ok (0.010s)
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 3
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 2
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.004s)
    test_async_python failed - num_retries_left: 1
  test_async_python (jit.test_async.TestAsync) ... FAIL (0.003s)
    test_async_python failed - num_retries_left: 0
  test_async_script (jit.test_async.TestAsync) ... ok (0.008s)
  test_async_script_capture (jit.test_async.TestAsync) ... ok (0.011s)
  test_async_script_error (jit.test_async.TestAsync) ... ok (0.039s)
...

======================================================================
FAIL [0.003s]: test_async_python (jit.test_async.TestAsync)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/janeyx/pytorch/test/jit/test_async.py", line 30, in test_async_python
    self.assertTrue(False)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 26 tests in 0.390s

FAILED (failures=1, expected failures=4)
```
With test reports: 
[TEST-jit.test_async.TestAsync-20211110224810.txt](https://github.com/pytorch/pytorch/files/7517663/TEST-jit.test_async.TestAsync-20211110224810.txt)
And running print_test_stats:
```
(pytorch) janeyx@janeyx-mbp pytorch % python tools/stats/print_test_stats.py test-reports/python-unittest/test.test_jit
[scribe] Not invoking RDS lambda outside GitHub Actions:
[{'create_table': {'table_name': 'flaky_tests', 'fields': {'name': 'string', 'suite': 'string', 'file': 'string', 'num_green': 'int', 'num_red': 'int', 'pr': 'string', 'ref': 'string', 'branch': 'string', 'workflow_id': 'string', 'build_environment': 'string'}}}]
[scribe] Writing for None
[scribe] Wrote stats for flaky_tests
[scribe] Not invoking RDS lambda outside GitHub Actions:
[{'write': {'table_name': 'flaky_tests', 'values': {'name': 'test_async_future_type_python', 'suite': 'jit.test_async.TestAsync', 'file': 'test/test_jit', 'num_green': 1, 'num_red': 1, 'pr': None, 'ref': None, 'branch': None, 'workflow_id': None, 'build_environment': 'linux-xenial-gcc5.4-py3'}}}]
```