### PR TITLE
[Static Runtime] Move implementation details from impl.h into internal.h

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -356,6 +356,7 @@ core_sources_full_mobile = core_sources_full_mobile_no_backend_interface + [
 core_sources_full = core_sources_full_mobile + [
     "torch/csrc/jit/runtime/static/fusion.cpp",
     "torch/csrc/jit/runtime/static/impl.cpp",
+    "torch/csrc/jit/runtime/static/internal.cpp",
     "torch/csrc/jit/runtime/static/memory_planner.cpp",
     "torch/csrc/jit/runtime/static/native_ops.cpp",
     "torch/csrc/jit/runtime/static/ops.cpp",

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -17,6 +17,7 @@
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/variadic_ops.h>
+#include <torch/csrc/jit/runtime/static/internal.h>
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
@@ -29,12 +30,6 @@
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #endif
-
-// used in test only
-C10_DEFINE_bool(
-    static_runtime_disable_debug_memory_overlap_check,
-    false,
-    "If true, disable the memory overlap check in debug mode in ProcessedNode::run()");
 
 namespace torch {
 namespace jit {
@@ -76,18 +71,6 @@ bool canEnableStaticRuntime(const std::shared_ptr<torch::jit::Graph>& graph) {
     can_support = false;
   }
   return can_support;
-}
-
-std::string dumpValueSet(
-    const FastSet<const Value*>& value_set,
-    const char* set_name) {
-  std::ostringstream oss;
-  oss << set_name << ": {";
-  for (const auto* val : value_set) {
-    oss << "%" << val->debugName() << ", ";
-  }
-  oss << "}";
-  return oss.str();
 }
 
 namespace {
@@ -149,28 +132,6 @@ c10::FunctionSchema RemoveSelfFromSchema(const c10::FunctionSchema& s) {
   TORCH_CHECK(s.arguments().size() >= 1 && s.arguments()[0].name() == "self");
   std::vector<Argument> args({s.arguments().begin() + 1, s.arguments().end()});
   return s.cloneWithArguments(args);
-}
-
-std::vector<Value*> valueVecFromFastSet(const FastSet<const Value*>& s) {
-  std::vector<Value*> result;
-  result.reserve(s.size());
-  for (auto* v : s) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    result.emplace_back(const_cast<Value*>(v));
-  }
-  return result;
-}
-
-bool mayContainAlias(AliasDb& db, const Value* a, const Value* b) {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  return db.mayContainAlias(const_cast<Value*>(a), const_cast<Value*>(b));
-}
-
-bool mayContainAlias(
-    AliasDb& db,
-    const FastSet<const Value*>& a,
-    const FastSet<const Value*>& b) {
-  return db.mayContainAlias(valueVecFromFastSet(a), valueVecFromFastSet(b));
 }
 
 //  Map each value to all values that are alive at the same time.
@@ -623,61 +584,6 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
   return std::make_pair(graph, c10::nullopt);
 }
 
-} // namespace
-
-void ValueGroup::init(
-    const std::shared_ptr<torch::jit::Graph>& graph,
-    AliasDb& db) {
-  external_aliases_.clear();
-  output_aliases_.clear();
-  // Build `input_or_constant_aliases` as we look through nodes forwardly from
-  // the graph's inputs and add aliases of the inputs being created by the
-  // nodes.
-  external_aliases_.insert(graph->inputs().begin(), graph->inputs().end());
-  for (const auto* node : graph->nodes()) {
-    if (node->kind() == prim::Constant) {
-      for (const auto* output : node->outputs()) {
-        external_aliases_.insert(output);
-      }
-    }
-  }
-  for (const auto* node : graph->nodes()) {
-    if (node->kind() == prim::Constant) {
-      // Constants are already in `input_or_constant_aliases`.
-      continue;
-    }
-    for (const auto* v : node->outputs()) {
-      if (mayContainAlias(db, {v}, external_aliases_)) {
-        external_aliases_.insert(v);
-      }
-    }
-  }
-
-  // Build `output_aliases` as we look through nodes reversely so that we can
-  // start from the output values, and follow the flows backwardly from there.
-  output_aliases_.insert(graph->outputs().begin(), graph->outputs().end());
-  for (const auto* node : graph->nodes().reverse()) {
-    if (node->kind() == prim::Constant) {
-      // Constants cannot create any aliases.
-      continue;
-    }
-    for (const auto* v : node->outputs()) {
-      // Add values that can aliase input/constant values. Note some output
-      // aliases may end up in this category via collection objects (e.g.,
-      // Tuple).
-      if (mayContainAlias(db, {v}, external_aliases_)) {
-        external_aliases_.insert(v);
-        continue;
-      }
-      if (mayContainAlias(db, {v}, output_aliases_)) {
-        output_aliases_.insert(v);
-      }
-    }
-  }
-}
-
-namespace {
-
 bool containTensorsOnly(at::ArrayRef<Value*> values) {
   // return true only if all outputs are tensors
   return std::all_of(values.begin(), values.end(), [](const Value* value) {
@@ -685,163 +591,7 @@ bool containTensorsOnly(at::ArrayRef<Value*> values) {
   });
 }
 
-bool mayContainAlias(const Value* v1, const Value* v2, const AliasDb& db) {
-  // AliasDb is not const-correct here, so we have to const_cast
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  return db.mayContainAlias(const_cast<Value*>(v1), const_cast<Value*>(v2));
-}
-
-bool isPureFunction(const Node* node) {
-  auto* schema = node->maybeSchema();
-  return schema &&
-      schema->aliasAnalysis() == c10::AliasAnalysisKind::PURE_FUNCTION;
-}
-
 } // namespace
-
-ManagedTensorRanges::ManagedTensorRanges(
-    const std::shared_ptr<Graph>& graph,
-    const FastSet<const Value*>& managed_tensor_values) {
-  AliasDb alias_db(graph);
-  const std::vector<Node*> nodes(graph->nodes().begin(), graph->nodes().end());
-  const FastSet<const Value*> graph_inputs(
-      graph->inputs().begin(), graph->inputs().end());
-
-  auto isUntrackedValue = [&alias_db, &graph_inputs](const Value* value) {
-    return !alias_db.isMutableType(value) ||
-        graph_inputs.find(value) != graph_inputs.end();
-  };
-
-  const auto num_nodes = nodes.size();
-  for (const auto i : c10::irange(num_nodes)) {
-    auto* node = nodes[i];
-    for (auto* input : node->inputs()) {
-      auto* lifetime = getLifetime(input);
-      if (!lifetime) {
-        DCHECK(isUntrackedValue(input));
-        continue;
-      }
-      DCHECK(lifetime->end <= i);
-      lifetime->end = i;
-    }
-    for (auto* output : node->outputs()) {
-      if (!alias_db.isMutableType(output)) {
-        continue;
-      }
-      value_lifetimes_.emplace(output, Lifetime(i, i));
-    }
-  }
-  for (auto* graph_output : graph->outputs()) {
-    auto* lifetime = getLifetime(graph_output);
-    if (!lifetime) {
-      DCHECK(isUntrackedValue(graph_output));
-      continue;
-    }
-    lifetime->end = num_nodes;
-  }
-
-  // Handle aliases. Aliases may extend a Value*'s lifetime. If a node
-  // has an input and output that may alias each other, set the input's
-  // lifetime end to max(input.lifetime_end, output.lifetime_end). Iterate
-  // backwards to handle chains of aliases.
-  for (const auto* node : graph->nodes().reverse()) {
-    if (isPureFunction(node)) {
-      // If the node is a pure function, it doesn't create any aliases,
-      // so we can safely skip it.
-      continue;
-    }
-
-    auto inputs = collectValuesWithTrackedLifetimes(node->inputs());
-    auto outputs = collectValuesWithTrackedLifetimes(node->outputs());
-    for (auto* input : inputs) {
-      auto* input_lifetime = getLifetime(input);
-      DCHECK(input_lifetime != nullptr);
-      for (auto* output : outputs) {
-        if (mayContainAlias(input, output, alias_db)) {
-          auto* output_lifetime = getLifetime(output);
-          DCHECK(output_lifetime != nullptr);
-          input_lifetime->end =
-              std::max(output_lifetime->end, input_lifetime->end);
-        }
-      }
-    }
-  }
-  for (auto* managed_tensor : managed_tensor_values) {
-    auto* lifetime = getLifetime(managed_tensor);
-    DCHECK(lifetime && lifetime->end <= num_nodes);
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    Node* freeing_node;
-    if (lifetime->end == num_nodes) {
-      freeing_node = graph->return_node();
-    } else {
-      freeing_node = nodes[lifetime->end];
-    }
-    node_to_newly_free_tensors_[freeing_node].emplace_back(managed_tensor);
-  }
-}
-
-bool ManagedTensorRanges::isUnusedValue(const Value* value) const {
-  auto* lifetime = getLifetime(value);
-  return lifetime && lifetime->start == lifetime->end;
-}
-
-bool ManagedTensorRanges::nodeFreesManagedTensors(Node* node) const {
-  auto it = node_to_newly_free_tensors_.find(node);
-  return it != node_to_newly_free_tensors_.end() && !it->second.empty();
-}
-
-const std::vector<const Value*>& ManagedTensorRanges::availableTensorsAfterNode(
-    Node* node) const {
-  return node_to_newly_free_tensors_.at(node);
-}
-
-bool ManagedTensorRanges::lifetimesOverlap(const Value* v1, const Value* v2)
-    const {
-  const auto* v1_lifetime = getLifetime(v1);
-  const auto* v2_lifetime = getLifetime(v2);
-  if (!v1_lifetime || !v2_lifetime) {
-    return false;
-  }
-
-  if (v1_lifetime->start < v2_lifetime->start) {
-    return v1_lifetime->end >= v2_lifetime->start;
-  }
-  return v2_lifetime->end >= v1_lifetime->start;
-}
-
-const ManagedTensorRanges::Lifetime* ManagedTensorRanges::getLifetime(
-    const Value* value) const {
-  auto it = value_lifetimes_.find(value);
-  if (it != value_lifetimes_.end()) {
-    return &it->second;
-  }
-  return nullptr;
-}
-
-ManagedTensorRanges::Lifetime* ManagedTensorRanges::getLifetime(
-    const Value* value) {
-  // const_cast is safe here, this is just a way to avoid code duplication
-  // between the const/non-const versions of getLifetime.
-
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  const auto* const_this = const_cast<const ManagedTensorRanges*>(this);
-
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  return const_cast<ManagedTensorRanges::Lifetime*>(
-      const_this->getLifetime(value));
-}
-
-std::vector<const Value*> ManagedTensorRanges::
-    collectValuesWithTrackedLifetimes(at::ArrayRef<const Value*> values) {
-  std::vector<const Value*> mutable_values;
-  mutable_values.reserve(values.size());
-  std::copy_if(
-      values.begin(),
-      values.end(),
-      std::back_inserter(mutable_values),
-      [this](const Value* value) { return getLifetime(value) != nullptr; });
-  return mutable_values;
-}
 
 StaticModule::StaticModule(
     std::shared_ptr<torch::jit::Graph> g,
@@ -1042,14 +792,14 @@ StaticModule::StaticModule(
   }
 
   // Prepare for memory planning
-  value_group_.init(graph_, alias_db);
-  GRAPH_DEBUG(value_group_.toString());
+  value_group_ = std::make_unique<ValueGroup>(graph_, alias_db);
+  GRAPH_DEBUG(value_group_->toString());
 
   if (opts_.optimize_memory) {
-    auto lm = GetLivenessMap(graph_, value_group_, alias_db);
+    auto lm = GetLivenessMap(graph_, *value_group_, alias_db);
     auto values = GetMemoryPlanningCandidates(graph_, node_has_out_variant);
     value_to_same_storage_values_ =
-        GenerateSameStorageValues(lm, value_group_, values, alias_db);
+        GenerateSameStorageValues(lm, *value_group_, values, alias_db);
   }
 
   prepareForMemoryPlanner();
@@ -1077,11 +827,11 @@ void StaticModule::prepareForMemoryPlanner() {
       bool is_tensor_type = out_v->type()->castRaw<TensorType>();
       if (opts_.manage_output_tensors && is_tensor_type &&
           graph_output_values.find(out_v) == graph_output_values.end() &&
-          value_group_.isOutputAlias(out_v)) {
+          value_group_->isOutputAlias(out_v)) {
         managed_output_tensor_values_.insert(out_v);
         continue;
       }
-      if (value_group_.isAlwaysAlive(out_v)) {
+      if (value_group_->isAlwaysAlive(out_v)) {
         continue;
       }
       if (is_tensor_type) {
@@ -1103,6 +853,11 @@ void StaticModule::prepareForMemoryPlanner() {
       dumpValueSet(managed_output_tensor_values_));
 }
 
+// These are needed to be defined in.cpp file since they require
+// concrete types for ProcessedFunction/ProcessedNode.
+StaticModule::StaticModule(torch::jit::StaticModule&&) noexcept {}
+StaticModule::~StaticModule() = default;
+
 const StaticModuleOptions& StaticModule::opts() const {
   return opts_;
 }
@@ -1120,6 +875,14 @@ StaticRuntime& StaticModule::runtime() {
     cached_runtime_ = std::make_unique<StaticRuntime>(*this);
   }
   return *cached_runtime_;
+}
+
+const std::vector<ProcessedNode>& StaticModule::nodes() const {
+  return nodes_;
+}
+
+size_t StaticModule::num_nodes() const {
+  return nodes_.size();
 }
 
 Node* StaticModule::findNodeWithKindForTesting(const std::string& kind) const {
@@ -1852,6 +1615,14 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   return results;
 }
 
+const std::vector<ProcessedNode>& StaticRuntime::nodes() const {
+  return nodes_;
+}
+
+std::vector<ProcessedNode>& StaticRuntime::nodes() {
+  return nodes_;
+}
+
 void StaticRuntime::check_for_memory_leak(bool output_returned) {
   if (!static_module_.opts().cleanup_activations) {
     return;
@@ -1976,228 +1747,6 @@ void StaticRuntime::disableManageOutputTensors() {
     }
   }
   planner_.reset();
-}
-
-ProcessedFunction::ProcessedFunction(
-    Node* node,
-    bool enable_out_variant,
-    bool check_memory_overlap)
-    : check_memory_overlap_(check_memory_overlap) {
-  if (enable_out_variant) {
-    f_ = getOutOfPlaceOperation(node);
-    if (f_) {
-      kind_ = ProcessedFunction::Kind::kOutVariant;
-      // do not check memory overlap for out variants
-      check_memory_overlap_ = false;
-      VLOG(1) << "Switch to out variant for node: " << PrintNode(node);
-      return;
-    }
-  }
-  {
-    f_ = getNativeOperation(node);
-    if (f_) {
-      kind_ = ProcessedFunction::Kind::kNativeFunction;
-#ifdef NDEBUG
-      // skip this check in opt mode because these ops are better vetted
-      check_memory_overlap_ = false;
-#endif
-      VLOG(1) << "Switch to native impl for node: " << PrintNode(node);
-      return;
-    }
-  }
-  {
-    const Operator& op = node->getOperator();
-    f_ = [node_op = op.getOperation(node)](ProcessedNode* pnode) mutable {
-      std::vector<IValue> stack;
-      Node* node = pnode->node();
-      const size_t size = node->inputs().size();
-      stack.reserve(size + (hasVarArgs(node) ? 1 : 0));
-      for (const auto i : c10::irange(size)) {
-        stack.emplace_back(pnode->Input(i));
-      }
-      // Need to store the number of inputs in stack for variadic ops.
-      if (hasVarArgs(node)) {
-        stack.emplace_back(static_cast<int>(size));
-      }
-
-      node_op(stack);
-
-      DCHECK_EQ(stack.size(), node->outputs().size());
-      for (const auto i : c10::irange(node->outputs().size())) {
-        pnode->Output(i) = std::move(stack[i]);
-      }
-    };
-    kind_ = ProcessedFunction::Kind::kInterpreterFallback;
-    VLOG(1) << "Fallback interpreter for node: " << PrintNode(node);
-  }
-}
-
-ProcessedNode::ProcessedNode(
-    Node* node,
-    ProcessedFunction* fn,
-    ProcessedNodeInputs inputs,
-    uint16_t outputs_offset)
-    : node_(node),
-      fn_(fn),
-      inputs_(std::move(inputs)),
-      outputs_offset_(outputs_offset)
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-      ,
-      op_name_(node->kind().toQualString())
-#endif
-{
-  TORCH_CHECK(
-      node->outputs().size() < (1 << (sizeof(num_outputs_) * 8)),
-      node->outputs().size(),
-      " outputs to ProcessedNode ",
-      node->kind().toQualString(),
-      " is too many to use 2-byte indexing");
-  num_outputs_ = node->outputs().size();
-}
-
-std::vector<IValue> ProcessedNode::inputs_ivalue_vec() const {
-  std::vector<IValue> result;
-  result.reserve(inputs_.size());
-  for (const auto idx : c10::irange(num_inputs())) {
-    result.emplace_back(Input(idx));
-  }
-  return result;
-}
-
-void ProcessedNode::run() {
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  bool pre_sampled = false;
-  if (C10_UNLIKELY(at::shouldRunRecordFunction(&pre_sampled))) {
-    at::RecordFunction guard(at::RecordScope::FUNCTION, pre_sampled);
-    if (guard.isActive()) {
-      if (guard.needsInputs()) {
-        guard.before(get_op_name(), inputs_ivalue_vec());
-      } else {
-        guard.before(get_op_name());
-      }
-    }
-    fn_->f()(this);
-  } else {
-    fn_->f()(this);
-  }
-#else
-  fn_->f()(this);
-#endif
-#ifndef NDEBUG
-  if (FLAGS_static_runtime_disable_debug_memory_overlap_check) {
-    // run check but do not enforce
-    verify_no_memory_overlap();
-  } else {
-    DCHECK(verify_no_memory_overlap());
-  }
-#endif
-}
-
-static bool checkNoMemoryOverlap(const at::Tensor& a, const at::Tensor& b) {
-  at::MemOverlapStatus status = at::get_overlap_status(a, b);
-  if (status == at::MemOverlapStatus::FULL ||
-      status == at::MemOverlapStatus::PARTIAL) {
-    return false;
-  }
-  if (status == at::MemOverlapStatus::TOO_HARD) {
-    VLOG(1) << "Detected TOO_HARD memory overlap status";
-  }
-  return true;
-}
-
-bool ProcessedNode::verify_no_memory_overlap(bool force_check) const {
-  const static std::array<c10::Symbol, 3> special_case_ops = {
-      fromQualString("prim::TypeCheck"),
-      fromQualString("static_runtime::VarTupleUnpack"),
-      fromQualString("static_runtime::dict_unpack")};
-  if (!force_check &&
-      std::find(
-          begin(special_case_ops), end(special_case_ops), node()->kind()) !=
-          end(special_case_ops)) {
-    return true;
-  }
-
-  return verify_outputs_dont_overlap_each_other() &&
-      verify_inputs_dont_overlap_outputs(force_check);
-}
-
-bool ProcessedNode::verify_outputs_dont_overlap_each_other() const {
-  for (const auto i : c10::irange(num_outputs_)) {
-    if (!Output(i).isTensor()) {
-      continue;
-    }
-    const auto& out0_t = Output(i).toTensor();
-    for (const auto j : c10::irange(i + 1, num_outputs_)) {
-      if (!Output(j).isTensor()) {
-        continue;
-      }
-      const auto& out1_t = Output(j).toTensor();
-      if (!checkNoMemoryOverlap(out0_t, out1_t)) {
-        LOG(INFO) << "Node output " << i << " overlaps with output " << j
-                  << ", " << PrintNode(node_);
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-bool ProcessedNode::verify_inputs_dont_overlap_outputs(bool force_check) const {
-  auto schema = node()->maybeSchema();
-  // skip memory overlap check for mutable or view ops with only one output
-  bool skip_check = !schema ||
-      ((schema->is_mutable() || !fn_->checkMemoryOverlap()) &&
-       num_outputs_ == 1);
-  if (!force_check && skip_check) {
-    if (!schema) {
-      VLOG(2) << "Detected that op schema is null";
-      return true;
-    }
-    VLOG(2) << "schema->is_mutable: " << schema->is_mutable()
-            << ", fn_->checkMemoryOverlap: " << fn_->checkMemoryOverlap()
-            << ", num_outputs_: " << num_outputs_;
-    return true;
-  }
-
-  for (const auto i : c10::irange(inputs_.size())) {
-    const IValue* in = &Input(i);
-    if (!in->isTensor()) {
-      continue;
-    }
-    const auto& in_t = in->toTensor();
-    for (const auto j : c10::irange(num_outputs_)) {
-      const IValue& out = Output(j);
-      if (!out.isTensor()) {
-        continue;
-      }
-      const auto& out_t = out.toTensor();
-      if (!checkNoMemoryOverlap(in_t, out_t)) {
-        LOG(INFO) << "Node input " << i << " overlaps with output " << j << ", "
-                  << PrintNode(node_);
-        LOG(INFO) << *schema;
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-void ProcessedNode::verify_and_correct_memory_overlap() {
-  for (const auto i : c10::irange(inputs_.size())) {
-    const IValue& in = Input(i);
-    if (!in.isTensor()) {
-      continue;
-    }
-    const auto& in_t = in.toTensor();
-    for (const auto j : c10::irange(num_outputs_)) {
-      const auto& out_t = Output(j).toTensor();
-      if (!checkNoMemoryOverlap(in_t, out_t)) {
-        DLOG(INFO) << "Detected alias for node: " << PrintNode(node());
-        Output(i) = at::native::clone(out_t, c10::nullopt);
-        set_outputs_memory_overlap_detected();
-      }
-    }
-  }
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -36,112 +36,6 @@ using FastSet = std::unordered_set<Key>;
 TORCH_API bool canEnableStaticRuntime(
     const std::shared_ptr<torch::jit::Graph>& graph);
 
-TORCH_API std::string dumpValueSet(
-    const FastSet<const Value*>& value_set,
-    const char* set_name = "");
-
-TORCH_API inline bool doesNotHeapAllocateWhenStoredInIValue(const Type& type) {
-  switch (type.kind()) {
-    // NOTE: NumberType may allocate because it includes complex.
-    case TypeKind::NoneType:
-    case TypeKind::IntType:
-    case TypeKind::FloatType:
-    case TypeKind::BoolType:
-    case TypeKind::DeviceObjType:
-    case TypeKind::StreamObjType:
-      return true;
-    default:
-      return false;
-  }
-}
-
-// Group values used by `graph` into three categories:
-//
-// - output_aliases:
-//     values that are either outputs or contain aliases of outputs
-// - external_aliases:
-//     values that are inputs, constants, or their aliases.
-//     The output aliases that end up here are as a result of aliasDb failing to
-//     recognize them as outputs due to collection object (e.g., Tuple) aliasing
-//     inputs.
-// Values that dont't show up in output_aliases or external_aliases are created
-// and consumed within the graph.
-class ValueGroup {
- public:
-  explicit ValueGroup() = default;
-  void init(const std::shared_ptr<torch::jit::Graph>& graph, AliasDb& db);
-
-  bool isExternalAlias(const Value* value) const {
-    return external_aliases_.find(value) != external_aliases_.end();
-  }
-
-  bool isOutputAlias(const Value* value) const {
-    return output_aliases_.find(value) != output_aliases_.end();
-  }
-
-  bool isAlwaysAlive(const Value* value) const {
-    return isExternalAlias(value) || isOutputAlias(value);
-  }
-
-  std::string toString() const {
-    return c10::str(
-        dumpValueSet(output_aliases_, "ValueGroup::output_aliases_"),
-        "\n",
-        dumpValueSet(external_aliases_, "ValueGroup::external_aliases_"));
-  }
-
- private:
-  FastSet<const Value*> output_aliases_;
-  FastSet<const Value*> external_aliases_;
-};
-
-class TORCH_API ManagedTensorRanges {
- public:
-  ManagedTensorRanges() = default;
-  ManagedTensorRanges(
-      const std::shared_ptr<Graph>& graph,
-      const FastSet<const Value*>& managed_tensor_values);
-
-  // If true, then this node is the last use of at least one
-  // managed tensor. availableTensorsAfterNode(node) will return a vector
-  // of the managed tensors that are available for re-use
-  // in the nodes following this one.
-  bool nodeFreesManagedTensors(Node* node) const;
-  const std::vector<const Value*>& availableTensorsAfterNode(Node* node) const;
-
-  // True if the value has a tracked lifetime and lifetime.start ==
-  // lifetime.end. "Unused" does not imply "unmanaged" -
-  // managed tensors can be unused if they're not passed to any ops!
-  bool isUnusedValue(const Value* value) const;
-
-  // For testing. True if v1 and v2 are both mutable types and have lifetimes
-  // that overlap.
-  bool lifetimesOverlap(const Value* v1, const Value* v2) const;
-
- private:
-  struct Lifetime {
-    Lifetime(size_t start_, size_t end_) : start(start_), end(end_) {}
-    size_t start;
-    size_t end;
-  };
-
-  // Returns nullptr if we are not tracking the lifetime of value
-  Lifetime* getLifetime(const Value* value);
-  const Lifetime* getLifetime(const Value* value) const;
-  // Collect all values in the input that have tracked lifetimes.
-  // A value's lifetime may not be tracked if it is a graph input
-  // or immutable type (containers with at least one mutable
-  // type are mutable)
-  std::vector<const Value*> collectValuesWithTrackedLifetimes(
-      at::ArrayRef<const Value*> values);
-
-  // Maps Node* to the set of managed tensors that are now available
-  // for re-use after this node.
-  FastMap<Node*, std::vector<const Value*>> node_to_newly_free_tensors_{};
-  // Maps each Value* to its lifetime (start node index, end node index)
-  FastMap<const Value*, Lifetime> value_lifetimes_{};
-};
-
 struct TORCH_API StaticModuleOptions {
   // to batch allocate (deallocate) tensor storage for all non-escaping
   // temporary tensors
@@ -206,6 +100,7 @@ class MemoryPlanner;
 class ProcessedFunction;
 class ProcessedNode;
 class StaticRuntime;
+class ValueGroup;
 class TORCH_API StaticModule {
  public:
   explicit StaticModule(
@@ -216,6 +111,11 @@ class TORCH_API StaticModule {
       const torch::jit::Module& m,
       bool is_frozen = false,
       const StaticModuleOptions& opts = StaticModuleOptions());
+
+  StaticModule(const torch::jit::StaticModule&) = delete;
+  StaticModule(torch::jit::StaticModule&&) noexcept;
+  StaticModule& operator=(StaticModule&&) = delete;
+  ~StaticModule();
 
   typedef enum {
     CONSTANT_VALUE = -2, // VALUE nodes defined by prim::Constant
@@ -255,7 +155,7 @@ class TORCH_API StaticModule {
   const StaticModuleOptions& opts() const;
 
   const ValueGroup& valueGroup() const {
-    return value_group_;
+    return *value_group_;
   }
 
   size_t num_inputs() const;
@@ -274,14 +174,10 @@ class TORCH_API StaticModule {
 
   // Our nodes don't have their inputs & outputs initialized; don't
   // let anybody but StaticRuntime and tests get them.
-  const std::vector<ProcessedNode>& nodes() const {
-    return nodes_;
-  }
+  const std::vector<ProcessedNode>& nodes() const;
 
  public:
-  auto num_nodes() const {
-    return nodes_.size();
-  }
+  size_t num_nodes() const;
 
   C10_NODISCARD Node* findNodeWithKindForTesting(const std::string& kind) const;
 
@@ -300,7 +196,7 @@ class TORCH_API StaticModule {
   }
 
   const ValueGroup& value_group() const {
-    return value_group_;
+    return *value_group_;
   }
 
   const FastSet<const Value*>& managed_tensor_values() const {
@@ -336,13 +232,13 @@ class TORCH_API StaticModule {
   // IValue table (defined by prim::Constant nodes)
   std::vector<IValue> constants_;
   // The functions to be called by corresponding ProcessedNode.
-  std::vector<ProcessedFunction> functions_{};
+  std::vector<ProcessedFunction> functions_;
   // The nodes we need to run
   std::vector<ProcessedNode> nodes_;
   // Indices of graph outputs in the single values array.
   std::vector<uint16_t> output_indices_;
 
-  ValueGroup value_group_;
+  std::unique_ptr<ValueGroup> value_group_;
 
   // map a value to the set of values that may share the same storage with it
   FastMap<const Value*, std::vector<const Value*>>
@@ -420,13 +316,9 @@ class TORCH_API StaticRuntime {
     return outputs_;
   }
 
-  const std::vector<ProcessedNode>& nodes() const {
-    return nodes_;
-  }
+  const std::vector<ProcessedNode>& nodes() const;
 
-  std::vector<ProcessedNode>& nodes() {
-    return nodes_;
-  }
+  std::vector<ProcessedNode>& nodes();
 
   const Graph& graph() const {
     return static_module_.graph();
@@ -507,152 +399,6 @@ class TORCH_API StaticRuntime {
   std::vector<IValue> values_;
   std::vector<IValue*> outputs_;
   std::vector<ProcessedNode> nodes_;
-};
-
-class TORCH_API ProcessedFunction {
- public:
-  ProcessedFunction(
-      Node* node,
-      bool enable_out_variant,
-      bool check_memory_overlap);
-
-  enum class Kind : uint8_t {
-    kOutVariant,
-    kNativeFunction,
-    kInterpreterFallback,
-  };
-
-  const std::function<void(ProcessedNode*)>& f() const {
-    return f_;
-  }
-
-  Kind kind() const {
-    return kind_;
-  }
-
-  bool checkMemoryOverlap() const {
-    return check_memory_overlap_;
-  }
-
- private:
-  std::function<void(ProcessedNode*)> f_;
-  Kind kind_{ProcessedFunction::Kind::kOutVariant};
-  bool check_memory_overlap_{false};
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-class TORCH_API ProcessedNode {
- public:
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-  ProcessedNode() = default;
-  // ProcessedNodes are created within StaticModule and then
-  // associated with a shared values array using set_values() when
-  // they are copied into a StaticRuntime.
-  ProcessedNode(
-      Node* n,
-      ProcessedFunction* fn,
-      ProcessedNodeInputs inputs,
-      uint16_t outputs_offset);
-
-  ProcessedNode(const ProcessedNode&) = default;
-  ProcessedNode& operator=(const ProcessedNode&) = default;
-
-  // These should be noexcept, but some Android build is failing
-  // saying the noexcept specification doesn't match the calculated
-  // one. Maybe c10::variant is throwing it off?
-  ProcessedNode(ProcessedNode&&) = default;
-  ProcessedNode& operator=(ProcessedNode&&) = default;
-
-  void run();
-
-  Node* node() const {
-    return node_;
-  }
-
-  // Input is readonly
-  C10_NODISCARD const IValue& Input(uint32_t i) const {
-    return values_[inputs_[i]];
-  }
-
-  // Output is readwrite
-  IValue& Output(uint32_t i) {
-    DCHECK(i < num_outputs_);
-    return values_[outputs_offset_ + i];
-  }
-
-  C10_NODISCARD const IValue& Output(uint32_t i) const {
-    DCHECK(i < num_outputs_);
-    return values_[outputs_offset_ + i];
-  }
-
-  C10_NODISCARD c10::ArrayRef<const IValue> outputs() const {
-    return c10::ArrayRef<const IValue>(values_ + outputs_offset_, num_outputs_);
-  }
-
-  C10_NODISCARD auto num_outputs() const {
-    return num_outputs_;
-  }
-
-  C10_NODISCARD uint16_t num_inputs() const {
-    return inputs_.size();
-  }
-
-  std::vector<IValue> inputs_ivalue_vec() const;
-
-  bool has_out_variant() const {
-    return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
-  }
-
-  bool has_native() const {
-    return fn_->kind() == ProcessedFunction::Kind::kNativeFunction;
-  }
-
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  const char* get_op_name() const {
-    return op_name_;
-  }
-#endif
-
-  bool check_outputs_for_memory_overlap() const {
-    return fn_->checkMemoryOverlap();
-  }
-
-  void set_outputs_memory_overlap_detected() {
-    overlap_detected_ = true;
-  }
-
-  bool outputs_memory_overlap_detected() {
-    return overlap_detected_;
-  }
-
-  void verify_and_correct_memory_overlap();
-
-  void set_values(IValue* values) {
-    DCHECK(values_ == nullptr);
-    values_ = values;
-  }
-
-  C10_NODISCARD uint16_t output_ivalue_index(uint16_t i) const {
-    return outputs_offset_ + i;
-  }
-  // used in debug mode
-  bool verify_no_memory_overlap(bool force_check = false) const;
-
- private:
-  C10_NODISCARD bool verify_outputs_dont_overlap_each_other() const;
-
-  C10_NODISCARD bool verify_inputs_dont_overlap_outputs(bool force_check) const;
-
-  Node* node_;
-  const ProcessedFunction* fn_;
-  bool overlap_detected_{false};
-  ProcessedNodeInputs inputs_;
-  uint16_t outputs_offset_;
-  uint16_t num_outputs_;
-  IValue* values_ = nullptr; // unowned
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  const char* op_name_;
-#endif
 };
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/runtime/static/fusion.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/internal.h>
 
 // This number is a heuristic determined with pytorch/benchmark
 #define DEFAULT_FUSION_SIZE 4

--- a/torch/csrc/jit/runtime/static/internal.cpp
+++ b/torch/csrc/jit/runtime/static/internal.cpp
@@ -1,0 +1,509 @@
+#include <torch/csrc/jit/runtime/static/internal.h>
+
+#include <ATen/MemoryOverlap.h>
+#include <ATen/core/interned_strings.h>
+#include <ATen/record_function.h>
+#include <c10/core/CPUAllocator.h>
+#include <c10/core/InferenceMode.h>
+#include <c10/util/irange.h>
+#include <caffe2/core/scope_guard.h>
+#include <caffe2/core/timer.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/canonicalize.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/eliminate_no_ops.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/remove_mutation.h>
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/passes/variadic_ops.h>
+#include <torch/csrc/jit/runtime/static/memory_planner.h>
+#include <torch/csrc/jit/runtime/static/ops.h>
+#include <torch/csrc/jit/runtime/static/passes.h>
+#include <torch/csrc/jit/runtime/vararg_functions.h>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+
+// used in test only
+C10_DEFINE_bool(
+    static_runtime_disable_debug_memory_overlap_check,
+    false,
+    "If true, disable the memory overlap check in debug mode in ProcessedNode::run()");
+
+namespace torch {
+namespace jit {
+
+std::string dumpValueSet(
+    const FastSet<const Value*>& value_set,
+    const char* set_name) {
+  std::ostringstream oss;
+  oss << set_name << ": {";
+  for (const auto* val : value_set) {
+    oss << "%" << val->debugName() << ", ";
+  }
+  oss << "}";
+  return oss.str();
+}
+
+bool mayContainAlias(AliasDb& db, const Value* a, const Value* b) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  return db.mayContainAlias(const_cast<Value*>(a), const_cast<Value*>(b));
+}
+
+namespace {
+
+std::vector<Value*> valueVecFromFastSet(const FastSet<const Value*>& s) {
+  std::vector<Value*> result;
+  result.reserve(s.size());
+  for (auto* v : s) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    result.emplace_back(const_cast<Value*>(v));
+  }
+  return result;
+}
+
+} // namespace
+
+bool mayContainAlias(
+    AliasDb& db,
+    const FastSet<const Value*>& a,
+    const FastSet<const Value*>& b) {
+  return db.mayContainAlias(valueVecFromFastSet(a), valueVecFromFastSet(b));
+}
+
+ValueGroup::ValueGroup(
+    const std::shared_ptr<torch::jit::Graph>& graph,
+    AliasDb& db) {
+  external_aliases_.clear();
+  output_aliases_.clear();
+  // Build `input_or_constant_aliases` as we look through nodes forwardly from
+  // the graph's inputs and add aliases of the inputs being created by the
+  // nodes.
+  external_aliases_.insert(graph->inputs().begin(), graph->inputs().end());
+  for (const auto* node : graph->nodes()) {
+    if (node->kind() == prim::Constant) {
+      for (const auto* output : node->outputs()) {
+        external_aliases_.insert(output);
+      }
+    }
+  }
+  for (const auto* node : graph->nodes()) {
+    if (node->kind() == prim::Constant) {
+      // Constants are already in `input_or_constant_aliases`.
+      continue;
+    }
+    for (const auto* v : node->outputs()) {
+      if (mayContainAlias(db, {v}, external_aliases_)) {
+        external_aliases_.insert(v);
+      }
+    }
+  }
+
+  // Build `output_aliases` as we look through nodes reversely so that we can
+  // start from the output values, and follow the flows backwardly from there.
+  output_aliases_.insert(graph->outputs().begin(), graph->outputs().end());
+  for (const auto* node : graph->nodes().reverse()) {
+    if (node->kind() == prim::Constant) {
+      // Constants cannot create any aliases.
+      continue;
+    }
+    for (const auto* v : node->outputs()) {
+      // Add values that can aliase input/constant values. Note some output
+      // aliases may end up in this category via collection objects (e.g.,
+      // Tuple).
+      if (mayContainAlias(db, {v}, external_aliases_)) {
+        external_aliases_.insert(v);
+        continue;
+      }
+      if (mayContainAlias(db, {v}, output_aliases_)) {
+        output_aliases_.insert(v);
+      }
+    }
+  }
+}
+
+namespace {
+
+bool mayContainAlias(const Value* v1, const Value* v2, const AliasDb& db) {
+  // AliasDb is not const-correct here, so we have to const_cast
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  return db.mayContainAlias(const_cast<Value*>(v1), const_cast<Value*>(v2));
+}
+
+bool isPureFunction(const Node* node) {
+  auto* schema = node->maybeSchema();
+  return schema &&
+      schema->aliasAnalysis() == c10::AliasAnalysisKind::PURE_FUNCTION;
+}
+
+} // namespace
+
+ManagedTensorRanges::ManagedTensorRanges(
+    const std::shared_ptr<Graph>& graph,
+    const FastSet<const Value*>& managed_tensor_values) {
+  AliasDb alias_db(graph);
+  const std::vector<Node*> nodes(graph->nodes().begin(), graph->nodes().end());
+  const FastSet<const Value*> graph_inputs(
+      graph->inputs().begin(), graph->inputs().end());
+
+  auto isUntrackedValue = [&alias_db, &graph_inputs](const Value* value) {
+    return !alias_db.isMutableType(value) ||
+        graph_inputs.find(value) != graph_inputs.end();
+  };
+
+  const auto num_nodes = nodes.size();
+  for (const auto i : c10::irange(num_nodes)) {
+    auto* node = nodes[i];
+    for (auto* input : node->inputs()) {
+      auto* lifetime = getLifetime(input);
+      if (!lifetime) {
+        DCHECK(isUntrackedValue(input));
+        continue;
+      }
+      DCHECK(lifetime->end <= i);
+      lifetime->end = i;
+    }
+    for (auto* output : node->outputs()) {
+      if (!alias_db.isMutableType(output)) {
+        continue;
+      }
+      value_lifetimes_.emplace(output, Lifetime(i, i));
+    }
+  }
+  for (auto* graph_output : graph->outputs()) {
+    auto* lifetime = getLifetime(graph_output);
+    if (!lifetime) {
+      DCHECK(isUntrackedValue(graph_output));
+      continue;
+    }
+    lifetime->end = num_nodes;
+  }
+
+  // Handle aliases. Aliases may extend a Value*'s lifetime. If a node
+  // has an input and output that may alias each other, set the input's
+  // lifetime end to max(input.lifetime_end, output.lifetime_end). Iterate
+  // backwards to handle chains of aliases.
+  for (const auto* node : graph->nodes().reverse()) {
+    if (isPureFunction(node)) {
+      // If the node is a pure function, it doesn't create any aliases,
+      // so we can safely skip it.
+      continue;
+    }
+
+    auto inputs = collectValuesWithTrackedLifetimes(node->inputs());
+    auto outputs = collectValuesWithTrackedLifetimes(node->outputs());
+    for (auto* input : inputs) {
+      auto* input_lifetime = getLifetime(input);
+      DCHECK(input_lifetime != nullptr);
+      for (auto* output : outputs) {
+        if (mayContainAlias(input, output, alias_db)) {
+          auto* output_lifetime = getLifetime(output);
+          DCHECK(output_lifetime != nullptr);
+          input_lifetime->end =
+              std::max(output_lifetime->end, input_lifetime->end);
+        }
+      }
+    }
+  }
+  for (auto* managed_tensor : managed_tensor_values) {
+    auto* lifetime = getLifetime(managed_tensor);
+    DCHECK(lifetime && lifetime->end <= num_nodes);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    Node* freeing_node;
+    if (lifetime->end == num_nodes) {
+      freeing_node = graph->return_node();
+    } else {
+      freeing_node = nodes[lifetime->end];
+    }
+    node_to_newly_free_tensors_[freeing_node].emplace_back(managed_tensor);
+  }
+}
+
+bool ManagedTensorRanges::isUnusedValue(const Value* value) const {
+  auto* lifetime = getLifetime(value);
+  return lifetime && lifetime->start == lifetime->end;
+}
+
+bool ManagedTensorRanges::nodeFreesManagedTensors(Node* node) const {
+  auto it = node_to_newly_free_tensors_.find(node);
+  return it != node_to_newly_free_tensors_.end() && !it->second.empty();
+}
+
+const std::vector<const Value*>& ManagedTensorRanges::availableTensorsAfterNode(
+    Node* node) const {
+  return node_to_newly_free_tensors_.at(node);
+}
+
+bool ManagedTensorRanges::lifetimesOverlap(const Value* v1, const Value* v2)
+    const {
+  const auto* v1_lifetime = getLifetime(v1);
+  const auto* v2_lifetime = getLifetime(v2);
+  if (!v1_lifetime || !v2_lifetime) {
+    return false;
+  }
+
+  if (v1_lifetime->start < v2_lifetime->start) {
+    return v1_lifetime->end >= v2_lifetime->start;
+  }
+  return v2_lifetime->end >= v1_lifetime->start;
+}
+
+const ManagedTensorRanges::Lifetime* ManagedTensorRanges::getLifetime(
+    const Value* value) const {
+  auto it = value_lifetimes_.find(value);
+  if (it != value_lifetimes_.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+ManagedTensorRanges::Lifetime* ManagedTensorRanges::getLifetime(
+    const Value* value) {
+  // const_cast is safe here, this is just a way to avoid code duplication
+  // between the const/non-const versions of getLifetime.
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  const auto* const_this = const_cast<const ManagedTensorRanges*>(this);
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  return const_cast<ManagedTensorRanges::Lifetime*>(
+      const_this->getLifetime(value));
+}
+
+std::vector<const Value*> ManagedTensorRanges::
+    collectValuesWithTrackedLifetimes(at::ArrayRef<const Value*> values) {
+  std::vector<const Value*> mutable_values;
+  mutable_values.reserve(values.size());
+  std::copy_if(
+      values.begin(),
+      values.end(),
+      std::back_inserter(mutable_values),
+      [this](const Value* value) { return getLifetime(value) != nullptr; });
+  return mutable_values;
+}
+
+ProcessedFunction::ProcessedFunction(
+    Node* node,
+    bool enable_out_variant,
+    bool check_memory_overlap)
+    : check_memory_overlap_(check_memory_overlap) {
+  if (enable_out_variant) {
+    f_ = getOutOfPlaceOperation(node);
+    if (f_) {
+      kind_ = ProcessedFunction::Kind::kOutVariant;
+      // do not check memory overlap for out variants
+      check_memory_overlap_ = false;
+      VLOG(1) << "Switch to out variant for node: " << PrintNode(node);
+      return;
+    }
+  }
+  {
+    f_ = getNativeOperation(node);
+    if (f_) {
+      kind_ = ProcessedFunction::Kind::kNativeFunction;
+#ifdef NDEBUG
+      // skip this check in opt mode because these ops are better vetted
+      check_memory_overlap_ = false;
+#endif
+      VLOG(1) << "Switch to native impl for node: " << PrintNode(node);
+      return;
+    }
+  }
+  {
+    const Operator& op = node->getOperator();
+    f_ = [node_op = op.getOperation(node)](ProcessedNode* pnode) mutable {
+      std::vector<IValue> stack;
+      Node* node = pnode->node();
+      const size_t size = node->inputs().size();
+      stack.reserve(size + (hasVarArgs(node) ? 1 : 0));
+      for (const auto i : c10::irange(size)) {
+        stack.emplace_back(pnode->Input(i));
+      }
+      // Need to store the number of inputs in stack for variadic ops.
+      if (hasVarArgs(node)) {
+        stack.emplace_back(static_cast<int>(size));
+      }
+
+      node_op(stack);
+
+      DCHECK_EQ(stack.size(), node->outputs().size());
+      for (const auto i : c10::irange(node->outputs().size())) {
+        pnode->Output(i) = std::move(stack[i]);
+      }
+    };
+    kind_ = ProcessedFunction::Kind::kInterpreterFallback;
+    VLOG(1) << "Fallback interpreter for node: " << PrintNode(node);
+  }
+}
+
+ProcessedNode::ProcessedNode(
+    Node* node,
+    ProcessedFunction* fn,
+    ProcessedNodeInputs inputs,
+    uint16_t outputs_offset)
+    : node_(node),
+      fn_(fn),
+      inputs_(std::move(inputs)),
+      outputs_offset_(outputs_offset)
+#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
+      ,
+      op_name_(node->kind().toQualString())
+#endif
+{
+  TORCH_CHECK(
+      node->outputs().size() < (1 << (sizeof(num_outputs_) * 8)),
+      node->outputs().size(),
+      " outputs to ProcessedNode ",
+      node->kind().toQualString(),
+      " is too many to use 2-byte indexing");
+  num_outputs_ = node->outputs().size();
+}
+
+std::vector<IValue> ProcessedNode::inputs_ivalue_vec() const {
+  std::vector<IValue> result;
+  result.reserve(inputs_.size());
+  for (const auto idx : c10::irange(num_inputs())) {
+    result.emplace_back(Input(idx));
+  }
+  return result;
+}
+
+void ProcessedNode::run() {
+#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
+  bool pre_sampled = false;
+  if (C10_UNLIKELY(at::shouldRunRecordFunction(&pre_sampled))) {
+    at::RecordFunction guard(at::RecordScope::FUNCTION, pre_sampled);
+    if (guard.isActive()) {
+      if (guard.needsInputs()) {
+        guard.before(get_op_name(), inputs_ivalue_vec());
+      } else {
+        guard.before(get_op_name());
+      }
+    }
+    fn_->f()(this);
+  } else {
+    fn_->f()(this);
+  }
+#else
+  fn_->f()(this);
+#endif
+#ifndef NDEBUG
+  if (FLAGS_static_runtime_disable_debug_memory_overlap_check) {
+    // run check but do not enforce
+    verify_no_memory_overlap();
+  } else {
+    DCHECK(verify_no_memory_overlap());
+  }
+#endif
+}
+
+static bool checkNoMemoryOverlap(const at::Tensor& a, const at::Tensor& b) {
+  at::MemOverlapStatus status = at::get_overlap_status(a, b);
+  if (status == at::MemOverlapStatus::FULL ||
+      status == at::MemOverlapStatus::PARTIAL) {
+    return false;
+  }
+  if (status == at::MemOverlapStatus::TOO_HARD) {
+    VLOG(1) << "Detected TOO_HARD memory overlap status";
+  }
+  return true;
+}
+
+bool ProcessedNode::verify_no_memory_overlap(bool force_check) const {
+  const static std::array<c10::Symbol, 3> special_case_ops = {
+      fromQualString("prim::TypeCheck"),
+      fromQualString("static_runtime::VarTupleUnpack"),
+      fromQualString("static_runtime::dict_unpack")};
+  if (!force_check &&
+      std::find(
+          begin(special_case_ops), end(special_case_ops), node()->kind()) !=
+          end(special_case_ops)) {
+    return true;
+  }
+
+  return verify_outputs_dont_overlap_each_other() &&
+      verify_inputs_dont_overlap_outputs(force_check);
+}
+
+bool ProcessedNode::verify_outputs_dont_overlap_each_other() const {
+  for (const auto i : c10::irange(num_outputs_)) {
+    if (!Output(i).isTensor()) {
+      continue;
+    }
+    const auto& out0_t = Output(i).toTensor();
+    for (const auto j : c10::irange(i + 1, num_outputs_)) {
+      if (!Output(j).isTensor()) {
+        continue;
+      }
+      const auto& out1_t = Output(j).toTensor();
+      if (!checkNoMemoryOverlap(out0_t, out1_t)) {
+        LOG(INFO) << "Node output " << i << " overlaps with output " << j
+                  << ", " << PrintNode(node_);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool ProcessedNode::verify_inputs_dont_overlap_outputs(bool force_check) const {
+  auto schema = node()->maybeSchema();
+  // skip memory overlap check for mutable or view ops with only one output
+  bool skip_check = !schema ||
+      ((schema->is_mutable() || !fn_->checkMemoryOverlap()) &&
+       num_outputs_ == 1);
+  if (!force_check && skip_check) {
+    if (!schema) {
+      VLOG(2) << "Detected that op schema is null";
+      return true;
+    }
+    VLOG(2) << "schema->is_mutable: " << schema->is_mutable()
+            << ", fn_->checkMemoryOverlap: " << fn_->checkMemoryOverlap()
+            << ", num_outputs_: " << num_outputs_;
+    return true;
+  }
+
+  for (const auto i : c10::irange(inputs_.size())) {
+    const IValue* in = &Input(i);
+    if (!in->isTensor()) {
+      continue;
+    }
+    const auto& in_t = in->toTensor();
+    for (const auto j : c10::irange(num_outputs_)) {
+      const IValue& out = Output(j);
+      if (!out.isTensor()) {
+        continue;
+      }
+      const auto& out_t = out.toTensor();
+      if (!checkNoMemoryOverlap(in_t, out_t)) {
+        LOG(INFO) << "Node input " << i << " overlaps with output " << j << ", "
+                  << PrintNode(node_);
+        LOG(INFO) << *schema;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+void ProcessedNode::verify_and_correct_memory_overlap() {
+  for (const auto i : c10::irange(inputs_.size())) {
+    const IValue& in = Input(i);
+    if (!in.isTensor()) {
+      continue;
+    }
+    const auto& in_t = in.toTensor();
+    for (const auto j : c10::irange(num_outputs_)) {
+      const auto& out_t = Output(j).toTensor();
+      if (!checkNoMemoryOverlap(in_t, out_t)) {
+        DLOG(INFO) << "Detected alias for node: " << PrintNode(node());
+        Output(i) = at::native::clone(out_t, c10::nullopt);
+        set_outputs_memory_overlap_detected();
+      }
+    }
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/runtime/static/internal.h
+++ b/torch/csrc/jit/runtime/static/internal.h
@@ -1,0 +1,281 @@
+#pragma once
+
+#include <ATen/core/interned_strings.h>
+#include <ATen/core/ivalue.h>
+#include <c10/core/CPUAllocator.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/variant.h>
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/inliner.h>
+#include <torch/csrc/jit/runtime/static/ProcessedNodeInputs.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
+
+namespace torch {
+namespace jit {
+
+TORCH_API std::string dumpValueSet(
+    const FastSet<const Value*>& value_set,
+    const char* set_name = "");
+
+TORCH_API inline bool doesNotHeapAllocateWhenStoredInIValue(const Type& type) {
+  switch (type.kind()) {
+    // NOTE: NumberType may allocate because it includes complex.
+    case TypeKind::NoneType:
+    case TypeKind::IntType:
+    case TypeKind::FloatType:
+    case TypeKind::BoolType:
+    case TypeKind::DeviceObjType:
+    case TypeKind::StreamObjType:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool mayContainAlias(AliasDb& db, const Value* a, const Value* b);
+
+bool mayContainAlias(
+    AliasDb& db,
+    const FastSet<const Value*>& a,
+    const FastSet<const Value*>& b);
+
+// Group values used by `graph` into three categories:
+//
+// - output_aliases:
+//     values that are either outputs or contain aliases of outputs
+// - external_aliases:
+//     values that are inputs, constants, or their aliases.
+//     The output aliases that end up here are as a result of aliasDb failing to
+//     recognize them as outputs due to collection object (e.g., Tuple) aliasing
+//     inputs.
+// Values that dont't show up in output_aliases or external_aliases are created
+// and consumed within the graph.
+class ValueGroup {
+ public:
+  explicit ValueGroup(
+      const std::shared_ptr<torch::jit::Graph>& graph,
+      AliasDb& db);
+
+  bool isExternalAlias(const Value* value) const {
+    return external_aliases_.find(value) != external_aliases_.end();
+  }
+
+  bool isOutputAlias(const Value* value) const {
+    return output_aliases_.find(value) != output_aliases_.end();
+  }
+
+  bool isAlwaysAlive(const Value* value) const {
+    return isExternalAlias(value) || isOutputAlias(value);
+  }
+
+  std::string toString() const {
+    return c10::str(
+        dumpValueSet(output_aliases_, "ValueGroup::output_aliases_"),
+        "\n",
+        dumpValueSet(external_aliases_, "ValueGroup::external_aliases_"));
+  }
+
+ private:
+  FastSet<const Value*> output_aliases_;
+  FastSet<const Value*> external_aliases_;
+};
+
+class TORCH_API ManagedTensorRanges {
+ public:
+  ManagedTensorRanges() = default;
+  ManagedTensorRanges(
+      const std::shared_ptr<Graph>& graph,
+      const FastSet<const Value*>& managed_tensor_values);
+
+  // If true, then this node is the last use of at least one
+  // managed tensor. availableTensorsAfterNode(node) will return a vector
+  // of the managed tensors that are available for re-use
+  // in the nodes following this one.
+  bool nodeFreesManagedTensors(Node* node) const;
+  const std::vector<const Value*>& availableTensorsAfterNode(Node* node) const;
+
+  // True if the value has a tracked lifetime and lifetime.start ==
+  // lifetime.end. "Unused" does not imply "unmanaged" -
+  // managed tensors can be unused if they're not passed to any ops!
+  bool isUnusedValue(const Value* value) const;
+
+  // For testing. True if v1 and v2 are both mutable types and have lifetimes
+  // that overlap.
+  bool lifetimesOverlap(const Value* v1, const Value* v2) const;
+
+ private:
+  struct Lifetime {
+    Lifetime(size_t start_, size_t end_) : start(start_), end(end_) {}
+    size_t start;
+    size_t end;
+  };
+
+  // Returns nullptr if we are not tracking the lifetime of value
+  Lifetime* getLifetime(const Value* value);
+  const Lifetime* getLifetime(const Value* value) const;
+  // Collect all values in the input that have tracked lifetimes.
+  // A value's lifetime may not be tracked if it is a graph input
+  // or immutable type (containers with at least one mutable
+  // type are mutable)
+  std::vector<const Value*> collectValuesWithTrackedLifetimes(
+      at::ArrayRef<const Value*> values);
+
+  // Maps Node* to the set of managed tensors that are now available
+  // for re-use after this node.
+  FastMap<Node*, std::vector<const Value*>> node_to_newly_free_tensors_{};
+  // Maps each Value* to its lifetime (start node index, end node index)
+  FastMap<const Value*, Lifetime> value_lifetimes_{};
+};
+
+class TORCH_API ProcessedFunction {
+ public:
+  ProcessedFunction(
+      Node* node,
+      bool enable_out_variant,
+      bool check_memory_overlap);
+
+  enum class Kind : uint8_t {
+    kOutVariant,
+    kNativeFunction,
+    kInterpreterFallback,
+  };
+
+  const std::function<void(ProcessedNode*)>& f() const {
+    return f_;
+  }
+
+  Kind kind() const {
+    return kind_;
+  }
+
+  bool checkMemoryOverlap() const {
+    return check_memory_overlap_;
+  }
+
+ private:
+  std::function<void(ProcessedNode*)> f_;
+  Kind kind_{ProcessedFunction::Kind::kOutVariant};
+  bool check_memory_overlap_{false};
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+class TORCH_API ProcessedNode {
+ public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  ProcessedNode() = default;
+  // ProcessedNodes are created within StaticModule and then
+  // associated with a shared values array using set_values() when
+  // they are copied into a StaticRuntime.
+  ProcessedNode(
+      Node* n,
+      ProcessedFunction* fn,
+      ProcessedNodeInputs inputs,
+      uint16_t outputs_offset);
+
+  ProcessedNode(const ProcessedNode&) = default;
+  ProcessedNode& operator=(const ProcessedNode&) = default;
+
+  // These should be noexcept, but some Android build is failing
+  // saying the noexcept specification doesn't match the calculated
+  // one. Maybe c10::variant is throwing it off?
+  ProcessedNode(ProcessedNode&&) = default;
+  ProcessedNode& operator=(ProcessedNode&&) = default;
+
+  void run();
+
+  Node* node() const {
+    return node_;
+  }
+
+  // Input is readonly
+  C10_NODISCARD const IValue& Input(uint32_t i) const {
+    return values_[inputs_[i]];
+  }
+
+  // Output is readwrite
+  IValue& Output(uint32_t i) {
+    DCHECK(i < num_outputs_);
+    return values_[outputs_offset_ + i];
+  }
+
+  C10_NODISCARD const IValue& Output(uint32_t i) const {
+    DCHECK(i < num_outputs_);
+    return values_[outputs_offset_ + i];
+  }
+
+  C10_NODISCARD c10::ArrayRef<const IValue> outputs() const {
+    return c10::ArrayRef<const IValue>(values_ + outputs_offset_, num_outputs_);
+  }
+
+  C10_NODISCARD auto num_outputs() const {
+    return num_outputs_;
+  }
+
+  C10_NODISCARD uint16_t num_inputs() const {
+    return inputs_.size();
+  }
+
+  std::vector<IValue> inputs_ivalue_vec() const;
+
+  bool has_out_variant() const {
+    return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
+  }
+
+  bool has_native() const {
+    return fn_->kind() == ProcessedFunction::Kind::kNativeFunction;
+  }
+
+#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
+  const char* get_op_name() const {
+    return op_name_;
+  }
+#endif
+
+  bool check_outputs_for_memory_overlap() const {
+    return fn_->checkMemoryOverlap();
+  }
+
+  void set_outputs_memory_overlap_detected() {
+    overlap_detected_ = true;
+  }
+
+  bool outputs_memory_overlap_detected() {
+    return overlap_detected_;
+  }
+
+  void verify_and_correct_memory_overlap();
+
+  void set_values(IValue* values) {
+    DCHECK(values_ == nullptr);
+    values_ = values;
+  }
+
+  C10_NODISCARD uint16_t output_ivalue_index(uint16_t i) const {
+    return outputs_offset_ + i;
+  }
+  // used in debug mode
+  bool verify_no_memory_overlap(bool force_check = false) const;
+
+ private:
+  C10_NODISCARD bool verify_outputs_dont_overlap_each_other() const;
+
+  C10_NODISCARD bool verify_inputs_dont_overlap_outputs(bool force_check) const;
+
+  Node* node_;
+  const ProcessedFunction* fn_;
+  bool overlap_detected_{false};
+  ProcessedNodeInputs inputs_;
+  uint16_t outputs_offset_;
+  uint16_t num_outputs_;
+  IValue* values_ = nullptr; // unowned
+#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
+  const char* op_name_;
+#endif
+};
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -1,7 +1,6 @@
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 
 #include <torch/csrc/jit/jit_log.h>
-#include <torch/csrc/jit/runtime/static/impl.h>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/internal.h>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -20,7 +20,6 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
-#include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/te_wrapper.h>
 #include <torch/csrc/jit/runtime/vararg_functions.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -3,6 +3,7 @@
 #include <ATen/Utils.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/internal.h>
 
 namespace at {
 namespace native {


### PR DESCRIPTION
Summary:
`impl.h` is the main header file that defines the interface of Static Runtime to its clients.

However, it is currently filled with implementation details that should not be leaked to our clients.

To alleviate the situation, this change moves the implementation details from impl.h into a new file, internal.h, that's internally kept without leaking the details to our clients.

This change will be followed by another change to rename `impl.h` into `runtime.h` or anything better since `impl.h` is currently not about implementation but SR's interface.

Note that this change is NOT complete since the remaining declarations in impl.h still contain a lot of implementation details. Therefore, we should keep working on minimizing the interface to prevent our API from being bloated unnecessarily. Also we need to work on modularizing our implementations into separate pieces organized by separate files in the near future.

Test Plan: Existing unittests

Differential Revision: D32780415

