### PR TITLE
torchx/monitor: simplify event naming

### DIFF
--- a/test/cpp/monitor/test_counters.cpp
+++ b/test/cpp/monitor/test_counters.cpp
@@ -236,14 +236,13 @@ TEST(MonitorTest, IntervalStatEvent) {
 
   ASSERT_EQ(guard.handler->events.size(), 1);
   Event e = guard.handler->events.at(0);
-  ASSERT_EQ(e.type, "torch.monitor.Stat");
-  ASSERT_EQ(e.message, "a");
+  ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, metadata_value_t> metadata{
+  std::unordered_map<std::string, data_value_t> data{
       {"a.sum", 3L},
       {"a.count", 2L},
   };
-  ASSERT_EQ(e.metadata, metadata);
+  ASSERT_EQ(e.data, data);
 }
 
 TEST(MonitorTest, IntervalStatEventDestruction) {
@@ -262,14 +261,13 @@ TEST(MonitorTest, IntervalStatEventDestruction) {
   ASSERT_EQ(guard.handler->events.size(), 1);
 
   Event e = guard.handler->events.at(0);
-  ASSERT_EQ(e.type, "torch.monitor.Stat");
-  ASSERT_EQ(e.message, "a");
+  ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, metadata_value_t> metadata{
+  std::unordered_map<std::string, data_value_t> data{
       {"a.sum", 1L},
       {"a.count", 1L},
   };
-  ASSERT_EQ(e.metadata, metadata);
+  ASSERT_EQ(e.data, data);
 }
 
 TEST(MonitorTest, FixedCountStatEvent) {
@@ -293,14 +291,13 @@ TEST(MonitorTest, FixedCountStatEvent) {
   ASSERT_EQ(guard.handler->events.size(), 1);
 
   Event e = guard.handler->events.at(0);
-  ASSERT_EQ(e.type, "torch.monitor.Stat");
-  ASSERT_EQ(e.message, "a");
+  ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, metadata_value_t> metadata{
+  std::unordered_map<std::string, data_value_t> data{
       {"a.sum", 4L},
       {"a.count", 3L},
   };
-  ASSERT_EQ(e.metadata, metadata);
+  ASSERT_EQ(e.data, data);
 }
 
 TEST(MonitorTest, FixedCountStatEventDestruction) {
@@ -320,12 +317,11 @@ TEST(MonitorTest, FixedCountStatEventDestruction) {
   ASSERT_EQ(guard.handler->events.size(), 1);
 
   Event e = guard.handler->events.at(0);
-  ASSERT_EQ(e.type, "torch.monitor.Stat");
-  ASSERT_EQ(e.message, "a");
+  ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, metadata_value_t> metadata{
+  std::unordered_map<std::string, data_value_t> data{
       {"a.sum", 1L},
       {"a.count", 1L},
   };
-  ASSERT_EQ(e.metadata, metadata);
+  ASSERT_EQ(e.data, data);
 }

--- a/test/cpp/monitor/test_events.cpp
+++ b/test/cpp/monitor/test_events.cpp
@@ -14,13 +14,12 @@ struct AggregatingEventHandler : public EventHandler {
 
 TEST(EventsTest, EventHandler) {
   Event e;
-  e.type = "test";
-  e.message = "test message";
+  e.name = "test";
   e.timestamp = std::chrono::system_clock::now();
-  e.metadata["string"] = "asdf";
-  e.metadata["double"] = 1234.5678;
-  e.metadata["int"] = 1234L;
-  e.metadata["bool"] = true;
+  e.data["string"] = "asdf";
+  e.data["double"] = 1234.5678;
+  e.data["int"] = 1234L;
+  e.data["bool"] = true;
 
   // log to nothing
   logEvent(e);

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -52,19 +52,17 @@ class TestMonitor(TestCase):
 
     def test_log_event(self) -> None:
         e = Event(
-            type="torch.monitor.TestEvent",
-            message="a test event",
+            name="torch.monitor.TestEvent",
             timestamp=datetime.now(),
-            metadata={
+            data={
                 "str": "a string",
                 "float": 1234.0,
                 "int": 1234,
             },
         )
-        self.assertEqual(e.type, "torch.monitor.TestEvent")
-        self.assertEqual(e.message, "a test event")
+        self.assertEqual(e.name, "torch.monitor.TestEvent")
         self.assertIsNotNone(e.timestamp)
-        self.assertIsNotNone(e.metadata)
+        self.assertIsNotNone(e.data)
         log_event(e)
 
     def test_event_handler(self) -> None:
@@ -75,10 +73,9 @@ class TestMonitor(TestCase):
 
         handle = register_event_handler(handler)
         e = Event(
-            type="torch.monitor.TestEvent",
-            message="a test event",
+            name="torch.monitor.TestEvent",
             timestamp=datetime.now(),
-            metadata={},
+            data={},
         )
         log_event(e)
         self.assertEqual(len(events), 1)

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -1,0 +1,95 @@
+from torch.testing._internal.common_utils import (
+    TestCase, run_tests,
+)
+
+from datetime import timedelta, datetime
+import time
+
+from torch.monitor import (
+    Aggregation,
+    FixedCountStat,
+    IntervalStat,
+    Event,
+    log_event,
+    register_event_handler,
+    unregister_event_handler,
+)
+
+class TestMonitor(TestCase):
+    def test_interval_stat(self) -> None:
+        events = []
+
+        def handler(event):
+            events.append(event)
+
+        handle = register_event_handler(handler)
+        s = IntervalStat(
+            "asdf",
+            (Aggregation.SUM, Aggregation.COUNT),
+            timedelta(milliseconds=1),
+        )
+        s.add(2)
+        time.sleep(0.002)
+        s.add(3)
+        self.assertEqual(s.name, "asdf")
+        self.assertGreaterEqual(len(events), 1)
+        unregister_event_handler(handle)
+
+    def test_fixed_count_stat(self) -> None:
+        s = FixedCountStat(
+            "asdf",
+            (Aggregation.SUM, Aggregation.COUNT),
+            3,
+        )
+        s.add(1)
+        s.add(2)
+        name = s.name
+        self.assertEqual(name, "asdf")
+        self.assertEqual(s.count, 2)
+        s.add(3)
+        self.assertEqual(s.count, 0)
+        self.assertEqual(s.get(), {Aggregation.SUM: 6.0, Aggregation.COUNT: 3})
+
+    def test_log_event(self) -> None:
+        e = Event(
+            type="torch.monitor.TestEvent",
+            message="a test event",
+            timestamp=datetime.now(),
+            metadata={
+                "str": "a string",
+                "float": 1234.0,
+                "int": 1234,
+            },
+        )
+        self.assertEqual(e.type, "torch.monitor.TestEvent")
+        self.assertEqual(e.message, "a test event")
+        self.assertIsNotNone(e.timestamp)
+        self.assertIsNotNone(e.metadata)
+        log_event(e)
+
+    def test_event_handler(self) -> None:
+        events = []
+
+        def handler(event: Event) -> None:
+            events.append(event)
+
+        handle = register_event_handler(handler)
+        e = Event(
+            type="torch.monitor.TestEvent",
+            message="a test event",
+            timestamp=datetime.now(),
+            metadata={},
+        )
+        log_event(e)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0], e)
+        log_event(e)
+        self.assertEqual(len(events), 2)
+
+        unregister_event_handler(handle)
+        log_event(e)
+        self.assertEqual(len(events), 2)
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -847,6 +847,7 @@ libtorch_python_core_sources = [
     "torch/csrc/jit/python/python_tree_views.cpp",
     "torch/csrc/jit/runtime/static/init.cpp",
     "torch/csrc/jit/tensorexpr/tensorexpr_init.cpp",
+    "torch/csrc/monitor/python_init.cpp",
     "torch/csrc/multiprocessing/init.cpp",
     "torch/csrc/onnx/init.cpp",
     "torch/csrc/serialization.cpp",

--- a/torch/_C/_monitor.pyi
+++ b/torch/_C/_monitor.pyi
@@ -1,0 +1,52 @@
+# Defined in torch/csrc/monitor/python_init.cpp
+
+from typing import List, Dict, Callable
+from enum import Enum
+import datetime
+
+class Aggregation(Enum):
+    VALUE = ...
+    MEAN = ...
+    COUNT = ...
+    SUM = ...
+    MAX = ...
+    MIN = ...
+
+class Stat:
+    name: str
+    count: int
+    def add(self, v: float) -> None: ...
+    def get(self) -> Dict[Aggregation, float]: ...
+
+class IntervalStat(Stat):
+    def __init__(
+        self,
+        name: str,
+        aggregations: List[Aggregation],
+        window_size: datetime.timedelta,
+    ) -> None: ...
+
+class FixedCountStat(Stat):
+    def __init__(
+        self, name: str, aggregations: List[Aggregation], window_size: int
+    ) -> None: ...
+
+class Event:
+    type: str
+    message: str
+    timestamp: datetime.datetime
+    metadata: Dict[str, Union[int, float, bool, str]]
+    def __init__(
+        self,
+        type: str,
+        message: str,
+        timestamp: datetime.datetime,
+        metadata: Dict[str, Union[int, float, bool, str]],
+    ) -> None: ...
+
+def log_event(e: Event) -> None: ...
+
+class PythonEventHandler: ...
+
+def register_event_handler(handler: Callable[[Event], None]) -> PythonEventHandler: ...
+def unregister_event_handler(handle: PythonEventHandler) -> None: ...

--- a/torch/_C/_monitor.pyi
+++ b/torch/_C/_monitor.pyi
@@ -32,16 +32,14 @@ class FixedCountStat(Stat):
     ) -> None: ...
 
 class Event:
-    type: str
-    message: str
+    name: str
     timestamp: datetime.datetime
-    metadata: Dict[str, Union[int, float, bool, str]]
+    data: Dict[str, Union[int, float, bool, str]]
     def __init__(
         self,
-        type: str,
-        message: str,
+        name: str,
         timestamp: datetime.datetime,
-        metadata: Dict[str, Union[int, float, bool, str]],
+        data: Dict[str, Union[int, float, bool, str]],
     ) -> None: ...
 
 def log_event(e: Event) -> None: ...

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -61,6 +61,7 @@
 #include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/python/init.h>
 #include <torch/csrc/jit/python/python_ir.h>
+#include <torch/csrc/monitor/python_init.h>
 #include <torch/csrc/onnx/init.h>
 #include <torch/csrc/utils/init.h>
 #include <torch/csrc/utils/crash_handler.h>
@@ -832,6 +833,7 @@ PyObject* initModule() {
   // init.
   torch::onnx::initONNXBindings(module);
   torch::jit::initJITBindings(module);
+  torch::monitor::initMonitorBindings(module);
   torch::impl::dispatch::initDispatchBindings(module);
   torch::throughput_benchmark::initThroughputBenchmarkBindings(module);
   torch::crash_handler::initCrashHandlerBindings(module);

--- a/torch/csrc/monitor/counters.h
+++ b/torch/csrc/monitor/counters.h
@@ -152,18 +152,17 @@ class Stat {
     }
 
     Event e;
-    e.type = "torch.monitor.Stat";
-    e.message = name_;
+    e.name = "torch.monitor.Stat";
     e.timestamp = std::chrono::system_clock::now();
 
     auto stats = getLocked();
-    e.metadata.reserve(stats.size());
+    e.data.reserve(stats.size());
     for (auto& kv : stats) {
       std::stringstream key;
       key << name_;
       key << ".";
       key << aggregationName(kv.first);
-      e.metadata[key.str()] = kv.second;
+      e.data[key.str()] = kv.second;
     }
 
     logEvent(e);

--- a/torch/csrc/monitor/counters.h
+++ b/torch/csrc/monitor/counters.h
@@ -43,8 +43,8 @@ template <typename T>
 class Stat;
 
 namespace {
-inline std::bitset<NUM_AGGREGATIONS> merge(
-    std::initializer_list<Aggregation>& list) {
+template <typename T>
+inline std::bitset<NUM_AGGREGATIONS> merge(T& list) {
   std::bitset<NUM_AGGREGATIONS> a;
   for (Aggregation b : list) {
     a.set(b);
@@ -82,7 +82,7 @@ class Stat {
   };
 
  public:
-  Stat(std::string name, std::initializer_list<Aggregation> aggregations)
+  Stat(std::string name, std::vector<Aggregation> aggregations)
       : name_(std::move(name)), aggregations_(merge(aggregations)) {
     detail::registerStat(this);
   }
@@ -219,6 +219,12 @@ class IntervalStat : public Stat<T> {
       std::chrono::milliseconds windowSize)
       : Stat<T>(std::move(name), aggregations), windowSize_(windowSize) {}
 
+  IntervalStat(
+      std::string name,
+      std::vector<Aggregation> aggregations,
+      std::chrono::milliseconds windowSize)
+      : Stat<T>(std::move(name), aggregations), windowSize_(windowSize) {}
+
  protected:
   virtual uint64_t currentWindowId() const {
     auto now = std::chrono::steady_clock::now().time_since_epoch();
@@ -248,6 +254,12 @@ class FixedCountStat : public Stat<T> {
   FixedCountStat(
       std::string name,
       std::initializer_list<Aggregation> aggregations,
+      int64_t windowSize)
+      : Stat<T>(std::move(name), aggregations), windowSize_(windowSize) {}
+
+  FixedCountStat(
+      std::string name,
+      std::vector<Aggregation> aggregations,
       int64_t windowSize)
       : Stat<T>(std::move(name), aggregations), windowSize_(windowSize) {}
 

--- a/torch/csrc/monitor/events.h
+++ b/torch/csrc/monitor/events.h
@@ -9,38 +9,34 @@
 namespace torch {
 namespace monitor {
 
-// metadata_value_t is the type for Event metadata values.
-using metadata_value_t = c10::variant<std::string, double, int64_t, bool>;
+// data_value_t is the type for Event data values.
+using data_value_t = c10::variant<std::string, double, int64_t, bool>;
 
 // Event represents a single event that can be logged out to an external
 // tracker. This does acquire a lock on logging so should be used relatively
 // infrequently to avoid performance issues.
 struct Event {
-  // type is the type of the event. This is a static string that's used to
+  // name is the name of the event. This is a static string that's used to
   // differentiate between event types for programmatic access. The type should
   // be in the format of a fully qualified Python-style class name.
   // Ex: torch.monitor.MonitorEvent
-  std::string type;
-
-  // message is a human readable name. This is optional for machine intended
-  // stats.
-  std::string message;
+  std::string name;
 
   // timestamp is a timestamp relative to the Unix epoch time.
   std::chrono::system_clock::time_point timestamp;
 
-  // metadata contains rich information about the event. The contents are event
+  // data contains rich information about the event. The contents are event
   // specific so you should check the type to ensure it's what you expect before
-  // accessing the metadata.
+  // accessing the data.
   //
   // NOTE: these events are not versioned and it's up to the consumer of the
   // events to check the fields to ensure backwards compatibility.
-  std::unordered_map<std::string, metadata_value_t> metadata;
+  std::unordered_map<std::string, data_value_t> data;
 };
 
 inline bool operator==(const Event& lhs, const Event& rhs) {
-  return lhs.type == rhs.type && lhs.message == rhs.message &&
-      lhs.timestamp == rhs.timestamp && lhs.metadata == rhs.metadata;
+  return lhs.name == rhs.name && lhs.timestamp == rhs.timestamp &&
+      lhs.data == rhs.data;
 }
 
 // EventHandler represents an abstract event handler that can be registered to

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -14,9 +14,9 @@
 namespace pybind11 {
 namespace detail {
 template <>
-struct type_caster<torch::monitor::metadata_value_t> {
+struct type_caster<torch::monitor::data_value_t> {
  public:
-  PYBIND11_TYPE_CASTER(torch::monitor::metadata_value_t, _("metadata_value_t"));
+  PYBIND11_TYPE_CASTER(torch::monitor::data_value_t, _("data_value_t"));
 
   // Python -> C++
   bool load(handle src, bool) {
@@ -38,7 +38,7 @@ struct type_caster<torch::monitor::metadata_value_t> {
 
   // C++ -> Python
   static handle cast(
-      torch::monitor::metadata_value_t src,
+      torch::monitor::data_value_t src,
       return_value_policy /* policy */,
       handle /* parent */) {
     if (c10::holds_alternative<double>(src)) {
@@ -55,7 +55,7 @@ struct type_caster<torch::monitor::metadata_value_t> {
       std::string str = c10::get<std::string>(src);
       return PyUnicode_FromStringAndSize(str.data(), str.size());
     }
-    throw std::runtime_error("unknown metadata_value_t type");
+    throw std::runtime_error("unknown data_value_t type");
   }
 };
 } // namespace detail
@@ -110,35 +110,30 @@ void initMonitorBindings(PyObject* module) {
 
   py::class_<Event>(m, "Event")
       .def(
-          py::init(
-              [](const std::string& type,
-                 const std::string& message,
-                 std::chrono::system_clock::time_point timestamp,
-                 std::unordered_map<std::string, metadata_value_t> metadata) {
-                Event e;
-                e.type = type;
-                e.message = message;
-                e.timestamp = timestamp;
-                e.metadata = metadata;
-                return e;
-              }),
-          py::arg("type"),
-          py::arg("message"),
+          py::init([](const std::string& name,
+                      std::chrono::system_clock::time_point timestamp,
+                      std::unordered_map<std::string, data_value_t> data) {
+            Event e;
+            e.name = name;
+            e.timestamp = timestamp;
+            e.data = data;
+            return e;
+          }),
+          py::arg("name"),
           py::arg("timestamp"),
-          py::arg("metadata"))
-      .def_readwrite("type", &Event::type)
-      .def_readwrite("message", &Event::message)
+          py::arg("data"))
+      .def_readwrite("name", &Event::name)
       .def_readwrite("timestamp", &Event::timestamp)
-      .def_readwrite("metadata", &Event::metadata);
+      .def_readwrite("data", &Event::data);
 
   m.def("log_event", &logEvent);
 
-  py::class_<metadata_value_t> metadataClass(m, "metadata_value_t");
+  py::class_<data_value_t> dataClass(m, "data_value_t");
 
-  py::implicitly_convertible<std::string, metadata_value_t>();
-  py::implicitly_convertible<double, metadata_value_t>();
-  py::implicitly_convertible<int64_t, metadata_value_t>();
-  py::implicitly_convertible<bool, metadata_value_t>();
+  py::implicitly_convertible<std::string, data_value_t>();
+  py::implicitly_convertible<double, data_value_t>();
+  py::implicitly_convertible<int64_t, data_value_t>();
+  py::implicitly_convertible<bool, data_value_t>();
 
   py::class_<PythonEventHandler, std::shared_ptr<PythonEventHandler>>
       eventHandlerClass(m, "PythonEventHandler");

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -1,0 +1,158 @@
+#include <utility>
+
+#include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/utils/python_arg_parser.h>
+
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include <torch/csrc/monitor/counters.h>
+#include <torch/csrc/monitor/events.h>
+
+namespace pybind11 {
+namespace detail {
+template <>
+struct type_caster<torch::monitor::metadata_value_t> {
+ public:
+  PYBIND11_TYPE_CASTER(torch::monitor::metadata_value_t, _("metadata_value_t"));
+
+  // Python -> C++
+  bool load(handle src, bool) {
+    PyObject* source = src.ptr();
+    if (PyLong_Check(source)) {
+      this->value = PyLong_AsLong(source);
+    } else if (PyFloat_Check(source)) {
+      this->value = PyFloat_AsDouble(source);
+    } else if (PyUnicode_Check(source)) {
+      this->value =
+          std::string(reinterpret_cast<char*>(PyUnicode_1BYTE_DATA(source)));
+    } else if (PyBool_Check(source)) {
+      this->value = source == Py_True;
+    } else {
+      return false;
+    }
+    return !PyErr_Occurred();
+  }
+
+  // C++ -> Python
+  static handle cast(
+      torch::monitor::metadata_value_t src,
+      return_value_policy /* policy */,
+      handle /* parent */) {
+    if (c10::holds_alternative<double>(src)) {
+      return PyFloat_FromDouble(c10::get<double>(src));
+    } else if (c10::holds_alternative<int64_t>(src)) {
+      return PyLong_FromLong(c10::get<int64_t>(src));
+    } else if (c10::holds_alternative<bool>(src)) {
+      if (c10::get<bool>(src)) {
+        Py_RETURN_TRUE;
+      } else {
+        Py_RETURN_FALSE;
+      }
+    } else if (c10::holds_alternative<std::string>(src)) {
+      std::string str = c10::get<std::string>(src);
+      return PyUnicode_FromStringAndSize(str.data(), str.size());
+    }
+    throw std::runtime_error("unknown metadata_value_t type");
+  }
+};
+} // namespace detail
+} // namespace pybind11
+
+namespace torch {
+namespace monitor {
+
+namespace {
+class PythonEventHandler : public EventHandler {
+ public:
+  explicit PythonEventHandler(std::function<void(const Event&)> handler)
+      : handler_(std::move(handler)) {}
+
+  void handle(const Event& e) override {
+    handler_(e);
+  }
+
+ private:
+  std::function<void(const Event&)> handler_;
+};
+} // namespace
+
+void initMonitorBindings(PyObject* module) {
+  auto rootModule = py::handle(module).cast<py::module>();
+
+  auto m = rootModule.def_submodule("_monitor");
+
+  py::enum_<Aggregation>(m, "Aggregation")
+      .value("VALUE", Aggregation::NONE)
+      .value("MEAN", Aggregation::MEAN)
+      .value("COUNT", Aggregation::COUNT)
+      .value("SUM", Aggregation::SUM)
+      .value("MAX", Aggregation::MAX)
+      .value("MIN", Aggregation::MIN)
+      .export_values();
+
+  py::class_<Stat<double>>(m, "Stat")
+      .def("add", &Stat<double>::add)
+      .def("get", &Stat<double>::get)
+      .def_property_readonly("name", &Stat<double>::name)
+      .def_property_readonly("count", &Stat<double>::count);
+
+  py::class_<IntervalStat<double>, Stat<double>>(m, "IntervalStat")
+      .def(py::init<
+           std::string,
+           std::vector<Aggregation>,
+           std::chrono::milliseconds>());
+
+  py::class_<FixedCountStat<double>, Stat<double>>(m, "FixedCountStat")
+      .def(py::init<std::string, std::vector<Aggregation>, int64_t>());
+
+  py::class_<Event>(m, "Event")
+      .def(
+          py::init(
+              [](const std::string& type,
+                 const std::string& message,
+                 std::chrono::system_clock::time_point timestamp,
+                 std::unordered_map<std::string, metadata_value_t> metadata) {
+                Event e;
+                e.type = type;
+                e.message = message;
+                e.timestamp = timestamp;
+                e.metadata = metadata;
+                return e;
+              }),
+          py::arg("type"),
+          py::arg("message"),
+          py::arg("timestamp"),
+          py::arg("metadata"))
+      .def_readwrite("type", &Event::type)
+      .def_readwrite("message", &Event::message)
+      .def_readwrite("timestamp", &Event::timestamp)
+      .def_readwrite("metadata", &Event::metadata);
+
+  m.def("log_event", &logEvent);
+
+  py::class_<metadata_value_t> metadataClass(m, "metadata_value_t");
+
+  py::implicitly_convertible<std::string, metadata_value_t>();
+  py::implicitly_convertible<double, metadata_value_t>();
+  py::implicitly_convertible<int64_t, metadata_value_t>();
+  py::implicitly_convertible<bool, metadata_value_t>();
+
+  py::class_<PythonEventHandler, std::shared_ptr<PythonEventHandler>>
+      eventHandlerClass(m, "PythonEventHandler");
+  m.def("register_event_handler", [](std::function<void(const Event&)> f) {
+    auto handler = std::make_shared<PythonEventHandler>(f);
+    registerEventHandler(handler);
+    return handler;
+  });
+  m.def(
+      "unregister_event_handler",
+      [](std::shared_ptr<PythonEventHandler> handler) {
+        unregisterEventHandler(handler);
+      });
+}
+
+} // namespace monitor
+} // namespace torch

--- a/torch/csrc/monitor/python_init.h
+++ b/torch/csrc/monitor/python_init.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torch/csrc/utils/pybind.h>
+
+namespace torch {
+namespace monitor {
+
+void initMonitorBindings(PyObject* module);
+
+}
+} // namespace torch

--- a/torch/monitor/__init__.py
+++ b/torch/monitor/__init__.py
@@ -1,0 +1,1 @@
+from torch._C._monitor import *  # noqa: F403


### PR DESCRIPTION
Summary: This cleans up the naming for events. type is now name, message is gone, and metadata is renamed data.

Test Plan: https://www.internalfb.com/intern/testinfra/testconsole/testrun/7318349461027367/

Reviewed By: kiukchung

Differential Revision: D32969391

