### PR TITLE
Rename View class into LazyView

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
@@ -1,4 +1,4 @@
-#include "lazy_tensor_core/csrc/view.h"
+#include "lazy_tensor_core/csrc/lazy_view.h"
 
 #include <torch/csrc/lazy/core/permutation_util.h>
 
@@ -180,31 +180,31 @@ torch::lazy::Value Alias::SyncUpdateOperations() {
   return root_ir_value_;
 }
 
-View::View(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
+LazyView::LazyView(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
            ViewInfo view_info)
     : shape_(std::move(shape)), alias_(std::move(alias)) {
   view_infos_.push_back(std::move(view_info));
 }
 
-View::View(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
+LazyView::LazyView(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
            std::vector<ViewInfo> view_infos)
     : view_infos_(std::move(view_infos)),
       shape_(std::move(shape)),
       alias_(std::move(alias)) {}
 
-void View::Update(torch::lazy::Value ir_value) {
+void LazyView::Update(torch::lazy::Value ir_value) {
   alias_->Update(std::move(ir_value), view_infos_);
 }
 
-std::shared_ptr<View> View::CreateSubView(torch::lazy::Shape shape,
+std::shared_ptr<LazyView> LazyView::CreateSubView(torch::lazy::Shape shape,
                                           ViewInfo view_info) {
   std::vector<ViewInfo> view_infos(view_infos_);
   view_infos.push_back(std::move(view_info));
-  return std::make_shared<View>(std::move(shape), alias_,
+  return std::make_shared<LazyView>(std::move(shape), alias_,
                                 std::move(view_infos));
 }
 
-std::tuple<torch::lazy::Value, bool> View::GetViewIrNode() {
+std::tuple<torch::lazy::Value, bool> LazyView::GetViewIrNode() {
   if (IsUpToDate()) {
     return {ir_value_, false};
   }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.h
@@ -123,11 +123,11 @@ class Alias {
   size_t generation_ = 0;
 };
 
-class View {
+class LazyView {
  public:
-  View(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
+  LazyView(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
        ViewInfo view_info);
-  View(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
+  LazyView(torch::lazy::Shape shape, std::shared_ptr<Alias> alias,
        std::vector<ViewInfo> view_infos);
 
   void Update(torch::lazy::Value ir_value);
@@ -136,7 +136,7 @@ class View {
 
   const std::shared_ptr<Alias>& alias() const { return alias_; }
 
-  std::shared_ptr<View> CreateSubView(torch::lazy::Shape shape,
+  std::shared_ptr<LazyView> CreateSubView(torch::lazy::Shape shape,
                                       ViewInfo view_info);
 
   // Extracts the current IrNode out of a view, into a IrNode structure

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -3,7 +3,7 @@
 #include <torch/csrc/lazy/backend/backend_device.h>
 #include <torch/csrc/lazy/backend/backend_interface.h>
 
-#include "lazy_tensor_core/csrc/view.h"
+#include "lazy_tensor_core/csrc/lazy_view.h"
 #include "lazy_tensors/computation_client/util.h"
 #include "torch/csrc/lazy/core/ir.h"
 
@@ -24,7 +24,7 @@ class LazyTensor {
         : ir_value(std::move(ir_value)),
           device(device),
           unique_id(GetNextTensorId()) {}
-    Data(std::shared_ptr<View> view, const torch::lazy::BackendDevice& device)
+    Data(std::shared_ptr<LazyView> view, const torch::lazy::BackendDevice& device)
         : view(std::move(view)), device(device), unique_id(GetNextTensorId()) {}
     Data(at::Tensor tensor_data, const torch::lazy::BackendDevice& device)
         : tensor_data(std::move(tensor_data)),
@@ -35,7 +35,7 @@ class LazyTensor {
 
     torch::lazy::BackendDataPtr handle;
     torch::lazy::Value ir_value;
-    std::shared_ptr<View> view;
+    std::shared_ptr<LazyView> view;
     c10::optional<at::Tensor> tensor_data;
     const torch::lazy::BackendDevice device;
     const int64_t unique_id = 0;
@@ -132,12 +132,12 @@ class LazyTensor {
   LazyTensor(const at::Tensor& tensor, const torch::lazy::BackendDevice& device);
   LazyTensor(torch::lazy::Value ir_value,
              const torch::lazy::BackendDevice& device);
-  LazyTensor(std::shared_ptr<View> view,
+  LazyTensor(std::shared_ptr<LazyView> view,
              const torch::lazy::BackendDevice& device);
   LazyTensor(torch::lazy::BackendDataPtr handle);
   LazyTensor(std::shared_ptr<Data> data);
 
-  static LazyTensor Create(std::shared_ptr<View> view,
+  static LazyTensor Create(std::shared_ptr<LazyView> view,
                            const torch::lazy::BackendDevice& device);
 
   std::shared_ptr<Data> data_ptr() const { return data_; }
@@ -150,12 +150,12 @@ class LazyTensor {
                                       bool read_only) const;
 
   std::tuple<torch::lazy::Value, bool> GetViewUpdate(
-      const std::shared_ptr<View>& view) const;
+      const std::shared_ptr<LazyView>& view) const;
 
-  std::shared_ptr<View> UpdateView(std::shared_ptr<View> view,
+  std::shared_ptr<LazyView> UpdateView(std::shared_ptr<LazyView> view,
                                    torch::lazy::Value ir_value) const;
 
-  std::shared_ptr<View> CreateView(ViewInfo view_info) const;
+  std::shared_ptr<LazyView> CreateView(ViewInfo view_info) const;
 
   // We build a graph accumulating operations, but at a given point we
   // need to force a rendering, otherwise the graph can grow without control.


### PR DESCRIPTION
Summary: To avoid name confusion with the view operator
