### PR TITLE
[pytorch] Fix loading from checkpoint after "maximize" flag was introduced in SGD

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -104,6 +104,7 @@ class SGD(Optimizer):
         super(SGD, self).__setstate__(state)
         for group in self.param_groups:
             group.setdefault('nesterov', False)
+            group.setdefault('maximize', False)
 
     @torch.no_grad()
     def step(self, closure=None):


### PR DESCRIPTION
Summary:
After 'maximize' flag was introduced in  https://github.com/pytorch/pytorch/issues/46480 some jobs fail because they resume training from the checkpoints.

After we load old checkpoints we will get an error during optimizer.step() call during backward pass in [torch/optim/sgd.py", line 129] because there is no key 'maximize' in the parameter groups of the SGD.

To circumvent this I add a default value `group.setdefault('maximize', False)` when the optimizer state is restored.

Differential Revision: D32480963

