### PR TITLE
fractional_max_pool2d_backward: port to structured kernel

### DIFF
--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -107,7 +107,11 @@ TORCH_META_FUNC(fractional_max_pool2d_backward)(
     "fractional_max_pool2d_backward(): gradOutput height unexpected");
 
   /* resize */
-  set_output(0, input.sizes(), input.options());
+  if (ndims == 3) {
+    set_output(0, {numPlanes, outputH, outputW}, input.options());
+  } else {
+    set_output(0, {numBatch, numPlanes, outputH, outputW}, input.options());
+  }
 }
 } // namespace meta
 

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -108,9 +108,9 @@ TORCH_META_FUNC(fractional_max_pool2d_backward)(
 
   /* resize */
   if (ndims == 3) {
-    set_output(0, {numPlanes, outputH, outputW}, input.options());
+    set_output(0, {numPlanes, inputH, inputW}, input.options());
   } else {
-    set_output(0, {numBatch, numPlanes, outputH, outputW}, input.options());
+    set_output(0, {numBatch, numPlanes, inputH, inputW}, input.options());
   }
 }
 } // namespace meta

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -70,6 +70,45 @@ TORCH_META_FUNC(fractional_max_pool2d) (
   }
 }
 
+TORCH_META_FUNC(fractional_max_pool2d_backward)(
+  const at::Tensor& gradOutput_,
+  const at::Tensor& input,
+  IntArrayRef pool_size /* unused */,
+  IntArrayRef output_size,
+  const at::Tensor& indices) {
+
+  int numBatch = 1;
+  int planeDim = 0;
+  int heightDim = 1;
+  int widthDim = 2;
+
+  int outputH = output_size[0];
+  int outputW = output_size[1];
+
+  int ndims = input.ndimension();
+  if (ndims == 4) {
+    numBatch = input.size(0);
+    planeDim = 1;
+    heightDim++;
+    widthDim++;
+  }
+
+  /* sizes */
+  int numPlanes = input.size(planeDim);
+  int inputH = input.size(heightDim);
+  int inputW = input.size(widthDim);
+
+  /* get contiguous gradOutput */
+  auto gradOutput = gradOutput_.contiguous();
+
+  TORCH_CHECK(outputW == gradOutput.size(widthDim),
+    "fractional_max_pool2d_backward(): gradOutput width unexpected");
+  TORCH_CHECK(outputH == gradOutput.size(heightDim),
+    "fractional_max_pool2d_backward(): gradOutput height unexpected");
+
+  /* resize */
+  set_output(0, input.sizes(), input.options());
+}
 } // namespace meta
 
 namespace native {
@@ -189,63 +228,6 @@ static void fractional_max_pool2d_out_frame(
     });
   }
 
-} // anonymous namespace
-
-TORCH_IMPL_FUNC(fractional_max_pool2d_out_cpu) (
-  const at::Tensor& input_,
-  IntArrayRef pool_size,
-  IntArrayRef output_size,
-  const at::Tensor& randomSamples,
-  const at::Tensor& output,
-  const at::Tensor& indices) {
-
-  int64_t numBatch = 1;
-  int64_t planeDim = 0;
-  int64_t heightDim = 1;
-  int64_t widthDim = 2;
-  int64_t outputH = output_size[0]; // output.size(heightDim)
-  int64_t outputW = output_size[1]; // output.size(widthDim)
-  int64_t poolSizeH = pool_size[0];
-  int64_t poolSizeW = pool_size[1];
-
-  /* get contiguous input */
-  auto input = input_.contiguous();
-
-  int64_t ndims = input.ndimension();
-
-  if (ndims == 4) {
-    numBatch = input.size(0);
-    planeDim++;
-    heightDim++;
-    widthDim++;
-  }
-
-  /* sizes */
-  int64_t numPlanes = input.size(planeDim);
-  int64_t inputH = input.size(heightDim);
-  int64_t inputW = input.size(widthDim);
-
-  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
-  "fractional_max_pool2d_out_frame", [&] {
-    auto input_data = input.data_ptr<scalar_t>();
-    auto output_data = output.data_ptr<scalar_t>();
-    auto indices_data = indices.data_ptr<int64_t>();
-    auto randomSamples_data = randomSamples.data_ptr<scalar_t>();
-    fractional_max_pool2d_out_frame<scalar_t>(
-      input_data,
-      output_data,
-      indices_data,
-      randomSamples_data,
-      numBatch, numPlanes,
-      inputW, inputH,
-      outputW, outputH,
-      poolSizeW, poolSizeH);
-    }
-  );
-}
-
-namespace {
-
 template <typename scalar_t>
 static void fractional_max_pool2d_backward_out_single_batch_frame(
   scalar_t* gradInput,
@@ -302,13 +284,70 @@ static void fractional_max_pool2d_backward_out_frame(
     });
 }
 
-Tensor& fractional_max_pool2d_backward_out_cpu_template(
-  const at::Tensor& input,
-  const at::Tensor& gradOutput_,
-  at::Tensor& gradInput,
+} // anonymous namespace
+
+TORCH_IMPL_FUNC(fractional_max_pool2d_out_cpu) (
+  const at::Tensor& input_,
+  IntArrayRef pool_size,
   IntArrayRef output_size,
-  IntArrayRef pool_size /* unused */,
+  const at::Tensor& randomSamples,
+  const at::Tensor& output,
   const at::Tensor& indices) {
+
+  int64_t numBatch = 1;
+  int64_t planeDim = 0;
+  int64_t heightDim = 1;
+  int64_t widthDim = 2;
+  int64_t outputH = output_size[0]; // output.size(heightDim)
+  int64_t outputW = output_size[1]; // output.size(widthDim)
+  int64_t poolSizeH = pool_size[0];
+  int64_t poolSizeW = pool_size[1];
+
+  /* get contiguous input */
+  auto input = input_.contiguous();
+
+  int64_t ndims = input.ndimension();
+
+  if (ndims == 4) {
+    numBatch = input.size(0);
+    planeDim++;
+    heightDim++;
+    widthDim++;
+  }
+
+  /* sizes */
+  int64_t numPlanes = input.size(planeDim);
+  int64_t inputH = input.size(heightDim);
+  int64_t inputW = input.size(widthDim);
+
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
+  "fractional_max_pool2d_out_frame", [&] {
+    auto input_data = input.data_ptr<scalar_t>();
+    auto output_data = output.data_ptr<scalar_t>();
+    auto indices_data = indices.data_ptr<int64_t>();
+    auto randomSamples_data = randomSamples.data_ptr<scalar_t>();
+    fractional_max_pool2d_out_frame<scalar_t>(
+      input_data,
+      output_data,
+      indices_data,
+      randomSamples_data,
+      numBatch, numPlanes,
+      inputW, inputH,
+      outputW, outputH,
+      poolSizeW, poolSizeH);
+    }
+  );
+}
+
+TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cpu) (
+  const at::Tensor& gradOutput_,
+  const at::Tensor& input,
+  IntArrayRef pool_size,
+  IntArrayRef output_size,
+  const at::Tensor& indices,
+  const at::Tensor& gradInput) {
+
+  gradInput.zero_();
 
   int numBatch = 1;
   int planeDim = 0;
@@ -334,15 +373,6 @@ Tensor& fractional_max_pool2d_backward_out_cpu_template(
   /* get contiguous gradOutput */
   auto gradOutput = gradOutput_.contiguous();
 
-  TORCH_CHECK(outputW == gradOutput.size(widthDim),
-    "fractional_max_pool2d_backward(): gradOutput width unexpected");
-  TORCH_CHECK(outputH == gradOutput.size(heightDim),
-    "fractional_max_pool2d_backward(): gradOutput height unexpected");
-
-  /* resize */
-  gradInput.resize_as_(input);
-  gradInput.zero_();
-
   /* backprop */
   AT_DISPATCH_FLOATING_TYPES(
     input.scalar_type(), "fractional_max_pool2d_backward_out_frame", [&] {
@@ -357,47 +387,8 @@ Tensor& fractional_max_pool2d_backward_out_cpu_template(
         inputW, inputH,
         outputW, outputH
       );
-      }
-    );
-  return gradInput;
-}
-
-} // namespace
-
-Tensor& fractional_max_pool2d_backward_out_cpu(const at::Tensor& gradOutput_,
-  const at::Tensor& input,
-  IntArrayRef pool_size,
-  IntArrayRef output_size,
-  const at::Tensor& indices,
-  at::Tensor& gradInput)
-{
-  gradInput.resize_as_(input);
-  fractional_max_pool2d_backward_out_cpu_template(
-    input,
-    gradOutput_,
-    gradInput,
-    output_size,
-    pool_size,
-    indices);
-  return gradInput;
-}
-
-Tensor fractional_max_pool2d_backward_cpu(
-  const at::Tensor& gradOutput_,
-  const at::Tensor& input,
-  IntArrayRef pool_size,
-  IntArrayRef output_size,
-  const at::Tensor& indices)
-{
-  Tensor gradInput = at::empty({0}, input.options());
-  fractional_max_pool2d_backward_out_cpu_template(
-    input,
-    gradOutput_,
-    gradInput,
-    output_size,
-    pool_size,
-    indices);
-  return gradInput;
+    }
+  );
 }
 
 } // at::native

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -220,7 +220,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
-  gradInput.resize_as(input)
+  gradInput.resize_as_(input)
   if (gradInput.numel() == 0) {
     return;
   }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -219,6 +219,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
+  gradInput.resize_as_(input);
   if (gradInput.numel() == 0) {
     return;
   }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -202,6 +202,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("fractional_max_pool2d_backward_cuda");
+  gradInput = at::empty({0}, input.options());
 
   int dimh = 1;
   int dimw = 2;
@@ -219,6 +220,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
+  gradInput.resize_as(input)
   if (gradInput.numel() == 0) {
     return;
   }
@@ -230,7 +232,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   auto indices_ = indices;
 
   if(ndims == 3) {
-    gradInput_ = gradInput_.reshape({1, gradInput.size(0), inputH, inputW});
+    gradInput_ = gradInput_.reshape({1, input.size(0), inputH, inputW});
     gradOutput_ = gradOutput_.reshape({1, gradOutput.size(0), outputH, outputW});
     indices_ = indices_.reshape({1, indices_.size(0), outputH, outputW});
   }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -193,8 +193,8 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_out_cuda) (
 TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   const Tensor& gradOutput,
   const Tensor& input,
-  IntArrayRef output_size,
   IntArrayRef pool_size /* unused */,
+  IntArrayRef output_size,
   const Tensor& indices,
   const Tensor& gradInput)
 {

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -219,7 +219,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
-  if (gradOutput.numel() == 0) {
+  if (gradInput.numel() == 0) {
     return;
   }
 
@@ -230,7 +230,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   auto indices_ = indices;
 
   if(ndims == 3) {
-    gradInput_ = gradInput_.reshape({1, input.size(0), inputH, inputW});
+    gradInput_ = gradInput_.reshape({1, gradInput.size(0), inputH, inputW});
     gradOutput_ = gradOutput_.reshape({1, gradOutput.size(0), outputH, outputW});
     indices_ = indices_.reshape({1, indices_.size(0), outputH, outputW});
   }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -219,10 +219,10 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
-  gradInput.resize_as_(input);
-  if (gradInput.numel() == 0) {
+  if (gradOutput.numel() == 0) {
     return;
   }
+
   gradInput.zero_();
 
   auto gradInput_ = gradInput;

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -220,7 +220,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
-  gradInput.resize_as_(input)
+  gradInput.resize_as_(input);
   if (gradInput.numel() == 0) {
     return;
   }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -202,7 +202,6 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage
   globalContext().alertNotDeterministic("fractional_max_pool2d_backward_cuda");
-  gradInput = at::empty({0}, input.options());
 
   int dimh = 1;
   int dimw = 2;
@@ -220,7 +219,6 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   int outputH = output_size[0];
   int outputW = output_size[1];
 
-  gradInput.resize_as_(input);
   if (gradInput.numel() == 0) {
     return;
   }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -198,6 +198,11 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   const Tensor& indices,
   const Tensor& gradInput)
 {
+
+  // See Note [Writing Nondeterministic Operations]
+  // Nondeterministic because of atomicAdd usage
+  globalContext().alertNotDeterministic("fractional_max_pool2d_backward_cuda");
+
   int dimh = 1;
   int dimw = 2;
 
@@ -224,6 +229,7 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
   auto indices_ = indices;
 
   if(ndims == 3) {
+    gradInput_ = gradInput_.reshape({1, input.size(0), inputH, inputW});
     gradOutput_ = gradOutput_.reshape({1, gradOutput.size(0), outputH, outputW});
     indices_ = indices_.reshape({1, indices_.size(0), outputH, outputW});
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9256,15 +9256,14 @@
 
 - func: fractional_max_pool2d_backward.grad_input(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
-  dispatch:
-    CPU: fractional_max_pool2d_backward_out_cpu
-    CUDA: fractional_max_pool2d_backward_out_cuda
-
-- func: fractional_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices) -> Tensor
-  python_module: nn
+  structured: True
   dispatch:
     CPU: fractional_max_pool2d_backward_cpu
     CUDA: fractional_max_pool2d_backward_cuda
+
+- func: fractional_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices) -> Tensor
+  python_module: nn
+  structured_delegate: fractional_max_pool2d_backward.grad_input
 
 # Return: (Tensor output, Tensor indices)
 - func: fractional_max_pool3d.output(Tensor self, int[3] kernel_size, int[3] output_size, Tensor random_samples, *, Tensor(a!) output, Tensor(b!) indices) -> (Tensor(a!), Tensor(b!))


### PR DESCRIPTION
Ported to structured kernel the fractional_max_pool2d_backward. 

Ref #55070
