### PR TITLE
omitting always() seems to cancel test reporting when a prev step fails

### DIFF
--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -136,7 +136,7 @@ jobs:
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
-      !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
+      !{{ common.upload_test_statistics(build_environment, when="${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}") }}
 {% endblock +%}
 {%- endif %}
 

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -195,7 +195,7 @@ jobs:
           path:
             test-reports-*.zip
       - name: Display and upload test statistics (Click Me)
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:


### PR DESCRIPTION
e.g., here
https://github.com/pytorch/pytorch/runs/4373039939?check_suite_focus=true