### PR TITLE
fix fsdp overlap flaky test

### DIFF
--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -190,11 +190,11 @@ class TestForwardOverlapWorldSizeOne(FSDPTest):
         # wait should be long, except when there is no real work on GPU.
         #
         # If the assertions fail below, we likely have a cpu-gpu wait in the forward/backward pass.
+        # e4["cpu_iter"] may not be short as cpu may take some time to queue both compute and all-gather.
         short = [
             e1["cpu_iter"],
             e2["cpu_iter"],
             e3["cpu_iter"],
-            e4["cpu_iter"],
             e1["cpu_wait"],
         ]
         long = [e3["cpu_wait"], e4["cpu_wait"]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68415

remove e4["cpu_iter"] from short list as cpu may take some time to queue both compute and all-gather.
close #68391

Differential Revision: [D32457334](https://our.internmc.facebook.com/intern/diff/D32457334/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang