### PR TITLE
GHA: add print_tests_stats step to MacOS workflow

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -41,9 +41,9 @@ concurrency:
         run: .github/scripts/parse_ref.py
 {%- endmacro -%}
 
-{%- macro upload_test_statistics(build_environment) -%}
+{%- macro upload_test_statistics(build_environment, when="always()") -%}
       - name: Display and upload test statistics (Click Me)
-        if: always()
+        if: !{{ when }}
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -85,6 +85,7 @@ jobs:
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
+      !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
 {%- endif %}
 {% endblock +%}
 

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -85,6 +85,7 @@ jobs:
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
+      !{{ common.parse_ref() }}
       !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
 {%- endif %}
 {% endblock +%}

--- a/.github/workflows/generated-macos-10-15-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-x86-64.yml
@@ -127,6 +127,23 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Display and upload test statistics (Click Me)
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        # temporary hack: set CIRCLE_* vars, until we update
+        # tools/stats/print_test_stats.py to natively support GitHub Actions
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          JOB_BASE_NAME: macos-10-15-py3-x86-64-test
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          TAG: ${{ steps.parse-ref.outputs.tag }}
+          WORKFLOW_ID: '${{ github.run_id }}_${{ github.run_number }}'
+        shell: bash
+        run: |
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install boto3==1.19.12
+          python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 
 
 concurrency:

--- a/.github/workflows/generated-macos-10-15-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-x86-64.yml
@@ -127,6 +127,9 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
+      - name: Parse ref
+        id: parse-ref
+        run: .github/scripts/parse_ref.py
       - name: Display and upload test statistics (Click Me)
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         # temporary hack: set CIRCLE_* vars, until we update


### PR DESCRIPTION
This will allow trunk CI to print test stats and upload stats (test reports, flaky tests, failed tests) to
- Scribe
- S3
- RDS