### PR TITLE
[nnc] Add a run method to TensorExprKernel that takes in output tensors

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -45,6 +45,7 @@ namespace c10 {
   _(prim, add_optional)              \
   _(prim, DifferentiableGraph)       \
   _(prim, TensorExprGroup)           \
+  _(prim, TensorExprDynamicGroup)    \
   _(prim, StaticSubgraph)            \
   _(prim, If)                        \
   _(prim, Jump) /* debug */          \

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -48,7 +48,7 @@ class ModuleStaticRuntimeTestContext : public StaticRuntimeTestContext {
   }
 
   StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
-    return torch::jit::StaticModule(module_, /* is_frozen */ false, opt);
+    return torch::jit::StaticModule(module_, /* is_frozen */ false, {}, opt);
   }
 
  private:
@@ -76,7 +76,7 @@ class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
   }
 
   StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
-    return StaticModule(graph_, opt);
+    return StaticModule(graph_, {}, opt);
   }
 
  private:

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -645,6 +645,7 @@ void AliasDb::analyzeImpl(Node* node) {
     }
     // TODO: think more about TensorExpr alias correctness
     case prim::TensorExprGroup:
+    case prim::TensorExprDynamicGroup:
     case prim::MKLDNNGroup:
     case prim::ConstantMKLDNNTensor:
     case prim::StaticSubgraph:

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/functional.h>
+#include <ATen/core/interned_strings.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
@@ -67,7 +68,8 @@ std::map<int64_t, Value*> InsertSymbolicShapesCompute(
 
 void insertDynamicShapesGuard(
     const ShapeComputeGraphMapping& shape_mapping,
-    Node* guarded_node);
+    Node* guarded_node,
+    bool add_composed_op);
 
 // Generalize Complete Shapes inputs to Symbolic Shapes.
 // Dimensions of value 1 will be preserved, otherwise
@@ -104,7 +106,7 @@ bool TryGeneralizeInputDimensionsToSymbolicShapes(
   return true;
 }
 
-bool GenerateGuard(Node* tensorexpr_graph_node) {
+bool GenerateGuard(Node* tensorexpr_graph_node, bool add_composed_op) {
   auto tensorexpr_graph = SubgraphUtils::getSubgraph(tensorexpr_graph_node);
 
   // Generalize Inputs
@@ -123,14 +125,16 @@ bool GenerateGuard(Node* tensorexpr_graph_node) {
   }
 
   // Insert Guard
-  insertDynamicShapesGuard(*maybe_shape_compute_mapping, tensorexpr_graph_node);
+  insertDynamicShapesGuard(
+      *maybe_shape_compute_mapping, tensorexpr_graph_node, add_composed_op);
   return true;
 }
 
 // TODO: share more logic with tensorexpr_fuser ?
 void insertDynamicShapesGuard(
     const ShapeComputeGraphMapping& shape_mapping,
-    Node* guarded_node) {
+    Node* guarded_node,
+    bool add_composed_op) {
   GRAPH_DEBUG(
       "Inserting a prim::TensorExprDynamicGuard guard for a node",
       *guarded_node);
@@ -217,6 +221,13 @@ void insertDynamicShapesGuard(
     subgraph->addInput(ss.str())->setType(IntType::get());
   }
   guarded_node->is_(attr::symbolic_shape_inputs, symbolic_shape_inputs);
+
+  if (add_composed_op) {
+    // Create a TensorExprDynamicGroup node
+    auto te_dyn_group = SubgraphUtils::createSingletonSubgraph(
+        typecheck_node, prim::TensorExprDynamicGroup);
+    SubgraphUtils::mergeNodeIntoSubgraph(versioning_if, te_dyn_group);
+  }
 }
 
 // On each invocation of this guard, we need to check all of the static
@@ -376,5 +387,23 @@ RegisterOperators reg_guard({
         },
         aliasAnalysisFromSchema()),
 });
+
+Operation createTensorExprDynamicGroup(const Node* node) {
+  auto graph = node->g(attr::Subgraph);
+  return [=](Stack& stack) {
+    Code code(graph, "");
+    InterpreterState interpreter{code};
+    interpreter.run(stack);
+    return 0;
+  };
+}
+
+RegisterOperators TensorExprDynamicOp({
+    torch::jit::Operator(
+        prim::TensorExprDynamicGroup,
+        createTensorExprDynamicGroup,
+        AliasAnalysisKind::INTERNAL_SPECIAL_CASE),
+});
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
@@ -25,7 +25,7 @@ namespace jit {
 // shape propagation fails to propagate # of dims or if complete shapes on
 // inputs not set
 
-TORCH_API bool GenerateGuard(Node* tensorexpr_graph_node);
+TORCH_API bool GenerateGuard(Node* tensorexpr_graph_node, bool add_composed_op = false);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -1174,7 +1174,7 @@ class TensorExprFuser {
     }
     for (Node* fusion_group : fusion_groups) {
       VLOG(1) << "GenerateGuard for fusion group: " << *fusion_group;
-      if (!GenerateGuard(fusion_group)) {
+      if (!GenerateGuard(fusion_group, /*add_composed_op=*/true)) {
         VLOG(1) << "  Unfusing the fusion group because GenerateGuard failed"
                 << std::endl;
         SubgraphUtils::unmergeSubgraph(fusion_group);
@@ -1238,15 +1238,50 @@ void FuseTensorExprs(
 }
 
 Operation createTensorExprOp(const Node* node) {
-  std::vector<int64_t> sym_shapes;
-  if (node->hasAttribute(attr::symbolic_shape_inputs)) {
-    sym_shapes = node->is(attr::symbolic_shape_inputs);
+  if (!tensorExprDynamicShapeFusionEnabled()) {
+    auto kernel =
+        std::make_shared<tensorexpr::TensorExprKernel>(node->g(attr::Subgraph));
+    return [kernel](Stack& stack) {
+      RECORD_FUNCTION(kernel->getKernelName(), std::vector<c10::IValue>());
+      kernel->run(stack);
+      return 0;
+    };
   }
-  std::unordered_map<c10::Symbol, tensorexpr::NNCLoweringFunction>
-      custom_lowerings;
-  auto kernel = std::make_shared<tensorexpr::TensorExprKernel>(
-      node->g(attr::Subgraph), custom_lowerings, sym_shapes);
-  return [kernel](Stack& stack) {
+
+  // Handle the case when dynamic shape fusion is enabled.
+  //
+  // This case is different because the TensorExprGroup node is not part of
+  // the main graph, but it is part of the composed op TensorExprDynamicGroup.
+  // So, every run of the TensorExprDynamicGroup op will end up calling this
+  // function, but that still does not require creating a new TensorExprKernel
+  // for every such call. So, we maintain a cache from the node to the kernels
+  // created.
+  return [=](Stack& stack) {
+    // A cache from the node to the corresponding kernel.
+    static std::unordered_map<
+        std::string,
+        std::shared_ptr<tensorexpr::TensorExprKernel>>
+        cached_kernels;
+    std::ostringstream node_ss;
+    node->print(node_ss, 0, nullptr);
+    auto node_str = node_ss.str();
+    auto it = cached_kernels.find(node_str);
+    std::shared_ptr<tensorexpr::TensorExprKernel> kernel;
+    if (it != cached_kernels.end()) {
+      kernel = it->second;
+    } else {
+      VLOG(1) << "Compiling a new kernel for " << *node;
+      std::vector<int64_t> sym_shapes;
+      if (node->hasAttribute(attr::symbolic_shape_inputs)) {
+        sym_shapes = node->is(attr::symbolic_shape_inputs);
+      }
+      std::unordered_map<c10::Symbol, tensorexpr::NNCLoweringFunction>
+          custom_lowerings;
+      auto subgraph = node->g(attr::Subgraph);
+      kernel = std::make_shared<tensorexpr::TensorExprKernel>(
+          subgraph, custom_lowerings, sym_shapes);
+      cached_kernels[node_str] = kernel;
+    }
     RECORD_FUNCTION(kernel->getKernelName(), std::vector<c10::IValue>());
     kernel->run(stack);
     return 0;

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -13,10 +13,12 @@
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/passes/remove_redundant_profiles.h>
+#include <torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/operator_options.h>
+#include <torch/csrc/jit/runtime/symbolic_shape_registry.h>
 #include <torch/csrc/jit/runtime/symbolic_shape_registry_util.h>
 #include <torch/csrc/jit/tensorexpr/kernel.h>
 #include <torch/csrc/utils/memory.h>
@@ -26,6 +28,12 @@ C10_DEFINE_bool(
     torch_jit_disable_cat,
     false,
     "disable aten::cat in TE fusion groups");
+
+C10_DEFINE_bool(
+    torch_jit_enable_dynamic_shape_fusion,
+    false,
+    "enable TE fusion using dynamic shapes");
+
 namespace torch {
 namespace jit {
 
@@ -149,6 +157,17 @@ bool tensorExprFuserEnabled() {
     return false;
   }
   return true;
+}
+
+static bool texpr_dynamic_shape_fuser_enabled_ = false;
+
+bool tensorExprDynamicShapeFusionEnabled() {
+  return FLAGS_torch_jit_enable_dynamic_shape_fusion ||
+      texpr_dynamic_shape_fuser_enabled_;
+}
+
+void setTensorExprDynamicShapeFusionEnabled(bool val) {
+  texpr_dynamic_shape_fuser_enabled_ = val;
 }
 
 bool setTexprReductionsEnabled(bool value) {
@@ -489,10 +508,17 @@ class TensorExprFuser {
     // fusion is done.
     inlineSmallFusionGroups(graph_->block());
     GRAPH_DUMP("After inlining small fusion groups: ", graph_);
-    prepareFusionGroupAndGuardOutputs(graph_->block());
-    GRAPH_DUMP("After guarding fusion groups: ", graph_);
-    removeTensorTypeSpecializations(graph_->block());
-    GRAPH_DUMP("After removing tensor type specializations: ", graph_);
+    if (tensorExprDynamicShapeFusionEnabled()) {
+      VLOG(1) << "TensorExpr fusion with dynamic shapes is enabled"
+              << std::endl;
+      generalizeFusionGroups(graph_->block());
+      GRAPH_DUMP("After generalizing fusion groups: ", graph_);
+    } else {
+      prepareFusionGroupAndGuardOutputs(graph_->block());
+      GRAPH_DUMP("After guarding fusion groups: ", graph_);
+      removeTensorTypeSpecializations(graph_->block());
+      GRAPH_DUMP("After removing tensor type specializations: ", graph_);
+    }
   }
 
  private:
@@ -1013,6 +1039,14 @@ class TensorExprFuser {
     // A hook to optimizations limitter to allow bisecting the pass
     REQ(JIT_OPT_ALLOWED);
 
+    if (tensorExprDynamicShapeFusionEnabled()) {
+      // Allow only if the node has a shape function defined.
+      // ListConstruct node is an exception since that is needed to fuse
+      // aten::cat, though it does not have a shape function.
+      REQ(node->kind() == prim::ListConstruct ||
+          (node->maybeSchema() && shapeComputeGraphForSchema(node->schema())));
+    }
+
     return true;
   }
 
@@ -1128,6 +1162,26 @@ class TensorExprFuser {
     }
   }
 
+  void generalizeFusionGroups(Block* block) {
+    std::vector<Node*> fusion_groups;
+    for (Node* n : block->nodes()) {
+      for (Block* b : n->blocks()) {
+        generalizeFusionGroups(b);
+      }
+      if (n->kind() == prim::TensorExprGroup) {
+        fusion_groups.push_back(n);
+      }
+    }
+    for (Node* fusion_group : fusion_groups) {
+      VLOG(1) << "GenerateGuard for fusion group: " << *fusion_group;
+      if (!GenerateGuard(fusion_group)) {
+        VLOG(1) << "  Unfusing the fusion group because GenerateGuard failed"
+                << std::endl;
+        SubgraphUtils::unmergeSubgraph(fusion_group);
+      }
+    }
+  }
+
   // This function parses the option provided by the environment variable
   // "PYTORCH_TENSOREXPR_DONT_FUSE".
   // This variable allows users to disable fusion on a list of specified
@@ -1184,8 +1238,14 @@ void FuseTensorExprs(
 }
 
 Operation createTensorExprOp(const Node* node) {
-  auto kernel =
-      std::make_shared<tensorexpr::TensorExprKernel>(node->g(attr::Subgraph));
+  std::vector<int64_t> sym_shapes;
+  if (node->hasAttribute(attr::symbolic_shape_inputs)) {
+    sym_shapes = node->is(attr::symbolic_shape_inputs);
+  }
+  std::unordered_map<c10::Symbol, tensorexpr::NNCLoweringFunction>
+      custom_lowerings;
+  auto kernel = std::make_shared<tensorexpr::TensorExprKernel>(
+      node->g(attr::Subgraph), custom_lowerings, sym_shapes);
   return [kernel](Stack& stack) {
     RECORD_FUNCTION(kernel->getKernelName(), std::vector<c10::IValue>());
     kernel->run(stack);

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -22,6 +22,8 @@ TORCH_API void FuseTensorExprs(
 
 TORCH_API void setTensorExprFuserEnabled(bool val);
 TORCH_API bool tensorExprFuserEnabled();
+TORCH_API void setTensorExprDynamicShapeFusionEnabled(bool val);
+TORCH_API bool tensorExprDynamicShapeFusionEnabled();
 TORCH_API bool setTexprReductionsEnabled(bool value);
 TORCH_API bool texprReductionsEnabled();
 

--- a/torch/csrc/jit/runtime/interpreter/can_emit_inline.h
+++ b/torch/csrc/jit/runtime/interpreter/can_emit_inline.h
@@ -49,6 +49,7 @@ struct CanEmitInline {
         // by the later BailOut in createBailoutBlock and its jf_index
         // will become invalid.
         v->node()->kind() != prim::TensorExprGroup &&
+        v->node()->kind() != prim::TensorExprDynamicGroup &&
         v->node()->kind() != prim::StaticSubgraph &&
         v->node()->kind() != prim::CudaFusionGroup &&
         v->node()->kind() != prim::FusionGroup &&

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -241,6 +241,7 @@ bool printerHasSpecialCaseFor(Symbol sym) {
       prim::CudaFusionGroup, // optimization pass adds it
       prim::CudaFusionGuard, // optimization pass adds it
       prim::TensorExprGroup, // optimization pass adds it
+      prim::TensorExprDynamicGroup, // optimization pass adds it
       prim::StaticSubgraph, // optimization pass adds it
       prim::ConstantMKLDNNTensor, // optimization pass adds it
       prim::BroadcastMKLDNNTensors, // optimization pass adds it
@@ -281,6 +282,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::CudaFusionGroup,
       prim::DifferentiableGraph,
       prim::TensorExprGroup,
+      prim::TensorExprDynamicGroup,
       prim::StaticSubgraph,
       prim::FunctionalGraph,
       prim::Constant,

--- a/torch/csrc/jit/runtime/static/fusion.h
+++ b/torch/csrc/jit/runtime/static/fusion.h
@@ -9,5 +9,9 @@ TORCH_API void fuseStaticSubgraphs(
     std::shared_ptr<Graph> graph,
     size_t min_size);
 
+TORCH_API void performTEFusion(
+    std::shared_ptr<Graph> graph,
+    std::vector<IValue> sample_inputs);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -17,7 +17,7 @@
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/variadic_ops.h>
-#include <torch/csrc/jit/runtime/jit_trace.h>
+#include <torch/csrc/jit/runtime/static/fusion.h>
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
@@ -132,6 +132,11 @@ void OptimizeGraph(
   EliminateNoOps(
       graph, /* custom_ops */ {fromQualString("fb::scale_gradient")});
   GRAPH_DUMP("Final graph after optimizations: ", graph);
+}
+
+bool IsSelfInGraphInput(std::shared_ptr<torch::jit::Graph>& graph) {
+  return graph->inputs().size() > 0 &&
+      graph->inputs().at(0)->type()->is_module();
 }
 
 // remove unused input 0 from graph
@@ -564,6 +569,10 @@ void PrepareGraphForStaticModule(
     std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts) {
   TORCH_CHECK(canEnableStaticRuntime(graph));
+  if (!sample_inputs.empty() && opts.enable_te_fusion) {
+    VLOG(1) << "Performing TensorExpr fusion";
+    performTEFusion(graph, std::move(sample_inputs));
+  }
   OptimizeGraph(graph, opts);
 }
 
@@ -576,7 +585,8 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
           << opts.cleanup_activations << ", enable_out_variant "
           << opts.enable_out_variant << ", optimize_memory "
           << opts.optimize_memory << ", manage_output_tensors "
-          << opts.manage_output_tensors;
+          << opts.manage_output_tensors << ", enable_te_fusion "
+          << opts.enable_te_fusion;
 
   Module module = m.copy();
   if (!is_frozen) {
@@ -587,7 +597,12 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
   Method method = module.get_method("forward");
   auto graph = module.get_method("forward").graph();
 
-  PrepareGraphForStaticModule(graph, sample_inputs, opts);
+  if (!sample_inputs.empty()) {
+    if (IsSelfInGraphInput(graph)) {
+      sample_inputs.insert(sample_inputs.begin(), m._ivalue());
+    }
+  }
+  PrepareGraphForStaticModule(graph, std::move(sample_inputs), opts);
 
   return std::make_pair(graph, module);
 }
@@ -596,7 +611,7 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
     std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts) {
-  PrepareGraphForStaticModule(graph, sample_inputs, opts);
+  PrepareGraphForStaticModule(graph, std::move(sample_inputs), opts);
   return std::make_pair(graph, c10::nullopt);
 }
 
@@ -825,7 +840,7 @@ StaticModule::StaticModule(
     std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts)
     : StaticModule(
-          PrepareForStaticModule(g->copy(), sample_inputs, opts),
+          PrepareForStaticModule(g->copy(), std::move(sample_inputs), opts),
           opts) {}
 
 StaticModule::StaticModule(
@@ -834,7 +849,7 @@ StaticModule::StaticModule(
     std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts)
     : StaticModule(
-          PrepareForStaticModule(m, is_frozen, sample_inputs, opts),
+          PrepareForStaticModule(m, is_frozen, std::move(sample_inputs), opts),
           opts) {}
 
 StaticModule::StaticModule(

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -17,6 +17,7 @@
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/variadic_ops.h>
+#include <torch/csrc/jit/runtime/jit_trace.h>
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
@@ -560,6 +561,7 @@ FastMap<const Value*, std::vector<const Value*>> GenerateSameStorageValues(
 
 void PrepareGraphForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
+    std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts) {
   TORCH_CHECK(canEnableStaticRuntime(graph));
   OptimizeGraph(graph, opts);
@@ -568,6 +570,7 @@ void PrepareGraphForStaticModule(
 std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
     const torch::jit::Module& m,
     bool is_frozen,
+    std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts) {
   VLOG(1) << "StaticModuleOptions: cleanup_activations "
           << opts.cleanup_activations << ", enable_out_variant "
@@ -584,15 +587,16 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
   Method method = module.get_method("forward");
   auto graph = module.get_method("forward").graph();
 
-  PrepareGraphForStaticModule(graph, opts);
+  PrepareGraphForStaticModule(graph, sample_inputs, opts);
 
   return std::make_pair(graph, module);
 }
 
 std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
+    std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts) {
-  PrepareGraphForStaticModule(graph, opts);
+  PrepareGraphForStaticModule(graph, sample_inputs, opts);
   return std::make_pair(graph, c10::nullopt);
 }
 
@@ -818,14 +822,20 @@ std::vector<const Value*> ManagedTensorRanges::
 
 StaticModule::StaticModule(
     std::shared_ptr<torch::jit::Graph> g,
+    std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts)
-    : StaticModule(PrepareForStaticModule(g->copy(), opts), opts) {}
+    : StaticModule(
+          PrepareForStaticModule(g->copy(), sample_inputs, opts),
+          opts) {}
 
 StaticModule::StaticModule(
     const torch::jit::Module& m,
     bool is_frozen,
+    std::vector<IValue> sample_inputs,
     const StaticModuleOptions& opts)
-    : StaticModule(PrepareForStaticModule(m, is_frozen, opts), opts) {}
+    : StaticModule(
+          PrepareForStaticModule(m, is_frozen, sample_inputs, opts),
+          opts) {}
 
 StaticModule::StaticModule(
     std::pair<std::shared_ptr<torch::jit::Graph>, c10::optional<Module>>

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -156,7 +156,7 @@ struct TORCH_API StaticModuleOptions {
   // (enable_out_variant must be true)
   bool manage_output_tensors{false};
   // enable fusion of ops at model loading time
-  bool enable_fusion{false};
+  bool enable_te_fusion{false};
 };
 
 /// The static runime supports two execution modes.

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -155,6 +155,8 @@ struct TORCH_API StaticModuleOptions {
   // graph, where storage is deallocated outside static runtime
   // (enable_out_variant must be true)
   bool manage_output_tensors{false};
+  // enable fusion of ops at model loading time
+  bool enable_fusion{false};
 };
 
 /// The static runime supports two execution modes.
@@ -210,11 +212,13 @@ class TORCH_API StaticModule {
  public:
   explicit StaticModule(
       std::shared_ptr<torch::jit::Graph> g,
+      std::vector<IValue> sample_inputs = {},
       const StaticModuleOptions& opts = StaticModuleOptions());
 
   explicit StaticModule(
       const torch::jit::Module& m,
       bool is_frozen = false,
+      std::vector<IValue> sample_inputs = {},
       const StaticModuleOptions& opts = StaticModuleOptions());
 
   typedef enum {

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -133,6 +133,10 @@ class TORCH_API TensorExprKernel {
   void runFast(
       const std::vector<void*>& inputs,
       const std::vector<void*>& outputs);
+  // Expected format of stack:
+  //  [<outputs>] <inputs>
+  // i.e., output IValues must be at the bottom of the stack.
+  void runWithAllocatedOutputs(Stack& stack);
 
   void fallback(Stack& stack) {
     InterpreterState(code_).run(stack);


### PR DESCRIPTION
Summary:
This diff adds a new run method to `TensorExprKernel` which takes in
output tensors as inputs and stores the output in those given tensors.

Test Plan: buck test mode/dev-nosan //caffe2/test/cpp/tensorexpr:tensorexpr -- --exact 'caffe2/test/cpp/tensorexpr:tensorexpr - Kernel.RunWithAllocatedOutputs'

Differential Revision: D32823890

