### PR TITLE
[LTC] Code-gen mul.Tensor

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -177,16 +177,6 @@ void fill_(LazyTensor& input, const at::Scalar& value) {
   input.SetInPlaceIrValue(std::move(constant));
 }
 
-LazyTensor mul(const LazyTensor& input, const LazyTensor& other) {
-  return LazyTensor::Create(input.GetIrValue() * other.GetIrValue(), input.GetDevice());
-}
-
-LazyTensor mul(const LazyTensor& input, const at::Scalar& other) {
-  torch::lazy::Value constant = LazyGraphExecutor::Get()->GetIrValueForExpandedScalar(
-      other, input.shape(), input.GetDevice());
-  return LazyTensor::Create(input.GetIrValue() * constant, input.GetDevice());
-}
-
 LazyTensor narrow(const LazyTensor& input, int64_t dim, int64_t start,
                   int64_t length) {
   auto input_shape = input.shape();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -35,9 +35,6 @@ LazyTensor expand(const LazyTensor& input,
 // Fills the input with the given value.
 void fill_(LazyTensor& input, const at::Scalar& value);
 
-LazyTensor mul(const LazyTensor& input, const LazyTensor& other);
-LazyTensor mul(const LazyTensor& input, const at::Scalar& other);
-
 // Returns a new tensor that is a narrowed view of the input in the given
 // dimension.
 LazyTensor narrow(const LazyTensor& input, int64_t dim, int64_t start,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
@@ -12,61 +12,6 @@
 
 namespace torch_lazy_tensors {
 namespace tensor_ops {
-namespace {
-using torch::lazy::ScopePusher;
-
-// Returns the sub-tensor at the given index in the given dimension. Its rank
-// is one less than the input, in other words the singleton dimension is
-// squeezed out.
-LazyTensor IndexAcrossDims(const LazyTensor& input, int64_t dim,
-                           int64_t index) {
-  return lazy_tensor_aten_ops::squeeze(
-      lazy_tensor_aten_ops::slice(input, dim, index, index + 1, 1), dim);
-}
-
-}  // namespace
-
-LazyTensor Cross(const LazyTensor& input, const LazyTensor& other,
-                 c10::optional<int64_t> dim) {
-  int64_t canonical_dim;
-  if (dim) {
-    canonical_dim = torch::lazy::GetCanonicalDimensionIndex(
-        *dim, input.shape().Get().dim());
-  } else {
-    auto input_shape_ref = input.shape();
-    auto dim_3_it = std::find((*input_shape_ref).sizes().begin(),
-                              (*input_shape_ref).sizes().end(), 3);
-    CHECK(dim_3_it != (*input_shape_ref).sizes().end())
-        << "No dimension of size 3 in input: " << (*input_shape_ref).to_string();
-    canonical_dim = dim_3_it - (*input_shape_ref).sizes().begin();
-  }
-  CHECK_EQ(input.size(canonical_dim), 3)
-      << "Invalid cross argument: dimension " << canonical_dim
-      << " does not have size 3";
-  CHECK_LT(canonical_dim, input.shape().Get().dim())
-      << "Invalid cross argument: dimension " << canonical_dim
-      << " out of range";
-  // Extract the slices for each axis.
-  LazyTensor u1 = IndexAcrossDims(input, canonical_dim, 0);
-  LazyTensor v1 = IndexAcrossDims(other, canonical_dim, 0);
-  LazyTensor u2 = IndexAcrossDims(input, canonical_dim, 1);
-  LazyTensor v2 = IndexAcrossDims(other, canonical_dim, 1);
-  LazyTensor u3 = IndexAcrossDims(input, canonical_dim, 2);
-  LazyTensor v3 = IndexAcrossDims(other, canonical_dim, 2);
-  // Compute the term for each axis.
-  at::Scalar one(1);
-  LazyTensor s1 =
-      lazy_tensor_aten_ops::sub(lazy_tensor_aten_ops::mul(u2, v3),
-                                lazy_tensor_aten_ops::mul(u3, v2), one);
-  LazyTensor s2 =
-      lazy_tensor_aten_ops::sub(lazy_tensor_aten_ops::mul(u3, v1),
-                                lazy_tensor_aten_ops::mul(u1, v3), one);
-  LazyTensor s3 =
-      lazy_tensor_aten_ops::sub(lazy_tensor_aten_ops::mul(u1, v2),
-                                lazy_tensor_aten_ops::mul(u2, v1), one);
-  // Stack the terms into one result tensor.
-  return lazy_tensor_aten_ops::stack({s1, s2, s3}, canonical_dim);
-}
 
 LazyTensor Select(const LazyTensor& input, int64_t dim, int64_t index) {
   auto shape = input.shape();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.h
@@ -9,9 +9,6 @@
 namespace torch_lazy_tensors {
 namespace tensor_ops {
 
-LazyTensor Cross(const LazyTensor& input, const LazyTensor& other,
-                 c10::optional<int64_t> dim);
-
 LazyTensor Select(const LazyTensor& input, int64_t dim, int64_t index);
 
 }  // namespace tensor_ops

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -303,24 +303,6 @@ at::Tensor LazyNativeFunctions::max_pool3d(
       self, kernel_size, stride, padding, dilation, ceil_mode);
 }
 
-at::Tensor LazyNativeFunctions::mul(const at::Tensor& self,
-                                    const at::Tensor& other) {
-  TORCH_LAZY_FN_COUNTER("lazy::");
-  return DoBinaryOp(self, other,
-                    [&](const LazyTensor& xself, const LazyTensor& xother) {
-                      return lazy_tensor_aten_ops::mul(xself, xother);
-                    });
-}
-
-at::Tensor LazyNativeFunctions::mul(const at::Tensor& self,
-                                    const at::Scalar& other) {
-  TORCH_LAZY_FN_COUNTER("lazy::");
-  return DoBinaryOp(self, other,
-                    [&](const LazyTensor& xself, const at::Scalar& other) {
-                      return lazy_tensor_aten_ops::mul(xself, other);
-                    });
-}
-
 std::tuple<at::Tensor, at::Tensor, at::Tensor>
 LazyNativeFunctions::native_batch_norm(
     const at::Tensor& input, const c10::optional<at::Tensor>& weight,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -54,6 +54,7 @@ full_codegen:
   - mean
   - mean.dim
   - mm
+  - mul.Tensor
   - mv
   - native_dropout
   - native_dropout_backward
@@ -103,8 +104,6 @@ supported:
   - empty_strided
   - expand
   - fill_.Scalar
-  - mul.Tensor
-  - mul.Scalar
   - native_batch_norm
   - native_batch_norm_backward
   - normal_

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -518,7 +518,7 @@
   result: self_t / other_p - other_t * (self_p / other_p) / other_p
 
 - name: div.Scalar(Tensor self, Scalar other) -> Tensor
-  self: div_tensor_self_backward(grad, at::native::wrapped_scalar_tensor(other), self.scalar_type())
+  self: div_tensor_self_backward(grad, at::scalar_to_tensor(other), self.scalar_type())
   result: self_t / other
 
 - name: div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor
@@ -527,7 +527,7 @@
   result: "rounding_mode.has_value() ? result.new_zeros(result.sizes()) : self_t / other_p - other_t * (self_p / other_p) / other_p"
 
 - name: div.Scalar_mode(Tensor self, Scalar other, *, str? rounding_mode) -> Tensor
-  self: div_tensor_self_backward(grad, at::native::wrapped_scalar_tensor(other), self.scalar_type(), rounding_mode)
+  self: div_tensor_self_backward(grad, at::scalar_to_tensor(other), self.scalar_type(), rounding_mode)
   result: "rounding_mode.has_value() ? result.new_zeros(result.sizes()) : self_t / other"
 
 - name: dot(Tensor self, Tensor tensor) -> Tensor
@@ -1065,7 +1065,7 @@
   result: other_t * self_p + self_t * other_p
 
 - name: mul.Scalar(Tensor self, Scalar other) -> Tensor
-  self: mul_tensor_backward(grad, at::native::wrapped_scalar_tensor(other), self.scalar_type())
+  self: mul_tensor_backward(grad, at::scalar_to_tensor(other), self.scalar_type())
   result: self_t * other
 
 - name: mv(Tensor self, Tensor vec) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -518,7 +518,7 @@
   result: self_t / other_p - other_t * (self_p / other_p) / other_p
 
 - name: div.Scalar(Tensor self, Scalar other) -> Tensor
-  self: div_tensor_self_backward(grad, at::scalar_to_tensor(other), self.scalar_type())
+  self: div_tensor_self_backward(grad, at::native::wrapped_scalar_tensor(other), self.scalar_type())
   result: self_t / other
 
 - name: div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor
@@ -527,7 +527,7 @@
   result: "rounding_mode.has_value() ? result.new_zeros(result.sizes()) : self_t / other_p - other_t * (self_p / other_p) / other_p"
 
 - name: div.Scalar_mode(Tensor self, Scalar other, *, str? rounding_mode) -> Tensor
-  self: div_tensor_self_backward(grad, at::scalar_to_tensor(other), self.scalar_type(), rounding_mode)
+  self: div_tensor_self_backward(grad, at::native::wrapped_scalar_tensor(other), self.scalar_type(), rounding_mode)
   result: "rounding_mode.has_value() ? result.new_zeros(result.sizes()) : self_t / other"
 
 - name: dot(Tensor self, Tensor tensor) -> Tensor
@@ -1065,7 +1065,7 @@
   result: other_t * self_p + self_t * other_p
 
 - name: mul.Scalar(Tensor self, Scalar other) -> Tensor
-  self: mul_tensor_backward(grad, at::scalar_to_tensor(other), self.scalar_type())
+  self: mul_tensor_backward(grad, at::native::wrapped_scalar_tensor(other), self.scalar_type())
   result: self_t * other
 
 - name: mv(Tensor self, Tensor vec) -> Tensor


### PR DESCRIPTION
Summary:
This commit code-generates mul.Tensor. Besides, it also fixes a bug
in derivatives.yaml when wrapped scalar tensors won't set is_wrapped_number_
flag in TensorImpl. This flag is crucial for LTC while converting an at::Tensor
to a LazyTensor. Details see GetOrCreateForWrappedNumber.

Test Plan:
lazy_tensor_core/test/cpp/build/test_ptltc

Fixes #65576.
