### PR TITLE
[Vulkan] Thread-safe Vulkan backend for OSS

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -2,9 +2,7 @@
 #include <ATen/native/vulkan/api/Adapter.h>
 #include <ATen/native/vulkan/api/Utils.h>
 
-#ifdef MAKE_VULKAN_THREADSAFE
 #include <mutex>
-#endif /* MAKE_VULKAN_THREADSAFE */
 
 namespace at {
 namespace native {
@@ -12,9 +10,7 @@ namespace vulkan {
 namespace api {
 namespace {
 
-#ifdef MAKE_VULKAN_THREADSAFE
 std::mutex queue_mutex;
-#endif /* MAKE_VULKAN_THREADSAFE */
 
 VkCommandPool create_command_pool(
     const VkDevice device,
@@ -496,7 +492,6 @@ void Command::Pool::submit(
       nullptr,
     };
 
-#ifdef MAKE_VULKAN_THREADSAFE
     {
       // vkQueueSubmit is not thread-safe, only one thread can push the commands at a time.
       // (See https://vkguide.dev/docs/chapter-1/vulkan_command_flow/#vulkan-command-execution)
@@ -507,9 +502,6 @@ void Command::Pool::submit(
       std::lock_guard<std::mutex> guard(queue_mutex);
       VK_CHECK(vkQueueSubmit(queue, 1u, &submit_info, fence.handle()));
     }
-#else
-    VK_CHECK(vkQueueSubmit(queue, 1u, &submit_info, fence.handle()));
-#endif /* MAKE_VULKAN_THREADSAFE */
   }
 }
 

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -113,36 +113,14 @@ Context::Context(const Adapter& adapter)
       queue_(acquire_queue(device(), adapter.compute_queue_family_index)),
       shader_(gpu()),
       pipeline_(gpu()),
-#ifdef MAKE_VULKAN_THREADSAFE
       threadcontext_(gpu()) {
-#else
-      command_(gpu()),
-      descriptor_(gpu()),
-      resource_(gpu()) {
-#endif /* MAKE_VULKAN_THREADSAFE */
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       device_,
       "Invalid Vulkan device!");
 }
 
 Context::~Context() {
-#ifdef MAKE_VULKAN_THREADSAFE
   // Do not call flush() since all per-thread objects will be destroyed as each thread exits
-#else
-  try {
-    flush();
-  }
-  catch (const std::exception& e) {
-    TORCH_WARN(
-        "Vulkan: Context destructor raised an exception! Error: ",
-        e.what());
-  }
-  catch (...) {
-    TORCH_WARN(
-        "Vulkan: Context destructor raised an exception! "
-        "Error: Unknown");
-  }
-#endif /* MAKE_VULKAN_THREADSAFE */
 }
 
 void Context::flush() {

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -9,10 +9,7 @@
 #include <ATen/native/vulkan/api/Pipeline.h>
 #include <ATen/native/vulkan/api/Resource.h>
 #include <ATen/native/vulkan/api/Shader.h>
-
-#ifdef MAKE_VULKAN_THREADSAFE
 #include <ATen/native/vulkan/api/ThreadContext.h>
-#endif /* MAKE_VULKAN_THREADSAFE */
 
 namespace at {
 namespace native {
@@ -75,13 +72,7 @@ class Context final {
   VkQueue queue_;
   Shader shader_;
   Pipeline pipeline_;
-#ifdef MAKE_VULKAN_THREADSAFE
   ThreadContext threadcontext_;
-#else
-  Command command_;
-  Descriptor descriptor_;
-  Resource resource_;
-#endif /* MAKE_VULKAN_THREADSAFE */
 };
 
 bool available();
@@ -108,7 +99,6 @@ inline Pipeline& Context::pipeline() {
   return pipeline_;
 }
 
-#ifdef MAKE_VULKAN_THREADSAFE
 inline Command& Context::command() {
   return threadcontext_.command();
 }
@@ -120,19 +110,6 @@ inline Descriptor& Context::descriptor() {
 inline Resource& Context::resource() {
   return threadcontext_.resource();
 }
-#else
-inline Command& Context::command() {
-  return command_;
-}
-
-inline Descriptor& Context::descriptor() {
-  return descriptor_;
-}
-
-inline Resource& Context::resource() {
-  return resource_;
-}
-#endif /* MAKE_VULKAN_THREADSAFE */
 
 inline VkDevice Context::device() {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(device_);

--- a/aten/src/ATen/native/vulkan/ops/Clone.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clone.cpp
@@ -1,0 +1,46 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+Tensor clone(const Tensor& src, c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto memory_format =
+      optional_memory_format.value_or(MemoryFormat::Preserve);
+  TORCH_CHECK(
+        (c10::MemoryFormat::Preserve == memory_format) ||
+          (c10::MemoryFormat::Contiguous == memory_format),
+      "Vulkan supports Preserve and Contiguous memory foramts");
+
+  Tensor self;
+  if (memory_format == MemoryFormat::Preserve) {
+    if (src.is_non_overlapping_and_dense()) {
+      // Copy all strides, this is marginally faster than calling empty_like
+      self = at::empty_strided(src.sizes(), src.strides(), src.options());
+    } else {
+      self = at::empty_like(src);
+    }
+  } else {
+    self = at::empty_like(src, src.options(), memory_format);
+  }
+
+  self.copy_(src);
+  return self;
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::clone"), TORCH_FN(clone));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_perf_test.cpp
@@ -47,9 +47,7 @@ BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Threads(1)->Iter
 BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Threads(1)->Iterations(1000)->Args({3, 39, 221, 193}); // big non-multiple of 4 channels
 BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Threads(1)->Iterations(5000)->Args({3, 4, 221, 193}); // small multiple of 4 channels
 BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Threads(1)->Iterations(5000)->Args({3, 3, 221, 193}); // small non-multiple of 4 channels
-#ifdef MAKE_VULKAN_THREADSAFE
 BENCHMARK(cat_op_channel_perf)->Apply(CommonBenchmarkSettings)->Threads(3)->Iterations(1000)->Args({3, 40, 221, 193}); // big multiple of 4 channels (multi-thread)
-#endif
 BENCHMARK_MAIN();
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
**Summary:**
Vulkan backend for OSS is also thread-safe by default:
* Removed `MAKE_VULKAN_THREADSAFE` preprocessor and if-conditions

**Test Plan:**
Test build on Android:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_perf_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_perf_test
adb shell "/data/local/tmp/vulkan_perf_test"
```
Test build on MacOS:
```
cd ~/fbsource
buck build //xplat/caffe2:pt_vulkan_perf_test_binAppleMac
./buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAppleMac\#macosx-x86_64
```

Test result on Google Pixel 5:
```
//xplat/caffe2:pt_vulkan_perf_test_binAndroid#android-arm64 buck-out/gen/fe3a39b8/xplat/caffe2/pt_vulkan_perf_test_binAndroid#android-arm64
buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAndroid#android-arm64: 1 file pushed, 0 skipped. 145.4 MB/s (826929592 bytes in 5.426s)
Running /data/local/tmp/vulkan_perf_test
Run on (8 X 1804.8 MHz CPU s)
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------------------
Benchmark                                                                   Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:1       39.3 ms         10.1 ms         1000
cat_op_channel_perf/N:3/C:20/H:221/W:193/iterations:1000/threads:1       27.1 ms         5.86 ms         1000
cat_op_channel_perf/N:3/C:39/H:221/W:193/iterations:1000/threads:1       58.5 ms         11.8 ms         1000
cat_op_channel_perf/N:3/C:4/H:221/W:193/iterations:5000/threads:1        5.98 ms        0.803 ms         5000
cat_op_channel_perf/N:3/C:3/H:221/W:193/iterations:5000/threads:1        9.14 ms        0.857 ms         5000
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:3       32.1 ms         31.3 ms         3000
```

Test result on MacOS:
```
Running ./buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAppleMac#macosx-x86_64
Run on (16 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 18.89, 29.61, 24.95
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------------------------------------------
Benchmark                                                                   Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:1       53.3 ms         39.6 ms         1000
cat_op_channel_perf/N:3/C:20/H:221/W:193/iterations:1000/threads:1       28.0 ms         20.7 ms         1000
cat_op_channel_perf/N:3/C:39/H:221/W:193/iterations:1000/threads:1       51.8 ms         38.7 ms         1000
cat_op_channel_perf/N:3/C:4/H:221/W:193/iterations:5000/threads:1        2.76 ms         1.31 ms         5000
cat_op_channel_perf/N:3/C:3/H:221/W:193/iterations:5000/threads:1        2.29 ms         1.11 ms         5000
cat_op_channel_perf/N:3/C:40/H:221/W:193/iterations:1000/threads:3       49.2 ms         41.8 ms         3000
```

Differential Revision: D32933891

