### PR TITLE
[BE] Simplify magma installation logic

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -86,10 +86,10 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     conda_install numpy=1.18.5 astunparse pyyaml mkl mkl-include setuptools cffi future six dataclasses typing_extensions
   fi
 
-  # Magma package names are concatenation of CUDA major and minor
-  # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2
+  # Magma package names are concatenation of CUDA major and minor ignoring revision
+  # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2 and CUDA_VERSION=10.2.89
   if [ -n "$CUDA_VERSION" ]; then
-    conda_install magma-cuda${CUDA_VERSION//./} -c pytorch
+    conda_install magma-cuda${${CUDA_VERSION/./}/.*[0-9]/} -c pytorch
   fi
 
   # TODO: This isn't working atm

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -86,17 +86,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     conda_install numpy=1.18.5 astunparse pyyaml mkl mkl-include setuptools cffi future six dataclasses typing_extensions
   fi
 
-  if [[ "$CUDA_VERSION" == 10.2* ]]; then
-    conda_install magma-cuda102 -c pytorch
-  elif [[ "$CUDA_VERSION" == 11.0* ]]; then
-    conda_install magma-cuda110 -c pytorch
-  elif [[ "$CUDA_VERSION" == 11.1* ]]; then
-    conda_install magma-cuda111 -c pytorch
-  elif [[ "$CUDA_VERSION" == 11.3* ]]; then
-    conda_install magma-cuda113 -c pytorch
-  elif [[ "$CUDA_VERSION" == 11.5* ]]; then
-    conda_install magma-cuda115 -c pytorch
-  fi
+  # Magma package names are concatenation of CUDA major and minor
+  # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2
+  conda_install magma-cuda${CUDA_VERSION//./}
 
   # TODO: This isn't working atm
   conda_install nnpack -c killeent

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -89,7 +89,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Magma package names are concatenation of CUDA major and minor ignoring revision
   # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2 and CUDA_VERSION=10.2.89
   if [ -n "$CUDA_VERSION" ]; then
-    conda_install magma-cuda${${CUDA_VERSION/./}/.*[0-9]/} -c pytorch
+    conda_install magma-cuda$(TMP=${CUDA_VERSION/./};echo ${TMP%.*[0-9]}) -c pytorch
   fi
 
   # TODO: This isn't working atm

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -88,7 +88,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   # Magma package names are concatenation of CUDA major and minor
   # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2
-  conda_install magma-cuda${CUDA_VERSION//./}
+  conda_install magma-cuda${CUDA_VERSION//./} -c pytorch
 
   # TODO: This isn't working atm
   conda_install nnpack -c killeent

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -88,7 +88,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   # Magma package names are concatenation of CUDA major and minor
   # I.e. magma-cuda102 package corresponds to CUDA_VERSION=10.2
-  conda_install magma-cuda${CUDA_VERSION//./} -c pytorch
+  if [ -n "$CUDA_VERSION" ]; then
+    conda_install magma-cuda${CUDA_VERSION//./} -c pytorch
+  fi
 
   # TODO: This isn't working atm
   conda_install nnpack -c killeent


### PR DESCRIPTION
Difference between `CUDA_VERSION` is magma package name is just a dot between major and minor

In process of refactoring, discovered that some docker images set `CUDA_VERSION` to contain minor revision, so modified pattern to strip it, i.e. `cuda-magma102` would be installed for `CUDA_VERSION=10.2.89` and `cuda-magma113` would be installed for `CUDA_VERSION=11.3.0`

