### PR TITLE
[LTC] Refactor computation_client/util.h

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -525,7 +525,7 @@ torch::lazy::Value LazyGraphExecutor::GetIrValueForScalar(
   torch::lazy::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
     ir_value = torch::lazy::MakeNode<ir::ops::Expand>(
-        ir_value, lazy_tensors::util::ToVector<int64_t>(dimensions),
+        ir_value, dimensions.vec(),
         /*is_scalar_expand=*/true);
   }
   return ir_value;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -291,9 +291,8 @@ std::shared_ptr<View> LazyTensor::UpdateView(
     std::shared_ptr<View> view, torch::lazy::Value ir_value) const {
   if (torch::lazy::GetShapeFromTsValue(ir_value).sizes() !=
       view->shape().sizes()) {
-    CHECK_EQ(lazy_tensors::util::Multiply<int64_t>(
-                 torch::lazy::GetShapeFromTsValue(ir_value).sizes()),
-             lazy_tensors::util::Multiply<int64_t>(view->shape().sizes()));
+    CHECK_EQ(torch::lazy::GetShapeFromTsValue(ir_value).numel(),
+             view->shape().numel());
 
     ViewInfo view_info(ViewInfo::Type::kReshape,
                        torch::lazy::GetShapeFromTsValue(ir_value),

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -49,7 +49,7 @@ torch::lazy::Value MaybeExpand(const torch::lazy::Value& input,
     return input;
   }
   return torch::lazy::MakeNode<ir::ops::Expand>(
-      input, lazy_tensors::util::ToVector<int64_t>(target_shape.sizes()),
+      input, target_shape.sizes().vec(),
       /*is_scalar_expand=*/false);
 }
 
@@ -362,10 +362,8 @@ void copy_(LazyTensor& input, LazyTensor& src) {
   } else {
     auto input_shape = input.shape();
     at::Tensor src_tensor = src.ToTensor(/*detached=*/true);
-    if (!lazy_tensors::util::Equal(src_tensor.sizes(),
-                                   input_shape.get().sizes())) {
-      src_tensor = src_tensor.expand(lazy_tensors::util::ToVector<int64_t>(
-          input_shape.get().sizes()));
+    if (src_tensor.sizes() != input_shape.get().sizes()) {
+      src_tensor = src_tensor.expand(input_shape.get().sizes().vec());
     }
     input.UpdateFromTensor(std::move(src_tensor), /*sync=*/false);
   }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -396,7 +396,7 @@ at::Tensor LazyNativeFunctions::expand(const at::Tensor& self,
                                        at::IntArrayRef size, bool implicit) {
   LTC_FN_COUNTER("lazy::");
   return CreateAtenFromLtcTensor(lazy_tensor_aten_ops::expand(
-      TryGetLtcTensor(self), lazy_tensors::util::ToVector<int64_t>(size)));
+      TryGetLtcTensor(self), size.vec()));
 }
 
 at::Tensor& LazyNativeFunctions::fill_(at::Tensor& self,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view.cpp
@@ -39,15 +39,15 @@ torch::lazy::Value ApplyViewInfo(torch::lazy::Value ir_value, const ViewInfo& vi
     case ViewInfo::Type::kReshape:
       return torch::lazy::MakeNode<ir::ops::View>(
           ir_value,
-          lazy_tensors::util::ToVector<int64_t>(view_info.shape.sizes()));
+          view_info.shape.sizes().vec());
     case ViewInfo::Type::kResize:
       return torch::lazy::MakeNode<ir::ops::Resize>(
           ir_value,
-          lazy_tensors::util::ToVector<int64_t>(view_info.shape.sizes()));
+          view_info.shape.sizes().vec());
     case ViewInfo::Type::kAsStrided:
       return torch::lazy::MakeNode<ir::ops::AsStrided>(
           ir_value,
-          lazy_tensors::util::ToVector<int64_t>(view_info.shape.sizes()),
+          view_info.shape.sizes().vec(),
           view_info.as_strided->stride, view_info.as_strided->offset);
     case ViewInfo::Type::kDiagonal:
       return torch::lazy::MakeNode<ir::ops::Diagonal>(
@@ -91,19 +91,16 @@ torch::lazy::Value ApplyUpdate(torch::lazy::Value ir_value,
         break;
       case ViewInfo::Type::kReshape:
         result = torch::lazy::MakeNode<ir::ops::View>(
-            result, lazy_tensors::util::ToVector<int64_t>(
-                        view_info.source_shape.sizes()));
+            result, view_info.source_shape.sizes().vec());
         break;
       case ViewInfo::Type::kResize:
         result = torch::lazy::MakeNode<ir::ops::Resize>(
-            result, lazy_tensors::util::ToVector<int64_t>(
-                        view_info.source_shape.sizes()));
+            result, view_info.source_shape.sizes().vec());
         break;
       case ViewInfo::Type::kAsStrided:
         result = torch::lazy::MakeNode<ir::ops::AsStridedViewUpdate>(
             tmp_values[i - 1], result,
-            lazy_tensors::util::ToVector<int64_t>(
-                view_info.source_shape.sizes()),
+            view_info.source_shape.sizes().vec(),
             view_info.as_strided->stride, view_info.as_strided->offset);
         break;
       case ViewInfo::Type::kDiagonal:

--- a/lazy_tensor_core/test/cpp/metrics_snapshot.cpp
+++ b/lazy_tensor_core/test/cpp/metrics_snapshot.cpp
@@ -7,6 +7,15 @@
 namespace torch_lazy_tensors {
 namespace cpp_test {
 
+namespace {
+template <typename T>
+typename T::mapped_type FindOr(const T& cont, const typename T::key_type& key,
+                               const typename T::mapped_type& defval) {
+  auto it = cont.find(key);
+  return it != cont.end() ? it->second : defval;
+}
+}  // namespace
+
 MetricsSnapshot::MetricsSnapshot() {
   for (auto& name : lazy_tensors::metrics::GetMetricNames()) {
     lazy_tensors::metrics::MetricData* metric =
@@ -33,7 +42,7 @@ std::vector<MetricsSnapshot::ChangedCounter> MetricsSnapshot::CounterChanged(
     if ((ignore_set == nullptr || ignore_set->count(name_counter.first) == 0) &&
         std::regex_match(name_counter.first, match, cregex)) {
       int64_t start_value =
-          lazy_tensors::util::FindOr(counters_map_, name_counter.first, 0);
+          FindOr(counters_map_, name_counter.first, 0);
       if (name_counter.second != start_value) {
         changed.push_back(
             {name_counter.first, start_value, name_counter.second});
@@ -50,7 +59,7 @@ std::string MetricsSnapshot::DumpDifferences(
   for (auto& name_counter : after.counters_map_) {
     if (ignore_set == nullptr || ignore_set->count(name_counter.first) == 0) {
       int64_t start_value =
-          lazy_tensors::util::FindOr(counters_map_, name_counter.first, 0);
+          FindOr(counters_map_, name_counter.first, 0);
       if (name_counter.second != start_value) {
         ss << "Counter '" << name_counter.first << "' changed from "
            << start_value << " to " << name_counter.second << "\n";

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -182,6 +182,11 @@ static inline hash_t Hash(const hash_t& value) {
 }
 
 template <typename T>
+torch::lazy::hash_t Hash(c10::ArrayRef<T> values) {
+  return torch::lazy::ContainerHash(values);
+}
+
+template <typename T>
 hash_t ContainerHash(const T& values) {
   hash_t h(static_cast<uint64_t>(0x85ebca77c2b2ae63));
   for (const auto& value : values) {


### PR DESCRIPTION
Summary:
This commit refactors computation_client/util.h:
1) Consolidates some of the utils with c10/std equivalent.
2) Removes unused ones.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc
