### PR TITLE
Fix TSAN issue in TCPStore

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -599,7 +599,11 @@ class TCPStoreWorkerDaemon : public BackgroundThread {
     callbackRegisteredData_ = false;
   }
   void setCallbackRegistered() {
-    callbackRegisteredData_ = true;
+    {
+      std::unique_lock<std::mutex> callbackRegistrationLock(
+          callbackRegistrationMutex_);
+      callbackRegisteredData_ = true;
+    }
     callbackRegisteredCV_.notify_one();
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

The variable `callbackRegisteredData_` was written to without
synchronization.

Differential Revision: [D32938979](https://our.internmc.facebook.com/intern/diff/D32938979/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang