### PR TITLE
correct GroupNorm explanation

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -231,7 +231,7 @@ class GroupNorm(Module):
         >>> m = nn.GroupNorm(3, 6)
         >>> # Separate 6 channels into 6 groups (equivalent with InstanceNorm)
         >>> m = nn.GroupNorm(6, 6)
-        >>> # Put all 6 channels into a single group (equivalent with LayerNorm)
+        >>> # Put all 6 channels into a single group
         >>> m = nn.GroupNorm(1, 6)
         >>> # Activating the module
         >>> output = m(input)


### PR DESCRIPTION
I delete " (equivalent with LayerNorm)". Assuming the input format is  [N, C, W, H], when group number is 1, GroupNorm is still not equivalent with LayerNorm since the affine weight shape of GroupNorm is always [C] while the affine weight shape of LayerNorm is [C, H, W].
