### PR TITLE
Fix mypy in cpp_extensions.py

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -311,7 +311,7 @@ def check_compiler_abi_compatibility(compiler) -> bool:
             minimum_required_version = MINIMUM_MSVC_VERSION
             compiler_info = subprocess.check_output(compiler, stderr=subprocess.STDOUT)
             match = re.search(r'(\d+)\.(\d+)\.(\d+)', compiler_info.decode(*SUBPROCESS_DECODE_ARGS).strip())
-            version = (0, 0, 0) if match is None else match.groups()
+            version = ['0', '0', '0'] if match is None else list(match.groups())
     except Exception:
         _, error, _ = sys.exc_info()
         warnings.warn(f'Error checking compiler version for {compiler}: {error}')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69094 Add support for C++ frontend wrapper on Linux
* #69093 Introduce `IS_LINUX` and `IS_MACOS` global vars
* **#69101 Fix mypy in cpp_extesions.py**

Differential Revision: [D32730081](https://our.internmc.facebook.com/intern/diff/D32730081)