### PR TITLE
Fix masked_softmax's perf for element_size is not 8

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -952,7 +952,7 @@ Tensor masked_softmax_cuda(const Tensor& input, const Tensor& mask) {
     // Therefore once softmax_elements > 1024, we need to fallback to vanilla masked_softmax
     Tensor output = at::empty_like(input, input.options());
     // Fallback to a slower masked softmax solution
-    if (softmax_elements > 1024 || softmax_elements * sizeof(input.element_size()) > 4096 || !mask.is_contiguous()) {
+    if (softmax_elements > 1024 || softmax_elements * input.element_size() > 4096 || !mask.is_contiguous()) {
         AT_DISPATCH_FLOATING_TYPES_AND2(
           ScalarType::Half,
           ScalarType::BFloat16,


### PR DESCRIPTION
Test Plan:
Rebase on top of D32407544 and
buck run mode/opt -c fbcode.enable_gpu_sections=true pytext/fb/tools:benchmark_masked_softmax -- masked-softmax --batch-size=10
to see correct perf data ( PT time = ~2.5x PT native time )

Differential Revision: D33268055

