### PR TITLE
[fbgemm] remove assumption number of rows is in 32 bit

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -1,10 +1,10 @@
 #include <ATen/native/quantized/cpu/qembeddingbag_prepack.h>
 
-#include <c10/core/ScalarType.h>
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/quantized/cpu/embedding_packed_params.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <c10/core/ScalarType.h>
 #include <torch/library.h>
 
 #include <c10/util/irange.h>
@@ -57,11 +57,11 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
   at::Tensor channel_scales = qweight.q_per_channel_scales();
   at::Tensor channel_zero_points = qweight.q_per_channel_zero_points();
   std::vector<float> weight_scales(
-    channel_scales.data_ptr<float>(),
-    channel_scales.data_ptr<float>() + embedding_rows);
+      channel_scales.data_ptr<float>(),
+      channel_scales.data_ptr<float>() + embedding_rows);
   std::vector<float> weight_zero_points(
-    channel_zero_points.data_ptr<float>(),
-    channel_zero_points.data_ptr<float>() + embedding_rows);
+      channel_zero_points.data_ptr<float>(),
+      channel_zero_points.data_ptr<float>() + embedding_rows);
 
   for (const auto i : c10::irange(embedding_rows)) {
     weight_bias[i] = weight_zero_points[i] * weight_scales[i] * -1;
@@ -83,7 +83,7 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
 
   if (bit_width == 8) {
     at::parallel_for(
-        0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
+        0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
           for (const auto row : c10::irange(start_idx, end_idx)) {
             const uint8_t* input_row = weight_data + row * embedding_cols;
             std::uint8_t* output_row = output_data + row * output_columns;
@@ -102,7 +102,7 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
     embedding_cols =
         (embedding_cols + num_elem_per_byte - 1) / num_elem_per_byte;
     at::parallel_for(
-        0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
+        0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
           for (const auto row : c10::irange(start_idx, end_idx)) {
             const uint8_t* input_row = weight_data + row * embedding_cols;
             std::uint8_t* output_row = output_data + row * output_columns;
@@ -120,7 +120,12 @@ c10::intrusive_ptr<EmbeddingPackedParamsBase> PackedEmbeddingBagWeight::prepack(
   }
 
   auto packed_ptr = c10::make_intrusive<PackedEmbeddingBagWeight>(
-      output, std::move(weight_scales), std::move(weight_zero_points), bit_width, qtype, version);
+      output,
+      std::move(weight_scales),
+      std::move(weight_zero_points),
+      bit_width,
+      qtype,
+      version);
 
   return packed_ptr;
 }
@@ -203,16 +208,18 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
   // assert(packed_weights.size() == torch.Size([2, 10, 11]))
 
   TORCH_CHECK(
-    weight.scalar_type() == at::ScalarType::Float || weight.scalar_type() == at::ScalarType::Half,
-    "'embedding_bag_byte_prepack' only support float32 or float16.");
+      weight.scalar_type() == at::ScalarType::Float ||
+          weight.scalar_type() == at::ScalarType::Half,
+      "'embedding_bag_byte_prepack' only support float32 or float16.");
 
   const auto weight_sizes = weight.sizes();
   const auto cols_dim = weight_sizes.size() - 1;
-  const int32_t embedding_rows = c10::size_to_dim_(cols_dim, weight_sizes);
+  const int64_t embedding_rows = c10::size_to_dim_(cols_dim, weight_sizes);
   const int32_t embedding_cols = weight_sizes[cols_dim];
   // Add 8 bytes per column to store FP32 scale and zero_point per row.
   const int32_t output_columns = embedding_cols + 2 * sizeof(float);
-  const auto weight_contig = weight.expect_contiguous(weight.suggest_memory_format());
+  const auto weight_contig =
+      weight.expect_contiguous(weight.suggest_memory_format());
 
   // Adjust output dimensions to account for FP32 scale and zero_points.
   std::vector<int64_t> output_shape = weight_sizes.vec();
@@ -224,32 +231,32 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
   if (weight.scalar_type() == at::ScalarType::Half) {
     const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
     at::parallel_for(
-        0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (const auto row : c10::irange(start_idx, end_idx)) {
-            fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<fbgemm::float16>(
-              weight_data + row * embedding_cols, 1,
-                embedding_cols, output_data + row * output_columns);
-          }
+        0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
+          fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<
+              fbgemm::float16>(
+              weight_data + start_idx * embedding_cols,
+              end_idx - start_idx,
+              embedding_cols,
+              output_data + start_idx * output_columns);
         });
-  }
-  else {
+  } else {
     const auto weight_data = weight.data_ptr<float>();
     at::parallel_for(
-        0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (const auto row : c10::irange(start_idx, end_idx)) {
-            fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
-              weight_data + row * embedding_cols, 1,
-                embedding_cols, output_data + row * output_columns);
-          }
+        0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
+          fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
+              weight_data + start_idx * embedding_cols,
+              end_idx - start_idx,
+              embedding_cols,
+              output_data + start_idx * output_columns);
         });
   }
 
 #else
   const auto weight_data = weight_contig->scalar_type() == at::ScalarType::Half
-    ? weight_contig->to(at::ScalarType::Float).data_ptr<float>()
-    : weight_contig->data_ptr<float>();
+      ? weight_contig->to(at::ScalarType::Float).data_ptr<float>()
+      : weight_contig->data_ptr<float>();
   constexpr float kEpsilon = 1e-8f;
-  for (auto row: c10::irange(embedding_rows)) {
+  for (auto row : c10::irange(embedding_rows)) {
     const float* input_row = weight_data + row * embedding_cols;
     std::uint8_t* output_row = output_data + row * output_columns;
     float* output_row_scale_zp =
@@ -264,7 +271,7 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
     output_row_scale_zp[0] = range / 255.0f;
     output_row_scale_zp[1] = minimum_element;
     const auto inverse_scale = 255.0f / (range + kEpsilon);
-    for (auto col: c10::irange(embedding_cols)) {
+    for (auto col : c10::irange(embedding_cols)) {
       output_row[col] =
           lrintf((input_row[col] - minimum_element) * inverse_scale);
     } // embedding_cols
@@ -275,7 +282,8 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
 }
 
 Tensor qembeddingbag_byte_prepack(const Tensor& weight) {
-  const auto weight_contig = weight.expect_contiguous(weight.suggest_memory_format());
+  const auto weight_contig =
+      weight.expect_contiguous(weight.suggest_memory_format());
   auto output = at::detail::empty_cpu(
       {0},
       at::kByte,
@@ -289,7 +297,8 @@ Tensor qembeddingbag_byte_prepack(const Tensor& weight) {
 
 namespace {
 
-// TODO: Extend support to N-D batched embeddings, similar to qembeddingbag_byte_prepack
+// TODO: Extend support to N-D batched embeddings, similar to
+// qembeddingbag_byte_prepack
 Tensor _qembeddingbag_nbit_prepack_helper(
     const Tensor& weight,
     int bit_width,
@@ -297,8 +306,9 @@ Tensor _qembeddingbag_nbit_prepack_helper(
     const int64_t nbins,
     const double ratio) {
   TORCH_CHECK(
-    weight.scalar_type() == at::ScalarType::Float || weight.scalar_type() == at::ScalarType::Half,
-    "'qembeddingbag_nbit_prepack' only support float32 or float16.");
+      weight.scalar_type() == at::ScalarType::Float ||
+          weight.scalar_type() == at::ScalarType::Half,
+      "'qembeddingbag_nbit_prepack' only support float32 or float16.");
 
   int64_t embedding_rows = weight.size(0);
   int64_t embedding_cols = weight.size(1);
@@ -339,29 +349,32 @@ Tensor _qembeddingbag_nbit_prepack_helper(
     if (weight.scalar_type() == at::ScalarType::Half) {
       const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
       at::parallel_for(
-        0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (const auto row : c10::irange(start_idx, end_idx)) {
-            fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<fbgemm::float16>(
-              bit_width, weight_data + row * embedding_cols, 1,
-              embedding_cols, output_data + row * output_shape[1]);
-          }
-        });
-    }
-    else {
+          0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
+            fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<
+                fbgemm::float16>(
+                bit_width,
+                weight_data + start_idx * embedding_cols,
+                end_idx - start_idx,
+                embedding_cols,
+                output_data + start_idx * output_shape[1]);
+          });
+    } else {
       const auto weight_data = weight.data_ptr<float>();
       at::parallel_for(
-        0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
-          for (const auto row : c10::irange(start_idx, end_idx)) {
+          0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
-              bit_width, weight_data + row * embedding_cols, 1,
-              embedding_cols, output_data + row * output_shape[1]);
-          }
-        });
+                bit_width,
+                weight_data + start_idx * embedding_cols,
+                end_idx - start_idx,
+                embedding_cols,
+                output_data + start_idx * output_shape[1]);
+          });
     }
   } else {
 #endif // USE_FBGEMM
     const auto output_columns = output.size(output.dim() - 1);
-    const auto float_weight = weight_contig.scalar_type() == at::ScalarType::Half
+    const auto float_weight =
+        weight_contig.scalar_type() == at::ScalarType::Half
         ? weight_contig.to(at::ScalarType::Float)
         : weight_contig;
     const auto weight_data = float_weight.data_ptr<float>();


### PR DESCRIPTION
Summary: And remove unnecessary looping inside parallel_for despite fbgemm routines support batching multiple rows

Test Plan: CI

Differential Revision: D32715453

