### PR TITLE
[WIP] check stack size after calling operator

### DIFF
--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -258,17 +258,6 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
     };
 #endif
 
-#if !defined(NDEBUG)
-#define CHECK_STACK_SIZE(fn, X, stack)                                                \
-    size_t expected_returns = fn->full_operator_table_[X].schema().returns().size();  \
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(stack.size() == expected_returns,                \
-                          "Expected ",                                                \
-                          expected_returns,                                           \
-                          " outputs from op but found ",                              \
-                          stack.size(),                                               \
-                          " values on the stack");
-#endif
-
     try {
       while (true) {
         Frame& frame = frames.back();
@@ -296,14 +285,14 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           case INST(OP): {
             INST_GUARD;
             frame.function->operator_table_[inst.X](stack);
-            CHECK_STACK_SIZE(frame.function, inst.X, stack);
+            frame.function->assert_stack_size(inst.X, stack.size());
           }
             INST_NEXT;
           case INST(OPN): {
             INST_GUARD;
             stack.push_back(inst.N);
             frame.function->operator_table_[inst.X](stack);
-            CHECK_STACK_SIZE(frame.function, inst.X, stack);
+            frame.function->assert_stack_size(inst.X, stack.size());
           }
             INST_NEXT;
           case INST(LOAD): {

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -771,6 +771,20 @@ struct CodeImpl {
 #endif
     return size;
   }
+
+  void assert_stack_size(int32_t instruction_index, size_t actual_size) const {
+#ifndef NDEBUG
+    size_t expected_size = full_operator_table_[instruction_index].schema().returns().size();
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      expected_size == actual_size,
+      "Expected ",
+      expected_size,
+      " return values, but found ",
+      actual_size,
+      " on the stack."
+    );
+#endif
+  }
 };
 
 struct MobileCodeImpl : CodeImpl {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68681

In debug mode, this should throw errors for ops where the wrong number ops is returned (i.e. the number of values left on the stack is different from the number shown in the schema)

Test Plan:
Run this in debug mode and verify that it doesn't throw an assert
```
import torch

class Thing(torch.nn.Module):
    @torch.jit.export
    def en(self, x: torch.Tensor):
        return torch.add(x, 2.0)

    def forward(self, x: torch.Tensor, y: torch.Tensor):
        a = torch.mm(x, y)
        b = torch.nn.functional.gelu(a)
        c = self.en(b)
        return c.std_mean()

if __name__ == '__main__':
    unsc = Thing()
    thing = torch.jit.script(unsc)
    x = torch.randn(4, 4)
    y = torch.randn(4, 4)
    std, mean = thing.forward(x, y)
    print(std, mean)
    print(str(thing.forward.graph))
```