### PR TITLE
[Profiler] Factor common logic into `torch/csrc/profiler/api.h`

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -135,6 +135,7 @@ libtorch_sources_common = sorted(core_sources_common + torch_unpickler_common)
 libtorch_profiler_sources = [
     "torch/csrc/autograd/profiler_legacy.cpp",
     "torch/csrc/autograd/profiler_kineto.cpp",
+    "torch/csrc/profiler/api.cpp",
     "torch/csrc/monitor/counters.cpp",
     "torch/csrc/monitor/events.cpp",
 ]
@@ -596,7 +597,7 @@ libtorch_cuda_core_sources = [
     "torch/csrc/CudaIPCTypes.cpp",
     "torch/csrc/cuda/comm.cpp",
     "torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp",
-    "torch/csrc/autograd/profiler_cuda.cpp",
+    "torch/csrc/profiler/cuda.cpp",
     "torch/csrc/autograd/functions/comm.cpp",
     "torch/csrc/jit/codegen/cuda/arith.cpp",
     "torch/csrc/jit/codegen/cuda/compute_at.cpp",

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <torch/csrc/autograd/profiler_legacy.h>
 #include <string>
 #include <vector>
+
+#include <torch/csrc/profiler/api.h>
+#include <torch/csrc/profiler/util.h>
 
 #ifdef USE_KINETO
 namespace libkineto {
@@ -14,12 +16,6 @@ class ActivityTraceInterface;
 namespace torch {
 namespace autograd {
 namespace profiler {
-
-enum class C10_API_ENUM ActivityType {
-  CPU = 0,
-  CUDA, // CUDA kernels, runtime
-  NUM_KINETO_ACTIVITIES, // must be the last one
-};
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct KinetoObserverContext : public at::ObserverContext {
@@ -37,8 +33,8 @@ struct KinetoObserverContext : public at::ObserverContext {
   c10::optional<std::vector<std::string>> module_hierarchy;
   // Extra arguments for computing op flops
   c10::optional<std::unordered_map<std::string, c10::IValue>> extraArgs;
-  CUDAEventStub cuda_event_start_ = nullptr;
-  CUDAEventStub cuda_event_end_ = nullptr;
+  torch::profiler::impl::CUDAEventStub cuda_event_start_ = nullptr;
+  torch::profiler::impl::CUDAEventStub cuda_event_end_ = nullptr;
   int64_t debug_handle;
 };
 
@@ -294,8 +290,8 @@ struct TORCH_API KinetoEvent {
   int64_t debug_handle_{-1};
   std::string backend_;
 
-  CUDAEventStub cuda_event_start_ = nullptr;
-  CUDAEventStub cuda_event_end_ = nullptr;
+  torch::profiler::impl::CUDAEventStub cuda_event_start_ = nullptr;
+  torch::profiler::impl::CUDAEventStub cuda_event_end_ = nullptr;
 };
 
 // Consolidating events returned directly from Kineto
@@ -364,8 +360,8 @@ TORCH_API void reportBackendEventToActiveKinetoProfiler(
     const std::string& backend_name);
 
 TORCH_API void enableProfiler(
-    const ProfilerConfig& config,
-    const std::set<ActivityType>& activities,
+    const torch::profiler::impl::ProfilerConfig& config,
+    const std::set<torch::profiler::impl::ActivityType>& activities,
     const std::unordered_set<at::RecordScope>& scopes = {});
 
 /*
@@ -385,16 +381,16 @@ TORCH_API void enableProfiler(
  * and generates stack trace and module hierarchy information, once profiling is done.
  */
 TORCH_API void enableProfilerWithEventPostProcess(
-    const ProfilerConfig& config,
-    const std::set<ActivityType>& activities,
+    const torch::profiler::impl::ProfilerConfig& config,
+    const std::set<torch::profiler::impl::ActivityType>& activities,
     std::function<void(std::vector<KinetoEvent>&)>&& cb,
     const std::unordered_set<at::RecordScope>& scopes = {});
 
 TORCH_API std::unique_ptr<ProfilerResult> disableProfiler();
 
 TORCH_API void prepareProfiler(
-    const ProfilerConfig& config,
-    const std::set<ActivityType>& activities);
+    const torch::profiler::impl::ProfilerConfig& config,
+    const std::set<torch::profiler::impl::ActivityType>& activities);
 
 namespace python_tracer {
 

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -116,27 +116,7 @@ namespace torch { namespace autograd { namespace profiler {
 //  - save profiling events into the profiling state
 //
 
-namespace {
-const CUDAStubs default_stubs;
-constexpr const CUDAStubs* default_stubs_addr = &default_stubs;
-// Constant initialization, so it is guaranteed to be initialized before
-// static initialization calls which may invoke registerCUDAMethods
-inline const CUDAStubs*& cuda_stubs() {
-  static const CUDAStubs* stubs_ = default_stubs_addr;
-  return stubs_;
-}
-}
-
-const CUDAStubs* cudaStubs() {
-  return cuda_stubs();
-}
-
-// Profiler state
-const ProfilerConfig& ProfilerThreadLocalState::config() const {
-  return config_;
-}
-
-thread_event_lists ProfilerThreadLocalState::consolidate() {
+thread_event_lists ProfilerLegacyThreadLocalState::consolidate() {
   std::lock_guard<std::mutex> g(state_mutex_);
   thread_event_lists result;
   for (auto& kv : event_lists_map_) {
@@ -153,24 +133,24 @@ thread_event_lists ProfilerThreadLocalState::consolidate() {
   return result;
 }
 
-void ProfilerThreadLocalState::mark(std::string name, bool include_cuda) {
-  if (config_.state == ProfilerState::Disabled) {
+void ProfilerLegacyThreadLocalState::mark(std::string name, bool include_cuda) {
+  if (config_.state == torch::profiler::impl::ProfilerState::Disabled) {
     return;
   }
-  if (config_.state == ProfilerState::NVTX) {
-    cuda_stubs()->nvtxMarkA(name.c_str());
+  if (config_.state == torch::profiler::impl::ProfilerState::NVTX) {
+    torch::profiler::impl::cudaStubs()->nvtxMarkA(name.c_str());
   } else {
     LegacyEvent evt(
         EventKind::Mark,
         at::StringView(std::move(name)),
         at::RecordFunction::currentThreadId(),
-        include_cuda && config_.state == ProfilerState::CUDA);
+        include_cuda && config_.state == torch::profiler::impl::ProfilerState::CUDA);
     evt.setNodeId(at::RecordFunction::getDefaultNodeId());
     getEventList().record(std::move(evt));
   }
 }
 
-void ProfilerThreadLocalState::setOrAddRemoteProfiledEvents(
+void ProfilerLegacyThreadLocalState::setOrAddRemoteProfiledEvents(
     std::vector<LegacyEvent>&& remoteProfiledEvents) {
   // Lock to serialize access from multiple callback threads.
   std::lock_guard<std::mutex> guard(state_mutex_);
@@ -181,15 +161,15 @@ void ProfilerThreadLocalState::setOrAddRemoteProfiledEvents(
   }
 }
 
-void ProfilerThreadLocalState::pushRange(
+void ProfilerLegacyThreadLocalState::pushRange(
     const at::RecordFunction& fn,
     const bool record_cuda,
     std::vector<std::vector<int64_t>>&& shapes) {
-  if (config_.state == ProfilerState::Disabled) {
+  if (config_.state == torch::profiler::impl::ProfilerState::Disabled) {
     return;
   }
-  if (config_.state == ProfilerState::NVTX) {
-    cuda_stubs()->nvtxRangePushA(torch::profiler::impl::getNvtxStr(
+  if (config_.state == torch::profiler::impl::ProfilerState::NVTX) {
+    torch::profiler::impl::cudaStubs()->nvtxRangePushA(torch::profiler::impl::getNvtxStr(
         fn.name(), fn.seqNr(), shapes).c_str());
   } else {
     LegacyEvent evt(
@@ -225,12 +205,12 @@ void ProfilerThreadLocalState::pushRange(
   }
 }
 
-void ProfilerThreadLocalState::popRange(const at::RecordFunction& fn, const bool record_cuda) {
-  if (config_.state == ProfilerState::Disabled) {
+void ProfilerLegacyThreadLocalState::popRange(const at::RecordFunction& fn, const bool record_cuda) {
+  if (config_.state == torch::profiler::impl::ProfilerState::Disabled) {
     return;
   }
-  if (config_.state == ProfilerState::NVTX) {
-    cuda_stubs()->nvtxRangePop();
+  if (config_.state == torch::profiler::impl::ProfilerState::NVTX) {
+    torch::profiler::impl::cudaStubs()->nvtxRangePop();
   } else {
     // In some cases RecordFunction (and popRange) may be
     // called on a different thread than pushRange
@@ -247,29 +227,25 @@ void ProfilerThreadLocalState::popRange(const at::RecordFunction& fn, const bool
   }
 }
 
-void ProfilerThreadLocalState::reportMemoryUsage(
+void ProfilerLegacyThreadLocalState::reportMemoryUsage(
     void* /* unused */,
     int64_t alloc_size,
     int64_t /* total_allocated, unused for legacy */,
     int64_t /* total_reserved, unused for legacy */,
     c10::Device device) {
-  if (config_.profile_memory && config_.state != ProfilerState::Disabled) {
+  if (config_.profile_memory && config_.state != torch::profiler::impl::ProfilerState::Disabled) {
     uint64_t thread_id = at::RecordFunction::currentThreadId();
     LegacyEvent evt(
         EventKind::MemoryAlloc,
         at::StringView(""),
         thread_id,
-        config_.state == ProfilerState::CUDA);
+        config_.state == torch::profiler::impl::ProfilerState::CUDA);
     evt.updateMemoryStats(alloc_size, device);
     getEventList(thread_id).record(std::move(evt));
   }
 }
 
-bool ProfilerThreadLocalState::memoryProfilingEnabled() const {
-  return config_.profile_memory;
-}
-
-RangeEventList& ProfilerThreadLocalState::getEventList(int64_t thread_id) {
+RangeEventList& ProfilerLegacyThreadLocalState::getEventList(int64_t thread_id) {
   if (thread_id < 0) {
     thread_id = at::RecordFunction::currentThreadId();
   }
@@ -304,13 +280,6 @@ enum EventIValueIdx {
   NUM_EVENT_IVALUE_IDX // must be last in list
 };
 
-enum ProfilerIValueIdx {
-  STATE = 0,
-  REPORT_INPUT_SHAPES,
-  PROFILE_MEMORY,
-  NUM_PROFILER_CFG_IVALUE_IDX // must be last in list
-};
-
 const std::unordered_set<std::string> disable_cuda_profiling = {
   "aten::view",
   "aten::t",
@@ -329,8 +298,8 @@ const std::unordered_set<std::string> disable_cuda_profiling = {
   "aten::size"
 };
 
-ProfilerThreadLocalState* getProfilerTLSState() {
-  return static_cast<ProfilerThreadLocalState*>(
+ProfilerLegacyThreadLocalState* getProfilerTLSState() {
+  return static_cast<ProfilerLegacyThreadLocalState*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PROFILER_STATE));
 }
 
@@ -340,11 +309,11 @@ void pushProfilingCallbacksLegacy() {
   auto handle = at::addThreadLocalCallback(at::RecordFunctionCallback(
       [](const at::RecordFunction& fn) -> std::unique_ptr<at::ObserverContext> {
         auto state_ptr = getProfilerTLSState();
-        if (!state_ptr || state_ptr->config().state == ProfilerState::Disabled) {
+        if (!state_ptr || state_ptr->config().state == torch::profiler::impl::ProfilerState::Disabled) {
           return nullptr;
         }
         bool record_cuda =
-            state_ptr->config().state == ProfilerState::CUDA;
+            state_ptr->config().state == torch::profiler::impl::ProfilerState::CUDA;
         if (record_cuda && disable_cuda_profiling.find(fn.name()) != disable_cuda_profiling.end()) {
           record_cuda = false;
         }
@@ -360,11 +329,11 @@ void pushProfilingCallbacksLegacy() {
       },
       [](const at::RecordFunction& fn, at::ObserverContext*) {
         auto state_ptr = getProfilerTLSState();
-        if (!state_ptr || state_ptr->config().state == ProfilerState::Disabled) {
+        if (!state_ptr || state_ptr->config().state == torch::profiler::impl::ProfilerState::Disabled) {
           return;
         }
         bool record_cuda =
-            state_ptr->config().state == ProfilerState::CUDA;
+            state_ptr->config().state == torch::profiler::impl::ProfilerState::CUDA;
         if (record_cuda && disable_cuda_profiling.find(fn.name()) != disable_cuda_profiling.end()) {
           record_cuda = false;
         }
@@ -377,38 +346,7 @@ void pushProfilingCallbacksLegacy() {
 
 } // namespace
 
-void registerCUDAMethods(CUDAStubs* stubs) {
-  cuda_stubs() = stubs;
-}
-
-at::IValue ProfilerConfig::toIValue() const {
-  c10::impl::GenericList eventIValueList(at::AnyType::get());
-  eventIValueList.reserve(NUM_PROFILER_CFG_IVALUE_IDX);
-  eventIValueList.emplace_back(static_cast<int64_t>(state));
-  eventIValueList.emplace_back(report_input_shapes);
-  eventIValueList.emplace_back(profile_memory);
-  return eventIValueList;
-}
-
-ProfilerConfig ProfilerConfig::fromIValue(
-    const at::IValue& profilerConfigIValue) {
-  TORCH_INTERNAL_ASSERT(
-      profilerConfigIValue.isList(),
-      "Expected IValue to contain type c10::impl::GenericList");
-  auto ivalues = profilerConfigIValue.toList();
-  TORCH_INTERNAL_ASSERT(
-      ivalues.size() == NUM_PROFILER_CFG_IVALUE_IDX,
-      c10::str(
-          "Expected exactly ",
-          NUM_PROFILER_CFG_IVALUE_IDX,
-          " ivalues to resconstruct ProfilerConfig."));
-  return ProfilerConfig(
-      static_cast<ProfilerState>(ivalues.get(ProfilerIValueIdx::STATE).toInt()),
-      ivalues.get(ProfilerIValueIdx::REPORT_INPUT_SHAPES).toBool(),
-      ivalues.get(ProfilerIValueIdx::PROFILE_MEMORY).toBool());
-}
-
-ProfilerConfig getProfilerConfig() {
+torch::profiler::impl::ProfilerConfig getProfilerConfig() {
   auto state_ptr = getProfilerTLSState();
   TORCH_CHECK(
       state_ptr,
@@ -416,20 +354,15 @@ ProfilerConfig getProfilerConfig() {
   return state_ptr->config();
 }
 
-bool profilerEnabled() {
-  auto state_ptr = getProfilerTLSState();
-  return state_ptr && state_ptr->config().state != ProfilerState::Disabled;
-}
-
-void enableProfilerLegacy(const ProfilerConfig& new_config) {
-  TORCH_CHECK(new_config.state != ProfilerState::NVTX || cuda_stubs()->enabled(),
+void enableProfilerLegacy(const torch::profiler::impl::ProfilerConfig& new_config) {
+  TORCH_CHECK(new_config.state != torch::profiler::impl::ProfilerState::NVTX || torch::profiler::impl::cudaStubs()->enabled(),
     "Can't use NVTX profiler - PyTorch was compiled without CUDA");
 
-  TORCH_CHECK(new_config.state != ProfilerState::KINETO);
+  TORCH_CHECK(new_config.state != torch::profiler::impl::ProfilerState::KINETO);
 
   auto state_ptr = getProfilerTLSState();
   TORCH_CHECK(!state_ptr, "Profiler is already enabled on this thread");
-  auto state = std::make_shared<ProfilerThreadLocalState>(new_config);
+  auto state = std::make_shared<ProfilerLegacyThreadLocalState>(new_config);
   c10::ThreadLocalDebugInfo::_push(c10::DebugInfoKind::PROFILER_STATE, state);
 
   pushProfilingCallbacksLegacy();
@@ -448,15 +381,15 @@ thread_event_lists disableProfilerLegacy(c10::optional<ProfilerDisableOptions> p
     state = c10::ThreadLocalDebugInfo::_peek(c10::DebugInfoKind::PROFILER_STATE);
   }
 
-  auto state_ptr = static_cast<ProfilerThreadLocalState*>(state.get());
-  TORCH_CHECK(state_ptr && state_ptr->config().state != ProfilerState::Disabled,
+  auto state_ptr = static_cast<ProfilerLegacyThreadLocalState*>(state.get());
+  TORCH_CHECK(state_ptr && state_ptr->config().state != torch::profiler::impl::ProfilerState::Disabled,
       "Can't disable profiler when it's not running");
 
   if (cleanupTLSState) {
     at::removeCallback(state_ptr->callbackHandle());
   }
 
-  if (!consolidate || state_ptr->config().state == ProfilerState::NVTX) {
+  if (!consolidate || state_ptr->config().state == torch::profiler::impl::ProfilerState::NVTX) {
     return thread_event_lists();
   }
 
@@ -473,7 +406,7 @@ void addEventList(std::vector<LegacyEvent>&& profiledEvents) {
 
 void LegacyEvent::record(bool record_cuda) {
   if (record_cuda) {
-    cuda_stubs()->record(&device_, &cuda_event, &cpu_ns_);
+    torch::profiler::impl::cudaStubs()->record(&device_, &cuda_event, &cpu_ns_);
     return;
   }
   cpu_ns_ = torch::profiler::impl::getTime();
@@ -577,10 +510,8 @@ double LegacyEvent::cudaElapsedUs(const LegacyEvent& e) const {
     TORCH_INTERNAL_ASSERT(cuda_us_ >= 0 && e.cuda_us_ >= 0);
     return static_cast<double>(e.cuda_us_ - cuda_us_);
   }
-  return cuda_stubs()->elapsed(&cuda_event, &e.cuda_event);
+  return torch::profiler::impl::cudaStubs()->elapsed(&cuda_event, &e.cuda_event);
 }
-
-CUDAStubs::~CUDAStubs() = default;
 
 static const jit::CodeTemplate event_template(R"(
 {
@@ -648,7 +579,7 @@ RecordProfile::RecordProfile(const std::string& filename)
 }
 
 void RecordProfile::init() {
-  enableProfilerLegacy(ProfilerConfig(ProfilerState::CPU));
+  enableProfilerLegacy(torch::profiler::impl::ProfilerConfig(torch::profiler::impl::ProfilerState::CPU));
 }
 
 RecordProfile::~RecordProfile() {

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -10,54 +10,15 @@
 #include <forward_list>
 #include <tuple>
 #include <ATen/ATen.h>
-#include <torch/csrc/profiler/util.h>
 #include <torch/csrc/Export.h>
-
-struct CUevent_st;
-typedef std::shared_ptr<CUevent_st> CUDAEventStub;
+#include <torch/csrc/profiler/util.h>
+#include <torch/csrc/profiler/api.h>
 
 namespace torch { namespace autograd {
 
 struct Node;
 
 namespace profiler {
-
-struct TORCH_API CUDAStubs {
-  virtual void record(int* device, CUDAEventStub* event, int64_t* cpu_ns) const {
-    fail();
-  }
-  virtual float elapsed(const CUDAEventStub* event, const CUDAEventStub* event2) const {
-    fail();
-    return 0.f;
-  }
-  virtual void nvtxMarkA(const char* name) const {
-    fail();
-  }
-  virtual void nvtxRangePushA(const char* name) const {
-    fail();
-  }
-  virtual void nvtxRangePop() const {
-    fail();
-  }
-  virtual bool enabled() const {
-    return false;
-  }
-  virtual void onEachDevice(std::function<void(int)> op) const {
-    fail();
-  }
-  virtual void synchronize() const {
-    fail();
-  }
-  virtual ~CUDAStubs();
-
-private:
-  void fail() const {
-    AT_ERROR("CUDA used in profiler but not enabled.");
-  }
-};
-
-TORCH_API void registerCUDAMethods(CUDAStubs* stubs);
-TORCH_API const CUDAStubs* cudaStubs();
 
 enum class C10_API_ENUM EventKind : uint16_t {
   Mark,
@@ -301,7 +262,7 @@ struct TORCH_API LegacyEvent {
   int64_t cpu_memory_usage_ = 0;
   int64_t cuda_memory_usage_ = 0;
   int device_ = -1;
-  CUDAEventStub cuda_event = nullptr;
+  torch::profiler::impl::CUDAEventStub cuda_event = nullptr;
   int node_id_ = 0;
   bool is_remote_ = false;
   int64_t cuda_us_ = -1;
@@ -357,46 +318,6 @@ struct RangeEventList {
   static const size_t kReservedCapacity = 1024;
 };
 
-enum class C10_API_ENUM ProfilerState {
-  Disabled = 0,
-  CPU, // CPU-only profiling
-  CUDA, // CPU + CUDA events
-  NVTX,  // only emit NVTX markers
-  KINETO, // use libkineto
-  KINETO_GPU_FALLBACK, // use CUDA events when CUPTI is not available
-  NUM_PROFILER_STATES, // must be the last one
-};
-
-struct TORCH_API ProfilerConfig {
-  explicit ProfilerConfig(
-      ProfilerState state,
-      bool report_input_shapes = false,
-      bool profile_memory = false,
-      bool with_stack = false,
-      bool with_flops = false,
-      bool with_modules = false)
-      : state(state),
-        report_input_shapes(report_input_shapes),
-        profile_memory(profile_memory),
-        with_stack(with_stack),
-        with_flops(with_flops),
-        with_modules(with_modules) {}
-  ~ProfilerConfig() = default;
-  ProfilerState state;
-  bool report_input_shapes;
-  bool profile_memory;
-  bool with_stack;
-  bool with_flops;
-  bool with_modules;
-
-  // Returns IValues corresponding to ProfilerConfig struct, to be used for
-  // serialization.
-  at::IValue toIValue() const;
-
-  // Reconstructs a ProfilerConfig from IValues given by toIValue.
-  static ProfilerConfig fromIValue(const at::IValue& profilerConfigIValue);
-};
-
 // A struct to control settings of disableProfiler options.
 struct TORCH_API ProfilerDisableOptions {
   ProfilerDisableOptions() = default;
@@ -414,17 +335,15 @@ struct TORCH_API ProfilerDisableOptions {
 
 // NOTE: profiler mode is thread local, with automatic propagation
 // across thread boundary (e.g. at::launch tasks)
-TORCH_API void enableProfilerLegacy(const ProfilerConfig&);
+TORCH_API void enableProfilerLegacy(const torch::profiler::impl::ProfilerConfig&);
 using thread_event_lists = std::vector<std::vector<LegacyEvent>>;
 TORCH_API thread_event_lists disableProfilerLegacy(c10::optional<ProfilerDisableOptions> profilerDisableOptions = c10::nullopt);
 
 // adds profiledEvents to the current thread local recorded events. Each event
 // will be marked with node ID given by fromNodeId.
 TORCH_API void addEventList(std::vector<LegacyEvent>&& profiledEvents);
-// Returns if the profiler is currently enabled in the current thread.
-TORCH_API bool profilerEnabled();
 // Retrieve the thread_local ProfilerConfig.
-TORCH_API ProfilerConfig getProfilerConfig();
+TORCH_API torch::profiler::impl::ProfilerConfig getProfilerConfig();
 // Writes profiled events to a stream.
 TORCH_API void writeProfilerEventsToStream(std::ostream& out, const std::vector<LegacyEvent*>& events);
 
@@ -457,7 +376,7 @@ private:
 // }
 struct TORCH_API TLSLegacyProfilerGuard {
   explicit TLSLegacyProfilerGuard(
-      const ProfilerConfig& cfg,
+      const torch::profiler::impl::ProfilerConfig& cfg,
       c10::optional<std::function<void(const thread_event_lists&)>>
           resultCallback = c10::nullopt,
       c10::optional<ProfilerDisableOptions> profilerDisableOptions =
@@ -484,13 +403,11 @@ struct TORCH_API TLSLegacyProfilerGuard {
   const c10::optional<ProfilerDisableOptions> profilerDisableOptions_;
 };
 
-struct TORCH_API ProfilerThreadLocalState : public c10::MemoryReportingInfoBase {
+struct TORCH_API ProfilerLegacyThreadLocalState : public torch::profiler::impl::ProfilerThreadLocalStateBase {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-  explicit ProfilerThreadLocalState(const ProfilerConfig& config)
-      : config_(config), remoteProfiledEvents_{c10::nullopt} {}
-  ~ProfilerThreadLocalState() override = default;
-
-  const ProfilerConfig& config() const;
+  explicit ProfilerLegacyThreadLocalState(const torch::profiler::impl::ProfilerConfig& config)
+      : ProfilerThreadLocalStateBase(config), remoteProfiledEvents_{c10::nullopt} {}
+  ~ProfilerLegacyThreadLocalState() override = default;
 
   thread_event_lists consolidate();
 
@@ -506,26 +423,12 @@ struct TORCH_API ProfilerThreadLocalState : public c10::MemoryReportingInfoBase 
 
   void popRange(const at::RecordFunction& fn, const bool record_cuda);
 
-  void setCallbackHandle(at::CallbackHandle handle) {
-    handle_ = handle;
-  }
-
-  at::CallbackHandle callbackHandle() const {
-    return handle_;
-  }
-
-  bool hasCallbackHandle() {
-    return handle_ > 0;
-  }
-
   void reportMemoryUsage(
       void* /* unused */,
       int64_t alloc_size,
       int64_t /* total_allocated, unused for legacy */,
       int64_t /* total_reserved, unused for legacy */,
       c10::Device device) override;
-
-  bool memoryProfilingEnabled() const override;
 
  protected:
   RangeEventList& getEventList(int64_t thread_id = -1);
@@ -536,10 +439,6 @@ struct TORCH_API ProfilerThreadLocalState : public c10::MemoryReportingInfoBase 
       // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
       event_lists_map_;
 
-  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  ProfilerConfig config_ = ProfilerConfig(ProfilerState::Disabled);
-  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  at::CallbackHandle handle_ = 0;
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   c10::optional<std::vector<std::vector<LegacyEvent>>> remoteProfiledEvents_;
 };

--- a/torch/csrc/profiler/api.cpp
+++ b/torch/csrc/profiler/api.cpp
@@ -1,0 +1,112 @@
+#include <torch/csrc/profiler/api.h>
+
+namespace torch {
+namespace profiler {
+namespace impl {
+
+namespace {
+enum ProfilerIValueIdx {
+  STATE = 0,
+  REPORT_INPUT_SHAPES,
+  PROFILE_MEMORY,
+  NUM_PROFILER_CFG_IVALUE_IDX // must be last in list
+};
+} // namespace
+
+at::IValue ProfilerConfig::toIValue() const {
+  c10::impl::GenericList eventIValueList(at::AnyType::get());
+  eventIValueList.reserve(NUM_PROFILER_CFG_IVALUE_IDX);
+  eventIValueList.emplace_back(static_cast<int64_t>(state));
+  eventIValueList.emplace_back(report_input_shapes);
+  eventIValueList.emplace_back(profile_memory);
+  return eventIValueList;
+}
+
+ProfilerConfig ProfilerConfig::fromIValue(
+    const at::IValue& profilerConfigIValue) {
+  TORCH_INTERNAL_ASSERT(
+      profilerConfigIValue.isList(),
+      "Expected IValue to contain type c10::impl::GenericList");
+  auto ivalues = profilerConfigIValue.toList();
+  TORCH_INTERNAL_ASSERT(
+      ivalues.size() == NUM_PROFILER_CFG_IVALUE_IDX,
+      c10::str(
+          "Expected exactly ",
+          NUM_PROFILER_CFG_IVALUE_IDX,
+          " ivalues to resconstruct ProfilerConfig."));
+  return ProfilerConfig(
+      static_cast<ProfilerState>(ivalues.get(ProfilerIValueIdx::STATE).toInt()),
+      ivalues.get(ProfilerIValueIdx::REPORT_INPUT_SHAPES).toBool(),
+      ivalues.get(ProfilerIValueIdx::PROFILE_MEMORY).toBool());
+}
+
+bool profilerEnabled() {
+  const auto& state =
+      c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PROFILER_STATE);
+  auto state_ptr = static_cast<ProfilerThreadLocalStateBase*>(state);
+  return state_ptr &&
+      state_ptr->config().state !=
+      torch::profiler::impl::ProfilerState::Disabled;
+}
+
+CUDAStubs::~CUDAStubs() = default;
+
+namespace {
+struct DefaultCUDAStubs : public CUDAStubs {
+  void record(int* /*device*/, CUDAEventStub* /*event*/, int64_t* /*cpu_ns*/)
+      const override {
+    fail();
+  }
+  float elapsed(const CUDAEventStub* /*event*/, const CUDAEventStub* /*event2*/)
+      const override {
+    fail();
+    return 0.f;
+  }
+  void nvtxMarkA(const char* /*name*/) const override {
+    fail();
+  }
+  void nvtxRangePushA(const char* /*name*/) const override {
+    fail();
+  }
+  void nvtxRangePop() const override {
+    fail();
+  }
+  bool enabled() const override {
+    return false;
+  }
+  void onEachDevice(std::function<void(int)> /*op*/) const override {
+    fail();
+  }
+  void synchronize() const override {
+    fail();
+  }
+  ~DefaultCUDAStubs() override = default;
+
+ private:
+  void fail() const {
+    AT_ERROR("CUDA used in profiler but not enabled.");
+  }
+};
+
+const DefaultCUDAStubs default_stubs;
+constexpr const DefaultCUDAStubs* default_stubs_addr = &default_stubs;
+// Constant initialization, so it is guaranteed to be initialized before
+// static initialization calls which may invoke registerCUDAMethods
+inline const CUDAStubs*& cuda_stubs() {
+  static const CUDAStubs* stubs_ =
+      static_cast<const CUDAStubs*>(default_stubs_addr);
+  return stubs_;
+}
+} // namespace
+
+const CUDAStubs* cudaStubs() {
+  return cuda_stubs();
+}
+
+void registerCUDAMethods(CUDAStubs* stubs) {
+  cuda_stubs() = stubs;
+}
+
+} // namespace impl
+} // namespace profiler
+} // namespace torch

--- a/torch/csrc/profiler/api.h
+++ b/torch/csrc/profiler/api.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/record_function.h>
+#include <torch/csrc/Export.h>
+
+struct CUevent_st;
+
+namespace torch {
+namespace profiler {
+namespace impl {
+
+// ----------------------------------------------------------------------------
+// -- Profiler Config ---------------------------------------------------------
+// ----------------------------------------------------------------------------
+enum class C10_API_ENUM ActivityType {
+  CPU = 0,
+  CUDA, // CUDA kernels, runtime
+  NUM_KINETO_ACTIVITIES, // must be the last one
+};
+
+enum class C10_API_ENUM ProfilerState {
+  Disabled = 0,
+  CPU, // CPU-only profiling
+  CUDA, // CPU + CUDA events
+  NVTX, // only emit NVTX markers
+  KINETO, // use libkineto
+  KINETO_GPU_FALLBACK, // use CUDA events when CUPTI is not available
+  NUM_PROFILER_STATES, // must be the last one
+};
+
+struct TORCH_API ProfilerConfig {
+  explicit ProfilerConfig(
+      ProfilerState state,
+      bool report_input_shapes = false,
+      bool profile_memory = false,
+      bool with_stack = false,
+      bool with_flops = false,
+      bool with_modules = false)
+      : state(state),
+        report_input_shapes(report_input_shapes),
+        profile_memory(profile_memory),
+        with_stack(with_stack),
+        with_flops(with_flops),
+        with_modules(with_modules) {}
+  ~ProfilerConfig() = default;
+  ProfilerState state;
+  bool report_input_shapes;
+  bool profile_memory;
+  bool with_stack;
+  bool with_flops;
+  bool with_modules;
+
+  // Returns IValues corresponding to ProfilerConfig struct, to be used for
+  // serialization.
+  at::IValue toIValue() const;
+
+  // Reconstructs a ProfilerConfig from IValues given by toIValue.
+  static ProfilerConfig fromIValue(const at::IValue& profilerConfigIValue);
+};
+
+struct TORCH_API ProfilerThreadLocalStateBase
+    : public c10::MemoryReportingInfoBase {
+  explicit ProfilerThreadLocalStateBase(const ProfilerConfig& config)
+      : c10::MemoryReportingInfoBase(), config_(config) {}
+  ~ProfilerThreadLocalStateBase() override = default;
+
+  const ProfilerConfig& config() const {
+    return config_;
+  }
+
+  void setCallbackHandle(at::CallbackHandle handle) {
+    handle_ = handle;
+  }
+
+  at::CallbackHandle callbackHandle() const {
+    return handle_;
+  }
+
+  bool hasCallbackHandle() {
+    return handle_ > 0;
+  }
+
+  bool memoryProfilingEnabled() const override {
+    return config_.profile_memory;
+  }
+
+ protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  std::mutex state_mutex_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  ProfilerConfig config_ = ProfilerConfig(ProfilerState::Disabled);
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  at::CallbackHandle handle_ = 0;
+};
+
+// Returns if the profiler is currently enabled in the current thread.
+TORCH_API bool profilerEnabled();
+
+// ----------------------------------------------------------------------------
+// -- CUDA --------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+using CUDAEventStub = std::shared_ptr<CUevent_st>;
+
+struct TORCH_API CUDAStubs {
+  virtual void record(int* device, CUDAEventStub* event, int64_t* cpu_ns)
+      const = 0;
+  virtual float elapsed(const CUDAEventStub* event, const CUDAEventStub* event2)
+      const = 0;
+  virtual void nvtxMarkA(const char* name) const = 0;
+  virtual void nvtxRangePushA(const char* name) const = 0;
+  virtual void nvtxRangePop() const = 0;
+  virtual bool enabled() const {
+    return false;
+  }
+  virtual void onEachDevice(std::function<void(int)> op) const = 0;
+  virtual void synchronize() const = 0;
+  virtual ~CUDAStubs();
+};
+
+TORCH_API void registerCUDAMethods(CUDAStubs* stubs);
+TORCH_API const CUDAStubs* cudaStubs();
+
+} // namespace impl
+} // namespace profiler
+} // namespace torch
+
+// There are some components which use these symbols. Until we migrate them
+// we have to mirror them in the old autograd namespace.
+namespace torch {
+namespace autograd {
+namespace profiler {
+using torch::profiler::impl::ActivityType;
+using torch::profiler::impl::ProfilerConfig;
+using torch::profiler::impl::ProfilerState;
+using torch::profiler::impl::profilerEnabled;
+} // namespace profiler
+} // namespace autograd
+} // namespace torch

--- a/torch/csrc/profiler/cuda.cpp
+++ b/torch/csrc/profiler/cuda.cpp
@@ -5,8 +5,9 @@
 
 #include <sstream>
 
-namespace torch { namespace autograd { namespace profiler {
-
+namespace torch {
+namespace profiler {
+namespace impl {
 namespace {
 
 static inline void cudaCheck(cudaError_t result, const char * file, int line) {
@@ -101,7 +102,7 @@ struct RegisterCUDAMethods {
 };
 RegisterCUDAMethods reg;
 
-} // namespaces
+} // namespace
+} // namespace impl
 } // namespace profiler
-} // namespace autograd
 } // namespace torch


### PR DESCRIPTION
Summary:
This change breaks the dependency between the kineto and legacy profiler; instead of `profiler_kineto.h` including `profiler_legacy.h`, they both include `profiler/api.h`. As part of this refactor, I injected some intermediate classes to keep legacy behavior from leaking into the kineto profiler:

1) ProfilerThreadLocalState has become ProfilerThreadLocalStateBase which just handles config and callback handle. Legacy and Kineto profilers inherit this and implement their own very disjoint set of logic.

2) CUDAStubs is a pure virtual class to make the interface more readable, and the "always fail" behavior has been moved to a `DefaultCUDAStubs` class in `api.cpp`.

Test Plan: Ran the overhead ubenchmark.

Differential Revision: D32678163



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang