### PR TITLE
Use TORCH_CHECK in MapAllocator

### DIFF
--- a/aten/src/ATen/MapAllocator.cpp
+++ b/aten/src/ATen/MapAllocator.cpp
@@ -77,11 +77,11 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     flags &= ~ALLOCATOR_MAPPED_NOCREATE;
   }
   if ((flags ^ ALLOCATOR_MAPPED_EXCLUSIVE) == 0) {
-    TORCH_INTERNAL_ASSERT(false, "ALLOCATOR_MAPPED_EXCLUSIVE flag requires opening the file in shared mode");
+    TORCH_CHECK(false, "ALLOCATOR_MAPPED_EXCLUSIVE flag requires opening the file in shared mode");
   }
 #ifdef _WIN32
   if (fd != -1) {
-    TORCH_INTERNAL_ASSERT(false, "MapAllocator_newWithFd is unsupported on Windows");
+    TORCH_CHECK(false, "MapAllocator_newWithFd is unsupported on Windows");
   }
 #endif
   flags_ = flags;
@@ -116,11 +116,11 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     } else if (flags_ & ALLOCATOR_MAPPED_NOCREATE) {
       event_ = OpenEventW(EVENT_ALL_ACCESS, FALSE, eventname);
     } else {
-      TORCH_INTERNAL_ASSERT(false, "Expected either ALLOCATOR_MAPPED_EXCLUSIVE or ALLOCATOR_MAPPED_NOCREATE");
+      TORCH_CHECK(false, "Expected either ALLOCATOR_MAPPED_EXCLUSIVE or ALLOCATOR_MAPPED_NOCREATE");
     }
 
     if (event_ == nullptr) {
-      TORCH_INTERNAL_ASSERT(false, "Couldn't open shared event: <", eventname, ">, error code: <", GetLastError(), ">");
+      TORCH_CHECK(false, "Couldn't open shared event: <", eventname, ">, error code: <", GetLastError(), ">");
     }
 
     if (flags_ & ALLOCATOR_MAPPED_EXCLUSIVE) {
@@ -128,17 +128,17 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     } else if (flags_ & ALLOCATOR_MAPPED_NOCREATE) {
       handle_ = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, filename);
     } else {
-      TORCH_INTERNAL_ASSERT(false, "Expected either ALLOCATOR_MAPPED_EXCLUSIVE or ALLOCATOR_MAPPED_NOCREATE");
+      TORCH_CHECK(false, "Expected either ALLOCATOR_MAPPED_EXCLUSIVE or ALLOCATOR_MAPPED_NOCREATE");
     }
 
     if (handle_ == nullptr) {
-      TORCH_INTERNAL_ASSERT(false, "Couldn't open shared file mapping: <", filename, ">, error code: <", GetLastError(), ">");
+      TORCH_CHECK(false, "Couldn't open shared file mapping: <", filename, ">, error code: <", GetLastError(), ">");
     }
 
     size_ = size;
     base_ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size);
     if (!base_ptr_) {
-      TORCH_INTERNAL_ASSERT(false, "Couldn't map view of shared file <", filename, ">, error code: <", GetLastError(), ">");
+      TORCH_CHECK(false, "Couldn't map view of shared file <", filename, ">, error code: <", GetLastError(), ">");
     }
   } else {
 
@@ -147,16 +147,16 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     LARGE_INTEGER hfilesz;
 
     if (flags_ & ALLOCATOR_MAPPED_EXCLUSIVE) {
-      TORCH_INTERNAL_ASSERT(false, "exclusive file mapping is not supported on Windows");
+      TORCH_CHECK(false, "exclusive file mapping is not supported on Windows");
     }
     if (flags_ & ALLOCATOR_MAPPED_NOCREATE) {
-      TORCH_INTERNAL_ASSERT(false, "file mapping without creation is not supported on Windows");
+      TORCH_CHECK(false, "file mapping without creation is not supported on Windows");
     }
     if (flags_ & ALLOCATOR_MAPPED_KEEPFD) {
-      TORCH_INTERNAL_ASSERT(false, "ALLOCATOR_MAPPED_KEEPFD not supported on Windows");
+      TORCH_CHECK(false, "ALLOCATOR_MAPPED_KEEPFD not supported on Windows");
     }
     if (flags_ & ALLOCATOR_MAPPED_FROMFD) {
-      TORCH_INTERNAL_ASSERT(false, "ALLOCATOR_MAPPED_FROMFD not supported on Windows");
+      TORCH_CHECK(false, "ALLOCATOR_MAPPED_FROMFD not supported on Windows");
     }
 
     // Shadowing
@@ -170,17 +170,17 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     if (flags_) {
       hfile = CreateFileW(filename, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
       if (hfile == INVALID_HANDLE_VALUE) {
-        TORCH_INTERNAL_ASSERT(false, "could not open file <", filename_, "> in read-write mode; error code: <", GetLastError(), ">");
+        TORCH_CHECK(false, "could not open file <", filename_, "> in read-write mode; error code: <", GetLastError(), ">");
       }
     } else {
       hfile = CreateFileW(filename, GENERIC_READ, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
       if (hfile == INVALID_HANDLE_VALUE) {
-        TORCH_INTERNAL_ASSERT(false, "could not open file <", filename_, "> in read-only mode; error code: <", GetLastError(), ">");
+        TORCH_CHECK(false, "could not open file <", filename_, "> in read-only mode; error code: <", GetLastError(), ">");
       }
     }
 
     if (GetFileSizeEx(hfile, &hfilesz) == 0) {
-      TORCH_INTERNAL_ASSERT(false, "could not get file size: <", filename_, ">; error code: <", GetLastError(), ">");
+      TORCH_CHECK(false, "could not get file size: <", filename_, ">; error code: <", GetLastError(), ">");
     }
 
     if (size > 0) {
@@ -189,15 +189,15 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
           hfilesz.QuadPart = size;
           if (SetFilePointerEx(hfile, hfilesz, NULL, FILE_BEGIN) == 0) {
             CloseHandle(hfile);
-            TORCH_INTERNAL_ASSERT(false, "unable to stretch file <", filename_, "> to the right size; error code: <", GetLastError(), ">", filename_);
+            TORCH_CHECK(false, "unable to stretch file <", filename_, "> to the right size; error code: <", GetLastError(), ">", filename_);
           }
           if (SetEndOfFile(hfile) == 0) {
             CloseHandle(hfile);
-            TORCH_INTERNAL_ASSERT(false, "unable to write to file <", filename_, ">; error code: <", GetLastError(), ">");
+            TORCH_CHECK(false, "unable to write to file <", filename_, ">; error code: <", GetLastError(), ">");
           }
         } else {
           CloseHandle(hfile);
-          TORCH_INTERNAL_ASSERT(false, "file <", filename_, "> size is smaller than the required mapping size <", size, ">; error code: <", GetLastError(), ">");
+          TORCH_CHECK(false, "file <", filename_, "> size is smaller than the required mapping size <", size, ">; error code: <", GetLastError(), ">");
         }
       }
     } else {
@@ -211,11 +211,11 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     /* get map handle */
     if (flags_) {
       if ( (hmfile = CreateFileMappingW(hfile, NULL, PAGE_READWRITE, hfilesz.HighPart, hfilesz.LowPart, NULL)) == NULL ) {
-        TORCH_INTERNAL_ASSERT(false, "could not create a map on file <", filename_, ">; error code: <", GetLastError(), ">");
+        TORCH_CHECK(false, "could not create a map on file <", filename_, ">; error code: <", GetLastError(), ">");
       }
     } else {
       if ( (hmfile = CreateFileMappingW(hfile, NULL, PAGE_WRITECOPY, hfilesz.HighPart, hfilesz.LowPart, NULL)) == NULL ) {
-        TORCH_INTERNAL_ASSERT(false, "could not create a map on file <", filename_, ">; error code: <", GetLastError(), ">");
+        TORCH_CHECK(false, "could not create a map on file <", filename_, ">; error code: <", GetLastError(), ">");
       }
     }
 
@@ -255,19 +255,19 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
     if (!(flags_ & ALLOCATOR_MAPPED_FROMFD)) {
       if (flags_ & ALLOCATOR_MAPPED_SHARED) {
         if ((fd = open(filename_.c_str(), flags, (mode_t)0600)) == -1) {
-          TORCH_INTERNAL_ASSERT(false, "unable to open file <", filename_, "> in read-write mode");
+          TORCH_CHECK(false, "unable to open file <", filename_, "> in read-write mode");
         }
       } else if (flags_ & ALLOCATOR_MAPPED_SHAREDMEM) {
 #ifdef HAVE_SHM_OPEN
         if((fd = shm_open(filename_.c_str(), flags, (mode_t)0600)) == -1) {
-          TORCH_INTERNAL_ASSERT(false, "unable to open shared memory object <", filename_, "> in read-write mode");
+          TORCH_CHECK(false, "unable to open shared memory object <", filename_, "> in read-write mode");
         }
 #else
-        TORCH_INTERNAL_ASSERT(false, "unable to open file <", filename_, "> in sharedmem mode, shm_open unavailable on this platform");
+        TORCH_CHECK(false, "unable to open file <", filename_, "> in sharedmem mode, shm_open unavailable on this platform");
 #endif
       } else {
         if ((fd = open(filename_.c_str(), O_RDONLY)) == -1) {
-          TORCH_INTERNAL_ASSERT(false, "unable to open file <", filename_, "> in read-only mode");
+          TORCH_CHECK(false, "unable to open file <", filename_, "> in read-only mode");
         }
       }
     } else {
@@ -278,18 +278,18 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
       if (!(flags_ & ALLOCATOR_MAPPED_FROMFD)) {
         ::close(fd);
       }
-      TORCH_INTERNAL_ASSERT(false, "unable to stat the file <", filename_, ">");
+      TORCH_CHECK(false, "unable to stat the file <", filename_, ">");
     }
 
     if (size > 0) {
       if (static_cast<int64_t>(size) > file_stat.st_size) {
         if (flags_) {
           if (ftruncate(fd, size) == -1) {
-            TORCH_INTERNAL_ASSERT(false, "unable to resize file <", filename_, "> to the right size");
+            TORCH_CHECK(false, "unable to resize file <", filename_, "> to the right size");
           }
           if (fstat(fd, &file_stat) == -1 || file_stat.st_size < static_cast<int64_t>(size)) {
             ::close(fd);
-            TORCH_INTERNAL_ASSERT(false, "unable to stretch file <", filename_, "> to the right size");
+            TORCH_CHECK(false, "unable to stretch file <", filename_, "> to the right size");
           }
 /* on macOS write returns with errno 45 (Opperation not supported) when used
  * with a file descriptor obtained via shm_open
@@ -297,12 +297,12 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
 #ifndef __APPLE__
           if ((write(fd, "", 1)) != 1) /* note that the string "" contains the '\0' byte ... */ {
             ::close(fd);
-            TORCH_INTERNAL_ASSERT(false, "unable to write to file <", filename_, ">");
+            TORCH_CHECK(false, "unable to write to file <", filename_, ">");
           }
 #endif
         } else {
           ::close(fd);
-          TORCH_INTERNAL_ASSERT(false, "file <", filename_, "> size is smaller than the required mapping size <", size, ">");
+          TORCH_CHECK(false, "file <", filename_, "> size is smaller than the required mapping size <", size, ">");
         }
       }
     } else {
@@ -320,14 +320,14 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
 
     if (base_ptr_ == MAP_FAILED) {
       base_ptr_ = nullptr; /* let's be sure it is NULL */
-      TORCH_INTERNAL_ASSERT(false, "unable to mmap ", size_, " bytes from file <", filename_, ">: ", strerror(errno), " (", errno, ")");
+      TORCH_CHECK(false, "unable to mmap ", size_, " bytes from file <", filename_, ">: ", strerror(errno), " (", errno, ")");
     }
 
     if (flags_ & ALLOCATOR_MAPPED_KEEPFD) {
       fd_ = fd;
     } else {
       if (::close(fd) == -1) {
-        TORCH_INTERNAL_ASSERT(false, "Error closing file <", filename_, ">");
+        TORCH_CHECK(false, "Error closing file <", filename_, ">");
       }
       fd_ = -1;
     }
@@ -336,19 +336,19 @@ MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size
       if (flags_ & ALLOCATOR_MAPPED_SHAREDMEM) {
 #ifdef HAVE_SHM_UNLINK
         if (shm_unlink(filename_.c_str()) == -1) {
-          TORCH_INTERNAL_ASSERT(false, "could not unlink the shared memory file ", filename_);
+          TORCH_CHECK(false, "could not unlink the shared memory file ", filename_);
         }
 #else
-        TORCH_INTERNAL_ASSERT(false, "could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
+        TORCH_CHECK(false, "could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
 #endif
       } else {
         if (unlink(filename_.c_str()) == -1)
-          TORCH_INTERNAL_ASSERT(false, "could not unlink file %s", filename_);
+          TORCH_CHECK(false, "could not unlink file %s", filename_);
       }
     }
 
     if (base_ptr_ == MAP_FAILED) {
-      TORCH_INTERNAL_ASSERT(false, "$ Torch: unable to mmap memory: you tried to mmap ", size_/1073741824, " GB.");
+      TORCH_CHECK(false, "$ Torch: unable to mmap memory: you tried to mmap ", size_/1073741824, " GB.");
     }
   }
 #endif
@@ -393,26 +393,26 @@ void MapAllocator::close() {
   if ((flags_ & ALLOCATOR_MAPPED_KEEPFD) || (flags_ & ALLOCATOR_MAPPED_SHAREDMEM))
     CloseHandle(handle_);
   if(UnmapViewOfFile(base_ptr_) == 0)
-    TORCH_INTERNAL_ASSERT(false, "could not unmap the shared memory file");
+    TORCH_CHECK(false, "could not unmap the shared memory file");
 #else /* _WIN32 */
   if (flags_ & ALLOCATOR_MAPPED_KEEPFD) {
     if (::close(fd_) == -1) {
-      TORCH_INTERNAL_ASSERT(false, "could not close file descriptor ", fd_);
+      TORCH_CHECK(false, "could not close file descriptor ", fd_);
     }
   }
 
   if (munmap(base_ptr_, size_)) {
-    TORCH_INTERNAL_ASSERT(false, "could not unmap the shared memory file");
+    TORCH_CHECK(false, "could not unmap the shared memory file");
   }
 
   if (!(flags_ & (ALLOCATOR_MAPPED_FROMFD | ALLOCATOR_MAPPED_UNLINK))) {
     if (flags_ & ALLOCATOR_MAPPED_SHAREDMEM) {
 #ifdef HAVE_SHM_UNLINK
       if (shm_unlink(filename_.c_str()) == -1) {
-        TORCH_INTERNAL_ASSERT(false, "could not unlink the shared memory file ", filename_);
+        TORCH_CHECK(false, "could not unlink the shared memory file ", filename_);
       }
 #else
-      TORCH_INTERNAL_ASSERT(false, "could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
+      TORCH_CHECK(false, "could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
 #endif
     }
   }
@@ -422,11 +422,11 @@ void MapAllocator::close() {
 #else /* defined(_WIN32) || defined(HAVE_MMAP) */
 
 MapAllocator::MapAllocator(std::string filename, int flags, size_t size) {
-  TORCH_INTERNAL_ASSERT(false, "file mapping not supported on your system");
+  TORCH_CHECK(false, "file mapping not supported on your system");
 }
 
 MapAllocator::MapAllocator(WithFd, std::string filename, int fd, int flags, size_t size) {
-  TORCH_INTERNAL_ASSERT(false, "file mapping not supported on your system");
+  TORCH_CHECK(false, "file mapping not supported on your system");
 }
 
 void MapAllocator::close() { }
@@ -437,16 +437,16 @@ void MapAllocator::close() { }
 
 RefcountedMapAllocatorArgCheck::RefcountedMapAllocatorArgCheck(int flags) {
   if (flags & ALLOCATOR_MAPPED_FROMFD) {
-    TORCH_INTERNAL_ASSERT(false, "RefcountedMapAllocator doesn't support ALLOCATOR_MAPPED_FROMFD flag");
+    TORCH_CHECK(false, "RefcountedMapAllocator doesn't support ALLOCATOR_MAPPED_FROMFD flag");
   }
   if (flags & ALLOCATOR_MAPPED_KEEPFD) {
-    TORCH_INTERNAL_ASSERT(false, "RefcountedMapAllocator doesn't support ALLOCATOR_MAPPED_KEEPFD flag");
+    TORCH_CHECK(false, "RefcountedMapAllocator doesn't support ALLOCATOR_MAPPED_KEEPFD flag");
   }
   if (flags & ALLOCATOR_MAPPED_UNLINK) {
-    TORCH_INTERNAL_ASSERT(false, "RefcountedMapAllocator doesn't support ALLOCATOR_MAPPED_UNLINK flag");
+    TORCH_CHECK(false, "RefcountedMapAllocator doesn't support ALLOCATOR_MAPPED_UNLINK flag");
   }
   if (!(flags & ALLOCATOR_MAPPED_SHAREDMEM)) {
-    TORCH_INTERNAL_ASSERT(false, "RefcountedMapAllocator requires ALLOCATOR_MAPPED_SHAREDMEM flag");
+    TORCH_CHECK(false, "RefcountedMapAllocator requires ALLOCATOR_MAPPED_SHAREDMEM flag");
   }
 }
 
@@ -472,7 +472,7 @@ void RefcountedMapAllocator::initializeAlloc() {
   r_ctx->event = event_;
   r_ctx->wait = NULL;
   BOOL can_wait = RegisterWaitForSingleObject(&r_ctx->wait, event_, WaitForReleaseHandle, (PVOID)r_ctx, INFINITE, WT_EXECUTEONLYONCE);
-  TORCH_INTERNAL_ASSERT(can_wait, "Couldn't register wait on event, error code: <", GetLastError(), ">");
+  TORCH_CHECK(can_wait, "Couldn't register wait on event, error code: <", GetLastError(), ">");
 #endif
 
   if (flags_ & ALLOCATOR_MAPPED_EXCLUSIVE) {
@@ -496,7 +496,7 @@ void RefcountedMapAllocator::close() {
     SetEvent(event_);
   }
   if(UnmapViewOfFile(data) == 0) {
-    TORCH_INTERNAL_ASSERT(false, "could not unmap the shared memory file");
+    TORCH_CHECK(false, "could not unmap the shared memory file");
   }
 #else /* _WIN32 */
 
@@ -504,14 +504,14 @@ void RefcountedMapAllocator::close() {
   if (--info->refcount == 0) {
 #ifdef HAVE_SHM_UNLINK
     if (shm_unlink(filename_.c_str()) == -1) {
-      TORCH_INTERNAL_ASSERT(false, "could not unlink the shared memory file ", filename_);
+      TORCH_CHECK(false, "could not unlink the shared memory file ", filename_);
     }
 #else
-    TORCH_INTERNAL_ASSERT(false, "could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
+    TORCH_CHECK(false, "could not unlink the shared memory file ", filename_, ", shm_unlink not available on platform");
 #endif /* HAVE_SHM_UNLINK */
   }
   if (munmap(info, size_)) {
-    TORCH_INTERNAL_ASSERT(false, "could not unmap the shared memory file ", filename_);
+    TORCH_CHECK(false, "could not unmap the shared memory file ", filename_);
   }
 #endif /* _WIN32 */
 }
@@ -537,14 +537,14 @@ RefcountedMapAllocator::RefcountedMapAllocator(const char *filename, int flags, 
   : RefcountedMapAllocatorArgCheck(flags),
     MapAllocator(filename, flags, size + map_alloc_alignment)
 {
-  TORCH_INTERNAL_ASSERT(false, "refcounted file mapping not supported on your system");
+  TORCH_CHECK(false, "refcounted file mapping not supported on your system");
 }
 
 RefcountedMapAllocator::RefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size)
   : RefcountedMapAllocatorArgCheck(flags),
     MapAllocator(WITH_FD, filename, flags, fd, size + map_alloc_alignment)
 {
-  TORCH_INTERNAL_ASSERT(false, "refcounted file mapping not supported on your system");
+  TORCH_CHECK(false, "refcounted file mapping not supported on your system");
 }
 
 void RefcountedMapAllocator::initializeAlloc() {}


### PR DESCRIPTION
When porting `THAllocator` to ATen I changed `AT_ERROR` to `TORCH_INTERNAL_ASSERT` but the direct translation should have been `TORCH_CHECK`. 

https://github.com/pytorch/pytorch/blob/33e9a0b5f6674bd429bda689534e1c987b38cf6e/c10/util/Exception.h#L619-L623

