### PR TITLE
[SR] Fix stack/concat bug

### DIFF
--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -21,4 +21,12 @@ inline void check_cat_shape_except_dim(const Tensor & first, const Tensor & seco
    }
  }
 
+inline void check_cat_no_zero_dim(at::ArrayRef<Tensor> tensors) {
+  for(const auto i : c10::irange(tensors.size())) {
+    auto& t = tensors[i];
+    TORCH_CHECK(t.dim() > 0,
+             "zero-dimensional tensor (at position ", i, ") cannot be concatenated");
+  }
+}
+
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -430,6 +430,8 @@ inline c10::MemoryFormat compute_output_memory_format(const TensorList &inputs) 
 }
 
 Tensor& cat_out_cuda(TensorList inputs, int64_t dimension, Tensor& out) {
+  check_cat_no_zero_dim(inputs);
+  dimension = legacy_cat_wrap_dim(dimension, inputs);
 
   // previously, size [0] tensors were the only possible empty tensors; thus, it
   // wasn't possible to cat empty tensors unless all the other tensors were

--- a/aten/src/ATen/native/quantized/cpu/qconcat.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconcat.cpp
@@ -2,6 +2,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/TensorShape.h>
 #include <ATen/NativeFunctions.h>
 #include <c10/util/irange.h>
 #include <torch/library.h>
@@ -138,7 +139,8 @@ Tensor cat_quantized_cpu(TensorList qxs, int64_t dim) {
   TORCH_CHECK(
       all_inputs_sharing_qparams(qxs),
       "All inputs should share the same quantization parameters.");
-
+  check_cat_no_zero_dim(qxs);
+  dim = legacy_cat_wrap_dim(dim, qxs);
   double _scale = qxs[0].q_scale();
   int64_t _zero_point = qxs[0].q_zero_point();
   return quantized_cat_impl<false>(c10::List<Tensor>(qxs), dim, _scale, _zero_point);
@@ -149,6 +151,8 @@ Tensor& cat_out_quantized_cpu(TensorList qxs, int64_t dim, Tensor& out) {
               "Only per-tensor quantization is supported in 'cat'!")
   TORCH_CHECK(is_valid_quantization_scheme(out),
               "Only per-tensor quantization is supported in 'cat'!")
+  check_cat_no_zero_dim(qxs);
+  dim = legacy_cat_wrap_dim(dim, qxs);
   auto out_ = quantized_cat_impl<false>(c10::List<Tensor>(qxs), dim, out.q_scale(),
                                         out.q_zero_point());
   at::native::copy_(out, out_, /*non_blocking=*/false);

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -657,12 +657,16 @@ TEST(StaticRuntime, NanToNum) {
 TEST(StaticRuntime, Stack) {
   const auto stack_dim = R"JIT(
     def forward(self, a: Tensor, b: Tensor, dim: int):
-        return torch.stack((a, b), dim = dim).clone()
+        inputs = [a]
+        inputs.append(b) # mutation to avoid using VarStack
+        return torch.stack(inputs, dim = dim).clone()
   )JIT";
 
   const auto stack_three = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.stack((a, b, c)).clone()
+        inputs = [a, b]
+        inputs.append(c) # mutation to avoid using VarStack
+        return torch.stack(inputs).clone()
   )JIT";
 
   auto a = at::randn({2, 2});
@@ -675,12 +679,15 @@ TEST(StaticRuntime, Stack) {
 
   std::vector<IValue> args1_dim{a, b, 0};
   std::vector<IValue> args2_dim{d, e, 1};
+  std::vector<IValue> args_dim_negative{d, e, -1};
 
   std::vector<IValue> args1_three_tensors{a, b, c};
   std::vector<IValue> args2_three_tensors{d, e, f};
 
   testStaticRuntime(stack_dim, args1_dim);
   testStaticRuntime(stack_dim, args1_dim, args2_dim);
+
+  testStaticRuntime(stack_dim, args_dim_negative);
 
   testStaticRuntime(stack_three, args1_three_tensors);
   testStaticRuntime(stack_three, args1_three_tensors, args2_three_tensors);
@@ -1183,6 +1190,10 @@ TEST(StaticRuntime, VarCat) {
   // 3D tensors - cat dim = 2
   std::vector<IValue> args3 = {at::randn({4, 5, 6}), at::randn({4, 5, 7}), 2};
   testStaticRuntime(var_cat_script, args3);
+
+  // Negative dim
+  std::vector<IValue> args4 = {at::randn({4, 5, 6}), at::randn({4, 5, 7}), -1};
+  testStaticRuntime(var_cat_script, args4);
 
   testStaticRuntime(var_cat_script, args1, args2);
 }
@@ -1718,6 +1729,10 @@ TEST(StaticRuntime, VarStack) {
   std::vector<IValue> args3 = {at::randn({4, 5, 6}), at::randn({4, 5, 6}), 2};
   testStaticRuntime(var_stack_script, args3);
 
+  // Negative dim
+  std::vector<IValue> args4 = {at::randn({4, 5, 6}), at::randn({4, 5, 6}), -1};
+  testStaticRuntime(var_stack_script, args4);
+
   testStaticRuntime(var_stack_script, args1, args2);
 }
 
@@ -1844,6 +1859,9 @@ TEST(StaticRuntime, Cat) {
   auto d = at::randn({3, 5});
   std::vector<IValue> args1{c, d, 1};
   testStaticRuntime(cat_script, args0, args1);
+
+  std::vector<IValue> args_dim_negative{c, d, -1};
+  testStaticRuntime(cat_script, args_dim_negative);
 }
 
 TEST(StaticRuntime, Cumsum) {


### PR DESCRIPTION
Summary:
Fixed some cases where negative dimensions were not handled correctly

* `_stack_cpu` calls `maybe_wrap_dim`, but `_stack_cpu_out` does not. This is only problematic when `_stack_cpu_out` forwards to the serial kernel: [ref](https://www.internalfb.com/code/fbsource/[1b5af978b48f2e5d308d42b588bde3275869a57b]/fbcode/caffe2/aten/src/ATen/native/TensorShape.cpp?lines=1541-1547).
* concat also needs to wrap its dim

Test Plan:
`buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Added new tests to cover this case

Differential Revision: D32604623

