### PR TITLE
[Vulkan] Implement permute operator

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/permute_4d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/permute_4d.glsl
@@ -1,0 +1,117 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba16f) uniform PRECISION           image3D uOutput;
+layout(set = 0, binding = 1)          uniform PRECISION           sampler3D uInput;
+layout(set = 0, binding = 2)          uniform PRECISION restrict  Block {
+  ivec4 size;            // output texture size (x=width,y=height,z=depth,w=unused)
+  ivec4 isize;           // input texture size (x=width,y=height,z=depth,w=unused)
+  uvec4 tensor_size;     // output tensor size
+  uvec4 itensor_size;    // input tensor size
+  uvec4 dims;            // output dims
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 posOut = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(posOut, uBlock.size.xyz))) {
+    const uint max_dst_index = uBlock.tensor_size[0] * uBlock.tensor_size[1];
+    vec4 outval = vec4(0.0);
+
+    for (uint j = 0; j < 4; ++j) {
+      uint dst_index = posOut.z * 4 + j;
+      if (dst_index >= max_dst_index) {
+        imageStore(uOutput, posOut, outval);
+        // out of range
+        break;
+      }
+
+      uint b1 = int(dst_index / uBlock.tensor_size[1]);
+      uint c1 = dst_index % uBlock.tensor_size[1];
+      uint h1 = posOut.y;
+      uint w1 = posOut.x;
+
+      uint b, c, h, w;
+      switch (uBlock.dims[0]) {
+      case 0:
+        b = b1;
+        break;
+      case 1:
+        c = b1;
+        break;
+      case 2:
+        h = b1;
+        break;
+      case 3:
+        w = b1;
+        break;
+      }
+
+      switch (uBlock.dims[1]) {
+      case 0:
+        b = c1;
+        break;
+      case 1:
+        c = c1;
+        break;
+      case 2:
+        h = c1;
+        break;
+      case 3:
+        w = c1;
+        break;
+      }
+
+      switch (uBlock.dims[2]) {
+      case 0:
+        b = h1;
+        break;
+      case 1:
+        c = h1;
+        break;
+      case 2:
+        h = h1;
+        break;
+      case 3:
+        w = h1;
+        break;
+      }
+
+      switch (uBlock.dims[3]) {
+      case 0:
+        b = w1;
+        break;
+      case 1:
+        c = w1;
+        break;
+      case 2:
+        h = w1;
+        break;
+      case 3:
+        w = w1;
+        break;
+      }
+
+      uint src_index = b * uBlock.itensor_size[1] + c;
+      ivec3 posIn;
+      posIn.x = int(w);
+      posIn.y = int(h);
+      posIn.z = int(src_index / 4);
+      uint i = (src_index % 4);
+
+      vec4 inval = texelFetch(uInput, posIn, 0);
+      outval[j] = inval[i];
+
+      if (j == 3) {
+        imageStore(uOutput, posOut, outval);
+      }
+    }
+  }
+
+}

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -252,7 +252,7 @@ Tensor cat(
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl("_cat", TORCH_FN(cat));
+  m.impl(TORCH_SELECTIVE_NAME("aten::_cat"), TORCH_FN(cat));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -1,0 +1,131 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor permute_4d(const Tensor& input, const uvec4& in_size, const uvec4& out_size, const uvec4& out_dims, vTensor& v_output) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  auto dst_image = v_output.image(
+    command_buffer,
+    vTensor::Stage::Compute,
+    vTensor::Access::Read | vTensor::Access::Write);
+
+  const Tensor self = input.is_vulkan() ? input : input.vulkan();
+  const vTensor& v_self = convert(self);
+  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+    auto src_image = v_self.image(
+            command_buffer,
+            vTensor::Stage::Compute);
+
+    const struct Block final {
+      uvec3 size;                // output texture size
+      uint32_t fill_0;           // dummy
+      uvec3 isize;               // input texture size
+      uint32_t fill_1;           // dummy
+      uvec4 tensor_size;         // output tensor size
+      uvec4 itensor_size;        // input tensor size
+      uvec4 dims;                // output dims
+    } block {
+      v_output.extents(),
+      0u,
+      v_self.extents(),
+      0u,
+      out_size,
+      in_size,
+      out_dims,
+    };
+
+    context->dispatch(
+        command_buffer,
+        {
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        },
+        VK_KERNEL(permute_4d),
+        // build up shader operations from the output texture point of view
+        // to avoid the nondeterministic order of GPU shader operations between texels
+        v_output.extents(),
+        context->gpu().adapter->local_work_group_size(),
+        // Read/Write access bypasses synchronization but inserts appropriate
+        // barriers if necessary.
+        dst_image,
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
+        src_image,
+        // Object lifetime is managed by the resource pool.
+        // It is OK not to keep track of the handle.
+        context->resource().pool.uniform(block).object);
+  }
+  else {
+    TORCH_CHECK(false, "Not implemented!");
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+
+  return convert(v_output);
+}
+
+Tensor permute(const Tensor& self, IntArrayRef dims) {
+  auto nDims = safe_downcast<uint32_t>(self.dim());
+  TORCH_INTERNAL_ASSERT(
+    nDims <= 4, "Vulkan permute expects 4 or less dimensional inputs");
+  TORCH_CHECK(dims.size() == (size_t)nDims,
+           "number of dims don't match in permute");
+
+  uvec4 in_size{1u, 1u, 1u, 1u}, out_size{1u, 1u, 1u, 1u};
+  uvec4 out_dims{0u, 1u, 2u, 3u};
+
+  auto oldSizes = self.sizes();
+  DimVector newSizes(nDims);
+  bool sameDims = true;
+  std::vector<bool> seen(nDims);
+  for (const auto i : c10::irange(nDims)) {
+    auto dim = safe_downcast<uint32_t>(maybe_wrap_dim(dims[i], nDims));
+    TORCH_CHECK(!seen[dim],
+             "repeated dim in permute");
+    seen[dim] = true;
+    newSizes[i] = oldSizes[dim];
+    if (dim != i) {
+      sameDims = false;
+    }
+    // generalize into 4D tensor
+    in_size.data[(4u - nDims) + i] = self.sizes()[i];
+    out_size.data[(4u - nDims) + i] = self.sizes()[dim];
+    out_dims.data[(4u - nDims) + i] = dim + (4u - nDims);
+  }
+
+  if (sameDims) {
+    return self;
+  }
+
+  vTensor v_output{
+    api::context(),
+    newSizes,
+    self.options()};
+
+  return permute_4d(self, in_size, out_size, out_dims, v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::permute"), TORCH_FN(permute));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
**Summary:**
Pull Request resolved: https://github.com/pytorch/pytorch/pull/68274

Implemented `permute` operator on the Vulkan backend:
* Supports only <= 4D tensors.
* Builds up shader operations from the output texture point of view to avoid the nondeterministic order of GPU shader operations between texels. See [incoherent memory access](https://www.khronos.org/opengl/wiki/Memory_Model#Incoherent_memory_access)
* Generalized input tensors to 4D ones to simplify input/output texture handling. For example, {2, 3} is treated as {1,1,2,3} internally.
* 1D to 4D inputs with all possible permutations are used for test cases.
* Reference on CPU implementation of `permute` operator: [TensorShape.cpp](https://github.com/pytorch/pytorch/blob/cbf596bf8ee48f4ed895964fe4faf75a851b49c4/aten/src/ATen/native/TensorShape.cpp#L936)
* When shuffling dims, a new depth size of output texture needs to be determined by `ceil(batch*channel)/4`. This logic will be handled in a separate change.
    * The depth of texture cannot exceed a certain number, depending on the device's capability. It is typically 2048 on most of android devices but less than or equal to 16,384 (see [Value distribution for maxImageDimension3D on Android](https://vulkan.gpuinfo.org/displaydevicelimit.php?name=maxImageDimension3D&platform=android)). i.e., 2048 on MacOS and Google Pixel 5.
    * Due to this limitation, `permute` op needs to throw an exception if the depth of output texture is greater than or equal to `VkImageFormatProperties.maxExtent.depth`.
    * Otherwise, the following error will occur: `-[MTLTextureDescriptorInternal validateWithDevice:]:1325: failed assertion "Texture Descriptor Validation MTLTextureDescriptor has depth (10664) greater than the maximum allowed size of 2048."`
* Vulkan `permute` operator tensor conversion:
![image](https://user-images.githubusercontent.com/88354936/141701415-8d1e65b0-dd82-4196-97c2-7b448f4988ff.png)
![image](https://user-images.githubusercontent.com/88354936/141701419-ba40dc6b-4711-4024-9ffa-994186f722aa.png)
* Vulkan `permute` operator shader equation:
![image](https://user-images.githubusercontent.com/88354936/141701426-c42f6ef3-d927-4f10-a8aa-d00b6328d065.png)
* Error/edge cases:
```
X = torch.randint(0, 23, (2, 3, 2, 2))
O = torch.permute(X, (2, 2, 1, 0))
# RuntimeError: repeated dim in permute

O = torch.permute(X, (2, 1, 0))
# RuntimeError: number of dims don't match in permute

O = torch.permute(X, (4, 3, 2, 1, 0))
# RuntimeError: number of dims don't match in permute

O = torch.permute(X, (3, 2, -1, 0))
# RuntimeError: repeated dim in permute

data2 = [0,1,2]
X2 = torch.tensor(data2)
O2 = torch.permute(X2, (0))
# permute(): argument 'dims' (position 2) must be tuple of ints, not int
# TypeError: permute(): argument 'dims' (position 2) must be tuple of ints, not int

O = torch.permute(X, (0, 1, 2, 3))
# do nothing since the dims doesn't change?
```
* Shader debug traces with a 4D tensor size {2,3,2,2} with permute by {3,2,1,0}:
```
output tensor:
(1,1,.,.) =
  0.4395  0.5652
  0.1309  0.9768
  0.0490  0.1127
(2,1,.,.) =
  0.7058  0.2238
  0.6542  0.4064
  0.4813  0.0500
(1,2,.,.) =
  0.1716  0.4951
  0.2225  0.3255
  0.0758  0.7150
(2,2,.,.) =
  0.3762  0.0228
  0.6367  0.4411
  0.7682  0.7599
[ CPUFloatType{2,2,3,2} ]

shader debug traces:
src_index:0, b c h w: 0 0 0 0, posIn: (0 0 0) i:0 -> b c h w: 0 0 0 0, dst_index: 0, posOut: (0 0 0) j:0 -> inval[0.439453] outval[0.439453] -> inval[0.439453 0.130859 0.049011 0.564941] outval[0.439453 0.000000 0.000000 0.000000]
src_index:3, b c h w: 1 0 0 0, posIn: (0 0 0) i:3 -> b c h w: 0 0 0 1, dst_index: 0, posOut: (1 0 0) j:0 -> inval[0.564941] outval[0.564941] -> inval[0.439453 0.130859 0.049011 0.564941] outval[0.564941 0.000000 0.000000 0.000000]
src_index:1, b c h w: 0 1 0 0, posIn: (0 0 0) i:1 -> b c h w: 0 0 1 0, dst_index: 0, posOut: (0 1 0) j:0 -> inval[0.130859] outval[0.130859] -> inval[0.439453 0.130859 0.049011 0.564941] outval[0.130859 0.000000 0.000000 0.000000]
src_index:4, b c h w: 1 1 0 0, posIn: (0 0 1) i:0 -> b c h w: 0 0 1 1, dst_index: 0, posOut: (1 1 0) j:0 -> inval[0.976562] outval[0.976562] -> inval[0.976562 0.112671 -65504.000000 -65504.000000] outval[0.976562 0.000000 0.000000 0.000000]
src_index:2, b c h w: 0 2 0 0, posIn: (0 0 0) i:2 -> b c h w: 0 0 2 0, dst_index: 0, posOut: (0 2 0) j:0 -> inval[0.049011] outval[0.049011] -> inval[0.439453 0.130859 0.049011 0.564941] outval[0.049011 0.000000 0.000000 0.000000]
src_index:5, b c h w: 1 2 0 0, posIn: (0 0 1) i:1 -> b c h w: 0 0 2 1, dst_index: 0, posOut: (1 2 0) j:0 -> inval[0.112671] outval[0.112671] -> inval[0.976562 0.112671 -65504.000000 -65504.000000] outval[0.112671 0.000000 0.000000 0.000000]
src_index:0, b c h w: 0 0 1 0, posIn: (0 1 0) i:0 -> b c h w: 0 1 0 0, dst_index: 1, posOut: (0 0 0) j:1 -> inval[0.171509] outval[0.171509] -> inval[0.171509 0.222412 0.075745 0.494873] outval[0.439453 0.171509 0.000000 0.000000]
src_index:3, b c h w: 1 0 1 0, posIn: (0 1 0) i:3 -> b c h w: 0 1 0 1, dst_index: 1, posOut: (1 0 0) j:1 -> inval[0.494873] outval[0.494873] -> inval[0.171509 0.222412 0.075745 0.494873] outval[0.564941 0.494873 0.000000 0.000000]
src_index:1, b c h w: 0 1 1 0, posIn: (0 1 0) i:1 -> b c h w: 0 1 1 0, dst_index: 1, posOut: (0 1 0) j:1 -> inval[0.222412] outval[0.222412] -> inval[0.171509 0.222412 0.075745 0.494873] outval[0.130859 0.222412 0.000000 0.000000]
src_index:4, b c h w: 1 1 1 0, posIn: (0 1 1) i:0 -> b c h w: 0 1 1 1, dst_index: 1, posOut: (1 1 0) j:1 -> inval[0.325439] outval[0.325439] -> inval[0.325439 0.714844 -65504.000000 -65504.000000] outval[0.976562 0.325439 0.000000 0.000000]
src_index:2, b c h w: 0 2 1 0, posIn: (0 1 0) i:2 -> b c h w: 0 1 2 0, dst_index: 1, posOut: (0 2 0) j:1 -> inval[0.075745] outval[0.075745] -> inval[0.171509 0.222412 0.075745 0.494873] outval[0.049011 0.075745 0.000000 0.000000]
src_index:5, b c h w: 1 2 1 0, posIn: (0 1 1) i:1 -> b c h w: 0 1 2 1, dst_index: 1, posOut: (1 2 0) j:1 -> inval[0.714844] outval[0.714844] -> inval[0.325439 0.714844 -65504.000000 -65504.000000] outval[0.112671 0.714844 0.000000 0.000000]
src_index:0, b c h w: 0 0 0 1, posIn: (1 0 0) i:0 -> b c h w: 1 0 0 0, dst_index: 2, posOut: (0 0 0) j:2 -> inval[0.705566] outval[0.705566] -> inval[0.705566 0.653809 0.481201 0.223755] outval[0.439453 0.171509 0.705566 0.000000]
src_index:3, b c h w: 1 0 0 1, posIn: (1 0 0) i:3 -> b c h w: 1 0 0 1, dst_index: 2, posOut: (1 0 0) j:2 -> inval[0.223755] outval[0.223755] -> inval[0.705566 0.653809 0.481201 0.223755] outval[0.564941 0.494873 0.223755 0.000000]
src_index:1, b c h w: 0 1 0 1, posIn: (1 0 0) i:1 -> b c h w: 1 0 1 0, dst_index: 2, posOut: (0 1 0) j:2 -> inval[0.653809] outval[0.653809] -> inval[0.705566 0.653809 0.481201 0.223755] outval[0.130859 0.222412 0.653809 0.000000]
src_index:4, b c h w: 1 1 0 1, posIn: (1 0 1) i:0 -> b c h w: 1 0 1 1, dst_index: 2, posOut: (1 1 0) j:2 -> inval[0.406250] outval[0.406250] -> inval[0.406250 0.049957 -65504.000000 -65504.000000] outval[0.976562 0.325439 0.406250 0.000000]
src_index:2, b c h w: 0 2 0 1, posIn: (1 0 0) i:2 -> b c h w: 1 0 2 0, dst_index: 2, posOut: (0 2 0) j:2 -> inval[0.481201] outval[0.481201] -> inval[0.705566 0.653809 0.481201 0.223755] outval[0.049011 0.075745 0.481201 0.000000]
src_index:5, b c h w: 1 2 0 1, posIn: (1 0 1) i:1 -> b c h w: 1 0 2 1, dst_index: 2, posOut: (1 2 0) j:2 -> inval[0.049957] outval[0.049957] -> inval[0.406250 0.049957 -65504.000000 -65504.000000] outval[0.112671 0.714844 0.049957 0.000000]
src_index:0, b c h w: 0 0 1 1, posIn: (1 1 0) i:0 -> b c h w: 1 1 0 0, dst_index: 3, posOut: (0 0 0) j:3 -> inval[0.376221] outval[0.376221] -> inval[0.376221 0.636719 0.768066 0.022751] outval[0.439453 0.171509 0.705566 0.376221] outval_after[0.439453 0.171509 0.705566 0.376221]
src_index:3, b c h w: 1 0 1 1, posIn: (1 1 0) i:3 -> b c h w: 1 1 0 1, dst_index: 3, posOut: (1 0 0) j:3 -> inval[0.022751] outval[0.022751] -> inval[0.376221 0.636719 0.768066 0.022751] outval[0.564941 0.494873 0.223755 0.022751] outval_after[0.564941 0.494873 0.223755 0.022751]
src_index:1, b c h w: 0 1 1 1, posIn: (1 1 0) i:1 -> b c h w: 1 1 1 0, dst_index: 3, posOut: (0 1 0) j:3 -> inval[0.636719] outval[0.636719] -> inval[0.376221 0.636719 0.768066 0.022751] outval[0.130859 0.222412 0.653809 0.636719] outval_after[0.130859 0.222412 0.653809 0.636719]
src_index:4, b c h w: 1 1 1 1, posIn: (1 1 1) i:0 -> b c h w: 1 1 1 1, dst_index: 3, posOut: (1 1 0) j:3 -> inval[0.440918] outval[0.440918] -> inval[0.440918 0.759766 -65504.000000 -65504.000000] outval[0.976562 0.325439 0.406250 0.440918] outval_after[0.976562 0.325439 0.406250 0.440918]
src_index:2, b c h w: 0 2 1 1, posIn: (1 1 0) i:2 -> b c h w: 1 1 2 0, dst_index: 3, posOut: (0 2 0) j:3 -> inval[0.768066] outval[0.768066] -> inval[0.376221 0.636719 0.768066 0.022751] outval[0.049011 0.075745 0.481201 0.768066] outval_after[0.049011 0.075745 0.481201 0.768066]
src_index:5, b c h w: 1 2 1 1, posIn: (1 1 1) i:1 -> b c h w: 1 1 2 1, dst_index: 3, posOut: (1 2 0) j:3 -> inval[0.759766] outval[0.759766] -> inval[0.440918 0.759766 -65504.000000 -65504.000000] outval[0.112671 0.714844 0.049957 0.759766] outval_after[0.112671 0.714844 0.049957 0.759766]
```

**Test Plan:**
Build & test on Android:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```
Build & test on MacOS:
```
cd ~/fbsource
buck build //xplat/caffe2:pt_vulkan_api_test_binAppleMac
./buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAppleMac\#macosx-x86_64
```
Test result on Android (Google Pixel 5):
```
[ RUN      ] VulkanAPITest.permute_2d_success
[       OK ] VulkanAPITest.permute_2d_success (27 ms)
[ RUN      ] VulkanAPITest.permute_3d_success
[       OK ] VulkanAPITest.permute_3d_success (6 ms)
[ RUN      ] VulkanAPITest.permute_4d_success
[       OK ] VulkanAPITest.permute_4d_success (8 ms)
[ RUN      ] VulkanAPITest.permute_4dmclaren_success
[       OK ] VulkanAPITest.permute_4dmclaren_success (0 ms)
[ RUN      ] VulkanAPITest.permute_4dbig_success
[       OK ] VulkanAPITest.permute_4dbig_success (226 ms)
[ RUN      ] VulkanAPITest.permute_1d_nochange
[       OK ] VulkanAPITest.permute_1d_nochange (0 ms)
[ RUN      ] VulkanAPITest.permute_sameDims_nochange
[       OK ] VulkanAPITest.permute_sameDims_nochange (0 ms)
[ RUN      ] VulkanAPITest.permute_invalidinputs_exceptions
[       OK ] VulkanAPITest.permute_invalidinputs_exceptions (1 ms)
```
Test result on MacOS:
```
[ RUN      ] VulkanAPITest.permute_2d_success
[       OK ] VulkanAPITest.permute_2d_success (21 ms)
[ RUN      ] VulkanAPITest.permute_3d_success
[       OK ] VulkanAPITest.permute_3d_success (11 ms)
[ RUN      ] VulkanAPITest.permute_4d_success
[       OK ] VulkanAPITest.permute_4d_success (33 ms)
[ RUN      ] VulkanAPITest.permute_4dmclaren_success
[       OK ] VulkanAPITest.permute_4dmclaren_success (1 ms)
[ RUN      ] VulkanAPITest.permute_4dbig_success
[       OK ] VulkanAPITest.permute_4dbig_success (264 ms)
[ RUN      ] VulkanAPITest.permute_1d_nochange
[       OK ] VulkanAPITest.permute_1d_nochange (1 ms)
[ RUN      ] VulkanAPITest.permute_sameDims_nochange
[       OK ] VulkanAPITest.permute_sameDims_nochange (1 ms)
[ RUN      ] VulkanAPITest.permute_invalidinputs_exceptions
[       OK ] VulkanAPITest.permute_invalidinputs_exceptions (2 ms)
```

Differential Revision: D32292554

