### PR TITLE
[LTC] Code-gen tanh_backward

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -691,6 +691,7 @@ _(aten, take_along_dim) \
 _(aten, tan) \
 _(aten, tanh) \
 _(aten, tanh_) \
+_(aten, tanh_backward) \
 _(aten, tensor) \
 _(aten, tensordot) \
 _(aten, tensor_split) \

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -452,18 +452,6 @@ std::tuple<LazyTensor, LazyTensor, LazyTensor> svd(const LazyTensor& input,
                          LazyTensor::Create(torch::lazy::Value(node, 2), input.GetDevice()));
 }
 
-LazyTensor tanh_backward(const LazyTensor& grad_output,
-                         const LazyTensor& output) {
-  // Shape stays the same since pow is a unary op
-  std::vector<torch::lazy::Shape> shapes{output.shape().Get()};
-  torch::lazy::NodePtr pow_node =
-      torch::lazy::MakeNode<ir::ops::PowTensorScalar>(output.GetIrValue(), 
-                                                      LazyGraphExecutor::Get()->GetIrValueForScalar(2, output.GetDevice()),
-                                                      std::move(shapes));
-  return mul(grad_output,
-             rsub(LazyTensor::Create(pow_node, output.GetDevice()), 1, 1));
-}
-
 LazyTensor transpose(const LazyTensor& input, int64_t dim0, int64_t dim1) {
   auto input_shape = input.shape();
   auto permute_dims = torch::lazy::MakeTransposePermutation(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -119,9 +119,6 @@ LazyTensor sub(const LazyTensor& input, const at::Scalar& other,
 std::tuple<LazyTensor, LazyTensor, LazyTensor> svd(const LazyTensor& input,
                                                    bool some, bool compute_uv);
 
-LazyTensor tanh_backward(const LazyTensor& grad_output,
-                         const LazyTensor& output);
-
 // Swap given dimensions of the input.
 LazyTensor transpose(const LazyTensor& input, int64_t dim0, int64_t dim1);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -683,13 +683,6 @@ at::Tensor& LazyNativeFunctions::t_(at::Tensor& self) {
   return self;
 }
 
-at::Tensor LazyNativeFunctions::tanh_backward(const at::Tensor& grad_output,
-                                              const at::Tensor& output) {
-  TORCH_LAZY_FN_COUNTER("lazy::");
-  return CreateAtenFromLtcTensor(lazy_tensor_aten_ops::tanh_backward(
-      TryGetLtcTensor(grad_output), TryGetLtcTensor(output)));
-}
-
 at::Tensor LazyNativeFunctions::transpose(const at::Tensor& self, int64_t dim0,
                                           int64_t dim1) {
   TORCH_LAZY_FN_COUNTER("lazy::");

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -80,6 +80,7 @@ full_codegen:
   - sum
   - sum.dim_IntList
   - tanh
+  - tanh_backward
   - threshold
   - threshold_backward
   - topk
@@ -131,6 +132,5 @@ supported:
   - sub.Scalar
   - view
   - alias
-  - tanh_backward
 autograd:
   - max_pool3d


### PR DESCRIPTION
Summary:
This commit code-generates tanh_backward. To be noted, tanh_backward
symbol is added to aten_interned_strings.h as it is missing.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestTanhBackward

Fixes #65576.
