### PR TITLE
Safely disable profiler

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -766,6 +766,14 @@ void enableProfiler(
 }
 
 std::unique_ptr<ProfilerResult> disableProfiler() {
+  // In PyTorch Lightning, it would call disableProfiler first before enabling it
+  // In this case, it would raise c10:Error and the pytorch would Aborted
+  // As the result, we need check the instance before invoking ThreadLocalDebugInfo::_pop.
+  auto debug_info = c10::ThreadLocalDebugInfo::current();
+  if (!debug_info){
+    return std::unique_ptr<ProfilerResult>();
+  }
+
   // all the DebugInfoBase objects are scope based and supposed to use DebugInfoGuard
   auto state = c10::ThreadLocalDebugInfo::_pop(c10::DebugInfoKind::PROFILER_STATE);
 

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -46,7 +46,7 @@ class _KinetoProfile(object):
             and not eager mode models.
 
     .. note::
-        This API is an experimental and subject to change in future.
+        This API is experimental and subject to change in future.
 
         Enabling shape and stack tracing results in additional overhead.
         When record_shapes=True is specified, profiler will temporarily hold references to the tensors;


### PR DESCRIPTION
### Reason of the change
In PyTorch Lightning, the torch.autograd._disable_profiler() will be called firstly before enable_profiler to support multiple profilers scenarios. 
However, in nightly build, the torch.autograd._disable_profiler would crash with the following errors screenshot.
![image](https://user-images.githubusercontent.com/817030/146516325-499c12cd-7699-4c3c-9635-374ad290c05b.png)

The PTL call disable_profiler at https://github.com/PyTorchLightning/pytorch-lightning/blob/e0d8623ca50bee8c03c2412005e86034d424ef1a/pytorch_lightning/profiler/pytorch.py#L249-L254

### How to fix

Before pop the thread local state from tls storage, we will check whether there are tls state or not. In this way, the crash is fixed. 
