### PR TITLE
Handle the corner case when min == max in L2 search

### DIFF
--- a/caffe2/quantization/server/dnnlowp.cc
+++ b/caffe2/quantization/server/dnnlowp.cc
@@ -309,18 +309,20 @@ adjust_hist_to_include_zero(const Histogram& hist, float* min, float* max) {
   // Pad histogram to include zero
   int additional_nbins = 0;
   int offset = 0;
-  if (*min > 0) {
-    // additional nbins to include 0
-    additional_nbins = ceil(*min / bin_width);
-    offset = additional_nbins;
-    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-    *min -= additional_nbins * bin_width;
-    assert(*min <= 0);
-  } else if (*max < 0) {
-    additional_nbins = ceil((-*max) / bin_width);
-    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-    *max += additional_nbins * bin_width;
-    assert(*max >= 0);
+  if (bin_width > 0) {
+    if (*min > 0) {
+      // additional nbins to include 0
+      additional_nbins = ceil(*min / bin_width);
+      offset = additional_nbins;
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+      *min -= additional_nbins * bin_width;
+      assert(*min <= 0);
+    } else if (*max < 0) {
+      additional_nbins = ceil((-*max) / bin_width);
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+      *max += additional_nbins * bin_width;
+      assert(*max >= 0);
+    }
   }
 
   vector<float> bins_f(nbins + additional_nbins);


### PR DESCRIPTION
Summary: In corner case when min == max, adjust_hist_to_include_zero() function used in L2 search will cause additional_nbins = -2147483648 and initialize bins_f with negative size.

Test Plan:
Before fix:
f315187213

After fix:
f315471862

Reviewed By: jspark1105

Differential Revision: D33227717

