### PR TITLE
Fix MacOS artifact upload

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -123,7 +123,7 @@ concurrency:
       - name: Zip test reports for upload
         if: always()
         env:
-{%- if name == 'linux' or name == 'windows' %}
+{%- if name == 'linux' or name == 'windows' or name == 'macos' %}
           FILE_SUFFIX: '${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}'
 {%- else %}
           FILE_SUFFIX: '!{{ name }}-${{ github.job }}'

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Zip test reports for upload
         if: always()
         env:
-          FILE_SUFFIX: 'macos-${{ github.job }}'
+          FILE_SUFFIX: '${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}'
         run: |
           # Remove any previous test reports if they exist
           rm -f test-reports-*.zip


### PR DESCRIPTION
Add test shard number and runner name to the test name suffix
Otherwise test report names for shard 1 and shard 2 will be identical
and override each other
