### PR TITLE
Add mkl implementation for exponential on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -115,8 +115,7 @@ void exponential_kernel(TensorIteratorBase& iter, double lambda, c10::optional<G
 #else
 void exponential_kernel(TensorIteratorBase &iter, double lambda, c10::optional<Generator> gen) {
   Tensor self = iter.tensor(0);
-  if (lambda > 0 && !std::isinf(lambda) && !std::isnan(lambda) && cpuinfo_initialize() &&
-      cpuinfo_vendor_intel == cpuinfo_get_processor(0)->core->vendor) {
+  if (lambda > 0 && !std::isinf(lambda) && !std::isnan(lambda)) {
     CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
     int64_t seed;
     {
@@ -179,7 +178,7 @@ void exponential_kernel(TensorIteratorBase &iter, double lambda, c10::optional<G
       }
     });
   } else {
-    // The situation of AMD, move to using the default version
+    // The situation of inf and nan, move to using the default version
     exponential_kernel_default(iter, lambda, gen);
   }
 }

--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -103,10 +103,87 @@ void bernoulli_scalar_kernel(const TensorBase &self, double p, c10::optional<Gen
 }
 #endif
 
-static void exponential_kernel(TensorIteratorBase& iter, double lambda, c10::optional<Generator> gen) {
+static void exponential_kernel_default(TensorIteratorBase& iter, double lambda, c10::optional<Generator> gen) {
   CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
   templates::cpu::exponential_kernel(iter, lambda, generator);
 }
+
+#if !AT_MKL_ENABLED()
+void exponential_kernel(TensorIteratorBase& iter, double lambda, c10::optional<Generator> gen) {
+  exponential_kernel_default(iter, lambda, gen);
+}
+#else
+void exponential_kernel(TensorIteratorBase &iter, double lambda, c10::optional<Generator> gen) {
+  Tensor self = iter.tensor(0);
+  if (lambda > 0 && !std::isinf(lambda) && !std::isnan(lambda) && cpuinfo_initialize() &&
+      cpuinfo_vendor_intel == cpuinfo_get_processor(0)->core->vendor) {
+    CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
+    int64_t seed;
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(generator->mutex_);
+      if (self.scalar_type() == at::kDouble)
+        seed = generator->random64();
+      else
+        seed = generator->random();
+    }
+    int64_t n = self.numel();
+    bool contig = self.is_contiguous();
+
+    AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "exponential_cpu", [&] {
+      at::Tensor tmp_tensor;
+      constexpr bool is_df = std::is_same<scalar_t, float>::value || std::is_same<scalar_t, double>::value;
+      if (is_df && contig) {
+        tmp_tensor = self;
+      } else if (std::is_same<scalar_t, double>::value) {
+        tmp_tensor = at::empty(self.sizes(), self.options().dtype(at::kDouble));
+      } else {
+        tmp_tensor = at::empty(self.sizes(), self.options().dtype(at::kFloat));
+      }
+
+      scalar_t *self_ptr = self.data_ptr<scalar_t>();
+      using tmp_scalar_t = typename std::conditional_t<std::is_same<scalar_t, double>::value, double, float>;
+      tmp_scalar_t *sample_ptr = tmp_tensor.data_ptr<tmp_scalar_t>();
+
+      auto sample = [&](int64_t begin, int64_t end) {
+        int64_t len = end - begin;
+        if (len > 0) {
+          VSLStreamStatePtr stream;
+          if (std::is_same<scalar_t, double>::value) {
+            vslNewStream(&stream, VSL_BRNG_MCG31, seed);
+            vslSkipAheadStream(stream, begin);
+            vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF, stream, len,
+              (double *)(sample_ptr + begin), 0, 1./lambda);
+            vslDeleteStream(&stream);
+          } else {
+            vslNewStream(&stream, VSL_BRNG_MCG31, seed);
+            vslSkipAheadStream(stream, begin);
+            vsRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF, stream, len,
+              (float *) (sample_ptr + begin), 0, 1./lambda);
+            vslDeleteStream(&stream);
+          }
+          // vectorized copy if using buffer and contiguous
+          if (!is_df && contig) {
+            scalar_t *self_seg = self_ptr + begin;
+            tmp_scalar_t *tmp_seg = sample_ptr + begin;
+            at::vec::convert<tmp_scalar_t, scalar_t>(tmp_seg, self_seg, len);
+          }
+        }
+      };
+
+      parallel_for(0, n, /* grain_size= */ 800, sample);
+
+      // copy_ if using buffer and non contiguous
+      if (!contig) {
+        self.copy_(tmp_tensor);
+      }
+    });
+  } else {
+    // The situation of AMD, move to using the default version
+    exponential_kernel_default(iter, lambda, gen);
+  }
+}
+#endif
 
 static void geometric_kernel(TensorIteratorBase& iter, double p, c10::optional<Generator> gen) {
   CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2413,12 +2413,12 @@ class TestDistributions(DistributionsTestCase):
 
         def mean_var(lambd, sample):
             sample.exponential_(lambd)
-            mean = sample.mean()
-            var = sample.var()
-            self.assertEqual((1. / lambd), mean, atol=1e-2, rtol=1e-2)
-            self.assertEqual((1. / lambd) ** 2, var, atol=2e-2, rtol=1e-2)
+            mean = sample.float().mean()
+            var = sample.float().var()
+            self.assertEqual((1. / lambd), mean, atol=2e-2, rtol=2e-2)
+            self.assertEqual((1. / lambd) ** 2, var, atol=2e-2, rtol=2e-2)
 
-        for dtype in [torch.float, torch.double]:
+        for dtype in [torch.float, torch.double, torch.bfloat16, torch.float16]:
             for lambd in [0.2, 0.5, 1., 1.5, 2., 5.]:
                 sample_len = 50000
                 mean_var(lambd, torch.rand(sample_len, dtype=dtype))

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2411,6 +2411,18 @@ class TestDistributions(DistributionsTestCase):
         self._check_log_prob(Exponential(rate), ref_log_prob)
         self._check_forward_ad(lambda x: x.exponential_())
 
+        def mean_var(lambd, sample):
+            sample.exponential_(lambd)
+            mean = sample.mean()
+            var = sample.var()
+            self.assertEqual((1. / lambd), mean, atol=1e-2, rtol=1e-2)
+            self.assertEqual((1. / lambd) ** 2, var, atol=2e-2, rtol=1e-2)
+
+        for dtype in [torch.float, torch.double]:
+            for lambd in [0.2, 0.5, 1., 1.5, 2., 5.]:
+                sample_len = 50000
+                mean_var(lambd, torch.rand(sample_len, dtype=dtype))
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_exponential_sample(self):
         set_rng_seed(1)  # see Note [Randomized statistical tests]

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -5063,7 +5063,10 @@ class TestJit(DistributionsTestCase):
             xfail = [
                 Cauchy,  # aten::cauchy(Double(2,1), float, float, Generator)
                 HalfCauchy,  # aten::cauchy(Double(2, 1), float, float, Generator)
-                VonMises  # Variance is not Euclidean
+                VonMises,  # Variance is not Euclidean
+                Exponential,  # mkl implementation path on intel cpu will produce diffrent results from jit.trace
+                Pareto,  # base_distribution is Exponential
+                Weibull  # base_distribution is Exponential
             ]
             if Dist in xfail:
                 continue
@@ -5094,6 +5097,9 @@ class TestJit(DistributionsTestCase):
             xfail = [
                 Cauchy,  # aten::cauchy(Double(2,1), float, float, Generator)
                 HalfCauchy,  # aten::cauchy(Double(2, 1), float, float, Generator)
+                Exponential,  # mkl implementation path on intel cpu will produce diffrent results from jit.trace
+                Pareto,  # base_distribution is Exponential
+                Weibull  # base_distribution is Exponential
             ]
             if Dist in xfail:
                 continue

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -5075,10 +5075,7 @@ class TestJit(DistributionsTestCase):
             xfail = [
                 Cauchy,  # aten::cauchy(Double(2,1), float, float, Generator)
                 HalfCauchy,  # aten::cauchy(Double(2, 1), float, float, Generator)
-                VonMises,  # Variance is not Euclidean
-                Exponential,  # mkl implementation path on intel cpu will produce diffrent results from jit.trace
-                Pareto,  # base_distribution is Exponential
-                Weibull  # base_distribution is Exponential
+                VonMises  # Variance is not Euclidean
             ]
             if Dist in xfail:
                 continue
@@ -5109,9 +5106,6 @@ class TestJit(DistributionsTestCase):
             xfail = [
                 Cauchy,  # aten::cauchy(Double(2,1), float, float, Generator)
                 HalfCauchy,  # aten::cauchy(Double(2, 1), float, float, Generator)
-                Exponential,  # mkl implementation path on intel cpu will produce diffrent results from jit.trace
-                Pareto,  # base_distribution is Exponential
-                Weibull  # base_distribution is Exponential
             ]
             if Dist in xfail:
                 continue

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -57,10 +57,6 @@ class Exponential(ExponentialFamily):
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        if torch._C._get_tracing_state():
-            # [JIT WORKAROUND] lack of support for ._exponential()
-            u = torch.rand(shape, dtype=self.rate.dtype, device=self.rate.device)
-            return -(-u).log1p() / self.rate
         return self.rate.new(shape).exponential_() / self.rate
 
     def log_prob(self, value):


### PR DESCRIPTION
### Description
Add mkl implementation for exponential on CPU to improve the performance of exponential.

### Testing
data type: float32 
single socket (28cores):
```
before: torch.Size([10, 128, 10, 124])  0.065 s
        torch.Size([10, 128, 20, 124])  0.130 s
            
after:  torch.Size([10, 128, 10, 124])  5.9e-05 s
        torch.Size([10, 128, 20, 124])  0.000113 s
```
single core:
```
before: torch.Size([10, 128, 10, 124])  0.065 s
        torch.Size([10, 128, 20, 124])  0.130 s 

after:  torch.Size([10, 128, 10, 124])  0.00117 s
        torch.Size([10, 128, 20, 124])  0.002347 s
```

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10