### PR TITLE
Remove std::is_pod, deprecated in C++-20

### DIFF
--- a/aten/src/ATen/CPUGeneratorImpl.cpp
+++ b/aten/src/ATen/CPUGeneratorImpl.cpp
@@ -3,6 +3,7 @@
 #include <ATen/core/MT19937RNGEngine.h>
 #include <c10/util/C++17.h>
 #include <c10/util/MathConstants.h>
+#include <c10/util/TypeTraits.h>
 #include <algorithm>
 
 namespace at {
@@ -127,8 +128,8 @@ void CPUGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   using detail::CPUGeneratorImplState;
   using detail::CPUGeneratorImplStateLegacy;
 
-  static_assert(std::is_pod<CPUGeneratorImplStateLegacy>::value, "CPUGeneratorImplStateLegacy is not a PODType");
-  static_assert(std::is_pod<CPUGeneratorImplState>::value, "CPUGeneratorImplState is not a PODType");
+  static_assert(guts::is_pod<CPUGeneratorImplStateLegacy>::value, "CPUGeneratorImplStateLegacy is not a PODType");
+  static_assert(guts::is_pod<CPUGeneratorImplState>::value, "CPUGeneratorImplState is not a PODType");
 
   static const size_t size_legacy = sizeof(CPUGeneratorImplStateLegacy);
   static const size_t size_current = sizeof(CPUGeneratorImplState);
@@ -207,7 +208,7 @@ c10::intrusive_ptr<c10::TensorImpl> CPUGeneratorImpl::get_state() const {
   using detail::CPUGeneratorImplState;
 
   static const size_t size = sizeof(CPUGeneratorImplState);
-  static_assert(std::is_pod<CPUGeneratorImplState>::value, "CPUGeneratorImplState is not a PODType");
+  static_assert(guts::is_pod<CPUGeneratorImplState>::value, "CPUGeneratorImplState is not a PODType");
 
   auto state_tensor = at::detail::empty_cpu({(int64_t)size}, ScalarType::Byte, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt);
   auto rng_state = state_tensor.data_ptr();

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Config.h>
+#include <c10/util/TypeTraits.h>
 
 // TODO: Remove the condition on AT_ROCM_ENABLED entirely,
 // don't build this file as part of CPU build.
@@ -199,7 +200,7 @@ struct ConvolutionParams
 };
 // ConvolutionParams must be a POD because we read out its memory
 // contenst as char* when hashing
-static_assert(std::is_pod<ConvolutionParams>::value, "ConvolutionParams not POD");
+static_assert(guts::is_pod<ConvolutionParams>::value, "ConvolutionParams not POD");
 
 void setConvolutionParams(
     ConvolutionParams* params, miopenHandle_t handle,

--- a/aten/src/ATen/native/utils/ParamsHash.h
+++ b/aten/src/ATen/native/utils/ParamsHash.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <mutex>
 
+#include <c10/util/TypeTraits.h>
+
 namespace at { namespace native {
 
 // Hashing machinery for Params
@@ -12,7 +14,7 @@ template <typename Params>
 struct ParamsHash {
   // Params must be a POD because we read out its memory
   // contenst as char* when hashing
-  static_assert(std::is_pod<Params>::value, "Params is not POD");
+  static_assert(guts::is_pod<Params>::value, "Params is not POD");
 
   size_t operator()(const Params& params) const {
     auto ptr = reinterpret_cast<const uint8_t*>(&params);
@@ -29,7 +31,7 @@ template <typename Params>
 struct ParamsEqual {
   // Params must be a POD because we read out its memory
   // contenst as char* when comparing
-  static_assert(std::is_pod<Params>::value, "Params is not POD");
+  static_assert(guts::is_pod<Params>::value, "Params is not POD");
 
   bool operator()(const Params& a, const Params& b) const {
     auto ptr1 = reinterpret_cast<const uint8_t*>(&a);

--- a/c10/core/impl/LocalDispatchKeySet.h
+++ b/c10/core/impl/LocalDispatchKeySet.h
@@ -3,6 +3,7 @@
 #include <c10/core/DispatchKeySet.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Flags.h>
+#include <c10/util/TypeTraits.h>
 
 // TLS management for DispatchKeySet (the "local" DispatchKeySet(s))
 //
@@ -52,7 +53,7 @@ struct C10_API PODLocalDispatchKeySet {
   }
 };
 static_assert(
-    std::is_pod<PODLocalDispatchKeySet>::value,
+    guts::is_pod<PODLocalDispatchKeySet>::value,
     "PODLocalDispatchKeySet must be a POD type.");
 
 struct C10_API LocalDispatchKeySet {

--- a/c10/util/SmallBuffer.h
+++ b/c10/util/SmallBuffer.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <type_traits>
+#include <c10/util/TypeTraits.h>
 
 /** Helper class for allocating temporary fixed size arrays with SBO.
  *
@@ -15,7 +15,9 @@ namespace c10 {
 
 template <typename T, size_t N>
 class SmallBuffer {
-  static_assert(std::is_pod<T>::value, "SmallBuffer is intended for POD types");
+  static_assert(
+      guts::is_pod<T>::value,
+      "SmallBuffer is intended for POD types");
 
   T storage_[N];
   size_t size_;

--- a/c10/util/TypeTraits.h
+++ b/c10/util/TypeTraits.h
@@ -7,6 +7,13 @@ namespace c10 {
 namespace guts {
 
 /**
+ * is_pod<T> is true_type iff T is a plain old data type. It replaces
+ * std::is_pod, which got deprecated in C++-20.
+ */
+template <class T>
+using is_pod = conjunction<std::is_trivial<T>, std::is_standard_layout<T>>;
+
+/**
  * is_equality_comparable<T> is true_type iff the equality operator is defined
  * for T.
  */

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <ATen/core/stack.h>
+#include <c10/util/TypeTraits.h>
 #include <c10/util/hash.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
@@ -61,7 +62,7 @@ struct ArgumentInfo {
 };
 
 static_assert(
-    std::is_pod<ArgumentInfo>::value,
+    c10::guts::is_pod<ArgumentInfo>::value,
     "ArgumentInfo is to be a POD struct");
 static_assert(
     sizeof(ArgumentInfo) == sizeof(ArgumentInfo::plain_data_type),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69708

I was building a PyTorch extension using C++-20 and my compiler logs were full of deprecation warnings because some PyTorch headers used `std::is_pod` (which became deprecated in C++-20). Being a "POD" (plain old datatype) is equivalent to having standard layout and being trivial, we can use those checks instead and avoid the warning.

Differential Revision: [D32987179](https://our.internmc.facebook.com/intern/diff/D32987179/)