### PR TITLE
Use non-blocking copy for creation of lazy tensors in TS backend impl

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
@@ -69,7 +69,8 @@ class TSBackendImpl : public torch::lazy::BackendImplInterface {
       const at::Tensor& tensor, const torch::lazy::Shape& shape,
       const torch::lazy::BackendDevice& device) const override {
     at::TensorOptions options = tensor.options().device(default_device_type_.c10Type());
-    if (tensor.device().type() == default_device_type_.c10Type()) {
+    if (tensor.device().type() == default_device_type_.c10Type() &&
+        default_device_type_.c10Type() == at::kCUDA) {
       return std::make_shared<TSData>(tensor.to(options, /*non_blocking=*/true), shape, device);
     } else if (tensor.device().type() == at::kCPU && tensor.numel() == 1) {
       // calling .item() on singleton cpu tensor is fast, and using fill is a safe,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
@@ -75,7 +75,7 @@ class TSBackendImpl : public torch::lazy::BackendImplInterface {
     } else if (tensor.device().type() == at::kCPU && tensor.numel() == 1) {
       // calling .item() on singleton cpu tensor is fast, and using fill is a safe,
       // async way to copy cpu to cuda for a single value
-      auto device_tensor = at::full({}, tensor.item(), options);
+      auto device_tensor = at::full(tensor.sizes(), tensor.item(), options);
       return std::make_shared<TSData>(device_tensor, shape, device);
     } else {
       return std::make_shared<TSData>(tensor.to(options, /*non_blocking=*/false), shape, device);


### PR DESCRIPTION
- blocking here makes cpu tracing thread wait for the transfer and cuda
  sync, before continuing on to trace more stuff.  we want to overlap
  cpu tracing with doing the copy in the background
- blocking is not required if the tensor is already on the cuda device,
  but it is if the tensor is on the cpu device since the cpu thread
  could modify the tensor while it is being copied asynchronously.
- we make an exception for numel()=1 tensors since (presumably?) they
  get copied as a stack variable safely, but maybe this is not true.