### PR TITLE
Port tensor variants of normal to structured kernel

### DIFF
--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -258,27 +258,6 @@ Tensor& normal_out_impl(Tensor& output, const Tensor& mean, const Tensor& std, c
   return output;
 }
 
-template<template<typename> class normal_kernel, typename RNG>
-Tensor normal_impl(const Tensor& mean, double std, c10::optional<Generator> gen) {
-  Tensor ret = at::empty_like(mean, MemoryFormat::Contiguous);
-  normal_out_impl<normal_kernel, RNG>(ret, mean, std, gen);
-  return ret;
-}
-
-template<template<typename> class normal_kernel, typename RNG>
-Tensor normal_impl(double mean, const Tensor& std, c10::optional<Generator> gen) {
-  Tensor ret = at::empty_like(std, MemoryFormat::Contiguous);
-  normal_out_impl<normal_kernel, RNG>(ret, mean, std, gen);
-  return ret;
-}
-
-template<template<typename> class normal_kernel, typename RNG>
-Tensor normal_impl(const Tensor& mean, const Tensor& std, c10::optional<Generator> gen) {
-  Tensor ret = at::empty({0}, mean.options(), MemoryFormat::Contiguous);
-  normal_out_impl<normal_kernel, RNG>(ret, mean, std, gen);
-  return ret;
-}
-
 // ==================================================== Uniform =======================================================
 
 template<template<typename> class uniform_kernel, typename RNG>

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -266,30 +266,6 @@ Tensor& normal_meta_(Tensor& self, double mean, double std, c10::optional<Genera
   return self;
 }
 
-Tensor& normal_out(const Tensor& mean, double std, c10::optional<Generator> gen, Tensor& output) {
-  return at::native::templates::normal_out_impl<NormalStub, Generator>(output, mean, std, gen);
-}
-
-Tensor& normal_out(double mean, const Tensor& std, c10::optional<Generator> gen, Tensor& output) {
-  return at::native::templates::normal_out_impl<NormalStub, Generator>(output, mean, std, gen);
-}
-
-Tensor& normal_out(const Tensor& mean, const Tensor& std, c10::optional<Generator> gen, Tensor& output) {
-  return at::native::templates::normal_out_impl<NormalStub, Generator>(output, mean, std, gen);
-}
-
-Tensor normal(const Tensor& mean, double std, c10::optional<Generator> gen) {
-  return at::native::templates::normal_impl<NormalStub, Generator>(mean, std, gen);
-}
-
-Tensor normal(double mean, const Tensor& std, c10::optional<Generator> gen) {
-  return at::native::templates::normal_impl<NormalStub, Generator>(mean, std, gen);
-}
-
-Tensor normal(const Tensor& mean, const Tensor& std, c10::optional<Generator> gen) {
-  return at::native::templates::normal_impl<NormalStub, Generator>(mean, std, gen);
-}
-
 // ==================================================== Random ========================================================
 
 template<typename RNG>
@@ -600,4 +576,72 @@ Tensor multinomial(
   return result;
 }
 
-}} // namespace at::native
+} // namespace at::native
+
+namespace meta {
+
+// ==================================================== Normal ========================================================
+
+TORCH_META_FUNC2(normal, float_Tensor) (
+  double mean,
+  const Tensor& std,
+  c10::optional<Generator> gen
+) {
+  set_output(std.sizes(), std.options());
+}
+
+TORCH_META_FUNC2(normal, Tensor_float) (
+  const Tensor& mean,
+  double std,
+  c10::optional<Generator> gen
+) {
+  set_output(mean.sizes(), mean.options());
+}
+
+TORCH_META_FUNC2(normal, Tensor_Tensor) (
+  Tensor const& mean,
+  Tensor const& std,
+  c10::optional<Generator> gen
+) {
+  auto shape = at::infer_size(mean.sizes(), std.sizes());
+  set_output(shape, mean.options());
+}
+
+} // namespace at::meta
+
+namespace native {
+
+// ==================================================== Normal ========================================================
+
+TORCH_IMPL_FUNC(normal_float_Tensor_out) (
+  double mean,
+  const Tensor& std,
+  c10::optional<Generator> gen,
+  const Tensor& out
+) {
+  at::native::templates::normal_out_impl<NormalStub, Generator>(
+    const_cast<Tensor&>(out), mean, std, gen);
+}
+
+TORCH_IMPL_FUNC(normal_Tensor_float_out) (
+  const Tensor& mean,
+  double std,
+  c10::optional<Generator> gen,
+  const Tensor& out
+) {
+  at::native::templates::normal_out_impl<NormalStub, Generator>(
+    const_cast<Tensor&>(out), mean, std, gen);
+}
+
+TORCH_IMPL_FUNC(normal_Tensor_Tensor_out) (
+  const Tensor& mean,
+  const Tensor& std,
+  c10::optional<Generator> gen,
+  const Tensor& out
+) {
+  at::native::templates::normal_out_impl<NormalStub, Generator>(
+    const_cast<Tensor&>(out), mean, std, gen);
+}
+
+} // namespace at::native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7768,28 +7768,28 @@
     Meta: normal_meta_
 
 - func: normal.Tensor_float_out(Tensor mean, float std=1, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
-    CPU, CUDA: normal_out
+    CPU, CUDA: normal_Tensor_float_out
 
 - func: normal.Tensor_float(Tensor mean, float std=1, *, Generator? generator=None) -> Tensor
-  dispatch:
-    CPU, CUDA: normal
+  structured_delegate: normal.Tensor_float_out
 
 - func: normal.float_Tensor_out(float mean, Tensor std, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
-    CPU, CUDA: normal_out
+    CPU, CUDA: normal_float_Tensor_out
 
 - func: normal.float_Tensor(float mean, Tensor std, *, Generator? generator=None) -> Tensor
-  dispatch:
-    CPU, CUDA: normal
+  structured_delegate: normal.float_Tensor_out
 
 - func: normal.Tensor_Tensor_out(Tensor mean, Tensor std, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
-    CPU, CUDA: normal_out
+    CPU, CUDA: normal_Tensor_Tensor_out
 
 - func: normal.Tensor_Tensor(Tensor mean, Tensor std, *, Generator? generator=None) -> Tensor
-  dispatch:
-    CPU, CUDA: normal
+  structured_delegate: normal.Tensor_Tensor_out
 
 - func: normal.float_float(float mean, float std, int[] size, *, Generator? generator=None, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/test/cpu_rng_test.cpp
+++ b/aten/src/ATen/test/cpu_rng_test.cpp
@@ -73,18 +73,6 @@ Tensor& normal_Tensor_Tensor_out(const Tensor& mean, const Tensor& std, c10::opt
   return at::native::templates::normal_out_impl<native::templates::cpu::NormalKernel, TestCPUGenerator>(output, mean, std, gen);
 }
 
-Tensor normal_Tensor_float(const Tensor& mean, double std, c10::optional<Generator> gen) {
-  return at::native::templates::normal_impl<native::templates::cpu::NormalKernel, TestCPUGenerator>(mean, std, gen);
-}
-
-Tensor normal_float_Tensor(double mean, const Tensor& std, c10::optional<Generator> gen) {
-  return at::native::templates::normal_impl<native::templates::cpu::NormalKernel, TestCPUGenerator>(mean, std, gen);
-}
-
-Tensor normal_Tensor_Tensor(const Tensor& mean, const Tensor& std, c10::optional<Generator> gen) {
-  return at::native::templates::normal_impl<native::templates::cpu::NormalKernel, TestCPUGenerator>(mean, std, gen);
-}
-
 // ==================================================== Uniform =======================================================
 
 Tensor& uniform_(Tensor& self, double from, double to, c10::optional<Generator> generator) {
@@ -139,9 +127,7 @@ TORCH_LIBRARY_IMPL(aten, CustomRNGKeyId, m) {
   m.impl("normal.Tensor_float_out",  normal_Tensor_float_out);
   m.impl("normal.float_Tensor_out",  normal_float_Tensor_out);
   m.impl("normal.Tensor_Tensor_out", normal_Tensor_Tensor_out);
-  m.impl("normal.Tensor_float",      normal_Tensor_float);
-  m.impl("normal.float_Tensor",      normal_float_Tensor);
-  m.impl("normal.Tensor_Tensor",     normal_Tensor_Tensor);
+  // Uniform
   m.impl("uniform_",                 uniform_);
   // Cauchy
   m.impl("cauchy_",                  cauchy_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69632
* #69631
* #69630
* #69629
* __->__ #69628

- Refactor tensor variants to use structured in native_functions.yaml
- Other variants don't fit this model well, so not doing those for now
- Remove some normal templates and RNG tests that relied on them.

See #69386.