### PR TITLE
[PyTorch] Remove enabled checks in RecordFunction constructor

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -495,13 +495,11 @@ void enableRecordFunction(bool enable) {
 }
 
 RecordFunction::RecordFunction(RecordScope scope, bool pre_sampled) {
-  auto* rf_tls_ptr = &rf_tls();
-  if (rf_tls_ptr->tls_record_function_enabled_) {
-    auto& m = manager();
-    if (!m.sorted_global_callbacks_.empty() || !rf_tls_ptr->sorted_tls_callbacks_.empty()) {
-      m.init(*this, scope, pre_sampled);
-    }
-  }
+  // Don't bother checking if we're enabled; caller should be using
+  // `shouldRunRecordFunction`. Can't debug-check that because there's
+  // the possibility that another thread turned it off after
+  // shouldRunRecordFunction returned.
+  manager().init(*this, scope, pre_sampled);
 }
 
 /* static */


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

All callers should be checking `shouldRunRecordFunction` before creating a RecordFunction, so we don't need to check if we're enabled again.

Differential Revision: [D32440630](https://our.internmc.facebook.com/intern/diff/D32440630/)