### PR TITLE
make inverse call linalg_inv

### DIFF
--- a/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.cpp
@@ -348,34 +348,6 @@ Tensor& _linalg_inv_out_helper_cuda_lib(Tensor& result, Tensor& infos_getrf, Ten
   return result;
 }
 
-// entrance of calculations of `inverse` using cusolver getrf + getrs, cublas getrfBatched + getriBatched
-Tensor _inverse_helper_cuda_lib(const Tensor& self) {
-  Tensor self_working_copy = cloneBatchedColumnMajor(self);
-  Tensor self_inv_working_copy = column_major_identity_matrix_like(self_working_copy);
-  const int batch_size = cuda_int_cast(batchCount(self), "batchCount");
-
-  if (self.dim() > 2 && batch_size > 1) {
-    Tensor infos_getrf = at::zeros({std::max<int64_t>(1, batchCount(self))}, self.options().dtype(kInt));
-    Tensor infos_getrs = at::zeros({std::max<int64_t>(1, batchCount(self))}, self.options().dtype(kInt));
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self.scalar_type(), "inverse_cuda", [&]{
-      apply_batched_inverse_lib<scalar_t>(
-        self_working_copy, self_inv_working_copy, infos_getrf, infos_getrs);
-    });
-    batchCheckErrors(infos_getrf, "inverse_cuda");
-    batchCheckErrors(infos_getrs, "inverse_cuda");
-  } else {
-    Tensor infos_getrf = at::zeros({1}, self.options().dtype(kInt));
-    Tensor infos_getrs = at::zeros({1}, self.options().dtype(kInt));
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self.scalar_type(), "inverse_cuda", [&]{
-      apply_single_inverse_lib<scalar_t>(self_working_copy, self_inv_working_copy, infos_getrf, infos_getrs);
-    });
-    batchCheckErrors(infos_getrf, "inverse_cuda");
-    batchCheckErrors(infos_getrs, "inverse_cuda");
-  }
-
-  return self_inv_working_copy;
-}
-
 // call cusolver gesvd function to calculate svd
 template<typename scalar_t>
 inline static void _apply_svd_lib_gesvd(const Tensor& self, const Tensor& U, const Tensor& S, const Tensor& VT,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2403,12 +2403,6 @@
   dispatch:
     CompositeExplicitAutograd: inverse_out
 
-- func: _inverse_helper(Tensor self) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _inverse_helper_cpu
-    CUDA: _inverse_helper_cuda
-
 - func: isclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> Tensor
   variants: function, method
 

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -99,6 +99,7 @@ ALLOW_LIST = [
     ("prepacked::unpack_prepacked_sizes_linear", datetime.date(9999, 1, 1)),
     ("q::_FloatToBfloat16Quantized", datetime.date(2021, 12, 21)),
     ("q::_Bfloat16QuantizedToFloat", datetime.date(2021, 12, 21)),
+    ("aten::_invers_helper", datetime.date(2021, 12, 31)),
 ]
 
 ALLOW_LIST_COMPILED = [

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -99,7 +99,7 @@ ALLOW_LIST = [
     ("prepacked::unpack_prepacked_sizes_linear", datetime.date(9999, 1, 1)),
     ("q::_FloatToBfloat16Quantized", datetime.date(2021, 12, 21)),
     ("q::_Bfloat16QuantizedToFloat", datetime.date(2021, 12, 21)),
-    ("aten::_invers_helper", datetime.date(2021, 12, 31)),
+    ("aten::_inverse_helper", datetime.date(2021, 12, 31)),
 ]
 
 ALLOW_LIST_COMPILED = [


### PR DESCRIPTION
`linalg.inv` and `inverse` are aliases according to documentation, yet their implementation is somewhat diverged. This makes `inverse` call into `linalg_inv`. 
