### PR TITLE
Codegen: Generate static dispatch headers per operator

### DIFF
--- a/aten/src/ATen/templates/DispatchKeyFunction.h
+++ b/aten/src/ATen/templates/DispatchKeyFunction.h
@@ -1,0 +1,45 @@
+#pragma once
+// ${generated_comment}
+
+// NB: The implementing C++ file is RegisterDispatchKey.cpp
+
+// The only #includes we need are for custom classes that have defaults in the C++ API
+#include <c10/core/MemoryFormat.h>
+#include <c10/core/Scalar.h>
+#include <ATen/core/Reduction.h>
+
+// Forward declarations of any types needed in the operator signatures.
+// We can't directly include these classes because it will cause circular include dependencies.
+// This file is included by TensorBody.h, which defines the Tensor class.
+namespace c10 {
+
+template<typename T>
+class optional;
+template<typename T>
+class List;
+class Stream;
+class Scalar;
+struct Storage;
+struct TensorOptions;
+
+}
+
+namespace at {
+
+class Tensor;
+struct Dimname;
+struct Generator;
+using TensorList = c10::ArrayRef<Tensor>;
+using DimnameList = c10::ArrayRef<Dimname>;
+using c10::Stream;
+using c10::Storage;
+using c10::QScheme;
+using c10::Scalar;
+using c10::TensorOptions;
+
+namespace ${dispatch_namespace} {
+
+${dispatch_namespaced_declarations}
+
+} // namespace ${dispatch_namespace}
+} // namespace at

--- a/aten/src/ATen/templates/DispatchKeyFunctions_inl.h
+++ b/aten/src/ATen/templates/DispatchKeyFunctions_inl.h
@@ -1,3 +1,4 @@
+#pragma once
 // ${generated_comment}
 
 // NB: The implementing C++ file is RegisterDispatchKey.cpp
@@ -11,14 +12,8 @@
 #ifdef TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #error This change adds a dependency on all pytorch operators, meaning the     \
   file will need to be re-compiled every time an operator is changed or added. \
-  Consider if your change would be better placed in another file, or if a more \
-  specific header might achieve the same goal.
+  Consider including a specific operator from \
+  <ATen/ops/{my_operator}_${dispatch_namespace}_dispatch.h>
 #endif
 
-namespace at {
-namespace ${dispatch_namespace} {
-
-${dispatch_namespaced_declarations}
-
-} // namespace ${dispatch_namespace}
-} // namespace at
+$DispatchKeyFunctions_inl_includes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68462
* #68693
* #68692
* #68691
* #68697
* #68690
* #68689
* __->__ #68704
* #68688
* #68687
* #68247
* #68246

This splits the static dispatch headers (e.g. `CPUFunctions.h`)
into per operators headers (e.g. `ops/empty_cpu_dispatch.h`) which is
needed for when `Tensor.h` is compiled with static dispatch enabled.

There are also several places in ATen where the static dispatch
headers are used as an optimization even in dynamic dispatch builds.