### PR TITLE
Make vec512 bfloat16 map function clang-Wall clean

### DIFF
--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -279,6 +279,8 @@ public:
     }
     return b;
   }
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wignored-qualifiers"
   Vectorized<BFloat16> map(const __m512 (*const vop)(__m512)) const {
     __m512 lo, hi;
     cvtbf16_fp32(values, lo, hi);
@@ -286,6 +288,7 @@ public:
     const auto o2 = vop(hi);
     return cvtfp32_bf16(o1, o2);
   }
+  #pragma clang diagnostic pop
   Vectorized<BFloat16> abs() const {
     __m512 lo, hi;
     cvtbf16_fp32(values, lo, hi);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69712 [CI] Build clang configs with `-Werror`
* #69711 Make c10 tests compilable with -Werror
* #69710 Suppress common warnings when building by clang
* #69709 [c2] Remove unused private fields
* **#69707 Make vec512 bfloat16 map function clang-Wall clean**
* #69706 Cleanup ProcessGroup.cpp
* #69705 Make blend operations clang-Wall clean
* #69704 Do not use `std::labs`
* #69703 Make c10d tests -Werror clean

`const` modifier for `__m512` return value doesn't make much sense

Differential Revision: [D32997008](https://our.internmc.facebook.com/intern/diff/D32997008)