### PR TITLE
Add slow path to `getCustomClassTypeImpl` (#68717)

### DIFF
--- a/.github/generated-ciflow-ruleset.json
+++ b/.github/generated-ciflow-ruleset.json
@@ -27,7 +27,7 @@
       "linux-xenial-py3.6-gcc7-bazel-test",
       "macos-10-15-py3-arm64",
       "macos-10-15-py3-lite-interpreter-x86-64",
-      "macos-10-15-py3-x86-64",
+      "macos-11-py3-x86-64",
       "parallelnative-linux-xenial-py3.6-gcc5.4",
       "periodic-libtorch-linux-xenial-cuda11.1-py3.6-gcc7",
       "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
@@ -134,7 +134,7 @@
       "ios-12-5-1-x86-64-full-jit",
       "macos-10-15-py3-arm64",
       "macos-10-15-py3-lite-interpreter-x86-64",
-      "macos-10-15-py3-x86-64"
+      "macos-11-py3-x86-64"
     ],
     "ciflow/mobile": [
       "linux-xenial-py3-clang5-mobile-build",

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -33,9 +33,11 @@ LINUX_RUNNERS = {
 }
 
 MACOS_TEST_RUNNER_10_15 = "macos-10.15"
+MACOS_TEST_RUNNER_11 = "macos-11"
 
 MACOS_RUNNERS = {
     MACOS_TEST_RUNNER_10_15,
+    MACOS_TEST_RUNNER_11,
 }
 
 CUDA_RUNNERS = {
@@ -628,9 +630,9 @@ IOS_WORKFLOWS = [
 MACOS_WORKFLOWS = [
     CIWorkflow(
         arch="macos",
-        build_environment="macos-10-15-py3-x86-64",
-        xcode_version="12",
-        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        build_environment="macos-11-py3-x86-64",
+        xcode_version="12.4",
+        test_runner_type=MACOS_TEST_RUNNER_11,
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_MACOS},
         ),

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/macos_ci_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: macos-10-15-py3-x86-64
+name: macos-11-py3-x86-64
 
 on:
   pull_request:
@@ -17,14 +17,14 @@ defaults:
   run:
     shell: bash -e -l {0}
 env:
-  BUILD_ENVIRONMENT: macos-10-15-py3-x86-64
-  COMPACT_JOB_NAME: macos-10-15-py3-x86-64
+  BUILD_ENVIRONMENT: macos-11-py3-x86-64
+  COMPACT_JOB_NAME: macos-11-py3-x86-64
   IN_CI: 1
   IS_GHA: 1
   PYTORCH_RETRY_TEST_CASES: 1
 
-  # Set xcode xcode version to 12
-  DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+  # Set xcode xcode version to 12.4
+  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
 
 jobs:
 
@@ -48,10 +48,10 @@ jobs:
         run: echo "${LABELS}"
 
   build-test:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: [ciflow_should_run]
     env:
-      JOB_BASE_NAME: macos-10-15-py3-x86-64
+      JOB_BASE_NAME: macos-11-py3-x86-64
       # For sccache access (only on non-forked PRs)
       AWS_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
@@ -137,7 +137,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
-          JOB_BASE_NAME: macos-10-15-py3-x86-64-test
+          JOB_BASE_NAME: macos-11-py3-x86-64-test
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           TAG: ${{ steps.parse-ref.outputs.tag }}
@@ -150,5 +150,5 @@ jobs:
 
 
 concurrency:
-  group: macos-10-15-py3-x86-64-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: macos-11-py3-x86-64-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1228,8 +1228,23 @@ getCustomClassTypeMap();
 template <typename T>
 c10::ClassTypePtr getCustomClassTypeImpl() {
   auto& tmap = c10::getCustomClassTypeMap();
-  auto res = tmap.find(std::type_index(typeid(T)));
-  TORCH_CHECK(res != tmap.end(), "Can't find class id in custom class type map", "");
+  auto tindex = std::type_index(typeid(T));
+  auto res = tmap.find(tindex);
+  if (C10_UNLIKELY(res == tmap.end())) {
+    // type_index is not guaranteed to be unique across shared libraries on some platforms
+    // For example see https://github.com/llvm-mirror/libcxx/blob/78d6a7767ed57b50122a161b91f59f19c9bd0d19/include/typeinfo#L133
+    // Also, this is not the case if RTLD_LOCAL option is used, see
+    // https://github.com/pybind/pybind11/blob/f791dc8648e1f6ec33f402d679b6b116a76d4e1b/include/pybind11/detail/internals.h#L101-L106
+    // Take a slow path of iterating over all registered types and compare their names
+    auto class_name = std::string(tindex.name());
+    for(const auto &it: tmap) {
+      if (class_name == it.first.name()) {
+          tmap[tindex] = it.second;
+          return it.second;
+      }
+    }
+    TORCH_CHECK(false, "Can't find class id in custom class type map for ", tindex.name());
+  }
   return res->second;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:
This fixes custom class registration issue when `typeid` is not guaranteed to be unique across multiple libraries, which is the case for libc++ runtime on MacOS 11 in particular for M1
From [libcxx/include/typeinfo](https://github.com/llvm-mirror/libcxx/blob/78d6a7767ed57b50122a161b91f59f19c9bd0d19/include/typeinfo#L139):
```
// -------------------------------------------------------------------------- //
//                          NonUniqueARMRTTIBit
// -------------------------------------------------------------------------- //
// This implementation of type_info does not assume always a unique copy of
// the RTTI for a given type inside a program. It packs the pointer to the
// type name into a uintptr_t and reserves the high bit of that pointer (which
// is assumed to be free for use under the ABI in use) to represent whether
// that specific copy of the RTTI can be assumed unique inside the program.
// To implement equality-comparison of type_infos, we check whether BOTH
// type_infos are guaranteed unique, and if so, we simply compare the addresses
// of their type names instead of doing a deep string comparison, which is
// faster. If at least one of the type_infos can't guarantee uniqueness, we
// have no choice but to fall back to a deep string comparison.
```

But `std::type_index` hash is computed always assuming that implementation is unique
By adding a slow path this problem can be fixed in those scenarios.

Fixes https://github.com/pytorch/pytorch/issues/68039

Reviewed By: seemethere

Differential Revision: D32605187

Pulled By: malfet

fbshipit-source-id: 8d50e56885b8c97dad3bc34a69c47ef879456dd1