### PR TITLE
ns for fx: fix bug in graph matcher

### DIFF
--- a/torch/ao/ns/fx/graph_matcher.py
+++ b/torch/ao/ns/fx/graph_matcher.py
@@ -81,7 +81,7 @@ class _NSGraphMatchableSubgraphsIterator:
             # be made configurable later if needed.
             for _reverse_fusion_ops, base_op_idx in get_reversed_fusions():
                 is_match = end_node_matches_reversed_fusion(
-                    cur_end_node, _reverse_fusion_ops, self.gm)
+                    cur_end_node, _reverse_fusion_ops, self.gm, self.seen_nodes)
                 if is_match:
                     # navigate to the base node
                     for rev_fusion_idx in range(len(_reverse_fusion_ops) - 1):

--- a/torch/ao/ns/fx/pattern_utils.py
+++ b/torch/ao/ns/fx/pattern_utils.py
@@ -118,6 +118,7 @@ def end_node_matches_reversed_fusion(
     end_node: Node,
     reversed_fusion: NSFusionType,
     gm: GraphModule,
+    seen_nodes: Set[Node],
 ) -> bool:
     """
     Returns true if a pattern ending with `end_node` matches
@@ -125,6 +126,10 @@ def end_node_matches_reversed_fusion(
     """
     cur_node = end_node
     for fusion_idx in range(len(reversed_fusion)):
+        # each node can only belong to one matched pattern
+        if cur_node in seen_nodes:
+            return False
+
         cur_fusion_el = reversed_fusion[fusion_idx]
 
         if cur_node.op == 'call_function':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69238

Summary:

The NS for FX graph matcher was not properly taking into account
seen_nodes, this allowed a node to be matched twice.

Test Plan:

FB-only testing on real model fixes the issue with that model.

Ideally we would have a test case to capture this, but hopefully we can land this soon to unblock production work.

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D32765761](https://our.internmc.facebook.com/intern/diff/D32765761)