### PR TITLE
[ONNX] shapeValueMap: Represent symbolic shape as value

### DIFF
--- a/test/onnx/expect/TestOperators.test_dynamic_axes_add_inputs_same_symbolic_shape.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_add_inputs_same_symbolic_shape.expect
@@ -1,0 +1,48 @@
+ir_version: 7
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "input_1"
+    input: "input_1"
+    output: "1"
+    name: "Add_0"
+    op_type: "Add"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "input_1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "input_1_dim_1"
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_param: "input_1_dim_1"
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 12
+}

--- a/test/onnx/expect/TestOperators.test_shape_value_map.expect
+++ b/test/onnx/expect/TestOperators.test_shape_value_map.expect
@@ -1,0 +1,203 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "x"
+    output: "1"
+    name: "Shape_0"
+    op_type: "Shape"
+  }
+  node {
+    output: "2"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 7
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "1"
+    input: "2"
+    output: "3"
+    name: "Gather_2"
+    op_type: "Gather"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "3"
+    output: "7"
+    name: "Unsqueeze_3"
+    op_type: "Unsqueeze"
+    attribute {
+      name: "axes"
+      ints: 0
+      type: INTS
+    }
+  }
+  node {
+    input: "7"
+    input: "21"
+    input: "22"
+    input: "23"
+    output: "11"
+    name: "Concat_4"
+    op_type: "Concat"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "x"
+    input: "11"
+    output: "12"
+    name: "Reshape_5"
+    op_type: "Reshape"
+  }
+  node {
+    input: "12"
+    output: "13"
+    name: "Transpose_6"
+    op_type: "Transpose"
+    attribute {
+      name: "perm"
+      ints: 0
+      ints: 3
+      ints: 1
+      ints: 2
+      type: INTS
+    }
+  }
+  node {
+    input: "13"
+    output: "14"
+    name: "Softmax_7"
+    op_type: "Softmax"
+    attribute {
+      name: "axis"
+      i: 3
+      type: INT
+    }
+  }
+  node {
+    input: "14"
+    output: "15"
+    name: "Transpose_8"
+    op_type: "Transpose"
+    attribute {
+      name: "perm"
+      ints: 0
+      ints: 3
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+  }
+  node {
+    input: "3"
+    output: "17"
+    name: "Unsqueeze_9"
+    op_type: "Unsqueeze"
+    attribute {
+      name: "axes"
+      ints: 0
+      type: INTS
+    }
+  }
+  node {
+    input: "17"
+    input: "24"
+    output: "19"
+    name: "Concat_10"
+    op_type: "Concat"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "15"
+    input: "19"
+    output: "20"
+    name: "Reshape_11"
+    op_type: "Reshape"
+  }
+  name: "torch-jit-export"
+  initializer {
+    dims: 1
+    data_type: 7
+    name: "21"
+    raw_data: "\001\000\000\000\000\000\000\000"
+  }
+  initializer {
+    dims: 1
+    data_type: 7
+    name: "22"
+    raw_data: "\002\000\000\000\000\000\000\000"
+  }
+  initializer {
+    dims: 1
+    data_type: 7
+    name: "23"
+    raw_data: "\377\377\377\377\377\377\377\377"
+  }
+  initializer {
+    dims: 1
+    data_type: 7
+    name: "24"
+    raw_data: "\377\377\377\377\377\377\377\377"
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "x_dim_0"
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 128
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "20"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_param: "x_dim_0"
+          }
+          dim {
+            dim_value: 128
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -10,6 +10,7 @@ from torch.onnx import register_custom_op_symbolic, unregister_custom_op_symboli
 from torch.autograd import Variable, Function
 from torch.nn import Module, functional
 import torch.nn as nn
+import torch.nn.functional as F
 
 import itertools
 import io
@@ -915,6 +916,12 @@ class TestOperators(TestCase):
                         dynamic_axes={"input_1": {1: "dim_1"}, "input_2": {1: "dim_2"}},
                         opset_version=12)
 
+    def test_dynamic_axes_add_inputs_same_symbolic_shape(self):
+        m1 = torch.randn(2, 3, requires_grad=True)
+        self.assertONNX(lambda x: torch.add(x, x), (m1,), input_names=["input_1"],
+                        dynamic_axes={"input_1": {1: "dim_1"}},
+                        opset_version=12)
+
     def test_dynamic_axes_matmul(self):
         m1 = torch.randn(2, 2, 4, requires_grad=True)
         m2 = torch.randn(2, 4, 3, requires_grad=True)
@@ -1012,6 +1019,41 @@ class TestOperators(TestCase):
                         dynamic_axes={"input_1": {0: "dim_0"}, 'input_2': {0: "dim_1", 1: "dim_2"}})
 
         unregister_custom_op_symbolic('::embedding', _onnx_opset_version)
+
+    # Without shapeValueMap, the onnx graph looks like:
+    # graph(%0 : Float(*, 1, 128, 1, strides=[128, 128, 1, 1], requires_grad=0, device=cpu)):
+    #   %2 : Long(4, strides=[1], device=cpu) = onnx::Shape(%0)
+    #   %4 : Long(device=cpu) = onnx::Constant[value={0}]()
+    #   %5 : Long(device=cpu) = onnx::Gather[axis=0](%2, %4)
+    #   %6 : Long(device=cpu) = onnx::Constant[value={1}]()
+    #   %7 : Long(device=cpu) = onnx::Constant[value={2}]()
+    #   %8 : Long(device=cpu) = onnx::Constant[value={-1}]()
+    #   %9 : int[] = prim::ListConstruct(%5, %6, %7, %8)
+    #   %10 : Float(*, *, *, *, strides=[128, 128, 64, 1], requires_grad=0, device=cpu) = onnx::Reshape(%0, %9)
+    #   ...
+    # With shapeValueMap, it becomes:
+    #   ...
+    #   %10 : Float(*, 1, 2, 64, strides=[128, 128, 64, 1], requires_grad=0, device=cpu) = onnx::Reshape(%0, %9)
+    #   ...
+    def test_shape_value_map(self):
+        class RSoftMax(torch.nn.Module):
+            def __init__(self, radix, cardinality):
+                super().__init__()
+                self.radix = radix
+                self.cardinality = cardinality
+
+            def forward(self, x):
+                batch = x.size(0)
+                x = x.view(batch, self.cardinality, self.radix, -1).transpose(1, 2)
+                x = F.softmax(x, dim=1)
+                x = x.reshape(batch, -1)
+                return x
+        radix = 2
+        cardinality = 1
+        x = torch.randn(10, 1, 128, 1)
+        self.assertONNX(RSoftMax(radix, cardinality), (x,),
+                        input_names=["x"],
+                        dynamic_axes={"x": {0: "dim_0"}})
 
 if __name__ == "__main__":
     no_onnx_dep_flag = "--no-onnx"

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -15,6 +15,7 @@ import random
 import model_defs.word_language_model as word_language_model
 import onnx
 
+import torch.nn.functional as F
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import (LstmFlatteningResultWithSeqLength,
                                                LstmFlatteningResultWithoutSeqLength)
@@ -10137,6 +10138,27 @@ class TestONNXRuntime(unittest.TestCase):
                     return torch.zeros(5), torch.zeros(5)
         x = torch.zeros(1)
         self.run_test(torch.jit.script(M()), (x,))
+
+    def test_shape_value_map(self):
+        class RSoftMax(torch.nn.Module):
+            def __init__(self, radix, cardinality):
+                super().__init__()
+                self.radix = radix
+                self.cardinality = cardinality
+
+            def forward(self, x):
+                batch = x.size(0)
+                x = x.view(batch, self.cardinality, self.radix, -1).transpose(1, 2)
+                x = F.softmax(x, dim=1)
+                x = x.reshape(batch, -1)
+                return x
+        radix = 2
+        cardinality = 1
+        x = torch.randn(10, 1, 128, 1)
+        f = io.BytesIO()
+        torch.onnx.export(RSoftMax(radix, cardinality), (x, ), f, input_names=["x"], dynamic_axes={"x": [0]})
+        loaded_model = onnx.load_from_string(f.getvalue())
+        self.assertEqual(loaded_model.graph.output[0].type.tensor_type.shape.dim[1].dim_value, 128)
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -186,6 +186,25 @@ c10::optional<bool> ConstantValueMap::GetUseInferredType(
   return ConstantValueMap::getInstance().useInferredTypeMap[tensorName];
 }
 
+void ConstantValueMap::SetShapeValue(
+    const std::string& tensorName,
+    const c10::SymbolicShape& shapeValue) {
+  ConstantValueMap::getInstance().shapeValueMap[tensorName] = shapeValue;
+}
+
+bool ConstantValueMap::HasShapeValue(const std::string& tensorName) {
+  return ConstantValueMap::getInstance().shapeValueMap.find(tensorName) !=
+      ConstantValueMap::getInstance().shapeValueMap.end();
+}
+
+c10::optional<c10::SymbolicShape> ConstantValueMap::GetShapeValue(
+    const std::string& tensorName) {
+  if (!HasShapeValue(tensorName)) {
+    return c10::nullopt;
+  }
+  return ConstantValueMap::getInstance().shapeValueMap[tensorName];
+}
+
 template <typename Map>
 void UpdateStrKey(
     Map& map,
@@ -215,6 +234,8 @@ void ConstantValueMap::UpdateValueName(
       ConstantValueMap::getInstance().typeReliableMap, old_name, new_name);
   UpdateStrKey<decltype(useInferredTypeMap)>(
       ConstantValueMap::getInstance().useInferredTypeMap, old_name, new_name);
+  UpdateStrKey<decltype(shapeValueMap)>(
+      ConstantValueMap::getInstance().shapeValueMap, old_name, new_name);
 }
 
 void ConstantValueMap::ClearMaps() {
@@ -223,11 +244,12 @@ void ConstantValueMap::ClearMaps() {
   ConstantValueMap::getInstance().tensorValueMap.clear();
   ConstantValueMap::getInstance().typeReliableMap.clear();
   ConstantValueMap::getInstance().useInferredTypeMap.clear();
+  ConstantValueMap::getInstance().shapeValueMap.clear();
 }
 
 // For debug only.
 void ConstantValueMap::PrintMaps() {
-  std::cout << "Print rank/shape Maps:" << std::endl;
+  std::cout << "Rank/Shape Map:" << std::endl;
   for (const auto& x : ConstantValueMap::getInstance().rankMap) {
     std::stringstream ss;
     if (ConstantValueMap::getInstance().shapeMap.find(x.first) !=
@@ -248,12 +270,12 @@ void ConstantValueMap::PrintMaps() {
     std::cout << "node " << x.first << ": " << ss.str() << std::endl;
   }
   std::cout << std::endl;
-  std::cout << "Print Value Maps:" << std::endl;
+  std::cout << "Value Map:" << std::endl;
   for (const auto& x : ConstantValueMap::getInstance().tensorValueMap) {
     std::cout << "node " << x.first << ": " << x.second << std::endl;
   }
   std::cout << std::endl;
-  std::cout << "Print TypeReliable Maps:" << std::endl;
+  std::cout << "TypeReliable Map:" << std::endl;
   size_t count = 0;
   for (const auto& x : ConstantValueMap::getInstance().typeReliableMap) {
     std::cout << "(node " << x.first << ": " << x.second << "), ";
@@ -263,9 +285,19 @@ void ConstantValueMap::PrintMaps() {
     }
   }
   std::cout << std::endl;
-  std::cout << "Print UseInferredType Maps:" << std::endl;
+  std::cout << "UseInferredType Map:" << std::endl;
   count = 0;
   for (const auto& x : ConstantValueMap::getInstance().useInferredTypeMap) {
+    std::cout << "(node " << x.first << ": " << x.second << "), ";
+    count++;
+    if (count % 10 == 0) {
+      std::cout << std::endl;
+    }
+  }
+  std::cout << std::endl;
+  std::cout << "ShapeValue Map:" << std::endl;
+  count = 0;
+  for (const auto& x : ConstantValueMap::getInstance().shapeValueMap) {
     std::cout << "(node " << x.first << ": " << x.second << "), ";
     count++;
     if (count % 10 == 0) {

--- a/torch/csrc/jit/passes/onnx/constant_map.h
+++ b/torch/csrc/jit/passes/onnx/constant_map.h
@@ -45,6 +45,13 @@ class ConstantValueMap {
   static bool HasUseInferredType(const std::string& tensorName);
   static c10::optional<bool> GetUseInferredType(const std::string& tensorName);
 
+  static void SetShapeValue(
+      const std::string& tensorName,
+      const c10::SymbolicShape& shapeValue);
+  static bool HasShapeValue(const std::string& tensorName);
+  static c10::optional<c10::SymbolicShape> GetShapeValue(
+      const std::string& tensorName);
+
   static void UpdateValueName(
       const std::string& old_name,
       const std::string& new_name);
@@ -66,6 +73,14 @@ class ConstantValueMap {
   // This map indicates whether the current type is estimated through inference
   // or tracer.
   std::unordered_map<std::string, bool> useInferredTypeMap;
+  // This map indicates a tensor value which represents a shape.
+  // We assume that the rank of the tensor value <= 1, and we ensure this when
+  // we write the processing logic for the operators. When the rank > 1, we
+  // should be able to rewrite the model so that the rank <= 1. The difference
+  // between shapeMap and shapeValueMap: shapeMap stores the shape of the tensor
+  // from a node. shapeValueMap stores the value of the tensor from a node when
+  // this tensor represents a shape.
+  std::unordered_map<std::string, c10::SymbolicShape> shapeValueMap;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -15,6 +15,7 @@
 #include <onnx/shape_inference/implementation.h>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <unordered_set>
 
 namespace torch {
@@ -431,84 +432,215 @@ c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
 }
 
 // When the Reshape node's two inputs are constant, compute the output shape.
-// The reshape value 0 and -1 are converted to the real value explicitly.
-std::vector<int64_t> ComputeShapeFromReshape(
+// The shape value 0 and -1 are converted to the real value explicitly.
+c10::optional<std::vector<int64_t>> ComputeShapeFromReshape(
     Node* n,
     const std::vector<int64_t>& input_shape,
-    const std::vector<int64_t>& reshape,
+    const std::vector<int64_t>& shape,
     int opset_version) {
   TORCH_INTERNAL_ASSERT(
-      input_shape.size() > 0 || reshape.size() > 0,
+      !input_shape.empty() || !shape.empty(),
       "Reshape node should have at least one input size > 0 when constant folding.");
-  // Case: reshape.size() == 0
+  // Case: shape.empty()
   // %22 : int[] = prim::Constant[value=annotate(List[int], [])]()
   // %15 : Float(requires_grad=0, device=cpu) = aten::view(%1, %22)
-  if (reshape.size() == 0) {
+  if (shape.empty()) {
     return input_shape;
   }
-  // Case: input_shape.size() == 0
+  // Case: input_shape.empty()
   // (1) input_shape is not obtained,
   // (2) input_shape is scalar (output is still a tensor, not a scalar),
-  // Both cases return reshape
+  // Both cases return shape
   // TODO: for (1), multiple -1 may conflict each other. Consider use
   // newSymbol() in shapeMap.
-  if (input_shape.size() == 0) {
-    return reshape;
+  if (input_shape.empty()) {
+    return shape;
   }
-  auto reshape_size = static_cast<int>(reshape.size());
-  auto it_0 = std::find(reshape.begin(), reshape.end(), 0);
-  auto reshape_has_zero = it_0 != reshape.end();
+  auto it_0 = std::find(shape.begin(), shape.end(), 0);
+  bool shape_has_zero = it_0 != shape.end();
 
   // Allowzero is set to 0 by default
   // When opset version > 14, assign appropriate allowzero value
-  int allowzero = 0;
   if (opset_version >= 14 && n->hasAttributeS("allowzero")) {
-    allowzero = n->i(attr::allowzero);
-    if (allowzero == 1 && reshape_has_zero) {
-      return reshape;
+    int allowzero = n->i(attr::allowzero);
+    if (allowzero == 1 && shape_has_zero) {
+      // Return here, because the denominator in shape_ratio calculation cannot
+      // be 0.
+      // TODO: Shall we handle the case when shape has -1 here?
+      return shape;
     }
   }
 
-  auto input_shape_size = static_cast<int>(input_shape.size());
-  auto it_minus_one = std::find(reshape.begin(), reshape.end(), -1);
-  int minus_one_pos = it_minus_one == reshape.end()
-      ? -1
-      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-      : std::distance(reshape.begin(), it_minus_one);
+  int minus_one_pos = -1;
+  for (int i = 0; i < shape.size(); ++i) {
+    if (shape[i] == -1) {
+      minus_one_pos = i;
+      break;
+    }
+  }
 
-  if (!reshape_has_zero && minus_one_pos == -1) {
-    return reshape;
+  if (!shape_has_zero && minus_one_pos == -1) {
+    return shape;
   }
   std::vector<int64_t> final_shape;
   // shape_ratio is used to calculate the real value of -1.
-  // One example with reshape 0 and -1:
+  // One example with shape 0 and -1:
   // input_shape = 2 16 5 4
-  // reshape = -1 0 4
+  // shape = -1 0 4
   // final_shape = 10 16 4
-  double shape_ratio = 1.0;
-  for (const auto i : c10::irange(input_shape_size)) {
-    shape_ratio *= static_cast<double>(input_shape[i]);
+  uint64_t shape_ratio = 1;
+  for (const auto& cur_input_shape : input_shape) {
+    if (shape_ratio >= std::numeric_limits<uint64_t>::max() / cur_input_shape) {
+      std::cerr
+          << "WARNING: ComputeShapeFromReshape(), shape_ratio overflows, skip shape inference."
+          << std::endl;
+      return c10::nullopt;
+    } else {
+      shape_ratio *= static_cast<uint64_t>(cur_input_shape);
+    }
   }
-  for (const auto i : c10::irange(reshape_size)) {
-    if (i != minus_one_pos) {
-      if (reshape[i] != 0) {
-        shape_ratio /= static_cast<double>(reshape[i]);
+  int shape_size = static_cast<int>(shape.size());
+  for (const auto i : c10::irange(shape_size)) {
+    if (i == minus_one_pos) {
+      continue;
+    }
+    if (shape[i] != 0) {
+      shape_ratio /= static_cast<uint64_t>(shape[i]);
+    } else {
+      shape_ratio /= static_cast<uint64_t>(input_shape[i]);
+    }
+  }
+
+  TORCH_INTERNAL_ASSERT(
+      minus_one_pos != -1,
+      "ComputeShapeFromReshape(): shape_has_zero && minus_one_pos == -1, but we assumed this could never happen. Please file a bug with repro instructions.");
+
+  for (const int i : c10::irange(minus_one_pos)) {
+    int64_t cur_shape = shape[i] == 0 ? input_shape[i] : shape[i];
+    final_shape.push_back(cur_shape);
+  }
+  if (minus_one_pos != -1) {
+    final_shape.push_back(static_cast<int64_t>(shape_ratio));
+  }
+  for (auto i = minus_one_pos + 1; i < shape_size; i++) {
+    int64_t cur_shape = shape[i] == 0 ? input_shape[i] : shape[i];
+    final_shape.push_back(cur_shape);
+  }
+  return final_shape;
+}
+
+// Similar to the function above, but for symbolic shapes.
+c10::optional<::c10::SymbolicShape> ComputeShapeFromReshape(
+    Node* n,
+    const c10::SymbolicShape& input_shape,
+    const c10::SymbolicShape& shape,
+    int opset_version) {
+  std::vector<c10::ShapeSymbol> input_shape_vector =
+      input_shape.sizes().value();
+  std::vector<c10::ShapeSymbol> shape_vector = shape.sizes().value();
+  TORCH_INTERNAL_ASSERT(
+      !input_shape_vector.empty() || !shape_vector.empty(),
+      "Reshape node should have at least one input size > 0 when constant folding.");
+  if (shape_vector.empty()) {
+    return input_shape;
+  }
+  if (input_shape_vector.empty()) {
+    return shape;
+  }
+
+  auto is_zero = [](c10::ShapeSymbol& ss) { return ss.value() == 0; };
+  auto it_0 = std::find_if(shape_vector.begin(), shape_vector.end(), is_zero);
+  bool shape_has_zero = it_0 != shape_vector.end();
+
+  if (opset_version >= 14 && n->hasAttributeS("allowzero")) {
+    int allowzero = n->i(attr::allowzero);
+    if (allowzero == 1 && shape_has_zero) {
+      // Return here, because the denominator in shape_ratio calculation cannot
+      // be 0.
+      // TODO: Shall we handle the case when shape has -1 here?
+      return shape;
+    }
+  }
+
+  int minus_one_pos = -1;
+  for (int i = 0; i < shape_vector.size(); ++i) {
+    if (shape_vector[i].value() == -1) {
+      minus_one_pos = i;
+      break;
+    }
+  }
+
+  if (!shape_has_zero && minus_one_pos == -1) {
+    return shape;
+  }
+  std::vector<c10::ShapeSymbol> final_shape;
+  uint64_t shape_ratio = 1;
+  std::unordered_map<int64_t, int64_t> sym_map;
+  for (const c10::ShapeSymbol& input_shape : input_shape_vector) {
+    if (input_shape.is_static()) {
+      if (shape_ratio >=
+          std::numeric_limits<uint64_t>::max() / input_shape.static_size()) {
+        std::cerr
+            << "WARNING: ComputeShapeFromReshape(), shape_ratio overflows, skip shape inference."
+            << std::endl;
+        return c10::nullopt;
       } else {
-        shape_ratio /= static_cast<double>(input_shape[i]);
+        shape_ratio *= static_cast<uint64_t>(input_shape.static_size());
+      }
+    } else {
+      auto value = input_shape.value();
+      sym_map.emplace(value, 0).first->second += 1;
+    }
+  }
+  int shape_size = static_cast<int>(shape_vector.size());
+  for (const int i : c10::irange(shape_size)) {
+    if (i == minus_one_pos) {
+      continue;
+    }
+    c10::ShapeSymbol& target_shape = shape_vector[i];
+    if (target_shape.value() == 0) {
+      target_shape = input_shape_vector[i];
+    }
+    if (target_shape.is_static()) {
+      shape_ratio /= static_cast<uint64_t>(target_shape.static_size());
+    } else {
+      auto value = target_shape.value();
+      if (sym_map.find(value) == sym_map.end()) {
+        return c10::nullopt;
+      }
+      sym_map[value]--;
+      if (sym_map[value] == 0) {
+        sym_map.erase(value);
       }
     }
   }
 
+  // sym_map is used to match shape symbols between the input and shape.
+  // If there is a mismatch, the output shape cannot be estimated.
+  if (!sym_map.empty()) {
+    return c10::nullopt;
+  }
+
+  TORCH_INTERNAL_ASSERT(
+      minus_one_pos != -1,
+      "There are no examples for shape_has_zero = true && minus_one_pos == -1.");
+
   for (const auto i : c10::irange(minus_one_pos)) {
-    int64_t cur_shape = reshape[i] == 0 ? input_shape[i] : reshape[i];
+    c10::ShapeSymbol cur_shape(
+        shape_vector[i].value() == 0 ? input_shape_vector[i] : shape_vector[i]);
     final_shape.push_back(cur_shape);
   }
-  final_shape.push_back(static_cast<int64_t>(std::round(shape_ratio)));
-  for (auto i = minus_one_pos + 1; i < reshape_size; i++) {
-    int64_t cur_shape = reshape[i] == 0 ? input_shape[i] : reshape[i];
+  if (minus_one_pos != -1) {
+    final_shape.push_back(
+        ShapeSymbol::fromStaticSize(static_cast<int64_t>(shape_ratio)));
+  }
+  for (auto i = minus_one_pos + 1; i < shape_size; i++) {
+    c10::ShapeSymbol cur_shape(
+        shape_vector[i].value() == 0 ? input_shape_vector[i] : shape_vector[i]);
     final_shape.push_back(cur_shape);
   }
-  return final_shape;
+  c10::SymbolicShape final_shape_0(final_shape);
+  return final_shape_0;
 }
 
 c10::optional<::c10::SymbolicShape> ComputeShapeFromExpand(
@@ -626,27 +758,49 @@ void UpdateShapeConstantValueMap(
 
 c10::optional<std::vector<int64_t>> GetValueFromListConstructNode(
     Node* lc_node) {
-  auto rank = lc_node->inputs().size();
   std::vector<int64_t> shape_size;
-  for (const auto i : c10::irange(rank)) {
-    if (TensorTypePtr shape_type =
-            lc_node->input(i)->type()->cast<TensorType>()) {
-      if (ConstantValueMap::HasValue(lc_node->input(i)->debugName())) {
-        auto lc_value =
-            ConstantValueMap::GetValue(lc_node->input(i)->debugName()).value();
-        if (lc_value.dim() == 0) {
-          auto lc_value_0 = lc_value.item<int64_t>();
-          shape_size.emplace_back(static_cast<int64_t>(lc_value_0));
-        }
+  for (const auto& input : lc_node->inputs()) {
+    if (input->type()->cast<TensorType>() &&
+        ConstantValueMap::HasValue(input->debugName())) {
+      auto lc_value = ConstantValueMap::GetValue(input->debugName()).value();
+      if (lc_value.dim() == 0) {
+        int64_t lc_value_0 = lc_value.item<int64_t>();
+        shape_size.emplace_back(lc_value_0);
       }
     }
   }
-  return rank == shape_size.size()
+  return lc_node->inputs().size() == shape_size.size()
       ? c10::optional<std::vector<int64_t>>(shape_size)
       : c10::nullopt;
 }
 
-void ProcessBroadCastNode(Node* n) {
+void SetShapeValueFromListConstructNode(Node* lc_node) {
+  std::vector<c10::ShapeSymbol> shape_size;
+  for (const auto& input : lc_node->inputs()) {
+    if (TensorTypePtr shape_type = input->type()->cast<TensorType>()) {
+      if (ConstantValueMap::HasValue(input->debugName())) {
+        auto lc_value = ConstantValueMap::GetValue(input->debugName()).value();
+        if (lc_value.dim() == 0) {
+          int64_t lc_value_0 = lc_value.item<int64_t>();
+          shape_size.emplace_back(c10::ShapeSymbol::fromStaticSize(lc_value_0));
+        }
+      } else if (ConstantValueMap::HasShapeValue(input->debugName())) {
+        auto lc_value =
+            ConstantValueMap::GetShapeValue(input->debugName()).value();
+        if (lc_value.rank() == 1) {
+          shape_size.emplace_back(lc_value.at(0));
+        }
+      }
+    }
+  }
+  if (lc_node->inputs().size() == shape_size.size()) {
+    c10::SymbolicShape final_shape(shape_size);
+    ConstantValueMap::SetShapeValue(
+        lc_node->output()->debugName(), final_shape);
+  }
+}
+
+void ProcessBroadcastNode(Node* n) {
   TORCH_INTERNAL_ASSERT(n->inputs().size() == 2);
   if (ConstantValueMap::HasShape(n->input(0)->debugName()) &&
       ConstantValueMap::HasShape(n->input(1)->debugName())) {
@@ -664,17 +818,21 @@ void ProcessBroadCastNode(Node* n) {
       final_shape.emplace_back(::c10::ShapeSymbol::newSymbol());
     }
     for (auto idx = 0; idx < rank_min; idx++) {
-      auto is_static_0 =
-          input_shape_value_0.value()[rank_0 - 1 - idx].is_static();
-      auto is_static_1 =
-          input_shape_value_1.value()[rank_1 - 1 - idx].is_static();
+      const c10::ShapeSymbol& ss_shape_0 =
+          input_shape_value_0.value()[rank_0 - 1 - idx];
+      const c10::ShapeSymbol& ss_shape_1 =
+          input_shape_value_1.value()[rank_1 - 1 - idx];
+      bool is_static_0 = ss_shape_0.is_static();
+      bool is_static_1 = ss_shape_1.is_static();
       if (is_static_0 && is_static_1) {
-        auto static_0_sz =
-            input_shape_value_0.value()[rank_0 - 1 - idx].static_size();
-        auto static_1_sz =
-            input_shape_value_1.value()[rank_1 - 1 - idx].static_size();
+        int64_t static_0_sz = ss_shape_0.static_size();
+        int64_t static_1_sz = ss_shape_1.static_size();
         final_shape[rank_max - 1 - idx] = ::c10::ShapeSymbol::fromStaticSize(
             std::max(static_0_sz, static_1_sz));
+      } else if (!is_static_0 && !is_static_1) {
+        if (ss_shape_0.value() == ss_shape_1.value()) {
+          final_shape[rank_max - 1 - idx] = ss_shape_0;
+        }
       }
     }
 
@@ -694,7 +852,7 @@ void ProcessBroadCastNode(Node* n) {
   }
 }
 
-void ProcessConcatNode(Node* n) {
+void ProcessShapeForConcatNode(Node* n) {
   int axis = n->i(attr::axis);
   if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
     auto rank = ConstantValueMap::GetRank(n->input(0)->debugName()).value();
@@ -753,6 +911,37 @@ void ProcessConcatNode(Node* n) {
     }
     UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
   }
+}
+
+void ProcessShapeValueForConcatNode(Node* n) {
+  auto rank = n->inputs().size();
+  std::vector<c10::ShapeSymbol> shape_size;
+  for (const auto& input : n->inputs()) {
+    if (ConstantValueMap::HasValue(input->debugName())) {
+      auto concat_value =
+          ConstantValueMap::GetValue(input->debugName()).value();
+      if (concat_value.dim() == 1 && concat_value.size(0) == 1) {
+        auto concat_value_0 = concat_value[0].item<int64_t>();
+        shape_size.emplace_back(
+            c10::ShapeSymbol::fromStaticSize(concat_value_0));
+      }
+    } else if (ConstantValueMap::HasShapeValue(input->debugName())) {
+      auto concat_value =
+          ConstantValueMap::GetShapeValue(input->debugName()).value();
+      if (concat_value.rank() == 1) {
+        shape_size.emplace_back(concat_value.at(0));
+      }
+    }
+  }
+  if (rank == shape_size.size()) {
+    c10::SymbolicShape final_shape(shape_size);
+    ConstantValueMap::SetShapeValue(n->output(0)->debugName(), final_shape);
+  }
+}
+
+void ProcessConcatNode(Node* n) {
+  ProcessShapeForConcatNode(n);
+  ProcessShapeValueForConcatNode(n);
 }
 
 void ProcessMatMulNode(Node* n) {
@@ -853,7 +1042,23 @@ void ProcessReshapeNode(Node* n, int opset_version) {
     if (shape_vector_0.has_value() || shape_temp.size() > 0) {
       auto final_shape = ComputeShapeFromReshape(
           n, shape_vector_0_value, shape_temp, opset_version);
-      UpdateShapeFromVector(n->output(), final_shape);
+      if (final_shape.has_value()) {
+        UpdateShapeFromVector(n->output(), final_shape.value());
+        return;
+      }
+    }
+  }
+
+  if (ConstantValueMap::HasShapeValue(n->input(1)->debugName()) &&
+      ConstantValueMap::HasShape(n->input(0)->debugName())) {
+    auto shape_vector_0 =
+        ConstantValueMap::GetShape(n->input(0)->debugName()).value();
+    auto shape_vector_1 =
+        ConstantValueMap::GetShapeValue(n->input(1)->debugName()).value();
+    auto final_shape = ComputeShapeFromReshape(
+        n, shape_vector_0, shape_vector_1, opset_version);
+    if (final_shape.has_value()) {
+      UpdateShape(n->output(), final_shape.value());
       return;
     }
   }
@@ -1074,6 +1279,21 @@ void ProcessTimeSeriesNode(Node* n) {
   }
 }
 
+void ProcessUnsqueezeNode(Node* n) {
+  TensorTypePtr output_type = n->output(0)->type()->cast<TensorType>();
+  if (output_type == nullptr) {
+    return;
+  }
+  if (output_type->dim().has_value() && output_type->dim().value() == 1 &&
+      ConstantValueMap::HasShapeValue(n->input(0)->debugName())) {
+    auto shape_value =
+        ConstantValueMap::GetShapeValue(n->input(0)->debugName()).value();
+    // When the scalar represents a shape, it is the same as the shape value
+    // when it gets unsqueezed.
+    ConstantValueMap::SetShapeValue(n->output()->debugName(), shape_value);
+  }
+}
+
 // As an addition to onnx shape inference, this function leverages constant
 // folding and a per-Op based process to update rank/shape for the graph, also
 // it update ConstantValueMap accordingly.
@@ -1114,7 +1334,7 @@ void ComputeConstant(Node* n, int opset_version) {
     case ::c10::onnx::Mul:
     case ::c10::onnx::Pow:
     case ::c10::onnx::Sub: {
-      ProcessBroadCastNode(n);
+      ProcessBroadcastNode(n);
       break;
     }
     case ::c10::onnx::Shape: {
@@ -1136,6 +1356,10 @@ void ComputeConstant(Node* n, int opset_version) {
             1, c10::ShapeSymbol::fromStaticSize(shape_value_size));
         ::c10::SymbolicShape final_shape(final_shape_vector);
         UpdateShape(n->output(), final_shape);
+      } else if (ConstantValueMap::HasShape(n->input()->debugName())) {
+        ConstantValueMap::SetShapeValue(
+            n->output()->debugName(),
+            ConstantValueMap::GetShape(n->input()->debugName()).value());
       }
       break;
     }
@@ -1152,6 +1376,22 @@ void ComputeConstant(Node* n, int opset_version) {
             ConstantValueMap::GetRank(n->input(1)->debugName()).value();
         only_rank_available = true;
         rank = rank_0 + rank_1 - 1;
+      }
+      if (ConstantValueMap::HasShapeValue(n->input(0)->debugName()) &&
+          ConstantValueMap::HasValue(n->input(1)->debugName())) {
+        auto shape_value =
+            ConstantValueMap::GetShapeValue(n->input(0)->debugName()).value();
+        auto idx_value =
+            ConstantValueMap::GetValue(n->input(1)->debugName()).value();
+        // Consider the case when Gather index is a scalar.
+        if (idx_value.dim() == 0) {
+          auto idx_value_0 = idx_value.item<int64_t>();
+          if (idx_value_0 >= 0) {
+            std::vector<c10::ShapeSymbol> dims = {shape_value.at(idx_value_0)};
+            c10::SymbolicShape symShape(dims);
+            ConstantValueMap::SetShapeValue(n->output()->debugName(), symShape);
+          }
+        }
       }
       break;
     }
@@ -1352,6 +1592,10 @@ void ComputeConstant(Node* n, int opset_version) {
       }
       break;
     }
+    case ::c10::onnx::Unsqueeze: {
+      ProcessUnsqueezeNode(n);
+      break;
+    }
     default: {
       break;
     }
@@ -1455,6 +1699,7 @@ void ProcessConstantValueMap(Node* n, int opset_version) {
       } else {
         UpdateShapeFromVector(n->input(i), {static_cast<int64_t>(rank)});
       }
+      SetShapeValueFromListConstructNode(lc_node);
     }
   }
   // Additional logic to update the graph and ConstantValueMap


### PR DESCRIPTION
Fixes https://msdata.visualstudio.com/Vienna/_workitems/edit/1423457
The symbolic shape inference is further improved with the newly introduced shapeValueMap. Starting from `Shape` node, we save the value into constant map where this value is actually a symbolic shape.
Before this change, the `test_shape_value_map` in unit test gives the shape inference after onnx pass like this:
```python
graph(%0 : Float(*, 1, 128, 1, strides=[128, 128, 1, 1], requires_grad=0, device=cpu)):
  %2 : Long(4, strides=[1], device=cpu) = onnx::Shape(%0)
  %4 : Long(device=cpu) = onnx::Constant[value={0}]() 
  %5 : Long(device=cpu) = onnx::Gather[axis=0](%2, %4)
  %6 : Long(device=cpu) = onnx::Constant[value={1}]()
  %7 : Long(device=cpu) = onnx::Constant[value={2}]()
  %8 : Long(device=cpu) = onnx::Constant[value={-1}]()
  %9 : int[] = prim::ListConstruct(%5, %6, %7, %8)
  %10 : Float(*, *, *, *, strides=[128, 128, 64, 1], requires_grad=0, device=cpu) = onnx::Reshape(%0, %9) 
  %x : Float(*, *, *, *, strides=[128, 64, 128, 1], requires_grad=0, device=cpu) = onnx::Transpose[perm=[0, 2, 1, 3]](%10)
  %16 : Float(*, *, *, *, device=cpu) = onnx::Transpose[perm=[0, 3, 2, 1]](%x) 
  %17 : Float(*, *, *, *, device=cpu) = onnx::Softmax[axis=3](%16) 
  %18 : Float(*, *, *, *, strides=[128, 64, 64, 1], requires_grad=0, device=cpu) = onnx::Transpose[perm=[0, 3, 2, 1]](%17) 
  %19 : Long(device=cpu) = onnx::Constant[value={-1}]()
  %20 : int[] = prim::ListConstruct(%5, %19)
  %21 : Float(*, *, strides=[128, 1], requires_grad=0, device=cpu) = onnx::Reshape(%18, %20)
  return (%21)
```
after this change, the shape inference is propagated like this:
```python
graph(%0 : Float(*, 1, 128, 1, strides=[128, 128, 1, 1], requires_grad=0, device=cpu)):
  %2 : Long(4, strides=[1], device=cpu) = onnx::Shape(%0)
  %4 : Long(device=cpu) = onnx::Constant[value={0}]() 
  %5 : Long(device=cpu) = onnx::Gather[axis=0](%2, %4)
  %6 : Long(device=cpu) = onnx::Constant[value={1}]()
  %7 : Long(device=cpu) = onnx::Constant[value={2}]()
  %8 : Long(device=cpu) = onnx::Constant[value={-1}]()
  %9 : int[] = prim::ListConstruct(%5, %6, %7, %8)
  %10 : Float(*, 1, 2, 64, strides=[128, 128, 64, 1], requires_grad=0, device=cpu) = onnx::Reshape(%0, %9) 
  %x : Float(*, 2, 1, 64, strides=[128, 64, 128, 1], requires_grad=0, device=cpu) = onnx::Transpose[perm=[0, 2, 1, 3]](%10)
  %16 : Float(*, 64, 1, 2, device=cpu) = onnx::Transpose[perm=[0, 3, 2, 1]](%x) 
  %17 : Float(*, 64, 1, 2, device=cpu) = onnx::Softmax[axis=3](%16) 
  %18 : Float(*, 2, 1, 64, strides=[128, 64, 64, 1], requires_grad=0, device=cpu) = onnx::Transpose[perm=[0, 3, 2, 1]](%17) 
  %19 : Long(device=cpu) = onnx::Constant[value={-1}]()
  %20 : int[] = prim::ListConstruct(%5, %19)
  %21 : Float(*, 128, strides=[128, 1], requires_grad=0, device=cpu) = onnx::Reshape(%18, %20)
  return (%21)
```

Current shapeValueMap supports the shape propagation for the following node types:
ListConstruct, Concat, Gather, Unsqueeze, Shape.