### PR TITLE
Fix c10d TCP store with mutex

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -19,8 +19,9 @@ class WorkNCCLSimulateErrors : public c10d::ProcessGroupNCCL::WorkNCCL {
       const std::vector<at::Device>& devices,
       bool simulate_error,
       int rank,
-      c10d::OpType opType)
-      : WorkNCCL(devices, rank, opType), simulate_error_(simulate_error) {}
+      c10d::OpType opType,
+      uint64_t seq)
+      : WorkNCCL(devices, rank, opType, seq), simulate_error_(simulate_error) {}
 
   std::exception_ptr checkForNCCLErrors(
       const std::vector<std::shared_ptr<c10d::NCCLComm>>& ncclComms)
@@ -63,7 +64,7 @@ class ProcessGroupNCCLSimulateErrors : public c10d::ProcessGroupNCCL {
       c10d::OpType opType,
       const char* profilingTitle, const c10::optional<std::vector<at::Tensor>>& inputs = c10::nullopt) override {
     return c10::make_intrusive<WorkNCCLSimulateErrors>(
-        devices, simulate_error_, rank, opType);
+        devices, simulate_error_, rank, opType, seq_);
   }
 
   size_t getNCCLCommCacheSize() {
@@ -88,8 +89,9 @@ class WorkNCCLTimedoutErrors : public c10d::ProcessGroupNCCL::WorkNCCL {
       const std::vector<at::Device>& devices,
       bool set_timedout_error,
       int rank,
-      c10d::OpType opType)
-      : WorkNCCL(devices, rank, opType),
+      c10d::OpType opType,
+      uint64_t seq)
+      : WorkNCCL(devices, rank, opType, seq),
         set_timedout_error_(set_timedout_error) {}
 
  private:
@@ -120,7 +122,7 @@ class ProcessGroupNCCLTimedOutErrors : public ProcessGroupNCCLSimulateErrors {
       c10d::OpType opType,
       const char* profilingTitle, const c10::optional<std::vector<at::Tensor>>& inputs = c10::nullopt) override {
     return c10::make_intrusive<WorkNCCLTimedoutErrors>(
-        devices, set_timedout_error_, rank, opType);
+        devices, set_timedout_error_, rank, opType, seq_);
   }
 
   void set_timedout_error() {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -12,15 +12,16 @@
 #include <THC/THC.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10d/ParamCommsUtils.hpp>
-#include <c10d/Utils.hpp>
 #include <c10/core/DeviceType.h>
 #include <c10/cuda/CUDAGraphsC10Utils.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/Exception.h>
-#include <c10/util/irange.h>
 #include <c10/util/Logging.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
+#include <c10d/ParamCommsUtils.hpp>
+#include <c10d/TraceUtils.h>
+#include <c10d/Utils.hpp>
 
 #include <torch/csrc/cuda/nccl.h>
 
@@ -249,7 +250,9 @@ std::ostream& operator<<(
   if (workNCCL.outputs_) {
     workInfo = c10::str(
         "WorkNCCL(",
-        "OpType=",
+        "SeqNum=",
+        workNCCL.seq_,
+        ", OpType=",
         opTypeToString(workNCCL.opType_),
         ", TensorShape=",
         (*workNCCL.outputs_)[0].sizes(),
@@ -259,7 +262,9 @@ std::ostream& operator<<(
   } else {
     workInfo = c10::str(
         "WorkNCCL(",
-        "OpType=",
+        "SeqNum=",
+        workNCCL.seq_,
+        ", OpType=",
         opTypeToString(workNCCL.opType_),
         ", Timeout(ms)=",
         workNCCL.opTimeout_.count(),
@@ -272,15 +277,22 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(
     const std::vector<at::Device>& devices,
     int rank,
     OpType opType,
+    uint64_t seq,
     const char* profilingTitle,
-    const c10::optional<std::vector<at::Tensor>>& inputs)
+    const c10::optional<std::vector<at::Tensor>>& inputs,
+    bool desyncDebug)
     : Work(rank, opType, profilingTitle, inputs),
       devices_(devices),
-      workStartTime_(std::chrono::steady_clock::now()) {
+      workStartTime_(std::chrono::steady_clock::now()),
+      seq_(seq) {
   // Creates the CUDA event wrappers
   // Note: The actual events are lazily created when first recorded to with
   // DEFAULT_FLAGS = cudaEventDisableTiming.
-  cudaEvents_ =
+  if (desyncDebug) {
+    ncclStartEvents_ =
+        std::make_shared<std::vector<at::cuda::CUDAEvent>>(devices.size());
+  }
+  ncclEndEvents_ =
       std::make_shared<std::vector<at::cuda::CUDAEvent>>(devices.size());
   ncclComms_.resize(devices.size());
 }
@@ -289,11 +301,15 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const WorkNCCL& w)
     : Work(w.rank_, w.opType_),
       std::enable_shared_from_this<WorkNCCL>(w),
       devices_(w.devices_),
-      cudaEvents_(w.cudaEvents_),
+      ncclStartEvents_(w.ncclStartEvents_),
+      ncclEndEvents_(w.ncclEndEvents_),
       ncclComms_(w.ncclComms_),
       blockingWait_(w.blockingWait_),
       opTimeout_(w.opTimeout_),
-      workStartTime_(w.workStartTime_) {
+      workStartTime_(w.workStartTime_),
+      seq_(w.seq_),
+      startTraceUpdated_(w.startTraceUpdated_),
+      store_(w.store_) {
   exception_ = w.exception_;
 }
 
@@ -302,6 +318,11 @@ ProcessGroupNCCL::WorkNCCL::~WorkNCCL() {}
 bool ProcessGroupNCCL::WorkNCCL::isCompleted() {
   checkAndSetException();
   return exception() || finishedGPUExecutionInternal();
+}
+
+bool ProcessGroupNCCL::WorkNCCL::isStarted() {
+  checkAndSetException();
+  return exception() || startedGPUExecutionInternal();
 }
 
 bool ProcessGroupNCCL::WorkNCCL::isSuccess() const {
@@ -341,10 +362,20 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecution() {
   return finishedGPUExecutionInternal();
 }
 
+bool ProcessGroupNCCL::WorkNCCL::startedGPUExecutionInternal() const {
+  for (const auto i : c10::irange(devices_.size())) {
+    // Checking the work's corresponding CUDA events' status
+    if (!(*ncclStartEvents_)[i].query()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
   for (const auto i : c10::irange(devices_.size())) {
     // Checking the work's corresponding CUDA events' status
-    if (!(*cudaEvents_)[i].query()) {
+    if (!(*ncclEndEvents_)[i].query()) {
       return false;
     }
   }
@@ -385,7 +416,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
   for (const auto i : c10::irange(devices_.size())) {
     auto currentStream = at::cuda::getCurrentCUDAStream(devices_[i].index());
     // Block the current stream on the NCCL stream
-    (*cudaEvents_)[i].block(currentStream);
+    (*ncclEndEvents_)[i].block(currentStream);
   }
 }
 
@@ -498,19 +529,33 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       store_(store),
       options_(options),
       ncclCommCounter_(0),
+      traceKeyStart_(getTraceStartKey("NCCL", rank)),
+      traceKeyEnd_(getTraceEndKey("NCCL", rank)),
       terminateProcessGroup_(false) {
   TORCH_CHECK(
       at::cuda::getNumGPUs() != 0,
       "ProcessGroupNCCL is only supported with GPUs, no GPUs found!");
   blockingWait_ = parseEnvVarFlag(NCCL_BLOCKING_WAIT);
   asyncErrorHandling_ = parseEnvVarFlag(NCCL_ASYNC_ERROR_HANDLING);
+  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG);
 
-  if (blockingWait_ && asyncErrorHandling_) {
-    LOG(INFO) << "[Rank " << rank_
-              << "] NCCL_BLOCKING_WAIT and NCCL_ASYNC_ERROR_HANDLING "
-              << "should not both be enabled. "
-              << "Only NCCL_BLOCKING_WAIT is being used in this process.";
-    asyncErrorHandling_ = false;
+  if (blockingWait_) {
+    if (asyncErrorHandling_ || desyncDebug_) {
+      LOG(INFO) << "[Rank " << rank_ << "] NCCL_BLOCKING_WAIT and "
+                << "NCCL_ASYNC_ERROR_HANDLING|NCCL_DESYNC_DEBUG"
+                << "should not both be enabled. "
+                << "Only NCCL_BLOCKING_WAIT is being used in this process.";
+      asyncErrorHandling_ = false;
+      desyncDebug_ = false;
+    }
+  } else {
+    if (desyncDebug_ && !asyncErrorHandling_) {
+      LOG(INFO) << "[Rank " << rank_
+                << "] NCCL_DESYNC_DEBUG and NCCL_ASYNC_ERROR_HANDLING "
+                << "must both be enabled. "
+                << "Enabling NCCL_ASYNC_ERROR_HANDLING.";
+      asyncErrorHandling_ = true;
+    }
   }
 
   if (parseEnvVarFlag(ENABLE_NCCL_HEALTH_CHECK)) {
@@ -540,6 +585,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   LOG(INFO) << "[Rank " << rank_
             << "] ProcessGroupNCCL initialized with following options:"
             << "\nNCCL_ASYNC_ERROR_HANDLING: " << asyncErrorHandling_
+            << "\nNCCL_DESYNC_DEBUG: " << desyncDebug_
             << "\nNCCL_BLOCKING_WAIT: " << blockingWait_
             << "\nTIMEOUT(ms): " << options_->timeout.count()
             << "\nUSE_HIGH_PRIORITY_STREAM: "
@@ -605,28 +651,10 @@ void ProcessGroupNCCL::runHealthCheck() {
       rank_);
 }
 
-void ProcessGroupNCCL::setSequenceNumberForGroup() {
-  if (rank_ == 0) {
-    // Create and broadcast sequence number
-    auto seq = 1 + rand();
-    sequenceNum_ = c10d::SequenceNum(seq);
-    std::vector<uint8_t> values = c10d::toVec<uint8_t>(seq, kBytes);
-    store_->set(kSeqNumStoreKey, values);
-  } else {
-    // Read rank 0's sequence number from store.
-    sequenceNum_ = c10d::SequenceNum();
-    store_->wait({kSeqNumStoreKey}, options_->timeout);
-    std::vector<uint8_t> values = store_->get(kSeqNumStoreKey);
-    uint64_t num = c10d::fromVec<uint8_t>(values);
-    sequenceNum_->set(num);
-  }
-}
+void ProcessGroupNCCL::setSequenceNumberForGroup() {}
 
 uint64_t ProcessGroupNCCL::getSequenceNumberForGroup() {
-  if (sequenceNum_ == c10::nullopt) {
-    return 0;
-  }
-  return sequenceNum_->get();
+  return seq_;
 }
 
 ProcessGroupNCCL::~ProcessGroupNCCL() {
@@ -682,6 +710,9 @@ void ProcessGroupNCCL::abortTimedOutCollectives(
           " ran for ",
           timeElapsed.count(),
           " milliseconds before timing out.");
+      if (desyncDebug_) {
+        exceptionMsg += retrieveDesyncReport(store_, "NCCL", rank_, size_);
+      }
       LOG(ERROR) << exceptionMsg;
       std::exception_ptr exception_ptr =
           std::make_exception_ptr(std::runtime_error(exceptionMsg));
@@ -858,7 +889,39 @@ void ProcessGroupNCCL::workCleanupLoop() {
       for (auto it = workMetaList_.begin(); it != workMetaList_.end();
            /* no increment*/) {
         auto& work = *it;
+
+        if (desyncDebug_ && !work.exception()) {
+          if (!work.startTraceUpdated_ && work.isStarted() &&
+              !terminateProcessGroup_.load() && !storeError_) {
+            work.startTraceUpdated_ = true;
+            storeError_ = !c10d::traceUpdate(
+                store_,
+                traceKeyStart_,
+                work.seq_,
+                opTypeToString(work.opType_));
+          }
+        }
+
         if (work.isCompleted()) {
+          if (desyncDebug_ && !work.exception()) {
+            // To close the window between the check of work.isStarted() and
+            // the check of work.isCompleted().
+            if (!work.startTraceUpdated_ && !terminateProcessGroup_.load() &&
+                !storeError_) {
+              storeError_ = !c10d::traceUpdate(
+                  store_,
+                  traceKeyStart_,
+                  work.seq_,
+                  opTypeToString(work.opType_));
+            }
+            if (!terminateProcessGroup_.load() && !storeError_) {
+              storeError_= !c10d::traceUpdate(
+                  store_,
+                  traceKeyEnd_,
+                  work.seq_,
+                  opTypeToString(work.opType_));
+            }
+          }
           // Handle Exceptions on failed GPU operations and remove completed
           // workNCCL objects from work vector.
           if (!terminateProcessGroup_.load()) {
@@ -1210,7 +1273,13 @@ c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL> ProcessGroupNCCL::initWork(
     const char* profilingTitle,
     const c10::optional<std::vector<at::Tensor>>& inputs) {
   return c10::make_intrusive<ProcessGroupNCCL::WorkNCCL>(
-      devices, rank, opType, profilingTitle, inputs);
+      devices,
+      rank,
+      opType,
+      seq_,
+      profilingTitle,
+      inputs,
+      desyncDebug_);
 }
 
 std::vector<at::Tensor> ProcessGroupNCCL::WorkNCCL::result() {
@@ -1251,9 +1320,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
   errorIfCapturingNonCapturableNCCL();
 
   // Bump collective counter
-  if (sequenceNum_) {
-    sequenceNum_->increment();
-  }
+  seq_++;
+
   const auto devices = getDeviceList(inputs);
   const auto key = getKeyFromDevices(devices);
   auto& ncclComms = getNCCLComm(key, devices, opType);
@@ -1275,6 +1343,14 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
   work->outputs_ = std::make_shared<std::vector<at::Tensor>>(outputs);
 
   at::cuda::OptionalCUDAGuard gpuGuard;
+
+  // Start event should only be recorded before the ncclGroupStart()
+  if (desyncDebug_) {
+    for (const auto i : c10::irange(inputs.size())) {
+      at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
+      (*work->ncclStartEvents_)[i].record(ncclStream);
+    }
+  }
 
   pre(ncclStreams_[key]);
 
@@ -1306,10 +1382,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
 
   post(ncclStreams_[key]);
 
-  // Event should only be recorded after the ncclGroupEnd()
+  // End event should only be recorded after the ncclGroupEnd()
   for (const auto i : c10::irange(inputs.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
-    (*work->cudaEvents_)[i].record(ncclStream);
+    (*work->ncclEndEvents_)[i].record(ncclStream);
     work->ncclComms_[i] = ncclComms[i];
   }
 
@@ -1321,7 +1397,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
 
     // Add a callback that runs profiling end callbacks. wrapCallback() in CUDA
     // future blocks the stream this callback runs on the corresponding
-    // cudaEvents_ ensuring appropriate synchronization.
+    // ncclEndEvents_ ensuring appropriate synchronization.
     if (work->recordFunctionEndCallback_) {
       work->future_->addCallback(
           [work](at::ivalue::Future& /* unused */) { work->recordFunctionEndCallback_(); });
@@ -1377,6 +1453,14 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
 
   at::cuda::OptionalCUDAGuard gpuGuard;
 
+  // Start event should only be recorded before the ncclGroupStart()
+  if (desyncDebug_) {
+    for (const auto i : c10::irange(tensors.size())) {
+      at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
+      (*work->ncclStartEvents_)[i].record(ncclStream);
+    }
+  }
+
   pre(ncclStreams_[key]);
 
   for (const auto i : c10::irange(tensors.size())) {
@@ -1407,10 +1491,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
 
   post(ncclStreams_[key]);
 
-  // Event should only be recorded after the ncclGroupEnd()
+  // End event should only be recorded after the ncclGroupEnd()
   for (const auto i : c10::irange(tensors.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
-    (*work->cudaEvents_)[i].record(ncclStream);
+    (*work->ncclEndEvents_)[i].record(ncclStream);
     work->ncclComms_[i] = ncclComms[i];
     work->blockingWait_ = blockingWait_;
     work->opTimeout_ = options_->timeout;
@@ -1430,7 +1514,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
 
   // Add a callback that runs profiling end callbacks. wrapCallback() in CUDA
   // future blocks the stream this callback runs on the corresponding
-  // cudaEvents_ ensuring appropriate synchronization.
+  // ncclEndEvents_ ensuring appropriate synchronization.
   if (work->recordFunctionEndCallback_) {
     work->future_->addCallback(
         [work](at::ivalue::Future& /* unused */) { work->recordFunctionEndCallback_(); });

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -1063,6 +1063,7 @@ void TCPStore::waitForWorkers() {
 }
 
 void TCPStore::set(const std::string& key, const std::vector<uint8_t>& data) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   client_->sendCommandForKey(detail::QueryType::SET, keyPrefix_ + key);
   client_->sendBytes(data);
 }
@@ -1071,6 +1072,7 @@ std::vector<uint8_t> TCPStore::compareSet(
     const std::string& key,
     const std::vector<uint8_t>& expectedValue,
     const std::vector<uint8_t>& desiredValue) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   client_->sendCommandForKey(detail::QueryType::COMPARE_SET, keyPrefix_ + key);
   client_->sendBytes(expectedValue);
   client_->sendBytes(desiredValue);
@@ -1079,6 +1081,7 @@ std::vector<uint8_t> TCPStore::compareSet(
 }
 
 std::vector<uint8_t> TCPStore::get(const std::string& key) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   return doGet(keyPrefix_ + key);
 }
 
@@ -1089,16 +1092,19 @@ std::vector<uint8_t> TCPStore::doGet(const std::string& key) {
 }
 
 int64_t TCPStore::add(const std::string& key, int64_t value) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   return incrementValueBy(keyPrefix_ + key, value);
 }
 
 bool TCPStore::deleteKey(const std::string& key) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   client_->sendCommandForKey(detail::QueryType::DELETE_KEY, keyPrefix_ + key);
   auto numDeleted = client_->receiveValue<std::int64_t>();
   return numDeleted == 1;
 }
 
 void TCPStore::watchKey(const std::string& key, WatchKeyCallback callback) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   callbackClient_->setCallback(keyPrefix_ + key, callback);
 }
 
@@ -1109,11 +1115,13 @@ int64_t TCPStore::incrementValueBy(const std::string& key, int64_t delta) {
 }
 
 int64_t TCPStore::getNumKeys() {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   client_->sendCommand(detail::QueryType::GETNUMKEYS);
   return client_->receiveValue<std::int64_t>();
 }
 
 bool TCPStore::check(const std::vector<std::string>& keys) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   std::vector<std::string> prefixedKeys{};
   prefixedKeys.reserve(keys.size());
   for (const std::string& key : keys) {
@@ -1140,6 +1148,7 @@ void TCPStore::wait(const std::vector<std::string>& keys) {
 void TCPStore::wait(
     const std::vector<std::string>& keys,
     const std::chrono::milliseconds& timeout) {
+  const std::lock_guard<std::mutex> lock(activeOpLock_);
   std::vector<std::string> prefixedKeys{};
   prefixedKeys.reserve(keys.size());
   for (const std::string& key : keys) {

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -110,6 +110,7 @@ class TORCH_API TCPStore : public Store {
 
   const std::string initKey_ = "init/";
   const std::string keyPrefix_ = "/";
+  std::mutex activeOpLock_;
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <c10d/Store.hpp>
+#include <c10d/Types.hpp>
+
+#include <sys/types.h>
+
+#include <cstdlib>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace c10d {
+inline std::string getTraceStartKey(const std::string& pgName, int rank) {
+  return pgName + "_" + std::to_string(rank) + "_trace_start";
+}
+
+inline std::string getTraceEndKey(const std::string& pgName, int rank) {
+  return pgName + "_" + std::to_string(rank) + "_trace_end";
+}
+
+inline bool traceUpdate(
+    c10::intrusive_ptr<Store>& store,
+    const std::string& key,
+    uint64_t seq,
+    const std::string& col) {
+  std::vector<uint8_t> value(col.size() + sizeof(seq) + 1);
+  memcpy(value.data(), &seq, sizeof(seq));
+  memcpy(value.data() + sizeof(seq), col.data(), col.size());
+  try {
+    store->set(key, value);
+    return true;
+  } catch (...) {
+    LOG(ERROR) << "Store is down while updating #" << seq << " with key "
+               << key;
+    return false;
+  }
+  return true;
+}
+
+enum TraceDebugEvent {
+  kEventStart,
+  kEventEnd,
+};
+// <seq, <rank, <col, start/end>>>
+using TraceMap =
+    std::map<uint64_t, std::map<int, std::pair<std::string, TraceDebugEvent>>>;
+
+inline std::string ranksToString(const std::vector<int>& ranks) {
+  std::string str;
+  for (int rank : ranks) {
+    if (str.empty()) {
+      str = std::to_string(rank);
+    } else {
+      str += ", " + std::to_string(rank);
+    }
+  }
+  return str;
+}
+
+inline std::string ranksFromTrace(
+    const std::vector<std::pair<int, std::string>>& items) {
+  std::string ranks;
+  for (auto& p : items) {
+    if (ranks.empty()) {
+      ranks = std::to_string(p.first);
+    } else {
+      ranks += ", " + std::to_string(p.first);
+    }
+  }
+  return ranks;
+}
+
+inline std::string analyzeMissingRanks(const std::vector<int>& missingRanks) {
+  return c10::str(
+      "\n\t - To our best knowledge, ranks [",
+      ranksToString(missingRanks),
+      "] are the lagging ranks that caused this timeout. "
+      "They never joined any collectives");
+}
+
+inline std::string analyzeLaggingRanks(const TraceMap& traceMap) {
+  uint64_t lagSeq = traceMap.begin()->first;
+  std::vector<int> startRanks;
+  std::vector<int> endRanks;
+  for (auto& p : traceMap.begin()->second) {
+    if (p.second.second == kEventStart) {
+      startRanks.push_back(p.first);
+    } else {
+      endRanks.push_back(p.first);
+    }
+  }
+  std::string report =
+      "\n\t - To our best knowledge, the lagging/dead/mismatched ranks "
+      "that caused the desync are:";
+  if (startRanks.size()) {
+    report += c10::str(
+        "\n\t   - [",
+        ranksToString(startRanks),
+        "] joined but didn't finish collective #",
+        lagSeq,
+        " (count from 1)");
+  }
+  if (endRanks.size()) {
+    report += c10::str(
+        "\n\t     [",
+        ranksToString(endRanks),
+        "] finished collective #",
+        lagSeq,
+        ", but didn't join collective #",
+        lagSeq + 1,
+        " (count from 1)");
+  }
+  return report;
+}
+
+inline std::string dumpSnapshot(TraceMap& traceMap) {
+  std::string report = "\n\t - Snapshot of ranks' latest states:";
+  for (auto& tracePair : traceMap) {
+    uint64_t seq = tracePair.first;
+    std::map<int, std::pair<std::string, TraceDebugEvent>>& subMap =
+        tracePair.second;
+
+    std::unordered_map<std::string, std::vector<int>> collectivesStart;
+    std::unordered_map<std::string, std::vector<int>> collectivesEnd;
+    for (auto& p : subMap) {
+      int rank = p.first;
+      const std::string& col = p.second.first;
+      if (p.second.second == kEventStart) {
+        collectivesStart[col].push_back(rank);
+      } else {
+        collectivesEnd[col].push_back(rank);
+      }
+    }
+
+    if (collectivesStart.size()) {
+      report += c10::str("\n\t   #", seq, " started ranks:");
+      for (auto& mapPair : collectivesStart) {
+        report += c10::str(
+            "\n\t     [",
+            ranksToString(mapPair.second),
+            "] started ",
+            mapPair.first);
+      }
+    }
+    if (collectivesEnd.size()) {
+      report += c10::str("\n\t   #", seq, " finished ranks:");
+      for (auto& mapPair : collectivesEnd) {
+        report += c10::str(
+            "\n\t     [",
+            ranksToString(mapPair.second),
+            "] finished ",
+            mapPair.first);
+      }
+    }
+  }
+  return report;
+}
+
+inline bool parseTraceValue(
+    c10::intrusive_ptr<Store>& store,
+    const std::string& key,
+    uint64_t& seq,
+    std::string& col) {
+  try {
+    std::vector<uint8_t> traceValue = store->get(key);
+    memcpy(&seq, traceValue.data(), sizeof(seq));
+    std::string colName((char*)traceValue.data() + sizeof(seq));
+    col = colName;
+    return true;
+  } catch (...) {
+    LOG(ERROR) << "Store is down while getting key " << key;
+    return false;
+  }
+  return true;
+}
+
+inline std::string retrieveDesyncReport(
+    c10::intrusive_ptr<Store>& store,
+    const std::string& pgName,
+    int myRank,
+    int worldSize) {
+  std::string report;
+
+  uint64_t thisSeq;
+  std::string thisCol;
+
+  std::vector<int> missingRanks;
+  TraceMap traceMap;
+
+  for (int rank = 0; rank < worldSize; rank++) {
+    // Build traceMapStart.
+    uint64_t seqStart;
+    {
+      std::string traceKeyStart = getTraceStartKey(pgName, rank);
+      if (!store->check({traceKeyStart})) {
+        missingRanks.push_back(rank);
+        continue;
+      }
+      std::string col;
+      if (!parseTraceValue(store, traceKeyStart, seqStart, col)) {
+        return report;
+      }
+      traceMap[seqStart].emplace(rank, std::make_pair(col, kEventStart));
+      if (rank == myRank) {
+        thisSeq = seqStart;
+        thisCol = std::move(col);
+      }
+    }
+
+    // Build traceMapEnd.
+    {
+      std::string traceKeyEnd = getTraceEndKey(pgName, rank);
+      if (!store->check({traceKeyEnd})) {
+        continue;
+      }
+      uint64_t seq;
+      std::string col;
+      if (!parseTraceValue(store, traceKeyEnd, seq, col)) {
+        return report;
+      }
+      if (seq == seqStart) {
+        traceMap[seq][rank].second = kEventEnd;
+      }
+    }
+  }
+
+  TORCH_INTERNAL_ASSERT(
+      !missingRanks.empty() || !traceMap.empty(),
+      "Trace shouldn't be empty while enabled GLOO_ASYNC_TIMEOUT_DEBUG");
+  TORCH_INTERNAL_ASSERT(
+      !thisCol.empty(),
+      "Timeout rank [",
+      myRank,
+      "] must have collective tracking iteam in c10::Store trace");
+  TORCH_INTERNAL_ASSERT(
+      traceMap[thisSeq][myRank].second == kEventStart,
+      "Timeout rank [",
+      myRank,
+      "] last trace item must be kEventStart. thisSeq = ",
+      thisSeq,
+      ", col = ",
+      thisCol);
+
+  report += c10::str(
+      "\n\t - [", myRank, "] Timeout at collective: ", thisCol, ", #", thisSeq);
+
+  if (!missingRanks.empty()) {
+    report += analyzeMissingRanks(missingRanks);
+  } else {
+    report += analyzeLaggingRanks(traceMap);
+    report += dumpSnapshot(traceMap);
+  }
+
+  return report;
+}
+
+} // namespace c10d


### PR DESCRIPTION
Summary: TCP store is actually being accessed by multi-threading (NCCL watch dog thread), but no mutex protection while FileStore and HashStore have. As enabling desync root cause analysis makes store calls more often, the race condition of TCP store was always triggered when creating another process group like gloo. Adding mutex to TCP store, to be the same with FileStore and HashStore.

Test Plan:
DDP benchmark with desync debug enabled
https://www.internalfb.com/intern/fblearner/details/309398285?tab=Outputs

Differential Revision: D32482254



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang