### PR TITLE
Make blend operations clang-Wall clean

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -46,7 +46,7 @@ public:
   template <int64_t mask>
   static Vectorized<c10::complex<double>> blend(const Vectorized<c10::complex<double>>& a, const Vectorized<c10::complex<double>>& b) {
      // convert c10::complex<V> index mask to V index mask: xy -> xxyy
-    // NOLINTNEXTLINE(clang-diagnostic-warning)
+    static_assert (mask > -1 && mask < 4, "Unexpected mask value");
     switch (mask) {
       case 0:
         return a;
@@ -54,6 +54,7 @@ public:
         return _mm256_blend_pd(a.values, b.values, 0x03);
       case 2:
         return _mm256_blend_pd(a.values, b.values, 0x0c);
+      case 3: break;
     }
     return b;
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -51,7 +51,7 @@ public:
   template <int64_t mask>
   static Vectorized<c10::complex<float>> blend(const Vectorized<c10::complex<float>>& a, const Vectorized<c10::complex<float>>& b) {
      // convert c10::complex<V> index mask to V index mask: xy -> xxyy
-    // NOLINTNEXTLINE(clang-diagnostic-warning)
+    static_assert(mask > -1 && mask < 16, "Unexpected mask range");
     switch (mask) {
       case 0:
         return a;
@@ -83,6 +83,7 @@ public:
         return _mm256_blend_ps(a.values, b.values, 0xF3); //b0000 1101 = b1111 0011
       case 14:
         return _mm256_blend_ps(a.values, b.values, 0xFC); //b0000 1110 = b1111 1100
+      default: break;
     }
     return b;
   }

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -62,7 +62,7 @@ public:
   static Vectorized<c10::complex<float>> blend(const Vectorized<c10::complex<float>>& a,
                                               const Vectorized<c10::complex<float>>& b) {
     // convert c10::complex<V> index mask to V index mask: xy -> xxyy
-    // NOLINTNEXTLINE(clang-diagnostic-warning)
+    static_assert(mask > -1 && mask < 256, "Unexpected mask value");
     // The compiler would hopefully convert this switch condition
     // into a jump table
     switch (mask) {
@@ -576,6 +576,7 @@ public:
         return _mm512_mask_blend_ps(0xFFF3, a.values, b.values);
       case 254:
         return _mm512_mask_blend_ps(0xFFFC, a.values, b.values);
+      default: break;
     }
     return b;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69712 [CI] Build clang configs with `-Werror`
* #69711 Make c10 tests compilable with -Werror
* #69710 Suppress common warnings when building by clang
* #69709 [c2] Remove unused private fields
* #69707 Make vec512 bfloat16 map function clang-Wall clean
* #69706 Cleanup ProcessGroup.cpp
* **#69705 Make blend operations clang-Wall clean**
* #69704 Do not use `std::labs`
* #69703 Make c10d tests -Werror clean

Differential Revision: [D32997007](https://our.internmc.facebook.com/intern/diff/D32997007)