### PR TITLE
[DataPipe] Optimize Grouper from N^2 to N

### DIFF
--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -1,6 +1,7 @@
 import random
 
 from collections import defaultdict
+from heapq import heappush, heappop
 
 from torch.utils.data import IterDataPipe, functional_datapipe, DataChunk
 from torch.utils.data.datapipes.utils.common import deprecation_warning_torchdata
@@ -315,7 +316,7 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
                 if result_to_yield is not None:
                     yield self.wrapper_class(result_to_yield)
 
-        while buffer_size:
-            (result_to_yield, buffer_size) = self._remove_biggest_key(buffer_elements, buffer_size)
-            if result_to_yield is not None:
-                yield self.wrapper_class(result_to_yield)
+        for key in tuple(buffer_elements.keys()):
+            res = buffer_elements.pop(key)
+            buffer_size -= len(res)
+            yield self.wrapper_class(res)

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -1,7 +1,6 @@
 import random
 
 from collections import defaultdict
-from heapq import heappush, heappop
 
 from torch.utils.data import IterDataPipe, functional_datapipe, DataChunk
 from torch.utils.data.datapipes.utils.common import deprecation_warning_torchdata


### PR DESCRIPTION
Fixes #68539

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#68647 [DataPipe] Optimize Grouper from N^2 to N**

After source datapipe is depleted, there is no need to yield the biggest group in the buffer. By yielding data directly from buffer, we can reduce time complexity to `O(N)` from `O(N^2)` for the case of unlimited buffer.

I don't want to change the `_remove_biggest_key` to use heap or priority queue, because the time complexity for both implementations need to be carefully analyzed. Let's say the average size of groups in buffer is `group_size` and the number of elements in buffer is `buffer_size`, and the average size of each group is `group_size`. `N` refers to the number of groups before `source_datapipe` is depleted

|                                   | dict                        | heap+dict                                                                    |
|-----------------------------------|-----------------------------|------------------------------------------------------------------------------|
| First group                       | `O(buffer_size)+O(groups)`  | `O(buffer_size)*O(log(groups))+O(log(groups))=O(buffer_size)*O(log(groups))` |
| Other groups                      | `O(group_size)+O(groups)`   | `O(group_size)*O(log(groups))+O(log(groups))=O(group_size)*O(log(groups))`   |
| Before `source_datapipe` depleted | `O(N)*O(group_size+groups)` | `O(N)*O(group_size)*O(log(groups))`                                          |

Summary:
With a fixed buffer size,
- If the average size of each group is large then the number of groups in buffer would decrease, `dict` would be a better choice
- If the average size of each group is smaller then the number of groups in buffer would increase, `heap+dict` would be a better choice

Differential Revision: [D32562646](https://our.internmc.facebook.com/intern/diff/D32562646)