### PR TITLE
[LTC] Update quickstart documentation

### DIFF
--- a/lazy_tensor_core/QUICKSTART.md
+++ b/lazy_tensor_core/QUICKSTART.md
@@ -1,7 +1,7 @@
 # Lazy Tensors Core
 
 1. Clone a copy of the PyTorch repo, switch to the `lazy_tensor_staging` branch and use `git submodule update --init --recursive` to fetch all submodules.
-1. From the PyTorch project root directory, run `python setup.py develop` to build PyTorch.
+1. From the PyTorch project root directory, run `python setup.py install` to build PyTorch.
 1. From the `lazy_tensor_core` subfolder, run `scripts/apply_patches.sh`.
 1. From the `lazy_tensor_core` subfolder, run `python setup.py develop`.
 1. Run `example.py`. It'll register and use the TorchScript backend.


### PR DESCRIPTION
Suppose the following happens:
1. Do some development on master
2. Switch to lazy_tensor_staging and `python3 setup.py develop`
3. `cd lazy_tensor_core` and `python3 setup.py develop`

On step 3, it seems like the build will try to build/include/link with
the local installation of pytorch, which is still the version from
master.

Instead, in step 2, `python3 setup.py install` should be used instead of
`python3 setup.py develop`
