### PR TITLE
Avoid adding torch::deploy interpreter library to the data section

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -1,14 +1,14 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/deploy/deploy.h>
+#include <torch/csrc/deploy/elf_file.h>
 #include <torch/cuda.h>
 
 #include <dlfcn.h>
 #include <libgen.h>
 #include <unistd.h>
 
-struct InterpreterSymbol {
-  const char* startSym;
-  const char* endSym;
+struct ExeSection {
+  const char* sectionName;
   bool customLoader;
 };
 
@@ -21,38 +21,36 @@ struct InterpreterSymbol {
 namespace torch {
 namespace deploy {
 
-const std::initializer_list<InterpreterSymbol> kInterpreterSearchPath = {
-    {"_binary_libtorch_deployinterpreter_all_so_start",
-     "_binary_libtorch_deployinterpreter_all_so_end",
-     true},
-    {"_binary_libtorch_deployinterpreter_cuda_so_start",
-     "_binary_libtorch_deployinterpreter_cuda_so_end",
-     false},
-    {"_binary_libtorch_deployinterpreter_cpu_so_start",
-     "_binary_libtorch_deployinterpreter_cpu_so_end",
-     false},
+const std::initializer_list<ExeSection> pythonInterpreterSection = {
+    {".torch_deploy_payload.interpreter_all", true},
+    {".torch_deploy_payload.interpreter_cuda", false},
+    {".torch_deploy_payload.interpreter_cpu", false},
 };
 
 static bool writeDeployInterpreter(FILE* dst) {
   TORCH_INTERNAL_ASSERT(dst);
-  const char* libStart = nullptr;
-  const char* libEnd = nullptr;
+  const char* payloadStart = nullptr;
+  size_t size = 0;
   bool customLoader = false;
-  for (const auto& s : kInterpreterSearchPath) {
-    libStart = (const char*)dlsym(nullptr, s.startSym);
-    if (libStart) {
-      libEnd = (const char*)dlsym(nullptr, s.endSym);
+  std::string exePath;
+  std::ifstream("/proc/self/cmdline") >> exePath;
+  ElfFile elfFile(exePath.c_str());
+  for (const auto& s : pythonInterpreterSection) {
+    at::optional<Section> payloadSection = elfFile.findSection(s.sectionName);
+    if (payloadSection != at::nullopt) {
+      payloadStart = payloadSection->start;
       customLoader = s.customLoader;
+      size = payloadSection->len;
+      TORCH_CHECK(payloadSection.has_value(), "Missing the payload section");
       break;
     }
   }
+
   TORCH_CHECK(
-      libStart != nullptr && libEnd != nullptr,
+      payloadStart != nullptr,
       "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.  torch::cuda::is_available()=",
       torch::cuda::is_available());
-
-  size_t size = libEnd - libStart;
-  size_t written = fwrite(libStart, 1, size, dst);
+  size_t written = fwrite(payloadStart, 1, size, dst);
   TORCH_INTERNAL_ASSERT(size == written, "expected written == size");
   return customLoader;
 }
@@ -68,7 +66,6 @@ InterpreterManager::InterpreterManager(
     // make torch.version.interp be the interpreter id
     // can be used for balancing work across GPUs
     I.global("torch", "version").attr("__setattr__")({"interp", int(i)});
-    // std::cerr << "Interpreter " << i << " initialized\n";
     instances_.back().pImpl_->setFindModule(
         [this](const std::string& name) -> at::optional<std::string> {
           auto it = registeredModuleSource_.find(name);
@@ -203,6 +200,7 @@ Interpreter::Interpreter(
   FILE* dst = fdopen(fd, "wb");
 
   customLoader_ = writeDeployInterpreter(dst);
+
   fclose(dst);
   int flags = RTLD_LOCAL | RTLD_LAZY;
   if (customLoader_) {

--- a/torch/csrc/deploy/elf_file.cpp
+++ b/torch/csrc/deploy/elf_file.cpp
@@ -1,5 +1,4 @@
 #include <torch/csrc/deploy/elf_file.h>
-
 namespace torch {
 namespace deploy {
 
@@ -33,6 +32,7 @@ at::optional<Section> ElfFile::findSection(const char* name) const {
       break;
     }
   }
+
   return found;
 }
 

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -12,14 +12,9 @@
 #include <iostream>
 #include <string>
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  int rc = RUN_ALL_TESTS();
-  return rc;
-}
-
 void compare_torchpy_jit(const char* model_filename, const char* jit_filename) {
   // Test
+
   torch::deploy::InterpreterManager m(1);
   torch::deploy::Package p = m.loadPackage(model_filename);
   auto model = p.loadPickle("model", "model.pkl");
@@ -483,3 +478,9 @@ TEST(TorchpyTest, TestPyYAML) {
   EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
 }
 #endif
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  return rc;
+}

--- a/torch/csrc/deploy/unity/xar_environment.cpp
+++ b/torch/csrc/deploy/unity/xar_environment.cpp
@@ -67,8 +67,7 @@ void XarEnvironment::setupPythonApp() {
   constexpr const char* SECTION_NAME = ".torch_deploy_payload.unity";
   ElfFile elfFile(exePath_.c_str());
   auto payloadSection = elfFile.findSection(SECTION_NAME);
-  TORCH_CHECK(payloadSection.has_value(), "Missing the payload section");
-
+  TORCH_CHECK(payloadSection != at::nullopt, "Missing the payload section");
   const char* pythonAppPkgStart = payloadSection->start;
   auto pythonAppPkgSize = payloadSection->len;
   LOG(INFO) << "Embedded binary size " << pythonAppPkgSize;


### PR DESCRIPTION
Summary: Create custom section ".embedded_interpreter" in order to store interpreter instead of .data in order to allow in order to increae the amount of memory that can be used by 33% for the other sections of the executable (1.5GB -> 2.0GB) such as .test/.data/.bss. This also removes memory limitations of the interpreter and tech debt.

Test Plan:
buck test mode/opt //caffe2/torch/csrc/deploy:test_deploy
readelf -S ~/fbcode/buck-out/gen/caffe2/torch/csrc/deploy/test_deploy
check the size of the .data section
Apply the fix and check the size of the .data section again. It should be reduced by the size of the interpreter.so

The output of `readelf -S ~/fbcode/buck-out/gen/caffe2/torch/csrc/deploy/test_deploy` is as follows. The .data section is now 0.0015415GB and the .torch_deploy_payXXX section is 0.605125GB

```
(pytorch) [sahanp@devvm4333.vll0 ~/local/fbsource/fbcode] readelf -S buck-out/gen/caffe2/torch/csrc/deploy/test_deploy
There are 55 section headers, starting at offset 0x24bac82b0:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .interp           PROGBITS         0000000000200350  00000350
       0000000000000028  0000000000000000   A       0     0     1
  [ 2] .note.ABI-tag     NOTE             0000000000200378  00000378
       0000000000000020  0000000000000000   A       0     0     4
  [ 3] .note.gnu.build-i NOTE             0000000000200398  00000398
       0000000000000024  0000000000000000   A       0     0     4
  [ 4] .dynsym           DYNSYM           00000000002003c0  000003c0
       0000000000d07a48  0000000000000018   A       9     1     8
  [ 5] .gnu.version      VERSYM           0000000000f07e08  00d07e08
       0000000000115f86  0000000000000002   A       4     0     2
  [ 6] .gnu.version_r    VERNEED          000000000101dd90  00e1dd90
       0000000000000510  0000000000000000   A       9    15     4
  [ 7] .gnu.hash         GNU_HASH         000000000101e2a0  00e1e2a0
       00000000003b4fb0  0000000000000000   A       4     0     8
  [ 8] .hash             HASH             00000000013d3250  011d3250
       0000000000457e20  0000000000000004   A       4     0     4
  [ 9] .dynstr           STRTAB           000000000182b070  0162b070
       0000000004ef205a  0000000000000000   A       0     0     1
  [10] .rela.dyn         RELA             000000000671d0d0  0651d0d0
       0000000000110b80  0000000000000018   A       4     0     8
  [11] .rela.plt         RELA             000000000682dc50  0662dc50
       00000000000093f0  0000000000000018   A       4    35     8
  [12] .rodata           PROGBITS         0000000006837040  06637040
       00000000034067a8  0000000000000000 AMS       0     0     64
  [13] fb_build_info     PROGBITS         0000000009c3d7f0  09a3d7f0
       00000000000002ee  0000000000000000   A       0     0     16
  [14] .gcc_except_table PROGBITS         0000000009c3dae0  09a3dae0
       00000000014a9340  0000000000000000   A       0     0     4
  [15] .eh_frame_hdr     PROGBITS         000000000b0e6e20  0aee6e20
       00000000004abf54  0000000000000000   A       0     0     4
  [16] .eh_frame         PROGBITS         000000000b592d78  0b392d78
       000000000200e344  0000000000000000   A       0     0     8
  [17] .text             PROGBITS         000000000d5a2000  0d3a2000
       000000001e55944e  0000000000000000  AX       0     0     256
  [18] .init             PROGBITS         000000002bafb450  2b8fb450
       0000000000000017  0000000000000000  AX       0     0     4
  [19] .fini             PROGBITS         000000002bafb468  2b8fb468
       0000000000000009  0000000000000000  AX       0     0     4
  [20] .never_hugify     PROGBITS         000000002bafb480  2b8fb480
       0000000000000db3  0000000000000000  AX       0     0     16
  [21] text_env          PROGBITS         000000002bafc240  2b8fc240
       0000000000002e28  0000000000000000  AX       0     0     16
  [22] .plt              PROGBITS         000000002baff070  2b8ff070
       00000000000062b0  0000000000000000  AX       0     0     16
  [23] .tdata            PROGBITS         000000002bb06000  2b906000
       0000000000000b20  0000000000000000 WAT       0     0     8
  [24] .tbss             NOBITS           000000002bb06b40  2b906b20
       0000000000007cb8  0000000000000000 WAT       0     0     64
  [25] .fini_array       FINI_ARRAY       000000002bb06b20  2b906b20
       0000000000000028  0000000000000000  WA       0     0     8
  [26] .init_array       INIT_ARRAY       000000002bb06b48  2b906b48
       0000000000008878  0000000000000000  WA       0     0     8
  [27] .data.rel.ro      PROGBITS         000000002bb0f3c0  2b90f3c0
       0000000000029ce0  0000000000000000  WA       0     0     64
  [28] .ctors            PROGBITS         000000002bb390a0  2b9390a0
       0000000000000010  0000000000000000  WA       0     0     8
  [29] .dynamic          DYNAMIC          000000002bb390b0  2b9390b0
       0000000000000340  0000000000000010  WA       9     0     8
  [30] .got              PROGBITS         000000002bb393f0  2b9393f0
       000000000001f040  0000000000000000  WA       0     0     8
  [31] .bss.rel.ro       NOBITS           000000002bb58440  2b958430
       0000000000000c40  0000000000000000  WA       0     0     32
  [32] .data             PROGBITS         000000002bb5a000  2b959000
       0000000000194188  0000000000000000  WA       0     0     4096
  [33] .tm_clone_table   PROGBITS         000000002bcee188  2baed188
       0000000000000000  0000000000000000  WA       0     0     8
  [34] .probes           PROGBITS         000000002bcee188  2baed188
       0000000000000002  0000000000000000  WA       0     0     2
  [35] .got.plt          PROGBITS         000000002bcee190  2baed190
       0000000000003168  0000000000000000  WA       0     0     8
  [36] .bss              NOBITS           000000002bcf1300  2baf02f8
       00000000005214f0  0000000000000000  WA       0     0     128
  [37] .nvFatBinSegment  PROGBITS         000000002c213000  2baf1000
       0000000000002850  0000000000000000   A       0     0     8
  [38] .nv_fatbin        PROGBITS         000000002c216000  2baf4000
       0000000052baed38  0000000000000000  WA       0     0     8
  [39] .comment          PROGBITS         0000000000000000  7e6a2d38
       00000000000001dc  0000000000000000  MS       0     0     1
  [40] .debug_aranges    PROGBITS         0000000000000000  7e6a2f20
       0000000001266c00  0000000000000000           0     0     16
  [41] .debug_info       PROGBITS         0000000000000000  7f909b20
       000000007b21de49  0000000000000000           0     0     1
  [42] .debug_abbrev     PROGBITS         0000000000000000  fab27969
       000000000179f365  0000000000000000           0     0     1
  [43] .debug_line       PROGBITS         0000000000000000  fc2c6cce
       00000000176954ac  0000000000000000           0     0     1
  [44] .debug_str        PROGBITS         0000000000000000  11395c17a
       0000000039dc32b0  0000000000000001  MS       0     0     1
  [45] .debug_ranges     PROGBITS         0000000000000000  14d71f430
       0000000026a2d930  0000000000000000           0     0     16
  [46] .debug_types      PROGBITS         0000000000000000  17414cd60
       000000000b211ff5  0000000000000000           0     0     1
  [47] .debug_loc        PROGBITS         0000000000000000  17f35ed55
       000000009ca80c7e  0000000000000000           0     0     1
  [48] .debug_macinfo    PROGBITS         0000000000000000  21bddf9d3
       000000000000151c  0000000000000000           0     0     1
  [49] .note.stapsdt     NOTE             0000000000000000  21bde0ef0
       0000000000001b3c  0000000000000000           0     0     4
  [50] .debug_macro      PROGBITS         0000000000000000  21bde2a2c
       0000000000040e6a  0000000000000000           0     0     1
  [51] .torch_deploy_pay PROGBITS         0000000000000000  21be23896
       0000000026ba5d28  0000000000000000           0     0     1
  [52] .symtab           SYMTAB           0000000000000000  2429c95c0
       00000000020ce0c8  0000000000000018          54   863985     8
  [53] .shstrtab         STRTAB           0000000000000000  244a97688
       000000000000025c  0000000000000000           0     0     1
  [54] .strtab           STRTAB           0000000000000000  244a978e4
       00000000070309c6  0000000000000000           0     0     1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  l (large), p (processor specific)
```

Differential Revision: D32596676

