### PR TITLE
Fix crash in `checkCustomClassType` if arg is null

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -30,9 +30,9 @@ void checkCustomClassType(const Type* expected_type, const Type* actual_type) {
   // Type's, this needs to be changed!
   TORCH_CHECK(actual_type == expected_type,
               "Tried to convert an IValue of type ",
-              actual_type->repr_str(),
+              actual_type ? actual_type->repr_str() : std::string("*NULL*"),
               " to custom class type ",
-              expected_type->repr_str());
+              expected_type ? expected_type->repr_str() : std::string("*NULL*"));
 }
 
 TORCH_API c10::intrusive_ptr<ConstantString> ConstantString::create(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69261 Do not modify type map from getCustomClassTypeImpl()
* **#69259 Fix crash in `checkCustomClassType` if arg is null**

Otherwise `checkCustomClassType(nullptr, new Type())` will crash

Differential Revision: [D32775297](https://our.internmc.facebook.com/intern/diff/D32775297)