### PR TITLE
Commit the learning-rate hack for instructional purposes, not for checkin

### DIFF
--- a/torch/optim/_functional.py
+++ b/torch/optim/_functional.py
@@ -105,7 +105,7 @@ def adam(params: List[Tensor],
 
         step_size = lr / bias_correction1
 
-        param.addcdiv_(exp_avg, denom, value=-step_size)
+        param.addcdiv_(exp_avg, denom, value=-lr)
 
 
 def adamw(params: List[Tensor],


### PR DESCRIPTION
the `step_size` value is a python float that is updated on every training iteration.  

The current lazy_tensor_staging code stores scalars such as addcdiv_'s `value` as fields in the IR, and hashes over them.  they get burned into the compiled program as compile-time constants.  This means recompiling every training step.

The hack is to fix the 'value' to a non-changing value, in this case I just used `lr` since `lr` is fixed through training.  This is not a correct change, just used for unblocking other performance work while we implement better handling of scalars in lazy tensor. 