### PR TITLE
fixed: type checking errors in match_utils.py

### DIFF
--- a/torch/ao/quantization/fx/match_utils.py
+++ b/torch/ao/quantization/fx/match_utils.py
@@ -79,9 +79,9 @@ def find_matches(
         modules: Dict[str, torch.nn.Module],
         patterns: Dict[Pattern, QuantizeHandler],
         qconfig_map: Dict[str, QConfigAny],
-        standalone_module_names: List[str] = None,
-        standalone_module_classes: List[Callable] = None,
-        custom_module_classes: List[Any] = None) -> Dict[str, MatchResult]:
+        standalone_module_names: Optional[List[str]] = None,
+        standalone_module_classes: Optional[List[Callable]] = None,
+        custom_module_classes: Optional[List[Any]] = None) -> Dict[str, MatchResult]:
     """
     Matches the nodes in the input graph to quantization patterns, and
     outputs the information needed to quantize them in future steps.


### PR DESCRIPTION
Fixes issue #72

This PR fixes the type checking errors in Pytorch torch/ao/quantization/fx/match_utils.py

Variables on line 82, 83 and 84 had a type checking error

- 82 -> standalone_module_names expected a `List[str] ` and `None` was given
- 83 -> standalone_module_classess expected a `List[Callable] ` and `None` was given
- 84 -> custom_module_names expected a `List[Any] ` and `None` was given

The fix was to add `Optional[]` to each type so it can handle the None statment

Signed-off-by: Jorge Sanchez Diaz
@S4ND1X