### PR TITLE
[Jit] Fix schema of aten::split int[] version

### DIFF
--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -1532,6 +1532,65 @@ TEST(AliasRegistrationTest, WildcardAliasForTupleConstructWithUses) {
   EXPECT_TRUE(aliasDb.mayContainAlias(vmap["b"], vmap["z"]));
 }
 
+TEST(AliasRegistrationTest, ATenSplitIntListAliasCheck) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  auto graph_string = R"IR(
+  graph():
+    %x : Tensor = prim::MakeTestTensor()
+    %2 : int = prim::Constant[value=2]()
+    %0 : int = prim::Constant[value=0]()
+    %1 : int = prim::Constant[value=1]()
+    %y : Tensor = aten::add(%x, %x, %0)
+    %lengths_list : int[] = prim::tolist(%1, %2)
+    %a : Tensor[] = aten::split(%y, %lengths_list, %0)
+    %b : Tensor, %c : Tensor = prim::ListUnpack(%a)
+    %b1 : Tensor = aten::flatten(%b, %0, %1)
+    %c1 : Tensor = aten::flatten(%c, %0, %1)
+    %d : Tensor = aten::add(%b1, %c1, %0)
+    return (%d))IR";
+
+  torch::jit::parseIR(graph_string, graph.get(), vmap);
+  AliasDb aliasDb(
+      graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
+  aliasDb.dump();
+  LOG(INFO) << "finished printing";
+
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["b"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["c"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["b1"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["c1"]));
+}
+
+TEST(AliasRegistrationTest, ATenSplitIntAliasCheck) {
+  auto graph = std::make_shared<Graph>();
+  std::unordered_map<std::string, Value*> vmap;
+  auto graph_string = R"IR(
+  graph():
+    %x : Tensor = prim::MakeTestTensor()
+    %2 : int = prim::Constant[value=2]()
+    %0 : int = prim::Constant[value=0]()
+    %1 : int = prim::Constant[value=1]()
+    %y : Tensor = aten::add(%x, %x, %0)
+    %a : Tensor[] = aten::split(%y, %2, %0)
+    %b : Tensor, %c : Tensor = prim::ListUnpack(%a)
+    %b1 : Tensor = aten::flatten(%b, %0, %1)
+    %c1 : Tensor = aten::flatten(%c, %0, %1)
+    %d : Tensor = aten::add(%b1, %c1, %0)
+    return (%d))IR";
+
+  torch::jit::parseIR(graph_string, graph.get(), vmap);
+  AliasDb aliasDb(
+      graph, /*isFrozen=*/false, /*enablePreciseTupleContainerAnalysis=*/true);
+  aliasDb.dump();
+  LOG(INFO) << "finished printing";
+
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["b"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["c"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["b1"]));
+  EXPECT_TRUE(aliasDb.mayAlias(vmap["y"], vmap["c1"]));
+}
+
 TEST(AliasRegistrationTest, PureWithAnnotationsShouldError2) {
   auto registry = torch::RegisterOperators().op(
       "foo::rand12(Tensor(a) arg1) -> Tensor(b)",

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -245,7 +245,7 @@ void createTensorFromList(Stack& stack) {
 RegisterOperators reg({
     OperatorGenerator(
         TORCH_SELECTIVE_SCHEMA(
-            "aten::split(Tensor self, int[] split_sizes, int dim=0) -> Tensor[]"),
+            "aten::split(Tensor(a -> *) self, int[] split_sizes, int dim=0) -> Tensor(a)[]"),
         [](Stack& stack) {
           RECORD_FUNCTION("split_with_sizes", last(stack, 3));
 


### PR DESCRIPTION
Summary: Missed in D31935573 (https://github.com/pytorch/pytorch/commit/6b44e75f6bccca7acc8ec31a635f1175c265ac54).

Reviewed By: d1jang

Differential Revision: D31889867

