### PR TITLE
fixed: type checking errors fusion_patterns.py

### DIFF
--- a/torch/ao/quantization/fx/fusion_patterns.py
+++ b/torch/ao/quantization/fx/fusion_patterns.py
@@ -1,3 +1,4 @@
+import typing
 import torch
 from torch.fx.graph import Node
 from .pattern_utils import (
@@ -22,7 +23,7 @@ class FuseHandler(ABC):
 
     @abstractmethod
     def fuse(self, quantizer: QuantizerCls, load_arg: Callable,
-             fuse_custom_config_dict: Dict[str, Any]) -> Node:
+             fuse_custom_config_dict: typing.Optional[Dict[str, Any]]=None) -> Node:
         pass
 
 @register_fusion_pattern((torch.nn.ReLU, torch.nn.Conv1d))
@@ -62,7 +63,7 @@ class ConvOrLinearBNReLUFusion(FuseHandler):
         self.conv_or_linear = quantizer.modules[self.conv_or_linear_node.target]
 
     def fuse(self, quantizer: QuantizerCls, load_arg: Callable,
-             fuse_custom_config_dict: Dict[str, Any]) -> Node:
+             fuse_custom_config_dict: typing.Optional[Dict[str, Any]]=None ) -> Node:
         additional_fuser_method_mapping = fuse_custom_config_dict.get("additional_fuser_method_mapping", {})
         op_list = []
         if self.relu_node is not None:
@@ -117,7 +118,7 @@ class ModuleReLUFusion(FuseHandler):
         self.module = quantizer.modules[self.module_node.target]
 
     def fuse(self, quantizer: QuantizerCls, load_arg: Callable,
-             fuse_custom_config_dict: Dict[str, Any]) -> Node:
+             fuse_custom_config_dict: typing.Optional[Dict[str, Any]]=None) -> Node:
         additional_fuser_method_mapping = fuse_custom_config_dict.get("additional_fuser_method_mapping", {})
         op_list = []
         # since relu can be used multiple times, we'll need to create a relu module for each match

--- a/torch/ao/quantization/fx/fusion_patterns.py
+++ b/torch/ao/quantization/fx/fusion_patterns.py
@@ -8,7 +8,7 @@ from .utils import _parent_name
 from .quantization_types import QuantizerCls
 from ..fuser_method_mappings import get_fuser_method
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 # ---------------------
 # Fusion Pattern Registrations
@@ -23,7 +23,7 @@ class FuseHandler(ABC):
 
     @abstractmethod
     def fuse(self, quantizer: QuantizerCls, load_arg: Callable,
-             fuse_custom_config_dict: typing.Optional[Dict[str, Any]]=None) -> Node:
+             fuse_custom_config_dict: Optional[Dict[str, Any]]=None) -> Node:
         pass
 
 @register_fusion_pattern((torch.nn.ReLU, torch.nn.Conv1d))
@@ -63,7 +63,7 @@ class ConvOrLinearBNReLUFusion(FuseHandler):
         self.conv_or_linear = quantizer.modules[self.conv_or_linear_node.target]
 
     def fuse(self, quantizer: QuantizerCls, load_arg: Callable,
-             fuse_custom_config_dict: typing.Optional[Dict[str, Any]]=None ) -> Node:
+             fuse_custom_config_dict: Optional[Dict[str, Any]]=None ) -> Node:
         additional_fuser_method_mapping = fuse_custom_config_dict.get("additional_fuser_method_mapping", {})
         op_list = []
         if self.relu_node is not None:
@@ -118,7 +118,7 @@ class ModuleReLUFusion(FuseHandler):
         self.module = quantizer.modules[self.module_node.target]
 
     def fuse(self, quantizer: QuantizerCls, load_arg: Callable,
-             fuse_custom_config_dict: typing.Optional[Dict[str, Any]]=None) -> Node:
+             fuse_custom_config_dict: Optional[Dict[str, Any]]=None) -> Node:
         additional_fuser_method_mapping = fuse_custom_config_dict.get("additional_fuser_method_mapping", {})
         op_list = []
         # since relu can be used multiple times, we'll need to create a relu module for each match


### PR DESCRIPTION
Fixes issue [#71](https://github.com/MLH-Fellowship/pyre-check/issues/71)

This PR fixes the type checking errors in Pytorch torch/ao/quantization/fx/fusion_patterns.py

Variables on line 25, 64 and 121 had a type checking error

25 -> `fuse_custom_config_dict` expected a `Dict[str, typing.Any]` and None was given
64 -> `fuse_custom_config_dict` expected a `Dict[str, typing.Any]` and None was given
121 -> `fuse_custom_config_dict` expected a` Dict[str, typing.Any]` and None was given

The fix was to add `Optional[]` to each type so it can handle the None statment

Signed-off-by: Jorge Sanchez Diaz
@S4ND1X
