### PR TITLE
[Quant] Added 4 bit support for embedding quantized module

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -819,23 +819,26 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         obs = default_float_qparams_observer()
         obs(weights)
         qparams = obs.calculate_qparams()
-        # Quantize the weights to 8bits
-        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
-        qemb = nnq.Embedding(num_embeddings=num_embeddings, embedding_dim=embedding_dim)
-        qemb.set_weight(qweight)
-        qemb(indices)
 
-        # Ensure the module has the correct weights
-        self.assertEqual(qweight, qemb.weight())
+        dtypes = [torch.quint4x2, torch.quint8]
+        embedding_funcs = [torch.ops.quantized.embedding_4bit, torch.ops.quantized.embedding_byte]
 
-        w_packed = qemb._packed_params._packed_weight
-        module_out = qemb(indices)
+        for dtype, embedding_func in zip(dtypes, embedding_funcs):
+            # Quantize the weights
+            qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=dtype)
+            qemb = nnq.Embedding(num_embeddings=num_embeddings, embedding_dim=embedding_dim, dtype=dtype)
+            qemb.set_weight(qweight)
+            qemb(indices)
 
-        # Call the qembedding operator directly
-        ref = torch.ops.quantized.embedding_byte(w_packed, indices, pruned_weights=False)
-        self.assertEqual(module_out, ref)
-        self.checkEmbeddingSerialization(qemb, num_embeddings, embedding_dim, indices, None, set_qconfig=False, is_emb_bag=False)
+            # Ensure the module has the correct weights
+            self.assertEqual(qweight, qemb.weight())
+            w_packed = qemb._packed_params._packed_weight
+            module_out = qemb(indices)
 
+            # Call the bit qembedding operator directly
+            ref = embedding_func(w_packed, indices, pruned_weights=False)
+            self.assertEqual(module_out, ref)
+            self.checkEmbeddingSerialization(qemb, num_embeddings, embedding_dim, indices, None, set_qconfig=False, is_emb_bag=False, dtype=dtype)
 
     @given(
         num_embeddings=st.integers(10, 50),

--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -838,7 +838,8 @@ class TestStaticQuantizedModule(QuantizationTestCase):
             # Call the bit qembedding operator directly
             ref = embedding_func(w_packed, indices, pruned_weights=False)
             self.assertEqual(module_out, ref)
-            self.checkEmbeddingSerialization(qemb, num_embeddings, embedding_dim, indices, None, set_qconfig=False, is_emb_bag=False, dtype=dtype)
+            self.checkEmbeddingSerialization(qemb, num_embeddings, embedding_dim, indices, None, set_qconfig=False,
+                                            is_emb_bag=False, dtype=dtype)
 
     @given(
         num_embeddings=st.integers(10, 50),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69765
* #69764
* __->__ #69760
* #69759

Summary: Added 4 bit support and the correpsonding test in the module api. Restructured the test_quantized_module for both 4 & 8 bit support.

Reviewers: jerryzh168

Subscribers: jerryzh168, supriyar

Tasks: T106931792

Tags