### PR TITLE
[Static Runtime] [Code Cleanup] Avoid exposing function objects from ProcessedFunction

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -976,7 +976,6 @@ TEST(ProcessedFunction, ProcessedFunction) {
       sigmoid_node,
       /*enable_out_variant=*/true,
       /*check_memory_overlap=*/false);
-  EXPECT_TRUE(sigmoid_fn.f());
   EXPECT_EQ(sigmoid_fn.kind(), ProcessedFunction::Kind::kOutVariant);
   EXPECT_FALSE(sigmoid_fn.checkMemoryOverlap());
 
@@ -985,7 +984,6 @@ TEST(ProcessedFunction, ProcessedFunction) {
       transpose_node,
       /*enable_out_variant=*/true,
       /*check_memory_overlap=*/false);
-  EXPECT_TRUE(transpose_fn.f());
   EXPECT_EQ(transpose_fn.kind(), ProcessedFunction::Kind::kNativeFunction);
   EXPECT_FALSE(transpose_fn.checkMemoryOverlap());
 }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1648,12 +1648,12 @@ void ProcessedNode::run() {
         guard.before(get_op_name());
       }
     }
-    fn_->f()(this);
+    fn_->run(this);
   } else {
-    fn_->f()(this);
+    fn_->run(this);
   }
 #else
-  fn_->f()(this);
+  fn_->run(this);
 #endif
 #ifndef NDEBUG
   if (FLAGS_static_runtime_disable_debug_memory_overlap_check) {

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -523,8 +523,8 @@ class TORCH_API ProcessedFunction {
     kInterpreterFallback,
   };
 
-  const std::function<void(ProcessedNode*)>& f() const {
-    return f_;
+  void run(ProcessedNode* pnode) const {
+    return f_(pnode);
   }
 
   Kind kind() const {


### PR DESCRIPTION
Summary: This changes encapsulates `function` object in `ProcessedFunction` objects instead of exposing it unnecessarily just for executing it.

Test Plan: Existing tests

Differential Revision: D32908341

