### PR TITLE
Added AutocastCPU string

### DIFF
--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -125,7 +125,7 @@ const char* toString(DispatchKey t) {
     case DispatchKey::Tracer:
       return "Tracer";
 
-    // Note: AutocastCUDA and Autocast are the same, currently. 
+    // Note: AutocastCUDA and Autocast are the same, currently.
     // See comments in DispatchKey.h
     case DispatchKey::Autocast:
       return "Autocast";

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -125,6 +125,8 @@ const char* toString(DispatchKey t) {
     case DispatchKey::Tracer:
       return "Tracer";
 
+    // Note: AutocastCUDA and Autocast are the same, currently. 
+    // See comments in DispatchKey.h
     case DispatchKey::Autocast:
       return "Autocast";
 

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -128,6 +128,9 @@ const char* toString(DispatchKey t) {
     case DispatchKey::Autocast:
       return "Autocast";
 
+    case DispatchKey::AutocastCPU:
+      return "AutocastCPU";
+
     case DispatchKey::Batched:
       return "Batched";
 


### PR DESCRIPTION
Description:
- Added "AutocastCPU" string repr into `toString` method

Before
```
std::cout << c10::DispatchKey::AutocastCPU;
> UNKNOWN_TENSOR_TYPE_ID
```
and now:
```
std::cout << c10::DispatchKey::AutocastCPU;
> AutocastCPU
```