### PR TITLE
[fusion] Add ConvTranspose+BN fusion support

### DIFF
--- a/test/quantization/eager/test_fuse_eager.py
+++ b/test/quantization/eager/test_fuse_eager.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_quantization import (
     ModelWithSequentialFusion,
     ModelForLinearBNFusion,
     ModelForFusionWithBias,
+    ModelForConvTransposeBNFusion,
     test_only_eval_fn,
     test_only_train_fn,
     skipIfNoFBGEMM,
@@ -329,6 +330,23 @@ class TestFuseEager(QuantizationTestCase):
 
         model = fuse_modules(model, [["fc", "bn"]])
         self.assertEqual(type(model.bn), nn.Identity)
+        self.assertEqual(golden, model(inp2))
+
+    def test_fusion_convtranspose_bn_eval(self):
+        model = ModelForConvTransposeBNFusion().train()
+        inp1 = torch.randn(8, 3, 16)
+        inp2 = torch.randn(8, 3, 16)
+
+        # Get some interesting values into the running mean and variance.
+        model(inp1)
+        model.eval()
+        golden = model(inp2)
+
+        model = fuse_modules(model, [["conv1", "bn1"], ["conv2", "bn2"], ["conv3", "bn3"]])
+        self.assertEqual(type(model.bn1), nn.Identity)
+        self.assertEqual(type(model.bn2), nn.Identity)
+        self.assertEqual(type(model.bn3), nn.Identity)
+
         self.assertEqual(golden, model(inp2))
 
     def test_forward_hooks_preserved(self):

--- a/torch/ao/quantization/fuser_method_mappings.py
+++ b/torch/ao/quantization/fuser_method_mappings.py
@@ -106,6 +106,30 @@ def fuse_linear_bn(linear, bn):
     else:
         return nn.utils.fusion.fuse_linear_bn_eval(linear, bn)
 
+
+def fuse_convtranspose_bn(convt, bn):
+    r"""Given ConvTranspose and bn modules, fuses them and returns the fused module
+
+    Args:
+        convt: Module instance of type ConvTransposeNd
+        bn: BatchNormNd instance that needs to be fused with the linear layer.
+            batch norm N should match the ConvTranspose N
+
+    Examples::
+
+        >>> m1 = nn.ConvTranspose2d(10, 20, 3)
+        >>> b1 = nn.BatchNorm2d(20)
+        >>> m2 = fuse_convtranspose_bn(m1, b1)
+    """
+    assert(convt.training == bn.training),\
+        "ConvTranspose and BN both must be in the same mode (train or eval)."
+
+    if convt.training:
+        raise Exception("Fusing ConvTranspose+BatchNorm not yet supported in training.")
+    else:
+        return nn.utils.fusion.fuse_conv_bn_eval(convt, bn, transpose=True)
+
+
 DEFAULT_OP_LIST_TO_FUSER_METHOD: Dict[Tuple, Union[nn.Sequential, Callable]] = {
     (nn.Conv1d, nn.BatchNorm1d): fuse_conv_bn,
     (nn.Conv1d, nn.BatchNorm1d, nn.ReLU): fuse_conv_bn_relu,
@@ -120,6 +144,9 @@ DEFAULT_OP_LIST_TO_FUSER_METHOD: Dict[Tuple, Union[nn.Sequential, Callable]] = {
     (nn.Linear, nn.ReLU): nni.LinearReLU,
     (nn.BatchNorm2d, nn.ReLU): nni.BNReLU2d,
     (nn.BatchNorm3d, nn.ReLU): nni.BNReLU3d,
+    (nn.ConvTranspose1d, nn.BatchNorm1d): fuse_convtranspose_bn,
+    (nn.ConvTranspose2d, nn.BatchNorm2d): fuse_convtranspose_bn,
+    (nn.ConvTranspose3d, nn.BatchNorm3d): fuse_convtranspose_bn,
 }
 
 def get_fuser_method(op_list, additional_fuser_method_mapping=None):
@@ -157,6 +184,9 @@ DEFAULT_PATTERN_TO_FUSER_METHOD: Dict[Pattern, Union[nn.Sequential, Callable]] =
     (nn.ReLU, nn.Linear): reverse2(nni.LinearReLU),
     (nn.ReLU, nn.BatchNorm2d): reverse2(nni.BNReLU2d),
     (nn.ReLU, nn.BatchNorm3d): reverse2(nni.BNReLU3d),
+    (nn.BatchNorm1d, nn.ConvTranspose1d): reverse2(fuse_convtranspose_bn),
+    (nn.BatchNorm2d, nn.ConvTranspose2d): reverse2(fuse_convtranspose_bn),
+    (nn.BatchNorm3d, nn.ConvTranspose3d): reverse2(fuse_convtranspose_bn),
 }
 
 def get_fuser_method_new(

--- a/torch/ao/quantization/fx/fusion_patterns.py
+++ b/torch/ao/quantization/fx/fusion_patterns.py
@@ -53,6 +53,9 @@ class FuseHandler(ABC):
 @register_fusion_pattern((torch.nn.functional.relu, (torch.nn.BatchNorm1d, torch.nn.Conv1d)))
 @register_fusion_pattern((torch.nn.functional.relu, (torch.nn.BatchNorm2d, torch.nn.Conv2d)))
 @register_fusion_pattern((torch.nn.functional.relu, (torch.nn.BatchNorm3d, torch.nn.Conv3d)))
+@register_fusion_pattern((torch.nn.BatchNorm1d, torch.nn.ConvTranspose1d))
+@register_fusion_pattern((torch.nn.BatchNorm2d, torch.nn.ConvTranspose2d))
+@register_fusion_pattern((torch.nn.BatchNorm3d, torch.nn.ConvTranspose3d))
 class DefaultFuseHandler(FuseHandler):
     def __init__(
             self,

--- a/torch/nn/utils/fusion.py
+++ b/torch/nn/utils/fusion.py
@@ -3,17 +3,17 @@
 import copy
 import torch
 
-def fuse_conv_bn_eval(conv, bn):
+def fuse_conv_bn_eval(conv, bn, transpose=False):
     assert(not (conv.training or bn.training)), "Fusion only for eval!"
     fused_conv = copy.deepcopy(conv)
 
     fused_conv.weight, fused_conv.bias = \
         fuse_conv_bn_weights(fused_conv.weight, fused_conv.bias,
-                             bn.running_mean, bn.running_var, bn.eps, bn.weight, bn.bias)
+                             bn.running_mean, bn.running_var, bn.eps, bn.weight, bn.bias, transpose)
 
     return fused_conv
 
-def fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b):
+def fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=False):
     if conv_b is None:
         conv_b = torch.zeros_like(bn_rm)
     if bn_w is None:
@@ -22,7 +22,12 @@ def fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b):
         bn_b = torch.zeros_like(bn_rm)
     bn_var_rsqrt = torch.rsqrt(bn_rv + bn_eps)
 
-    conv_w = conv_w * (bn_w * bn_var_rsqrt).reshape([-1] + [1] * (len(conv_w.shape) - 1))
+    if transpose:
+        shape = [1, -1] + [1] * (len(conv_w.shape) - 2)
+    else:
+        shape = [-1, 1] + [1] * (len(conv_w.shape) - 2)
+
+    conv_w = conv_w * (bn_w * bn_var_rsqrt).reshape(shape)
     conv_b = (conv_b - bn_rm) * bn_var_rsqrt * bn_w + bn_b
 
     return torch.nn.Parameter(conv_w), torch.nn.Parameter(conv_b)

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1865,6 +1865,28 @@ class DummyObserver(torch.nn.Module):
         return x
 
 
+class ModelForConvTransposeBNFusion(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.ConvTranspose1d(3, 3, 1)
+        self.bn1 = nn.BatchNorm1d(3)
+        self.conv2 = nn.ConvTranspose2d(3, 3, 1)
+        self.bn2 = nn.BatchNorm2d(3)
+        self.conv3 = nn.ConvTranspose3d(3, 3, 1)
+        self.bn3 = nn.BatchNorm3d(3)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = x.unsqueeze(2)
+        x = self.conv2(x)
+        x = self.bn2(x)
+        x = x.unsqueeze(2)
+        x = self.conv3(x)
+        x = self.bn3(x)
+        return x
+
+
 class ModelWithFunctionals(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Summary: Add support for fusing ConvTranpose{1,2,3}d with BatchNorm{1,2,3}d. This re-uses the existing fusion logic but adds a "transpose" flag to the fusing function which when enabled will use the appropriate reshape for ConTranspose's transposed weights.

Test Plan: `buck test mode/dev //caffe2/test:quantization -- -r quantization.eager.test_fusion.TestFusion`

Differential Revision: D33074405

