### PR TITLE
[SR][RFC] Strategy pattern for storage assignment algorithms

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/runtime/static/ProcessedNodeInputs.h>
 #include <torch/csrc/jit/runtime/static/fusion.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/memory_planner.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
 
@@ -1011,11 +1012,13 @@ TEST(ManagedTensorRanges, NoAliases) {
 
   EXPECT_TRUE(ranges.nodeFreesManagedTensors(nodes[1]));
   EXPECT_EQ(
-      ranges.availableTensorsAfterNode(nodes[1]), std::vector<const Value*>{y});
+      ranges.availableTensorValuesAfterNode(nodes[1]),
+      std::vector<const Value*>{y});
 
   EXPECT_TRUE(ranges.nodeFreesManagedTensors(nodes[2]));
   EXPECT_EQ(
-      ranges.availableTensorsAfterNode(nodes[2]), std::vector<const Value*>{z});
+      ranges.availableTensorValuesAfterNode(nodes[2]),
+      std::vector<const Value*>{z});
 }
 
 TEST(ManagedTensorRanges, AliasExtendingLifetimes) {
@@ -1050,35 +1053,18 @@ TEST(ManagedTensorRanges, AliasExtendingLifetimes) {
 
   EXPECT_TRUE(ranges.nodeFreesManagedTensors(nodes[4]));
   EXPECT_EQ(
-      ranges.availableTensorsAfterNode(nodes[4]), std::vector<const Value*>{y});
+      ranges.availableTensorValuesAfterNode(nodes[4]),
+      std::vector<const Value*>{y});
 
   EXPECT_TRUE(ranges.nodeFreesManagedTensors(nodes[5]));
-  const auto& available_after_5 = ranges.availableTensorsAfterNode(nodes[5]);
+  const auto& available_after_5 =
+      ranges.availableTensorValuesAfterNode(nodes[5]);
   // We don't care about the order, so convert to set. But make sure
   // there are no duplicates.
   FastSet<const Value*> available_after_5_set(
       available_after_5.begin(), available_after_5.end());
   EXPECT_EQ(available_after_5_set.size(), available_after_5.size());
   EXPECT_EQ(available_after_5_set, FastSet<const Value*>({z1, z2}));
-}
-
-TEST(ManagedTensorRanges, UnusedTensor) {
-  const std::string src = R"IR(
-    graph(%x : Tensor):
-        %y : Tensor = aten::mul(%x, %x)
-        %z : Tensor = aten::mul(%x, %x)
-        %output : Tensor = aten::mul(%z, %z)
-        return (%output)
-  )IR";
-  auto graph = std::make_shared<Graph>();
-  std::unordered_map<std::string, Value*> vmap;
-  parseIR(src, graph.get(), vmap);
-  auto* y = vmap["y"];
-  auto* z = vmap["z"];
-
-  ManagedTensorRanges ranges(graph, {y});
-  EXPECT_TRUE(ranges.isUnusedValue(y));
-  EXPECT_FALSE(ranges.isUnusedValue(z));
 }
 
 TEST(ManagedTensorRanges, LifetimeOverlap) {
@@ -1158,4 +1144,151 @@ TEST(ManagedTensorRanges, OverlappingLifetimesOutputs) {
   ManagedTensorRanges ranges(graph, {b, output});
 
   EXPECT_TRUE(ranges.lifetimesOverlap(b, output));
+}
+
+namespace {
+
+// For checking the correctness of assignStorageToManageTensors, the following
+// conditions must hold
+// 1. All managed tensors are assigned to some storage group, and a tensor
+//    may not be assigned to more than 1 storage group.
+// 2. Managed tensors with overlapping lifetimes should not be in the same
+//    storage group.
+void checkStorageGroups(
+    const std::vector<StorageGroup>& storage_groups,
+    const ManagedTensorRanges& ranges,
+    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor) {
+  // Some extra bookkeeping; construct the set of managed Tensor* and
+  // invert the tensor_value_to_tensor map. StorageGroup stores
+  // Tensor*, so this will make everything a little easier.
+  FastMap<at::Tensor*, const Value*> tensor_to_tensor_value;
+  FastSet<at::Tensor*> managed_tensors;
+  for (auto& key_value : tensor_value_to_tensor) {
+    ASSERT_EQ(
+        tensor_to_tensor_value.find(key_value.second),
+        tensor_to_tensor_value.end());
+    tensor_to_tensor_value.emplace(key_value.second, key_value.first);
+    managed_tensors.insert(key_value.second);
+  }
+
+  // Condition (1)
+  FastSet<at::Tensor*> actual_assigned_tensors;
+  for (const auto& storage_group : storage_groups) {
+    for (auto* tensor : storage_group.group()) {
+      ASSERT_EQ(
+          actual_assigned_tensors.find(tensor), actual_assigned_tensors.end());
+      actual_assigned_tensors.insert(tensor);
+    }
+  }
+  ASSERT_EQ(actual_assigned_tensors, managed_tensors);
+
+  // Condition (2)
+  for (const auto& storage_group : storage_groups) {
+    const auto& group = storage_group.group();
+    for (const auto i : c10::irange(group.size() - 1)) {
+      for (const auto j : c10::irange(i + 1, group.size())) {
+        const auto* v1 = tensor_to_tensor_value.at(group[i]);
+        const auto* v2 = tensor_to_tensor_value.at(group[j]);
+        EXPECT_FALSE(ranges.lifetimesOverlap(v1, v2));
+      }
+    }
+  }
+}
+
+// A convenience function for testing assignStorageToManagedTensors. It
+// takes in an IR graph as well as a map from managed tensor name to tensor
+// value. It constructs all of the necessary data structures, invokes
+// assignStorageToManageTensors, and verifies correctness with
+// checkStorageGroups.
+void testAssignStorageToManagedTensors(
+    const std::string& src,
+    FastMap<std::string, at::Tensor> managed_tensor_name_to_tensor) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  parseIR(src, graph.get(), vmap);
+
+  FastSet<const Value*> managed_tensor_values;
+  FastMap<const Value*, at::Tensor*> tensor_value_to_tensor;
+
+  for (auto& key_value : managed_tensor_name_to_tensor) {
+    const auto& tensor_name = key_value.first;
+    auto vmap_it = vmap.find(tensor_name);
+    ASSERT_TRUE(vmap_it != vmap.end());
+    managed_tensor_values.insert(vmap_it->second);
+    tensor_value_to_tensor.emplace(vmap_it->second, &key_value.second);
+  }
+  ASSERT_EQ(managed_tensor_values.size(), tensor_value_to_tensor.size());
+
+  auto ranges = ManagedTensorRanges(graph, managed_tensor_values);
+  std::vector<StorageGroup> groups;
+  assignStorageToManagedTensors(
+      graph->block()->nodes(), ranges, tensor_value_to_tensor, groups);
+
+  checkStorageGroups(groups, ranges, tensor_value_to_tensor);
+}
+
+} // namespace
+
+TEST(AssignStorageToManagedTensors, NoAliases) {
+  const auto src = R"IR(
+    graph(%a : Tensor):
+      %b : Tensor = aten::mul(%a, %a)
+      %c : Tensor = aten::mul(%b, %b)
+      %d : Tensor = aten::mul(%c, %c)
+      %e : Tensor = aten::mul(%b, %d)
+      %output : Tensor = aten::mul(%e, %e)
+      return (%output)
+  )IR";
+  FastMap<std::string, at::Tensor> managed_tensor_name_to_tensor{
+      {"b", at::randn({1})},
+      {"c", at::randn({1})},
+      {"d", at::randn({1})},
+      {"e", at::randn({1})}};
+  testAssignStorageToManagedTensors(
+      src, std::move(managed_tensor_name_to_tensor));
+}
+
+TEST(AssignStorageToManagedTensors, Aliases) {
+  const auto src = R"IR(
+    graph(%a : Tensor):
+      %b : Tensor = aten::mul(%a, %a)
+      %c : Tensor = aten::mul(%b, %b)
+      %d : Tensor = aten::mul(%c, %c)
+      %c_size : int[] = aten::size(%c)
+      %c_alias : Tensor = aten::view(%c, %c_size)
+      %e : Tensor = aten::mul(%b, %d)
+      %f : Tensor = aten::mul(%c_alias, %c_alias)
+      %output : Tensor = aten::mul(%e, %f)
+      return (%output)
+  )IR";
+  FastMap<std::string, at::Tensor> managed_tensor_name_to_tensor{
+      {"b", at::randn({1})},
+      {"c", at::randn({1})},
+      {"d", at::randn({1})},
+      {"e", at::randn({1})},
+      {"f", at::randn({1})}};
+  testAssignStorageToManagedTensors(
+      src, std::move(managed_tensor_name_to_tensor));
+}
+
+namespace {
+TORCH_LIBRARY_FRAGMENT(static_runtime_tests, m) {
+  m.def(torch::schema(
+      "static_runtime_tests::any_outputs(Tensor a) -> ...",
+      at::AliasAnalysisKind::PURE_FUNCTION));
+}
+} // namespace
+
+TEST(AssignStorageToManagedTensors, MultipleUnused) {
+  const auto src = R"IR(
+    graph(%a : Tensor):
+        %z : Tensor = aten::mul(%a, %a)
+        %out: Tensor = aten::mul(%z, %z)
+        %x : Tensor, %y : Tensor = static_runtime_tests::any_outputs(%a)
+        return (%out)
+  )IR";
+  FastMap<std::string, at::Tensor> managed_tensor_name_to_tensor{
+      {"z", at::randn({1})}, {"x", at::randn({1})}, {"y", at::randn({1})}};
+  testAssignStorageToManagedTensors(
+      src, std::move(managed_tensor_name_to_tensor));
 }

--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -1220,9 +1220,8 @@ void testAssignStorageToManagedTensors(
   ASSERT_EQ(managed_tensor_values.size(), tensor_value_to_tensor.size());
 
   auto ranges = ManagedTensorRanges(graph, managed_tensor_values);
-  std::vector<StorageGroup> groups;
-  assignStorageToManagedTensors(
-      graph->block()->nodes(), ranges, tensor_value_to_tensor, groups);
+  auto groups = assignStorageToManagedTensors(
+      graph->block()->nodes(), ranges, tensor_value_to_tensor);
 
   checkStorageGroups(groups, ranges, tensor_value_to_tensor);
 }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -997,6 +997,56 @@ StaticModule::StaticModule(
     value_to_same_storage_values_ =
         GenerateSameStorageValues(lm, value_group_, values, alias_db);
   }
+
+  prepareForMemoryPlanner();
+}
+
+void StaticModule::prepareForMemoryPlanner() {
+  if (!opts_.enable_out_variant) {
+    return;
+  }
+
+  // Never manage graph outputs so that we can do std::move(output_ivalue).
+  // This does not affect performance if the graph returns a collection object.
+  FastSet<const Value*> graph_output_values(
+      graph_->outputs().begin(), graph_->outputs().end());
+
+  // collect register indices of outputs of ops with out variant
+  for (ProcessedNode& pnode : nodes_) {
+    if (!pnode.has_out_variant()) {
+      continue;
+    }
+    auto outputs = pnode.node()->outputs();
+    for (const auto i : c10::irange(outputs.size())) {
+      const Value* out_v = outputs[i];
+      // Types are stored in the underlying TorchScript IR
+      bool is_tensor_type = out_v->type()->castRaw<TensorType>();
+      if (opts_.manage_output_tensors && is_tensor_type &&
+          graph_output_values.find(out_v) == graph_output_values.end() &&
+          value_group_.isOutputAlias(out_v)) {
+        managed_output_tensor_values_.insert(out_v);
+        continue;
+      }
+      if (value_group_.isAlwaysAlive(out_v)) {
+        continue;
+      }
+      if (is_tensor_type) {
+        managed_tensor_values_.insert(out_v);
+      } else if (is_optimizable_container_type(pnode.node())) {
+        // We "leak" certain container types because their allocations
+        // take a long time
+        leaked_values_.insert(out_v);
+      }
+    }
+  }
+
+  for (const Value* output : graph_->outputs()) {
+    managed_tensor_values_.erase(output);
+  }
+  GRAPH_DEBUG("managed_tensor_values: ", dumpValueSet(managed_tensor_values_));
+  GRAPH_DEBUG(
+      "managed_output_tensor_values_: ",
+      dumpValueSet(managed_output_tensor_values_));
 }
 
 const StaticModuleOptions& StaticModule::opts() const {
@@ -1154,6 +1204,9 @@ void StaticRuntime::create_memory_planner() {
         this,
         static_module_.values_share_same_storage(),
         static_module_.value_group(),
+        static_module_.managed_tensor_values(),
+        static_module_.managed_output_tensor_values(),
+        static_module_.leaked_values(),
         static_module_.opts().enable_out_variant,
         manage_output_tensors_enabled_);
   }
@@ -1763,7 +1816,7 @@ void StaticRuntime::check_for_memory_leak(bool output_returned) {
     for (const auto i : c10::irange(pnode.num_outputs())) {
       const IValue* ival = &pnode.Output(i);
       const Value* val = pnode.node()->output(i);
-      if (planner_ && planner_->isManagedOutputTensorValue(val)) {
+      if (planner_ && isManagedOutputTensorValue(val)) {
         // `ival` contains a managed output tensor that the runtime doesn't
         // reclaim at the end of an iteration, but the client does so
         // by explicitly calling `StaticRuntime::deallocateOutputTensors`.
@@ -1825,7 +1878,7 @@ bool StaticRuntime::checkOutputTensorMemoryLeaks() {
     for (const auto i : c10::irange(pnode.num_outputs())) {
       const IValue* ival = &pnode.Output(i);
       const Value* val = pnode.node()->output(i);
-      if (!planner_->isManagedOutputTensorValue(val)) {
+      if (!isManagedOutputTensorValue(val)) {
         continue;
       }
       const auto& t = ival->toTensor();
@@ -1842,8 +1895,18 @@ bool StaticRuntime::checkOutputTensorMemoryLeaks() {
   return true;
 }
 
-bool StaticRuntime::isManagedOutputTensor(const IValue& ivalue) {
+bool StaticRuntime::isManagedOutputTensor(const IValue& ivalue) const {
   return planner_ && planner_->isManagedOutputTensor(ivalue);
+}
+
+bool StaticRuntime::isManagedOutputTensorValue(const Value* value) const {
+  // It's possible that manage_output_tensors_ was disabled after initializing
+  // managed_output_tensor_values, so we have to check that flag here.
+  if (!planner_ || !manage_output_tensors_enabled_) {
+    return false;
+  }
+  const auto& managed_outputs = static_module_.managed_output_tensor_values();
+  return managed_outputs.find(value) != managed_outputs.end();
 }
 
 void StaticRuntime::disableManageOutputTensors() {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -167,372 +167,6 @@ bool mayContainAlias(
   return db.mayContainAlias(valueVecFromFastSet(a), valueVecFromFastSet(b));
 }
 
-//  Map each value to all values that are alive at the same time.
-using LivenessMap = FastMap<const Value*, FastSet<const Value*>>;
-
-std::string dumpLivenessMap(const LivenessMap& liveness_map) {
-  std::ostringstream oss;
-  oss << "{";
-  for (const auto& p : liveness_map) {
-    oss << "{%" << p.first->debugName() << ": {";
-    for (const auto* val : p.second) {
-      oss << "%" << val->debugName() << ", ";
-    }
-    oss << "}},\n";
-  }
-  oss << "}";
-  return oss.str();
-}
-
-//  The algorithm does a traversal of the execution graph
-//  while keeping track of the live values.
-LivenessMap GetLivenessMap(
-    const std::shared_ptr<torch::jit::Graph>& graph,
-    const ValueGroup& value_group,
-    AliasDb& db) {
-  // map a Value to a set of Values that overlap live-ranges with the Value's
-  FastMap<const Value*, FastSet<const Value*>> liveness_map;
-
-  // map Values to its creation order in graph (Note: only traverse top-level
-  // nodes such that nodes under control-flows are represented by top-level
-  // block nodes)
-  std::vector<const Value*> values_in_creation_order;
-  FastMap<const Value*, size_t> values_to_idx_in_creation_order;
-  for (const auto* node : graph->nodes()) {
-    values_to_idx_in_creation_order.reserve(
-        values_to_idx_in_creation_order.size() + node->outputs().size());
-    for (const auto* v : node->outputs()) {
-      values_to_idx_in_creation_order.emplace(
-          v, values_in_creation_order.size());
-      values_in_creation_order.emplace_back(v);
-    }
-  }
-
-  // presence of a Value in live_values_use_chain means the Value alive
-  // Value mapped to set of Nodes that may use the Value (i.e., use-chain of
-  // Value)
-  FastMap<const Value*, FastSet<const Node*>> live_values_use_chain;
-  // Node mapped to set of Values that the Node may use (i.e., def-chain of node
-  // inputs)
-  FastMap<const Node*, FastSet<const Value*>> live_nodes_def_chain;
-
-  // add v to the current liveness_map
-  std::function<void(const Value* v)> add_live_value_fn = [&](const Value* v) {
-    if (liveness_map.count(v)) {
-      return;
-    }
-
-    auto& v_live_set = liveness_map[v] = {};
-
-    v_live_set.reserve(live_values_use_chain.size());
-    for (const auto& live_v : live_values_use_chain) {
-      v_live_set.insert(live_v.first);
-      liveness_map[live_v.first].insert(v);
-    }
-
-    // only add values to the live set if they
-    // have deps, otherwise they die immediately
-    if (v->uses().size()) {
-      live_values_use_chain[v] = FastSet<const Node*>(v->uses().size());
-      // record the relationship between v (Value) and its uses (Node)
-      for (const auto& u : v->uses()) {
-        const auto* node = u.user;
-        live_values_use_chain[v].insert(node);
-        live_nodes_def_chain[node].insert(v);
-      }
-    }
-
-    // FIXME(penguin): the following alias refinement seems to assume
-    // that `v` refers to a new  tensor created by the node that defines
-    // v, thus other Values "before" the node that defines `v` cannot
-    // possibly be aliased to `v`.
-    // TODO(penguin): Is it a limitation of TS alias analysis
-    // so that we need to do such refinement? If so, better improve
-    // alias analysis so that we dont need this special handling here
-    //
-    // Refine aliases of v by include only those created after v
-    std::vector<const Value*> refined_aliases;
-    auto idx = values_to_idx_in_creation_order[v];
-    for (; idx < values_in_creation_order.size(); ++idx) {
-      auto* alias_v = values_in_creation_order[idx];
-      if (mayContainAlias(db, v, alias_v)) {
-        refined_aliases.emplace_back(alias_v);
-      }
-    }
-    // for all the values in the alias set,
-    // we set them "alive"
-    for (auto* aliased_v : refined_aliases) {
-      GRAPH_DEBUG("aliased_v: %", aliased_v->debugName());
-      add_live_value_fn(aliased_v);
-    }
-  };
-
-  auto remove_dead_values = [&](const Node* node) {
-    auto find = live_nodes_def_chain.find(node);
-    if (find != live_nodes_def_chain.end()) {
-      for (const auto* v : find->second) {
-        live_values_use_chain[v].erase(node);
-        if (!live_values_use_chain[v].size()) {
-          // v is now dead
-          live_values_use_chain.erase(v);
-        }
-      }
-    }
-  };
-
-  for (const auto* node : graph->nodes()) {
-    for (const auto* v : node->outputs()) {
-      if (!value_group.isAlwaysAlive(v)) {
-        add_live_value_fn(v);
-      }
-    }
-
-    remove_dead_values(node);
-  }
-  GRAPH_DEBUG("LivenessMap: ", dumpLivenessMap(liveness_map));
-
-  for (const auto& v : live_values_use_chain) {
-    TORCH_CHECK(
-        value_group.isAlwaysAlive(v.first),
-        v.first->debugName(),
-        "is not in the value_group.isAlwaysAlive group");
-  }
-
-  auto insert_all_pairs_in_liveness_map =
-      [&](at::ArrayRef<const Value*> values) {
-        for (size_t i = 0; !values.empty() && i < values.size() - 1; ++i) {
-          auto value_it = liveness_map.find(values[i]);
-          if (value_it == liveness_map.end()) {
-            continue;
-          }
-          for (size_t j = i + 1; j < values.size(); ++j) {
-            auto value2_it = liveness_map.find(values[j]);
-            if (value2_it != liveness_map.end()) {
-              value_it->second.insert(values[j]);
-              value2_it->second.insert(values[i]);
-            }
-          }
-        }
-      };
-
-  for (const auto* node : graph->nodes()) {
-    auto inputs = node->inputs();
-    auto outputs = node->outputs();
-    for (const auto* input : inputs) {
-      for (const auto* output : outputs) {
-        auto input_it = liveness_map.find(input);
-        if (input_it == liveness_map.end()) {
-          continue;
-        }
-        auto output_it = liveness_map.find(output);
-        if (output_it == liveness_map.end()) {
-          continue;
-        }
-        input_it->second.insert(output);
-        output_it->second.insert(input);
-      }
-    }
-
-    // All inputs should be alive at the same time.
-    insert_all_pairs_in_liveness_map(inputs);
-
-    // All outputs should be alive at the same time.
-    insert_all_pairs_in_liveness_map(outputs);
-  };
-
-  return liveness_map;
-};
-
-// Collect the set of Values that are candidates for memory planning:
-//   - Values that are used in in-place operators (i.e., _out variants), and
-//   - excluding those that are either inputs or outputs of
-//     non in-place operators
-//
-// Returns
-//   first: Values that are candidates for memory planning
-//   second: A deterministc order of all values
-std::pair<std::vector<const Value*>, std::vector<const Value*>>
-GetMemoryPlanningCandidates(
-    const std::shared_ptr<torch::jit::Graph>& graph,
-    const FastMap<Node*, bool>& node_has_out_variant) {
-  // for determinism
-  FastSet<const Value*> seen_values;
-  std::vector<const Value*> all_values;
-  FastSet<const Value*> can_reuse;
-  // values used by unsupported ops (as either inputs or outputs)
-  // these need to be removed from "can_reuse" after analyzing all nodes
-  FastSet<const Value*> cannot_reuse;
-  for (auto* n : graph->nodes()) {
-    bool can_reuse_inputs_outputs =
-        canReuseInputsOutputs(n, node_has_out_variant);
-    for (const auto* v : n->inputs()) {
-      if (!seen_values.count(v)) {
-        all_values.emplace_back(v);
-        seen_values.insert(v);
-      }
-      if (can_reuse_inputs_outputs) {
-        can_reuse.insert(v);
-      } else {
-        cannot_reuse.insert(v);
-      }
-    }
-    for (const auto* v : n->outputs()) {
-      all_values.emplace_back(v);
-      seen_values.insert(v);
-      if (can_reuse_inputs_outputs) {
-        can_reuse.insert(v);
-      } else {
-        cannot_reuse.insert(v);
-      }
-    }
-  }
-  for (const auto* v : cannot_reuse) {
-    can_reuse.erase(v);
-  }
-  // find a deterministic order
-  std::vector<const Value*> optimizable;
-  for (const auto* v : all_values) {
-    if (can_reuse.count(v)) {
-      optimizable.emplace_back(v);
-      can_reuse.erase(v);
-    }
-  }
-  return std::make_pair(optimizable, all_values);
-}
-
-// Equipped with a liveness map we can allocate memory to
-// ivalues, reusing memory along the way. However, we are
-// constrained by the set of optimizable_values
-// (inputs/outputs of out variants). Inputs/outputs of view ops
-// can't be reused.
-//
-// Algorithm:
-// # clusters of values sharing the same memory
-// # are called "value_to_same_storage_values" in the implementation
-// # inserting into a cluster denotes sharing memory.
-//
-// clusters = {}
-// for all v in optimzable_values:
-//   for all cluster in clusters: # can we insert into cluster?
-//     for all live_v in live_during(v):
-//        if cluster.contains(live_v):
-//          skip to next custer
-//     cluster.add(v)
-//     skip to next v
-//   if no cluster found:
-//     clusters.add(cluster{v})
-//
-//
-// NB: This is a deterministic implementation, which makes it easier to tune
-// and debug.
-FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
-    const LivenessMap& alive_during,
-    const ValueGroup& value_group,
-    const std::pair<std::vector<const Value*>, std::vector<const Value*>>&
-        optimizable,
-    AliasDb& db) {
-  const auto& optimizable_values = optimizable.first;
-  const auto& all_values = optimizable.second;
-
-  // map Value* to a set Value* that can share the same storage with it
-  FastMap<const Value*, std::vector<const Value*>> same_storage_values;
-
-  // make new_v and old_v map to the same storage (i.e., add to each other's
-  // same_storage_values set)
-  auto share_storage_fn = [&](const Value* new_v, const Value* old_v) {
-    if (new_v == old_v) {
-      return;
-    }
-    DCHECK(same_storage_values.count(old_v));
-    FastSet<const Value*> seen;
-    std::vector<const Value*> values;
-    for (auto* v : same_storage_values.at(old_v)) {
-      if (seen.count(v)) {
-        continue;
-      }
-      seen.insert(v);
-      values.emplace_back(v);
-    }
-    for (auto* v : same_storage_values.at(new_v)) {
-      if (seen.count(v)) {
-        continue;
-      }
-      seen.insert(v);
-      values.emplace_back(v);
-    }
-    for (const auto* v : values) {
-      same_storage_values[v] = values;
-    }
-  };
-
-  // initialize with known same_storage_values (aliasing values)
-  for (const auto* v : all_values) {
-    if (!same_storage_values.count(v)) {
-      same_storage_values[v] = {v};
-    }
-    // NOTE: if we had AliasDb::mustAlias, we could do the following:
-    // // skip always alive values (alias inputs/outputs/weights)
-    // if (value_group.isAlwaysAlive(v)) {
-    //   continue;
-    // }
-    // for (const auto& p : same_storage_values) {
-    //   if (db.mustAlias(p.first, v)) {
-    //     share_storage_fn(v, p.first);
-    //   }
-    // }
-    // It also wouldn't matter because ops always create new Tensor
-    // objects as aliases; there is no point in trying to reuse their
-    // storage.
-  }
-
-  // to preserve determinism
-  std::vector<const Value*> seen;
-
-  auto compute_liveset_fn = [&alive_during, &same_storage_values](
-                                FastSet<const Value*>& live, const Value* v) {
-    for (const auto* sv : same_storage_values.at(v)) {
-      const auto& l = alive_during.count(sv) ? alive_during.at(sv)
-                                             : FastSet<const Value*>{};
-      live.insert(l.begin(), l.end());
-    }
-  };
-
-  // check if same_storage_values[s] intersects with live
-  auto intersect_fn = [&same_storage_values](
-                          FastSet<const Value*>& live, const Value* s) {
-    bool intersect = false;
-    for (const auto* v : same_storage_values.at(s)) {
-      if (live.count(v)) {
-        intersect = true;
-        break;
-      }
-    }
-    return intersect;
-  };
-
-  for (const auto* v : optimizable_values) {
-    if (value_group.isAlwaysAlive(v)) {
-      continue;
-    }
-    // get values that are live during the lifetime of v
-    FastSet<const Value*> live;
-    compute_liveset_fn(live, v);
-    for (const auto* s : seen) {
-      // if live(same_storage_values[v]) and same_storage_values[s]
-      // do not overlap, then s and v can share the same storage
-      if (!intersect_fn(live, s) && !value_group.isAlwaysAlive(s)) {
-        share_storage_fn(v, s);
-        // since s is added to same_storage_values[v], live needs
-        // to be recomputed, so bail out here
-        break;
-      }
-    }
-    seen.emplace_back(v);
-  }
-
-  return same_storage_values;
-}
-
 void PrepareGraphForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
     const StaticModuleOptions& opts) {
@@ -728,18 +362,13 @@ ManagedTensorRanges::ManagedTensorRanges(
   }
 }
 
-bool ManagedTensorRanges::isUnusedValue(const Value* value) const {
-  auto* lifetime = getLifetime(value);
-  return lifetime && lifetime->start == lifetime->end;
-}
-
 bool ManagedTensorRanges::nodeFreesManagedTensors(Node* node) const {
   auto it = node_to_newly_free_tensors_.find(node);
   return it != node_to_newly_free_tensors_.end() && !it->second.empty();
 }
 
-const std::vector<const Value*>& ManagedTensorRanges::availableTensorsAfterNode(
-    Node* node) const {
+const std::vector<const Value*>& ManagedTensorRanges::
+    availableTensorValuesAfterNode(Node* node) const {
   return node_to_newly_free_tensors_.at(node);
 }
 
@@ -840,10 +469,6 @@ StaticModule::StaticModule(
     Value* input = graph_->inputs()[i];
     value_to_ssa_def[input] = std::make_pair(INPUT_VALUE, i);
   }
-
-  // NB: before optimizing the order of execution, ensure that the
-  // memory optimization pass (LivenessMap) is
-  // aware of the new order!
 
   {
     size_t nodes_size = 0, constants_size = 0;
@@ -991,13 +616,6 @@ StaticModule::StaticModule(
   value_group_.init(graph_, alias_db);
   GRAPH_DEBUG(value_group_.toString());
 
-  if (opts_.optimize_memory) {
-    auto lm = GetLivenessMap(graph_, value_group_, alias_db);
-    auto values = GetMemoryPlanningCandidates(graph_, node_has_out_variant);
-    value_to_same_storage_values_ =
-        GenerateSameStorageValues(lm, value_group_, values, alias_db);
-  }
-
   prepareForMemoryPlanner();
 }
 
@@ -1012,7 +630,10 @@ void StaticModule::prepareForMemoryPlanner() {
       graph_->outputs().begin(), graph_->outputs().end());
 
   // collect register indices of outputs of ops with out variant
+  std::vector<Node*> node_ptrs;
+  node_ptrs.reserve(nodes_.size());
   for (ProcessedNode& pnode : nodes_) {
+    node_ptrs.push_back(pnode.node());
     if (!pnode.has_out_variant()) {
       continue;
     }
@@ -1047,6 +668,8 @@ void StaticModule::prepareForMemoryPlanner() {
   GRAPH_DEBUG(
       "managed_output_tensor_values_: ",
       dumpValueSet(managed_output_tensor_values_));
+
+  managed_tensor_ranges_ = ManagedTensorRanges(graph_, managed_tensor_values_);
 }
 
 const StaticModuleOptions& StaticModule::opts() const {
@@ -1202,13 +825,14 @@ void StaticRuntime::create_memory_planner() {
   if (!planner_) {
     planner_ = std::make_unique<MemoryPlanner>(
         this,
-        static_module_.values_share_same_storage(),
         static_module_.value_group(),
         static_module_.managed_tensor_values(),
         static_module_.managed_output_tensor_values(),
         static_module_.leaked_values(),
+        static_module_.managed_tensor_ranges(),
         static_module_.opts().enable_out_variant,
-        manage_output_tensors_enabled_);
+        manage_output_tensors_enabled_,
+        static_module_.opts().optimize_memory);
   }
 }
 
@@ -1361,9 +985,6 @@ c10::IValue StaticRuntime::run_impl(
 
   set_inputs(std::forward<IValueList>(args), kwargs);
 
-  // NB: before optimizing the order of execution, ensure that the
-  // memory optimization pass (LivenessMap) is
-  // aware of the new order!
   for (auto& n : nodes_) {
     // LOG(INFO) << "Running node: " << PrintNode(n.node());
     n.run();

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -302,6 +302,18 @@ class TORCH_API StaticModule {
     return value_group_;
   }
 
+  const FastSet<const Value*>& managed_tensor_values() const {
+    return managed_tensor_values_;
+  }
+
+  const FastSet<const Value*>& managed_output_tensor_values() const {
+    return managed_output_tensor_values_;
+  }
+
+  const FastSet<const Value*>& leaked_values() const {
+    return leaked_values_;
+  }
+
   bool first_input_is_self() const {
     return module_.has_value();
   }
@@ -309,6 +321,10 @@ class TORCH_API StaticModule {
   StaticRuntime& runtime();
 
  private:
+  // Initialize various attributes that the memory planner will need.
+  // To be called at the tail of the ctor.
+  void prepareForMemoryPlanner();
+
   StaticModuleOptions opts_;
   std::shared_ptr<torch::jit::Graph> graph_;
   c10::optional<torch::jit::Module> module_;
@@ -332,6 +348,10 @@ class TORCH_API StaticModule {
       value_to_same_storage_values_;
 
   FastSet<const Node*> node_is_optimizable_container_type_;
+
+  FastSet<const Value*> managed_tensor_values_{};
+  FastSet<const Value*> managed_output_tensor_values_{};
+  FastSet<const Value*> leaked_values_{};
 };
 
 class TORCH_API StaticRuntime {
@@ -430,7 +450,8 @@ class TORCH_API StaticRuntime {
 
   bool checkOutputTensorMemoryLeaks();
 
-  bool isManagedOutputTensor(const IValue& ivalue);
+  bool isManagedOutputTensor(const IValue& ivalue) const;
+  bool isManagedOutputTensorValue(const Value* value) const;
 
   void disableManageOutputTensors();
 

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -7,6 +7,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/variant.h>
 #include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/graph_node_list.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
@@ -103,16 +104,12 @@ class TORCH_API ManagedTensorRanges {
       const FastSet<const Value*>& managed_tensor_values);
 
   // If true, then this node is the last use of at least one
-  // managed tensor. availableTensorsAfterNode(node) will return a vector
+  // managed tensor. availableTensorValuesAfterNode(node) will return a vector
   // of the managed tensors that are available for re-use
   // in the nodes following this one.
   bool nodeFreesManagedTensors(Node* node) const;
-  const std::vector<const Value*>& availableTensorsAfterNode(Node* node) const;
-
-  // True if the value has a tracked lifetime and lifetime.start ==
-  // lifetime.end. "Unused" does not imply "unmanaged" -
-  // managed tensors can be unused if they're not passed to any ops!
-  bool isUnusedValue(const Value* value) const;
+  const std::vector<const Value*>& availableTensorValuesAfterNode(
+      Node* node) const;
 
   // For testing. True if v1 and v2 are both mutable types and have lifetimes
   // that overlap.
@@ -284,6 +281,10 @@ class TORCH_API StaticModule {
 
   C10_NODISCARD Node* findNodeWithKindForTesting(const std::string& kind) const;
 
+  graph_node_list node_ptrs() const {
+    return graph_->nodes();
+  }
+
   bool is_optimizable_container_type(const Node* n) const {
     auto it = node_is_optimizable_container_type_.find(n);
     return it != node_is_optimizable_container_type_.end();
@@ -291,11 +292,6 @@ class TORCH_API StaticModule {
 
   const c10::optional<c10::FunctionSchema>& schema() const {
     return schema_;
-  }
-
-  const FastMap<const Value*, std::vector<const Value*>>&
-  values_share_same_storage() const {
-    return value_to_same_storage_values_;
   }
 
   const ValueGroup& value_group() const {
@@ -312,6 +308,10 @@ class TORCH_API StaticModule {
 
   const FastSet<const Value*>& leaked_values() const {
     return leaked_values_;
+  }
+
+  const ManagedTensorRanges& managed_tensor_ranges() const {
+    return managed_tensor_ranges_;
   }
 
   bool first_input_is_self() const {
@@ -343,15 +343,12 @@ class TORCH_API StaticModule {
 
   ValueGroup value_group_;
 
-  // map a value to the set of values that may share the same storage with it
-  FastMap<const Value*, std::vector<const Value*>>
-      value_to_same_storage_values_;
-
   FastSet<const Node*> node_is_optimizable_container_type_;
 
   FastSet<const Value*> managed_tensor_values_{};
   FastSet<const Value*> managed_output_tensor_values_{};
   FastSet<const Value*> leaked_values_{};
+  ManagedTensorRanges managed_tensor_ranges_{};
 };
 
 class TORCH_API StaticRuntime {
@@ -426,6 +423,10 @@ class TORCH_API StaticRuntime {
 
   std::vector<ProcessedNode>& nodes() {
     return nodes_;
+  }
+
+  graph_node_list node_ptrs() const {
+    return static_module_.node_ptrs();
   }
 
   const Graph& graph() const {

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -2,7 +2,7 @@
 
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/runtime/static/fusion.h>
-#include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/memory_planner.h>
 
 // This number is a heuristic determined with pytorch/benchmark
 #define DEFAULT_FUSION_SIZE 4

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -1,7 +1,10 @@
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 
+#include <ATen/Tensor.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <iterator>
 
 namespace torch {
 namespace jit {
@@ -20,46 +23,105 @@ bool isUnmanagedSpecialCase(const ProcessedNode& pnode, size_t output_idx) {
       pnode.Output(output_idx).isNone();
 }
 
-void assign_storage_to_managed_tensors(
-    StaticRuntime* runtime,
-    const FastSet<const Value*>& managed_tensor_values,
-    const FastMap<const Value*, std::vector<const Value*>>&
-        value_to_same_storage_values,
-    std::vector<StorageGroup>& managed_tensors) {
-  // map Value to index to managed_storage, where multiple values can
-  // map to the same index (i.e., sharing the same storage)
-  FastMap<const Value*, size_t> value_to_storage_idx;
+FastMap<const Value*, at::Tensor*> tensorValueToTensor(
+    const std::vector<ProcessedNode>& nodes,
+    const FastSet<const Value*>& managed_tensor_values) {
+  FastMap<const Value*, at::Tensor*> tensor_value_to_tensor;
+  for (auto& pnode : nodes) {
+    auto* node = pnode.node();
+    for (const auto output_idx : c10::irange(node->outputs().size())) {
+      auto* output = node->output(output_idx);
 
-  // Snapshot of the current memory state
-  for (auto& pnode : runtime->nodes()) {
-    for (const auto i : c10::irange(pnode.outputs().size())) {
-      auto& ival = pnode.Output(i);
-      const auto* val = pnode.node()->outputs()[i];
-      if (managed_tensor_values.count(val) &&
-          !isUnmanagedSpecialCase(pnode, i)) {
-        TORCH_CHECK(ival.isTensor());
-        at::Tensor* tensor = &ival.toTensor();
-        auto f = value_to_storage_idx.find(val);
-        if (f != value_to_storage_idx.end()) {
-          auto storage_idx = f->second;
-          managed_tensors[storage_idx].addTensor(tensor);
-        } else {
-          managed_tensors.emplace_back(tensor);
-          // first of a group, update the value_to_storage_idx map with the
-          // index
-          auto f = value_to_same_storage_values.find(val);
-          if (f != value_to_same_storage_values.end()) {
-            auto storage_idx = managed_tensors.size() - 1;
-            const auto& same_storage_values = f->second;
-            for (const auto* v : same_storage_values) {
-              value_to_storage_idx[v] = storage_idx;
-            }
-          }
+      if (managed_tensor_values.find(output) == managed_tensor_values.end()) {
+        continue;
+      }
+
+      auto& ival = pnode.Output(output_idx);
+
+      // ival is allowed to be None in special cases, e.g. to_maybe_copy_out
+      DCHECK(
+          ival.isTensor() ||
+          (ival.isNone() && isUnmanagedSpecialCase(pnode, output_idx)));
+
+      if (ival.isTensor()) {
+        tensor_value_to_tensor.emplace(
+            output,
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            const_cast<at::Tensor*>(&ival.toTensor()));
+      }
+    }
+  }
+  return tensor_value_to_tensor;
+}
+
+} // namespace
+
+void assignStorageToManagedTensors(
+    graph_node_list nodes,
+    const ManagedTensorRanges& ranges,
+    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor,
+    std::vector<StorageGroup>& managed_tensor_groups) {
+  // This set maps each Value* to its assigned storage group.
+  FastMap<const Value*, size_t> storage_group_mapping;
+  // On each iteration, this vector stores the set of storage groups that
+  // are available for re-use.
+  std::vector<size_t> free_storage_groups;
+
+  auto makeNewStorageGroup = [&](const Value* value) {
+    const auto storage_group = managed_tensor_groups.size();
+    storage_group_mapping.emplace(value, storage_group);
+    auto* tensor_ptr = tensor_value_to_tensor.at(value);
+    managed_tensor_groups.emplace_back(tensor_ptr);
+  };
+
+  auto assignToAvailableStorageGroup = [&](const Value* value) {
+    DCHECK(!free_storage_groups.empty());
+    const auto storage_group = free_storage_groups.back();
+    DCHECK(storage_group < managed_tensor_groups.size());
+    storage_group_mapping.emplace(value, storage_group);
+    auto* tensor_ptr = tensor_value_to_tensor.at(value);
+    managed_tensor_groups[storage_group].addTensor(tensor_ptr);
+    free_storage_groups.pop_back();
+  };
+
+  auto isManagedTensor = [&](const Value* value) {
+    return tensor_value_to_tensor.find(value) != tensor_value_to_tensor.end();
+  };
+
+  for (auto* node : nodes) {
+    // Assign storage groups to outputs
+    for (const auto output_idx : c10::irange(node->outputs().size())) {
+      Value* output = node->output(output_idx);
+      if (!isManagedTensor(output)) {
+        continue;
+      }
+      if (free_storage_groups.empty()) {
+        makeNewStorageGroup(output);
+        continue;
+      }
+      assignToAvailableStorageGroup(output);
+    }
+
+    // This node may be the last use of some managed tensors. If so, we
+    // can mark the corresponding storage groups as free.
+    if (ranges.nodeFreesManagedTensors(node)) {
+      const auto& new_free_tensors =
+          ranges.availableTensorValuesAfterNode(node);
+      for (auto* tensor_value : new_free_tensors) {
+        // We to check this here to handle special cases like to_maybe_copy_out
+        // - we don't know if the tensor value is managed until after the first
+        // iter, but `ranges` is initialized at load time!
+        if (!isManagedTensor(tensor_value)) {
+          continue;
         }
+        const auto storage_group = storage_group_mapping.at(tensor_value);
+        free_storage_groups.push_back(storage_group);
       }
     }
   }
 }
+
+namespace {
 
 bool setIncludes(const FastSet<const Value*>& set, const Value* v) {
   return set.find(v) != set.end();
@@ -88,14 +150,14 @@ void assignStorageToOutputTensors(
 
 MemoryPlanner::MemoryPlanner(
     StaticRuntime* runtime,
-    const FastMap<const Value*, std::vector<const Value*>>&
-        value_to_same_storage_values,
     const ValueGroup& value_group,
     const FastSet<const Value*>& managed_tensor_values,
     const FastSet<const Value*>& managed_output_tensor_values,
     const FastSet<const Value*>& leaked_values,
+    const ManagedTensorRanges& ranges,
     bool enable_out_variant,
-    bool manage_output_tensors) {
+    bool manage_output_tensors,
+    bool optimize_memory) {
   // collect unmanaged output ivalues
   FastSet<IValue*> unmanaged_ivalues;
   FastSet<IValue*> unmanaged_borrowed_ivalues;
@@ -155,11 +217,19 @@ MemoryPlanner::MemoryPlanner(
       unmanaged_borrowed_ivalues.end());
 
   if (enable_out_variant) {
-    ::torch::jit::assign_storage_to_managed_tensors(
-        runtime,
-        managed_tensor_values,
-        value_to_same_storage_values,
-        managed_tensors_);
+    const auto tensor_value_to_tensor =
+        tensorValueToTensor(runtime->nodes(), managed_tensor_values);
+    if (optimize_memory) {
+      ::torch::jit::assignStorageToManagedTensors(
+          runtime->node_ptrs(),
+          ranges,
+          tensor_value_to_tensor,
+          managed_tensors_);
+    } else {
+      for (auto& tensor : tensor_value_to_tensor) {
+        managed_tensors_.emplace_back(tensor.second);
+      }
+    }
   }
 
   if (enable_out_variant && manage_output_tensors) {

--- a/torch/csrc/jit/runtime/static/memory_planner.cpp
+++ b/torch/csrc/jit/runtime/static/memory_planner.cpp
@@ -56,11 +56,11 @@ FastMap<const Value*, at::Tensor*> tensorValueToTensor(
 
 } // namespace
 
-void assignStorageToManagedTensors(
+std::vector<StorageGroup> assignStorageToManagedTensors(
     graph_node_list nodes,
     const ManagedTensorRanges& ranges,
-    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor,
-    std::vector<StorageGroup>& managed_tensor_groups) {
+    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor) {
+  std::vector<StorageGroup> managed_tensor_groups;
   // This set maps each Value* to its assigned storage group.
   FastMap<const Value*, size_t> storage_group_mapping;
   // On each iteration, this vector stores the set of storage groups that
@@ -119,6 +119,7 @@ void assignStorageToManagedTensors(
       }
     }
   }
+  return managed_tensor_groups;
 }
 
 namespace {
@@ -127,10 +128,10 @@ bool setIncludes(const FastSet<const Value*>& set, const Value* v) {
   return set.find(v) != set.end();
 }
 
-void assignStorageToOutputTensors(
+std::vector<std::pair<size_t, at::Tensor*>> assignStorageToOutputTensors(
     StaticRuntime* runtime,
-    const FastSet<const Value*>& managed_output_tensor_values,
-    std::vector<std::pair<size_t, at::Tensor*>>& managed_output_tensors) {
+    const FastSet<const Value*>& managed_output_tensor_values) {
+  std::vector<std::pair<size_t, at::Tensor*>> managed_output_tensors;
   for (auto& pnode : runtime->nodes()) {
     for (const auto i : c10::irange(pnode.outputs().size())) {
       auto& ival = pnode.Output(i);
@@ -144,6 +145,7 @@ void assignStorageToOutputTensors(
       managed_output_tensors.emplace_back(0, tensor);
     }
   }
+  return managed_output_tensors;
 }
 
 } // namespace
@@ -220,11 +222,8 @@ MemoryPlanner::MemoryPlanner(
     const auto tensor_value_to_tensor =
         tensorValueToTensor(runtime->nodes(), managed_tensor_values);
     if (optimize_memory) {
-      ::torch::jit::assignStorageToManagedTensors(
-          runtime->node_ptrs(),
-          ranges,
-          tensor_value_to_tensor,
-          managed_tensors_);
+      managed_tensors_ = assignStorageToManagedTensors(
+          runtime->node_ptrs(), ranges, tensor_value_to_tensor);
     } else {
       for (auto& tensor : tensor_value_to_tensor) {
         managed_tensors_.emplace_back(tensor.second);
@@ -233,8 +232,8 @@ MemoryPlanner::MemoryPlanner(
   }
 
   if (enable_out_variant && manage_output_tensors) {
-    ::torch::jit::assignStorageToOutputTensors(
-        runtime, managed_output_tensor_values, managed_output_tensors_);
+    managed_output_tensors_ =
+        assignStorageToOutputTensors(runtime, managed_output_tensor_values);
   }
 
   num_managed_tensors_ = 0;

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -39,6 +39,12 @@ class StorageGroup {
   std::vector<at::Tensor*> group_{};
 };
 
+TORCH_API void assignStorageToManagedTensors(
+    graph_node_list nodes,
+    const ManagedTensorRanges& ranges,
+    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor,
+    std::vector<StorageGroup>& managed_tensor_groups);
+
 /// There are three types of ops in a processed graph in Static Runtime:
 ///   1. op with _out variant
 ///   2. view producing op
@@ -69,13 +75,14 @@ class MemoryPlanner {
  public:
   explicit MemoryPlanner(
       StaticRuntime* runtime,
-      const FastMap<const Value*, std::vector<const Value*>>&,
       const ValueGroup& value_group,
       const FastSet<const Value*>& managed_tensor_values,
       const FastSet<const Value*>& managed_output_tensor_values,
       const FastSet<const Value*>& leaked_values,
+      const ManagedTensorRanges& ranges,
       bool enable_out_variant,
-      bool manage_output_tensors);
+      bool manage_output_tensors,
+      bool optimize_memory);
   // disable copying and moving
   MemoryPlanner(const MemoryPlanner&) = delete;
   MemoryPlanner& operator=(const MemoryPlanner&) = delete;

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -39,11 +39,10 @@ class StorageGroup {
   std::vector<at::Tensor*> group_{};
 };
 
-TORCH_API void assignStorageToManagedTensors(
+TORCH_API std::vector<StorageGroup> assignStorageToManagedTensors(
     graph_node_list nodes,
     const ManagedTensorRanges& ranges,
-    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor,
-    std::vector<StorageGroup>& managed_tensor_groups);
+    const FastMap<const Value*, at::Tensor*>& tensor_value_to_tensor);
 
 /// There are three types of ops in a processed graph in Static Runtime:
 ///   1. op with _out variant


### PR DESCRIPTION
Summary:
The current way we assign tensors to storage groups is not very extensible since the algorithm that `MemoryPlanner` calls is hard-coded. Here, we pass `MemoryPlanner` a `StorageAssignmentStrategy` object that encapsulates the algorithm instead. We also add a `storageAssignmentStrategyFactory` that instantiates a `StorageAssignmentStrategy` based on `StaticModuleOptions`.

In the future, if we want to add a new memory planning strategy, we simply add a new subclass and update the factory logic. No need to dig into the memory planner code.

This also makes it easier to do fancier things. **In theory, we could change algorithms at runtime, or fall back to the trivial one if the memory planner fails.** That would make experimental algorithms a lot safer in the production environment! Note that this is possible with normal functions, but it requires digging into memory planner code.

This diff also does some refactoring to take us one step closer to cleaning up the `MemoryPlanner` ctor and `StaticModule` interface. Instead of exposing `managed_tensor_values_`, I simply have the `StorageAssignmentStrategy` take ownership of it.

Test Plan:
`buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Perf impact: TBD
I expect that this will be a slight regression due to the dynamic dispatch. But it only occurs once, and I don't expect that cost to outweight the improvements from the refactor in D32400593.

Differential Revision: D32766492

