### PR TITLE
fix the error: #error "You must define THC_GENERIC_FILE before includ…

### DIFF
--- a/aten/src/THC/THCGenerateByteType.h
+++ b/aten/src/THC/THCGenerateByteType.h
@@ -1,5 +1,5 @@
 #ifndef THC_GENERIC_FILE
-#error "You must define THC_GENERIC_FILE before including THGenerateByteType.h"
+#error "You must define THC_GENERIC_FILE before including THCGenerateByteType.h"
 #endif
 
 #define scalar_t uint8_t


### PR DESCRIPTION
 fix the error: #error "You must define THC_GENERIC_FILE before including THGenerateByteTypes.h", the "THGenerateByteTypes.h" should be "THCGenerateByteTypes.h".

Fixes #69444 
