### PR TITLE
update run_test.py to avoid --jit argument conflict

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -664,7 +664,7 @@ def parse_args():
         default=0,
         help="print verbose information and test-by-test results",
     )
-    parser.add_argument("--jit", "--jit", action="store_true", help="run all jit tests")
+    parser.add_argument("--jit", "--jit-tests", action="store_true", help="run all jit tests")
     parser.add_argument(
         "--distributed-tests",
         "--distributed-tests",


### PR DESCRIPTION
Otherwise, it may conflict with 
torch/testing/_internal/common_utils.py:parser.add_argument('--jit_executor', type=str)
because the prefix is the same.

Fixes #ISSUE_NUMBER
