### PR TITLE
Keep the sequence or mapping type in `default_collate`

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -832,6 +832,14 @@ class BulkLoadingSampler(torch.utils.data.Sampler):
         return int(math.ceil(len(self.dataset) / float(self.batch_size)))
 
 
+class CustomList(list):
+    pass
+
+
+class CustomDict(dict):
+    pass
+
+
 @unittest.skipIf(
     TEST_WITH_TSAN,
     "Fails with TSAN with the following error: starting new threads after multi-threaded "
@@ -1905,6 +1913,24 @@ except RuntimeError as e:
             batch = next(iter(loader))
             self.assertIsInstance(batch, tt)
 
+    def test_default_convert_mapping_keep_type(self):
+        data = CustomDict({"a": 1, "b": 2})
+        converted = _utils.collate.default_convert(data)
+
+        self.assertEqual(converted, data)
+
+    def test_default_convert_sequence_keep_type(self):
+        data = CustomList([1, 2, 3])
+        converted = _utils.collate.default_convert(data)
+
+        self.assertEqual(converted, data)
+
+    def test_default_convert_sequence_dont_keep_type(self):
+        data = range(2)
+        converted = _utils.collate.default_convert(data)
+
+        self.assertEqual(converted, [0, 1, 2])
+
     def test_default_collate_dtype(self):
         arr = [1, 2, -1]
         collated = _utils.collate.default_collate(arr)
@@ -1925,6 +1951,30 @@ except RuntimeError as e:
         # Should be a no-op
         arr = ['a', 'b', 'c']
         self.assertEqual(arr, _utils.collate.default_collate(arr))
+
+    def test_default_collate_mapping_keep_type(self):
+        batch = [CustomDict({"a": 1, "b": 2}), CustomDict({"a": 3, "b": 4})]
+        collated = _utils.collate.default_collate(batch)
+
+        expected = CustomDict({"a": torch.tensor([1, 3]), "b": torch.tensor([2, 4])})
+        self.assertEqual(collated, expected)
+
+    def test_default_collate_sequence_keep_type(self):
+        batch = [CustomList([1, 2, 3]), CustomList([4, 5, 6])]
+        collated = _utils.collate.default_collate(batch)
+
+        expected = CustomList([
+            torch.tensor([1, 4]),
+            torch.tensor([2, 5]),
+            torch.tensor([3, 6]),
+        ])
+        self.assertEqual(collated, expected)
+
+    def test_default_collate_sequence_dont_keep_type(self):
+        batch = [range(2), range(2)]
+        collated = _utils.collate.default_collate(batch)
+
+        self.assertEqual(collated, [torch.tensor([0, 0]), torch.tensor([1, 1])])
 
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_default_collate_bad_numpy_types(self):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1929,7 +1929,7 @@ except RuntimeError as e:
         data = range(2)
         converted = _utils.collate.default_convert(data)
 
-        self.assertEqual(converted, [0, 1, 2])
+        self.assertEqual(converted, [0, 1])
 
     def test_default_collate_dtype(self):
         arr = [1, 2, -1]

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1,3 +1,4 @@
+import collections.abc
 import copy
 from dataclasses import dataclass
 from typing import Callable, Any

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1014,6 +1014,10 @@ class DistributedDataParallel(Module, Joinable):
                 return [type(obj)(*args) for args in zip(*map(to_map, obj))]
             if isinstance(obj, tuple) and len(obj) > 0:
                 return list(zip(*map(to_map, obj)))
+            if isinstance(obj, str):
+                # Needs to be checked, otherwise it's taken as a sequence infinitely.
+                # This is because the elements of a string are also strings, and so on.
+                return [obj]
             if isinstance(obj, collections.abc.Sequence) and len(obj) > 0:
                 try:
                     return [type(obj)(i) for i in zip(*map(to_map, obj))]

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -95,7 +95,7 @@ def default_collate(batch):
         if not all(len(elem) == elem_size for elem in it):
             raise RuntimeError('each element in list of batch should be of equal size')
         transposed = list(zip(*batch))  # It may be accessed twice, so we use a list.
-        
+
         if elem is tuple:
             return [default_collate(samples) for samples in transposed]  # Backwards compatibility.
         else:

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -27,7 +27,7 @@ def default_convert(data):
         return torch.as_tensor(data)
     elif isinstance(data, collections.abc.Mapping):
         try:
-            return elem_type((key, default_convert(data[key])) for key in data)
+            return elem_type({key: default_convert(data[key]) for key in data})
         except BaseException:
             # The mapping type may not support `__init__(iterable)`.
             return {key: default_convert(data[key]) for key in data}
@@ -80,7 +80,7 @@ def default_collate(batch):
         return batch
     elif isinstance(elem, collections.abc.Mapping):
         try:
-            return elem_type((key, default_collate([d[key] for d in batch])) for key in elem)
+            return elem_type({key: default_collate([d[key] for d in batch]) for key in elem})
         except BaseException:
             # The mapping type may not support `__init__(iterable)`.
             return {key: default_collate([d[key] for d in batch]) for key in elem}

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -35,7 +35,7 @@ def default_convert(data):
         return elem_type(*(default_convert(d) for d in data))
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, string_classes):
         try:
-            return elem_type(default_convert(d) for d in data)
+            return elem_type([default_convert(d) for d in data])
         except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [default_convert(d) for d in data]
@@ -94,7 +94,7 @@ def default_collate(batch):
             raise RuntimeError('each element in list of batch should be of equal size')
         transposed = zip(*batch)
         try:
-            return elem_type(default_collate(samples) for samples in transposed)
+            return elem_type([default_collate(samples) for samples in transposed])
         except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [default_collate(samples) for samples in transposed]

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -28,7 +28,7 @@ def default_convert(data):
     elif isinstance(data, collections.abc.Mapping):
         try:
             return elem_type({key: default_convert(data[key]) for key in data})
-        except BaseException:
+        except TypeError:
             # The mapping type may not support `__init__(iterable)`.
             return {key: default_convert(data[key]) for key in data}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
@@ -36,7 +36,7 @@ def default_convert(data):
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, string_classes):
         try:
             return elem_type([default_convert(d) for d in data])
-        except BaseException:
+        except TypeError:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [default_convert(d) for d in data]
     else:
@@ -81,7 +81,7 @@ def default_collate(batch):
     elif isinstance(elem, collections.abc.Mapping):
         try:
             return elem_type({key: default_collate([d[key] for d in batch]) for key in elem})
-        except BaseException:
+        except TypeError:
             # The mapping type may not support `__init__(iterable)`.
             return {key: default_collate([d[key] for d in batch]) for key in elem}
     elif isinstance(elem, tuple) and hasattr(elem, '_fields'):  # namedtuple
@@ -95,7 +95,7 @@ def default_collate(batch):
         transposed = zip(*batch)
         try:
             return elem_type([default_collate(samples) for samples in transposed])
-        except BaseException:
+        except TypeError:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [default_collate(samples) for samples in transposed]
 

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -30,7 +30,11 @@ def default_convert(data):
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return elem_type(*(default_convert(d) for d in data))
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, string_classes):
-        return [default_convert(d) for d in data]
+        try:
+            return elem_type(default_convert(d) for d in data)
+        except:
+            # The sequence type may not support `__init__(iterable)` (e.g., `range`).
+            return [default_convert(d) for d in data]
     else:
         return data
 
@@ -81,6 +85,10 @@ def default_collate(batch):
         if not all(len(elem) == elem_size for elem in it):
             raise RuntimeError('each element in list of batch should be of equal size')
         transposed = zip(*batch)
-        return [default_collate(samples) for samples in transposed]
+        try:
+            return elem_type(default_collate(samples) for samples in transposed)
+        except:
+            # The sequence type may not support `__init__(iterable)` (e.g., `range`).
+            return [default_collate(samples) for samples in transposed]
 
     raise TypeError(default_collate_err_msg_format.format(elem_type))

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -33,7 +33,7 @@ def default_convert(data):
             return {key: default_convert(data[key]) for key in data}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return elem_type(*(default_convert(d) for d in data))
-    elif elem_type is tuple:
+    elif isinstance(data, tuple):
         return [default_convert(d) for d in data]  # Backwards compatibility.
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, string_classes):
         try:
@@ -96,7 +96,7 @@ def default_collate(batch):
             raise RuntimeError('each element in list of batch should be of equal size')
         transposed = list(zip(*batch))  # It may be accessed twice, so we use a list.
 
-        if elem is tuple:
+        if isinstance(elem,  tuple):
             return [default_collate(samples) for samples in transposed]  # Backwards compatibility.
         else:
             try:

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -97,8 +97,7 @@ def default_collate(batch):
         transposed = list(zip(*batch))  # It may be accessed twice, so we use a list.
         
         if elem is tuple:
-            
-            return [default_collate(samples) for samples in transposed]  # Backwards compatibility
+            return [default_collate(samples) for samples in transposed]  # Backwards compatibility.
         else:
             try:
                 return elem_type([default_collate(samples) for samples in transposed])

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -96,7 +96,7 @@ def default_collate(batch):
             raise RuntimeError('each element in list of batch should be of equal size')
         transposed = list(zip(*batch))  # It may be accessed twice, so we use a list.
 
-        if isinstance(elem,  tuple):
+        if isinstance(elem, tuple):
             return [default_collate(samples) for samples in transposed]  # Backwards compatibility.
         else:
             try:

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -32,7 +32,7 @@ def default_convert(data):
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, string_classes):
         try:
             return elem_type(default_convert(d) for d in data)
-        except:
+        except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [default_convert(d) for d in data]
     else:
@@ -87,7 +87,7 @@ def default_collate(batch):
         transposed = zip(*batch)
         try:
             return elem_type(default_collate(samples) for samples in transposed)
-        except:
+        except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [default_collate(samples) for samples in transposed]
 

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -92,7 +92,7 @@ def default_collate(batch):
         elem_size = len(next(it))
         if not all(len(elem) == elem_size for elem in it):
             raise RuntimeError('each element in list of batch should be of equal size')
-        transposed = zip(*batch)
+        transposed = list(zip(*batch))  # It may be accessed twice, so we use a list.
         try:
             return elem_type([default_collate(samples) for samples in transposed])
         except TypeError:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -52,7 +52,7 @@ def pin_memory(data):
         return data
     elif isinstance(data, collections.abc.Mapping):
         try:
-            return type(data)((k, pin_memory(sample)) for k, sample in data.items())  # type: ignore[call-arg]
+            return type(data)({k: pin_memory(sample) for k, sample in data.items()})  # type: ignore[call-arg]
         except BaseException:
             # The mapping type may not support `__init__(iterable)`.
             return {k: pin_memory(sample) for k, sample in data.items()}

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -56,8 +56,8 @@ def pin_memory(data):
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, collections.abc.Sequence):
         try:
-            return elem_type(pin_memory(sample) for sample in data)
-        except:
+            return type(data)(pin_memory(sample) for sample in data)
+        except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [pin_memory(sample) for sample in data]
     elif hasattr(data, "pin_memory"):

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -55,7 +55,11 @@ def pin_memory(data):
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, collections.abc.Sequence):
-        return [pin_memory(sample) for sample in data]
+        try:
+            return elem_type(pin_memory(sample) for sample in data)
+        except:
+            # The sequence type may not support `__init__(iterable)` (e.g., `range`).
+            return [pin_memory(sample) for sample in data]
     elif hasattr(data, "pin_memory"):
         return data.pin_memory()
     else:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -60,7 +60,7 @@ def pin_memory(data):
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, collections.abc.Sequence):
         try:
-            return type(data)(pin_memory(sample) for sample in data)  # type: ignore[call-arg]
+            return type(data)([pin_memory(sample) for sample in data])  # type: ignore[call-arg]
         except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [pin_memory(sample) for sample in data]

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -53,7 +53,7 @@ def pin_memory(data):
     elif isinstance(data, collections.abc.Mapping):
         try:
             return type(data)({k: pin_memory(sample) for k, sample in data.items()})  # type: ignore[call-arg]
-        except BaseException:
+        except TypeError:
             # The mapping type may not support `__init__(iterable)`.
             return {k: pin_memory(sample) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
@@ -61,7 +61,7 @@ def pin_memory(data):
     elif isinstance(data, collections.abc.Sequence):
         try:
             return type(data)([pin_memory(sample) for sample in data])  # type: ignore[call-arg]
-        except BaseException:
+        except TypeError:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [pin_memory(sample) for sample in data]
     elif hasattr(data, "pin_memory"):

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -58,6 +58,8 @@ def pin_memory(data):
             return {k: pin_memory(sample) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return type(data)(*(pin_memory(sample) for sample in data))
+    elif type(data) is tuple:
+        return [pin_memory(sample) for sample in data]  # Backwards compatibility.
     elif isinstance(data, collections.abc.Sequence):
         try:
             return type(data)([pin_memory(sample) for sample in data])  # type: ignore[call-arg]

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -58,7 +58,7 @@ def pin_memory(data):
             return {k: pin_memory(sample) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return type(data)(*(pin_memory(sample) for sample in data))
-    elif type(data) is tuple:
+    elif isinstance(data, tuple):
         return [pin_memory(sample) for sample in data]  # Backwards compatibility.
     elif isinstance(data, collections.abc.Sequence):
         try:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -56,7 +56,7 @@ def pin_memory(data):
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, collections.abc.Sequence):
         try:
-            return type(data)(pin_memory(sample) for sample in data)  # type: ignore
+            return type(data)(pin_memory(sample) for sample in data)  # type: ignore[call-arg]
         except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [pin_memory(sample) for sample in data]

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -52,7 +52,7 @@ def pin_memory(data):
         return data
     elif isinstance(data, collections.abc.Mapping):
         try:
-            return type(data)((k, pin_memory(sample)) for k, sample in data.items())
+            return type(data)((k, pin_memory(sample)) for k, sample in data.items())  # type: ignore[call-arg]
         except BaseException:
             # The mapping type may not support `__init__(iterable)`.
             return {k: pin_memory(sample) for k, sample in data.items()}

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -51,7 +51,11 @@ def pin_memory(data):
     elif isinstance(data, string_classes):
         return data
     elif isinstance(data, collections.abc.Mapping):
-        return {k: pin_memory(sample) for k, sample in data.items()}
+        try:
+            return type(data)((k, pin_memory(sample)) for k, sample in data.items())
+        except BaseException:
+            # The mapping type may not support `__init__(iterable)`.
+            return {k: pin_memory(sample) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, collections.abc.Sequence):

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -56,7 +56,7 @@ def pin_memory(data):
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, collections.abc.Sequence):
         try:
-            return type(data)(pin_memory(sample) for sample in data)
+            return type(data)(pin_memory(sample) for sample in data)  # type: ignore
         except BaseException:
             # The sequence type may not support `__init__(iterable)` (e.g., `range`).
             return [pin_memory(sample) for sample in data]


### PR DESCRIPTION
`default_collate`, `default_convert`, and `pin_memory` convert sequences into lists. I believe they should keep the original type when possible (e.g., I have a class that inherits from `list`, which comes from a 3rd party library that I can't change, and provides extra functionality).

Note it's easy to do when the type supports an iterable in its creation but it's not always the case (e.g., `range`).

Even though this can be accomplished if using a custom `default_collate`/`default_convert`, 1) this is behavior they should support out-of-the-box IMHO, and 2) `pin_memory` still does it.

cc @VitalyFedyunin @ejguan @NivekT