### PR TITLE
Minor typo in contributing doc fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -739,7 +739,7 @@ same. Using ccache in a situation like this is a real time-saver.
 Before building pytorch, install ccache from your package manager of choice:
 
 ```bash
-conda install ccache -f conda-forge
+conda install ccache -c conda-forge
 sudo apt install ccache
 sudo yum install ccache
 brew install ccache


### PR DESCRIPTION
Hi. While looking at the contributing doc for pytorch in master. I saw a typo about installing `ccache` via `conda`. This tiny PR fixed it.

Hope this could help someone copy-paste the command faster!