### PR TITLE
Expand composite compliance tests

### DIFF
--- a/torch/testing/_internal/composite_compliance.py
+++ b/torch/testing/_internal/composite_compliance.py
@@ -184,6 +184,10 @@ def _check_composite_compliance(op, args, kwargs):
     args = tree_map(wrap, args)
     kwargs = tree_map(wrap, kwargs)
     try:
+        # Yes, we want to run once with python mode and once without.
+        # The run without python mode catches problems where we do things like:
+        # torch.zeros(blah).in_place_(tensor_subclass):
+        op(*args, **kwargs)
         with enable_python_mode(CompositeCompliantTensor):
             op(*args, **kwargs)
     except RuntimeError as err:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#69990 Expand composite compliance tests**

This PR expands the composite compliance to catch Tensor-subclass-incompatible
operations.

Certain in-place operations can eliminate the typing of the Tensor
subclass. For example:
>>> torch.zeros(input.sizes(), grad.options()).diag().copy_(input)

We want operator writers to either:
(1) Avoid writing code like this
(2) Put code like this into a fast-path and guard the common case (the
slow path) with areAnyTensorSubclassLike checks.

To test for this, we run composite compliance without python mode.

Test Plan:
- run tests