### PR TITLE
[lint] fix up clangtidy lintrunner integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,7 @@ performance-*,
 -performance-noexcept-move-constructor,
 -performance-unnecessary-value-param,
 '
-HeaderFilterRegex: 'torch/csrc/.*'
+HeaderFilterRegex: 'torch/csrc/(?!deploy/interpreter/cpython).*'
 AnalyzeTemporaryDtors: false
 WarningsAsErrors: '*'
 CheckOptions:

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -125,12 +125,38 @@ command = [
 [[linter]]
 code = 'CLANGTIDY'
 include_patterns = [
-    '**/*.cpp',
     'torch/csrc/fx/**/*.cpp',
     'torch/csrc/utils/**/*.cpp',
     'torch/csrc/generic/**/*.cpp',
     'torch/csrc/deploy/**/*.cpp',
     'torch/csrc/tensor/**/*.cpp',
+]
+exclude_patterns = [
+    # The negative filters below are to exclude files that include onnx_pb.h or
+    # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
+    # FunctionsManual.cpp is excluded to keep this diff clean. It will be fixed
+    # in a follow up PR.
+    # /torch/csrc/generic/*.cpp is excluded because those files aren't actually built.
+    # deploy/interpreter files are excluded due to using macros and other techniquies
+    # that are not easily converted to accepted c++
+    'torch/csrc/jit/passes/onnx/helper.cpp',
+    'torch/csrc/jit/passes/onnx/shape_type_inference.cpp',
+    'torch/csrc/jit/serialization/onnx.cpp',
+    'torch/csrc/jit/serialization/export.cpp',
+    'torch/csrc/jit/serialization/import.cpp',
+    'torch/csrc/jit/serialization/import_legacy.cpp',
+    'torch/csrc/onnx/init.cpp',
+    'torch/csrc/cuda/nccl.*',
+    'torch/csrc/cuda/python_nccl.cpp',
+    'torch/csrc/autograd/FunctionsManual.cpp',
+    'torch/csrc/generic/*.cpp',
+    'torch/csrc/jit/codegen/cuda/runtime/*',
+    'torch/csrc/deploy/interactive_embedded_interpreter.cpp',
+    'torch/csrc/deploy/interpreter/**',
+    'torch/csrc/deploy/test_deploy_python_ext.cpp',
+    'torch/csrc/deploy/test_deploy_missing_interpreter.cpp',
+    'torch/csrc/deploy/test_deploy_gpu.cpp',
+    'torch/csrc/utils/disable_torch_function.cpp',
 ]
 init_command = [
     'python3',

--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -125,7 +125,7 @@ for dir in include_dir:
 def check_file(
     filename: str,
     binary: str,
-    build_dir: str,
+    build_dir: Path,
 ) -> List[LintMessage]:
     try:
         proc = run_command(
@@ -233,6 +233,8 @@ def main() -> None:
         print(json.dumps(err_msg._asdict()), flush=True)
         exit(0)
 
+    abs_build_dir = Path(args.build_dir).resolve()
+
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=os.cpu_count(),
         thread_name_prefix="Thread",
@@ -242,7 +244,7 @@ def main() -> None:
                 check_file,
                 filename,
                 args.binary,
-                args.build_dir,
+                abs_build_dir,
             ): filename
             for filename in args.filenames
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68192
* #68191

- Run on exactly the same stuff as the existing linter checks.
- Exclude deploy interpreter headers from being reported.

Differential Revision: [D32364023](https://our.internmc.facebook.com/intern/diff/D32364023)