### PR TITLE
[acc_ops] No longer mark acc_ops.cat as unary

### DIFF
--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -244,7 +244,6 @@ def clamp(*, input, min=None, max=None):
     return torch.clamp(**locals())
 
 
-@register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", torch.cat))
 @register_acc_op
 def cat(*, tensors, dim):


### PR DESCRIPTION
Summary: We should only mark ops as unary if they should have a single fx.Node input. However, `cat` has a sequence of `tensors` input.

Differential Revision: D33299988

