### PR TITLE
[LTC] Use functools.lru_cache instead

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -56,7 +56,7 @@ SKIP_TRAIN_ONLY = {
 current_name = ""
 current_device = ""
 
-@functools.cache
+@functools.lru_cache
 def output_csv(name, headers):
     output = csv.writer(
         io.TextIOWrapper(

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -56,7 +56,7 @@ SKIP_TRAIN_ONLY = {
 current_name = ""
 current_device = ""
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def output_csv(name, headers):
     output = csv.writer(
         io.TextIOWrapper(


### PR DESCRIPTION
Use functools.lru_cache instead of functools.cache given the TorchBench CI only supports Python 3.8.
