### PR TITLE
[PyTorch][kineto] Remove heap-allocated vectors in saveExtraArgs

### DIFF
--- a/torch/csrc/autograd/profiler_utils.cpp
+++ b/torch/csrc/autograd/profiler_utils.cpp
@@ -27,8 +27,8 @@ static constexpr auto kMat1Size = "mat1_size";
 static constexpr auto kMat2Size = "mat2_size";
 
 static bool validateInput(const std::string &op_name, size_t min_size,
-                       const std::vector<c10::IValue>& inputs,
-                       const std::vector<int>& should_be_tensor) {
+                          const std::vector<c10::IValue>& inputs,
+                          const c10::ArrayRef<int>& should_be_tensor) {
   std::stringstream ss;
   if (inputs.size() < min_size) {
       ss << "Failed to save extra arguments for flops compuation of op "
@@ -63,8 +63,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
   }
 
   if (fname == kConv2dOp) {
-    std::vector<int> tensors{0, 1};
-    bool check = validateInput(fname, kConv2dGroups + 1, inputs, tensors);
+    bool check = validateInput(fname, kConv2dGroups + 1, inputs, {0, 1});
     if (!check) {
       return map;
     }
@@ -82,8 +81,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
     map[kDilation] = inputs[kConv2dDilation];
     map[kGroups] = inputs[kConv2dGroups];
   } else if (fname == kMMOp) {
-    std::vector<int> tensors{0, 1};
-    bool check = validateInput(fname, 2, inputs, tensors);
+    bool check = validateInput(fname, 2, inputs, {0, 1});
     if (!check) {
       return map;
     }
@@ -93,8 +91,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
     map[kMat1Size] = at::IValue(left.sizes());
     map[kMat2Size] = at::IValue(right.sizes());
   } else if (fname == kAddMMOp) {
-    std::vector<int> tensors{0, 1, 2};
-    bool check = validateInput(fname, 3, inputs, tensors);
+    bool check = validateInput(fname, 3, inputs, {0, 1, 2});
     if (!check) {
       return map;
     }
@@ -108,8 +105,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
     map[kMat1Size] = at::IValue(left.sizes());
     map[kMat2Size] = at::IValue(right.sizes());
   } else if (fname == kMulOp) {
-    std::vector<int> tensors{0};
-    bool check = validateInput(fname, 1, inputs, tensors);
+    bool check = validateInput(fname, 1, inputs, {0});
     if (!check) {
       return map;
     }
@@ -117,8 +113,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
     at::Tensor mat = inputs[0].toTensor();
     map[kMatSize] = at::IValue(mat.sizes());
   } else if (fname == kAddOp) {
-    std::vector<int> tensors{0};
-    bool check = validateInput(fname, 1, inputs, tensors);
+    bool check = validateInput(fname, 1, inputs, {0});
     if (!check) {
       return map;
     }
@@ -126,8 +121,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
     at::Tensor mat = inputs[0].toTensor();
     map[kMatSize] = at::IValue(mat.sizes());
   } else if (fname == kBMMOp) {
-    std::vector<int> tensors{0, 1};
-    bool check = validateInput(fname, 2, inputs, tensors);
+    bool check = validateInput(fname, 2, inputs, {0, 1});
     if (!check) {
       return map;
     }
@@ -137,8 +131,7 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
     map[kMat1Size] = at::IValue(left.sizes());
     map[kMat2Size] = at::IValue(right.sizes());
   } else if (fname == kBAddBMMOp) {
-    std::vector<int> tensors{0, 1, 2};
-    bool check = validateInput(fname, 3, inputs, tensors);
+    bool check = validateInput(fname, 3, inputs, {0, 1, 2});
     if (!check) {
       return map;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69738
* __->__ #69737

We can use stack allocation instead.

Differential Revision: [D33007329](https://our.internmc.facebook.com/intern/diff/D33007329/)