### PR TITLE
[not for land] dbr quant: turn off overrides on regions of model

### DIFF
--- a/torch/ao/quantization/_dbr/quantization_state.py
+++ b/torch/ao/quantization/_dbr/quantization_state.py
@@ -121,14 +121,20 @@ class AutoQuantizationState(torch.nn.Module):
         # will be returned as is. This value can be precalculated and it is set
         # to its final value after tracing.
         self.needs_dtype_transform_on_outputs = False
+        # Version of the flag above for self or any descendant
+        self.self_or_any_descendant_needs_dtype_transform_on_outputs = False
 
         # If this is True, at least one child of the parent module was
         # detected to need arg dequants during tracing.
         self.any_child_needs_arg_dequants = False
+        # Version of the flag above for self or any descendant
+        self.any_descendant_needs_arg_dequants = False
 
         # If this is True, at least one child of the parent module was
         # detected to need op hooks during tracing.
         self.any_child_needs_op_hooks = False
+        # Version of the flag above for self or any descendant
+        self.any_descendant_needs_op_hooks = False
 
     def has_at_least_one_seen_op_info(self) -> bool:
         return len(self.idx_to_seen_op_infos) > 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#68998 [not for land] dbr quant: turn off overrides on regions of model**
* #68997 [not for land] dbr quant: add any_child_needs_op_hooks flag
* #68996 [not for land] dbr quant: add any_child_needs_arg_dequants flag
* #68995 [not for lnad] dbr quant: improve needs_dtype_transform_on_outputs
* #68877 dbr quant overhead [14/x]: cache whether an op is a module
* #68841 dbr quant overhead [13/x]: cache results of get_module_hook_type
* #68840 dbr quant: fix debugging fqn info for converted model
* #68839 dbr quant overhead[12/x]: turn off overrides for module convert output hook
* #68838 dbr quant: remove unnecessary outputs hook
* #68837 dbr quant overhead[11/x]: speed up module convert hook
* #68836 dbr quant overhead[10/x]: disable torch_function overrides for leaf nodes

Summary:

Adds logic to turn off DBR quant on regions of model where it is not
needed, based on information collected during tracing.

Not for land yet because the performance metric do not show this
as a clear win yet, needs more debugging.

Test plan:

TODO