### PR TITLE
Enable default reference path for CopyNodeQuantizeHandler

### DIFF
--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -1488,14 +1488,11 @@ class CopyNodeQuantizeHandler(QuantizeHandler):
                 convert_custom_config_dict: Dict[str, Any] = None) -> Node:
         # always produce reference pattern for relu
         func_list = [
-            torch.nn.functional.hardtanh,
-            torch.nn.functional.hardtanh_,
             torch.nn.functional.relu,
-            torch.nn.functional.relu6,
             torch.flatten,
             torch.max,
-            torch.mean,
             torch.min,
+            torch.clamp,
         ]
         is_relu = node.op == "call_function" and node.target in func_list
         if is_reference or is_relu:

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -1486,7 +1486,7 @@ class CopyNodeQuantizeHandler(QuantizeHandler):
                 load_arg: Callable,
                 is_reference: bool = False,
                 convert_custom_config_dict: Dict[str, Any] = None) -> Node:
-        # always produce reference pattern for relu
+        # always produce reference pattern for following functions
         func_list = [
             torch.nn.functional.relu,
             torch.flatten,
@@ -1494,8 +1494,8 @@ class CopyNodeQuantizeHandler(QuantizeHandler):
             torch.min,
             torch.clamp,
         ]
-        is_relu = node.op == "call_function" and node.target in func_list
-        if is_reference or is_relu:
+        is_func = node.op == "call_function" and node.target in func_list
+        if is_reference or is_func:
             # when activation dtype is torch.float, the node does not require
             # observation
             # e.g. dynamic quantization or weight_only quantization

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -1488,27 +1488,14 @@ class CopyNodeQuantizeHandler(QuantizeHandler):
                 convert_custom_config_dict: Dict[str, Any] = None) -> Node:
         # always produce reference pattern for relu
         func_list = [
-            torch.adaptive_avg_pool1d,
-            torch.nn.functional.adaptive_avg_pool2d,
-            torch.nn.functional.adaptive_avg_pool3d,
-            torch.nn.functional.dropout,
             torch.nn.functional.hardtanh,
             torch.nn.functional.hardtanh_,
-            torch.nn.functional.interpolate,
-            torch.nn.functional.max_pool1d,
-            torch.nn.functional.max_pool2d,
-            torch.nn.functional.max_pool3d,
             torch.nn.functional.relu,
             torch.nn.functional.relu6,
-            torch.avg_pool1d,
-            torch._C._nn.avg_pool2d,
-            torch._C._nn.avg_pool3d,
-            torch.clamp,
             torch.flatten,
             torch.max,
             torch.mean,
             torch.min,
-            operator.floordiv,
         ]
         is_relu = node.op == "call_function" and node.target in func_list
         if is_reference or is_relu:

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -1487,7 +1487,30 @@ class CopyNodeQuantizeHandler(QuantizeHandler):
                 is_reference: bool = False,
                 convert_custom_config_dict: Dict[str, Any] = None) -> Node:
         # always produce reference pattern for relu
-        is_relu = node.op == "call_function" and node.target == torch.nn.functional.relu
+        func_list = [
+            torch.adaptive_avg_pool1d,
+            torch.nn.functional.adaptive_avg_pool2d,
+            torch.nn.functional.adaptive_avg_pool3d,
+            torch.nn.functional.dropout,
+            torch.nn.functional.hardtanh,
+            torch.nn.functional.hardtanh_,
+            torch.nn.functional.interpolate,
+            torch.nn.functional.max_pool1d,
+            torch.nn.functional.max_pool2d,
+            torch.nn.functional.max_pool3d,
+            torch.nn.functional.relu,
+            torch.nn.functional.relu6,
+            torch.avg_pool1d,
+            torch._C._nn.avg_pool2d,
+            torch._C._nn.avg_pool3d,
+            torch.clamp,
+            torch.flatten,
+            torch.max,
+            torch.mean,
+            torch.min,
+            operator.floordiv,
+        ]
+        is_relu = node.op == "call_function" and node.target in func_list
         if is_reference or is_relu:
             # when activation dtype is torch.float, the node does not require
             # observation

--- a/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
+++ b/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
@@ -1,20 +1,255 @@
 import torch
 import operator
 
-def relu_inplace_pattern(x, scale, zero_point):
+def relu_pattern(x, scale, zero_point, inplace):
     x = x.dequantize()
-    x = torch.nn.functional.relu(x, inplace=True)
+    x = torch.nn.functional.relu(x, inplace)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def relu_non_inplace_pattern(x, scale, zero_point):
+def relu_replacement(x, scale, zero_point, inplace):
+    x = torch.nn.functional.relu(x, inplace)
+    return x
+
+def relu_op_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.relu(x, inplace=False)
+    x = x.relu()
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def relu_replacement(x, scale, zero_point):
-    x = torch.nn.functional.relu(x)
+def relu_op_replacement(x, scale, zero_point):
+    x = x.relu()
+    return x
+
+def relu_inplace_op_pattern(x, scale, zero_point):
+    x = x.dequantize()
+    x = x.relu_()
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def relu_inplace_op_replacement(x, scale, zero_point):
+    x = x.relu_()
+    return x
+
+def relu6_pattern(x, scale, zero_point, inplace=False):
+    x = x.dequantize()
+    x = torch.nn.functional.relu6(x, inplace=inplace)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def relu6_replacement(x, scale, zero_point, inplace=False):
+    x = torch.nn.functional.relu6(x, inplace=inplace)
+    return x
+
+def hardtanh_pattern(x, scale, zero_point, min_val=-1.0, max_val=1.0, inplace=False):
+    x = x.dequantize()
+    x = torch.nn.functional.hardtanh(x, min_val=min_val, max_val=max_val, inplace=inplace)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def hardtanh_replacement(x, scale, zero_point, min_val=-1.0, max_val=1.0, inplace=False):
+    x = torch.nn.functional.hardtanh(x, min_val=min_val, max_val=max_val, inplace=inplace)
+    return x
+
+def hardtanh_inplace_pattern(x, scale, zero_point, min_val=-1.0, max_val=1.0):
+    x = x.dequantize()
+    x = torch.nn.functional.hardtanh_(x, min_val=min_val, max_val=max_val)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def hardtanh_inplace_replacement(x, scale, zero_point, min_val=-1.0, max_val=1.0):
+    x = torch.nn.functional.hardtanh_(x, min_val=min_val, max_val=max_val)
+    return x
+
+def adaptive_avg_pool1d_pattern(x, scale, zero_point, output_size):
+    x = x.dequantize()
+    x = torch.nn.functional.adaptive_avg_pool1d(x, output_size)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def adaptive_avg_pool1d_replacement(x, scale, zero_point, output_size):
+    x = torch.nn.functional.adaptive_avg_pool1d(x, output_size)
+    return x
+
+def adaptive_avg_pool2d_pattern(x, scale, zero_point, output_size):
+    x = x.dequantize()
+    x = torch.nn.functional.adaptive_avg_pool2d(x, output_size)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def adaptive_avg_pool2d_replacement(x, scale, zero_point, output_size):
+    x = torch.nn.functional.adaptive_avg_pool2d(x, output_size)
+    return x
+
+def adaptive_avg_pool3d_pattern(x, scale, zero_point, output_size):
+    x = x.dequantize()
+    x = torch.nn.functional.adaptive_avg_pool3d(x, output_size)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def adaptive_avg_pool3d_replacement(x, scale, zero_point, output_size):
+    x = torch.nn.functional.adaptive_avg_pool3d(x, output_size)
+    return x
+
+def dropout_pattern(x, scale, zero_point, p=0.5, training=True, inplace=False):
+    x = x.dequantize()
+    x = torch.nn.functional.dropout(x, p=p, training=training, inplace=inplace)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def dropout_replacement(x, scale, zero_point, p=0.5, training=True, inplace=False):
+    x = torch.nn.functional.dropout(x, p=p, training=training, inplace=inplace)
+    return x
+
+def interpolate_pattern(x, scale, zero_point, size=None, scale_factor=None, mode='nearest', align_corners=None, recompute_scale_factor=None):
+    x = x.dequantize()
+    x = torch.nn.functional.interpolate(x, size, scale_factor, mode, align_corners, recompute_scale_factor)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def interpolate_replacement(x, scale, zero_point, size=None, scale_factor=None, mode='nearest', align_corners=None, recompute_scale_factor=None):
+    x = torch.nn.functional.interpolate(x, size, scale_factor, mode, align_corners, recompute_scale_factor)
+    return x
+
+def max_pool1d_pattern(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
+    x = x.dequantize()
+    x = torch.nn.functional.MaxPool1d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def max_pool1d_replacement(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
+    x = torch.nn.functional.MaxPool1d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    return x
+
+def max_pool2d_pattern(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
+    x = x.dequantize()
+    x = torch.nn.functional.MaxPool2d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def max_pool2d_replacement(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
+    x = torch.nn.functional.MaxPool2d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    return x
+
+def max_pool3d_pattern(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
+    x = x.dequantize()
+    x = torch.nn.functional.MaxPool3d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def max_pool3d_replacement(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
+    x = torch.nn.functional.MaxPool3d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    return x
+
+def avg_pool1d_pattern(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad):
+    x = x.dequantize()
+    x = torch.avg_pool1d(x, kernel_size, stride, padding, ceil_mode, count_include_pad)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def avg_pool1d_replacement(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad):
+    x = torch.avg_pool1d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
+    return x
+
+def avg_pool2d_pattern(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
+    x = x.dequantize()
+    x = _C._nn.avg_pool2d(x, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def avg_pool2d_replacement(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
+    x = _C._nn.avg_pool2d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode, divisor_override)
+    return x
+
+def avg_pool3d_pattern(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
+    x = x.dequantize()
+    x = torch._C._nn.avg_pool3d(x, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def avg_pool3d_replacement(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
+    x = torch._C._nn.avg_pool3d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode, divisor_override)
+    return x
+
+def clamp_pattern(x, scale, zero_point, min_val, max_val):
+    x = x.dequantize()
+    x = torch.clamp(x, min_val, max_val)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def clamp_replacement(x, scale, zero_point, min_val, max_val):
+    x = torch.clamp(x, min_val, max_val)
+    return x
+
+def clamp_op_pattern(x, scale, zero_point, min_val, max_val):
+    x = x.dequantize()
+    x = x.clamp(min_val, max_val)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def clamp_op_replacement(x, scale, zero_point, min_val, max_val):
+    x = x.clamp(min_val, max_val)
+    return x
+
+def min_pattern(x, scale, zero_point, dim, keepdim):
+    x = x.dequantize()
+    x = torch.min(x, dim, keepdim)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def min_replacement(x, scale, zero_point, dim, keepdim):
+    x = torch.min(x, dim, keepdim)
+    return x
+
+def max_pattern(x, scale, zero_point, dim, keepdim):
+    x = x.dequantize()
+    x = torch.max(x, dim, keepdim)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def max_replacement(x, scale, zero_point, dim, keepdim):
+    x = torch.max(x, dim, keepdim)
+    return x
+
+def mean_pattern(x, scale, zero_point, dim, keepdim):
+    x = x.dequantize()
+    x = torch.mean(x, dim, keepdim)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def mean_replacement(x, scale, zero_point, dim, keepdim):
+    x = torch.mean(x, dim, keepdim)
+    return x
+
+def mean_op_pattern(x, scale, zero_point, dim, keepdim):
+    x = x.dequantize()
+    x = x.mean(dim, keepdim)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def mean_op_replacement(x, scale, zero_point, dim, keepdim):
+    x = x.mean(dim, keepdim)
+    return x
+
+def flatten_pattern(x, scale, zero_point, start_dim, end_dim):
+    x = x.dequantize()
+    x = torch.flatten(x, start_dim, end_dim)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def flatten_replacement(x, scale, zero_point, start_dim, end_dim):
+    x = torch.flatten(x, start_dim, end_dim)
+    return x
+
+def floordiv_pattern(x, scale, zero_point, y):
+    x = x.dequantize()
+    # TODO quantize 2nd input
+    x = operator.floordiv(x, y)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def floordiv_replacement(x, scale, zero_point, y):
+    x = operator.floordiv(x, y)
     return x
 
 #
@@ -227,8 +462,31 @@ def get_binary_op_pattern_and_replacements():
 def _get_all_patterns_and_replacements():
     return [
         *get_binary_op_pattern_and_replacements(),
-        (relu_inplace_pattern, relu_replacement, []),
-        (relu_non_inplace_pattern, relu_replacement, []),
+        (relu_pattern, relu_replacement, []),
+        (relu_op_pattern, relu_op_replacement, []),
+        (relu_inplace_op_pattern, relu_inplace_op_replacement, []),
+        (relu6_pattern, relu6_replacement, []),
+        (adaptive_avg_pool1d_pattern, adaptive_avg_pool1d_replacement, []),
+        (adaptive_avg_pool2d_pattern, adaptive_avg_pool2d_replacement, []),
+        (adaptive_avg_pool3d_pattern, adaptive_avg_pool3d_replacement, []),
+        (hardtanh_pattern, hardtanh_replacement, []),
+        (hardtanh_inplace_pattern, hardtanh_inplace_replacement, []),
+        (dropout_pattern, dropout_replacement, []),
+        (interpolate_pattern, interpolate_replacement, []),
+        (max_pool1d_pattern, max_pool1d_replacement, []),
+        (max_pool2d_pattern, max_pool2d_replacement, []),
+        (max_pool3d_pattern, max_pool3d_replacement, []),
+        (avg_pool1d_pattern, avg_pool1d_replacement, []),
+        (avg_pool2d_pattern, avg_pool2d_replacement, []),
+        (avg_pool3d_pattern, avg_pool3d_replacement, []),
+        (clamp_pattern, clamp_replacement, []),
+        (clamp_op_pattern, clamp_op_replacement, []),
+        (min_pattern, min_replacement, []),
+        (max_pattern, max_replacement, []),
+        (mean_pattern, mean_replacement, []),
+        (mean_op_pattern, mean_op_replacement, []),
+        (flatten_pattern, flatten_replacement, []),
+        (floordiv_pattern, floordiv_replacement, []),
     ]
 
 

--- a/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
+++ b/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
@@ -1,14 +1,20 @@
 import torch
 import operator
 
-def relu_pattern(x, scale, zero_point, inplace):
+def relu_inplace_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.relu(x, inplace)
+    x = torch.nn.functional.relu(x, inplace=True)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def relu_replacement(x, scale, zero_point, inplace):
-    x = torch.nn.functional.relu(x, inplace)
+def relu_non_inplace_pattern(x, scale, zero_point):
+    x = x.dequantize()
+    x = torch.nn.functional.relu(x, inplace=False)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def relu_replacement(x, scale, zero_point):
+    x = torch.nn.functional.relu(x)
     return x
 
 def relu_op_pattern(x, scale, zero_point):
@@ -31,225 +37,91 @@ def relu_inplace_op_replacement(x, scale, zero_point):
     x = x.relu_()
     return x
 
-def relu6_pattern(x, scale, zero_point, inplace=False):
+def relu6_inplace_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.relu6(x, inplace=inplace)
+    x = torch.nn.functional.relu6(x, inplace=True)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def relu6_replacement(x, scale, zero_point, inplace=False):
-    x = torch.nn.functional.relu6(x, inplace=inplace)
-    return x
-
-def hardtanh_pattern(x, scale, zero_point, min_val=-1.0, max_val=1.0, inplace=False):
+def relu6_non_inplace_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.hardtanh(x, min_val=min_val, max_val=max_val, inplace=inplace)
+    x = torch.nn.functional.relu6(x, inplace=False)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def hardtanh_replacement(x, scale, zero_point, min_val=-1.0, max_val=1.0, inplace=False):
-    x = torch.nn.functional.hardtanh(x, min_val=min_val, max_val=max_val, inplace=inplace)
+def relu6_replacement(x, scale, zero_point):
+    x = torch.nn.functional.relu6(x)
     return x
 
-def hardtanh_inplace_pattern(x, scale, zero_point, min_val=-1.0, max_val=1.0):
+
+def hardtanh_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.hardtanh_(x, min_val=min_val, max_val=max_val)
+    x = torch.nn.functional.hardtanh(x, inplace=False)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def hardtanh_inplace_replacement(x, scale, zero_point, min_val=-1.0, max_val=1.0):
-    x = torch.nn.functional.hardtanh_(x, min_val=min_val, max_val=max_val)
+def hardtanh_replacement(x, scale, zero_point):
+    x = torch.nn.functional.hardtanh(x, inplace=False)
     return x
 
-def adaptive_avg_pool1d_pattern(x, scale, zero_point, output_size):
+def hardtanh_inplace_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.adaptive_avg_pool1d(x, output_size)
+    x = torch.nn.functional.hardtanh_(x)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def adaptive_avg_pool1d_replacement(x, scale, zero_point, output_size):
-    x = torch.nn.functional.adaptive_avg_pool1d(x, output_size)
+def hardtanh_inplace_replacement(x, scale, zero_point):
+    x = torch.nn.functional.hardtanh_(x)
     return x
 
-def adaptive_avg_pool2d_pattern(x, scale, zero_point, output_size):
+def min_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.adaptive_avg_pool2d(x, output_size)
+    x = torch.min(x)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def adaptive_avg_pool2d_replacement(x, scale, zero_point, output_size):
-    x = torch.nn.functional.adaptive_avg_pool2d(x, output_size)
+def min_replacement(x, scale, zero_point):
+    x = torch.min(x)
     return x
 
-def adaptive_avg_pool3d_pattern(x, scale, zero_point, output_size):
+def max_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.adaptive_avg_pool3d(x, output_size)
+    x = torch.max(x)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def adaptive_avg_pool3d_replacement(x, scale, zero_point, output_size):
-    x = torch.nn.functional.adaptive_avg_pool3d(x, output_size)
+def max_replacement(x, scale, zero_point):
+    x = torch.max(x)
     return x
 
-def dropout_pattern(x, scale, zero_point, p=0.5, training=True, inplace=False):
+def mean_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.nn.functional.dropout(x, p=p, training=training, inplace=inplace)
+    x = torch.mean(x)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def dropout_replacement(x, scale, zero_point, p=0.5, training=True, inplace=False):
-    x = torch.nn.functional.dropout(x, p=p, training=training, inplace=inplace)
+def mean_replacement(x, scale, zero_point):
+    x = torch.mean(x)
     return x
 
-def interpolate_pattern(x, scale, zero_point, size=None, scale_factor=None, mode='nearest', align_corners=None, recompute_scale_factor=None):
-    x = x.dequantize()
-    x = torch.nn.functional.interpolate(x, size, scale_factor, mode, align_corners, recompute_scale_factor)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def interpolate_replacement(x, scale, zero_point, size=None, scale_factor=None, mode='nearest', align_corners=None, recompute_scale_factor=None):
-    x = torch.nn.functional.interpolate(x, size, scale_factor, mode, align_corners, recompute_scale_factor)
-    return x
-
-def max_pool1d_pattern(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
-    x = x.dequantize()
-    x = torch.nn.functional.MaxPool1d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def max_pool1d_replacement(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
-    x = torch.nn.functional.MaxPool1d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    return x
-
-def max_pool2d_pattern(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
-    x = x.dequantize()
-    x = torch.nn.functional.MaxPool2d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def max_pool2d_replacement(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
-    x = torch.nn.functional.MaxPool2d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    return x
-
-def max_pool3d_pattern(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
-    x = x.dequantize()
-    x = torch.nn.functional.MaxPool3d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def max_pool3d_replacement(x, scale, zero_point, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False):
-    x = torch.nn.functional.MaxPool3d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    return x
-
-def avg_pool1d_pattern(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad):
-    x = x.dequantize()
-    x = torch.avg_pool1d(x, kernel_size, stride, padding, ceil_mode, count_include_pad)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def avg_pool1d_replacement(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad):
-    x = torch.avg_pool1d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode)
-    return x
-
-def avg_pool2d_pattern(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
-    x = x.dequantize()
-    x = _C._nn.avg_pool2d(x, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def avg_pool2d_replacement(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
-    x = _C._nn.avg_pool2d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode, divisor_override)
-    return x
-
-def avg_pool3d_pattern(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
-    x = x.dequantize()
-    x = torch._C._nn.avg_pool3d(x, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def avg_pool3d_replacement(x, scale, zero_point, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
-    x = torch._C._nn.avg_pool3d(x, kernel_size, stride, padding, dilation, return_indices, ceil_mode, divisor_override)
-    return x
-
-def clamp_pattern(x, scale, zero_point, min_val, max_val):
-    x = x.dequantize()
-    x = torch.clamp(x, min_val, max_val)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def clamp_replacement(x, scale, zero_point, min_val, max_val):
-    x = torch.clamp(x, min_val, max_val)
-    return x
-
-def clamp_op_pattern(x, scale, zero_point, min_val, max_val):
-    x = x.dequantize()
-    x = x.clamp(min_val, max_val)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def clamp_op_replacement(x, scale, zero_point, min_val, max_val):
-    x = x.clamp(min_val, max_val)
-    return x
-
-def min_pattern(x, scale, zero_point, dim, keepdim):
-    x = x.dequantize()
-    x = torch.min(x, dim, keepdim)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def min_replacement(x, scale, zero_point, dim, keepdim):
-    x = torch.min(x, dim, keepdim)
-    return x
-
-def max_pattern(x, scale, zero_point, dim, keepdim):
-    x = x.dequantize()
-    x = torch.max(x, dim, keepdim)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def max_replacement(x, scale, zero_point, dim, keepdim):
-    x = torch.max(x, dim, keepdim)
-    return x
-
-def mean_pattern(x, scale, zero_point, dim, keepdim):
-    x = x.dequantize()
-    x = torch.mean(x, dim, keepdim)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def mean_replacement(x, scale, zero_point, dim, keepdim):
-    x = torch.mean(x, dim, keepdim)
-    return x
-
-def mean_op_pattern(x, scale, zero_point, dim, keepdim):
+def mean_op_pattern(x, scale, zero_point):
     x = x.dequantize()
     x = x.mean(dim, keepdim)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def mean_op_replacement(x, scale, zero_point, dim, keepdim):
+def mean_op_replacement(x, scale, zero_point):
     x = x.mean(dim, keepdim)
     return x
 
-def flatten_pattern(x, scale, zero_point, start_dim, end_dim):
+def flatten_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = torch.flatten(x, start_dim, end_dim)
+    x = torch.flatten(x)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def flatten_replacement(x, scale, zero_point, start_dim, end_dim):
-    x = torch.flatten(x, start_dim, end_dim)
-    return x
-
-def floordiv_pattern(x, scale, zero_point, y):
-    x = x.dequantize()
-    # TODO quantize 2nd input
-    x = operator.floordiv(x, y)
-    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
-    return x
-
-def floordiv_replacement(x, scale, zero_point, y):
-    x = operator.floordiv(x, y)
+def flatten_replacement(x, scale, zero_point):
+    x = torch.flatten(x)
     return x
 
 #
@@ -462,31 +334,19 @@ def get_binary_op_pattern_and_replacements():
 def _get_all_patterns_and_replacements():
     return [
         *get_binary_op_pattern_and_replacements(),
-        (relu_pattern, relu_replacement, []),
+        (relu_inplace_pattern, relu_replacement, []),
+        (relu_non_inplace_pattern, relu_replacement, []),
         (relu_op_pattern, relu_op_replacement, []),
         (relu_inplace_op_pattern, relu_inplace_op_replacement, []),
-        (relu6_pattern, relu6_replacement, []),
-        (adaptive_avg_pool1d_pattern, adaptive_avg_pool1d_replacement, []),
-        (adaptive_avg_pool2d_pattern, adaptive_avg_pool2d_replacement, []),
-        (adaptive_avg_pool3d_pattern, adaptive_avg_pool3d_replacement, []),
+        (relu6_inplace_pattern, relu6_replacement, []),
+        (relu6_non_inplace_pattern, relu6_replacement, []),
         (hardtanh_pattern, hardtanh_replacement, []),
         (hardtanh_inplace_pattern, hardtanh_inplace_replacement, []),
-        (dropout_pattern, dropout_replacement, []),
-        (interpolate_pattern, interpolate_replacement, []),
-        (max_pool1d_pattern, max_pool1d_replacement, []),
-        (max_pool2d_pattern, max_pool2d_replacement, []),
-        (max_pool3d_pattern, max_pool3d_replacement, []),
-        (avg_pool1d_pattern, avg_pool1d_replacement, []),
-        (avg_pool2d_pattern, avg_pool2d_replacement, []),
-        (avg_pool3d_pattern, avg_pool3d_replacement, []),
-        (clamp_pattern, clamp_replacement, []),
-        (clamp_op_pattern, clamp_op_replacement, []),
         (min_pattern, min_replacement, []),
         (max_pattern, max_replacement, []),
         (mean_pattern, mean_replacement, []),
         (mean_op_pattern, mean_op_replacement, []),
         (flatten_pattern, flatten_replacement, []),
-        (floordiv_pattern, floordiv_replacement, []),
     ]
 
 

--- a/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
+++ b/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
@@ -106,12 +106,12 @@ def mean_replacement(x, scale, zero_point):
 
 def mean_op_pattern(x, scale, zero_point):
     x = x.dequantize()
-    x = x.mean(dim, keepdim)
+    x = x.mean()
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
 def mean_op_replacement(x, scale, zero_point):
-    x = x.mean(dim, keepdim)
+    x = x.mean()
     return x
 
 def flatten_pattern(x, scale, zero_point):

--- a/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
+++ b/torch/ao/quantization/fx/quantized_fusion_patterns_and_replacements.py
@@ -17,23 +17,23 @@ def relu_replacement(x, scale, zero_point):
     x = torch.nn.functional.relu(x)
     return x
 
-def relu_op_pattern(x, scale, zero_point):
+def relu_method_pattern(x, scale, zero_point):
     x = x.dequantize()
     x = x.relu()
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def relu_op_replacement(x, scale, zero_point):
+def relu_method_replacement(x, scale, zero_point):
     x = x.relu()
     return x
 
-def relu_inplace_op_pattern(x, scale, zero_point):
+def relu_inplace_method_pattern(x, scale, zero_point):
     x = x.dequantize()
     x = x.relu_()
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def relu_inplace_op_replacement(x, scale, zero_point):
+def relu_inplace_method_replacement(x, scale, zero_point):
     x = x.relu_()
     return x
 
@@ -56,12 +56,18 @@ def relu6_replacement(x, scale, zero_point):
 
 def hardtanh_pattern(x, scale, zero_point):
     x = x.dequantize()
+    x = torch.nn.functional.hardtanh(x, inplace=True)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def hardtanh_non_inplace_pattern(x, scale, zero_point):
+    x = x.dequantize()
     x = torch.nn.functional.hardtanh(x, inplace=False)
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
 def hardtanh_replacement(x, scale, zero_point):
-    x = torch.nn.functional.hardtanh(x, inplace=False)
+    x = torch.nn.functional.hardtanh(x)
     return x
 
 def hardtanh_inplace_pattern(x, scale, zero_point):
@@ -104,13 +110,13 @@ def mean_replacement(x, scale, zero_point):
     x = torch.mean(x)
     return x
 
-def mean_op_pattern(x, scale, zero_point):
+def mean_method_pattern(x, scale, zero_point):
     x = x.dequantize()
     x = x.mean()
     x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
     return x
 
-def mean_op_replacement(x, scale, zero_point):
+def mean_method_replacement(x, scale, zero_point):
     x = x.mean()
     return x
 
@@ -122,6 +128,16 @@ def flatten_pattern(x, scale, zero_point):
 
 def flatten_replacement(x, scale, zero_point):
     x = torch.flatten(x)
+    return x
+
+def clamp_pattern(x, scale, zero_point):
+    x = x.dequantize()
+    x = torch.clamp(x)
+    x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+    return x
+
+def clamp_replacement(x, scale, zero_point):
+    x = torch.clamp(x)
     return x
 
 #
@@ -336,17 +352,19 @@ def _get_all_patterns_and_replacements():
         *get_binary_op_pattern_and_replacements(),
         (relu_inplace_pattern, relu_replacement, []),
         (relu_non_inplace_pattern, relu_replacement, []),
-        (relu_op_pattern, relu_op_replacement, []),
-        (relu_inplace_op_pattern, relu_inplace_op_replacement, []),
+        (relu_method_pattern, relu_method_replacement, []),
+        (relu_inplace_method_pattern, relu_inplace_method_replacement, []),
         (relu6_inplace_pattern, relu6_replacement, []),
         (relu6_non_inplace_pattern, relu6_replacement, []),
         (hardtanh_pattern, hardtanh_replacement, []),
+        (hardtanh_non_inplace_pattern, hardtanh_replacement, []),
         (hardtanh_inplace_pattern, hardtanh_inplace_replacement, []),
         (min_pattern, min_replacement, []),
         (max_pattern, max_replacement, []),
         (mean_pattern, mean_replacement, []),
-        (mean_op_pattern, mean_op_replacement, []),
+        (mean_method_pattern, mean_method_replacement, []),
         (flatten_pattern, flatten_replacement, []),
+        (clamp_pattern, clamp_replacement, []),
     ]
 
 


### PR DESCRIPTION
Summary:
In this PR we want to enable the reference path by default for CopyNodeQuantizeHandler

Test Plan:
```
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
```

Reviewers:

Subscribers: