### PR TITLE
Add histogramdd to torch.rst

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -512,6 +512,7 @@ Other Operations
     gcd
     histc
     histogram
+    histogramdd
     meshgrid
     lcm
     logcumsumexp


### PR DESCRIPTION
The `torch.histogramdd` operator is documented in `torch/functional.py` but does not appear in the generated docs because it is missing from `docs/source/torch.rst`.