### PR TITLE
[Vulkan] Implement slice operator

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/slice_4d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/slice_4d.glsl
@@ -1,0 +1,71 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba16f) uniform PRECISION           image3D uOutput;
+layout(set = 0, binding = 1)          uniform PRECISION           sampler3D uInput;
+layout(set = 0, binding = 2)          uniform PRECISION restrict  Block {
+  ivec4 size;            // output texture size (x=width,y=height,z=depth,w=unused)
+  ivec4 isize;           // input texture size (x=width,y=height,z=depth,w=unused)
+  uvec4 tensor_size;     // output tensor size
+  uvec4 itensor_size;    // input tensor size
+  uvec4 args;            // input arguments (dim, start, end, step)
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 posOut = ivec3(gl_GlobalInvocationID);
+  const uint max_dst_index = uBlock.tensor_size[0] * uBlock.tensor_size[1];
+  const uint dim = uBlock.args[0];
+  const uint start = uBlock.args[1];
+  const uint step = uBlock.args[3];
+
+  if (all(lessThan(posOut, uBlock.size.xyz))) {
+    vec4 outval = vec4(0.0);
+    for (uint j = 0; j < 4; ++j) {
+      uint dst_index = posOut.z * 4 + j;
+      if (dst_index >= max_dst_index) {
+        imageStore(uOutput, posOut, outval);
+        // out of range
+        break;
+      }
+
+      // dst dims
+      uint b1 = int(dst_index / uBlock.tensor_size[1]);
+      uint c1 = dst_index % uBlock.tensor_size[1];
+      uint h1 = posOut.y;
+      uint w1 = posOut.x;
+
+      // src dims
+      uint b = b1;
+      uint c = c1;
+      uint h = h1;
+      uint w = w1;
+
+      if (dim == 0) { // batch
+        b = start + step * b1;
+      }
+      else if (dim == 1) {  // feature(channel)
+        c = start + step * c1;
+      }
+
+      uint src_index = b * uBlock.itensor_size[1] + c;
+      ivec3 posIn;
+      posIn.x = int(w);
+      posIn.y = int(h);
+      posIn.z = int(src_index / 4);
+      uint i = (src_index % 4);
+
+      vec4 inval = texelFetch(uInput, posIn, 0);
+      outval[j] = inval[i];
+
+      if (j == 3) {
+        imageStore(uOutput, posOut, outval);
+      }
+    }
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -77,8 +77,6 @@ Tensor permute_4d(const Tensor& input, const uvec4& in_size, const uvec4& out_si
 
 Tensor permute(const Tensor& self, IntArrayRef dims) {
   auto nDims = safe_downcast<uint32_t>(self.dim());
-  TORCH_INTERNAL_ASSERT(
-    nDims <= 4, "Vulkan permute expects 4 or less dimensional inputs");
   TORCH_CHECK(dims.size() == (size_t)nDims,
            "number of dims don't match in permute");
 

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -1,0 +1,278 @@
+#include <ATen/NamedTensorUtils.h>
+#include <ATen/native/vulkan/api/Helper.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor slice_4d(const Tensor& input, const int64_t dim, const int64_t start, const int64_t end,
+                const int64_t step, const uvec4& in_tsize, const uvec4& out_tsize, vTensor& v_output) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  const Tensor self = input.is_vulkan() ? input : input.vulkan();
+  const vTensor& v_self = convert(self);
+  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+    auto src_image = v_self.image(
+            command_buffer,
+            vTensor::Stage::Compute);
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Compute,
+      vTensor::Access::Write);
+
+    const struct Block final {
+      uvec3 size;                // output texture size
+      uint32_t fill_0;           // dummy
+      uvec3 isize;               // input texture size
+      uint32_t fill_1;           // dummy
+      uvec4 tensor_size;         // output tensor size
+      uvec4 itensor_size;        // input tensor size
+      uvec4 args;                // input arguments (dim, start, end, step)
+    } block {
+      v_output.extents(),
+      0u,
+      v_self.extents(),
+      0u,
+      out_tsize,
+      in_tsize,
+      { safe_downcast<uint32_t>(dim),
+        safe_downcast<uint32_t>(start),
+        safe_downcast<uint32_t>(end),
+        safe_downcast<uint32_t>(step) },
+    };
+
+    context->dispatch(
+        command_buffer,
+        {
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        },
+        VK_KERNEL(slice_4d),
+        // build up shader operations from the output texture point of view
+        // to avoid the nondeterministic order of GPU shader operations between texels
+        v_output.extents(),
+        context->gpu().adapter->local_work_group_size(),
+        // Write-only access bypasses synchronization but inserts appropriate
+        // barriers if necessary.
+        dst_image,
+        // Read-only access is implied on const tensors and triggers an async
+        // synchronization if necessary.
+        src_image,
+        // Object lifetime is managed by the resource pool.
+        // It is OK not to keep track of the handle.
+        context->resource().pool.uniform(block).object);
+  }
+  else {
+    TORCH_CHECK(false, "Not implemented!");
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+  return convert(v_output);
+}
+
+Tensor slice_width(const Tensor& input, const int64_t start, const int64_t end, const int64_t step, vTensor& v_output) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  const Tensor self = input.is_vulkan() ? input : input.vulkan();
+  const vTensor& v_self = convert(self);
+  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+    auto src_image = v_self.image(
+            command_buffer,
+            vTensor::Stage::Transfer);
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Transfer,
+      vTensor::Access::Write);
+
+    uvec3 src_offset{};
+    uvec3 dst_offset{};
+
+    if (step == 1) {
+      src_offset.data[0u] = start;
+      uvec3 copy_extents {safe_downcast<uint32_t>(end - start),
+        v_self.extents().data[1u],
+        v_self.extents().data[2u]};
+      api::helper::copy_texture_to_texture(command_buffer,
+        src_image,
+        dst_image,
+        copy_extents,
+        src_offset,
+        dst_offset);
+    } else {
+      uvec3 copy_extents {1u,
+        v_self.extents().data[1u],
+        v_self.extents().data[2u]};
+      const auto x_max = v_self.extents().data[0u];
+      for (int64_t x = start, x_new = 0; x < end; x += step, ++x_new) {
+        if (x >= x_max) { // out of range
+          continue;
+        }
+        src_offset.data[0u] = x;
+        dst_offset.data[0u] = x_new;
+        api::helper::copy_texture_to_texture(command_buffer,
+          src_image,
+          dst_image,
+          copy_extents,
+          src_offset,
+          dst_offset);
+      }
+    }
+  }
+  else {
+    TORCH_CHECK(false, "Not implemented!");
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+  return convert(v_output);
+}
+
+Tensor slice_height(const Tensor& input, const int64_t start, const int64_t end, const int64_t step, vTensor& v_output) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+
+  const Tensor self = input.is_vulkan() ? input : input.vulkan();
+  const vTensor& v_self = convert(self);
+  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+    auto src_image = v_self.image(
+            command_buffer,
+            vTensor::Stage::Transfer);
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Transfer,
+      vTensor::Access::Write);
+
+    uvec3 src_offset{};
+    uvec3 dst_offset{};
+
+    if (step == 1) {
+      src_offset.data[1u] = start;
+      uvec3 copy_extents {v_self.extents().data[0u],
+        safe_downcast<uint32_t>(end - start),
+        v_self.extents().data[2u]};
+      api::helper::copy_texture_to_texture(command_buffer,
+        src_image,
+        dst_image,
+        copy_extents,
+        src_offset,
+        dst_offset);
+    } else {
+      uvec3 copy_extents {v_self.extents().data[0u],
+        1u,
+        v_self.extents().data[2u]};
+      const auto y_max = v_self.extents().data[1u];
+      for (int64_t y = start, y_new = 0; y < end; y += step, ++y_new) {
+        if (y >= y_max) { // out of range
+          continue;
+        }
+        src_offset.data[1u] = y;
+        dst_offset.data[1u] = y_new;
+        api::helper::copy_texture_to_texture(command_buffer,
+          src_image,
+          dst_image,
+          copy_extents,
+          src_offset,
+          dst_offset);
+      }
+    }
+  }
+  else {
+    TORCH_CHECK(false, "Not implemented!");
+  }
+
+  command_pool.submit(context->gpu().queue, command_buffer);
+  return convert(v_output);
+}
+
+Tensor slice(
+    const Tensor& self,
+    int64_t dim,
+    c10::optional<int64_t> start,
+    c10::optional<int64_t> end,
+    const int64_t step) {
+  TORCH_CHECK(step > 0, "slice step must be positive");
+  auto nDims = safe_downcast<uint32_t>(self.dim());
+  dim = maybe_wrap_dim(dim, nDims);
+  DimVector newSizes(self.sizes().begin(), self.sizes().end());
+
+  // handle optional parameters
+  int64_t start_val = start.has_value() ? start.value() : 0;
+  int64_t end_val = end.has_value() ? end.value() : INT64_MAX;
+
+  // INT64_MAX stands for default value.
+  if (start_val == INT64_MAX) {
+    start_val = 0;
+  }
+  if (start_val < 0) {
+    start_val += newSizes[dim];
+  }
+  if (end_val < 0) {
+    end_val += newSizes[dim];
+  }
+  if (start_val < 0) {
+    start_val = 0;
+  } else if (start_val >= newSizes[dim]) {
+    start_val = newSizes[dim];
+  }
+  if (end_val < start_val) {
+    end_val = start_val;
+  } else if (end_val >= newSizes[dim]) {
+    end_val = newSizes[dim];
+  }
+
+  auto len = end_val - start_val;
+  newSizes[dim] = (len + step - 1) / step; // round-up
+  TORCH_CHECK(len > 0, "Vulkan doesn't support zero-sized slice");
+
+  // generalize into 4D tensor
+  uvec4 in_tsize{1u, 1u, 1u, 1u}, out_tsize{1u, 1u, 1u, 1u};
+  for (const auto i : c10::irange(nDims)) {
+    in_tsize.data[(4u - nDims) + i] = self.sizes()[i];
+    out_tsize.data[(4u - nDims) + i] = newSizes[i];
+  }
+  dim += 4 - nDims;
+
+  vTensor v_output{
+    api::context(),
+    newSizes,
+    self.options()};
+
+  if (dim == 3) {
+    slice_width(self, start_val, end_val, step, v_output);
+  }
+  else if (dim == 2) {
+    slice_height(self, start_val, end_val, step, v_output);
+  }
+  else {
+    slice_4d(self, dim, start_val, end_val, step, in_tsize, out_tsize, v_output);
+  }
+
+  auto result = convert(v_output);
+  namedinference::propagate_names(result, self);
+  return result;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::slice.Tensor"), TORCH_FN(slice));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -62,6 +62,57 @@ void showRtol(const at::Tensor& a, const at::Tensor& b) {
   }
 }
 
+
+static void gen_allpermutations(std::vector<std::vector<int64_t>>& out, std::vector<int64_t> in, int i) {
+  // generate all permutations of a given dims
+  if (i == in.size()) {
+    out.push_back(in);
+  }
+  else {
+    for (int j = i; j < in.size(); ++j) {
+      std::swap(in[i], in[j]);
+      gen_allpermutations(out, in, i + 1);
+    }
+  }
+}
+
+static void slice_test(const std::vector<int64_t>& size, int64_t dim, c10::optional<int64_t> start, c10::optional<int64_t> end, int64_t step) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu = at::rand(size, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+
+  // Act
+  const auto out_cpu = at::slice(in_cpu, dim, start, end, step);
+  const auto out_vulkan = at::slice(in_vulkan, dim, start, end, step);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+static void slice_tests(const std::unordered_map<int64_t, std::vector<int64_t>>& dim2sizes) {
+  for (const auto& dim2size : dim2sizes) {
+    slice_test(dim2size.second, dim2size.first, 10, 30, 1);         // i.e., 4D tensor's equivalent indexing = [:,:,:,10:30:1]
+    slice_test(dim2size.second, dim2size.first, 10, 30, 7);         // i.e., 4D tensor's equivalent indexing = [:,:,:,10:30:7]
+    slice_test(dim2size.second, dim2size.first, 10, 50, 2);         // i.e., 4D tensor's equivalent indexing = [:,:,:,10:50:2] with end=out of range
+    slice_test(dim2size.second, dim2size.first, -60, 60, 2);        // i.e., 4D tensor's equivalent indexing = [:,:,:,-60:60:2] with start/end=out of range
+    slice_test(dim2size.second, dim2size.first, -30, -10, 1);       // i.e., 4D tensor's equivalent indexing = [:,:,:,-30:-10:1] with negative start/end
+    slice_test(dim2size.second, dim2size.first, 0, INT64_MAX, 1);   // i.e., 4D 's equivalent indexing = [:,:,:,0:9223372036854775807:1] with end=INT64_MAX
+    slice_test(dim2size.second, dim2size.first, -10, INT64_MAX, 1); // i.e., 4D 's equivalent indexing = [:,:,:,-10:9223372036854775807:1] with negative start and end=INT64_MAX
+    slice_test(dim2size.second, dim2size.first, INT64_MIN, INT64_MAX, 1); // i.e., 4D 's equivalent indexing = [:,:,:,-9223372036854775808:9223372036854775807:1] with start=INT64_MIN and end=INT64_MAX
+    slice_test(dim2size.second, dim2size.first, {}, {}, 1);         // i.e., 4D 's equivalent indexing = [:,:,:,::1] with empty start/end
+  }
+}
+
 } // namespace
 
 namespace {
@@ -2123,19 +2174,6 @@ TEST(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
   }
 }
 
-static void gen_allpermutations(std::vector<std::vector<int64_t>>& out, std::vector<int64_t> in, int i) {
-  // generate all permutations of a given dims
-  if (i == in.size()) {
-    out.push_back(in);
-  }
-  else {
-    for (int j = i; j < in.size(); ++j) {
-      std::swap(in[i], in[j]);
-      gen_allpermutations(out, in, i + 1);
-    }
-  }
-}
-
 TEST(VulkanAPITest, permute_2d_success) {
   // Guard
   if (!at::is_vulkan_available()) {
@@ -2384,6 +2422,72 @@ TEST(VulkanAPITest, permute_invalidinputs_exceptions) {
   EXPECT_THROW({
     const auto out_vulkan_5d = in_cpu_5d.vulkan();
     out_vulkan_5d.permute({4, 3, 2, 1, 0});
+  }, ::c10::Error);
+}
+
+TEST(VulkanAPITest, slice_width_success) {
+  // Arrange
+  std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
+    {3, {2, 3, 40, 50}},  // 4D tensors with dim=width
+    {2, {3, 40, 50}},     // 3D tensors with dim=width
+    {1, {40, 50}},        // 2D tensors with dim=width
+    {0, {50}},            // 1D tensors with dim=width
+  };
+
+  // Act/Assert
+  slice_tests(dim2sizes);
+}
+
+TEST(VulkanAPITest, slice_height_success) {
+  // Arrange
+  std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
+    {2, {2, 3, 40, 50}},  // 4D tensors with dim=height
+    {1, {3, 40, 50}},     // 3D tensors with dim=height
+    {0, {40, 50}},        // 2D tensors with dim=height
+                          // 1D tesnors don't have height dim for test
+  };
+
+  // Act/Assert
+  slice_tests(dim2sizes);
+}
+
+TEST(VulkanAPITest, slice_feature_success) {
+  // Arrange
+  std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
+    {1, {2, 40, 13, 14}}, // 4D tensors with dim=feature(channel)
+    {0, {40, 13, 14}},    // 3D tensors with dim=feature(channel)
+                          // 1D and 2D tesnors don't have feature(channel) dim for test
+  };
+
+  // Act/Assert
+  slice_tests(dim2sizes);
+}
+
+TEST(VulkanAPITest, slice_batch_success) {
+  // Arrange
+  std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
+    {0, {40, 3, 13, 14}}, // 4D tensors with dim=batch
+                          // 1D, 2D and 3D tesnors don't have batch dim for test
+  };
+
+  // Act/Assert
+  slice_tests(dim2sizes);
+}
+
+TEST(VulkanAPITest, slice_invalidinputs_exceptions) {
+  // Act: slice step must be positive
+  EXPECT_THROW({
+    slice_test({2, 3, 4, 5}, 3, 0, 3, 0);
+  }, ::c10::Error);
+
+  // Act: Vulkan doesn't support zero-sized slice (when start=end)
+  EXPECT_THROW({
+    slice_test({2, 3, 4, 5}, 3, 0, 0, 1);
+  }, ::c10::Error);
+
+  // Act: Vulkan doesn't support zero-sized slice (when start > end)
+  EXPECT_THROW({
+    slice_test({2, 3, 4, 5}, 3, 3, 2, 1);
   }, ::c10::Error);
 }
 


### PR DESCRIPTION
**Summary**
Implemented `slice` operator in the Vulkan backend:
* Supports only <= 4D tensors.
* `aten::slice.Tensor` will be executed internally by indexing Tensor.
* Slicing means selecting the elements present in the tensor by using `:` slice operator. We can slice the elements by using the index of that particular element.
* Indexing starts with 0. `end` is exclusive. In this example, we will be getting the elements from the very start to the end index 4(exclusive) of the tensor.
```
tensor = torch.tensor([2, 4, 1, 7, 0, 9])
print(tensor[ : 4])
# Outputs- tensor([2, 4, 1, 7])
```
* Generalized input tensors to 4D ones to simplify input/output texture handling. For example, {2, 3} is treated as {1,1,2,3} internally.
* Negative `start` and `end` inputs are allowed.
* CPU implementation: [/aten/src/ATen/native/TensorShape.cpp::slice()](https://github.com/pytorch/pytorch/blob/3e45739543fbce471fc4ed26ff079efe170de0f1/aten/src/ATen/native/TensorShape.cpp#L1262)
* For **width** dimension, use `vkCmdCopyImage` API,
  * input texture size = `{x,y,z}`
  * if `step` is 1, copy a region from the input texture to the output texture once where
    * source offset = `{start,0,0}`
    * destination offset = `{0,0,0}`
    * copy extents = `{end-start,y,z}`
    * call `vkCmdCopyImage` API
  * if `step` is not 1, do for-loop from x=`start` to `end-1` by `step` (also from x_new=`0` to `end-start-1`) where
    * x_max = x
    * copy extents = `{1,y,z}`
    * if (x >= x_max) continue; // out of range
    * source offset = `{x,0,0}`
    * destination offset = `{x_new,0,0}`
    * call `vkCmdCopyImage` API
* For **height** dimension, use `vkCmdCopyImage` API,
  * input texture size = `{x,y,z}`
  * if `step` is 1, copy a region from the input texture to the output texture once where
    * source offset = `{0,start,0}`
    * destination offset = `{0,0,0}`
    * copy extents = `{x,end-start,z}`
    * call `vkCmdCopyImage` API
  * if `step` is not 1, do for-loop from y=`start` to `end-1` by `step` (also from y_new=`0` to `end-start-1`) where
    * y_max = y
    * copy extents = `{x,1,z}`
    * if (y >= y_max) continue; // out of range
    * source offset = `{0,y,0}`
    * destination offset = `{0,y_new,0}`
    * call `vkCmdCopyImage` API
* For **batch** and **feature**(channel) dimensions, we build up shader operations from the output texture point of view to avoid the nondeterministic order of GPU shader operations between texels. See [incoherent memory access](https://www.khronos.org/opengl/wiki/Memory_Model#Incoherent_memory_access)
  * `b,c,h,w` = input tensor dims (NCHW)
  * `b1,c1,h1,w1` = output tensor dims (NCHW)
  * `posIn` = position (x,y,z) for input texture
  * `posOut` = position (x,y,z) for output texture
  * `inval` = input texel value
  * `outval` = output texel value
  * `max_dst_index` = batch size of output tensor * channel size of output tensor
  * `n` = end - start
  * `i` = index of input texel (0...3) and `j` = index of output texel (0..3)
  * Pseudo code:
```
for (uint j = 0; j < 4; ++j) {
  dst_index = posOut.z * 4 + j;
  if (dst_index >= max_dst_index) {
    save outval to output texture at posOut
    break; // out of reange
  }

  b1 = int(dst_index / channel size of output tensor);
  c1 = dst_index % channel size of output tensor;
  h1 = posOut.y;
  w1 = posOut.x;

  b=b1
  c=c1
  h=h1
  w=w1

  if (dim==0) { // batch
    b=start+step*b1;
  } else { // feature(channel)
    c=start+step*c1
  }

  src_index = b * channel size of input tensor + c;
  posIn.x = int(w);
  posIn.y = int(h);
  posIn.z = int(src_index / 4);
  i = (src_index % 4);
  read inval from input texture at posIn
  outval[j] = inval[i]
  if (j == 3) {
    save outval to output texture at posOut
  }
}
```
* Error/edge cases:
  * Vulkan backend doesn't support zero-sized slice. It throws an exception when allocating a Vulkan buffer if any dim size is zero.
  * The slice step should be positive.
* Generalized test cases with different dim size tensors for batch, feature, height and width. For example, a 4D tensor slicing by dim=width:
```
tensor {2, 3, 40, 50} slicing with dim=3, start=10, end=30, step=1 <-> tensor indexing by [:,:,:,10:30:1]
tensor {2, 3, 40, 50} slicing with dim=3, start=10, end=30, step=7 <-> tensor indexing by [:,:,:,10:30:7]
tensor {2, 3, 40, 50} slicing with dim=3, start=10, end=50, step=2 <-> tensor indexing by [:,:,:,10:50:2] with end=out of range
tensor {2, 3, 40, 50} slicing with dim=3, start=-60, end=60, step=2 <-> tensor indexing by [:,:,:,-60:60:2] with start/end=out of range
tensor {2, 3, 40, 50} slicing with dim=3, start=-30, end=-10, step=2 <-> tensor indexing by [:,:,:,-30:-10:1] with negative start/end
tensor {2, 3, 40, 50} slicing with dim=3, start=0, end=INT64_MAX, step=2 <-> tensor indexing by [:,:,:,0:9223372036854775807:1] with end=INT64_MAX
tensor {2, 3, 40, 50} slicing with dim=3, start=-10, end=INT64_MAX, step=2 <-> tensor indexing by [:,:,:,-10:9223372036854775807:1] with negative start and end=INT64_MAX
tensor {2, 3, 40, 50} slicing with dim=3, start=INT64_MIN, end=INT64_MAX, step=2 <-> tensor indexing by [:,:,:,-9223372036854775808:9223372036854775807:1] with start=INT64_MIN and end=INT64_MAX
tensor {2, 3, 40, 50} slicing with dim=3, start=empty, end=empty, step=2 <-> tensor indexing by [:,:,:,::1] with empty start/end
```
* References:
  * [Slicing PyTorch Datasets](https://lewtun.github.io/blog/til/nlp/pytorch/2021/01/24/til-slicing-torch-datasets.html)
  * [How to Slice a 3D Tensor in Pytorch?](https://www.geeksforgeeks.org/how-to-slice-a-3d-tensor-in-pytorch/)
  * [PyTorch Tensor Indexing API](https://pytorch.org/cppdocs/notes/tensor_indexing.html#translating-between-python-c-index-types)
  * [PyTorch Tensor Indexing](https://deeplearninguniversity.com/pytorch/pytorch-tensor-indexing/)
  * [Slicing and Striding](https://mlverse.github.io/torch/articles/indexing.html#slicing-and-striding)
* Vulkan `slice` operator tensor conversion:
![image](https://user-images.githubusercontent.com/88354936/144672944-89e2ff80-dcd0-4669-bb59-e22da15362c2.png)

**Test Plan**
Build & test on Android:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```
Build & test on MacOS:
```
cd ~/fbsource
buck build //xplat/caffe2:pt_vulkan_api_test_binAppleMac
./buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAppleMac\#macosx-x86_64
```
Test result on Android (Google Pixel 5):
```
[ RUN      ] VulkanAPITest.slice_width_success
[       OK ] VulkanAPITest.slice_width_success (17 ms)
[ RUN      ] VulkanAPITest.slice_height_success
[       OK ] VulkanAPITest.slice_height_success (13 ms)
[ RUN      ] VulkanAPITest.slice_feature_success
[       OK ] VulkanAPITest.slice_feature_success (20 ms)
[ RUN      ] VulkanAPITest.slice_batch_success
[       OK ] VulkanAPITest.slice_batch_success (9 ms)
[ RUN      ] VulkanAPITest.slice_invalidinputs_exceptions
[       OK ] VulkanAPITest.slice_invalidinputs_exceptions (0 ms)
```
Test result on MacOS:
```
[ RUN      ] VulkanAPITest.slice_width_success
[       OK ] VulkanAPITest.slice_width_success (81 ms)
[ RUN      ] VulkanAPITest.slice_height_success
[       OK ] VulkanAPITest.slice_height_success (56 ms)
[ RUN      ] VulkanAPITest.slice_feature_success
[       OK ] VulkanAPITest.slice_feature_success (132 ms)
[ RUN      ] VulkanAPITest.slice_batch_success
[       OK ] VulkanAPITest.slice_batch_success (33 ms)
[ RUN      ] VulkanAPITest.slice_invalidinputs_exceptions
[       OK ] VulkanAPITest.slice_invalidinputs_exceptions (1 ms)
```

Differential Revision: D32482638