### PR TITLE
[Draft] Throw exception to test that generated code is called

### DIFF
--- a/test_generated_unboxing.py
+++ b/test_generated_unboxing.py
@@ -1,0 +1,6 @@
+import torch
+
+m = torch.nn.ReLU()
+m = torch.jit.script(m)
+x = torch.Tensor(1)
+m(x)

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -478,6 +478,7 @@ OperatorGenerator(
     [](Stack & stack) {{
         RECORD_FUNCTION("{sig.name()}", std::vector<c10::IValue>());
         {code}
+        throw std::runtime_error("In Generated Code");
         drop(stack, {len(args)});
         {func_call_and_push}
     }},


### PR DESCRIPTION
After building, running `python test_generated_unboxing.py` gives

```
Traceback (most recent call last):
  File "test_generated_unboxing.py", line 6, in <module>
    m(x)
  File "/Users/salilsdesai/pytorch/torch/nn/modules/module.py", line 1106, in _call_impl
    return forward_call(*input, **kwargs)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "/Users/salilsdesai/pytorch/torch/nn/modules/activation.py", line 98, in forward
    def forward(self, input: Tensor) -> Tensor:
        return F.relu(input, inplace=self.inplace)
               ~~~~~~ <--- HERE
  File "/Users/salilsdesai/pytorch/torch/nn/functional.py", line 1347, in relu
        result = torch.relu_(input)
    else:
        result = torch.relu(input)
                 ~~~~~~~~~~ <--- HERE
    return result
RuntimeError: In Generated Code
```