### PR TITLE
Cleanup ProcessGroup.cpp

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -73,11 +73,11 @@ ProcessGroup::Work::Work(
       if (inputTensors) {
         inputs.reserve(inputTensors->size());
         for (const auto& tensor : *inputTensors) {
-          inputs.push_back(tensor);
+          inputs.emplace_back(tensor);
         }
       }
       recordingFunction->before(profilingTitle, inputs);
-      std::function<void()> end_handler = [this, recordingFunction]() {
+      std::function<void()> end_handler = [recordingFunction]() {
         recordingFunction->end();
       };
       recordFunctionEndCallback_ = at::wrapPropagateTLSState(end_handler);
@@ -89,7 +89,7 @@ OpType ProcessGroup::Work::retrieveOpType() {
   return opType_;
 }
 
-ProcessGroup::Work::~Work() {}
+ProcessGroup::Work::~Work()=default;
 
 bool ProcessGroup::Work::isCompleted() {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69712 [CI] Build clang configs with `-Werror`
* #69711 Make c10 tests compilable with -Werror
* #69710 Suppress common warnings when building by clang
* #69709 [c2] Remove unused private fields
* #69707 Make vec512 bfloat16 map function clang-Wall clean
* **#69706 Cleanup ProcessGroup.cpp**
* #69705 Make blend operations clang-Wall clean
* #69704 Do not use `std::labs`
* #69703 Make c10d tests -Werror clean

Mostly code modernization, also do not capture unused `this` in
end_handler functor

Differential Revision: [D32997009](https://our.internmc.facebook.com/intern/diff/D32997009)