### PR TITLE
[quant] Remove warning for quantized Tensor in `__dir__`

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -700,8 +700,6 @@ class Tensor(torch._C._TensorBase):
     def __dir__(self):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__dir__, (self,), self)
-        if self.is_quantized:
-            warnings.warn('Only a small subset of methods are supported for quantized tensors.')
         tensor_methods = dir(self.__class__)
         tensor_methods.remove('volatile')  # deprecated
         attrs = list(self.__dict__.keys())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69265

Summary:
This is used in tab completion, we should not put warning here

Test Plan:
ci

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D32778736](https://our.internmc.facebook.com/intern/diff/D32778736)