### PR TITLE
Fix inference_mode decorator

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8707,16 +8707,17 @@ class TestAutogradInferenceMode(TestCase):
         self.assertFalse(torch.is_inference_mode_enabled())
 
     def test_inference_mode_decorator(self):
-        @torch.inference_mode()
-        def func(x):
-            self.assertTrue(torch.is_inference_mode_enabled())
-            return x * x
+        for mode in (True, False):
+            @torch.inference_mode(mode)
+            def func(x):
+                self.assertEqual(torch.is_inference_mode_enabled(), mode)
+                return x * x
 
-        for requires_grad in (True, False):
-            c = torch.ones(1, 2, 3, requires_grad=requires_grad)
-            d = func(c)
-            self.assertTrue(torch.is_inference(d))
-            self.assertFalse(d.requires_grad)
+            for requires_grad in (True, False):
+                c = torch.ones(1, 2, 3, requires_grad=requires_grad)
+                d = func(c)
+                self.assertTrue(not mode or torch.is_inference(d))
+                self.assertEqual(d.requires_grad, requires_grad and not mode)
 
     def test_inference_mode_tensor_creation(self):
         with torch.inference_mode():

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -4,7 +4,6 @@ import functools
 import inspect
 from typing import Any, Callable, TypeVar, cast
 
-
 __all__ = ['no_grad', 'enable_grad', 'set_grad_enabled',
            'inference_mode']
 
@@ -24,7 +23,7 @@ class _DecoratorContextManager:
 
         @functools.wraps(func)
         def decorate_context(*args, **kwargs):
-            with self.__class__():
+            with self.clone():
                 return func(*args, **kwargs)
         return cast(F, decorate_context)
 
@@ -38,10 +37,9 @@ class _DecoratorContextManager:
             # make sure the grad mode is properly set every time the execution
             # flow returns into the wrapped generator and restored when it
             # returns through our `yield` to our caller (see PR #49017).
-            cls = type(self)
             try:
                 # Issuing `None` to a generator fires it up
-                with cls():
+                with self.clone():
                     response = gen.send(None)
 
                 while True:
@@ -51,18 +49,18 @@ class _DecoratorContextManager:
 
                     except GeneratorExit:
                         # Inform the still active generator about its imminent closure
-                        with cls():
+                        with self.clone():
                             gen.close()
                         raise
 
                     except BaseException:
                         # Propagate the exception thrown at us by the caller
-                        with cls():
+                        with self.clone():
                             response = gen.throw(*sys.exc_info())
 
                     else:
                         # Pass the last request to the generator and get its response
-                        with cls():
+                        with self.clone():
                             response = gen.send(request)
 
             # We let the exceptions raised above by the generator's `.throw` or
@@ -80,6 +78,10 @@ class _DecoratorContextManager:
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         raise NotImplementedError
+
+    def clone(self):
+        # override this method if your children class takes __init__ parameters
+        return self.__class__()
 
 
 class no_grad(_DecoratorContextManager):
@@ -172,7 +174,7 @@ class enable_grad(_DecoratorContextManager):
         torch._C._set_grad_enabled(self.prev)
 
 
-class set_grad_enabled(object):
+class set_grad_enabled(_DecoratorContextManager):
     r"""Context-manager that sets gradient calculation to on or off.
 
     ``set_grad_enabled`` will enable or disable grads based on its argument :attr:`mode`.
@@ -213,12 +215,16 @@ class set_grad_enabled(object):
     def __init__(self, mode: bool) -> None:
         self.prev = torch.is_grad_enabled()
         torch._C._set_grad_enabled(mode)
+        self.mode = mode
 
     def __enter__(self) -> None:
         pass
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         torch._C._set_grad_enabled(self.prev)
+
+    def clone(self):
+        return self.__class__(self.mode)
 
 
 class inference_mode(_DecoratorContextManager):
@@ -274,3 +280,6 @@ class inference_mode(_DecoratorContextManager):
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         del self._inference_mode_raii_guard
+
+    def clone(self):
+        return self.__class__(self.mode)


### PR DESCRIPTION
This fixes the case when `torch.inference_mode` is called with `mode=False` (disabled). When used as a decorator, it ignored the argument and enabled inference mode anyway.

`_DecoratorContextManager` is changed so that a new instance is a copy instead of a new instance with default parameters.

I also added more tests to cover this case.


Current behaviour:

```python
>>> import torch
>>> x = torch.ones(1, 2, 3, requires_grad=True)
>>> @torch.inference_mode(mode=False)
... def func(x):
...     return x * x
...
>>> out = func(x)
>>> out.requires_grad
False
```


New behaviour (fixed):

```python
>>> import torch
>>> x = torch.ones(1, 2, 3, requires_grad=True)
>>> @torch.inference_mode(mode=False)
... def func(x):
...     return x * x
...
>>> out = func(x)
>>> out.requires_grad
True
```

