### PR TITLE
Remove unused `shared_mutex` header from `LeftRight.h`

### DIFF
--- a/c10/util/LeftRight.h
+++ b/c10/util/LeftRight.h
@@ -3,7 +3,6 @@
 #include <atomic>
 #include <functional>
 #include <mutex>
-#include <shared_mutex>
 #include <thread>
 
 namespace c10 {


### PR DESCRIPTION
`shared_mutex` isn't being used but its header has been included in `c10/util/LeftRight.h`.
This seems to be a very low-key change.
