### PR TITLE
Fix some sign issues

### DIFF
--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/FunctionalTensorWrapper.h>
 #include <torch/library.h>
+#include <c10/util/irange.h>
 
 namespace {
   void functionalizeFallback(const c10::OperatorHandle& op, c10::DispatchKeySet dispatchKeySet, torch::jit::Stack* stack) {
@@ -33,7 +34,7 @@ namespace {
     const auto returns_begin = stack->size() - num_returns;
     auto returns = torch::jit::last(stack, num_returns);
 
-    for (int64_t idx = 0; idx < num_returns; ++idx) {
+    for (const auto idx : c10::irange(num_returns)) {
       const auto& ivalue = returns[idx];
       if (ivalue.isTensor()) {
         auto t = ivalue.toTensor();

--- a/aten/src/ATen/native/Histogram.cpp
+++ b/aten/src/ATen/native/Histogram.cpp
@@ -57,7 +57,7 @@ void histogramdd_check_inputs(const Tensor& input, const TensorList& bins, const
 
     const int64_t N = input.size(-1);
 
-    TORCH_CHECK(bins.size() == N, "torch.histogramdd: expected ", N, " sequences of bin edges for a ", N,
+    TORCH_CHECK(static_cast<int64_t>(bins.size()) == N, "torch.histogramdd: expected ", N, " sequences of bin edges for a ", N,
                 "-dimensional histogram but got ", bins.size());
 
     auto input_dtype = input.dtype();

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.cpp
@@ -7,6 +7,7 @@
 #include <ATen/cuda/CUDABlas.h>
 #include <ATen/cuda/CUDAEvent.h>
 #include <c10/cuda/CUDAStream.h>
+#include <c10/util/irange.h>
 
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/cuda/MiscUtils.h>
@@ -638,13 +639,16 @@ std::string _format_non_converging_batches(const std::vector<int64_t>& batches) 
   std::stringstream ss;
   const int too_long = 5;
 
+  ss << "batches ";
   if (batches.size() <= too_long) {
-    ss << "batches ";
-    for (int i = 0; i < batches.size() - 1; i++) ss << batches[i] << ", ";
+    for (const auto i : c10::irange(batches.size() - 1)) {
+      ss << batches[i] << ", ";
+    }
     ss << batches.back();
   } else {
-    ss << "batches ";
-    for (int i = 0; i < too_long; i++) ss << batches[i] << ", ";
+    for (const auto i : c10::irange(too_long)) {
+      ss << batches[i] << ", ";
+    }
     ss << "and other " << batches.size() - too_long << " batches";
   }
 

--- a/aten/src/ATen/native/cuda/Sorting.cpp
+++ b/aten/src/ATen/native/cuda/Sorting.cpp
@@ -84,7 +84,7 @@ std::tuple<Tensor&, Tensor&> median_with_indices_impl(
   zero_numel_check_dims(self, dim, "median()");
   if (self.dim() > 0) {
     assert(dim >= 0);
-    assert(dim < out_shape.size());
+    assert(dim < static_cast<int64_t>(out_shape.size()));
 
     if (keepdim) {
       out_shape[dim] = 1;


### PR DESCRIPTION
Summary:
Fixes
```
caffe2/aten/src/ATen/FunctionalizeFallbackKernel.cpp:36:31: error: comparison of integers of different signs: 'int64_t' (aka 'long') and 'const unsigned long' [-Werror,-Wsign-compare]
    for (int64_t idx = 0; idx < num_returns; ++idx) {
                          ~~~ ^ ~~~~~~~~~~~
caffe2/aten/src/ATen/native/cuda/Sorting.cpp:87:16: error: comparison of integers of different signs: 'int64_t' (aka 'long') and 'std::vector::size_type' (aka 'unsigned long') [-Werror,-Wsign-compare]
    assert(dim < out_shape.size());
           ~~~ ^ ~~~~~~~~~~~~~~~~
```

Differential Revision: D32433063

