### PR TITLE
Release GIL during RPC shutdown.

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -645,9 +645,10 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
       },
       py::call_guard<py::gil_scoped_release>());
 
-  module.def("_reset_current_rpc_agent", []() {
-    RpcAgent::setCurrentRpcAgent(nullptr);
-  });
+  module.def(
+      "_reset_current_rpc_agent",
+      []() { RpcAgent::setCurrentRpcAgent(nullptr); },
+      py::call_guard<py::gil_scoped_release>());
 
   module.def(
       "_delete_all_user_and_unforked_owner_rrefs",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

In certain scenarios during shutdown the following assert failed:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/distributed/rpc/rpc_agent.cpp#L39.
This was due to _reset_current_rpc_agent not releasing GIL.

Fixed this issue by releasing GIL.

Differential Revision: [D32937687](https://our.internmc.facebook.com/intern/diff/D32937687/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang