### PR TITLE
Reduce binary size of TensorCompare.cu

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -485,12 +485,15 @@ TORCH_IMPL_FUNC(clamp_out)
  const OptionalScalarRef min,
  const OptionalScalarRef max,
  const Tensor& result) {
+  using at::native::detail::ClampLimits;
   if (min && max) {
-    clamp_scalar_stub(device_type(), *this, min.get(), max.get());
+    clamp_scalar_stub(device_type(), *this, min.get(), max.get(), ClampLimits::MinMax);
   } else if (max) {
-    at::clamp_max_outf(self, max.get(), const_cast<Tensor&>(result));
+    clamp_scalar_stub(device_type(), *this, max.get(), max.get(), ClampLimits::Max);
+//    at::clamp_max_outf(self, max.get(), const_cast<Tensor&>(result));
   } else if (min) {
-    at::clamp_min_outf(self, min.get(), const_cast<Tensor&>(result));
+    clamp_scalar_stub(device_type(), *this, min.get(), min.get(), ClampLimits::Min);
+//    at::clamp_min_outf(self, min.get(), const_cast<Tensor&>(result));
   }
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -365,11 +365,11 @@ Tensor _s_where(const Tensor& condition, const Tensor& self, const Tensor& other
   auto iter = at::TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(ret)
-    .add_input(condition)
+    .add_input(condition.scalar_type() == ScalarType::Bool ? condition : condition.to(ScalarType::Bool))
     .add_input(self)
     .add_input(other)
     .build();
-  where_kernel(iter.device_type(), iter, condition.scalar_type());
+  where_kernel(iter.device_type(), iter);
   return ret;
 }
 
@@ -490,10 +490,8 @@ TORCH_IMPL_FUNC(clamp_out)
     clamp_scalar_stub(device_type(), *this, min.get(), max.get(), ClampLimits::MinMax);
   } else if (max) {
     clamp_scalar_stub(device_type(), *this, max.get(), max.get(), ClampLimits::Max);
-//    at::clamp_max_outf(self, max.get(), const_cast<Tensor&>(result));
   } else if (min) {
     clamp_scalar_stub(device_type(), *this, min.get(), min.get(), ClampLimits::Min);
-//    at::clamp_min_outf(self, min.get(), const_cast<Tensor&>(result));
   }
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -362,10 +362,12 @@ std::vector<Tensor> where(const Tensor& condition) {
 Tensor _s_where(const Tensor& condition, const Tensor& self, const Tensor& other) {
   TORCH_CHECK(self.dtype() == other.dtype(), "expected scalar type ", self.dtype(), " but found ", other.dtype());
   Tensor ret = at::empty(self.sizes(), self.options());
+  //
+  Tensor cond_bool = condition.scalar_type() == ScalarType::Byte ? condition.to(ScalarType::Bool) : condition;
   auto iter = at::TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(ret)
-    .add_input(condition.scalar_type() == ScalarType::Bool ? condition : condition.to(ScalarType::Bool))
+    .add_input(cond_bool)
     .add_input(self)
     .add_input(other)
     .build();

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -37,10 +37,16 @@ DECLARE_DISPATCH(clamp_fn, clamp_stub);
 DECLARE_DISPATCH(clamp_fn, clamp_min_stub);
 DECLARE_DISPATCH(clamp_fn, clamp_max_stub);
 
-DECLARE_DISPATCH(void (*)(TensorIteratorBase &, const c10::Scalar&, const c10::Scalar&), clamp_scalar_stub);
+namespace detail {
+    enum class ClampLimits {Min, Max, MinMax};
+}
+
+DECLARE_DISPATCH(void (*)(TensorIteratorBase &, const c10::Scalar&, const c10::Scalar&,
+const at::native::detail::ClampLimits minmax), clamp_scalar_stub);
 DECLARE_DISPATCH(void (*)(TensorIterator &, c10::Scalar), clamp_min_scalar_stub);
 DECLARE_DISPATCH(void (*)(TensorIterator &, c10::Scalar), clamp_max_scalar_stub);
 
 using isin_default_fn = void (*)(const Tensor&, const Tensor&, bool, const Tensor&);
 DECLARE_DISPATCH(isin_default_fn, isin_default_stub);
+
 }} // namespace at::native

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -22,7 +22,7 @@ using structured_reduce_minmax_fn =
 DECLARE_DISPATCH(structured_reduce_minmax_fn, max_stub);
 DECLARE_DISPATCH(structured_reduce_minmax_fn, min_stub);
 
-using where_fn = void (*)(TensorIterator &, c10::ScalarType);
+using where_fn = void (*)(TensorIterator &);
 DECLARE_DISPATCH(where_fn, where_kernel);
 
 using is_infinity_op_fn = void (*)(TensorIteratorBase &);

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -195,22 +195,14 @@ static void aminmax_kernel(
   });
 }
 
-static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
+static void where_kernel_impl(TensorIterator &iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Half, at::ScalarType::BFloat16, at::ScalarType::Bool,
     iter.dtype(), "where_cpu", [&] {
-    if (condition_type == at::ScalarType::Byte) {
-      cpu_kernel(
-        iter,
-        [=](uint8_t cond_val, scalar_t self_val, scalar_t other_val) -> scalar_t {
-          return cond_val ? self_val : other_val;
-        });
-    } else {
       cpu_kernel(
         iter,
         [=](bool cond_val, scalar_t self_val, scalar_t other_val) -> scalar_t {
           return cond_val ? self_val : other_val;
         });
-    }
   });
 }
 


### PR DESCRIPTION
This PR does several things
1) eliminates `where` instantiations for deprecated `byte` condition dtype, and casts `condition` to `bool` in this case. This is a perf penalty for people using deprecated calls
2) Makes `clamp_{min/max}.Tensor` overload reuse `clamp_{min/max}.Scalar` kernels if limit argument is cpu scalar, instead of instantiating `gpu_kernel_with_scalars`
3) Unifies all clamp_scalar kernels to use a single kernel with lambda picking the correct operation. I've verified that it doesn't degrade kernel performance. 
4) Eliminates redundant TensorIterator construction that `clamp` structured kernel was doing when only `min` or `max` was specified

This reduces the cubin size for TensorCompare.cu on V100 from 15751920 bytes to 7691120 bytes, with corresponding reduction in compile time.  
