### PR TITLE
NNAPI: quant logistic fix

### DIFF
--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -286,6 +286,10 @@ class TestNNAPI(TestCase):
                             return torch.sigmoid(arg)
                         raise Exception("Bad op")
                 self.check(UnaryModule(), torch.tensor([-1.0, 1.0]))
+                self.check(
+                    UnaryModule(),
+                    qpt(torch.tensor([-1.0, 1.0]), 1. / 256, 0),
+                )
 
     def test_pointwise_binary(self):
         for op in ["add", "sub", "mul", "div"]:


### PR DESCRIPTION
Summary: NNAPI needs a fixed zero point and scale for sigmoid (logistic)

Test Plan: LIBNEURALNETWORKS_PATH="/path/to/libneuralnetworks.so" pytest test/test_nnapi.py

Reviewed By: dreiss

Differential Revision: D33237918

