### PR TITLE
[Profiler] Address issues from profiler bifurcation.

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -123,6 +123,10 @@ struct KinetoThreadLocalState : public torch::profiler::impl::ProfilerThreadLoca
   }
   ~KinetoThreadLocalState() override = default;
 
+  torch::profiler::impl::ActiveProfilerType profilerType() override {
+    return torch::profiler::impl::ActiveProfilerType::KINETO;
+  }
+
   void reportClientActivity(
       const std::string& evt_name,
       const bool is_async,

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -346,14 +346,6 @@ void pushProfilingCallbacksLegacy() {
 
 } // namespace
 
-torch::profiler::impl::ProfilerConfig getProfilerConfig() {
-  auto state_ptr = getProfilerTLSState();
-  TORCH_CHECK(
-      state_ptr,
-      "Tried to access profiler config, but profiler is not enabled!");
-  return state_ptr->config();
-}
-
 void enableProfilerLegacy(const torch::profiler::impl::ProfilerConfig& new_config) {
   TORCH_CHECK(new_config.state != torch::profiler::impl::ProfilerState::NVTX || torch::profiler::impl::cudaStubs()->enabled(),
     "Can't use NVTX profiler - PyTorch was compiled without CUDA");

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -342,8 +342,6 @@ TORCH_API thread_event_lists disableProfilerLegacy(c10::optional<ProfilerDisable
 // adds profiledEvents to the current thread local recorded events. Each event
 // will be marked with node ID given by fromNodeId.
 TORCH_API void addEventList(std::vector<LegacyEvent>&& profiledEvents);
-// Retrieve the thread_local ProfilerConfig.
-TORCH_API torch::profiler::impl::ProfilerConfig getProfilerConfig();
 // Writes profiled events to a stream.
 TORCH_API void writeProfilerEventsToStream(std::ostream& out, const std::vector<LegacyEvent*>& events);
 
@@ -429,6 +427,10 @@ struct TORCH_API ProfilerLegacyThreadLocalState : public torch::profiler::impl::
       int64_t /* total_allocated, unused for legacy */,
       int64_t /* total_reserved, unused for legacy */,
       c10::Device device) override;
+
+  torch::profiler::impl::ActiveProfilerType profilerType() override {
+    return torch::profiler::impl::ActiveProfilerType::LEGACY;
+  }
 
  protected:
   RangeEventList& getEventList(int64_t thread_id = -1);

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -161,6 +161,10 @@ c10::intrusive_ptr<JitFuture> sendMessageWithAutograd(
   // tell the remote end to process this request with the profiler enabled.
   if (!forceDisableProfiling && torch::autograd::profiler::profilerEnabled()) {
     auto profilerConfig = torch::autograd::profiler::getProfilerConfig();
+    TORCH_CHECK(
+        torch::profiler::impl::profilerType() ==
+            torch::profiler::impl::ActiveProfilerType::LEGACY,
+        "Currently only the legacy autograd profiler is supported in a distributed context.");
     auto msgWithProfiling = getMessageWithProfiling(
         std::move(msg),
         rpc::MessageType::RUN_WITH_PROFILING_REQ,

--- a/torch/csrc/profiler/api.h
+++ b/torch/csrc/profiler/api.h
@@ -29,6 +29,12 @@ enum class C10_API_ENUM ProfilerState {
   NUM_PROFILER_STATES, // must be the last one
 };
 
+enum class C10_API_ENUM ActiveProfilerType {
+  NONE = 0,
+  LEGACY,
+  KINETO
+};
+
 struct TORCH_API ProfilerConfig {
   explicit ProfilerConfig(
       ProfilerState state,
@@ -85,6 +91,8 @@ struct TORCH_API ProfilerThreadLocalStateBase
     return config_.profile_memory;
   }
 
+  virtual ActiveProfilerType profilerType() = 0;
+
  protected:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::mutex state_mutex_;
@@ -96,6 +104,11 @@ struct TORCH_API ProfilerThreadLocalStateBase
 
 // Returns if the profiler is currently enabled in the current thread.
 TORCH_API bool profilerEnabled();
+
+TORCH_API ActiveProfilerType profilerType();
+
+// Retrieve the thread_local ProfilerConfig.
+TORCH_API ProfilerConfig getProfilerConfig();
 
 // ----------------------------------------------------------------------------
 // -- CUDA --------------------------------------------------------------------
@@ -134,6 +147,7 @@ using torch::profiler::impl::ActivityType;
 using torch::profiler::impl::ProfilerConfig;
 using torch::profiler::impl::ProfilerState;
 using torch::profiler::impl::profilerEnabled;
+using torch::profiler::impl::getProfilerConfig;
 } // namespace profiler
 } // namespace autograd
 } // namespace torch


### PR DESCRIPTION
Summary:
After D32678163 (https://github.com/pytorch/pytorch/commit/7ea86dfdb162758c9fbbf6807ab1dd778591c062), test_rpc_profiler began failing. This was surprising, because it should have been a no-op refactor. However, one change is that a Kineto profiler is no longer also an autograd profiler; the RPC framework was assuming a legacy profiler but when a kineto profiler was active things still kind of worked due to that implementation detail. (But crashed after the class split.)

This diff tidys up a couple of things:
1) Move `getProfilerConfig` into `api.cpp`, since it is no longer correct to static_cast a `KinetoThreadLocalState` to a `ProfilerLegacyThreadLocalState`. (And really the class we want is `ProfilerThreadLocalStateBase` anyway.)

2) Add a mechanism for callers to check if the active profiler is a legacy or kineto profiler. (So callers like RPC can adjust or provide a nice error message.)

3) Fix the RPC test to create a legacy profiler.

Test Plan: `caffe2/torch/fb/training_toolkit/backend/tests:test_rpc_profiler` now passes, and before the fix to `test_rpc_profiler.py`, I verified that the test failed with the error message added to `utils.cpp` rather than just crashing.

Reviewed By: suphoff

Differential Revision: D33283314



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang