### PR TITLE
Add method to access EmbeddingPackedParamsBase packed data.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/embedding_packed_params.h
+++ b/aten/src/ATen/native/quantized/cpu/embedding_packed_params.h
@@ -25,4 +25,6 @@ struct EmbeddingPackedParamsBase : public torch::jit::CustomClassHolder {
 
   virtual int64_t bit_rate() const = 0;
   virtual int64_t version() const = 0;
+
+  virtual at::Tensor packed_weights() const = 0;
 };

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -536,7 +536,8 @@ int register_embedding_params() {
             return PackedEmbeddingBagWeight::prepack(weight);
           })
       .def("bit_rate", &EmbeddingPackedParamsBase::bit_rate)
-      .def("version", &EmbeddingPackedParamsBase::version);
+      .def("version", &EmbeddingPackedParamsBase::version)
+      .def("packed_weights", &EmbeddingPackedParamsBase::packed_weights);
 
   return 0;
 }

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -374,6 +374,10 @@ struct TORCH_API PackedEmbeddingBagWeight : public EmbeddingPackedParamsBase {
     return version_;
   }
 
+  at::Tensor packed_weights() const override {
+    return packed_w;
+  }
+
   at::Tensor embeddingbag_byte(
       const at::Tensor& indices,
       const c10::optional<at::Tensor>& offsets,


### PR DESCRIPTION
Summary: Add method to access EmbeddingPackedParamsBase packed data which can be very expensive to compute for large embedding bags.

Test Plan: buck run //caffe2/torch/fb/nvm:embedding_bag_nvm_test

Differential Revision: D32407852

