### PR TITLE
fix NameError of docstring in broadcast_object_list

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1819,7 +1819,7 @@ def broadcast_object_list(object_list, src=0, group=None, device=None):
         >>> # Assumes backend is not NCCL
         >>> device = torch.device("cpu")
         >>> dist.broadcast_object_list(objects, src=0, device=device)
-        >>> broadcast_objects
+        >>> objects
         ['foo', 12, {1: 2}]
     """
     if _rank_not_in_group(group):


### PR DESCRIPTION
This PR fixes NameError of docstring in broadcast_object_list.


cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang