### PR TITLE
Add flag to optionally average output attention weights across heads

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
     get_function_arglist, load_tests, ALL_TENSORTYPES, \
     ALL_TENSORTYPES2, suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC, \
-    parametrize as parametrize_test, subtest
+    parametrize as parametrize_test, subtest, instantiate_parametrized_tests
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, \
@@ -5073,8 +5073,10 @@ class TestNN(NNTestCase):
         self.assertRaises(AssertionError, lambda: F.pad(inputs, (1,)))
 
     @unittest.skipIf(not TEST_NUMPY, "numpy not found")
-    def test_multihead_attention(self):
-        def _scaled_dot_attn_ref(Q, K, V, dims, unseen_mask=None, key_padding_mask=None):
+    @parametrize_test("average_attn_weights", [True, False])
+    def test_multihead_attention(self, average_attn_weights):
+        def _scaled_dot_attn_ref(Q, K, V, dims, unseen_mask=None, key_padding_mask=None,
+                                 average_attn_weights=average_attn_weights):
             """ Numpy-based reference implementation of scaled dot attention
             for testing"""
 
@@ -5097,7 +5099,8 @@ class TestNN(NNTestCase):
 
             reference = _softmax(QKT)
             ref_attn_weight = reference
-            ref_attn_weight = np.sum(ref_attn_weight, axis=1) / b2
+            if average_attn_weights:
+                ref_attn_weight = np.sum(ref_attn_weight, axis=1) / b2
             reference = _batchmatmul(reference, V)
             return reference, ref_attn_weight
 
@@ -5158,7 +5161,8 @@ class TestNN(NNTestCase):
             return (src_indices < src_lengths).int().detach()
 
         def _multihead_attn_test_helper(add_key_padding_mask=False, add_bias_kv=False, add_zero_attn=False,
-                                        saved_kv=False, same_embed_dim=False, byte_mask=False):
+                                        saved_kv=False, same_embed_dim=False, byte_mask=False,
+                                        average_attn_weights=average_attn_weights):
             for _ in range(100):
                 batch_sz, seq_len = [random.randint(2, 10) for r in range(2)]
                 d_head = random.randint(3, 10)
@@ -5229,7 +5233,8 @@ class TestNN(NNTestCase):
                         multihead_attn_module.add_zero_attn, multihead_attn_module.dropout,
                         multihead_attn_module.out_proj.weight, multihead_attn_module.out_proj.bias,
                         multihead_attn_module.training, key_padding_mask_tensor, True, attn_mask_tensor,
-                        static_k=saved_k_tensor, static_v=saved_v_tensor)
+                        static_k=saved_k_tensor, static_v=saved_v_tensor,
+                        average_attn_weights=average_attn_weights)
                 else:
                     result, result_weight = torch.nn.functional.multi_head_attention_forward(
                         _Q, _K, _V,
@@ -5241,7 +5246,8 @@ class TestNN(NNTestCase):
                         multihead_attn_module.training, key_padding_mask_tensor, True, attn_mask_tensor,
                         True, multihead_attn_module.q_proj_weight,
                         multihead_attn_module.k_proj_weight, multihead_attn_module.v_proj_weight,
-                        static_k=saved_k_tensor, static_v=saved_v_tensor)
+                        static_k=saved_k_tensor, static_v=saved_v_tensor,
+                        average_attn_weights=average_attn_weights)
 
                 result = result.squeeze(0).detach().numpy()
 
@@ -20114,6 +20120,7 @@ class TestStateDictHooks(TestCase):
 
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
+instantiate_parametrized_tests(TestNN)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -607,7 +607,8 @@ inline std::tuple<Tensor, Tensor> multi_head_attention_forward(
   const Tensor& k_proj_weight = {},
   const Tensor& v_proj_weight = {},
   const Tensor& static_k = {},
-  const Tensor& static_v = {}) {
+  const Tensor& static_v = {},
+  bool average_attn_weights = true) {
   namespace F = torch::nn::functional;
 
   const auto query_sizes = query.sizes();
@@ -845,9 +846,12 @@ inline std::tuple<Tensor, Tensor> multi_head_attention_forward(
   attn_output = attn_output.transpose(0, 1).contiguous().view({tgt_len, bsz, embed_dim});
   attn_output = F::linear(attn_output, out_proj_weight, out_proj_bias);
   if (need_weights) {
-    // average attention weights over heads
     attn_output_weights = attn_output_weights.view({bsz, num_heads, tgt_len, src_len});
-    return std::make_tuple(attn_output, attn_output_weights.sum(/*dim=*/1) / num_heads);
+    if (average_attn_weights) {
+      // average attention weights over heads
+      attn_output_weights = attn_output_weights.sum(/*dim=*/1) / num_heads;
+    }
+    return std::make_tuple(attn_output, attn_output_weights);
   } else {
     return std::make_tuple(attn_output, Tensor());
   }
@@ -881,7 +885,8 @@ inline std::tuple<Tensor, Tensor> multi_head_attention_forward(
     options.k_proj_weight(),
     options.v_proj_weight(),
     options.static_k(),
-    options.static_v()
+    options.static_v(),
+    options.average_attn_weights()
   );
 }
 

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -849,9 +849,10 @@ class TORCH_API MultiheadAttentionImpl
 
   std::tuple<Tensor, Tensor> forward(const Tensor& query, const Tensor& key,
                  const Tensor& value, const Tensor& key_padding_mask = {},
-                 bool need_weights = true, const Tensor& attn_mask = {});
+                 bool need_weights = true, const Tensor& attn_mask = {},
+                 bool average_attn_weights = true);
  protected:
-  FORWARD_HAS_DEFAULT_ARGS({3, AnyValue(Tensor())}, {4, AnyValue(true)}, {5, AnyValue(Tensor())})
+  FORWARD_HAS_DEFAULT_ARGS({3, AnyValue(Tensor())}, {4, AnyValue(true)}, {5, AnyValue(Tensor())}, {6, AnyValue(true)})
 
  public:
   void reset() override;

--- a/torch/csrc/api/include/torch/nn/options/activation.h
+++ b/torch/csrc/api/include/torch/nn/options/activation.h
@@ -665,6 +665,8 @@ struct TORCH_API MultiheadAttentionForwardFuncOptions {
   TORCH_ARG(Tensor, static_k) = {};
 
   TORCH_ARG(Tensor, static_v) = {};
+
+  TORCH_ARG(bool, average_attn_weights) = true;
 };
 
 } // namespace functional

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -429,7 +429,8 @@ MultiheadAttentionImpl::MultiheadAttentionImpl(const MultiheadAttentionOptions& 
 std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
   const Tensor& query, const Tensor& key,
   const Tensor& value, const Tensor& key_padding_mask,
-  bool need_weights, const Tensor& attn_mask) {
+  bool need_weights, const Tensor& attn_mask,
+  bool average_attn_weights) {
   if (!_qkv_same_embed_dim) {
     return F::multi_head_attention_forward(
       query, key, value,
@@ -452,6 +453,7 @@ std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
        .q_proj_weight(q_proj_weight)
        .k_proj_weight(k_proj_weight)
        .v_proj_weight(v_proj_weight)
+       .average_attn_weights(average_attn_weights)
     );
   } else {
     return F::multi_head_attention_forward(
@@ -471,6 +473,7 @@ std::tuple<Tensor, Tensor> MultiheadAttentionImpl::forward(
        .key_padding_mask(key_padding_mask)
        .need_weights(need_weights)
        .attn_mask(attn_mask)
+       .average_attn_weights(average_attn_weights)
     );
   }
 }

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -374,7 +374,8 @@ def multi_head_attention_forward(query: Tensor,
                                  k_proj_weight: Optional[Tensor] = None,
                                  v_proj_weight: Optional[Tensor] = None,
                                  static_k: Optional[Tensor] = None,
-                                 static_v: Optional[Tensor] = None
+                                 static_v: Optional[Tensor] = None,
+                                 average_attn_weights: bool = True
                                  ) -> Tuple[Tensor, Optional[Tensor]]: ...
 
 


### PR DESCRIPTION
Fixes #47583

This PR adds a new flag `average_attn_weights` allowing for optionally disabling the averaging of output attention weights across heads. Example usage:
```python
import torch

model = torch.nn.MultiheadAttention(embed_dim=100, num_heads=4)
query = torch.randn(196, 5, 100)
key = torch.randn(196, 5, 100)
value = torch.randn(196, 5, 100)
out, weights = model(query, key, value, average_attn_weights=False)
print(out.shape, weights.shape)
```
```
torch.Size([196, 5, 100]) torch.Size([5, 4, 196, 196])
```