### PR TITLE
Replace empty with new_empty in nn.functional.pad

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4738,7 +4738,7 @@ def _pad_circular(input: Tensor, padding: List[int]) -> Tensor:
     for idx, size in enumerate(paddable_shape):
         out_shape += (size + padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)],)
 
-    out = torch.empty(out_shape, dtype=input.dtype, layout=input.layout, device=input.device)
+    out = input.new_empty(out_shape)
 
     # Put original array in padded array
     if ndim == 1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#68565 Replace empty with new_empty in nn.functional.pad**

This makes it so that we can now vmap over nn.functional.pad (circular
variant). Previously we could not because we were effectively doing
`out.copy_(input)` where the out was created with empty.

This also has the added side effect of cleaning up the code.

Test Plan:
- I tested this using functorch.vmap and can confirm that vmap now
works.
- Unfortunately this doesn't work with the vmap in core so I cannot add
a test for this here.

Differential Revision: [D32520188](https://our.internmc.facebook.com/intern/diff/D32520188)