### PR TITLE
fixing conv2d decomposition and tests

### DIFF
--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -1962,6 +1962,8 @@ void decomposeConvOps(Block* block) {
     auto bias_n = graph->insertNode(graph->create(
         prim::add_optional, {n->output(0), unsqueezed_bias->output()}, 1));
     bias_n->output()->setType(n->output(0)->type());
+    // moving add_optional after conv2d since it uses its output.
+    bias_n->moveAfter(n);
 
     // replace later uses
     n->output(0)->replaceAllUsesAfterNodeWith(bias_n, bias_n->output());


### PR DESCRIPTION
Current implementation has a bug where decomposed `add_optional` from `conv2d` is placed before the producer node, this causes linter error on graph.

Cherry-picked from https://github.com/csarofeen/pytorch/pull/1333
Fixing issue posted in https://github.com/csarofeen/pytorch/issues/1325