### PR TITLE
[fx2trt][easy] Replace all network.add_activation() call with helper function

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1408,9 +1408,7 @@ def acc_ops_sigmoid(network, target, args, kwargs, name):
             "of the TensorRT region!"
         )
 
-    layer = network.add_activation(input=input_val, type=trt.ActivationType.SIGMOID)
-    set_layer_name(layer, target, name)
-    return layer.get_output(0)
+    return add_activation_layer(network, input_val, trt.ActivationType.SIGMOID, target, name)
 
 
 @tensorrt_converter(acc_ops.permute)
@@ -1687,8 +1685,12 @@ def acc_ops_hardtanh(network, target, args, kwargs, name):
         raise RuntimeError(f"hardtanh received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    layer = network.add_activation(input_val, trt.ActivationType.CLIP)
-    layer.alpha = kwargs["min_val"]
-    layer.beta = kwargs["max_val"]
-    set_layer_name(layer, target, name)
-    return layer.get_output(0)
+    return add_activation_layer(
+        network,
+        input_val,
+        trt.ActivationType.CLIP,
+        target,
+        name,
+        alpha=kwargs["min_val"],
+        beta=kwargs["max_val"],
+    )

--- a/torch/fx/experimental/fx2trt/converters/converter_utils.py
+++ b/torch/fx/experimental/fx2trt/converters/converter_utils.py
@@ -314,6 +314,7 @@ def broadcast(
 
     return a, b
 
+
 def add_binary_elementwise_layer(
     network: trt.INetworkDefinition,
     lhs_val: Union[int, float, trt.tensorrt.ITensor, torch.Tensor],
@@ -413,6 +414,8 @@ def add_activation_layer(
     operation_type: trt.ActivationType,
     target: Target,
     name: str,
+    alpha: Optional[Any] = None,
+    beta: Optional[Any] = None,
 ) -> trt.tensorrt.ITensor:
     """
     Add a TensorRT Activation layer to `network`.
@@ -425,6 +428,10 @@ def add_activation_layer(
             operation.
         target (Target): Target of fx node.
         name (str): The name we want to assign to the created TensorRT layer.
+        alpha (Optional[Any]): If not None, we will use it to set the alpha
+            attribute of the created TensorRT activation layer.
+        beta (Optional[Any]): If not None, we will use it to set the beta
+            attribute of the created TensorRT activation layer.
 
     Returns:
         The output of TensorRT Activation layer.
@@ -435,6 +442,10 @@ def add_activation_layer(
             "of the TensorRT region!"
         )
     layer = network.add_activation(input_val, operation_type)
+    if alpha:
+        layer.alpha = alpha
+    if beta:
+        layer.beta = beta
     set_layer_name(layer, target, name)
     return layer.get_output(0)
 


### PR DESCRIPTION
Summary: As the title, the helper functions handles setting layer name. We would want to use those helper functions whenever possible.

Test Plan: CI

Differential Revision: D32571061

