### PR TITLE
Use adaptive_avg_pool2d instead of adaptive_avg_pool2d_out

### DIFF
--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -790,9 +790,10 @@ void nnc_aten_adaptive_avg_pool2d(
     W = extra_args[1];
   }
   try {
-    at::adaptive_avg_pool2d_out(r, x, {H, W});
+    r = at::adaptive_avg_pool2d(x, {H, W});
   } catch (...) {
   }
+  memcpy(buf_data[0], r.data_ptr(), r.element_size() * r.numel());
 }
 
 void nnc_aten_mean(


### PR DESCRIPTION
- Update nnc_aten_adaptive_avg_pool2d to use adaptive_avg_pool2d instead of adaptive_avg_pool2d_out as the latter is not included in the traced operators of models

Reviewed By: larryliu0820

Differential Revision: D33301477

