### PR TITLE
[LTC] Code-gen nll_loss2d_forward

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -349,6 +349,24 @@ std::vector<Shape> compute_shape_log_sigmoid_backward(const at::Tensor& grad_out
   return {Shape(grad_output.scalar_type(), grad_output.sizes().vec())};
 }
 
+std::vector<Shape> compute_shape_nll_loss2d_forward(
+    const at::Tensor& self, const at::Tensor& target,
+    const c10::optional<at::Tensor>& weight, int64_t reduction,
+    int64_t ignore_index) {
+  // Based on definition of aten/src/ATen/native/LossNLL2d.cpp:nll_loss2d_forward_cpu
+  const std::vector<int64_t>& sizes =
+      (reduction == at::Reduction::Reduction::None ? target.sizes().vec()
+                                                   : std::vector<int64_t>({}));
+  return {Shape(self.scalar_type(), sizes), Shape(self.scalar_type(), {})};
+}
+
+std::vector<Shape> compute_shape_nll_loss2d_backward(
+    const at::Tensor& grad_output, const at::Tensor& self,
+    const at::Tensor& target, const c10::optional<at::Tensor>& weight,
+    int64_t reduction, int64_t ignore_index, const at::Tensor& total_weight) {
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
 } // namespace ops
 } // namespace ir
 } // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -354,7 +354,7 @@ std::vector<Shape> compute_shape_nll_loss2d_forward(
     const c10::optional<at::Tensor>& weight, int64_t reduction,
     int64_t ignore_index) {
   // Based on definition of aten/src/ATen/native/LossNLL2d.cpp:nll_loss2d_forward_cpu
-  const auto sizes =
+  auto sizes =
       (reduction == at::Reduction::Reduction::None ? target.sizes().vec()
                                                    : std::vector<int64_t>{});
   return {Shape(self.scalar_type(), sizes), Shape(self.scalar_type(), {})};

--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -354,9 +354,9 @@ std::vector<Shape> compute_shape_nll_loss2d_forward(
     const c10::optional<at::Tensor>& weight, int64_t reduction,
     int64_t ignore_index) {
   // Based on definition of aten/src/ATen/native/LossNLL2d.cpp:nll_loss2d_forward_cpu
-  const std::vector<int64_t>& sizes =
+  const auto sizes =
       (reduction == at::Reduction::Reduction::None ? target.sizes().vec()
-                                                   : std::vector<int64_t>({}));
+                                                   : std::vector<int64_t>{});
   return {Shape(self.scalar_type(), sizes), Shape(self.scalar_type(), {})};
 }
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -67,6 +67,8 @@ full_codegen:
   - ne.Tensor
   - nll_loss_backward
   - nll_loss_forward
+  - nll_loss2d_backward
+  - nll_loss2d_forward
   - pow.Tensor_Scalar
   - pow.Tensor_Tensor
   - relu


### PR DESCRIPTION
Summary:
Code-gen nll_loss2d_forward

Test:
```
lazy_tensor_core/test/cpp/build/test_ptltc
```

Also:
```python
import torch
import lazy_tensor_core
import lazy_tensor_core.debug.metrics

lazy_tensor_core._LAZYC._ltc_init_ts_backend()
device = 'lazy'

inp = torch.rand((3, 3, 100, 100), device=device)
target = torch.zeros((3, 100, 100), dtype=torch.long, device=device)

print(torch.nn.functional.nll_loss(inp, target))
print(lazy_tensor_core.debug.metrics.metrics_report())
```

Outputs:
```
...
Counter: lazy::nll_loss2d_forward
  Value: 1
...
```

Fixes #65576
