### PR TITLE
Use single int32 hash for aten optype rather than string

### DIFF
--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -28,8 +28,7 @@ OpKind OpKind::Get(const std::string& name) {
 }
 
 hash_t OpKind::hash() const {
-  // op contains only a `c10::unique_t value` field, and unique_t = uint32_t
-  return Hash(static_cast<uint32_t>(op));
+  return Hash(static_cast<c10::unique_t>(op));
 }
 
 Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, hash_t dag_hash)

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -28,7 +28,8 @@ OpKind OpKind::Get(const std::string& name) {
 }
 
 hash_t OpKind::hash() const {
-  return StringHash(op.toQualString());
+  // op contains only a `c10::unique_t value` field, and unique_t = uint32_t
+  return Hash(static_cast<uint32_t>(op));
 }
 
 Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, hash_t dag_hash)


### PR DESCRIPTION
- I haven't shown this to impact execution time, but I did see the
  tostring in flamegraph so this should be a strict improvement
  however small.
