### PR TITLE
Add meta variants to float variants of normal

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -8,6 +8,7 @@
 #include <ATen/TracerMode.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Deprecated.h>
+#include <ATen/native/DistributionTemplates.h>
 #include <ATen/native/Math.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorFactories.h>
@@ -819,24 +820,79 @@ Tensor& randn_out(IntArrayRef size, c10::optional<Generator> generator, Tensor& 
   return result.normal_(0, 1, generator);
 }
 
-Tensor normal(double mean, double std, IntArrayRef size,
-              c10::optional<Generator> generator,
-    c10::optional<ScalarType> dtype,
-    c10::optional<Layout> layout,
-    c10::optional<Device> device,
-    c10::optional<bool> pin_memory) {
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ normal ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tensor normal(
+  double mean,
+  double std,
+  IntArrayRef size,
+  c10::optional<Generator> generator,
+  c10::optional<ScalarType> dtype,
+  c10::optional<Layout> layout,
+  c10::optional<Device> device,
+  c10::optional<bool> pin_memory
+) {
+  CHECK_NORMAL_STD(std);
+
   // See [Note: hacky wrapper removal for TensorOptions]
-  TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  TensorOptions options = TensorOptions()
+    .dtype(dtype)
+    .layout(layout)
+    .device(device)
+    .pinned_memory(pin_memory);
 
   auto result = at::empty(size, options);
   return result.normal_(mean, std, generator);
 }
 
-Tensor& normal_out(double mean, double std,
-                   IntArrayRef size, c10::optional<Generator> generator, Tensor& result) {
+Tensor normal_meta(
+  double mean,
+  double std,
+  IntArrayRef size,
+  c10::optional<Generator> generator,
+  c10::optional<ScalarType> dtype,
+  c10::optional<Layout> layout,
+  c10::optional<Device> device,
+  c10::optional<bool> pin_memory
+) {
+  CHECK_NORMAL_STD(std);
+
+  // See [Note: hacky wrapper removal for TensorOptions]
+  TensorOptions options = TensorOptions()
+    .dtype(dtype)
+    .layout(layout)
+    .device(device)
+    .pinned_memory(pin_memory);
+
+  auto result = at::empty(size, options);
+  return result;  // similar to normal_meta_
+}
+
+Tensor& normal_out(
+  double mean,
+  double std,
+  IntArrayRef size,
+  c10::optional<Generator> generator,
+  Tensor& result
+) {
+  CHECK_NORMAL_STD(std);
   result.resize_(size);
   return result.normal_(mean, std, generator);
 }
+
+Tensor& normal_out_meta(
+  double mean,
+  double std,
+  IntArrayRef size,
+  c10::optional<Generator> generator,
+  Tensor& result
+) {
+  CHECK_NORMAL_STD(std);
+  result.resize_(size);
+  return result;  // similar to normal_meta_
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randn_like ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor randn_like(
     const Tensor& self,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7792,8 +7792,14 @@
   structured_delegate: normal.Tensor_Tensor_out
 
 - func: normal.float_float(float mean, float std, int[] size, *, Generator? generator=None, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  dispatch:
+    CPU, CUDA: normal
+    Meta: normal_meta
 
 - func: normal.float_float_out(float mean, float std, int[] size, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU, CUDA: normal_out
+    Meta: normal_out_meta
 
 - func: alias(Tensor(a) self) -> Tensor(a)
   variants: method, function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69632
* #69631
* #69630
* #69629
* #69628

This mimics what normal_ does.  Not sure whether TensorOptions need to
explicitly set the device type to meta for these.

Without this change, both of these variants already work with meta, but
maybe explicit definitions are somehow better (e.g., result in less
computations):

>>> torch.normal(mean=4., std=1., size=(1, 2, 3), device='meta')
tensor(..., device='meta', size=(1, 2, 3))
>>> torch.normal(mean=4., std=1., size=(4, 5), out=torch.rand(1, device='meta'))
tensor(..., device='meta', size=(4, 5))