### PR TITLE
Fix nanmedian result using more CUDA memory than necessary

### DIFF
--- a/aten/src/ATen/native/cuda/Sorting.cpp
+++ b/aten/src/ATen/native/cuda/Sorting.cpp
@@ -131,8 +131,8 @@ Tensor median_impl(const Tensor& self, bool ignore_nan) {
     return at::where(sorted[-1].isnan(), sorted[-1], sorted[k]);
   } else {
     // For torch.nanmedian return the middle element among the non-nan values
-    Tensor k = ((size - 1) - sorted.isnan().sum()) / 2;
-    return sorted[k.toType(kLong)];
+    int64_t k = ((size - 1) - sorted.isnan().sum().item<int64_t>()) / 2;
+    return sorted[k].clone();  // Clone so we aren't keeping `sorted` alive
   }
 }
 


### PR DESCRIPTION
CUDA's `at::nanmedian` creates a sorted copy of the array, then indexes into it to create a single element view. This view necessarily keeps the entire `sorted` tensor's storage alive which can be avoided by returning a copy, which is what `at::median` does indirectly via `at::where`.

This also changes the index variable `k` to be a simple `int64_t` instead of the CUDA tensor that was used before. This saves the  additional host and device operations from calling `Tensor`'s `operator -` which helps balance out the cost of the `clone` added here.
