### PR TITLE
Add qint16 support via int16

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -174,8 +174,20 @@ void NnapiCompilation::get_operand_type(const at::Tensor& t, ANeuralNetworksOper
     operand->zeroPoint = 0;
     return;
   }
+  if (t.scalar_type() == c10::kShort) {
+    TORCH_WARN(
+      "NNAPI qint16 inputs to model are only supported for ",
+      "testing with fixed scale, zero_point. Please change your ",
+      "inputs if you see this in production");
+    operand->type = ANEURALNETWORKS_TENSOR_QUANT16_ASYMM;
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
+    operand->scale = 0.125;
+    operand->zeroPoint = 0;
+    return;
+  }
+
   // TODO: Support more dtypes.
-  CAFFE_THROW("Bad dtype");
+  CAFFE_THROW("Bad dtype: " + std::to_string(static_cast<int8_t>(t.scalar_type())));
 }
 
 } // namespace bind

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -525,6 +525,8 @@ class _NnapiSerializer(object):
         shape_code = "".join(shape_parts)
         if oper.op_type == NNAPI_OperandCode.TENSOR_FLOAT32:
             return f"torch.zeros({shape_code}, dtype=torch.float32)"
+        elif oper.op_type == NNAPI_OperandCode.TENSOR_INT32:
+            return f"torch.zeros({shape_code}, dtype=torch.int32)"
         elif oper.op_type == NNAPI_OperandCode.TENSOR_QUANT8_ASYMM:
             return (
                 f"torch.quantize_per_tensor("


### PR DESCRIPTION
Summary:
Pytorch doesn't have support for qint16 yet. Add an option to handle qint16 via int16 & qint32 data types.

* For qint16 tensors in NNAPI, the user sends a qint32 tensor. We convert the qint32 to int16 for the converter and set the zero point and scale for nnapi
   * inputs to the model have to have fixed scale and zero point and are only supported for testing
* Added a flag `use_int16_for_qint16` which will be used maintain backwards compatibility in the converter when true qint16 is supported in PyTorch

Test Plan: pytest test/test_nnapi.py

Reviewed By: dreiss

Differential Revision: D33285124

