### PR TITLE
Remove logical_element_type from LazyTensor

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -516,14 +516,6 @@ torch::lazy::Value LazyGraphExecutor::GetIrValueForScalar(
                              device);
 }
 
-torch::lazy::Value LazyGraphExecutor::GetIrValueForScalar(
-    const at::Scalar& value, const torch::lazy::Shape& shape,
-    c10::optional<at::ScalarType> logical_element_type, const torch::lazy::BackendDevice& device) {
-  c10::ScalarType type =
-      logical_element_type ? *logical_element_type : shape.scalar_type();
-  return GetIrValueForScalar(value, type, shape.sizes(), device);
-}
-
 LazyGraphExecutor::Async::Async(SyncTensorCollection* coll,
                                 std::vector<compiler::BackendDataPtr> parameters_data,
                                 std::vector<compiler::BackendDataPtr> tensors_data,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
@@ -91,12 +91,9 @@ class LazyGraphExecutor {
                                          c10::ScalarType type,
                                          c10::ArrayRef<int64_t> dimensions,
                                          const torch::lazy::BackendDevice& device);
-  torch::lazy::Value GetIrValueForScalar(const at::Scalar& value,
-                                         const torch::lazy::Shape& shape,
-                                         const torch::lazy::BackendDevice& device);
   torch::lazy::Value GetIrValueForScalar(
       const at::Scalar& value, const torch::lazy::Shape& shape,
-      c10::optional<at::ScalarType> logical_element_type, const torch::lazy::BackendDevice& device);
+      const torch::lazy::BackendDevice& device);
 
  private:
   struct SyncTensorsConfig {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
@@ -228,9 +228,9 @@ LazyTensor IndexByTensors(const LazyTensor& base,
   LazyTensor indices_nd =
       lazy_tensor_aten_ops::stack(canonical_indices, indices_rank);
   return LazyTensor::Create(
-      torch::lazy::MakeNode<ir::ops::IndexGet>(base.GetIrValue(),
-                                      indices_nd.GetIrValue(), start_dim),
-      base.GetDevice(), base.dtype());
+      torch::lazy::MakeNode<ir::ops::IndexGet>(
+          base.GetIrValue(), indices_nd.GetIrValue(), start_dim),
+      base.GetDevice());
 }
 
 torch::lazy::Value IndexPutByTensors(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -107,7 +107,7 @@ LazyTensor DispatchComparisonOp(c10::Symbol kind, const LazyTensor& input,
   NodePtr node = ir::ops::ComparisonOp(
       kind, input.GetIrValue(),
       LazyGraphExecutor::Get()->GetIrValueForScalar(other, input.GetDevice()));
-  return LazyTensor::Create(node, input.GetDevice(), at::ScalarType::Bool);
+  return LazyTensor::Create(node, input.GetDevice());
 }
 
 }  // namespace
@@ -239,17 +239,14 @@ LazyTensor lt(const LazyTensor& input, const at::Scalar& other) {
   return DispatchComparisonOp(at::aten::lt, input, other);
 }
 
-LazyTensor mul(const LazyTensor& input, const LazyTensor& other,
-               c10::optional<at::ScalarType> logical_element_type) {
-  return input.CreateFrom(input.GetIrValue() * other.GetIrValue(),
-                          logical_element_type);
+LazyTensor mul(const LazyTensor& input, const LazyTensor& other) {
+  return input.CreateFrom(input.GetIrValue() * other.GetIrValue());
 }
 
-LazyTensor mul(const LazyTensor& input, const at::Scalar& other,
-               c10::optional<at::ScalarType> logical_element_type) {
+LazyTensor mul(const LazyTensor& input, const at::Scalar& other) {
   torch::lazy::Value constant = LazyGraphExecutor::Get()->GetIrValueForScalar(
-      other, input.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(input.GetIrValue() * constant, logical_element_type);
+      other, input.shape(), input.GetDevice());
+  return input.CreateFrom(input.GetIrValue() * constant);
 }
 
 LazyTensor narrow(const LazyTensor& input, int64_t dim, int64_t start,
@@ -333,10 +330,8 @@ std::pair<LazyTensor, LazyTensor> nms(const LazyTensor& boxes,
       boxes.GetIrValue(), scores.GetIrValue(), score_threshold.GetIrValue(),
       iou_threshold.GetIrValue(), output_size);
   return std::pair<LazyTensor, LazyTensor>(
-      LazyTensor::Create(torch::lazy::Value(node, 0), boxes.GetDevice(),
-                         at::ScalarType::Int),
-      LazyTensor::Create(torch::lazy::Value(node, 1), boxes.GetDevice(),
-                         at::ScalarType::Int));
+      LazyTensor::Create(torch::lazy::Value(node, 0), boxes.GetDevice()),
+      LazyTensor::Create(torch::lazy::Value(node, 1), boxes.GetDevice()));
 }
 
 LazyTensor permute(const LazyTensor& input, c10::ArrayRef<int64_t> dims) {
@@ -360,14 +355,12 @@ LazyTensor repeat(const LazyTensor& input, std::vector<int64_t> repeats) {
 }
 
 LazyTensor rsub(const LazyTensor& input, const at::Scalar& other,
-                const at::Scalar& alpha,
-                c10::optional<at::ScalarType> logical_element_type) {
+                const at::Scalar& alpha) {
   torch::lazy::Value alpha_ir = LazyGraphExecutor::Get()->GetIrValueForScalar(
-      alpha, input.shape(), logical_element_type, input.GetDevice());
+      alpha, input.shape(), input.GetDevice());
   torch::lazy::Value other_ir = LazyGraphExecutor::Get()->GetIrValueForScalar(
-      other, input.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(other_ir - alpha_ir * input.GetIrValue(),
-                          logical_element_type);
+      other, input.shape(), input.GetDevice());
+  return input.CreateFrom(other_ir - alpha_ir * input.GetIrValue());
 }
 
 void copy_(LazyTensor& input, LazyTensor& src) {
@@ -454,25 +447,21 @@ LazyTensor stack(c10::ArrayRef<LazyTensor> tensors, int64_t dim) {
 }
 
 LazyTensor sub(const LazyTensor& input, const LazyTensor& other,
-               const at::Scalar& alpha,
-               c10::optional<at::ScalarType> logical_element_type) {
+               const at::Scalar& alpha) {
   torch::lazy::Value constant = LazyGraphExecutor::Get()->GetIrValueForScalar(
-      alpha, other.shape(), logical_element_type, other.GetDevice());
-  return input.CreateFrom(input.GetIrValue() - other.GetIrValue() * constant,
-                          logical_element_type);
+      alpha, other.shape(), other.GetDevice());
+  return input.CreateFrom(input.GetIrValue() - other.GetIrValue() * constant);
 }
 
 LazyTensor sub(const LazyTensor& input, const at::Scalar& other,
-               const at::Scalar& alpha,
-               c10::optional<at::ScalarType> logical_element_type) {
+               const at::Scalar& alpha) {
   torch::lazy::Value other_constant =
-      LazyGraphExecutor::Get()->GetIrValueForScalar(
-          other, input.shape(), logical_element_type, input.GetDevice());
+      LazyGraphExecutor::Get()->GetIrValueForScalar(other, input.shape(),
+                                                    input.GetDevice());
   torch::lazy::Value alpha_constant =
-      LazyGraphExecutor::Get()->GetIrValueForScalar(
-          alpha, input.shape(), logical_element_type, input.GetDevice());
-  return input.CreateFrom(input.GetIrValue() - other_constant * alpha_constant,
-                          logical_element_type);
+      LazyGraphExecutor::Get()->GetIrValueForScalar(alpha, input.shape(),
+                                                    input.GetDevice());
+  return input.CreateFrom(input.GetIrValue() - other_constant * alpha_constant);
 }
 
 std::tuple<LazyTensor, LazyTensor, LazyTensor> svd(const LazyTensor& input,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -57,12 +57,8 @@ void fill_(LazyTensor& input, const at::Scalar& value);
 
 LazyTensor lt(const LazyTensor& input, const at::Scalar& other);
 
-LazyTensor mul(
-    const LazyTensor& input, const LazyTensor& other,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-LazyTensor mul(
-    const LazyTensor& input, const at::Scalar& other,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
+LazyTensor mul(const LazyTensor& input, const LazyTensor& other);
+LazyTensor mul(const LazyTensor& input, const at::Scalar& other);
 
 // Returns a new tensor that is a narrowed view of the input in the given
 // dimension.
@@ -96,9 +92,8 @@ LazyTensor pow(const LazyTensor& input, const at::Scalar& exponent);
 // repeats.
 LazyTensor repeat(const LazyTensor& input, std::vector<int64_t> repeats);
 
-LazyTensor rsub(
-    const LazyTensor& input, const at::Scalar& other, const at::Scalar& alpha,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
+LazyTensor rsub(const LazyTensor& input, const at::Scalar& other,
+                const at::Scalar& alpha);
 
 void copy_(LazyTensor& input, LazyTensor& src);
 
@@ -120,12 +115,10 @@ void squeeze_(LazyTensor& input, int64_t dim);
 
 LazyTensor stack(c10::ArrayRef<LazyTensor> tensors, int64_t dim);
 
-LazyTensor sub(
-    const LazyTensor& input, const LazyTensor& other, const at::Scalar& alpha,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
-LazyTensor sub(
-    const LazyTensor& input, const at::Scalar& other, const at::Scalar& alpha,
-    c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
+LazyTensor sub(const LazyTensor& input, const LazyTensor& other,
+               const at::Scalar& alpha);
+LazyTensor sub(const LazyTensor& input, const at::Scalar& other,
+               const at::Scalar& alpha);
 
 std::tuple<LazyTensor, LazyTensor, LazyTensor> svd(const LazyTensor& input,
                                                    bool some, bool compute_uv);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.cpp
@@ -59,8 +59,7 @@ std::pair<LazyTensor, torch::lazy::Value> all_to_all(
 LazyTensor get_dimensions_size(const LazyTensor& input,
                                std::vector<int64_t> dimensions) {
   return input.CreateFrom(torch::lazy::MakeNode<ir::ops::GetDimensionsSize>(
-                              input.GetIrValue(), std::move(dimensions)),
-                          at::ScalarType::Int);
+      input.GetIrValue(), std::move(dimensions)));
 }
 
 std::pair<LazyTensor, torch::lazy::Value> collective_permute(

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -178,12 +178,11 @@ class GenLazyNativeFuncDefinition:
 
         assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
         first_tensor = value_types[0]
-        bridge_str = f"""auto result = bridge::AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node,
-            out_dtype.front()));"""
+        bridge_str = f"""auto result = bridge::AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
         if returns_length > 1:
             bridge_str = f"""std::vector<LazyTensor> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
-            lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(torch::lazy::Value(node, i), out_dtype[i]));
+            lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(torch::lazy::Value(node, i)));
         }}
         auto result = bridge::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
         if schema.name.name.inplace:


### PR DESCRIPTION
Summary: Since dtype can be extracted from Shape, there is no need to
keep a logical_element_type field.
