### PR TITLE
[c10d] Fix object-based collectives for debug mode

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -351,6 +351,8 @@ class _ProcessGroupWrapper(ProcessGroup):
         pg: ProcessGroup,
         gloo_pg: ProcessGroupGloo
     ): ...
+    wrapped_pg: ProcessGroup
+
 
 class ProcessGroupNCCL(ProcessGroup):
     class Options: ...

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -334,6 +334,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::barrier(
   return pg_->barrier(opts);
 }
 
+c10::intrusive_ptr<ProcessGroup> ProcessGroupWrapper::getWrappedPg() const {
+  return pg_;
+}
+
 void ProcessGroupWrapper::runCollectiveChecks(
     OpType op_type,
     const std::vector<at::Tensor>& tensors) const {

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -111,6 +111,8 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
   c10::intrusive_ptr<ProcessGroup::Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
+  c10::intrusive_ptr<ProcessGroup> getWrappedPg() const;
+
  private:
   // Underlying process group that actual application collectives will be
   // dispatched to

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1390,7 +1390,10 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               }),
               py::arg("pg"),
               py::arg("gloo_pg"),
-              py::call_guard<py::gil_scoped_release>());
+              py::call_guard<py::gil_scoped_release>())
+         .def_property_readonly(
+              "wrapped_pg", &::c10d::ProcessGroupWrapper::getWrappedPg
+         );
 #endif
 
 #ifdef USE_C10D_NCCL

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -200,6 +200,7 @@ def with_dist_debug_levels(levels):
             for level in levels:
                 os.environ["TORCH_DISTRIBUTED_DEBUG"] = level
                 ret = func(*args, **kwargs)
+                c10d.barrier()
                 if old_level is not None:
                     os.environ["TORCH_DISTRIBUTED_DEBUG"] = old_level
             # Only returns test return for last test, but since these are

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5427,11 +5427,7 @@ class DistributedTest:
             self.assertEqual(len(indices_list), local_num_samples)
             validate_global_samples(local_num_samples)
 
-        @require_backend({"nccl", "gloo"})
-        @require_n_gpus_for_nccl_backend(
-            int(os.environ["WORLD_SIZE"]), os.environ["BACKEND"]
-        )
-        def test_allgather_object(self):
+        def _test_allgather_object(self, subgroup=None):
             # Only set device for NCCL backend since it must use GPUs.
             backend = os.environ["BACKEND"]
             if backend == "nccl":
@@ -5447,32 +5443,47 @@ class DistributedTest:
 
             output_gathered = [None for _ in range(dist.get_world_size())]
             dist.all_gather_object(
-                output_gathered, gather_objects[self.rank % len(gather_objects)]
+                output_gathered,
+                gather_objects[self.rank % len(gather_objects)],
+                group=subgroup,
             )
 
             for i, val in enumerate(output_gathered):
                 expected = gather_objects[i % len(gather_objects)]
                 self.assertEqual(val, expected)
 
-                output_gathered = [None for _ in range(dist.get_world_size())]
-                dist.all_gather_object(
-                    output_gathered, gather_objects[self.rank % len(gather_objects)]
-                )
+        @require_backend({"nccl", "gloo"})
+        @require_n_gpus_for_nccl_backend(
+            int(os.environ["WORLD_SIZE"]), os.environ["BACKEND"]
+        )
+        @with_dist_debug_levels(levels=["OFF", "INFO", "DETAIL"])
+        def test_all_gather_object_default_pg(self):
+            return self._test_allgather_object()
 
-        @require_backend({"gloo"})
-        @sandcastle_skip_if(BACKEND == "nccl", "NCCL does not support gather")
-        def test_gather_object(self):
+        @require_backend({"nccl", "gloo"})
+        @require_n_gpus_for_nccl_backend(
+            int(os.environ["WORLD_SIZE"]), os.environ["BACKEND"]
+        )
+        @with_dist_debug_levels(levels=["DETAIL", "OFF", "INFO"])
+        def test_all_gather_object_subgroup(self):
+            default = _get_default_group()
+            backend = dist.get_backend(default)
+            subgroup = dist.new_group(backend=backend)
+            return self._test_allgather_object(subgroup=subgroup)
+
+        def _test_gather_object(self, pg):
             # Ensure stateful objects can be gathered
             gather_objects = COLLECTIVES_OBJECT_TEST_LIST
-            output_gathered = [None for _ in range(dist.get_world_size())]
+            output_gathered = [None for _ in range(dist.get_world_size(pg))]
             gather_on_rank = 0
-            my_rank = dist.get_rank()
+            my_rank = dist.get_rank(pg)
             dist.gather_object(
                 gather_objects[self.rank % len(gather_objects)],
                 object_gather_list=output_gathered
                 if my_rank == gather_on_rank
                 else None,
                 dst=gather_on_rank,
+                group=pg
             )
             if my_rank != gather_on_rank:
                 self.assertEqual(
@@ -5493,11 +5504,29 @@ class DistributedTest:
                 dist.all_gather_object(
                     [None for _ in range(dist.get_world_size())],
                     gather_objects[self.rank],
+                    group=pg
                 )
+
+
+        @require_backend({"gloo"})
+        @sandcastle_skip_if(BACKEND == "nccl", "NCCL does not support gather")
+        @with_dist_debug_levels(levels=["DETAIL"])
+        def test_gather_object(self):
+            return self._test_gather_object()
+
+        @require_backend({"gloo"})
+        @sandcastle_skip_if(BACKEND == "nccl", "NCCL does not support gather")
+        @with_dist_debug_levels(levels=["DETAIL"])
+        def test_gather_object_subgroup(self):
+            default = _get_default_group()
+            backend = dist.get_backend(default)
+            subgroup = dist.new_group(backend=backend)
+            return self._test_gather_object(subgroup)
 
         @require_backend({"nccl"})
         @require_backends_available({"nccl"})
         @skip_if_lt_x_gpu(2)
+        @with_dist_debug_levels(levels=["OFF", "INFO", "DETAIL"])
         def test_nccl_gather_object_err(self):
             output_gathered = [None for _ in range(dist.get_world_size())]
             gather_on_rank = 0
@@ -6185,11 +6214,8 @@ class DistributedTest:
                     loss = out.sum()
                     loss.backward()
 
-        @require_backend({"nccl", "gloo"})
-        @require_n_gpus_for_nccl_backend(
-            int(os.environ["WORLD_SIZE"]), os.environ["BACKEND"]
-        )
-        def test_broadcast_object_list(self):
+
+        def _test_broadcast_object_list(self, group=None):
             # Only set device for NCCL backend since it must use GPUs.
             # Case where rank != GPU device.
             next_rank = (self.rank + 1) % int(self.world_size)
@@ -6216,7 +6242,7 @@ class DistributedTest:
                         single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0]
                     )
                 dist.broadcast_object_list(
-                    single_obj_list, src=0, group=None, device=torch.device("cpu")
+                    single_obj_list, src=0, group=group, device=torch.device("cpu")
                 )
                 self.assertEqual(single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0])
 
@@ -6230,7 +6256,7 @@ class DistributedTest:
                         single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0]
                     )
                 dist.broadcast_object_list(
-                    single_obj_list, src=0, group=None, device=torch.device(next_rank)
+                    single_obj_list, src=0, group=group, device=torch.device(next_rank)
                 )
                 self.assertEqual(single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0])
 
@@ -6242,7 +6268,7 @@ class DistributedTest:
                         single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0]
                     )
                 dist.broadcast_object_list(
-                    single_obj_list, src=0, group=None, device=torch.device(next_rank)
+                    single_obj_list, src=0, group=group, device=torch.device(next_rank)
                 )
                 self.assertEqual(single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0])
 
@@ -6250,14 +6276,33 @@ class DistributedTest:
             single_obj_list = [objects[0]]
             if self.rank != src_rank:
                 self.assertNotEqual(single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0])
-            dist.broadcast_object_list(single_obj_list, src=0)
+            dist.broadcast_object_list(single_obj_list, src=0, group=group)
             self.assertEqual(single_obj_list[0], COLLECTIVES_OBJECT_TEST_LIST[0])
 
             # Multiple input objects test
             if self.rank != src_rank:
                 self.assertNotEqual(objects, COLLECTIVES_OBJECT_TEST_LIST)
-            dist.broadcast_object_list(objects, src=0)
+            dist.broadcast_object_list(objects, src=0, group=group)
             self.assertEqual(objects, COLLECTIVES_OBJECT_TEST_LIST)
+
+        @require_backend({"nccl", "gloo"})
+        @require_n_gpus_for_nccl_backend(
+            int(os.environ["WORLD_SIZE"]), os.environ["BACKEND"]
+        )
+        @with_dist_debug_levels(levels=["DETAIL"])
+        def test_broadcast_object_list(self):
+            return self._test_broadcast_object_list()
+
+        @require_backend({"nccl", "gloo"})
+        @require_n_gpus_for_nccl_backend(
+            int(os.environ["WORLD_SIZE"]), os.environ["BACKEND"]
+        )
+        @with_dist_debug_levels(levels=["DETAIL"])
+        def _test_broadcast_object_list_subgroup(self):
+            default = _get_default_group()
+            backend = dist.get_backend(default)
+            subgroup = dist.new_group(backend=backend)
+            return self._test_broadcast_object_list(subgroup)
 
         def _test_ddp_ignore_params_arg(self, static_graph=False):
             class TestModel(nn.Module):

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5471,7 +5471,7 @@ class DistributedTest:
             subgroup = dist.new_group(backend=backend)
             return self._test_allgather_object(subgroup=subgroup)
 
-        def _test_gather_object(self, pg):
+        def _test_gather_object(self, pg=None):
             # Ensure stateful objects can be gathered
             gather_objects = COLLECTIVES_OBJECT_TEST_LIST
             output_gathered = [None for _ in range(dist.get_world_size(pg))]
@@ -5510,13 +5510,13 @@ class DistributedTest:
 
         @require_backend({"gloo"})
         @sandcastle_skip_if(BACKEND == "nccl", "NCCL does not support gather")
-        @with_dist_debug_levels(levels=["DETAIL"])
+        @with_dist_debug_levels(levels=["DETAIL", "OFF", "INFO"])
         def test_gather_object(self):
             return self._test_gather_object()
 
         @require_backend({"gloo"})
         @sandcastle_skip_if(BACKEND == "nccl", "NCCL does not support gather")
-        @with_dist_debug_levels(levels=["DETAIL"])
+        @with_dist_debug_levels(levels=["DETAIL", "OFF", "INFO"])
         def test_gather_object_subgroup(self):
             default = _get_default_group()
             backend = dist.get_backend(default)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68223

DETAIL debug mode didn't work with object-based collectives for NCCL backend, because we'd only check if backend is NCCL and then move tensors to CUDA.

Instead, check if it is a wrapped PG, and then check the pg that is wrapped to see if its nccl.

Differential Revision: [D32366840](https://our.internmc.facebook.com/intern/diff/D32366840/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang