### PR TITLE
Make MultiProcessTestCases call super().run

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -573,7 +573,7 @@ class MultiProcessTestCase(TestCase):
         # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
         # We're retrieving a corresponding test and executing it.
         try:
-            getattr(self, test_name)()
+            super().run()
         except unittest.SkipTest as se:
             logger.info(
                 f"Process {self.rank} skipping test {test_name} for following reason: {str(se)}"


### PR DESCRIPTION
This would subscribe these test cases to the code in TestCase.run(), including the ability to potentially retry flaky tests later!

I don't know if I'm doing it right though--would this be the way to call the super method?

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang