### PR TITLE
[ONNX] Improve Expand shape inference

### DIFF
--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -106,5 +106,14 @@ class TestONNXShapeInference(unittest.TestCase):
         slice = g.op("Slice", input, start_input, end, axis, step)
         self.run_test(g, slice.node(), expect_tensor(None, shape=(None, None)))
 
+    def test_expand(self):
+        g = self.create_empty_graph()
+        input = g.addInput()
+        constant = self.insert_tensor_constant(g, torch.ones(2, 4))
+        input.setType(constant.type().with_sizes([None, None]))
+        shape = g.op("Shape", input)
+        expand = g.op("Expand", constant, shape)
+        self.run_test(g, expand.node(), expect_tensor("Float", shape=(None, None)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1471,8 +1471,8 @@ void ComputeConstant(Node* n, int opset_version) {
         if (input0_shape_size.has_value()) {
           auto input0_shape_value = input0_shape_size.value();
           if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
-            // When value of `shape` is statically known.
-            // Shape of expand output can be computed.
+            // When value of `shape` is statically known,
+            // shape of expand output can be computed.
             auto shape_temp = ConstantValueMap::GetValueInto1DInt64Vector(
                 n->input(1)->debugName());
             auto final_shape =
@@ -1480,14 +1480,17 @@ void ComputeConstant(Node* n, int opset_version) {
             if (final_shape.has_value()) {
               UpdateShape(n->output(), final_shape.value());
             }
-          } else if (ConstantValueMap::HasShape(n->input(1)->debugName())) {
-            // When shape of `shape` is statically known.
-            // Rank of expand output can be computed.
-            auto expand_shape =
-                ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
-                    n->input(1)->debugName());
-            if (expand_shape.has_value() && expand_shape.value().size() == 1 &&
-                expand_shape.value()[0] > 0) {
+          } else if (
+              auto expand_shape =
+                  ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
+                      n->input(1)->debugName())) {
+            // When shape of `shape` is statically known,
+            // rank of expand output can be computed.
+            TORCH_INTERNAL_ASSERT(
+                expand_shape.value().size() == 1,
+                "`Shape` input to `Expand` should be a 1-D tensor. Instead got rank ",
+                expand_shape.value().size());
+            if (expand_shape.value()[0] > 0) {
               std::vector<c10::ShapeSymbol> final_shape;
               for (const auto i : c10::irange(expand_shape.value()[0])) {
                 final_shape.emplace_back(c10::ShapeSymbol::newSymbol());

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1472,7 +1472,7 @@ void ComputeConstant(Node* n, int opset_version) {
           auto input0_shape_value = input0_shape_size.value();
           if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
             // When value of `shape` is statically known,
-            // shape of expand output can be computed.
+            // output shape can be computed.
             auto shape_temp = ConstantValueMap::GetValueInto1DInt64Vector(
                 n->input(1)->debugName());
             auto final_shape =
@@ -1485,7 +1485,7 @@ void ComputeConstant(Node* n, int opset_version) {
                   ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
                       n->input(1)->debugName())) {
             // When shape of `shape` is statically known,
-            // rank of expand output can be computed.
+            // output rank can be computed.
             TORCH_INTERNAL_ASSERT(
                 expand_shape.value().size() == 1,
                 "`Shape` input to `Expand` should be a 1-D tensor. Instead got rank ",


### PR DESCRIPTION
Extend shape inference support for `Expand`, when value of argument `shape` is unknown. Infer the rank of the output of `Expand`, and set shape to dynamic, if shape of argument `shape` is known.

Without this, shape inference aborts, and falls back to the static shape provided by tracer, which is incorrect in many cases.