### PR TITLE
[PyTorch] CachingHostAllocator::free: checking for null should't need a lock

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -111,11 +111,11 @@ struct HostAllocator
 
   cudaError_t free(void* ptr)
   {
-    std::lock_guard<std::mutex> lock(mutex);
-
     if (!ptr) {
       return cudaSuccess;
     }
+
+    std::lock_guard<std::mutex> lock(mutex);
 
     // process outstanding cuda events which may have occurred
     cudaError_t err = processEvents();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68472

Locks are there to protect shared state. Our pointer argument in free is not shared state.

Differential Revision: [D32474493](https://our.internmc.facebook.com/intern/diff/D32474493/)