### PR TITLE
All get_attr node to be in64 type

### DIFF
--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -172,6 +172,9 @@ class OpSupports:
             node: torch.fx.Node,
         ) -> bool:
             for arg in node._input_nodes:
+                # escape dtype check for get_attr node
+                if arg.op == "get_attr":
+                    continue
                 arg_dtype = _get_arg_dtype(arg)
                 if arg_dtype == dtype:
                     return False


### PR DESCRIPTION
Summary: Operator Support was blocking all node with dtype int64 from lowering. This diff ease the condition, for input from get_attr node(which are known not gonna be used for trt compute) to have dtype int64.

Differential Revision: D32609457

