### PR TITLE
[ONNX] Remove f arg from export_to_pretty_string

### DIFF
--- a/test/jit/test_export_modes.py
+++ b/test/jit/test_export_modes.py
@@ -79,7 +79,7 @@ class TestExportModes(JitTestCase):
         x = torch.rand(3, 4)
         y = torch.rand(3, 4)
         torch.onnx.export_to_pretty_string(
-            ModelWithAtenNotONNXOp(), (x, y), None,
+            ModelWithAtenNotONNXOp(), (x, y),
             add_node_names=False,
             do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
@@ -95,7 +95,7 @@ class TestExportModes(JitTestCase):
         x = torch.randn(3, 4, dtype=torch.float32)
         y = torch.randn(3, 4, dtype=torch.float32)
         torch.onnx.export_to_pretty_string(
-            ModelWithAtenFmod(), (x, y), None,
+            ModelWithAtenFmod(), (x, y),
             add_node_names=False,
             do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN)

--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -60,8 +60,7 @@ class TestONNXExport(JitTestCase):
 
         traced = torch.jit.trace(foo, (torch.rand([2])))
 
-        f = io.BytesIO()
-        torch.onnx._export_to_pretty_string(traced, (torch.rand([2]),), f)
+        torch.onnx._export_to_pretty_string(traced, (torch.rand([2]),))
 
     def test_onnx_export_script_module(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -75,7 +74,7 @@ class TestONNXExport(JitTestCase):
 
         mte = ModuleToExport()
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+            mte, (torch.zeros(1, 2, 3),), verbose=False)
 
     @suppress_warnings
     def test_onnx_export_func_with_warnings(self):
@@ -92,7 +91,7 @@ class TestONNXExport(JitTestCase):
 
         # no exception
         torch.onnx.export_to_pretty_string(
-            WarningTest(), torch.randn(42), None, verbose=False)
+            WarningTest(), torch.randn(42), verbose=False)
 
     def test_onnx_export_script_python_fail(self):
         class PythonModule(torch.jit.ScriptModule):
@@ -138,7 +137,7 @@ class TestONNXExport(JitTestCase):
 
         mte = ModuleToExport()
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+            mte, (torch.zeros(1, 2, 3),), verbose=False)
 
     def test_onnx_export_script_inline_script(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -161,7 +160,7 @@ class TestONNXExport(JitTestCase):
 
         mte = ModuleToExport()
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+            mte, (torch.zeros(1, 2, 3),), verbose=False)
 
     def test_onnx_export_script_module_loop(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -179,7 +178,7 @@ class TestONNXExport(JitTestCase):
 
         mte = ModuleToExport()
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+            mte, (torch.zeros(1, 2, 3),), verbose=False)
 
     @suppress_warnings
     def test_onnx_export_script_truediv(self):
@@ -195,7 +194,7 @@ class TestONNXExport(JitTestCase):
         mte = ModuleToExport()
 
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3, dtype=torch.float),), None, verbose=False)
+            mte, (torch.zeros(1, 2, 3, dtype=torch.float),), verbose=False)
 
     def test_onnx_export_script_non_alpha_add_sub(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -209,7 +208,7 @@ class TestONNXExport(JitTestCase):
 
         mte = ModuleToExport()
         torch.onnx.export_to_pretty_string(
-            mte, (torch.rand(3, 4),), None, verbose=False)
+            mte, (torch.rand(3, 4),), verbose=False)
 
     def test_onnx_export_script_module_if(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -224,7 +223,7 @@ class TestONNXExport(JitTestCase):
 
         mte = ModuleToExport()
         torch.onnx.export_to_pretty_string(
-            mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+            mte, (torch.zeros(1, 2, 3),), verbose=False)
 
     def test_onnx_export_script_inline_params(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -253,7 +252,7 @@ class TestONNXExport(JitTestCase):
         reference = torch.mm(torch.mm(torch.zeros(2, 3), torch.ones(3, 3)), torch.ones(3, 4))
         self.assertEqual(result, reference)
         torch.onnx.export_to_pretty_string(
-            mte, (torch.ones(2, 3),), None, verbose=False)
+            mte, (torch.ones(2, 3),), verbose=False)
 
     def test_onnx_export_speculate(self):
 
@@ -289,12 +288,10 @@ class TestONNXExport(JitTestCase):
 
         torch.onnx.export_to_pretty_string(
             f1,
-            (torch.ones(1, 10, dtype=torch.float), ),
-            None, verbose=False)
+            (torch.ones(1, 10, dtype=torch.float), ))
         torch.onnx.export_to_pretty_string(
             f2,
-            (torch.ones(1, 10, dtype=torch.float), ),
-            None, verbose=False)
+            (torch.ones(1, 10, dtype=torch.float), ))
 
     def test_onnx_export_shape_reshape(self):
         class Foo(torch.nn.Module):
@@ -306,8 +303,7 @@ class TestONNXExport(JitTestCase):
                 return reshaped
 
         foo = torch.jit.trace(Foo(), torch.zeros(1, 2, 3))
-        f = io.BytesIO()
-        torch.onnx.export_to_pretty_string(foo, (torch.zeros(1, 2, 3)), f)
+        torch.onnx.export_to_pretty_string(foo, (torch.zeros(1, 2, 3)))
 
     def test_listconstruct_erasure(self):
         class FooMod(torch.nn.Module):
@@ -315,10 +311,8 @@ class TestONNXExport(JitTestCase):
                 mask = x < 0.0
                 return x[mask]
 
-        import io
-        f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
-            FooMod(), (torch.rand(3, 4),), f,
+            FooMod(), (torch.rand(3, 4),),
             add_node_names=False,
             do_constant_folding=False,
             operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
@@ -337,9 +331,8 @@ class TestONNXExport(JitTestCase):
 
         input = torch.rand(3, 4, 5)
 
-        f = io.BytesIO()
         torch.onnx.export_to_pretty_string(
-            DynamicSliceExportMod(), (input,), f, opset_version=10)
+            DynamicSliceExportMod(), (input,), opset_version=10)
 
     def test_export_dict(self):
         class DictModule(torch.nn.Module):
@@ -350,12 +343,11 @@ class TestONNXExport(JitTestCase):
         mod = DictModule()
         mod.train(False)
 
-        f = io.BytesIO()
-        torch.onnx.export_to_pretty_string(mod, (x_in,), f)
+        torch.onnx.export_to_pretty_string(mod, (x_in,))
 
         with self.assertRaisesRegex(RuntimeError, r"DictConstruct.+is not supported."):
             torch.onnx.export_to_pretty_string(
-                torch.jit.script(mod), (x_in,), f)
+                torch.jit.script(mod), (x_in,))
 
     def test_source_range_propagation(self):
         class ExpandingModule(torch.nn.Module):

--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -60,7 +60,7 @@ class TestONNXExport(JitTestCase):
 
         traced = torch.jit.trace(foo, (torch.rand([2])))
 
-        torch.onnx._export_to_pretty_string(traced, (torch.rand([2]),))
+        torch.onnx.export_to_pretty_string(traced, (torch.rand([2]),))
 
     def test_onnx_export_script_module(self):
         class ModuleToExport(torch.jit.ScriptModule):

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -1118,7 +1118,7 @@ class TestTracer(JitTestCase):
                 return torch.matmul(x, w).detach()
 
         torch.onnx.export_to_pretty_string(
-            Mod(), (torch.rand(3, 4), torch.rand(4, 5)), None)
+            Mod(), (torch.rand(3, 4), torch.rand(4, 5)))
 
     def test_trace_slice_full_dim(self):
         def foo(x):

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -33,7 +33,7 @@ _onnx_dep = True  # flag to import onnx package.
 
 def export_to_pbtxt(model, inputs, *args, **kwargs):
     return torch.onnx.export_to_pretty_string(
-        model, inputs, None, verbose=False, google_printer=True,
+        model, inputs, verbose=False, google_printer=True,
         *args, **kwargs)
 
 

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -33,8 +33,7 @@ _onnx_dep = True  # flag to import onnx package.
 
 def export_to_pbtxt(model, inputs, *args, **kwargs):
     return torch.onnx.export_to_pretty_string(
-        model, inputs, verbose=False, google_printer=True,
-        *args, **kwargs)
+        model, inputs, google_printer=True, *args, **kwargs)
 
 
 def export_to_pb(model, inputs, *args, **kwargs):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -330,8 +330,6 @@ def export_to_pretty_string(*args, **kwargs) -> str:
     as :func:`export`.
 
     Args:
-      f:  Deprecated and ignored. Will be removed in the next release of
-          PyTorch.
       add_node_names (bool, default True): Whether or not to set
           NodeProto.name. This makes no difference unless
           ``google_printer=True``.
@@ -344,12 +342,6 @@ def export_to_pretty_string(*args, **kwargs) -> str:
     """
     from torch.onnx import utils
     return utils.export_to_pretty_string(*args, **kwargs)
-
-
-def _export_to_pretty_string(*args, **kwargs):
-    from torch.onnx import utils
-    return utils._export_to_pretty_string(*args, **kwargs)
-
 
 def _optimize_trace(graph, operator_export_type):
     from torch.onnx import utils

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -553,28 +553,11 @@ def _model_to_graph(model, args, verbose=False,
     return graph, params_dict, torch_out
 
 
-def export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
+def export_to_pretty_string(model, args, export_params=True, verbose=False, training=None,
                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
                             export_type=ExportTypes.PROTOBUF_FILE, google_printer=False, opset_version=None,
                             keep_initializers_as_inputs=None, custom_opsets=None, add_node_names=True,
                             do_constant_folding=True, dynamic_axes=None):
-    if f is not None:
-        warnings.warn("'f' is deprecated and ignored. It will be removed in the next PyTorch release.")
-    return _export_to_pretty_string(model, args, f, export_params, verbose, training,
-                                    input_names, output_names, operator_export_type,
-                                    export_type, google_printer, opset_version,
-                                    do_constant_folding=do_constant_folding,
-                                    add_node_names=add_node_names,
-                                    keep_initializers_as_inputs=keep_initializers_as_inputs,
-                                    custom_opsets=custom_opsets, dynamic_axes=dynamic_axes)
-
-
-def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, training=None,
-                             input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
-                             export_type=ExportTypes.PROTOBUF_FILE, google_printer=False, opset_version=None,
-                             do_constant_folding=True, keep_initializers_as_inputs=None,
-                             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
-                             onnx_shape_inference=True, dynamic_axes=None):
     from torch.onnx.symbolic_helper import _default_onnx_opset_version, _set_opset_version
     from torch.onnx.symbolic_helper import _set_operator_export_type
     if opset_version is None:

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -567,7 +567,7 @@ def export_to_pretty_string(model, args, export_params=True, verbose=False, trai
     _set_opset_version(opset_version)
     _set_operator_export_type(operator_export_type)
     from torch.onnx.symbolic_helper import _set_onnx_shape_inference
-    _set_onnx_shape_inference(onnx_shape_inference)
+    _set_onnx_shape_inference(True)
     with exporter_context(model, training):
         val_keep_init_as_ip = _decide_keep_init_as_input(keep_initializers_as_inputs,
                                                          operator_export_type,
@@ -578,7 +578,6 @@ def export_to_pretty_string(model, args, export_params=True, verbose=False, trai
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type,
                                                         val_do_constant_folding,
-                                                        fixed_batch_size=fixed_batch_size,
                                                         training=training, dynamic_axes=dynamic_axes)
 
         return graph._pretty_print_onnx(params_dict, opset_version, False,


### PR DESCRIPTION
The arg is not used and was previously deprecated.

Also remove torch.onnx._export_to_pretty_string. It's redundant with the
public version.