### PR TITLE
Override stride-related methods in LTCTensorImpl

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.cpp
@@ -121,6 +121,11 @@ at::IntArrayRef LTCTensorImpl::sizes() const {
   return c10::TensorImpl::sizes();
 }
 
+at::IntArrayRef LTCTensorImpl::strides() const {
+  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
+  return c10::TensorImpl::strides();
+}
+
 int64_t LTCTensorImpl::dim() const {
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::dim();
@@ -143,6 +148,11 @@ bool LTCTensorImpl::is_contiguous(c10::MemoryFormat memory_format) const {
 int64_t LTCTensorImpl::size(int64_t d) const {
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::size(d);
+}
+
+int64_t LTCTensorImpl::stride(int64_t d) const {
+  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
+  return c10::TensorImpl::stride(d);
 }
 
 void LTCTensorImpl::setup_size_properties() {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_impl.h
@@ -33,6 +33,8 @@ class LTCTensorImpl final : public c10::TensorImpl {
 
   at::IntArrayRef sizes() const override;
 
+  at::IntArrayRef strides() const override;
+
   int64_t dim() const override;
 
   int64_t numel() const override;
@@ -40,6 +42,8 @@ class LTCTensorImpl final : public c10::TensorImpl {
   bool is_contiguous(at::MemoryFormat memory_format) const override;
 
   int64_t size(int64_t d) const override;
+
+  int64_t stride(int64_t d) const override;
 
   const at::Storage& storage() const override;
 


### PR DESCRIPTION
Summary: Strides on lazy tensor should only be read after calling setup_size_properties. Fixes a failure in hf_Longformer.
