### PR TITLE
Skips failing ROCm test

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -562,6 +562,7 @@ class TestBinaryUfuncs(TestCase):
     # NOTE: because the cross-product of all possible type promotion tests is huge, this
     #   just spot checks some handwritten cases.
     # NOTE: It may be possible to refactor this test into something simpler
+    @skipCUDAIfRocm
     @ops(binary_ufuncs, dtypes=OpDTypes.none)
     def test_type_promotion(self, device, op):
         supported_dtypes = op.supported_dtypes(torch.device(device).type)


### PR DESCRIPTION
ROCm and CUDA type promotion are slightly divergent and need to be updated.

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH