### PR TITLE
[CachingHostAllocator] Expose API to set custom allocator

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.h
+++ b/aten/src/ATen/cuda/CachingHostAllocator.h
@@ -21,7 +21,22 @@ namespace cuda {
 // Note that this allocator does not split larger allocations into smaller
 // blocks, unlike the caching device allocator.
 //
-TORCH_CUDA_CPP_API c10::Allocator* getCachingHostAllocator();
+
+// Basic interface for the cuda host allocator to follow
+// There are four public methods: allocate, free, record_event and empty cache.
+class ICachingHostAllocator {
+ public:
+  virtual ~ICachingHostAllocator() = default;
+
+  virtual cudaError_t malloc(void** ptr, size_t size) = 0;
+  virtual cudaError_t free(void* ctx) = 0;
+  virtual cudaError_t recordEvent(void *ctx, CUDAStream stream)  = 0;
+  virtual void emptyCache() = 0;
+};
+TORCH_CUDA_CPP_API void setICachingHostAllocator(ICachingHostAllocator* pAllocator);
+
+// The API to use if you want to use the caching host allocator anywhere
+TORCH_CUDA_CPP_API at::Allocator* getCachingHostAllocator();
 
 // Records an event in the specified stream. The allocation 'ptr' will not be
 // re-used until the event has occurred.
@@ -35,4 +50,6 @@ inline TORCH_CUDA_CPP_API at::DataPtr HostAlloc(size_t size) {
   return getCachingHostAllocator()->allocate(size);
 }
 
-}}
+
+} // namespace cuda
+} // namespace at


### PR DESCRIPTION
Summary: We want have an API to use custom allocator wiht host side caching, so we can fully leverage the benefits of folly libraries

Test Plan:
Ran an benchmark with the new API, checks to see that the new allocator is being used instead

{px/p/1N195}

Differential Revision: D30343605

