### PR TITLE
[SR] Give VarStackNodeWrapper an iterator

### DIFF
--- a/aten/src/ATen/native/cpu/SerialStackImpl.h
+++ b/aten/src/ATen/native/cpu/SerialStackImpl.h
@@ -35,8 +35,7 @@ void stack_serial_kernel_impl(Tensor& result, TensorListType tensors, int64_t di
   int64_t ninputs = tensors.size();
   std::vector<InputMeta> inputs;
   inputs.reserve(ninputs);
-  for (const auto i : c10::irange(tensors.size())) {
-    auto& tensor = tensors[i];
+  for (const auto& tensor : tensors) {
     inputs.emplace_back(tensor, dim, tensor.strides()[dim]);
   }
 


### PR DESCRIPTION
Summary:
D32596934 made the serial stack implementation a bit brittle. It introduced a new container type: `VarStackNodeWrapper`. This type was used as a template parameter in the serial stack implementation.

The other type used in the serial stack implementation is `at::ArrayRef<at::Tensor>`. Ideally, the interface of `VarStackNodeWrapper` should be as close as possible to this other type. However, because the new container type did not have an iterator, expressions like this would fail to compile:
```
for (const auto& tensor : tensors) {
  // do something
}
```
Introducing this iterator will make the code easier to maintain going forward.

Test Plan:
`buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- Stack`

I consider this a `VarStack` implementation detail, so I'd prefer not to test it directly. We can test it implicitly by adding some code to the serial stack implementation that uses the iterator.

Differential Revision: D33101489

