### PR TITLE
[5/n] Remove the Tensor subclass requirement for Python mode

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -330,7 +330,7 @@ $6 = torch._ops.aten.add_($1, $5)''')
             with enable_python_mode(torch.Tensor):
                 pass
         z = LoggingTensor(torch.empty([]))
-        with self.assertRaisesRegex(ValueError, "must be the type"):
+        with self.assertRaisesRegex(ValueError, "must be a type"):
             with enable_python_mode(z):
                 pass
 
@@ -450,7 +450,7 @@ $6 = torch._ops.aten.add_($1, $5)''')
     def test_detach_dispatched_for_non_subclassed_tensor(self) -> None:
         num_detach_dispatched = 0
 
-        class FakeTensor(torch.Tensor):
+        class FakeDispatcher:
             @classmethod
             def __torch_dispatch__(cls, func, types, args, kwargs):
                 nonlocal num_detach_dispatched
@@ -461,7 +461,7 @@ $6 = torch._ops.aten.add_($1, $5)''')
                 with no_dispatch():
                     return func(*args, **kwargs)
 
-        with enable_python_mode(FakeTensor):
+        with enable_python_mode(FakeDispatcher):
             tmp = torch.ones([10, 10]).detach()
 
         self.assertEqual(num_detach_dispatched, 2)

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -24,9 +24,9 @@ def enable_python_mode(cls) -> Iterator[None]:
     if not hasattr(cls, '__torch_dispatch__'):
         raise ValueError('The class passed to enable_python_mode '
                          'must have a __torch_dispatch__ classmethod')
-    if not isinstance(cls, type) or not issubclass(cls, (torch.Tensor,)):
+    if not isinstance(cls, type):
         raise ValueError('The argument passed to enable_python_mode '
-                         'must be the type of a Tensor subclass')
+                         'must be a type')
     torch._C._enter_python_mode(cls)
     try:
         yield


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #68965
* #68955
* #68954
* #68953
* #68952

With the `detach()` fix in #68954 the `__torch_dispatch__` type passed to `enable_python_mode()` now works for "vanilla" tensors (i.e. of type `torch.Tensor`). With that fix in place this PR relaxes the requirement for the argument passed to `enable_python_mode()` to be a Tensor subclass and allows *any* type with a `__torch_dispatch__` to be used in Python mode. Note that this is a backwards compatible change and does not affect the use of Tensor subclasses in Python mode.

Differential Revision: [D32688928](https://our.internmc.facebook.com/intern/diff/D32688928/)

cc @albanD @zou3519