### PR TITLE
Back out "[Quant] Added 4 bit support for embedding quantized module"

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -819,27 +819,23 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         obs = default_float_qparams_observer()
         obs(weights)
         qparams = obs.calculate_qparams()
+        # Quantize the weights to 8bits
+        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
+        qemb = nnq.Embedding(num_embeddings=num_embeddings, embedding_dim=embedding_dim)
+        qemb.set_weight(qweight)
+        qemb(indices)
 
-        dtypes = [torch.quint4x2, torch.quint8]
-        embedding_funcs = [torch.ops.quantized.embedding_4bit, torch.ops.quantized.embedding_byte]
+        # Ensure the module has the correct weights
+        self.assertEqual(qweight, qemb.weight())
 
-        for dtype, embedding_func in zip(dtypes, embedding_funcs):
-            # Quantize the weights
-            qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=dtype)
-            qemb = nnq.Embedding(num_embeddings=num_embeddings, embedding_dim=embedding_dim, dtype=dtype)
-            qemb.set_weight(qweight)
-            qemb(indices)
+        w_packed = qemb._packed_params._packed_weight
+        module_out = qemb(indices)
 
-            # Ensure the module has the correct weights
-            self.assertEqual(qweight, qemb.weight())
-            w_packed = qemb._packed_params._packed_weight
-            module_out = qemb(indices)
+        # Call the qembedding operator directly
+        ref = torch.ops.quantized.embedding_byte(w_packed, indices, pruned_weights=False)
+        self.assertEqual(module_out, ref)
+        self.checkEmbeddingSerialization(qemb, num_embeddings, embedding_dim, indices, None, set_qconfig=False, is_emb_bag=False)
 
-            # Call the bit qembedding operator directly
-            ref = embedding_func(w_packed, indices, pruned_weights=False)
-            self.assertEqual(module_out, ref)
-            self.checkEmbeddingSerialization(qemb, num_embeddings, embedding_dim, indices, None, set_qconfig=False,
-                                             is_emb_bag=False, dtype=dtype)
 
     @given(
         num_embeddings=st.integers(10, 50),

--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -18,7 +18,6 @@ from torch.ao.quantization import (
     per_channel_dynamic_qconfig,
     float16_dynamic_qconfig,
     float_qparams_weight_only_qconfig,
-    float_qparams_weight_only_qconfig_4bit,
     PerChannelMinMaxObserver,
     default_dynamic_quant_observer,
     QConfig,
@@ -569,28 +568,26 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
         r""" Test the post-training quantization flow, serialization and scripting
         of embedding modules
         """
+        model = EmbeddingModule().eval()
+        indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
+        weights = torch.randn(10, 12, dtype=torch.float32)
+        model.qconfig = float_qparams_weight_only_qconfig
+        prepare(model, inplace=True)
+        convert(model, inplace=True)
+        self.assertTrue('QuantizedEmbedding' in str(model))
+        self.assertEqual(type(model.emb), torch.nn.quantized.Embedding)
+        self.checkScriptable(model, [[indices]], check_save_load=True)
 
-        for qconfig in [float_qparams_weight_only_qconfig, float_qparams_weight_only_qconfig_4bit]:
-            model = EmbeddingModule().eval()
-            indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
-            weights = torch.randn(10, 12, dtype=torch.float32)
-            model.qconfig = qconfig
-            prepare(model, inplace=True)
-            convert(model, inplace=True)
-            self.assertTrue('QuantizedEmbedding' in str(model))
-            self.assertEqual(type(model.emb), torch.nn.quantized.Embedding)
-            self.checkScriptable(model, [[indices]], check_save_load=True)
-
-            idx = torch.LongTensor([1, 2, 4, 5, 4, 3, 2, 9])
-            offsets = torch.LongTensor([0, 4])
-            x = torch.randn(2, 4)
-            model = EmbeddingWithStaticLinear().eval()
-            prepare(model, inplace=True)
-            convert(model, inplace=True)
-            self.assertTrue('QuantizedEmbedding' in str(model))
-            self.assertTrue('QuantizedLinear' in str(model))
-            self.checkQuantizedLinear(model.fc)
-            model(idx, offsets, x)
+        idx = torch.LongTensor([1, 2, 4, 5, 4, 3, 2, 9])
+        offsets = torch.LongTensor([0, 4])
+        x = torch.randn(2, 4)
+        model = EmbeddingWithStaticLinear().eval()
+        prepare(model, inplace=True)
+        convert(model, inplace=True)
+        self.assertTrue('QuantizedEmbedding' in str(model))
+        self.assertTrue('QuantizedLinear' in str(model))
+        self.checkQuantizedLinear(model.fc)
+        model(idx, offsets, x)
 
     @skipIfNoFBGEMM
     def test_dequant_stub(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -44,7 +44,6 @@ from torch.ao.quantization import (
     float16_dynamic_qconfig,
     float16_static_qconfig,
     float_qparams_weight_only_qconfig,
-    float_qparams_weight_only_qconfig_4bit,
     get_default_qconfig,
     get_default_qat_qconfig,
     get_default_qconfig_dict,
@@ -5205,26 +5204,25 @@ class TestQuantizeFxOps(QuantizationTestCase):
             def forward(self, indices):
                 return self.emb(indices)
 
-        for qconfig_type in [float_qparams_weight_only_qconfig, float_qparams_weight_only_qconfig_4bit]:
-            model = M().eval()
-            indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
-            quantized_node = ns.call_module(nnq.Embedding)
-            configs = [
-                (qconfig_type, ns.call_module(nnq.Embedding)),
-                (None, ns.call_module(nn.Embedding)),
-                (default_qconfig, ns.call_module(nn.Embedding)),
-            ]
+        model = M().eval()
+        indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
+        quantized_node = ns.call_module(nnq.Embedding)
+        configs = [
+            (float_qparams_weight_only_qconfig, ns.call_module(nnq.Embedding)),
+            (None, ns.call_module(nn.Embedding)),
+            (default_qconfig, ns.call_module(nn.Embedding)),
+        ]
 
-            for qconfig, node in configs:
-                qconfig_dict = {"": qconfig}
-                m = prepare_fx(model, qconfig_dict)
-                self.checkGraphModuleNodes(m, expected_node_occurrence={
-                    ns.call_module(torch.ao.quantization.MinMaxObserver): 0
-                })
-                m = convert_fx(m)
-                self.checkGraphModuleNodes(m, expected_node=node)
-                # make sure it runs
-                m(indices)
+        for qconfig, node in configs:
+            qconfig_dict = {"": qconfig}
+            m = prepare_fx(model, qconfig_dict)
+            self.checkGraphModuleNodes(m, expected_node_occurrence={
+                ns.call_module(torch.ao.quantization.MinMaxObserver): 0
+            })
+            m = convert_fx(m)
+            self.checkGraphModuleNodes(m, expected_node=node)
+            # make sure it runs
+            m(indices)
 
     def test_embedding_bag(self):
         class M(torch.nn.Module):

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -158,12 +158,13 @@ class Embedding(torch.nn.Module):
                 weight_observer = float_qparams_weight_only_qconfig.weight()
 
         dtype = weight_observer.dtype
+
         is_float_qparams_qconfig = weight_observer.qscheme == torch.per_channel_affine_float_qparams
         assert is_float_qparams_qconfig, \
             'Embedding quantization is only supported with float_qparams_weight_only_qconfig.'
 
-        assert dtype == torch.quint8 or dtype == torch.quint4x2, \
-            f'The only supported dtype for nnq.Embedding is torch.quint8 and torch.quint4x2, got {dtype}'
+        assert dtype == torch.quint8, \
+            f'The only supported weight dtype for nnq.Embedding is torch.quint8, got {dtype}'
 
         # Run the observer to calculate qparams.
         weight_observer(mod.weight)

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -93,7 +93,6 @@ class Embedding(torch.nn.Module):
         super(Embedding, self).__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
-        self.dtype = dtype
 
         if _weight is None:
             scales = torch.ones(num_embeddings, dtype=torch.float)
@@ -110,10 +109,7 @@ class Embedding(torch.nn.Module):
         self._packed_params.set_weight(qweight)
 
     def forward(self, indices: Tensor) -> Tensor:
-        if self.dtype == torch.quint4x2:
-            return torch.ops.quantized.embedding_4bit(self._packed_params._packed_weight, indices)
-        else:
-            return torch.ops.quantized.embedding_byte(self._packed_params._packed_weight, indices)
+        return torch.ops.quantized.embedding_byte(self._packed_params._packed_weight, indices)
 
     def _get_name(self):
         return 'QuantizedEmbedding'


### PR DESCRIPTION
Summary:
Original commit changeset: 73e63383cf60

Original Phabricator Diff: D33152674 (https://github.com/pytorch/pytorch/commit/9f512e129b48a84ca742f64d1a4c742361b3300c)

Differential Revision: D33268459

