### PR TITLE
[PyTorch] Add Enum to IValue Deepcopy

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -840,6 +840,13 @@ IValue IValue::deepcopy(
         copy = IValue(toObject()->deepcopy(memo));
       }
     } break;
+    case IValue::Tag::Enum: {
+      auto enum_holder = toEnumHolder();
+      copy = IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          enum_holder->type(),
+          enum_holder->name(),
+          enum_holder->value().deepcopy(memo)));
+    } break;
     case IValue::Tag::String:
     case IValue::Tag::None:
     case IValue::Tag::Double:

--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -260,6 +260,45 @@ TEST(ModuleAPITest, DeepCopyString) {
   ASSERT_EQ(copied.attr(attr1).toString()->string(), original_str);
 }
 
+TEST(ModuleAPITest, DeepCopyEnum) {
+  auto cu = std::make_shared<CompilationUnit>();
+  auto cls = ClassType::create("foo.bar", cu, true);
+  auto enum_attr = "enum_attr";
+  auto int_enum_type = EnumType::create(
+      "enum_class",
+      IntType::get(),
+      {{"enum_name_1", 1}, {"enum_name_2", 2}},
+      cu);
+  cls->addAttribute(enum_attr, int_enum_type);
+  Module m(cu, cls);
+  m.setattr(
+      enum_attr,
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          int_enum_type, "enum_name_1", 1)));
+  Module m2 = m.deepcopy();
+
+  // Make sure deepcopy works
+  c10::ivalue::EnumHolder* m2_holder = m2.attr(enum_attr).toEnumHolder().get();
+  ASSERT_EQ(m2_holder->value().toInt(), 1);
+  ASSERT_EQ(m2_holder->name(), "enum_name_1");
+  ASSERT_EQ(m2_holder->type(), int_enum_type);
+
+  // Test overlaps
+  ASSERT_TRUE(!IValue(m2._ivalue()).overlaps(IValue(m._ivalue())));
+
+  // Deepcopy will preserve the type
+  ASSERT_EQ(m.type(), m2.type());
+
+  // Change original, should not affect deepcopy
+  m.setattr(
+      enum_attr,
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          int_enum_type, "enum_name_2", 2)));
+  ASSERT_NE(
+      m.attr(enum_attr).toEnumHolder().get()->value().toInt(),
+      m2.attr(enum_attr).toEnumHolder().get()->value().toInt());
+}
+
 TEST(ModuleAPITest, DeepCopyPreservesAliasing) {
   // check deepcopy preserves aliasing
   auto cu = std::make_shared<CompilationUnit>();


### PR DESCRIPTION
Summary: This enables ```export_torch_mobile_model``` compatibility with Enum IValues

Test Plan: Modified ```DeepCopy``` test

Differential Revision: D33104681

