### PR TITLE
added set_printoptions examples

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -42,6 +42,16 @@ def set_printoptions(
             None (default) is specified, the value is defined by
             `torch._tensor_str._Formatter`. This value is automatically chosen
             by the framework.
+    
+    Example::
+
+        >>> torch.set_printoptions(precision=2)
+        >>> torch.tensor([1.12345])
+        tensor([1.12])
+        >>> torch.set_printoptions(threshold=5)
+        >>> torch.arange(10)
+        tensor([0, 1, 2, ..., 7, 8, 9])
+
     """
     if profile is not None:
         if profile == "default":

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -42,7 +42,7 @@ def set_printoptions(
             None (default) is specified, the value is defined by
             `torch._tensor_str._Formatter`. This value is automatically chosen
             by the framework.
-    
+
     Example::
 
         >>> torch.set_printoptions(precision=2)


### PR DESCRIPTION
Added examples for `torch.set_printoptions`

```
>>> torch.set_printoptions(precision=2)
>>> torch.tensor([1.12345])
tensor([1.12])
>>> torch.set_printoptions(threshold=5)
>>> torch.arange(10)
tensor([0, 1, 2, ..., 7, 8, 9])
```