### PR TITLE
[StaticRuntime] Refactor StaticModule to pass in sample inputs.

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -45,6 +45,7 @@ namespace c10 {
   _(prim, add_optional)              \
   _(prim, DifferentiableGraph)       \
   _(prim, TensorExprGroup)           \
+  _(prim, TensorExprDynamicGroup)    \
   _(prim, StaticSubgraph)            \
   _(prim, If)                        \
   _(prim, Jump) /* debug */          \

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -48,7 +48,7 @@ class ModuleStaticRuntimeTestContext : public StaticRuntimeTestContext {
   }
 
   StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
-    return torch::jit::StaticModule(module_, /* is_frozen */ false, opt);
+    return torch::jit::StaticModule(module_, /* is_frozen */ false, {}, opt);
   }
 
  private:
@@ -76,7 +76,7 @@ class GraphStaticRuntimeContext : public StaticRuntimeTestContext {
   }
 
   StaticModule makeStaticModule(const StaticModuleOptions& opt) const override {
-    return StaticModule(graph_, opt);
+    return StaticModule(graph_, {}, opt);
   }
 
  private:

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -645,6 +645,7 @@ void AliasDb::analyzeImpl(Node* node) {
     }
     // TODO: think more about TensorExpr alias correctness
     case prim::TensorExprGroup:
+    case prim::TensorExprDynamicGroup:
     case prim::MKLDNNGroup:
     case prim::ConstantMKLDNNTensor:
     case prim::StaticSubgraph:

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/functional.h>
+#include <ATen/core/interned_strings.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
@@ -67,7 +68,8 @@ std::map<int64_t, Value*> InsertSymbolicShapesCompute(
 
 void insertDynamicShapesGuard(
     const ShapeComputeGraphMapping& shape_mapping,
-    Node* guarded_node);
+    Node* guarded_node,
+    bool add_composed_op);
 
 // Generalize Complete Shapes inputs to Symbolic Shapes.
 // Dimensions of value 1 will be preserved, otherwise
@@ -104,7 +106,7 @@ bool TryGeneralizeInputDimensionsToSymbolicShapes(
   return true;
 }
 
-bool GenerateGuard(Node* tensorexpr_graph_node) {
+bool GenerateGuard(Node* tensorexpr_graph_node, bool add_composed_op) {
   auto tensorexpr_graph = SubgraphUtils::getSubgraph(tensorexpr_graph_node);
 
   // Generalize Inputs
@@ -123,14 +125,16 @@ bool GenerateGuard(Node* tensorexpr_graph_node) {
   }
 
   // Insert Guard
-  insertDynamicShapesGuard(*maybe_shape_compute_mapping, tensorexpr_graph_node);
+  insertDynamicShapesGuard(
+      *maybe_shape_compute_mapping, tensorexpr_graph_node, add_composed_op);
   return true;
 }
 
 // TODO: share more logic with tensorexpr_fuser ?
 void insertDynamicShapesGuard(
     const ShapeComputeGraphMapping& shape_mapping,
-    Node* guarded_node) {
+    Node* guarded_node,
+    bool add_composed_op) {
   GRAPH_DEBUG(
       "Inserting a prim::TensorExprDynamicGuard guard for a node",
       *guarded_node);
@@ -217,6 +221,13 @@ void insertDynamicShapesGuard(
     subgraph->addInput(ss.str())->setType(IntType::get());
   }
   guarded_node->is_(attr::symbolic_shape_inputs, symbolic_shape_inputs);
+
+  if (add_composed_op) {
+    // Create a TensorExprDynamicGroup node
+    auto te_dyn_group = SubgraphUtils::createSingletonSubgraph(
+        typecheck_node, prim::TensorExprDynamicGroup);
+    SubgraphUtils::mergeNodeIntoSubgraph(versioning_if, te_dyn_group);
+  }
 }
 
 // On each invocation of this guard, we need to check all of the static
@@ -376,5 +387,23 @@ RegisterOperators reg_guard({
         },
         aliasAnalysisFromSchema()),
 });
+
+Operation createTensorExprDynamicGroup(const Node* node) {
+  auto graph = node->g(attr::Subgraph);
+  return [=](Stack& stack) {
+    Code code(graph, "");
+    InterpreterState interpreter{code};
+    interpreter.run(stack);
+    return 0;
+  };
+}
+
+RegisterOperators TensorExprDynamicOp({
+    torch::jit::Operator(
+        prim::TensorExprDynamicGroup,
+        createTensorExprDynamicGroup,
+        AliasAnalysisKind::INTERNAL_SPECIAL_CASE),
+});
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
@@ -25,7 +25,7 @@ namespace jit {
 // shape propagation fails to propagate # of dims or if complete shapes on
 // inputs not set
 
-TORCH_API bool GenerateGuard(Node* tensorexpr_graph_node);
+TORCH_API bool GenerateGuard(Node* tensorexpr_graph_node, bool add_composed_op = false);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -22,6 +22,8 @@ TORCH_API void FuseTensorExprs(
 
 TORCH_API void setTensorExprFuserEnabled(bool val);
 TORCH_API bool tensorExprFuserEnabled();
+TORCH_API void setTensorExprDynamicShapeFusionEnabled(bool val);
+TORCH_API bool tensorExprDynamicShapeFusionEnabled();
 TORCH_API bool setTexprReductionsEnabled(bool value);
 TORCH_API bool texprReductionsEnabled();
 

--- a/torch/csrc/jit/runtime/interpreter/can_emit_inline.h
+++ b/torch/csrc/jit/runtime/interpreter/can_emit_inline.h
@@ -49,6 +49,7 @@ struct CanEmitInline {
         // by the later BailOut in createBailoutBlock and its jf_index
         // will become invalid.
         v->node()->kind() != prim::TensorExprGroup &&
+        v->node()->kind() != prim::TensorExprDynamicGroup &&
         v->node()->kind() != prim::StaticSubgraph &&
         v->node()->kind() != prim::CudaFusionGroup &&
         v->node()->kind() != prim::FusionGroup &&

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -241,6 +241,7 @@ bool printerHasSpecialCaseFor(Symbol sym) {
       prim::CudaFusionGroup, // optimization pass adds it
       prim::CudaFusionGuard, // optimization pass adds it
       prim::TensorExprGroup, // optimization pass adds it
+      prim::TensorExprDynamicGroup, // optimization pass adds it
       prim::StaticSubgraph, // optimization pass adds it
       prim::ConstantMKLDNNTensor, // optimization pass adds it
       prim::BroadcastMKLDNNTensors, // optimization pass adds it
@@ -281,6 +282,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::CudaFusionGroup,
       prim::DifferentiableGraph,
       prim::TensorExprGroup,
+      prim::TensorExprDynamicGroup,
       prim::StaticSubgraph,
       prim::FunctionalGraph,
       prim::Constant,

--- a/torch/csrc/jit/runtime/static/fusion.h
+++ b/torch/csrc/jit/runtime/static/fusion.h
@@ -9,5 +9,9 @@ TORCH_API void fuseStaticSubgraphs(
     std::shared_ptr<Graph> graph,
     size_t min_size);
 
+TORCH_API void performTEFusion(
+    std::shared_ptr<Graph> graph,
+    std::vector<IValue> sample_inputs);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -155,6 +155,8 @@ struct TORCH_API StaticModuleOptions {
   // graph, where storage is deallocated outside static runtime
   // (enable_out_variant must be true)
   bool manage_output_tensors{false};
+  // enable fusion of ops at model loading time
+  bool enable_te_fusion{false};
 };
 
 /// The static runime supports two execution modes.
@@ -210,11 +212,13 @@ class TORCH_API StaticModule {
  public:
   explicit StaticModule(
       std::shared_ptr<torch::jit::Graph> g,
+      std::vector<IValue> sample_inputs = {},
       const StaticModuleOptions& opts = StaticModuleOptions());
 
   explicit StaticModule(
       const torch::jit::Module& m,
       bool is_frozen = false,
+      std::vector<IValue> sample_inputs = {},
       const StaticModuleOptions& opts = StaticModuleOptions());
 
   typedef enum {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69918
* __->__ #69917

Summary:
This diff refactors StaticModule and its uses to pass in sample
inputs.

Test Plan: buck run mode/opt //caffe2/caffe2/fb/predictor:pytorch_predictor_test

Differential Revision: D32320084

fbshipit-source-id: 91fd44319f0fc3cffe28038dbd687fd2fc49dafe

[jit] Add support for dynamic shape fusion in JIT.

Summary:
This diff adds support for dynamic shape fusion in JIT. This is done
by performing fusion with the static shapes observed on the first run,
generalizing the fused subgraphs and generating code for the generalized fused
subgraphs with dynamic shapes.

Test Plan: buck test mode/dev-nosan //caffe2/test/cpp/jit:jit

Differential Revision: D32781307

fbshipit-source-id: ffbc0e1afc708a0cd7916a27519530d37d99927c

[StaticRuntime] Add TensorExpr fusion with dynamic shapes in SR

Summary:
This diff adds TensorExpr fusion with dynamic shapes in SR. This
includes tracing the input graph with sample inputs, and then performing fusion
with generalization to get fused graphs with dynamic shapes.

Test Plan: buck run mode/opt //caffe2/caffe2/fb/predictor:pytorch_predictor_test

Differential Revision: D32320088

fbshipit-source-id: a9a925a7d0e93151ccd61ed6e19f07bb4e2bbf66

[jit] Add a new op that composes all of the dynamic shape logic (#68207)

Summary:

This diff adds a new op, `TensorExprDynamicGroup`, that composes all the logic behind running a dynamic shaped fused node. This includes a guard instruction that checks for conditions, a conditional that calls the fused node or the fallback graph depending on the guard.

Test Plan:
```
buck test mode/dev-nosan //caffe2/test/cpp/jit:jit
```

Differential Revision: D32320082

fbshipit-source-id: d6d25d39acaf7be2873af140ab53da4ba4153d06