### PR TITLE
[quant] make quantize_per_tensor/per_channel accept qscheme argument

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5502,10 +5502,20 @@
   dispatch:
     CPU: quantize_per_tensor_list_cpu
 
+- func: quantize_per_tensor.qscheme(Tensor self, float scale, int zero_point, ScalarType dtype, QScheme qscheme) -> Tensor
+  variants: function
+  dispatch:
+    CPU, CUDA: quantize_per_tensor_w_qscheme
+
 - func: quantize_per_channel(Tensor self, Tensor scales, Tensor zero_points, int axis, ScalarType dtype) -> Tensor
   variants: function
   dispatch:
     CPU, CUDA: quantize_per_channel
+
+- func: quantize_per_channel.qscheme(Tensor self, Tensor scales, Tensor zero_points, int axis, ScalarType dtype, QScheme qscheme) -> Tensor
+  variants: function
+  dispatch:
+    CPU, CUDA: quantize_per_channel_w_qscheme
 
 - func: dequantize.self(Tensor self) -> Tensor
   variants: function, method

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -41,16 +41,18 @@ QuantizerPtr TensorBase::quantizer() const {
 QuantizerPtr make_per_tensor_affine_quantizer(
     double scale,
     int64_t zero_point,
-    ScalarType scalar_type) {
+    ScalarType scalar_type,
+    QScheme qscheme) {
   return c10::make_intrusive<PerTensorQuantizer>(scalar_type,
-      scale, zero_point);
+      scale, zero_point, qscheme);
 }
 
 QuantizerPtr make_per_channel_affine_quantizer(
     const Tensor& scales,
     const Tensor& zero_points,
     int64_t axis,
-    ScalarType scalar_type) {
+    ScalarType scalar_type,
+    QScheme qscheme) {
   checkPerChannelParamDims(scales, zero_points);
   TORCH_CHECK(
       isFloatingType(scales.scalar_type()),
@@ -60,17 +62,18 @@ QuantizerPtr make_per_channel_affine_quantizer(
     Tensor scales_float = scales.to(kFloat).contiguous();
     Tensor zero_points_float = zero_points.to(kFloat).contiguous();
     return c10::make_intrusive<PerChannelFloatQParamsQuantizer>(scalar_type,
-                                                                      scales_float,
-                                                                      zero_points_float,
-                                                                      axis);
+                                                                scales_float,
+                                                                zero_points_float,
+                                                                axis);
   }
   else {
     Tensor scales_double = scales.to(kDouble).contiguous();
     Tensor zero_points_int64 = zero_points.to(kLong).contiguous();
     return c10::make_intrusive<PerChannelQuantizer>(scalar_type,
-                                                          scales_double,
-                                                          zero_points_int64,
-                                                          axis);
+                                                    scales_double,
+                                                    zero_points_int64,
+                                                    axis,
+                                                    qscheme);
   }
 }
 

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -204,13 +204,14 @@ TORCH_API QTensorImpl* get_qtensorimpl(const TensorBase& self);
 // argument types right now in native functions
 TORCH_API QuantizerPtr
 make_per_tensor_affine_quantizer(
-    double scale, int64_t zero_point, ScalarType scalar_type);
+    double scale, int64_t zero_point, ScalarType scalar_type, QScheme qscheme=kPerTensorAffine);
 
 TORCH_API QuantizerPtr make_per_channel_affine_quantizer(
     const Tensor& scales,
     const Tensor& zero_points,
     int64_t axis,
-    ScalarType scalar_type);
+    ScalarType scalar_type,
+    QScheme qscheme=kPerChannelAffine);
 
 // Create a Quantized Tensor given arguments for normal Tensor and a quantizer
 TORCH_API Tensor new_qtensor(

--- a/tools/codegen/api/python.py
+++ b/tools/codegen/api/python.py
@@ -1017,6 +1017,8 @@ def arg_parser_unpack_method(t: Type, has_default: bool) -> str:
             return 'toDouble'
         elif t.name == BaseTy.str:
             return 'stringView'
+        elif t.name == BaseTy.QScheme:
+            return 'toQScheme'
 
     elif isinstance(t, OptionalType):
         if str(t.elem) == 'Tensor':

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -675,6 +675,9 @@ void addInputs(Node* n, const char* name, at::ScalarType value) {
 void addInputs(Node* n, const char* name, at::MemoryFormat value) {
   detail::genericAddInput(n, static_cast<int64_t>(value));
 }
+void addInputs(Node* n, const char* name, c10::QScheme value) {
+  detail::genericAddInput(n, static_cast<int64_t>(value));
+}
 void addInputs(
     Node* n,
     const char* name,

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -291,6 +291,7 @@ TORCH_API void addInputs(Node* n, const char* name, at::Device value);
 TORCH_API void addInputs(Node* n, const char* name, c10::Stream stream);
 TORCH_API void addInputs(Node* n, const char* name, at::Layout value);
 TORCH_API void addInputs(Node* n, const char* name, at::ScalarType value);
+TORCH_API void addInputs(Node* n, const char* name, c10::QScheme value);
 TORCH_API void addInputs(
     Node* n,
     const char* name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70324
* #70323

Summary:
qscheme is used to denote which mode was used to calculate the scale/zero_point for the tensor

Test Plan:
```
>>> x = torch.rand(2, 2)
>>> qx = torch.quantize_per_tensor(x, 1.0, 0, torch.quint8, torch.per_tensor_affine)
>>> qx
tensor([[0., 0.],
        [0., 1.]], size=(2, 2), dtype=torch.quint8,
       quantization_scheme=torch.per_tensor_affine, scale=1.0, zero_point=0)
>>> qx = torch.quantize_per_tensor(x, 1.0, 0, torch.quint8, torch.per_tensor_symmetric)
>>> qx
tensor([[0., 0.],
        [0., 1.]], size=(2, 2), dtype=torch.quint8,
       quantization_scheme=torch.per_tensor_symmetric, scale=1.0, zero_point=0)

>>> qx = torch.quantize_per_channel(x, torch.tensor([1.0, 1.0]), torch.tensor([0, 0]), 0, torch.quint8, torch.per_channel_symmetric)
>>> qx
tensor([[0., 0.],
        [0., 1.]], size=(2, 2), dtype=torch.quint8,
       quantization_scheme=torch.per_channel_symmetric,
       scale=tensor([1., 1.], dtype=torch.float64), zero_point=tensor([0, 0]),
       axis=0)
>>> qx = torch.quantize_per_channel(x, torch.tensor([1.0, 1.0]), torch.tensor([0, 0]), 0, torch.quint8, torch.per_channel_affine)
>>> qx
tensor([[0., 0.],
        [0., 1.]], size=(2, 2), dtype=torch.quint8,
       quantization_scheme=torch.per_channel_affine,
       scale=tensor([1., 1.], dtype=torch.float64), zero_point=tensor([0, 0]),
       axis=0)
```

Reviewers:

Subscribers:

Tasks:

Tags: