### PR TITLE
[quant][graphmode][fx] Refactor node_name_to_target_dtype to make it clearer

### DIFF
--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -90,6 +90,7 @@ from .backend_config_dict.utils import (
 )
 
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Set
+from collections import defaultdict
 
 def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Module]) -> bool:
     return isinstance(node, torch.fx.Node) and node.op == "call_module" and \
@@ -121,7 +122,7 @@ def node_arg_is_bias(node: Node, arg: Any) -> bool:
 def is_input_arg_dtype_supported_by_backend(
     arg: Argument,
     node: Node,
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     dtype_config: Dict[str, torch.dtype],
 ) -> bool:
     """ Check if the configured qconfig for the argument
@@ -137,7 +138,8 @@ def is_input_arg_dtype_supported_by_backend(
     is_activation = not (is_weight or is_bias)
     input_activation_dtype = dtype_config.get("input_activation_dtype", None)
     if is_activation:
-        return input_activation_dtype is None or node_name_to_target_dtype[arg.name] == input_activation_dtype
+        return input_activation_dtype is None or \
+            node_name_to_target_dtype[node.name]["input_activation_dtype"] == input_activation_dtype
     elif is_weight:
         # TODO: we need to refactor get_target_activation_dtype_for_node to include
         # weight, and maybe have a separate current_node_name_to_dtype dict
@@ -150,20 +152,20 @@ def is_input_arg_dtype_supported_by_backend(
 
 def is_output_dtype_supported_by_backend(
     node: Node,
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     dtype_config: Dict[str, torch.dtype],
 ) -> bool:
     """ Check if the configured qconfig for the output
     is supported by the backend or not
     """
     output_dtype = dtype_config.get("output_dtype", None)
-    return output_dtype is None or output_dtype == node_name_to_target_dtype[node.name]
-
+    return output_dtype is None or \
+        output_dtype == node_name_to_target_dtype[node.name]["output_activation_dtype"]
 
 def is_pattern_dtype_config_supported_by_backend(
     pattern: Optional[Pattern],
     matched_nodes: Optional[List[Node]],
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     backend_config_dict: Optional[Dict[str, Any]]
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
@@ -226,6 +228,7 @@ def qat_swap_modules(
         get_default_qat_module_mappings(), additional_qat_module_mapping)
     convert(root, mapping=all_mappings, inplace=True, remove_qconfig=False)
 
+# TODO: remove observed_op, looks like it's not used
 def insert_observer(
     node: Node,
     observed_op: Node,
@@ -265,7 +268,7 @@ def get_target_activation_dtype_for_node(
     qhandler: Optional[QuantizeHandler],
     modules: Dict[str, torch.nn.Module],
     cache_for_no_tensor_check: Dict[Node, bool],
-) -> Optional[torch.dtype]:
+) -> Dict[str, Optional[torch.dtype]]:
     """
     Returns the expected dtype of the input and output of this node after
     convert. If the value is not None, it represents the dtype of the
@@ -278,49 +281,96 @@ def get_target_activation_dtype_for_node(
     """
     if node.op == 'placeholder':
         if inputs_seen_counter in input_quantized_idxs:
-            return torch.quint8
+            return {
+                "input_activation_dtype": torch.quint8,
+                "output_activation_dtype": torch.quint8,
+            }
         else:
             # if dtype is fp32 (default), do nothing
             # note: other dtypes are not supported
-            return torch.float
+            return {
+                "input_activation_dtype": torch.float,
+                "output_activation_dtype": torch.float,
+            }
 
     elif node.op in ('call_module', 'call_method', 'call_function'):
         args_have_no_tensors = \
             all_node_args_have_no_tensors(
                 node, modules, cache_for_no_tensor_check)
         if args_have_no_tensors:
-            return None
+            return {
+                "input_activation_dtype": None,
+                "output_activation_dtype": None,
+            }
 
         # TODO(future PR): consider stopping matching getitem
         is_getitem = node.op == 'call_function' and \
             node.target == operator.getitem
         if is_getitem:
-            return torch.float
+            return {
+                "input_activation_dtype": torch.float,
+                "output_activation_dtype": torch.float,
+            }
 
         # get qconfig to determine the eventual dtype of this node
         if qconfig is not None:
             if qhandler is not None and qhandler.input_output_observed() and qhandler.is_output_quantized(qconfig):
                 act_dtype, weight_dtype, act_compute_dtype = \
                     get_qconfig_dtypes(qconfig)
-                return act_dtype
-            else:
-                return torch.float
-        else:
-            return torch.float
+                bias_dtype = torch.float16 \
+                    if act_dtype == torch.float16 and weight_dtype == torch.float16 \
+                    else torch.float
+                return {
+                    "input_activation_dtype": act_dtype,
+                    "weight_dtype": weight_dtype,
+                    "bias_dtype": bias_dtype,
+                    "output_activation_dtype": act_dtype,
+                }
+        return {
+            "input_activation_dtype": torch.float,
+            "output_activation_dtype": torch.float,
+        }
 
     elif node.op == 'get_attr':
-        return torch.float
+        return {
+            "input_activation_dtype": torch.float,
+            "output_activation_dtype": torch.float,
+        }
 
     elif node.op == 'output':
         if outputs_seen_counter in output_quantized_idxs:
-            return torch.quint8
+            return {
+                "input_activation_dtype": torch.quint8,
+                "output_activation_dtype": torch.quint8
+            }
         else:
             # if dtype is fp32 (default), do nothing
             # note: other dtypes are not supported
-            return torch.float
+            return {
+                "input_activation_dtype": torch.float,
+                "output_activation_dtype": torch.float,
+            }
 
     else:
         raise AssertionError(f'need to handle {node.format_node()}')
+
+def get_arg_target_dtype(
+    arg: Node,
+    modules: Dict[str, torch.nn.Module],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
+) -> Node:
+    """ Get the target output activation dtype for
+    the argumnet in the original graph, skipping inserted observers
+    We are assuming that the observers are inserted correctly, and the dtype for
+    argument in quantized graph will match what is specified by the qconfig
+    """
+    assert isinstance(arg, Node)
+    if is_activation_post_process_node(arg, modules):
+        observed_arg = arg.args[0]
+        assert isinstance(observed_arg, Node), "Currently we only support observing Node"
+        return node_name_to_target_dtype[observed_arg.name]["output_activation_dtype"]
+    else:
+        return node_name_to_target_dtype[arg.name]["output_activation_dtype"]
 
 def maybe_insert_input_observer_for_arg_or_kwarg(
     node: Union[Node, Any],
@@ -329,7 +379,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config_dict: Dict[str, Any],
 ) -> Argument:
@@ -371,8 +421,8 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
         bias_needs_obs = \
             (is_bias and activation_dtype(qconfig) == torch.float16) and \
             weight_dtype(qconfig) == torch.float16
-        arg_dtype = node_name_to_target_dtype[arg.name]
-        node_dtype = node_name_to_target_dtype[node.name]
+        arg_dtype = get_arg_target_dtype(arg, modules, node_name_to_target_dtype)
+        node_dtype = node_name_to_target_dtype[node.name]["input_activation_dtype"]
         dtype_changes_and_second_dtype_not_float = (
             # if the dtypes are different, we need an observer
             (arg_dtype != node_dtype) and
@@ -411,7 +461,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
         if cur_input_idx is None:
             needs_obs = False
         else:
-            arg_dtype = node_name_to_target_dtype[arg.name]
+            arg_dtype = get_arg_target_dtype(arg, modules, node_name_to_target_dtype)
             node_dtype = torch.quint8 if cur_input_idx in sm_input_quantized_idxs \
                 else torch.float
             needs_obs = (
@@ -428,21 +478,26 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
         # of the correct type already exists. If it does, use it.
         # This prevents duplicate observer insertions if a node is
         # used by multiple nodes.
+        # TODO: this is looking into how the value is used in the future
+        # we should remove this
+        # removing this means we insert one observer for each use, even if they
+        # have the same dtype, we can have an extra pass that removes the extra observers
         for maybe_obs_node, _ in arg.users.items():
             if maybe_obs_node.op == 'call_module':
                 maybe_obs_mod = modules[maybe_obs_node.target]  # type: ignore[index]
                 if (
                     type(maybe_obs_mod) == type(new_obs_mod) and
-                    node_name_to_target_dtype[maybe_obs_node.name] == node_dtype
+                    maybe_obs_mod.dtype == node_dtype
                 ):
                     existing_obs_node = maybe_obs_node
                     break
+        # if get_arg_target_dtype(
+        #         arg, modules, node_name_to_target_dtype) == node_dtype:
+        #     existing_obs_node = arg
 
         if existing_obs_node is None:
             new_obs_node = insert_observer(
                 arg, node, new_obs_mod, model, modules, graph)
-            # set the type, so the next node can read it
-            node_name_to_target_dtype[new_obs_node.name] = node_dtype
             # override this arg to be the observed arg
             new_arg = new_obs_node
         else:
@@ -457,7 +512,7 @@ def maybe_insert_input_observers_for_node(
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config_dict: Dict[str, Any],
 ) -> None:
@@ -507,7 +562,7 @@ def maybe_insert_input_equalization_observers_for_node(
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     is_branch: bool,
 ) -> None:
     """
@@ -540,9 +595,6 @@ def maybe_insert_input_equalization_observers_for_node(
         new_eq_obs_node = insert_observer(
             arg, node, new_eq_obs_mod, model, modules, graph)
 
-        # set the type, so the next node can read it
-        node_name_to_target_dtype[new_eq_obs_node.name] = node_name_to_target_dtype[arg.name]
-
         new_args.append(new_eq_obs_node)
 
     # assign the new args and kwargs to the node, inplace
@@ -554,7 +606,7 @@ def maybe_insert_output_observer_for_node(
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
     matches: Dict[str, MatchResult],
-    node_name_to_target_dtype: Dict[str, Any],
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
     matched_pattern: Any,
     qhandler: Optional[QuantizeHandler],
 ) -> Optional[Node]:
@@ -576,7 +628,7 @@ def maybe_insert_output_observer_for_node(
     is_standalone_module = qhandler is not None and \
         isinstance(qhandler, StandaloneModuleQuantizeHandler)
 
-    dtype = node_name_to_target_dtype[node.name]
+    dtype = node_name_to_target_dtype[node.name]["output_activation_dtype"]
     should_insert_observer = \
         qhandler.should_insert_observer_for_output(
             qconfig, model.training) and dtype not in (torch.bool, None, torch.float)
@@ -598,9 +650,6 @@ def maybe_insert_output_observer_for_node(
                 matched_pattern)
         observer = act_post_process_ctr()
         new_obs = insert_observer(node, node, observer, model, modules, graph)
-        # set the type, so the next node can read it
-        node_name_to_target_dtype[new_obs.name] = \
-            node_name_to_target_dtype[node.name]
         return new_obs
     else:
         return None
@@ -608,7 +657,7 @@ def maybe_insert_output_observer_for_node(
 def maybe_insert_observers_before_graph_output(
     graph_output_node: Node,
     output_quantized_idxs: List[int],
-    node_name_to_target_dtype: Dict[str, torch.dtype],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     qconfig_map: Dict[str, QConfigAny],
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
@@ -637,7 +686,7 @@ def maybe_insert_observers_before_graph_output(
     def _recursive_maybe_replace_node_with_obs(
         maybe_node: Argument,
         target_dtype: torch.dtype,
-        node_name_to_target_dtype: Dict[str, torch.dtype],
+        node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
         qconfig_map: Dict[str, QConfigAny],
         model: torch.nn.Module,
         modules: Dict[str, torch.nn.Module],
@@ -661,7 +710,7 @@ def maybe_insert_observers_before_graph_output(
         """
         if isinstance(maybe_node, Node):
             # check dtype of this node
-            this_node_dtype = node_name_to_target_dtype[maybe_node.name]
+            this_node_dtype = get_arg_target_dtype(maybe_node, modules, node_name_to_target_dtype)
             if this_node_dtype != target_dtype:
                 # insert observer
                 qconfig = qconfig_map.get(maybe_node.name)
@@ -708,7 +757,7 @@ def maybe_insert_observers_before_graph_output(
 def maybe_propagate_dtype_for_node(
     node: Node,
     target_dtype: torch.dtype,
-    node_name_to_target_dtype: Dict[str, torch.dtype],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     matches: Dict[str, MatchResult],
 ) -> None:
     """
@@ -717,7 +766,8 @@ def maybe_propagate_dtype_for_node(
     also call this function recursively on
     the first argument, to propagate the dtype to the caller.
     """
-    node_name_to_target_dtype[node.name] = target_dtype
+    node_name_to_target_dtype[node.name]["input_activation_dtype"] = target_dtype
+    node_name_to_target_dtype[node.name]["output_activation_dtype"] = target_dtype
     # if this is a copy node, propagate to first arg
     root_node, matched_nodes, pattern, qhandler, qconfig = matches.get(
         node.name, (None, None, None, None, None))
@@ -729,7 +779,7 @@ def maybe_propagate_dtype_for_node(
 
 def propagate_dtypes_for_known_nodes(
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, torch.dtype],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     matches: Dict[str, MatchResult],
 ) -> None:
     """
@@ -908,7 +958,28 @@ def insert_observers_for_model(
     passes which optimize the graph by deduplicating observers, etc.
     """
 
-    node_name_to_target_dtype: Dict[str, Any] = {}
+    # name of Node in original FX Graph to the target dtype information
+    # that's derived from qconfig for the Node, for example, if we have
+    # a conv2d node that has a qconfig
+    # {
+    #   # for getattr node
+    #   # weight = getattr(self, 'weight')
+    #   'weight': {
+    #      'output_activation_dtype': torch.float,
+    #   }
+    #   # for conv2d node
+    #   # conv2d = call_function[target=torch.nn.functional.conv2d](
+    #   #            args=(input, weight, bias))
+    #   'conv2d': {
+    #       'input_activation_dtype': torch.quint8,
+    #       'weight_dtype': torch.qint8,
+    #       'bias_dtype': torch.float,
+    #       'output_activation_dtype': torch.quint8,
+    #     }
+    #   }
+    #
+    # TODO: rename this to node_name_to_target_dtype_info
+    node_name_to_target_dtype: Dict[str, Dict[str, Any]] = defaultdict(dict)
     cache_for_no_tensor_check: Dict[Node, bool] = dict()
 
     inputs_seen_counter = 0

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -122,7 +122,7 @@ def node_arg_is_bias(node: Node, arg: Any) -> bool:
 def is_input_arg_dtype_supported_by_backend(
     arg: Argument,
     node: Node,
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     dtype_config: Dict[str, torch.dtype],
 ) -> bool:
     """ Check if the configured qconfig for the argument
@@ -152,7 +152,7 @@ def is_input_arg_dtype_supported_by_backend(
 
 def is_output_dtype_supported_by_backend(
     node: Node,
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     dtype_config: Dict[str, torch.dtype],
 ) -> bool:
     """ Check if the configured qconfig for the output
@@ -165,7 +165,7 @@ def is_output_dtype_supported_by_backend(
 def is_pattern_dtype_config_supported_by_backend(
     pattern: Optional[Pattern],
     matched_nodes: Optional[List[Node]],
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     backend_config_dict: Optional[Dict[str, Any]]
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
@@ -379,7 +379,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config_dict: Dict[str, Any],
 ) -> Argument:
@@ -509,7 +509,7 @@ def maybe_insert_input_observers_for_node(
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config_dict: Dict[str, Any],
 ) -> None:
@@ -559,7 +559,7 @@ def maybe_insert_input_equalization_observers_for_node(
     model: torch.nn.Module,
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     is_branch: bool,
 ) -> None:
     """
@@ -603,7 +603,7 @@ def maybe_insert_output_observer_for_node(
     modules: Dict[str, torch.nn.Module],
     graph: Graph,
     matches: Dict[str, MatchResult],
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]],
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
     matched_pattern: Any,
     qhandler: Optional[QuantizeHandler],
 ) -> Optional[Node]:
@@ -977,7 +977,7 @@ def insert_observers_for_model(
     #   }
     #
     # TODO: rename this to node_name_to_target_dtype_info
-    node_name_to_target_dtype: Dict[str, Dict[str, Any]] = defaultdict(dict)
+    node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]] = defaultdict(dict)
     cache_for_no_tensor_check: Dict[Node, bool] = dict()
 
     inputs_seen_counter = 0

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -491,9 +491,6 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
                 ):
                     existing_obs_node = maybe_obs_node
                     break
-        # if get_arg_target_dtype(
-        #         arg, modules, node_name_to_target_dtype) == node_dtype:
-        #     existing_obs_node = arg
 
         if existing_obs_node is None:
             new_obs_node = insert_observer(

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -959,6 +959,7 @@ def insert_observers_for_model(
     # that's derived from qconfig for the Node, for example, if we have
     # a conv2d node that has a qconfig
     # {
+    #   # information for input and bias node omitted
     #   # for getattr node
     #   # weight = getattr(self, 'weight')
     #   'weight': {

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -358,7 +358,7 @@ def get_arg_target_dtype(
     arg: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[torch.dtype]]],
-) -> Node:
+) -> Optional[torch.dtype]:
     """ Get the target output activation dtype for
     the argumnet in the original graph, skipping inserted observers
     We are assuming that the observers are inserted correctly, and the dtype for


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68317

Summary:
We use the node_name_to_target_dtype to store the target dtype for output activations for each node, computed from qconfig for the node,
there are two problems with node_name_to_target_dtype that makes it hard to work with:
1. we mutate node_name_to_target_dtype when we insert observers, this makes the data structure confusing because it's typically unexpected
to change a data structure that store the "target" dtype
2. currently it only stores target dtype about output activations, while we also need target dtype for input activation, weight and bias

This PR fixes both problem by removing mutation from the node_name_to_target_dtype and expanding the target_dtype for node to include
the missing target dtype for input activation, weight and bias. We will have another refactor to simplify the observation for weight and bias dtype
in the future.

Please see comments for the updated structure of node_name_to_target_dtype

TODO: we may want to rename node_name_to_target_dtype to node_name_to_target_dtype_info in a separate PR.

Test Plan:
```
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D32411858](https://our.internmc.facebook.com/intern/diff/D32411858)