### PR TITLE
[fix] #69894: setuptools LooseVersion missing from the latest setuptools, s…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ astunparse
 expecttest
 future
 numpy
+packaging
 psutil
 pyyaml
 requests

--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,12 +1,9 @@
 import tensorboard
-from setuptools import distutils
-
-LooseVersion = distutils.version.LooseVersion
+from packaging.version import Version as LooseVersion
 
 if not hasattr(tensorboard, '__version__') or LooseVersion(tensorboard.__version__) < LooseVersion('1.15'):
     raise ImportError('TensorBoard logging requires TensorBoard version 1.15 or above')
 
-del distutils
 del LooseVersion
 del tensorboard
 


### PR DESCRIPTION
setuptools LooseVersion missing from the latest setuptools, so migrated to using packaging.version.Version.

Fixes #69894
