### PR TITLE
[shard] fix named_params_with_sharded_tensor

### DIFF
--- a/torch/distributed/_sharded_optim/__init__.py
+++ b/torch/distributed/_sharded_optim/__init__.py
@@ -48,6 +48,6 @@ def named_params_with_sharded_tensor(
                 name = mod_prefix + ('.' if mod_prefix else '') + name
                 yield name, val
 
-        # find all nn.Parameters
-        for name, val in mod.named_parameters():
-            yield name, val
+    # find all nn.Parameters
+    for name, val in module.named_parameters():
+        yield name, val


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

fix named_params_with_sharded_tensor impl, where `named_parameters` already loop the submodules recursively, so we shouldn't put it in the submodule loop.

Differential Revision: [D33251428](https://our.internmc.facebook.com/intern/diff/D33251428/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang