### PR TITLE
fix dtypesIfCPU -> dtypes in  a few OpInfos

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13088,7 +13088,7 @@ op_db: List[OpInfo] = [
     OpInfo(
         '_masked.softmax',
         method_variant=None,
-        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_masked_softmax,
         skips=(
@@ -13102,7 +13102,7 @@ op_db: List[OpInfo] = [
     OpInfo(
         '_masked.log_softmax',
         method_variant=None,
-        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_masked_softmax,
         skips=(
@@ -13120,7 +13120,7 @@ op_db: List[OpInfo] = [
     OpInfo(
         '_masked.softmin',
         method_variant=None,
-        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
         sample_inputs_func=sample_inputs_masked_softmax,
         skips=(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -524,8 +524,8 @@ class OpInfo(object):
                  error_inputs_func=None,  # function to generate inputs that will throw errors
 
                  # the following metadata relates to dtype support and is tested for correctness in test_ops.py
-                 dtypes=None,  # dtypes this function works with on the CPU,
-                               # inherited by other device types that don't specify their own dtypes
+                 dtypes, # dtypes this function works with on the CPU,
+                         # inherited by other device types that don't specify their own dtypes
 
                  # the following dtypesIf... options override the dtypes value
                  # on their respective device types
@@ -594,7 +594,6 @@ class OpInfo(object):
                  assert_jit_shape_analysis=False,  # assert that jit shape analysis fully propagates shape
                  ):
 
-        assert dtypes is not None, f"`dtypes` argument for OpInfo should not be None, but found None for {name}"
         dtypes_args = (dtypes, dtypesIfCPU, dtypesIfCUDA, dtypesIfROCM)
         # Validates the dtypes are generated from the dispatch-related functions
         for dtype_list in dtypes_args:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -594,8 +594,7 @@ class OpInfo(object):
                  assert_jit_shape_analysis=False,  # assert that jit shape analysis fully propagates shape
                  ):
 
-        assert dtypes is not None, ("`dtypes` argument for OpInfo should not be None,",
-                                    f"but found None for {name}")
+        assert dtypes is not None, f"`dtypes` argument for OpInfo should not be None, but found None for {name}"
         dtypes_args = (dtypes, dtypesIfCPU, dtypesIfCUDA, dtypesIfROCM)
         # Validates the dtypes are generated from the dispatch-related functions
         for dtype_list in dtypes_args:


### PR DESCRIPTION
#67619 added a check that the `dtypes` parameter of an `OpInfo` cannot be omitted:

https://github.com/pytorch/pytorch/blob/7c6a8a47db112e6efe24d2d55d69fe634b732de1/torch/testing/_internal/common_methods_invocations.py#L597-L598

The PR was not up to date and missed the OpInfos added in #68463. Without this patch, currently test collection fails.

cc @mruberry