### PR TITLE
[fx2trt] Add a helper function to generate specs for dynamic batch size

### DIFF
--- a/test/fx2trt/core/test_input_tensor_spec.py
+++ b/test/fx2trt/core/test_input_tensor_spec.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+import unittest
+
+import torch
+from torch.fx.experimental.fx2trt.fx2trt import (
+    InputTensorSpec,
+)
+
+
+class TestTRTModule(unittest.TestCase):
+    def _validate_spec(
+        self,
+        spec: InputTensorSpec,
+        tensor: torch.Tensor,
+        dynamic_dims: Optional[List[int]] = None
+    ):
+        expected_shape = list(tensor.shape)
+        if dynamic_dims:
+            for dim in dynamic_dims:
+                expected_shape[dim] = -1
+        self.assertSequenceEqual(spec.shape, expected_shape)
+        self.assertEqual(spec.dtype, tensor.dtype)
+        self.assertEqual(spec.device, tensor.device)
+        self.assertTrue(spec.has_batch_dim)
+
+    def test_from_tensor(self):
+        tensor = torch.randn(1, 2, 3)
+        spec = InputTensorSpec.from_tensor(tensor)
+        self._validate_spec(spec, tensor)
+
+    def test_from_tensors(self):
+        tensors = [torch.randn(1, 2, 3), torch.randn(2, 4)]
+        specs = InputTensorSpec.from_tensors(tensors)
+        for spec, tensor in zip(specs, tensors):
+            self._validate_spec(spec, tensor)
+
+    def test_from_tensors_with_dynamic_batch_size(self):
+        tensors = [torch.randn(1, 2, 3), torch.randn(1, 4)]
+        batch_size_range = [2, 3, 4]
+        specs = InputTensorSpec.from_tensors_with_dynamic_batch_size(tensors, batch_size_range)
+        for spec, tensor in zip(specs, tensors):
+            self._validate_spec(spec, tensor, dynamic_dims=[0])
+
+            for batch_size, shape in zip(batch_size_range, spec.shape_ranges[0]):
+                self.assertEqual(batch_size, shape[0])
+                self.assertSequenceEqual(tensor.shape[1:], shape[1:])

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -370,10 +370,9 @@ def acc_ops_layer_norm(network, target, args, kwargs, name):
     gamma = to_numpy(kwargs["weight"].reshape(*shape))
     beta = to_numpy(kwargs["bias"].reshape(*shape))
     eps = kwargs["eps"]
-    normalized_shape = kwargs["normalized_shape"]
 
     axes = 0
-    for d in range(len(normalized_shape)):
+    for d in range(len(shape)):
         axes |= 1 << (len(input_val.shape) - d - 1)
 
     # E[x]


### PR DESCRIPTION
Summary:
Add a helper function that will generate input tensor specs with dynamic batch size.

Note that the constraint currently on this function is that the batch dimension of all these tensors should be the first dimension.

Also add more doc strings.

Test Plan:
Added unit tests.
```
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/7881299413036896
    ✓ ListingSuccess: caffe2/test/fx2trt/core:test_input_tensor_spec - main (7.455)
    ✓ Pass: caffe2/test/fx2trt/core:test_input_tensor_spec - test_from_tensor (caffe2.test.fx2trt.core.test_input_tensor_spec.TestTRTModule) (7.047)
    ✓ Pass: caffe2/test/fx2trt/core:test_input_tensor_spec - test_from_tensors_with_dynamic_batch_size (caffe2.test.fx2trt.core.test_input_tensor_spec.TestTRTModule) (7.066)
    ✓ Pass: caffe2/test/fx2trt/core:test_input_tensor_spec - test_from_tensors (caffe2.test.fx2trt.core.test_input_tensor_spec.TestTRTModule) (7.181)
Summary
  Pass: 3
  ListingSuccess: 1
```

Wait for CI to verify if this unit test can run without RE.

Differential Revision: D32853947

