### PR TITLE
fix sccache issue on Windows CPU (#68870)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,7 +667,7 @@ endif()
 
 include(cmake/Dependencies.cmake)
 
-if((CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 10.2) AND (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows"))
+if(USE_CUDA AND (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 10.2) AND (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows"))
   # CUDA < 10.2 doesn't support compiling and extracting header dependencies in
   # one call, so instead CMake calls nvcc twice with && in between.
   # However, on windows cmd.exe has a 8191 character limit for commands which we


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:
Fixes https://github.com/pytorch/pytorch/issues/68796

```
2021-11-24T10:12:40.7634007Z Compile requests                   4312
2021-11-24T10:12:40.7634484Z Compile requests executed          4300
2021-11-24T10:12:40.7634823Z Cache hits                         4227
2021-11-24T10:12:40.7635122Z Cache hits (C/C++)                 4227
2021-11-24T10:12:40.7636139Z Cache misses                         62
2021-11-24T10:12:40.7636930Z Cache misses (C/C++)                 62
2021-11-24T10:12:40.7637333Z Cache timeouts                        0
2021-11-24T10:12:40.7637839Z Cache read errors                     0
2021-11-24T10:12:40.7638161Z Forced recaches                       0
2021-11-24T10:12:40.7638489Z Cache write errors                    0
2021-11-24T10:12:40.7638828Z Compilation failures                  1
2021-11-24T10:12:40.7639180Z Cache errors                         10
2021-11-24T10:12:40.7639490Z Cache errors (C/C++)                 10
2021-11-24T10:12:40.7639856Z Non-cacheable compilations            0
2021-11-24T10:12:40.7640244Z Non-cacheable calls                   0
2021-11-24T10:12:40.7640601Z Non-compilation calls                12
2021-11-24T10:12:40.7640987Z Unsupported compiler calls            0
2021-11-24T10:12:40.7641426Z Average cache write               0.104 s
2021-11-24T10:12:40.7641763Z Average cache read miss           6.000 s
2021-11-24T10:12:40.7642110Z Average cache read hit            0.046 s
2021-11-24T10:12:40.7642485Z Failed distributed compilations       0
```
https://github.com/pytorch/pytorch/runs/4310176911?check_suite_focus=true

cc seemethere malfet pytorch/pytorch-dev-infra

Reviewed By: ejguan

Differential Revision: D32646289

Pulled By: janeyx99

fbshipit-source-id: bf04446439e55a4ccaf9ce7c77812752ca717a7c