### PR TITLE
Deep clone the torchbench repo in torchbench CI

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           repository: pytorch/benchmark
           path: benchmark
+          # deep clone, user may request to run on a branch
+          fetch-depth: 0
       - name: Create conda environment
         run: |
           conda create -y -n pr-ci python="${PYTHON_VERSION}"


### PR DESCRIPTION
User would like to benchmark using their customized TB branch, so we need to clone everything and get all the branches.

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: alanwaketan/csv