### PR TITLE
[fx2trt] fix a bug in conversion from negative dim to positive dim

### DIFF
--- a/test/fx2trt/converters/acc_op/test_getitem.py
+++ b/test/fx2trt/converters/acc_op/test_getitem.py
@@ -12,6 +12,7 @@ class TestGetitemConverter(AccTestCase):
         [
             ("slice_batch_dim", slice(None, None, None)),
             ("slice_basic", (slice(None, None, None), slice(0, 3, 2))),
+            ("slice_full", (slice(None, None, None), slice(0, 10, 3))),
             ("ellipsis", (slice(None, None, None), ..., slice(0, 3, 2))),
             (
                 "slice_all_none",

--- a/torch/fx/experimental/fx2trt/converters/converter_utils.py
+++ b/torch/fx/experimental/fx2trt/converters/converter_utils.py
@@ -36,6 +36,24 @@ def get_trt_plugin(
     return plugin
 
 
+def get_positive_dim(dim: int, dim_size: int) -> int:
+    """
+    Given an integer number that represents a dimension in the array,
+    transform it to a positive integer dim if it's negative. Otherwise, do
+    nothing.
+
+    Args:
+        dim (int): A integer number that represents a dimension in an array.
+        dim_size (int): The size of the dimension in the array.
+
+    Returns:
+        A positive integer that represent the same dimension as the given dim.
+    """
+    if dim < 0:
+        return dim % dim_size
+    return dim
+
+
 def set_layer_name(layer: trt.ILayer, target: Target, name: str) -> None:
     """
     Set the TensorRT layer name to "[TensorRT Layer Type]_[Original Op Name]_[FX Node Name with Suffix]"


### PR DESCRIPTION
Summary:
Added a helper function to do this. Only use `mod` to convert negative dim to positive. Do nothing when it's already positive.

Previously in `getitem` if we are slicing to the very end, we will get the dimension wrong.

Test Plan: Add a unit test

Differential Revision: D32432893

