### PR TITLE
Codegen: Do less work in dry-runs for sharded files

### DIFF
--- a/tools/codegen/utils.py
+++ b/tools/codegen/utils.py
@@ -196,11 +196,14 @@ class FileManager:
                 else:
                     shard[key] = []
 
-
         def merge_env(into: Dict[str, List[str]], from_: Dict[str, List[str]]) -> None:
             for k, v in from_.items():
                 assert k in sharded_keys, f"undeclared sharded key {k}"
                 into[k] += v
+
+        if self.dry_run:
+            # Dry runs don't write any templates, so incomplete environments are fine
+            items = ()
 
         for item in items:
             key = key_fn(item)


### PR DESCRIPTION
This improves a dry-run of `gen.py` from 0.80s to 0.45s.

`FileManager` in `dry_run` mode doesn't actually need to compute the
environment; it just records the filenames that would have been
written.


cc @ezyang @bhosmer @bdhirsh