### PR TITLE
ci: Use default blank if no TEST_CONFIG (#69008)

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -141,7 +141,7 @@ fi
 # Linux bionic cannot find conda mkl with cmake 3.10, so we need a cmake from conda.
 # Alternatively we could point cmake to the right place
 # export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
-if [[ "${TEST_CONFIG}" == *xla* ]] || \
+if [[ "${TEST_CONFIG:-}" == *xla* ]] || \
    [[ "$BUILD_ENVIRONMENT" == *centos* ]] || \
    [[ "$BUILD_ENVIRONMENT" == *linux-bionic* ]]; then
   if ! which conda; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Test Plan: Imported from OSS

Reviewed By: malfet

Differential Revision: D32699051

Pulled By: seemethere

fbshipit-source-id: 9ed12fe8a7f541c6eda77182cfd1b0a733a545f0