### PR TITLE
Fix generating files for Vulkan on Windows

### DIFF
--- a/aten/src/ATen/gen_vulkan_glsl.py
+++ b/aten/src/ATen/gen_vulkan_glsl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import glob
 import sys
 import os
 from tools.codegen.code_template import CodeTemplate
@@ -10,8 +11,7 @@ CPP_NAME = "glsl.cpp"
 DEFAULT_ENV = {"precision": "highp", "format": "rgba32f"}
 
 def findAllGlsls(path):
-    cmd = "find " + path + " -name \"*.glsl\""
-    vexs = os.popen(cmd).read().split('\n')
+    vexs = glob.glob(os.path.join(path, '**', '*.glsl'), recursive=True)
     output = []
     for f in vexs:
         if len(f) > 1:

--- a/aten/src/ATen/gen_vulkan_spv.py
+++ b/aten/src/ATen/gen_vulkan_spv.py
@@ -2,6 +2,7 @@
 
 import argparse
 import array
+import glob
 import os
 import sys
 import subprocess
@@ -18,8 +19,7 @@ def genCppH(hFilePath, cppFilePath, srcDirPath, glslcPath, tmpDirPath, env):
     print("hFilePath:{} cppFilePath:{} srcDirPath:{} glslcPath:{} tmpDirPath:{}".format(
         hFilePath, cppFilePath, srcDirPath, glslcPath, tmpDirPath))
 
-    cmd = "find " + srcDirPath + " -name \"*.glsl\""
-    vexs = os.popen(cmd).read().split('\n')
+    vexs = glob.glob(os.path.join(srcDirPath, '**', '*.glsl'), recursive=True)
     templateSrcPaths = []
     for f in vexs:
         if len(f) > 1:


### PR DESCRIPTION
Summary: Using `find` is not portable as it won't be there on Windows for example. We can use `glob` with the recursive option added in Python 3.5 instead.

Test Plan: CircleCI

Differential Revision: D32994229

