### PR TITLE
[GHA] Fix doc push jobs

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -332,7 +332,7 @@ jobs:
       - name: Generate netrc (only for docs-push)
         if: ${{ github.event_name == 'schedule' }}
         env:
-          GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GITHUB_PYTORCHBOT_TOKEN }}
+          GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
           # set credentials for https pushing
           echo "machine github.com" > "${RUNNER_TEMP}/.netrc"
@@ -364,7 +364,7 @@ jobs:
             --detach \
             --user jenkins \
 {%- if is_scheduled %}
-            -v "${RUNNER_TEMP}/.netrc":/home/jenkins/.netrc \
+            -v "${RUNNER_TEMP}/.netrc":/var/lib/jenkins/.netrc \
 {%- endif %}
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -330,7 +330,7 @@ jobs:
           unzip -o artifacts.zip
 {%- if is_scheduled %}
       - name: Generate netrc (only for docs-push)
-        if: ${{ github.event_name == 'schedule' }}
+        # if: ${{ github.event_name == 'schedule' }}
         env:
           GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Generate netrc (only for docs-push)
         if: ${{ github.event_name == 'schedule' }}
         env:
-          GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GITHUB_PYTORCHBOT_TOKEN }}
+          GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
           # set credentials for https pushing
           echo "machine github.com" > "${RUNNER_TEMP}/.netrc"
@@ -356,7 +356,7 @@ jobs:
             --tty \
             --detach \
             --user jenkins \
-            -v "${RUNNER_TEMP}/.netrc":/home/jenkins/.netrc \
+            -v "${RUNNER_TEMP}/.netrc":/var/lib/jenkins/.netrc \
             -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -324,7 +324,7 @@ jobs:
         run: |
           unzip -o artifacts.zip
       - name: Generate netrc (only for docs-push)
-        if: ${{ github.event_name == 'schedule' }}
+        # if: ${{ github.event_name == 'schedule' }}
         env:
           GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |


### PR DESCRIPTION
Home folder in docker images is `/var/lib/jenkins`, rather than `/home/jenkins`
Also repo secrets can not start with `GITHUB_` prefix according to [Naming your secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#naming-your-secrets) guide
    
Fixes https://github.com/pytorch/pytorch/issues/70211
