### PR TITLE
Sort Measurement by description when merging Tasks

### DIFF
--- a/torch/utils/benchmark/utils/common.py
+++ b/torch/utils/benchmark/utils/common.py
@@ -251,7 +251,7 @@ class Measurement:
                 metadata=None,
             )
 
-        return [merge_group(t, g) for t, g in grouped_measurements.items()]
+        return [merge_group(t, g) for t, g in sorted(grouped_measurements.items(), key=lambda x: x[0].description)]
 
 
 def select_unit(t: float) -> Tuple[str, float]:


### PR DESCRIPTION
Without this sort, the rendered benchmark may have different sorted columns in different tables, e.g.

```
[-------------------- avg_pool2d, dtype='float', kernel_size=2 --------------------]
                                      |  1.11.0a0+git92e400b  |  1.11.0a0+gitd176c82
1 threads: -------------------------------------------------------------------------
      torch.Size([16, 18, 114, 79])   |         129.7         |         121.0       
      torch.Size([6, 153, 60, 9])     |           8.4         |           8.1       
      torch.Size([13, 25, 243, 96])   |         131.3         |         110.3       
 
[-------------------- avg_pool2d, dtype='float', kernel_size=3 --------------------]
                                      |  1.11.0a0+gitd176c82 |  1.11.0a0+git92e400b  
1 threads: -------------------------------------------------------------------------
      torch.Size([16, 18, 114, 79])   |         129.7         |         121.0       
      torch.Size([6, 153, 60, 9])     |           8.4         |           8.1       
      torch.Size([13, 25, 243, 96])   |         131.3         |         110.3       
```

Note the git commits as column descriptions. Task.description is str type. By sorting columns when merging Tasks, it will be much easier for human to read and do the comparisons.