### PR TITLE
Create trt plugin base

### DIFF
--- a/torch/fx/experimental/fx2trt/converters/converter_utils.py
+++ b/torch/fx/experimental/fx2trt/converters/converter_utils.py
@@ -29,6 +29,7 @@ def get_trt_plugin(
     """
     plugin_registry = trt.get_plugin_registry()
     plugin_creator = plugin_registry.get_plugin_creator(plugin_name, version, plugin_namespace)
+    assert plugin_creator, f"Unabled to find plugin creator with name {plugin_name}"
     plugin = plugin_creator.create_plugin(name=plugin_name, field_collection=field_collection)
 
     assert plugin is not None, f"Plugin: {plugin_name} could not be fetched"


### PR DESCRIPTION
Summary:
Write customized plugin for trt requires extend IPluginV2IOExt.  This diff extract functions that should share comon impl between plugins from IPluginV2IOExt into plugin_base, make writing customized plugin for oss user easier.

This diff also fix double creator issue, the root cause is about get_trt_plugin in converters.py look for plugin by name matching. Swith to use the util function from converters_utils.py resolve the issue.

Test Plan: CL

Differential Revision: D32747052

