### PR TITLE
CUDACachingAllocator: make an error message more accurate.

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -361,7 +361,7 @@ class CachingAllocatorConfig {
             size_t val2 = stoi(kv[1]);
             TORCH_CHECK(
                 val2 > kLargeBuffer / (1024 * 1024),
-                "CachingAllocator option max_split_size_mb too small, must be >= ",
+                "CachingAllocator option max_split_size_mb too small, must be > ",
                 kLargeBuffer / (1024 * 1024),
                 "");
             val2 = std::max(val2, kLargeBuffer / (1024 * 1024));


### PR DESCRIPTION
The `TORCH_CHECK` asserts for strictly-greater-than `kLargeBuffer`,
but the exception claims `>=`. Fix the error message to match the
code.

Happy to open an issue if it's helpful; I was hopeful the trivial fix doesn't need a separate issue.