### PR TITLE
[Pytorch Edge] Make Tracer support xirp metal segmentation

### DIFF
--- a/torch/csrc/jit/mobile/model_tracer/MobileModelRunner.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/MobileModelRunner.cpp
@@ -202,10 +202,8 @@ void MobileModelRunner::run_argless_functions(
 bool MobileModelRunner::set_has_metal_gpu_operators(
     std::set<std::string> const& op_list) {
   for (std::string const& op : op_list) {
-    if (op.find("metal::") == 0) {
-      return true;
-    }
-    if (op.find("metal_prepack_unet::") == 0) {
+    if (op.find("metal::") == 0 || op.find("metal_prepack::") == 0 ||
+        op.find("metal_prepack_unet::") == 0) {
       return true;
     }
   }


### PR DESCRIPTION
Summary: Aten_metal_prepack is cpp based and can be safely included here.

Test Plan: "Traced" the xirp model with the script.

Reviewed By: xta0

Differential Revision: D32813686

