### PR TITLE
[PyTorch][kineto] RFC: Use a deque for KinetoEvent

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -234,11 +234,11 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
     }
   }
 
-  const std::function<void(std::vector<KinetoEvent>&)>& getEventPostProcessingCallback() const {
+  const std::function<void(std::deque<KinetoEvent>&)>& getEventPostProcessingCallback() const {
     return event_post_process_cb_;
   }
 
-  void setEventPostProcessingCallback(std::function<void(std::vector<KinetoEvent>&)>&& cb) {
+  void setEventPostProcessingCallback(std::function<void(std::deque<KinetoEvent>&)>&& cb) {
     event_post_process_cb_ = std::move(cb);
   }
 
@@ -527,9 +527,9 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
   std::unique_ptr<libkineto::CpuTraceBuffer> cpu_trace;
 #endif // USE_KINETO
   uint64_t start_time_;
-  std::vector<KinetoEvent> kineto_events_;
+  std::deque<KinetoEvent> kineto_events_;
   // Optional, if event post-processing is enabled.
-  std::function<void(std::vector<KinetoEvent>&)> event_post_process_cb_;
+  std::function<void(std::deque<KinetoEvent>&)> event_post_process_cb_;
 };
 
 std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
@@ -803,7 +803,7 @@ void prepareProfiler(
 void enableProfilerWithEventPostProcess(
     const ProfilerConfig& config,
     const std::set<ActivityType>& activities,
-    std::function<void(std::vector<KinetoEvent>&)>&& cb,
+    std::function<void(std::deque<KinetoEvent>&)>&& cb,
     const std::unordered_set<at::RecordScope>& scopes) {
   enableProfiler(config, activities, scopes);
   auto state_ptr = getProfilerTLSState();
@@ -909,13 +909,13 @@ int64_t KinetoEvent::cudaElapsedUs() const {
 #ifdef USE_KINETO
 ProfilerResult::ProfilerResult(
     uint64_t start_time,
-    std::vector<KinetoEvent> events,
+    std::deque<KinetoEvent> events,
     std::unique_ptr<libkineto::ActivityTraceInterface> trace)
   : trace_start_us_(start_time),
     events_(std::move(events)),
     trace_(std::move(trace)) {}
 #else
-ProfilerResult::ProfilerResult(std::vector<KinetoEvent> events)
+ProfilerResult::ProfilerResult(std::deque<KinetoEvent> events)
   : events_(std::move(events)) {}
 #endif // USE_KINETO
 ProfilerResult::ProfilerResult() = default;

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -317,10 +317,10 @@ struct TORCH_API ProfilerResult {
 #ifdef USE_KINETO
   ProfilerResult(
       uint64_t start_time,
-      std::vector<KinetoEvent> events,
+      std::deque<KinetoEvent> events,
       std::unique_ptr<libkineto::ActivityTraceInterface> trace);
 #else
-  ProfilerResult(std::vector<KinetoEvent> events);
+  ProfilerResult(std::deque<KinetoEvent> events);
 #endif // USE_KINETO
   ~ProfilerResult();
 
@@ -328,7 +328,7 @@ struct TORCH_API ProfilerResult {
     return trace_start_us_;
   }
 
-  const std::vector<KinetoEvent>& events() const {
+  const std::deque<KinetoEvent>& events() const {
     return events_;
   }
 
@@ -338,7 +338,7 @@ struct TORCH_API ProfilerResult {
 
  private:
   uint64_t trace_start_us_ = 0;
-  std::vector<KinetoEvent> events_;
+  std::deque<KinetoEvent> events_;
 #ifdef USE_KINETO
   std::unique_ptr<libkineto::ActivityTraceInterface> trace_;
   bool saved_ = false;
@@ -398,7 +398,7 @@ TORCH_API void enableProfiler(
 TORCH_API void enableProfilerWithEventPostProcess(
     const ProfilerConfig& config,
     const std::set<ActivityType>& activities,
-    std::function<void(std::vector<KinetoEvent>&)>&& cb,
+    std::function<void(std::deque<KinetoEvent>&)>&& cb,
     const std::unordered_set<at::RecordScope>& scopes = {});
 
 TORCH_API std::unique_ptr<ProfilerResult> disableProfiler();

--- a/torch/csrc/jit/mobile/profiler_edge.cpp
+++ b/torch/csrc/jit/mobile/profiler_edge.cpp
@@ -28,7 +28,7 @@ KinetoEdgeCPUProfiler::KinetoEdgeCPUProfiler(
   profiler::prepareProfiler(config, {profiler::ActivityType::CPU});
   if (with_modules || with_stack) {
     auto post_processing = [this, with_stack, with_modules](
-                               std::vector<profiler::KinetoEvent>& events) {
+                               std::deque<profiler::KinetoEvent>& events) {
       std::string no_debug_info("Model was not saved with debug information");
       for (auto& e : events) {
         if (with_modules) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69738
* #69737

We use a deque for the overall trace because of jitter observed due to reallocation. Shouldn't we use one for events too?

Differential Revision: [D33007666](https://our.internmc.facebook.com/intern/diff/D33007666/)