### PR TITLE
remove c10 cmake globs that match no files

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -26,15 +26,9 @@ configure_file(
 # check with the core PyTorch developers as the dependency will be
 # transitively passed on to all libraries dependent on PyTorch.
 file(GLOB C10_SRCS
-        *.cpp
         core/*.cpp
-        core/boxing/*.cpp
-        core/boxing/impl/*.cpp
-        core/dispatch/*.cpp
-        core/op_registration/*.cpp
         core/impl/*.cpp
         mobile/*.cpp
-        macros/*.cpp
         util/*.cpp
         )
 file(GLOB_RECURSE C10_ALL_TEST_FILES test/*.cpp)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69680

Summary:
Most of these globs refer to directories that no longer exist. The
only exceptions are the top-level and macros/ directories which exist
but do not contains any .cpp files.

Test Plan:
Relying on CI to test.

Reviewers:

Subscribers:

Tasks:

Tags: