### PR TITLE
Support torch.equal for ShardedTensor.

### DIFF
--- a/test/distributed/_sharded_tensor/ops/test_equals.py
+++ b/test/distributed/_sharded_tensor/ops/test_equals.py
@@ -1,0 +1,121 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+import torch
+import torch.distributed as dist
+
+from torch.distributed import _sharded_tensor
+from torch.distributed._sharding_spec import (
+    ChunkShardingSpec,
+)
+from torch.testing._internal.common_distributed import (
+    requires_nccl,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.distributed._sharded_tensor import (
+    ShardedTensorTestBase,
+    with_comms,
+)
+from torch.testing._internal.common_utils import (
+    TEST_WITH_DEV_DBG_ASAN,
+    run_tests,
+)
+
+from torch.distributed.distributed_c10d import _get_default_group
+
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print("Skip dev-asan as torch + multiprocessing spawn have known issues", file=sys.stderr)
+    sys.exit(0)
+
+class TestShardedTensorEquals(ShardedTensorTestBase):
+    """ Testing torch.equal, torch.allclose etc. functions for ShardedTensor """
+    seed = 42
+
+    def get_random_tensors(self, spec1, spec2, *sizes, pg1=None, pg2=None):
+        pg1 = _get_default_group() if pg1 is None else pg1
+        pg2 = _get_default_group() if pg2 is None else pg2
+        torch.manual_seed(TestShardedTensorEquals.seed)
+        st1 = _sharded_tensor.rand(spec1, sizes, process_group=pg1)
+        torch.manual_seed(TestShardedTensorEquals.seed)
+        st2 = _sharded_tensor.rand(spec2, sizes, process_group=pg2)
+
+        TestShardedTensorEquals.seed += 1
+        return st1, st2
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_torch_equal(self):
+        """ Test torch.equal(ShardedTensor, ShardedTensor) """
+
+        spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:0/cuda:0",
+                "rank:1/cuda:1",
+                "rank:2/cuda:2",
+                "rank:3/cuda:3",
+            ],
+        )
+
+        alt_spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:1/cuda:1",
+                "rank:0/cuda:0",
+                "rank:3/cuda:3",
+                "rank:2/cuda:2",
+            ],
+        )
+
+        st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
+        self.assertTrue(torch.equal(st1, st2))
+
+        st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
+        if self.rank == 0:
+            torch.nn.init.uniform_(st1.local_shards()[0].tensor)
+        self.assertFalse(torch.equal(st1, st2))
+
+        st1 = _sharded_tensor.ones(spec, 10, 10)
+        st2 = _sharded_tensor.ones(spec, 10, 5)
+        self.assertFalse(torch.equal(st1, st2))
+
+        st1, st2 = self.get_random_tensors(spec, alt_spec, 10, 10)
+        self.assertFalse(torch.equal(st1, st2))
+
+        st1 = _sharded_tensor.ones(spec, 10, 10)
+        st2 = _sharded_tensor.zeros(spec, 10, 10)
+        self.assertFalse(torch.equal(st1, st2))
+
+        st1 = _sharded_tensor.ones(spec, 10, 10)
+        st2 = _sharded_tensor.ones(spec, 10, 10, dtype=torch.double)
+        self.assertFalse(torch.equal(st1, st2))
+
+        st1 = _sharded_tensor.ones(spec, 10, 10)
+        st2 = _sharded_tensor.ones(spec, 10, 10, requires_grad=True)
+        self.assertFalse(torch.equal(st1, st2))
+
+        cpu_spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:0/cpu",
+                "rank:1/cpu",
+                "rank:2/cpu",
+                "rank:3/cpu",
+            ],
+        )
+        st1 = _sharded_tensor.ones(cpu_spec, 10, 10)
+        st2 = _sharded_tensor.ones(cpu_spec, 10, 10, pin_memory=True)
+        self.assertFalse(torch.equal(st1, st2))
+
+        pg = dist.new_group([1, 0, 3, 2])
+        st1, st2 = self.get_random_tensors(spec, spec, 10, 10, pg2=pg)
+        self.assertFalse(torch.equal(st1, st2))
+
+        pg = dist.new_group([0, 1, 2, 3])
+        st1, st2 = self.get_random_tensors(spec, spec, 10, 10, pg2=pg)
+        self.assertFalse(torch.equal(st1, st2))
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -201,6 +201,7 @@ WINDOWS_BLOCKLIST = [
     "distributed/_sharded_tensor/test_sharded_tensor",
     "distributed/_sharded_tensor/ops/test_embedding",
     "distributed/_sharded_tensor/ops/test_embedding_bag",
+    "distributed/_sharded_tensor/ops/test_equals",
     "distributed/_sharded_tensor/ops/test_init",
     "distributed/_sharded_tensor/ops/test_linear",
 ] + FSDP_TEST
@@ -213,6 +214,7 @@ ROCM_BLOCKLIST = [
     "distributed/_sharded_tensor/test_sharded_tensor",
     "distributed/_sharded_tensor/ops/test_embedding",
     "distributed/_sharded_tensor/ops/test_embedding_bag",
+    "distributed/_sharded_tensor/ops/test_equals",
     "distributed/_sharded_tensor/ops/test_init",
     "distributed/_sharded_tensor/ops/test_linear",
     "test_determination",
@@ -350,6 +352,7 @@ DISTRIBUTED_TESTS = [
     "distributed/_sharded_tensor/test_sharded_tensor",
     "distributed/_sharded_tensor/ops/test_embedding",
     "distributed/_sharded_tensor/ops/test_embedding_bag",
+    "distributed/_sharded_tensor/ops/test_equals",
     "distributed/_sharded_tensor/ops/test_init",
     "distributed/_sharded_tensor/ops/test_linear",
 ] + [test for test in TESTS if test.startswith("distributed/fsdp")]

--- a/torch/distributed/_sharded_tensor/api.py
+++ b/torch/distributed/_sharded_tensor/api.py
@@ -27,6 +27,7 @@ from torch.distributed._sharding_spec._internals import (
 from torch.types import Number
 from .metadata import TensorProperties, ShardedTensorMetadata
 from .ops import (
+    equal,
     kaiming_uniform_,
     normal_,
     sharded_embedding,
@@ -559,6 +560,8 @@ class ShardedTensor(object):
             return uniform_(types, args, kwargs)
         elif func == torch.nn.init.kaiming_uniform_:
             return kaiming_uniform_(types, args, kwargs)
+        elif func == torch.equal:
+            return equal(types, args, kwargs)
         raise RuntimeError(
             f"torch function '{func.__name__}', with args: {args} and "
             f"kwargs: {kwargs} not supported for ShardedTensor!")

--- a/torch/distributed/_sharded_tensor/ops/__init__.py
+++ b/torch/distributed/_sharded_tensor/ops/__init__.py
@@ -2,3 +2,4 @@ from .init import kaiming_uniform_, normal_, uniform_
 from .linear import sharded_linear
 from .embedding import sharded_embedding
 from .embedding_bag import sharded_embedding_bag
+from .equals import equal

--- a/torch/distributed/_sharded_tensor/ops/equals.py
+++ b/torch/distributed/_sharded_tensor/ops/equals.py
@@ -1,0 +1,51 @@
+import torch
+import torch.distributed as dist
+
+def _communicate_result(result, pg):
+    # Gather results from all ranks.
+    if result:
+        result_tensor = torch.ones(1, device=torch.cuda.current_device())
+    else:
+        result_tensor = torch.zeros(1, device=torch.cuda.current_device())
+
+    dist.all_reduce(result_tensor, group=pg)
+
+    expected_result = torch.ones(1, device=torch.cuda.current_device()) * dist.get_world_size(pg)
+
+    return torch.equal(result_tensor, expected_result)
+
+def equal(types, args=(), kwargs=None):
+    from torch.distributed._sharded_tensor import ShardedTensor
+
+    if len(args) != 2:
+        raise ValueError('Expected two arguments for torch.equal')
+
+    result = True
+    st1 = args[0]
+    st2 = args[1]
+    if not(isinstance(st1, ShardedTensor) and isinstance(st2, ShardedTensor)):
+        raise TypeError('Both arguments to torch.equal need to be of type ShardedTensor')
+
+    # Verify same PG
+    if st1._process_group != st2._process_group:
+        return False
+
+    # Verify metadata
+    if st1.metadata() != st2.metadata():
+        return _communicate_result(False, st1._process_group)
+
+    # Verify number of local shards
+    st1_local_shards = st1.local_shards()
+    st2_local_shards = st2.local_shards()
+    if len(st1_local_shards) != len(st2_local_shards):
+        return _communicate_result(False, st1._process_group)
+
+    # Verify each local shard
+    for idx in range(len(st1_local_shards)):
+        if st1_local_shards[idx].metadata != st2_local_shards[idx].metadata:
+            return _communicate_result(False, st1._process_group)
+        if not torch.equal(st1_local_shards[idx].tensor, st2_local_shards[idx].tensor):
+            return _communicate_result(False, st1._process_group)
+
+
+    return _communicate_result(True, st1._process_group)

--- a/torch/testing/_internal/distributed/_sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_sharded_tensor/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from functools import wraps
+from functools import wraps, partial
 
 import torch
 import torch.distributed as dist
@@ -43,6 +43,7 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         )
 
     def init_comms(self, init_rpc=True, backend="nccl"):
+        torch.cuda.set_device(self.rank)
         if init_rpc:
             self.init_rpc()
         self.init_pg(backend=backend)
@@ -72,14 +73,19 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         self.assertEqual(len(st1.remote_shards()), len(st2.remote_shards()))
 
 # wrapper to initialize comms (processgroup + rpc)
-def with_comms(init_rpc=True, backend="nccl"):
-    def with_comms_decorator(func):
-        @wraps(func)
-        def wrapper(self):
-            if backend == "nccl" and torch.cuda.device_count() < self.world_size:
-                sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-            self.init_comms(init_rpc=init_rpc, backend=backend)
-            func(self)
-            self.destroy_comms(destroy_rpc=init_rpc)
-        return wrapper
-    return with_comms_decorator
+def with_comms(func=None, init_rpc=True, backend="nccl"):
+    if func is None:
+        return partial(
+            with_comms,
+            init_rpc=init_rpc,
+            backend=backend,
+        )
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if backend == "nccl" and torch.cuda.device_count() < self.world_size:
+            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+        self.init_comms(init_rpc=init_rpc, backend=backend)
+        func(self)
+        self.destroy_comms(destroy_rpc=init_rpc)
+    return wrapper


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69734

Added support for `torch.equal` to ShardedTensor. This is really
helpful in terms of comparing two ShardedTensors.

Differential Revision: [D33004315](https://our.internmc.facebook.com/intern/diff/D33004315/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D33004315/)!

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang