### PR TITLE
[Static Runtime] Fix a bug that aten::embedding_bag keeps cannot handle resized input tensors

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -493,8 +493,8 @@ void make_bag_size_out(
     const bool include_last_offset,
     const bool requires_grad) {
   if (requires_grad || mode == MODE_MEAN || mode == MODE_MAX) {
-    auto num_bags = offsets.size(0) - (include_last_offset ? 1 : 0);
-    bag_size_out = at::zeros({num_bags}, offsets.options());
+    auto num_bags = offsets.sizes()[0] - (include_last_offset ? 1 : 0);
+    at::native::resize_(bag_size_out, {num_bags}, c10::nullopt);
     // Compute this for MODE_MEAN and MODE_MAX (latter needed for backwards)
     if (num_bags != 1) {
       bag_size_out.slice(0, 0, bag_size_out.sizes()[0] - 1, 1) =
@@ -504,6 +504,8 @@ void make_bag_size_out(
     if (num_bags > 0) {
       bag_size_out[-1] = indices.sizes()[0] - offsets[num_bags - 1];
     }
+  } else {
+    at::native::resize_(bag_size_out, offsets.sizes(), c10::nullopt);
   }
 }
 

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -208,50 +208,64 @@ TEST(StaticRuntime, Logit) {
   testStaticRuntime(logit_script_3, args_2, {c, b});
 }
 
-// TODO: check for dynamic shapes
 TEST(StaticRuntime, EmbeddingBag) {
   const std::string embedding_bag_default = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.embedding_bag(a, b, c)
+        x, y, z, _ = torch.embedding_bag(a, b, c)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
   )JIT";
 
   const std::string embedding_bag_mean = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.embedding_bag(a, b, c, False, 1)
+        x, y, z, _ = torch.embedding_bag(a, b, c, False, 1)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
   )JIT";
 
   const std::string embedding_bag_max = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.embedding_bag(a, b, c, False, 2)
+        x, y, z, _ = torch.embedding_bag(a, b, c, False, 2)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
   )JIT";
 
   const std::string embedding_bag_sum_last_offset = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.embedding_bag(a, b, c, False, 0, False, None, True)
+        x, y, z, _ = torch.embedding_bag(a, b, c, False, 0, False, None, True)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
   )JIT";
 
   const std::string embedding_bag_mean_last_offset = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.embedding_bag(a, b, c, False, 1, False, None, True)
+        x, y, z, _ = torch.embedding_bag(a, b, c, False, 1, False, None, True)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
   )JIT";
 
   const std::string embedding_bag_max_last_offset = R"JIT(
     def forward(self, a: Tensor, b: Tensor, c: Tensor):
-        return torch.embedding_bag(a, b, c, False, 2, False, None, True)
+        x, y, z, _ = torch.embedding_bag(a, b, c, False, 2, False, None, True)
+        return (x.clone(), y.clone(), z.clone(), _.clone())
   )JIT";
 
   at::Tensor weight = torch::randn({3, 11}, at::ScalarType::Float);
   at::Tensor input = torch::tensor({0, 1, 0, 2});
   at::Tensor offset = torch::tensor({0, 2, 4});
-
   std::vector<IValue> args{weight, input, offset};
-
   testStaticRuntime(embedding_bag_default, args);
   testStaticRuntime(embedding_bag_mean, args);
   testStaticRuntime(embedding_bag_max, args);
   testStaticRuntime(embedding_bag_sum_last_offset, args);
   testStaticRuntime(embedding_bag_mean_last_offset, args);
   testStaticRuntime(embedding_bag_max_last_offset, args);
+
+  at::Tensor weight2 = torch::randn({10, 11}, at::ScalarType::Float);
+  at::Tensor input2 = torch::tensor({0, 1, 0, 2, 1});
+  at::Tensor offset2 = torch::tensor({0, 1, 2, 3, 4, 5});
+  std::vector<IValue> args2{weight2, input2, offset2};
+  testStaticRuntime(embedding_bag_default, args, args2);
+  testStaticRuntime(embedding_bag_mean, args, args2);
+  testStaticRuntime(embedding_bag_max, args, args2);
+  testStaticRuntime(embedding_bag_sum_last_offset, args, args2);
+  testStaticRuntime(embedding_bag_mean_last_offset, args, args2);
+  testStaticRuntime(embedding_bag_max_last_offset, args, args2);
 }
 
 TEST(StaticRuntime, EmbeddingBagWithManagedOutput) {


### PR DESCRIPTION
Summary: This change fixes a bug that `aten::embedding_bag` implementation does not adjust the size of a managed output tensor according to a given input after memory planning starts.

Test Plan: Enhanced `StaticRuntime.EmbeddingBag` to trigger the existing bug that's fixed by this change.

Reviewed By: mikeiovine

Differential Revision: D32544399

