### PR TITLE
Surface duplicated device error earlier for NCCL

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -376,6 +376,9 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       const std::string& devicesKey,
       int p2pRank);
 
+  // Helper that checks if there is any duplicated device across all the ranks.
+  void duplicatedDeviceCheck(const std::string& devicesKey);
+
   // Helper that either looks up the cached NCCL communicators or creates
   // a new set of NCCL communicators as a cache entry
   std::vector<std::shared_ptr<NCCLComm>>& getNCCLComm(


### PR DESCRIPTION
Summary:
NCCL doesn't allow multi-rank mapped to the same GPU device. If world_size > total number of GPUs, NCCL barrier will throw unhandled system error `RuntimeError: NCCL error in: caffe2/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:1080, unhandled system error, NCCL version 21.0.3` which could confuse users.

Surfacing the duplicated GPU device error earlier with more detailed error message.

Test Plan:
```
RuntimeError: Duplicated GPU device is not allowed by NCCL. Rank [0] and rank [8] both attached to GPU device 0 on the same host learngpu001.09.ftw5.facebook.com. Most likely your world_size is larger than the total number of GPUs
Traceback (most recent call last):
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/__run_xar_main__.py", line 309, in <module>
    __invoke_main()
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/__run_xar_main__.py", line 265, in __invoke_main
    runpy._run_module_as_main(module, False)
  File "/usr/local/fbcode/platform009/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform009/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/scripts/jiayisuse/gloo/link/benchmark/test_pytorch.py", line 226, in <module>
    main()
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/scripts/jiayisuse/gloo/link/benchmark/test_pytorch.py", line 138, in main
    dist.barrier()
  File "/mnt/xarfuse/uid-0/184d8789-seed-nspid4026531836_cgpid11383-ns-4026531840/torch/distributed/distributed_c10d.py", line 2767, in barrier
    work = default_pg.barrier(opts=opts)
```

Differential Revision: D32555066



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang