### PR TITLE
[quant] don't print affine/symmetric qscheme for qtensor

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -364,12 +364,13 @@ def _str_intern(inp):
         suffixes.append('size=' + str(tuple(self.shape)))
         if not has_default_dtype:
             suffixes.append('dtype=' + str(self.dtype))
-        suffixes.append('quantization_scheme=' + str(self.qscheme()))
         if self.qscheme() == torch.per_tensor_affine or self.qscheme() == torch.per_tensor_symmetric:
+            suffixes.append('quantization_scheme=per_tensor')
             suffixes.append('scale=' + str(self.q_scale()))
             suffixes.append('zero_point=' + str(self.q_zero_point()))
         elif self.qscheme() == torch.per_channel_affine or self.qscheme() == torch.per_channel_symmetric \
                 or self.qscheme() == torch.per_channel_affine_float_qparams:
+            suffixes.append('quantization_scheme=per_channel')
             suffixes.append('scale=' + str(self.q_per_channel_scales()))
             suffixes.append('zero_point=' + str(self.q_per_channel_zero_points()))
             suffixes.append('axis=' + str(self.q_per_channel_axis()))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70020

Summary:
We don't accept the qscheme information when we call `quantize_per_tensor` so printing per_tensor_affine in the qscheme is a bit misleading to the users.

In the future we could consider storing the qscheme with the tensor and accept it for quantize_per_tensor

As discussed in https://github.com/pytorch/pytorch/issues/51152

Test Plan:
```
>>> import torch
>>> x = torch.rand(2, 2)
>>> qx = torch.quantize_per_tensor(x, 1.0, 0, torch.quint8)
>>> qx
tensor([[1., 1.],
        [1., 1.]], size=(2, 2), dtype=torch.quint8,
       quantization_scheme=per_tensor, scale=1.0, zero_point=0)
```

Reviewers:

Subscribers:

Tasks:

Tags: