### PR TITLE
[RPC][Dist CI][BE] RPC tests run in subprocess (#68821)

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -619,6 +619,9 @@ CUSTOM_HANDLERS = {
     "distributed/test_distributed_spawn": test_distributed,
     "distributed/test_c10d_nccl": get_run_test_with_subprocess_fn(),
     "distributed/test_c10d_gloo": get_run_test_with_subprocess_fn(),
+    "distributed/rpc/test_faulty_agent": get_run_test_with_subprocess_fn(),
+    "distributed/rpc/test_tensorpipe_agent": get_run_test_with_subprocess_fn(),
+    "distributed/rpc/cuda/test_tensorpipe_agent": get_run_test_with_subprocess_fn(),
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:

Continuing effort to move most distributed tests to run in subprocess
for better reproducibility + reduce flakiness.

Test Plan: CI

Reviewed By: H-Huang

Differential Revision: D32624199

fbshipit-source-id: 04448636320554d7a3ab29ae92bc1ca9fbe37da2