### PR TITLE
Bump view generation on ModifyCurrentView for t_()

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -309,6 +309,7 @@ void LazyTensor::SetSubView(ViewInfo view_info) const {
 void LazyTensor::ModifyCurrentView(ViewInfo view_info) const {
   if (data()->view != nullptr) {
     data()->view = data()->view->CreateSubView(view_info.shape, view_info);
+    data()->generation += 1;
     return;
   }
   // This node is not a view. Since this function is meant to modify a view

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -308,16 +308,14 @@ void LazyTensor::SetSubView(ViewInfo view_info) const {
 
 void LazyTensor::ModifyCurrentView(ViewInfo view_info) const {
   if (data()->view != nullptr) {
-    data()->view = data()->view->CreateSubView(view_info.shape, view_info);
-    data()->generation += 1;
+    SetSubView(view_info);
     return;
   }
   // This node is not a view. Since this function is meant to modify a view
   // in place, we need to turn this existing tensor into a view.
   torch::lazy::Value ir_value = GetIrValue();
   std::shared_ptr<Alias> alias = std::make_shared<Alias>(ir_value);
-  data()->view = std::make_shared<LazyView>(
-      torch::lazy::GetShapeFromTsValue(ir_value), alias, std::move(view_info));
+  data()->view = std::make_shared<LazyView>(view_info.shape, alias, std::move(view_info));
   AssignIrValue(torch::lazy::Value());
 }
 

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -6497,6 +6497,7 @@ TEST_F(AtenLtcTsTensorTest, TestTransposeInPlace) {
     torch::Tensor xla_input = CopyToDevice(input, device);
     torch::Tensor output = input.t_();
     torch::Tensor xla_output = xla_input.t_();
+    EXPECT_EQ(xla_output.sizes(), output.sizes());
     AllClose(output, xla_output);
     AllClose(input, xla_input);
   });


### PR DESCRIPTION
Bump the generation counter, to ensure any other views get the effects of a transpose.

Also, use the shape from the transposed view_info in the ModifyCurrentView code, since the original shape is no longer valid for a mutation transpose.