### PR TITLE
Add missing defaults to poisson_nll_loss

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3445,7 +3445,7 @@
 - func: pinverse(Tensor self, float rcond=1e-15) -> Tensor
   variants: function, method
 
-- func: poisson_nll_loss(Tensor input, Tensor target, bool log_input, bool full, float eps, int reduction) -> Tensor
+- func: poisson_nll_loss(Tensor input, Tensor target, bool log_input=False, bool full=False, float eps=1e-8, int reduction=Mean) -> Tensor
   variants: function
 
 - func: rad2deg(Tensor self) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3446,6 +3446,7 @@
   variants: function, method
 
 - func: poisson_nll_loss(Tensor input, Tensor target, bool log_input=False, bool full=False, float eps=1e-08, int reduction=Mean) -> Tensor
+  python_module: nn
   variants: function
 
 - func: rad2deg(Tensor self) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3445,7 +3445,7 @@
 - func: pinverse(Tensor self, float rcond=1e-15) -> Tensor
   variants: function, method
 
-- func: poisson_nll_loss(Tensor input, Tensor target, bool log_input=False, bool full=False, float eps=1e-8, int reduction=Mean) -> Tensor
+- func: poisson_nll_loss(Tensor input, Tensor target, bool log_input=False, bool full=False, float eps=1e-08, int reduction=Mean) -> Tensor
   variants: function
 
 - func: rad2deg(Tensor self) -> Tensor

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -84,6 +84,7 @@ blocklist = [
     'hinge_embedding_loss',
     'kl_div',
     'margin_ranking_loss',
+    'poisson_nll_loss',
     'triplet_margin_loss',
     # Somehow, these are defined in both _C and in functional. Ick!
     'broadcast_tensors',
@@ -355,6 +356,9 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
         'cosine_embedding_loss': ['def cosine_embedding_loss(input1: Tensor, input2: Tensor, '
                                   'target: Tensor, margin: float = ..., size_average: Optional[bool] = ..., '
                                   'reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
+        'poisson_nll_loss': ['def poisson_nll_loss(input1: Tensor, target: Tensor, '
+                                  'log_input: bool = ..., full: bool = ..., size_average: Optional[bool] = ..., '
+                                  'eps: float = ..., reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
         'ctc_loss': ['def ctc_loss(log_probs: Tensor, targets: Tensor, input_lengths: Tensor, target_lengths: Tensor,'
                      ' blank: int = ..., reduction: str = ..., zero_infinity: bool = ...) -> Tensor: ...'],
         'hinge_embedding_loss': ['def hinge_embedding_loss(input: Tensor, target: Tensor, margin: float = ...,'

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -357,8 +357,8 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
                                   'target: Tensor, margin: float = ..., size_average: Optional[bool] = ..., '
                                   'reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
         'poisson_nll_loss': ['def poisson_nll_loss(input: Tensor, target: Tensor, '
-                                  'log_input: bool = ..., full: bool = ..., size_average: Optional[bool] = ..., '
-                                  'eps: float = ..., reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
+                             'log_input: bool = ..., full: bool = ..., size_average: Optional[bool] = ..., '
+                             'eps: float = ..., reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
         'ctc_loss': ['def ctc_loss(log_probs: Tensor, targets: Tensor, input_lengths: Tensor, target_lengths: Tensor,'
                      ' blank: int = ..., reduction: str = ..., zero_infinity: bool = ...) -> Tensor: ...'],
         'hinge_embedding_loss': ['def hinge_embedding_loss(input: Tensor, target: Tensor, margin: float = ...,'

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -356,7 +356,7 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
         'cosine_embedding_loss': ['def cosine_embedding_loss(input1: Tensor, input2: Tensor, '
                                   'target: Tensor, margin: float = ..., size_average: Optional[bool] = ..., '
                                   'reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
-        'poisson_nll_loss': ['def poisson_nll_loss(input1: Tensor, target: Tensor, '
+        'poisson_nll_loss': ['def poisson_nll_loss(input: Tensor, target: Tensor, '
                                   'log_input: bool = ..., full: bool = ..., size_average: Optional[bool] = ..., '
                                   'eps: float = ..., reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
         'ctc_loss': ['def ctc_loss(log_probs: Tensor, targets: Tensor, input_lengths: Tensor, target_lengths: Tensor,'

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -84,7 +84,6 @@ blocklist = [
     'hinge_embedding_loss',
     'kl_div',
     'margin_ranking_loss',
-    'poisson_nll_loss',
     'triplet_margin_loss',
     # Somehow, these are defined in both _C and in functional. Ick!
     'broadcast_tensors',
@@ -356,9 +355,6 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
         'cosine_embedding_loss': ['def cosine_embedding_loss(input1: Tensor, input2: Tensor, '
                                   'target: Tensor, margin: float = ..., size_average: Optional[bool] = ..., '
                                   'reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
-        'poisson_nll_loss': ['def poisson_nll_loss(input: Tensor, target: Tensor, '
-                             'log_input: bool = ..., full: bool = ..., size_average: Optional[bool] = ..., '
-                             'eps: float = ..., reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...'],
         'ctc_loss': ['def ctc_loss(log_probs: Tensor, targets: Tensor, input_lengths: Tensor, target_lengths: Tensor,'
                      ' blank: int = ..., reduction: str = ..., zero_infinity: bool = ...) -> Tensor: ...'],
         'hinge_embedding_loss': ['def hinge_embedding_loss(input: Tensor, target: Tensor, margin: float = ...,'

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -750,10 +750,6 @@ for name in dir(_C._VariableFunctions):
 # needs to be after the above ATen bindings so we can overwrite from Python side
 from .functional import *  # noqa: F403
 
-# torch.poisson_nll_loss only preserved for backwards compatibility,
-# should be invoked with torch.nn.functional.poisson_nll_loss
-from ._C._nn import poisson_nll_loss 
-
 
 ################################################################################
 # Remove unnecessary members

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -749,6 +749,7 @@ for name in dir(_C._VariableFunctions):
 
 # needs to be after the above ATen bindings so we can overwrite from Python side
 from .functional import *  # noqa: F403
+from torch._C.nn import poisson_nll_loss
 
 
 ################################################################################

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -750,6 +750,10 @@ for name in dir(_C._VariableFunctions):
 # needs to be after the above ATen bindings so we can overwrite from Python side
 from .functional import *  # noqa: F403
 
+# torch.poisson_nll_loss only preserved for backwards compatibility,
+# should be invoked with torch.nn.functional.poisson_nll_loss
+from ._C._nn import poisson_nll_loss 
+
 
 ################################################################################
 # Remove unnecessary members

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -749,7 +749,7 @@ for name in dir(_C._VariableFunctions):
 
 # needs to be after the above ATen bindings so we can overwrite from Python side
 from .functional import *  # noqa: F403
-from torch._C.nn import poisson_nll_loss
+from _C.nn import poisson_nll_loss
 
 
 ################################################################################

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2702,7 +2702,7 @@ def poisson_nll_loss(
         ret = input
         raise ValueError(reduction + " is not valid")
 
-    return torch._C.nn.poisson_nll_loss(input, target, log_input, full, eps, _Reduction.get_enum(reduction))
+    return torch._C._nn.poisson_nll_loss(input, target, log_input, full, eps, _Reduction.get_enum(reduction))
 
 
 def gaussian_nll_loss(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2702,8 +2702,7 @@ def poisson_nll_loss(
         ret = input
         raise ValueError(reduction + " is not valid")
 
-    ret = torch.poisson_nll_loss(input, target, log_input, full, eps, _Reduction.get_enum(reduction))
-    return ret
+    return torch._C.nn.poisson_nll_loss(input, target, log_input, full, eps, _Reduction.get_enum(reduction))
 
 
 def gaussian_nll_loss(

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -829,7 +829,6 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.pixel_shuffle: lambda input, upscale_factor: -1,
         torch.pixel_unshuffle: lambda input, downscale_factor: -1,
         torch.poisson: lambda input, generator=None: -1,
-        torch.poisson_nll_loss: lambda input, target, log_input, full, eps, reduction: -1,
         torch.polygamma: lambda input, n, out=None: -1,
         torch.positive: lambda input, out=None: -1,
         torch.prelu: lambda input, weight: -1,

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -157,7 +157,6 @@ class AutocastTestLists(object):
             ("norm", pointwise0_fp16, {"p": 1}),
             ("norm", pointwise0_fp16, {"p": 1, "dim": 0}),
             ("cosine_similarity", mat0_fp16 + mat1_fp16),
-            ("poisson_nll_loss", mat0_fp16 + mat1_fp16 + (True, False, 1.e-8, torch.nn._reduction.get_enum('mean'))),
             ("cosine_embedding_loss", (torch.tensor([[1, 2, 3]], device=dev, dtype=torch.float16),
                                        torch.tensor([[1, 3, 4]], device=dev, dtype=torch.float16),
                                        torch.tensor([1], device=dev, dtype=torch.int))),
@@ -219,6 +218,7 @@ class AutocastTestLists(object):
             ("smooth_l1_loss", mat0_fp16 + mat1_fp16),
             ("mse_loss", mat0_fp16 + mat1_fp16),
             ("multilabel_margin_loss", mat0_fp16 + (torch.ones((n, n), device=dev, dtype=torch.long),)),
+            ("poisson_nll_loss", mat0_fp16 + mat1_fp16 + (True, False, 1.e-8, torch.nn._reduction.get_enum('mean'))),
             ("soft_margin_loss", mat0_fp16 + (torch.ones((n, n), device=dev, dtype=torch.long),)),
             ("multi_margin_loss", mat0_fp16 + (torch.ones((n,), device=dev, dtype=torch.long),)),
         ]

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -157,6 +157,7 @@ class AutocastTestLists(object):
             ("norm", pointwise0_fp16, {"p": 1}),
             ("norm", pointwise0_fp16, {"p": 1, "dim": 0}),
             ("cosine_similarity", mat0_fp16 + mat1_fp16),
+            ("poisson_nll_loss", mat0_fp16 + mat1_fp16 + (True, False, 1.e-8, torch.nn._reduction.get_enum('mean'))),
             ("cosine_embedding_loss", (torch.tensor([[1, 2, 3]], device=dev, dtype=torch.float16),
                                        torch.tensor([[1, 3, 4]], device=dev, dtype=torch.float16),
                                        torch.tensor([1], device=dev, dtype=torch.int))),


### PR DESCRIPTION
The defaults are present in the C++ and Python APIs, but not in native_functions.yaml, which means generated third-party bindings don't get them for free. Simply an oversight as far as I can tell. https://discuss.pytorch.org/t/torch-nn-functional-api-and-declarations-yaml/138374/2. 

cc @ezyang @gchanan