### PR TITLE
make broadcast fastpath the default for currently rolled-out ops

### DIFF
--- a/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
@@ -22,9 +22,6 @@ int getSizeFromDims(const std::vector<int>& dims) {
 
 template <class Functor>
 struct FP16PairWiseCPUFunctor {
-  explicit FP16PairWiseCPUFunctor(bool allow_broadcast_fastpath=false)
-    : functor(allow_broadcast_fastpath) {}
-
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -72,7 +69,7 @@ OPERATOR_SCHEMA(SumFakeFp16).NumInputs(1, INT_MAX).NumOutputs(1, INT_MAX);
 
 REGISTER_CPU_OPERATOR(
     AddFakeFp16,
-    BinaryElementwiseBroadcastOp<
+    BinaryElementwiseOp<
         TensorTypes<float, int, long>,
         CPUContext,
         FP16PairWiseCPUFunctor<AddFunctor<CPUContext>>>);
@@ -80,7 +77,7 @@ OPERATOR_SCHEMA(AddFakeFp16).NumInputs(2).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(
     DivFakeFp16,
-    BinaryElementwiseBroadcastOp<
+    BinaryElementwiseOp<
         TensorTypes<float, double>,
         CPUContext,
         FP16PairWiseCPUFunctor<DivFunctor<CPUContext>>>);
@@ -88,7 +85,7 @@ OPERATOR_SCHEMA(DivFakeFp16).NumInputs(2).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(
     MulFakeFp16,
-    BinaryElementwiseBroadcastOp<
+    BinaryElementwiseOp<
         TensorTypes<float>,
         CPUContext,
         FP16PairWiseCPUFunctor<MulFunctor<CPUContext>>>);
@@ -96,7 +93,7 @@ OPERATOR_SCHEMA(MulFakeFp16).NumInputs(2).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(
     SubFakeFp16,
-    BinaryElementwiseBroadcastOp<
+    BinaryElementwiseOp<
         TensorTypes<float>,
         CPUContext,
         FP16PairWiseCPUFunctor<SubFunctor<CPUContext>>>);

--- a/caffe2/ideep/operators/elementwise_sum_op.cc
+++ b/caffe2/ideep/operators/elementwise_sum_op.cc
@@ -12,7 +12,7 @@ class IDEEPSumOp final : public IDEEPOperator {
   USE_IDEEP_DEF_ALIASES();
   USE_IDEEP_OPERATOR_FUNCTIONS();
   using FALLBACK_SUM = IDEEPFallbackOp<SumOp<CPUContext>, SkipIndices<0>>;
-  using FALLBACK_ADD = IDEEPFallbackOp<BinaryElementwiseBroadcastOp<
+  using FALLBACK_ADD = IDEEPFallbackOp<BinaryElementwiseOp<
     NumericTypes, CPUContext, AddFunctor<CPUContext>>, SkipIndices<0>>;
 
   IDEEPSumOp(const OperatorDef& operator_def, Workspace* ws)

--- a/caffe2/ideep/operators/operator_fallback_ideep.cc
+++ b/caffe2/ideep/operators/operator_fallback_ideep.cc
@@ -205,15 +205,15 @@ REGISTER_IDEEP_OPERATOR(
         SignFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Div,
-    IDEEPFallbackOp<BinaryElementwiseBroadcastOp<
+    IDEEPFallbackOp<BinaryElementwiseOp<
       NumericTypes, CPUContext, DivFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Mul,
     IDEEPFallbackOp<
-        BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>>);
+        BinaryElementwiseOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Sub,
-    IDEEPFallbackOp<BinaryElementwiseBroadcastOp<
+    IDEEPFallbackOp<BinaryElementwiseOp<
       NumericTypes, CPUContext, SubFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     Tanh,
@@ -231,7 +231,7 @@ REGISTER_IDEEP_OPERATOR(
 
 REGISTER_IDEEP_OPERATOR(
     AddGradient,
-    IDEEPFallbackOp<BinaryElementwiseGradientBroadcastOp<
+    IDEEPFallbackOp<BinaryElementwiseGradientOp<
         NumericTypes,
         CPUContext,
         AddFunctor<CPUContext>>>);
@@ -243,7 +243,7 @@ REGISTER_IDEEP_OPERATOR(
         TanhGradientFunctor<CPUContext>>>);
 REGISTER_IDEEP_OPERATOR(
     MulGradient,
-    IDEEPFallbackOp<BinaryElementwiseGradientBroadcastOp<
+    IDEEPFallbackOp<BinaryElementwiseGradientOp<
         NumericTypes,
         CPUContext,
         MulFunctor<CPUContext>>>);

--- a/caffe2/operators/elementwise_add_gradient_op.cc
+++ b/caffe2/operators/elementwise_add_gradient_op.cc
@@ -7,7 +7,7 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     AddGradient,
-    BinaryElementwiseGradientBroadcastOp<
+    BinaryElementwiseGradientOp<
         NumericTypes,
         CPUContext,
         AddFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_add_op.cc
+++ b/caffe2/operators/elementwise_add_op.cc
@@ -4,6 +4,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Add,
-    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>);
+    BinaryElementwiseOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_add_op.h
+++ b/caffe2/operators/elementwise_add_op.h
@@ -13,9 +13,6 @@ namespace caffe2 {
 
 template <class Context>
 struct AddFunctor {
-  explicit AddFunctor(bool allow_broadcast_fastpath=false)
-    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
-
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -62,7 +59,7 @@ struct AddFunctor {
         dC,
         dA,
         context,
-        allow_broadcast_fastpath_);
+        true);
     math::ReduceSum(
         C_dims.size(),
         C_dims.data(),
@@ -71,11 +68,9 @@ struct AddFunctor {
         dC,
         dB,
         context,
-        allow_broadcast_fastpath_);
+        true);
     return true;
   }
-
-  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_add_op_gpu.cc
+++ b/caffe2/operators/elementwise_add_op_gpu.cc
@@ -6,10 +6,10 @@ namespace caffe2 {
 
 REGISTER_CUDA_OPERATOR(
     Add,
-    BinaryElementwiseBroadcastOp<NumericTypes, CUDAContext, AddFunctor<CUDAContext>>);
+    BinaryElementwiseOp<NumericTypes, CUDAContext, AddFunctor<CUDAContext>>);
 REGISTER_CUDA_OPERATOR(
     AddGradient,
-    BinaryElementwiseGradientBroadcastOp<
+    BinaryElementwiseGradientOp<
         NumericTypes,
         CUDAContext,
         AddFunctor<CUDAContext>>);

--- a/caffe2/operators/elementwise_div_op.cc
+++ b/caffe2/operators/elementwise_div_op.cc
@@ -5,6 +5,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Div,
-    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, DivFunctor<CPUContext>>);
+    BinaryElementwiseOp<NumericTypes, CPUContext, DivFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_div_op.h
+++ b/caffe2/operators/elementwise_div_op.h
@@ -10,9 +10,6 @@ namespace caffe2 {
 
 template <class Context>
 struct DivFunctor {
-  explicit DivFunctor(bool allow_broadcast_fastpath=false)
-    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
-
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -44,8 +41,6 @@ struct DivFunctor {
       TGrad* dA_data,
       TGrad* dB_data,
       Context* context) const;
-
-  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_mul_gradient_op.cc
+++ b/caffe2/operators/elementwise_mul_gradient_op.cc
@@ -50,16 +50,14 @@ void ComputeMulGradient(
     const TIn* B,
     TGrad* dA,
     TGrad* dB,
-    CPUContext* context,
-    bool allow_broadcast_fastpath) {
+    CPUContext* context) {
   const auto A_size = c10::multiply_integers(A_dims, A_dims + ndim);
   const auto B_size = c10::multiply_integers(B_dims, B_dims + ndim);
   const auto C_size = c10::multiply_integers(C_dims, C_dims + ndim);
   math::Set<TGrad, CPUContext>(A_size, TGrad(0), dA, context);
   math::Set<TGrad, CPUContext>(B_size, TGrad(0), dB, context);
   if (
-      allow_broadcast_fastpath
-      && math::can_use_broadcast_fastpath(ndim, A_dims)
+      math::can_use_broadcast_fastpath(ndim, A_dims)
       && math::can_use_broadcast_fastpath(ndim, B_dims)) {
     ComputeMulGradientFastpath(A_size, B_size, C_size, dC, A, B, dA, dB);
     return;
@@ -270,8 +268,7 @@ bool MulFunctor<CPUContext>::Backward(
         B,
         dA,
         dB,
-        context,
-        allow_broadcast_fastpath_);
+        context);
   }
 
   return true;
@@ -324,7 +321,7 @@ template bool MulFunctor<CPUContext>::Backward<int64_t, int64_t, int64_t>(
 
 REGISTER_CPU_OPERATOR(
     MulGradient,
-    BinaryElementwiseGradientBroadcastOp<
+    BinaryElementwiseGradientOp<
         NumericTypes,
         CPUContext,
         MulFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_mul_op.cc
+++ b/caffe2/operators/elementwise_mul_op.cc
@@ -4,6 +4,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Mul,
-    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>);
+    BinaryElementwiseOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_mul_op.h
+++ b/caffe2/operators/elementwise_mul_op.h
@@ -10,9 +10,6 @@ namespace caffe2 {
 
 template <class Context>
 struct MulFunctor {
-  explicit MulFunctor(bool allow_broadcast_fastpath=false)
-    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
-
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -44,8 +41,6 @@ struct MulFunctor {
       TGrad* dA_data,
       TGrad* dB_data,
       Context* context) const;
-
-  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_sub_gradient_op.cc
+++ b/caffe2/operators/elementwise_sub_gradient_op.cc
@@ -7,7 +7,7 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     SubGradient,
-    BinaryElementwiseGradientBroadcastOp<
+    BinaryElementwiseGradientOp<
         NumericTypes,
         CPUContext,
         SubFunctor<CPUContext>>);

--- a/caffe2/operators/elementwise_sub_op.cc
+++ b/caffe2/operators/elementwise_sub_op.cc
@@ -4,6 +4,6 @@ namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(
     Sub,
-    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, SubFunctor<CPUContext>>);
+    BinaryElementwiseOp<NumericTypes, CPUContext, SubFunctor<CPUContext>>);
 
 } // namespace caffe2

--- a/caffe2/operators/elementwise_sub_op.h
+++ b/caffe2/operators/elementwise_sub_op.h
@@ -13,9 +13,6 @@ namespace caffe2 {
 
 template <class Context>
 struct SubFunctor {
-  explicit SubFunctor(bool allow_broadcast_fastpath=false)
-    : allow_broadcast_fastpath_(allow_broadcast_fastpath) {}
-
   template <typename TIn, typename TOut>
   bool Forward(
       const std::vector<int>& A_dims,
@@ -62,7 +59,7 @@ struct SubFunctor {
         dC,
         dA,
         context,
-        allow_broadcast_fastpath_);
+        true);
     math::ReduceSum(
         C_dims.size(),
         C_dims.data(),
@@ -71,11 +68,9 @@ struct SubFunctor {
         dC,
         dB,
         context,
-        allow_broadcast_fastpath_);
+        true);
     return true;
   }
-
-  const bool allow_broadcast_fastpath_;
 };
 
 } // namespace caffe2

--- a/caffe2/quantization/server/elementwise_add_dnnlowp_op.cc
+++ b/caffe2/quantization/server/elementwise_add_dnnlowp_op.cc
@@ -13,7 +13,7 @@ using namespace std;
 using namespace dnnlowp;
 
 using AddFp32Op =
-    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>;
+    BinaryElementwiseOp<NumericTypes, CPUContext, AddFunctor<CPUContext>>;
 
 template <typename T>
 class AddDNNLowPOp : public BinaryElementwiseDNNLowPOp<T, AddFp32Op> {

--- a/caffe2/quantization/server/elementwise_mul_dnnlowp_op.cc
+++ b/caffe2/quantization/server/elementwise_mul_dnnlowp_op.cc
@@ -9,7 +9,7 @@ using namespace std;
 using namespace dnnlowp;
 
 using MulFp32Op =
-    BinaryElementwiseBroadcastOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>;
+    BinaryElementwiseOp<NumericTypes, CPUContext, MulFunctor<CPUContext>>;
 
 template <typename T>
 class MulDNNLowPOp : public BinaryElementwiseDNNLowPOp<T, MulFp32Op> {


### PR DESCRIPTION
Summary: title. broadcast fastpath has been running fine for the enabled ops for a while now, so make it the default for these ops.

Test Plan: diff is a no-op, so sandcastle

Differential Revision: D32107847

