### PR TITLE
[ONNX] Add Concat to Scalar type analysis JIT pass

### DIFF
--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -283,12 +283,12 @@ class TestONNXOpset(TestCase):
                  {"op_name" : "Unsqueeze"},
                  {"op_name" : "Unsqueeze"},
                  {"op_name" : "Concat"},
-                 {"op_name" : "Constant"},
                  {"op_name" : "Cast"},
                  {"op_name" : "Shape"},
                  {"op_name" : "Slice"},
                  {"op_name" : "Cast"},
                  {"op_name" : "Div"},
+                 {"op_name" : "Constant"},
                  {"op_name" : "Concat"},
                  {"op_name" : "Upsample",
                   "attributes" :
@@ -306,7 +306,6 @@ class TestONNXOpset(TestCase):
                   {"op_name" : "Unsqueeze"},
                   {"op_name" : "Unsqueeze"},
                   {"op_name" : "Concat"},
-                  {"op_name" : "Constant"},
                   {"op_name" : "Cast"},
                   {"op_name" : "Shape"},
                   {"op_name" : "Constant"},
@@ -315,6 +314,7 @@ class TestONNXOpset(TestCase):
                   {"op_name" : "Slice"},
                   {"op_name" : "Cast"},
                   {"op_name" : "Div"},
+                  {"op_name" : "Constant"},
                   {"op_name" : "Concat"},
                   {"op_name" : "Resize",
                    "attributes" :
@@ -325,23 +325,23 @@ class TestONNXOpset(TestCase):
         check_onnx_opsets_operator(MyModel(), x, ops, opset_versions=[9, 10],
                                    input_names=["x"], dynamic_axes={"x": [0, 1, 2, 3]})
 
-        ops_9 = [{"op_name" : "Constant"},
-                 {"op_name" : "Shape"},
+        ops_9 = [{"op_name" : "Shape"},
                  {"op_name" : "Slice"},
                  {"op_name" : "Cast"},
                  {"op_name" : "Div"},
+                 {"op_name" : "Constant"},
                  {"op_name" : "Concat"},
                  {"op_name" : "Upsample",
                   "attributes" :
                   [{"name": "mode", "s": ("nearest").encode(), "type": 3}]}]
-        ops_10 = [{"op_name" : "Constant"},
-                  {"op_name" : "Shape"},
+        ops_10 = [{"op_name" : "Shape"},
                   {"op_name" : "Constant"},
                   {"op_name" : "Constant"},
                   {"op_name" : "Constant"},
                   {"op_name" : "Slice"},
                   {"op_name" : "Cast"},
                   {"op_name" : "Div"},
+                  {"op_name" : "Constant"},
                   {"op_name" : "Concat"},
                   {"op_name" : "Resize"}]
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5927,6 +5927,14 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor(12.)
         self.run_test(FullModel(), x)
 
+        class CatModel(torch.nn.Module):
+            def forward(self, fp16, fp32):
+                return torch.cat([fp16, fp32])
+        fp16 = torch.Tensor([0.5])
+        fp16 = fp16.half()
+        fp32 = torch.Tensor([1.5])
+        self.run_test(CatModel(), (fp16, fp32))
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_full_like(self):
         class FullLikeModel(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -52,6 +52,7 @@ static const std::unordered_set<NodeKind> standardOps = {
     onnx::Gemm,
     onnx::Pow,
     onnx::Mod,
+    onnx::Concat,
 };
 
 // For these operators, all inputs share the same scalar type.


### PR DESCRIPTION
By using scalar type analysis for Concat, the exported model can do
automatic type promotion for Concat nodes, including mixed fp16 and fp32
inputs, for example.

Unit tests based on the original PR https://github.com/pytorch/pytorch/pull/24378/