### PR TITLE
Low precision support for jiterator

### DIFF
--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -148,7 +148,7 @@ at::opmath_type<f_inputs_type> scalar_val=0) {
   }
   // TODO: FIXME: support these datatypes!
   TORCH_CHECK(dtype0 != kComplexDouble && dtype0 != kComplexFloat &&
-              dtype0 != kBFloat16 && dtype0 != at::kHalf,
+              dtype0 != kBFloat16,
                 "Encountered an unsupported dtype ", dtype0, "!");
 
   // Checks input(s)
@@ -160,7 +160,7 @@ at::opmath_type<f_inputs_type> scalar_val=0) {
       // NOTE: can't short-circuit here yet because the dtype check below needs to run on every arg
     }
     TORCH_CHECK(dtypei != kComplexDouble && dtypei != kComplexFloat &&
-                dtypei != kBFloat16 && dtypei != at::kHalf,
+                dtypei != kBFloat16,
                 "Encountered an unsupported dtype ", dtypei, "!");
   }
   if (scalar_pos == at::cuda::jit::BinaryFuncVariant::NoScalar) {

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -114,6 +114,12 @@ void jitted_gpu_kernel(TensorIteratorBase& iter, const std::string& f,
 at::opmath_type<f_inputs_type> scalar_val=0) {
   // TODO: much of preamble is common to both jitted_gpu_kernel and gpu_kernel
   //   Maybe it could be refactored?
+  static_assert((!std::is_same<return_type, c10::complex<double>>::value &&
+  !std::is_same<return_type, c10::complex<float>>::value), "complex types are not supported \
+  in jiterator functors");
+  static_assert((!std::is_same<f_inputs_type, c10::complex<double>>::value &&
+  !std::is_same<return_type, c10::complex<float>>::value), "complex types are not supported \
+  in jiterator functors");
   for (int arg = 0; arg < iter.ntensors(); arg++) {
     TORCH_INTERNAL_ASSERT(
       iter.device(arg).is_cuda(),
@@ -146,9 +152,6 @@ at::opmath_type<f_inputs_type> scalar_val=0) {
   if (dtype0 != return_scalar_type) {
     needs_dynamic_casting = true;
   }
-  // TODO: FIXME: support these datatypes!
-  TORCH_CHECK(dtype0 != kComplexDouble && dtype0 != kComplexFloat,
-                "Encountered an unsupported dtype ", dtype0, "!");
 
   // Checks input(s)
   const ScalarType inputs_scalar_type = c10::CppTypeToScalarType<f_inputs_type>::value;

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -147,8 +147,7 @@ at::opmath_type<f_inputs_type> scalar_val=0) {
     needs_dynamic_casting = true;
   }
   // TODO: FIXME: support these datatypes!
-  TORCH_CHECK(dtype0 != kComplexDouble && dtype0 != kComplexFloat &&
-              dtype0 != kBFloat16,
+  TORCH_CHECK(dtype0 != kComplexDouble && dtype0 != kComplexFloat,
                 "Encountered an unsupported dtype ", dtype0, "!");
 
   // Checks input(s)
@@ -159,8 +158,7 @@ at::opmath_type<f_inputs_type> scalar_val=0) {
       needs_dynamic_casting = true;
       // NOTE: can't short-circuit here yet because the dtype check below needs to run on every arg
     }
-    TORCH_CHECK(dtypei != kComplexDouble && dtypei != kComplexFloat &&
-                dtypei != kBFloat16,
+    TORCH_CHECK(dtypei != kComplexDouble && dtypei != kComplexFloat,
                 "Encountered an unsupported dtype ", dtypei, "!");
   }
   if (scalar_pos == at::cuda::jit::BinaryFuncVariant::NoScalar) {

--- a/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
@@ -30,21 +30,16 @@ void exp2_kernel_cuda(TensorIteratorBase& iter) {
       });
 }
 
-#define stringify(...) std::string(#__VA_ARGS__);
-const auto fake_i0_string = stringify(
-  template <typename scalar_t>
-  scalar_t i0(scalar_t x) {
-    return x + 1;
-  }
-);
+namespace {
 const char i0_name[] = "i0";
+}
 void i0_kernel_cuda(TensorIteratorBase& iter) {
   #ifdef USE_JITERATOR
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "i0_cuda", [&]() {
     jitted_gpu_kernel</*name=*/i0_name,
                       /*return_dtype=*/ scalar_t,
                       /*common_dtype=*/ scalar_t,
-                      /*arity=*/ 1>(iter, fake_i0_string);
+                      /*arity=*/ 1>(iter, i0_string);
     });
   #else
     AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "i0_cuda", [&]() {
@@ -68,7 +63,9 @@ void i0e_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 // See note [Jiterator]
+namespace {
 const char i1_name[] = "i1";
+}
 void i1_kernel_cuda(TensorIteratorBase& iter) {
   #ifdef USE_JITERATOR
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "i1_cuda", [&]() {

--- a/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
@@ -30,15 +30,32 @@ void exp2_kernel_cuda(TensorIteratorBase& iter) {
       });
 }
 
+#define stringify(...) std::string(#__VA_ARGS__);
+const auto fake_i0_string = stringify(
+  template <typename scalar_t>
+  scalar_t i0(scalar_t x) {
+    return x + 1;
+  }
+);
+const char i0_name[] = "i0";
 void i0_kernel_cuda(TensorIteratorBase& iter) {
+  #ifdef USE_JITERATOR
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "i0_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-      using opmath_t = at::opmath_type<scalar_t>;
-      // implicit conversion of a to opmath_t will happen here,
-      //   but as far as TI is concerned, it's still a no-dynamic-cast kernel because lambda input is scalar_t
-      return calc_i0<opmath_t>(a);
+    jitted_gpu_kernel</*name=*/i0_name,
+                      /*return_dtype=*/ scalar_t,
+                      /*common_dtype=*/ scalar_t,
+                      /*arity=*/ 1>(iter, fake_i0_string);
     });
-  });
+  #else
+    AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "i0_cuda", [&]() {
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+        using opmath_t = at::opmath_type<scalar_t>;
+        // implicit conversion of a to opmath_t will happen here,
+        //   but as far as TI is concerned, it's still a no-dynamic-cast kernel because lambda input is scalar_t
+        return calc_i0<opmath_t>(a);
+      });
+    });
+  #endif
 }
 
 void i0e_kernel_cuda(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/cuda/jit_utils.cu
+++ b/aten/src/ATen/native/cuda/jit_utils.cu
@@ -42,7 +42,7 @@ const std::string jit_common_types = R"ESCAPE(
   _(void, ComplexFloat) /* 9 */                          \
   _(void, ComplexDouble) /* 10 */                         \
   _(bool, Bool) /* 11 */                                 \
-  _(void, BFloat16) /* 12 */                             \
+  _(at::BFloat16, BFloat16) /* 12 */                             \
 
   #define AT_FORALL_SCALAR_TYPES(_) \
   _(uint8_t, Byte)                \
@@ -52,6 +52,7 @@ const std::string jit_common_types = R"ESCAPE(
   _(int64_t, Long)                \
   _(float, Float)                 \
   _(at::Half, Half)               \
+  _(at::BFloat16, BFloat16)       \
   _(double, Double)               \
   _(bool, Bool)
 

--- a/aten/src/ATen/native/cuda/jit_utils.cu
+++ b/aten/src/ATen/native/cuda/jit_utils.cu
@@ -97,7 +97,7 @@ struct alignas(2) Half {
   }
   inline __host__ __device__ operator float() const{
       float val;
-      asm("{  cvt.f32.f16 %0, %1;}\n" : "=f"(val) : "h"(x));
+      asm("{  cvt.f32.f16 %0, %1;}\n" : "=f"(val) : "h"(x)); // do we need const cast here?
       //asm("{  cvt.f32.f16 %0, %1;}\n" : "=f"(val) : "h"(__HALF_TO_CUS(x)));
       return val;
   }
@@ -147,7 +147,7 @@ struct alignas(2) BFloat16 {
 
   inline __host__ __device__ operator float() const{
     float val;
-    asm("{ mov.b32 %0, {0,%1};}\n" : "=f"(val) : "h"(x));
+    asm("{ mov.b32 %0, {0,%1};}\n" : "=f"(val) : "h"(x)); //do we need const cast here?
     return val;
   }
 

--- a/aten/src/ATen/native/cuda/jit_utils.cu
+++ b/aten/src/ATen/native/cuda/jit_utils.cu
@@ -141,6 +141,8 @@ struct alignas(2) BFloat16 {
   inline __host__ __device__ BFloat16(float value){
   #if __CUDA_ARCH__ >= 800
   asm("{  cvt.rn.bf16.f32 %0, %1;}\n" : "=h"(x) : "f"(value));
+  )ESCAPE"
+  R"ESCAPE(
   #else
   unsigned int sign;
   unsigned int remainder;

--- a/aten/src/ATen/native/cuda/jit_utils.cu
+++ b/aten/src/ATen/native/cuda/jit_utils.cu
@@ -6,7 +6,6 @@
 #include <ATen/native/cuda/jit_utils.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/irange.h>
-#include <iostream>
 
 namespace at { namespace cuda { namespace jit {
 
@@ -92,7 +91,7 @@ const std::string jit_common_types = R"ESCAPE(
 
 )ESCAPE";
 
-//we need to include half and bfloat16 strings to all kernels with half arguments and to all kernels with type casting
+//we need to include half, bfloat16 and complex strings to all kernels with half arguments and to all kernels with type casting
 //regardless of whether they have half arguments (because fetch_and_cast and cast_and_store loop over all types)
 const std::string jiterator_half_support_literal = R"ESCAPE(
 namespace at {
@@ -163,6 +162,7 @@ struct alignas(2) BFloat16 {
 }
 )ESCAPE";
 
+//copy-pasted from util/complex.h
 const std::string jiterator_complex_support_literal = R"ESCAPE(
 //a very limited complex class, the only thing it currently allows is implicit conversion
 //to complex, and complex -> real that is unused

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -562,7 +562,6 @@ class TestBinaryUfuncs(TestCase):
     # NOTE: because the cross-product of all possible type promotion tests is huge, this
     #   just spot checks some handwritten cases.
     # NOTE: It may be possible to refactor this test into something simpler
-    @skipCUDAIfRocm
     @ops(binary_ufuncs, dtypes=OpDTypes.none)
     def test_type_promotion(self, device, op):
         supported_dtypes = op.supported_dtypes(torch.device(device).type)
@@ -714,21 +713,6 @@ class TestBinaryUfuncs(TestCase):
                     out = torch.empty_like(lhs_f64, dtype=torch.int64)
                     self.assertEqual(op(lhs_f32, rhs_f64, out=out).dtype, torch.int64)
                     self.assertEqual(op(lhs_f32, rhs_f64), out, exact_dtype=False)
-
-    # Verifies that gcd throws an error when given an out of float16, bfloat16, or complex dtype
-    #   because the jiterator does not support casting to these datatypes
-    # TODO: FIXME: the jiterator should be updated to support these datatypes
-    @skipCUDAIfRocm
-    @onlyCUDA
-    def test_jiterator_unsupported(self, device):
-        lhs = torch.tensor((1, 2, 3), device=device)
-        rhs = torch.tensor((4, 2, 1), device=device)
-
-        unsupported_dtypes = (torch.float16, torch.bfloat16, torch.complex64, torch.complex128)
-        for dtype in unsupported_dtypes:
-            out = torch.empty_like(lhs, dtype=dtype)
-            with self.assertRaisesRegex(RuntimeError, "Encountered an unsupported dtype"):
-                torch.gcd(lhs, rhs, out=out)
 
     # TODO: move to error input test
     @ops(binary_ufuncs, allowed_dtypes=(torch.float32,))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -10829,12 +10829,7 @@ op_db: List[OpInfo] = [
                         # TODO: FIXME: jiterator doesn't support non-tensor inputs
                         DecorateInfo(unittest.expectedFailure,
                                      'TestBinaryUfuncs',
-                                     'test_broadcast_python_scalar'),
-                        # TODO: FIXME: jiterator doesn't support casts to unsupported types
-                        DecorateInfo(unittest.expectedFailure,
-                                     'TestBinaryUfuncs',
-                                     'test_type_promotion',
-                                     device_type='cuda'))),
+                                     'test_broadcast_python_scalar'),)),
     BinaryUfuncInfo('isclose',
                     ref=np.isclose,
                     dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),


### PR DESCRIPTION
This adds support for bfloat16 and fp16 types for jiterator by adding at::Half and at::BFloat16 classes to the jiterator code template. The only methods defined in those classes are construction from float and implicit conversion to float. Mathematical operations on them never need to be defined, because jiterator is written in a way to implicitly upcast the inputs to the functor, so all math has to be performed on float only (e.g. compute part of the kernel would always be written as 
```
        out[j] = i0<float>(arg0[j]);
```
It also adds support for casting to complex outputs, by adding a similar templated class c10::complex<T>. Originally I planned to only support float -> complex complex for it, but to compile fetch_and_cast function we also need complex -> float conversion. We can avoid it by compiling fetch_and_cast for a different subset of types, but I'm not doing it in this PR. Thus, technically, we can compile a kernel that would accept complex inputs and produce wrong results, but we are guarding against it by static asserting that none of the functor datatype are complex, and runtime-checking that none of the inputs are complex.
Adding bfloat16, half and complex support allows us to remove special handling for type promotion tests for gcd.
i0 (that supports half and bfloat16 inputs) is moved to use jiterator. 
 
