### PR TITLE
[fx2trt] Use weights shape as normalize shape in layer norm

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -370,10 +370,9 @@ def acc_ops_layer_norm(network, target, args, kwargs, name):
     gamma = to_numpy(kwargs["weight"].reshape(*shape))
     beta = to_numpy(kwargs["bias"].reshape(*shape))
     eps = kwargs["eps"]
-    normalized_shape = kwargs["normalized_shape"]
 
     axes = 0
-    for d in range(len(normalized_shape)):
+    for d in range(len(shape)):
         axes |= 1 << (len(input_val.shape) - d - 1)
 
     # E[x]


### PR DESCRIPTION
Summary: As the title. In PyTorch, these two shapes are the same. Normalize shape might be retrieved from tensor.size and in explicit batch dim, it won't work right now.

Test Plan: CI

Differential Revision: D32853359

