### PR TITLE
fix TensorLikePair origination

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -745,7 +745,7 @@ class TestAssertClose(TestCase):
         expected = "0"
 
         for fn in assert_close_with_inputs(actual, expected):
-            with self.assertRaisesRegex(ValueError, str(type(actual))):
+            with self.assertRaisesRegex(TypeError, str(type(actual))):
                 fn()
 
     def test_mismatching_shape(self):

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -570,23 +570,19 @@ class TensorLikePair(Pair):
         if not allow_subclasses and type(actual) is not type(expected):
             raise UnsupportedInputs()
 
-        actual, expected = [self._to_tensor(input, id=id) for input in (actual, expected)]
+        actual, expected = [self._to_tensor(input) for input in (actual, expected)]
         for tensor in (actual, expected):
             self._check_supported(tensor, id=id)
         return actual, expected
 
-    def _to_tensor(self, tensor_like: Any, *, id: Tuple[Any, ...]) -> torch.Tensor:
+    def _to_tensor(self, tensor_like: Any) -> torch.Tensor:
         if isinstance(tensor_like, torch.Tensor):
             return tensor_like
 
         try:
             return torch.as_tensor(tensor_like)
-        except Exception as error:
-            raise ErrorMeta(
-                ValueError,
-                f"Constructing a tensor from {type(tensor_like)} failed with \n{error}.",
-                id=id,
-            ) from error
+        except Exception:
+            raise UnsupportedInputs()
 
     def _check_supported(self, tensor: torch.Tensor, *, id: Tuple[Any, ...]) -> None:
         if tensor.layout not in {torch.strided, torch.sparse_coo, torch.sparse_csr}:  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #69751
* #67796
* __->__ #70304
* #69750
* #68911
* #68728
* #68802
* #68977

Without this patch `TensorLikePair` will try to instantiate everything although it should only do so for tensor-likes. This is problematic if it is used before a different pair that would be able to handle the inputs but never gets to do so, because `TensorLikePair` bails out before.

```python
from torch.testing._comparison import assert_equal, TensorLikePair, ObjectPair

assert_equal("a", "a", pair_types=(TensorLikePair, ObjectPair))
```

```
ValueError: Constructing a tensor from <class 'str'> failed with 
new(): invalid data type 'str'.
```

Differential Revision: [D33542995](https://our.internmc.facebook.com/intern/diff/D33542995)