### PR TITLE
[lint] small pass to make lint clean

### DIFF
--- a/benchmarks/operator_benchmark/pt/bmm_test.py
+++ b/benchmarks/operator_benchmark/pt/bmm_test.py
@@ -9,7 +9,7 @@ class BmmBenchmark(op_bench.TorchBenchmarkBase):
             "batch1": torch.rand((B, M, K), device=device, requires_grad=self.auto_set()),
             "batch2": torch.rand((B, K, N,), device=device, requires_grad=self.auto_set())
         }
-        self.set_module_name(f"bmm (actual {op=}")
+        self.set_module_name(f"bmm (actual op={op}")
         self.op = torch.bmm if op == "bmm" else torch.matmul
 
     def forward(self, batch1, batch2):

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1422,7 +1422,7 @@ class TestClassType(JitTestCase):
         Test that the error message displayed when convering a class type
         to an IValue that has an attribute of the wrong type.
         """
-        @torch.jit.script
+        @torch.jit.script  # noqa: B903
         class ValHolder(object):  # noqa: B903
             def __init__(self, val):
                 self.val = val

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1015,7 +1015,7 @@ class TestFreezing(JitTestCase):
             m_f = torch._C._freeze_module(m_s._c)
 
     def test_freeze_module_inlining(self):
-        @torch.jit.script
+        @torch.jit.script  # noqa: B903
         class Obj(object):  # noqa: B903
             def __init__(self, x: int, y: int):
                 self.x = x

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -812,7 +812,7 @@ class TestSaveLoad(JitTestCase):
             def not_bar(self, x: Tensor) -> Tensor:
                 pass
 
-        @torch.jit.script
+        @torch.jit.script  # noqa: F811
         class ImplementInterface(object):  # noqa: F811
             def __init__(self):
                 pass

--- a/test/jit/test_union.py
+++ b/test/jit/test_union.py
@@ -97,7 +97,7 @@ class TestUnion(JitTestCase):
 
     def test_union_in_class_constructor(self):
 
-        @torch.jit.script
+        @torch.jit.script  # noqa: B903
         class A(object):    # noqa: B903
             def __init__(self, x: Union[int, str]) -> None:
                 self.x = x

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14626,7 +14626,7 @@ dedent """
         @torch.jit._overload
         def null_overload(x: int) -> int: ...  # noqa: E704
 
-        @torch.jit._overload
+        @torch.jit._overload  # noqa: F811
         def null_overload(x: str) -> str:  # noqa: F811
             pass
 
@@ -14644,7 +14644,7 @@ dedent """
             def forward(self, x: int):
                 pass
 
-            @torch.jit._overload_method
+            @torch.jit._overload_method  # noqa: F811
             def forward(self, x: Tensor):  # noqa: F811
                 pass
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1059,15 +1059,15 @@ else:
     def tensordot(a, b, dims: int = 2, out: Optional[torch.Tensor] = None):
         pass
 
-    @overload
+    @overload  # noqa: F811
     def tensordot(a, b, dims: Tuple[List[int], List[int]], out: Optional[torch.Tensor] = None):  # noqa: F811
         pass
 
-    @overload
+    @overload  # noqa: F811
     def tensordot(a, b, dims: List[List[int]], out: Optional[torch.Tensor] = None):  # noqa: F811
         pass
 
-    @overload
+    @overload  # noqa: F811
     def tensordot(a, b, dims: torch.Tensor, out: Optional[torch.Tensor] = None):  # noqa: F811
         pass
 
@@ -1421,17 +1421,17 @@ else:
         # type: (Tensor, str, Optional[List[int]], bool, Optional[Tensor], Optional[int]) -> Tensor
         pass
 
-    @overload
+    @overload  # noqa: F811
     def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa: F811
         # type: (Tensor, Optional[number], Optional[List[int]], bool, Optional[Tensor], Optional[int]) -> Tensor
         pass
 
-    @overload
+    @overload  # noqa: F811
     def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa: F811
         # type: (Tensor, Optional[number], Optional[int], bool, Optional[Tensor], Optional[int]) -> Tensor
         pass
 
-    @overload
+    @overload  # noqa: F811
     def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa: F811
         # type: (Tensor, str, Optional[int], bool, Optional[Tensor], Optional[int]) -> Tensor
         pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68367

- bmm_test.py was using syntax not allowed in 3.6
- Some suppressions were not placed on the correct line.

With this file,
```
lintrunner --paths-cmd='git grep -Il .'
```
passes successfully.

Differential Revision: [D32436644](https://our.internmc.facebook.com/intern/diff/D32436644)