### PR TITLE
[torchelastic] Remove stale `test_get_default_executable` test

### DIFF
--- a/test/distributed/launcher/run_test.py
+++ b/test/distributed/launcher/run_test.py
@@ -596,6 +596,3 @@ class ElasticLaunchTest(unittest.TestCase):
             ]
         )
         # nothing to validate, just make sure it runs
-
-    def test_get_default_executable(self):
-        self.assertEqual(sys.executable, launch.get_executable())


### PR DESCRIPTION
Summary: The test is stale and tests non-existent method

Test Plan: ci

Differential Revision: D32540127



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang