### PR TITLE
[quant] Refactor Quantizer to remove the Affine keyword

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1751,7 +1751,7 @@ Tensor squeeze_qtensor(const Tensor& self) {
   DimVector strides;
   std::tie(sizes, strides) = inferSqueezeGeometry(self);
   if (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE) {
-    const auto* per_channel_quantizer = static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
+    const auto* per_channel_quantizer = static_cast<at::PerChannelQuantizer*>(quantizer.get());
     auto axis = per_channel_quantizer->axis();
     int64_t shift = 0;
     for (const auto d : c10::irange(self.dim())) {
@@ -1777,7 +1777,7 @@ Tensor squeeze_qtensor(const Tensor& self, int64_t dim) {
   DimVector strides;
   std::tie(sizes, strides) = inferSqueezeGeometry(self, dim);
   if (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE) {
-    const auto* per_channel_quantizer = static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
+    const auto* per_channel_quantizer = static_cast<at::PerChannelQuantizer*>(quantizer.get());
     auto axis = per_channel_quantizer->axis();
     TORCH_CHECK(axis != dim, "Squeeze is only possible on non-axis dimension for Per-Channel Quantized Tensors.");
     if (axis >= dim) {
@@ -1889,7 +1889,7 @@ Tensor unsqueeze_qtensor(const Tensor& self, int64_t dim) {
   auto g = inferUnsqueezeGeometry(self, dim);
   auto quantizer = get_qtensorimpl(self)->quantizer();
   if (quantizer->qscheme() == QScheme::PER_CHANNEL_AFFINE) {
-    const auto* per_channel_quantizer = static_cast<at::PerChannelAffineQuantizer*>(quantizer.get());
+    const auto* per_channel_quantizer = static_cast<at::PerChannelQuantizer*>(quantizer.get());
     auto axis = per_channel_quantizer->axis();
     if (axis >= dim) {
       axis += 1;

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -113,31 +113,31 @@ std::vector<Tensor> dequantize_tensors_quantized_cpu(TensorList tensors) {
 double q_scale_quant(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerTensorAffine);
-  return static_cast<PerTensorAffineQuantizer*>(quantizer.get())->scale();
+  return static_cast<PerTensorQuantizer*>(quantizer.get())->scale();
 }
 
 int64_t q_zero_point_quant(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerTensorAffine);
-  return static_cast<PerTensorAffineQuantizer*>(quantizer.get())->zero_point();
+  return static_cast<PerTensorQuantizer*>(quantizer.get())->zero_point();
 }
 
 Tensor q_per_channel_scales(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine || quantizer->qscheme() == kPerChannelAffineFloatQParams);
-  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->scales();
+  return static_cast<PerChannelQuantizer*>(quantizer.get())->scales();
 }
 
 Tensor q_per_channel_zero_points(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine || quantizer->qscheme() == kPerChannelAffineFloatQParams);
-  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->zero_points();
+  return static_cast<PerChannelQuantizer*>(quantizer.get())->zero_points();
 }
 
 int64_t q_per_channel_axis(const Tensor& self) {
   auto quantizer = get_qtensorimpl(self)->quantizer();
   TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine || quantizer->qscheme() == kPerChannelAffineFloatQParams);
-  return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->axis();
+  return static_cast<PerChannelQuantizer*>(quantizer.get())->axis();
 }
 
 Tensor make_per_channel_quantized_tensor_cpu(

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -18,6 +18,16 @@
 
 namespace at {
 
+namespace {
+  void checkPerTensorQScheme(QScheme qscheme) {
+    TORCH_CHECK(qscheme == kPerTensorAffine || qscheme == kPerTensorSymmetric);
+  }
+
+  void checkPerChannelQScheme(QScheme qscheme) {
+    TORCH_CHECK(qscheme == kPerChannelAffine || qscheme == kPerChannelSymmetric);
+  }
+}
+
 /**
  * UniformQuantizer is the parent class for all uniform quantizers.
  * These quantization scheme will map float value uniformly to
@@ -48,7 +58,9 @@ struct TORCH_API PerTensorQuantizer : public UniformQuantizer {
     : UniformQuantizer(scalar_type),
         scale_(scale),
         zero_point_(zero_point),
-        qscheme_(qscheme) {}
+        qscheme_(qscheme) {
+          checkPerTensorQScheme(qscheme);
+        }
 
   Tensor quantize(const Tensor& tensor) override;
   Tensor dequantize(const Tensor& qtensor) override;
@@ -106,7 +118,9 @@ struct TORCH_API PerChannelQuantizer : public UniformQuantizer {
         scales_(scales),
         zero_points_(zero_points),
         axis_(axis),
-        qscheme_(qscheme) {}
+        qscheme_(qscheme) {
+          checkPerChannelQScheme(qscheme);
+        }
 
   QScheme qscheme() const override {
     return qscheme_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #70324
* __->__ #70323

Summary:
the current Quantizer only uses the Affine keyword even though it may be used for quantized tensors created using affine/symmetric qscheme.
This PR refactors the code to remove the affine keyword from the class name and make it accept qscheme as input.
Future PRs will update the callsites for creating affine/symmetric quantized tensor.

Addresses https://github.com/pytorch/pytorch/issues/51152
Test Plan:
python test/test_quantization.py

Reviewers:

Subscribers:

Tasks:

Tags: