### PR TITLE
Add codegen support for avg_pool2d + backward

### DIFF
--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -9,6 +9,8 @@ full_codegen:
   - addcdiv
   - addcmul
   - addmm
+  - avg_pool2d
+  - avg_pool2d_backward
   - baddbmm
   - bitwise_and.Tensor
   - bmm


### PR DESCRIPTION
Used in a handful of torchbench vision models.