### PR TITLE
Add lightweight reparametrization for `_stateless` calls

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -58,9 +58,16 @@ class TestStatelessFunctionalAPI(TestCase):
         jit_module = torch.jit.script(module)
         with self.assertRaisesRegex(
             RuntimeError,
-            r'delete methods or parameters'
+            r'used with Jitted modules'
         ):
             self._run_call_with_mock_module(jit_module)
+        x = torch.rand((1, 1))
+        traced_module = torch.jit.trace(module, x)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r'used with Jitted modules'
+        ):
+            self._run_call_with_mock_module(traced_module)
 
     @unittest.skipIf(not TEST_MULTIGPU, 'multi-GPU not supported')
     def test_functional_call_with_data_parallel(self):

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -134,21 +134,51 @@ class TestStatelessFunctionalAPI(TestCase):
         self.assertEqual(cur_weight, prev_weight)
         self.assertEqual(cur_buffer, prev_buffer)
 
-    def test_reparametrized_module(self):
+    def test_reparametrized_module_change_parametrization_original(self):
         module = MockModule()
         torch.nn.utils.parametrizations.spectral_norm(module.l1)
         self.assertTrue('l1.parametrizations.weight.original' in dict(module.named_parameters()))
         orig_sn_weight = module.l1.weight.clone()
         x = torch.rand((1, 1))
+        # We substitute the parameter inside the parametrization
+        # the parametrization itself is not overwritten so it will be applied with a different
+        # value for the original tensor
         parameters = {'l1.parametrizations.weight.original': torch.nn.Parameter(torch.tensor([[1.0]])),
                       'l1.bias': torch.tensor([0.0]),
                       'buffer': torch.tensor([0.0])}
-        res = torch.nn.utils._stateless.functional_call(module, parameters, x)
+        res = torch.nn.utils._stateless.functional_call(module, parameters, x, apply_parametrizations=False)
         self.assertEqual(x, res)
         # verify that the spectral normalization is still applied
         self.assertTrue('l1.parametrizations.weight.original' in dict(module.named_parameters()))
         self.assertEqual(orig_sn_weight, module.l1.weight)
 
+    def test_reparametrized_module(self):
+        # In an alternative design to the above one, we allow to keep the parametrizations as they are
+        # and applied them to the element matching in the state dict, so we do not directly overwrite them
+        class _ParamScaler(torch.nn.Module):
+            def forward(self, orig):
+                return orig * 10
+
+        module = MockModule()
+        torch.nn.utils.parametrize.register_parametrization(module.l1, 'weight', _ParamScaler())
+        self.assertTrue('l1.parametrizations.weight.original' in dict(module.named_parameters()))
+        orig_sn_weight = module.l1.weight.clone()
+        x = torch.rand((1, 1))
+        weight = torch.tensor([[1.0]])
+        bias = torch.tensor([0.0])
+        buffer = torch.tensor([0.0])
+        parameters = {'l1.weight': weight,
+                      'l1.bias': bias,
+                      'buffer': buffer}
+        res = torch.nn.utils._stateless.functional_call(module, parameters, x, apply_parametrizations=True)
+        self.assertEqual(x * 10, res)
+        # verify that the original reparametrization is still applied
+        self.assertTrue('l1.parametrizations.weight.original' in dict(module.named_parameters()))
+        self.assertEqual(orig_sn_weight, module.l1.weight)
+
+        # Parametrizations will be completely ignored and the provided value will be used instead
+        res = torch.nn.utils._stateless.functional_call(module, parameters, x, apply_parametrizations=False)
+        self.assertEqual(x, res)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -1,16 +1,31 @@
 import contextlib
+from typing import Any, Callable, Optional, Dict, Tuple
 
-import torch.jit
+import torch
+from torch import Tensor
+from torch.nn.utils.parametrize import ParametrizationList
 
 
-def _change_class(module) -> None:
+def _create_new_parametrization(parametrization: ParametrizationList, tensor: Tensor) -> None:
+    modules = [module for module in parametrization]
+    # TODO: Find a way to cache it? but if tensor value changes each time
+    # this will be hard
+    return ParametrizationList(modules, tensor, parametrization.unsafe)
+
+
+def _change_class(module: torch.nn.Module, apply_parametrizations: bool) -> None:
     cls = module.__class__
     func_params = module._functional_parameters
+    parametrizations = None
+    if apply_parametrizations:
+        parametrizations = getattr(module, 'parametrizations', None)
 
     def _getattribute(self, name):
         if name in func_params:
+            if parametrizations is not None and name in parametrizations:
+                return _create_new_parametrization(parametrizations[name], func_params[name])()
             return func_params[name]
-        return object.__getattribute__(self, name)
+        return cls.__getattribute__(self, name)
 
     param_cls = type(
         f"StatelessReplacer{cls.__name__}",
@@ -24,34 +39,30 @@ def _change_class(module) -> None:
     module._orig_class = cls
 
 
-def _swap_parameters(module, tensor_name, tensor):
+def _swap_parameters(module: torch.nn.Module, tensor_name: str, tensor: Tensor, apply_parametrizations: bool):
     # Changes the module class to get a new __getattr__ dunder method
     # that looks for the reparametrized tensor
     if hasattr(module, "_functional_parameters"):
-        # Check if the module has an active reparametrization
-        # for this parameter
         module._functional_parameters[tensor_name] = tensor
     else:
-        # change module class to set a new __getattr__ function
-        # register tensor
         module._functional_parameters = {}
         module._functional_parameters[tensor_name] = tensor
-        _change_class(module)
+        _change_class(module, apply_parametrizations)
 
 
-def _remove_swap(module, name):
+def _remove_swap(module: torch.nn.Module, name: str):
     if hasattr(module, "_orig_class"):
         module.__class__ = module._orig_class
         delattr(module, "_orig_class")
+        delattr(module, "_functional_parameters")
 
 
 @contextlib.contextmanager
-def reparametrize_module(module, parameters_and_buffers):
-    # Parametrization does not support to change submodules directly
+def reparametrize_module(module: torch.nn.Module, parameters_and_buffers: Dict[str, Tensor], apply_parametrizations: bool):
     for name, tensor in parameters_and_buffers.items():
         _apply_func_submodules(
             _swap_parameters,
-            module, name.split("."), (tensor,))
+            module, name.split("."), (tensor, apply_parametrizations))
     yield
     for name in parameters_and_buffers:
         _apply_func_submodules(
@@ -59,14 +70,41 @@ def reparametrize_module(module, parameters_and_buffers):
             module, name.split("."), ())
 
 
-def _apply_func_submodules(func, module, path, args):
+def _apply_func_submodules(
+    func: Callable[[torch.nn.Module, str, Tuple[Any]], None],
+    module: torch.nn.Module,
+    path: str, args: Tuple[Any],
+):
     if len(path) == 1:
         func(module, path[0], *args)
     else:
         _apply_func_submodules(func, getattr(module, path[0]), path[1:], args)
 
 
-def functional_call(module, parameters_and_buffers, args, kwargs=None):
+def functional_call(
+    module: torch.nn.Module,
+    parameters_and_buffers: Dict[str, Tensor],
+    args: Tuple[Any],
+    kwargs : Dict[str, Any] = None,
+    *, apply_parametrizations : Optional[bool] = False,
+):
+    r"""Performs a functional call on the module by replacing the module parameters with
+    the provideed ones.
+
+    Args:
+        module (torch.nn.Module): the module to call
+        parameters_and_buffers (dict of str and Tensor): the parameters that will be used in
+            the module call.
+        args (tuple): arguments to be passed to the module call
+        kwargs (dict): keyword arguments to be passed to the module call
+        apply_parametrizations (bool): if ``True`` and ``module`` has parametrizations registered
+            the parametrizations will be applied on the parameter provided in ``parameters_and_buffers``.
+            If false, parametrizations will be ignored and the value in ``parameters_and_buffers`` will
+            be used directly. Default: ``False``.
+
+    Returns:
+        Any: the result of calling ``module``.
+    """
     # TODO allow kwargs such as unsafe and others for parametrization
     if (
             torch.jit.is_tracing()
@@ -80,7 +118,7 @@ def functional_call(module, parameters_and_buffers, args, kwargs=None):
         raise RuntimeError("The stateless API can't be used with Jitted modules")
     if kwargs is None:
         kwargs = {}
-    with reparametrize_module(module, parameters_and_buffers):
+    with reparametrize_module(module, parameters_and_buffers, apply_parametrizations):
         if isinstance(args, tuple):
             out = module(*args, **kwargs)
         else:

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -1,6 +1,43 @@
 import contextlib
 
-import torch
+
+def _change_class(module) -> None:
+    cls = module.__class__
+
+    def _getattr(self, name):
+        if name in module._functional_parameters:
+            return module._functional_parameters[name]
+        return cls.__getattr__(self, name)
+
+    param_cls = type(
+        f"Parametrized{cls.__name__}",
+        (cls,),
+        {
+            "__getattr__": _getattr,
+        },
+    )
+
+    module.__class__ = param_cls
+    module._orig_class = cls
+
+
+def _swap_parameters(module, tensor_name, tensor):
+    # Changes the module class to get a new __getattr__ dunder method
+    # that looks for the reparametrized tensor
+    if hasattr(module, '_functional_parameters'):
+        module._functional_parameters[tensor_name] = tensor
+    else:
+        # change module class to set a new __getattr__ function
+        # register tensor
+        _change_class(module)
+        module._functional_parameters = {}
+        module._functional_parameters[tensor_name] = tensor
+
+
+def _remove_swap(module, name):
+    if hasattr(module, '_orig_class'):
+        module.__class__ = module._orig_class
+        delattr(module, '_orig_class')
 
 
 @contextlib.contextmanager
@@ -8,22 +45,13 @@ def reparametrize_module(module, parameters_and_buffers):
     # Parametrization does not support to change submodules directly
     for name, tensor in parameters_and_buffers.items():
         _apply_func_submodules(
-            torch.nn.utils.parametrize.register_parametrization,
-            module, name.split("."), (_ReparametrizedTensor(tensor),))
+            _swap_parameters,
+            module, name.split("."), (tensor,))
     yield
     for name in parameters_and_buffers:
         _apply_func_submodules(
-            torch.nn.utils.parametrize.remove_parametrizations,
-            module, name.split("."), (False,))
-
-
-class _ReparametrizedTensor(torch.nn.Module):
-    def __init__(self, tensor):
-        super().__init__()
-        self._tensor = tensor
-
-    def forward(self, original):
-        return self._tensor
+            _remove_swap,
+            module, name.split("."), ())
 
 
 def _apply_func_submodules(func, module, path, args):

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -80,14 +80,14 @@ def functional_call(
     args: Tuple,
     kwargs : Dict[str, Any] = None,
 ):
-    r"""Performs a functional call on the module by replacing the module parameters with
-    the provideed ones.
+    r"""Performs a functional call on the module by replacing the module parameters
+    and buffers with the provided ones.
 
-    If the module has active parametrizations, passing a value in the `parameters_and_buffers`
-    argument with the name set to the regular parameter name will completely disable
-    the parametrization. If you want to apply the parametrization function to the value passed
-    please set the key as
-    `{parameter_name}.parametrizations.{parameter_name_on_parametrization}.original`.
+    .. note:: If the module has active parametrizations, passing a value in the
+        `parameters_and_buffers` argument with the name set to the regular parameter
+         name will completely disable the parametrization.
+         If you want to apply the parametrization function to the value passed
+         please set the key as `{submodule_name}.parametrizations.{parameter_name}.original`.
 
     Args:
         module (torch.nn.Module): the module to call

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -1,30 +1,18 @@
 import contextlib
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Tuple
 
 import torch
 from torch import Tensor
-from torch.nn.utils.parametrize import ParametrizationList
-
-
-def _create_new_parametrization(parametrization: ParametrizationList, tensor: Tensor) -> ParametrizationList:
-    # TODO: Find a way to cache it? but if tensor value changes each time this will be hard
-    modules = list(parametrization)
-    return ParametrizationList(modules, tensor, parametrization.unsafe)
 
 
 # We avoid typing module here because module attributes are declared as Union[Parameter, Tensor] by default
 # and using other types causes mypy errors
-def _change_class(module, apply_parametrizations: bool) -> None:
+def _change_class(module) -> None:
     cls = module.__class__
     func_params : Dict[str, Tensor] = module._functional_parameters
-    parametrizations : Optional[ParametrizationList] = None
-    if apply_parametrizations:
-        parametrizations = getattr(module, 'parametrizations', None)
 
     def _getattribute(self, name: str) -> Any:
         if name in func_params:
-            if parametrizations is not None and name in parametrizations:
-                return _create_new_parametrization(parametrizations[name], func_params[name])()
             return func_params[name]
         return cls.__getattribute__(self, name)
 
@@ -40,7 +28,7 @@ def _change_class(module, apply_parametrizations: bool) -> None:
     module._orig_class = cls
 
 
-def _swap_parameters(module, tensor_name: str, tensor: Tensor, apply_parametrizations: bool) -> None:
+def _swap_parameters(module, tensor_name: str, tensor: Tensor) -> None:
     # Changes the module class to get a new __getattr__ dunder method
     # that looks for the reparametrized tensor
     if hasattr(module, "_functional_parameters"):
@@ -48,7 +36,7 @@ def _swap_parameters(module, tensor_name: str, tensor: Tensor, apply_parametriza
     else:
         module._functional_parameters = {}
         module._functional_parameters[tensor_name] = tensor
-        _change_class(module, apply_parametrizations)
+        _change_class(module)
 
 
 def _remove_swap(module, name: str) -> None:
@@ -62,12 +50,11 @@ def _remove_swap(module, name: str) -> None:
 def reparametrize_module(
     module: torch.nn.Module,
     parameters_and_buffers: Dict[str, Tensor],
-    apply_parametrizations: bool
 ) -> Iterator[None]:
     for name, tensor in parameters_and_buffers.items():
         _apply_func_submodules(
             _swap_parameters,
-            module, name.split("."), (tensor, apply_parametrizations))
+            module, name.split("."), (tensor,))
     yield
     for name in parameters_and_buffers:
         _apply_func_submodules(
@@ -92,10 +79,15 @@ def functional_call(
     parameters_and_buffers: Dict[str, Tensor],
     args: Tuple,
     kwargs : Dict[str, Any] = None,
-    *, apply_parametrizations : bool = False,
 ):
     r"""Performs a functional call on the module by replacing the module parameters with
     the provideed ones.
+
+    If the module has active parametrizations, passing a value in the `parameters_and_buffers`
+    argument with the name set to the regular parameter name will completely disable
+    the parametrization. If you want to apply the parametrization function to the value passed
+    please set the key as
+    `{parameter_name}.parametrizations.{parameter_name_on_parametrization}.original`.
 
     Args:
         module (torch.nn.Module): the module to call
@@ -103,10 +95,6 @@ def functional_call(
             the module call.
         args (tuple): arguments to be passed to the module call
         kwargs (dict): keyword arguments to be passed to the module call
-        apply_parametrizations (bool): if ``True`` and ``module`` has parametrizations registered
-            the parametrizations will be applied on the parameter provided in ``parameters_and_buffers``.
-            If false, parametrizations will be ignored and the value in ``parameters_and_buffers`` will
-            be used directly. Default: ``False``.
 
     Returns:
         Any: the result of calling ``module``.
@@ -124,7 +112,7 @@ def functional_call(
         raise RuntimeError("The stateless API can't be used with Jitted modules")
     if kwargs is None:
         kwargs = {}
-    with reparametrize_module(module, parameters_and_buffers, apply_parametrizations):
+    with reparametrize_module(module, parameters_and_buffers):
         if isinstance(args, tuple):
             out = module(*args, **kwargs)
         else:

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -59,7 +59,11 @@ def _remove_swap(module, name: str) -> None:
 
 
 @contextlib.contextmanager
-def reparametrize_module(module: torch.nn.Module, parameters_and_buffers: Dict[str, Tensor], apply_parametrizations: bool) -> Iterator[None]:
+def reparametrize_module(
+    module: torch.nn.Module,
+    parameters_and_buffers: Dict[str, Tensor],
+    apply_parametrizations: bool
+) -> Iterator[None]:
     for name, tensor in parameters_and_buffers.items():
         _apply_func_submodules(
             _swap_parameters,

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -1,26 +1,27 @@
 import contextlib
-from typing import Any, Callable, Optional, Dict, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 import torch
 from torch import Tensor
 from torch.nn.utils.parametrize import ParametrizationList
 
 
-def _create_new_parametrization(parametrization: ParametrizationList, tensor: Tensor) -> None:
-    modules = [module for module in parametrization]
-    # TODO: Find a way to cache it? but if tensor value changes each time
-    # this will be hard
+def _create_new_parametrization(parametrization: ParametrizationList, tensor: Tensor) -> ParametrizationList:
+    # TODO: Find a way to cache it? but if tensor value changes each time this will be hard
+    modules = list(parametrization)
     return ParametrizationList(modules, tensor, parametrization.unsafe)
 
 
-def _change_class(module: torch.nn.Module, apply_parametrizations: bool) -> None:
+# We avoid typing module here because module attributes are declared as Union[Parameter, Tensor] by default
+# and using other types causes mypy errors
+def _change_class(module, apply_parametrizations: bool) -> None:
     cls = module.__class__
-    func_params = module._functional_parameters
-    parametrizations = None
+    func_params : Dict[str, Tensor] = module._functional_parameters
+    parametrizations : Optional[ParametrizationList] = None
     if apply_parametrizations:
         parametrizations = getattr(module, 'parametrizations', None)
 
-    def _getattribute(self, name):
+    def _getattribute(self, name: str) -> Any:
         if name in func_params:
             if parametrizations is not None and name in parametrizations:
                 return _create_new_parametrization(parametrizations[name], func_params[name])()
@@ -39,7 +40,7 @@ def _change_class(module: torch.nn.Module, apply_parametrizations: bool) -> None
     module._orig_class = cls
 
 
-def _swap_parameters(module: torch.nn.Module, tensor_name: str, tensor: Tensor, apply_parametrizations: bool):
+def _swap_parameters(module, tensor_name: str, tensor: Tensor, apply_parametrizations: bool) -> None:
     # Changes the module class to get a new __getattr__ dunder method
     # that looks for the reparametrized tensor
     if hasattr(module, "_functional_parameters"):
@@ -50,7 +51,7 @@ def _swap_parameters(module: torch.nn.Module, tensor_name: str, tensor: Tensor, 
         _change_class(module, apply_parametrizations)
 
 
-def _remove_swap(module: torch.nn.Module, name: str):
+def _remove_swap(module, name: str) -> None:
     if hasattr(module, "_orig_class"):
         module.__class__ = module._orig_class
         delattr(module, "_orig_class")
@@ -58,7 +59,7 @@ def _remove_swap(module: torch.nn.Module, name: str):
 
 
 @contextlib.contextmanager
-def reparametrize_module(module: torch.nn.Module, parameters_and_buffers: Dict[str, Tensor], apply_parametrizations: bool):
+def reparametrize_module(module: torch.nn.Module, parameters_and_buffers: Dict[str, Tensor], apply_parametrizations: bool) -> Iterator[None]:
     for name, tensor in parameters_and_buffers.items():
         _apply_func_submodules(
             _swap_parameters,
@@ -71,9 +72,10 @@ def reparametrize_module(module: torch.nn.Module, parameters_and_buffers: Dict[s
 
 
 def _apply_func_submodules(
-    func: Callable[[torch.nn.Module, str, Tuple[Any]], None],
+    func: Callable[..., None],
     module: torch.nn.Module,
-    path: str, args: Tuple[Any],
+    path: List[str],
+    args: Tuple,
 ):
     if len(path) == 1:
         func(module, path[0], *args)
@@ -84,9 +86,9 @@ def _apply_func_submodules(
 def functional_call(
     module: torch.nn.Module,
     parameters_and_buffers: Dict[str, Tensor],
-    args: Tuple[Any],
+    args: Tuple,
     kwargs : Dict[str, Any] = None,
-    *, apply_parametrizations : Optional[bool] = False,
+    *, apply_parametrizations : bool = False,
 ):
     r"""Performs a functional call on the module by replacing the module parameters with
     the provideed ones.


### PR DESCRIPTION
#61447 introduced a mechanism for performing functional calls in a model using the reparametrization API. However, the overhead introduced in a single call was too large.
I tried to address this by modifying the reparametrization code to support spare tensors, but the changes needed were too large due to type checking and several parts of the code expecting actual `nn.Module` objects so this option was not feasible.

resnet50 and call functional with a parameters dict covering the 0, 25, 50, and 100% of the model total parameters.


Used script:
https://gist.github.com/emcastillo/f344a58638bd71d130c71c45f86f0c3a

| % of parameters passed | CPU Time (us) | GPU Time (us) |
|------------------------|---------------|---------------|
| regular call           | 5539          | 184909        |
| 0                      | 5561          | 184843        |
| 25                     | 11363         | 189236        |
| 50                     | 18716         | 195378        |
| 75                     | 22851         | 198641        |
| 100                    | 27441         | 202281        |



This PR just swaps the `__getattr__` of the submodules to look into a dict holding only the parameters when called, greatly reducing the burden of having to instantiate custom modules and calling forward to just retrieve a tensor.

The execution times now are as follows:

| % of parameters passed | CPU Time (us) | GPU Time (us) |
|------------------------|---------------|---------------|
| regular call           | 5939          | 187533        |
| 0                      | 5899          | 187570        |
| 25                     | 8541         | 188953        |
| 50                     | 10045         | 189826        |
| 75                     | 11049         | 190344        |
| 100                    | 11911         | 190800        |
| functorch with 100% params | 14014 | 191727




Now we see that the CPU time overhead is greatly reduced and the GPU time barely increases due to the effective overlap.

cc @albanD @zou3519 