### PR TITLE
[WIP] Per sample gradients mechanism

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -582,7 +582,7 @@ Tensor batch_norm(
                                                 training, momentum, eps, cudnn_enabled));
 }
 
-Tensor instance_norm(
+std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _instance_norm_all_outputs(
     const Tensor& input, const c10::optional<Tensor>& weight_opt /* optional */, const c10::optional<Tensor>& bias_opt /* optional */, const c10::optional<Tensor>& running_mean_opt /* optional */, const c10::optional<Tensor>& running_var_opt /* optional */,
     bool use_input_stats, double momentum, double eps, bool cudnn_enabled) {
   // See [Note: hacky wrapper removal for optional tensor]
@@ -606,7 +606,7 @@ Tensor instance_norm(
   Tensor running_var_ = repeat_if_defined(running_var, b);
 
   auto input_reshaped = input.contiguous().view(shape);
-  auto out = at::batch_norm(input_reshaped, weight_, bias_, running_mean_, running_var_,
+  auto outs = at::native::_batch_norm_impl_index(input_reshaped, weight_, bias_, running_mean_, running_var_,
                             use_input_stats, momentum, eps, cudnn_enabled);
 
   // we alias running_mean and running_var because they are const but we want to modify their data
@@ -616,20 +616,15 @@ Tensor instance_norm(
   if (running_var.defined()) {
     at::alias(running_var).copy_(running_var_.view({ b, c }).mean(0, false));
   }
+  auto out = std::get<0>(outs);
 
-  return out.view(input.sizes());
+  return std::make_tuple(out.view(input.sizes()), std::get<1>(outs), std::get<2>(outs), std::get<3>(outs), std::get<4>(outs));
 }
 
-std::tuple<Tensor, Tensor> batch_norm_update_stats_cpu(
-        const Tensor& self, const c10::optional<Tensor>& running_mean_opt, const c10::optional<Tensor>& running_var_opt, double momentum) {
-  // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> running_mean_maybe_owned = at::borrow_from_optional_tensor(running_mean_opt);
-  const Tensor& running_mean = *running_mean_maybe_owned;
-  const Tensor& running_var = c10::value_or_else(running_var_opt, [] {return Tensor();});
-
-  return AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "batch_norm_update_stats_cpu", [&] {
-      return batch_norm_cpu_update_stats_template<scalar_t, Var>(self, running_mean, running_var, momentum, 0);
-    });
+Tensor instance_norm(
+    const Tensor& input, const c10::optional<Tensor>& weight_opt /* optional */, const c10::optional<Tensor>& bias_opt /* optional */, const c10::optional<Tensor>& running_mean_opt /* optional */, const c10::optional<Tensor>& running_var_opt /* optional */,
+    bool use_input_stats, double momentum, double eps, bool cudnn_enabled) {
+  return std::get<0>(at::native::_instance_norm_all_outputs(input, weight_opt, bias_opt, running_mean_opt, running_var_opt, use_input_stats, momentum, eps, cudnn_enabled));
 }
 
 std::tuple<Tensor, Tensor, Tensor> batch_norm_cpu(const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt, const c10::optional<Tensor>& running_mean_opt, const c10::optional<Tensor>& running_var_opt,

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -168,7 +168,6 @@ Tensor layer_norm(
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 
-
   return std::get<0>(at::native_layer_norm(input, normalized_shape, weight, bias, eps));
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2280,6 +2280,8 @@
 
 - func: group_norm(Tensor input, int num_groups, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enabled=True) -> Tensor
 
+- func: _group_norm_all_outputs(Tensor input, int num_groups, Tensor? weight=None, Tensor? bias=None, float eps=1e-05) -> (Tensor, Tensor, Tensor)
+
 - func: native_group_norm(Tensor input, Tensor? weight, Tensor? bias, int N, int C, int HxW, int group, float eps) -> (Tensor, Tensor, Tensor)
   dispatch:
     CPU, CUDA: native_group_norm
@@ -2384,6 +2386,8 @@
 
 - func: instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> Tensor
   variants: function
+
+- func: _instance_norm_all_outputs(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)
 
 - func: inverse(Tensor self) -> Tensor
   variants: function, method

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -453,3 +453,14 @@ Lazy Modules Initialization
     :template: classtemplate.rst
 
     nn.modules.lazy.LazyModuleMixin
+
+Stateless API
+-------------
+
+.. currentmodule:: torch
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    nn.utils._stateless.per_sample_call

--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -1,0 +1,221 @@
+
+from functools import partial
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_device_type import OpDTypes, instantiate_device_type_tests, ops
+from torch.testing._internal.common_utils import TestCase, freeze_rng_state, make_tensor, run_tests
+from torch.testing._internal.common_methods_invocations import SampleInput, op_db
+from torch.expanded_weights import ExpandedWeight
+from torch.nn.utils._stateless import per_sample_call
+from torch.testing._internal.common_nn import TestBase, module_tests, new_module_tests
+
+from torch.overrides import handle_torch_function, has_torch_function_variadic
+
+class TestExpandedWeightFunctional(TestCase):
+    @ops(filter(lambda op: op.supports_expanded_weight, op_db), dtypes=OpDTypes.supported, allowed_dtypes=(torch.double,))
+    def test_expanded_weight_per_sample_grad(self, device, dtype, op):
+        sample_inputs = op.sample_inputs(device, dtype, requires_grad=True)
+        for sample_input in supported_inputs(op, sample_inputs):
+            input = sample_input.input
+            args = sample_input.args
+            kwargs = sample_input.kwargs
+
+            if op.name == "nn.functional.embedding":  # embedding flips its argument order for autograd tests
+                sample_input = SampleInput(args[0], args=(input,), kwargs=kwargs)
+            batch_size = input.shape[0] if len(input.shape) > 1 else 1
+
+            # get per sample grads with ExpandedWeights objects
+            (ew_input, ew_args, ew_kwargs) = make_expanded_weight(sample_input, batch_size)
+            result = run_op(op, ew_input, *ew_args, **ew_kwargs)
+            diff_input_list = (ew_input,) + tuple(ew_args) + tuple(ew_kwargs.values())
+            diff_input_list = [i for i in diff_input_list if is_diff_tensor(i) or isinstance(i, ExpandedWeight)]
+            diff_input_list = [i.orig_weight if isinstance(i, ExpandedWeight) else i for i in diff_input_list]
+            if not diff_input_list:
+                continue
+            result.sum().backward()  # grad doesn't work with ExpandedWeight because it calls __torch_function__
+            expanded_weight_grad = (ew_input.grad,) + tuple(i.grad_sample for i in diff_input_list if hasattr(i, "grad_sample"))
+
+            # get per sample grads with for loop
+            func = partial(run_op, op)
+            per_sample_grad = for_loop_per_sample_grad(batch_size, input, func, *args, **kwargs)
+
+            # check equality
+            self.assertEqual(len(per_sample_grad), len(expanded_weight_grad))
+            for (result_grad, expected_grad) in zip(expanded_weight_grad, per_sample_grad):
+                if result_grad is None:
+                    result_grad = torch.zeros_like(expected_grad)
+                assert torch.allclose(result_grad, expected_grad), f"Got {result_grad}, expected {expected_grad}"
+
+
+    @ops(filter(lambda op: op.supports_expanded_weight, op_db), dtypes=OpDTypes.supported)
+    def test_expanded_weight_forward(self, device, dtype, op):
+        sample_inputs = op.sample_inputs(device, dtype)
+        for sample_input in supported_inputs(op, sample_inputs):
+            batch_size = sample_input.input.shape[0] if len(sample_input.input.shape) > 1 else 1
+            (ew_input, ew_args, ew_kwargs) = make_expanded_weight(sample_input, batch_size)
+            expanded_weight_result = op(ew_input, *ew_args, **ew_kwargs)
+            normal_result = op(sample_input.input, *sample_input.args, **sample_input.kwargs)
+            self.assertEqual(expanded_weight_result, normal_result)
+
+    def test_expanded_weight_fallback(self, device):
+        def linear_fallback(input, weight, bias):
+            if has_torch_function_variadic(input, weight, bias):
+                return handle_torch_function(linear_fallback, (input, weight, bias,), input, weight, bias,)
+            return torch.nn.functional.linear(input, weight, bias)
+
+        batch_size = 3
+        sample_linear_input = make_tensor((batch_size, 4), device, torch.float32, requires_grad=True)
+        sample_weight = make_tensor((5, 4), device, torch.float32, requires_grad=True)
+        sample_bias = make_tensor((5), device, torch.float32, requires_grad=True)
+
+        # use fallback
+        fallback_weight = torch.clone(sample_weight)
+        fallback_bias = torch.clone(sample_bias)
+        ew_constructor = partial(ExpandedWeight, batch_size=batch_size)
+        res = linear_fallback(sample_linear_input, ew_constructor(fallback_weight), ew_constructor(fallback_bias)).sum()
+        res.backward()
+        fallback_grad = (sample_linear_input.grad, fallback_weight.grad_sample, fallback_bias.grad_sample)
+
+        sample_linear_input.grad = None  # reset input to be used again
+
+        # use for loop
+        per_sample_grad = for_loop_per_sample_grad(batch_size, sample_linear_input, linear_fallback, sample_weight, sample_bias)
+
+        # check equality
+        self.assertEqual(len(per_sample_grad), len(fallback_grad))
+        for (result_grad, expected_grad) in zip(fallback_grad, per_sample_grad):
+            if result_grad is None:
+                result_grad = torch.zeros_like(expected_grad)
+            assert torch.allclose(result_grad, expected_grad)
+
+
+class TestExpandedWeightModule(TestCase):
+    def _do_test(self, module, input):
+        if sum(1 for _ in module.parameters()) == 0:  # for norms with affine=False
+            return
+        batch_size = input.shape[0]
+        with freeze_rng_state():
+            # get per sample grads with ExpandedWeights context manager
+            actual_res = per_sample_call(module, batch_size, input).sum()
+            actual_res.backward()
+            actual_grads = []
+            for param in module.parameters():
+                actual_grads.append(param.grad_sample)
+                del param.grad_sample
+
+            # get per sample grads with a for loop
+            expected_res = torch.tensor(0.)
+            expected_grads = []
+            for i in range(batch_size):
+                res = module(input[i].unsqueeze(0)).sum()
+                expected_grads.append(torch.autograd.grad(res, module.parameters(), torch.ones_like(res)))
+                expected_res += res
+            expected_grads = tuple(torch.stack(grad) for grad in zip(*expected_grads))
+        self.assertEqual(actual_res, expected_res)
+        assert [torch.allclose(actual, expected) for (actual, expected) in zip(actual_grads, expected_grads)]
+
+class ContextManagerTests(TestBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def constructor_args(self):
+        return self._get_arg('constructor_args', False)
+
+    def test_context_manager(self, test_case):
+        module = self.constructor(*self.constructor_args)
+        input = self._get_input()
+        if len(input.shape) == 0 or input.shape[0] == 0:
+            return
+        if self.constructor == torch.nn.Linear and len(input.shape) == 1:
+            return
+        test_case._do_test(module, input)
+
+# TODO: Once all of these use ModuleInfo, replace with ModuleInfo tests
+supported_modules = ['Linear', 'Conv2d', 'GroupNorm', 'LayerNorm', 'InstanceNorm', 'Embedding']
+supported_tests = [t for t in module_tests + new_module_tests if 'module_name' in t and t['module_name'] in supported_modules]
+for test_param in supported_tests:
+    if 'constructor' not in test_param:
+        name = test_param.pop('module_name')
+        test_param['constructor'] = getattr(nn, name)
+    decorator = test_param.pop('decorator', None)
+    test = ContextManagerTests(**test_param)
+    test_name = test.get_name()
+    if hasattr(TestExpandedWeightModule, test_name):
+        raise RuntimeError('Found two tests with the same name: ' + test_name)
+    if decorator is not None:
+        fn = decorator(fn)
+    setattr(TestExpandedWeightModule, test_name, lambda self, test=test: test.test_context_manager(self))
+
+# ------------- HELPER FUNCTIONS -----------------
+
+def run_op(op, input, *args, **kwargs):
+    r"""
+    OpInfo for Embedding switches the input and weight so autograd tests will only check the derivative
+    of the weight, not the input, which can't be differentiable since its dtype is int. Calls op,
+    using the special ordering that Embedding's OpInfo expects for that case.
+    """
+    if op.name == "nn.functional.embedding":
+        return op(args[0], input, **kwargs)
+    else:
+        return op(input, *args, **kwargs)
+
+def make_expanded_weight(sample_input, batch_size):
+    def expanded_weight_or_clone(arg):
+        return ExpandedWeight(torch.clone(arg), batch_size) if is_diff_tensor(arg) else clone_if_tensor(arg)
+
+    ew_input = clone_if_tensor(sample_input.input)
+    ew_args = tuple(expanded_weight_or_clone(arg) for arg in sample_input.args)
+    ew_kwargs = {name: expanded_weight_or_clone(arg) for (name, arg) in sample_input.kwargs.items()}
+    return ew_input, ew_args, ew_kwargs
+
+def supported_inputs(op, sample_inputs, supported_inputs=True):
+    r"""
+    ExpandedWeights currently does not support some use cases when there's no batch dimension or
+    operations that would cause inter-batch operations. Removes all of the cases it cannot deal with
+    """
+    def filter_fn(input):
+        if op.name == "nn.functional.linear":
+            is_supported_input = len(input.input.shape) > 1  # input of rank 1 means no batch dim
+        elif op.name == "nn.functional.layer_norm":
+            normalized_shape = input.args[0]
+            is_supported_input = input.input.shape != normalized_shape  # would cause inter-batch operations
+        elif op.name == "nn.functional.conv2d":
+            # currently can't deal with padding computation on Python level
+            is_supported_input = 'padding' in input.kwargs and isinstance(input.kwargs['padding'], int)
+        elif op.name == "nn.functional.embedding":
+            idx = input.args[0]
+            is_supported_input = len(idx.shape) > 2  # there's no batch size
+        else:
+            is_supported_input = True
+        is_supported_input = is_supported_input and input.input.shape[0] > 0  # 0 is not a valid batch size
+        return is_supported_input if supported_inputs else not is_supported_input
+    return [input for input in sample_inputs if filter_fn(input)]
+
+def for_loop_per_sample_grad(batch_size, input, func, *args, **kwargs):
+    # get per sample grads by getting derivative for each input in a for loop
+    per_sample_grad = []
+    for i in range(batch_size):
+        per_sample_input = input[i]
+        result = func(per_sample_input.unsqueeze(0), *args, **kwargs)
+        diff_input_list = (per_sample_input,) + tuple(args) + tuple(kwargs.values())
+        diff_input_list = [i for i in diff_input_list if isinstance(i, torch.Tensor) and i.requires_grad]
+        per_sample_grad.append(torch.autograd.grad(result, diff_input_list, torch.ones_like(result), allow_unused=True))
+    if len(per_sample_grad) == batch_size:
+        per_sample_grad = tuple(torch.stack(grad) for grad in zip(*per_sample_grad))
+    return per_sample_grad
+
+def is_diff_tensor(t):
+    return isinstance(t, torch.Tensor) and t.requires_grad
+
+def clone_if_tensor(t):
+    if isinstance(t, torch.Tensor):
+        res = torch.clone(t).detach()
+        res.requires_grad_(t.requires_grad)
+        return res
+    else:
+        return t
+
+instantiate_device_type_tests(TestExpandedWeightFunctional, globals())
+if __name__ == '__main__':
+    run_tests()

--- a/torch/expanded_weights/__init__.py
+++ b/torch/expanded_weights/__init__.py
@@ -1,0 +1,9 @@
+import torch.expanded_weights.linear_expanded_weights
+import torch.expanded_weights.conv_expanded_weights
+import torch.expanded_weights.embedding_expanded_weights
+import torch.expanded_weights.group_norm_expanded_weights
+import torch.expanded_weights.instance_norm_expanded_weights
+import torch.expanded_weights.layer_norm_expanded_weights
+from torch.expanded_weights.expanded_weights_impl import ExpandedWeight
+
+__all__ = ['ExpandedWeight']

--- a/torch/expanded_weights/conv_expanded_weights.py
+++ b/torch/expanded_weights/conv_expanded_weights.py
@@ -1,0 +1,103 @@
+import torch
+import torch.nn.functional as F
+from torch.expanded_weights.expanded_weights_impl import forward_helper, implements_per_sample_grads
+from torch.expanded_weights.expanded_weights_utils import grad_if_exists, grad_if_exists_for_input, unpack_expanded_weight_or_tensor
+
+import numpy as np
+
+THRESHOLD = 257
+
+@implements_per_sample_grads(F.conv2d)
+class ConvFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *expanded_args):
+        if any([isinstance(i, str) for i in expanded_args]):
+            raise RuntimeError("ExpandedWeights does not support convolution padding as a string. "
+                               "Please file an issue to prioritize support")
+        return forward_helper(F.conv2d, ctx, expanded_args, num_true_outs=1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        def compute_input_grad():
+            height = input.shape[2]
+            width = input.shape[3]
+
+            # compute output padding
+            output_padding_height = (2 * padding[0] + height - (kernel_height * dilation[0] - dilation[0] + 1)) % stride[0]
+            output_padding_width = (2 * padding[1] + width - (kernel_width * dilation[1] - dilation[1] + 1)) % stride[1]
+            output_padding = (output_padding_height, output_padding_width)
+            weight_ = unpack_expanded_weight_or_tensor(weight)
+            return F.conv_transpose2d(grad_output, weight_, None, stride, padding, output_padding, groups, dilation)
+
+        def weight_grad_sample(weight):
+            if (batch_size < THRESHOLD and groups == 1):
+                # TODO (samdow) conv_group to deal with groups
+                return conv_group_weight_grad_sample(input, grad_output, weight, stride, padding, dilation, batch_size)
+            else:
+                return conv_unfold_weight_grad_sample(input, grad_output, weight, kernel_size, stride, padding, dilation, groups)
+
+        def expand(param):
+            if isinstance(param, int):
+                return (param, param)
+            else:
+                return param
+
+        (input, weight, bias, stride, padding, dilation, groups) = ctx.args
+        stride, padding, dilation = expand(stride), expand(padding), expand(dilation)
+
+        kernel_height = weight.shape[2]
+        kernel_width = weight.shape[3]
+
+        kernel_size = (kernel_height, kernel_width)
+        batch_size = input.shape[0]
+        results = []
+
+        results.append(grad_if_exists_for_input(input, compute_input_grad))
+        results.append(grad_if_exists(weight, weight_grad_sample))
+        results.append(grad_if_exists(bias, lambda _: grad_output.reshape(*grad_output.shape[:2], -1).sum(dim=2)))
+
+        # no other arguments are differentiable
+        results = results + [None] * (len(ctx.args) - 3)
+        return tuple(results)
+
+def conv_unfold_weight_grad_sample(input, grad_output, weight, kernel_size, stride, padding, dilation, groups):
+    n = input.shape[0]
+    in_channels = input.shape[1]
+
+    input = torch.nn.functional.unfold(
+        input,
+        kernel_size,
+        padding=padding,
+        stride=stride,
+        dilation=dilation,
+    )
+    grad_output = grad_output.reshape(n, -1, input.shape[-1])
+
+    # n=batch_sz; o=num_out_channels; p=(num_in_channels/groups)*kernel_sz
+    weight_grad_sample = torch.einsum("noq,npq->nop", grad_output, input)
+    # rearrange the above tensor and extract diagonals.
+    weight_grad_sample = weight_grad_sample.view(
+        n,
+        groups,
+        -1,
+        groups,
+        int(in_channels / groups),
+        np.prod(kernel_size),
+    )
+    weight_grad_sample = torch.einsum("ngrg...->ngr...", weight_grad_sample).contiguous()
+    shape = [n] + list(weight.shape)
+    weight_grad_sample = weight_grad_sample.view(shape)
+    return weight_grad_sample
+
+def conv_group_weight_grad_sample(input, grad_output, weight, stride, padding, dilation, batch_size):
+    I = input.shape[1]
+    O = grad_output.shape[1]
+
+    input_ = input.transpose(0, 1)
+    grad_output_ = grad_output.view(grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2], grad_output.shape[3])
+
+    weight_grad_sample = F.conv2d(input_, grad_output_, None, stride=dilation, padding=padding, dilation=stride, groups=batch_size)
+    weight_grad_sample = weight_grad_sample.narrow(2, 0, weight.shape[2]).narrow(3, 0, weight.shape[3])
+    weight_grad_sample = weight_grad_sample.view(I, batch_size, O, *weight_grad_sample.shape[-2:])
+    weight_grad_sample = weight_grad_sample.movedim(0, 2)
+    return weight_grad_sample

--- a/torch/expanded_weights/embedding_expanded_weights.py
+++ b/torch/expanded_weights/embedding_expanded_weights.py
@@ -1,0 +1,51 @@
+
+import torch
+import torch.nn.functional as F
+from torch.expanded_weights.expanded_weights_impl import forward_helper, implements_per_sample_grads
+from torch.expanded_weights.expanded_weights_utils import grad_if_exists, grad_if_exists_for_input
+from functools import partial
+
+@implements_per_sample_grads(F.embedding)
+class EmbeddingPerSampleGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *expanded_args):
+        return forward_helper(F.embedding, ctx, expanded_args, 1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (input, weight, padding_idx, _, _, scale_grad_by_freq, sparse) = ctx.args
+
+        def input_grad(padding_idx):
+            if padding_idx is not None:
+                if padding_idx >= weight.shape[0]:
+                    raise RuntimeError("Padding_idx must be within num_embeddings, "
+                                       f"was ${padding_idx} but expected less than ${weight.shape[0]}")
+                elif padding_idx < -weight.shape[0]:
+                    raise RuntimeError("Padding_idx must be within num_embeddings, "
+                                       f"was ${padding_idx} but expected more than -${weight.shape[0]}")
+                elif padding_idx < 0:
+                    padding_idx = weight.shape[0] + padding_idx
+            else:
+                padding_idx = -1
+            return torch.embedding_grad(grad_output, input, weight.shape[0], padding_idx, scale_grad_by_freq, sparse)
+
+        def weight_per_sample_grad(weight):
+            batch_size = input.shape[0]
+            embedding_dim = weight.shape[1]
+            index = (
+                input.unsqueeze(-1)
+                .expand(*input.shape, embedding_dim)
+                .reshape(batch_size, -1, embedding_dim)
+            )
+            grad_sample = torch.zeros(
+                batch_size, *weight.shape, device=weight.device, dtype=grad_output.dtype
+            )
+            return grad_sample.scatter_add_(1, index, grad_output.reshape(batch_size, -1, embedding_dim))
+
+        results = []
+        results.append(grad_if_exists_for_input(input, partial(input_grad, padding_idx)))
+        results.append(grad_if_exists(weight, weight_per_sample_grad))
+
+        # no other arguments nor was_expanded are differentiable
+        results = results + [None] * (len(ctx.args) - 2)
+        return tuple(results)

--- a/torch/expanded_weights/expanded_weights_impl.py
+++ b/torch/expanded_weights/expanded_weights_impl.py
@@ -1,0 +1,180 @@
+import torch
+import functools
+import warnings
+
+from typing import Callable, Dict
+
+HANDLED_FUNCTIONS: Dict[Callable, torch.autograd.Function] = {}
+
+# ExpandedWeight represents a weight (parameter) Tensor that has an expanded
+# batch dimension. Operations on the ExpandedWeight Tensor take advantage of
+# how the batch dimension is expanded by de-expanding the weight before
+# computation. A subsequent call to .backward() computes gradients for
+# ExpandedWeight. Those gradients are equivalent to per-sample-grads for the
+# unexpanded weight Tensors.
+#
+# ExpandedWeight has a fallback that does the forward + backward computation.
+# The backward computation is not optimized: it runs torch.autograd.grad in
+# a loop. To optimize the backward computation further, we must register
+# overrides for specific operators.
+#
+# This is a __torch_function__ object but it could have also been a Tensor Extension
+# with a dispatch key.
+class ExpandedWeight(torch.Tensor):
+    handled_functions = HANDLED_FUNCTIONS
+
+    # needed for conv2d default kwargs
+    conv_kwarg_options = ['stride', 'padding', 'dilation', 'groups']
+    conv_kwarg_defaults = {'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 1}
+
+    def __new__(cls, orig_weight, batch_size):
+        ret = torch.Tensor._make_subclass(cls, orig_weight.detach(), orig_weight.requires_grad)
+        if not isinstance(orig_weight, torch.Tensor):
+            raise RuntimeError(f"Can only make ExpandedWeights of Tensors, got {type(orig_weight).__name__}")
+        ret.batch_size = batch_size
+        ret.orig_weight = orig_weight
+        return ret
+
+    @classmethod
+    def __torch_function__(cls, func, _, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if func not in cls.handled_functions:
+            warnings.warn(f"don't have custom implementation for function {func.__name__}. Using slow fallback")
+            return MyFunction.apply(func, *(args + tuple(kwargs.values())))
+        if func == torch.nn.functional.conv2d:
+            remaining_kwargs = 7 - len(args)
+            remaining_kwargs_options = cls.conv_kwarg_options[4 - remaining_kwargs:]
+            kwargs = {key: cls.conv_kwarg_defaults[key] for key in remaining_kwargs_options} | kwargs
+        return cls.handled_functions[func].apply(*(args + tuple(kwargs.values())))
+
+    @property
+    def shape(self):
+        return self.orig_weight.shape
+
+    @property
+    def grad(self):
+        return None
+
+    @property
+    def dtype(self):
+        return self.orig_weight.dtype
+
+    @grad.setter
+    def grad(self, value):
+        if value is None:
+            return
+        else:
+            raise RuntimeError("ExpandedWeights should never have a grad value set on it.")
+
+    @property
+    def requires_grad(self):
+        return self.orig_weight.requires_grad
+
+    @property
+    def grad_fn(self):
+        return None
+
+    def __hash__(self):
+        return id(self)
+
+    def __repr__(self):
+        return "ExpandedWeight for:\n" + self.orig_weight.__repr__() + f" with batch size {self.batch_size}"
+
+class MyFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *func_and_expanded_args):
+        func = func_and_expanded_args[0]
+        expanded_args = func_and_expanded_args[1:]
+        with torch.enable_grad():
+            output = forward_helper(func, ctx, expanded_args, 1)
+            true_output = ctx.true_outputs
+            if not isinstance(true_output, torch.Tensor):
+                raise RuntimeError(f"Fallback only works on Tensor output, got output was {type(true_output).__name__}")
+            outputs = tuple(true_output[i] for i in range(true_output.shape[0]))
+        ctx.outputs = outputs
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        outputs = ctx.outputs
+        diff_args = tuple(arg for arg in ctx.args
+                          if isinstance(arg, torch.Tensor) and arg.requires_grad)
+        diff_args = tuple(arg.orig_weight if isinstance(arg, ExpandedWeight) else arg for arg in diff_args)
+        batch_size = grad_output.shape[0]
+        per_sample_grads = tuple(torch.autograd.grad(outputs[i], diff_args, grad_output[i],
+                                                     retain_graph=(i != batch_size - 1))
+                                 for i in range(batch_size))
+        per_sample_grads = zip(*per_sample_grads)
+        result = []
+        result.append(None)  # for function input
+        for arg in ctx.args:
+            if isinstance(arg, ExpandedWeight):
+                per_sample_grad = next(per_sample_grads)
+                arg.orig_weight.grad_sample = torch.stack(per_sample_grad)
+                result.append(None)
+            elif isinstance(arg, torch.Tensor) and arg.requires_grad:
+                per_sample_grad = next(per_sample_grads)
+                result.append(torch.stack(per_sample_grad).sum(0))
+            else:
+                result.append(None)
+        result.append(None)
+        return tuple(result)
+
+# Fallback:
+# - forward pass: run operation with de-expanded input
+# - backward pass: run autograd.grad in a for-loop to compute per-sample-grads.
+#                  This is NOT something the vmap API can handle, something more
+#                  low-level is at work here.
+
+
+# We can override the fallback by implementing efficient "per-sample-grad" rules
+# for the backward pass. The forward pass should still be the same, though.
+def implements_per_sample_grads(torch_function):
+    @functools.wraps(torch_function)
+    def decorator(autograd_func):
+        HANDLED_FUNCTIONS[torch_function] = autograd_func
+        return autograd_func
+    return decorator
+
+def forward_helper(func, ctx, expanded_args, num_true_outs):
+    unexpanded_args = _check_and_unexpand_args(ctx, expanded_args)
+    output = func(*unexpanded_args)
+    return _check_and_detach_output(ctx, output, num_true_outs)
+
+def _check_and_unexpand_args(ctx, expanded_args):
+    # input being an ExpandedWeight is unsupported
+    if isinstance(expanded_args[0], ExpandedWeight):
+        raise RuntimeError("ExpandedWeights do not support inputs that are also ExpandedWeights. "
+                           "Input must be a Tensor")
+    unexpanded_args = tuple(arg.orig_weight if isinstance(arg, ExpandedWeight) else arg for arg in expanded_args)
+    ctx.args = expanded_args
+    return unexpanded_args
+
+def _check_and_detach_output(ctx, output, num_true_outs):
+    ctx.all_outputs = output
+
+    # separates differentiable outputs from outputs only needed for the backwards computation
+    if isinstance(output, tuple):
+        if len(output) < num_true_outs:
+            raise RuntimeError(f"Got fewer outputs ({len(output)}) than expected ({num_true_outs}). "
+                               "Issues in ExpandedWeights' autograd.Function")
+        if num_true_outs == 1:
+            output = output[0]  # removes tuple wrapper
+        else:
+            output = output[:num_true_outs]
+    elif num_true_outs != 1:
+        raise RuntimeError(f"Got single output but expected at least {num_true_outs} outputs. "
+                           "Issues in ExpandedWeights' autograd.Function")
+    ctx.true_outputs = output
+
+    def check_and_detach(output):
+        if not isinstance(output, torch.Tensor):
+            raise RuntimeError("Can only ")
+        return output.detach()
+
+    # NB: currently only works for differentiable, Tensor outputs
+    if isinstance(output, tuple):
+        return tuple(check_and_detach(o) for o in output)
+    else:
+        return check_and_detach(output)

--- a/torch/expanded_weights/expanded_weights_utils.py
+++ b/torch/expanded_weights/expanded_weights_utils.py
@@ -1,0 +1,47 @@
+import torch
+from torch.expanded_weights.expanded_weights_impl import ExpandedWeight
+
+def grad_if_exists(maybe_expanded_weight, per_sample_grad_fn):
+    unpacked = unpack_expanded_weight_or_tensor(maybe_expanded_weight)
+    if isinstance(maybe_expanded_weight, ExpandedWeight):
+        unpacked.grad_sample = per_sample_grad_fn(unpacked)
+
+def grad_if_exists_for_input(input, grad_fn):
+    if isinstance(input, torch.Tensor) and input.requires_grad:
+        return grad_fn()
+    else:
+        return None
+
+def unpack_expanded_weight_or_tensor(maybe_expanded_weight, func=lambda x: x):
+    if isinstance(maybe_expanded_weight, ExpandedWeight):
+        orig_weight = maybe_expanded_weight.orig_weight
+        return func(orig_weight)
+    elif isinstance(maybe_expanded_weight, torch.Tensor) and not torch.requires_grad:
+        return func(maybe_expanded_weight)
+    elif isinstance(maybe_expanded_weight, torch.Tensor):
+        raise RuntimeError("ExpandedWeights currently does not support a mixture of ExpandedWeight parameters "
+                           "and normal Parameters. Please file and issue with pytorch/pytorch")
+
+def sum_over_all_but_batch_and_last_n(
+    tensor: torch.Tensor, n_dims: int
+) -> torch.Tensor:
+    r"""
+    Calculates the sum over all dimensions, except the first
+    (batch dimension), and excluding the last n_dims.
+    This function will ignore the first dimension and it will
+    not aggregate over the last n_dims dimensions.
+    Args:
+        tensor: An input tensor of shape ``(B, ..., X[n_dims-1])``.
+        n_dims: Number of dimensions to keep.
+    Example:
+        >>> tensor = torch.ones(1, 2, 3, 4, 5)
+        >>> sum_over_all_but_batch_and_last_n(tensor, n_dims=2).shape
+        torch.Size([1, 4, 5])
+    Returns:
+        A tensor of shape ``(B, ..., X[n_dims-1])``
+    """
+    if tensor.dim() == n_dims + 1:
+        return tensor
+    else:
+        dims = list(range(1, tensor.dim() - n_dims))
+        return tensor.sum(dim=dims)

--- a/torch/expanded_weights/group_norm_expanded_weights.py
+++ b/torch/expanded_weights/group_norm_expanded_weights.py
@@ -1,0 +1,38 @@
+import torch
+import torch.nn.functional as F
+from torch.expanded_weights.expanded_weights_impl import forward_helper, implements_per_sample_grads
+from torch.expanded_weights.expanded_weights_utils import grad_if_exists, grad_if_exists_for_input, unpack_expanded_weight_or_tensor
+
+@implements_per_sample_grads(F.group_norm)
+class GroupNormFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *expanded_args):
+        return forward_helper(torch._group_norm_all_outputs, ctx, expanded_args, 1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        def input_grad():
+            weight_c = unpack_expanded_weight_or_tensor(weight, lambda orig_weight: orig_weight.contiguous())
+            input_c = input.contiguous()
+            grad_output_c = grad_output.contiguous() if grad_output is not None else torch.zeros(output.shape).contiguous()
+            N = input.shape[0]
+            C = input.shape[1]
+            HxW = 1
+            for s in input.shape[2:]:
+                HxW *= s
+            input_grad_fn = torch.ops.aten.native_group_norm_backward
+            return input_grad_fn(grad_output_c, input_c, mean, rstd, weight_c, N, C, HxW, num_groups, (True, False, False))
+
+        (input, num_groups, weight, bias, eps) = ctx.args
+
+        (output, mean, rstd) = ctx.all_outputs
+
+        results = []
+        results.append(grad_if_exists_for_input(input, lambda: input_grad()[0]))
+        results.append(None)  # for num_groups
+        results.append(grad_if_exists(weight,
+                                      lambda _: torch.einsum("ni...->ni", F.group_norm(input, num_groups, eps=eps) * grad_output)))
+        results.append(grad_if_exists(bias, lambda _: torch.einsum("ni...->ni", grad_output)))
+
+        results = results + [None] * (len(ctx.args) - 3)
+        return tuple(results)

--- a/torch/expanded_weights/instance_norm_expanded_weights.py
+++ b/torch/expanded_weights/instance_norm_expanded_weights.py
@@ -1,0 +1,45 @@
+
+from functools import partial
+import torch
+import torch.nn.functional as F
+from torch.expanded_weights.expanded_weights_impl import forward_helper, implements_per_sample_grads
+from torch.expanded_weights.expanded_weights_utils import grad_if_exists, grad_if_exists_for_input, unpack_expanded_weight_or_tensor
+
+@implements_per_sample_grads(F.instance_norm)
+class InstanceNormFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *expanded_args):
+        instance_norm = partial(torch._instance_norm_all_outputs, cudnn_enabled=True)
+        return forward_helper(instance_norm, ctx, expanded_args, 1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (input, running_mean, running_var, weight, bias, _, _, eps) = ctx.args
+        (_, mean, rstd, reserve, idx) = ctx.all_outputs
+
+        def input_grad():
+            b = input.shape[0]
+            c = input.shape[1]
+            new_shape = (1, b * c, *input.shape[2:])
+
+            weight_ = unpack_expanded_weight_or_tensor(weight, lambda orig_weight: orig_weight.repeat(b))
+            running_mean_ = running_mean.repeat(b) if running_mean is not None else None
+            running_var_ = running_var.repeat(b) if running_var is not None else None
+            input_reshaped = input.contiguous().view(new_shape)
+            grad_output_reshaped = grad_output.contiguous().view(new_shape)
+            res = torch.ops.aten._batch_norm_impl_index_backward(
+                idx, input_reshaped, grad_output_reshaped, weight_, running_mean_, running_var_,
+                mean, rstd, True, eps, (True, False, False), reserve)
+            return res[0].reshape(input.shape)
+
+        results = []
+        results.append(grad_if_exists_for_input(input, input_grad))
+        results.append(None)  # for running_mean
+        results.append(None)  # for running_var
+        results.append(grad_if_exists(weight,
+                                      lambda _: torch.einsum("ni...->ni", F.instance_norm(input, eps=eps) * grad_output)))
+        results.append(grad_if_exists(bias, lambda _: torch.einsum("ni...->ni", grad_output)))
+
+        # no other arguments nor was_expanded are differentiable
+        results = results + [None] * (len(ctx.args) - 3)
+        return tuple(results)

--- a/torch/expanded_weights/layer_norm_expanded_weights.py
+++ b/torch/expanded_weights/layer_norm_expanded_weights.py
@@ -1,0 +1,39 @@
+
+import torch
+import torch.nn.functional as F
+from torch.expanded_weights.expanded_weights_impl import forward_helper, implements_per_sample_grads
+from torch.expanded_weights.expanded_weights_utils import \
+    grad_if_exists, grad_if_exists_for_input, sum_over_all_but_batch_and_last_n, unpack_expanded_weight_or_tensor
+
+@implements_per_sample_grads(F.layer_norm)
+class LayerNormFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *expanded_args):
+        input = expanded_args[0]
+        normalized_shape = expanded_args[1]
+        if len(input.shape) <= len(normalized_shape):
+            raise RuntimeError("Layer norm should not normalize over batch dimension for per sample gradient computations "
+                               f"but got that normalized shape, {normalized_shape}, matched input shape.")
+        return forward_helper(torch.native_layer_norm, ctx, expanded_args, 1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        def input_grad():
+            weight_ = unpack_expanded_weight_or_tensor(weight)
+            bias_ = unpack_expanded_weight_or_tensor(bias)
+            return torch.ops.aten.native_layer_norm_backward(
+                grad_output, input, normalized_shape, mean, rstd, weight_, bias_, (True, False, False))[0]
+
+        def weight_per_sample_grad(weight):
+            return sum_over_all_but_batch_and_last_n(F.layer_norm(input, normalized_shape, eps=eps) * grad_output, weight.dim())
+
+        (input, normalized_shape, weight, bias, eps) = ctx.args
+        (_, mean, rstd) = ctx.all_outputs
+
+        results = []
+        results.append(grad_if_exists_for_input(input, input_grad))
+        results.append(None)  # for normalized_shape
+        results.append(grad_if_exists(weight, weight_per_sample_grad))
+        results.append(grad_if_exists(bias, lambda bias: sum_over_all_but_batch_and_last_n(grad_output, bias.dim())))
+        results.append(None)  # for eps
+        return tuple(results)

--- a/torch/expanded_weights/linear_expanded_weights.py
+++ b/torch/expanded_weights/linear_expanded_weights.py
@@ -1,0 +1,23 @@
+import torch
+import torch.nn.functional as F
+from torch.expanded_weights.expanded_weights_impl import forward_helper, implements_per_sample_grads
+from torch.expanded_weights.expanded_weights_utils import grad_if_exists, grad_if_exists_for_input, unpack_expanded_weight_or_tensor
+
+@implements_per_sample_grads(F.linear)
+class LinearPerSampleGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *expanded_args):
+        if len(expanded_args[0].shape) <= 1:
+            raise ValueError("Input does not have a batch dimension. "
+                             f"Expected input of at least rank 2, got of rank {len(expanded_args[0].shape)}")
+        return forward_helper(F.linear, ctx, expanded_args, 1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (input, weight, bias) = ctx.args
+        results = []
+
+        results.append(grad_if_exists_for_input(input, lambda: grad_output.matmul(unpack_expanded_weight_or_tensor(weight))))
+        results.append(grad_if_exists(weight, lambda _: torch.einsum("n...i,n...j->nij", grad_output, input)))
+        results.append(grad_if_exists(bias, lambda _: torch.einsum("n...k->nk", grad_output)))
+        return tuple(results)

--- a/torch/nn/utils/_stateless.py
+++ b/torch/nn/utils/_stateless.py
@@ -2,6 +2,7 @@ import contextlib
 
 import torch
 
+from torch.expanded_weights.expanded_weights_impl import ExpandedWeight
 
 @contextlib.contextmanager
 def reparametrize_module(module, parameters_and_buffers):
@@ -43,3 +44,44 @@ def functional_call(module, parameters_and_buffers, args, kwargs=None):
         else:
             out = module(args, **kwargs)
     return out
+
+def per_sample_call(module, batch_size, args, kwargs=None):
+    r"""
+    per_sample_call(module, batch_size, args, kwargs=None) -> Tensor
+
+    Invoked just like a forward pass, ``per_sample_call`` will produce the same
+    forward result. Then, when backward is invoked, the parameters of ``module``
+    will have a ``grad_sample`` field populated with the per sample gradients
+    instead of the batched gradients
+
+    Args:
+        module: The module to get per sample gradients with respect to. All trainable
+          parameters will compute per sample gradients, located in a ``grad_sample``
+          field when ``backward`` is invoked
+        batch_size: The batch size of the input. Typically the input's first dimension
+        args: Tuple of positional args passed to ``module`` to perform the forward pass
+        kwargs: Dict of named args passed to ``module`` to perform the forward pass.
+          Default: None
+
+    Examples::
+
+        >>> model = nn.Linear(4, 3)
+        >>> batched_input = torch.randn(5, 4)  # batch size of 5
+        >>> res = per_sample_call(model, batched_input.shape[0], batched_input).sum()
+        >>> res.backward()
+        >>> assert model.weight.shape == (3, 4)
+        >>> assert model.weight.grad_sample.shape == (5, 3, 4)
+        >>> assert model.weight.grad == None
+        >>> assert model.bias.shape == (3,)
+        >>> assert model.bias.grad_sample.shape == (5, 3)
+        >>> assert model.bias.grad == None
+
+    """
+    def maybe_build_expanded_weight(og_tensor):
+        if og_tensor.requires_grad:
+            return ExpandedWeight(og_tensor, batch_size)
+        else:
+            return og_tensor
+
+    params = {name: maybe_build_expanded_weight(value) for (name, value) in module.named_parameters()}
+    return functional_call(module, params, args, kwargs)

--- a/torch/nn/utils/per_sample_call.py
+++ b/torch/nn/utils/per_sample_call.py
@@ -1,0 +1,19 @@
+import torch
+
+from torch.expanded_weights.expanded_weights_impl import ExpandedWeight
+from ._stateless import functional_call
+
+def per_sample_call(module: torch.nn.Module, batch_size, *args, **kwargs):
+    r"""Invoked just like a forward pass, per_sample_call will produce the same
+    forward result. Then, when backward is invoked, the parameters of ``module``
+    will have a ``grad_sample`` field populated with the per sample gradients
+    instead of the batched gradients
+    """
+    def maybe_build_expanded_weight(og_tensor):
+        if og_tensor.requires_grad:
+            return ExpandedWeight(og_tensor, batch_size)
+        else:
+            return og_tensor
+
+    params = {name: maybe_build_expanded_weight(value) for (name, value) in module.named_parameters()}
+    return functional_call(module, params, args, kwargs)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -606,6 +606,8 @@ class OpInfo(object):
                  test_conjugated_samples=True,
                  test_neg_view=True,
                  assert_jit_shape_analysis=False,  # assert that jit shape analysis fully propagates shape
+                 # the following metadata relates to ExpandedWeights support and is checked in test_ops.py
+                 supports_expanded_weight=False,
                  ):
 
         dtypes_args = (dtypes, dtypesIfCPU, dtypesIfCUDA, dtypesIfROCM)
@@ -748,6 +750,7 @@ class OpInfo(object):
 
         self.test_conjugated_samples = test_conjugated_samples
         self.test_neg_view = test_neg_view
+        self.supports_expanded_weight = supports_expanded_weight
 
     def __call__(self, *args, **kwargs):
         """Calls the function variant of the operator."""
@@ -10880,6 +10883,7 @@ op_db: List[OpInfo] = [
                # "../torch/csrc/jit/passes/utils/check_alias_annotation.cpp":103, please report a bug to PyTorch.
                DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit'),
            ),
+           supports_expanded_weight=True,
            supports_out=False,),
     OpInfo('nn.functional.group_norm',
            aten_name='group_norm',
@@ -10893,7 +10897,8 @@ op_db: List[OpInfo] = [
                # Consider making it a parameter or input, or detaching the gradient
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32,))
            ],
-           sample_inputs_func=sample_inputs_group_norm,),
+           sample_inputs_func=sample_inputs_group_norm,
+           supports_expanded_weight=True,),
     OpInfo('nn.functional.instance_norm',
            # no ref because instance_norm will often have numerical instability (large numbers or nan)
            dtypes=floating_types(),
@@ -10904,7 +10909,8 @@ op_db: List[OpInfo] = [
                # Consider making it a parameter or input, or detaching the gradient
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32,))
            ],
-           sample_inputs_func=sample_inputs_instance_norm,),
+           sample_inputs_func=sample_inputs_instance_norm,
+           supports_expanded_weight=True,),
     OpInfo('nn.functional.layer_norm',
            aten_name='layer_norm',
            aliases=('layer_norm',),
@@ -10918,7 +10924,8 @@ op_db: List[OpInfo] = [
                    'TestCommon', 'test_reference_testing'
                )
            ],
-           sample_inputs_func=sample_inputs_layer_norm,),
+           sample_inputs_func=sample_inputs_layer_norm,
+           supports_expanded_weight=True,),
     OpInfo('nn.functional.local_response_norm',
            dtypes=floating_types_and(torch.int64),
            dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
@@ -11223,6 +11230,7 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            # See https://github.com/pytorch/pytorch/issues/66357
            check_batched_forward_grad=False,
+           supports_expanded_weight=True,
            supports_out=False),
     OpInfo('nn.functional.bilinear',
            aten_name='bilinear',
@@ -13459,7 +13467,7 @@ op_db: List[OpInfo] = [
                   dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
                   supports_out=False,
                   supports_forward_ad=True,
-                  sample_inputs_func=sample_repeat_tile),
+                  sample_inputs_func=sample_repeat_tile,),
     OpInfo('squeeze',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            supports_out=False,
@@ -14103,6 +14111,7 @@ op_db: List[OpInfo] = [
             # Reference: https://github.com/pytorch/pytorch/issues/67084
             DecorateInfo(unittest.skip("Skipped!"), 'TestMathBits', 'test_neg_view', device_type='cuda'),
         ),
+        supports_expanded_weight=True,
         supports_out=False,
     ),
     OpInfo(


### PR DESCRIPTION
Adds a mechanism to compute efficient per sample gradients on modules.

The current intended way of using them is:
```python
model: torch.nn.Module
input: tensor[N, *]

with model.compute_per_sample_grad(batch_size=N):
  res = model(input)
  res.backward()

# Each parameter of model will now have a `grad_sample` field with the correct per sample grads.
# The `grad` field will be empty
```

TODO:
- [x] remove functions added to native_functions.yaml
- [ ] add documentation about best practices on using it
- [ ] add negative tests for non-supported sample inputs
~add support for non-first element batch size~ For now, this will only show up with SequenceBias, which is a custom Opacus module. We'll end up making this decision on a per function basis

---------------------
API options from discussion (11/9):
```python
# Opt 1
with element_wise_grad(model):
    model(inp).sum().backward()

    for p in model.parameter():
        print(p.grad_sample) # RuntimeError
        print(p.grad is not None) # has per-sample gradient

for p in model.parameter():
    print(p.grad_sample is not None)
    print(p.grad is None)



# Opt 2
out = nn.util.per_sample_call(model, inp)
out.sum().backward()

for p in model.parameter():
    print(p.grad_sample is not None)
    print(p.grad is None)


# Opt 3
some_dict = model.state_dict()
for k in some_dict:
    some_dict[k] = PerSampleObj(some_dict[k])

out = nn.util.stateless.functional_call(model, some_dict, inp)
out.sum().backward()

for k in some_dict:
    print(some_dict[k].grad)
for p in model.parameter():
    print(p.grad is None)
    
# Opt 4
model.per_sample_model_()
out = model(input)
out.sum().backward()

for p in model.parameter():
    print(p.grad_sample is not None)
    print(p.grad is None)
```