### PR TITLE
Add operator div

### DIFF
--- a/test/fx2trt/converters/acc_op/test_binary_ops.py
+++ b/test/fx2trt/converters/acc_op/test_binary_ops.py
@@ -13,6 +13,11 @@ elementwise_ops = [
     ((lambda x, y: x - y), acc_ops.sub),
     # Avoid dividing by 0.
     ((lambda x, y: x / (y + 1.0)), acc_ops.div),
+    ((lambda x, y: x // (y + 1.0)), acc_ops.div),
+    ((lambda x, y: torch.div(x, y + 1.0, rounding_mode="trunc")), acc_ops.div),
+    ((lambda x, y: torch.div(x, y + 1.0, rounding_mode="floor")), acc_ops.div),
+    ((lambda x, y: torch.div(x, y + 1.0)), acc_ops.div),
+    ((lambda x, y: torch.floor_divide(x, y + 1.0)), acc_ops.div),
     ((lambda x, y: x * y), acc_ops.mul),
     (torch.pow, acc_ops.pow),
 ]
@@ -43,7 +48,7 @@ class TestBinaryOpConverters(AccTestCase):
 
             def forward(self, x):
                 x = self.orig_op(x, self.constant)
-                return self.orig_op(x, 1)
+                return self.orig_op(x, -2)
 
         m = TestModule(orig_op)
         inputs = [torch.randn(2, 2)]

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -617,11 +617,58 @@ def mul(*, input, other):
     return input * other
 
 
-@register_acc_op_properties(AccOpProperty.pointwise)
-@register_acc_op_mapping(op_and_target=("call_function", operator.truediv))
+# Torch.floor_divide is announced to be deprecated, consider using torch.div() with 'trunc' or 'floor'
+# mode instead.
+# This implementation matches torch.floor_div's behavior, which for negative number the divide result
+# is round toward zero, rather than -Inf.
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.floor_divide),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", operator.floordiv),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.div),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+        ("rounding_mode", "rounding_mode", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", operator.truediv),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+    ],
+)
+def div_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    with node.graph.inserting_before(node):
+        div_kwargs = dict(node.kwargs)
+        if "rounding_mode" not in div_kwargs and node.op == "call_function":
+            div_kwargs["rounding_mode"] = None
+            if node.target is torch.floor_divide:
+                div_kwargs["rounding_mode"] = "trunc"
+            elif node.target is operator.floordiv:
+                div_kwargs["rounding_mode"] = "floor"
+            elif node.target is operator.truediv:
+                div_kwargs["rounding_mode"] = None
+        div_node = node.graph.call_function(div, kwargs=div_kwargs)
+        div_node.meta = node.meta.copy()
+        return div_node
+
+
 @register_acc_op
-def div(*, input, other):
-    return input / other
+def div(input, other, *, rounding_mode=None):
+    return torch.div(input, other, rounding_mode=rounding_mode)
 
 
 @register_acc_op_properties(AccOpProperty.pointwise)


### PR DESCRIPTION
Summary: Add operator converter div, torch.floor_div is announce to be deprecated by pytorch, consider remove after full deprecation done by pytorch.

Test Plan:
buck test mode/opt caffe2/test/fx2trt/converters:test_floor_div
buck test mode/opt caffe2/test/fx2trt/converters:test_div

Differential Revision: D32497573

