### PR TITLE
enhance the custom loader to handle XAR

### DIFF
--- a/torch/csrc/deploy/interpreter/import_find_sharedfuncptr.cpp
+++ b/torch/csrc/deploy/interpreter/import_find_sharedfuncptr.cpp
@@ -27,11 +27,9 @@ extern "C" dl_funcptr _PyImport_FindSharedFuncptr(
   // when the manager unloads. Otherwise some libraries can live longer than
   // they are needed, and the process of unloading them might use functionality
   // that itself gets unloaded.
-  loaded_files_.emplace_back(CustomLibrary::create(pathname, 1, args));
+  loaded_files_.emplace_back(
+      CustomLibrary::create(pathname, 1, args, deploy_self));
   CustomLibrary& lib = *loaded_files_.back();
-  lib.add_search_library(SystemLibrary::create(deploy_self));
-  lib.add_search_library(SystemLibrary::create());
-  lib.load();
   std::stringstream ss;
   ss << prefix << "_" << shortname;
   auto r = (dl_funcptr)lib.sym(ss.str().c_str()).value();

--- a/torch/csrc/deploy/loader.h
+++ b/torch/csrc/deploy/loader.h
@@ -40,7 +40,8 @@ struct CustomLibrary : public SymbolProvider {
   static std::shared_ptr<CustomLibrary> create(
       const char* filename,
       int argc = 0,
-      const char** argv = nullptr);
+      const char** argv = nullptr,
+      void* interp_handle = nullptr);
   virtual void add_search_library(std::shared_ptr<SymbolProvider> lib) = 0;
   virtual void load() = 0;
 };

--- a/torch/csrc/deploy/unity/xar_environment.cpp
+++ b/torch/csrc/deploy/unity/xar_environment.cpp
@@ -126,6 +126,11 @@ void XarEnvironment::setupPythonApp() {
   r = system(extractCommand.c_str());
   TORCH_CHECK(r == 0, "Fail to extract the python package");
 
+  // change current working directory to pythonAppDir_ since code like
+  // https://fburl.com/code/bd117dek makes such assumption
+  TORCH_CHECK(
+      chdir(pythonAppRoot_.c_str()) == 0,
+      "Fail to change the current working directory");
   alreadySetupPythonApp_ = true;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69652

We only used the custom loader to load python extension modules but use dlopen for the shared libraries needed by the extension modules. This causes issue if the non-extension shared libraries uses CPython APIs. There are a few cases why this can happen. E.g., if an extension is created using boost.python, the extension module will depends on libboost_python.so . The latter need access CPython APIs.

This diff maintains a list of non-extension libraries that should be loaded by the custom loader. In long term we should enhance the custom loader to load all shared libraries with it.

Differential Revision: [D32632556](https://our.internmc.facebook.com/intern/diff/D32632556/)