### PR TITLE
Fix errors in common_utils.py

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -614,8 +614,8 @@ def run_tests(argv=UNITTEST_ARGS):
         test_cases = discover_test_cases_recursively(suite)
         for case in test_cases:
             test_case_full_name = case.id().split('.', 1)[1]
-            other_args = (['--import-disabled-tests'] if IMPORT_DISABLED_TESTS else List[str]([]) +
-                          ['--import-slow-tests'] if IMPORT_SLOW_TESTS else List[str]([]))
+            other_args = (['--import-disabled-tests'] if IMPORT_DISABLED_TESTS else list() +
+                          ['--import-slow-tests'] if IMPORT_SLOW_TESTS else list())
             cmd = [sys.executable] + [argv[0]] + other_args + argv[1:] + [test_case_full_name]
             string_cmd = " ".join(cmd)
             exitcode = shell(cmd)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -615,7 +615,7 @@ def run_tests(argv=UNITTEST_ARGS):
         for case in test_cases:
             test_case_full_name = case.id().split('.', 1)[1]
             other_args = list(('--import-disabled-tests',) if IMPORT_DISABLED_TESTS else () +
-                          ('--import-slow-tests',) if IMPORT_SLOW_TESTS else ())
+                              ('--import-slow-tests',) if IMPORT_SLOW_TESTS else ())
             cmd = [sys.executable] + [argv[0]] + other_args + argv[1:] + [test_case_full_name]
             string_cmd = " ".join(cmd)
             exitcode = shell(cmd)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -614,8 +614,8 @@ def run_tests(argv=UNITTEST_ARGS):
         test_cases = discover_test_cases_recursively(suite)
         for case in test_cases:
             test_case_full_name = case.id().split('.', 1)[1]
-            other_args = (['--import-disabled-tests'] if IMPORT_DISABLED_TESTS else list() +
-                          ['--import-slow-tests'] if IMPORT_SLOW_TESTS else list())
+            other_args = (['--import-disabled-tests'] if IMPORT_DISABLED_TESTS else [] +
+                          ['--import-slow-tests'] if IMPORT_SLOW_TESTS else [])
             cmd = [sys.executable] + [argv[0]] + other_args + argv[1:] + [test_case_full_name]
             string_cmd = " ".join(cmd)
             exitcode = shell(cmd)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -614,8 +614,8 @@ def run_tests(argv=UNITTEST_ARGS):
         test_cases = discover_test_cases_recursively(suite)
         for case in test_cases:
             test_case_full_name = case.id().split('.', 1)[1]
-            other_args = (['--import-disabled-tests'] if IMPORT_DISABLED_TESTS else [] +
-                          ['--import-slow-tests'] if IMPORT_SLOW_TESTS else [])
+            other_args = (('--import-disabled-tests',) if IMPORT_DISABLED_TESTS else () +
+                          ('--import-slow-tests',) if IMPORT_SLOW_TESTS else ())
             cmd = [sys.executable] + [argv[0]] + other_args + argv[1:] + [test_case_full_name]
             string_cmd = " ".join(cmd)
             exitcode = shell(cmd)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -614,7 +614,7 @@ def run_tests(argv=UNITTEST_ARGS):
         test_cases = discover_test_cases_recursively(suite)
         for case in test_cases:
             test_case_full_name = case.id().split('.', 1)[1]
-            other_args = (('--import-disabled-tests',) if IMPORT_DISABLED_TESTS else () +
+            other_args = list(('--import-disabled-tests',) if IMPORT_DISABLED_TESTS else () +
                           ('--import-slow-tests',) if IMPORT_SLOW_TESTS else ())
             cmd = [sys.executable] + [argv[0]] + other_args + argv[1:] + [test_case_full_name]
             string_cmd = " ".join(cmd)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -614,8 +614,11 @@ def run_tests(argv=UNITTEST_ARGS):
         test_cases = discover_test_cases_recursively(suite)
         for case in test_cases:
             test_case_full_name = case.id().split('.', 1)[1]
-            other_args = list(('--import-disabled-tests',) if IMPORT_DISABLED_TESTS else () +
-                              ('--import-slow-tests',) if IMPORT_SLOW_TESTS else ())
+            other_args = []
+            if IMPORT_DISABLED_TESTS:
+                other_args.append('--import-disabled-tests')
+            if IMPORT_SLOW_TESTS:
+                other_args.append('--import-slow-tests')
             cmd = [sys.executable] + [argv[0]] + other_args + argv[1:] + [test_case_full_name]
             string_cmd = " ".join(cmd)
             exitcode = shell(cmd)


### PR DESCRIPTION
This fixes the following error:
```python
Traceback (most recent call last):
  File "/home/gaoxiang/pytorch-ucc2/test/distributed/test_distributed_spawn.py", line 40, in <module>
    run_tests()
  File "/home/gaoxiang/.local/lib/python3.9/site-packages/torch/testing/_internal/common_utils.py", line 618, in run_tests
    ['--import-slow-tests'] if IMPORT_SLOW_TESTS else List[str]([]))
  File "/usr/lib/python3.9/typing.py", line 680, in __call__
    raise TypeError(f"Type {self._name} cannot be instantiated; "
TypeError: Type List cannot be instantiated; use list() instead
Traceback (most recent call last):
  File "/home/gaoxiang/pytorch-ucc2/test/run_test.py", line 1058, in <module>
    main()
  File "/home/gaoxiang/pytorch-ucc2/test/run_test.py", line 1036, in main
    raise RuntimeError(err_message)
RuntimeError: distributed/test_distributed_spawn failed!
```
