### PR TITLE
[LTC] Refactor LTCTensorImpl

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -501,10 +501,14 @@ LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const 
       GetOrCreateLtcTensor(tensor, device) : GetLtcTensor(tensor);
 }
 
-at::Tensor CreateAtenFromLtcTensor(LazyTensor ltc_tensor) {
+at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor) {
   return ltc_tensor.is_null() ? at::Tensor()
-                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(
-                                    std::move(ltc_tensor)));
+                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor));
+}
+
+at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor) {
+  return ltc_tensor.is_null() ? at::Tensor()
+                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(std::move(ltc_tensor)));
 }
 
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -195,7 +195,8 @@ LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const 
 
 // Section 2: LazyTensor => at::Tensor.
 // Creates an ATen tensor from an LazyTensor.
-at::Tensor CreateAtenFromLtcTensor(LazyTensor ltc_tensor);
+at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor);
+at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor);
 
 template <size_t... Indices>
 auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.h
@@ -10,13 +10,14 @@ namespace torch_lazy_tensors {
 
 // Tensor implementation class used to be fed to the at::Tensor.
 // Its scope is just to handle an LazyTensor.
-class LTCTensorImpl : public c10::TensorImpl {
+class LTCTensorImpl final : public c10::TensorImpl {
  public:
-  explicit LTCTensorImpl(LazyTensor tensor);
+  explicit LTCTensorImpl(const LazyTensor& tensor);
+  explicit LTCTensorImpl(LazyTensor&& tensor);
 
   LazyTensor& tensor() { return tensor_; }
 
-  void set_tensor(LazyTensor lazy_tensor);
+  void set_tensor(const LazyTensor& lazy_tensor);
 
   void force_refresh_sizes() { generation_ = 0; }
 
@@ -42,22 +43,13 @@ class LTCTensorImpl : public c10::TensorImpl {
 
   const at::Storage& storage() const override;
 
-  bool has_storage() const override;
-
-  void MarkAsInteropView() { is_interop_view_ = true; }
-
-  bool IsInteropView() const { return is_interop_view_; }
-
-  static void AtenInitialize();
+  bool has_storage() const override { return false; }
 
  private:
-  void SetupSizeProperties();
-
-  static caffe2::TypeMeta GetTypeMeta(const LazyTensor& tensor);
+  void setup_size_properties();
 
   LazyTensor tensor_;
-  size_t generation_ = 0;
-  bool is_interop_view_ = false;
+  size_t generation_ {0};
 };
 
 }  // namespace torch_lazy_tensors


### PR DESCRIPTION
Summary:
This commit refactors LTCTensorImpl:
1) Adds both const& and && ctors for readability.
2) Removes unused APIs.
3) Keeps coding style to be consistent on the snake case.
4) Adds comments to some unconventional implementations, and consolidates some.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc
