### PR TITLE
Modify torch.movedim to handle scalar as no-op

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2449,7 +2449,7 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
 
   // handle the case of scalar tensor as a no-op
   if (self_dim == 0)
-    return self.as_strided(self.sizes(), self.strides());
+    return self.view(self.sizes());
 
   // TODO: The algorithm below can probably be optimized.
   // Reference: https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2449,7 +2449,7 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
 
   // handle the case of scalar tensor as a no-op
   if (self_dim == 0)
-    return self.view(self.sizes());
+    return self.alias();
 
   // TODO: The algorithm below can probably be optimized.
   // Reference: https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2447,6 +2447,9 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
   TORCH_CHECK(all_unique(normalized_src), "movedim: repeated dim in `source` (", src, ")");
   TORCH_CHECK(all_unique(normalized_dst), "movedim: repeated dim in `destination` (", dst, ")");
 
+  // handle the case of scalar tensor as a no-op
+  if (self_dim == 0) return self;
+
   // TODO: The algorithm below can probably be optimized.
   // Reference: https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2448,7 +2448,8 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
   TORCH_CHECK(all_unique(normalized_dst), "movedim: repeated dim in `destination` (", dst, ")");
 
   // handle the case of scalar tensor as a no-op
-  if (self_dim == 0) return self.as_strided(self.sizes(), self.strides());
+  if (self_dim == 0)
+    return self.as_strided(self.sizes(), self.strides());
 
   // TODO: The algorithm below can probably be optimized.
   // Reference: https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2448,7 +2448,7 @@ Tensor movedim(const Tensor& self, IntArrayRef src, IntArrayRef dst) {
   TORCH_CHECK(all_unique(normalized_dst), "movedim: repeated dim in `destination` (", dst, ")");
 
   // handle the case of scalar tensor as a no-op
-  if (self_dim == 0) return self;
+  if (self_dim == 0) return self.as_strided(self.sizes(), self.strides());
 
   // TODO: The algorithm below can probably be optimized.
   // Reference: https://github.com/pytorch/pytorch/pull/41480#discussion_r456100505


### PR DESCRIPTION
Summary: `torch.movedim` directly handle the case of a scalar tensor (0-dim) in input as a no-op by returning a view of the input tensor (after all the usual checks for the other parameters)

Test:  This code now works fine and res1 is a view of tensor
```
import torch

tensor = torch.rand(torch.Size([]))
res1 = torch.movedim(tensor, 0, 0)
```

Fixes #69432