### PR TITLE
Add nvidia-smi memory and utilization as native Python API

### DIFF
--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -26,11 +26,13 @@ torch.cuda
     ipc_collect
     is_available
     is_initialized
+    memory_usage
     set_device
     set_stream
     set_sync_debug_mode
     stream
     synchronize
+    utilization
 
 Random Number Generator
 -------------------------

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -11,6 +11,7 @@ It is lazily initialized, so you can always import it, and use
 import contextlib
 import os
 import torch
+from torch.types import Device
 import traceback
 import warnings
 import threading
@@ -570,6 +571,58 @@ def get_sync_debug_mode() -> int:
 
     _lazy_init()
     return torch._C._cuda_get_sync_debug_mode()
+
+
+def memory_usage(device: Optional[Union[Device, int]] = None) -> int:
+    r"""Returns the percent of time over the past sample period during which global (device)
+    memory was being read or written. as given by `nvidia-smi`.
+
+    Args:
+        device (torch.device or int, optional): selected device. Returns
+            statistic for the current device, given by :func:`~torch.cuda.current_device`,
+            if :attr:`device` is ``None`` (default).
+
+    Warning: Each sample period may be between 1 second and 1/6 second,
+    depending on the product being queried.
+    """
+    try:
+        import pynvml  # type: ignore[import]
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("pynvml module not found, please install pynvml")
+    from pynvml import NVMLError_DriverNotLoaded
+    try:
+        pynvml.nvmlInit()
+    except NVMLError_DriverNotLoaded:
+        raise RuntimeError("cuda driver can't be loaded, is cuda enabled?")
+    device = _get_device_index(device, optional=True)
+    handle = pynvml.nvmlDeviceGetHandleByIndex(device)
+    return pynvml.nvmlDeviceGetUtilizationRates(handle).memory
+
+
+def utilization(device: Optional[Union[Device, int]] = None) -> int:
+    r"""Returns the percent of time over the past sample period during which one or
+    more kernels was executing on the GPU as given by `nvidia-smi`.
+
+    Args:
+        device (torch.device or int, optional): selected device. Returns
+            statistic for the current device, given by :func:`~torch.cuda.current_device`,
+            if :attr:`device` is ``None`` (default).
+
+    Warning: Each sample period may be between 1 second and 1/6 second,
+    depending on the product being queried.
+    """
+    try:
+        import pynvml  # type: ignore[import]
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("pynvml module not found, please install pynvml")
+    from pynvml import NVMLError_DriverNotLoaded
+    try:
+        pynvml.nvmlInit()
+    except NVMLError_DriverNotLoaded:
+        raise RuntimeError("cuda driver can't be loaded, is cuda enabled?")
+    device = _get_device_index(device, optional=True)
+    handle = pynvml.nvmlDeviceGetHandleByIndex(device)
+    return pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
 
 
 from .memory import *  # noqa: F403


### PR DESCRIPTION
Summary: Add nvidia-smi memory and utilization as native Python API

Test Plan:
testing the function returns the appropriate value.
Unit tests to come.

Differential Revision: D32711562

