### PR TITLE
Fix Hash(c10::Scalar), account for garbage data in union

### DIFF
--- a/test/cpp/lazy/test_misc.cpp
+++ b/test/cpp/lazy/test_misc.cpp
@@ -11,9 +11,29 @@ template <typename T>
 void test_hash_repeatable_sensitive(T example_a, T example_b) {
   // repeatable
   EXPECT_EQ(Hash(example_a), Hash(example_a));
+  EXPECT_EQ(MHash(example_a), MHash(example_a));
+  EXPECT_EQ(MHash(example_a, example_a), MHash(example_a, example_a));
 
   // sensitive
   EXPECT_NE(Hash(example_a), Hash(example_b));
+  EXPECT_NE(MHash(example_a), MHash(example_b));
+  EXPECT_NE(MHash(example_a, example_a), MHash(example_a, example_b));
+}
+
+TEST(HashTest, Scalar) {
+  c10::Scalar a(0);
+  c10::Scalar b(0);
+
+  // simulate some garbage in the unused bits of the
+  // the tagged union that is c10::Scalar, which is bigger
+  // than the size of the int64_t we're currently using it with
+  *((uint8_t*)&b)  = 1;
+  // actual 'value' of the Scalar as a 64 bit int shouldn't have changed
+  EXPECT_EQ(a.toLong(), b.toLong());
+  // and hash should ignore this garbage
+  EXPECT_EQ(Hash(a), Hash(b));
+  EXPECT_EQ(MHash(a), MHash(b));
+  EXPECT_EQ(MHash(a, a), MHash(a, b));
 }
 
 TEST(HashTest, Sanity) {

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -74,7 +74,18 @@ static inline hash_t Hash(const c10::ScalarType& value) {
 }
 
 static inline hash_t Hash(const c10::Scalar& value) {
-  return DataHash(&value, sizeof(value));
+  switch(value.type()){
+  case c10::ScalarType::ComplexDouble:
+    return Hash(value.toComplexDouble());
+  case c10::ScalarType::Double:
+    return Hash(value.toDouble());
+  case c10::ScalarType::Long:
+    return Hash(value.toLong());
+  case c10::ScalarType::Bool:
+    return Hash(value.toBool());
+  default:
+    TORCH_INTERNAL_ASSERT(false, "Unknown scalar type.");
+  }
 }
 
 static inline hash_t Hash(const std::string& value) {


### PR DESCRIPTION
Summary:
Hash(c10::Scalar) made a bad assumption that it was valid to just hash over all the bytes of data of the c10::Scalar struct.

Becuase c10::Scalar stores a union of different (float/int/complex) types with different sizes, not all bytes are valid in all cases.  Hash() should only read the bytes corresponding to the currently active type.

Test Plan: Added new unit tests.  Verified HashTest.Scalar failed with the original Hash() impl and then fixed.

Differential Revision: D32367564

