### PR TITLE
Improve efficiency of shape hash by not using tostring

### DIFF
--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -41,5 +41,9 @@ size_t Shape::numel() const {
   return elts;
 }
 
+hash_t Shape::hash() const {
+  return HashCombine(Hash(scalar_type_), DataHash(sizes_.data(), sizes_.size() * sizeof(int64_t)));
+}
+
 }  // namespace lazy
 }  // namespace torch

--- a/torch/csrc/lazy/core/shape.h
+++ b/torch/csrc/lazy/core/shape.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <c10/core/Scalar.h>
+#include <torch/csrc/lazy/core/hash.h>
 
 namespace torch {
 namespace lazy {
@@ -24,6 +25,7 @@ class TORCH_API Shape {
   int64_t size(int64_t dim) const { return sizes_.at(dim); }
   void set_size(int64_t dim, int64_t size) { sizes_.at(dim) = size; }
   size_t numel() const;
+  hash_t hash() const;
 
   bool operator==(const Shape& other) const;
 

--- a/torch/csrc/lazy/ts_backend/ts_node.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node.cpp
@@ -121,7 +121,7 @@ std::string TsNode::ToString() const {
 }
 
 hash_t TsNode::GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed) {
-  hash_t h = HashCombine(op.hash(), Hash(shape.to_string()));
+  hash_t h = HashCombine(op.hash(), shape.hash());
   return HashCombine(h, hash_seed);
 }
 


### PR DESCRIPTION
@Krovatkin should we also switch from hashing over the whole shape vector to just hashing over .dim()? or do we need to keep shape-specializing for now until we flesh out the dynamic mode.