### PR TITLE
[Static Runtime] Support native op split_with_sizes

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -2201,6 +2201,21 @@ TEST(StaticRuntime, Split) {
   testStaticRuntime(src, {a, 2, -1}, {b, 2, 2});
 }
 
+TEST(StaticRuntime, SplitWithSizes) {
+  const auto src = R"JIT(
+    def forward(self, inp, split_sizes: List[int], dim: int):
+        return inp.split(split_sizes, dim)
+  )JIT";
+
+  const auto a = at::randn({2, 2});
+  const auto b = at::randn({2, 2, 2});
+  const auto split_sizes = c10::List<int64_t>{1, 1};
+
+  testStaticRuntime(src, {a, split_sizes, 0});
+  testStaticRuntime(src, {a, split_sizes, 1});
+  testStaticRuntime(src, {a, split_sizes, -1}, {b, split_sizes, 2});
+}
+
 namespace {
 
 void maybe_throw(bool should_throw) {

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -549,19 +549,48 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
     });
 
 REGISTER_NATIVE_OPERATOR_FUNCTOR(aten::split, aten_split, [](Node* n) -> SROperator {
-  if (!n->matches(torch::schema(
+  if (n->matches(torch::schema(
           "aten::split(Tensor(a -> *) self, int split_size, int dim=0) -> Tensor(a)[]"))) {
-    LogAndDumpSchema(n);
-    return nullptr;
+    return [](ProcessedNode* p_node) {
+      const auto& self = p_node->Input(0).toTensor();
+      const auto split_size = p_node->Input(1).toInt();
+      const auto dim = p_node->Input(2).toInt();
+      p_node->Output(0) = at::native::split(self, split_size, dim);
+    };
   }
 
-  return [](ProcessedNode* p_node) {
-    const auto& self = p_node->Input(0).toTensor();
-    const auto split_size = p_node->Input(1).toInt();
-    const auto dim = p_node->Input(2).toInt();
-    p_node->Output(0) = at::native::split(self, split_size, dim);
-  };
+  if (n->matches(torch::schema(
+          "aten::split(Tensor(a -> *) self, int[] split_sizes, int dim=0) -> (Tensor[])"))) {
+    return [](ProcessedNode* p_node) {
+      const auto& self = p_node->Input(0).toTensor();
+      const auto& split_sizes = p_node->Input(1).toIntList();
+      const auto dim = p_node->Input(2).toInt();
+      p_node->Output(0) =
+          at::native::split_with_sizes(self, split_sizes.vec(), dim);
+    };
+  }
+
+  LogAndDumpSchema(n);
+  return nullptr;
 });
+
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    aten::split_with_sizes,
+    aten_split_with_sizes,
+    [](Node* n) -> SROperator {
+      if (!n->matches(torch::schema(
+              "aten::split_with_sizes(Tensor(a -> *) self, int[] split_sizes, int dim=0) -> Tensor(a)[]"))) {
+        LogAndDumpSchema(n);
+        return nullptr;
+      }
+
+      return [](ProcessedNode* p_node) {
+        const auto& self = p_node->Input(0).toTensor();
+        const auto split_size = p_node->Input(1).toInt();
+        const auto dim = p_node->Input(2).toInt();
+        p_node->Output(0) = at::native::split(self, split_size, dim);
+      };
+    });
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
This adds support for the split_with_sizes operator in static runtime by adding native operators. Those operators will have less overhead comparing to their JIT fallbacks (no dispatching, no stack constructing in runtime).

split_with_sizes can be called directly from cpp API, or in `torch.split`  when `split_sizes` is a list. This diff adds support for both use cases.

Test Plan:
- Added unit tests. Made sure the operators are used
- Benchmark
```
./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench \
--scripted_model=/data/users/dxd/305797439_0.predictor.precompute.remote_request_only \
--method_name=user.forward --pt_cleanup_activations=1 \
--pt_enable_out_variant=1 --pt_optimize_memory=1 --iters=1000 --warmup_iters=500 \
--num_threads=1 --pt_enable_static_runtime=1 --set_compatibility=1 \
--input_type="recordio" --pt_inputs=/data/users/dxd/305797439_0_user.inputs.recordio \
--recordio_use_ivalue_format=1 --do_profile=1 --do_benchmark=1
```

#### Before
```
Static runtime ms per iter: 3.62073. Iters per second: 276.187
0.0471904 ms.    1.31501%. aten::split_with_sizes (5 nodes)
```
#### After
```
Static runtime ms per iter: 3.36062. Iters per second: 297.564
0.0444289 ms.    1.37531%. aten::split_with_sizes (5 nodes)
```

Differential Revision: D33141006

