### PR TITLE
Fix some usages of CUDA_VERSION

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -76,11 +76,11 @@ TORCH_API void record_kernel_function_dtype(std::string name);
 // Workaround for C10_UNUSED because CUDA 10.1 and below fails to handle unused
 // attribute in the type aliasing context. Keep name long and verbose to avoid
 // macro collisions.
-#if defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10100
+#if defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10010
 #define C10_UNUSED_DISPATCH_CUDA_WORKAROUND
 #else
 #define C10_UNUSED_DISPATCH_CUDA_WORKAROUND C10_UNUSED
-#endif // defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10100
+#endif // defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10010
 
 #if defined __cpp_if_constexpr
 #define AT_QINT_PRIVATE_CASE_TYPE(                                           \

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -136,7 +136,7 @@ C10_EXPORT const char* _cublasGetErrorEnum(cublasStatus_t error) {
 /* LEVEL 3 BLAS FUNCTIONS */
 
 #ifndef USE_ROCM
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11200
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11020
 #define cublasGemmStridedBatchedExFix cublasGemmStridedBatchedEx
 #else
 // Workaround for https://github.com/pytorch/pytorch/issues/45724

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -507,7 +507,7 @@ namespace c10_internal {
 template <typename T>
 C10_HOST_DEVICE constexpr thrust::complex<T>
 cuda101bug_cast_c10_complex_to_thrust_complex(const c10::complex<T>& x) {
-#if defined(CUDA_VERSION) && (CUDA_VERSION < 10200)
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 10020)
   // This is to circumvent a CUDA compilation bug. See
   // https://github.com/pytorch/pytorch/pull/38941 . When the bug is fixed, we
   // should do static_cast directly.


### PR DESCRIPTION
See https://pytorch.slack.com/archives/G4Z791LL8/p1638229956006300

I grepped c10, aten, and torch for CUDA_VERSION and checked the usages I saw.
I can't guarantee I made a clean sweep. but this improves the status quo.

cc @ngimel