### PR TITLE
[Core ML] Avoid recompiling models when the OS version is not changed

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -529,6 +529,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     list(APPEND TORCH_SRCS ${DELEGATE_SRCS})
     if(IOS AND USE_COREML_DELEGATE)
       set(COREML_DELEGATE_SRCS
+        ${TORCH_SRC_DIR}/csrc/jit/backends/coreml/cpp/context.cpp
         ${TORCH_SRC_DIR}/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
         ${TORCH_SRC_DIR}/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
       )

--- a/torch/csrc/jit/backends/coreml/cpp/context.cpp
+++ b/torch/csrc/jit/backends/coreml/cpp/context.cpp
@@ -1,0 +1,29 @@
+#include <torch/csrc/jit/backends/coreml/cpp/context.h>
+#include <atomic>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+namespace coreml {
+
+std::atomic<ContextInterface*> g_coreml_ctx_registry;
+
+BackendRegistrar::BackendRegistrar(ContextInterface* ctx) {
+  g_coreml_ctx_registry.store(ctx);
+}
+
+bool isCoreMLAvailable() {
+  auto p = g_coreml_ctx_registry.load();
+  return p ? p->isCoreMLAvailable() : false;
+}
+void setModelCacheDirectory(std::string path) {
+  auto p = g_coreml_ctx_registry.load();
+  if (p) {
+    p->setModelCacheDirectory(path);
+  }
+}
+
+} // namespace coreml
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/backends/coreml/cpp/context.h
+++ b/torch/csrc/jit/backends/coreml/cpp/context.h
@@ -1,0 +1,31 @@
+#ifndef PTM_COREML_Context_h
+#define PTM_COREML_Context_h
+
+#include <atomic>
+#include <string>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+namespace coreml {
+
+struct ContextInterface {
+  virtual ~ContextInterface() = default;
+  virtual bool isCoreMLAvailable() const = 0;
+  virtual void setModelCacheDirectory(std::string path) = 0;
+};
+
+class BackendRegistrar {
+ public:
+  explicit BackendRegistrar(ContextInterface* ctx);
+};
+
+bool isCoremlAvailable();
+void setModelCacheDirectory(std::string path);
+
+} // namespace coreml
+} // namespace mobile
+} // namespace jit
+} // namespace torch
+
+#endif

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.h
@@ -19,11 +19,13 @@ API_AVAILABLE(ios(11.0), macos(10.13))
 API_AVAILABLE(ios(11.0), macos(10.13))
 @interface PTMCoreMLExecutor : NSObject
 
-@property(nonatomic, readonly, copy) NSString* modelPath;
-@property(nonatomic, readonly, copy) NSString* compiledModelPath;
 @property(nonatomic, copy) NSString* backend;
 @property(nonatomic, assign) BOOL allowLowPrecision;
 @property(nonatomic, assign) NSUInteger coreMLVersion;
+
++ (BOOL)isAvailable;
++ (void)setModelCacheDirectory:(NSString*)dir;
++ (NSString*)modelCacheDirectory;
 
 - (BOOL)compileMLModel:(const std::string&)modelSpecs
             identifier:(const std::string&)identifier;

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
@@ -3,6 +3,10 @@
 
 #import <CoreML/CoreML.h>
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #include <sys/utsname.h>
 #include <fstream>
 #include <iostream>
@@ -58,26 +62,77 @@
 
 @end
 
+static NSString* gModelCacheDirectory = @"";
+
 @implementation PTMCoreMLExecutor {
   MLModel* _mlModel;
+  NSURL* _modelPath;
+  NSURL* _compiledModelPath;
+}
+
++ (void)setModelCacheDirectory:(NSString*)dir {
+  gModelCacheDirectory = dir;
+}
+
++ (NSString*)modelCacheDirectory {
+  if (gModelCacheDirectory.length == 0 ||
+      ![[NSFileManager defaultManager]
+          isWritableFileAtPath:gModelCacheDirectory]) {
+    // set the default directory to tmp
+    gModelCacheDirectory = NSTemporaryDirectory();
+  }
+  return gModelCacheDirectory;
+}
+
++ (BOOL)isAvailable {
+#if !defined(__APPLE__)
+  return false;
+#elif TARGET_OS_IPHONE
+  if ([UIDevice currentDevice].systemVersion.floatValue > 14.0) {
+    return true;
+  }
+#elif TARGET_OS_MAC
+  NSOperatingSystemVersion supportedVer = {10, 13, 0};
+  if ([[NSProcessInfo processInfo]
+          isOperatingSystemAtLeastVersion:supportedVer]) {
+    return true;
+  }
+#endif
+  return false;
 }
 
 - (BOOL)compileMLModel:(const std::string&)modelSpecs
             identifier:(const std::string&)identifier
     API_AVAILABLE(ios(11.0), macos(10.13)) {
-  _modelPath = [self _save:modelSpecs
-                identifier:[NSString stringWithCString:identifier.c_str()
-                                              encoding:NSUTF8StringEncoding]];
+  NSString* mlModelName = [NSString stringWithCString:identifier.c_str()
+                                             encoding:NSUTF8StringEncoding];
+  _modelPath = [self _cacheFilePath:mlModelName];
+  [self _saveModel:modelSpecs];
   NSError* error = nil;
-  NSURL* compiledModelPath = nil;
-  if (@available(iOS 11.0, macOS 10.13, *)) {
-    compiledModelPath =
-        [MLModel compileModelAtURL:[NSURL URLWithString:_modelPath]
-                             error:&error];
-  } else {
-    TORCH_CHECK(false, "CoreML is not available on your deivce");
+  _compiledModelPath = [self _compiledModelFilePath:_modelPath.path];
+  // Compile the model when OS version changes
+  if ([self _shouldRecompileModel]) {
+    if (@available(iOS 11.0, macOS 10.13, *)) {
+      NSURL* temporaryFileURL = [MLModel compileModelAtURL:_modelPath
+                                                     error:&error];
+      if (!error) {
+        // move the model to the cache directory
+        NSFileManager* fileManager = [NSFileManager defaultManager];
+        if (![temporaryFileURL isEqual:_compiledModelPath]) {
+          if ([fileManager fileExistsAtPath:_compiledModelPath.path]) {
+            [fileManager removeItemAtURL:_compiledModelPath error:&error];
+          }
+          [fileManager moveItemAtURL:temporaryFileURL
+                               toURL:_compiledModelPath
+                               error:&error];
+        }
+      }
+    } else {
+      TORCH_CHECK(false, "CoreML is not available on your deivce");
+    }
   }
-  if (error || !compiledModelPath) {
+
+  if (error) {
     // remove cached models if compalition failed.
     [self cleanup];
     TORCH_CHECK(
@@ -96,11 +151,11 @@
     }
     config.computeUnits = backend;
     config.allowLowPrecisionAccumulationOnGPU = self.allowLowPrecision;
-    _mlModel = [MLModel modelWithContentsOfURL:compiledModelPath
+    _mlModel = [MLModel modelWithContentsOfURL:_compiledModelPath
                                  configuration:config
                                          error:&error];
   } else {
-    _mlModel = [MLModel modelWithContentsOfURL:compiledModelPath error:&error];
+    _mlModel = [MLModel modelWithContentsOfURL:_compiledModelPath error:&error];
   }
   if (error || !_mlModel) {
     TORCH_CHECK(
@@ -108,8 +163,6 @@
         "Error loading the MLModel",
         error.localizedDescription.UTF8String);
   }
-
-  _compiledModelPath = compiledModelPath.path;
   return YES;
 }
 
@@ -145,20 +198,19 @@
 - (BOOL)cleanup {
   NSFileManager* fileManager = [NSFileManager defaultManager];
   NSError* error = nil;
-  if (![fileManager fileExistsAtPath:_modelPath]) {
-    [fileManager removeItemAtPath:_modelPath error:&error];
+  NSString* modelPath = _modelPath.path;
+  NSString* compiledModelPath = _compiledModelPath.path;
+  if ([fileManager fileExistsAtPath:modelPath]) {
+    [fileManager removeItemAtPath:modelPath error:&error];
   }
-  if (![fileManager fileExistsAtPath:_compiledModelPath]) {
-    [fileManager removeItemAtPath:_compiledModelPath error:&error];
+  if ([fileManager fileExistsAtPath:compiledModelPath]) {
+    [fileManager removeItemAtPath:compiledModelPath error:&error];
   }
   return !error;
 }
 
-- (NSString*)_save:(const std::string&)spec identifier:(NSString*)identifier {
-  NSURL* temporaryDirectoryURL = [NSURL fileURLWithPath:NSTemporaryDirectory()
-                                            isDirectory:YES];
-  NSString* modelPath = [NSString
-      stringWithFormat:@"%@/%@", temporaryDirectoryURL.path, identifier];
+- (void)_saveModel:(const std::string&)spec {
+  NSString* modelPath = _modelPath.path;
   if (![[NSFileManager defaultManager] fileExistsAtPath:modelPath]) {
     // Note that the serialized protobuf binary contains bytes, not text;
     // see
@@ -167,7 +219,42 @@
     BOOL ret = [data writeToFile:modelPath atomically:YES];
     TORCH_CHECK(ret, "Error saving the MLModel", modelPath.UTF8String);
   }
-  return modelPath;
+}
+
+- (BOOL)_shouldRecompileModel {
+#if TARGET_OS_IPHONE
+  NSError* error = nil;
+  NSString* currentOSVer = [UIDevice currentDevice].systemVersion;
+  NSString* versionPath = [self _cacheFilePath:@"version"].path;
+  BOOL shouldRecompileModel = YES;
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  if ([fileManager fileExistsAtPath:versionPath]) {
+    NSString* cachedOSVer =
+        [NSString stringWithContentsOfFile:versionPath
+                                  encoding:NSUTF8StringEncoding
+                                     error:&error];
+    if ([cachedOSVer isEqualToString:currentOSVer]) {
+      if ([fileManager fileExistsAtPath:_compiledModelPath.path]) {
+        shouldRecompileModel = NO;
+      }
+    }
+  }
+  [currentOSVer writeToFile:versionPath atomically:YES];
+  return shouldRecompileModel;
+#else
+  return YES;
+#endif
+}
+
+- (NSURL*)_cacheFilePath:(NSString*)fileName {
+  NSString* filePath = [[[self class] modelCacheDirectory]
+      stringByAppendingPathComponent:fileName];
+  return [NSURL fileURLWithPath:filePath];
+}
+
+- (NSURL*)_compiledModelFilePath:(NSString*)modelPath {
+  NSString* filePath = [modelPath stringByAppendingString:@".mlmodelc"];
+  return [NSURL fileURLWithPath:filePath];
 }
 
 @end


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69438

We don't need to recompile the model if the OS version is not changed. This could save hundreds of ms when loading the model.

{F683788183}

Differential Revision: [D32866326](https://our.internmc.facebook.com/intern/diff/D32866326/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D32866326/)!