### PR TITLE
Add codegen support for logdet

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -224,6 +224,15 @@ std::vector<Shape> compute_shape_smooth_l1_loss_backward(
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
+std::vector<Shape> compute_shape_logdet(const at::Tensor & self) {
+  // assumes self.shape is {*, n, n} and returns shape *
+  TORCH_INTERNAL_ASSERT(self.dim() >= 2);
+  std::vector<int64_t> out_sizes(self.sizes().begin(), self.sizes().end() - 2);
+  // Doesn't check input dtype, but output dtype either matches it,
+  // or the actual logdet operation will throw if it's an unsupported type
+  return {Shape(self.scalar_type(), out_sizes)};
+}
+
 std::vector<Shape> compute_shape_log_sigmoid_forward(const at::Tensor& self) {
   // Based on definition of aten/src/ATen/native/Activation.cpp::log_sigmoid_forward_out_cpu.
   return {Shape(self.scalar_type(), self.sizes().vec()),

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -38,6 +38,7 @@ full_codegen:
   - leaky_relu
   - leaky_relu_backward
   - log2
+  - logdet
   - log_sigmoid_backward
   - log_sigmoid_forward
   - lt.Scalar


### PR DESCRIPTION
- Fixes test_ptltc for debug build, becuase at::native::logdet does
  something odd that causes LTCTensorImpl to get destructed with
  refcount=1.  Suspect this is related to EXCLUSIVE_OWNED usage, but
  didn't debug it.

