### PR TITLE
Add lazy::Shape::numel() (#68314)

### DIFF
--- a/test/cpp/lazy/test_shape.cpp
+++ b/test/cpp/lazy/test_shape.cpp
@@ -20,6 +20,7 @@ TEST(ShapeTest, Basic1) {
 TEST(ShapeTest, Basic2) {
   auto shape = Shape(c10::ScalarType::Float, {1, 2, 3});
 
+  EXPECT_EQ(shape.numel(), 6);
   EXPECT_STREQ(shape.to_string().c_str(), "Float[1,2,3]");
   EXPECT_EQ(shape.scalar_type(), c10::ScalarType::Float);
   EXPECT_EQ(shape.dim(), 3);
@@ -36,6 +37,8 @@ TEST(ShapeTest, Basic3) {
   EXPECT_STREQ(shape.to_string().c_str(), "Float[]");
   EXPECT_EQ(shape.scalar_type(), c10::ScalarType::Float);
   EXPECT_EQ(shape.dim(), 0);
+  // this is surprising, but it's in line with how 0-D tensors behave
+  EXPECT_EQ(shape.numel(), 1);
   EXPECT_TRUE(shape.sizes().empty());
   EXPECT_THROW(shape.size(0), std::out_of_range);
 }

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -33,5 +33,13 @@ std::vector<Shape> convertShapes(
   return shape;
 }
 
+size_t Shape::numel() const {
+  size_t elts = 1;
+  for (auto size : sizes_) {
+    elts *= size;
+  }
+  return elts;
+}
+
 }  // namespace lazy
 }  // namespace torch

--- a/torch/csrc/lazy/core/shape.h
+++ b/torch/csrc/lazy/core/shape.h
@@ -23,6 +23,7 @@ class TORCH_API Shape {
   c10::ArrayRef<int64_t> sizes() const { return sizes_; }
   int64_t size(int64_t dim) const { return sizes_.at(dim); }
   void set_size(int64_t dim, int64_t size) { sizes_.at(dim) = size; }
+  size_t numel() const;
 
   bool operator==(const Shape& other) const;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:

Add a convenience to lazy::Shape for counting the number of elements (by multiplying out the dimensions).  This is a method on Tensor, and in switching other lazy tensor shape utils to use aten shape inference, we need numel counts.

Test Plan: add unit tests

Reviewed By: alanwaketan

Differential Revision: D32409138

fbshipit-source-id: 3ae725300f8826d38e45412f46501d5e5f776fb2