### PR TITLE
Provide functionality to write custom ShardedTensor ops.

### DIFF
--- a/test/distributed/_sharded_tensor/ops/test_init.py
+++ b/test/distributed/_sharded_tensor/ops/test_init.py
@@ -126,10 +126,10 @@ class TestShardedTensorNNInit(ShardedTensorTestBase):
         # Clone local tensor to ensure torch.nn.init starts from the same input
         local_tensor_clone = torch.clone(sharded_tensor.local_shards()[0].tensor)
         torch.manual_seed(seed)
-        torch.nn.init.kaiming_normal_(sharded_tensor, a=a, mode=mode, nonlinearity=nonlinearity)
+        torch.nn.init.kaiming_uniform_(sharded_tensor, a=a, mode=mode, nonlinearity=nonlinearity)
 
         torch.manual_seed(seed)
-        torch.nn.init.kaiming_normal_(local_tensor_clone, a=a, mode=mode, nonlinearity=nonlinearity)
+        torch.nn.init.kaiming_uniform_(local_tensor_clone, a=a, mode=mode, nonlinearity=nonlinearity)
         self.assertEqual(local_tensor_clone, sharded_tensor.local_shards()[0].tensor)
 
 if __name__ == '__main__':

--- a/test/distributed/_sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_sharded_tensor/test_sharded_tensor.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 from torch.distributed import rpc
 from torch.distributed import _sharded_tensor
 from torch.distributed._sharded_tensor import (
-    custom_sharded_op,
+    sharded_op_impl,
     load_with_process_group,
     pre_load_state_dict_hook,
     shard_parameter,
@@ -2129,7 +2129,7 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
     @requires_nccl()
     def test_custom_op(self):
 
-        @custom_sharded_op(torch.asin)
+        @sharded_op_impl(torch.asin)
         def my_sharded_asin(types, args, kwargs, process_group):
             return torch.asin(args[0].local_shards()[0].tensor)
 
@@ -2154,7 +2154,7 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
 
         t = torch.rand(10, 10).cuda(self.rank)
 
-        @custom_sharded_op(torch.nn.functional.linear)
+        @sharded_op_impl(torch.nn.functional.linear)
         def my_sharded_linear(types, args, kwargs, process_group):
             return t
 
@@ -2179,12 +2179,12 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
     def test_custom_op_errors(self):
 
         with self.assertRaisesRegex(TypeError, 'expects signature'):
-            @custom_sharded_op(torch.nn.functional.linear)
+            @sharded_op_impl(torch.nn.functional.linear)
             def my_op1(types, args, kwargs, process_group, random_param):
                 pass
 
         with self.assertRaisesRegex(TypeError, 'expects signature'):
-            @custom_sharded_op(torch.nn.functional.linear)
+            @sharded_op_impl(torch.nn.functional.linear)
             def my_op2(types):
                 pass
 

--- a/test/distributed/_sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_sharded_tensor/test_sharded_tensor.py
@@ -10,6 +10,7 @@ import torch.distributed as dist
 from torch.distributed import rpc
 from torch.distributed import _sharded_tensor
 from torch.distributed._sharded_tensor import (
+    custom_sharded_op,
     load_with_process_group,
     pre_load_state_dict_hook,
     shard_parameter,
@@ -2120,6 +2121,72 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 wrong_pin_memory_shards,
                 sharded_tensor_metadata
             )
+
+class TestShardedTensorCustomOps(ShardedTensorTestBase):
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_custom_op(self):
+
+        @custom_sharded_op(torch.asin)
+        def my_sharded_asin(types, args, kwargs, process_group):
+            return torch.asin(args[0].local_shards()[0].tensor)
+
+        spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:0/cuda:0",
+                "rank:1/cuda:1",
+                "rank:2/cuda:2",
+                "rank:3/cuda:3",
+            ],
+        )
+
+        st = _sharded_tensor.rand(spec, 10, 10)
+        res = torch.asin(st)
+        self.assertEqual(res, torch.asin(st.local_shards()[0].tensor))
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_custom_op_override(self):
+
+        t = torch.rand(10, 10).cuda(self.rank)
+
+        @custom_sharded_op(torch.nn.functional.linear)
+        def my_sharded_linear(types, args, kwargs, process_group):
+            return t
+
+        spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:0/cuda:0",
+                "rank:1/cuda:1",
+                "rank:2/cuda:2",
+                "rank:3/cuda:3",
+            ],
+        )
+        m = torch.nn.Linear(32, 16).cuda(self.rank)
+        shard_parameter(m, 'weight', spec)
+
+        result = m(torch.rand(15, 32).cuda(self.rank))
+        self.assertEqual(t, result)
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_custom_op_errors(self):
+
+        with self.assertRaisesRegex(TypeError, 'expects signature'):
+            @custom_sharded_op(torch.nn.functional.linear)
+            def my_op1(types, args, kwargs, process_group, random_param):
+                pass
+
+        with self.assertRaisesRegex(TypeError, 'expects signature'):
+            @custom_sharded_op(torch.nn.functional.linear)
+            def my_op2(types):
+                pass
 
 
 if __name__ == '__main__':

--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -553,4 +553,4 @@ def sharded_op_impl(func):
     return decorator_sharded_func
 
 # Import all builtin sharded ops
-from .ops import *  # noqa
+from .ops import *  # noqa: 403

--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -553,4 +553,4 @@ def sharded_op_impl(func):
     return decorator_sharded_func
 
 # Import all builtin sharded ops
-from .ops import *  # noqa: E403
+from .ops import *  # noqa: F403

--- a/torch/distributed/_sharded_tensor/__init__.py
+++ b/torch/distributed/_sharded_tensor/__init__.py
@@ -553,4 +553,4 @@ def sharded_op_impl(func):
     return decorator_sharded_func
 
 # Import all builtin sharded ops
-from .ops import *  # noqa: 403
+from .ops import *  # noqa: E403

--- a/torch/distributed/_sharded_tensor/api.py
+++ b/torch/distributed/_sharded_tensor/api.py
@@ -27,14 +27,6 @@ from torch.distributed._sharding_spec._internals import (
 )
 from torch.types import Number
 from .metadata import TensorProperties, ShardedTensorMetadata
-from .ops import (
-    kaiming_uniform_,
-    normal_,
-    sharded_embedding,
-    sharded_embedding_bag,
-    sharded_linear,
-    uniform_,
-)
 from .shard import Shard
 from .utils import (
     get_current_process_group,
@@ -51,8 +43,8 @@ _sharded_tensor_current_id = 0
 _sharded_tensor_map: Dict[int, 'ShardedTensor'] = {}
 
 # Custom sharded ops
-_CUSTOM_SHARDED_OPS: Dict[str, Callable] = {}
-def _register_custom_sharded_op(op, func):
+_SHARDED_OPS: Dict[str, Callable] = {}
+def _register_sharded_op(op, func):
     from inspect import signature
     if len(signature(func).parameters) != 4:
         raise TypeError(
@@ -60,8 +52,8 @@ def _register_custom_sharded_op(op, func):
             f'(types, args, kwargs, process_group), but received '
             f'signature: {signature(func)}')
 
-    global _CUSTOM_SHARDED_OPS
-    _CUSTOM_SHARDED_OPS[op] = func
+    global _SHARDED_OPS
+    _SHARDED_OPS[op] = func
 
 def _register_remote_shards(sharded_tensor_id: int, rrefs: List[rpc.RRef[Shard]], rpc_rank: int):
     with _sharded_tensor_lock:
@@ -559,20 +551,8 @@ class ShardedTensor(object):
         return self._sharding_spec
 
     def __torch_function__(self, func, types, args=(), kwargs=None):
-        if func in _CUSTOM_SHARDED_OPS:
-            return _CUSTOM_SHARDED_OPS[func](types, args, kwargs, self._process_group)
-        elif func == torch.nn.functional.linear:
-            return sharded_linear(types, args, kwargs, self._process_group)
-        elif func == torch.nn.functional.embedding:
-            return sharded_embedding(types, args, kwargs, self._process_group)
-        elif func == torch.nn.functional.embedding_bag:
-            return sharded_embedding_bag(types, args, kwargs, self._process_group)
-        elif func == torch.nn.init.normal_:
-            return normal_(types, args, kwargs)
-        elif func == torch.nn.init.uniform_:
-            return uniform_(types, args, kwargs)
-        elif func == torch.nn.init.kaiming_uniform_:
-            return kaiming_uniform_(types, args, kwargs)
+        if func in _SHARDED_OPS:
+            return _SHARDED_OPS[func](types, args, kwargs, self._process_group)
         raise RuntimeError(
             f"torch function '{func.__name__}', with args: {args} and "
             f"kwargs: {kwargs} not supported for ShardedTensor!")

--- a/torch/distributed/_sharded_tensor/ops/embedding.py
+++ b/torch/distributed/_sharded_tensor/ops/embedding.py
@@ -11,8 +11,12 @@ from torch.distributed._sharded_tensor.ops._common import (
     _handle_max_norm_col_wise,
 )
 from torch.distributed._sharding_spec import ChunkShardingSpec
+from torch.distributed._sharded_tensor import (
+    sharded_op_impl,
+    ShardedTensor
+)
 
-
+@sharded_op_impl(torch.nn.functional.embedding)
 def sharded_embedding(types, args, kwargs, pg):
     """
     Handles ``__torch_function__`` dispatch for ``torch.nn.functional.embedding``.
@@ -140,7 +144,6 @@ def _validate_embedding_param(args, kwargs):
 
     Return: None.
     """
-    from torch.distributed._sharded_tensor import ShardedTensor
 
     input = args[0]
     weight = args[1]

--- a/torch/distributed/_sharded_tensor/ops/embedding_bag.py
+++ b/torch/distributed/_sharded_tensor/ops/embedding_bag.py
@@ -15,8 +15,13 @@ from torch.distributed._sharded_tensor.ops._common import (
     _handle_max_norm_col_wise,
 )
 from torch.distributed._sharding_spec import ChunkShardingSpec
+from torch.distributed._sharded_tensor import (
+    sharded_op_impl,
+    ShardedTensor
+)
 
 
+@sharded_op_impl(torch.nn.functional.embedding_bag)
 def sharded_embedding_bag(types, args, kwargs, pg):
     """
     Handles ``__torch_function__`` dispatch for ``torch.nn.functional.embedding_bag``.
@@ -173,7 +178,6 @@ def _validate_embedding_bag_param(args, kwargs):
 
     Return: None.
     """
-    from torch.distributed._sharded_tensor import ShardedTensor
 
     input = args[0]
     weight = args[1]

--- a/torch/distributed/_sharded_tensor/ops/init.py
+++ b/torch/distributed/_sharded_tensor/ops/init.py
@@ -1,10 +1,14 @@
 import torch
+from torch.distributed._sharded_tensor import (
+    sharded_op_impl,
+)
 
 def validate_param(param, param_name):
     if param is None:
         raise ValueError(f"param: {param_name} shouldn't be None!")
 
-def uniform_(types, args=(), kwargs=None):
+@sharded_op_impl(torch.nn.init.uniform_)
+def uniform_(types, args=(), kwargs=None, pg=None):
     r"""
     Fills the Tensor in sharded_tensor.local_shards with values drawn from the uniform
     distribution :math:`\mathcal{U}(a, b)`.
@@ -25,7 +29,8 @@ def uniform_(types, args=(), kwargs=None):
         torch.nn.init.uniform_(shard.tensor, a=a, b=b)
     return sharded_tensor
 
-def normal_(types, args=(), kwargs=None):
+@sharded_op_impl(torch.nn.init.normal_)
+def normal_(types, args=(), kwargs=None, pg=None):
     r"""
     Fills the Tensors in sharded_tensor.local_shards with values drawn from the normal
     distribution :math:`\mathcal{N}(\text{mean}, \text{std}^2)`.
@@ -46,7 +51,8 @@ def normal_(types, args=(), kwargs=None):
         torch.nn.init.normal_(shard.tensor, mean=mean, std=std)
     return sharded_tensor
 
-def kaiming_uniform_(types, args=(), kwargs=None):
+@sharded_op_impl(torch.nn.init.kaiming_uniform_)
+def kaiming_uniform_(types, args=(), kwargs=None, pg=None):
     r"""
     Fills the Tensors in sharded_tensor.local_shards with values according to the method
     described in `Delving deep into rectifiers: Surpassing human-level

--- a/torch/distributed/_sharded_tensor/ops/linear.py
+++ b/torch/distributed/_sharded_tensor/ops/linear.py
@@ -15,7 +15,12 @@ from torch.distributed.nn.functional import (
     reduce_scatter,
 )
 
+from torch.distributed._sharded_tensor import (
+    sharded_op_impl,
+    ShardedTensor
+)
 
+@sharded_op_impl(torch.nn.functional.linear)
 def sharded_linear(types, args, kwargs, pg):
     """
     Handles ``__torch_function__`` dispatch for ``torch.nn.functional.linear``.
@@ -76,8 +81,6 @@ def sharded_linear(types, args, kwargs, pg):
     5. If placements are not in order any appropriate rearrangement of rows
        are done for the (13 x 16) matrix and finally the bias term is added.
     """
-    from torch.distributed._sharded_tensor import ShardedTensor
-
     input = args[0]
     weight = args[1]
     bias = kwargs["bias"]

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -136,7 +136,7 @@ def uniform_(tensor: Tensor, a: float = 0., b: float = 1.) -> Tensor:
         >>> nn.init.uniform_(w)
     """
     if has_torch_function_variadic(tensor):
-        return handle_torch_function(uniform_, (), tensor=tensor, a=a, b=b)
+        return handle_torch_function(uniform_, (tensor,), tensor=tensor, a=a, b=b)
     return _no_grad_uniform_(tensor, a, b)
 
 
@@ -154,7 +154,7 @@ def normal_(tensor: Tensor, mean: float = 0., std: float = 1.) -> Tensor:
         >>> nn.init.normal_(w)
     """
     if has_torch_function_variadic(tensor):
-        return handle_torch_function(normal_, (), tensor=tensor, mean=mean, std=std)
+        return handle_torch_function(normal_, (tensor,), tensor=tensor, mean=mean, std=std)
     return _no_grad_normal_(tensor, mean, std)
 
 def trunc_normal_(tensor: Tensor, mean: float = 0., std: float = 1., a: float = -2., b: float = 2.) -> Tensor:
@@ -392,7 +392,7 @@ def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
         >>> nn.init.kaiming_uniform_(w, mode='fan_in', nonlinearity='relu')
     """
     if has_torch_function_variadic(tensor):
-        return handle_torch_function(kaiming_uniform_, (), tensor=tensor, a=a, mode=mode, nonlinear=nonlinearity)
+        return handle_torch_function(kaiming_uniform_, (tensor,), tensor=tensor, a=a, mode=mode, nonlinearity=nonlinearity)
 
     if 0 in tensor.shape:
         warnings.warn("Initializing zero-element tensors is a no-op")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69874

We have a handful of ops supported for ShardedTensor via
``__torch_function__`` dispatch. However, we currently can't cover all torch
operators and having a way for users to extend this functionality will make
this functionality much more general.

In this PR, I've introduced a @custom_sharded_op decorator which can be used to
register a custom sharded op implementation.

Differential Revision: [D33078587](https://our.internmc.facebook.com/intern/diff/D33078587/)