### PR TITLE
Add `CUDAExtension` with cusparse to cpp extension test

### DIFF
--- a/test/cpp_extensions/cusparse_extension.cpp
+++ b/test/cpp_extensions/cusparse_extension.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include <cublas_v2.h>
+#include <cusparse.h>
+
+torch::Tensor noop_cusparse_function(torch::Tensor x) {
+  cusparseHandle_t sparse_handle;
+  TORCH_CUDASPARSE_CHECK(cusparseCreate(&sparse_handle));
+  TORCH_CUDASPARSE_CHECK(cusparseDestroy(sparse_handle));
+  return x;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("noop_cusparse_function", &noop_cusparse_function, "a cublas function");
+}

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -49,7 +49,8 @@ if torch.cuda.is_available() and (CUDA_HOME is not None or ROCM_HOME is not None
                             'nvcc': ['-O2']})
     ext_modules.append(extension)
 
-# todo(mkozuki): Figure out the root cause
+# todo (mkozuki): Enable extension build on Windows.
+# see https://github.com/pytorch/pytorch/pull/67161#issuecomment-958062611
 if (not IS_WINDOWS) and torch.cuda.is_available() and CUDA_HOME is not None:
     cublas_extension = CUDAExtension(
         name='torch_test_cpp_extension.cublas_extension',
@@ -62,6 +63,12 @@ if (not IS_WINDOWS) and torch.cuda.is_available() and CUDA_HOME is not None:
         sources=['cusolver_extension.cpp']
     )
     ext_modules.append(cusolver_extension)
+
+    cusparse_extension = CUDAExtension(
+        name="torch_test_cpp_extension.cusparse_extension",
+        sources=["cusparse_extension.cpp"],
+    )
+    ext_modules.append(cusparse_extension)
 
 setup(
     name='torch_test_cpp_extension',

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -102,6 +102,16 @@ class TestCppExtensionAOT(common.TestCase):
         z = cusolver_extension.noop_cusolver_function(x)
         self.assertEqual(z, x)
 
+    @common.skipIfRocm
+    @unittest.skipIf(common.IS_WINDOWS, "Windows not supported")
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_cusparse_extension(self):
+        from torch_test_cpp_extension import cusparse_extension
+
+        x = torch.zeros(100, device="cuda", dtype=torch.float32)
+        z = cusparse_extension.noop_cusparse_function(x)
+        self.assertEqual(z, x)
+
     @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
     def test_no_python_abi_suffix_sets_the_correct_library_name(self):
         # For this test, run_test.py will call `python setup.py install` in the


### PR DESCRIPTION
Add a small CUDA extension using `TORCH_CUDASPARSE_CHECK` to assure that `TORCH_CUDASPARSE_CHECK` is usable in `CUDAExtension` as well as `TORCH_CUDABLAS_CHECK` and `TORCH_CUSOLVER_CHECK`.

Follow-up of https://github.com/pytorch/pytorch/issues/67073

cc @xwang233 @ptrblck 