### PR TITLE
Update onnxruntime.InferenceSession call to the latest version

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -99,7 +99,7 @@ def convert_to_onnx(model, input=None, opset_version=9, do_constant_folding=True
     # suppress ort warnings.
     # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
     so.log_severity_level = 3
-    ort_sess = onnxruntime.InferenceSession(f.getvalue(), so)
+    ort_sess = onnxruntime.InferenceSession(f.getvalue(), so, providers=onnxruntime.get_available_providers())
     return ort_sess
 
 
@@ -373,7 +373,9 @@ class TestONNXRuntime(unittest.TestCase):
                 # suppress ort warnings.
                 # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
                 ort_sess_opt.log_severity_level = 3
-                ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt)
+                ort_sess = onnxruntime.InferenceSession(model_file_name,
+                                                        sess_options=ort_sess_opt,
+                                                        providers=onnxruntime.get_available_providers())
                 input_copy = copy.deepcopy(input)
                 ort_outs = run_ort(ort_sess, input_copy)
                 ort_compare_with_pytorch(ort_outs, output, rtol, atol)


### PR DESCRIPTION
As of onnxruntime 1.9, `onnxruntime.InferenceSession` requires `providers` parameter to be specified.