### PR TITLE
[libkineto] Refactor 4/n: Simplify activity logger step 2/3 (#466)

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -480,7 +480,11 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
       auto iter = tidSeq2activity.find(key);
       if (iter != tidSeq2activity.end()) {
         libkineto::GenericTraceActivity* fwd = iter->second;
+#ifdef USE_KINETO_UPDATED
+        fwd->flow.start = true;
+#else
         activity.flow.linkedActivity = fwd; // Only destination side set this, to distinguish with start side.
+#endif
         activity.flow.id = fwd->flow.id = fwd_bwd_link_id;
         activity.flow.type = fwd->flow.type = libkineto::kLinkFwdBwd;
         ++fwd_bwd_link_id;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/kineto/pull/466

1. Generalize ChromeTraceLogger::handleGenericActivity to enable it to handle Cuda runtime activities as well as the Roctracer generic activities.
This primarily involves enabling generic support for CPU -> GPU flows.

2. In the event of out-of-order GPU activities (an issue with Cuda11.0, likely fixed in later versions), no longer remove them but print warnings. Another diff will add these warnings to the metadata section.

Reviewed By: briancoutinho

Differential Revision: D31624496

