### PR TITLE
Remove if conditioning from some MacOS workflow steps

### DIFF
--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -136,9 +136,9 @@ jobs:
           python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh
       !{{ common.render_test_results() }}
-      !{{ common.upload_downloaded_files(name='macos', use_s3=False, artifact_name="test-jsons", when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
+      !{{ common.upload_downloaded_files(name='macos', artifact_name="test-jsons", use_s3=False) }}
       !{{ common.upload_test_reports("macos", artifact_name="test-reports", use_s3=False) }}
-      !{{ common.upload_test_statistics(build_environment, when="${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}") }}
+      !{{ common.upload_test_statistics(build_environment) }}
 {% endblock +%}
 {%- endif %}
 

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           python3 tools/render_junit.py test/
       - name: Zip JSONs for upload
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: always()
         env:
           FILE_SUFFIX: '${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}'
         run: |
@@ -188,7 +188,7 @@ jobs:
           zip -r "test-jsons-${FILE_SUFFIX}.zip" test -i '*.json'
       - uses: actions/upload-artifact@v2
         name: Store Test Downloaded JSONs on Github
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: always()
         with:
           name: test-jsons
           retention-days: 14
@@ -213,7 +213,7 @@ jobs:
           path:
             test-reports-*.zip
       - name: Display and upload test statistics (Click Me)
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: always()
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:


### PR DESCRIPTION
Indirectly fixes #69389

These steps shouldn't error out when the credentials aren't set anyway--note that the step runs and doesn't fail when credentials are not found
https://github.com/pytorch/pytorch/runs/4490004565?check_suite_focus=true
![image](https://user-images.githubusercontent.com/31798555/145846198-1fb547df-9fc3-40b4-963a-77b87bc3dba8.png)

