### PR TITLE
DOC: Merge extraheader block from theme instead of override

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -9,6 +9,7 @@
 -->
 <meta name="robots" content="noindex">
 {% endif %}
+{{ super() }}
 {% endblock %}
 
 {% block menu %}


### PR DESCRIPTION
Fixes #70185

The extraheader block in docs/source/_templates/layout.html overrides the one from the pytorch theme. The theme block adds Google Analytics, so they were missing from the `master` documentation. This came up in PR pytorch/pytorch.github.io#899.

@brianjo