### PR TITLE
[LTC] Refactor namespace bridge

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -16,11 +16,12 @@ namespace bridge {
 // at::Tensor => LazyTensor
 //////////////////////////////////////////////////////////////////////////////
 
-bool IsLtcTensor(const at::Tensor& tensor);
-c10::optional<LazyTensor> TryGetLtcTensor(const at::Tensor& tensor);
+// Extracts the LazyTensor out of an at::Tensor. Returns a null LazyTensor
+// if the tensor is not a lazy tensor.
+LazyTensor TryGetLtcTensor(const at::Tensor& tensor);
 
-// Extracts the LazyTensor out of our version of at::Tensor. Throws an exception
-// if tensor is not a lazy tensor.
+// Extracts the LazyTensor out of an at::Tensor. Throws an exception
+// if the tensor is not a lazy tensor.
 LazyTensor GetLtcTensor(const at::Tensor& tensor);
 
 // Same as above, applied to a list of tensors.
@@ -28,19 +29,10 @@ std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
 
 // If tensor is a lazy tensor type, returns the LazyTensor embedded within it,
 // otherwise creates a new lazy tensor type with tensor as data.
-LazyTensor GetOrCreateLtcTensor(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
-
 LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
                                 const torch::lazy::BackendDevice& device);
 
 LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
-
-// Creates a lazy tensor holding the data in tensor, on the given device.
-at::Tensor CreateLtcTensor(at::Tensor tensor,
-                           const c10::optional<torch::lazy::BackendDevice>& device);
-
-// Creates a vector of at::Tensor objects extracted from a list of lazy tensors.
-std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors);
 
 //////////////////////////////////////////////////////////////////////////////
 // LazyTensor => at::Tensor

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -11,46 +11,6 @@
 
 namespace torch_lazy_tensors {
 namespace bridge {
-
-//////////////////////////////////////////////////////////////////////////////
-// at::Tensor => LazyTensor
-//////////////////////////////////////////////////////////////////////////////
-
-// Extracts the LazyTensor out of an at::Tensor. Returns a null LazyTensor
-// if the tensor is not a lazy tensor.
-LazyTensor TryGetLtcTensor(const at::Tensor& tensor);
-
-// Extracts the LazyTensor out of an at::Tensor. Throws an exception
-// if the tensor is not a lazy tensor.
-LazyTensor GetLtcTensor(const at::Tensor& tensor);
-
-// Same as above, applied to a list of tensors.
-std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
-
-// If tensor is a lazy tensor type, returns the LazyTensor embedded within it,
-// otherwise creates a new lazy tensor type with tensor as data.
-LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
-                                const torch::lazy::BackendDevice& device);
-
-LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
-
-//////////////////////////////////////////////////////////////////////////////
-// LazyTensor => at::Tensor
-//////////////////////////////////////////////////////////////////////////////
-
-// Creates an ATen tensor from an LazyTensor.
-at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor);
-
-template <size_t... Indices>
-auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {
-    return std::make_tuple(AtenFromLtcTensor(tensors[Indices])...);
-}
-
-template <size_t N>
-auto TupleAtenFromLtcTensors(const std::vector<LazyTensor>& tensors) {
-    return TupleAtenFromLtcTensorsImpl(tensors, std::make_index_sequence<N>{});
-}
-
 //////////////////////////////////////////////////////////////////////////////
 // Device Management
 //////////////////////////////////////////////////////////////////////////////

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -6,21 +6,22 @@
 
 #include <vector>
 
+#include "c10/util/Optional.h"
 #include "lazy_tensor_core/csrc/tensor.h"
 
 namespace torch_lazy_tensors {
 namespace bridge {
 
-c10::optional<LazyTensor> TryGetLtcTensor(const at::Tensor& tensor);
+//////////////////////////////////////////////////////////////////////////////
+// at::Tensor => LazyTensor
+//////////////////////////////////////////////////////////////////////////////
 
 bool IsLtcTensor(const at::Tensor& tensor);
+c10::optional<LazyTensor> TryGetLtcTensor(const at::Tensor& tensor);
 
 // Extracts the LazyTensor out of our version of at::Tensor. Throws an exception
 // if tensor is not a lazy tensor.
 LazyTensor GetLtcTensor(const at::Tensor& tensor);
-
-// Replaces the lazy tensor embedded within the TensorImpl with the new version.
-void ReplaceLtcTensor(const at::Tensor& tensor, LazyTensor new_ltc_tensor);
 
 // Same as above, applied to a list of tensors.
 std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
@@ -34,36 +35,39 @@ LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
 
 LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
 
+// Creates a lazy tensor holding the data in tensor, on the given device.
+at::Tensor CreateLtcTensor(at::Tensor tensor,
+                           const c10::optional<torch::lazy::BackendDevice>& device);
+
 // Creates a vector of at::Tensor objects extracted from a list of lazy tensors.
 std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors);
 
-// Creates a vector of c10::optional<at::Tensor> objects extracted from a list
-// of optional lazy tensors.
-std::vector<c10::optional<at::Tensor>> LtcCreateOptTensorList(
-    const std::vector<c10::optional<at::Tensor>>& tensors);
+//////////////////////////////////////////////////////////////////////////////
+// LazyTensor => at::Tensor
+//////////////////////////////////////////////////////////////////////////////
 
-void LtcUpdateTensors(c10::ArrayRef<at::Tensor> dest_ltc_tensors,
-                      c10::ArrayRef<at::Tensor> source_cpu_tensors,
-                      c10::ArrayRef<size_t> indices);
+// Creates an ATen tensor from an LazyTensor.
+at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor);
 
-void LtcUpdateTensorsMeta(c10::ArrayRef<at::Tensor> dest_ltc_tensors,
-                          c10::ArrayRef<at::Tensor> source_cpu_tensors,
-                          c10::ArrayRef<size_t> indices);
+template <size_t... Indices>
+auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {
+    return std::make_tuple(AtenFromLtcTensor(tensors[Indices])...);
+}
+
+template <size_t N>
+auto TupleAtenFromLtcTensors(const std::vector<LazyTensor>& tensors) {
+    return TupleAtenFromLtcTensorsImpl(tensors, std::make_index_sequence<N>{});
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Device Management
+//////////////////////////////////////////////////////////////////////////////
 
 // Tries to extract the device out of the lazy tensor. Returns nullopt if the
 // input is not a lazy tensor.
 c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const at::Tensor& tensor);
 
-c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const c10::optional<at::Tensor>& tensor);
-
-c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const at::TensorList& tensors);
-
-c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const at::TensorOptions& tensor_options);
-
-c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const c10::Device& device);
-
-c10::optional<torch::lazy::BackendDevice> GetLtcDevice(
-    const c10::optional<c10::Device>& device = c10::nullopt);
+c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const c10::optional<c10::Device>& device = c10::nullopt);
 
 template<typename T, typename... Args>
 c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const T& tensor, const Args&... forward_tensors) {
@@ -77,39 +81,6 @@ c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const T& tensor, const Ar
 torch::lazy::BackendDevice AtenDeviceToLtcDevice(const c10::Device& device);
 
 c10::Device LtcDeviceToAtenDevice(const torch::lazy::BackendDevice& device);
-
-std::string ToLtcString(const c10::Device& device);
-
-at::Tensor LtcToAtenTensor(LazyTensor ltc_tensor,
-                           const at::TensorOptions& tensor_options);
-
-// Creates an ATen tensor from an LazyTensor.
-at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor);
-
-std::vector<at::Tensor> AtenFromLtcTensors(
-    c10::ArrayRef<LazyTensor> ltc_tensors);
-
-// Creates a lazy tensor holding the data in tensor, on the given device.
-at::Tensor CreateLtcTensor(at::Tensor tensor,
-                           const c10::optional<torch::lazy::BackendDevice>& device);
-
-// Given a vector of at::Tensor creates a vector of lazy tensors on the given
-// device.
-std::vector<at::Tensor> CreateLtcTensors(const std::vector<at::Tensor>& tensors,
-                                         const c10::optional<torch::lazy::BackendDevice>& device);
-
-// Returns true if the tensor is a view created via interoperability.
-bool IsInteropView(const at::Tensor& t);
-
-template <size_t... Indices>
-auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {
-    return std::make_tuple(AtenFromLtcTensor(tensors[Indices])...);
-}
-
-template <size_t N>
-auto TupleAtenFromLtcTensors(const std::vector<LazyTensor>& tensors) {
-    return TupleAtenFromLtcTensorsImpl(tensors, std::make_index_sequence<N>{});
-}
 
 }  // namespace bridge
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -181,7 +181,7 @@ std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> AllReduce(
       TryGetLtcTensor(input), *token, GetReduceType(reduce_type), scale,
       replica_groups);
   return std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>>(
-      AtenFromLtcTensor(std::move(result)),
+      CreateAtenFromLtcTensor(std::move(result)),
       std::make_shared<torch::lazy::Value>(new_token));
 }
 
@@ -195,7 +195,7 @@ std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> AllToAll(
       TryGetLtcTensor(input), *token, split_dimension, concat_dimension,
       split_count, replica_groups);
   return std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>>(
-      AtenFromLtcTensor(std::move(result)),
+      CreateAtenFromLtcTensor(std::move(result)),
       std::make_shared<torch::lazy::Value>(new_token));
 }
 
@@ -207,7 +207,7 @@ std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>> CollectivePermute(
   std::tie(result, new_token) = lazy_tensor_distributed::collective_permute(
       TryGetLtcTensor(input), *token, source_target_pairs);
   return std::pair<at::Tensor, std::shared_ptr<torch::lazy::Value>>(
-      AtenFromLtcTensor(std::move(result)),
+      CreateAtenFromLtcTensor(std::move(result)),
       std::make_shared<torch::lazy::Value>(new_token));
 }
 
@@ -311,7 +311,7 @@ std::vector<at::Tensor> GetLtcTensorsFromAten(
   lazy_tensors.reserve(data_handles.size());
   for (auto& data_handle : data_handles) {
     LazyTensor lazy_tensor = LazyTensor::Create(std::move(data_handle));
-    lazy_tensors.push_back(AtenFromLtcTensor(std::move(lazy_tensor)));
+    lazy_tensors.push_back(CreateAtenFromLtcTensor(std::move(lazy_tensor)));
   }
   return lazy_tensors;
 }
@@ -371,8 +371,8 @@ py::object LtcNms(const at::Tensor& boxes, const at::Tensor& scores,
         TryGetLtcTensor(boxes), TryGetLtcTensor(scores),
         TryGetLtcTensor(score_threshold),
         TryGetLtcTensor(iou_threshold), output_size);
-    selected_indices = AtenFromLtcTensor(std::move(nms_result.first));
-    num_valid = AtenFromLtcTensor(std::move(nms_result.second));
+    selected_indices = CreateAtenFromLtcTensor(std::move(nms_result.first));
+    num_valid = CreateAtenFromLtcTensor(std::move(nms_result.second));
   }
   auto result_tuple = py::tuple(2);
   result_tuple[0] =

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -501,7 +501,7 @@ LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const 
       GetOrCreateLtcTensor(tensor, device) : GetLtcTensor(tensor);
 }
 
-at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor) {
+at::Tensor CreateAtenFromLtcTensor(LazyTensor ltc_tensor) {
   return ltc_tensor.is_null() ? at::Tensor()
                               : at::Tensor(c10::make_intrusive<LTCTensorImpl>(
                                     std::move(ltc_tensor)));

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -4,6 +4,7 @@
 #include "lazy_tensor_core/csrc/helpers.h"
 #include "lazy_tensor_core/csrc/ir_dump_util.h"
 #include "lazy_tensor_core/csrc/lazy_graph_executor.h"
+#include "lazy_tensor_core/csrc/tensor_impl.h"
 #include "lazy_tensor_core/csrc/ops/arithmetic_ir_ops.h"
 #include "lazy_tensor_core/csrc/ops/cast.h"
 #include "lazy_tensor_core/csrc/ops/device_data.h"
@@ -16,6 +17,16 @@
 #include "lazy_tensors/computation_client/metrics.h"
 
 namespace torch_lazy_tensors {
+namespace {
+LazyTensor GetOrCreateLtcTensor(const at::Tensor& tensor,
+                                const torch::lazy::BackendDevice& device) {
+  if (!tensor.defined()) {
+    return LazyTensor();
+  }
+  auto xtensor = TryGetLtcTensor(tensor);
+  return xtensor ? xtensor : LazyTensor::Create(tensor, device);
+}
+}  // namespace
 
 LazyTensor::Data::~Data() { LazyGraphExecutor::Get()->UnregisterTensor(this); }
 
@@ -455,6 +466,45 @@ void LazyTensor::ApplyPendingGraph() {
 int64_t LazyTensor::GetNextTensorId() {
   static std::atomic<int64_t>* id_generator = new std::atomic<int64_t>(1);
   return id_generator->fetch_add(1);
+}
+
+LazyTensor TryGetLtcTensor(const at::Tensor& tensor) {
+  auto* impl = dynamic_cast<LTCTensorImpl*>(tensor.unsafeGetTensorImpl());
+  if (impl == nullptr) {
+    return LazyTensor();
+  }
+  return impl->tensor();
+}
+
+LazyTensor GetLtcTensor(const at::Tensor& tensor) {
+  auto lazy_tensor = TryGetLtcTensor(tensor);
+  CHECK(lazy_tensor) << "Input tensor is not a lazy tensor: " << tensor.toString();
+  return lazy_tensor;
+}
+
+std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors) {
+  std::vector<LazyTensor> ltc_tensors;
+  ltc_tensors.reserve(tensors.size());
+  for (const auto& tensor : tensors) {
+    ltc_tensors.push_back(TryGetLtcTensor(tensor));
+  }
+  return ltc_tensors;
+}
+
+LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
+                                const torch::lazy::BackendDevice& device) {
+  return GetOrCreateLtcTensor(tensor.value_or(at::Tensor()), device);
+}
+
+LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const torch::lazy::BackendDevice& device) {
+  return tensor.unsafeGetTensorImpl()->is_wrapped_number() ?
+      GetOrCreateLtcTensor(tensor, device) : GetLtcTensor(tensor);
+}
+
+at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor) {
+  return ltc_tensor.is_null() ? at::Tensor()
+                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(
+                                    std::move(ltc_tensor)));
 }
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -9,6 +9,7 @@
 
 namespace torch_lazy_tensors {
 using NodePtr = torch::lazy::NodePtr;
+
 class LazyTensor {
  public:
   // This is the core lazy tensor data structure where all the tensor data is
@@ -59,6 +60,7 @@ class LazyTensor {
   LazyTensor() = default;
 
   bool is_null() const { return data_ptr() == nullptr; }
+  operator bool() const { return !is_null(); }
 
   size_t generation() const { return data()->generation; }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -195,11 +195,11 @@ LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const 
 
 // Section 2: LazyTensor => at::Tensor.
 // Creates an ATen tensor from an LazyTensor.
-at::Tensor AtenFromLtcTensor(LazyTensor ltc_tensor);
+at::Tensor CreateAtenFromLtcTensor(LazyTensor ltc_tensor);
 
 template <size_t... Indices>
 auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {
-    return std::make_tuple(AtenFromLtcTensor(tensors[Indices])...);
+    return std::make_tuple(CreateAtenFromLtcTensor(tensors[Indices])...);
 }
 
 template <size_t N>

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -83,6 +83,8 @@ at::Tensor subtensor(const at::Tensor& tensor, int dim, int groups, int g) {
   return tensor.narrow(dim, n * g, n).contiguous();
 }
 
+
+
 }  // namespace
 
 at::Tensor LazyNativeFunctions::alias(const at::Tensor& self) {
@@ -334,7 +336,8 @@ at::Tensor LazyNativeFunctions::_copy_from(const at::Tensor& self,
       }
     } else {
       lazy_tensor_aten_ops::copy_(*dst_tensor, *self_tensor);
-      bridge::ReplaceLtcTensor(dst, *dst_tensor);
+      auto* impl = dynamic_cast<LTCTensorImpl*>(dst.unsafeGetTensorImpl());
+      impl->set_tensor(*dst_tensor);
     }
   }
   return dst;

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -16,6 +16,10 @@ namespace torch_lazy_tensors {
 namespace cpp_test {
 namespace {
 
+bool IsLtcTensor(const at::Tensor& tensor) {
+  return dynamic_cast<LTCTensorImpl*>(tensor.unsafeGetTensorImpl());
+}
+
 void DumpDifferences(const at::Tensor& tensor1, const at::Tensor& tensor2) {
   static bool dump_tensors =
       lazy_tensors::sys_util::GetEnvBool("XLA_TEST_DUMP_TENSORS", false);
@@ -39,7 +43,7 @@ void DumpDifferences(const at::Tensor& tensor1, const at::Tensor& tensor2) {
 void MaybeDumpGraph(const at::Tensor& tensor) {
   static std::string dump_graph =
       lazy_tensors::sys_util::GetEnvString("XLA_TEST_DUMP_GRAPHS", "");
-  if (!dump_graph.empty() && bridge::IsLtcTensor(tensor)) {
+  if (!dump_graph.empty() && IsLtcTensor(tensor)) {
     std::string graph_str;
     if (dump_graph == "text") {
       graph_str = GetTensorTextGraph(tensor);

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -170,12 +170,12 @@ bool CloseValues(at::Tensor tensor1, at::Tensor tensor2, double rtol,
 }
 
 std::string GetTensorTextGraph(at::Tensor tensor) {
-  LazyTensor xtensor = bridge::GetLtcTensor(tensor);
+  LazyTensor xtensor = TryGetLtcTensor(tensor);
   return ir::DumpUtil::ToText({xtensor.GetIrValue().node.get()});
 }
 
 std::string GetTensorDotGraph(at::Tensor tensor) {
-  LazyTensor xtensor = bridge::GetLtcTensor(tensor);
+  LazyTensor xtensor = TryGetLtcTensor(tensor);
   return ir::DumpUtil::ToDot({xtensor.GetIrValue().node.get()});
 }
 

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -181,7 +181,7 @@ class GenLazyNativeFuncDefinition:
 
         assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
         first_tensor = value_types[0]
-        bridge_str = f"""auto result = AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
+        bridge_str = f"""auto result = CreateAtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
         if returns_length > 1:
             bridge_str = f"""std::vector<LazyTensor> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -127,12 +127,12 @@ def lazy_tensor_decls(value_types: List[NamedCType]) -> str:
         if isinstance(t.type, BaseCType):
             lazy_tensor_decls.append(
                 f"LazyTensor lazy_{t.name} = "
-                f"bridge::GetLtcTensorOrCreateForWrappedNumber({t.name}, *device);")
+                f"GetLtcTensorOrCreateForWrappedNumber({t.name}, *device);")
         elif isinstance(t.type, OptionalCType):
             # TODO(alanwaketan): Maybe we want to apply GetLtcTensorOrCreateForWrappedNumber here, but hold it
             # until we encounter a real world example.
             lazy_tensor_decls.append(
-                f"    LazyTensor lazy_{t.name} =  bridge::TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
+                f"    LazyTensor lazy_{t.name} = TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
         else:
             raise AssertionError("TODO not sure if there are other valid types to handle here")
     return "\n    ".join(lazy_tensor_decls)
@@ -181,13 +181,13 @@ class GenLazyNativeFuncDefinition:
 
         assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
         first_tensor = value_types[0]
-        bridge_str = f"""auto result = bridge::AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
+        bridge_str = f"""auto result = AtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
         if returns_length > 1:
             bridge_str = f"""std::vector<LazyTensor> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
             lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(torch::lazy::Value(node, i)));
         }}
-        auto result = bridge::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
+        auto result = TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
         if schema.name.name.inplace:
             assert returns_length == 1, "We assumed there was no such case where an op is an in-place variant " \
                                         "and has tuple outputs."

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -21,7 +21,7 @@ def node_ctor_arg_rvalue_string(arg: NamedCType) -> str:
             return f"lazy_{arg.name}.GetIrValue()"
         elif isinstance(arg.type, OptionalCType):
             return f"lazy_{arg.name} ? " \
-                   f"c10::make_optional(lazy_{arg.name}->GetIrValue()) : " \
+                   f"c10::make_optional(lazy_{arg.name}.GetIrValue()) : " \
                    "c10::nullopt"
         else:
             raise AssertionError("TODO not sure if there are other valid types to handle here")
@@ -132,10 +132,7 @@ def lazy_tensor_decls(value_types: List[NamedCType]) -> str:
             # TODO(alanwaketan): Maybe we want to apply GetLtcTensorOrCreateForWrappedNumber here, but hold it
             # until we encounter a real world example.
             lazy_tensor_decls.append(
-                f"c10::optional<LazyTensor> lazy_{t.name} =  "
-                f"{t.name} ? "
-                f"bridge::TryGetLtcTensor(*{t.name}) : "
-                f"c10::nullopt;")
+                f"    LazyTensor lazy_{t.name} =  bridge::TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
         else:
             raise AssertionError("TODO not sure if there are other valid types to handle here")
     return "\n    ".join(lazy_tensor_decls)


### PR DESCRIPTION
Summary:
This pull request refactors namespace bridge:
1. Removes unused functions from namespace bridge.
2. Merge and prune some bridge utils.
3. Move at::Tensor <=> LazyTensor utilities to tensor.h
3. WIP: holding on #67869 to move device related utils out of bridge.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc

P.S. It's easier to review one commit by another.
