### PR TITLE
[fx2trt] Convert to tuple is output_size of adaptive avg pool is an integer

### DIFF
--- a/test/fx2trt/converters/acc_op/test_adaptive_avgpool.py
+++ b/test/fx2trt/converters/acc_op/test_adaptive_avgpool.py
@@ -11,6 +11,7 @@ class TestAdaptiveAvgPoolConverter(AccTestCase):
         [
             ((64, 64),),
             ((128, 64),),
+            (64,),
         ]
     )
     def test_adaptive_avgpool(

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -1233,8 +1233,8 @@ def acc_ops_adaptive_avg_pool2d(
     assert (
         input_val.shape[-1] != -1 and input_val.shape[-1] != -1
     ), "AdaptiveAvgPool2d currently doesn't support dynamic shapes for last two dims."
-    output_size = cast(Sequence[int], kwargs["output_size"])
 
+    output_size = cast(Sequence[int], extend_attr_to_tuple(kwargs["output_size"], 2))
     for input_dim, output_dim in zip(input_val.shape[-2:], output_size):
         if input_dim % output_dim != 0:
             raise RuntimeError(

--- a/torch/fx/experimental/fx2trt/converters/converter_utils.py
+++ b/torch/fx/experimental/fx2trt/converters/converter_utils.py
@@ -73,7 +73,7 @@ def extend_attr_to_tuple(
     num_elem: int,
 ) -> Tuple[Any, ...]:
     """
-    If `val` is not a tuple, then we make a tuple of size `num_elem` by
+    If `val` is not a tuple or a list, then we make a tuple of size `num_elem` by
     replicating `val` `num_elem` times.
 
     Args:
@@ -82,7 +82,7 @@ def extend_attr_to_tuple(
     Returns:
         A tuple.
     """
-    if not isinstance(val, tuple):
+    if not isinstance(val, (tuple, list)):
         val = (val,) * num_elem
     return val
 


### PR DESCRIPTION
Summary: It can be an integer and in this case we need to extend it.

Test Plan:
Added a unit test.
```
RemoteExecution session id: reSessionID-d97b46e3-20d1-4f5c-a166-4efcf1579352-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/8162774391775638
    ✓ ListingSuccess: caffe2/test/fx2trt/converters:test_adaptive_avgpool - main (9.454)
    ✓ Pass: caffe2/test/fx2trt/converters:test_adaptive_avgpool - test_adaptive_avgpool_with_dynamic_shape (caffe2.test.fx2trt.converters.acc_op.test_adaptive_avgpool.TestAdaptiveAvgPoolConverter) (16.083)
    ✓ Pass: caffe2/test/fx2trt/converters:test_adaptive_avgpool - test_adaptive_avgpool_1 (caffe2.test.fx2trt.converters.acc_op.test_adaptive_avgpool.TestAdaptiveAvgPoolConverter) (16.349)
    ✓ Pass: caffe2/test/fx2trt/converters:test_adaptive_avgpool - test_adaptive_avgpool_2 (caffe2.test.fx2trt.converters.acc_op.test_adaptive_avgpool.TestAdaptiveAvgPoolConverter) (16.543)
    ✓ Pass: caffe2/test/fx2trt/converters:test_adaptive_avgpool - test_adaptive_avgpool_0 (caffe2.test.fx2trt.converters.acc_op.test_adaptive_avgpool.TestAdaptiveAvgPoolConverter) (16.651)
Summary
  Pass: 4
  ListingSuccess: 1
```

Reviewed By: wushirong

Differential Revision: D33200773

