### PR TITLE
[LTC] Adopt the upstreamed c10::Device <=> BackendDevice helpers

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.cpp
@@ -17,18 +17,5 @@ c10::optional<torch::lazy::BackendDevice> GetBackendDevice() {
   return c10::nullopt;
 }
 
-// TODO(whc) refactor this: we need to support non-zero default ordinal for torch/XLA.
-torch::lazy::BackendDevice AtenDeviceToBackendDevice(const c10::Device& device) {
-  CHECK_EQ(device.type(), at::kLazy) << device;
-  int ordinal = device.has_index() ? device.index() : 0;
-  return torch::lazy::BackendDevice(
-      torch::lazy::getBackend()->GetDefaultDeviceType(), ordinal);
-}
-
-// TODO(whc) refactor this: we need to support non 1 on 1 mapping for torch/XLA.
-c10::Device BackendDeviceToAtenDevice(const torch::lazy::BackendDevice& device) {
-  return c10::Device(at::kLazy, device.ordinal());
-}
-
 }  // namespace bridge
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/aten_ltc_bridge.h
@@ -28,9 +28,5 @@ c10::optional<torch::lazy::BackendDevice> GetBackendDevice(const T& tensor, cons
     return GetBackendDevice(forward_tensors...);
 }
 
-torch::lazy::BackendDevice AtenDeviceToBackendDevice(const c10::Device& device);
-
-c10::Device BackendDeviceToAtenDevice(const torch::lazy::BackendDevice& device);
-
 }  // namespace bridge
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -47,14 +47,14 @@ c10::optional<torch::lazy::BackendDevice> GetOptionalDevice(const std::string& d
   if (device_str.empty()) {
     return c10::nullopt;
   }
-  return bridge::AtenDeviceToBackendDevice(c10::Device(device_str));
+  return torch::lazy::atenDeviceToBackendDevice(c10::Device(device_str));
 }
 
 torch::lazy::BackendDevice GetDeviceOrCurrent(const std::string& device_str) {
   if (device_str.empty()) {
     return torch::lazy::BackendDevice();
   }
-  return bridge::AtenDeviceToBackendDevice(c10::Device(device_str));
+  return torch::lazy::atenDeviceToBackendDevice(c10::Device(device_str));
 }
 
 void PrepareToExit() {
@@ -83,7 +83,7 @@ std::vector<std::string> GetLtcDeviceStrings(
   std::vector<std::string> ltc_devices;
   ltc_devices.reserve(devices.size());
   for (auto& device_str : devices) {
-    auto device = bridge::AtenDeviceToBackendDevice(c10::Device(device_str));
+    auto device = torch::lazy::atenDeviceToBackendDevice(c10::Device(device_str));
     ltc_devices.emplace_back(device.toString());
   }
   return ltc_devices;
@@ -94,7 +94,7 @@ std::vector<torch::lazy::BackendDevice> GetLtcDevices(const std::vector<std::str
   ltc_devices.reserve(devices.size());
   for (auto& device_str : devices) {
     ltc_devices.push_back(
-        bridge::AtenDeviceToBackendDevice(c10::Device(device_str)));
+        torch::lazy::atenDeviceToBackendDevice(c10::Device(device_str)));
   }
   return ltc_devices;
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
@@ -67,7 +67,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
     : c10::TensorImpl(c10::DispatchKeySet{c10::DispatchKey::Lazy,
                                           c10::DispatchKey::AutogradLazy},
                       c10::scalarTypeToTypeMeta(tensor.dtype()),
-                      bridge::BackendDeviceToAtenDevice(tensor.GetDevice())),
+                      torch::lazy::backendDeviceToAtenDevice(tensor.GetDevice())),
       tensor_(std::move(tensor)) {
   // This is a temporary fix for a PyTorch core issue,
   // according to https://github.com/pytorch/xla/pull/2682.

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -95,7 +95,7 @@ c10::optional<torch::lazy::BackendDevice> GetLtcDevice(const c10::optional<c10::
   if (device->type() != at::kLazy) {
     return c10::nullopt;
   }
-  return bridge::AtenDeviceToBackendDevice(*device);
+  return torch::lazy::atenDeviceToBackendDevice(*device);
 }
 
 }  // namespace

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -140,7 +140,7 @@ void ForEachDevice(const std::function<void(const torch::Device&)>& devfn) {
   // which is set by env. And the ordinal is always 0 given distributed training/
   // multi-device is not supported yet.
   auto device = torch::lazy::BackendDevice();
-  torch::Device torch_device = bridge::BackendDeviceToAtenDevice(device);
+  torch::Device torch_device = torch::lazy::backendDeviceToAtenDevice(device);
   devfn(torch_device);
 }
 


### PR DESCRIPTION
Summary:
This commit adopts the upstreamed c10::Device <=> BackendDevice helpers.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc