### PR TITLE
Change misleading MaxUnpool2d example to better demonstrate output_size usage

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -361,10 +361,10 @@ class MaxUnpool2d(_MaxUnpoolNd):
 
         >>> pool = nn.MaxPool2d(2, stride=2, return_indices=True)
         >>> unpool = nn.MaxUnpool2d(2, stride=2)
-        >>> input = torch.tensor([[[[ 1.,  2,  3,  4],
-                                    [ 5,  6,  7,  8],
-                                    [ 9, 10, 11, 12],
-                                    [13, 14, 15, 16]]]])
+        >>> input = torch.tensor([[[[ 1.,  2.,  3.,  4.],
+                                    [ 5.,  6.,  7.,  8.],
+                                    [ 9., 10., 11., 12.],
+                                    [13., 14., 15., 16.]]]])
         >>> output, indices = pool(input)
         >>> unpool(output, indices)
         tensor([[[[  0.,   0.,   0.,   0.],
@@ -372,17 +372,17 @@ class MaxUnpool2d(_MaxUnpoolNd):
                   [  0.,   0.,   0.,   0.],
                   [  0.,  14.,   0.,  16.]]]])
         >>> # Now using output_size to resolve an ambiguous size for the inverse
-        >>> input = torch.torch.tensor([[[[ 1.,  2,  3,  4, 5],
-                                          [ 6,  7,  8, 9, 10],
-                                          [11, 12, 13, 14, 15],
-                                          [16, 17, 18, 19, 20]]]])
+        >>> input = torch.torch.tensor([[[[ 1.,  2.,  3., 4., 5.],
+                                          [ 6.,  7.,  8., 9., 10.],
+                                          [11., 12., 13., 14., 15.],
+                                          [16., 17., 18., 19., 20.]]]])
         >>> output, indices = pool(input)
         >>> # This call will not work without specifying output_size
         >>> unpool(output, indices, output_size=input.size())
         tensor([[[[ 0.,  0.,  0.,  0.,  0.],
                   [ 0.,  7.,  0.,  9.,  0.],
                   [ 0.,  0.,  0.,  0.,  0.],
-                  [ 0., 17.,  0., 19.,  0.]]]]) 
+                  [ 0., 17.,  0., 19.,  0.]]]])
 
 
     """

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -371,14 +371,20 @@ class MaxUnpool2d(_MaxUnpoolNd):
                   [  0.,   6.,   0.,   8.],
                   [  0.,   0.,   0.,   0.],
                   [  0.,  14.,   0.,  16.]]]])
+        >>> # Now using output_size to resolve an ambiguous size for the inverse
+        >>> input = torch.torch.tensor([[[[ 1.,  2,  3,  4, 5],
+                                          [ 6,  7,  8, 9, 10],
+                                          [11, 12, 13, 14, 15],
+                                          [16, 17, 18, 19, 20]]]])
+        >>> output, indices = pool(input)
+        >>> # This call will not work without specifying output_size
+        >>> unpool(output, indices, output_size=input.size())
+        tensor([[[[ 0.,  0.,  0.,  0.,  0.],
+                  [ 0.,  7.,  0.,  9.,  0.],
+                  [ 0.,  0.,  0.,  0.,  0.],
+                  [ 0., 17.,  0., 19.,  0.]]]]) 
 
-        >>> # specify a different output size than input size
-        >>> unpool(output, indices, output_size=torch.Size([1, 1, 5, 5]))
-        tensor([[[[  0.,   0.,   0.,   0.,   0.],
-                  [  6.,   0.,   8.,   0.,   0.],
-                  [  0.,   0.,   0.,  14.,   0.],
-                  [ 16.,   0.,   0.,   0.,   0.],
-                  [  0.,   0.,   0.,   0.,   0.]]]])
+
     """
 
     kernel_size: _size_2_t


### PR DESCRIPTION
At #68873, @jbschlosser states that maxunpool2d with the `output_size` argument only works for indices of the same size. This makes sense, but unfortunately it's not what's shown in the example! I've removed the wrong example and replaced it with one where specifying `output_size` is actually necessary -- the unpool call fails without it. 