### PR TITLE
clear predict_net field from PredictorExporterMeta stored in the exporter to save memory

### DIFF
--- a/caffe2/python/predictor/predictor_exporter.py
+++ b/caffe2/python/predictor/predictor_exporter.py
@@ -88,10 +88,11 @@ class PredictorExportMeta(collections.namedtuple(
             "Intersection: {}".format(set(parameters).intersection(outputs)))
         shapes = shapes or {}
 
-        if isinstance(predict_net, (core.Net, core.Plan)):
-            predict_net = predict_net.Proto()
+        if predict_net is not None:
+            if isinstance(predict_net, (core.Net, core.Plan)):
+                predict_net = predict_net.Proto()
 
-        assert isinstance(predict_net, (caffe2_pb2.NetDef, caffe2_pb2.PlanDef))
+            assert isinstance(predict_net, (caffe2_pb2.NetDef, caffe2_pb2.PlanDef))
         return super(PredictorExportMeta, cls).__new__(
             cls, predict_net, parameters, inputs, outputs, shapes, name,
             extra_init_net, global_init_net, net_type, num_workers, trainer_prefix)


### PR DESCRIPTION
Summary: In OSS, the only change is that we make the predict_net field of PredictorExporterMeta nullable.

Test Plan: sandcastle, let CI run

Differential Revision: D32467138

