### PR TITLE
[RELAND] Fix Dispatching not considering List[Optional[Tensor]] for dispatch (#68073)

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -66,12 +66,17 @@ namespace detail {
         ts = ts | x.key_set();
       }
     }
-    void operator()(at::ArrayRef<c10::optional<at::Tensor>> xs) {
-      for (const auto& x : xs) {
+    // Tensor?[] translates to this case.
+    void operator()(const c10::List<c10::optional<at::Tensor>>& xs) {
+      for (c10::optional<at::Tensor> x : xs) {
         if (x.has_value()) {
           ts = ts | x.value().key_set();
         }
       }
+    }
+    void operator()(at::ArrayRef<c10::optional<at::Tensor>> xs) {
+      // Just checking that the handling of Tensor?[] didn't change.
+      TORCH_INTERNAL_ASSERT(false);
     }
     void operator()(const at::Generator& gen) {
       if (gen.defined()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:

Relanding the original PR. Its body was as follows:

Followup to https://github.com/pytorch/pytorch/pull/60787

It turns out that the original PR was wrong for unboxed kernels. We
recently ran into this in
https://github.com/facebookresearch/functorch/issues/124

For unboxed kernels, the correct type for a Tensor?[] argument is
actually `List<optional<Tensor>>`, not `ArrayRef<optional<Tensor>>`

Test Plan:
- assert that https://github.com/facebookresearch/functorch/issues/124
actually works

Reviewed By: gchanan

Differential Revision: D32313601

Pulled By: zou3519

fbshipit-source-id: 8028d5f34eecabc53d603bd54d6b6748b5db461a