### PR TITLE
[fx2trt] Add type hints to converters and separate main files

### DIFF
--- a/test/fx2trt/core/test_input_tensor_spec.py
+++ b/test/fx2trt/core/test_input_tensor_spec.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 import unittest
 
 import torch
-from torch.fx.experimental.fx2trt.fx2trt import (
+from torch.fx.experimental.fx2trt import (
     InputTensorSpec,
 )
 

--- a/test/fx2trt/core/test_input_tensor_spec.py
+++ b/test/fx2trt/core/test_input_tensor_spec.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+import unittest
+
+import torch
+from torch.fx.experimental.fx2trt.fx2trt import (
+    InputTensorSpec,
+)
+
+
+class TestTRTModule(unittest.TestCase):
+    def _validate_spec(
+        self,
+        spec: InputTensorSpec,
+        tensor: torch.Tensor,
+        dynamic_dims: Optional[List[int]] = None
+    ):
+        expected_shape = list(tensor.shape)
+        if dynamic_dims:
+            for dim in dynamic_dims:
+                expected_shape[dim] = -1
+        self.assertSequenceEqual(spec.shape, expected_shape)
+        self.assertEqual(spec.dtype, tensor.dtype)
+        self.assertEqual(spec.device, tensor.device)
+        self.assertTrue(spec.has_batch_dim)
+
+    def test_from_tensor(self):
+        tensor = torch.randn(1, 2, 3)
+        spec = InputTensorSpec.from_tensor(tensor)
+        self._validate_spec(spec, tensor)
+
+    def test_from_tensors(self):
+        tensors = [torch.randn(1, 2, 3), torch.randn(2, 4)]
+        specs = InputTensorSpec.from_tensors(tensors)
+        for spec, tensor in zip(specs, tensors):
+            self._validate_spec(spec, tensor)
+
+    def test_from_tensors_with_dynamic_batch_size(self):
+        tensors = [torch.randn(1, 2, 3), torch.randn(1, 4)]
+        batch_size_range = [2, 3, 4]
+        specs = InputTensorSpec.from_tensors_with_dynamic_batch_size(tensors, batch_size_range)
+        for spec, tensor in zip(specs, tensors):
+            self._validate_spec(spec, tensor, dynamic_dims=[0])
+
+            for batch_size, shape in zip(batch_size_range, spec.shape_ranges[0]):
+                self.assertEqual(batch_size, shape[0])
+                self.assertSequenceEqual(tensor.shape[1:], shape[1:])

--- a/test/fx2trt/core/test_trt_module.py
+++ b/test/fx2trt/core/test_trt_module.py
@@ -3,7 +3,7 @@ import unittest
 import torch
 import torch.fx
 import torch.fx.experimental.fx_acc.acc_tracer as acc_tracer
-from torch.fx.experimental.fx2trt.fx2trt import (
+from torch.fx.experimental.fx2trt import (
     TRTInterpreter,
     InputTensorSpec,
     TRTModule,

--- a/test/fx2trt/test_quant_trt.py
+++ b/test/fx2trt/test_quant_trt.py
@@ -2,7 +2,7 @@
 
 import torch
 import torch.fx.experimental.fx_acc.acc_tracer as acc_tracer
-from torch.fx.experimental.fx2trt.fx2trt import (
+from torch.fx.experimental.fx2trt import (
     TRTInterpreter,
     InputTensorSpec,
     TRTModule,

--- a/torch/fx/experimental/fx2trt/__init__.py
+++ b/torch/fx/experimental/fx2trt/__init__.py
@@ -1,4 +1,10 @@
-import tensorrt as trt
-
-if hasattr(trt, "__version__"):
-    from .converters import *  # noqa: F403
+from .converters import *  # noqa: F403
+from .converter_registry import (
+    CONVERTERS,
+    NO_EXPLICIT_BATCH_DIM_SUPPORT,
+    NO_IMPLICIT_BATCH_DIM_SUPPORT,
+    tensorrt_converter,
+)
+from .fx2trt import TRTInterpreter, TRTInterpreterResult
+from .input_tensor_spec import InputTensorSpec
+from .trt_module import TRTModule

--- a/torch/fx/experimental/fx2trt/converter_registry.py
+++ b/torch/fx/experimental/fx2trt/converter_registry.py
@@ -1,0 +1,31 @@
+from typing import Callable, Dict, Any
+
+from torch.fx.node import Target
+
+
+CONVERTERS: Dict[Target, Any] = {}
+NO_IMPLICIT_BATCH_DIM_SUPPORT = {}
+NO_EXPLICIT_BATCH_DIM_SUPPORT = {}
+
+
+def tensorrt_converter(
+    key: Target,
+    no_implicit_batch_dim: bool = False,
+    no_explicit_batch_dim: bool = False,
+    enabled: bool = True
+) -> Callable[[Any], Any]:
+    def register_converter(converter):
+        CONVERTERS[key] = converter
+        if no_implicit_batch_dim:
+            NO_IMPLICIT_BATCH_DIM_SUPPORT[key] = converter
+        if no_explicit_batch_dim:
+            NO_EXPLICIT_BATCH_DIM_SUPPORT[key] = converter
+        return converter
+
+    def disable_converter(converter):
+        return converter
+
+    if enabled:
+        return register_converter
+    else:
+        return disable_converter

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -370,10 +370,9 @@ def acc_ops_layer_norm(network, target, args, kwargs, name):
     gamma = to_numpy(kwargs["weight"].reshape(*shape))
     beta = to_numpy(kwargs["bias"].reshape(*shape))
     eps = kwargs["eps"]
-    normalized_shape = kwargs["normalized_shape"]
 
     axes = 0
-    for d in range(len(normalized_shape)):
+    for d in range(len(shape)):
         axes |= 1 << (len(input_val.shape) - d - 1)
 
     # E[x]

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1,18 +1,21 @@
 import math
 import operator
 import warnings
+from typing import Dict, Tuple, Sequence, cast, Optional, Union
 
 import numpy as np
 import tensorrt as trt
 import torch
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
 import torch.fx.experimental.fx_acc.acc_utils as acc_utils
-from torch.fx.experimental.fx2trt.fx2trt import (
-    tensorrt_converter,
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
+from torch.fx.experimental.fx2trt.types import *  # noqa: F403
+from torch.fx.experimental.fx2trt.utils import (
     torch_dtype_from_trt,
     get_dynamic_dims,
 )
 from torch.fx.immutable_collections import immutable_list
+from torch.fx.node import Target, Argument
 
 from .converter_utils import (
     get_trt_plugin,
@@ -33,10 +36,16 @@ from .converter_utils import (
 
 
 @tensorrt_converter(acc_ops.conv2d)
-def acc_ops_conv2d(network, target, args, kwargs, name):
+def acc_ops_conv2d(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"Conv2d received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -48,11 +57,15 @@ def acc_ops_conv2d(network, target, args, kwargs, name):
     # for now we'll assume bias is constant Tensor or None,
     # and bias being ITensor is not supported in TensorRT api
     # right now
-    bias = to_numpy(kwargs["bias"])
+    if kwargs["bias"] is not None and not isinstance(kwargs["bias"], torch.Tensor):
+        raise RuntimeError(
+            f"linear {name} has bias of type {type(kwargs['bias'])}, Expect Optional[Tenosr]"
+        )
+    bias = to_numpy(kwargs["bias"])  # type: ignore[arg-type]
 
     if network.has_explicit_precision:
         weight = get_trt_tensor(network, kwargs["weight"], f"{name}_weight")
-        weight_shape = tuple(kwargs["weight"].shape)
+        weight_shape = tuple(kwargs["weight"].shape)  # type: ignore[union-attr]
         # will need to use uninitialized weight and set it later to support
         # ITensor weights
         dummy_weight = trt.Weights()
@@ -67,6 +80,10 @@ def acc_ops_conv2d(network, target, args, kwargs, name):
 
         layer.set_input(1, weight)
     else:
+        if not isinstance(kwargs["weight"], torch.Tensor):
+            raise RuntimeError(
+                f"linear {name} has weight of type {type(kwargs['weight'])}, Expect Optional[Tenosr]"
+            )
         weight = to_numpy(kwargs["weight"])
         layer = network.add_convolution(
             input=input_val,
@@ -87,14 +104,20 @@ def acc_ops_conv2d(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.pad, enabled=trt.__version__ < "8.2")
-def acc_ops_pad_with_padding_layer(network, target, args, kwargs, name):
+def acc_ops_pad_with_padding_layer(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    pad = kwargs["pad"]
+    pad = cast(Sequence[int], kwargs["pad"])
     mode = kwargs["mode"]
     value = kwargs["value"]
-    rank = len(input_val.shape)
+    rank = len(input_val.shape)  # type: ignore[union-attr]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"pad received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -131,14 +154,20 @@ def acc_ops_pad_with_padding_layer(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.pad, enabled=trt.__version__ >= "8.2")
-def acc_ops_pad_with_slice_layer(network, target, args, kwargs, name):
+def acc_ops_pad_with_slice_layer(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    pad = kwargs["pad"]
+    pad = cast(Sequence[int], kwargs["pad"])
     mode = kwargs["mode"]
     value = kwargs["value"]
-    rank = len(input_val.shape)
+    rank = len(input_val.shape)  # type: ignore[union-attr]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"pad received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -173,7 +202,7 @@ def acc_ops_pad_with_slice_layer(network, target, args, kwargs, name):
         pre_stride,
     )
     layer.mode = trt.SliceMode.FILL
-    set_layer_name(layer, target, f"pre-{name}")
+    set_layer_name(layer, target, f"pre_{name}")
     half_pad_output = layer.get_output(0)
 
     shape = half_pad_output.shape
@@ -186,12 +215,14 @@ def acc_ops_pad_with_slice_layer(network, target, args, kwargs, name):
         mid_stride
     )
     layer.mode = trt.SliceMode.FILL
-    set_layer_name(layer, target, f"transpose-{name}")
+    set_layer_name(layer, target, f"transpose_{name}")
     transpose_output = layer.get_output(0)
 
     shape = transpose_output.shape
     post_start = tuple([0] * len(shape))
-    post_shape = tuple(shape[i] + (pad[-(i - prefix_len) * 2 - 1] if i >= prefix_len else 0) for i in range(0, len(shape)))
+    post_shape = tuple(
+        shape[i] + (pad[-(i - prefix_len) * 2 - 1] if i >= prefix_len else 0) for i in range(0, len(shape))
+    )
     post_stride = tuple([1] * len(shape))
 
     layer = network.add_slice(
@@ -201,23 +232,29 @@ def acc_ops_pad_with_slice_layer(network, target, args, kwargs, name):
         post_stride
     )
     layer.mode = trt.SliceMode.FILL
-    set_layer_name(layer, target, f"post-{name}")
+    set_layer_name(layer, target, f"post_{name}")
     return layer.get_output(0)
 
 
 @tensorrt_converter(acc_ops.flatten)
-def acc_ops_flatten(network, target, args, kwargs, name):
+def acc_ops_flatten(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"flatten received input {input_val} that is not part "
             "of the TensorRT region!"
         )
 
     num_dims = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
-    start_dim = get_positive_dim(kwargs["start_dim"] if "start_dim" in kwargs else 0, num_dims)
-    end_dim = get_positive_dim(kwargs["end_dim"] if "end_dim" in kwargs else -1, num_dims)
+    start_dim = get_positive_dim(cast(int, kwargs["start_dim"] if "start_dim" in kwargs else 0), num_dims)
+    end_dim = get_positive_dim(cast(int, kwargs["end_dim"] if "end_dim" in kwargs else -1), num_dims)
 
     if network.has_implicit_batch_dimension:
         assert start_dim != 0, "Can't flatten batch dimension when it's implicit."
@@ -311,10 +348,16 @@ IMPLICIT_BATCH_DIM = -999
 
 
 @tensorrt_converter(acc_ops.size)
-def acc_ops_size(network, target, args, kwargs, name):
+def acc_ops_size(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"size received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -331,10 +374,16 @@ def acc_ops_size(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.batch_norm)
-def acc_ops_batch_norm(network, target, args, kwargs, name):
+def acc_ops_batch_norm(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"BatchNorm2d received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -343,12 +392,13 @@ def acc_ops_batch_norm(network, target, args, kwargs, name):
     if has_dynamic_shape(input_val.shape):
         assert input_val.shape[1] != -1, "Channel dim can't be dynamic for batch norm."
 
-    scale = to_numpy(kwargs["weight"]) / np.sqrt(
-        to_numpy(kwargs["running_var"]) + kwargs["eps"]
+    scale = cast(torch.Tensor, to_numpy(cast(torch.Tensor, kwargs["weight"]))) / np.sqrt(
+        cast(torch.Tensor, to_numpy(cast(torch.Tensor, kwargs["running_var"]))) + cast(float, kwargs["eps"])
     )
+
     bias = (
-        to_numpy(kwargs["bias"])
-        - to_numpy(kwargs["running_mean"]) * scale
+        to_numpy(cast(torch.Tensor, kwargs["bias"]))
+        - to_numpy(cast(torch.Tensor, kwargs["running_mean"])) * scale
     )
     power = np.ones_like(scale)
 
@@ -358,17 +408,23 @@ def acc_ops_batch_norm(network, target, args, kwargs, name):
     return layer.get_output(0)
 
 @tensorrt_converter(acc_ops.layer_norm)
-def acc_ops_layer_norm(network, target, args, kwargs, name):
+def acc_ops_layer_norm(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"LayerNorm received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    shape = kwargs["weight"].shape
+    shape = kwargs["weight"].shape  # type: ignore[union-attr]
     broadcasted_shape = (1,) * (len(input_val.shape) - len(shape)) + shape
-    gamma = to_numpy(kwargs["weight"].reshape(*shape))
-    beta = to_numpy(kwargs["bias"].reshape(*shape))
+    gamma = to_numpy(kwargs["weight"].reshape(*shape))  # type: ignore[union-attr]
+    beta = to_numpy(kwargs["bias"].reshape(*shape))  # type: ignore[union-attr]
     eps = kwargs["eps"]
 
     axes = 0
@@ -422,27 +478,34 @@ def acc_ops_layer_norm(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.softmax)
-def acc_ops_softmax(network, target, args, kwargs, name):
+def acc_ops_softmax(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    dim = kwargs["dim"]
-    input_ranks = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
+    input_ranks = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)  # type: ignore[union-attr]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"softmax received input {input_val} that is not part "
             "of the TensorRT region!"
         )
 
     # Used to get dim when dim is None. Copied from PyTorch softmax implementation.
-    def get_softmax_dim(ndim):
+    def get_softmax_dim(ndim: int) -> int:
         if ndim == 0 or ndim == 1 or ndim == 3:
             ret = 0
         else:
             ret = 1
         return ret
 
-    if dim is None:
+    if kwargs["dim"] is None:
         dim = get_softmax_dim(input_ranks)
+    else:
+        dim = cast(int, kwargs["dim"])
 
     dim = get_positive_dim(dim, input_ranks)
     if network.has_implicit_batch_dimension:
@@ -456,16 +519,22 @@ def acc_ops_softmax(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.tile)
-def acc_ops_tile(network, target, args, kwargs, name):
+def acc_ops_tile(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"tile received input {input_val} that is not part "
             "of the TensorRT region!"
         )
 
-    dims = kwargs["dims"]
+    dims = tuple(cast(Sequence[int], kwargs["dims"]))
     n_input_dims = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
 
     if len(dims) > n_input_dims:
@@ -495,17 +564,17 @@ def acc_ops_tile(network, target, args, kwargs, name):
         dims = dims[1:]
 
     starts = [0] * len(dims)
-    shapes = [i * j for i, j in zip(input_val.shape, dims)]
+    shapes = [i * j for i, j in zip(input_val.shape, dims)]  # type: ignore[union-attr]
     # If there's dynmaic dim then there would be negative dims in shapes which is not allowed.
     # Here we build a dummy shapes array.
-    if has_dynamic_shape(input_val.shape):
+    if has_dynamic_shape(input_val.shape):  # type: ignore[union-attr]
         shapes = [1] * len(dims)
     strides = [1] * len(dims)
     layer = network.add_slice(input_val, starts, shapes, strides)
     layer.mode = trt.SliceMode.WRAP
     set_layer_name(layer, target, name)
 
-    if has_dynamic_shape(input_val.shape):
+    if has_dynamic_shape(input_val.shape):  # type: ignore[union-attr]
         starts_tensor = network.add_constant(
             (len(dims),), np.ascontiguousarray([0] * len(dims), np.int32)
         ).get_output(0)
@@ -528,135 +597,249 @@ def acc_ops_tile(network, target, args, kwargs, name):
     return layer.get_output(0)
 
 @tensorrt_converter(acc_ops.relu)
-def acc_ops_relu(network, target, args, kwargs, name):
+def acc_ops_relu(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.ActivationType.RELU
     return add_activation_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.sin)
-def acc_ops_sin(network, target, args, kwargs, name):
+def acc_ops_sin(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.SIN
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.cos)
-def acc_ops_cos(network, target, args, kwargs, name):
+def acc_ops_cos(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.COS
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.tan)
-def acc_ops_tan(network, target, args, kwargs, name):
+def acc_ops_tan(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.TAN
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.sinh)
-def acc_ops_sinh(network, target, args, kwargs, name):
+def acc_ops_sinh(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.SINH
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.cosh)
-def acc_ops_cosh(network, target, args, kwargs, name):
+def acc_ops_cosh(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.COSH
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.tanh)
-def acc_ops_tanh(network, target, args, kwargs, name):
+def acc_ops_tanh(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.ActivationType.TANH
     return add_activation_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.asin)
-def acc_ops_asin(network, target, args, kwargs, name):
+def acc_ops_asin(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.ASIN
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.acos)
-def acc_ops_acos(network, target, args, kwargs, name):
+def acc_ops_acos(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.ACOS
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.atan)
-def acc_ops_atan(network, target, args, kwargs, name):
+def acc_ops_atan(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.ATAN
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.exp)
-def acc_ops_exp(network, target, args, kwargs, name):
+def acc_ops_exp(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.EXP
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.log)
-def acc_ops_log(network, target, args, kwargs, name):
+def acc_ops_log(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.LOG
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.sqrt)
-def acc_ops_sqrt(network, target, args, kwargs, name):
+def acc_ops_sqrt(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.SQRT
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.reciprocal)
-def acc_ops_reciprocal(network, target, args, kwargs, name):
+def acc_ops_reciprocal(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.RECIP
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.abs)
-def acc_ops_abs(network, target, args, kwargs, name):
+def acc_ops_abs(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.ABS
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.neg)
-def acc_ops_neg(network, target, args, kwargs, name):
+def acc_ops_neg(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.NEG
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.floor)
-def acc_ops_floor(network, target, args, kwargs, name):
+def acc_ops_floor(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.FLOOR
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.ceil)
-def acc_ops_ceil(network, target, args, kwargs, name):
+def acc_ops_ceil(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     operation_type = trt.UnaryOperation.CEIL
     return add_unary_layer(network, input_val, operation_type, target, name)
 
 
 @tensorrt_converter(acc_ops.sum)
-def acc_ops_sum(network, target, args, kwargs, name):
+def acc_ops_sum(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"sum received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -671,7 +854,7 @@ def acc_ops_sum(network, target, args, kwargs, name):
         ), "Do not support sum all the elements for implicit batch."
         dim = range(0, len(input_val.shape))
     else:
-        dim = kwargs["dim"]
+        dim = kwargs["dim"]  # type: ignore[assignment]
 
     keepdim = False if "keepdim" not in kwargs else kwargs["keepdim"]
     layer = network.add_reduce(
@@ -686,7 +869,7 @@ def acc_ops_sum(network, target, args, kwargs, name):
 
 def add_acc_ops_full_reduce(network, target, args, kwargs, name, reduce_op):
     input_val = kwargs["input"]
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"max received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -717,13 +900,13 @@ def add_acc_ops_dim_reduce(network, target, args, kwargs, name, reduce_op):
         new_kwargs['largest'] = False
     new_kwargs['sorted'] = False
 
-    (topk_out0, topk_out1) = acc_ops_topk(network, target, args, new_kwargs, name + "_topk")
+    topk_out0, topk_out1 = acc_ops_topk(network, target, args, new_kwargs, name + "_topk")
 
     topk_out0.name = f"{name}_topk0"
     topk_out1.name = f"{name}_topk1"
 
     if 'keepdim' in new_kwargs and new_kwargs['keepdim']:
-        return (topk_out0, topk_out1)
+        return topk_out0, topk_out1
 
     dim = new_kwargs['dim']
     if network.has_implicit_batch_dimension:
@@ -750,48 +933,90 @@ def add_acc_ops_dim_reduce(network, target, args, kwargs, name, reduce_op):
     shuffle_layer1.reshape_dims = tuple(output_shape)
     set_layer_name(shuffle_layer1, target, f"{name}_shuffle1")
 
-    return (shuffle_layer0.get_output(0), shuffle_layer1.get_output(0))
+    return shuffle_layer0.get_output(0), shuffle_layer1.get_output(0)
 
 
 @tensorrt_converter(acc_ops.max_full_reduce, no_implicit_batch_dim=True)
-def acc_ops_max_full_reduce(network, target, args, kwargs, name):
+def acc_ops_max_full_reduce(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_acc_ops_full_reduce(network, target, args, kwargs, name, trt.ReduceOperation.MAX)
 
 
 @tensorrt_converter(acc_ops.min_full_reduce, no_implicit_batch_dim=True)
-def acc_ops_min_full_reduce(network, target, args, kwargs, name):
+def acc_ops_min_full_reduce(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_acc_ops_full_reduce(network, target, args, kwargs, name, trt.ReduceOperation.MIN)
 
 
 @tensorrt_converter(acc_ops.max_dim_reduce)
-def acc_ops_max_dim_reduce(network, target, args, kwargs, name):
+def acc_ops_max_dim_reduce(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_acc_ops_dim_reduce(network, target, args, kwargs, name, trt.ReduceOperation.MAX)
 
 
 @tensorrt_converter(acc_ops.min_dim_reduce)
-def acc_ops_min_dim_reduce(network, target, args, kwargs, name):
+def acc_ops_min_dim_reduce(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_acc_ops_dim_reduce(network, target, args, kwargs, name, trt.ReduceOperation.MIN)
 
 
 @tensorrt_converter(acc_ops.maximum)
-def acc_ops_maximum(network, target, args, kwargs, name):
+def acc_ops_maximum(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_binary_elementwise_layer(
         network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.MAX, target, name
     )
 
 
 @tensorrt_converter(acc_ops.minimum)
-def acc_ops_minimum(network, target, args, kwargs, name):
+def acc_ops_minimum(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_binary_elementwise_layer(
         network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.MIN, target, name
     )
 
 
 @tensorrt_converter(acc_ops.max_pool2d)
-def acc_ops_max_pool2d(network, target, args, kwargs, name):
+def acc_ops_max_pool2d(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"MaxPool2d received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -822,19 +1047,25 @@ def acc_ops_max_pool2d(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.squeeze)
-def acc_ops_squeeze(network, target, args, kwargs, name):
+def acc_ops_squeeze(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"squeeze received input {input_val} that is not part "
             "of the TensorRT region!"
         )
 
-    dim = kwargs["dim"] if "dim" in kwargs else None
+    dim = cast(Optional[int], kwargs["dim"] if "dim" in kwargs else None)
     # Squeeze with dim=None would only work in explicit batch dim mode without any dynamic
     # dim, which is a very rare case. For now we just claim not supporting dim=None.
-    assert dim is not None, "We don't support dim=None right now."
+    assert dim is not None, "We don't support dim=None right now for squeeze."
 
     dim = get_positive_dim(dim, len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0))
     if network.has_implicit_batch_dimension:
@@ -858,21 +1089,39 @@ def acc_ops_squeeze(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.add)
-def acc_ops_add(network, target, args, kwargs, name):
+def acc_ops_add(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_binary_elementwise_layer(
         network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.SUM, target, name
     )
 
 
 @tensorrt_converter(acc_ops.sub)
-def acc_ops_sub(network, target, args, kwargs, name):
+def acc_ops_sub(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_binary_elementwise_layer(
         network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.SUB, target, name
     )
 
 
 @tensorrt_converter(acc_ops.div)
-def acc_ops_div(network, target, args, kwargs, name):
+def acc_ops_div(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     if kwargs["rounding_mode"] == "trunc":
         inputs = kwargs["input"]
         other = kwargs["other"]
@@ -891,26 +1140,44 @@ def acc_ops_div(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.mul)
-def acc_ops_mul(network, target, args, kwargs, name):
+def acc_ops_mul(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_binary_elementwise_layer(
         network, kwargs["input"], kwargs["other"], trt.ElementWiseOperation.PROD, target, name
     )
 
 @tensorrt_converter(acc_ops.pow)
-def acc_ops_pow(network, target, args, kwargs, name):
+def acc_ops_pow(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return add_binary_elementwise_layer(
         network, kwargs["input"], kwargs["exponent"], trt.ElementWiseOperation.POW, target, name
     )
 
 @tensorrt_converter(acc_ops.unsqueeze)
-def acc_ops_unsqueeze(network, target, args, kwargs, name):
+def acc_ops_unsqueeze(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"unsqueeze received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    dim = kwargs["dim"]
+    dim = cast(int, kwargs["dim"])
     input_shape = input_val.shape
     input_shape_size = len(input_val.shape) + 1 if network.has_implicit_batch_dimension else len(input_val.shape)
     dim = get_positive_dim(dim, input_shape_size + 1)
@@ -927,10 +1194,16 @@ def acc_ops_unsqueeze(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.topk)
-def acc_ops_topk(network, target, args, kwargs, name):
+def acc_ops_topk(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"topk received input {input_val} that is not part "
                            "of the TensorRT region!")
 
@@ -942,7 +1215,7 @@ def acc_ops_topk(network, target, args, kwargs, name):
 
     num_dims = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
     k = kwargs["k"]
-    dim = get_positive_dim(kwargs["dim"] if kwargs["dim"] is not None else -1, num_dims)
+    dim = get_positive_dim(kwargs["dim"] if kwargs["dim"] is not None else -1, num_dims)  # type: ignore[arg-type]
     operation = trt.TopKOperation.MAX if kwargs["largest"] else trt.TopKOperation.MIN
     layer = network.add_topk(
         input_val, operation, k, get_axes_for_reduce_op(dim, network.has_implicit_batch_dimension)
@@ -952,10 +1225,16 @@ def acc_ops_topk(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.adaptive_avg_pool2d)
-def acc_ops_adaptive_avg_pool2d(network, target, args, kwargs, name):
+def acc_ops_adaptive_avg_pool2d(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"AdaptiveAvgPool2d received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -964,7 +1243,7 @@ def acc_ops_adaptive_avg_pool2d(network, target, args, kwargs, name):
     assert (
         input_val.shape[-1] != -1 and input_val.shape[-1] != -1
     ), "AdaptiveAvgPool2d currently doesn't support dynamic shapes for last two dims."
-    output_size = kwargs["output_size"]
+    output_size = cast(Sequence[int], kwargs["output_size"])
 
     for input_dim, output_dim in zip(input_val.shape[-2:], output_size):
         if input_dim % output_dim != 0:
@@ -991,10 +1270,16 @@ def acc_ops_adaptive_avg_pool2d(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.avg_pool2d)
-def acc_ops_avg_pool2d(network, target, args, kwargs, name):
+def acc_ops_avg_pool2d(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"AvgPool2d received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -1025,16 +1310,22 @@ def acc_ops_avg_pool2d(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.reshape)
-def acc_ops_reshape(network, target, args, kwargs, name):
+def acc_ops_reshape(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"Reshape received input {input_val} that is not part "
             "of the TensorRT region!"
         )
 
-    shape = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "shape")
+    shape = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "shape")  # type: ignore[arg-type]
     if network.has_implicit_batch_dimension:
         shape = shape[1:]
 
@@ -1047,7 +1338,7 @@ def acc_ops_reshape(network, target, args, kwargs, name):
         trt_shape = []
 
         for i, s in enumerate(shape):
-            if isinstance(s, trt.tensorrt.ITensor):
+            if isinstance(s, TRTTensor):
                 if len(s.shape) == 0:
                     s = prepend_ones(network, s, f"{name}_{i}", 1)
                 trt_shape.append(s)
@@ -1066,15 +1357,21 @@ def acc_ops_reshape(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.slice_tensor)
-def acc_ops_slice_tensor(network, target, args, kwargs, name):
+def acc_ops_slice_tensor(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"slice_tensor received input {input_val} that is not part "
                            "of the TensorRT region!")
 
     ranks = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
-    dims = [get_positive_dim(dim, ranks) for dim in kwargs["dims"]]
+    dims = [get_positive_dim(dim, ranks) for dim in cast(Sequence[int], kwargs["dims"])]
 
     if network.has_implicit_batch_dimension:
         if not len(dims):
@@ -1090,9 +1387,9 @@ def acc_ops_slice_tensor(network, target, args, kwargs, name):
     start = [0] * len(input_val.shape)
     stride = [1] * len(start)
     output_shape = list(input_val.shape)
-    starts = kwargs["starts"]
-    stops = kwargs["stops"]
-    steps = kwargs["steps"]
+    starts = cast(Sequence[int], kwargs["starts"])
+    stops = cast(Sequence[int], kwargs["stops"])
+    steps = cast(Sequence[int], kwargs["steps"])
 
     for i, dim in enumerate(dims):
         start[dim] = starts[i]
@@ -1105,21 +1402,27 @@ def acc_ops_slice_tensor(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.split, no_explicit_batch_dim=True)
-def acc_ops_split(network, target, args, kwargs, name):
+def acc_ops_split(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"split received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    dim = kwargs["dim"]
+    dim = cast(int, kwargs["dim"])
     if network.has_implicit_batch_dimension:
         assert dim != 0, "Can't split on batch dim when it's implicit!"
         dim -= 1
     else:
         raise RuntimeError("We don't support split with explicit batch dimension yet!")
 
-    split_size = kwargs["split_size"]
+    split_size = cast(int, kwargs["split_size"])
     start = [0] * len(input_val.shape)
     stride = [1] * len(start)
     offset = 0
@@ -1132,7 +1435,7 @@ def acc_ops_split(network, target, args, kwargs, name):
     output = []
     for i in range(num_splits):
         shape = list(input_val.shape)
-        shape[dim] = min(split_size, max_offset - offset)
+        shape[dim] = min(split_size, cast(int, max_offset - offset))
         start[dim] = offset
         layer = network.add_slice(input_val, start=start, shape=shape, stride=stride)
         offset += split_size
@@ -1142,10 +1445,16 @@ def acc_ops_split(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.linear)
-def acc_ops_linear(network, target, args, kwargs, name):
+def acc_ops_linear(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"Linear received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -1164,7 +1473,7 @@ def acc_ops_linear(network, target, args, kwargs, name):
     layer = network.add_shuffle(input_val)
     layer.reshape_dims = tuple(input_val.shape) + (1, 1)
     set_layer_name(layer, target, f"{name}_pre_shuffle")
-    bias = to_numpy(kwargs["bias"])
+    bias = to_numpy(kwargs["bias"])  # type: ignore[arg-type]
 
     if network.has_explicit_precision:
         weight = get_trt_tensor(network, kwargs["weight"], f"{name}_weight")
@@ -1181,7 +1490,7 @@ def acc_ops_linear(network, target, args, kwargs, name):
         )
         layer.set_input(1, weight)
     else:
-        weight = to_numpy(kwargs["weight"])
+        weight = to_numpy(kwargs["weight"])  # type: ignore[arg-type]
         layer = network.add_fully_connected(
             input=layer.get_output(0),
             num_outputs=weight.shape[0],
@@ -1192,7 +1501,7 @@ def acc_ops_linear(network, target, args, kwargs, name):
 
     # reshape back
     layer = network.add_shuffle(layer.get_output(0))
-    layer.reshape_dims = tuple(input_val.shape[:-1]) + (kwargs["weight"].shape[0],)
+    layer.reshape_dims = tuple(input_val.shape[:-1]) + (kwargs["weight"].shape[0],)  # type: ignore[union-attr]
     set_layer_name(layer, target, f"{name}_post_shuffle")
 
     return layer.get_output(0)
@@ -1213,12 +1522,18 @@ def add_clamp(network, input, val, op):
 
 
 @tensorrt_converter(acc_ops.clamp)
-def acc_ops_clamp(network, target, args, kwargs, name):
+def acc_ops_clamp(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     min_val = kwargs["min"]
     max_val = kwargs["max"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"Clamp received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -1240,22 +1555,40 @@ def acc_ops_clamp(network, target, args, kwargs, name):
     return input_val
 
 @tensorrt_converter(acc_ops.tuple_construct)
-def acc_ops_tuple_construct(network, target, args, kwargs, name):
+def acc_ops_tuple_construct(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return kwargs["tensors"]
 
 
 @tensorrt_converter(acc_ops.contiguous)
-def acc_ops_contiguous(network, target, args, kwargs, name):
+def acc_ops_contiguous(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return kwargs["input"]
 
 
 @tensorrt_converter(acc_ops.getitem)
-def acc_ops_getitem(network, target, args, kwargs, name):
+def acc_ops_getitem(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     slices = kwargs["idx"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
-        return operator.getitem(input_val, slices)
+    if not isinstance(input_val, TRTTensor):
+        return operator.getitem(input_val, slices)  # type: ignore[arg-type]
 
     assert not has_dynamic_shape(
         input_val.shape
@@ -1368,27 +1701,39 @@ def acc_ops_getitem(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.cat)
-def acc_ops_cat(network, target, args, kwargs, name):
+def acc_ops_cat(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     tensors = kwargs["tensors"]
 
-    if any(not isinstance(t, trt.tensorrt.ITensor) for t in tensors):
+    if any(not isinstance(t, TRTTensor) for t in tensors):  # type: ignore[union-attr]
         raise RuntimeError(
             f"cat received inputs {tensors} that is not part " "of the TensorRT region!"
         )
 
     layer = network.add_concatenation(inputs=tensors)
-    layer.axis = kwargs["dim"] - (1 if network.has_implicit_batch_dimension else 0)
+    layer.axis = cast(int, kwargs["dim"]) - (1 if network.has_implicit_batch_dimension else 0)
     set_layer_name(layer, target, name)
     return layer.get_output(0)
 
 
 @tensorrt_converter(acc_ops.matmul)
-def acc_ops_matmul(network, target, args, kwargs, name):
+def acc_ops_matmul(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = get_trt_tensor(network, kwargs["input"], f"{name}_input")
     other_val = get_trt_tensor(network, kwargs["other"], f"{name}_other")
 
     for i in [input_val, other_val]:
-        if not isinstance(i, trt.tensorrt.ITensor):
+        if not isinstance(i, TRTTensor):
             raise RuntimeError(
                 f"matmul received input {i} that is not part of the TensorRT region!"
             )
@@ -1411,10 +1756,16 @@ def acc_ops_matmul(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.sigmoid)
-def acc_ops_sigmoid(network, target, args, kwargs, name):
+def acc_ops_sigmoid(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"Sigmoid received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -1424,12 +1775,18 @@ def acc_ops_sigmoid(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.permute)
-def acc_ops_permute(network, target, args, kwargs, name):
+def acc_ops_permute(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    ranks = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
-    permutation = [get_positive_dim(i, ranks) for i in kwargs["permutation"]]
+    ranks = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)  # type: ignore[union-attr]
+    permutation = [get_positive_dim(i, ranks) for i in cast(Sequence[int], kwargs["permutation"])]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"permute received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -1446,18 +1803,24 @@ def acc_ops_permute(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.quantize_per_tensor)
-def acc_ops_quantize_per_tensor(network, target, args, kwargs, name):
+def acc_ops_quantize_per_tensor(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = get_trt_tensor(network, kwargs["input"], f"{name}_input")
 
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"{name} received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    qparams = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "qparams")
+    qparams = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "qparams")  # type: ignore[arg-type]
     q_scale = qparams["scale"]
     q_zero_point = qparams["zero_point"]
-    dtype = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "dtype")
+    dtype = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "dtype")  # type: ignore[arg-type]
     if dtype not in (torch.quint8, torch.qint8, torch.qint32):
         raise RuntimeError("Only support (torch.quint8, torch.qint8, torch.qint32) "
                            f"quantized type in quantize_per_tensor, get {dtype}.")
@@ -1477,18 +1840,24 @@ def acc_ops_quantize_per_tensor(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.quantize_per_channel)
-def acc_ops_quantize_per_channel(network, target, args, kwargs, name):
+def acc_ops_quantize_per_channel(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = get_trt_tensor(network, kwargs["input"], f"{name}_input")
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"{name} received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    qparams = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "qparams")
+    qparams = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "qparams")  # type: ignore[arg-type]
     q_per_channel_scales = qparams["scale"]
     q_per_channel_zero_points = qparams["zero_point"]
     q_per_channel_axis = qparams["axis"]
-    dtype = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "dtype")
+    dtype = acc_utils.get_field_from_acc_out_ty(kwargs["acc_out_ty"], "dtype")  # type: ignore[arg-type]
     if dtype not in (torch.quint8, torch.qint8, torch.qint32):
         raise RuntimeError("Only support (torch.quint8, torch.qint8, torch.qint32) "
                            f"quantized type in quantize_per_tensor, get {dtype}.")
@@ -1517,15 +1886,21 @@ def acc_ops_quantize_per_channel(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.dequantize)
-def acc_ops_dequantize(network, target, args, kwargs, name):
+def acc_ops_dequantize(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    input_val_tensor_meta = kwargs["_itensor_to_tensor_meta"][input_val]
+    input_val_tensor_meta = kwargs["_itensor_to_tensor_meta"][input_val]  # type: ignore[index]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"{name} received input {input_val} that is not part "
                            "of the TensorRT region!")
 
-    qparams = acc_utils.get_field_from_acc_out_ty(input_val_tensor_meta, "qparams")
+    qparams = acc_utils.get_field_from_acc_out_ty(input_val_tensor_meta, "qparams")  # type: ignore[arg-type]
     qscheme = qparams["qscheme"]
     if qscheme == torch.per_tensor_affine:
         q_scale = qparams["scale"]
@@ -1545,7 +1920,7 @@ def acc_ops_dequantize(network, target, args, kwargs, name):
     else:
         raise RuntimeError("Unsupported qscheme in dequantize: {qscheme}")
 
-    dtype = acc_utils.get_field_from_acc_out_ty(input_val_tensor_meta, "dtype")
+    dtype = acc_utils.get_field_from_acc_out_ty(input_val_tensor_meta, "dtype")  # type: ignore[arg-type]
 
     if dtype not in (torch.quint8, torch.qint8, torch.qint32):
         raise RuntimeError("Only support (torch.quint8, torch.qint8, torch.qint32) "
@@ -1563,9 +1938,15 @@ def acc_ops_dequantize(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.gelu, no_implicit_batch_dim=True)
-def acc_ops_gelu(network, target, args, kwargs, name):
+def acc_ops_gelu(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"GELU received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -1578,7 +1959,7 @@ def acc_ops_gelu(network, target, args, kwargs, name):
     plugin_name = "CustomGeluPluginDynamic"
     # type_id 0 for float32, 1 for  float16
     type_id = trt.PluginField("type_id", np.array(0, dtype=np.int32), trt.PluginFieldType.INT32)
-    field_collection = trt.PluginFieldCollection([type_id])
+    field_collection = TRTPluginFieldCollection([type_id])
     plugin_version = "1"
 
     plugin = get_trt_plugin(plugin_name, field_collection, plugin_version)
@@ -1589,13 +1970,19 @@ def acc_ops_gelu(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.chunk)
-def acc_ops_chunk(network, target, args, kwargs, name):
+def acc_ops_chunk(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    chunks = kwargs["chunks"]
-    dim = kwargs["dim"]
-    input_dim_size = len(input_val.shape)
+    chunks = cast(int, kwargs["chunks"])
+    dim = cast(int, kwargs["dim"])
+    input_dim_size = len(input_val.shape)  # type: ignore[union-attr]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"chunk received input {input_val} that is not part "
                            "of the TensorRT region!")
 
@@ -1605,6 +1992,7 @@ def acc_ops_chunk(network, target, args, kwargs, name):
         assert dim != 0, "Can't chunk on batch dim when it's implicit!"
         dim -= 1
     else:
+        assert not has_dynamic_shape(input_val.shape), "We currently don't support dynamic shape for chunk."
         dim = get_positive_dim(dim, input_dim_size)
 
     if chunks > input_val.shape[dim]:
@@ -1635,13 +2023,19 @@ def acc_ops_chunk(network, target, args, kwargs, name):
     return output
 
 @tensorrt_converter(acc_ops.cumsum, no_implicit_batch_dim=True)
-def acc_ops_cumsum(network, target, args, kwargs, name):
+def acc_ops_cumsum(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
-    dim = kwargs["dim"]
-    input_shape = input_val.shape
-    input_dim_size = len(input_val.shape)
+    dim = cast(int, kwargs["dim"])
+    input_shape = input_val.shape  # type: ignore[union-attr]
+    input_dim_size = len(input_val.shape)  # type: ignore[union-attr]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"cumsum received input {input_val} that is not part "
                            "of the TensorRT region!")
     if network.has_implicit_batch_dimension:
@@ -1690,10 +2084,16 @@ def acc_ops_cumsum(network, target, args, kwargs, name):
 
 
 @tensorrt_converter(acc_ops.hardtanh)
-def acc_ops_hardtanh(network, target, args, kwargs, name):
+def acc_ops_hardtanh(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
 
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(f"hardtanh received input {input_val} that is not part "
                            "of the TensorRT region!")
 

--- a/torch/fx/experimental/fx2trt/converters/activation.py
+++ b/torch/fx/experimental/fx2trt/converters/activation.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer
 

--- a/torch/fx/experimental/fx2trt/converters/adaptive_avgpool.py
+++ b/torch/fx/experimental/fx2trt/converters/adaptive_avgpool.py
@@ -1,6 +1,6 @@
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer, extend_mod_attr_to_tuple
 

--- a/torch/fx/experimental/fx2trt/converters/add.py
+++ b/torch/fx/experimental/fx2trt/converters/add.py
@@ -1,7 +1,7 @@
 import operator
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, mark_as_int8_layer
 

--- a/torch/fx/experimental/fx2trt/converters/batchnorm.py
+++ b/torch/fx/experimental/fx2trt/converters/batchnorm.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer, to_numpy, get_dyn_range
 

--- a/torch/fx/experimental/fx2trt/converters/converter_utils.py
+++ b/torch/fx/experimental/fx2trt/converters/converter_utils.py
@@ -1,26 +1,25 @@
-from typing import Callable, Any, Tuple, Sequence, Union, List, Optional
+from typing import Any, Tuple, Sequence, Union, List, Optional
 
 import numpy as np
 import tensorrt as trt
 import torch
-from torch.fx.experimental.fx2trt.fx2trt import torch_dtype_from_trt
-
-Target = Union[Callable[..., Any], str]
-ShapeType = Union[Sequence[int], trt.Dims]
+from torch.fx.node import Target
+from torch.fx.experimental.fx2trt.types import *  # noqa: F403
+from torch.fx.experimental.fx2trt.utils import torch_dtype_from_trt
 
 
 def get_trt_plugin(
     plugin_name: str,
-    field_collection: List[trt.PluginFieldCollection],
+    field_collection: List[TRTPluginFieldCollection],
     version: str,
     plugin_namespace: str = ""
-) -> trt.IPluginV2:
+) -> TRTPlugin:
     """
     Get a TensorRT plugin based on the given parameters.
 
     Args:
         plugin_name (str): Name of the plugin.
-        field_collection (List[trt.PluginFieldCollection]): Parameters that needed
+        field_collection (List[TRTPluginFieldCollection]): Parameters that needed
             to create a plugin using the plugin creator.
         version (str): Version of the plugin.
         plugin_namespace (str): Namespace of the plugin.
@@ -54,12 +53,12 @@ def get_positive_dim(dim: int, dim_size: int) -> int:
     return dim
 
 
-def set_layer_name(layer: trt.ILayer, target: Target, name: str) -> None:
+def set_layer_name(layer: TRTLayer, target: Target, name: str) -> None:
     """
     Set the TensorRT layer name to "[TensorRT Layer Type]_[Original Op Name]_[FX Node Name with Suffix]"
 
     Args:
-        layer (trt.ILayer): A TensorRT layer of which we want to set the name.
+        layer (TRTLayer): A TensorRT layer of which we want to set the name.
         target (Target): A fx node.target. For call_function node, it's the function that
             the node represents.
         name (str): Consists of fx node.name with optional suffix.
@@ -117,12 +116,12 @@ def to_numpy(tensor: Optional[torch.Tensor]) -> Optional[np.ndarray]:
     return tensor.cpu().detach().contiguous().numpy()
 
 
-def has_dynamic_shape(shape: ShapeType) -> bool:
+def has_dynamic_shape(shape: Shape) -> bool:
     """
     Determine if the given shape has dynamic dim. i.e. if there're -1 in shape.
 
     Args:
-        shape (ShapeType): Shape of a tensor. Essentially is a sequence of integers.
+        shape (Shape): Shape of a tensor. Essentially is a sequence of integers.
 
     Returns:
         A boolean value indicates whether there's dynamic dim in the shape.
@@ -163,16 +162,16 @@ def get_axes_for_reduce_op(
 
 
 def create_constant(
-    network: trt.INetworkDefinition,
+    network: TRTNetwork,
     value: Union[int, float, torch.Tensor],
     name: str,
     dtype: Optional[torch.dtype],
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     Add a TensorRT constant layer whose value is `value` to `network`.
 
     Args:
-        network (trt.INetworkDefinition): A TensorRT network to which we want to add
+        network (TRTNetwork): A TensorRT network to which we want to add
             a constant layer.
         value (Union[int, float, torch.Tensor]): A literal value or a PyTorch tensor
             that will be used as value of the added TensorRT Constant layer.
@@ -198,17 +197,17 @@ def create_constant(
 
 
 def get_trt_tensor(
-    network: trt.INetworkDefinition,
+    network: TRTNetwork,
     input_val: Any,
     name: str,
     dtype: Optional[torch.dtype] = None
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     Given a value of random type, we try to convert it to a TensorRT ITensor.
     An runtime error is raised if we're not able to do that.
 
     Args:
-        network (trt.INetworkDefinition): A TensorRT network. If we want to
+        network (TRTNetwork): A TensorRT network. If we want to
             add a TensorRT Constant layer, we will add it to this network.
         input_val (Any): An value that we want to convert to a TensorRT ITensor.
         name (str): The name of the created TensorRT Constant layer if there's
@@ -221,7 +220,7 @@ def get_trt_tensor(
     """
     if isinstance(input_val, (torch.Tensor, int, float)):
         return create_constant(network, input_val, name, dtype)
-    elif not isinstance(input_val, trt.tensorrt.ITensor):
+    elif not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"Received input {input_val} of name {name} that "
             "is not part of the TensorRT region!"
@@ -231,18 +230,18 @@ def get_trt_tensor(
 
 
 def prepend_ones(
-    network: trt.INetworkDefinition,
-    tensor: trt.tensorrt.ITensor,
+    network: TRTNetwork,
+    tensor: TRTTensor,
     name: str,
     num_prepend_ones: int,
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     Prepend 1s to the shape of TensorRT ITensor `tensor`.
 
     Args:
-        network (trt.INetworkDefinition): The TensorRT network that `tensor`
+        network (TRTNetwork): The TensorRT network that `tensor`
             belongs to.
-        tensor (trt.tensorrt.ITensor): A TensorRT tensor.
+        tensor (TRTTensor): A TensorRT tensor.
         name (str): Name of the TensorRT Shuffle layer which is used to prepend
             1s.
         num_prepend_ones (int): Number of 1s that will be prepend.
@@ -276,21 +275,21 @@ def prepend_ones(
 
 
 def broadcast(
-    network: trt.INetworkDefinition,
-    a: trt.tensorrt.ITensor,
-    b: trt.tensorrt.ITensor,
+    network: TRTNetwork,
+    a: TRTTensor,
+    b: TRTTensor,
     a_name: str,
     b_name: str,
     preset_diff: int = 0
-) -> Tuple[trt.tensorrt.ITensor, trt.tensorrt.ITensor]:
+) -> Tuple[TRTTensor, TRTTensor]:
     """
     Broadcast two TensorRT tensors to the same number of dimensions by
     prepending 1s to the tensor with less number of dimensions.
 
     Args:
-        network (trt.INetworkDefinition): TensorRT network object.
-        a (trt.tensorrt.ITensor): A TensorRT ITensor.
-        b (trt.tensorrt.ITensor): A TensorRT ITensor.
+        network (TRTNetwork): TensorRT network object.
+        a (TRTTensor): A TensorRT ITensor.
+        b (TRTTensor): A TensorRT ITensor.
         a_name (str): Name of tensor a.
         b_name (str): Name of tensor b.
         preset_diff (int): The difference of number of dimensions after broadcast.
@@ -316,13 +315,13 @@ def broadcast(
 
 
 def add_binary_elementwise_layer(
-    network: trt.INetworkDefinition,
-    lhs_val: Union[int, float, trt.tensorrt.ITensor, torch.Tensor],
-    rhs_val: Union[int, float, trt.tensorrt.ITensor, torch.Tensor],
+    network: TRTNetwork,
+    lhs_val: Union[int, float, TRTTensor, torch.Tensor],
+    rhs_val: Union[int, float, TRTTensor, torch.Tensor],
     op_type: trt.ElementWiseOperation,
     target: Target,
     name: str
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     This function adds a TensorRT elementwise layer. We only allow at most one
     operand to not be a trt tensor, otherwise, we should const fold it first.
@@ -335,10 +334,10 @@ def add_binary_elementwise_layer(
     tensor are not allowed to have larger ranks than the trt tensor operand.
 
     Args:
-        network (trt.INetworkDefinition): TensorRT network object.
-        lhs_val (trt.tensorrt.ITensor): Left operand of the binary operation. Could
+        network (TRTNetwork): TensorRT network object.
+        lhs_val (TRTTensor): Left operand of the binary operation. Could
             be a TensorRT tensor, a PyTorch tensor or a simple value.
-        rhs_val (trt.tensorrt.ITensor): Right operand of the binary operation. Similar
+        rhs_val (TRTTensor): Right operand of the binary operation. Similar
             to lhs_val.
         op_type (trt.ElementWiseOperation): Type of the TensorRT elementwise binary operation.
         target (Target): Target of fx node.
@@ -350,10 +349,10 @@ def add_binary_elementwise_layer(
     dtype = None
     is_lhs_trt_tensor = False
     is_rhs_trt_tensor = False
-    if isinstance(lhs_val, trt.tensorrt.ITensor):
+    if isinstance(lhs_val, TRTTensor):
         dtype = torch_dtype_from_trt(lhs_val.dtype)
         is_lhs_trt_tensor = True
-    if isinstance(rhs_val, trt.tensorrt.ITensor):
+    if isinstance(rhs_val, TRTTensor):
         dtype = torch_dtype_from_trt(rhs_val.dtype)
         is_rhs_trt_tensor = True
     if not is_lhs_trt_tensor and not is_rhs_trt_tensor:
@@ -379,18 +378,18 @@ def add_binary_elementwise_layer(
 
 
 def add_unary_layer(
-    network: trt.INetworkDefinition,
-    input_val: trt.tensorrt.ITensor,
+    network: TRTNetwork,
+    input_val: TRTTensor,
     operation_type: trt.UnaryOperation,
     target: Target,
     name: str,
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     Add a TensorRT Unary layer to `network`.
 
     Args:
-        network (trt.INetworkDefinition): TensorRT network object.
-        input_val (trt.tensorrt.ITensor): Input to the unary op. Must be a TensorRT tensor.
+        network (TRTNetwork): TensorRT network object.
+        input_val (TRTTensor): Input to the unary op. Must be a TensorRT tensor.
         op_type (trt.ElementWiseOperation): Type of the TensorRT unary operation.
         target (Target): Target of fx node.
         name (str): The name we want to assign to the created TensorRT layer.
@@ -398,7 +397,7 @@ def add_unary_layer(
     Returns:
         The output of TensorRT Unary layer.
     """
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"{operation_type} received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -409,20 +408,20 @@ def add_unary_layer(
 
 
 def add_activation_layer(
-    network: trt.INetworkDefinition,
-    input_val: trt.tensorrt.ITensor,
+    network: TRTNetwork,
+    input_val: TRTTensor,
     operation_type: trt.ActivationType,
     target: Target,
     name: str,
     alpha: Optional[Any] = None,
     beta: Optional[Any] = None,
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     Add a TensorRT Activation layer to `network`.
 
     Args:
-        network (trt.INetworkDefinition): TensorRT network object.
-        input_val (trt.tensorrt.ITensor): Input to the activation op.
+        network (TRTNetwork): TensorRT network object.
+        input_val (TRTTensor): Input to the activation op.
             Must be a TensorRT tensor.
         op_type (trt.ElementWiseOperation): Type of the TensorRT activation
             operation.
@@ -436,7 +435,7 @@ def add_activation_layer(
     Returns:
         The output of TensorRT Activation layer.
     """
-    if not isinstance(input_val, trt.tensorrt.ITensor):
+    if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"{operation_type} received input {input_val} that is not part "
             "of the TensorRT region!"
@@ -490,12 +489,12 @@ def get_inputs_from_args_and_kwargs(args, kwargs, input_names):
 
 
 def trunc_div(
-    input: trt.tensorrt.ITensor,
-    other: trt.tensorrt.ITensor,
-    network: trt.INetworkDefinition,
+    input: TRTTensor,
+    other: TRTTensor,
+    network: TRTNetwork,
     target: Target,
     name: str
-) -> trt.tensorrt.ITensor:
+) -> TRTTensor:
     """
     Perform trunc divide on Tensor, result of divide will be round toward zero.
     This means for positive number, it will be floor round; for negative number,
@@ -528,9 +527,9 @@ def trunc_div(
                                                trt.ElementWiseOperation.SUB, target, f"{name}_binary_sign")
 
     # Convert constant input into ITensor for UnaryOperation
-    if not isinstance(input, trt.tensorrt.ITensor):
+    if not isinstance(input, TRTTensor):
         input = get_trt_tensor(network, input, f"{name}_input")
-    if not isinstance(other, trt.tensorrt.ITensor):
+    if not isinstance(other, TRTTensor):
         other = get_trt_tensor(network, other, f"{name}_other", dtype=torch_dtype_from_trt(input.dtype))
 
     abs_a_output = add_unary_layer(network, input, trt.UnaryOperation.ABS, target, f"{name}_abs_a")

--- a/torch/fx/experimental/fx2trt/converters/convolution.py
+++ b/torch/fx/experimental/fx2trt/converters/convolution.py
@@ -1,6 +1,6 @@
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import extend_mod_attr_to_tuple, mark_as_int8_layer, to_numpy, get_dyn_range
 

--- a/torch/fx/experimental/fx2trt/converters/linear.py
+++ b/torch/fx/experimental/fx2trt/converters/linear.py
@@ -1,6 +1,6 @@
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer, to_numpy, get_dyn_range
 

--- a/torch/fx/experimental/fx2trt/converters/maxpool.py
+++ b/torch/fx/experimental/fx2trt/converters/maxpool.py
@@ -1,6 +1,6 @@
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer, extend_mod_attr_to_tuple
 

--- a/torch/fx/experimental/fx2trt/converters/mul.py
+++ b/torch/fx/experimental/fx2trt/converters/mul.py
@@ -1,7 +1,7 @@
 import operator
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, mark_as_int8_layer
 

--- a/torch/fx/experimental/fx2trt/converters/quantization.py
+++ b/torch/fx/experimental/fx2trt/converters/quantization.py
@@ -1,6 +1,6 @@
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, get_inputs_from_args_and_kwargs
 

--- a/torch/fx/experimental/fx2trt/converters/transformation.py
+++ b/torch/fx/experimental/fx2trt/converters/transformation.py
@@ -1,6 +1,6 @@
 import torch
 import tensorrt as trt
-from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer
 

--- a/torch/fx/experimental/fx2trt/example/fx2trt_example.py
+++ b/torch/fx/experimental/fx2trt/example/fx2trt_example.py
@@ -5,7 +5,7 @@ import torch.fx
 import torch.nn as nn
 import torch.fx.experimental.fx_acc.acc_tracer as acc_tracer
 from torch.fx.experimental.fx2trt.tools.trt_splitter import TRTSplitter
-from torch.fx.experimental.fx2trt.fx2trt import TRTInterpreter, InputTensorSpec, TRTModule
+from torch.fx.experimental.fx2trt import TRTInterpreter, InputTensorSpec, TRTModule
 
 
 # The purpose of this example is to demonstrate the overall flow of lowering a PyTorch

--- a/torch/fx/experimental/fx2trt/example/quantized_resnet_test.py
+++ b/torch/fx/experimental/fx2trt/example/quantized_resnet_test.py
@@ -1,6 +1,6 @@
 import torch.fx
 import torchvision.models as models
-from torch.fx.experimental.fx2trt.fx2trt import TRTInterpreter, InputTensorSpec, TRTModule
+from torch.fx.experimental.fx2trt import TRTInterpreter, InputTensorSpec, TRTModule
 from torch.ao.quantization.quantize_fx import prepare_fx, convert_fx
 import torch.fx.experimental.fx_acc.acc_tracer as acc_tracer
 import copy

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -1,15 +1,16 @@
 import warnings
-from typing import List, NamedTuple, Iterable, Any, Optional, Tuple, Sequence, Dict
+from typing import List, NamedTuple, Any, Optional, Sequence, Dict
 
+import numpy
 import tensorrt as trt
 import torch
 import torch.fx
 from torch.fx.node import _get_qualified_name
 from torch.fx.passes.shape_prop import TensorMetadata
-import numpy
 
-Shape = Tuple[int, ...]
-ShapeRange = Tuple[Shape, Shape, Shape]
+from .converter_registry import CONVERTERS
+from .input_tensor_spec import InputTensorSpec
+from .utils import torch_dtype_to_trt, get_dynamic_dims
 
 
 class TRTInterpreterResult(NamedTuple):
@@ -17,390 +18,6 @@ class TRTInterpreterResult(NamedTuple):
     input_names: Sequence[str]
     output_names: Sequence[str]
     serialized_cache: bytearray
-
-
-# Borrowed from torch2trt
-def torch_dtype_to_trt(dtype):
-    if trt.__version__ >= "7.0" and dtype == torch.bool:
-        return trt.bool
-    elif dtype == torch.int8:
-        return trt.int8
-    elif dtype == torch.int32:
-        return trt.int32
-    elif dtype == torch.float16:
-        return trt.float16
-    elif dtype == torch.float32:
-        return trt.float32
-    else:
-        raise TypeError("%s is not supported by tensorrt" % dtype)
-
-
-def torch_dtype_from_trt(dtype):
-    if dtype == trt.int8:
-        return torch.int8
-    elif trt.__version__ >= "7.0" and dtype == trt.bool:
-        return torch.bool
-    elif dtype == trt.int32:
-        return torch.int32
-    elif dtype == trt.float16:
-        return torch.float16
-    elif dtype == trt.float32:
-        return torch.float32
-    else:
-        raise TypeError("%s is not supported by torch" % dtype)
-
-
-class TRTModule(torch.nn.Module):
-    def __init__(self, engine=None, input_names=None, output_names=None, cuda_graph_batch_size=-1):
-        super(TRTModule, self).__init__()
-        self._register_state_dict_hook(TRTModule._on_state_dict)
-        self.engine = engine
-        self.input_names = input_names
-        self.output_names = output_names
-        self.cuda_graph_batch_size = cuda_graph_batch_size
-        self.initialized = False
-
-        if engine:
-            self._initialize()
-
-    def _initialize(self):
-        self.initialized = True
-        self.context = self.engine.create_execution_context()
-
-        # Indices of inputs/outputs in the trt engine bindings, in the order
-        # as they are in the original PyTorch model.
-        self.input_binding_indices_in_order: Sequence[int] = [
-            self.engine.get_binding_index(name) for name in self.input_names
-        ]
-        self.output_binding_indices_in_order: Sequence[int] = [
-            self.engine.get_binding_index(name) for name in self.output_names
-        ]
-        primary_input_outputs = set()
-        primary_input_outputs.update(self.input_binding_indices_in_order)
-        primary_input_outputs.update(self.output_binding_indices_in_order)
-        self.hidden_output_binding_indices_in_order: Sequence[int] = []
-        self.hidden_output_names: Sequence[str] = []
-        for i in range(self.engine.num_bindings):
-            if i not in primary_input_outputs:
-                self.hidden_output_binding_indices_in_order.append(i)
-                self.hidden_output_names.append(self.engine.get_binding_name(i))
-
-        assert self.engine.num_bindings == (len(self.input_names) + len(self.output_names) + len(self.hidden_output_names))
-
-        self.input_dtypes: Sequence[torch.dtype] = [
-            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
-            for idx in self.input_binding_indices_in_order
-        ]
-        self.input_shapes: Sequence[Sequence[int]] = [
-            tuple(self.engine.get_binding_shape(idx))
-            for idx in self.input_binding_indices_in_order
-        ]
-        self.output_dtypes: Sequence[torch.dtype] = [
-            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
-            for idx in self.output_binding_indices_in_order
-        ]
-        self.output_shapes = [
-            tuple(self.engine.get_binding_shape(idx)) if self.engine.has_implicit_batch_dimension else tuple()
-            for idx in self.output_binding_indices_in_order
-        ]
-        self.hidden_output_dtypes: Sequence[torch.dtype] = [
-            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
-            for idx in self.hidden_output_binding_indices_in_order
-        ]
-        self.hidden_output_shapes = [
-            tuple(self.engine.get_binding_shape(idx)) if self.engine.has_implicit_batch_dimension else tuple()
-            for idx in self.hidden_output_binding_indices_in_order
-        ]
-
-
-    def _check_initialized(self):
-        if not self.initialized:
-            raise RuntimeError("TRTModule is not initialized.")
-
-    def _on_state_dict(self, state_dict, prefix, local_metadata):
-        self._check_initialized()
-        state_dict[prefix + "engine"] = bytearray(self.engine.serialize())
-        state_dict[prefix + "input_names"] = self.input_names
-        state_dict[prefix + "output_names"] = self.output_names
-        state_dict[prefix + "cuda_graph_batch_size"] = self.cuda_graph_batch_size
-
-    def _load_from_state_dict(
-        self,
-        state_dict,
-        prefix,
-        local_metadata,
-        strict,
-        missing_keys,
-        unexpected_keys,
-        error_msgs,
-    ):
-        engine_bytes = state_dict[prefix + "engine"]
-
-        logger = trt.Logger()
-        runtime = trt.Runtime(logger)
-        self.engine = runtime.deserialize_cuda_engine(engine_bytes)
-
-        self.input_names = state_dict[prefix + "input_names"]
-        self.output_names = state_dict[prefix + "output_names"]
-        self._initialize()
-
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state["engine"] = bytearray(self.engine.serialize())
-        state.pop('context', None)
-        return state
-
-    def __setstate__(self, state):
-        logger = trt.Logger()
-        runtime = trt.Runtime(logger)
-        state["engine"] = runtime.deserialize_cuda_engine(state["engine"])
-        self.__dict__.update(state)
-        if self.engine:
-            self.context = self.engine.create_execution_context()
-
-    def forward(self, *inputs):
-        with torch.autograd.profiler.record_function("TRTModule:Forward"):
-            self._check_initialized()
-
-            with torch.autograd.profiler.record_function("TRTModule:ProcessInputs"):
-                assert len(inputs) == len(
-                    self.input_names
-                ), f"Wrong number of inputs, expect {len(self.input_names)} get {len(inputs)}."
-
-                # This is only used when the trt engine is using implicit batch dim.
-                batch_size = inputs[0].shape[0]
-                contiguous_inputs: List[torch.Tensor] = [i.contiguous() for i in inputs]
-                bindings: List[Any] = [None] * (
-                    len(self.input_names) + len(self.output_names) + len(self.hidden_output_names)
-                )
-
-                for i, input_name in enumerate(self.input_names):
-                    assert inputs[
-                        i
-                    ].is_cuda, f"{i}th input({input_name}) is not on cuda device."
-                    assert (
-                        inputs[i].dtype == self.input_dtypes[i]
-                    ), f"Dtype mismatch for {i}th input({input_name}). Expect {self.input_dtypes[i]}, got {inputs[i].dtype}."
-
-                    idx = self.input_binding_indices_in_order[i]
-                    bindings[idx] = contiguous_inputs[i].data_ptr()
-
-                    if not self.engine.has_implicit_batch_dimension:
-                        self.context.set_binding_shape(
-                            idx, tuple(contiguous_inputs[i].shape)
-                        )
-                    else:
-                        assert (
-                            inputs[i].size()[1:] == self.input_shapes[i]
-                        ), f"Shape mismatch for {i}th input({input_name}). " \
-                           f"Expect {self.input_shapes[i]}, got {inputs[i].size()[1:]}."
-
-            with torch.autograd.profiler.record_function("TRTModule:ProcessOutputs"):
-                # create output tensors
-                outputs: List[torch.Tensor] = []
-
-                for i, idx in enumerate(self.output_binding_indices_in_order):
-                    if self.engine.has_implicit_batch_dimension:
-                        shape = (batch_size,) + self.output_shapes[i]
-                    else:
-                        shape = tuple(self.context.get_binding_shape(idx))
-
-                    output = torch.empty(  # type: ignore[call-overload]
-                        size=shape,
-                        dtype=self.output_dtypes[i],
-                        device=torch.cuda.current_device(),
-                    )
-                    outputs.append(output)
-                    bindings[idx] = output.data_ptr()
-
-                for i, idx in enumerate(self.hidden_output_binding_indices_in_order):
-                    if self.engine.has_implicit_batch_dimension:
-                        shape = (batch_size,) + self.hidden_output_shapes[i]
-                    else:
-                        shape = tuple(self.context.get_binding_shape(idx))
-
-                    output = torch.empty(  # type: ignore[call-overload]
-                        size=shape,
-                        dtype=self.hidden_output_dtypes[i],
-                        device=torch.cuda.current_device(),
-                    )
-                    bindings[idx] = output.data_ptr()
-
-            with torch.autograd.profiler.record_function("TRTModule:TensorRTRuntime"):
-                if self.engine.has_implicit_batch_dimension:
-                    self.context.execute_async(
-                        batch_size, bindings, torch.cuda.current_stream().cuda_stream
-                    )
-                else:
-                    self.context.execute_async_v2(
-                        bindings, torch.cuda.current_stream().cuda_stream
-                    )
-
-            if len(outputs) == 1:
-                return outputs[0]
-
-            return tuple(outputs)
-
-    def enable_profiling(self):
-        """
-        Enable TensorRT profiling. After calling this function, TensorRT will report
-        time spent on each layer in stdout for each forward run.
-        """
-        self._check_initialized()
-
-        if not self.context.profiler:
-            self.context.profiler = trt.Profiler()
-
-    def disable_profiling(self):
-        """
-        Disable TensorRT profiling.
-        """
-        self._check_initialized()
-
-        torch.cuda.synchronize()
-        del self.context
-        self.context = self.engine.create_execution_context()
-
-
-CONVERTERS = {}
-NO_IMPLICIT_BATCH_DIM_SUPPORT = {}
-NO_EXPLICIT_BATCH_DIM_SUPPORT = {}
-
-
-def tensorrt_converter(key, no_implicit_batch_dim=False, no_explicit_batch_dim=False, enabled=True):
-    def register_converter(converter):
-        CONVERTERS[key] = converter
-        if no_implicit_batch_dim:
-            NO_IMPLICIT_BATCH_DIM_SUPPORT[key] = converter
-        if no_explicit_batch_dim:
-            NO_EXPLICIT_BATCH_DIM_SUPPORT[key] = converter
-        return converter
-
-    def pass_converter(converter):
-        return converter
-
-    if enabled:
-        return register_converter
-    else:
-        return pass_converter
-
-
-class InputTensorSpec(NamedTuple):
-    """
-    This class contains the information of a input tensor.
-
-    shape: shape of the tensor.
-
-    dtype: dtyep of the tensor.
-
-    device: device of the tensor. This is only used to generate inputs to the given model
-        in order to run shape prop. For TensorRT engine, inputs have to be on cuda device.
-
-    shape_ranges: If dynamic shape is needed (shape has dimensions of -1), then this field
-        has to be provided (default is empty list). Every shape_range is a tuple of three
-        tuples ((min_input_shape), (optimized_input_shape), (max_input_shape)). Each shape_range
-        is used to populate a TensorRT optimization profile.
-        e.g. If the input shape varies from (1, 224) to (100, 224) and we want to optimize
-        for (25, 224) because it's the most common input shape, then we set shape_ranges to
-        ((1, 224), (25, 225), (100, 224)).
-
-    has_batch_dim: Whether the shape includes batch dimension. Batch dimension has to be provided
-        if the engine want to run with dynamic shape.
-    """
-
-    shape: Shape
-    dtype: torch.dtype
-    device: torch.device = torch.device("cpu")
-    shape_ranges: List[ShapeRange] = []
-    has_batch_dim: bool = True
-
-    @classmethod
-    def from_tensor(cls, tensor: torch.Tensor) -> "InputTensorSpec":
-        """
-        Produce an InputTenosrSpec named tuple which contains the
-        information of the given PyTorch tensor.
-
-        Args:
-            tensor (torch.Tensor): A PyTorch tensor.
-
-        Returns:
-            An InputTensorSpec named tuple.
-        """
-        return cls(tensor.shape, tensor.dtype, tensor.device)
-
-    @classmethod
-    def from_tensors(cls, tensors: Iterable[torch.Tensor]) -> List["InputTensorSpec"]:
-        """
-        Produce a list of InputTenosrSpec named tuples which contain
-        the information of all the given PyTorch tensors.
-
-        Args:
-            tensors (Iterable[torch.Tensor]): A list of PyTorch tensors.
-
-        Returns:
-            A list of InputTensorSpec named tuples.
-        """
-        return [cls.from_tensor(t) for t in tensors]
-
-    @classmethod
-    def from_tensors_with_dynamic_batch_size(
-        cls,
-        tensors: Sequence[torch.Tensor],
-        batch_size_range: Tuple[int, int, int]
-    ) -> List["InputTensorSpec"]:
-        """
-        Produce a list of InputTenosrSpec named tuples which would contain
-        the information of all the given PyTorch tensors. The produced input
-        tensor specs will treat all tensors' first dimension as batch dimension
-        and mark them as dynmaic.
-
-        Args:
-            tensors (Sequence[torch.Tensor]): A list of PyTorch tensors.
-            batch_size_range (Tuple[int, int, int]): The first integer indicates
-                the smallest batch size allowed. The second integer indiceates
-                the batch size that we'll optimize for. The third integer indicates
-                the largest batch size allowed.
-
-        Returns:
-            A list of InputTensorSpec named tuples with dynamic ranges.
-        """
-        input_specs = []
-        batch_size = tensors[0].size(0)
-
-        for i, tensor in enumerate(tensors):
-            assert (
-                batch_size == tensor.size(0)
-            ), f"The {i}th tensor (shape: {tensor.shape}) doesn't have the correct batch size: {batch_size}."
-            shape = list(tensor.shape)
-            shape[0] = -1
-            shape_ranges: List[ShapeRange] = [tuple(tuple([bs] + shape[1:]) for bs in batch_size_range)]  # type: ignore[list-item]
-            input_specs.append(cls(tuple(shape), tensor.dtype, tensor.device, shape_ranges))
-
-        return input_specs
-
-
-def get_dynamic_dims(shape):
-    dynamic_dims = []
-
-    for i, s in enumerate(shape):
-        if s == -1:
-            dynamic_dims.append(i)
-
-    return dynamic_dims
-
-
-def create_inputs_from_specs(input_specs):
-    inputs = []
-
-    for shape, dtype, device, shape_ranges, has_batch_dim in input_specs:
-        if len(get_dynamic_dims(shape)):
-            shape = shape_ranges[0][1]
-        elif not has_batch_dim:
-            shape = (1,) + tuple(shape)
-
-        inputs.append(torch.randn(shape).to(dtype=dtype, device=device))
-
-    return inputs
 
 
 class TRTInterpreter(torch.fx.Interpreter):
@@ -631,6 +248,7 @@ class TRTInterpreter(torch.fx.Interpreter):
                 f"Conversion of module of type {submod_type} not currently supported!"
             )
 
+        assert self._cur_node_name is not None
         return converter(self.network, submod, args, kwargs, self._cur_node_name)
 
     def call_function(self, target, args, kwargs):
@@ -641,6 +259,7 @@ class TRTInterpreter(torch.fx.Interpreter):
                 f"Conversion of function {torch.typename(target)} not currently supported!"
             )
 
+        assert self._cur_node_name is not None
         return converter(self.network, target, args, kwargs, self._cur_node_name)
 
     def call_method(self, target, args, kwargs):
@@ -652,6 +271,7 @@ class TRTInterpreter(torch.fx.Interpreter):
                 f"Conversion of method {target} not currently supported!"
             )
 
+        assert self._cur_node_name is not None
         return converter(self.network, target, args, kwargs, self._cur_node_name)
 
     def output(self, target, args, kwargs):

--- a/torch/fx/experimental/fx2trt/input_tensor_spec.py
+++ b/torch/fx/experimental/fx2trt/input_tensor_spec.py
@@ -1,0 +1,118 @@
+from typing import List, NamedTuple, Iterable, Tuple, Sequence
+
+import torch
+
+from .types import Shape, ShapeRange
+from .utils import get_dynamic_dims
+
+
+class InputTensorSpec(NamedTuple):
+    """
+    This class contains the information of a input tensor.
+
+    shape: shape of the tensor.
+
+    dtype: dtyep of the tensor.
+
+    device: device of the tensor. This is only used to generate inputs to the given model
+        in order to run shape prop. For TensorRT engine, inputs have to be on cuda device.
+
+    shape_ranges: If dynamic shape is needed (shape has dimensions of -1), then this field
+        has to be provided (default is empty list). Every shape_range is a tuple of three
+        tuples ((min_input_shape), (optimized_input_shape), (max_input_shape)). Each shape_range
+        is used to populate a TensorRT optimization profile.
+        e.g. If the input shape varies from (1, 224) to (100, 224) and we want to optimize
+        for (25, 224) because it's the most common input shape, then we set shape_ranges to
+        ((1, 224), (25, 225), (100, 224)).
+
+    has_batch_dim: Whether the shape includes batch dimension. Batch dimension has to be provided
+        if the engine want to run with dynamic shape.
+    """
+
+    shape: Shape
+    dtype: torch.dtype
+    device: torch.device = torch.device("cpu")
+    shape_ranges: List[ShapeRange] = []
+    has_batch_dim: bool = True
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> "InputTensorSpec":
+        """
+        Produce an InputTenosrSpec named tuple which contains the
+        information of the given PyTorch tensor.
+
+        Args:
+            tensor (torch.Tensor): A PyTorch tensor.
+
+        Returns:
+            An InputTensorSpec named tuple.
+        """
+        return cls(tensor.shape, tensor.dtype, tensor.device)
+
+    @classmethod
+    def from_tensors(cls, tensors: Iterable[torch.Tensor]) -> List["InputTensorSpec"]:
+        """
+        Produce a list of InputTenosrSpec named tuples which contain
+        the information of all the given PyTorch tensors.
+
+        Args:
+            tensors (Iterable[torch.Tensor]): A list of PyTorch tensors.
+
+        Returns:
+            A list of InputTensorSpec named tuples.
+        """
+        return [cls.from_tensor(t) for t in tensors]
+
+    @classmethod
+    def from_tensors_with_dynamic_batch_size(
+        cls,
+        tensors: Sequence[torch.Tensor],
+        batch_size_range: Tuple[int, int, int]
+    ) -> List["InputTensorSpec"]:
+        """
+        Produce a list of InputTenosrSpec named tuples which would contain
+        the information of all the given PyTorch tensors. The produced input
+        tensor specs will treat all tensors' first dimension as batch dimension
+        and mark them as dynmaic.
+
+        Args:
+            tensors (Sequence[torch.Tensor]): A list of PyTorch tensors.
+            batch_size_range (Tuple[int, int, int]): The first integer indicates
+                the smallest batch size allowed. The second integer indiceates
+                the batch size that we'll optimize for. The third integer indicates
+                the largest batch size allowed.
+
+        Returns:
+            A list of InputTensorSpec named tuples with dynamic ranges.
+        """
+        input_specs = []
+        batch_size = tensors[0].size(0)
+
+        for i, tensor in enumerate(tensors):
+            assert (
+                batch_size == tensor.size(0)
+            ), f"The {i}th tensor (shape: {tensor.shape}) doesn't have the correct batch size: {batch_size}."
+            shape = list(tensor.shape)
+            shape[0] = -1
+            shape_ranges: List[ShapeRange] = [tuple(tuple([bs] + shape[1:]) for bs in batch_size_range)]  # type: ignore[list-item]
+            input_specs.append(cls(tuple(shape), tensor.dtype, tensor.device, shape_ranges))
+
+        return input_specs
+
+    def to_random_tensor(self):
+        shape = tuple(self.shape)
+        if len(get_dynamic_dims(shape)):
+            shape = tuple(self.shape_ranges[0][1])
+        elif not self.has_batch_dim:
+            shape = (1,) + tuple(shape)
+
+        return torch.randn(shape).to(dtype=self.dtype, device=self.device)
+
+    @staticmethod
+    def create_inputs_from_specs(input_specs: Iterable["InputTensorSpec"]):
+        inputs = []
+
+        for spec in input_specs:
+            inputs.append(spec.to_random_tensor())
+
+        return inputs

--- a/torch/fx/experimental/fx2trt/passes/fuse_pass.py
+++ b/torch/fx/experimental/fx2trt/passes/fuse_pass.py
@@ -111,7 +111,7 @@ def fuse_unsqueeze_cat_sum(gm: torch.fx.GraphModule):
 
 try:
     import tensorrt as trt
-    from torch.fx.experimental.fx2trt.fx2trt import tensorrt_converter
+    from torch.fx.experimental.fx2trt.converter_registry import tensorrt_converter
     from torch.fx.experimental.fx2trt.converters.acc_ops_converters import (
         get_trt_tensor,
         add_binary_elementwise_layer,

--- a/torch/fx/experimental/fx2trt/tools/trt_minimizer.py
+++ b/torch/fx/experimental/fx2trt/tools/trt_minimizer.py
@@ -2,7 +2,7 @@ from typing import Tuple, Callable, Any
 
 import torch
 import torch.fx.passes.net_min_base as net_min_base
-from torch.fx.experimental.fx2trt.fx2trt import (
+from torch.fx.experimental.fx2trt import (
     TRTModule,
     TRTInterpreter,
     InputTensorSpec,

--- a/torch/fx/experimental/fx2trt/tools/trt_splitter.py
+++ b/torch/fx/experimental/fx2trt/tools/trt_splitter.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, Tuple
 import torch
 import torch.fx.passes.splitter_base as splitter_base
 from torch.fx.experimental.fx2trt.tools.trt_minimizer import TensorRTMinimizer
-from torch.fx.experimental.fx2trt.fx2trt import (
+from torch.fx.experimental.fx2trt import (
     InputTensorSpec,
     TRTModule,
     TRTInterpreter,

--- a/torch/fx/experimental/fx2trt/trt_module.py
+++ b/torch/fx/experimental/fx2trt/trt_module.py
@@ -1,0 +1,218 @@
+from typing import List, Any, Sequence
+
+import tensorrt as trt
+import torch
+
+from .utils import torch_dtype_from_trt
+
+
+class TRTModule(torch.nn.Module):
+    def __init__(self, engine=None, input_names=None, output_names=None, cuda_graph_batch_size=-1):
+        super(TRTModule, self).__init__()
+        self._register_state_dict_hook(TRTModule._on_state_dict)
+        self.engine = engine
+        self.input_names = input_names
+        self.output_names = output_names
+        self.cuda_graph_batch_size = cuda_graph_batch_size
+        self.initialized = False
+
+        if engine:
+            self._initialize()
+
+    def _initialize(self):
+        self.initialized = True
+        self.context = self.engine.create_execution_context()
+
+        # Indices of inputs/outputs in the trt engine bindings, in the order
+        # as they are in the original PyTorch model.
+        self.input_binding_indices_in_order: Sequence[int] = [
+            self.engine.get_binding_index(name) for name in self.input_names
+        ]
+        self.output_binding_indices_in_order: Sequence[int] = [
+            self.engine.get_binding_index(name) for name in self.output_names
+        ]
+        primary_input_outputs = set()
+        primary_input_outputs.update(self.input_binding_indices_in_order)
+        primary_input_outputs.update(self.output_binding_indices_in_order)
+        self.hidden_output_binding_indices_in_order: Sequence[int] = []
+        self.hidden_output_names: Sequence[str] = []
+        for i in range(self.engine.num_bindings):
+            if i not in primary_input_outputs:
+                self.hidden_output_binding_indices_in_order.append(i)
+                self.hidden_output_names.append(self.engine.get_binding_name(i))
+
+        assert self.engine.num_bindings == (len(self.input_names) + len(self.output_names) + len(self.hidden_output_names))
+
+        self.input_dtypes: Sequence[torch.dtype] = [
+            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
+            for idx in self.input_binding_indices_in_order
+        ]
+        self.input_shapes: Sequence[Sequence[int]] = [
+            tuple(self.engine.get_binding_shape(idx))
+            for idx in self.input_binding_indices_in_order
+        ]
+        self.output_dtypes: Sequence[torch.dtype] = [
+            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
+            for idx in self.output_binding_indices_in_order
+        ]
+        self.output_shapes = [
+            tuple(self.engine.get_binding_shape(idx)) if self.engine.has_implicit_batch_dimension else tuple()
+            for idx in self.output_binding_indices_in_order
+        ]
+        self.hidden_output_dtypes: Sequence[torch.dtype] = [
+            torch_dtype_from_trt(self.engine.get_binding_dtype(idx))
+            for idx in self.hidden_output_binding_indices_in_order
+        ]
+        self.hidden_output_shapes = [
+            tuple(self.engine.get_binding_shape(idx)) if self.engine.has_implicit_batch_dimension else tuple()
+            for idx in self.hidden_output_binding_indices_in_order
+        ]
+
+
+    def _check_initialized(self):
+        if not self.initialized:
+            raise RuntimeError("TRTModule is not initialized.")
+
+    def _on_state_dict(self, state_dict, prefix, local_metadata):
+        self._check_initialized()
+        state_dict[prefix + "engine"] = bytearray(self.engine.serialize())
+        state_dict[prefix + "input_names"] = self.input_names
+        state_dict[prefix + "output_names"] = self.output_names
+        state_dict[prefix + "cuda_graph_batch_size"] = self.cuda_graph_batch_size
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        engine_bytes = state_dict[prefix + "engine"]
+
+        logger = trt.Logger()
+        runtime = trt.Runtime(logger)
+        self.engine = runtime.deserialize_cuda_engine(engine_bytes)
+
+        self.input_names = state_dict[prefix + "input_names"]
+        self.output_names = state_dict[prefix + "output_names"]
+        self._initialize()
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["engine"] = bytearray(self.engine.serialize())
+        state.pop('context', None)
+        return state
+
+    def __setstate__(self, state):
+        logger = trt.Logger()
+        runtime = trt.Runtime(logger)
+        state["engine"] = runtime.deserialize_cuda_engine(state["engine"])
+        self.__dict__.update(state)
+        if self.engine:
+            self.context = self.engine.create_execution_context()
+
+    def forward(self, *inputs):
+        with torch.autograd.profiler.record_function("TRTModule:Forward"):
+            self._check_initialized()
+
+            with torch.autograd.profiler.record_function("TRTModule:ProcessInputs"):
+                assert len(inputs) == len(
+                    self.input_names
+                ), f"Wrong number of inputs, expect {len(self.input_names)} get {len(inputs)}."
+
+                # This is only used when the trt engine is using implicit batch dim.
+                batch_size = inputs[0].shape[0]
+                contiguous_inputs: List[torch.Tensor] = [i.contiguous() for i in inputs]
+                bindings: List[Any] = [None] * (
+                    len(self.input_names) + len(self.output_names) + len(self.hidden_output_names)
+                )
+
+                for i, input_name in enumerate(self.input_names):
+                    assert inputs[
+                        i
+                    ].is_cuda, f"{i}th input({input_name}) is not on cuda device."
+                    assert (
+                        inputs[i].dtype == self.input_dtypes[i]
+                    ), f"Dtype mismatch for {i}th input({input_name}). Expect {self.input_dtypes[i]}, got {inputs[i].dtype}."
+
+                    idx = self.input_binding_indices_in_order[i]
+                    bindings[idx] = contiguous_inputs[i].data_ptr()
+
+                    if not self.engine.has_implicit_batch_dimension:
+                        self.context.set_binding_shape(
+                            idx, tuple(contiguous_inputs[i].shape)
+                        )
+                    else:
+                        assert (
+                            inputs[i].size()[1:] == self.input_shapes[i]
+                        ), f"Shape mismatch for {i}th input({input_name}). " \
+                           f"Expect {self.input_shapes[i]}, got {inputs[i].size()[1:]}."
+
+            with torch.autograd.profiler.record_function("TRTModule:ProcessOutputs"):
+                # create output tensors
+                outputs: List[torch.Tensor] = []
+
+                for i, idx in enumerate(self.output_binding_indices_in_order):
+                    if self.engine.has_implicit_batch_dimension:
+                        shape = (batch_size,) + self.output_shapes[i]
+                    else:
+                        shape = tuple(self.context.get_binding_shape(idx))
+
+                    output = torch.empty(  # type: ignore[call-overload]
+                        size=shape,
+                        dtype=self.output_dtypes[i],
+                        device=torch.cuda.current_device(),
+                    )
+                    outputs.append(output)
+                    bindings[idx] = output.data_ptr()
+
+                for i, idx in enumerate(self.hidden_output_binding_indices_in_order):
+                    if self.engine.has_implicit_batch_dimension:
+                        shape = (batch_size,) + self.hidden_output_shapes[i]
+                    else:
+                        shape = tuple(self.context.get_binding_shape(idx))
+
+                    output = torch.empty(  # type: ignore[call-overload]
+                        size=shape,
+                        dtype=self.hidden_output_dtypes[i],
+                        device=torch.cuda.current_device(),
+                    )
+                    bindings[idx] = output.data_ptr()
+
+            with torch.autograd.profiler.record_function("TRTModule:TensorRTRuntime"):
+                if self.engine.has_implicit_batch_dimension:
+                    self.context.execute_async(
+                        batch_size, bindings, torch.cuda.current_stream().cuda_stream
+                    )
+                else:
+                    self.context.execute_async_v2(
+                        bindings, torch.cuda.current_stream().cuda_stream
+                    )
+
+            if len(outputs) == 1:
+                return outputs[0]
+
+            return tuple(outputs)
+
+    def enable_profiling(self):
+        """
+        Enable TensorRT profiling. After calling this function, TensorRT will report
+        time spent on each layer in stdout for each forward run.
+        """
+        self._check_initialized()
+
+        if not self.context.profiler:
+            self.context.profiler = trt.Profiler()
+
+    def disable_profiling(self):
+        """
+        Disable TensorRT profiling.
+        """
+        self._check_initialized()
+
+        torch.cuda.synchronize()
+        del self.context
+        self.context = self.engine.create_execution_context()

--- a/torch/fx/experimental/fx2trt/types.py
+++ b/torch/fx/experimental/fx2trt/types.py
@@ -1,0 +1,21 @@
+from typing import Tuple, Sequence
+
+import tensorrt as trt
+
+if hasattr(trt, "__version__"):
+    TRTNetwork = trt.INetworkDefinition
+    TRTTensor = trt.tensorrt.ITensor
+    TRTLayer = trt.ILayer
+    TRTPluginFieldCollection = trt.PluginFieldCollection
+    TRTPlugin = trt.IPluginV2
+    TRTDataType = trt.DataType
+else:
+    TRTNetwork = "trt.INetworkDefinition"
+    TRTTensor = "trt.tensorrt.ITensor"
+    TRTLayer = "trt.ILayer"
+    TRTPluginFieldCollection = "trt.PluginFieldCollection"
+    TRTPlugin = "trt.IPluginV2"
+    TRTDataType = "trt.DataType"
+
+Shape = Sequence[int]
+ShapeRange = Tuple[Shape, Shape, Shape]

--- a/torch/fx/experimental/fx2trt/utils.py
+++ b/torch/fx/experimental/fx2trt/utils.py
@@ -1,0 +1,76 @@
+from typing import List
+
+import torch
+import tensorrt as trt
+
+from .types import Shape, TRTDataType
+
+
+def torch_dtype_to_trt(dtype: torch.dtype) -> TRTDataType:
+    """
+    Convert PyTorch data types to TensorRT data types.
+
+    Args:
+        dtype (torch.dtype): A PyTorch data type.
+
+    Returns:
+        The equivalent TensorRT data type.
+    """
+    if trt.__version__ >= "7.0" and dtype == torch.bool:
+        return trt.bool
+    elif dtype == torch.int8:
+        return trt.int8
+    elif dtype == torch.int32:
+        return trt.int32
+    elif dtype == torch.float16:
+        return trt.float16
+    elif dtype == torch.float32:
+        return trt.float32
+    else:
+        raise TypeError("%s is not supported by tensorrt" % dtype)
+
+
+def torch_dtype_from_trt(dtype: TRTDataType) -> torch.dtype:
+    """
+    Convert TensorRT data types to PyTorch data types.
+
+    Args:
+        dtype (TRTDataType): A TensorRT data type.
+
+    Returns:
+        The equivalent PyTorch data type.
+    """
+    if dtype == trt.int8:
+        return torch.int8
+    elif trt.__version__ >= "7.0" and dtype == trt.bool:
+        return torch.bool
+    elif dtype == trt.int32:
+        return torch.int32
+    elif dtype == trt.float16:
+        return torch.float16
+    elif dtype == trt.float32:
+        return torch.float32
+    else:
+        raise TypeError("%s is not supported by torch" % dtype)
+
+
+def get_dynamic_dims(shape: Shape) -> List[int]:
+    """
+    This function finds the dynamic dimensions in the given
+    shape. A dimension is dynamic if it's -1.
+
+    Args:
+        shape (Shape): A sequence of integer that represents
+            the shape of a tensor.
+
+    Returns:
+        A list of integers contains all the dynamic dimensions
+        in the given shape
+    """
+    dynamic_dims = []
+
+    for i, s in enumerate(shape):
+        if s == -1:
+            dynamic_dims.append(i)
+
+    return dynamic_dims

--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -4,8 +4,7 @@ from typing import Callable, List, Tuple
 import torch
 import torch.fx
 import torch.fx.experimental.fx_acc.acc_tracer as acc_tracer
-from torch.fx.experimental.fx2trt.fx2trt import (
-    create_inputs_from_specs,
+from torch.fx.experimental.fx2trt import (
     TRTInterpreter,
     InputTensorSpec,
     TRTModule,
@@ -241,7 +240,7 @@ class AccTestCase(TRTTestCase):
         atol=1e-03,
     ):
         mod.eval()
-        inputs = create_inputs_from_specs(input_specs)
+        inputs = InputTensorSpec.create_inputs_from_specs(input_specs)
         mod = acc_tracer.trace(mod, inputs)
         interp = TRTInterpreter(mod, input_specs, explicit_batch_dimension=True)
         super().run_test(mod, inputs, expected_ops, unexpected_ops, interp, rtol, atol)


### PR DESCRIPTION
Summary:
1. Added type hints to acc ops converters.
2. Put some of the class/logic in fx2trt.py to some separated files. (input_tensor_spec.py, trt_module.py, converter_registry.py).
3. Added import in `__init__.py` so that user can just call `from torch.fx.experimental.fx2trt import xxx` instead of `experimental.fx2trt.fx2trt`.

Test Plan: CI

Differential Revision: D32884637

