### PR TITLE
Limit uploading JSONs to trunk

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -118,9 +118,9 @@ concurrency:
           submodules: !{{ submodules }}
 {%- endmacro -%}
 
-{%- macro upload_downloaded_files(name, artifact_name="", use_s3=True) -%}
+{%- macro upload_downloaded_files(name, artifact_name="", use_s3=True, when="always()") -%}
       - name: Zip JSONs for upload
-        if: always()
+        if: !{{ when }}
         env:
 {%- if name == 'linux' or name == 'windows' or name == 'macos' %}
           FILE_SUFFIX: '${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}'
@@ -145,7 +145,7 @@ concurrency:
       - uses: actions/upload-artifact@v2
         name: Store Test Downloaded JSONs on Github
 {%- endif %}
-        if: always()
+        if: !{{ when }}
         with:
 {%- if artifact_name != "" %}
           name: !{{ artifact_name }}

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -138,7 +138,6 @@ jobs:
           python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
-      !{{ common.upload_downloaded_files(name='macos', when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
       !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
 {% endblock +%}

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -138,7 +138,7 @@ jobs:
           python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
-      !{{ common.upload_downloaded_files(name='macos') }}
+      !{{ common.upload_downloaded_files(name='macos', when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
       !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
 {% endblock +%}

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           python3 tools/render_junit.py test/
       - name: Zip JSONs for upload
-        if: always()
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           FILE_SUFFIX: '${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}'
         run: |
@@ -190,7 +190,7 @@ jobs:
           zip -r "test-jsons-${FILE_SUFFIX}.zip" test -i '*.json'
       - uses: seemethere/upload-artifact-s3@v3
         name: Store Test Downloaded JSONs on S3
-        if: always()
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           retention-days: 14
           if-no-files-found: warn

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -180,22 +180,6 @@ jobs:
           PYTHONIOENCODING: "utf-8"
         run: |
           python3 tools/render_junit.py test/
-      - name: Zip JSONs for upload
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-        env:
-          FILE_SUFFIX: '${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}'
-        run: |
-          # Remove any previous test jsons if they exist
-          rm -f test-jsons-*.zip
-          zip -r "test-jsons-${FILE_SUFFIX}.zip" test -i '*.json'
-      - uses: seemethere/upload-artifact-s3@v3
-        name: Store Test Downloaded JSONs on S3
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-        with:
-          retention-days: 14
-          if-no-files-found: warn
-          path:
-            test-jsons-*.zip
       - name: Zip test reports for upload
         if: always()
         env:


### PR DESCRIPTION
Mac workflows on forked PRs don't have the right permissions to upload artifacts :/ 