### PR TITLE
Add conversion of torch.permute to acc_ops.permute

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -392,6 +392,13 @@ def t_mapper(node: torch.fx.Node, _: nn.Module):
         ("*", "permutation"),
     ],
 )
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.permute),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dims", "permutation"),
+    ],
+)
 @register_acc_op
 def permute(*, input, permutation):
     return input.permute(*permutation)


### PR DESCRIPTION
Summary:
In order to inference shape for permute, the node target needs to get converted from torch.permute to acc_opts.permute.

Differential Revision: D33267469

