### PR TITLE
.github: Add fbsync to push triggers

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -18,6 +18,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
 {%- endif %}
   workflow_dispatch:
 

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -18,6 +18,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
 {%- endif %}
   workflow_dispatch:
 

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -29,6 +29,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
 {%- endif %}
   workflow_dispatch:
 

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.6-gcc5.4.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.6-gcc7.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7-bazel-test.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-macos-10-15-py3-arm64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-arm64.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179

--- a/.github/workflows/generated-macos-10-15-py3-lite-interpreter-x86-64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-lite-interpreter-x86-64.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - release/*
+      - fbsync
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69718

canary is now pushing to fbsync so we should change our workflows to
reflect that.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D32999967](https://our.internmc.facebook.com/intern/diff/D32999967)