### PR TITLE
Wconstab/fallback

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -151,9 +151,10 @@ class DivAddMul(nn.Module):
     def __init__(self, dims, device='cuda', jit=False):
         super(DivAddMul, self).__init__()
         self.attention_head_size = dims[1]
+        self.W = torch.ones(*dims[-2:], device=device, dtype=torch.float32)
         self.name = "DivAddMul[" + ','.join([str(d) for d in dims]) + ']'
         self.example_inputs = (
-            torch.randn(*dims, device=device, dtype=torch.float32),
+            torch.ones(*dims, device=device, dtype=torch.float32),
             torch.randn(*dims, device=device, dtype=torch.float32),
         )
 
@@ -164,10 +165,11 @@ class DivAddMul(nn.Module):
         return self.name
 
     def forward(self, inputs, mask):
-        out1 = inputs / math.sqrt(self.attention_head_size)
-        out2 = out1 + mask
-        out3 = out2 * 5.0
-        return out3
+        out3 = ((inputs / 0.1) + mask) * 2.0
+        out5 = out3.matmul(self.W)
+        out8 = ((out5 / 0.1) + mask) * 2.00
+        return out8
+
 toy_models = [
     HardSwishBenchmark,
     DivAddMulBenchmark,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -397,7 +397,7 @@ std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors) {
     }
   }
   auto defined_aten_ltc_tensors =
-      torch::lazy::LazyGraphExecutor::Get()->GetTensors(&ltc_tensors);
+      torch::lazy::LazyGraphExecutor::Get()->GetTensors(&ltc_tensors, /*use_current_thread=*/false);
   // Insert undefined tensors into the result, back into the original undefined
   // positions.
   for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
@@ -1,7 +1,7 @@
 #include "lazy_tensor_core/csrc/ts_backend/EagerFallback.h"
 
 #include <sstream>
-#include "lazy_tensor_core/csrc/lazy_graph_executor.h"
+#include <torch/csrc/lazy/core/lazy_graph_executor.h>
 #include <ATen/Functions.h>
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/native/CPUFallback.h>
@@ -9,6 +9,8 @@
 
 namespace torch_lazy_tensors {
 namespace {
+using torch::lazy::LazyTensor;
+using torch::lazy::GetLtcTensor;
 
 std::vector<at::Tensor> to_eager(const at::TensorList& tensors,
                                  c10::DeviceType eager_device_type, bool use_main_thread) {
@@ -39,7 +41,7 @@ std::vector<at::Tensor> to_eager(const at::TensorList& tensors,
   }
 
   // Transfer all the lazy tensors as one computation rather than calling .to on each one
-  auto eager_valid_tensors = LazyGraphExecutor::Get()->GetTensors(&lazy_tensors, use_main_thread);
+  auto eager_valid_tensors = torch::lazy::LazyGraphExecutor::Get()->GetTensors(&lazy_tensors, use_main_thread);
 
   for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {
     if (to_translate[i]) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.h
@@ -7,6 +7,6 @@
 namespace torch_lazy_tensors {
 
 void eager_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack,
-                    c10::DeviceType device_type);
+                    c10::DeviceType device_type, bool use_main_thread);
 
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -13,6 +13,17 @@ namespace torch_lazy_tensors {
 static std::unordered_map<std::string, ::torch::lazy::Counter*>
     _eager_fallback_counters;
 
+bool force_eager_fallback(c10::Symbol op) {
+  static char* force_str = std::getenv("LTC_FORCE_FALLBACK");
+  if (force_str != nullptr) {
+    static auto force_sym = c10::Symbol::fromQualString(std::string(force_str));
+    if (op == force_sym) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack) {
   LTC_FN_TRACK(3);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -42,6 +42,9 @@ void ltc_eager_fallback(const c10::OperatorHandle& op,
   auto& args = op.schema().arguments();
   auto arguments = torch::jit::last(stack, args.size());
 
+  // TODO(whc) why do we do this at all?  And if we want to log the tensors,
+  // why don't we log them after we have already transferred them to eager tensors
+  // inside `eager_fallback`?
   // Log each tensor argument.
   for (int64_t idx = 0; idx < arguments.size(); ++idx) {
     const auto& ivalue = arguments[idx];

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -24,6 +24,15 @@ bool force_eager_fallback(c10::Symbol op) {
   return false;
 }
 
+bool fallback_main_thread() {
+  static char* env_str = std::getenv("LTC_FALLBACK_MAIN_THREAD");
+  if (env_str != nullptr) {
+    static bool use_main_thread = atoi(env_str);
+    return use_main_thread;
+  }
+  return false;
+}
+
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack) {
   LTC_FN_TRACK(3);
@@ -55,7 +64,7 @@ void ltc_eager_fallback(const c10::OperatorHandle& op,
 
   // Call the actual boxed CPU fallback.
   eager_fallback(op, stack,
-                 torch::lazy::getBackend()->EagerFallbackDeviceType());
+                 torch::lazy::getBackend()->EagerFallbackDeviceType(), fallback_main_thread());
 }
 
 TORCH_LIBRARY_IMPL(_, Lazy, m) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
@@ -4,6 +4,7 @@
 
 namespace torch_lazy_tensors {
 
+bool force_eager_fallback(c10::Symbol op);
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/Operators.h>
 #include <ATen/native/CPUFallback.h>
 
 namespace torch_lazy_tensors {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
@@ -5,6 +5,7 @@
 
 namespace torch_lazy_tensors {
 
+bool fallback_main_thread();
 bool force_eager_fallback(c10::Symbol op);
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -384,6 +384,11 @@ at::Tensor & LazyNativeFunctions::normal_(at::Tensor & self, double mean, double
     // Unconditionally fall back.
     // implementing normal_ via lazy tensor caused differences in results compared to eager.
     return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
+    
+    // if (force_eager_fallback(c10::Symbol::fromQualString("aten::normal_"))) {
+    //   return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
+    // }
+
     // if (generator.has_value()) {
     //   return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
     // }

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -59,7 +59,7 @@ def gen_fallback_code(schema: LazyIrSchema, overload_name: str) -> str:
     else:
         aten_op_str = f"ATEN_OP({schema.aten_name})"
     return f"""
-        if (force_eager_fallback(at::aten::{schema.aten_name})) {{
+        if (force_eager_fallback({aten_symbol(schema)})) {{
             return at::native::call_fallback_fn<&ltc_eager_fallback, {aten_op_str}>::call(
                 {fallback_args}
             );

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -164,6 +164,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
             "torch/csrc/lazy/core/lazy_graph_executor.h",
             "torch/csrc/lazy/core/metrics.h",
             "torch/csrc/lazy/core/shape.h",
+            "lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h",
             f"{output_dir}/{backend_key}NativeFunctions.h",
             f"{output_dir}/{backend_key}LazyIr.h",
             f"{output_dir}/{backend_key}ShapeInference.h",

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -160,6 +160,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     fm.write_with_template(f'{backend_key}NativeFunctions.cpp', 'DispatchKeyNativeFunctions.cpp', lambda: {
         'includes': [f'#include <{path}>' for path in [
             tensor_class_hdr,
+            "ATen/Functions.h",
             "ATen/MetaFunctions.h",
             "torch/csrc/lazy/core/lazy_graph_executor.h",
             "torch/csrc/lazy/core/metrics.h",

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -462,7 +462,7 @@ void LazyGraphExecutor::SyncTensorsGraph(
   SyncTensorsConfig config;
   config.sync_ltc_data = sync_ltc_data;
 
-  auto async = SyncTensorsGraphInternal(tensors, devices, config);
+  auto async = SyncTensorsGraphInternal(tensors, devices, config, /*use_current_thread=*/true);
   if (wait && async != nullptr) {
     async->mwait.Wait();
   }
@@ -495,9 +495,9 @@ void LazyGraphExecutor::WaitDeviceOps(c10::ArrayRef<BackendDevice> devices) {
 }
 
 std::vector<at::Tensor> LazyGraphExecutor::GetTensors(
-    std::vector<LazyTensor>* tensors) {
+    std::vector<LazyTensor>* tensors, bool use_current_thread) {
   VLOG(4) << "Trying to get the value of " << tensors->size() << " tensor(s)";
-  return GetTensorsFused(tensors);
+  return GetTensorsFused(tensors, use_current_thread);
 }
 
 size_t LazyGraphExecutor::IncTrimCounter() {
@@ -743,7 +743,8 @@ LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
     std::vector<LazyTensor>* tensors,
     SyncTensorCollection* coll,
-    PostOrderData* po_data) {
+    PostOrderData* po_data,
+    bool use_current_thread) {
   ComputationCache::TypePtr cached_computation =
       LookupCachedCompile(coll->hash);
   if (cached_computation == nullptr) {
@@ -756,7 +757,8 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
       tensors,
       coll,
       std::move(po_data->parameters_data),
-      std::move(cached_computation));
+      std::move(cached_computation),
+      use_current_thread);
 }
 
 LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
@@ -887,7 +889,8 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     SyncTensorsGraphInternal(
         std::vector<LazyTensor>* tensors,
         c10::ArrayRef<std::string> devices,
-        const SyncTensorsConfig& config) {
+        const SyncTensorsConfig& config,
+        bool use_current_thread) {
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
   if (coll.indices.empty()) {
     return nullptr;
@@ -898,7 +901,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
   PostOrderData po_data = RunPostOrder(*tensors, coll.indices);
   coll.hash = HashCombine(coll.hash, Hash(po_data.parameter_sequence));
   VLOG(4) << "Parameter sequence graph hash " << HashToString(coll.hash);
-  std::shared_ptr<Async> async = TryRunCachedSync(tensors, &coll, &po_data);
+  std::shared_ptr<Async> async = TryRunCachedSync(tensors, &coll, &po_data, use_current_thread);
   if (async != nullptr) {
     return async;
   }
@@ -916,7 +919,8 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
       tensors,
       &coll,
       std::move(compile_result.parameters_data),
-      std::move(cached_computation));
+      std::move(cached_computation),
+      use_current_thread);
 }
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
@@ -924,7 +928,8 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
         SyncTensorCollection* coll,
         std::vector<BackendDataPtr> parameters_data,
         std::vector<BackendDataPtr> tensors_data,
-        ComputationCache::TypePtr cached_computation) {
+        ComputationCache::TypePtr cached_computation,
+        bool use_current_thread) {
   std::shared_ptr<Async> async = std::make_shared<Async>(
       coll,
       std::move(parameters_data),
@@ -973,7 +978,15 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     }
   };
 
-  ScheduleIoClosure(async->mwait.Completer(std::move(syncfn)));
+  auto closure = async->mwait.Completer(std::move(syncfn));
+
+  if (use_current_thread) {
+    closure();
+  } else {
+    ScheduleIoClosure(closure);
+  }
+  // Critical to return the real 'async' even when use_current_thread since it maintains
+  // state about the computation/tensors
   return async;
 }
 
@@ -982,20 +995,22 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
         std::vector<LazyTensor>* tensors,
         SyncTensorCollection* coll,
         std::vector<BackendDataPtr> parameters_data,
-        ComputationCache::TypePtr cached_computation) {
+        ComputationCache::TypePtr cached_computation,
+        bool use_current_thread) {
   auto tensors_data = FetchTensorData(tensors, coll->config, coll->indices);
   return ScheduleSyncTensorsGraph(
       coll,
       std::move(parameters_data),
       std::move(tensors_data),
-      std::move(cached_computation));
+      std::move(cached_computation),
+      use_current_thread);
 }
 
 std::vector<at::Tensor> LazyGraphExecutor::GetTensorsFused(
-    std::vector<LazyTensor>* tensors) {
+    std::vector<LazyTensor>* tensors, bool use_current_thread) {
   SyncTensorsConfig config;
   config.force_ltc_data = false;
-  auto async = SyncTensorsGraphInternal(tensors, {}, config);
+  auto async = SyncTensorsGraphInternal(tensors, {}, config, use_current_thread);
   if (async != nullptr) {
     async->mwait.Wait();
   }

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -77,7 +77,8 @@ class TORCH_API LazyGraphExecutor {
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.
-  std::vector<at::Tensor> GetTensors(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensors(std::vector<LazyTensor>* tensors,
+                                     bool use_current_thread);
 
   size_t IncTrimCounter();
 
@@ -194,7 +195,8 @@ class TORCH_API LazyGraphExecutor {
   std::shared_ptr<Async> TryRunCachedSync(
       std::vector<LazyTensor>* tensors,
       SyncTensorCollection* coll,
-      PostOrderData* po_data);
+      PostOrderData* po_data,
+      bool use_current_thread););
 
   CompilationResult Compile(
       const std::vector<LazyTensor>& tensors,
@@ -214,7 +216,8 @@ class TORCH_API LazyGraphExecutor {
   std::shared_ptr<Async> SyncTensorsGraphInternal(
       std::vector<LazyTensor>* tensors,
       c10::ArrayRef<std::string> devices,
-      const SyncTensorsConfig& config);
+      const SyncTensorsConfig& config,
+      bool use_current_thread);
 
   // Schedules the execution of a sync tensors operation in background. The
   // asynchronous operation will hold the device locks by capturing the ones
@@ -223,15 +226,18 @@ class TORCH_API LazyGraphExecutor {
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
       std::vector<BackendDataPtr> tensors_data,
-      ComputationCache::TypePtr cached_computation);
+      ComputationCache::TypePtr cached_computation,
+      bool use_current_thread);
 
   std::shared_ptr<Async> ScheduleSyncTensorsGraph(
       std::vector<LazyTensor>* tensors,
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
-      ComputationCache::TypePtr cached_computation);
+      ComputationCache::TypePtr cached_computation,
+      bool use_current_thread);
 
-  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors,
+                                          bool use_current_thread);
 
   std::vector<at::Tensor> FetchTensors(
       std::vector<LazyTensor>* tensors,

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -196,7 +196,7 @@ class TORCH_API LazyGraphExecutor {
       std::vector<LazyTensor>* tensors,
       SyncTensorCollection* coll,
       PostOrderData* po_data,
-      bool use_current_thread););
+      bool use_current_thread);
 
   CompilationResult Compile(
       const std::vector<LazyTensor>& tensors,


### PR DESCRIPTION
Add a mechanism for forcing a particular op to fall back.
  - only supports codegenned ops for now
  - uses an env var LTC_FORCE_FALLBACK={aten op string, e.g.  aten::mm}, although a python binding might eventually be better
  - only supports a single op at a time for now, could be extended if needed

Update DivAddMul benchmark to be useful for benchmarking fallback in simple case
 - use mm as the fallback op (either make it fallback, or don't, using ENV var)
 - since compiler only fuses DivAddMul portion, it isolates the effect of falling back, and the optimized fallback should give nearly identical performance as the non-fallback case
 
 Optimize the fallback by avoiding unnecessary d2d copy and grouping lazy to eager transfers into one.

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc