### PR TITLE
re-enable layer_norm in autodiff

### DIFF
--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -1159,7 +1159,7 @@ const std::vector<std::string> functions = {
 
             return output, backward
 
-        def layer_norm_disabled(input : Tensor,
+        def layer_norm(input : Tensor,
                        normalized_shape : List[int],
                        weight : Optional[Tensor],
                        bias : Optional[Tensor],


### PR DESCRIPTION
Turn on layer_norm in autodiff

#67732 should have fixed the previously issue exposed by enabling layer_norm in autodiff.