### PR TITLE
[PT-D][Fix] Broken sharded embedding and embedding bag test fix

### DIFF
--- a/test/distributed/_sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_sharded_tensor/ops/test_embedding.py
@@ -152,23 +152,25 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             self._run_sharded_embedding(spec, [5, 12], 16, 22)
             self._run_sharded_embedding(spec, [5, 4], 32, 12)
             self._run_sharded_embedding(spec, [6, 7, 6], 64, 11)
-            self._run_sharded_embedding(
-                spec, [5, 12], 16, 22, max_norm=2.5, sharded_dim=0
-            )
             self._run_sharded_embedding(spec, [6, 7, 6], 64, 11, padding_idx=30)
-            self._run_sharded_embedding(
-                spec, [6, 5, 3], 26, 11, max_norm=2.0, sharded_dim=0
-            )
+            with torch.no_grad():
+                self._run_sharded_embedding(
+                    spec, [5, 12], 16, 22, max_norm=2.5, sharded_dim=0
+                )
+                self._run_sharded_embedding(
+                    spec, [6, 5, 3], 26, 11, max_norm=2.0, sharded_dim=0
+                )
 
             # Test uneven split.
             self._run_sharded_embedding(spec, [8, 6, 5, 4], 19, 11)
             self._run_sharded_embedding(spec, [6, 7, 6], 21, 11)
             self._run_sharded_embedding(spec, [4], 21, 11)
             self._run_sharded_embedding(spec, [8, 6, 5, 4], 21, 11, padding_idx=10)
-            self._run_sharded_embedding(
-                spec, [12, 16, 8], 27, 11, max_norm=2.0, sharded_dim=0
-            )
-            self._run_sharded_embedding(spec, [4], 14, 11, max_norm=2.5, sharded_dim=0)
+            with torch.no_grad():
+                self._run_sharded_embedding(
+                    spec, [12, 16, 8], 27, 11, max_norm=2.0, sharded_dim=0
+                )
+                self._run_sharded_embedding(spec, [4], 14, 11, max_norm=2.5, sharded_dim=0)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_sharded_tensor/ops/test_embedding_bag.py
@@ -182,29 +182,6 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
         self._run_sharded_embedding_bag(spec, [5, 5], 17, 14, "sum")
         self._run_sharded_embedding_bag(spec, [5, 4], 17, 12, "mean")
         self._run_sharded_embedding_bag(spec, [6, 7], 21, 11, "max")
-        self._run_sharded_embedding_bag(
-            spec, [5, 5], 17, 14, "sum", max_norm=2.5, sharded_dim=sharded_dim
-        )
-        self._run_sharded_embedding_bag(
-            spec,
-            [5, 4],
-            17,
-            12,
-            "mean",
-            max_norm=2.0,
-            norm_type=1.0,
-            sharded_dim=sharded_dim,
-        )
-        self._run_sharded_embedding_bag(
-            spec,
-            [6, 7],
-            21,
-            11,
-            "max",
-            max_norm=1.5,
-            norm_type=1.0,
-            sharded_dim=sharded_dim,
-        )
         self._run_sharded_embedding_bag(spec, [5, 5], 17, 14, "sum", padding_idx=6)
         self._run_sharded_embedding_bag(spec, [8, 6], 24, 13, "sum")
         self._run_sharded_embedding_bag(spec, [4, 3], 16, 14, "max")
@@ -217,72 +194,96 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
         self._run_sharded_embedding_bag(
             spec, [12], 16, 12, "max", offset_size=4, include_last_offset=True
         )
-        self._run_sharded_embedding_bag(
-            spec,
-            [12],
-            17,
-            12,
-            "sum",
-            offset_size=3,
-            max_norm=1.25,
-            sharded_dim=sharded_dim,
-        )
-        self._run_sharded_embedding_bag(
-            spec,
-            [5],
-            17,
-            12,
-            "mean",
-            offset_size=2,
-            max_norm=1.25,
-            sharded_dim=sharded_dim,
-        )
-        self._run_sharded_embedding_bag(
-            spec,
-            [5],
-            17,
-            12,
-            "max",
-            offset_size=2,
-            max_norm=1.15,
-            sharded_dim=sharded_dim,
-        )
         self._run_sharded_embedding_bag(spec, [4, 3], 16, 14, "sum", padding_idx=12)
         self._run_sharded_embedding_bag(spec, [4, 3], 16, 14, "mean", padding_idx=12)
         self._run_sharded_embedding_bag(spec, [4, 3], 16, 14, "max", padding_idx=12)
-        self._run_sharded_embedding_bag(
-            spec,
-            [12],
-            17,
-            12,
-            "sum",
-            offset_size=3,
-            max_norm=1.25,
-            padding_idx=10,
-            sharded_dim=sharded_dim,
-        )
-        self._run_sharded_embedding_bag(
-            spec,
-            [5],
-            17,
-            12,
-            "mean",
-            offset_size=2,
-            max_norm=1.25,
-            padding_idx=10,
-            sharded_dim=sharded_dim,
-        )
-        self._run_sharded_embedding_bag(
-            spec,
-            [5],
-            17,
-            12,
-            "max",
-            offset_size=2,
-            max_norm=1.15,
-            padding_idx=10,
-            sharded_dim=sharded_dim,
-        )
+        with torch.no_grad():
+            self._run_sharded_embedding_bag(
+                spec, [5, 5], 17, 14, "sum", max_norm=2.5, sharded_dim=sharded_dim
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [5, 4],
+                17,
+                12,
+                "mean",
+                max_norm=2.0,
+                norm_type=1.0,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [6, 7],
+                21,
+                11,
+                "max",
+                max_norm=1.5,
+                norm_type=1.0,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [12],
+                17,
+                12,
+                "sum",
+                offset_size=3,
+                max_norm=1.25,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [5],
+                17,
+                12,
+                "mean",
+                offset_size=2,
+                max_norm=1.25,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [5],
+                17,
+                12,
+                "max",
+                offset_size=2,
+                max_norm=1.15,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [12],
+                17,
+                12,
+                "sum",
+                offset_size=3,
+                max_norm=1.25,
+                padding_idx=10,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [5],
+                17,
+                12,
+                "mean",
+                offset_size=2,
+                max_norm=1.25,
+                padding_idx=10,
+                sharded_dim=sharded_dim,
+            )
+            self._run_sharded_embedding_bag(
+                spec,
+                [5],
+                17,
+                12,
+                "max",
+                offset_size=2,
+                max_norm=1.15,
+                padding_idx=10,
+                sharded_dim=sharded_dim,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

We have added a `no_grad` cx manager in the tensor sharding to ensure that the local_shard is the root node. But it turns out for embedding and embedding_bag, when the `max_norm` is specified, it will complain for row-wise sharding. We use the original `max_norm` of the operators.

Error traces:
```
  File "/data/sandcastle/boxes/fbsource/fbcode/buck-out/dev/gen/caffe2/test/distributed/_sharded_tensor/sharded_embedding#binary,link-tree/torch/overrides.py", line 1389, in handle_torch_function
    result = torch_func_method(public_api, types, args, kwargs)
  File "/data/sandcastle/boxes/fbsource/fbcode/buck-out/dev/gen/caffe2/test/distributed/_sharded_tensor/sharded_embedding#binary,link-tree/torch/distributed/_sharded_tensor/api.py", line 554, in __torch_function__
    return sharded_embedding(types, args, kwargs, self._process_group)
  File "/data/sandcastle/boxes/fbsource/fbcode/buck-out/dev/gen/caffe2/test/distributed/_sharded_tensor/sharded_embedding#binary,link-tree/torch/distributed/_sharded_tensor/ops/embedding.py", line 115, in sharded_embedding
    return _handle_row_wise_sharding(
  File "/data/sandcastle/boxes/fbsource/fbcode/buck-out/dev/gen/caffe2/test/distributed/_sharded_tensor/sharded_embedding#binary,link-tree/torch/distributed/_sharded_tensor/ops/embedding.py", line 309, in _handle_row_wise_sharding
    gathered_input_embeddings = torch.nn.functional.embedding(
  File "/data/sandcastle/boxes/fbsource/fbcode/buck-out/dev/gen/caffe2/test/distributed/_sharded_tensor/sharded_embedding#binary,link-tree/torch/nn/functional.py", line 2153, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: A view was created in no_grad mode and its base or another view of its base has been modified inplace with grad mode enabled. Given that this use case is ambiguous and error-prone, it is forbidden. You can clarify your code by moving both the view and the inplace either both inside the no_grad block (if you don't want the inplace to be tracked) or both outside (if you want the inplace to be tracked).
 exiting process 2 with exit code: 10
```

As a temporary fix, let's first run the tests with `max_norm` under the `no_grad` cx manager

Differential Revision: [D33000927](https://our.internmc.facebook.com/intern/diff/D33000927/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang