### PR TITLE
[dist_quant] change op registration to each file instead

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -18,7 +18,6 @@
 
 #ifdef USE_C10D_NCCL
 #include <c10d/ProcessGroupNCCL.hpp>
-#include <torch/csrc/distributed/c10d/quantization/quantization_gpu.h>
 #endif
 
 #ifdef USE_C10D_MPI
@@ -35,7 +34,6 @@
 
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/distributed/c10d/python_comm_hook.h>
-#include <torch/csrc/distributed/c10d/quantization/quantization.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/pybind.h>
@@ -1693,27 +1691,6 @@ static PyMethodDef methods[] = { // NOLINT
 PyMethodDef* python_functions() {
   return methods;
 }
-
-namespace quantization {
-TORCH_LIBRARY(quantization, m) {
-    m.def("_Bfloat16QuantizedToFloat(Tensor input) -> Tensor");
-    m.def("_FloatToBfloat16Quantized(Tensor input) -> Tensor");
-}
-    TORCH_LIBRARY_IMPL(quantization, CPU, m) {
-        m.impl("_Bfloat16QuantizedToFloat", _bfloat16_to_float_cpu);
-        m.impl("_FloatToBfloat16Quantized", _float_to_bfloat16_cpu);
-    }
-
-#ifdef USE_C10D_NCCL
-    #define DISPATCH_TO_CUDA(name, function) \
-        m.impl(name, torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(function)))
-    TORCH_LIBRARY_IMPL(quantization, CUDA, m) {
-        DISPATCH_TO_CUDA("_Bfloat16QuantizedToFloat", _bfloat16_to_float_cuda);
-        DISPATCH_TO_CUDA("_FloatToBfloat16Quantized", _float_to_bfloat16_cuda);
-    }
-#endif
-
-} // namespace quantization
 
 } // namespace c10d
 } // namespace distributed

--- a/torch/csrc/distributed/c10d/quantization/quantization.cpp
+++ b/torch/csrc/distributed/c10d/quantization/quantization.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/distributed/c10d/quantization/quantization.h>
 #include <torch/csrc/distributed/c10d/quantization/quantization_utils.h>
+#include <torch/library.h>
 
 namespace torch {
 namespace distributed {
@@ -87,6 +88,17 @@ at::Tensor _bfloat16_to_float_cpu(const at::Tensor& input) {
       output.data_ptr<float>());
 
   return output;
+}
+
+
+TORCH_LIBRARY(quantization, m) {
+    m.def("_Bfloat16QuantizedToFloat(Tensor input) -> Tensor");
+    m.def("_FloatToBfloat16Quantized(Tensor input) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(quantization, CPU, m) {
+    m.impl("_Bfloat16QuantizedToFloat", _bfloat16_to_float_cpu);
+    m.impl("_FloatToBfloat16Quantized", _float_to_bfloat16_cpu);
 }
 
 } // namespace quantization

--- a/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu
+++ b/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu
@@ -2,6 +2,7 @@
 #include <c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/quantization/quantization_gpu.h>
 #include <torch/csrc/distributed/c10d/quantization/quantization_utils.h>
+#include <torch/library.h>
 
 // TODO: The kernels are copied from fbgemm_gpu, we should dedup them later
 
@@ -142,6 +143,14 @@ at::Tensor _bfloat16_to_float_cuda(const at::Tensor& input) {
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return output;
+}
+
+#define DISPATCH_TO_CUDA(name, function) \
+    m.impl(name, torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(function)))
+
+TORCH_LIBRARY_IMPL(quantization, CUDA, m) {
+    DISPATCH_TO_CUDA("_Bfloat16QuantizedToFloat", _bfloat16_to_float_cuda);
+    DISPATCH_TO_CUDA("_FloatToBfloat16Quantized", _float_to_bfloat16_cuda);
 }
 
 } // namespace quantization


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

This change dist quantization op registration to each file instead, allow torch deploy test to pass

Differential Revision: [D32610679](https://our.internmc.facebook.com/intern/diff/D32610679/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang