### PR TITLE
native_functions.yaml: remove SparseXPU which is added by accident

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1275,7 +1275,7 @@
   device_guard: False
   dispatch:
     MkldnnCPU: copy_mkldnn_
-    SparseCPU, SparseCUDA, SparseHIP, SparseXPU: copy_sparse_wrapper_
+    SparseCPU, SparseCUDA, SparseHIP: copy_sparse_wrapper_
     CompositeExplicitAutograd: copy_
     SparseCsrCPU, SparseCsrCUDA: copy_sparse_csr_
 


### PR DESCRIPTION
gen_backend_stubs.py will report 'assert' when generate code with
SparseXPU dispatch key for external backends, if SparseXPU is in
native_functions.yaml.