### PR TITLE
emit inplace operator for bitwise AugAssign, fix #68064

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -539,9 +539,12 @@ _(aten, logical_not) \
 _(aten, logical_or) \
 _(aten, logical_xor) \
 _(aten, bitwise_and) \
+_(aten, bitwise_and_) \
 _(aten, bitwise_not) \
 _(aten, bitwise_or) \
+_(aten, bitwise_or_) \
 _(aten, bitwise_xor) \
+_(aten, bitwise_xor_) \
 _(aten, element_size) \
 _(aten, nll_loss) \
 _(aten, nll_loss2d) \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7033,6 +7033,39 @@ a")
 
         self.checkScript(func, (), optimize=True)
 
+    def test_tensor_subscript_augassign(self):
+        def bitwise_or(x):
+            x[0] |= 1
+            return x
+
+        def bitwise_and(x):
+            x[0] &= 0
+            return x
+
+        def bitwise_xor(x):
+            x[0] ^= 1
+            return x
+
+        def lshift(x):
+            x[0] <<= 1
+            return x
+
+        def rshift(x):
+            x[0] >>= 1
+            return x
+
+        def checkScriptCloneInput(func, inp):
+            cu = torch.jit.CompilationUnit(inspect.getsource(func))
+            script_fn = getattr(cu, func.__name__)
+            input_clone = inp.clone()
+            self.assertEqual(func(inp), script_fn(input_clone))
+
+        checkScriptCloneInput(bitwise_or, torch.tensor([0]))
+        checkScriptCloneInput(bitwise_and, torch.tensor([1]))
+        checkScriptCloneInput(bitwise_xor, torch.tensor([1]))
+        checkScriptCloneInput(lshift, torch.tensor([0b101]))
+        checkScriptCloneInput(rshift, torch.tensor([0b101]))
+
     def test_nested_select_assign(self):
         class SubSubModule(torch.nn.Module):
             def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7054,17 +7054,11 @@ a")
             x[0] >>= 1
             return x
 
-        def checkScriptCloneInput(func, inp):
-            cu = torch.jit.CompilationUnit(inspect.getsource(func))
-            script_fn = getattr(cu, func.__name__)
-            input_clone = inp.clone()
-            self.assertEqual(func(inp), script_fn(input_clone))
-
-        checkScriptCloneInput(bitwise_or, torch.tensor([0]))
-        checkScriptCloneInput(bitwise_and, torch.tensor([1]))
-        checkScriptCloneInput(bitwise_xor, torch.tensor([1]))
-        checkScriptCloneInput(lshift, torch.tensor([0b101]))
-        checkScriptCloneInput(rshift, torch.tensor([0b101]))
+        self.checkScriptCloneInput(bitwise_or, (torch.tensor([0]),))
+        self.checkScriptCloneInput(bitwise_and, (torch.tensor([1]),))
+        self.checkScriptCloneInput(bitwise_xor, (torch.tensor([1]),))
+        self.checkScriptCloneInput(lshift, (torch.tensor([0b101]),))
+        self.checkScriptCloneInput(rshift, (torch.tensor([0b101]),))
 
     def test_nested_select_assign(self):
         class SubSubModule(torch.nn.Module):

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2572,14 +2572,13 @@ struct to_ir {
       case '%':
         return use_inplace_op ? aten::fmod_ : aten::fmod;
       case '|':
-        return use_inplace_op ? aten::bitwise_or : aten::__or__;
+        return use_inplace_op ? aten::bitwise_or_ : aten::__or__;
       case '&':
-        return use_inplace_op ? aten::bitwise_and : aten::__and__;
+        return use_inplace_op ? aten::bitwise_and_ : aten::__and__;
       case '^':
-        return use_inplace_op ? aten::bitwise_xor : aten::__xor__;
+        return use_inplace_op ? aten::bitwise_xor_ : aten::__xor__;
       case TK_LSHIFT:
-        // NOLINTNEXTLINE(bugprone-branch-clone)
-        return use_inplace_op ? aten::__lshift__ : aten::__lshift__;
+        return use_inplace_op ? aten::__ilshift__ : aten::__lshift__;
       case TK_RSHIFT:
         return use_inplace_op ? aten::__irshift__ : aten::__rshift__;
       case TK_POW:

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -26,6 +26,7 @@ from functools import reduce
 from io import StringIO
 from collections import defaultdict
 
+import copy
 import importlib.util
 import inspect
 import io
@@ -521,6 +522,12 @@ class JitTestCase(JitCommonTestCase):
                 self.assertEqual(python_outputs, script_outputs, atol=atol, rtol=rtol)
                 self.assertEqual(script_outputs, opt_script_outputs, atol=atol, rtol=rtol)
                 return scripted_fn
+
+    def checkScriptCloneInput(self, func, inputs):
+        cu = torch.jit.CompilationUnit(inspect.getsource(func))
+        script_fn = getattr(cu, func.__name__)
+        input_clone = [copy.deepcopy(i) for i in inputs]
+        self.assertEqual(func(*inputs), script_fn(*input_clone))
 
     def checkTrace(self, func, reference_tensors, input_tensors=None,
                    drop=None, allow_unused=False, verbose=False,


### PR DESCRIPTION
Fixes #68064

**Problem** : `bitwise_or` is used when emitting AugAssign, tensor subscript AugAssign (`x[0] |= 1`) will be optimized out.

**Solution** : This PR change `bitwise_or` to it's inplace version `bitwise_or_`, makes following statements work in torchscript:

```python
x[0] |= 1
x[0] &= 1
x[0] ^= 1
x[0] <<= 1
x[0] >>= 1  # this one works already
```
