### PR TITLE
[android] Lite interpreter naming for android nightly publishing

### DIFF
--- a/android/pytorch_android/gradle.properties
+++ b/android/pytorch_android/gradle.properties
@@ -1,4 +1,4 @@
-POM_NAME=pytorch_android pytorch android api
-POM_DESCRIPTION=pytorch_android pytorch android api
-POM_ARTIFACT_ID=pytorch_android
+POM_NAME=pytorch_android_lite pytorch android api
+POM_DESCRIPTION=pytorch_android_lite pytorch android api
+POM_ARTIFACT_ID=pytorch_android_lite
 POM_PACKAGING=aar

--- a/android/pytorch_android_torchvision/gradle.properties
+++ b/android/pytorch_android_torchvision/gradle.properties
@@ -1,4 +1,4 @@
-POM_NAME=pytorch_android_torchvision
-POM_DESCRIPTION=pytorch_android_torchvision
-POM_ARTIFACT_ID=pytorch_android_torchvision
+POM_NAME=pytorch_android_torchvision_lite
+POM_DESCRIPTION=pytorch_android_torchvision_lite
+POM_ARTIFACT_ID=pytorch_android_torchvision_lite
 POM_PACKAGING=aar


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68651

Differential Revision: [D32564796](https://our.internmc.facebook.com/intern/diff/D32564796)

We publish artifacts with Lite (Mobile interpreter) by default.
The naming of artifacts must be consistent with it as it will be packaged with pytorch_jni_lite.so inside.