### PR TITLE
Adds retry logic to CUDA memory leak check

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1227,7 +1227,7 @@ class CudaMemoryLeakCheck():
             return
 
         afters = self.get_cuda_memory_usage()
-        result = self._compare_before_after(self.before, afters)
+        result = self._compare_before_after(self.befores, afters)
 
         # Implements retry logic
         if result is not None:
@@ -1238,11 +1238,11 @@ class CudaMemoryLeakCheck():
 
             torch.cuda.synchronize()
             afters = self.get_cuda_memory_usage()
-            result = self._compare_before_after(self.before, afters)
+            result = self._compare_before_after(self.befores, afters)
             if result is not None:
                 name, diff, i = result
-                self.fail('{} leaked {} bytes CUDA memory after retry on device {}'.format(
-                          name, diff, i))
+                self.testcase.fail('{} leaked {} bytes CUDA memory after retry on device {}'.format(
+                                   name, diff, i))
 
 
 @contextmanager

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1213,10 +1213,10 @@ class CudaMemoryLeakCheck():
 
     def __enter__(self):
         self.befores = self.get_cuda_memory_usage()
-        
+
     def _compare_before_after(self, befores, afters):
         for i, (before, after) in enumerate(zip(befores, afters)):
-            if (after - before) != 0
+            if (after - before) != 0:
                 return self.name, after - before, i
 
         return None


### PR DESCRIPTION
Attempts to address the intermittent CUDA memory leak failures in that occur while running CUDA grad tests. See https://github.com/pytorch/pytorch/runs/4271809926?check_suite_focus=true for an example, relevant snippet:

```
======================================================================
FAIL [3.993s]: test_fn_grad_nn_functional_unfold_cuda_complex128 (__main__.TestGradientsCUDA)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_utils.py", line 1463, in wrapper
    method(*args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_utils.py", line 1463, in wrapper
    method(*args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_utils.py", line 1228, in __exit__
    self.name, after - before, i))
  File "/opt/conda/lib/python3.6/site-packages/torch/testing/_internal/common_utils.py", line 2065, in assertEqual
    super().assertTrue(result, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
AssertionError: False is not true : Scalars failed to compare as equal! 0 != 1024
__main__.TestGradientsCUDA.test_fn_grad_nn_functional_unfold_cuda_complex128 leaked 1024 bytes CUDA memory on device 0
```

If this fix doesn't address the issue then it's likely there is a race condition actually causing a CUDA memory leak. 