### PR TITLE
[LTC] Skip even more tests for lazy_bench.py

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -51,6 +51,10 @@ SKIP_TRAIN_ONLY = {
     "hf_BigBird",
     "pyhpc_equation_of_state",
     "pyhpc_isoneutral_mixing",
+    "densenet121",
+    "resnet50_quantized_qat",
+    "Background_Matting",
+    "hf_Bart",
 }
 
 current_name = ""


### PR DESCRIPTION
Summary:
Skip even more tests for lazy_bench.py that cause out of memory.

Test:
CI.

