### PR TITLE
[pytorch][xros] Ensure all pytorch mobile operators build ok in XROS mode

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_wrapper.cpp
+++ b/aten/src/ATen/nnapi/nnapi_wrapper.cpp
@@ -336,6 +336,8 @@ int check_Execution_getOutputOperandDimensions(ANeuralNetworksExecution* executi
 void nnapi_wrapper_load(struct nnapi_wrapper** nnapi, struct nnapi_wrapper** check_nnapi) {
 #ifdef _WIN32
   TORCH_CHECK(false, "Running NNAPI models is not supported on Windows.");
+#elif __XROS__
+  TORCH_CHECK(false, "Running NNAPI models is not supported on XROS.");
 #else
   if (!loaded) {
     // Clear error flag.

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -51,7 +51,7 @@ static void forked_autograd_child() { in_bad_autograd_fork = true; }
 
 // Should be called before unsafe for forks (thread pool) calls
 static void track_bad_autograd_forks() {
-#ifndef WIN32
+#if !defined(WIN32) && !defined(__XROS__)
   static std::once_flag flag;
   std::call_once(
       flag, [&] { pthread_atfork(nullptr, nullptr, forked_autograd_child); });


### PR DESCRIPTION
Summary:
* Test `"//xplat/caffe2:torch_mobile_all_ops"` builds for XROS
* Use `if...endif` to adjust pyTorch internals towards XROS
* Sync `//third-party/cpuinfo` XROS changes from `aros//xros`. <- This is `XNNPACK` dependency

Test Plan: CI

Reviewed By: kkosik20

Differential Revision: D32190771

