### PR TITLE
[nit] Add nullptr check in XAR Enviroment for payload section

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -60,9 +60,13 @@ class TORCH_API Interpreter {
   bool customLoader_ = false;
   InterpreterManager* manager_; // optional if managed by one
   std::shared_ptr<Environment> env_;
+  std::string exePath_;
 
  public:
-  Interpreter(InterpreterManager* manager, std::shared_ptr<Environment> env);
+  Interpreter(
+      InterpreterManager* manager,
+      std::shared_ptr<Environment> env,
+      std::string exePath);
   InterpreterSession acquireSession() const {
     TORCH_DEPLOY_TRY
     return InterpreterSession(pImpl_->acquireSession(), manager_);
@@ -112,6 +116,7 @@ struct TORCH_API LoadBalancer {
 
 struct TORCH_API InterpreterManager {
   explicit InterpreterManager(
+      std::string exePath,
       size_t nInterp = 2,
       std::shared_ptr<Environment> env = std::make_shared<NoopEnvironment>());
 
@@ -163,6 +168,7 @@ struct TORCH_API InterpreterManager {
   std::vector<Interpreter> instances_;
   LoadBalancer resources_;
   std::unordered_map<std::string, std::string> registeredModuleSource_;
+  std::string _exePath;
 };
 
 struct TORCH_API ReplicatedObjImpl {

--- a/torch/csrc/deploy/unity/xar_environment.cpp
+++ b/torch/csrc/deploy/unity/xar_environment.cpp
@@ -68,7 +68,7 @@ void XarEnvironment::setupPythonApp() {
   ElfFile elfFile(exePath_.c_str());
   auto payloadSection = elfFile.findSection(SECTION_NAME);
   TORCH_CHECK(payloadSection.has_value(), "Missing the payload section");
-
+  TORCH_CHECK(payloadSection != at::nullopt, "Missing the payload section");
   const char* pythonAppPkgStart = payloadSection->start;
   auto pythonAppPkgSize = payloadSection->len;
   LOG(INFO) << "Embedded binary size " << pythonAppPkgSize;


### PR DESCRIPTION
Summary: The payload produced by ElfFile::findSection can return at::nullopt which can have a value. Therefore, we explicitly check that findSection doesn not return a at::nullopt in order to make sure it is found.

Test Plan:
buck test mode/opt //caffe2/torch/csrc/deploy/unity/tests:test_unity_sum -- --exact 'caffe2/torch/csrc/deploy/unity/tests:test_unity_sum - UnityTest.TestUnitySum' --run-disabled --jobs 18 --stress-runs 10 --record-results
buck test mode/opt //caffe2/torch/csrc/deploy/unity/tests:test_unity_simple_model -- --exact 'caffe2/torch/csrc/deploy/unity/tests:test_unity_simple_model - UnityTest.TestUnitySimpleModel' --run-disabled --jobs 18 --stress-runs 10 --record-results

Differential Revision: D32769174

