### PR TITLE
Don't call _jit_pass_onnx_function_extraction if export_modules_as_functions is False

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -2194,7 +2194,9 @@ void initJitScriptBindings(PyObject* module) {
       .def(py::init<>());
   m.def(
       "_check_onnx_proto",
-      [](const std::string& proto_string, bool full_check) { check_onnx_proto(proto_string, full_check); },
+      [](const std::string& proto_string, bool full_check) {
+        check_onnx_proto(proto_string, full_check);
+      },
       py::arg("proto_string"),
       py::arg("full_check") = false);
   m.def("_jit_is_script_object", [](const py::object& obj) {

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -21,9 +21,9 @@
 #include <atomic>
 
 #include <onnx/checker.h>
-#include <onnx/shape_inference/implementation.h>
 #include <onnx/onnx_pb.h>
 #include <onnx/proto_utils.h>
+#include <onnx/shape_inference/implementation.h>
 
 #include <fstream>
 #include <memory>
@@ -1260,7 +1260,6 @@ void check_onnx_proto(const std::string& proto_string, bool full_check) {
   if (full_check) {
     onnx::shape_inference::InferShapes(model);
   }
-
 }
 
 } // namespace jit

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -61,7 +61,9 @@ export_onnx(
 TORCH_API std::string serialize_model_proto_to_string(
     const std::shared_ptr<::ONNX_NAMESPACE::ModelProto>& model_proto);
 
-TORCH_API void check_onnx_proto(const std::string& proto_string, bool full_check=false);
+TORCH_API void check_onnx_proto(
+    const std::string& proto_string,
+    bool full_check = false);
 
 // Serializer for both oldsyle and unified format TorchScript serialization
 class TORCH_API ScriptModuleSerializer {

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -740,7 +740,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
 
             torch._C._jit_pass_dce_allow_deleting_nodes_with_side_effects(graph)
             node_attr_to_name = {}  # type: ignore[var-annotated]
-            if export_modules_as_functions is not None:
+            if export_modules_as_functions:
                 # NOTE: cannot call DCE after this pass. DCE will remove function definition nodes.
                 node_attr_to_name = torch._C._jit_pass_onnx_function_extraction(
                     graph, export_modules_as_functions, list(params_dict.keys()))


### PR DESCRIPTION
Don't call _jit_pass_onnx_function_extraction if export_modules_as_functions is False

It's just wasteful.

Also fix clang-format violations.