### PR TITLE
[SR] Scope exit guard for memory planner deallocation

### DIFF
--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -22,6 +22,27 @@ namespace test {
 
 namespace {
 
+class GraphExecutorWrapper {
+ public:
+  GraphExecutorWrapper() = default;
+
+  explicit GraphExecutorWrapper(const std::shared_ptr<Graph>& graph)
+      : graph_exec_(graph, "") {}
+
+  c10::IValue operator()(const std::vector<c10::IValue>& args) {
+    Stack stack(args);
+    graph_exec_.run(stack);
+
+    if (stack.size() == 1) {
+      return stack[0];
+    }
+    return c10::ivalue::Tuple::create(stack);
+  }
+
+ private:
+  GraphExecutor graph_exec_;
+};
+
 // Test scripts passed to testStaticRuntime can either be IR or JIT.
 // The logic for running the script and producing a corresponding StaticModule
 // is a bit different for each case. This logic is encapsulated within concrete
@@ -62,17 +83,11 @@ class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
     std::unordered_map<std::string, Value*> vmap;
     parseIR(source_ir, graph_.get(), vmap);
 
-    graph_exec_ = GraphExecutor(graph_, "");
+    graph_exec_ = GraphExecutorWrapper(graph_);
   }
 
   IValue getExpected(const std::vector<IValue>& args) override {
-    Stack stack(args);
-    graph_exec_.run(stack);
-
-    if (stack.size() == 1) {
-      return stack[0];
-    }
-    return c10::ivalue::Tuple::create(stack);
+    return graph_exec_(args);
   }
 
   StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
@@ -81,7 +96,7 @@ class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
 
  private:
   std::shared_ptr<Graph> graph_;
-  GraphExecutor graph_exec_;
+  GraphExecutorWrapper graph_exec_;
 };
 
 std::unique_ptr<StaticRuntimeTestContext> makeTestContext(
@@ -206,6 +221,19 @@ std::shared_ptr<Graph> getGraphFromIR(const std::string& ir) {
   std::unordered_map<std::string, Value*> vmap;
   parseIR(ir, graph.get(), vmap);
   return graph;
+}
+
+void compareResultsWithJIT(
+    StaticRuntime& runtime,
+    const std::shared_ptr<Graph>& graph,
+    const std::vector<c10::IValue>& args,
+    const bool use_allclose,
+    const bool use_equalnan) {
+  GraphExecutorWrapper graph_exec(graph);
+  auto expected = graph_exec(args);
+  auto actual = runtime(args, {});
+  runtime.check_for_memory_leak();
+  compareResults(expected, actual, use_allclose, use_equalnan);
 }
 
 void testStaticRuntime(

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -42,6 +42,13 @@ Node* getNodeWithKind(const StaticModule& smodule, const std::string& kind);
 
 bool hasNodeWithKind(const StaticModule& smodule, const std::string& kind);
 
+void compareResultsWithJIT(
+    StaticRuntime& runtime,
+    const std::shared_ptr<Graph>& graph,
+    const std::vector<c10::IValue>& args,
+    const bool use_allclose = false,
+    const bool use_equalnan = false);
+
 } // namespace test
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
This change improves static runtime exception safety. Added a scope exit guard that invokes `MemoryPlanner::deallocate` in its destructor.

Caveats:
* We have to be really careful with the exception behavior of `MemoryPlanner::deallocate` and `MemoryPlanner`'s constructor, because they're now both potentially called in the destructor of the scope exit guard. If an exception is thrown in the body of `run_impl`, and then `MemoryPlanner::deallocate` throws an exception, all bets are off - the program will terminate.
* There's an edge case - if it's the first run and the memory planner has not been initialized, we just don't construct the memory planner and let the tensor handles "leak" (they should be cleaned up when they're overwritten on the next run)

Test Plan: New unit tests: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Differential Revision: D32609915

