### PR TITLE
[Pytorch Edge] Get Operator Version from model file

### DIFF
--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -102,6 +102,29 @@ uint64_t _get_model_bytecode_version(
   TORCH_CHECK(false, "Failed to get bytecode version.");
 }
 
+/********************** Operator Version **********************/
+
+uint64_t _get_model_operator_version(std::istream& in) {
+  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
+  return _get_model_operator_version(std::move(rai));
+}
+
+uint64_t _get_model_operator_version(const std::string& filename) {
+  std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
+  return _get_model_operator_version(std::move(rai));
+}
+
+uint64_t _get_model_operator_version(
+    std::shared_ptr<ReadAdapterInterface> rai) {
+  if (!check_zip_file(rai)) {
+    TORCH_CHECK(
+        false,
+        "Failed to open .ptl file please ensure the model was exported for mobile");
+  }
+  PyTorchStreamReader reader(std::move(rai));
+  return reader.version();
+}
+
 /********************** Operators and Info **********************/
 
 // Forward declare

--- a/torch/csrc/jit/mobile/model_compatibility.h
+++ b/torch/csrc/jit/mobile/model_compatibility.h
@@ -29,6 +29,16 @@ TORCH_API uint64_t _get_model_bytecode_version(
 uint64_t _get_model_bytecode_version(
     const std::vector<c10::IValue>& bytecode_ivalues);
 
+// The family of methods below to get the operator version from a model
+// Throws if not passed in a well formed model
+TORCH_API uint64_t _get_model_operator_version(std::istream& in);
+
+TORCH_API uint64_t _get_model_operator_version(const std::string& filename);
+
+TORCH_API uint64_t _get_model_operator_version(
+    std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai);
+
+// Utility Functions
 std::vector<c10::IValue> get_bytecode_ivalues(
     caffe2::serialize::PyTorchStreamReader& reader);
 


### PR DESCRIPTION
Summary: Using in compatibility apis. Luckily the stream reader kinda just does this already so mostly just create a wrapper in our compatibility files

Test Plan: ci

Differential Revision: D32573132

