### PR TITLE
Wrap scalars in lazy IR values

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -457,7 +457,8 @@ LazyTensor tanh_backward(const LazyTensor& grad_output,
   // Shape stays the same since pow is a unary op
   std::vector<torch::lazy::Shape> shapes{output.shape().Get()};
   torch::lazy::NodePtr pow_node =
-      torch::lazy::MakeNode<ir::ops::PowTensorScalar>(output.GetIrValue(), 2,
+      torch::lazy::MakeNode<ir::ops::PowTensorScalar>(output.GetIrValue(), 
+                                                      LazyGraphExecutor::Get()->GetIrValueForScalar(2, output.GetDevice()),
                                                       std::move(shapes));
   return mul(grad_output,
              rsub(LazyTensor::Create(pow_node, output.GetDevice()), 1, 1));

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.h
@@ -3,6 +3,37 @@
 namespace torch_lazy_tensors {
 namespace compiler {
 
+class TSData : public torch::lazy::BackendData {
+public:
+
+TSData(const at::Scalar& scalar, const torch::lazy::BackendDevice& device)
+    : torch::lazy::BackendData(device, torch::lazy::Shape(scalar.type(), {})),
+        scalar(scalar) {}
+
+TSData(const at::Tensor& data, const torch::lazy::Shape& shape,
+        const torch::lazy::BackendDevice& device)
+    : torch::lazy::BackendData(device, shape), data_(data) {}
+
+TSData(const torch::lazy::Shape& shape,
+        const torch::lazy::BackendDevice& device)
+    : torch::lazy::BackendData(device, shape) {}
+
+Handle GetHandle() override { return reinterpret_cast<int64_t>(this); }
+
+void Assign(const torch::lazy::BackendData& data) override {
+    data_ = static_cast<const TSData&>(data).data_;
+}
+
+bool HasValue() const override { return data_.defined(); }
+
+at::Tensor data() { return data_; }
+
+c10::optional<at::Scalar> scalar;
+
+private:
+at::Tensor data_;
+};
+
 torch::lazy::BackendImplInterface* GetTSBackendImpl();
 
 void InitTorchScriptBackend();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
@@ -36,6 +36,9 @@ torch::jit::Value* TSLoweringContext::GetParameter(BackendDataPtr data) {
   if (it == parameters_map_.end()) {
     torch::jit::Value* param =
         graph_->addInput(c10::str("p", parameters_.size()));
+    if (data->is_scalar()) {
+      param->setType(c10::FloatType::get());
+    }
     it = parameters_map_.emplace(handle, Parameter{param, parameters_.size()})
              .first;
     parameters_.push_back(data);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_lowering_context.cpp
@@ -1,5 +1,5 @@
 #include <torch/csrc/lazy/ts_backend/ts_lowering_context.h>
-
+#include "lazy_tensor_core/csrc/ts_backend/backend_impl.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_shape_inference.h"
 
 namespace torch {
@@ -31,17 +31,25 @@ void TSLoweringContext::AssignOutputOp(const Output& output,
 }
 
 torch::jit::Value* TSLoweringContext::GetParameter(BackendDataPtr data) {
-  BackendData::Handle handle = data->GetHandle();
+  const auto ts_data = std::static_pointer_cast<torch_lazy_tensors::compiler::TSData>(data);
+  BackendData::Handle handle = ts_data->GetHandle();
   auto it = parameters_map_.find(handle);
   if (it == parameters_map_.end()) {
     torch::jit::Value* param =
         graph_->addInput(c10::str("p", parameters_.size()));
-    if (data->is_scalar()) {
-      param->setType(c10::FloatType::get());
+    if (ts_data->scalar.has_value()) {
+      auto scalarType = ts_data->scalar.value().type();
+      if (isFloatingType(scalarType)){
+        param->setType(c10::FloatType::get());
+      } else if (isIntegralType(scalarType)) {
+        param->setType(c10::IntType::get());
+      } else {
+        TORCH_CHECK(false, "Unhandled scalar type ");
+      }
     }
     it = parameters_map_.emplace(handle, Parameter{param, parameters_.size()})
              .first;
-    parameters_.push_back(data);
+    parameters_.push_back(ts_data);
   }
   parameter_sequence_.push_back(it->second.index);
   return it->second.param;

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -33,7 +33,9 @@ def process_ir_type(typ: Type) -> Union[BaseCType, VectorCType, OptionalCType, L
         if typ.name == BaseTy.Tensor:
             return BaseCType(valueT)
         elif typ.name == BaseTy.Scalar:
-            return BaseCType(scalarT)
+            # at::scalar has special handling,
+            # and is wrapped in an IR value just like at::tensor
+            return BaseCType(valueT)
         elif typ.name == BaseTy.ScalarType:
             return BaseCType(scalarTypeT)
         elif typ.name == BaseTy.int:
@@ -65,11 +67,29 @@ def isValueType(typ: Union[Type, BaseCType, OptionalCType, ConstRefCType, MutRef
     being Tensor-like, but assumes the type has already been transformed.
     """
     if isinstance(typ, BaseCType):
-        return typ.type == valueT
+        # I am regretting my naming conventions, but now we are wrapping at::scalar in
+        # lazy value, while preserving other 'scalar' types as scalars in the IR
+        return typ.type == valueT or typ.type == scalarT
     elif isinstance(typ, (OptionalCType, ListCType, VectorCType)):
         return isValueType(typ.elem)
     else:
         return False
+
+def isWrappedScalarType(typ: Type) -> bool:
+    """
+    Given a type, determine if it is a c10::scalar which we will wrap in a lazy Value.
+    Since we literally change the type from scalarT to valueT, information is lost.
+    This function helps build a list of wrapped scalars to save that information
+    """
+    if isinstance(typ, BaseType):
+        # I am regretting my naming conventions, but now we are wrapping at::scalar in
+        # lazy value, while preserving other 'scalar' types as scalars in the IR
+        return typ.name == BaseTy.Scalar
+    elif isinstance(typ, (OptionalType, ListType)):
+        return isWrappedScalarType(typ.elem)
+    else:
+        return False
+
 
 # Inspired by a FunctionSchema object, a LazyIrSchema holds the schema of a Lazy IR node.
 # Unlike a FunctionSchema, it has no round-trippable string form (relating to the YAML),
@@ -86,6 +106,8 @@ class LazyIrSchema:
 
     # TODO: Need to handle collisions with argument names at some point
     returns: Tuple['Return', ...]
+
+    wrapped_scalar_names: List[str]
 
     def __init__(self, func: FunctionSchema):
 
@@ -116,6 +138,7 @@ class LazyIrSchema:
         self.keyword_arg_types = tuple(keyword_arg_types)
         self.name = func.name
         self.returns = func.returns
+        self.wrapped_scalar_names = [arg.name for arg in func.schema_order_arguments() if isWrappedScalarType(arg.type)]
 
     @property
     def node_name(self) -> str:

--- a/tools/codegen/dest/lazy_ts_lowering.py
+++ b/tools/codegen/dest/lazy_ts_lowering.py
@@ -22,9 +22,8 @@ def ts_lowering_body(f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
 
     emplace_arguments_str = "\n    ".join(
         [f"arguments.emplace_back({a});" for a in emplace_arguments])
-    emplace_kwarg_values = [f'loctx->GetOutputOp(operand({i}))' for i in range(len(schema.keyword_values))]
+    emplace_kwarg_values = [f'"{t.name}", loctx->GetOutputOp(operand(i++))' for t in schema.keyword_values]
     emplace_kwarg_scalars = [f'"{t.name}", {t.name}_' for t in schema.keyword_scalars]
-    assert len(schema.keyword_values) == 0, "TODO the logic for operand(i) is broken if there are kw values"
     emplace_kwarguments = "\n    ".join(
         [f"kwarguments.emplace_back({a});" for a in emplace_kwarg_values + emplace_kwarg_scalars])
     return f"""\

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -212,6 +212,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
             ]],
             'lazy_ir_inc': [f'#include "{path}"' for path in [
                 "lazy_tensor_core/csrc/ops/scalar.h",
+                "lazy_tensor_core/csrc/lazy_graph_executor.h",
                 node_base_hdr if node_base_hdr is not None else None
             ] if path is not None],
             'external_backend_headers': f'#include "{output_dir}/{backend_key}NativeFunctions.h"',

--- a/torch/csrc/lazy/backend/backend_data.h
+++ b/torch/csrc/lazy/backend/backend_data.h
@@ -21,8 +21,8 @@ class TORCH_API BackendData {
    * */
   using Handle = int64_t;
 
-  BackendData(BackendDevice device, Shape shape)
-      : device_(std::move(device)), shape_(std::move(shape)) {}
+  BackendData(BackendDevice device, Shape shape, bool is_scalar = false)
+      : device_(std::move(device)), shape_(std::move(shape)), is_scalar_(is_scalar) {}
 
   virtual ~BackendData() = default;
 
@@ -37,6 +37,8 @@ class TORCH_API BackendData {
   Info* info() const {
     return info_.get();
   }
+
+  bool is_scalar() const { return is_scalar_; }
 
   std::shared_ptr<Info> SetInfo(std::shared_ptr<Info> info) {
     std::swap(info, info_);
@@ -53,6 +55,7 @@ class TORCH_API BackendData {
   BackendDevice device_;
   Shape shape_;
   std::shared_ptr<Info> info_;
+  bool is_scalar_ = false;
 };
 
 using BackendDataPtr = std::shared_ptr<BackendData>;

--- a/torch/csrc/lazy/backend/backend_data.h
+++ b/torch/csrc/lazy/backend/backend_data.h
@@ -21,8 +21,8 @@ class TORCH_API BackendData {
    * */
   using Handle = int64_t;
 
-  BackendData(BackendDevice device, Shape shape, bool is_scalar = false)
-      : device_(std::move(device)), shape_(std::move(shape)), is_scalar_(is_scalar) {}
+  BackendData(BackendDevice device, Shape shape)
+      : device_(std::move(device)), shape_(std::move(shape)) {}
 
   virtual ~BackendData() = default;
 
@@ -37,8 +37,6 @@ class TORCH_API BackendData {
   Info* info() const {
     return info_.get();
   }
-
-  bool is_scalar() const { return is_scalar_; }
 
   std::shared_ptr<Info> SetInfo(std::shared_ptr<Info> info) {
     std::swap(info, info_);
@@ -55,7 +53,6 @@ class TORCH_API BackendData {
   BackendDevice device_;
   Shape shape_;
   std::shared_ptr<Info> info_;
-  bool is_scalar_ = false;
 };
 
 using BackendDataPtr = std::shared_ptr<BackendData>;

--- a/torch/csrc/lazy/backend/backend_interface.h
+++ b/torch/csrc/lazy/backend/backend_interface.h
@@ -37,7 +37,9 @@ class TORCH_API BackendImplInterface {
   virtual BackendDataPtr MakeComputationDataFromTensor(
       const at::Tensor& tensor, const Shape& shape,
       const BackendDevice& device) const = 0;
-
+  virtual BackendDataPtr MakeComputationDataFromScalar(
+      const at::Scalar& scalar,
+      const torch::lazy::BackendDevice& device) const = 0;
   virtual BackendDataPtr CreateDataPlaceholder(
       const BackendDevice& device, const Shape& shape) const = 0;
 


### PR DESCRIPTION
- handle scalars specially to avoid over-specializing lazy traces
- wrap them in IR values and feed them in as part of graph execution,
  but don't recompile

WIP:
this diff helps bert training (from 55% to ~85%~ of speed of eager). [**now 91%**, see update below]
but, a simple hack to avoid the changing scalar in addcdiv (changing adam optimizer) helps bert training from 50% to 95% of eager.
so- this diff fixes the 'scalar recompilation' issue, but adds other tracing overhead that needs to be tracked down.

Example generated code (addcdiv):
```
// TODO(alanwaketan): Public members don't need to have _ suffix.
class Addcdiv : public torch::lazy::TsNode {
 public:
  Addcdiv(const torch::lazy::Value& self, const torch::lazy::Value& tensor1, const torch::lazy::Value& tensor2, const torch::lazy::Value& value, std::vector<Shape>&& shapes)
      : torch::lazy::TsNode(torch::lazy::OpKind(at::aten::addcdiv),
              {self, tensor1, tensor2, value}, std::move(shapes),
              /* num_outputs */ 1,
              torch::lazy::MHash())
        

  {
    
  }

  std::string ToString() const override {
    std::stringstream ss;
    ss << TsNode::ToString();
    
    return ss.str();
  }

  torch::lazy::TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
                   torch::lazy::TSLoweringContext* loctx) const override {
        std::vector<torch::jit::NamedValue> arguments;
    std::vector<torch::jit::NamedValue> kwarguments;
    arguments.reserve(3);
    kwarguments.reserve(1);
    size_t i = 0;
    arguments.emplace_back(loctx->GetOutputOp(operand(i++)));
    arguments.emplace_back(loctx->GetOutputOp(operand(i++)));
    arguments.emplace_back(loctx->GetOutputOp(operand(i++)));
    kwarguments.emplace_back("value", loctx->GetOutputOp(operand(i++)));
    torch::lazy::TSOpVector addcdiv_out = torch::lazy::LowerTSBuiltin(function, op().op, arguments, kwarguments);
    CHECK_EQ(addcdiv_out.size(), 1);

    // TODO: need to call GenerateClone sometimes? Or else return LowerBuiltIn() directly
    return addcdiv_out;

  }

  
  

};

    // TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
    at::Tensor LazyNativeFunctions::addcdiv(const at::Tensor & self, const at::Tensor & tensor1, const at::Tensor & tensor2, const at::Scalar & value) {
        LTC_FN_COUNTER("lazy::");
        auto device = bridge::GetBackendDevice(self, tensor1, tensor2, value);
        LazyTensor lazy_self = GetLtcTensorOrCreateForWrappedNumber(self, *device);
    LazyTensor lazy_tensor1 = GetLtcTensorOrCreateForWrappedNumber(tensor1, *device);
    LazyTensor lazy_tensor2 = GetLtcTensorOrCreateForWrappedNumber(tensor2, *device);
        auto out_meta = at::meta::addcdiv(self, tensor1, tensor2, value);
        std::vector<Shape> shapes{Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
        TORCH_INTERNAL_ASSERT(shapes.size() == 1);
        auto node = torch::lazy::MakeNode<ir::ops::Addcdiv>(lazy_self.GetIrValue(),
                              lazy_tensor1.GetIrValue(),
                              lazy_tensor2.GetIrValue(),
                              LazyGraphExecutor::Get()->GetIrValueForScalar(value, *device),
                                                                                      std::move(shapes));
        auto result = CreateAtenFromLtcTensor(LazyTensor::Create(node, lazy_self.GetDevice()));
        return result;
    };


```

### Update:
a significant portion of the overhead came from JIT interpreter calling .item() on cuda tensors that wrap scalars, then feeding the item value into another cuda kernel call.  I've worked around this with the latest WIP commit, and now I wrap scalars in _CPU_ tensors before handing them to the JIT interpreter, which thankfully does not complain about it and is more efficient.  (improves from 85% -> **91%** for bert train, leaving a 7% gap to close)

See https://gist.github.com/wconstab/1797b74db3df4f1935b461ab814bb864
for logs of traced JIT IR between baseline (with learning-rate hack) and latest commit with wrapped scalar cpu tensor:
* many changes to add operator- using 3-argument add operator instead of 2 argument operator with value=1 constant  - is this preventing fusion and/or slowing things down?

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc 