### PR TITLE
[Operator Versioning][demo][Do not land] An example to show how to edit an operator

### DIFF
--- a/tools/codegen/operator_versions/gen_mobile_upgraders.py
+++ b/tools/codegen/operator_versions/gen_mobile_upgraders.py
@@ -59,7 +59,8 @@ ONE_UPGRADER_SRC = CodeTemplate("""
     }),""")
 
 
-ONE_UPGRADER_IN_VERSION_MAP = CodeTemplate("""Upgrader({${upgrader_min_version}, ${upgrader_max_version}, "${upgrader_name}", ${bytecode_func_index}})""")  # noqa: E501
+ONE_UPGRADER_IN_VERSION_MAP = CodeTemplate("""Upgrader({${upgrader_min_version}, ${upgrader_max_version}, "${upgrader_name}", ${bytecode_func_index}}),
+""")  # noqa: E501
 
 ONE_OPERATOR_IN_VERSION_MAP = CodeTemplate("""
     {std::string("${operator_name}"),
@@ -155,6 +156,8 @@ def construct_constants(constants_list_from_yaml: List[Any]) -> str:
             convert_constant = "true" if constant_from_yaml else "false"
         elif constant_from_yaml is None:
             convert_constant = ""
+        elif isinstance(constant_from_yaml, int):
+            convert_constant = str(constant_from_yaml)
         else:
             raise ValueError(
                 f"The type of {constant_from_yaml} is {type(constant_from_yaml)}. "
@@ -222,12 +225,13 @@ def construct_version_maps(upgrader_bytecode_function_to_index_map: Dict[str, An
     for op_name in sorted_version_map:
         upgraders_in_version_map_part = []
         # TODO: remove the skip after these two operators schemas are fixed
-        if op_name == "aten::full.names" or op_name == "aten::full.out":
+        if op_name == "aten::full.names" or op_name == "aten::full.out" or op_name == "aten::full":
             continue
         for upgrader_entry in sorted_version_map[op_name]:
             # Split a string by "_" and filter empty string in the list
             # For example: "div__Scalar_0_3" => ['div', 'Scalar', '0', '3']
             upgrader_info = list(filter(lambda token: token != "", upgrader_entry.upgrader_name.split('_')))
+            print("upgrader_info: ", upgrader_info)
             upgrader_min_version = upgrader_info[2]
             upgrader_max_version = upgrader_info[3]
             upgrader_name = upgrader_entry.upgrader_name

--- a/torch/csrc/jit/mobile/upgrader_mobile.cpp
+++ b/torch/csrc/jit/mobile/upgrader_mobile.cpp
@@ -1,4 +1,12 @@
+/**
+ * @generated
+ * This is an auto-generated file. Please do not modify it by hand.
+ * To re-generate, please run:
+ * cd ~/pytorch && python torch/csrc/jit/mobile/upgrader_mobile.cpp
+ */
+
 #include <torch/csrc/jit/mobile/upgrader_mobile.h>
+#include <ATen/core/ivalue.h>
 
 namespace c10 {
 TypePtr parseType(const std::string& pythonStr);
@@ -7,251 +15,365 @@ TypePtr parseType(const std::string& pythonStr);
 namespace torch {
 namespace jit {
 
+// From operator_versions_map
+
 const std::unordered_map<std::string, std::vector<Upgrader>>
 getOperatorVersionMapForMobile() {
   static std::unordered_map<std::string, std::vector<Upgrader>>
-      operatorVersionMapForMobile({
-          {std::string("aten::div.Tensor"),
-           std::vector<Upgrader>({Upgrader({0, 3, "div_Tensor_0_3", 0})})},
-          {std::string("aten::div.Scalar"),
-           std::vector<Upgrader>({Upgrader({0, 3, "div_Scalar_0_3", 1})})},
-          {std::string("aten::div.out"),
-           std::vector<Upgrader>({Upgrader({0, 3, "div_out_0_3", 2})})},
-          {std::string("aten::div_.Tensor"),
-           std::vector<Upgrader>({Upgrader({0, 3, "div__Tensor_0_3", 3})})},
-          {std::string("aten::div_.Scalar"),
-           std::vector<Upgrader>({Upgrader({0, 3, "div__Scalar_0_3", 4})})},
+        operatorVersionMapForMobile({
+            
+                {std::string("aten::div.Scalar"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 3, "div_Scalar_0_3", 0}),
+                    })},
+                {std::string("aten::div.Tensor"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 3, "div_Tensor_0_3", 1}),
+                        Upgrader({4, 5, "div_Tensor_4_5", 2}),
+                    })},
+                {std::string("aten::div.out"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 3, "div_out_0_3", 5}),
+                    })},
+                {std::string("aten::div_.Scalar"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 3, "div__Scalar_0_3", 3}),
+                    })},
+                {std::string("aten::div_.Tensor"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 3, "div__Tensor_0_3", 4}),
+                    })},
       });
   return operatorVersionMapForMobile;
 }
 
 std::vector<ByteCodeFunctionWithOperator> getUpgraderBytecodeList() {
   static std::vector<ByteCodeFunctionWithOperator> upgraderBytecodeList({
-      ByteCodeFunctionWithOperator({
-          mobile::Function::registerFunc(
-              "div_Tensor_0_3",
-              std::vector<Instruction>({
-                  Instruction{OpCode::STOREN, 1, 2},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::JF, 3, 0},
-                  Instruction{OpCode::LOADC, 1, 0},
-                  Instruction{OpCode::JMP, 3, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::STORE, 3, 0},
-                  Instruction{OpCode::MOVE, 3, 0},
-                  Instruction{OpCode::JF, 5, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 1, 0},
-                  Instruction{OpCode::JMP, 5, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::LOADC, 0, 0},
-                  Instruction{OpCode::OP, 2, 0},
-                  Instruction{OpCode::STORE, 4, 0},
-                  Instruction{OpCode::DROPR, 2, 0},
-                  Instruction{OpCode::DROPR, 1, 0},
-                  Instruction{OpCode::MOVE, 4, 0},
-                  Instruction{OpCode::RET, 0, 0},
-              }), // instructions_
-              std::vector<c10::IValue>({
-                  c10::IValue("trunc"),
-                  c10::IValue(true),
-              }), // constants
-              std::vector<c10::TypePtr>(), // types
-              4 // register_size_
-              ),
-          std::vector<OperatorString>({
-              OperatorString({"aten::is_floating_point", "", 1}),
-              OperatorString({"aten::div", "Tensor", 2}),
-              OperatorString({"aten::div", "Tensor_mode", 3}),
-          }), // op_names
-      }),
-      ByteCodeFunctionWithOperator({
-          mobile::Function::registerFunc(
-              "div_Scalar_0_3",
-              std::vector<Instruction>({
-                  Instruction{OpCode::STOREN, 1, 2},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::JF, 3, 0},
-                  Instruction{OpCode::LOADC, 1, 0},
-                  Instruction{OpCode::JMP, 3, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::ISINSTANCE, 0, 1},
-                  Instruction{OpCode::STORE, 3, 0},
-                  Instruction{OpCode::MOVE, 3, 0},
-                  Instruction{OpCode::JF, 5, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 1, 0},
-                  Instruction{OpCode::JMP, 6, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 2, 0},
-                  Instruction{OpCode::LOADC, 0, 0},
-                  Instruction{OpCode::OP, 3, 0},
-                  Instruction{OpCode::STORE, 4, 0},
-                  Instruction{OpCode::DROPR, 2, 0},
-                  Instruction{OpCode::DROPR, 1, 0},
-                  Instruction{OpCode::MOVE, 4, 0},
-                  Instruction{OpCode::RET, 0, 0},
-              }), // instructions_
-              std::vector<c10::IValue>({
-                  c10::IValue("trunc"),
-                  c10::IValue(true),
-              }), // constants
-              std::vector<c10::TypePtr>({c10::parseType("float")}), // types
-              4 // register_size_
-              ),
-          std::vector<OperatorString>({
-              OperatorString({"aten::is_floating_point", "", 1}),
-              OperatorString({"aten::div", "Scalar", 2}),
-              OperatorString({"prim::unchecked_cast", "", 1}),
-              OperatorString({"aten::div", "Scalar_mode", 3}),
-          }), // op_names
-      }),
-      ByteCodeFunctionWithOperator({
-          mobile::Function::registerFunc(
-              "div_out_0_3",
-              std::vector<Instruction>({
-                  Instruction{OpCode::STOREN, 1, 3},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::JF, 3, 0},
-                  Instruction{OpCode::LOADC, 1, 0},
-                  Instruction{OpCode::JMP, 3, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::JF, 3, 0},
-                  Instruction{OpCode::LOADC, 1, 0},
-                  Instruction{OpCode::JMP, 3, 0},
-                  Instruction{OpCode::LOAD, 3, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::STORE, 4, 0},
-                  Instruction{OpCode::MOVE, 4, 0},
-                  Instruction{OpCode::JF, 6, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::LOAD, 3, 0},
-                  Instruction{OpCode::OP, 1, 0},
-                  Instruction{OpCode::JMP, 6, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::LOADC, 0, 0},
-                  Instruction{OpCode::LOAD, 3, 0},
-                  Instruction{OpCode::OP, 2, 0},
-                  Instruction{OpCode::STORE, 5, 0},
-                  Instruction{OpCode::DROPR, 3, 0},
-                  Instruction{OpCode::DROPR, 2, 0},
-                  Instruction{OpCode::DROPR, 1, 0},
-                  Instruction{OpCode::MOVE, 5, 0},
-                  Instruction{OpCode::RET, 0, 0},
-              }), // instructions_
-              std::vector<c10::IValue>({
-                  c10::IValue("trunc"),
-                  c10::IValue(true),
-              }), // constants
-              std::vector<c10::TypePtr>(), // types
-              5 // register_size_
-              ),
-          std::vector<OperatorString>({
-              OperatorString({"aten::is_floating_point", "", 1}),
-              OperatorString({"aten::div", "out", 3}),
-              OperatorString({"aten::div", "out_mode", 4}),
-          }), // op_names
-      }),
-      ByteCodeFunctionWithOperator({
-          mobile::Function::registerFunc(
-              "div__Tensor_0_3",
-              std::vector<Instruction>({
-                  Instruction{OpCode::STOREN, 1, 2},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::JF, 3, 0},
-                  Instruction{OpCode::LOADC, 1, 0},
-                  Instruction{OpCode::JMP, 3, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::STORE, 3, 0},
-                  Instruction{OpCode::MOVE, 3, 0},
-                  Instruction{OpCode::JF, 5, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 1, 0},
-                  Instruction{OpCode::JMP, 5, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::LOADC, 0, 0},
-                  Instruction{OpCode::OP, 2, 0},
-                  Instruction{OpCode::STORE, 4, 0},
-                  Instruction{OpCode::DROPR, 2, 0},
-                  Instruction{OpCode::DROPR, 1, 0},
-                  Instruction{OpCode::MOVE, 4, 0},
-                  Instruction{OpCode::RET, 0, 0},
-              }), // instructions_
-              std::vector<c10::IValue>({
-                  c10::IValue("trunc"),
-                  c10::IValue(true),
-              }), // constants
-              std::vector<c10::TypePtr>(), // types
-              4 // register_size_
-              ),
-          std::vector<OperatorString>({
-              OperatorString({"aten::is_floating_point", "", 1}),
-              OperatorString({"aten::div_", "Tensor", 2}),
-              OperatorString({"aten::div_", "Tensor_mode", 3}),
-          }), // op_names
-      }),
-      ByteCodeFunctionWithOperator({
-          mobile::Function::registerFunc(
-              "div__Scalar_0_3",
-              std::vector<Instruction>({
-                  Instruction{OpCode::STOREN, 1, 2},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::OP, 0, 0},
-                  Instruction{OpCode::JF, 3, 0},
-                  Instruction{OpCode::LOADC, 1, 0},
-                  Instruction{OpCode::JMP, 3, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::ISINSTANCE, 0, 1},
-                  Instruction{OpCode::STORE, 3, 0},
-                  Instruction{OpCode::MOVE, 3, 0},
-                  Instruction{OpCode::JF, 5, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 1, 0},
-                  Instruction{OpCode::JMP, 6, 0},
-                  Instruction{OpCode::LOAD, 1, 0},
-                  Instruction{OpCode::LOAD, 2, 0},
-                  Instruction{OpCode::OP, 2, 0},
-                  Instruction{OpCode::LOADC, 0, 0},
-                  Instruction{OpCode::OP, 3, 0},
-                  Instruction{OpCode::STORE, 4, 0},
-                  Instruction{OpCode::DROPR, 2, 0},
-                  Instruction{OpCode::DROPR, 1, 0},
-                  Instruction{OpCode::MOVE, 4, 0},
-                  Instruction{OpCode::RET, 0, 0},
-              }), // instructions_
-              std::vector<c10::IValue>({
-                  c10::IValue("trunc"),
-                  c10::IValue(true),
-              }), // constants
-              std::vector<c10::TypePtr>(), // types
-              4 // register_size_
-              ),
-          std::vector<OperatorString>({
-              OperatorString({"aten::is_floating_point", "", 1}),
-              OperatorString({"aten::div_", "Scalar", 2}),
-              OperatorString({"prim::unchecked_cast", "", 1}),
-              OperatorString({"aten::div_", "Scalar_mode", 3}),
-          }), // op_names
-      }),
+       
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "div_Scalar_0_3",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 2},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 3, 0},
+                                   Instruction{OpCode::LOADC, 1, 0},
+                                   Instruction{OpCode::JMP, 3, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::ISINSTANCE, 0, 1},
+                                   Instruction{OpCode::STORE, 3, 0},
+                                   Instruction{OpCode::MOVE, 3, 0},
+                                   Instruction{OpCode::JF, 5, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 1, 0},
+                                   Instruction{OpCode::JMP, 6, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 2, 0},
+                                   Instruction{OpCode::LOADC, 0, 0},
+                                   Instruction{OpCode::OP, 3, 0},
+                                   Instruction{OpCode::STORE, 4, 0},
+                                   Instruction{OpCode::DROPR, 2, 0},
+                                   Instruction{OpCode::DROPR, 1, 0},
+                                   Instruction{OpCode::MOVE, 4, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue("trunc"),c10::IValue(true),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                               c10::parseType("float"),
+                           }), // types list,
+                       4
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::is_floating_point", "", 1}),
+                           OperatorString({"aten::div", "Scalar", 2}),
+                           OperatorString({"prim::unchecked_cast", "", 1}),
+                           OperatorString({"aten::div", "Scalar_mode", 3}),
+                   }), // operators list
+           }),
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "div_Tensor_0_3",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 2},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 3, 0},
+                                   Instruction{OpCode::LOADC, 1, 0},
+                                   Instruction{OpCode::JMP, 3, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::STORE, 3, 0},
+                                   Instruction{OpCode::MOVE, 3, 0},
+                                   Instruction{OpCode::JF, 5, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 1, 0},
+                                   Instruction{OpCode::JMP, 5, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::LOADC, 0, 0},
+                                   Instruction{OpCode::OP, 2, 0},
+                                   Instruction{OpCode::STORE, 4, 0},
+                                   Instruction{OpCode::DROPR, 2, 0},
+                                   Instruction{OpCode::DROPR, 1, 0},
+                                   Instruction{OpCode::MOVE, 4, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue("trunc"),c10::IValue(true),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                       
+                           }), // types list,
+                       4
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::is_floating_point", "", 1}),
+                           OperatorString({"aten::div", "Tensor", 2}),
+                           OperatorString({"aten::div", "Tensor_mode", 3}),
+                   }), // operators list
+           }),
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "div_Tensor_4_5",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 2},
+                                   Instruction{OpCode::MOVE, 1, 0},
+                                   Instruction{OpCode::MOVE, 2, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue(1),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                       
+                           }), // types list,
+                       2
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::add", "Tensor", 2}),
+                   }), // operators list
+           }),
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "div__Scalar_0_3",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 2},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 3, 0},
+                                   Instruction{OpCode::LOADC, 1, 0},
+                                   Instruction{OpCode::JMP, 3, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::ISINSTANCE, 0, 1},
+                                   Instruction{OpCode::STORE, 3, 0},
+                                   Instruction{OpCode::MOVE, 3, 0},
+                                   Instruction{OpCode::JF, 5, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 1, 0},
+                                   Instruction{OpCode::JMP, 6, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 2, 0},
+                                   Instruction{OpCode::LOADC, 0, 0},
+                                   Instruction{OpCode::OP, 3, 0},
+                                   Instruction{OpCode::STORE, 4, 0},
+                                   Instruction{OpCode::DROPR, 2, 0},
+                                   Instruction{OpCode::DROPR, 1, 0},
+                                   Instruction{OpCode::MOVE, 4, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue("trunc"),c10::IValue(true),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                               c10::parseType("float"),
+                           }), // types list,
+                       4
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::is_floating_point", "", 1}),
+                           OperatorString({"aten::div_", "Scalar", 2}),
+                           OperatorString({"prim::unchecked_cast", "", 1}),
+                           OperatorString({"aten::div_", "Scalar_mode", 3}),
+                   }), // operators list
+           }),
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "div__Tensor_0_3",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 2},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 3, 0},
+                                   Instruction{OpCode::LOADC, 1, 0},
+                                   Instruction{OpCode::JMP, 3, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::STORE, 3, 0},
+                                   Instruction{OpCode::MOVE, 3, 0},
+                                   Instruction{OpCode::JF, 5, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 1, 0},
+                                   Instruction{OpCode::JMP, 5, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::LOADC, 0, 0},
+                                   Instruction{OpCode::OP, 2, 0},
+                                   Instruction{OpCode::STORE, 4, 0},
+                                   Instruction{OpCode::DROPR, 2, 0},
+                                   Instruction{OpCode::DROPR, 1, 0},
+                                   Instruction{OpCode::MOVE, 4, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue("trunc"),c10::IValue(true),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                       
+                           }), // types list,
+                       4
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::is_floating_point", "", 1}),
+                           OperatorString({"aten::div_", "Tensor", 2}),
+                           OperatorString({"aten::div_", "Tensor_mode", 3}),
+                   }), // operators list
+           }),
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "div_out_0_3",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 3},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 3, 0},
+                                   Instruction{OpCode::LOADC, 1, 0},
+                                   Instruction{OpCode::JMP, 3, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 3, 0},
+                                   Instruction{OpCode::LOADC, 1, 0},
+                                   Instruction{OpCode::JMP, 3, 0},
+                                   Instruction{OpCode::LOAD, 3, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::STORE, 4, 0},
+                                   Instruction{OpCode::MOVE, 4, 0},
+                                   Instruction{OpCode::JF, 6, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::LOAD, 3, 0},
+                                   Instruction{OpCode::OP, 1, 0},
+                                   Instruction{OpCode::JMP, 6, 0},
+                                   Instruction{OpCode::LOAD, 1, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::LOADC, 0, 0},
+                                   Instruction{OpCode::LOAD, 3, 0},
+                                   Instruction{OpCode::OP, 2, 0},
+                                   Instruction{OpCode::STORE, 5, 0},
+                                   Instruction{OpCode::DROPR, 3, 0},
+                                   Instruction{OpCode::DROPR, 2, 0},
+                                   Instruction{OpCode::DROPR, 1, 0},
+                                   Instruction{OpCode::MOVE, 5, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue("trunc"),c10::IValue(true),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                       
+                           }), // types list,
+                       5
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::is_floating_point", "", 1}),
+                           OperatorString({"aten::div", "out", 3}),
+                           OperatorString({"aten::div", "out_mode", 4}),
+                   }), // operators list
+           }),
+           ByteCodeFunctionWithOperator({
+               
+                   mobile::Function::registerFunc(
+                       "full_0_4",
+                       std::vector<Instruction>({
+                               
+                                   Instruction{OpCode::STOREN, 1, 6},
+                                   Instruction{OpCode::LOAD, 3, 0},
+                                   Instruction{OpCode::LOADC, 0, 0},
+                                   Instruction{OpCode::OP, 0, 0},
+                                   Instruction{OpCode::JF, 5, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::OP, 1, 0},
+                                   Instruction{OpCode::LOAD, 3, 0},
+                                   Instruction{OpCode::JMP, 4, 0},
+                                   Instruction{OpCode::LOAD, 2, 0},
+                                   Instruction{OpCode::LOAD, 3, 0},
+                                   Instruction{OpCode::OP, 2, 0},
+                                   Instruction{OpCode::STOREN, 7, 2},
+                                   Instruction{OpCode::DROPR, 3, 0},
+                                   Instruction{OpCode::DROPR, 2, 0},
+                                   Instruction{OpCode::MOVE, 1, 0},
+                                   Instruction{OpCode::MOVE, 7, 0},
+                                   Instruction{OpCode::MOVE, 8, 0},
+                                   Instruction{OpCode::MOVE, 4, 0},
+                                   Instruction{OpCode::MOVE, 5, 0},
+                                   Instruction{OpCode::MOVE, 6, 0},
+                                   Instruction{OpCode::OP, 3, 0},
+                                   Instruction{OpCode::RET, 0, 0},
+                           }), // instructions list,
+                       std::vector<c10::IValue>({
+                               c10::IValue(),
+                           }), // constants list,
+                       std::vector<c10::TypePtr>({
+                       
+                           }), // types list,
+                       8
+                   ),
+               
+                   std::vector<OperatorString>({
+                       
+                           OperatorString({"aten::__is__", "", 2}),
+                           OperatorString({"aten::Float", "Scalar", 1}),
+                           OperatorString({"prim::unchecked_cast", "", 1}),
+                           OperatorString({"aten::full", "", 6}),
+                   }), // operators list
+           }),
   });
   return upgraderBytecodeList;
 }
 
 } // namespace jit
 } // namespace torch
+

--- a/torch/csrc/jit/operator_upgraders/version_map.h
+++ b/torch/csrc/jit/operator_upgraders/version_map.h
@@ -14,9 +14,14 @@ struct UpgraderEntry {
 
 static std::unordered_map<std::string, std::vector<UpgraderEntry>> operatorVersionMap(
     {{"aten::div.Tensor",
-      {{4,
-        "div_Tensor_0_3",
-        "aten::div.Tensor(Tensor self, Tensor other) -> Tensor"}}},
+      {
+          {4,
+           "div_Tensor_0_3",
+           "aten::div.Tensor(Tensor self, Tensor other) -> Tensor"},
+          {6,
+           "div_Tensor_4_5",
+           "aten::div.Tensor(Tensor self, Tensor other) -> Tensor"},
+      }},
      {"aten::div.Scalar",
       {{4,
         "div_Scalar_0_3",

--- a/torch/jit/operator_upgraders.py
+++ b/torch/jit/operator_upgraders.py
@@ -23,6 +23,10 @@ with torch._jit_internal._disable_emit_hooks():
         return self.divide(other, rounding_mode='trunc')
 
     @torch.jit.script
+    def div_Tensor_4_5(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+        return torch.add(self, other)
+
+    @torch.jit.script
     def div_Scalar_0_3(self: torch.Tensor, other: Union[int, float]) -> torch.Tensor:
         if (self.is_floating_point() or isinstance(other, float)):
             return self.true_divide(other)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70101
* #70090

1. Add `upgrader` in `caffe2/torch/jit/operator_upgraders.py`
2. Register the upgrader in `caffe2/torch/csrc/jit/operator_upgraders/version_map.h`
3. Regenerate `fbcode/caffe2/torch/csrc/jit/mobile/upgrader_mobile.cpp` by running
OSS (after rebuild pytorch with `setup.py`)
```
python pytorch/tools/codegen/operator_versions/gen_mobile_upgraders.py
```
or (it includes rebuild step)
```
buck run @mode/opt //caffe2/torch/fb/mobile/upgrader_codegen:upgrader_codegen
```
4.Add tests
a. Write a python file to create a model with this operator  (note, add detection if the operator is not covered)
b. Create a model before this change and add it to `caffe2/test/jit/fixtures/`, following naming convention: `test_versioned_{op_name}_{short_description}_v{op_version_number}.ptl` (for example, `test_versioned_div_scalar_reciprocal_int_v2.ptl`)
c. Add a unit test in `caffe2/test/jit/test_save_load_for_op_version.py`



Differential Revision: [D33184721](https://our.internmc.facebook.com/intern/diff/D33184721/)

Differential Revision: [D33184721](https://our.internmc.facebook.com/intern/diff/D33184721)