### PR TITLE
Clean up opcode for several view ops

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
@@ -16,7 +16,7 @@
 #include "lazy_tensor_core/csrc/view_ops/permute.h"
 #include "lazy_tensor_core/csrc/view_ops/resize.h"
 #include "lazy_tensor_core/csrc/view_ops/select.h"
-#include "lazy_tensor_core/csrc/view_ops/unselect.h"
+#include "lazy_tensor_core/csrc/view_ops/select_view_update.h"
 #include "lazy_tensor_core/csrc/view_ops/update_slice.h"
 #include "lazy_tensor_core/csrc/view_ops/view.h"
 
@@ -74,7 +74,7 @@ torch::lazy::Value ApplyUpdate(torch::lazy::Value ir_value,
     const ViewInfo& view_info = update_data.view_infos[i - 1];
     switch (view_info.view_type) {
       case ViewInfo::Type::kSelect:
-        result = torch::lazy::MakeNode<ir::ops::Unselect>(
+        result = torch::lazy::MakeNode<ir::ops::SelectViewUpdate>(
             tmp_values[i - 1], result, view_info.select->dim,
             view_info.select->start, view_info.select->end,
             view_info.select->stride);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
@@ -12,7 +12,7 @@
 #include "lazy_tensor_core/csrc/view_ops/as_strided_view_update.h"
 #include "lazy_tensor_core/csrc/view_ops/diagonal.h"
 #include "lazy_tensor_core/csrc/view_ops/diagonal_view_update.h"
-#include "lazy_tensor_core/csrc/view_ops/generic_slice.h"
+#include "lazy_tensor_core/csrc/view_ops/narrow.h"
 #include "lazy_tensor_core/csrc/view_ops/permute.h"
 #include "lazy_tensor_core/csrc/view_ops/resize.h"
 #include "lazy_tensor_core/csrc/view_ops/select.h"
@@ -30,8 +30,8 @@ torch::lazy::Value ApplyViewInfo(torch::lazy::Value ir_value, const ViewInfo& vi
           ir_value, view_info.select->dim, view_info.select->start,
           view_info.select->end, view_info.select->stride);
     case ViewInfo::Type::kNarrow:
-      return torch::lazy::MakeNode<ir::ops::GenericSlice>(ir_value, view_info.indices,
-                                                 view_info.shape.sizes());
+      return torch::lazy::MakeNode<ir::ops::Narrow>(ir_value, view_info.indices,
+                                                    view_info.shape.sizes());
     case ViewInfo::Type::kNoOp:
       return ir_value;
     case ViewInfo::Type::kPermute:

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_view.cpp
@@ -13,11 +13,11 @@
 #include "lazy_tensor_core/csrc/view_ops/diagonal.h"
 #include "lazy_tensor_core/csrc/view_ops/diagonal_view_update.h"
 #include "lazy_tensor_core/csrc/view_ops/narrow.h"
+#include "lazy_tensor_core/csrc/view_ops/narrow_view_update.h"
 #include "lazy_tensor_core/csrc/view_ops/permute.h"
 #include "lazy_tensor_core/csrc/view_ops/resize.h"
 #include "lazy_tensor_core/csrc/view_ops/select.h"
 #include "lazy_tensor_core/csrc/view_ops/select_view_update.h"
-#include "lazy_tensor_core/csrc/view_ops/update_slice.h"
 #include "lazy_tensor_core/csrc/view_ops/view.h"
 
 namespace torch_lazy_tensors {
@@ -80,8 +80,8 @@ torch::lazy::Value ApplyUpdate(torch::lazy::Value ir_value,
             view_info.select->stride);
         break;
       case ViewInfo::Type::kNarrow:
-        result = torch::lazy::MakeNode<ir::ops::UpdateSlice>(tmp_values[i - 1], result,
-                                                    view_info.indices);
+        result = torch::lazy::MakeNode<ir::ops::NarrowViewUpdate>(
+            tmp_values[i - 1], result, view_info.indices);
         break;
       case ViewInfo::Type::kNoOp:
         break;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.cpp
@@ -23,7 +23,7 @@ const OpKindWrapper ltc_replication_pad("lazy_tensors::replication_pad");
 const OpKindWrapper ltc_replication_pad_backward(
     "lazy_tensors::replication_pad_backward");
 const OpKindWrapper ltc_tensor_data("lazy_tensors::tensor_data");
-const OpKindWrapper ltc_unselect("lazy_tensors::unselect");
+const OpKindWrapper ltc_select_view_update("lazy_tensors::unselect");
 const OpKindWrapper ltc_update_slice("lazy_tensors::update_slice");
 
 }  // namespace ops

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.cpp
@@ -13,18 +13,17 @@ const OpKindWrapper ltc_cross_replica_sum("lazy_tensors::cross_replica_sum");
 const OpKindWrapper ltc_device_data("lazy_tensors::device_data");
 const OpKindWrapper ltc_diagonal_view_update(
     "lazy_tensors::diagonal_view_update");
-const OpKindWrapper ltc_generic_slice("lazy_tensors::generic_slice");
 const OpKindWrapper ltc_get_dimensions_size(
     "lazy_tensors::ltc_get_dimensions_size");
 const OpKindWrapper ltc_moving_average("lazy_tensors::moving_average");
+const OpKindWrapper ltc_narrow_view_update("lazy_tensors::narrow_view_update");
 const OpKindWrapper ltc_nms("lazy_tensors::nms");
 const OpKindWrapper ltc_not_supported("lazy_tensors::not_supported");
 const OpKindWrapper ltc_replication_pad("lazy_tensors::replication_pad");
 const OpKindWrapper ltc_replication_pad_backward(
     "lazy_tensors::replication_pad_backward");
+const OpKindWrapper ltc_select_view_update("lazy_tensors::select_view_update");
 const OpKindWrapper ltc_tensor_data("lazy_tensors::tensor_data");
-const OpKindWrapper ltc_select_view_update("lazy_tensors::unselect");
-const OpKindWrapper ltc_update_slice("lazy_tensors::update_slice");
 
 }  // namespace ops
 }  // namespace ir

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.cpp
@@ -22,7 +22,6 @@ const OpKindWrapper ltc_not_supported("lazy_tensors::not_supported");
 const OpKindWrapper ltc_replication_pad("lazy_tensors::replication_pad");
 const OpKindWrapper ltc_replication_pad_backward(
     "lazy_tensors::replication_pad_backward");
-const OpKindWrapper ltc_select("lazy_tensors::select");
 const OpKindWrapper ltc_tensor_data("lazy_tensors::tensor_data");
 const OpKindWrapper ltc_unselect("lazy_tensors::unselect");
 const OpKindWrapper ltc_update_slice("lazy_tensors::update_slice");

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.h
@@ -36,16 +36,14 @@ extern const OpKindWrapper ltc_collective_permute;
 extern const OpKindWrapper ltc_cross_replica_sum;
 extern const OpKindWrapper ltc_device_data;
 extern const OpKindWrapper ltc_diagonal_view_update;
-extern const OpKindWrapper ltc_generic_slice;
 extern const OpKindWrapper ltc_get_dimensions_size;
 extern const OpKindWrapper ltc_moving_average;
 extern const OpKindWrapper ltc_nms;
 extern const OpKindWrapper ltc_not_supported;
 extern const OpKindWrapper ltc_replication_pad;
 extern const OpKindWrapper ltc_replication_pad_backward;
-extern const OpKindWrapper ltc_select;
+extern const OpKindWrapper ltc_select_view_update;
 extern const OpKindWrapper ltc_tensor_data;
-extern const OpKindWrapper ltc_unselect;
 extern const OpKindWrapper ltc_update_slice;
 
 }  // namespace ops

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ltc_ops.h
@@ -38,13 +38,13 @@ extern const OpKindWrapper ltc_device_data;
 extern const OpKindWrapper ltc_diagonal_view_update;
 extern const OpKindWrapper ltc_get_dimensions_size;
 extern const OpKindWrapper ltc_moving_average;
+extern const OpKindWrapper ltc_narrow_view_update;
 extern const OpKindWrapper ltc_nms;
 extern const OpKindWrapper ltc_not_supported;
 extern const OpKindWrapper ltc_replication_pad;
 extern const OpKindWrapper ltc_replication_pad_backward;
 extern const OpKindWrapper ltc_select_view_update;
 extern const OpKindWrapper ltc_tensor_data;
-extern const OpKindWrapper ltc_update_slice;
 
 }  // namespace ops
 }  // namespace ir

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -23,10 +23,10 @@
 #include "lazy_tensor_core/csrc/view_ops/as_strided.h"
 #include "lazy_tensor_core/csrc/view_ops/as_strided_view_update.h"
 #include "lazy_tensor_core/csrc/view_ops/narrow.h"
+#include "lazy_tensor_core/csrc/view_ops/narrow_view_update.h"
 #include "lazy_tensor_core/csrc/view_ops/permute.h"
 #include "lazy_tensor_core/csrc/view_ops/select.h"
 #include "lazy_tensor_core/csrc/view_ops/select_view_update.h"
-#include "lazy_tensor_core/csrc/view_ops/update_slice.h"
 #include "lazy_tensor_core/csrc/view_ops/view.h"
 
 namespace torch {
@@ -90,10 +90,10 @@ class TSNodeLowering : public TSNodeLoweringInterface {
           torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::SelectViewUpdate>(
               node, *torch_lazy_tensors::ir::ops::ltc_select_view_update));
     }
-    if (node->op() == *torch_lazy_tensors::ir::ops::ltc_update_slice) {
-      return LowerUpdateSlice(
-          torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::UpdateSlice>(
-              node, *torch_lazy_tensors::ir::ops::ltc_update_slice));
+    if (node->op() == *torch_lazy_tensors::ir::ops::ltc_narrow_view_update) {
+      return LowerNarrowViewUpdate(
+          torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::NarrowViewUpdate>(
+              node, *torch_lazy_tensors::ir::ops::ltc_narrow_view_update));
     }
     if (node->op().op == at::prim::Constant) {
       return LowerScalar(torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::Scalar>(
@@ -480,8 +480,8 @@ class TSNodeLowering : public TSNodeLoweringInterface {
     return {dest};
   }
 
-  TSOpVector LowerUpdateSlice(
-      const torch_lazy_tensors::ir::ops::UpdateSlice* node) {
+  TSOpVector LowerNarrowViewUpdate(
+      const torch_lazy_tensors::ir::ops::NarrowViewUpdate* node) {
     torch::jit::Value* dest =
         GenerateClone(loctx()->GetOutputOp(node->operand(0)));
     const auto& base_indices = node->base_indices();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_node_lowering.cpp
@@ -90,11 +90,6 @@ class TSNodeLowering : public TSNodeLoweringInterface {
           torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::GenericSlice>(
               node, *torch_lazy_tensors::ir::ops::ltc_generic_slice));
     }
-    if (node->op() == *torch_lazy_tensors::ir::ops::ltc_select) {
-      return LowerSelect(
-          torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::Select>(
-              node, *torch_lazy_tensors::ir::ops::ltc_select));
-    }
     if (node->op() == *torch_lazy_tensors::ir::ops::ltc_unselect) {
       return LowerUnselect(
           torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::Unselect>(
@@ -158,6 +153,11 @@ class TSNodeLowering : public TSNodeLoweringInterface {
       return LowerRepeat(
           torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::Repeat>(
               node, torch::lazy::OpKind(at::aten::repeat)));
+    }
+    if (node->op().op == at::aten::select) {
+      return LowerSelect(
+          torch::lazy::NodeCast<torch_lazy_tensors::ir::ops::Select>(
+              node, torch::lazy::OpKind(at::aten::select)));
     }
     if (node->op().op == at::aten::squeeze) {
       return LowerSqueeze(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow.cpp
@@ -1,4 +1,4 @@
-#include "lazy_tensor_core/csrc/view_ops/generic_slice.h"
+#include "lazy_tensor_core/csrc/view_ops/narrow.h"
 
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
 
@@ -6,10 +6,10 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-GenericSlice::GenericSlice(const torch::lazy::Value& input,
-                           c10::ArrayRef<int64_t> base_indices,
-                           c10::ArrayRef<int64_t> sizes)
-    : torch::lazy::TsNode(ltc_generic_slice, {input},
+Narrow::Narrow(const torch::lazy::Value& input,
+               c10::ArrayRef<int64_t> base_indices,
+               c10::ArrayRef<int64_t> sizes)
+    : torch::lazy::TsNode(torch::lazy::OpKind(at::aten::narrow), {input},
                           /*num_outputs=*/1,
                           torch::lazy::MHash(base_indices, sizes)),
       base_indices_(base_indices.begin(), base_indices.end()),
@@ -20,7 +20,7 @@ GenericSlice::GenericSlice(const torch::lazy::Value& input,
   });
 }
 
-std::string GenericSlice::ToString() const {
+std::string Narrow::ToString() const {
   std::stringstream ss;
   ss << torch::lazy::TsNode::ToString() << ", base_indices=("
      << c10::Join(", ", base_indices_) << "), sizes=("

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow.h
@@ -6,11 +6,10 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-class GenericSlice : public torch::lazy::TsNode {
+class Narrow : public torch::lazy::TsNode {
  public:
-  GenericSlice(const torch::lazy::Value& input,
-               c10::ArrayRef<int64_t> base_indices,
-               c10::ArrayRef<int64_t> sizes);
+  Narrow(const torch::lazy::Value& input, c10::ArrayRef<int64_t> base_indices,
+         c10::ArrayRef<int64_t> sizes);
 
   std::string ToString() const override;
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow_view_update.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow_view_update.cpp
@@ -1,4 +1,4 @@
-#include "lazy_tensor_core/csrc/view_ops/update_slice.h"
+#include "lazy_tensor_core/csrc/view_ops/narrow_view_update.h"
 
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
 
@@ -6,17 +6,17 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-UpdateSlice::UpdateSlice(const torch::lazy::Value& input,
-                         const torch::lazy::Value& source,
-                         c10::ArrayRef<int64_t> base_indices)
-    : torch::lazy::TsNode(ltc_update_slice, {input, source},
+NarrowViewUpdate::NarrowViewUpdate(const torch::lazy::Value& input,
+                                   const torch::lazy::Value& source,
+                                   c10::ArrayRef<int64_t> base_indices)
+    : torch::lazy::TsNode(ltc_narrow_view_update, {input, source},
                           /*num_outputs=*/1, torch::lazy::MHash(base_indices)),
       base_indices_(base_indices.begin(), base_indices.end()) {
   SetShapeDeferred(
       [&]() { return torch::lazy::GetShapeFromTsOutput(operand(0)); });
 }
 
-std::string UpdateSlice::ToString() const {
+std::string NarrowViewUpdate::ToString() const {
   std::stringstream ss;
   ss << torch::lazy::TsNode::ToString() << ", base_indices=("
      << c10::Join(", ", base_indices_) << ")";

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow_view_update.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/narrow_view_update.h
@@ -6,10 +6,11 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-class UpdateSlice : public torch::lazy::TsNode {
+class NarrowViewUpdate : public torch::lazy::TsNode {
  public:
-  UpdateSlice(const torch::lazy::Value& input, const torch::lazy::Value& source,
-              c10::ArrayRef<int64_t> base_indices);
+  NarrowViewUpdate(const torch::lazy::Value& input,
+                   const torch::lazy::Value& source,
+                   c10::ArrayRef<int64_t> base_indices);
 
   std::string ToString() const override;
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/select.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/select.cpp
@@ -9,7 +9,7 @@ namespace ops {
 Select::Select(const torch::lazy::Value& input, int64_t dim, int64_t start,
                int64_t end, int64_t stride)
     : torch::lazy::TsNode(
-          ltc_select, {input},
+          torch::lazy::OpKind(at::aten::select), {input},
           [&]() {
             return MakeSelectShape(torch::lazy::GetShapeFromTsValue(input), dim,
                                    start, end, stride);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/select_view_update.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/select_view_update.cpp
@@ -1,4 +1,4 @@
-#include "lazy_tensor_core/csrc/view_ops/unselect.h"
+#include "lazy_tensor_core/csrc/view_ops/select_view_update.h"
 
 #include "lazy_tensor_core/csrc/ops/ltc_ops.h"
 #include "lazy_tensor_core/csrc/tensor_util.h"
@@ -8,10 +8,11 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-Unselect::Unselect(const torch::lazy::Value& target,
-                   const torch::lazy::Value& source, int64_t dim, int64_t start,
-                   int64_t end, int64_t stride)
-    : torch::lazy::TsNode(ltc_unselect, {target, source},
+SelectViewUpdate::SelectViewUpdate(const torch::lazy::Value& target,
+                                   const torch::lazy::Value& source,
+                                   int64_t dim, int64_t start, int64_t end,
+                                   int64_t stride)
+    : torch::lazy::TsNode(ltc_select_view_update, {target, source},
                           {torch::lazy::GetShapeFromTsValue(target)},
                           /*num_outputs=*/1,
                           torch::lazy::MHash(dim, start, end, stride)),
@@ -20,7 +21,7 @@ Unselect::Unselect(const torch::lazy::Value& target,
       end_(end),
       stride_(stride) {}
 
-std::string Unselect::ToString() const {
+std::string SelectViewUpdate::ToString() const {
   std::stringstream ss;
   ss << torch::lazy::TsNode::ToString() << ", dim=" << dim_
      << ", start=" << start_ << ", end=" << end_ << ", stride=" << stride_;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/select_view_update.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/view_ops/select_view_update.h
@@ -6,10 +6,11 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-class Unselect : public torch::lazy::TsNode {
+class SelectViewUpdate : public torch::lazy::TsNode {
  public:
-  Unselect(const torch::lazy::Value& target, const torch::lazy::Value& source,
-           int64_t dim, int64_t start, int64_t end, int64_t stride);
+  SelectViewUpdate(const torch::lazy::Value& target,
+                   const torch::lazy::Value& source, int64_t dim, int64_t start,
+                   int64_t end, int64_t stride);
 
   std::string ToString() const override;
 


### PR DESCRIPTION
- Replace the internal opcode ltc_select with aten::select for Select, to enable future codegen
- Replace the internal opcode ltc_generic_slice with aten::narrow for Narrow, to enable future codegen
- Rename the internal opcode ltc_update_slice into ltc_narrow_view_update, to be consistent with the naming of other view ops
- Rename internal opcode ltc_unselect into ltc_select_view_update, to be consistent with the naming of other view ops

