### PR TITLE
test: Do cuda version comparison when applicable

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -913,7 +913,7 @@ def get_selected_tests(options):
 
         # This is exception thats caused by this issue https://github.com/pytorch/pytorch/issues/69460
         # This below code should be removed once this issue is solved
-        if LooseVersion(torch.version.cuda) >= LooseVersion("11.5"):
+        if torch.version.cuda and LooseVersion(torch.version.cuda) >= LooseVersion("11.5"):
             WINDOWS_BLOCKLIST.append("test_cpp_extensions_aot")
             WINDOWS_BLOCKLIST.append("test_cpp_extensions_aot_ninja")
             WINDOWS_BLOCKLIST.append("test_cpp_extensions_aot_no_ninja")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #69940

torch.version.cuda has the potential to be None so we should only
attempt the version comparison when it's not None

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33109119](https://our.internmc.facebook.com/intern/diff/D33109119)