### PR TITLE
Selective Intern

### DIFF
--- a/test/package/package_b/__init__.py
+++ b/test/package/package_b/__init__.py
@@ -3,10 +3,11 @@ __import__("subpackage_0.subsubpackage_0", globals(), fromlist=[""], level=1)
 __import__("subpackage_2", globals=globals(), locals=locals(), fromlist=["*"], level=1)
 
 result = "package_b"
-
+package_b_li = [123]
 
 class PackageBObject:
     __slots__ = ["obj"]
+    package_b_li = [789]
 
     def __init__(self, obj):
         self.obj = obj

--- a/test/package/package_b/subpackage_0/subsubpackage_0/__init__.py
+++ b/test/package/package_b/subpackage_0/subsubpackage_0/__init__.py
@@ -1,7 +1,7 @@
 __import__("subpackage_1", globals(), locals(), ["PackageBSubpackage1Object_0"], 3)
 
 result = "subsubpackage_0"
-
+subsubpackage_0_li = [123]
 
 class PackageBSubsubpackage0Object_0:
     pass

--- a/test/package/package_b/subpackage_1.py
+++ b/test/package/package_b/subpackage_1.py
@@ -1,4 +1,5 @@
 result = "subpackage_1"
+subpackage_1_li = [456]
 
 
 class PackageBSubpackage1Object_0:

--- a/test/package/package_d/__init__.py
+++ b/test/package/package_d/__init__.py
@@ -1,2 +1,2 @@
-result = "subpackage_0"
+result = "package_d"
 subpackage_0_li = [123]

--- a/test/package/package_d/extern_package/__init__.py
+++ b/test/package/package_d/extern_package/__init__.py
@@ -1,0 +1,2 @@
+result = "extern_package"
+test_number = [789]

--- a/test/package/package_d/selective_intern_package/__init__.py
+++ b/test/package/package_d/selective_intern_package/__init__.py
@@ -1,0 +1,2 @@
+result = "selective_intern_package"
+test_number = [456]

--- a/test/package/package_d/selective_intern_package/subpackage_0.py
+++ b/test/package/package_d/selective_intern_package/subpackage_0.py
@@ -1,0 +1,1 @@
+test_number = [1234]

--- a/test/package/package_d/test_extern.py
+++ b/test/package/package_d/test_extern.py
@@ -1,0 +1,7 @@
+import package_d.test_selective_intern as test_selective_intern # noqa
+
+result = "package_d_file"
+test_number =
+[
+    431
+]

--- a/test/package/package_d/test_selective_intern.py
+++ b/test/package/package_d/test_selective_intern.py
@@ -1,0 +1,2 @@
+result = "package_d_file"
+test_number = [124]

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -339,6 +339,136 @@ class TestDependencyAPI(PackageTestCase):
         with self.assertRaises(NotImplementedError):
             foo2.package_a.get_something()
 
+    def test_selective_intern(self):
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
+            he._selective_intern(
+                "package_d",
+                [
+                    "package_d.test_selective_intern",
+                    "package_d.selective_intern_package",
+                ],
+            )
+            he.save_source_string(
+                "foo",
+                "import package_d; \
+            import package_d.test_selective_intern as test_selective_intern; \
+            import package_d.test_extern as test_extern; \
+            import package_d.extern_package as extern_package; \
+            import package_d.selective_intern_package as selective_intern_package",
+            )
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
+        foo = hi.import_module("foo")
+
+        import package_d.extern_package
+        import package_d.selective_intern_package
+        import package_d.test_extern
+
+        # number is not getting overwritten
+        import package_d.test_selective_intern
+
+        # test access
+        self.assertEqual(foo.test_extern.test_number, package_d.test_extern.test_number)
+        self.assertEqual(
+            foo.test_selective_intern.test_number,
+            package_d.test_selective_intern.test_number,
+        )
+        self.assertEqual(
+            foo.extern_package.test_number, package_d.extern_package.test_number
+        )
+        self.assertEqual(
+            foo.selective_intern_package.test_number,
+            package_d.selective_intern_package.test_number,
+        )
+
+        # test that that test_selective_intern is actually interned properly
+        self.assertIs(foo.test_extern, package_d.test_extern)
+        self.assertIsNot(foo.test_selective_intern, package_d.test_selective_intern)
+        self.assertIs(foo.extern_package, package_d.extern_package)
+        self.assertIsNot(
+            foo.selective_intern_package, package_d.selective_intern_package
+        )
+
+        # test external dependencies are still externed
+        self.assertIs(
+            foo.test_extern.test_selective_intern, package_d.test_selective_intern
+        )
+
+    def test_selective_intern_subpackage(self):
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
+            he._selective_intern("package_b", ["package_b.subpackage_0"])
+            he.save_source_string(
+                "foo",
+                "import package_b; \
+                import package_b.subpackage_0 as subpackage_0; \
+                import package_b.subpackage_1 as subpackage_1; \
+                import package_b.subpackage_0.subsubpackage_0",
+            )
+
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
+        import package_b
+
+        foo = hi.import_module("foo")
+
+        # subpackage_0 should be interned, subpackage_1 should not.
+        self.assertIsNot(package_b.subpackage_0, foo.subpackage_0)
+        self.assertIsNot(
+            foo.subpackage_0.subsubpackage_0, package_b.subpackage_0.subsubpackage_0
+        )
+        self.assertIs(package_b.subpackage_1, foo.subpackage_1)
+
+        # Check that attribute access still works on selectively interned module.
+        self.assertEqual(
+            foo.subpackage_0.subpackage_0_li[0],
+            package_b.subpackage_0.subpackage_0_li[0],
+        )
+        self.assertEqual(
+            foo.subpackage_0.subsubpackage_0.subsubpackage_0_li[0],
+            package_b.subpackage_0.subsubpackage_0.subsubpackage_0_li[0],
+        )
+        self.assertIsNot(
+            foo.subpackage_0.subpackage_0_li, package_b.subpackage_0.subpackage_0_li
+        )
+        self.assertEqual(
+            foo.subpackage_1.subpackage_1_li, package_b.subpackage_1.subpackage_1_li
+        )
+
+        # Check that attribute access works correctly on the shim.
+        self.assertIs(foo.package_b.package_b_li, package_b.package_b_li)
+
+    def test_selective_intern_torch(self):
+        # test selective intern using torch toy examples
+        buffer = BytesIO()
+        with PackageExporter(buffer) as he:
+            he.save_source_string(
+                "foo",
+                "from torch.testing._internal.quantization_torch_package_models import LinearReluFunctional",
+            )
+
+        buffer.seek(0)
+        hi = PackageImporter(buffer)
+        from torch.testing._internal.quantization_torch_package_models import (
+            LinearReluFunctional,
+        )
+
+        foo = hi.import_module("foo")
+        self.assertIsNot(LinearReluFunctional, foo.LinearReluFunctional)
+
+
+def _read_file(filename: str) -> str:
+    with open(filename, "rb") as f:
+        b = f.read()
+        return b.decode("utf-8")
+
+
+def _write_file(filename: str, filecontent: str):
+    f = open(filename, "w")
+    f.write(filecontent)
+    f.close()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/foo.py
+++ b/torch/foo.py
@@ -1,0 +1,6 @@
+def i_am_intern():
+    print("i_am_intern")
+
+class A(object):
+    def report(self):
+        print("i_am_intern")

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -23,10 +23,10 @@ from . import _reduction as _Reduction
 from . import grad  # noqa: F401
 from .modules import utils
 from .modules.utils import _single, _pair, _triple, _list_with_default
-
+# import pdb
 
 Tensor = torch.Tensor
-
+# pdb.set_trace()
 conv1d = _add_docstr(
     torch.conv1d,
     r"""

--- a/torch/package/_selective_extern.py
+++ b/torch/package/_selective_extern.py
@@ -1,0 +1,10 @@
+SELECTIVE_INTERN_LIST = [$interned_modules] # noqa
+
+if "__torch_package__" in dir():
+
+    def __getattr__(name):
+        package_name = $package_name
+        if name not in SELECTIVE_INTERN_LIST:
+            return getattr(_extern_copy, name)
+        __import__(f'{package_name}.{name}', level=0)
+        return globals().get(name)

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -8,6 +8,7 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from string import Template
 from typing import (
     Any,
     BinaryIO,
@@ -39,6 +40,18 @@ _gate_torchscript_serialization = True
 
 ActionHook = Callable[["PackageExporter", str], None]
 
+# list of modules which selectively interned by default. These are generally unstable
+#  modules which should not be externed due to lack of backwards compatibility
+
+DEFAULT_SELECTIVE_INTERN_LIST = {
+    "torch": [
+        "torch.fb",
+        "torch.quantization",
+        "torch.fx",
+        "torch.testing._internal.quantization_torch_package_models",
+    ]
+}
+
 
 class _ModuleProviderAction(Enum):
     """Represents one of the actions that :class:`PackageExporter` can take on a module.
@@ -59,6 +72,7 @@ class _ModuleProviderAction(Enum):
     # (`torch_package_importer`) that allows packaged code to access it. Don't
     # re-export this.
     SKIP = 6
+    SELECTIVE_EXTERN = 7
 
 
 class PackagingErrorReason(Enum):
@@ -230,6 +244,17 @@ class PackageExporter:
 
         self.patterns: Dict[GlobGroup, _PatternInfo] = {}
         self._unique_id = 0
+        self._selective_interns: Dict[str, [str]] = {}
+        self._inverse_default_selective_intern_list = {}
+        for (package_name, interned_packages) in DEFAULT_SELECTIVE_INTERN_LIST.items():
+            if self._module_exists(package_name):
+                self._selective_intern(
+                    package_name, interned_packages, allow_empty=True
+                )
+            for interned_package in interned_packages:
+                self._inverse_default_selective_intern_list[
+                    interned_package
+                ] = package_name
 
     def save_source_file(
         self, module_name: str, file_or_directory: str, dependencies=True
@@ -427,7 +452,6 @@ class PackageExporter:
             and self.dependency_graph.nodes[module_name].get("provided") is True
         ):
             return
-
         # Special case: PackageImporter provides a special module called
         # `torch_package_importer` that allows packaged modules to reference
         # their PackageImporter. We don't want to re-export this.
@@ -452,12 +476,12 @@ class PackageExporter:
                 module_name, action=_ModuleProviderAction.EXTERN, provided=True
             )
             return
-
         for pattern, pattern_info in self.patterns.items():
             if pattern.matches(module_name):
                 pattern_info.was_matched = True
+                action = pattern_info.action
                 self.dependency_graph.add_node(
-                    module_name, action=pattern_info.action, provided=True
+                    module_name, action=action, provided=True
                 )
 
                 if pattern_info.action == _ModuleProviderAction.DENY:
@@ -468,8 +492,23 @@ class PackageExporter:
 
                 # If we are interning this module, we need to retrieve its
                 # dependencies and package those as well.
-                if pattern_info.action == _ModuleProviderAction.INTERN:
+                if action == _ModuleProviderAction.INTERN:
                     self._intern_module(module_name, dependencies)
+                if action == _ModuleProviderAction.SELECTIVE_EXTERN:
+                    module_obj = self._import_module(module_name)
+                    is_package = hasattr(module_obj, "__path__")
+                    source = self._get_source_of_module(module_obj)
+
+                    assert is_package
+                    assert source
+
+                    self.dependency_graph.add_node(
+                        module_name,
+                        action=_ModuleProviderAction.SELECTIVE_EXTERN,
+                        provided=True,
+                        source=source,
+                        is_package=is_package,
+                    )
                 return
 
         # No patterns have matched. Explicitly add this as an error.
@@ -676,6 +715,45 @@ class PackageExporter:
         handle = RemovableHandle(self._intern_hooks)
         self._intern_hooks[handle.id] = hook
         return handle
+
+    # TODO: can we replace interned_packages with an include/exclude and use a GlobGroup/pattern
+    # so things don't have to be so explicit
+
+    def _selective_intern(
+        self, package_name: str, interned_modules: [str], allow_empty: bool = True
+    ):
+        """Specify extra modules not included in DEFAULT_SELECTIVE_INTERN_LIST that should be selectively interned
+            that should be packaged.
+        Args:
+            package_name: name of selectively externed package which contains the interned modules
+
+            interned_modules: modules we are interning and expect to use in the source code that will be packaged
+                              and are submodules of package_name.
+
+
+            allow_empty (bool): An optional flag that specifies whether the intern modules specified by this call
+                to the ``intern`` method must be matched to some module during packaging. If an ``intern`` module glob
+                pattern is added with ``allow_empty=False``, and :meth:`close` is called (either explicitly or via ``__exit__``)
+                before any modules match that pattern, an exception is thrown. If ``allow_empty=True``, no such exception is thrown.
+
+        """
+        assert self._module_exists(package_name), package_name
+        if package_name not in self._selective_interns:
+            self._selective_interns[package_name] = set()
+        self._selective_interns[package_name].update(interned_modules)
+        included_packages_in_pattern = []
+
+        self.patterns[GlobGroup(include=package_name)] = _PatternInfo(
+            _ModuleProviderAction.SELECTIVE_EXTERN, allow_empty
+        )
+        interned_package_patterns = [f"{package}.**" for package in interned_modules]
+        self.patterns[GlobGroup(include=interned_package_patterns)] = _PatternInfo(
+            _ModuleProviderAction.INTERN, allow_empty
+        )
+        interned_package_patterns.append(package_name)
+        self.patterns[
+            GlobGroup(include=f"{package_name}.**", exclude=interned_package_patterns)
+        ] = _PatternInfo(_ModuleProviderAction.EXTERN, allow_empty)
 
     def intern(
         self,
@@ -890,6 +968,15 @@ class PackageExporter:
             mock_file = str(Path(__file__).parent / "_mock.py")
             self._write_source_string("_mock", _read_file(mock_file), is_package=False)
 
+    def _write_selective_externs(self):
+        if self._selective_interns:
+            selective_extern_file_contents = (
+                "\n".join(self._selective_interns.keys()) + "\n"
+            )
+            self._write(
+                ".data/selective_extern_packages", selective_extern_file_contents
+            )
+
     def _execute_dependency_graph(self):
         """Takes a finalized dependency graph describing how to package all
         modules and executes it, writing to the ZIP archive.
@@ -899,7 +986,7 @@ class PackageExporter:
         extern_modules = []
         for module_name, attrs in self.dependency_graph.nodes.items():
             action = attrs["action"]
-
+            is_selective_extern = self._check_if_selectively_externed(module_name)
             if action == _ModuleProviderAction.EXTERN:
                 for hook in self._extern_hooks.values():
                     hook(self, module_name)
@@ -929,9 +1016,35 @@ class PackageExporter:
                 if attrs.get("is_pickle") is True:
                     # This node came from save_source_pickle, we don't need to write any source for it.
                     continue
-
                 is_package = attrs["is_package"]
                 source = attrs["source"]
+                self._write_source_string(module_name, source, is_package)
+            elif action == _ModuleProviderAction.SELECTIVE_EXTERN:
+                is_package = attrs["is_package"]
+                source = attrs["source"]
+                selective_extern_template_file = str(
+                    Path(__file__).parent / "_selective_extern.py"
+                )
+                selective_extern_file_template = Template(
+                    _read_file(selective_extern_template_file)
+                )
+
+                matches = self._selective_interns[module_name]
+                original_init = self._get_source_of_module(
+                    self._import_module(module_name)
+                )
+                assert original_init
+                interned_modules = ", ".join(
+                    f'"{match[len(module_name) + 1:]}"' for match in matches
+                )
+                source = "\n\n".join(
+                    [
+                        selective_extern_file_template.substitute(
+                            interned_modules=interned_modules,
+                            package_name=f'"{module_name}"',
+                        )
+                    ]
+                )
                 self._write_source_string(module_name, source, is_package)
 
             elif action == _ModuleProviderAction.REPACKAGED_MOCK_MODULE:
@@ -945,6 +1058,7 @@ class PackageExporter:
 
         extern_file_contents = "\n".join(extern_modules) + "\n"
         self._write(".data/extern_modules", extern_file_contents)
+        self._write_selective_externs()
 
     def close(self):
         """Write the package to the filesystem. Any calls after :meth:`close` are now invalid.
@@ -969,11 +1083,19 @@ class PackageExporter:
         resource = _normalize_path(resource)
         return f"{package_path}/{resource}"
 
-    def _can_implicitly_extern(self, module_name: str):
+    def _check_if_selectively_externed(self, module_name: str) -> bool:
+        for pattern, pattern_info in self.patterns.items():
+            if pattern_info.action == _ModuleProviderAction.SELECTIVE_EXTERN:
+                if pattern.matches(module_name):
+                    return True
+        return False
+
+    def _can_implicitly_extern(self, module_name: str) -> bool:
         top_level_package_name = module_name.partition(".")[0]
-        return top_level_package_name == "torch" or (
-            top_level_package_name not in _DISALLOWED_MODULES
-            and is_stdlib_module(top_level_package_name)
+        if self._check_if_selectively_externed(module_name):
+            return False
+        return top_level_package_name not in _DISALLOWED_MODULES and is_stdlib_module(
+            top_level_package_name
         )
 
     def dependency_graph_string(self) -> str:
@@ -1055,7 +1177,8 @@ class PackageExporter:
 
 # even though these are in the standard library, we do not allow them to be
 # automatically externed since they offer a lot of system level access
-_DISALLOWED_MODULES = ["sys", "io"]
+# _DISALLOWED_MODULES = ["sys", "io"]
+_DISALLOWED_MODULES = ["io"]
 
 _MOCK_IMPL = """\
 from _mock import MockedObject


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69043

**Selective Intern**

TL;DR This PR creates a shim for certain externed modules as described here https://fb.quip.com/I9PeAGfkt9Wl

Traditionally we extern entire libraries such as torch. However, sometimes parts of these libraries such as torch.fb or torch.quanitization are unstable. Therefore, this PR allows you to selectively intern parts of these externed submodules in order to maintain an internal copy of the unstable bits of the externed module. The primary use case for this is actually for torch which is externed automatically, but has unstable libraries such as torch.fb and torch.quantization which can cause breaks later on if they are externed.

We define a **selective extern** module as a module which we extern but there are submodules in it which we want to intern (ie. torch). A **selective intern** module is one of those submodules we want to intern (ie. torch.fb). 

In order to achieve this we added a new function to the package_exporter api _selective_intern(str package_name, [str] interned_packages) which makes package_name a selective extern module and those defined by interned_packages which are selectively interned modules. Selective externed modules return a shim when import is called on them which either returns a selectively interned submodule or an externed submodule when requested. We also extern all submodules which were not selective intern modules.

For example if we packaged something with 
```
package_exporter._selective_intern("torch",["torch.fb"])
```
and then run

```
import torch 
use(torch.fb)
use(torch.nn)
```
torch.fb would be interned and torch.nn would be externed.

Lastly, we still maintain that external dependencies of selective intern modules are still externed. For example if torch has a dependency on foo which is dependent on torch.fb, then foo's copy of torch.fb would be externed which calling torch.fb would still give you the interned module.