### PR TITLE
.github: Add linux.large instance type

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -18,6 +18,12 @@
 #     is_ephemeral: true
 
 runner_types:
+  # mainly used for ciflow-should-run, not made to run any serious tests
+  linux.large:
+    instance_type: c5.large
+    os: linux
+    disk_size: 10
+    is_ephemeral: false
   linux.2xlarge:
     instance_type: c5.2xlarge
     os: linux


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69166
* __->__ #69165

We're hitting hard concurrency limits for built in github runners so
let's use our own runners and make them non-ephemeral so they'll have
basically constant uptime

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D32735494](https://our.internmc.facebook.com/intern/diff/D32735494)