### PR TITLE
Back out "[Quant][Eager] Added 4 bit support for eager mode quantization flow"

### DIFF
--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -18,7 +18,6 @@ from torch.ao.quantization import (
     per_channel_dynamic_qconfig,
     float16_dynamic_qconfig,
     float_qparams_weight_only_qconfig,
-    float_qparams_weight_only_qconfig_4bit,
     PerChannelMinMaxObserver,
     default_dynamic_quant_observer,
     QConfig,
@@ -569,28 +568,26 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
         r""" Test the post-training quantization flow, serialization and scripting
         of embedding modules
         """
+        model = EmbeddingModule().eval()
+        indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
+        weights = torch.randn(10, 12, dtype=torch.float32)
+        model.qconfig = float_qparams_weight_only_qconfig
+        prepare(model, inplace=True)
+        convert(model, inplace=True)
+        self.assertTrue('QuantizedEmbedding' in str(model))
+        self.assertEqual(type(model.emb), torch.nn.quantized.Embedding)
+        self.checkScriptable(model, [[indices]], check_save_load=True)
 
-        for qconfig in [float_qparams_weight_only_qconfig, float_qparams_weight_only_qconfig_4bit]:
-            model = EmbeddingModule().eval()
-            indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
-            weights = torch.randn(10, 12, dtype=torch.float32)
-            model.qconfig = qconfig
-            prepare(model, inplace=True)
-            convert(model, inplace=True)
-            self.assertTrue('QuantizedEmbedding' in str(model))
-            self.assertEqual(type(model.emb), torch.nn.quantized.Embedding)
-            self.checkScriptable(model, [[indices]], check_save_load=True)
-
-            idx = torch.LongTensor([1, 2, 4, 5, 4, 3, 2, 9])
-            offsets = torch.LongTensor([0, 4])
-            x = torch.randn(2, 4)
-            model = EmbeddingWithStaticLinear().eval()
-            prepare(model, inplace=True)
-            convert(model, inplace=True)
-            self.assertTrue('QuantizedEmbedding' in str(model))
-            self.assertTrue('QuantizedLinear' in str(model))
-            self.checkQuantizedLinear(model.fc)
-            model(idx, offsets, x)
+        idx = torch.LongTensor([1, 2, 4, 5, 4, 3, 2, 9])
+        offsets = torch.LongTensor([0, 4])
+        x = torch.randn(2, 4)
+        model = EmbeddingWithStaticLinear().eval()
+        prepare(model, inplace=True)
+        convert(model, inplace=True)
+        self.assertTrue('QuantizedEmbedding' in str(model))
+        self.assertTrue('QuantizedLinear' in str(model))
+        self.checkQuantizedLinear(model.fc)
+        model(idx, offsets, x)
 
     @skipIfNoFBGEMM
     def test_dequant_stub(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -44,7 +44,6 @@ from torch.ao.quantization import (
     float16_dynamic_qconfig,
     float16_static_qconfig,
     float_qparams_weight_only_qconfig,
-    float_qparams_weight_only_qconfig_4bit,
     get_default_qconfig,
     get_default_qat_qconfig,
     get_default_qconfig_dict,
@@ -5205,26 +5204,25 @@ class TestQuantizeFxOps(QuantizationTestCase):
             def forward(self, indices):
                 return self.emb(indices)
 
-        for qconfig_type in [float_qparams_weight_only_qconfig, float_qparams_weight_only_qconfig_4bit]:
-            model = M().eval()
-            indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
-            quantized_node = ns.call_module(nnq.Embedding)
-            configs = [
-                (qconfig_type, ns.call_module(nnq.Embedding)),
-                (None, ns.call_module(nn.Embedding)),
-                (default_qconfig, ns.call_module(nn.Embedding)),
-            ]
+        model = M().eval()
+        indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
+        quantized_node = ns.call_module(nnq.Embedding)
+        configs = [
+            (float_qparams_weight_only_qconfig, ns.call_module(nnq.Embedding)),
+            (None, ns.call_module(nn.Embedding)),
+            (default_qconfig, ns.call_module(nn.Embedding)),
+        ]
 
-            for qconfig, node in configs:
-                qconfig_dict = {"": qconfig}
-                m = prepare_fx(model, qconfig_dict)
-                self.checkGraphModuleNodes(m, expected_node_occurrence={
-                    ns.call_module(torch.ao.quantization.MinMaxObserver): 0
-                })
-                m = convert_fx(m)
-                self.checkGraphModuleNodes(m, expected_node=node)
-                # make sure it runs
-                m(indices)
+        for qconfig, node in configs:
+            qconfig_dict = {"": qconfig}
+            m = prepare_fx(model, qconfig_dict)
+            self.checkGraphModuleNodes(m, expected_node_occurrence={
+                ns.call_module(torch.ao.quantization.MinMaxObserver): 0
+            })
+            m = convert_fx(m)
+            self.checkGraphModuleNodes(m, expected_node=node)
+            # make sure it runs
+            m(indices)
 
     def test_embedding_bag(self):
         class M(torch.nn.Module):

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -158,12 +158,13 @@ class Embedding(torch.nn.Module):
                 weight_observer = float_qparams_weight_only_qconfig.weight()
 
         dtype = weight_observer.dtype
+
         is_float_qparams_qconfig = weight_observer.qscheme == torch.per_channel_affine_float_qparams
         assert is_float_qparams_qconfig, \
             'Embedding quantization is only supported with float_qparams_weight_only_qconfig.'
 
-        assert dtype == torch.quint8 or dtype == torch.quint4x2, \
-            f'The only supported dtype for nnq.Embedding is torch.quint8 and torch.quint4x2, got {dtype}'
+        assert dtype == torch.quint8, \
+            f'The only supported weight dtype for nnq.Embedding is torch.quint8, got {dtype}'
 
         # Run the observer to calculate qparams.
         weight_observer(mod.weight)


### PR DESCRIPTION
Summary:
Original commit changeset: 5cdaac5aee9b

Original Phabricator Diff: D33152675 (https://github.com/pytorch/pytorch/commit/75718e5059b30cb95f9c2ba2d9a68a7fafc43624)

Differential Revision: D33268415

