### PR TITLE
always use max cmake when cmake3 and cmake are all existed

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -120,13 +120,26 @@ class CMake:
             return cmake_command
         cmake3 = which('cmake3')
         cmake = which('cmake')
-        if cmake3 is not None and CMake._get_version(cmake3) >= LooseVersion("3.10.0"):
-            cmake_command = 'cmake3'
-            return cmake_command
-        elif cmake is not None and CMake._get_version(cmake) >= LooseVersion("3.10.0"):
-            return cmake_command
-        else:
+        cmake_version = None
+        cmake3_version = None
+
+        if cmake3 is not None and CMake._get_version(cmake3) >= distutils.version.LooseVersion("3.10.0"):
+            cmake3_version = CMake._get_version(cmake3)
+        if cmake is not None and CMake._get_version(cmake) >= distutils.version.LooseVersion("3.10.0"):
+            cmake_version = CMake._get_version(cmake)
+        if cmake3_version is None and cmake_version is None:
             raise RuntimeError('no cmake or cmake3 with version >= 3.10.0 found')
+
+        if cmake3_version is None:
+            cmake_command = 'cmake'
+        elif cmake_version is None:
+            cmake_command = 'cmake3'
+        else:
+            if cmake3_version >= cmake_version:
+                cmake_command = 'cmake3'
+            else:
+                cmake_command = 'cmake'
+        return cmake_command
 
     @staticmethod
     def _get_version(cmd: str) -> Any:

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -118,16 +118,11 @@ class CMake:
         cmake_command = 'cmake'
         if IS_WINDOWS:
             return cmake_command
-        cmake3 = which('cmake3')
-        cmake = which('cmake')
-        cmake_version = None
-        cmake3_version = None
+        cmake3_version = CMake._get_version(which('cmake3'))
+        cmake_version = CMake._get_version(which('cmake'))
 
-        if cmake3 is not None and CMake._get_version(cmake3) >= distutils.version.LooseVersion("3.10.0"):
-            cmake3_version = CMake._get_version(cmake3)
-        if cmake is not None and CMake._get_version(cmake) >= distutils.version.LooseVersion("3.10.0"):
-            cmake_version = CMake._get_version(cmake)
-        if cmake3_version is None and cmake_version is None:
+        _cmake_min_version = LooseVersion("3.10.0")
+        if all((ver is None or ver < _cmake_min_version for ver in [cmake_version, cmake3_version])):
             raise RuntimeError('no cmake or cmake3 with version >= 3.10.0 found')
 
         if cmake3_version is None:
@@ -142,9 +137,11 @@ class CMake:
         return cmake_command
 
     @staticmethod
-    def _get_version(cmd: str) -> Any:
+    def _get_version(cmd: Optional[str]) -> Any:
         "Returns cmake version."
 
+        if cmd is None:
+            return None
         for line in check_output([cmd, '--version']).decode('utf-8').split('\n'):
             if 'version' in line:
                 return LooseVersion(line.strip().split(' ')[2])


### PR DESCRIPTION
For Pytorch source build when using Ninja generator, it requires **CMake >=3.13**,  Pytorch always checks **cmake3 >= 3.10** first, so when **3.13> cmake3 >= 3.10** and then PyTorch will use cmake3, there will report an error: ```Using the Ninja generator requires CMake version 3.13 or greater```  even the **CMake >=3.13** .  

For example: for my centos machine, the system CMake3 is ```3.12```,  and my conda env's CMake is ```3.19.6```,  there will have a build error which PyTorch choose CMake 3, I can update CMake3 or create an alias or a symlink to solve this problem, but the more reasonable way is that ```_get_cmake_command ``` always return the newest CMake executable (unless explicitly overridden with a same CMAKE_PATH environment variable).

