### PR TITLE
Try to re-enable asan sharding

### DIFF
--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -52,5 +52,7 @@ popd
 
 assert_git_not_dirty
 
-# export test times so that potential sharded tests that'll branch off this build will use consistent data
-python test/run_test.py --export-past-test-times
+(
+  # export test times so that potential sharded tests that'll branch off this build will use consistent data
+  python test/run_test.py --export-past-test-times
+)

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -51,3 +51,6 @@ python setup.py build --cmake-only
 popd
 
 assert_git_not_dirty
+
+# export test times so that potential sharded tests that'll branch off this build will use consistent data
+python test/run_test.py --export-past-test-times


### PR DESCRIPTION
Trying to download the pytorch test time stats for ASAN configurations during the build job runs into the following error:
```
+ python test/run_test.py --export-past-test-times
2021-12-13T16:26:18.3191371Z ==13930==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
2021-12-13T16:26:18.3203033Z + cleanup
2021-12-13T16:26:18.3203470Z + retcode=1
```