### PR TITLE
[ROCm] Use hipCUB/rocPRIM scan algorithms for large index support

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -184,6 +184,16 @@ struct chained_iterator {
 
 template<typename InputIteratorT, typename OutputIteratorT, typename ScanOpT>
 inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT scan_op, int64_t num_items) {
+#if defined(USE_ROCM) && (ROCM_VERSION >= 50000)
+  //For ROCm, use hipCUB chained iterators
+  CUB_WRAPPER(NO_ROCM(detail)::hipcub::DeviceScan::InclusiveScan,
+      input,
+      output,
+      scan_op,
+      num_items,
+      at::cuda::getCurrentCUDAStream());
+  C10_HIP_KERNEL_LAUNCH_CHECK();
+#else
   // non synchronizing cub call
   // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
   // so split at int_max/2
@@ -227,10 +237,22 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         size_cub,
         at::cuda::getCurrentCUDAStream());
   }
+#endif
 }
 
 template<typename InputIteratorT, typename OutputIteratorT, typename ScanOpT, typename InitValueT>
 inline void exclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT scan_op, InitValueT init_value, int64_t num_items) {
+#if defined(USE_ROCM) && (ROCM_VERSION >= 50000)
+  //For ROCm, use hipCUB chained iterators
+  CUB_WRAPPER(NO_ROCM(detail)::hipcub::DeviceScan::ExclusiveScan,
+      input,
+      output,
+      scan_op,
+      init_value,
+      num_items,
+      at::cuda::getCurrentCUDAStream());
+  C10_HIP_KERNEL_LAUNCH_CHECK();
+#else
   // non synchronizing cub call
   // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
   // so split at int_max/2
@@ -265,6 +287,7 @@ inline void exclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         size_cub,
         at::cuda::getCurrentCUDAStream());
   }
+#endif
 }
 
 }}}  // namespace at::cuda::cub


### PR DESCRIPTION
For inclusive_scan and exclusive_scan, use hipCUB/rocPRIM scan algorithms for large index support.
Implemented for ROCm 5.0 and above.
Code reference : ROCmSoftwarePlatform/rocPRIM@5673df4#diff-47f4ef75e5af60dd5fe3906df9cf971f0635602a6b64a706dee6633d6677ef1a

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH