### PR TITLE
Add no-op execution mode to support profiling lazy trace overhead

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/lazy_model.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/lazy_model.py
@@ -970,3 +970,6 @@ def get_memory_info(device):
       memory in KB) keys.
     """
     return lazy_tensor_core._LAZYC._ltc_memory_info(str(device))
+
+def set_noop_execution_mode(enable):
+    return lazy_tensor_core._LAZYC._ltc_set_noop_execution_mode(enable)

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -685,6 +685,9 @@ void InitLtcModuleBindings(py::module m) {
   //   return GetMemoryInfo(device);
   // });
   m.def("_ltc_init_ts_backend", []() { compiler::InitTorchScriptBackend(); });
+  m.def("_ltc_set_noop_execution_mode", [](bool enable_noop) {
+    LazyGraphExecutor::Get()->SetNoOpExecutionMode(enable_noop);
+  });
 }  // namespace
 
 }  // namespace

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.cpp
@@ -886,7 +886,11 @@ LazyGraphExecutor::ScheduleSyncTensorsGraph(
       coll, std::move(parameters_data), std::move(tensors_data),
       std::move(cached_computation));
 
-  auto syncfn = [async, hash = coll->hash]() {
+  auto syncfn = [this, async, hash = coll->hash]() {
+    // For profiling lazy trace overhead
+    if (noop_execution_mode_)
+      return;
+
     try {
       VLOG(3) << "Executing IR graph hash " << torch::lazy::HashToString(hash)
               << " on device " << async->device << " ...";

--- a/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/lazy_graph_executor.h
@@ -96,6 +96,10 @@ class LazyGraphExecutor {
       const at::Scalar& value, const torch::lazy::Shape& shape,
       const torch::lazy::BackendDevice& device);
 
+  // Configure the executor treat compile/execute API calls as no-ops
+  // for use when profiling lazy trace overheads
+  void SetNoOpExecutionMode(bool enable_noop) { noop_execution_mode_ = enable_noop; }
+
  private:
   struct SyncTensorsConfig {
     // Whether we want to force data on the target tensors (hence trimming
@@ -218,6 +222,8 @@ class LazyGraphExecutor {
   std::vector<torch::lazy::BackendDataPtr> GatherTensorsData(
       const std::vector<LazyTensor>& tensors, c10::ArrayRef<size_t> indices,
       c10::ArrayRef<torch::lazy::BackendDataPtr> tensors_data);
+
+  bool noop_execution_mode_ = false;
 };
 
 }  // namespace torch_lazy_tensors


### PR DESCRIPTION
    Add no-op execution mode to support profiling lazy trace overhead
    
    - use python binding from lazy_bench script with new mode
      --run_tracing_execute_noops
      which works together with filter args to select a model and
      repeatedly trace it without any backend execution