### PR TITLE
Fix bug on empty GLOO_SOCKET_IFNAME_ENV

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1345,7 +1345,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
 
             // Use interfaces listed in "GLOO_SOCKET_IFNAME", if set.
             char* ifnameEnv = getenv(GLOO_SOCKET_IFNAME_ENV.c_str());
-            if (ifnameEnv) {
+            if (ifnameEnv && strlen(ifnameEnv) > 1) {
               for (const auto& iface : split(',', ifnameEnv)) {
                 options->devices.push_back(
                     ::c10d::ProcessGroupGloo::createDeviceForInterface(iface));


### PR DESCRIPTION
This PR is trying to fix the no device bug when user resets the `GLOO_SOCKET_IFNAME_ENV` with

```bash
export GLOO_SOCKET_IFNAME_ENV=
```

Thank you for your time on reviewing this PR :).

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang