### PR TITLE
Enable build-split for all CUDA-11.x version

### DIFF
--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -11,7 +11,7 @@ NUM_CPUS=$(( $(nproc) - 2 ))
 # Defaults here for **binary** linux builds so they can be changed in one place
 export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
 
-if [[ "${DESIRED_CUDA}" == "cu111" || "${DESIRED_CUDA}" == "cu113" ]]; then
+if [[ "${DESIRED_CUDA}" =~ cu11? ]]; then
   export BUILD_SPLIT_CUDA="ON"
 fi
 

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -11,7 +11,7 @@ NUM_CPUS=$(( $(nproc) - 2 ))
 # Defaults here for **binary** linux builds so they can be changed in one place
 export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
 
-if [[ "${DESIRED_CUDA}" =~ cu11? ]]; then
+if [[ "${DESIRED_CUDA}" =~ cu11[0-9] ]]; then
   export BUILD_SPLIT_CUDA="ON"
 fi
 


### PR DESCRIPTION
Should fix cu115 wheel binary builds, see https://hud.pytorch.org/ci/pytorch/pytorch/nightly?name_filter=cu115

