### PR TITLE
[reland][quant][fx][graphmode] Add support for conv add pattern in backend_config_dict

### DIFF
--- a/torch/ao/quantization/fx/_convert_do_not_use.py
+++ b/torch/ao/quantization/fx/_convert_do_not_use.py
@@ -15,9 +15,6 @@ from ..utils import (
 )
 from .backend_config_dict.utils import get_quantized_reference_module_mapping
 
-from .match_utils import (
-    find_matches,
-)
 from .graph_module import (
     QuantizedGraphModule,
 )
@@ -103,10 +100,6 @@ def _convert_do_not_use(
     custom_module_classes = get_custom_module_class_keys(
         convert_custom_config_dict,
         "observed_to_quantized_custom_module_class")
-    matches = find_matches(
-        model.graph, modules, patterns,
-        qconfig_map,
-        custom_module_classes=custom_module_classes)
 
     if model._equalization_qconfig_map is not None:
         # If we want to do equalization then do the following:

--- a/torch/ao/quantization/fx/backend_config_dict/fuse_handler.py
+++ b/torch/ao/quantization/fx/backend_config_dict/fuse_handler.py
@@ -1,5 +1,5 @@
 from ..fusion_patterns import DefaultFuseHandler
 
-# TODO: move ModuleReLUFusion here
+# TODO: move DefaultFuseHandler
 def get_fuse_handler_cls():
     return DefaultFuseHandler

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -174,8 +174,10 @@ def is_pattern_dtype_config_supported_by_backend(
     pattern_to_dtype_configs = get_pattern_to_dtype_configs(backend_config_dict)
     dtype_configs: List[Dict[str, torch.dtype]] = pattern_to_dtype_configs.get(pattern, [])
 
-    input_node = matched_nodes[0]
-    output_node = matched_nodes[-1]
+    # TODO: this only checks one input and one output, need to generalize to multiple
+    # inputs/output
+    input_node = matched_nodes[-1]
+    output_node = matched_nodes[0]
     for dtype_config in dtype_configs:
         # check if arg dtype are supported
         supported = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70007
* #70006

Summary:

This PR extends fusion pattern support from simple sequence of ops to a simple
subgraph like conv - add
```
x - conv ---\
y ---------add ---- ouptut
```
where input x, y and output are observed/quantized

Test Plan:
```
python test/fx2trt/test_quant_trt.py TestQuantizeFxTRTOps.test_conv_add
```

Imported from OSS

Reviewed By: vkuzo

Differential Revision: [D33144605](https://our.internmc.facebook.com/intern/diff/D33144605)