### PR TITLE
[JIT] fix static variable initialization order issue

### DIFF
--- a/torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
@@ -15,14 +15,17 @@
 namespace torch {
 namespace jit {
 
-std::function<void(std::shared_ptr<Graph>&)> _fuseFrozenConvAddReluImpl;
+std::function<void(std::shared_ptr<Graph>&)>& getFuseFrozenConvAddReluImpl() {
+  static std::function<void(std::shared_ptr<Graph>&)> impl;
+  return impl;
+}
 
 // Implementation is in frozen_conv_add_relu_fusion.cpp; at runtime the
 // implementation is registered in _fuseFrozenConvAddReluImpl. This allows
 // the GPU code to be built separately from CPU-only code.
 void FuseFrozenConvAddRelu(std::shared_ptr<Graph>& graph) {
-  if (_fuseFrozenConvAddReluImpl) {
-    _fuseFrozenConvAddReluImpl(graph);
+  if (getFuseFrozenConvAddReluImpl()) {
+    getFuseFrozenConvAddReluImpl()(graph);
   } else {
     TORCH_WARN("No definition of _fuseFrozenConvAddReluImpl found");
   }

--- a/torch/csrc/jit/passes/frozen_conv_add_relu_fusion.h
+++ b/torch/csrc/jit/passes/frozen_conv_add_relu_fusion.h
@@ -6,8 +6,8 @@
 namespace torch {
 namespace jit {
 
-TORCH_API extern std::function<void(std::shared_ptr<Graph>&)>
-    _fuseFrozenConvAddReluImpl;
+TORCH_API extern std::function<void(std::shared_ptr<Graph>&)>&
+    getFuseFrozenConvAddReluImpl();
 
 TORCH_API void FuseFrozenConvAddRelu(std::shared_ptr<Graph>& graph);
 

--- a/torch/csrc/jit/passes/frozen_conv_add_relu_fusion_cuda.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_add_relu_fusion_cuda.cpp
@@ -108,7 +108,7 @@ void fuseFrozenConvAddReluImpl(std::shared_ptr<Graph>& graph) {
 }
 
 auto dummyInitializer = []() {
-  _fuseFrozenConvAddReluImpl = fuseFrozenConvAddReluImpl;
+  getFuseFrozenConvAddReluImpl() = &fuseFrozenConvAddReluImpl;
   return true;
 }();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69180

the `_fuseFrozenConvAddReluImpl` static variable can be uninitialized before the lambda in frozen_conv_add_relu_fusion_impl.cpp runs.