### PR TITLE
Add lazy_bench.py to measure trace overhead and compute efficiency

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -45,6 +45,31 @@ def output_csv(name, headers):
     output.writerow(headers)
     return output
 
+class HardSwishBenchmark:
+    def __init__(self, dims):
+        self.name = "HardSwish[" + ','.join([str(d) for d in dims]) + ']'
+        self.dims = dims
+
+    def __call__(self, device, jit):
+        return HardSwish(self.dims, device, jit)
+
+class HardSwish(nn.Module):
+    def __init__(self, dims, device='cuda', jit=False):
+        super(HardSwish, self).__init__()
+        self.name = "HardSwish[" + ','.join([str(d) for d in dims]) + ']'
+        self.example_inputs = (
+            torch.randn(*dims, device=device, dtype=torch.float32),
+        )
+
+    def get_module(self):
+        return self, self.example_inputs
+
+    def name(self):
+        return self.name
+
+    def forward(self, x):
+        return x * torch.clamp(x + 3.0, 0.0, 6.0) / 6.0
+
 class DivAddMulBenchmark:
     """This wrapper helps interface with the same iterator as torchbench models
     """
@@ -78,9 +103,13 @@ class DivAddMul(nn.Module):
         return out3
 
 def list_toy_models():
+    yield HardSwishBenchmark(dims=[1, 1, 1, 1])
+    yield HardSwishBenchmark(dims=[1, 16, 128, 128])
+    yield HardSwishBenchmark(dims=[64, 16,  128,  128])
+    yield HardSwishBenchmark(dims=[256, 16, 128, 128])
     yield DivAddMulBenchmark(dims=[1, 1, 1, 1])
     yield DivAddMulBenchmark(dims=[1, 16, 128, 128])
-    yield DivAddMulBenchmark(dims=[128, 16,  128,  128])
+    yield DivAddMulBenchmark(dims=[64, 16,  128,  128])
     yield DivAddMulBenchmark(dims=[256, 16, 128, 128])
 
 def pick_grad(name):
@@ -107,7 +136,9 @@ def iter_models(args):
             or name in SKIP
         ):
             continue
-        for device in args.devices:
+        # TODO(whc) better to support list of devices;
+        # curently since env var needs to be set for GPU, have to launch one dev at a time
+        for device in [args.device]:
             try:
                 torch.manual_seed(1337)
                 benchmark = benchmark_cls(device=device, jit=False)
@@ -156,6 +187,9 @@ class CudaSync:
         torch.cuda.synchronize()
 
 class NoOpSync:
+    def __init__(self, sync_every_iter=False):
+        pass
+
     def iter_sync(self, results):
         pass
 
@@ -172,16 +206,12 @@ class LazySync:
             ltm.wait_device_ops()
             if current_device == 'cuda':
                 torch.cuda.synchronize()
-            else:
-                raise RuntimeError("unexpected to not have current device=cuda")
 
     def final_sync(self, results):
         ltm.mark_step()
         ltm.wait_device_ops()
         if current_device == 'cuda':
             torch.cuda.synchronize()
-        else:
-            raise RuntimeError("unexpected to not have current device=cuda")
 
 class ToDeviceSync:
     def __init__(self, device, sync_every_iter=False):
@@ -244,13 +274,14 @@ def to_device(inputs, device):
 
 def lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs):
     timings = np.zeros((args.repeat, 2), np.float64)
+    ref_sync = CudaSync if current_device == 'cuda' else NoOpSync
     for rep in range(args.warmup):
         # interleave the runs to handle frequency scaling and load changes
-        timed(model, example_inputs, sync=CudaSync(sync_every_iter=True))
+        timed(model, example_inputs, sync=ref_sync(sync_every_iter=True))
         timed(lazy_model, lazy_inputs, sync=LazySync(sync_every_iter=True))
     for rep in range(args.repeat):
         # interleave the runs to handle frequency scaling and load changes
-        _, timings[rep, 0] = timed(model, example_inputs, sync=CudaSync(sync_every_iter=True))
+        _, timings[rep, 0] = timed(model, example_inputs, sync=ref_sync(sync_every_iter=True))
         _, timings[rep, 1] = timed(lazy_model, lazy_inputs, sync=NoOpSync())
     pvalue = ttest_ind(timings[:, 0], timings[:, 1]).pvalue
     median = np.median(timings, axis=0)
@@ -266,20 +297,20 @@ def lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, l
 def lazy_compute_experiment(experiment, results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=False, to_dev_sync=None):
     timings = np.zeros((args.repeat, 2), np.float64)
     if to_dev_sync is not None:
-        cuda_sync = ToDeviceSync(to_dev_sync, sync_every_iter=sync_every_iter) 
+        ref_sync = ToDeviceSync(to_dev_sync, sync_every_iter=sync_every_iter)
         lazy_sync = ToDeviceSync(to_dev_sync, sync_every_iter=sync_every_iter)
     else:
-        cuda_sync = CudaSync(sync_every_iter=sync_every_iter) 
+        ref_sync = CudaSync(sync_every_iter=sync_every_iter) if current_device == 'cuda' else NoOpSync()
         lazy_sync = LazySync(sync_every_iter=sync_every_iter)
 
     # interleave the runs to handle frequency scaling and load changes
     for rep in range(args.warmup):
         # warmup
-        timed(model, example_inputs, sync=cuda_sync)
+        timed(model, example_inputs, sync=ref_sync)
         timed(lazy_model, lazy_inputs, sync=lazy_sync)
     for rep in range(args.repeat):
         # measure
-        _, timings[rep, 0] = timed(model, example_inputs, times=args.inner_loop_repeat, sync=cuda_sync)
+        _, timings[rep, 0] = timed(model, example_inputs, times=args.inner_loop_repeat, sync=ref_sync)
         _, timings[rep, 1] = timed(lazy_model, lazy_inputs, times=args.inner_loop_repeat, sync=lazy_sync)
     pvalue = ttest_ind(timings[:, 0], timings[:, 1]).pvalue
     median = np.median(timings, axis=0)
@@ -301,18 +332,28 @@ def check_results(name, correct_result, lazy_result, device):
     lazy_result = lazy_result.to(device)
     return torch.allclose(correct_result, lazy_result)
 
+def check_fuser(args):
+    if args.fuser is None:
+        args.fuser = 'fuser1' if args.device == 'cpu' else 'fuser2'
+    if args.device == 'cpu':
+        assert args.fuser in ['fuser0', 'fuser1']
+    if args.device == 'cuda':
+        assert args.fuser in ['fuser0', 'fuser2']
+
 if __name__ == "__main__" :
     parser = argparse.ArgumentParser()
-    parser.add_argument("--filter", "-k", action="append", default=["DivAddMul", "hf_Bert", "hf_Bart"], help="filter benchmarks")
+    parser.add_argument("--filter", "-k", action="append", default=["HardSwish", "DivAddMul", "hf_Bert", "hf_Bart"], help="filter benchmarks")
     parser.add_argument("--exclude", "-x", action="append", default=[], help="filter benchmarks")
-    parser.add_argument("--devices", "-d", action="append", default=['cuda'], help="cpu or cuda")
+    parser.add_argument("--device", "-d", default='cuda', help="cpu or cuda")
     parser.add_argument("--warmup", type=int, default=4, help="number of warmup runs")
     parser.add_argument("--repeat", "-n", type=int, default=6, help="number of timing runs (samples)")
     parser.add_argument("--inner_loop_repeat", type=int, default=6, help="repeat the computation this many times per sample")
-    parser.add_argument("--fuser", type=str, default='fuser2', choices=['fuser0', 'fuser1', 'fuser2'], help="0=legacy, 1=nnc, 2=nvfuser")
+    parser.add_argument("--fuser", type=str, choices=['fuser0', 'fuser1', 'fuser2'], help="0=legacy, 1=nnc, 2=nvfuser")
     parser.add_argument("--torchbench_dir", type=str, help="path to torchbenchmark repo")
     args = parser.parse_args()
     results = []
+
+    check_fuser(args)
 
     torchbench_dir = abspath(args.torchbench_dir) if args.torchbench_dir else abspath("../../benchmark")
     assert os.path.exists(os.path.join(torchbench_dir, "torchbenchmark")), "set --torchbench_dir to installed torchbench repo"
@@ -346,6 +387,7 @@ if __name__ == "__main__" :
                 lazy_compute_experiment("to_cpu amortized", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cpu')
                 lazy_compute_experiment("to_cpu unamortized", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cpu')
 
-                # using to_cuda sync
-                lazy_compute_experiment("to_cuda amortized", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cuda')
-                lazy_compute_experiment("to_cuda unamortized", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cuda')
+                if device == 'cuda':
+                    # using to_cuda sync
+                    lazy_compute_experiment("to_cuda amortized", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cuda')
+                    lazy_compute_experiment("to_cuda unamortized", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cuda')

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -251,10 +251,12 @@ def timed(model, example_inputs, sync, times=1):
     torch.manual_seed(1337)
     # keep the lazy tensor results alive until the final sync
     t0 = time.perf_counter()
-    for _ in range(times):
+    for i in range(times):
         results.append(call_model_with(model, example_inputs))
-        # may be just an async 'mark_step' for lazy, or no-op for cuda
-        sync.iter_sync(results)
+        # for the last i, let final_sync take care of it
+        if i < times - 1:
+            # may be just an async 'mark_step' for lazy, or no-op for cuda
+            sync.iter_sync(results)
 
     # should be a hard sync for lazy and cuda
     # unless strictly measuring lazy trace overhead, then no-op

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -1,5 +1,4 @@
 import argparse
-import copy
 import csv
 import functools
 import gc
@@ -18,7 +17,7 @@ from torch.jit import fuser, optimized_execution
 from os.path import abspath
 from scipy.stats import ttest_ind
 
-from caffe2.python import workspace
+# from caffe2.python import workspace
 # workspace.GlobalInit(['caffe2', '--caffe2_log_level=-5'])
 
 import lazy_tensor_core
@@ -135,7 +134,7 @@ def iter_models(args):
     from fastNLP.core import logger
 
     logger.setLevel(logging.WARNING)
-    from torchbenchmark import list_models  # noqa
+    from torchbenchmark import list_models
     for benchmark_cls in itertools.chain(list_toy_models(), list_models()):
         name = benchmark_cls.name if hasattr(benchmark_cls, 'name') else benchmark_cls.name()
         if (
@@ -252,7 +251,7 @@ def timed(args, benchmark, sync, times=1):
             results.append(call_model_with(model, example_inputs))
         elif args.test == 'train':
             benchmark.train(niter=1)
-            
+
         # for the last i, let final_sync take care of it
         if i < times - 1:
             # may be just an async 'mark_step' for lazy, or no-op for cuda
@@ -334,7 +333,7 @@ def lazy_compute_experiment(args, experiment, results, benchmark, lazy_benchmark
     lazy_metrics = dump_lazy_metrics(reset=True)
     if 'CachedCompile' not in lazy_metrics or lazy_metrics['CachedCompile'] != args.repeat * args.inner_loop_repeat:
         print("WARNING: lazy cached compile count indicates fallbacks, or something else")
-    fallbacks = {k:v for (k,v) in lazy_metrics.items() if 'aten::' in k}
+    fallbacks = {k: v for (k, v) in lazy_metrics.items() if 'aten::' in k}
     if len(fallbacks):
         print("WARNING: lazy-eager fallbacks detected for ["+ ",".join(fallbacks.keys()) + ']')
     if args.dump_lazy_counters:

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -103,14 +103,19 @@ class DivAddMul(nn.Module):
         return out3
 
 def list_toy_models():
-    yield HardSwishBenchmark(dims=[1, 1, 1, 1])
-    yield HardSwishBenchmark(dims=[1, 16, 128, 128])
-    yield HardSwishBenchmark(dims=[64, 16,  128,  128])
-    yield HardSwishBenchmark(dims=[256, 16, 128, 128])
-    yield DivAddMulBenchmark(dims=[1, 1, 1, 1])
-    yield DivAddMulBenchmark(dims=[1, 16, 128, 128])
-    yield DivAddMulBenchmark(dims=[64, 16,  128,  128])
-    yield DivAddMulBenchmark(dims=[256, 16, 128, 128])
+    toy_models = [
+        HardSwishBenchmark,
+        DivAddMulBenchmark,
+    ]
+    toy_dims = [
+        [1, 1, 1, 1],
+        [32, 16, 128, 128],
+        [128, 16, 128, 128],
+        [256, 16, 128, 128],
+    ]
+    for dims in toy_dims:
+        for model in toy_models:
+            yield model(dims=dims)
 
 def pick_grad(name):
     if name in ("maml",):

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -104,7 +104,6 @@ def short_name(name, limit=20):
     """Truncate a model name to limit chars"""
     return name if len(name) <= limit else f"{name[:limit - 3].rstrip('_')}..."
 
-
 # Iter torchbench models and toy models
 def iter_models(args):
     from fastNLP.core import logger
@@ -150,11 +149,11 @@ def call_model_with(model, inputs):
         return model(inputs)
     raise RuntimeError("invalid example inputs ", inputs)
 
+# TODO(whc)
 #2 understand delta between wait_device_ops, to_cuda
 #  see why to_cpu is _so much slower_, given cuda is also copying to cpu
 # - bert to_cpu amortized v unamortized huge delta... why?
 # - hf-bart, shows wait_device_ops method is way off from reality.  why?
-
 #3 see if bert vs bart data makes sense
 #4 see if divaddmul is getting fused into a single kernel or not
 #5 how much do my 'overhead fixes' from last night help?

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -361,6 +361,8 @@ def check_fuser(args):
         assert args.fuser in ['fuser0', 'fuser1']
     if args.device == 'cuda':
         assert args.fuser in ['fuser0', 'fuser2']
+    if args.fuser == 'fuser1':
+        assert torch._C._llvm_enabled(), "Can't use fuser1 (nnc) without building torch with llvm."
 
 if __name__ == "__main__" :
     parser = argparse.ArgumentParser()

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -1,4 +1,3 @@
-
 import argparse
 import collections
 import copy
@@ -44,7 +43,7 @@ SKIP = {}
 current_name = ""
 current_device = ""
 
-@functools.lru_cache(1)
+@functools.cache
 def output_csv(name, headers):
     output = csv.writer(
         io.TextIOWrapper(
@@ -217,7 +216,6 @@ class ToDeviceSync:
         if current_device == 'cuda':
             torch.cuda.synchronize()
 
-
 def timed(model, example_inputs, sync, times=1):
     results = []
     sync.final_sync(results)
@@ -272,8 +270,8 @@ def lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, l
     results.append(overhead)
     output_csv(
         "lazy_overheads.csv",
-        ("dev", "name", "overhead"),
-    ).writerow([current_device, current_name, f"{overhead:.4f}"])
+        ("dev", "name", "overhead", "pvalue"),
+    ).writerow([current_device, current_name, f"{overhead:.4f}", f"{pvalue:.4e}"])
     print(f"{short_name(name, 30):<30} {current_device:<4}  {'trace overheads':<20} overhead: {overhead:.4f} pvalue: {pvalue:.4e}")
     return (overhead, pvalue)
 
@@ -301,9 +299,9 @@ def lazy_compute_experiment(experiment, results, args, model, example_inputs, la
     results.append(speedup)
     output_csv(
         "lazy_compute.csv",
-        ("experiment", "dev", "name", "speedup"),
-    ).writerow([experiment, current_device, current_name, f"{speedup:.4f}"])
-    print(f"{short_name(name, 30):<30} {current_device:<4}  {experiment:<20} speedup: {speedup:.4f} pvalue: {pvalue:.4e}")
+        ("name", "dev", "experiment", "speedup", "pvalue"),
+    ).writerow([current_name, current_device, experiment, f"{speedup:.4f}", f"{pvalue:.4e}"])
+    print(f"{short_name(current_name, 30):<30} {current_device:<4}  {experiment:<20} speedup: {speedup:.4f} pvalue: {pvalue:.4e}")
     return (speedup, pvalue)
 
 def check_results(name, correct_result, lazy_result, device):

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -659,6 +659,8 @@ void InitLtcModuleBindings(py::module m) {
         LazyGraphExecutor::Get()->WaitDeviceOps({});
       },
       py::arg("devices"));
+  m.def("_ltc_reset_metrics",
+        []() { lazy_tensors::metrics::MetricsArena::Get()->Reset(); });
   m.def("_ltc_counter_names",
         []() { return lazy_tensors::metrics::GetCounterNames(); });
   m.def("_ltc_counter_value", [](const std::string& name) -> py::object {

--- a/lazy_tensor_core/lazy_tensor_core/debug/metrics.py
+++ b/lazy_tensor_core/lazy_tensor_core/debug/metrics.py
@@ -2,6 +2,9 @@ from __future__ import print_function
 
 import lazy_tensor_core
 
+def reset_metrics():
+  lazy_tensor_core._LAZYC._ltc_reset_metrics()
+
 
 def counter_names():
     """Retrieves all the currently active counter names."""

--- a/lazy_tensor_core/overhead.py
+++ b/lazy_tensor_core/overhead.py
@@ -1,0 +1,275 @@
+
+import argparse
+import collections
+import copy
+import csv
+import functools
+import gc
+import io
+import itertools
+import logging
+import math
+import numpy as np
+import os
+import re
+import sys
+import textwrap
+import time
+import torch
+import torch.nn.functional as F
+import torch.autograd.profiler as profiler
+import warnings
+from torch import nn
+from torch.nn import Module
+from torch.jit import fuser
+from os.path import abspath
+from os.path import exists
+from scipy.stats import gmean
+from scipy.stats import ttest_ind
+
+# from caffe2.python import workspace
+# workspace.GlobalInit(['caffe2', '--caffe2_log_level=-5'])
+
+import lazy_tensor_core
+import lazy_tensor_core.core.lazy_model as ltm
+import lazy_tensor_core.debug.metrics as met
+lazy_tensor_core._LAZYC._ltc_init_ts_backend()
+
+
+os.environ["KALDI_ROOT"] = "/tmp"  # avoids some spam
+torchbench_dir = abspath("/home/whc/benchmark")
+assert os.path.exists(torchbench_dir)
+# os.chdir(torchbench_dir)
+sys.path.append(torchbench_dir)
+log = logging.getLogger(__name__)
+SKIP = {}
+current_name = ""
+current_device = ""
+
+def synchronize():
+    pass
+
+@functools.lru_cache(1)
+def output_csv(name, headers):
+    output = csv.writer(
+        io.TextIOWrapper(
+            open(name, "wb", buffering=0),
+            "utf-8",
+            write_through=True,
+        )
+    )
+    output.writerow(headers)
+    return output
+
+
+class Fusion(nn.Module):
+
+    def __init__(self, dims=[128, 16, 128, 128], device='cuda', jit=False):
+        super(Fusion, self).__init__()
+        self.attention_head_size = dims[1]
+        self.example_inputs = (
+            torch.randn(*dims, device=device, dtype=torch.float32),
+            torch.randn(*dims, device=device, dtype=torch.float32),
+        )
+        
+    name = "DivAddMul"
+
+    def get_module(self):
+        return self, self.example_inputs
+
+    def forward(self, inputs, mask):
+        out1 = inputs / math.sqrt(self.attention_head_size)
+        out2 = out1 + mask
+        out3 = out2 * 5.0
+        return out3
+
+def list_toy_models():
+    yield Fusion
+
+def pick_grad(name):
+    if name in ("maml",):
+        return torch.enable_grad()
+    else:
+        return torch.no_grad()
+
+def short_name(name, limit=20):
+    """Truncate a model name to limit chars"""
+    return name if len(name) <= limit else f"{name[:limit - 3].rstrip('_')}..."
+
+
+# Iter torchbench models and toy models
+def iter_models(args):
+    from fastNLP.core import logger
+
+    logger.setLevel(logging.WARNING)
+    from torchbenchmark import list_models  # noqa
+    for benchmark_cls in itertools.chain(list_toy_models(), list_models()):
+        if (
+            (len(args.filter) and (not re.search("|".join(args.filter), benchmark_cls.name, re.I)))
+            or (len(args.exclude) and re.search("|".join(args.exclude), benchmark_cls.name, re.I))
+            or benchmark_cls.name in SKIP
+        ):
+            continue
+        for device in args.devices:
+            try:
+                torch.manual_seed(1337)
+                benchmark = benchmark_cls(device=device, jit=False)
+                torch.manual_seed(1337)
+                lazy_benchmark = benchmark_cls(device='lazy', jit=False)
+                model, example_inputs = benchmark.get_module()
+                lazy_model, lazy_example_inputs = lazy_benchmark.get_module()
+                model.eval()
+                lazy_model.eval()
+                gc.collect()
+                global current_name, current_device
+                current_device = device
+                current_name = short_name(benchmark.name)
+                yield device, current_name, model, example_inputs, lazy_model, lazy_example_inputs
+            except NotImplementedError:
+                print("NotImplementedError")
+                pass
+            except Exception as e:
+                print(f"Exception in iter_models for {benchmark_cls.name}", e)
+                log.exception(f"misconfigured model {benchmark_cls.name}")
+
+def call_model_with(model, inputs):
+    if isinstance(inputs, tuple) or isinstance(inputs, list):
+        return model(*inputs)
+    elif isinstance(inputs, dict):
+        return model(**inputs)
+    elif isistance(inputs, torch.Tensor):
+        return model(inputs)
+    raise RuntimeError("invalid example inputs ", inputs)
+
+def timed(model, example_inputs, times=1, iter_sync_fn=lambda:(), final_sync_fn=lambda:()):
+    
+    final_sync_fn()
+    gc.collect()
+    torch.manual_seed(1337)
+    # keep the lazy tensor results alive until the final sync
+    results = []
+    t0 = time.perf_counter()
+    for _ in range(times):
+        results.append(call_model_with(model, example_inputs))
+        # may be just an async 'mark_step' for lazy, or no-op for cuda
+        # iter_sync_fn()
+        to_device(results[-1], 'cpu')
+    
+    # should be a hard sync for lazy and cuda
+    # unless strictly measuring lazy trace overhead, then no-op
+    to_device(results[-1], 'cpu')
+    # final_sync_fn()
+    t1 = time.perf_counter()
+    return results[-1], t1 - t0
+
+def to_device(inputs, device):
+    try:
+        import transformer
+        if isinstance(inputs, transformers.modeling_outputs.MaskedLMOutput) \
+        or isinstance(inputs, transformers.modeling_outputs.Seq2SeqLMOutput):
+            correct_result = correct_result.to_tuple()[0]
+    except ImportError:
+        pass
+
+    if isinstance(inputs, tuple):
+        return tuple(to_device(i, device) for i in inputs)
+    elif isinstance(inputs, dict):
+        return {k: to_device(inputs[k], device) for k in inputs}
+    elif isinstance(inputs, torch.Tensor):
+        return inputs.to(device)
+    raise RuntimeError("invalid example inputs ", inputs)
+
+def lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs):
+    timings = np.zeros((args.repeat, 2), np.float64)
+    for rep in range(args.warmup):
+        # interleave the runs to handle frequency scaling and load changes
+        timed(model, example_inputs, iter_sync_fn=torch.cuda.synchronize, final_sync_fn=torch.cuda.synchronize)
+        timed(lazy_model, lazy_inputs)
+# lazy_inputs = to_device(example_inputs, 'lazy')
+    # lazy_model = model.to('lazy')
+    for rep in range(args.repeat):
+        # interleave the runs to handle frequency scaling and load changes
+        _, timings[rep, 0] = timed(model, example_inputs, iter_sync_fn=torch.cuda.synchronize, final_sync_fn=torch.cuda.synchronize)
+        _, timings[rep, 1] = timed(lazy_model, lazy_inputs)
+    pvalue = ttest_ind(timings[:, 0], timings[:, 1]).pvalue
+    median = np.median(timings, axis=0)
+    overhead = median[1] / median[0]
+    results.append(overhead)
+    output_csv(
+        "lazy_overheads.csv",
+        ("dev", "name", "overhead"),
+    ).writerow([current_device, current_name, f"{overhead:.4f}"])
+    return (overhead, pvalue)
+
+def lazy_compute_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs, times=10):
+    timings = np.zeros((args.repeat, 2), np.float64)
+    for rep in range(args.warmup):
+        # interleave the runs to handle frequency scaling and load changes
+        timed(model, example_inputs, final_sync_fn=torch.cuda.synchronize)
+        with fuser('fuser2'):
+            timed(lazy_model, lazy_inputs, iter_sync_fn=ltm.mark_step, final_sync_fn=ltm.wait_device_ops)
+    
+    for rep in range(args.repeat):
+        # interleave the runs to handle frequency scaling and load changes
+        _, timings[rep, 0] = timed(model, example_inputs, times=times, final_sync_fn=torch.cuda.synchronize)
+        _, timings[rep, 1] = timed(lazy_model, lazy_inputs, times=times, iter_sync_fn=ltm.mark_step, final_sync_fn=ltm.wait_device_ops)
+    pvalue = ttest_ind(timings[:, 0], timings[:, 1]).pvalue
+    median = np.median(timings, axis=0)
+    speedup = median[0] / median[1]
+    results.append(speedup)
+    output_csv(
+        "lazy_compute.csv",
+        ("dev", "name", "speedup"),
+    ).writerow([current_device, current_name, f"{speedup:.4f}"])
+    return (speedup, pvalue)
+
+def check_results(name, correct_result, lazy_result, device):
+    import transformers #noqa
+    if isinstance(correct_result, transformers.modeling_outputs.MaskedLMOutput) \
+      or isinstance(correct_result, transformers.modeling_outputs.Seq2SeqLMOutput):
+        correct_result = correct_result.to_tuple()[0]
+        lazy_result = lazy_result.to_tuple()[0]
+    lazy_result = lazy_result.to(device)
+    return torch.allclose(correct_result, lazy_result)
+
+
+if __name__ == "__main__" :
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--filter", "-k", action="append", default=["DivAddMul", "hf_Bert", "hf_Bart"], help="filter benchmarks")
+    parser.add_argument("--exclude", "-x", action="append", default=[], help="filter benchmarks")
+    parser.add_argument("--devices", "-d", action="append", default=['cuda'], help="cpu or cuda")
+    parser.add_argument("--warmup", type=int, default=4, help="number of warmup runs")
+    parser.add_argument("--repeat", "-n", type=int, default=16, help="number of timing runs")
+    parser.add_argument("--fuser", type=str, default='fuser2', choices=['fuser0', 'fuser1', 'fuser2'], help="0=legacy, 1=nnc, 2=nvfuser")
+    args = parser.parse_args()
+    results = []
+
+    for device, name, model, example_inputs, lazy_model, lazy_inputs in iter_models(args):
+        if device == 'cuda':
+            assert 'LTC_TS_CUDA' in os.environ and bool(os.environ['LTC_TS_CUDA'])
+
+        with pick_grad(name):
+            try:
+                torch.manual_seed(1337)
+                correct_result = call_model_with(copy.deepcopy(model), example_inputs)
+                torch.manual_seed(1337)
+                lazy_result = call_model_with(lazy_model, lazy_inputs)
+            except Exception:
+                logging.exception("unhandled error")
+                print("ERROR")
+                continue
+            if not check_results(name, correct_result, lazy_result, device):
+                print("INCORRECT")
+                import ipdb; ipdb.set_trace()
+                continue
+            overhead, pvalue = lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs)
+            print(f"name: {name},  trace overhead: {overhead}, pvalue: {pvalue}")
+
+            with fuser(args.fuser): 
+                speedup, pvalue = lazy_compute_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs)
+                print(f"name: {name},  amortized compute speedup: {speedup}, pvalue: {pvalue} (using {args.fuser})")
+            
+            with fuser(args.fuser): 
+                speedup, pvalue = lazy_compute_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs, times=1)
+                print(f"name: {name},  unamortized compute speedup: {speedup}, pvalue: {pvalue} (using {args.fuser})")
+        

--- a/lazy_tensor_core/overhead.py
+++ b/lazy_tensor_core/overhead.py
@@ -35,19 +35,14 @@ import lazy_tensor_core.core.lazy_model as ltm
 import lazy_tensor_core.debug.metrics as met
 lazy_tensor_core._LAZYC._ltc_init_ts_backend()
 
-
 os.environ["KALDI_ROOT"] = "/tmp"  # avoids some spam
 torchbench_dir = abspath("/home/whc/benchmark")
 assert os.path.exists(torchbench_dir)
-# os.chdir(torchbench_dir)
 sys.path.append(torchbench_dir)
 log = logging.getLogger(__name__)
 SKIP = {}
 current_name = ""
 current_device = ""
-
-def synchronize():
-    pass
 
 @functools.lru_cache(1)
 def output_csv(name, headers):
@@ -61,21 +56,31 @@ def output_csv(name, headers):
     output.writerow(headers)
     return output
 
+class DivAddMulBenchmark:
+    """This wrapper helps interface with the same iterator as torchbench models
+    """
+    def __init__(self, dims):
+        self.name = "DivAddMul[" + ','.join([str(d) for d in dims]) + ']'
+        self.dims = dims
 
-class Fusion(nn.Module):
+    def __call__(self, device, jit):
+        return DivAddMul(self.dims, device, jit)
 
+class DivAddMul(nn.Module):
     def __init__(self, dims=[128, 16, 128, 128], device='cuda', jit=False):
-        super(Fusion, self).__init__()
+        super(DivAddMul, self).__init__()
         self.attention_head_size = dims[1]
+        self.name = "DivAddMul[" + ','.join([str(d) for d in dims]) + ']'
         self.example_inputs = (
             torch.randn(*dims, device=device, dtype=torch.float32),
             torch.randn(*dims, device=device, dtype=torch.float32),
         )
-        
-    name = "DivAddMul"
 
     def get_module(self):
         return self, self.example_inputs
+
+    def name(self):
+        return self.name
 
     def forward(self, inputs, mask):
         out1 = inputs / math.sqrt(self.attention_head_size)
@@ -84,7 +89,10 @@ class Fusion(nn.Module):
         return out3
 
 def list_toy_models():
-    yield Fusion
+    yield DivAddMulBenchmark(dims=[1,1,1,1])
+    yield DivAddMulBenchmark(dims=[1,16,128,128])
+    yield DivAddMulBenchmark(dims=[128,16,128,128])
+    yield DivAddMulBenchmark(dims=[256,16,128,128])
 
 def pick_grad(name):
     if name in ("maml",):
@@ -104,10 +112,11 @@ def iter_models(args):
     logger.setLevel(logging.WARNING)
     from torchbenchmark import list_models  # noqa
     for benchmark_cls in itertools.chain(list_toy_models(), list_models()):
+        name = benchmark_cls.name if hasattr(benchmark_cls, 'name') else benchmark_cls.name()
         if (
-            (len(args.filter) and (not re.search("|".join(args.filter), benchmark_cls.name, re.I)))
-            or (len(args.exclude) and re.search("|".join(args.exclude), benchmark_cls.name, re.I))
-            or benchmark_cls.name in SKIP
+            (len(args.filter) and (not re.search("|".join(args.filter), name, re.I)))
+            or (len(args.exclude) and re.search("|".join(args.exclude), name, re.I))
+            or name in SKIP
         ):
             continue
         for device in args.devices:
@@ -129,8 +138,8 @@ def iter_models(args):
                 print("NotImplementedError")
                 pass
             except Exception as e:
-                print(f"Exception in iter_models for {benchmark_cls.name}", e)
-                log.exception(f"misconfigured model {benchmark_cls.name}")
+                print(f"Exception in iter_models for {name}", e)
+                log.exception(f"misconfigured model {name}")
 
 def call_model_with(model, inputs):
     if isinstance(inputs, tuple) or isinstance(inputs, list):
@@ -141,75 +150,90 @@ def call_model_with(model, inputs):
         return model(inputs)
     raise RuntimeError("invalid example inputs ", inputs)
 
-#1 make sync function interface capable of doing a .to (so it accepts args)
-#2 fix delta between .to sync function vs wait_device_ops
+#2 understand delta between wait_device_ops, to_cuda
+#  see why to_cpu is _so much slower_, given cuda is also copying to cpu
+# - bert to_cpu amortized v unamortized huge delta... why?
+# - hf-bart, shows wait_device_ops method is way off from reality.  why?
+
 #3 see if bert vs bart data makes sense
 #4 see if divaddmul is getting fused into a single kernel or not
 #5 how much do my 'overhead fixes' from last night help?
 class CudaSync:
-    def __init__(self, sync_every_iter=False, to_dev_sync=None):
+    def __init__(self, sync_every_iter=False):
         self.sync_every_iter = sync_every_iter
-        self.to_dev_sync = to_dev_sync
 
-    def iter_sync(self, inputs):
+    def iter_sync(self, results):
         if self.sync_every_iter:
-            if self.to_dev_sync == 'cpu':
-                to_device(inputs, self.to_dev_sync)
-            else:
-                torch.cuda.synchronize()
+           torch.cuda.synchronize()
 
-    def final_sync(self, inputs):
-        if self.to_dev_sync == 'cpu':
-            to_device(inputs, self.to_dev_sync)
-        else:
-            torch.cuda.synchronize()
+    def final_sync(self, results):
+       torch.cuda.synchronize()
 
 class NoOpSync:
-    def iter_sync(self, inputs):
+    def iter_sync(self, results):
         pass
 
-    def final_sync(self, inputs):
+    def final_sync(self, results):
         pass
 
 class LazySync:
-    def __init__(self, sync_every_iter=False, to_dev_sync=None):
+    def __init__(self, sync_every_iter=False):
         self.sync_every_iter = sync_every_iter
-        self.to_dev_sync = to_dev_sync
 
-    def iter_sync(self, inputs):
-        if self.to_dev_sync:
-            # this would sync just the computations needed by the provided tensors
-            # unclear how it would interact with calling mark_step right before?
-            to_device(inputs, self.to_dev_sync)
-        else:
-            ltm.mark_step()
-            if self.sync_every_iter:
-                ltm.wait_device_ops()
-
-    def final_sync(self, inputs):
-        if self.to_dev_sync:
-            to_device(inputs, self.to_dev_sync)
-        else:
-            ltm.mark_step()
+    def iter_sync(self, results):
+        ltm.mark_step()
+        if self.sync_every_iter:
             ltm.wait_device_ops()
+            if current_device == 'cuda':
+                torch.cuda.synchronize()
+            else:
+                raise RuntimeError("unexpected to not have current device=cuda")
+
+    def final_sync(self, results):
+        ltm.mark_step()
+        ltm.wait_device_ops()
+        if current_device == 'cuda':
+            torch.cuda.synchronize()
+        else:
+            raise RuntimeError("unexpected to not have current device=cuda")
+
+class ToDeviceSync:
+    def __init__(self, device, sync_every_iter=False):
+        self.sync_every_iter = sync_every_iter
+        self.device = device
+
+    def iter_sync(self, results):
+        if self.sync_every_iter:
+            to_device(results[-1], self.device)
+            if current_device == 'cuda':
+                torch.cuda.synchronize()
+
+    def final_sync(self, results):
+        if len(results):
+            if self.sync_every_iter:
+                to_device(results[-1], self.device)
+            else:
+                to_device(results, self.device)
+
+        if current_device == 'cuda':
+            torch.cuda.synchronize()
+
 
 def timed(model, example_inputs, sync, times=1):
-    sync.final_sync(None)
+    results = []
+    sync.final_sync(results)
     gc.collect()
     torch.manual_seed(1337)
     # keep the lazy tensor results alive until the final sync
-    results = []
     t0 = time.perf_counter()
     for _ in range(times):
         results.append(call_model_with(model, example_inputs))
         # may be just an async 'mark_step' for lazy, or no-op for cuda
-        sync.iter_sync(results[-1])
-        # to_device(results[-1], 'cpu')
+        sync.iter_sync(results)
     
     # should be a hard sync for lazy and cuda
     # unless strictly measuring lazy trace overhead, then no-op
-    # to_device(results[-1], 'cpu')
-    sync.final_sync(results[-1])
+    sync.final_sync(results)
     t1 = time.perf_counter()
     return results[-1], t1 - t0
 
@@ -225,7 +249,7 @@ def to_device(inputs, device):
     except ImportError:
         pass
 
-    if isinstance(inputs, tuple):
+    if isinstance(inputs, tuple) or isinstance(inputs, list):
         return tuple(to_device(i, device) for i in inputs)
     elif isinstance(inputs, dict):
         return {k: to_device(inputs[k], device) for k in inputs}
@@ -251,20 +275,27 @@ def lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, l
         "lazy_overheads.csv",
         ("dev", "name", "overhead"),
     ).writerow([current_device, current_name, f"{overhead:.4f}"])
+    print(f"{short_name(name, 30):<30} {current_device:<4}  {'trace overheads':<20} overhead: {overhead:.4f} pvalue: {pvalue:.4e}")
     return (overhead, pvalue)
 
-def lazy_compute_experiment(experiment, results, args, model, example_inputs, lazy_model, lazy_inputs, times=10, sync_every_iter=False, to_dev_sync=None):
+def lazy_compute_experiment(experiment, results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=False, to_dev_sync=None):
     timings = np.zeros((args.repeat, 2), np.float64)
-    for rep in range(args.warmup):
-        # interleave the runs to handle frequency scaling and load changes
-        timed(model, example_inputs, sync=CudaSync(sync_every_iter=True))
-        with fuser('fuser2'):
-            timed(lazy_model, lazy_inputs, sync=LazySync(sync_every_iter=True))
+    if to_dev_sync is not None:
+        cuda_sync = ToDeviceSync(to_dev_sync, sync_every_iter=sync_every_iter) 
+        lazy_sync = ToDeviceSync(to_dev_sync, sync_every_iter=sync_every_iter)
+    else:
+        cuda_sync = CudaSync(sync_every_iter=sync_every_iter) 
+        lazy_sync = LazySync(sync_every_iter=sync_every_iter)
     
+    # interleave the runs to handle frequency scaling and load changes
+    for rep in range(args.warmup):
+        # warmup
+        timed(model, example_inputs, sync=cuda_sync)
+        timed(lazy_model, lazy_inputs, sync=lazy_sync)
     for rep in range(args.repeat):
-        # interleave the runs to handle frequency scaling and load changes
-        _, timings[rep, 0] = timed(model, example_inputs, times=times, sync=CudaSync(sync_every_iter=sync_every_iter, to_dev_sync=to_dev_sync))
-        _, timings[rep, 1] = timed(lazy_model, lazy_inputs, times=times, sync=LazySync(sync_every_iter=sync_every_iter, to_dev_sync=to_dev_sync))
+        # measure
+        _, timings[rep, 0] = timed(model, example_inputs, times=args.inner_loop_repeat, sync=cuda_sync)
+        _, timings[rep, 1] = timed(lazy_model, lazy_inputs, times=args.inner_loop_repeat, sync=lazy_sync)
     pvalue = ttest_ind(timings[:, 0], timings[:, 1]).pvalue
     median = np.median(timings, axis=0)
     speedup = median[0] / median[1]
@@ -273,7 +304,7 @@ def lazy_compute_experiment(experiment, results, args, model, example_inputs, la
         "lazy_compute.csv",
         ("experiment", "dev", "name", "speedup"),
     ).writerow([experiment, current_device, current_name, f"{speedup:.4f}"])
-    print(f"experiment: {experiment}, model: {name},  {speedup}, pvalue: {pvalue} (using {args.fuser})")
+    print(f"{short_name(name, 30):<30} {current_device:<4}  {experiment:<20} speedup: {speedup:.4f} pvalue: {pvalue:.4e}")
     return (speedup, pvalue)
 
 def check_results(name, correct_result, lazy_result, device):
@@ -285,14 +316,14 @@ def check_results(name, correct_result, lazy_result, device):
     lazy_result = lazy_result.to(device)
     return torch.allclose(correct_result, lazy_result)
 
-
 if __name__ == "__main__" :
     parser = argparse.ArgumentParser()
     parser.add_argument("--filter", "-k", action="append", default=["DivAddMul", "hf_Bert", "hf_Bart"], help="filter benchmarks")
     parser.add_argument("--exclude", "-x", action="append", default=[], help="filter benchmarks")
     parser.add_argument("--devices", "-d", action="append", default=['cuda'], help="cpu or cuda")
     parser.add_argument("--warmup", type=int, default=4, help="number of warmup runs")
-    parser.add_argument("--repeat", "-n", type=int, default=16, help="number of timing runs")
+    parser.add_argument("--repeat", "-n", type=int, default=6, help="number of timing runs (samples)")
+    parser.add_argument("--inner_loop_repeat", type=int, default=6, help="repeat the computation this many times per sample")
     parser.add_argument("--fuser", type=str, default='fuser2', choices=['fuser0', 'fuser1', 'fuser2'], help="0=legacy, 1=nnc, 2=nvfuser")
     args = parser.parse_args()
     results = []
@@ -309,23 +340,22 @@ if __name__ == "__main__" :
                 lazy_result = call_model_with(lazy_model, lazy_inputs)
             except Exception:
                 logging.exception("unhandled error")
-                print("ERROR")
+                print(f"ERROR ({name})")
                 continue
             if not check_results(name, correct_result, lazy_result, device):
-                print("INCORRECT")
+                print(f"INCORRECT ({name})")
                 import ipdb; ipdb.set_trace()
                 continue
-            overhead, pvalue = lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs)
-            print(f"name: {name},  trace overhead: {overhead}, pvalue: {pvalue}")
+            lazy_overhead_experiment(results, args, model, example_inputs, lazy_model, lazy_inputs)
 
             with fuser(args.fuser): 
-                speedup, pvalue = lazy_compute_experiment("amortized compute speedup", results, args, model, example_inputs, lazy_model, lazy_inputs)
-                speedup, pvalue = lazy_compute_experiment("unamortized compute speedup", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True)
+                lazy_compute_experiment("amortized", results, args, model, example_inputs, lazy_model, lazy_inputs)
+                lazy_compute_experiment("unamortized", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True)
 
                 # using to_cpu sync
-                speedup, pvalue = lazy_compute_experiment("to_cpu amortized compute speedup", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cpu')
-                speedup, pvalue = lazy_compute_experiment("to_cpu unamortized compute speedup", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cpu')
+                lazy_compute_experiment("to_cpu amortized", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cpu')
+                lazy_compute_experiment("to_cpu unamortized", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cpu')
 
                 # using to_cuda sync
-                speedup, pvalue = lazy_compute_experiment("to_cuda amortized compute speedup", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cuda')
-                speedup, pvalue = lazy_compute_experiment("to_cuda unamortized compute speedup", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cuda')
+                lazy_compute_experiment("to_cuda amortized", results, args, model, example_inputs, lazy_model, lazy_inputs, to_dev_sync='cuda')
+                lazy_compute_experiment("to_cuda unamortized", results, args, model, example_inputs, lazy_model, lazy_inputs, sync_every_iter=True, to_dev_sync='cuda')

--- a/lazy_tensor_core/test/test_lazy.py
+++ b/lazy_tensor_core/test/test_lazy.py
@@ -46,4 +46,3 @@ class TestLazyTensor(JitTestCase):
 
 if __name__ == '__main__':
     run_tests()
-

--- a/lazy_tensor_core/third_party/computation_client/metrics.cc
+++ b/lazy_tensor_core/third_party/computation_client/metrics.cc
@@ -84,9 +84,19 @@ void EmitCounterInfo(const std::string& name, CounterData* data,
 
 }  // namespace
 
+
+
 MetricsArena* MetricsArena::Get() {
   static MetricsArena* arena = new MetricsArena();
   return arena;
+}
+
+void MetricsArena::Reset() {
+  for (auto& pair: counters_) {
+    if (pair.second){
+      pair.second->Reset();
+    }
+  }
 }
 
 void MetricsArena::RegisterMetric(const std::string& name, MetricReprFn repr_fn,

--- a/lazy_tensor_core/third_party/computation_client/metrics.h
+++ b/lazy_tensor_core/third_party/computation_client/metrics.h
@@ -67,6 +67,8 @@ class CounterData {
 
   int64_t Value() const { return value_; }
 
+  void Reset() { value_ = 0; }
+
  private:
   std::atomic<int64_t> value_;
 };
@@ -74,6 +76,8 @@ class CounterData {
 class MetricsArena {
  public:
   static MetricsArena* Get();
+
+  void Reset();
 
   // Registers a new metric in the global arena.
   void RegisterMetric(const std::string& name, MetricReprFn repr_fn,


### PR DESCRIPTION
This tool has 2 new 'experiments' and builds on infra from @jansel's torchdynamo bench script [torchdynamo/torchbench.py](https://github.com/jansel/torchdynamo/blob/main/torchbench.py ).

The infra components take care of 
* iterating over torchbench models in a more convenient way, handling filtering, errors
* correctness checks
* mixing in non-torchbenchmark benchmarks
* interleaving measurements of the control/experiment and computing statistical significance
* hooks for synchronization that can be specialized for cuda or lazytensor
* custom sync modes to allow syncing after every step or running many async steps before syncing

The overhead experiment compares the lazy trace overhead with the full cuda execution time.  This may sound like a strange choice, but the point is to provide a reference point of how much time lazy tracing takes with reference to the time eager normally spends in execution.  The expectation is a small fraction.
* an alternative approach is to measure lazy tracing against the portion of eager that launches cuda kernels but never sync.  If we could guarantee that some of the time, the cuda driver didn't force syncs, this would be fair.  It wouldn't work for CPU.  At least the full-sync way is consistent
* another alternative is to compare lazy trace overhead to execution with meta-tensors.  We don't expect meta-tensors to work for this case, since we know that many of the ops we lazy-trace are not yet structured kernels.
![image](https://user-images.githubusercontent.com/4984825/142338200-4caae656-1781-4ff2-b5c4-c5dfc4bfb3c9.png)

The compute experiment performs synchronization and compares the full cost of execution of an eager device vs a lazy device.  There are two flavors- Unamortized and Amortized.  Unamortized means you synchronize every step, which is unfavorable for both lazy and cuda, (but fine for cpu).  Amortized means you run N steps asynchronously before finally synchronizing.  Each measurement includes at least one begin and one final sync.

![image](https://user-images.githubusercontent.com/4984825/142338618-9675b0d5-7e15-4a6f-bc4b-a5f8534060e6.png)

Notes/Todos/Opens
* run the same experiments using cpu, flush out any issues
* Ideally the LazySync and CudaSync classes would be sufficient; The ToDeviceSync class is added as a sanity check, and indeed disagrees with LazySync implying something isn't quite right yet
* debug the deltas between different sync modes for cuda/lazycuda- expect more similar results.