### PR TITLE
Abate unused variable warnings in ProcessGroupGlooTest, FileStoreTest.cpp

### DIFF
--- a/test/cpp/c10d/FileStoreTest.cpp
+++ b/test/cpp/c10d/FileStoreTest.cpp
@@ -83,12 +83,14 @@ void stressTestStore(std::string path, std::string prefix = "") {
 
   for (const auto i : c10::irange(numThreads)) {
     threads.push_back(std::thread([&] {
+      std::ignore = i;
       auto fileStore =
           c10::make_intrusive<c10d::FileStore>(path, numThreads + 1);
       c10d::PrefixStore store(prefix, fileStore);
       sem1.post();
       sem2.wait();
       for (const auto j : c10::irange(numIterations)) {
+        std::ignore = j;
         store.add("counter", 1);
       }
     }));

--- a/test/cpp/c10d/ProcessGroupGlooTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooTest.cpp
@@ -127,6 +127,7 @@ class CollectiveTest {
       bool delayed = false) {
     std::vector<CollectiveTest> tests;
     for (const auto i : c10::irange(num)) {
+      std::ignore = i;
       tests.push_back(CollectiveTest(path));
     }
 


### PR DESCRIPTION
cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang