### PR TITLE
[JIT] Compute input sym shapes in partial eval graph

### DIFF
--- a/test/jit/test_symbolic_shape_analysis.py
+++ b/test/jit/test_symbolic_shape_analysis.py
@@ -110,7 +110,14 @@ class TestSymbolicShapeAnalysis(JitTestCase):
 
         torch._C._jit_pass_constant_propagation(foo.graph)
         torch._C._jit_pass_propagate_shapes_on_graph(foo.graph)
-        FileCheck().check("*, 3, 2, *").check("*, 3, *, *) = prim::If").run(foo.graph)
+        view = foo.graph.findNode("aten::view")
+
+        def neg_to_one(li):
+            return [elem if elem >= 0 else -1 for elem in li]
+
+        self.assertEqual(neg_to_one(view.output().type().symbolic_sizes()), [-1, 3, 2, -1])
+        if_out = next(foo.graph.findNode("prim::If").outputs())
+        self.assertEqual(neg_to_one(if_out.type().symbolic_sizes()), [-1, 3, -1, -1])
 
     def test_unary_shape_functions(self):
         unary_ops = [
@@ -325,7 +332,6 @@ class TestSymbolicShapeAnalysis(JitTestCase):
         inps = list(mm.graph.inputs())
         inps[1].setType(inps[1].type().with_sizes([None, None, None, None]))
         shape_compute_graph = torch._C._jit_pass_propagate_shapes_on_graph_and_build_compute(mm.graph)
-        print(shape_compute_graph.partial_eval_shape_graph())
         g = shape_compute_graph.partial_eval_shape_graph()
         # to make into a jit function cant have multiple outputs
         g.makeMultiOutputIntoTuple()
@@ -427,11 +433,9 @@ class TestSymbolicShapeAnalysis(JitTestCase):
         mod = torch.jit.freeze(mod.eval())
         inp = list(mod.graph.inputs())[1]
         inp.setType(inp.type().with_sizes([None, None, None, None]))
-        shape_compute_graph = torch._C._jit_pass_propagate_shapes_on_graph_and_build_compute(
-            mod.graph,
-            next(mod.graph.nodes()),
-            mod.graph.findNode("prim::TupleConstruct")
-        )
+        output_tensor = list(mod(tensor)[0].size())
+        self.run_pass('lower_all_tuples', mod.graph)
+        shape_compute_graph = torch._C._jit_pass_propagate_shapes_on_graph_and_build_compute(mod.graph)
         max_pool_node = mod.graph.findNode("aten::max_pool2d_with_indices")
         outs = list(max_pool_node.outputs())
         self.assertEqual(outs[0].type().symbolic_sizes(), outs[1].type().symbolic_sizes())
@@ -439,8 +443,11 @@ class TestSymbolicShapeAnalysis(JitTestCase):
         # to make into a jit function cant have multiple outputs
         g.makeMultiOutputIntoTuple()
         func = torch._C._create_function_from_graph("partial_eval_graph", g)
+        mapping = shape_compute_graph.graph_output_to_symbolic_shape_dim()
         output_shape = func(tensor.size())
-        self.assertEqual(list(output_shape), list(mod(tensor)[0].size()))
+        # the first 4 dims are input sym dimensions, then the ,
+        self.assertEqual(list(output_shape[0:4]), list(tensor.size()))
+        self.assertEqual(list(output_shape[4:]), output_tensor[2:])
 
     def test_stitching_concat(self):
         @torch.jit.script

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -757,6 +757,18 @@ struct SymbolicShapeGraphAnalyzer {
     }
   }
 
+  void registerStitchedComputeOutput(
+      std::shared_ptr<Graph> stitched_shape_compute_graph,
+      Value* output,
+      int64_t symbolic_shape) {
+    stitched_shape_compute_graph->registerOutput(output);
+    output_index_to_symbolic_shape_
+        [stitched_shape_compute_graph->outputs().size() - 1] = symbolic_shape;
+    symbolic_shape_value_to_graph_output_[symbolic_shape] =
+        stitched_shape_compute_graph->outputs().at(
+            stitched_shape_compute_graph->outputs().size() - 1);
+  }
+
   void joinPartialEvaluatedShapeGraphToLargeShapeGraph(
       Node* curr,
       std::shared_ptr<Graph> partial_eval_graph,
@@ -811,7 +823,31 @@ struct SymbolicShapeGraphAnalyzer {
             shape_graph_input;
         partial_eval_inputs.push_back(shape_graph_input);
       }
+      // make sure all symbolic dimensions in the graph we are creating are
+      // computed in the partial eval graph
+      if (auto tt = node_input->type()->cast<TensorType>()) {
+        if (!tt->symbolic_sizes().rank()) {
+          continue;
+        }
+        auto rank = *tt->symbolic_sizes().rank();
+        for (size_t i = 0; i < rank; ++i) {
+          auto shape = tt->symbolic_sizes()[i];
+          if (shape.is_static() ||
+              symbolic_shape_value_to_graph_output_.count(shape.value())) {
+            continue;
+          }
+          auto input = enclosing_graph_value_to_shape_graph_input_[node_input];
+          WithInsertPoint guard(stitched_shape_compute_graph->block());
+          auto index = stitched_shape_compute_graph->insertConstant(
+              static_cast<int64_t>(i));
+          auto li_index = stitched_shape_compute_graph->insert(
+              aten::__getitem__, {input, index});
+          registerStitchedComputeOutput(
+              stitched_shape_compute_graph, li_index, shape.value());
+        }
+      }
     }
+
     WithInsertPoint guard(stitched_shape_compute_graph->block());
     std::unordered_map<Value*, Value*> value_map;
     insertGraph(
@@ -842,14 +878,10 @@ struct SymbolicShapeGraphAnalyzer {
         if (symbolic_shape_value_to_graph_output_.count(symbolic_shape)) {
           continue;
         }
-        stitched_shape_compute_graph->registerOutput(
-            new_list_output->node()->input(i));
-        output_index_to_symbolic_shape_
-            [stitched_shape_compute_graph->outputs().size() - 1] =
-                symbolic_shape;
-        symbolic_shape_value_to_graph_output_[symbolic_shape] =
-            stitched_shape_compute_graph->outputs().at(
-                stitched_shape_compute_graph->outputs().size() - 1);
+        registerStitchedComputeOutput(
+            stitched_shape_compute_graph,
+            new_list_output->node()->input(i),
+            symbolic_shape);
       }
     }
   }

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -830,8 +830,8 @@ struct SymbolicShapeGraphAnalyzer {
           continue;
         }
         auto rank = *tt->symbolic_sizes().rank();
-        for (size_t i = 0; i < rank; ++i) {
-          auto shape = tt->symbolic_sizes()[i];
+        for (size_t j = 0; j < rank; ++j) {
+          auto shape = tt->symbolic_sizes()[j];
           if (shape.is_static() ||
               symbolic_shape_value_to_graph_output_.count(shape.value())) {
             continue;
@@ -839,7 +839,7 @@ struct SymbolicShapeGraphAnalyzer {
           auto input = enclosing_graph_value_to_shape_graph_input_[node_input];
           WithInsertPoint guard(stitched_shape_compute_graph->block());
           auto index = stitched_shape_compute_graph->insertConstant(
-              static_cast<int64_t>(i));
+              static_cast<int64_t>(j));
           auto li_index = stitched_shape_compute_graph->insert(
               aten::__getitem__, {input, index});
           registerStitchedComputeOutput(


### PR DESCRIPTION
Needed for NNC dynamic shape fusion. Previously, when creating a partially evaluated graph for symbolic shape compute, if the input wasn't used, we wouldn't compute it, which led to failures when NNC expected this value to be passed in.