### PR TITLE
[SR][easy] Accessors for value array offsets

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -269,6 +269,18 @@ class TORCH_API StaticModule {
   size_t num_inputs() const;
   size_t num_outputs() const;
 
+  size_t num_constants() const {
+    return constants_.size();
+  }
+
+  size_t num_intermediate_values() const {
+    return num_intermediate_values_;
+  }
+
+  size_t total_num_values() const {
+    return num_inputs() + num_constants() + num_intermediate_values();
+  }
+
   C10_NODISCARD const std::vector<uint16_t>& output_indices() const {
     return output_indices_;
   }
@@ -330,6 +342,18 @@ class TORCH_API StaticModule {
     return module_.has_value();
   }
 
+  size_t inputs_offset() const {
+    return 0;
+  }
+
+  size_t constants_offset() const {
+    return inputs_offset() + num_inputs();
+  }
+
+  size_t intermediate_values_offset() const {
+    return constants_offset() + num_constants();
+  }
+
   StaticRuntime& runtime();
 
  private:
@@ -361,6 +385,8 @@ class TORCH_API StaticModule {
   FastSet<const Value*> managed_output_tensor_values_{};
   FastSet<const Value*> leaked_values_{};
   ManagedTensorRanges managed_tensor_ranges_{};
+
+  size_t num_intermediate_values_ = 0;
 };
 
 class TORCH_API StaticRuntime {


### PR DESCRIPTION
Summary: Per swolchok's suggestion on D32609915 (https://github.com/pytorch/pytorch/commit/1c43b1602ce3c77a1a0c64868a5358ea79c730ba). Hide the value offset indices behind accessors to provide more flexibility if we ever decide to change the layout of the values array.

Test Plan: `buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest`

Reviewed By: hlu1

Differential Revision: D32838145

