### PR TITLE
HANDLE_TH_ERRORS: Move exception translation out of line

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -139,6 +139,15 @@ static std::string formatMessage(const char *format, va_list fmt_args) {
   return std::string(error_buf);
 }
 
+void translate_exception_to_python(const std::exception_ptr &e_ptr) {
+  try {
+    TORCH_INTERNAL_ASSERT(e_ptr, "translate_exception_to_python "
+                          "called with invalid exception pointer");
+    std::rethrow_exception(e_ptr);
+  }
+  CATCH_ALL_ERRORS(return)
+}
+
 IndexError::IndexError(const char *format, ...) {
   va_list fmt_args;
   va_start(fmt_args, format);


### PR DESCRIPTION
I've noticed that the `HANDLE_TH_ERRORS` macros are actually very expensive in terms of compile time.  Moving the bulk of the catch statements out of line using a lippincott function significantly improves compile times and object file binary sizes. For just the generated autograd bindings, this halves serial build time from 8 minutes to 4 and binary size is more than halved for most files with the biggest difference being `python_variable_methods.cpp` which went from 126 MB to 43 MB.