### PR TITLE
[nnc][quantization] Quantized.add to native_functions yaml

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -403,6 +403,10 @@
     SparseCsrCUDA: add_out_sparse_csr_cuda
     MkldnnCPU: mkldnn_add_out
 
+- func: add.quantized(Tensor self, Tensor other, float output_scale, int output_zero_point) -> Tensor
+  dispatch:
+    QuantizedCPU: quantized_add
+
 - func: _add_relu.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
   variants: function
   dispatch:

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -310,8 +310,8 @@ TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
 
 }  // namespace
 
-Tensor quantized_add(Tensor qa, Tensor qb, double scale, int64_t zero_point){
-  return qadd<false>(qa, qb, scale, zero_point);
+Tensor quantized_add(const Tensor& self, const Tensor& other, double scale, int64_t zero_point){
+  return qadd<false>(self, other, scale, zero_point);
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/quantized/cpu/qadd.h
+++ b/aten/src/ATen/native/quantized/cpu/qadd.h
@@ -1,8 +1,0 @@
-#include <ATen/ATen.h>
-
-namespace at {
-namespace native {
-TORCH_API Tensor
-quantized_add(Tensor qa, Tensor qb, double scale, int64_t zero_point);
-}
-} // namespace at

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -6,7 +6,6 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/quantized/cpu/conv_packed_params.h>
 #include <ATen/native/quantized/cpu/conv_serialization.h>
-#include <ATen/native/quantized/cpu/qadd.h>
 #include <ATen/native/xnnpack/OpContext.h>
 #include <ATen/quantized/QTensorImpl.h>
 #include <c10/core/TensorOptions.h>
@@ -269,7 +268,7 @@ void nnc_aten_quantized_add(
       toQIntType(b_qdtype));
   const double out_qscale = ((double*)extra_args)[6];
   const int64_t out_qzero = extra_args[7];
-  auto r = at::native::quantized_add(qa, qb, out_qscale, out_qzero);
+  auto r = at::add(qa, qb, out_qscale, out_qzero);
   memcpy(buf_data[0], r.data_ptr(), r.element_size() * r.numel());
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68313
* #68018

Differential Revision: [D32409832](https://our.internmc.facebook.com/intern/diff/D32409832)


Adding quantized.add to native_functions to be able to call at:add for quantized tensors. Need it for internal build to call it from nnc external functions without direct call to at::native and without Dispatcher get by scheme as it fails on Buck windows builds