### PR TITLE
Do not modify type map from getCustomClassTypeImpl()

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1239,7 +1239,8 @@ c10::ClassTypePtr getCustomClassTypeImpl() {
     auto class_name = std::string(tindex.name());
     for(const auto &it: tmap) {
       if (class_name == it.first.name()) {
-          tmap[tindex] = it.second;
+          // Do not modify existing type map here as this template is supposed to be called only once per type
+          // from getCustomClassTypeImpl()
           return it.second;
       }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#69261 Do not modify type map from getCustomClassTypeImpl()**
* #69259 Fix crash in `checkCustomClassType` if arg is null

As this function is supposed to be called only once per type from
caching getCustomClassType template

Differential Revision: [D32776564](https://our.internmc.facebook.com/intern/diff/D32776564)