### PR TITLE
use irange for loops

### DIFF
--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -5,6 +5,7 @@
 #include <test/cpp/api/support.h>
 
 #include <c10/util/ArrayRef.h>
+#include <c10/util/irange.h>
 #include <c10/util/tempfile.h>
 
 #include <algorithm>
@@ -173,7 +174,7 @@ TEST(DataTest, InfiniteStreamDataset) {
   for (auto& batch : *data_loader) {
     ASSERT_LT(batch_index, 3);
     ASSERT_EQ(batch.size(), kBatchSize);
-    for (size_t j = 0; j < kBatchSize; ++j) {
+    for (const auto j : c10::irange(kBatchSize)) {
       ASSERT_EQ(batch.at(j), 1 + (batch_index * kBatchSize) + j);
     }
     batch_index += 1;
@@ -837,7 +838,7 @@ TEST(DataTest, CanUseCustomTypeAsIndexType) {
 
   size_t i = 0;
   for (auto batch : *data_loader) {
-    for (int j = 0; j < kBatchSize; ++j) {
+    for (const auto j : c10::irange(kBatchSize)) {
       ASSERT_EQ(batch.at(j), 10 + j);
     }
     i += 1;
@@ -857,7 +858,7 @@ TEST(DataTest, DistributedRandomSamplerSingleReplicaProduceCorrectSamples) {
   ASSERT_EQ(res.size(), sample_count);
 
   std::sort(res.begin(), res.end());
-  for (size_t i = 0; i < res.size(); ++i) {
+  for (const auto i : c10::irange(res.size())) {
     ASSERT_EQ(res[i], i);
   }
 }
@@ -872,14 +873,14 @@ TEST(DataTest, DistributedRandomSamplerMultiReplicaProduceCorrectSamples) {
                            size_t batch_size) {
     std::vector<std::unique_ptr<samplers::DistributedRandomSampler>> samplers;
 
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       samplers.emplace_back(
           torch::make_unique<samplers::DistributedRandomSampler>(
               sample_count, num_replicas, i, allow_duplicates));
     }
 
     std::vector<size_t> res;
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       (*samplers[i]).reset();
       torch::optional<std::vector<size_t>> idx;
       while ((idx = (*samplers[i]).next(batch_size)).has_value()) {
@@ -953,7 +954,7 @@ TEST(DataTest, DistributedSequentialSamplerSingleReplicaProduceCorrectSamples) {
   ASSERT_EQ(res.size(), sample_count);
 
   std::sort(res.begin(), res.end());
-  for (size_t i = 0; i < res.size(); ++i) {
+  for (const auto i : c10::irange(res.size())) {
     ASSERT_EQ(res[i], i);
   }
 }
@@ -969,14 +970,14 @@ TEST(DataTest, DistributedSequentialSamplerMultiReplicaProduceCorrectSamples) {
     std::vector<std::unique_ptr<samplers::DistributedSequentialSampler>>
         samplers;
 
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       samplers.emplace_back(
           torch::make_unique<samplers::DistributedSequentialSampler>(
               sample_count, num_replicas, i, allow_duplicates));
     }
 
     std::vector<size_t> res;
-    for (size_t i = 0; i < num_replicas; ++i) {
+    for (const auto i : c10::irange(num_replicas)) {
       (*samplers[i]).reset();
       torch::optional<std::vector<size_t>> idx;
       while ((idx = (*samplers[i]).next(batch_size)).has_value()) {
@@ -1490,7 +1491,7 @@ TEST(DataLoaderTest, StatefulDatasetWithNoWorkers) {
 
   auto data_loader = torch::data::make_data_loader(D{});
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     const auto number_of_iterations =
         std::distance(data_loader->begin(), data_loader->end());
     ASSERT_EQ(
@@ -1531,7 +1532,7 @@ TEST(DataLoaderTest, StatefulDatasetWithManyWorkers) {
       torch::data::datasets::make_shared_dataset<D>(),
       DataLoaderOptions().workers(kNumberOfWorkers));
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     const auto number_of_iterations =
         std::distance(data_loader->begin(), data_loader->end());
     ASSERT_EQ(
@@ -1574,7 +1575,7 @@ TEST(DataLoaderTest, StatefulDatasetWithMap) {
               })),
       DataLoaderOptions{});
 
-  for (size_t i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     const auto number_of_iterations =
         std::distance(data_loader->begin(), data_loader->end());
     ASSERT_EQ(
@@ -1675,7 +1676,8 @@ TEST(DataLoaderTest, ChunkDataSetGetBatch) {
             dataset,
             DataLoaderOptions(batch_size).workers(dataloader_worker_count));
 
-        for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+        for (const auto epoch_index : c10::irange(epoch_count)) {
+          (void)epoch_index; // Suppress unused variable warning
           std::vector<bool> result(total_example_count, false);
           int iteration_count = 0;
           for (auto iterator = data_loader->begin();
@@ -1687,11 +1689,11 @@ TEST(DataLoaderTest, ChunkDataSetGetBatch) {
             // When prefetch_count is equal to 1 and no worker thread, the batch
             // order is deterministic. So we can verify elements in each batch.
             if (prefetch_count == 1 && dataloader_worker_count == 0) {
-              for (size_t j = 0; j < batch_size; ++j) {
+              for (const auto j : c10::irange(batch_size)) {
                 ASSERT_EQ(batch[j], iteration_count * batch_size + j);
               }
             }
-            for (size_t j = 0; j < batch_size; ++j) {
+            for (const auto j : c10::irange(batch_size)) {
               result[batch[j]] = true;
             }
           }
@@ -1978,7 +1980,8 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
         dataset,
         DataLoaderOptions(batch_size).workers(dataloader_worker_count));
 
-    for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+    for (const auto epoch_index : c10::irange(epoch_count)) {
+      (void)epoch_index; // Suppress unused variable warning
       int iteration_count = 0;
       for (auto iterator = data_loader->begin(); iterator != data_loader->end();
            ++iterator, ++iteration_count) {
@@ -2079,7 +2082,7 @@ TEST(DataLoaderTest, ChunkDatasetLoad) {
   auto data_loader = torch::data::make_data_loader(
       dataset, DataLoaderOptions(batch_size).workers(dataloader_worker_count));
 
-  for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+  for (const auto epoch_index : c10::irange(epoch_count)) {
     int iteration_count = 0;
 
     // For the first epoch, the returned batch should be returned from the
@@ -2128,7 +2131,7 @@ TEST(DataLoaderTest, ChunkDatasetCrossChunkShuffle) {
       size_t index = 0;
 
       // Repeatly sample every 5 indices.
-      for (size_t i = 0; i < batch_size; ++i) {
+      for (const auto i : c10::irange(batch_size)) {
         for (size_t j = 0; j < size_ / batch_size; ++j) {
           indices_[index++] = i + batch_size * j;
         }
@@ -2222,11 +2225,11 @@ TEST(DataLoaderTest, ChunkDatasetCrossChunkShuffle) {
         // construct expected result
         int offset = 0;
 
-        for (int i = 0; i < (chunk_count + cross_chunk_shuffle_count - 1) /
-                 cross_chunk_shuffle_count;
-             i++) {
-          for (int j = 0; j < chunk_size; ++j) {
-            for (int k = 0; k < cross_chunk_shuffle_count; ++k) {
+        for (const auto i : c10::irange((chunk_count + cross_chunk_shuffle_count - 1) /
+                 cross_chunk_shuffle_count)) {
+          for (const auto j : c10::irange(chunk_size)) {
+            (void)j; // Suppress unused variable warning
+            for (const auto k : c10::irange(cross_chunk_shuffle_count)) {
               if (i * cross_chunk_shuffle_count + k < chunk_count) {
                 expected_result.push_back(i * cross_chunk_shuffle_count + k);
               }

--- a/test/cpp/api/dispatch.cpp
+++ b/test/cpp/api/dispatch.cpp
@@ -2,6 +2,7 @@
 
 #include <torch/torch.h>
 #include <ATen/native/Pow.h>
+#include <c10/util/irange.h>
 #include <torch/types.h>
 #include <torch/utils.h>
 #include <test/cpp/api/support.h>
@@ -24,7 +25,7 @@ TEST_F(DispatchTest, TestAVX2) {
   setenv("ATEN_CPU_CAPABILITY", "avx2", 1);
 #endif
   const auto actual_pow_avx2 = vals_tensor.pow(pows_tensor);
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_EQ(result[i], actual_pow_avx2[i].item<int>());
   }
 }
@@ -40,7 +41,7 @@ TEST_F(DispatchTest, TestAVX512) {
   setenv("ATEN_CPU_CAPABILITY", "avx512", 1);
 #endif
   const auto actual_pow_avx512 = vals_tensor.pow(pows_tensor);
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_EQ(result[i], actual_pow_avx512[i].item<int>());
   }
 }
@@ -56,7 +57,7 @@ TEST_F(DispatchTest, TestDefault) {
   setenv("ATEN_CPU_CAPABILITY", "default", 1);
 #endif
   const auto actual_pow_default = vals_tensor.pow(pows_tensor);
-  for (int i = 0; i < 4; i++) {
+  for (const auto i : c10::irange(4)) {
     ASSERT_EQ(result[i], actual_pow_default[i].item<int>());
   }
 }

--- a/test/cpp/api/expanding-array.cpp
+++ b/test/cpp/api/expanding-array.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -13,7 +14,7 @@ struct ExpandingArrayTest : torch::test::SeedingFixture {};
 TEST_F(ExpandingArrayTest, CanConstructFromInitializerList) {
   torch::ExpandingArray<5> e({1, 2, 3, 4, 5});
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], i + 1);
   }
 }
@@ -21,7 +22,7 @@ TEST_F(ExpandingArrayTest, CanConstructFromInitializerList) {
 TEST_F(ExpandingArrayTest, CanConstructFromVector) {
   torch::ExpandingArray<5> e(std::vector<int64_t>{1, 2, 3, 4, 5});
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], i + 1);
   }
 }
@@ -29,7 +30,7 @@ TEST_F(ExpandingArrayTest, CanConstructFromVector) {
 TEST_F(ExpandingArrayTest, CanConstructFromArray) {
   torch::ExpandingArray<5> e(std::array<int64_t, 5>({1, 2, 3, 4, 5}));
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], i + 1);
   }
 }
@@ -37,7 +38,7 @@ TEST_F(ExpandingArrayTest, CanConstructFromArray) {
 TEST_F(ExpandingArrayTest, CanConstructFromSingleValue) {
   torch::ExpandingArray<5> e(5);
   ASSERT_EQ(e.size(), 5);
-  for (size_t i = 0; i < e.size(); ++i) {
+  for (const auto i : c10::irange(e.size())) {
     ASSERT_EQ((*e)[i], 5);
   }
 }

--- a/test/cpp/api/fft.cpp
+++ b/test/cpp/api/fft.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 #include <test/cpp/api/support.h>
 
@@ -14,15 +15,15 @@ torch::Tensor naive_dft(torch::Tensor x, bool forward=true) {
   // Roots of unity, exp(-2*pi*j*n/N) for n in [0, N), reversed for inverse transform
   std::vector<c10::complex<double>> roots(len);
   const auto angle_base = (forward ? -2.0 : 2.0) * M_PI / len;
-  for (int64_t i = 0; i < len; ++i) {
+  for (const auto i : c10::irange(len)) {
     auto angle = i * angle_base;
     roots[i] = c10::complex<double>(std::cos(angle), std::sin(angle));
   }
 
   const auto in = x.data_ptr<c10::complex<double>>();
   const auto out = out_tensor.data_ptr<c10::complex<double>>();
-  for (int64_t i = 0; i < len; ++i) {
-    for (int64_t j = 0; j < len; ++j) {
+  for (const auto i : c10::irange(len)) {
+    for (const auto j : c10::irange(len)) {
       out[i] += roots[(j * i) % len] * in[j];
     }
   }

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -1127,7 +1128,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
   int dims[] = {1, -1};
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers)
   int expected[] = {5*3, 5*4};
-  for(auto i=0; i<2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto logits = torch::randn({5, 4, 3});
     int expected_count = expected[i];
     auto y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true).dim(dims[i]));
@@ -1149,7 +1150,8 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
 
     auto counts = torch::zeros_like(logits);
     torch::Tensor y_draw;
-    for (auto i=0; i<num_draws; i++) {
+    for (const auto i : c10::irange(num_draws)) {
+        (void)i; // Suppress unused variable warning
         y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true));
         counts += y_draw;
     }
@@ -1175,7 +1177,7 @@ TEST_F(FunctionalTest, Softmax) {
   auto output = F::softmax(input, /*dim=*/1);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -1187,7 +1189,7 @@ TEST_F(FunctionalTest, Softmin) {
   auto output = F::softmin(input, /*dim=*/1);
   auto sum = torch::sum(torch::exp(-input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(-input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -1199,7 +1201,7 @@ TEST_F(FunctionalTest, LogSoftmax) {
   auto output = F::log_softmax(input, /*dim=*/1);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::log(torch::exp(input[i]) / sum[i]);
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }

--- a/test/cpp/api/init.cpp
+++ b/test/cpp/api/init.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/init_baseline.h>
@@ -14,7 +15,7 @@ void check_exact_values(
     const std::vector<std::vector<torch::Tensor>>& expected_parameters) {
   ASSERT_EQ(parameters.size(), expected_parameters.size());
 
-  for (size_t i = 0; i < parameters.size(); i++) {
+  for (const auto i : c10::irange(parameters.size())) {
     auto layerParameters = parameters[i];
     auto expectedLayerParameters = expected_parameters[i];
 
@@ -27,7 +28,7 @@ void check_exact_values(
       ASSERT_TRUE(false);
     }
 
-    for (size_t p = 0; p < layerParameters.size(0); p++) {
+    for (const auto p : c10::irange(layerParameters.size(0))) {
       // Always compare using double dtype, regardless of the original dtype of the tensors
       auto tensor = layerParameters[p].to(torch::kFloat64);
       auto expectedTensor = expectedLayerParameters[p].to(torch::kFloat64);

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -122,10 +123,12 @@ bool test_mnist(
   torch::Device device(with_cuda ? torch::kCUDA : torch::kCPU);
   model->to(device);
 
-  for (size_t epoch = 0; epoch < number_of_epochs; epoch++) {
+  for (const auto epoch : c10::irange(number_of_epochs)) {
+    (void)epoch; // Suppress unused variable warning
     // NOLINTNEXTLINE(performance-for-range-copy)
     for (torch::data::Example<> batch : *data_loader) {
-      auto data = batch.data.to(device), targets = batch.target.to(device);
+      auto data = batch.data.to(device);
+      auto targets = batch.target.to(device);
       torch::Tensor prediction = forward_op(std::move(data));
       // NOLINTNEXTLINE(performance-move-const-arg)
       torch::Tensor loss = torch::nll_loss(prediction, std::move(targets));
@@ -196,7 +199,7 @@ TEST_F(IntegrationTest, CartPole) {
 
     std::vector<torch::Tensor> policy_loss;
     std::vector<torch::Tensor> value_loss;
-    for (auto i = 0U; i < saved_log_probs.size(); i++) {
+    for (const auto i : c10::irange(0U, saved_log_probs.size())) {
       auto advantage = r_t[i] - saved_values[i].item<float>();
       policy_loss.push_back(-advantage * saved_log_probs[i]);
       value_loss.push_back(

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -704,7 +705,7 @@ TEST_F(ModuleTest, ModulesReturnsExpectedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model.ptr(), model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].get(), expected[i].get());
   }
@@ -717,7 +718,7 @@ TEST_F(ModuleTest, ModulesExcludesSelfWhenIncludeSelfSetToFalse) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].get(), expected[i].get());
   }
@@ -730,7 +731,7 @@ TEST_F(ModuleTest, NamedModulesReturnsExpectedNamedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model.ptr(), model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].key(), i ? std::to_string(i - 1) : std::string());
     ASSERT_EQ(modules[i].value().get(), expected[i].get());
@@ -745,7 +746,7 @@ TEST_F(ModuleTest, NamedModulesExcludesSelfWhenIncludeSelfSetToFalse) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].key(), std::to_string(i));
     ASSERT_EQ(modules[i].value().get(), expected[i].get());
@@ -758,7 +759,7 @@ TEST_F(ModuleTest, ChildrenReturnsExpectedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].get(), expected[i].get());
   }
@@ -774,7 +775,7 @@ TEST_F(ModuleTest, NamedChildrenReturnsExpectedNamedSubmodulesForFlatModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> expected = {
       model[0], model[1], model[2]};
   ASSERT_EQ(modules.size(), expected.size());
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     // Assert pointer equality.
     ASSERT_EQ(modules[i].key(), std::to_string(i));
     ASSERT_EQ(modules[i].value().get(), expected[i].get());
@@ -822,7 +823,7 @@ TEST_F(ModuleTest, NamedBuffersReturnsExpectedTensorsForFlatModel) {
 struct TestContainer : torch::nn::Module {
   TestContainer(int64_t number, std::vector<TestContainer> modules = {})
       : tensor(torch::tensor(number)) {
-    for (size_t i = 0; i < modules.size(); ++i) {
+    for (const auto i : c10::irange(modules.size())) {
       register_module(
           std::to_string(i),
           std::make_shared<TestContainer>(std::move(modules[i])));
@@ -866,7 +867,7 @@ TEST_F(ModuleTest, ModulesReturnsExpectedSubmodulesForDeepModel) {
   std::vector<std::shared_ptr<torch::nn::Module>> modules = model->modules();
 
   ASSERT_EQ(modules.size(), 10);
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(get_test_container_item(modules[i]), i);
   }
 }
@@ -879,7 +880,7 @@ TEST_F(ModuleTest, NamedModulesReturnsExpectedNamedSubmodulesForDeepModel) {
 
   ASSERT_EQ(modules.size(), expected.size());
 
-  for (size_t i = 0; i < expected.size(); ++i) {
+  for (const auto i : c10::irange(expected.size())) {
     ASSERT_EQ(modules[i].key(), expected[i].first);
     ASSERT_EQ(get_test_container_item(modules[i].value()), expected[i].second);
   }

--- a/test/cpp/api/modulelist.cpp
+++ b/test/cpp/api/modulelist.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <algorithm>
@@ -118,7 +119,7 @@ TEST_F(ModuleListTest, AccessWithAt) {
   ASSERT_EQ(list->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(&list->at<M>(i), modules[i].get());
   }
 
@@ -143,7 +144,7 @@ TEST_F(ModuleListTest, AccessWithPtr) {
   ASSERT_EQ(list->size(), 3);
 
   // returns the correct module for a given index
-  for (size_t i = 0; i < modules.size(); ++i) {
+  for (const auto i : c10::irange(modules.size())) {
     ASSERT_EQ(list->ptr(i).get(), modules[i].get());
     ASSERT_EQ(list[i].get(), modules[i].get());
     ASSERT_EQ(list->ptr<M>(i).get(), modules[i].get());

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -1148,7 +1149,7 @@ TEST_F(ModulesTest, LayerNorm) {
   s.backward();
   ASSERT_EQ(y.ndimension(), 2);
   ASSERT_EQ(s.ndimension(), 0);
-  for (auto i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(y.size(i), 2);
   }
 
@@ -1166,7 +1167,7 @@ TEST_F(ModulesTest, GroupNorm) {
   s.backward();
   ASSERT_EQ(y.ndimension(), 2);
   ASSERT_EQ(s.ndimension(), 0);
-  for (auto i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     ASSERT_EQ(y.size(i), 2);
   }
 
@@ -2595,7 +2596,7 @@ TEST_F(ModulesTest, Softmax) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -2607,7 +2608,7 @@ TEST_F(ModulesTest, Softmin) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(-input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::exp(-input[i]) / sum[i];
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -2619,7 +2620,7 @@ TEST_F(ModulesTest, LogSoftmax) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 2; i++) {
+  for (const auto i : c10::irange(2)) {
     auto expected = torch::log(torch::exp(input[i]) / sum[i]);
     ASSERT_TRUE(torch::allclose(output[i], expected));
   }
@@ -2656,7 +2657,7 @@ TEST_F(ModulesTest, AdaptiveLogSoftmaxWithLoss) {
     auto logprob_out = asfm->log_prob(x);
     NLLLoss nll_loss;
 
-    for (int64_t v = 0; v < 4; ++v) {
+    for (const auto v : c10::irange(4)) {
       auto y = torch::full({4}, v, torch::kLong);
       auto asm_out = asfm(x, y);
       auto out = asm_out.output;
@@ -2675,10 +2676,10 @@ TEST_F(ModulesTest, Softmax2d) {
   auto output = m(input);
   auto sum = torch::sum(torch::exp(input), 1);
 
-  for (int i = 0; i < 1; i++) {
-    for (int j = 0; j < 2; j++) {
-      for (int k = 0; k < 3; k++) {
-        for (int l = 0; l < 4; l++) {
+  for (const auto i : c10::irange(1)) {
+    for (const auto j : c10::irange(2)) {
+      for (const auto k : c10::irange(3)) {
+        for (const auto l : c10::irange(4)) {
           auto expected = torch::exp(input[i][j][k][l]) / sum[i][k][l];
           ASSERT_TRUE(torch::allclose(output[i][j][k][l], expected));
         }
@@ -3389,8 +3390,8 @@ namespace detail {
     TORCH_INTERNAL_ASSERT(a.size(0) == b.size(0));
     TORCH_INTERNAL_ASSERT(a.size(1) == b.size(1));
     auto retval = torch::zeros({a.size(0), a.size(1), a.size(2), b.size(3)}, torch::kFloat32);
-    for (int i = 0; i < a.size(0); i++) {
-      for (int j = 0; j < a.size(1); j++) {
+    for (const auto i : c10::irange(a.size(0))) {
+      for (const auto j : c10::irange(a.size(1))) {
         retval[i][j] = torch::matmul(a[i][j], b[i][j]);
       }
     }
@@ -3399,9 +3400,9 @@ namespace detail {
 
   torch::Tensor _softmax(const torch::Tensor& x) {
     auto output = torch::zeros(x.sizes());
-    for (int i = 0; i < x.size(0); i++) {
-      for (int j = 0; j < x.size(1); j++) {
-        for (int k = 0; k < x.size(2); k++) {
+    for (const auto i : c10::irange(x.size(0))) {
+      for (const auto j : c10::irange(x.size(1))) {
+        for (const auto k : c10::irange(x.size(2))) {
           const auto& x_curr = x[i][j][k];
           const auto e_x = torch::exp(x_curr - torch::max(x_curr));
           output[i][j][k] = e_x / torch::sum(e_x);
@@ -3424,10 +3425,10 @@ namespace detail {
     const auto s1 = QKT.size(2);
     const auto s2 = QKT.size(3);
     if (unseen_mask.defined() || key_padding_mask.defined()) {
-      for (int i = 0; i < b1; i++) {
-        for (int j = 0; j < b2; j++) {
-          for (int m = 0; m < s1; m++) {
-            for (int n = 0; n < s2; n++) {
+      for (const auto i : c10::irange(b1)) {
+        for (const auto j : c10::irange(b2)) {
+          for (const auto m : c10::irange(s1)) {
+            for (const auto n : c10::irange(s2)) {
               if (unseen_mask.defined() && unseen_mask[m][n].item<double>() == 0) {
                 QKT[i][j][m][n] = -std::numeric_limits<double>::infinity();
               }
@@ -3475,7 +3476,8 @@ namespace detail {
     std::uniform_int_distribution<int> d_2_10(2, 10);
     std::uniform_int_distribution<int> d_3_10(3, 10);
     bool registration_checked = false;
-    for (int i = 0; i < 100; i++) {
+    for (const auto i : c10::irange(100)) {
+      (void)i; // Suppress unused variable warning
       const auto batch_sz = d_2_10(generator);
       const auto seq_len = d_2_10(generator);
       const auto d_head = d_3_10(generator);

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -40,7 +41,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   auto compare_scaling =
       [&](const std::vector<torch::Tensor>& grads) -> torch::Tensor {
     std::vector<torch::Tensor> p_scale;
-    for (int i = 0; i < grads.size(); i++) {
+    for (const auto i : c10::irange(grads.size())) {
       auto param = l->parameters()[i];
       auto grad = grads[i];
       p_scale.push_back(param.grad().data().div(grad).view(-1));
@@ -61,7 +62,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
       std::numeric_limits<float>::infinity(),
   };
   for (auto norm_type : norm_types) {
-    for (int i = 0; i < grads.size(); i++) {
+    for (const auto i : c10::irange(grads.size())) {
       l->parameters()[i].mutable_grad() =
           grads[i].clone().view_as(l->parameters()[i].data());
     }
@@ -80,7 +81,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
       torch::ones(10).div(500),
   };
   for (auto norm_type : norm_types) {
-    for (int i = 0; i < grads.size(); i++) {
+    for (const auto i : c10::irange(grads.size())) {
       l->parameters()[i].grad().data().copy_(grads[i]);
     }
     auto norm_before = compute_norm(norm_type);
@@ -227,7 +228,7 @@ TEST_F(NNUtilsTest, ClipGradNormErrorIfNonfinite) {
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
       EXPECT_THROW(utils::clip_grad_norm_(parameters, 1., norm_type, true), std::exception) << msg;
       // Grads should not change if error is thrown
-      for (int64_t p_idx = 0; p_idx < parameters.size(); p_idx++) {
+      for (const auto p_idx : c10::irange(parameters.size())) {
         ASSERT_TRUE(torch::allclose(parameters[p_idx].grad(), grads_before[p_idx], 1.0, 0.0, /*equal_nan*/ true)) << msg;
       }
     } else {
@@ -285,7 +286,7 @@ TEST_F(NNUtilsTest, ClipGradValue) {
   std::vector<std::vector<torch::Tensor>> grad_lists = {
       {grad_w, grad_b}, {grad_w, torch::Tensor()}};
   for (auto grad_list : grad_lists) {
-    for (int i = 0; i < grad_list.size(); i++) {
+    for (const auto i : c10::irange(grad_list.size())) {
       auto p = l->parameters()[i];
       auto g = grad_list[i];
       p.mutable_grad() = g.defined() ? g.clone().view_as(p.data()) : g;
@@ -335,7 +336,7 @@ TEST_F(NNUtilsTest, ConvertParameters) {
   };
 
   utils::vector_to_parameters(vector, zero_parameters);
-  for (int i = 0; i < zero_parameters.size(); ++i) {
+  for (const auto i : c10::irange(zero_parameters.size())) {
     ASSERT_TRUE(zero_parameters[i].allclose(parameters[i]));
   }
 
@@ -368,7 +369,8 @@ int64_t PackedSequenceTest_max_length = 6;
 std::vector<torch::Tensor> PackedSequenceTest_ordered_sequence(torch::ScalarType tensor_type) {
   std::vector<torch::Tensor> seqs;
   seqs.reserve(PackedSequenceTest_batch_size);
-  for (int64_t i = 0; i < PackedSequenceTest_batch_size; i++) {
+  for (const auto i : c10::irange(PackedSequenceTest_batch_size)) {
+    (void)i; // Suppress unused variable warning
     seqs.emplace_back(torch::empty({
       torch::randint(1, PackedSequenceTest_max_length, {1}).item<int64_t>()
     }, tensor_type));
@@ -390,7 +392,7 @@ std::tuple<torch::Tensor, torch::Tensor> PackedSequenceTest_padded_sequence(torc
   // Create Tensor of random padded sequences
   auto ordered = PackedSequenceTest_ordered_sequence(tensor_type);
   auto lengths = torch::empty({(int64_t)ordered.size()}, torch::kInt64);
-  for (int64_t i = 0; i < ordered.size(); i++) {
+  for (const auto i : c10::irange(ordered.size())) {
     lengths[i] = ordered[i].size(0);
   }
   auto padded_tensor = rnn_utils::pad_sequence(ordered);
@@ -619,9 +621,9 @@ TEST_F(NNUtilsTest, PackPaddedSequence) {
     }
     auto padded = torch::cat(tensors_to_be_cat, 1);
     std::vector<torch::Tensor> expected_data_vec;
-    for (int64_t n = 0; n < batch_sizes.size(0); n++) {
+    for (const auto n : c10::irange(batch_sizes.size(0))) {
       int64_t batch_size = batch_sizes[n].item<int64_t>();
-      for (int64_t i = 0; i < batch_size; i++) {
+      for (const auto i : c10::irange(batch_size)) {
         expected_data_vec.emplace_back(torch::arange(1., 6) + (i + 1) * 100 + 5 * n);
       }
     }
@@ -631,7 +633,7 @@ TEST_F(NNUtilsTest, PackPaddedSequence) {
     if (should_shuffle) {
       // Shuffle the padded sequence to create an unsorted sequence
       std::vector<int64_t> permutation;
-      for (int64_t i = 0; i < sorted_lengths.size(); i++) {
+      for (const auto i : c10::irange(sorted_lengths.size())) {
         permutation.emplace_back(i);
       }
       std::shuffle(
@@ -702,7 +704,7 @@ TEST_F(NNUtilsTest, PackPaddedSequence) {
       if (batch_first) {
         grad_output.transpose_(0, 1);
       }
-      for (int64_t i = 0; i < lengths.size(0); i++) {
+      for (const auto i : c10::irange(lengths.size(0))) {
         int64_t l = lengths[i].item<int64_t>();
         ASSERT_TRUE(torch::allclose(
           padded.grad().narrow(0, 0, l).select(1, i),


### PR DESCRIPTION
Summary:
Modified loops in files under fbsource/fbcode/caffe2/ from the format
```
for(TYPE var=x0;var<x_max;x++)
```
to the format
```
for(const auto var: irange(xmax))
```

This was achieved by running r-barnes's loop upgrader script (D28874212) with some modification to exclude all files under /torch/jit and a number of reversions or unused variable suppression warnings added by hand.

Test Plan: Sandcastle

Differential Revision: D32837991

