### PR TITLE
[PyTorch][JIT] Use stack.pop_back() instead of pop(stack) for DROP

### DIFF
--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -317,7 +317,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             INST_NEXT;
           case INST(DROP): {
             INST_GUARD;
-            pop(stack);
+            stack.pop_back();
           }
             INST_NEXT;
           case INST(DROPR): {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69326
* #69324

Looks like this really is slightly cheaper (see assembly diff screenshot in internal test plan). The problem is that `pop()` returns the value, so we have to spend instructions moving it out of the stack and then destroying it via a local.

Differential Revision: [D32812841](https://our.internmc.facebook.com/intern/diff/D32812841/)