### PR TITLE
Add tanh_backward to AT symbols

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -679,6 +679,7 @@ _(aten, take_along_dim) \
 _(aten, tan) \
 _(aten, tanh) \
 _(aten, tanh_) \
+_(aten, tanh_backward) \
 _(aten, tensor) \
 _(aten, tensordot) \
 _(aten, tensor_split) \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70071

Summary:
This commit adds tanh_backward to aten_interned_strings.h as an AT symbol.

Test Plan:
CI.

Differential Revision: [D33173370](https://our.internmc.facebook.com/intern/diff/D33173370)