### PR TITLE
Add sync after each overhead computation step

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -194,8 +194,9 @@ class NoOpSync:
         pass
 
 class LazySync:
-    def __init__(self, sync_every_iter=False):
+    def __init__(self, sync_every_iter=False, skip_final_sync=False):
         self.sync_every_iter = sync_every_iter
+        self.skip_final_sync = skip_final_sync
 
     def iter_sync(self, results):
         ltm.mark_step()
@@ -206,6 +207,8 @@ class LazySync:
 
     def final_sync(self, results):
         ltm.mark_step()
+        if self.skip_final_sync:
+            return
         ltm.wait_device_ops()
         if current_device == 'cuda':
             torch.cuda.synchronize()
@@ -304,7 +307,11 @@ def lazy_overhead_experiment(args, results, benchmark, lazy_benchmark):
     for rep in range(args.repeat):
         # interleave the runs to handle frequency scaling and load changes
         _, timings[rep, 0] = timed(args, benchmark, sync=ref_sync(sync_every_iter=True))
-        _, timings[rep, 1] = timed(args, lazy_benchmark, sync=NoOpSync())
+        _, timings[rep, 1] = timed(args, lazy_benchmark, sync=LazySync(skip_final_sync=True))
+        ltm.wait_device_ops()
+        if current_device == 'cuda':
+            torch.cuda.synchronize()
+
     pvalue = ttest_ind(timings[:, 0], timings[:, 1]).pvalue
     median = np.median(timings, axis=0)
     overhead = median[1] / median[0]
@@ -412,7 +419,6 @@ if __name__ == "__main__" :
     torchbench_dir = abspath(args.torchbench_dir) if args.torchbench_dir else abspath("../../benchmark")
     assert os.path.exists(os.path.join(torchbench_dir, "torchbenchmark")), "set --torchbench_dir to installed torchbench repo"
     sys.path.append(torchbench_dir)
-
     for device, name, benchmark, lazy_benchmark in iter_models(args):
 
         if device == 'cuda':


### PR DESCRIPTION
need to mark step at least, for the lazy case to ensure that we don't end up generating longer graphs and we do include the overhead of scheduling the async computation.

also, we should make sure to sync the lazy/cuda ops _after_ the timing, so that cpu/cuda is free of operations when we start the next cuda eager run.