### PR TITLE
Add a missing precondition to `DistributedSampler` docstring

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -19,7 +19,8 @@ class DistributedSampler(Sampler[T_co]):
     original dataset that is exclusive to it.
 
     .. note::
-        Dataset is assumed to be of constant size.
+        Dataset is assumed to be of constant size and that any instance of it always
+        returns the same elements in the same order.
 
     Args:
         dataset: Dataset used for sampling.


### PR DESCRIPTION
Distributed sampler sets different indices for different processes. By doing this, it assumes that the data is the same across the board and in the same order. This may seem trivial, however, there are times that users don't guarantee the order items are gonna have, because they rely on something such as the order the filesystem lists a directory (which is not guaranteed and may vary on different computers), or the order a `set` is iterated.

I think it's better to make it clearer.

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang