### PR TITLE
Add explicit OperatorHandle destructor

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -114,6 +114,8 @@ OperatorHandle Dispatcher::findOrRegisterName_(const OperatorName& op_name) {
   return handle;
 }
 
+OperatorHandle::~OperatorHandle() = default;
+
 RegistrationHandleRAII Dispatcher::registerLibrary(std::string ns, std::string debug) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto found = libraries_.find(ns);

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -41,10 +41,6 @@ Dispatcher::Dispatcher()
 , listeners_(std::make_unique<detail::RegistrationListenerList>())
 , mutex_() {}
 
-// Adding explicit destructor definition in the cpp to over linker error in Windows builds.
-// Windows build doesn't produce the destructor symbol in PyTorch libs
-// causing a linker failure in downstream projects.
-// x-ref https://github.com/pytorch/pytorch/issues/70032
 Dispatcher::~Dispatcher() = default;
 
 C10_EXPORT Dispatcher& Dispatcher::realSingleton() {
@@ -118,6 +114,11 @@ OperatorHandle Dispatcher::findOrRegisterName_(const OperatorName& op_name) {
   return handle;
 }
 
+
+// Adding explicit destructor definition in the cpp to over linker error in Windows builds.
+// Windows build doesn't produce the destructor symbol in PyTorch libs
+// causing a linker failure in downstream projects.
+// x-ref https://github.com/pytorch/pytorch/issues/70032
 OperatorHandle::~OperatorHandle() = default;
 
 RegistrationHandleRAII Dispatcher::registerLibrary(std::string ns, std::string debug) {

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -41,6 +41,10 @@ Dispatcher::Dispatcher()
 , listeners_(std::make_unique<detail::RegistrationListenerList>())
 , mutex_() {}
 
+// Adding explicit destructor definition in the cpp to over linker error in Windows builds.
+// Windows build doesn't produce the destructor symbol in PyTorch libs
+// causing a linker failure in downstream projects.
+// x-ref https://github.com/pytorch/pytorch/issues/70032
 Dispatcher::~Dispatcher() = default;
 
 C10_EXPORT Dispatcher& Dispatcher::realSingleton() {

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -308,6 +308,7 @@ public:
   OperatorHandle& operator=(OperatorHandle&&) noexcept = default;
   OperatorHandle(const OperatorHandle&) = default;
   OperatorHandle& operator=(const OperatorHandle&) = default;
+  ~OperatorHandle();
 
   const OperatorName& operator_name() const {
     return operatorDef_->op.operator_name();


### PR DESCRIPTION
Fixes #70032

Windows build of PyTorch doesn't produce the `c10::OperatorHandle::~OperatorHandle(void)` symbol in any of its `*.lib` files. This fix is to explicitly define it in Dispatcher.cpp, so downstream consumers wanting to dllimport can find it.