### PR TITLE
Unify checks for normal

### DIFF
--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -157,50 +157,28 @@ at::Tensor& random_from_to_impl(at::Tensor& self, int64_t from, c10::optional<in
 
 // ==================================================== Normal ========================================================
 
-// This function computes broadcasted size of mean and std, resize the output to the broadcasted size if it was empty
-// [Note] The following features will be deprecated in version 1.6 release and function signature will be changed after
-//   When mean and std are not broadcastable but have same number of elements:
-//     This function will resize the output to the size of mean if it was empty.
-//     This function will reshape the std to the shape of mean.
-//     This function will return true in deprecated case, false in broadcastable case and throw in all other cases before deprecation.
-//     This function will not return and throw if mean and std are not broadcastable after deprecation
-static bool resize_output_for_normal(at::Tensor& output, const at::Tensor& mean, const at::Tensor& std) {
-  bool expandable = at::are_expandable(mean.sizes(), std.sizes());
-  bool empty_output = output.numel() == 0;
+#define CHECK_NORMAL_SIZES(output, input) \
+  TORCH_CHECK( \
+    output.sizes().equals(input.sizes()), \
+    "inconsistent tensor, output size (", output.sizes(), \
+    ") is not the same as input size (", input.sizes(), ")");
 
-  if (expandable) {
-    auto shape = at::infer_size(mean.sizes(), std.sizes());
-    TORCH_CHECK(
-        empty_output || output.sizes().equals(shape),
-        "inconsistent tensor, output size (", output.sizes(), ") is not the same as broadcasted mean and std size (", shape, ")");
-    if (empty_output) {
-      at::native::resize_(output, shape);
-    }
-    return false;
-  }
-  else {
-    TORCH_CHECK(
-        mean.numel() == std.numel(),
-        "inconsistent tensor, std and mean are not broadcastable and have different number of elements, "
-        "expected mean ", mean.sizes(), " and std ", std.sizes(), " to have same number of elements)");
-    TORCH_CHECK(
-        empty_output || output.sizes().equals(mean.sizes()),
-        "inconsistent tensor, std and mean are not broadcastable, output size (", output.sizes(), ") is not the same as mean size (", mean.sizes(), ")");
-    TORCH_WARN_ONCE(
-        "std and mean have the same number of elements, but are not broadcastable. This was previously a "
-        "supported mode of operation, but is now deprecated and the support will be removed in version 1.6 release. "
-        "Note that the current implementation reshapes std to the shape of mean, which may be incur data copies. "
-        "Please ensure that std and mean are broadcastable to avoid these issues.");
-    if (empty_output) {
-      at::native::resize_(output, mean.sizes());
-    }
-    return true;
-  }
-}
+#define CHECK_NORMAL_TENSOR_STD(std) \
+  do { \
+    TORCH_CHECK( \
+      !std.is_complex(), \
+      "normal expects standard deviation to be non-complex"); \
+    TORCH_CHECK( \
+      std.numel() == 0 || std.min().ge(0).item<bool>(), \
+      "normal expects all elements of std >= 0.0"); \
+  } while (0)
+
+#define CHECK_NORMAL_STD(std) \
+  TORCH_CHECK(std >= 0.0, "normal expects std >= 0.0, but found std ", std);
 
 template<template<typename> class normal_kernel, typename RNG>
 Tensor& normal_impl_(Tensor& self, double mean, double std, c10::optional<Generator> gen) {
-  TORCH_CHECK(std >= 0.0, "normal_ expects std >= 0.0, but found std=", std);
+  CHECK_NORMAL_STD(std);
   if (self.is_complex()) {
     auto float_tensor = at::view_as_real(self);
     // variance for normal distribution of the real and imaginary values
@@ -214,6 +192,8 @@ Tensor& normal_impl_(Tensor& self, double mean, double std, c10::optional<Genera
 
 template<template<typename> class normal_kernel, typename RNG>
 Tensor& normal_out_impl(Tensor& output, const Tensor& mean, double std, c10::optional<Generator> gen) {
+  CHECK_NORMAL_SIZES(output, mean);
+  CHECK_NORMAL_STD(std);
   normal_impl_<normal_kernel, RNG>(output, 0, std, gen);
   output.add_(mean);
   return output;
@@ -221,40 +201,21 @@ Tensor& normal_out_impl(Tensor& output, const Tensor& mean, double std, c10::opt
 
 template<template<typename> class normal_kernel, typename RNG>
 Tensor& normal_out_impl(Tensor& output, double mean, const Tensor& std, c10::optional<Generator> gen) {
-  TORCH_CHECK(!std.is_complex(), "normal expects standard deviation to be non-complex");
-  TORCH_CHECK(
-    std.min().ge(0).item<bool>(),
-    "normal expects all elements of std >= 0.0");
+  CHECK_NORMAL_SIZES(output, std);
+  CHECK_NORMAL_TENSOR_STD(std);
   normal_impl_<normal_kernel, RNG>(output, 0, 1, gen);
   auto mean_tensor = at::full({}, mean, output.options());
-  // CUDA NB: addcmul_out copies the tensor to be added into the output.
-  // Please look at aten/src/THC/generic/THCTensorMathPointwise.cu
-  // The previous function here was addcmul_out(output, mean_tensor, output, std, 1);
-  // The third argument is not a constant reference and hence the samples in output are overwritten.
-  // Consequently, the computation performed is mean_tensor + mean_tensor * std instead of mean_tensor + output * std
   output.mul_(std).add_(mean_tensor);
   return output;
 }
 
 template<template<typename> class normal_kernel, typename RNG>
 Tensor& normal_out_impl(Tensor& output, const Tensor& mean, const Tensor& std, c10::optional<Generator> gen) {
-  TORCH_CHECK(!std.is_complex(), "normal expects standard deviation to be non-complex");
-  TORCH_CHECK(
-    std.numel() == 0 || std.min().ge(0).item<bool>(),
-    "normal expects all elements of std >= 0.0");
-  bool is_deprecated_th_impl = resize_output_for_normal(output, mean, std);
+  CHECK_NORMAL_SIZES(output, mean);
+  CHECK_NORMAL_SIZES(output, std);
+  CHECK_NORMAL_TENSOR_STD(std);
   normal_impl_<normal_kernel, RNG>(output, 0, 1, gen);
-  // CUDA NB: addcmul_out copies the tensor to be added into the output.
-  // Please look at aten/src/THC/generic/THCTensorMathPointwise.cu
-  // The previous function here was addcmul_out(output, mean, output, std, 1);
-  // The third argument is not a constant reference and hence the samples in output are overwritten.
-  // Consequently, the computation performed is mean + mean * std instead of mean + output * std
-  if (is_deprecated_th_impl) {
-    output.mul_(std.reshape(mean.sizes())).add_(mean);
-  }
-  else {
-    output.mul_(std).add_(mean);
-  }
+  output.mul_(std).add_(mean);
   return output;
 }
 

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -587,6 +587,7 @@ TORCH_META_FUNC2(normal, float_Tensor) (
   const Tensor& std,
   c10::optional<Generator> gen
 ) {
+  CHECK_NORMAL_TENSOR_STD(std);
   set_output(std.sizes(), std.options());
 }
 
@@ -595,6 +596,7 @@ TORCH_META_FUNC2(normal, Tensor_float) (
   double std,
   c10::optional<Generator> gen
 ) {
+  CHECK_NORMAL_STD(std);
   set_output(mean.sizes(), mean.options());
 }
 
@@ -603,6 +605,7 @@ TORCH_META_FUNC2(normal, Tensor_Tensor) (
   Tensor const& std,
   c10::optional<Generator> gen
 ) {
+  CHECK_NORMAL_TENSOR_STD(std);
   auto shape = at::infer_size(mean.sizes(), std.sizes());
   set_output(shape, mean.options());
 }

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7296,11 +7296,9 @@ each output element's normal distribution
 The :attr:`std` is a tensor with the standard deviation of
 each output element's normal distribution
 
-The shapes of :attr:`mean` and :attr:`std` don't need to match, but the
-total number of elements in each tensor need to be the same.
-
-.. note:: When the shapes do not match, the shape of :attr:`mean`
-          is used as the shape for the returned output tensor
+The shapes of :attr:`mean`, :attr:`std`, and :attr:`out` (if present) must
+match exactly.  Unless the size of :attr:`out` is zero, then it will be resized
+based on the supplied arguments, which must still match.
 
 .. note:: When :attr:`std` is a CUDA tensor, this function synchronizes
           its device with the CPU.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69632
* #69631
* #69630
* __->__ #69629
* #69628

- Split up checks into multiple macros
- Use them in meta and impl functions for now since either might be called
- Get rid of what appear to be just legacy checks that are irrelevant now
- Update docs to not mention deprecated behavior.

Backward compatibility issues:

- Shapes must match exactly between mean and std (no automatic resizing):

Old:

>>> import torch
>>>
>>> mean = torch.rand(3, 4, 5, device='cpu')
>>> std  = torch.rand(3, 4, 1, device='cpu')
>>>
>>> torch.normal(mean=mean, std=std).size()
torch.Size([3, 4, 5])

New:

>>> import torch
>>>
>>> mean = torch.rand(3, 4, 5, device='cpu')
>>> std  = torch.rand(3, 4, 1, device='cpu')
>>>
>>> torch.normal(mean=mean, std=std)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: inconsistent tensor, output size ([3, 4, 5]) is not the same as
input size ([3, 4, 1])

- Tensors with the same number of elements are treated as different if their
  shapes don't match exactly:

Old:

>>> import torch
>>>
>>> out  = torch.rand(2, 3, device='cpu')
>>> mean = torch.rand(2, 3, device='cpu')
>>> std  = torch.rand(1, 6, device='cpu')
>>>
>>> torch.normal(out=out, mean=mean, std=std)
<stdin>:1: UserWarning: std and mean have the same number of elements, but are
not broadcastable. This was previously a supported mode of operation, but is
now deprecated and the support will be removed in version 1.6 release. Note
that the current implementation reshapes std to the shape of mean, which may be
incur data copies. Please ensure that std and mean are broadcastable to avoid
these issues. (Triggered internally at
aten/src/ATen/native/DistributionTemplates.h:189.)
tensor([[ 0.3345,  0.6314,  1.0163],
        [-0.0397,  0.8128,  1.1436]])

New:

>>> import torch
>>>
>>> out  = torch.rand(2, 3, device='cpu')
>>> mean = torch.rand(2, 3, device='cpu')
>>> std  = torch.rand(1, 6, device='cpu')
>>>
>>> torch.normal(out=out, mean=mean, std=std)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: The size of tensor a (3) must match the size of tensor b (6) at
non-singleton dimension 1

- An empty tensor is returned instead of an error when mean is a float and std
  is an empty tensor:

Old:

>>> import torch
>>>
>>> mean = 4.
>>> std  = torch.rand(0, device='cpu')
>>>
>>> torch.normal(mean=mean, std=std)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: min(): Expected reduction dim to be specified for input.numel()
== 0. Specify the reduction dim with the 'dim' argument.

New:

>>> import torch
>>>
>>> mean = 4.
>>> std  = torch.rand(0, device='cpu')
>>>
>>> torch.normal(mean=mean, std=std)
tensor([])