### PR TITLE
Bug fix: allow std 0 in the meta definition of normal_

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -262,7 +262,7 @@ Tensor& normal_(Tensor& self, double mean, double std, c10::optional<Generator> 
 }
 
 Tensor& normal_meta_(Tensor& self, double mean, double std, c10::optional<Generator> gen) {
-  TORCH_CHECK(std > 0.0, "normal_ expects std > 0.0, but found std=", std);  // TODO: dedupe
+  CHECK_NORMAL_STD(std);
   return self;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69632
* __->__ #69631
* #69630
* #69629
* #69628

All other normal variants allow 0.  Looks like a mistake made while
copying the check.  Even the normal_ implementation disagrees:

>>> t = torch.rand(2, 3, device='meta')
>>> t.normal_(mean=4, std=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: normal_ expects std > 0.0, but found std=0
>>>
>>>
>>> t = torch.rand(2, 3)
>>> t.normal_(mean=4, std=0)
tensor([[4., 4., 4.],
        [4., 4., 4.]])

Fixes #69523.