### PR TITLE
Do not use `std::labs`

### DIFF
--- a/aten/src/ATen/TensorNames.cpp
+++ b/aten/src/ATen/TensorNames.cpp
@@ -62,14 +62,14 @@ TensorNames::TensorNames(ArrayRef<Dimname> names, int64_t start, int64_t end) {
 }
 
 TensorNames& TensorNames::unifyFromRightInplace(const TensorNames& other, const char* op_name) {
-  // NOLINTNEXTLINE(bugprone-narrowing-conversions,clang-diagnostic-absolute-value,cppcoreguidelines-narrowing-conversions)
-  size_t size_diff = std::labs(names_.size() - other.names_.size());
 
   if (names_.size() > other.names_.size()) {
+    auto size_diff = names_.size() - other.names_.size();
     for (const auto idx : c10::irange(size_diff, names_.size())) {
       names_[idx] = names_[idx].unify(other.names_[idx - size_diff], op_name);
     }
   } else {
+    auto size_diff = other.names_.size() - names_.size();
     // pad names_ to the same length as other.names_ before unification
     names_.insert(
         names_.begin(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69712 [CI] Build clang configs with `-Werror`
* #69711 Make c10 tests compilable with -Werror
* #69710 Suppress common warnings when building by clang
* #69709 [c2] Remove unused private fields
* #69707 Make vec512 bfloat16 map function clang-Wall clean
* #69706 Cleanup ProcessGroup.cpp
* #69705 Make blend operations clang-Wall clean
* **#69704 Do not use `std::labs`**
* #69703 Make c10d tests -Werror clean

Instead, compute size diff inside the if statement

Differential Revision: [D32997004](https://our.internmc.facebook.com/intern/diff/D32997004)