### PR TITLE
[not for lnad] dbr quant: improve needs_dtype_transform_on_outputs

### DIFF
--- a/torch/ao/quantization/_dbr/auto_trace.py
+++ b/torch/ao/quantization/_dbr/auto_trace.py
@@ -18,7 +18,6 @@ from .model_utils import (
     pack_weights_for_functionals,
     attach_scale_zp_values_to_model,
     attach_op_convert_info_to_model,
-    attach_output_convert_info_to_model,
 )
 from . import auto_trace_rewriter
 
@@ -582,7 +581,6 @@ def add_auto_convert(module : torch.nn.Module) -> torch.nn.Module:
     pack_weights_for_functionals(module)
     attach_scale_zp_values_to_model(module)
     attach_op_convert_info_to_model(module)
-    attach_output_convert_info_to_model(module)
 
     # Since eager mode convert could have changed the IDs of some modules,
     # populate the FQN map again

--- a/torch/ao/quantization/_dbr/model_utils.py
+++ b/torch/ao/quantization/_dbr/model_utils.py
@@ -127,18 +127,3 @@ def attach_op_convert_info_to_model(
 
     for _, child in module.named_children():
         attach_op_convert_info_to_model(child)
-
-def attach_output_convert_info_to_model(
-    module: torch.nn.Module,
-) -> None:
-    """
-    Calculates the info needed to perform the module outputs hook
-    and attaches it to the parent module. This is done to avoid recalculating
-    these values at inference.
-    """
-    if hasattr(module, '_auto_quant_state'):
-        qstate: AutoQuantizationState = module._auto_quant_state  # type: ignore[assignment]
-        qstate.set_needs_dtype_transform_on_outputs()
-
-    for _, child in module.named_children():
-        attach_output_convert_info_to_model(child)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68998 [not for land] dbr quant: turn off overrides on regions of model
* #68997 [not for land] dbr quant: add any_child_needs_op_hooks flag
* #68996 [not for land] dbr quant: add any_child_needs_arg_dequants flag
* **#68995 [not for lnad] dbr quant: improve needs_dtype_transform_on_outputs**
* #68877 dbr quant overhead [14/x]: cache whether an op is a module
* #68841 dbr quant overhead [13/x]: cache results of get_module_hook_type
* #68840 dbr quant: fix debugging fqn info for converted model
* #68839 dbr quant overhead[12/x]: turn off overrides for module convert output hook
* #68838 dbr quant: remove unnecessary outputs hook
* #68837 dbr quant overhead[11/x]: speed up module convert hook
* #68836 dbr quant overhead[10/x]: disable torch_function overrides for leaf nodes

Summary:

Improves the `needs_dtype_transform_on_outputs` by making it be calculated
during tracing instead as a convert time pass, and adding a test case.

This will be useful in a future PR which will add more perfomance optimizations
based on the value of this flag.

Test plan:

```
python test/test_quantization.py TestQuantizeDBR
```