### PR TITLE
[Contrib][Fakelowp] Change Lut Size for Tanh

### DIFF
--- a/caffe2/contrib/fakelowp/quant_lut_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/quant_lut_fp16_fake_op.h
@@ -30,7 +30,7 @@ class TanhInt8QuantizeNNPIOp final : public Operator<CPUContext> {
     Y->scale = Y_scale;
     Y->zero_point = Y_offset;
 
-    constexpr int tanhLUTMinOffset = 7000;
+    constexpr int tanhLUTMinOffset = 0;
     constexpr int tanhLUTMaxOffset = 18000;
     constexpr int lutSize = tanhLUTMaxOffset - tanhLUTMinOffset;
 


### PR DESCRIPTION
Reference code LUT size increased and now mininum
starts from 0, instead of 7000 earlier
