### PR TITLE
[3/n] Fix the bug where Python mode fails to dispatch detach()

### DIFF
--- a/c10/core/PythonDispatcher.cpp
+++ b/c10/core/PythonDispatcher.cpp
@@ -74,7 +74,7 @@ bool hasPythonDispatcher() noexcept {
   }
 }
 
-DisablePythonDispatcherGuard::DisablePythonDispatcherGuard() {
+DisablePythonDispatcherGuard::DisablePythonDispatcherGuard() noexcept {
   disabled_ += 1;
 }
 

--- a/c10/core/PythonDispatcher.h
+++ b/c10/core/PythonDispatcher.h
@@ -31,6 +31,8 @@ struct C10_API PythonDispatcher {
 
   void dispatch(const OperatorHandle& op, torch::jit::Stack* s) const;
 
+  intrusive_ptr<TensorImpl> detach(const c10::TensorImpl* self) const;
+
   PyObject* type() const noexcept;
 
   c10::impl::PyInterpreter* interpreter() const noexcept;
@@ -47,5 +49,24 @@ C10_API void setPythonDispatcher(const std::shared_ptr<PythonDispatcher>& dispat
 C10_API void popPythonDispatcher() noexcept;
 
 C10_API bool hasPythonDispatcher() noexcept;
+
+// Temporarily disables the Python dispatcher. Note that this guard disables
+// only the thread-local dispatcher, not the Python dispatch key; this means
+// instances of Tensor subclasses with `__torch_dispatch__` will continue to
+// work.
+class C10_API DisablePythonDispatcherGuard {
+ public:
+  DisablePythonDispatcherGuard() noexcept;
+
+  DisablePythonDispatcherGuard(const DisablePythonDispatcherGuard&) = delete;
+
+  DisablePythonDispatcherGuard& operator=(const DisablePythonDispatcherGuard&) = delete;
+
+  DisablePythonDispatcherGuard(DisablePythonDispatcherGuard&&) = delete;
+
+  DisablePythonDispatcherGuard& operator=(DisablePythonDispatcherGuard&&) = delete;
+
+  ~DisablePythonDispatcherGuard();
+};
 
 } // namespace c10

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -250,12 +250,14 @@ struct C10_API AutogradMetaFactoryRegisterer {
 struct C10_API PyInterpreter {
   using name_sig = std::string(const PyInterpreter*);
   using decref_sig = void(const PyInterpreter*, PyObject*, bool);
-  using detach_sig =
-      c10::intrusive_ptr<TensorImpl>(const PyInterpreter*, const TensorImpl*);
+  using detach_sig = c10::intrusive_ptr<TensorImpl>(
+      const PyInterpreter*,
+      const TensorImpl* self,
+      PyObject* dispatcher_type);
   using dispatch_sig = void(
       const PyInterpreter*,
       const c10::OperatorHandle&,
-      torch::jit::Stack* stack,
+      torch::jit::Stack*,
       PyObject* dispatcher_type);
 
   PyInterpreter(
@@ -294,8 +296,9 @@ struct C10_API PyInterpreter {
   // detach, which will also arrange for the PyObject to get copied in this
   // situation
   __ubsan_ignore_function__ c10::intrusive_ptr<TensorImpl> detach(
-      const TensorImpl* self) const {
-    return (*detach_fn_)(this, self);
+      const TensorImpl* self,
+      PyObject* dispatcher_type = nullptr) const {
+    return (*detach_fn_)(this, self, dispatcher_type);
   }
 
   // Invoke the Python boxed fallback dispatch to go back into Python


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68965
* #68955
* __->__ #68954
* #68953
* #68952

This PR fixes a subtle bug where the `detach()` operation of tensors with no `__torch_dispatch__` are not dispatched in Python mode.

Differential Revision: [D32679739](https://our.internmc.facebook.com/intern/diff/D32679739/)

cc @albanD @zou3519