### PR TITLE
[ONNX] restore documentation of public functions

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -596,6 +596,8 @@ Functions
 .. autofunction:: export
 .. autofunction:: export_to_pretty_string
 .. autofunction:: register_custom_op_symbolic
+.. autofunction:: select_model_mode_for_export
+.. autofunction:: is_in_onnx_export
 
 Classes
 -------


### PR DESCRIPTION
The build-docs check requires all public functions to be documented.
These should really not be public, but we'll fix that later.'
