### PR TITLE
Add support for C++ frontend wrapper on Linux

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -864,5 +864,13 @@ class TestExtensionUtils(TestCase):
             torch._register_device_module('xpu', DummyXPUModule)
 
 
+class TestCppExtensionUtils(TestCase):
+    def test_cpp_compiler_is_ok(self):
+        self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform('c++'))
+
+    def test_cc_compiler_is_ok(self):
+        self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform('cc'))
+
+
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#69094 Add support for C++ frontend wrapper on Linux**
* #69093 Introduce `IS_LINUX` and `IS_MACOS` global vars
* #69101 Fix mypy in cpp_extesions.py

Partially addresses https://github.com/pytorch/pytorch/issues/68768

Differential Revision: [D32730079](https://our.internmc.facebook.com/intern/diff/D32730079)