### PR TITLE
Move view ops shape inference logic from ts_shape_inference.cpp

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
@@ -17,7 +17,6 @@
 #include "lazy_tensor_core/csrc/ops/scalar.h"
 #include "lazy_tensor_core/csrc/tensor_aten_ops.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
-#include "lazy_tensor_core/csrc/view_ops/permute.h"
 #include "lazy_tensors/computation_client/util.h"
 
 namespace torch_lazy_tensors {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ops.cpp
@@ -10,7 +10,6 @@
 #include "lazy_tensor_core/csrc/tensor_util.h"
 #include "lazy_tensor_core/csrc/ts_backend/LazyLazyIr.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
-#include "lazy_tensor_core/csrc/view_ops/permute.h"
 #include "lazy_tensors/computation_client/util.h"
 #include "torch/csrc/lazy/core/ir_metadata.h"
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_shape_inference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_shape_inference.cpp
@@ -23,14 +23,6 @@
 #include "lazy_tensor_core/csrc/ops/ts_native_batch_norm_forward.h"
 #include "lazy_tensor_core/csrc/ops/unsqueeze.h"
 #include "lazy_tensor_core/csrc/tensor_util.h"
-#include "lazy_tensor_core/csrc/view_ops/as_strided.h"
-#include "lazy_tensor_core/csrc/view_ops/as_strided_view_update.h"
-#include "lazy_tensor_core/csrc/view_ops/generic_slice.h"
-#include "lazy_tensor_core/csrc/view_ops/permute.h"
-#include "lazy_tensor_core/csrc/view_ops/select.h"
-#include "lazy_tensor_core/csrc/view_ops/unselect.h"
-#include "lazy_tensor_core/csrc/view_ops/update_slice.h"
-#include "lazy_tensor_core/csrc/view_ops/view.h"
 
 namespace torch_lazy_tensors {
 namespace compiler {
@@ -104,18 +96,6 @@ torch::lazy::Shape InferStack(const ir::ops::Stack* stack) {
   return torch::lazy::Shape(input_shape.scalar_type(), output_dimensions);
 }
 torch::lazy::Shape InferShape(const torch::lazy::Node* node) {
-  if (node->op() == *ir::ops::ltc_generic_slice) {
-    auto generic_slice = torch::lazy::NodeCast<ir::ops::GenericSlice>(
-        node, *ir::ops::ltc_generic_slice);
-    const torch::lazy::Output& argument = node->operand(0);
-    return torch::lazy::Shape(
-        torch::lazy::GetShapeFromTsOutput(argument).scalar_type(),
-        generic_slice->sizes());
-  }
-  if (node->op() == *ir::ops::ltc_update_slice) {
-    const torch::lazy::Output& argument = node->operand(0);
-    return torch::lazy::GetShapeFromTsOutput(argument);
-  }
   switch (node->op().op) {
     case at::aten::expand: {
       auto expand = torch::lazy::NodeCast<ir::ops::Expand>(
@@ -129,13 +109,6 @@ torch::lazy::Shape InferShape(const torch::lazy::Node* node) {
       return InferConvolutionOverrideable(
           torch::lazy::NodeCast<ir::ops::ConvolutionOverrideable>(
               node, torch::lazy::OpKind(at::aten::convolution_overrideable)));
-    }
-    case at::aten::permute: {
-      auto permute = torch::lazy::NodeCast<ir::ops::Permute>(
-          node, torch::lazy::OpKind(at::aten::permute));
-      const torch::lazy::Output& argument = node->operand(0);
-      return ir::ops::Permute::MakePermuteShape(
-          torch::lazy::GetShapeFromTsOutput(argument), permute->dims());
     }
     // activation and unary op do not change shape
     case at::aten::pow: {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/generic_slice.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/generic_slice.cpp
@@ -1,7 +1,6 @@
 #include "lazy_tensor_core/csrc/view_ops/generic_slice.h"
 
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
-#include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -15,7 +14,10 @@ GenericSlice::GenericSlice(const torch::lazy::Value& input,
                           torch::lazy::MHash(base_indices, sizes)),
       base_indices_(base_indices.begin(), base_indices.end()),
       sizes_(sizes.begin(), sizes.end()) {
-  SetShapeDeferred([&]() { return compiler::InferShape(this); });
+  SetShapeDeferred([&]() {
+    return torch::lazy::Shape(
+        torch::lazy::GetShapeFromTsOutput(operand(0)).scalar_type(), sizes);
+  });
 }
 
 std::string GenericSlice::ToString() const {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/permute.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/permute.cpp
@@ -1,7 +1,6 @@
 #include "lazy_tensor_core/csrc/view_ops/permute.h"
 
 #include "lazy_tensor_core/csrc/helpers.h"
-#include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -11,7 +10,10 @@ Permute::Permute(const torch::lazy::Value& input, std::vector<int64_t> dims)
     : torch::lazy::TsNode(torch::lazy::OpKind(at::aten::permute), {input},
                           /*num_outputs=*/1, torch::lazy::MHash(dims)),
       dims_(std::move(dims)) {
-  SetShapeDeferred([&]() { return compiler::InferShape(this); });
+  SetShapeDeferred([&]() {
+    return MakePermuteShape(torch::lazy::GetShapeFromTsOutput(operand(0)),
+                            dims_);
+  });
 }
 
 std::string Permute::ToString() const {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/update_slice.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/update_slice.cpp
@@ -1,7 +1,6 @@
 #include "lazy_tensor_core/csrc/view_ops/update_slice.h"
 
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
-#include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
 
 namespace torch_lazy_tensors {
 namespace ir {
@@ -13,7 +12,8 @@ UpdateSlice::UpdateSlice(const torch::lazy::Value& input,
     : torch::lazy::TsNode(ltc_update_slice, {input, source},
                           /*num_outputs=*/1, torch::lazy::MHash(base_indices)),
       base_indices_(base_indices.begin(), base_indices.end()) {
-  SetShapeDeferred([&]() { return compiler::InferShape(this); });
+  SetShapeDeferred(
+      [&]() { return torch::lazy::GetShapeFromTsOutput(operand(0)); });
 }
 
 std::string UpdateSlice::ToString() const {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/view.cpp
@@ -1,9 +1,6 @@
 #include "lazy_tensor_core/csrc/view_ops/view.h"
 
 #include <ATen/InferSize.h>
-#include <torch/csrc/lazy/core/shape.h>
-
-#include "lazy_tensor_core/csrc/helpers.h"
 
 namespace torch_lazy_tensors {
 namespace ir {


### PR DESCRIPTION
Summary: Implement view ops shape inference logic in the corresponding
node definition, to break the dependency on ts_shape_inference
