### PR TITLE
use irange for loops

### DIFF
--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -97,7 +98,7 @@ class ReshapeOp : public Operator<Context> {
     }
 
     int unknown_idx = -1;
-    for (int i = 0; i < actual_new_shape.size(); ++i) {
+    for (const auto i : c10::irange(actual_new_shape.size())) {
       const auto dim = actual_new_shape[i];
       if (dim == -1) {
         CAFFE_ENFORCE(
@@ -153,7 +154,7 @@ class ReshapeOp : public Operator<Context> {
     old_shape->Resize(input.sizes().size());
     T* old_shape_data = old_shape->template mutable_data<T>();
     std::vector<T> old_shape_vector(input.sizes().begin(), input.sizes().end());
-    for (int i = 0; i < old_shape_vector.size(); ++i) {
+    for (const auto i : c10::irange(old_shape_vector.size())) {
       old_shape_data[i] = old_shape_vector[i];
     }
 

--- a/caffe2/operators/reverse_packed_segs_op.h
+++ b/caffe2/operators/reverse_packed_segs_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -62,7 +63,7 @@ class ReversePackedSegsOp final : public Operator<Context> {
     context_.FinishDeviceComputation();
 
     T* rev_data_ptr = output->template mutable_data<T>();
-    for (int64_t i = 0; i < batch_size; i++) {
+    for (const auto i : c10::irange(batch_size)) {
       const auto& seg_length = lengths_host[i];
       CAFFE_ENFORCE_LE(seg_length, max_length);
       int64_t j = 0;

--- a/caffe2/operators/rnn/recurrent_network_blob_fetcher_op.h
+++ b/caffe2/operators/rnn/recurrent_network_blob_fetcher_op.h
@@ -31,8 +31,7 @@ class RecurrentNetworkBlobFetcherOp final : public Operator<Context> {
 
     std::vector<std::string> blob_names_vector = {};
 
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int64_t i = 0; i < stepWorkspaces.size(); i++) {
+    for (const auto i : c10::irange(stepWorkspaces.size())) {
       Workspace* currentStepWorkspace = stepWorkspaces[i].get();
       std::vector<std::string> blob_names = currentStepWorkspace->LocalBlobs();
 

--- a/caffe2/operators/rnn/recurrent_network_executor.h
+++ b/caffe2/operators/rnn/recurrent_network_executor.h
@@ -1,15 +1,16 @@
 #ifndef CAFFE2_OPERATORS_RECURRENT_NETWORK_EXECUTOR_H_
 #define CAFFE2_OPERATORS_RECURRENT_NETWORK_EXECUTOR_H_
 
-#include <map>
-#include <unordered_set>
-#include <vector>
-
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/timer.h"
 #include "caffe2/operators/rnn/recurrent_network_executor_incl.h"
+#include "c10/util/irange.h"
+
+#include <map>
+#include <unordered_set>
+#include <vector>
 
 namespace caffe2 {
 
@@ -38,7 +39,7 @@ class RecurrentNetworkExecutorBase {
         recurrent_input_map_(recurrent_input_map),
         timestep_blob_(timestep_blob) {
     const bool net_def_has_device_option = step_net_def_.has_device_option();
-    for (int i = 0; i < step_net_def_.op_size(); i++) {
+    for (const auto i : c10::irange(step_net_def_.op_size())) {
       if (net_def_has_device_option) {
         // In the case when net def specifies device option, final device option
         // will be equal to merge of operator and net def device options, with
@@ -86,7 +87,7 @@ class RecurrentNetworkExecutorBase {
       for (auto& rnn_op : timestep_ops_template_) {
         rnn_op.has_timestep_blob = false;
         const OperatorDef& op = step_net_def_.op(rnn_op.order);
-        for (int i = 0; i < op.input_size(); i++) {
+        for (const auto i : c10::irange(op.input_size())) {
           if (op.input(i) == timestep_blob_) {
             rnn_op.has_timestep_blob = true;
             break;
@@ -137,7 +138,7 @@ class RecurrentNetworkExecutorBase {
         if (rnn_op.has_timestep_blob) {
           OperatorDef op_copy = step_net_def_.op(rnn_op.order);
 
-          for (int i = 0; i < op_copy.input_size(); i++) {
+          for (const auto i : c10::irange(op_copy.input_size())) {
             if (op_copy.input(i) == timestep_blob_) {
               op_copy.set_input(i, this_timestep_blob);
             }
@@ -283,7 +284,7 @@ class RecurrentNetworkExecutorBase {
       int opidx,
       std::vector<RNNNetOperator>& rnn_ops,
       std::unordered_set<int>* dep_ops) {
-    for (int i = 0; i < rnn_ops.size(); i++) {
+    for (const auto i : c10::irange(rnn_ops.size())) {
       if (i == opidx) {
         continue;
       }
@@ -315,7 +316,7 @@ class RecurrentNetworkExecutorBase {
    * for each timestep.
    */
   void CalculateInternalDependencies() {
-    for (int i = 0; i < step_net_def_.op_size(); i++) {
+    for (const auto i : c10::irange(step_net_def_.op_size())) {
       timestep_ops_template_.push_back(RNNNetOperator(step_net_def_.op(i), i));
     }
     // Then see which outputs appear as inputs, and those are

--- a/caffe2/operators/rnn/recurrent_network_op.h
+++ b/caffe2/operators/rnn/recurrent_network_op.h
@@ -8,6 +8,7 @@
 #include "caffe2/operators/rnn/recurrent_network_executor.h"
 #include "caffe2/utils/conversions.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 C10_DECLARE_bool(caffe2_rnn_executor);
 
@@ -102,8 +103,7 @@ void repeatCopy(
     const T* src,
     T* dst,
     Context* context) {
-  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-  for (int i = 0; i < repeat_n; ++i) {
+  for (const auto i : c10::irange(repeat_n)) {
     context->template CopySameDevice<T>(n, src, dst + i * n);
   }
 }
@@ -227,8 +227,7 @@ class RecurrentNetworkOp final : public Operator<Context> {
         this->template GetRepeatedArgument<int>("initial_recurrent_state_ids");
     CAFFE_ENFORCE_EQ(states.size(), inputs.size(), "states/inputs mismatch");
     std::vector<detail::RecurrentInput> ris;
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (auto i = 0; i < states.size(); ++i) {
+    for (const auto i : c10::irange(states.size())) {
       // States need to be "global" (since they are shared between
       // forward and backward).
       sharedWs->CreateBlob(states[i]);
@@ -253,8 +252,7 @@ class RecurrentNetworkOp final : public Operator<Context> {
     CAFFE_ENFORCE(
         dst.size() == offset.size(), "alias_dst/alias_offset mismatch");
     std::vector<detail::OffsetAlias> aliases;
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (auto i = 0; i < src.size(); ++i) {
+    for (const auto i : c10::irange(src.size())) {
       detail::OffsetAlias oc;
       oc.src = src[i];
       oc.dst = dst[i];
@@ -343,7 +341,7 @@ class RecurrentNetworkOp final : public Operator<Context> {
       stepWorkspaces.resize(num_workspaces_on_fwd_only);
     }
 
-    for (auto t = 0; t < seqLen; ++t) {
+    for (const auto t : c10::irange(seqLen)) {
       auto& currentStepWorkspace =
           (has_backward_pass ? stepWorkspaces[t] :
               stepWorkspaces[t % num_workspaces_on_fwd_only]);
@@ -472,7 +470,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
   }
 
   void renameOpInputOutput(std::string from_name, std::string to_name) {
-    for (int j = 0; j < stepNetDef_.op_size(); j++) {
+    for (const auto j : c10::irange(stepNetDef_.op_size())) {
       auto* op = stepNetDef_.mutable_op(j);
       for (int i = 0; i < op->input_size(); i++) {
         if (op->input(i) == from_name) {
@@ -497,8 +495,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
         param.size(),
         " != ",
         param_grads.size());
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < param.size(); ++i) {
+    for (const auto i : c10::irange(param.size())) {
       detail::Param p;
       // Forward inputs come after [outputs_with_grads] gradient inputs
       p.param = operator_def.input(param[i] + gradInputs_.size());
@@ -525,18 +522,17 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
     const auto& offset =
         this->template GetRepeatedArgument<int32_t>("alias_offset");
 
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (auto i = 0; i < recurrent.size(); ++i) {
+    for (const auto i : c10::irange(recurrent.size())) {
       detail::RecurrentGradient rg;
       rg.param = recurrent[i];
       rg.grad = remappedName(recurrent[i] + "_grad");
 
-      for (int j = 0; j < alias_src.size(); ++j) {
+      for (const auto j : c10::irange(alias_src.size())) {
         if (alias_src[j] != recurrent[i]) {
           continue;
         }
         int idx = -1;
-        for (int k = 0; k < gradInputs_.size(); ++k) {
+        for (const auto k : c10::irange(gradInputs_.size())) {
           if (gradInputs_[k] == j) {
             idx = k;
           }
@@ -574,8 +570,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
         "backward_link_offset",
         "",
         &links);
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < links.size(); i++) {
+    for (const auto i : c10::irange(links.size())) {
       links[i] = remappedLink(links[i]);
     }
     return links;
@@ -715,7 +710,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
     // This code assumes that there are several inputs
     // sequences. Actually it is not supported by the rest of the code,
     // and numSequences_ is a constant, equal to 1.
-    for (int i = 0; i < numSequences_; ++i) {
+    for (const auto i : c10::irange(numSequences_)) {
       // Offseting as the first gradInputs_.size() inputs of the op
       // are from GO. Then all I(0..N).
       const int gradientInputIndex = i + gradInputs_.size();
@@ -789,8 +784,7 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
     }
 
     CAFFE_ENFORCE_EQ(recurrentInputIds_.size(), recurrentGradients_.size());
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < recurrentInputIds_.size(); ++i) {
+    for (const auto i : c10::irange(recurrentInputIds_.size())) {
       // See GetRecurrentNetworkGradient to understand offseting here
       // Outputs of the gradient are inputs of the forward pass.
       // So we need to offset on all inputs that go before recurrent

--- a/caffe2/operators/rowmul_op.h
+++ b/caffe2/operators/rowmul_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -32,9 +33,9 @@ class RowMulOp : public Operator<Context> {
         "Length of w should be equal to the first dim of mat");
 
     auto block_size = mat.size_from_dim(1);
-    for (int i = 0; i < w.numel(); i++) {
+    for (const auto i : c10::irange(w.numel())) {
       size_t offset = i * block_size;
-      for (int j = 0; j < block_size; j++) {
+      for (const auto j : c10::irange(block_size)) {
         output_data[offset + j] = mat_data[offset + j] * w_data[i];
       }
     }
@@ -60,10 +61,10 @@ class ReduceTailSumOp : public Operator<Context> {
     T* output_data = output->template mutable_data<T>();
     const T* mat_data = mat.template data<T>();
 
-    for (int i = 0; i < N; i++) {
+    for (const auto i : c10::irange(N)) {
       output_data[i] = 0;
       size_t offset = i * block_size;
-      for (int j = 0; j < block_size; j++) {
+      for (const auto j : c10::irange(block_size)) {
         output_data[i] += mat_data[offset + j];
       }
     }

--- a/caffe2/operators/scale_blobs_op.h
+++ b/caffe2/operators/scale_blobs_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -20,7 +21,7 @@ class ScaleBlobsOp final : public Operator<Context> {
   bool DoRunWithType() {
     int batchSize = InputSize();
 
-    for (int i = 0; i < batchSize; ++i) {
+    for (const auto i : c10::irange(batchSize)) {
       const auto& X = Input(i);
       auto* Y = Output(i, X.sizes(), at::dtype<T>());
       math::Scale<float, T, Context>(
@@ -34,7 +35,7 @@ class ScaleBlobsOp final : public Operator<Context> {
   }
 
   bool RunOnDevice() override {
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       auto& input = this->template Input<Tensor>(i, CPU);
       auto* output = this->template Output<Tensor>(i, CPU);
       output->ResizeLike(input);

--- a/caffe2/operators/self_binning_histogram_op.h
+++ b/caffe2/operators/self_binning_histogram_op.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include "caffe2/core/operator.h"
 
 namespace caffe2 {
 
@@ -59,12 +61,12 @@ class SelfBinningHistogramOp final : public Operator<Context> {
     T max = 0;
     T min = 0;
     int64_t total_count = 0;
-    for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+    for (const auto input_idx : c10::irange(InputSize())) {
       const auto& x = Input(input_idx);
       const int64_t N = x.numel();
       total_count += N;
       const auto* x_data = x.template data<T>();
-      for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+      for (const auto data_idx : c10::irange(N)) {
         const T val = this->abs_ ? std::abs(x_data[data_idx]) :  x_data[data_idx];
         if (!first_seen) {
           max = val;
@@ -91,7 +93,7 @@ class SelfBinningHistogramOp final : public Operator<Context> {
       scaled_max = min + (max - min) * RANGE_SCALING;
       T scaled_range = (scaled_max - min);
       // Avoid underflow by calculating advancement through multiplication.
-      for (int i = 0; i < num_edges_; i++) {
+      for (const auto i : c10::irange(num_edges_)) {
         T advancement_ratio = T(i) / num_bins_;
         histogram_values_data[i] = min + advancement_ratio * scaled_range;
       }
@@ -112,7 +114,7 @@ class SelfBinningHistogramOp final : public Operator<Context> {
       T log_multiplier_numerator =log(scaled_max) - log(min);
       // Avoid underflow by:
       // - Calculating each advancement separately for each i.
-      for (int i = 0; i < num_edges_; i++) {
+      for (const auto i : c10::irange(num_edges_)) {
         T advancement_ratio = T(i)/num_bins_;
         histogram_values_data[i] = min * exp(log_multiplier_numerator * advancement_ratio);
       }
@@ -127,11 +129,11 @@ class SelfBinningHistogramOp final : public Operator<Context> {
       histogram_counts_data[0] = total_count;
     }
     else {
-      for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+      for (const auto input_idx : c10::irange(InputSize())) {
         const auto& x = Input(input_idx);
         const int64_t N = x.numel();
         const auto* x_data = x.template data<T>();
-        for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+        for (const auto data_idx : c10::irange(N)) {
           const T val = this->abs_ ? std::abs(x_data[data_idx]) :  x_data[data_idx];
           const auto bisection_it = std::upper_bound(
               histogram_values_data,
@@ -163,7 +165,7 @@ class SelfBinningHistogramOp final : public Operator<Context> {
 
   void CheckInputs() {
     const auto& input_zero = Input(0);
-    for (int i = 1; i < InputSize(); i++) {
+    for (const auto i : c10::irange(1, InputSize())) {
       CAFFE_ENFORCE_EQ(
           Input(i).dtype(),
           input_zero.dtype(),

--- a/caffe2/operators/shape_op.h
+++ b/caffe2/operators/shape_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -34,7 +35,7 @@ class ShapeOp : public Operator<Context> {
     auto* output = Output(0, {numAxes}, at::dtype<int64_t>());
     auto src = reinterpret_cast<const char*>(data.sizes().data());
     auto out = reinterpret_cast<char*>(output->template mutable_data<int64_t>());
-    for (int i = 0; i < numAxes; i++) {
+    for (const auto i : c10::irange(numAxes)) {
       auto axis = axes_[i];
       CAFFE_ENFORCE_LT(axis, numDims, "Axis out of range");
       CAFFE_ENFORCE_GE(axis, 0, "Each axis should be non-negative");

--- a/caffe2/operators/sinusoid_position_encoding_op.h
+++ b/caffe2/operators/sinusoid_position_encoding_op.h
@@ -51,7 +51,7 @@ class SinusoidPositionEncodingOp : public Operator<Context> {
     float max_alpha_pow =
         ((float)embedding_size_ - 1.0f) / (float)embedding_size_;
 
-    for (int i = 0; i < M; ++i) {
+    for (const auto i : c10::irange(M)) {
       float pos = (float)idxs[i * K];
 
       // Compute the embedding for position i, example 0 first
@@ -72,7 +72,7 @@ class SinusoidPositionEncodingOp : public Operator<Context> {
       row_array = amplitude_ * row_array.sin().eval();
 
       // Copy the embedding to position i in the other examples
-      for (int j = 1; j < K; ++j) {
+      for (const auto j : c10::irange(1, K)) {
         int base = i * K * embedding_size_;
         std::copy(
             &out[base],

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -30,7 +31,7 @@ bool SliceImpl(
   std::vector<SIndex> ends_idx(data.dim());
   std::vector<SIndex> dst_sizes(data.dim());
 
-  for (int i = 0; i < data.dim(); ++i) {
+  for (const auto i : c10::irange(data.dim())) {
     if (i >= starts.numel()) {
       starts_idx[i] = 0;
       ends_idx[i] = data.size(i);
@@ -78,7 +79,7 @@ bool SliceImpl(
   }
   // for now only supports slicing in 1 dimension
   int dim = -1;
-  for (int i = 0; i < data.dim(); ++i) {
+  for (const auto i : c10::irange(data.dim())) {
     if (starts_idx[i] > 0 || ends_idx[i] < data.size(i)) {
       CAFFE_ENFORCE_EQ(
           dim, -1, "Currently only possible to slice in 1 dimension.");
@@ -131,7 +132,7 @@ bool SliceImpl(
 
     char* src_offset_bytes = src_bytes + itemsize * src_offset;
     char* dst_offset_bytes = dst_bytes;
-    for (size_t i = 0; i < num_blocks; ++i) {
+    for (const auto i : c10::irange(num_blocks)) {
       char* local_src_offset_bytes =
           src_offset_bytes + i * src_block_size_bytes;
       char* local_dst_offset_bytes =
@@ -177,7 +178,7 @@ bool SliceImpl(
       return true;
     }
 
-    for (size_t i = 0; i < num_blocks; ++i) {
+    for (const auto i : c10::irange(num_blocks)) {
       char* local_src_offset_bytes =
           src_offset_bytes + i * src_block_size_bytes;
       char* local_dst_offset_bytes =

--- a/caffe2/operators/space_batch_op.h
+++ b/caffe2/operators/space_batch_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -29,14 +30,14 @@ void spaceToBatch(
   const int input_height = input.dim32(2);
   const int input_width = input.dim32(3);
 
-  for (int out_b = 0; out_b < output_batch; ++out_b) {
+  for (const auto out_b : c10::irange(output_batch)) {
     const int in_b = out_b % input_batch;
     const int offset_w = (out_b / input_batch) % block_size;
     const int offset_h = (out_b / input_batch) / block_size;
-    for (int d = 0; d < input_depth; ++d) {
-      for (int out_h = 0; out_h < output_height; ++out_h) {
+    for (const auto d : c10::irange(input_depth)) {
+      for (const auto out_h : c10::irange(output_height)) {
         const int in_h = out_h * block_size + offset_h - pad_t;
-        for (int out_w = 0; out_w < output_width; ++out_w) {
+        for (const auto out_w : c10::irange(output_width)) {
           const int in_w = out_w * block_size + offset_w - pad_l;
           const auto output_offset =
               ((out_b * output_depth + d) * output_height + out_h) *
@@ -80,14 +81,14 @@ void batchToSpace(
   const int input_width = input.dim32(3);
 
   CAFFE_ENFORCE(input_depth == output_depth);
-  for (int in_b = 0; in_b < input_batch; ++in_b) {
+  for (const auto in_b : c10::irange(input_batch)) {
     const int out_b = in_b % output_batch;
     const int offset_w = (in_b / output_batch) % block_size;
     const int offset_h = (in_b / output_batch) / block_size;
-    for (int d = 0; d < input_depth; ++d) {
-      for (int in_h = 0; in_h < input_height; ++in_h) {
+    for (const auto d : c10::irange(input_depth)) {
+      for (const auto in_h : c10::irange(input_height)) {
         const int out_h = in_h * block_size + offset_h - pad_t;
-        for (int in_w = 0; in_w < input_width; ++in_w) {
+        for (const auto in_w : c10::irange(input_width)) {
           const int out_w = in_w * block_size + offset_w - pad_l;
           if (out_h >= 0 && out_w >= 0 && out_h < output_height &&
               out_w < output_width) {

--- a/caffe2/operators/sparse_to_dense_op.h
+++ b/caffe2/operators/sparse_to_dense_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -89,7 +90,7 @@ class SparseToDenseOp final : public Operator<Context> {
     const auto block_nitems = sparse_values.size_from_dim(1);
     const TData* sparse_values_vec = sparse_values.template data<TData>();
 
-    for (int32_t i = 0; i < sparse_indices_len; i++) {
+    for (const auto i : c10::irange(sparse_indices_len)) {
       const TInd idx = sparse_indices_vec[i];
       CAFFE_ENFORCE_GE(idx, 0);
       CAFFE_ENFORCE_LT(idx, output_first_dim);

--- a/caffe2/operators/square_root_divide_op.h
+++ b/caffe2/operators/square_root_divide_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -41,7 +42,7 @@ class SquareRootDivideOp final : public Operator<Context> {
     auto* scalePtr = scale.template data<TScale>();
     auto* dataPtr = data.template data<TData>();
     auto* yPtr = Y->template mutable_data<TData>();
-    for (auto i = 0U; i < batchSize; ++i) {
+    for (const auto i : c10::irange(0U, batchSize)) {
       auto scale = scalePtr[i];
       CAFFE_ENFORCE(scale >= 0, scale, " < 0");
       auto multiplier = scale == 0 ? 1.0 : 1 / std::sqrt(scale);

--- a/caffe2/operators/string_ops.h
+++ b/caffe2/operators/string_ops.h
@@ -20,7 +20,7 @@ struct ForEach {
 
   template <typename In, typename Out, typename Context>
   bool operator()(int n, const In* in, Out* out, Context* /*c*/) {
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       out[i] = functor(in[i]);
     }
     return true;

--- a/caffe2/operators/tensor_protos_db_input.h
+++ b/caffe2/operators/tensor_protos_db_input.h
@@ -1,11 +1,12 @@
 #ifndef CAFFE2_OPERATORS_TENSOR_PROTOS_DB_INPUT_H_
 #define CAFFE2_OPERATORS_TENSOR_PROTOS_DB_INPUT_H_
 
-#include <iostream>
-#include <mutex>
-
 #include "caffe2/core/db.h"
 #include "caffe2/operators/prefetch_op.h"
+#include "c10/util/irange.h"
+
+#include <iostream>
+#include <mutex>
 
 namespace caffe2 {
 
@@ -51,7 +52,7 @@ bool TensorProtosDBInput<Context>::Prefetch() {
     TensorProtos protos;
     CAFFE_ENFORCE(protos.ParseFromString(value_));
     CAFFE_ENFORCE(protos.protos_size() == OutputSize());
-    for (int i = 0; i < protos.protos_size(); ++i) {
+    for (const auto i : c10::irange(protos.protos_size())) {
       if (protos.protos(i).has_device_detail()) {
         protos.mutable_protos(i)->clear_device_detail();
       }
@@ -62,14 +63,14 @@ bool TensorProtosDBInput<Context>::Prefetch() {
       //     CPU));
     }
   } else {
-    for (int item_id = 0; item_id < batch_size_; ++item_id) {
+    for (const auto item_id : c10::irange(batch_size_)) {
       reader.Read(&key_, &value_);
       TensorProtos protos;
       CAFFE_ENFORCE(protos.ParseFromString(value_));
       CAFFE_ENFORCE(protos.protos_size() == OutputSize());
       // Note: shape_inferred_ is ignored, we'll always get dimensions from
       // proto
-      for (int i = 0; i < protos.protos_size(); ++i) {
+      for (const auto i : c10::irange(protos.protos_size())) {
         vector<int64_t> dims(
             protos.protos(i).dims().begin(), protos.protos(i).dims().end());
         dims.insert(dims.begin(), batch_size_);
@@ -94,7 +95,7 @@ bool TensorProtosDBInput<Context>::Prefetch() {
 
 template <class Context>
 bool TensorProtosDBInput<Context>::CopyPrefetched() {
-  for (int i = 0; i < OutputSize(); ++i) {
+  for (const auto i : c10::irange(OutputSize())) {
     OperatorBase::template Output<Tensor>(i, Context::GetDeviceType())
         ->CopyFrom(
             prefetched_blobs_[i].template Get<TensorCPU>(), /* async */ true);

--- a/caffe2/operators/tile_op.h
+++ b/caffe2/operators/tile_op.h
@@ -113,12 +113,12 @@ class TileOp final : public Operator<Context> {
   bool DoTile(const int outer_size, const int inner_size, const T* X, T* Y) {
     if (inner_size == 1) {
       EigenArrayMap<T> Y_arr(Y, tiles_, outer_size);
-      for (int i = 0; i < outer_size; ++i) {
+      for (const auto i : c10::irange(outer_size)) {
         Y_arr.col(i) = X[i];
       }
     } else {
       ConstEigenArrayMap<T> X_arr(X, inner_size, outer_size);
-      for (int i = 0; i < outer_size; ++i) {
+      for (const auto i : c10::irange(outer_size)) {
         EigenArrayMap<T>(Y + i * tiles_ * inner_size, inner_size, tiles_)
             .colwise() = X_arr.col(i);
       }
@@ -245,10 +245,10 @@ class TileGradientOp final : public Operator<Context> {
           dX,
           inner_size,
           &context_);
-      for (int i = 0; i < outer_size; ++i) {
+      for (const auto i : c10::irange(outer_size)) {
         const T* dY_ptr = dY + i * tiles_ * inner_size;
         T* dX_ptr = dX + i * inner_size;
-        for (int j = 1; j < tiles_; ++j) {
+        for (const auto j : c10::irange(1, tiles_)) {
           math::Add<T, Context>(
               inner_size, dX_ptr, dY_ptr + j * inner_size, dX_ptr, &context_);
         }

--- a/caffe2/operators/transpose_op.h
+++ b/caffe2/operators/transpose_op.h
@@ -7,6 +7,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -23,9 +24,8 @@ class TransposeOp : public Operator<Context> {
     // We will check the legality of axes_: it should be from 0 to axes_.size().
     std::vector<int> axes_sorted = axes_;
     std::sort(axes_sorted.begin(), axes_sorted.end());
-    for (std::size_t i = 0; i < axes_sorted.size(); ++i) {
-      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      if (axes_sorted[i] != i) {
+    for (const auto i : c10::irange(axes_sorted.size())) {
+      if (axes_sorted[i] != static_cast<int64_t>(i)) {
         CAFFE_THROW("Axes should be a permutation of 0 to ndim.");
       }
     }
@@ -49,7 +49,7 @@ class TransposeOp : public Operator<Context> {
     }
     const at::IntArrayRef X_dims = X.sizes();
     std::vector<std::int64_t> Y_dims(ndim);
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       Y_dims[i] = X_dims[axes_[i]];
     }
     Y->Resize(Y_dims);

--- a/caffe2/operators/tt_linear_op.h
+++ b/caffe2/operators/tt_linear_op.h
@@ -126,8 +126,7 @@ class TTLinearOp final : public Operator<Context> {
 
     // Check that output size of Y is the element-wise product of out_sizes
     int prod_out_sizes = 1;
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < out_sizes_.size(); i++) {
+    for (const auto i : c10::irange(out_sizes_.size())) {
       prod_out_sizes *= out_sizes_[i];
     }
     CAFFE_ENFORCE(

--- a/caffe2/operators/unsafe_coalesce.h
+++ b/caffe2/operators/unsafe_coalesce.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include <c10/util/irange.h>
 #include "caffe2/core/operator.h"
 
 
@@ -16,7 +17,7 @@ class UnsafeCoalesceOp final : public Operator<Context> {
 
   bool RunOnDevice() override {
     size_t coalesced_size = 0;
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       // For now only float type is supported
       CAFFE_ENFORCE(
           Input(i).dtype().template Match<float>(),
@@ -24,14 +25,14 @@ class UnsafeCoalesceOp final : public Operator<Context> {
           i);
     }
 
-    for (int i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       coalesced_size += Input(i).numel();
     }
     auto* coalesced = Output(OutputSize() - 1, coalesced_size, at::dtype<float>());
     auto coalesced_data = coalesced->template mutable_data<float>();
 
     size_t coalesced_offset = 0;
-    for (auto i = 0; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(InputSize())) {
       const auto num_elems = Input(i).numel();
       auto input_sizes = Input(i).sizes().vec();
       // Don't do anything if both tensors are already pointing on the same data

--- a/caffe2/operators/variable_length_sequence_padding.h
+++ b/caffe2/operators/variable_length_sequence_padding.h
@@ -17,7 +17,7 @@ void VariableLengthSequencePadding(
     const int32_t* seqLengths,
     const T padValue,
     Context* /*context*/) {
-  for (int j = 0; j < B; j++) {
+  for (const auto j : c10::irange(B)) {
     for (int i = seqLengths[j]; i < N; i++) {
       EigenVectorArrayMap<T>(X + B * M * i + M * j, M).setConstant(padValue);
     }

--- a/caffe2/opt/nql/ast.h
+++ b/caffe2/opt/nql/ast.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "c10/util/irange.h"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -20,8 +21,7 @@ struct ASTExpr {
     return starInputsFlag;
   }
   void dump(int level = 0) const {
-    for (int i = 0; i < level; i++)
-      std::cout << "  ";
+    for (const auto i : c10::irange(level))std::cout << "  ";
     if (!isCall())
       std::cout << "Var: " << name << std::endl;
     else {
@@ -41,8 +41,7 @@ struct ASTStmt {
     delete rhs;
   }
   void dump(int level = 0) const {
-    for (int i = 0; i < level; i++)
-      std::cout << "  ";
+    for (const auto i : c10::irange(level))std::cout << "  ";
     std::cout << "LHS:" << std::endl;
     for (auto s : lhs) {
       for (int i = 0; i < level + 1; i++)

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -6,6 +6,7 @@
 
 #include <c10/util/Exception.h>
 #include <c10/util/SmallVector.h>
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
@@ -138,7 +139,7 @@ class OnnxifiOp final : public Operator<Context> {
 
     if (use_passed_output_shapes_) {
       // Populate output_shapes_per_bs_
-      for (int bs = 1; bs < max_batch_size_; ++bs) {
+      for (const auto bs : c10::irange(1, max_batch_size_)) {
         auto output_shapes_tp = helper.GetRepeatedArgument<TensorProto>("output_shapes_bs_" + caffe2::to_string(bs));
         auto output_qshapes_tp = helper.GetRepeatedArgument<TensorProto>("output_qshapes_bs_" + caffe2::to_string(bs));
         CAFFE_ENFORCE_EQ(output_names_.size(), output_shapes_tp.size() + output_qshapes_tp.size());
@@ -267,7 +268,7 @@ class OnnxifiOp final : public Operator<Context> {
           ONNXIFI_STATUS_SUCCESS);
 
       // Release unused backend ids.
-      for (size_t i = 0; i < num_backends; ++i) {
+      for (const auto i : c10::irange(num_backends)) {
         if (i == static_cast<size_t>(backend_index)) {
           continue;
         }
@@ -287,7 +288,7 @@ class OnnxifiOp final : public Operator<Context> {
 
       // Extra weight shapes
       std::unordered_map<std::string, ShapeInfo> weight_shape_info;
-      for (size_t i = 0; i < weight_names.size(); ++i) {
+      for (const auto i : c10::irange(weight_names.size())) {
         TensorShape shape;
         const auto& shape0 = weight_shapes[i];
         for (const auto d : shape0) {

--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -6,6 +6,7 @@
 #include <immintrin.h>
 #endif
 #include <c10/util/Half.h>
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -26,7 +27,7 @@ static inline void adagrad_update_base_inlined(
     float epsilon,
     float lr,
     float weight_decay = 0.f) {
-  for (auto i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = std::fma(weight_decay, w[i], g[i]);
     float hi = decay * h[i] + gi * gi;
     nh[i] = hi;

--- a/caffe2/perfkernels/lstm_unit_cpu-impl.h
+++ b/caffe2/perfkernels/lstm_unit_cpu-impl.h
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <cmath>
 #include <cstdint>
+#include "c10/util/irange.h"
 #include "caffe2/utils/conversions.h"
 
 #if (ENABLE_VECTORIZATION > 0) && !defined(_DEBUG) && !defined(DEBUG)
@@ -53,7 +54,7 @@ inline void LstmUnitImpl(
     T* H,
     const float forget_bias) {
   const T forgetBias = convert::To<float, T>(forget_bias);
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
     if (!valid) {
       if (drop_states) {
@@ -67,7 +68,7 @@ inline void LstmUnitImpl(
       const T* X_D = &X[D];
       const T* X_2D = &X[2 * D];
       const T* X_3D = &X[3 * D];
-      VECTOR_LOOP for (int d = 0; d < D; ++d) {
+      VECTOR_LOOP for (const auto d : c10::irange(D)) {
         const T i = sigmoid(X[d]);
         const T f = sigmoid(X_D[d] + forgetBias);
         const T o = sigmoid(X_2D[d]);
@@ -105,7 +106,7 @@ inline void LstmUnitGradientImpl(
     T* X_diff,
     const float forget_bias) {
   const T localForgetBias = convert::To<float, T>(forget_bias);
-  for (int n = 0; n < N; ++n) {
+  for (const auto n : c10::irange(N)) {
     const bool valid = seqLengths == nullptr || t < seqLengths[n];
 
     if (!valid) {
@@ -118,7 +119,7 @@ inline void LstmUnitGradientImpl(
       }
       memset(X_diff, 0, 4 * sizeof(T) * D);
     } else {
-      VECTOR_LOOP for (int d = 0; d < D; ++d) {
+      VECTOR_LOOP for (const auto d : c10::irange(D)) {
         T* c_prev_diff = C_prev_diff + d;
         T* h_prev_diff = H_prev_diff + d;
         T* i_diff = X_diff + d;

--- a/caffe2/predictor/emulator/data_filler.h
+++ b/caffe2/predictor/emulator/data_filler.h
@@ -59,12 +59,12 @@ class DataNetFiller : public Filler {
       : init_net_(init_net), data_net_(data_net) {
     // The output of the data_net_ will be served as the input
     int op_size = data_net_.op_size();
-    for (int i = 0; i < op_size; ++i) {
+    for (const auto i : c10::irange(op_size)) {
       OperatorDef op_def = data_net_.op(i);
       // We rely on Fill op to generate inputs
       CAFFE_ENFORCE(op_def.type().find("Fill") != std::string::npos);
       int output_size = op_def.output_size();
-      for (int j = 0; j < output_size; ++j) {
+      for (const auto j : c10::irange(output_size)) {
         input_names_.push_back(op_def.output(j));
       }
     }
@@ -105,7 +105,7 @@ class DataRandomFiller : public Filler {
       int input_index,
       const std::vector<std::vector<int64_t>>& input_dims) {
     Workspace ws;
-    for (int i = 0; i < op_def.input_size(); ++i) {
+    for (const auto i : c10::irange(op_def.input_size())) {
       // CreateOperator requires all input blobs present
       ws.CreateBlob(op_def.input(i));
     }

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -153,12 +153,12 @@ class TensorFetcher : public BlobFetcherBase {
     if (numpy_type == NPY_OBJECT) {
       PyObject** outObj = reinterpret_cast<PyObject**>(outPtr);
       auto* str = tensor.template data<std::string>();
-      for (int i = 0; i < tensor.numel(); ++i) {
+      for (const auto i : c10::irange(tensor.numel())) {
         outObj[i] = PyBytes_FromStringAndSize(str->data(), str->size());
         str++;
         // cleanup on failure
         if (outObj[i] == nullptr) {
-          for (int j = 0; j < i; ++j) {
+          for (const auto j : c10::irange(i)) {
             Py_DECREF(outObj[j]);
           }
           CAFFE_THROW("Failed to allocate string for ndarray of strings.");
@@ -212,7 +212,7 @@ class TensorFeeder : public BlobFeederBase {
     int ndim = PyArray_NDIM(array);
     npy_intp* npy_dims = PyArray_DIMS(array);
     std::vector<int64_t> dims;
-    for (int i = 0; i < ndim; ++i) {
+    for (const auto i : c10::irange(ndim)) {
       dims.push_back(npy_dims[i]);
     }
 
@@ -229,7 +229,7 @@ class TensorFeeder : public BlobFeederBase {
               dims, at::dtype<std::string>().device(Context::GetDeviceType()));
         }
         auto* outPtr = tensor.template mutable_data<std::string>();
-        for (int i = 0; i < tensor.numel(); ++i) {
+        for (const auto i : c10::irange(tensor.numel())) {
           char* str;
           Py_ssize_t strSize;
           if (PyBytes_Check(input[i])) {
@@ -375,7 +375,7 @@ class PythonOpBase : public Operator<Context> {
 
       std::vector<py::object> inputs;
       inputs.reserve(InputSize());
-      for (auto i = 0; i < InputSize(); ++i) {
+      for (const auto i : c10::irange(InputSize())) {
         const auto* blob = &InputBlob(i);
         // Allow CPU tensors in addition to operator context's tensors
         py::object py_obj;
@@ -395,7 +395,7 @@ class PythonOpBase : public Operator<Context> {
       }
       std::vector<py::object> outputs;
       outputs.reserve(OutputSize());
-      for (auto i = 0; i < OutputSize(); ++i) {
+      for (const auto i : c10::irange(OutputSize())) {
         auto* blob = OutputBlob(i);
 
         // Python op is always used with CPUContext only and treats inputs and

--- a/caffe2/quantization/server/elementwise_dnnlowp_op.h
+++ b/caffe2/quantization/server/elementwise_dnnlowp_op.h
@@ -127,7 +127,7 @@ class BinaryElementwiseDNNLowPOp : public DNNLowPOp<T, FP32_OP> {
         size_t n,                                                            \
         size_t post,                                                         \
         CPUContext*) {                                                       \
-      for (int i = 0; i < pre; ++i) {                                        \
+      for (const auto i : c10::irange(pre)) {                                        \
         EigenArrayMap<R>(out + i * n * post, post, n) = eigen_op(            \
             (ConstEigenArrayMap<T>(a + i * n * post, post, n).rowwise()),    \
             (Eigen::Map<const Eigen::Array<T, 1, Eigen::Dynamic>>(b, n)));   \

--- a/caffe2/quantization/server/im2col_dnnlowp.h
+++ b/caffe2/quantization/server/im2col_dnnlowp.h
@@ -50,7 +50,7 @@ static void Im2ColNCHW(
       auto* dst = data_col + nip * (kernel_h * kernel_w * output_h * output_w) +
           kh * (kernel_w * output_h * output_w) + kw * (output_h * output_w);
       const auto* src = data_im + nip * (height * width);
-      for (auto y = 0; y < output_h; y++) {
+      for (const auto y : c10::irange(output_h)) {
         const auto iy = y * stride_h + kh;
         const auto ix = kw;
         if (stride_w == 1) {
@@ -59,7 +59,7 @@ static void Im2ColNCHW(
               src + (iy * width + ix),
               sizeof(T) * output_w);
         } else {
-          for (auto x = 0; x < output_w; x++) {
+          for (const auto x : c10::irange(output_w)) {
             memcpy(
                 dst + (y * output_w + x),
                 src + (iy * width + ix + x * stride_w),
@@ -78,8 +78,8 @@ static void Im2ColNCHW(
     const int pad_w = pad_l;
     const int channel_size = height * width;
     for (int channel = channels; channel--; data_im += channel_size) {
-      for (int kernel_row = 0; kernel_row < kernel_h; kernel_row++) {
-        for (int kernel_col = 0; kernel_col < kernel_w; kernel_col++) {
+      for (const auto kernel_row : c10::irange(kernel_h)) {
+        for (const auto kernel_col : c10::irange(kernel_w)) {
           int input_row = -pad_h + kernel_row * dilation_h;
           for (int output_rows = output_h; output_rows; output_rows--) {
             if (!utils::IsAGeZeroAndALtB(input_row, height)) {
@@ -113,12 +113,12 @@ static void Im2ColNCHW(
   int width_col = (width + pad_l + pad_r - dkernel_w) / stride_w + 1;
 
   int channels_col = channels * kernel_h * kernel_w;
-  for (int c = 0; c < channels_col; ++c) {
+  for (const auto c : c10::irange(channels_col)) {
     int w_offset = c % kernel_w;
     int h_offset = (c / kernel_w) % kernel_h;
     int c_im = c / kernel_h / kernel_w;
-    for (int h = 0; h < height_col; ++h) {
-      for (int w = 0; w < width_col; ++w) {
+    for (const auto h : c10::irange(height_col)) {
+      for (const auto w : c10::irange(width_col)) {
         int h_pad = h * stride_h - pad_t + h_offset * dilation_h;
         int w_pad = w * stride_w - pad_l + w_offset * dilation_w;
         if (h_pad >= 0 && h_pad < height && w_pad >= 0 && w_pad < width)
@@ -152,20 +152,20 @@ static void Im2ColNdNCHW(
       kernel_shape, kernel_shape + N, 1, std::multiplies<int>());
   std::vector<int> d_offset(N, 0);
   std::vector<int> d_iter(N, 0);
-  for (int i = 0; i < outer_size; ++i) {
+  for (const auto i : c10::irange(outer_size)) {
     // Loop over spatial axes in reverse order to compute a per-axis offset.
     int offset = i;
     for (int d_i = N - 1; d_i >= 0; --d_i) {
       d_offset[d_i] = offset % kernel_shape[d_i];
       offset /= kernel_shape[d_i];
     }
-    for (int j = 0; j < inner_size; ++j) {
+    for (const auto j : c10::irange(inner_size)) {
       // Loop over spatial axes in forward order to compute the indices in the
       // image and column, and whether the index lies in the padding.
       const int col_index = i * inner_size + j;
       int img_index = i / kernel_size;
       bool is_padding = false;
-      for (int d_i = 0; d_i < N; ++d_i) {
+      for (const auto d_i : c10::irange(N)) {
         const int d_img = d_iter[d_i] * stride[d_i] - pad[d_i] +
             d_offset[d_i] * dilation[d_i];
         is_padding |= d_img < 0 || d_img >= img_shape[d_i + 1];
@@ -216,13 +216,13 @@ static void Im2ColNHWC(
     T* data_col_temp =
         data_col + h * width_col * kernel_h * kernel_w * channels;
     int w_pad = -pad_l;
-    for (int w = 0; w < width_col; ++w) {
+    for (const auto w : c10::irange(width_col)) {
       int r = 0;
       for (int ih = h_pad; ih < h_pad + dkernel_h; ih += dilation_h, ++r) {
         int s = 0;
         for (int iw = w_pad; iw < w_pad + dkernel_w; iw += dilation_w, ++s) {
           if (ih >= 0 && ih < height && iw >= 0 && iw < width) {
-            for (int g = 0; g < groups; ++g) {
+            for (const auto g : c10::irange(groups)) {
               memcpy(
                   data_col_temp +
                       ((g * kernel_h + r) * kernel_w + s) * (channels / groups),
@@ -232,7 +232,7 @@ static void Im2ColNHWC(
             }
           } else {
             // This should be simply padded with zero.
-            for (int g = 0; g < groups; ++g) {
+            for (const auto g : c10::irange(groups)) {
               for (int i = 0; i < channels / groups; ++i) {
                 data_col_temp
                     [(((g * kernel_h + r) * kernel_w) + s) *
@@ -293,12 +293,12 @@ static void Im2Col3DNHWC(
 #endif
   for (int t = 0; t < frame_col; ++t) {
     int t_pad = -pad_p + t * stride_t;
-    for (int h = 0; h < height_col; ++h) {
+    for (const auto h : c10::irange(height_col)) {
       int h_pad = -pad_t + h * stride_h;
       T* data_col_temp = data_col +
           (t * height_col + h) * width_col * kernel_t * kernel_h * kernel_w *
               channels;
-      for (int w = 0; w < width_col; ++w) {
+      for (const auto w : c10::irange(width_col)) {
         int w_pad = -pad_l + w * stride_w;
         int q = 0;
         for (int it = t_pad; it < t_pad + dkernel_t; it += dilation_t, ++q) {
@@ -309,7 +309,7 @@ static void Im2Col3DNHWC(
                  iw += dilation_w, ++s) {
               if (it >= 0 && it < num_frames && ih >= 0 && ih < height &&
                   iw >= 0 && iw < width) {
-                for (int g = 0; g < groups; ++g) {
+                for (const auto g : c10::irange(groups)) {
                   memcpy(
                       data_col_temp +
                           (((g * kernel_t + q) * kernel_h + r) * kernel_w + s) *
@@ -320,7 +320,7 @@ static void Im2Col3DNHWC(
                 }
               } else {
                 // This should be simply padded with zero.
-                for (int g = 0; g < groups; ++g) {
+                for (const auto g : c10::irange(groups)) {
                   for (int i = 0; i < channels / groups; ++i) {
                     data_col_temp
                         [((((g * kernel_t + q) * kernel_h + r) * kernel_w) +

--- a/caffe2/quantization/server/mmio.h
+++ b/caffe2/quantization/server/mmio.h
@@ -36,8 +36,8 @@ void StoreMatrixInMatrixMarketFormat(
     }
     fprintf(fp, "%d %d\n", m, n);
     // matrix market array format uses column-major order
-    for (int j = 0; j < n; ++j) {
-      for (int i = 0; i < m; ++i) {
+    for (const auto j : c10::irange(n)) {
+      for (const auto i : c10::irange(m)) {
         if (is_integral<T>::value) {
           // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
           fprintf(fp, "%d\n", static_cast<int>(a[j * m + i]));

--- a/caffe2/quantization/server/utility_dnnlowp_ops.h
+++ b/caffe2/quantization/server/utility_dnnlowp_ops.h
@@ -54,7 +54,7 @@ class GatherDNNLowPOp final : public GatherOp<CPUContext> {
     const Index* idxs = indices.template data<Index>();
     auto out = static_cast<char*>(output->raw_mutable_data(data.dtype()));
 
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       auto idx = idxs[i];
       CAFFE_ENFORCE(
           0 <= idx && idx < data.size(0),

--- a/caffe2/queue/queue_ops.h
+++ b/caffe2/queue/queue_ops.h
@@ -149,7 +149,7 @@ class SafeDequeueBlobsOp final : public Operator<Context> {
     }
 
     const int kTensorGrowthPct = 40;
-    for (int i = 0; i < numRecords_; ++i) {
+    for (const auto i : c10::irange(numRecords_)) {
       if (!queue->blockingRead(blobPtrs_)) {
         // if we read at least one record, status is still true
         return i > 0;

--- a/caffe2/queue/rebatching_queue_ops.h
+++ b/caffe2/queue/rebatching_queue_ops.h
@@ -2,6 +2,8 @@
 
 #include "rebatching_queue.h"
 
+#include "c10/util/irange.h"
+
 namespace caffe2 {
 
 using RebatchingQueuePtr = std::unique_ptr<RebatchingQueue>;
@@ -32,7 +34,7 @@ class EnqueueRebatchingQueueOp : public Operator<CPUContext> {
     CAFFE_ENFORCE_EQ(InputSize(), queue->numBlobs() + 1);
     std::vector<const Tensor*> inputTensors;
     inputTensors.reserve(InputSize() - 1);
-    for (int i = 1; i < InputSize(); ++i) {
+    for (const auto i : c10::irange(1, InputSize())) {
       inputTensors.push_back(&Input(i));
     }
 
@@ -56,7 +58,7 @@ class DequeueRebatchingQueueOp : public Operator<CPUContext> {
 
     std::vector<Tensor*> outputTensors;
     outputTensors.reserve(OutputSize());
-    for (int i = 0; i < OutputSize(); ++i) {
+    for (const auto i : c10::irange(OutputSize())) {
       outputTensors.push_back(Output(i));
     }
 

--- a/caffe2/sgd/adadelta_op.h
+++ b/caffe2/sgd/adadelta_op.h
@@ -1,4 +1,5 @@
 #include "caffe2/core/operator.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 
@@ -18,7 +19,7 @@ void AdadeltaUpdate(
     float* nh,
     float* nd,
     Context* /*context*/) {
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     float gi = g[i];
     float di = d[i];
     float hi = nh[i] = decay * h[i] + (1.0f - decay) * gi * gi;
@@ -120,7 +121,7 @@ class SparseAdadeltaOp final : public Operator<Context> {
     }
 
     auto block_size = Input(GRAD).numel() / n;
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : c10::irange(n)) {
       auto idx = indices[i];
       if (block_size == 1) {
         float gi = gradIn[i];

--- a/caffe2/sgd/adagrad_fused.h
+++ b/caffe2/sgd/adagrad_fused.h
@@ -82,8 +82,8 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
     auto* grad_buffer_data =
         is_mean ? grad_buffer_.template mutable_data<T>() : NULL;
     if (is_mean) {
-      for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
-        for (auto tmpIndex = 0; tmpIndex < block_size; ++tmpIndex) {
+      for (const auto rangeIndex : c10::irange(numSegments)) {
+        for (const auto tmpIndex : c10::irange(block_size)) {
           auto offsetI = rangeIndex * block_size;
           grad_buffer_data[offsetI + tmpIndex] = lengths[rangeIndex] > 0
               ? gradIn[offsetI + tmpIndex] / lengths[rangeIndex]
@@ -92,7 +92,7 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
       }
     }
 
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -243,7 +243,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     // ignores this dependency and fuses these two loops.
     std::vector<T> temp_grad(block_size);
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -277,7 +277,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
     CAFFE_ENFORCE_EQ(dataIndex, n);
 
     dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -285,7 +285,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         auto offsetIdx = idx * block_size;
         auto localOffset = dataIndex - start;
 
-        for (int i = 0; i < block_size; ++i) {
+        for (const auto i : c10::irange(block_size)) {
           temp_grad[i] = auxParamIn[localOffset] * gradIn[offsetI + i];
         }
 
@@ -409,7 +409,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
 
     std::vector<T> temp_grad(block_size);
     int dataIndex = 0;
-    for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
+    for (const auto rangeIndex : c10::irange(numSegments)) {
       for (auto start = dataIndex; dataIndex < start + lengths[rangeIndex];
            ++dataIndex) {
         std::size_t idx = indices[dataIndex];
@@ -440,7 +440,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
             auxGrad + dataIndex,
             &context_);
 
-        for (int i = 0; i < block_size; ++i) {
+        for (const auto i : c10::irange(block_size)) {
           temp_grad[i] = auxParamIn[localOffset] * gradIn[offsetI + i];
         }
 


### PR DESCRIPTION
Summary:
Modified loops in files under fbsource/fbcode/caffe2/ from the format
```
for(TYPE var=x0;var<x_max;x++)
```
to the format
```
for(const auto var: irange(xmax))
```

This was achieved by running r-barnes's loop upgrader script (D28874212) with some modification to exclude all files under /torch/jit and a number of reversions or unused variable suppression warnings added by hand.

Test Plan: Sandcastle

Differential Revision: D32813863

