### PR TITLE
Use single int32 hash for aten optype rather than string

### DIFF
--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -28,7 +28,7 @@ OpKind OpKind::Get(const std::string& name) {
 }
 
 hash_t OpKind::hash() const {
-  return StringHash(op.toQualString());
+  return Hash(static_cast<c10::unique_t>(op));
 }
 
 Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, hash_t dag_hash)


### PR DESCRIPTION
Test Plan: covered by lazy tensor unit tests

Differential Revision: D32995239

