### PR TITLE
Change open source unit test deps

### DIFF
--- a/test/fx2trt/passes/test_fuse_permute_linear_trt.py
+++ b/test/fx2trt/passes/test_fuse_permute_linear_trt.py
@@ -1,6 +1,6 @@
 import torch
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
-from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase
+from torch.testing._internal.common_fx2trt import AccTestCase
 from torch.fx.experimental.fx2trt.passes.fuse_pass import (
     fuse_permute_linear,
     trt_transposed_linear,

--- a/test/fx2trt/passes/test_fuse_permute_matmul_trt.py
+++ b/test/fx2trt/passes/test_fuse_permute_matmul_trt.py
@@ -1,6 +1,6 @@
 import torch
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
-from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase
+from torch.testing._internal.common_fx2trt import AccTestCase
 from parameterized import parameterized, param
 from torch.fx.experimental.fx2trt.passes.fuse_pass import (
     fuse_permute_matmul,

--- a/test/fx2trt/passes/test_fuse_unsqueeze_cat_sum_trt.py
+++ b/test/fx2trt/passes/test_fuse_unsqueeze_cat_sum_trt.py
@@ -1,6 +1,6 @@
 import torch
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
-from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase
+from torch.testing._internal.common_fx2trt import AccTestCase
 from torch.fx.experimental.fx2trt.passes.fuse_pass import (
     fuse_unsqueeze_cat_sum,
 )

--- a/test/fx2trt/passes/test_multi_fuse_trt.py
+++ b/test/fx2trt/passes/test_multi_fuse_trt.py
@@ -1,6 +1,6 @@
 import torch
 import torch.fx.experimental.fx_acc.acc_ops as acc_ops
-from caffe2.torch.fb.fx2trt.tests.test_utils import AccTestCase
+from torch.testing._internal.common_fx2trt import AccTestCase
 from parameterized import parameterized
 from torch.fx.experimental.fx2trt.passes.fuse_pass import (
     fuse_permute_linear,

--- a/torch/fx/experimental/fx2trt/lower.py
+++ b/torch/fx/experimental/fx2trt/lower.py
@@ -120,7 +120,7 @@ class LowerTrtInterpreter:
         return interp_result
 
 
-class LowerFunc(t.Protocol):
+class LowerFunc:
     """Signature for fx2trt lower functions"""
 
     def __call__(

--- a/torch/fx/experimental/fx2trt/split.py
+++ b/torch/fx/experimental/fx2trt/split.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 Input = t.Sequence[t.Any]
 
 
-class SplitFunc(t.Protocol):
+class SplitFunc:
     """Signature for fx2trt split functions"""
 
     def __call__(

--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -9,6 +9,7 @@ from torch.fx.experimental.fx2trt import (
     InputTensorSpec,
     TRTModule,
 )
+from torch.testing._internal.common_utils import TestCase
 from torch.fx.experimental.normalize import NormalizeArgs
 from torch.fx.passes import shape_prop
 
@@ -35,7 +36,7 @@ def fetch_attr(mod, target):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "Skip because CUDA is not available")
-class TRTTestCase(unittest.TestCase):
+class TRTTestCase(TestCase):
     def setUp(self):
         torch.manual_seed(3)
 


### PR DESCRIPTION
Summary:
1. Change unit test dependency to open source base class, so that this unit test can run on git oss CI
2. Remove usage of typing.Protocol, so that lower can run with Python 3.6

Test Plan:
oss CI
passed with change included in commit:
https://github.com/pytorch/pytorch/actions/runs/1597530689
see test(fx2trt)

Differential Revision: D33228894

