### PR TITLE
BE: Use TORCH_CHECK instead of explicit c10::Error

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1226,9 +1226,7 @@ template <typename T>
 c10::ClassTypePtr getCustomClassTypeImpl() {
   auto& tmap = c10::getCustomClassTypeMap();
   auto res = tmap.find(std::type_index(typeid(T)));
-  if (res == tmap.end()) {
-    throw c10::Error("Can't find class id in custom class type map", "");
-  }
+  TORCH_CHECK(res != tmap.end(), "Can't find class id in custom class type map", "");
   return res->second;
 }
 


### PR DESCRIPTION
`if (cond) { raise c10::error("", msg)}` is identical to `TORCH_CHECK(!cond, msg);`, but with better attribution