### PR TITLE
Add support for transformer layout of masked_softmax

### DIFF
--- a/aten/src/ATen/native/cuda/PersistentSoftmax.cuh
+++ b/aten/src/ATen/native/cuda/PersistentSoftmax.cuh
@@ -59,13 +59,14 @@ __device__ __forceinline__ void warp_reduce(acc_t* sum) {
 // The template can be instantiated with any floating point type for the type arguments input_t, output_t and acc_t.
 // This allows SoftMax to be fused with a cast immediately following the SoftMax.
 // The mask should have the same shape as input, with a boolean indicate if the value is masked.
+// The head_chunk_size is only used for transformer mask softmax, equals to H * D * D.
 // For instance:
 // input_t=half,  acc_t=float, output_t=half  => read half tensor, float accumulators, write half tensor.
 // input_t=half,  acc_t=float, output_t=float => read half tensor, float accumulators, write float tensor.
 // input_t_float, acc_t=float, output_t=half  => read float tensor, float accumulators, write half tensor.
 
-template <typename input_t, typename output_t, typename acc_t, int log2_elements, bool is_log_softmax, bool is_masked = false>
-__global__ void softmax_warp_forward(output_t *dst, const input_t *src, int batch_size, int stride, int element_count, const bool *mask = nullptr)
+template <typename input_t, typename output_t, typename acc_t, int log2_elements, bool is_log_softmax, bool is_masked>
+__global__ void softmax_warp_forward(output_t *dst, const input_t *src, int batch_size, int stride, int element_count, const bool *mask = nullptr, const int head_chunk_size = -1, bool is_transformer_mask = false)
 {
     // WARP_SIZE and WARP_BATCH must match the return values batches_per_warp and warp_size of method warp_softmax_forward_kernel.
     constexpr int next_power_of_two = 1 << log2_elements;
@@ -83,11 +84,15 @@ __global__ void softmax_warp_forward(output_t *dst, const input_t *src, int batc
 
     // there might be multiple batches per warp. compute the index within the batch
     int local_idx = threadIdx.x;
+    int idx_offset = first_batch * stride + local_idx;
 
-    src += first_batch * stride + local_idx;
-    dst += first_batch * stride + local_idx;
-    if (is_masked) {
-        mask += first_batch * stride + local_idx;
+    src += idx_offset;
+    dst += idx_offset;
+
+    if (is_transformer_mask) {
+        mask += (idx_offset / head_chunk_size) * stride + local_idx;
+    } else {
+        mask += idx_offset;
     }
     // The nested loops over WARP_BATCH and then WARP_ITERATIONS can be simplified to one loop,
     // but I think doing so would obfuscate the logic of the algorithm, thus I chose to keep
@@ -117,7 +122,11 @@ __global__ void softmax_warp_forward(output_t *dst, const input_t *src, int batc
         #pragma unroll
         for (int it = 0;  it < WARP_ITERATIONS;  ++it) {
             if (is_masked) {
-                if (mask[i*element_count+it*WARP_SIZE]) {
+                int idx = it*WARP_SIZE;
+                if (!is_transformer_mask) {
+                    idx += i*element_count;
+                }
+                if (mask[idx]) {
                     max_value[i] = (is_meaningful_max && max_value[i] > elements[i][it]) ? max_value[i] : elements[i][it];
                     is_meaningful_max = true;
                 }
@@ -146,7 +155,12 @@ __global__ void softmax_warp_forward(output_t *dst, const input_t *src, int batc
                     sum[i] += elements[i][it];
                 }
             } else {
-                if (mask[i*element_count+it*WARP_SIZE]) {
+                int idx = it*WARP_SIZE;
+                if (!is_transformer_mask) {
+                    idx += i*element_count;
+                }
+
+                if (mask[idx]) {
                     if (is_log_softmax) {
                         sum[i] += std::exp(elements[i][it] - max_value[i]);
                     } else {
@@ -170,7 +184,11 @@ __global__ void softmax_warp_forward(output_t *dst, const input_t *src, int batc
             int element_index = local_idx + it * WARP_SIZE;
             if (element_index < element_count) {
                 if (is_masked) {
-                    if (!mask[i*element_count+it*WARP_SIZE]) {
+                    int idx = it*WARP_SIZE;
+                    if (!is_transformer_mask) {
+                        idx += i*element_count;
+                    }
+                    if (!mask[idx]) {
                         dst[i*element_count+it*WARP_SIZE] = 0;
                         continue;
                     }
@@ -268,8 +286,8 @@ __global__ void softmax_warp_backward(output_t *gradInput, const input_t *grad, 
 
 } // end of anonymous namespace
 
-template<typename input_t, typename output_t, typename acc_t, bool is_log_softmax, bool is_masked = false>
-void dispatch_softmax_forward(output_t *dst, const input_t *src, int softmax_elements, int softmax_elements_stride, int batch_count, const bool *mask = nullptr)
+template<typename input_t, typename output_t, typename acc_t, bool is_log_softmax, bool is_masked>
+void dispatch_softmax_forward(output_t *dst, const input_t *src, int softmax_elements, int softmax_elements_stride, int batch_count, const bool *mask = nullptr, int chunk_size = -1, bool is_transformer_mask = false)
 {
     TORCH_INTERNAL_ASSERT( softmax_elements >= 0 && softmax_elements <= 1024 );
     if (softmax_elements == 0) {
@@ -296,7 +314,7 @@ void dispatch_softmax_forward(output_t *dst, const input_t *src, int softmax_ele
             #define LAUNCH_SOFTMAX_WARP_FORWARD(L2E) case L2E:                    \
             softmax_warp_forward<input_t, output_t, acc_t, L2E, is_log_softmax, is_masked>   \
                 <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(dst,   \
-                    src, batch_count, softmax_elements_stride, softmax_elements, mask); \
+                    src, batch_count, softmax_elements_stride, softmax_elements, mask, chunk_size, is_transformer_mask); \
             C10_CUDA_KERNEL_LAUNCH_CHECK();                                       \
             break;
 

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -945,11 +945,17 @@ TORCH_IMPL_FUNC(softmax_backward_cuda_out)
 Tensor masked_softmax_cuda(const Tensor& input, const Tensor& mask) {
     TORCH_CHECK(mask.scalar_type() == ScalarType::Bool, "Mask should be a boolean tensor");
     TORCH_CHECK(mask.is_contiguous(), "Mask should always be contiguous");
+    bool is_transformer_mask = (input.dim() == 4 && mask.dim() == 2 && input.size(0) == mask.size(0) && input.size(2) == mask.size(1) && input.size(3) == mask.size(1));
+    TORCH_CHECK(mask.sizes() == input.sizes() || is_transformer_mask, "Mask shape should match input");
     // Always do masked softmax on last dim
     int softmax_elements = input.size(input.dim() - 1);
     TORCH_CHECK(softmax_elements <= 1024, "TODO: Masked softmax only support softmax elements <= 1024");
     Tensor output = at::empty_like(input, input.options());
     int batch_count = input.numel() / softmax_elements;
+    int chunk_size = input.numel() / input.size(0);
+    if (is_transformer_mask) {
+    // Only support when num_heads is even in transformer
+    TORCH_CHECK(input.size(1) % 2 == 0, "Only support when num_heads is even in transformer");
     AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -957,7 +963,27 @@ Tensor masked_softmax_cuda(const Tensor& input, const Tensor& mask) {
       "masked_softmax",
       [&] {
         using accscalar_t = acc_type<scalar_t, true>;
-        dispatch_softmax_forward<scalar_t, scalar_t, accscalar_t, false, true>(
+        dispatch_softmax_forward<scalar_t, scalar_t, accscalar_t, false/* is_log_softmax */, true/* is_masked */>(
+          output.data_ptr<scalar_t>(),      // dst
+          input.data_ptr<scalar_t>(),       // src
+          softmax_elements,
+          softmax_elements,
+          batch_count,
+          mask.data_ptr<bool>(),
+          chunk_size,
+          true // is_transformer_mask
+        );
+      });
+
+    } else {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      input.scalar_type(),
+      "masked_softmax",
+      [&] {
+        using accscalar_t = acc_type<scalar_t, true>;
+        dispatch_softmax_forward<scalar_t, scalar_t, accscalar_t, false/* is_log_softmax */, true/* is_masked */>(
           output.data_ptr<scalar_t>(),      // dst
           input.data_ptr<scalar_t>(),       // src
           softmax_elements,
@@ -966,6 +992,7 @@ Tensor masked_softmax_cuda(const Tensor& input, const Tensor& mask) {
           mask.data_ptr<bool>()
         );
       });
+    }
     return output;
 }
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15642,6 +15642,29 @@ class TestNNDeviceType(NNTestCase):
         pt_res = slow_masked_softmax(input, mask)
         self.assertEqual(pt_res, native_res, exact_dtype=True)
 
+    @onlyCUDA
+    def test_masked_softmax_transformer_layout(self, device):
+        B = 211
+        num_heads = 16
+        L = 42
+        input = torch.randn((B, num_heads, L, L))
+        mask = torch.randint(0, 2, (B, L))
+        if (self.device_type == "cuda"):
+            input = input.cuda()
+            mask = mask.cuda()
+        mask = mask.bool()
+        native_res = torch._masked_softmax(input, mask)
+        mask = mask.reshape(B, 1, 1, L).expand(B, num_heads, L, L)
+        mask = mask.float()
+
+        def slow_masked_softmax(input, mask):
+            exp = torch.exp(input)
+            exp = exp * mask
+            s = exp.sum(dim=3, keepdim=True).expand(exp.size())
+            return exp / s
+        pt_res = slow_masked_softmax(input, mask)
+        self.assertEqual(pt_res, native_res, exact_dtype=True)
+
     # Test fails on Vg20
     @skipCUDAIfRocm
     @dtypesIfCUDA(torch.half, torch.float)


### PR DESCRIPTION
Summary:
In transformer encoder and MHA, masked_softmax's mask is a 2D tensor (B, D), where input is a 4D tensor (B, H, D, D).
This mask could be simply broadcasted to a (B, H, D, D) like input, and then do a regular masked_softmax, however it will bring the problem of non-contiguous mask & consume more memory.
In this diff, we maintained mask's shape unchanged, while calc the corresponding mask for input in each cuda thread.

This new layout is not currently supported in CPU yet.

Test Plan: buck build mode/opt -c fbcode.enable_gpu_sections=true caffe2/test:nn && buck-out/gen/caffe2/test/nn\#binary.par -r test_masked_softmax

Differential Revision: D32605557

