### PR TITLE
Deprecate CreateFrom method in LazyTensor

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -48,13 +48,6 @@ class LazyTensor {
   static LazyTensor Create(torch::lazy::BackendDataPtr handle);
   static LazyTensor Create(std::shared_ptr<Data> data);
 
-  // TODO(whc) just a hack for now to get codegen to compile... need to refactor
-  // Create a new lazy tensor with the same metadata of the input tensor (with
-  // possible overrides), and the new IR value.
-  LazyTensor CreateFrom(torch::lazy::Value ir_value) const;
-  LazyTensor CreateFrom(torch::lazy::Value ir_value,
-                        const torch::lazy::BackendDevice& device) const;
-
   // Creates an empty/null tensor.
   LazyTensor() = default;
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.cpp
@@ -15,7 +15,7 @@ std::pair<LazyTensor, torch::lazy::Value> all_reduce(
   std::vector<torch::lazy::Value> input_values({input.GetIrValue()});
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
-  return {input.CreateFrom(torch::lazy::Value(node, 0)), torch::lazy::Value(node, 1)};
+  return {LazyTensor::Create(torch::lazy::Value(node, 0), input.GetDevice()), torch::lazy::Value(node, 1)};
 }
 
 torch::lazy::Value all_reduce_(LazyTensor& input,
@@ -53,13 +53,13 @@ std::pair<LazyTensor, torch::lazy::Value> all_to_all(
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::AllToAll>(
       input.GetIrValue(), token, split_dimension, concat_dimension, split_count,
       std::move(groups));
-  return {input.CreateFrom(torch::lazy::Value(node, 0)), torch::lazy::Value(node, 1)};
+  return {LazyTensor::Create(torch::lazy::Value(node, 0), input.GetDevice()), torch::lazy::Value(node, 1)};
 }
 
 LazyTensor get_dimensions_size(const LazyTensor& input,
                                std::vector<int64_t> dimensions) {
-  return input.CreateFrom(torch::lazy::MakeNode<ir::ops::GetDimensionsSize>(
-      input.GetIrValue(), std::move(dimensions)));
+  return LazyTensor::Create(torch::lazy::MakeNode<ir::ops::GetDimensionsSize>(
+      input.GetIrValue(), std::move(dimensions)), input.GetDevice());
 }
 
 std::pair<LazyTensor, torch::lazy::Value> collective_permute(
@@ -67,7 +67,7 @@ std::pair<LazyTensor, torch::lazy::Value> collective_permute(
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs) {
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::CollectivePermute>(
       input.GetIrValue(), token, std::move(source_target_pairs));
-  return {input.CreateFrom(torch::lazy::Value(node, 0)), torch::lazy::Value(node, 1)};
+  return {LazyTensor::Create(torch::lazy::Value(node, 0), input.GetDevice()), torch::lazy::Value(node, 1)};
 }
 
 }  // namespace lazy_tensor_distributed

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -180,7 +180,7 @@ at::Tensor LazyNativeFunctions::cat(at::TensorList tensors, int64_t dim) {
   auto node =
       torch::lazy::MakeNode<ir::ops::Cat>(values, dim, std::move(shapes));
   auto result = CreateAtenFromLtcTensor(
-      lazy_tensors[0].CreateFrom(torch::lazy::Value(node, 0)));
+      LazyTensor::Create(torch::lazy::Value(node, 0), lazy_tensors[0].GetDevice()));
   return result;
 }
 

--- a/lazy_tensor_core/test/test_lazy.py
+++ b/lazy_tensor_core/test/test_lazy.py
@@ -11,37 +11,39 @@ import lazy_tensor_core.debug.metrics as metrics
 lazy_tensor_core._LAZYC._ltc_init_ts_backend()
 torch.manual_seed(42)
 
+
 class TestLazyTensor(JitTestCase):
-        def testConvolutionBackward(self):
-                def clone_move(t):
-                        dev = 'lazy'
-                        copy_t = t.detach().clone().requires_grad_(True).to(device=dev)
-                        return copy_t
+    def testConvolutionBackward(self):
+        def clone_move(t):
+            dev = 'lazy'
+            copy_t = t.detach().clone().requires_grad_(True).to(device=dev)
+            return copy_t
 
-                inp = torch.rand(1, 3, 128, 128, device='cuda', requires_grad = True)
-                inp_copy = clone_move(inp)
-                grad = torch.rand(1, 32, 121, 121, device='cuda') # no requires_grad
-                grad_copy = clone_move(grad)
-                weight = torch.rand(32, 3, 8, 8, device='cuda', requires_grad = True)
-                weight_copy = clone_move(weight)
-                bias = torch.rand(32, device='cuda', requires_grad = True)
-                bias_copy = clone_move(bias)
+        inp = torch.rand(1, 3, 128, 128, device='cuda', requires_grad=True)
+        inp_copy = clone_move(inp)
+        grad = torch.rand(1, 32, 121, 121, device='cuda')  # no requires_grad
+        grad_copy = clone_move(grad)
+        weight = torch.rand(32, 3, 8, 8, device='cuda', requires_grad=True)
+        weight_copy = clone_move(weight)
+        bias = torch.rand(32, device='cuda', requires_grad=True)
+        bias_copy = clone_move(bias)
 
-                # run eager
-                conv_out = torch.nn.functional.conv2d(inp, weight, bias)
-                (inp_grad, weight_grad, bias_grad) = torch.autograd.grad([conv_out], [inp, weight, bias], [grad])
+        # run eager
+        conv_out = torch.nn.functional.conv2d(inp, weight, bias)
+        (inp_grad, weight_grad, bias_grad) = torch.autograd.grad([conv_out], [inp, weight, bias], [grad])
 
-                # run lazy
-                conv_copy_out = torch.nn.functional.conv2d(inp_copy, weight_copy, bias_copy)
-                (inp_copy_grad, weight_copy_grad, bias_copy_grad) = torch.autograd.grad([conv_copy_out], [inp_copy, weight_copy, bias_copy], [grad_copy])
+        # run lazy
+        conv_copy_out = torch.nn.functional.conv2d(inp_copy, weight_copy, bias_copy)
+        (inp_copy_grad, weight_copy_grad, bias_copy_grad) = torch.autograd.grad(
+            [conv_copy_out], [inp_copy, weight_copy, bias_copy], [grad_copy])
 
-                jit_graph = lazy_tensor_core._LAZYC._get_ltc_tensors_backend([bias_copy_grad])
-                FileCheck().check("aten::sum(").run(jit_graph)
+        jit_graph = lazy_tensor_core._LAZYC._get_ltc_tensors_backend([bias_copy_grad])
+        FileCheck().check("aten::sum(").run(jit_graph)
 
-                # check numerics
-                torch.testing.assert_allclose(bias_copy_grad.cpu(), bias_grad.cpu())
-                torch.testing.assert_allclose(weight_copy_grad.cpu(), weight_grad.cpu())
-                torch.testing.assert_allclose(inp_copy_grad.cpu(), inp_grad.cpu())
+        # check numerics
+        torch.testing.assert_allclose(bias_copy_grad.cpu(), bias_grad.cpu())
+        torch.testing.assert_allclose(weight_copy_grad.cpu(), weight_grad.cpu())
+        torch.testing.assert_allclose(inp_copy_grad.cpu(), inp_grad.cpu())
 
 
 if __name__ == '__main__':

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -188,11 +188,11 @@ class GenLazyNativeFuncDefinition:
 
         assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
         first_tensor = value_types[0]
-        bridge_str = f"""auto result = CreateAtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
+        bridge_str = f"""auto result = CreateAtenFromLtcTensor(LazyTensor::Create(node, lazy_{first_tensor.name}.GetDevice()));"""
         if returns_length > 1:
             bridge_str = f"""std::vector<{self.tensor_class}> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
-            lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(torch::lazy::Value(node, i)));
+            lazy_tensors.push_back(LazyTensor::Create(torch::lazy::Value(node, i), lazy_{first_tensor.name}.GetDevice()));
         }}
         auto result = TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
         if schema.name.name.inplace:


### PR DESCRIPTION
Summary: CreateFrom was used as a convenient way to create a LazyTensor
object with a default BackendDevice. Calling LazyTensor::Create instead
can make the meaning more explicit.

