### PR TITLE
[Operator Versioning][Edge] Initialize upgrader thread safe

### DIFF
--- a/torch/csrc/jit/mobile/upgrader_mobile.cpp
+++ b/torch/csrc/jit/mobile/upgrader_mobile.cpp
@@ -25,7 +25,7 @@ getOperatorVersionMapForMobile() {
   return operatorVersionMapForMobile;
 }
 
-std::vector<ByteCodeFunctionWithOperator> getUpgraderBytecodeList() {
+std::vector<ByteCodeFunctionWithOperator>& getUpgraderBytecodeList() {
   static std::vector<ByteCodeFunctionWithOperator> upgraderBytecodeList({
       ByteCodeFunctionWithOperator({
           mobile::Function::registerFunc(

--- a/torch/csrc/jit/mobile/upgrader_mobile.h
+++ b/torch/csrc/jit/mobile/upgrader_mobile.h
@@ -36,7 +36,7 @@ struct ByteCodeFunctionWithOperator {
   std::vector<OperatorString> operators;
 };
 
-TORCH_API std::vector<ByteCodeFunctionWithOperator> getUpgraderBytecodeList();
+TORCH_API std::vector<ByteCodeFunctionWithOperator>& getUpgraderBytecodeList();
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70161

Upgrader should only be initialized once when runtime loads the first module. It no longer needs to initialized afterwards.

Previously, instead of using an atomic variable, the upgrader will be initialized depends on whether byteCodeFunctionWithOperator.function.get_code().operators_ is empty. If it's empty, it means the operator from the upgrader is not initialized yet. However, it's not thread safe. When multiple thread loads module together, it's possible that they all consider it's the first module. Use an atomic variable here to make sure it's thread safe.



Differential Revision: [D33220320](https://our.internmc.facebook.com/intern/diff/D33220320/)

Differential Revision: [D33220320](https://our.internmc.facebook.com/intern/diff/D33220320)