### PR TITLE
Expose is_metal_available in header

### DIFF
--- a/aten/src/ATen/metal/Context.h
+++ b/aten/src/ATen/metal/Context.h
@@ -25,6 +25,11 @@ class MetalImplRegistrar {
 at::Tensor& metal_copy_(at::Tensor& self, const at::Tensor& src);
 
 } // namespace metal
+
+namespace native {
+bool is_metal_available();
+} // namespace native
+
 } // namespace at
 
 #endif /* MetalContext_h */


### PR DESCRIPTION
Summary: Currently, `at::native::is_metal_available()` is implemented, but it's not exposed in the header, so nobody can use it. It's a useful function and I want to use it, so exposing it in the header.

Test Plan: CI

Differential Revision: D32675236

