### PR TITLE
Implement sharding for MacOS jobs

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -628,11 +628,14 @@ IOS_WORKFLOWS = [
 ]
 
 MACOS_WORKFLOWS = [
+    # Distributed tests are still run on MacOS, but part of regular shards
     CIWorkflow(
         arch="macos",
         build_environment="macos-11-py3-x86-64",
         xcode_version="12.4",
         test_runner_type=MACOS_TEST_RUNNER_11,
+        num_test_shards=2,
+        distributed_test=False,
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_MACOS},
         ),

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -35,12 +35,8 @@ env:
 
 jobs:
 !{{ common.ciflow_should_run_job(ciflow_config) }}
-{% block build_test +%}
-{%- if exclude_test %}
+{% block build +%}
   build:
-{%- else %}
-  build-test:
-{%- endif %}
     runs-on: !{{ test_runner_type }}
     needs: [!{{ ciflow_config.root_job_name }}]
     env:
@@ -70,7 +66,7 @@ jobs:
         run: |
           zip -1 -r artifacts.zip dist/
       - uses: actions/upload-artifact@v2
-        name: Store PyTorch Build Artifacts on S3
+        name: Store PyTorch Build Artifacts on GHA
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
           retention-days: 14
@@ -78,16 +74,70 @@ jobs:
           path:
             artifacts.zip
 {%- endif %}
+{% endblock +%}
 {%- if not exclude_test %}
+{% block test +%}
+  generate-test-matrix:
+    runs-on: ubuntu-18.04
+    needs: [!{{ ciflow_config.root_job_name }}]
+    timeout-minutes: !{{ common.timeout_minutes }}
+    env:
+      TEST_RUNNER_TYPE: !{{ test_runner_type }}
+      ENABLE_DISTRIBUTED_TEST: !{{ enable_distributed_test }}
+      NUM_TEST_SHARDS: !{{ num_test_shards }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
+      ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
+    container:
+      image: python:3.9
+    steps:
+      - name: Install dependencies
+        run: pip install typing-extensions==3.10
+      - name: Clone pytorch/pytorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+      - name: Generating test matrix
+        id: set-matrix
+        run: .github/scripts/generate_pytorch_test_matrix.py
+
+  test:
+    needs: [build, generate-test-matrix, !{{ ciflow_config.root_job_name }}]
+    strategy:
+      matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
+      fail-fast: false
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: !{{ common.timeout_minutes }}
+    env:
+      JOB_BASE_NAME: !{{ build_environment }}-test
+      TEST_CONFIG: ${{ matrix.config }}
+      SHARD_NUMBER: ${{ matrix.shard }}
+      NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
+    steps:
+      !{{ common.checkout_pytorch("false") }}
+      - uses: actions/download-artifact@v2
+        name: Download PyTorch Build Artifacts from GHA
+        with:
+          name: ${{ env.BUILD_ENVIRONMENT }}
+          path: .
+      - name: Unzip artifacts
+        run: |
+          unzip -o artifacts.zip
+      !{{ common.setup_miniconda("3.8") }}
+      - name: Install macOS homebrew dependencies
+        run: |
+          # Install dependencies
+          brew install libomp
+      !{{ common.parse_ref() }}
       - name: Test
         run: |
-          python -m pip install dist/*.whl
+          python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
-      !{{ common.parse_ref() }}
       !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
-{%- endif %}
 {% endblock +%}
+{%- endif %}
 
 !{{ common.concurrency(build_environment) }}

--- a/.github/workflows/generated-macos-10-15-py3-arm64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-arm64.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           zip -1 -r artifacts.zip dist/
       - uses: actions/upload-artifact@v2
-        name: Store PyTorch Build Artifacts on S3
+        name: Store PyTorch Build Artifacts on GHA
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
           retention-days: 14

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -47,7 +47,7 @@ jobs:
       - name: print labels
         run: echo "${LABELS}"
 
-  build-test:
+  build:
     runs-on: macos-11
     needs: [ciflow_should_run]
     env:
@@ -86,16 +86,83 @@ jobs:
         run: |
           zip -1 -r artifacts.zip dist/
       - uses: actions/upload-artifact@v2
-        name: Store PyTorch Build Artifacts on S3
+        name: Store PyTorch Build Artifacts on GHA
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
           retention-days: 14
           if-no-files-found: error
           path:
             artifacts.zip
+
+
+  generate-test-matrix:
+    runs-on: ubuntu-18.04
+    needs: [ciflow_should_run]
+    timeout-minutes: 240
+    env:
+      TEST_RUNNER_TYPE: macos-11
+      ENABLE_DISTRIBUTED_TEST: ''
+      NUM_TEST_SHARDS: 2
+      PR_BODY: ${{ github.event.pull_request.body }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      render-matrix: ${{ steps.set-matrix.outputs.render-matrix }}
+      ignore-disabled-issues: ${{ steps.set-matrix.outputs.ignore-disabled-issues }}
+    container:
+      image: python:3.9
+    steps:
+      - name: Install dependencies
+        run: pip install typing-extensions==3.10
+      - name: Clone pytorch/pytorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+      - name: Generating test matrix
+        id: set-matrix
+        run: .github/scripts/generate_pytorch_test_matrix.py
+
+  test:
+    needs: [build, generate-test-matrix, ciflow_should_run]
+    strategy:
+      matrix: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
+      fail-fast: false
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 240
+    env:
+      JOB_BASE_NAME: macos-11-py3-x86-64-test
+      TEST_CONFIG: ${{ matrix.config }}
+      SHARD_NUMBER: ${{ matrix.shard }}
+      NUM_TEST_SHARDS: ${{ matrix.num_shards }}
+      PYTORCH_IGNORE_DISABLED_ISSUES: ${{ needs.generate-test-matrix.outputs.ignore-disabled-issues }}
+    steps:
+      - name: Checkout PyTorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
+          submodules: false
+      - uses: actions/download-artifact@v2
+        name: Download PyTorch Build Artifacts from GHA
+        with:
+          name: ${{ env.BUILD_ENVIRONMENT }}
+          path: .
+      - name: Unzip artifacts
+        run: |
+          unzip -o artifacts.zip
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.8
+          activate-environment: build
+      - name: Install macOS homebrew dependencies
+        run: |
+          # Install dependencies
+          brew install libomp
+      - name: Parse ref
+        id: parse-ref
+        run: .github/scripts/parse_ref.py
       - name: Test
         run: |
-          python -m pip install dist/*.whl
+          python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh
       - name: Install render_test_results dependencies
         if: always()
@@ -127,9 +194,6 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Parse ref
-        id: parse-ref
-        run: .github/scripts/parse_ref.py
       - name: Display and upload test statistics (Click Me)
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         # temporary hack: set CIRCLE_* vars, until we update


### PR DESCRIPTION
Do not run distributed tests as part of separate shard, but keep it inside one of the two shards (to limit concurrency problems)
Fixes https://github.com/pytorch/pytorch/issues/68260