### PR TITLE
Back out "[sparsity] Convert function for sparse kernels without a context manager"

### DIFF
--- a/test/ao/sparsity/test_kernels.py
+++ b/test/ao/sparsity/test_kernels.py
@@ -146,10 +146,6 @@ class TestQuantizedSparseLayers(TestCase):
             model.weight = nn.Parameter(W_q.dequantize())
             model.eval()
 
-            # Add `sparse_params` to the model. The test for correct
-            # sparse_param addition is in the sparsifier tests
-            model.linear.sparse_params = {'sparse_block_shape': (1, 4)}
-
             # Note: At the moment, for sparse kernels
             # fbgemm supports only static quantized sparse linear
             # qnnpack supports only dynamically quantized sparse linear
@@ -188,35 +184,33 @@ class TestQuantizedSparseLayers(TestCase):
                 Y_hat = sqmodel(X_q)
                 self.assertEqual(Y_ref.dequantize(), Y_hat.dequantize())
 
-            elif qengine_is_qnnpack():
+            if qengine_is_qnnpack():
                 qconfig = {nn.Linear : tq.qconfig.default_dynamic_qconfig}
-                qmodel = copy.deepcopy(model)
-                sqmodel = copy.deepcopy(model)
+                dqmodel = copy.deepcopy(model)
+                sdqmodel = copy.deepcopy(model)
 
-                tq.propagate_qconfig_(qmodel, qconfig)
-                tq.propagate_qconfig_(sqmodel, qconfig)
+                tq.propagate_qconfig_(dqmodel, qconfig)
+                tq.propagate_qconfig_(sdqmodel, qconfig)
 
                 # Make sure the quantization parameters are computed the same way
-                qparams = qmodel.linear.qconfig.weight().calculate_qparams()
-                sqparams = sqmodel.linear.qconfig.weight().calculate_qparams()
+                qparams = dqmodel.linear.qconfig.weight().calculate_qparams()
+                sqparams = sdqmodel.linear.qconfig.weight().calculate_qparams()
                 self.assertEqual(qparams, sqparams)
 
                 # Make sure mapping of sparse kernels does not affect the non-sparse
                 sparse_mapping = copy.deepcopy(tq.get_default_dynamic_quant_module_mappings())
                 sparse_mapping[nn.Linear] = ao_nn_sq.dynamic.Linear
-                tq.convert(sqmodel, inplace=True, mapping=sparse_mapping)
-                tq.convert(qmodel, mapping=tq.get_default_dynamic_quant_module_mappings(), inplace=True)
+                with LinearBlockSparsePattern(1, 4):
+                    tq.convert(sdqmodel, inplace=True, mapping=sparse_mapping)
+                tq.convert(dqmodel, mapping=tq.get_default_dynamic_quant_module_mappings(), inplace=True)
 
-                assert isinstance(sqmodel.linear, ao_nn_sq.dynamic.Linear), "Convert failed"
-                assert isinstance(qmodel.linear, nn.quantized.dynamic.Linear), "Mapping failed"
+                assert isinstance(sdqmodel.linear, ao_nn_sq.dynamic.Linear), "Convert failed"
+                assert isinstance(dqmodel.linear, nn.quantized.dynamic.Linear), "Mapping failed"
 
                 # Make sure numerics are right
-                Y_ref = qmodel(X_fp32)
-                Y_hat = sqmodel(X_fp32)
+                Y_ref = dqmodel(X_fp32)
+                Y_hat = sdqmodel(X_fp32)
                 self.assertEqual(Y_ref, Y_hat)
-
-            row_block_size, col_block_size = sqmodel.linear._packed_params._weight_bias()[2:]
-            assert row_block_size == 1 and col_block_size == 4
 
     @override_qengines
     def test_sparse_qlinear_serdes(self):
@@ -245,8 +239,7 @@ class TestQuantizedSparseLayers(TestCase):
             W_fp32 *= mask
             W_q = torch.quantize_per_tensor(W_fp32, W_scale, W_zp, torch.qint8)
 
-            model.linear.weight = nn.Parameter(W_q.dequantize())
-            model.linear.sparse_params = {'sparse_block_shape': (1, 4)}
+            model.weight = nn.Parameter(W_q.dequantize())
             model.eval()
 
             # Note: At the moment, for sparse kernels
@@ -294,7 +287,7 @@ class TestQuantizedSparseLayers(TestCase):
                 Y_hat = sqmodel(X_q)
                 self.assertEqual(Y_ref.dequantize(), Y_hat.dequantize())
 
-            elif qengine_is_qnnpack():
+            if qengine_is_qnnpack():
                 qconfig = {nn.Linear : tq.qconfig.default_dynamic_qconfig}
                 dqmodel = copy.deepcopy(model)
                 sdqmodel = copy.deepcopy(model)

--- a/torch/ao/nn/sparse/quantized/linear.py
+++ b/torch/ao/nn/sparse/quantized/linear.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import torch
+from torch.ao.nn.sparse.quantized.utils import LinearBlockSparsePattern
 from torch.nn.quantized.modules.utils import _quantize_weight, hide_packed_params_repr
 
 # TODO (zaf): Inherit from `quantized.LinearPackedParams` (T83294430)
@@ -162,15 +163,10 @@ class Linear(torch.nn.Module):
 
         We only care about the convert at this stage, no need for observers just yet.
 
-        TODO(zaf): Need to add the sparse params to the qconfig
+        TODO: Need to figure out how to store the block shapes in the mod
         """
         assert type(mod) == cls._FLOAT_MODULE, cls._get_name() + \
             '.from_float only works for ' + cls._FLOAT_MODULE.__name__
-        assert hasattr(mod, 'sparse_params'), \
-            'Expecting the Linear to have `sparse_params`.'
-        sparse_block_shape = mod.sparse_params.get('sparse_block_shape', None)
-        assert isinstance(sparse_block_shape, (tuple, list))
-        assert len(sparse_block_shape) == 2
         # TODO: Need to add options to qconfig to avoid the calibration.
         # TODO: Add calibration for the sparsity
         assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
@@ -192,15 +188,13 @@ class Linear(torch.nn.Module):
             assert w_zp == 0, 'Weight zero point must map to 0'
         qweight = _quantize_weight(weight.float(), weight_post_process)
 
-        row_block_size = mod.sparse_params['sparse_block_shape'][0]
-        col_block_size = mod.sparse_params['sparse_block_shape'][1]
+        row_block_size, col_block_size = LinearBlockSparsePattern.block_size()
         qlinear = cls(mod.in_features,
                       mod.out_features,
                       row_block_size,
                       col_block_size,
                       dtype=dtype)
-        qlinear.set_weight_bias(qweight, mod.bias,
-                                row_block_size, col_block_size)
+        qlinear.set_weight_bias(qweight, mod.bias, row_block_size, col_block_size)
         qlinear.scale = float(act_scale)
         qlinear.zero_point = int(act_zp)
         return qlinear

--- a/torch/ao/quantization/quantization_mappings.py
+++ b/torch/ao/quantization/quantization_mappings.py
@@ -16,7 +16,6 @@ import torch.nn.qat.dynamic as nnqatd
 
 from typing import Optional, Union, Dict, Set, Callable, Any
 
-import torch.ao.nn as ao_nn
 from torch.ao.quantization.stubs import QuantStub, DeQuantStub
 from torch.ao.quantization.fake_quantize import (
     default_affine_fixed_qparams_fake_quant,
@@ -142,16 +141,6 @@ DEFAULT_MODULE_TO_ACT_POST_PROCESS : Dict[Callable, Callable] = {
     nn.Tanh: default_symmetric_fixed_qparams_fake_quant,
 }
 
-# Default map for swapping float module to static sparse quantized ones
-DEFAULT_STATIC_SPARSE_QUANT_MODULE_MAPPINGS : Dict[Callable, Any] = {
-    nn.Linear: ao_nn.sparse.quantized.Linear
-}
-
-# Default map for swapping float module to dynamic sparse quantized ones
-DEFAULT_DYNAMIC_SPARSE_QUANT_MODULE_MAPPINGS : Dict[Callable, Any] = {
-    nn.Linear: ao_nn.sparse.quantized.dynamic.Linear
-}
-
 def no_observer_set() -> Set[Any]:
     r"""These modules cannot have observers inserted by default."""
     no_observers = set([
@@ -173,10 +162,6 @@ def get_embedding_static_quant_module_mappings() -> Dict[Callable, Any]:
     mapping[nnqat.Embedding] = nnq.Embedding
     return mapping
 
-def get_default_static_sparse_quant_module_mappings() -> Dict[Callable, Any]:
-    ''' Get module mapping for post training static sparse quantization
-    '''
-    return copy.deepcopy(DEFAULT_STATIC_SPARSE_QUANT_MODULE_MAPPINGS)
 
 def get_static_quant_module_class(
         float_module_class: Callable,
@@ -230,11 +215,6 @@ def get_default_dynamic_quant_module_mappings() -> Dict[Callable, Any]:
     ''' Get module mapping for post training dynamic quantization
     '''
     return DEFAULT_DYNAMIC_QUANT_MODULE_MAPPINGS
-
-def get_default_dynamic_sparse_quant_module_mappings() -> Dict[Callable, Any]:
-    ''' Get module mapping for post training dynamic sparse quantization
-    '''
-    return DEFAULT_DYNAMIC_SPARSE_QUANT_MODULE_MAPPINGS
 
 def get_default_qconfig_propagation_list() -> Set[Callable]:
     ''' Get the default list of module types that we'll attach qconfig


### PR DESCRIPTION
Summary:
Original commit changeset: c5fd2da3b09a

Original Phabricator Diff: D31835721 (https://github.com/pytorch/pytorch/commit/07932e27356c32df8a3c17361e4779c635d2d8ce)

Test Plan: waitforsandcastle

Differential Revision: D33035745

