### PR TITLE
[Bazel] Remove TH/THC in BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -294,7 +294,6 @@ filegroup(
             "aten/src/ATen/native/cudnn/*.cpp",
             "aten/src/ATen/native/miopen/*.cpp",
             "aten/src/ATen/native/sparse/cuda/*.cpp",
-            "aten/src/THC/*.cpp",
         ],
     ),
 )
@@ -355,9 +354,6 @@ cc_library(
         "aten/src/**/*.hpp",
         "aten/src/ATen/cuda/**/*.cuh",
         "aten/src/ATen/native/**/*.cuh",
-        "aten/src/TH/**/*.cpp",
-        "aten/src/THC/*.cuh",
-        "aten/src/THC/generic/*.cu",
     ],
     ) + [
         ":aten_src_ATen_config",


### PR DESCRIPTION
Codes in TH/THC were removed, this PR removes references to them in `BUILD.bazel`.
