### PR TITLE
[sparsity] Fix for the failing pruner test

### DIFF
--- a/test/ao/sparsity/test_pruner.py
+++ b/test/ao/sparsity/test_pruner.py
@@ -251,7 +251,7 @@ class TestBasePruner(TestCase):
                 assert module.parametrizations.weight[0].pruned_outputs == pruned_set
 
     def _test_constructor_on_device(self, model, device):
-        self.assertRaisesRegex(TypeError, 'with abstract method update_mask',
+        self.assertRaisesRegex(TypeError, 'BasePruner .* update_mask',
                                BasePruner)
         model1 = copy.deepcopy(model).to(device)
         pruner = SimplePruner(None)

--- a/test/ao/sparsity/test_pruner.py
+++ b/test/ao/sparsity/test_pruner.py
@@ -251,7 +251,7 @@ class TestBasePruner(TestCase):
                 assert module.parametrizations.weight[0].pruned_outputs == pruned_set
 
     def _test_constructor_on_device(self, model, device):
-        self.assertRaisesRegex(TypeError, 'with abstract methods update_mask',
+        self.assertRaisesRegex(TypeError, 'with abstract method update_mask',
                                BasePruner)
         model1 = copy.deepcopy(model).to(device)
         pruner = SimplePruner(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68794

The pruner `test_constructor` fails because of a typo in the regular expression matching for the error that the pruner throws. See for details: https://github.com/pytorch/pytorch/runs/4293615334?check_suite_focus=true
This fixes it.

Test Plan:

Separate test is not needed -- single letter change.
Previous test: `python test/test_ao_sparsity.py -- TestBasePruner

Differential Revision: [D32609589](https://our.internmc.facebook.com/intern/diff/D32609589)