### PR TITLE
Fixes forward AD codegen for multiple formulas

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -636,6 +636,14 @@ class TORCH_API TensorBase {
     return impl_->requires_grad();
   }
 
+  // The Forward AD API functions below are low level and are not to be used by end
+  // users who should use the API provided in torch/csrc/autograd.h
+
+  /// This function returns the forward gradient for this Tensor at the given level.
+  const Tensor& _fw_grad(uint64_t level) const {
+    return impl_->_fw_grad(level, *this);
+  }
+
   /// NOTE: This is similar to the legacy `.data()` function on `Variable`, and is intended
   /// to be used from functions that need to access the `Variable`'s equivalent `Tensor`
   /// (i.e. `Tensor` that shares the same storage and tensor metadata with the `Variable`).

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -644,6 +644,14 @@ class TORCH_API TensorBase {
     return impl_->_fw_grad(level, *this);
   }
 
+  /// This function can be used to set the value of the forward grad.
+  /// Note that the given new_grad might not be used directly if it has different
+  /// metadata (size/stride/storage offset) compared to this Tensor. In that case,
+  /// new_grad content will be copied into a new Tensor
+  void _set_fw_grad(const TensorBase& new_grad, uint64_t level, bool is_inplace_op) const {
+    impl_->_set_fw_grad(new_grad, *this, level, is_inplace_op);
+  }
+
   /// NOTE: This is similar to the legacy `.data()` function on `Variable`, and is intended
   /// to be used from functions that need to access the `Variable`'s equivalent `Tensor`
   /// (i.e. `Tensor` that shares the same storage and tensor metadata with the `Variable`).

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7290,6 +7290,16 @@ class TestAutogradForwardMode(TestCase):
             with self.assertRaisesRegex(RuntimeError, "Nested forward mode AD is not supported at the moment"):
                 nest_level = fwAD.enter_dual_level()
 
+    def test_set_fw_grad_having_own_fw_grad_at_same_level(self):
+        foo = torch.rand(2)
+        bar = torch.rand(2)
+        baz = torch.rand(2)
+
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(foo, bar)
+            with self.assertRaisesRegex(RuntimeError, "has a forward gradient at the same level"):
+                fwAD.make_dual(baz, dual)
+
     def test_print(self):
         with fwAD.dual_level() as level:
             a = torch.rand(3)

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -102,6 +102,8 @@ namespace {
 // This function is will ensure that the fw_grad_ is properly a view of the base for inplace ops on
 // Tensors that do not have forward grad originally.
 void AutogradMeta::set_fw_grad(const at::TensorBase& new_grad_base, const at::TensorBase& self_base, uint64_t level, bool is_inplace_op) {
+  TORCH_CHECK(!new_grad_base._fw_grad(level).defined(), "Setting a forward grad that "
+              "itself has a forward gradient at the same level", level, " is not supported.");
   // Lazy initialization
   {
     std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
Fixes #67367

- Adds check to make sure forward grad itself does not have forward grad at the same level
- Verify with `python test/test_ops.py -k test_forward_mode_AD_linalg_eigh_cpu_float64` that it fails the check before, but passes after the codegen update

Before:
```
  if (_any_has_forward_grad_eigenvalues) {
      auto self_t_raw = toNonOptFwGrad(self);
      auto self_t = self_t_raw.defined() ? self_t_raw : at::zeros_like(toNonOptTensor(self));
      auto eigenvalues_new_fw_grad = eigh_jvp_eigenvalues(self_t, eigenvalues, eigenvectors);
      if (eigenvalues_new_fw_grad.defined()) {
        // The hardcoded 0 here will need to be updated once we support multiple levels.
        eigenvalues._set_fw_grad(eigenvalues_new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
      }
  }
  if (_any_has_forward_grad_eigenvectors) {
      auto self_t_raw = toNonOptFwGrad(self);
      auto self_t = self_t_raw.defined() ? self_t_raw : at::zeros_like(toNonOptTensor(self));
      auto eigenvectors_new_fw_grad = eigh_jvp_eigenvectors(self_t, eigenvalues, eigenvectors);
      if (eigenvectors_new_fw_grad.defined()) {
        // The hardcoded 0 here will need to be updated once we support multiple levels.
        eigenvectors._set_fw_grad(eigenvectors_new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
      }
  }
```

After:
```
  c10::optional<at::Tensor> eigenvalues_new_fw_grad_opt = c10::nullopt;
  if (_any_has_forward_grad_eigenvalues) {
      auto self_t_raw = toNonOptFwGrad(self);
      auto self_t = self_t_raw.defined() ? self_t_raw : at::zeros_like(toNonOptTensor(self));
      eigenvalues_new_fw_grad_opt = eigh_jvp_eigenvalues(self_t, eigenvalues, eigenvectors);
  }
  c10::optional<at::Tensor> eigenvectors_new_fw_grad_opt = c10::nullopt;
  if (_any_has_forward_grad_eigenvectors) {
      auto self_t_raw = toNonOptFwGrad(self);
      auto self_t = self_t_raw.defined() ? self_t_raw : at::zeros_like(toNonOptTensor(self));
      eigenvectors_new_fw_grad_opt = eigh_jvp_eigenvectors(self_t, eigenvalues, eigenvectors);
  }
  if (eigenvalues_new_fw_grad_opt.has_value() && eigenvalues_new_fw_grad_opt.value().defined()) {
    // The hardcoded 0 here will need to be updated once we support multiple levels.
    eigenvalues._set_fw_grad(eigenvalues_new_fw_grad_opt.value(), /* level */ 0, /* is_inplace_op */ false);
  }
  
  if (eigenvectors_new_fw_grad_opt.has_value() && eigenvectors_new_fw_grad_opt.value().defined()) {
    // The hardcoded 0 here will need to be updated once we support multiple levels.
    eigenvectors._set_fw_grad(eigenvectors_new_fw_grad_opt.value(), /* level */ 0, /* is_inplace_op */ false);
  }
```

