### PR TITLE
[Static Runtime] Skip ReplaceWithCopy when inputs have writters

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -7,6 +7,7 @@
 #include <torch/csrc/jit/runtime/static/memory_planner.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
+#include <memory>
 
 #include "deep_wide_pt.h"
 #include "test_utils.h"
@@ -34,6 +35,14 @@ bool testCanEnableStaticRuntime(const std::string& jit_script) {
 
   // here we do not freeze graph
   return canEnableStaticRuntime(graph);
+}
+
+std::shared_ptr<Graph> testGetGraph(const std::string& jit_script) {
+  script::Module module("module");
+  module.define(jit_script);
+
+  Method method = module.get_method("forward");
+  return module.get_method("forward").graph();
 }
 
 bool testHasInplaceOp(const std::string& jit_script) {
@@ -226,6 +235,71 @@ TEST(StaticRuntime, ModuleHasOp) {
   EXPECT_TRUE(testModuleHasOp(reshape_inplace_script_1, "aten::reshape"));
   EXPECT_TRUE(testModuleHasOp(sigmoid_inplace_script, "aten::clone"));
   EXPECT_FALSE(testModuleHasOp(reshape_inplace_script_1, "aten::add_"));
+}
+
+TEST(StaticRuntime, ReplaceWithCopy_replaces_reshape_op) {
+  const auto jit_script = R"JIT(
+    def forward(self, inp: Tensor, shape: List[int]):
+        a = inp.reshape(shape)
+        return (a)
+  )JIT";
+  auto graph = testGetGraph(jit_script);
+
+  EXPECT_TRUE(graphHasOp(graph, "aten::reshape"));
+  EXPECT_FALSE(graphHasOp(graph, "static_runtime::reshape_copy"));
+
+  ReplaceWithCopy(graph);
+
+  // aten::reshape -> static_runtime::reshape_copy
+  EXPECT_FALSE(graphHasOp(graph, "aten::reshape"));
+  EXPECT_TRUE(graphHasOp(graph, "static_runtime::reshape_copy"));
+}
+
+TEST(
+    StaticRuntime,
+    ReplaceWithCopy_does_not_replace_reshape_if_input_has_writters) {
+  auto ExpectNotToReplaceWithCopy = [](const std::string& jit_script) {
+    auto graph = testGetGraph(jit_script);
+    EXPECT_TRUE(graphHasOp(graph, "aten::reshape"));
+    EXPECT_FALSE(graphHasOp(graph, "static_runtime::reshape_copy"));
+
+    ReplaceWithCopy(graph);
+
+    // No Replacement
+    EXPECT_TRUE(graphHasOp(graph, "aten::reshape"));
+    EXPECT_FALSE(graphHasOp(graph, "static_runtime::reshape_copy"));
+  };
+
+  ExpectNotToReplaceWithCopy(R"JIT(
+    def forward(self, inp: Tensor, shape: List[int]):
+        a = inp.reshape(shape)
+        inp *= 2
+        return (a)
+  )JIT");
+  ExpectNotToReplaceWithCopy(R"JIT(
+    def forward(self, inp: Tensor, shape: List[int]):
+        a = inp.reshape(shape)
+        a *= 2
+        return (a)
+  )JIT");
+  ExpectNotToReplaceWithCopy(R"JIT(
+    def forward(self, inp: Tensor, inp2: Tensor, shape: List[int]):
+        a = inp.reshape(shape)
+        a *= 2
+        b = a.reshape(shape)
+        return (b)
+  )JIT");
+  ExpectNotToReplaceWithCopy(R"JIT(
+    def forward(self, inp: Tensor, shape: List[int]):
+        a = inp.reshape(shape)
+        b = a.reshape(shape)
+        c = b.reshape(shape)
+        d = c.reshape(shape)
+        e = b.sigmoid_()
+        return (d)
+  )JIT");
+  ExpectNotToReplaceWithCopy(reshape_inplace_script);
+  ExpectNotToReplaceWithCopy(reshape_inplace_script_1);
 }
 
 TEST(StaticRuntime, CanEnableStaticRuntime) {

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -33,6 +33,7 @@ bool HasInplaceOp(Block* block, const AliasDb& alias_db) {
   }
   return false;
 }
+} // namespace
 
 bool graphHasOp(std::shared_ptr<Graph>& graph, const char* op_name) {
   DepthFirstGraphNodeIterator graph_it(graph);
@@ -44,7 +45,6 @@ bool graphHasOp(std::shared_ptr<Graph>& graph, const char* op_name) {
   }
   return false;
 }
-} // namespace
 
 bool HasInplaceOp(std::shared_ptr<Graph>& graph, const AliasDb& alias_db) {
   return HasInplaceOp(graph->block(), alias_db);
@@ -516,7 +516,6 @@ void ReplaceWithCopy(
     return false;
   };
 
-  bool has_inplace_ops = HasInplaceOp(graph, db);
   std::vector<std::pair<Node*, Node*>> replacement;
   for (auto* n : graph->nodes()) {
     c10::Symbol new_symbol;
@@ -527,8 +526,10 @@ void ReplaceWithCopy(
     }
     DCHECK(n->outputs().size() == 1);
 
-    // In cases of having in-place ops in the graph, only replace the op with
-    // the copy version for ops with input with number of use == 1. Example:
+    // We do not want to replace operators with their copy variant when the
+    // inputs to the operators have writers (can be updated). With an output
+    // that aliases to the input, updates to the input will be visible to the
+    // operator's output as well. For example:
     //
     // def forward(self, inp: Tensor, shape: List[int]):
     //   a = inp + inp
@@ -544,8 +545,7 @@ void ReplaceWithCopy(
     // and c are no longer aliases of a, the value of e would change as a
     // result. To keep static runtime consistent with the jit interpreter, here
     // we choose not to replace reshape with the copy version
-    auto* in = n->input(0);
-    if (has_inplace_ops && in->uses().size() > 1) {
+    if (db.hasInputWriters(n)) {
       continue;
     }
 

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -27,6 +27,8 @@ TORCH_API bool HasInplaceOp(
     std::shared_ptr<Graph>& graph,
     const AliasDb& alias_db);
 
+TORCH_API bool graphHasOp(std::shared_ptr<Graph>& graph, const char* op_name);
+
 TORCH_API bool forwardHasOp(const Module& module, const char* op_name);
 
 TORCH_API void FuseSignLog1P(std::shared_ptr<Graph>& graph);


### PR DESCRIPTION
Summary:
We should skip ReplaceWithCopy if the inputs to the operator can be updated during inference. For a set of tensors that share data, ReplaceWithCopy should not happy to any of them if there exists updates to any of them.

Currently, the check in place has missed some cases (suppose there exists updates, and uses <= 1). This diff addresses the missing cases by querying AliasDB.

After this diff, HasInplaceOp will no longer be used. I will follow up and

Test Plan:
- Added test cases, including a one that is problematic before this diff
- CI

Differential Revision: D33052562

