### PR TITLE
[const_fold] Fix call_module const folding

### DIFF
--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -171,6 +171,9 @@ def split_const_subgraphs(
     for node in non_const_gm.graph.nodes:
         if node.op == "call_module":
             setattr(split, node.target, getattr(non_const_gm, node.target))
+    for node in const_gm.graph.nodes:
+        if node.op == "call_module":
+            setattr(split, node.target, getattr(const_gm, node.target))
 
     # split_module currently does not use get_attrs for attrs. Instead it passes
     # them in as args from the parent module, which used get_attrs. Here we set


### PR DESCRIPTION
Summary: We need to copy modules over to the `split` graph during const folding. We were previously only doing so from the non-constant submod, but we need to do this for the constant one as well in case some `call_module` is const folded.

Test Plan: Added unit test

Reviewed By: 842974287

Differential Revision: D32543289

