### PR TITLE
Allow single node fusion for nvfuser (#70000)

### DIFF
--- a/test/package/package_a/bad_pickle.py
+++ b/test/package/package_a/bad_pickle.py
@@ -1,0 +1,10 @@
+class GoodPickle:
+    def __repr__(self):
+        return "GoodPickle"
+
+class BadPickle:
+    def __getstate__(self):
+        raise TypeError("I can't be pickled!")
+
+    def __repr__(self):
+        return "BadPickle"

--- a/test/package/test_debug_pickler.py
+++ b/test/package/test_debug_pickler.py
@@ -1,0 +1,273 @@
+from pickle import PicklingError
+from textwrap import dedent
+
+from torch.package import sys_importer
+from torch.package._package_pickler import debug_dumps
+from torch.testing._internal.common_utils import run_tests
+
+try:
+    from .common import PackageTestCase
+except ImportError:
+    # Support the case where we run this file directly.
+    from common import PackageTestCase
+
+
+class TestDebugPickler(PackageTestCase):
+
+    def test_set(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+        lst = [GoodPickle(), GoodPickle() ,BadPickle()]
+        obj = [
+            GoodPickle(),
+            set(lst),
+        ]
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, obj)
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'list'>)
+                  <object @ idx 1> (<class 'set'>)
+                  <object BadPickle> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_frozenset(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+        lst = [GoodPickle(), GoodPickle() ,BadPickle()]
+        obj = [
+            GoodPickle(),
+            frozenset(lst),
+        ]
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, obj)
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'list'>)
+                  <object @ idx 1> (<class 'frozenset'>)
+                  <object BadPickle> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_tuple(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+        obj1 = [
+            GoodPickle(),
+            (GoodPickle(), GoodPickle() ,BadPickle()),
+        ]
+        obj2 = [
+            GoodPickle(),
+            (GoodPickle(), GoodPickle() ,GoodPickle(), BadPickle(), GoodPickle()),
+        ]
+        with self.assertRaises(PicklingError) as e1:
+            debug_dumps(sys_importer, obj1)
+        with self.assertRaises(PicklingError) as e2:
+            debug_dumps(sys_importer, obj2)
+        self.assertEqual(
+            str(e1.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'list'>)
+                  <object @ idx 1> (<class 'tuple'>)
+                  <object @ idx 2> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+        self.assertEqual(
+            str(e2.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'list'>)
+                  <object @ idx 1> (<class 'tuple'>)
+                  <object @ idx 3> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_basic_msg(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        a = GoodPickle()
+        a.b = GoodPickle()
+        a.b.c = GoodPickle()
+        a.b.c.d = BadPickle()
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, a)
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .b (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .c (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .d (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_nested_lists(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        obj = [
+            GoodPickle(),
+            [GoodPickle(), GoodPickle(), [GoodPickle(), [BadPickle()]]],
+        ]
+        self.assertTrue(isinstance(obj[1][2][1][0], BadPickle))
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, obj)
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'list'>)
+                  <object @ idx 1> (<class 'list'>)
+                  <object @ idx 2> (<class 'list'>)
+                  <object @ idx 1> (<class 'list'>)
+                  <object @ idx 0> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_nested_list_obj(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        a = GoodPickle()
+        a.b = GoodPickle()
+        a.b.c = GoodPickle()
+        a.b.c.d = BadPickle()
+        obj = [GoodPickle(), [GoodPickle(), GoodPickle(), [GoodPickle(), [a]]]]
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, obj)
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'list'>)
+                  <object @ idx 1> (<class 'list'>)
+                  <object @ idx 2> (<class 'list'>)
+                  <object @ idx 1> (<class 'list'>)
+                  <object @ idx 0> (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .b (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .c (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .d (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_in_list_msg(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        a = GoodPickle()
+        a.bad_list = [GoodPickle(), GoodPickle(), BadPickle()]
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, a)
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .bad_list (<class 'list'>)
+                  <object @ idx 2> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_dict(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        obj = {"foo": GoodPickle(), "bar": BadPickle()}
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, obj)
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'dict'>)
+                  <object @ key bar> (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_nested_list_dict(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        a = GoodPickle()
+        a.b = GoodPickle()
+        a.b.c = GoodPickle()
+        a.b.c.d = BadPickle()
+        obj = {
+            "foo": GoodPickle(),
+            "bar": [GoodPickle(), [GoodPickle(), GoodPickle(), [GoodPickle(), [a]]]],
+        }
+
+        with self.assertRaises(PicklingError) as e:
+            debug_dumps(sys_importer, obj)
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """\
+                I can't be pickled!.
+
+                We think the problematic object is found at:
+                <pickled object> (<class 'dict'>)
+                  <object @ key bar> (<class 'list'>)
+                  <object @ idx 1> (<class 'list'>)
+                  <object @ idx 2> (<class 'list'>)
+                  <object @ idx 1> (<class 'list'>)
+                  <object @ idx 0> (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .b (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .c (<class 'package_a.bad_pickle.GoodPickle'>)
+                  .d (<class 'package_a.bad_pickle.BadPickle'>)
+                """
+            ),
+        )
+
+    def test_good_pickle(self):
+        """Passing an object that actually pickles should raise a ValueError."""
+        from package_a.bad_pickle import GoodPickle
+
+        with self.assertRaises(ValueError):
+            debug_dumps(sys_importer, GoodPickle())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -254,6 +254,18 @@ class TestSaveLoad(PackageTestCase):
         with PackageExporter(buffer2, importer=(importer, sys_importer)) as exporter:
             exporter.intern("**")
             exporter.save_module("package_a.use_torch_package_importer")
+    def test_save_bad_pickle(self):
+        from package_a.bad_pickle import BadPickle, GoodPickle
+
+        a = GoodPickle()
+        a.b = GoodPickle()
+        a.b.c = GoodPickle()
+        a.b.c.d = BadPickle()
+        buffer = BytesIO()
+
+        with self.assertRaisesRegex(pickle.PicklingError, "We think the problematic object is found at"):
+            with PackageExporter(buffer) as pe:
+                pe.save_pickle("foo", "foo.pkl", a)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -751,6 +751,9 @@ struct CudaGraphFuser {
           // we scan this consumer again to perform the fusion
           return std::make_pair(consumer->reverseIterator(), true);
         }
+        if (getSingletonFusion() && consumer->kind() != kind_) {
+          consumer = createSingletonFusionGroup(consumer);
+        }
         auto fusion_group = tryFuse(consumer, producer->node());
         if (fusion_group) {
           // after fusion, consumer moves into a FusionGroup, so inputs is no
@@ -758,7 +761,8 @@ struct CudaGraphFuser {
           return std::make_pair(fusion_group.value()->reverseIterator(), true);
         }
         // horizontal fusion only applies on tensor inputs
-        if (producer->type()->isSubtypeOf(*TensorType::get())) {
+        if (getHorizontalFusion() &&
+            producer->type()->isSubtypeOf(*TensorType::get())) {
           // fusing nodes sharing inputs, this could save memory bandwidth by
           // reducing number of tensor read.
           for (const auto& u : producer->uses()) {

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -5,10 +5,42 @@
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/register_ops_utils.h>
 
+// NOLINTNEXTLINE
+C10_DEFINE_bool(
+    torch_jit_nvfuser_singleton_fusion,
+    false,
+    "enable single node fusion for nvfuser");
+
+// NOLINTNEXTLINE
+C10_DEFINE_bool(
+    torch_jit_nvfuser_horizontal_fusion,
+    true,
+    "enable single node fusion for nvfuser");
+
 namespace torch {
 namespace jit {
 namespace fuser {
 namespace cuda {
+
+bool getSingletonFusion() {
+  return FLAGS_torch_jit_nvfuser_singleton_fusion;
+}
+
+bool setSingletonFusion(bool value) {
+  bool old_value = FLAGS_torch_jit_nvfuser_singleton_fusion;
+  FLAGS_torch_jit_nvfuser_singleton_fusion = value;
+  return old_value;
+}
+
+bool getHorizontalFusion() {
+  return FLAGS_torch_jit_nvfuser_horizontal_fusion;
+}
+
+bool setHorizontalFusion(bool value) {
+  bool old_value = FLAGS_torch_jit_nvfuser_horizontal_fusion;
+  FLAGS_torch_jit_nvfuser_horizontal_fusion = value;
+  return old_value;
+}
 
 static std::atomic<bool> cuda_fusion_guard_mode{true};
 

--- a/torch/csrc/jit/codegen/cuda/interface.h
+++ b/torch/csrc/jit/codegen/cuda/interface.h
@@ -19,6 +19,11 @@ namespace cuda {
 
 TORCH_API std::atomic<bool>& getCudaFusionGuardMode();
 
+C10_EXPORT bool getSingletonFusion();
+C10_EXPORT bool setSingletonFusion(bool value);
+C10_EXPORT bool getHorizontalFusion();
+C10_EXPORT bool setHorizontalFusion(bool value);
+
 // dummy struct to allow API registration
 struct CudaFuserInterface {
   void (*fn_compile_n)(Node*) = nullptr;

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -688,6 +688,18 @@ void initJITBindings(PyObject* module) {
           })
       .def("_jit_set_nvfuser_enabled", &RegisterCudaFuseGraph::registerPass)
       .def(
+          "_jit_set_nvfuser_single_node_mode",
+          [](bool flag) { return fuser::cuda::setSingletonFusion(flag); })
+      .def(
+          "_jit_nvfuser_single_node_mode",
+          []() { return fuser::cuda::getSingletonFusion(); })
+      .def(
+          "_jit_set_nvfuser_horizontal_mode",
+          [](bool flag) { return fuser::cuda::setHorizontalFusion(flag); })
+      .def(
+          "_jit_nvfuser_horizontal_mode",
+          []() { return fuser::cuda::getHorizontalFusion(); })
+      .def(
           "_jit_set_nvfuser_guard_mode",
           [](bool profiling_flag) {
             bool oldState = fuser::cuda::getCudaFusionGuardMode();

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -1,8 +1,30 @@
 """isort:skip_file"""
-from pickle import EXT1, EXT2, EXT4, GLOBAL, STACK_GLOBAL, Pickler, PicklingError
-from pickle import _compat_pickle, _extension_registry, _getattribute, _Pickler  # type: ignore[attr-defined]
+import io
+from pickle import (
+    EXT1,
+    EXT2,
+    EXT4,
+    GLOBAL,
+    STACK_GLOBAL,
+    Pickler,
+    PicklingError,
+    EMPTY_LIST,
+    EMPTY_TUPLE,
+    TUPLE,
+    MARK,
+    LIST,
+    APPEND,
+    EMPTY_DICT,
+    DICT,
+    SETITEM,
+    POP,
+    POP_MARK,
+    EMPTY_SET,
+)
+from pickle import _compat_pickle, _tuplesize2code, _extension_registry, _getattribute, _Pickler  # type: ignore[attr-defined]
 from struct import pack
 from types import FunctionType
+from itertools import islice
 
 from .importer import Importer, ObjMismatchError, ObjNotFoundError, sys_importer
 
@@ -91,6 +113,290 @@ class PackagePickler(_Pickler):
         self.memoize(obj)
 
     dispatch[FunctionType] = save_global
+
+class DebugInfo:
+    def format(self):
+        raise AssertionError(f"unknown debug type {self}")
+    def __repr__(self):
+        return f"DebugInfo({self.__class__.__name__})"
+
+class RootObject(DebugInfo):
+    def __init__(self, obj):
+        self.obj = obj
+
+    def format(self):
+        return f"<pickled object> ({type(self.obj)})"
+
+class ObjectAttribute(DebugInfo):
+    def __init__(self, attr_name, attr_value):
+        self.attr_name = attr_name
+        self.attr_value = attr_value
+
+    def format(self):
+        return f"  .{self.attr_name} ({type(self.attr_value)})"
+
+class ListElement(DebugInfo):
+    def __init__(self, idx, value):
+        self.idx = idx
+        self.value = value
+
+    def format(self):
+        return f"  <object @ idx {self.idx}> ({type(self.value)})"
+
+class TupleElement(DebugInfo):
+    def __init__(self, idx, value):
+        self.idx = idx
+        self.value = value
+
+    def format(self):
+        return f"  <object @ idx {self.idx}> ({type(self.value)})"
+
+class DictElement(DebugInfo):
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+    def format(self):
+        return f"  <object @ key {self.key}> ({type(self.value)})"
+
+class SetElement(DebugInfo):
+    def __init__(self, obj):
+        self.obj = obj
+
+    def format(self):
+        return f"  <object {self.obj}> ({type(self.obj)})"
+
+class SetElementPreProtocol4Flag(DebugInfo):
+    # for protocol < 4 converts sets into a tupled list, so we flag and error is handled in trace
+    def __init__(self, proto):
+        pass
+
+class TypeElement(DebugInfo):
+    def __init__(self, obj):
+        self.obj = obj
+
+    def format(self):
+        return f"  type {type(self.obj)} (from object {(self.obj)})"
+
+class DebugPickler(PackagePickler):
+    """A pickler that implements debug tracing functionality to better
+    """
+    def __init__(self, *args, **kwargs):
+        self.obj_stack = []
+        super().__init__(*args, **kwargs)
+
+    dispatch = _Pickler.dispatch.copy()
+
+    def save_list(self, obj):
+        if self.bin:
+            self.write(EMPTY_LIST)
+        else:  # proto 0 -- can't use EMPTY_LIST
+            self.write(MARK + LIST)
+
+        self.memoize(obj)
+        save = self.save
+        write = self.write
+
+        for idx, x in enumerate(obj):
+            self.obj_stack.append(ListElement(idx, x))
+            save(x)
+            write(APPEND)
+            self.obj_stack.pop()
+
+    dispatch[list] = save_list
+
+    def save_dict(self, obj):
+        if self.bin:
+            self.write(EMPTY_DICT)
+        else:  # proto 0 -- can't use EMPTY_DICT
+            self.write(MARK + DICT)
+
+        self.memoize(obj)
+        save = self.save
+        write = self.write
+
+        for k, v in obj.items():
+            self.obj_stack.append(DictElement(k, v))
+            save(k)
+            save(v)
+            write(SETITEM)
+            self.obj_stack.pop()
+
+    dispatch[dict] = save_dict
+
+    def save_tuple(self, obj):
+        if not obj:  # tuple is empty
+            if self.bin:
+                self.write(EMPTY_TUPLE)
+            else:
+                self.write(MARK + TUPLE)
+            return
+
+        n = len(obj)
+        save = self.save
+        memo = self.memo
+        idx = 0
+        if n <= 3 and self.proto >= 2:
+            for element in obj:
+                self.obj_stack.append(TupleElement(idx, element))
+                save(element)
+                self.obj_stack.pop()
+                idx += 1
+            # Subtle.  Same as in the big comment below.
+            if id(obj) in memo:
+                get = self.get(memo[id(obj)][0])
+                self.write(POP * n + get)
+            else:
+                self.write(_tuplesize2code[n])
+                self.memoize(obj)
+            return
+
+        # proto 0 or proto 1 and tuple isn't empty, or proto > 1 and tuple
+        # has more than 3 elements.
+        write = self.write
+        write(MARK)
+        for element in obj:
+            self.obj_stack.append(TupleElement(idx, element))
+            save(element)
+            self.obj_stack.pop()
+            idx += 1
+
+        if id(obj) in memo:
+            # Subtle.  d was not in memo when we entered save_tuple(), so
+            # the process of saving the tuple's elements must have saved
+            # the tuple itself:  the tuple is recursive.  The proper action
+            # now is to throw away everything we put on the stack, and
+            # simply GET the tuple (it's already constructed).  This check
+            # could have been done in the "for element" loop instead, but
+            # recursive tuples are a rare thing.
+            get = self.get(memo[id(obj)][0])
+            if self.bin:
+                write(POP_MARK + get)
+            else:   # proto 0 -- POP_MARK not available
+                write(POP * (n+1) + get)
+            return
+
+        # No recursion.
+        write(TUPLE)
+        self.memoize(obj)
+
+    dispatch[tuple] = save_tuple
+
+    def save_set(self, obj, set_type=set):
+        save = self.save
+        write = self.write
+
+        if self.proto < 4:
+            self.obj_stack.append(SetElementPreProtocol4Flag(self.proto))
+            self.save_reduce(set_type, (list(obj),), obj=obj)
+            self.obj_stack.pop()
+            return
+
+        write(EMPTY_SET)
+        self.memoize(obj)
+
+        it = iter(obj)
+        while True:
+            batch = list(islice(it, self._BATCHSIZE))
+            n = len(batch)
+            if n > 0:
+                write(MARK)
+                for item in batch:
+                    self.obj_stack.append(SetElement(item))
+                    save(item)
+                    self.obj_stack.pop()
+                write(ADDITEMS)
+            if n < self._BATCHSIZE:
+                return
+    dispatch[set] = save_set
+
+    def save_frozenset(self, obj, settype=set):
+        self.save_set(obj, set_type = frozenset)
+    dispatch[frozenset] = save_frozenset
+
+    def save(self, obj, save_persistent_id=True):
+        self.obj_stack.append(obj)
+        super().save(obj, save_persistent_id)
+        self.obj_stack.pop()
+
+
+
+    def format_trace(self):
+        stack = self.obj_stack
+        traced_stack = []
+        idx_to_skip = set()
+        for idx, obj in enumerate(stack):
+            if idx in idx_to_skip:
+                continue
+
+            if isinstance(obj, dict) and idx > 0:
+                # Fold:
+                # [
+                #   obj,
+                #   obj's __dict__,
+                #   DictElement(k, v)
+                #   obj for v
+                # ]
+                # into:
+                # [
+                #   obj,
+                #   (obj attribute, k, v)
+                # ]
+                prev_obj = stack[idx - 1]
+                if getattr(prev_obj, "__dict__", None) is obj:
+                    dict_element = stack[idx + 1]
+                    traced_stack.append(ObjectAttribute(dict_element.key, dict_element.value))
+                    idx_to_skip.add(idx + 1)
+                    idx_to_skip.add(idx + 2)
+                    continue
+            if isinstance(obj, (ListElement, DictElement, TupleElement, SetElement)):
+                # Fold [ListElement, obj] into just [ListElement]
+                traced_stack.append(obj)
+                idx_to_skip.add(idx + 1)
+                continue
+            elif isinstance(obj, SetElementPreProtocol4Flag):
+                # handle sets for protocol < 4 where set is converted to ([set],) / a list nested in a tuple
+                assert isinstance(stack[idx + 2], TupleElement)
+                assert isinstance(stack[idx + 4], ListElement)
+                idx_to_skip.add(idx + 1)
+                idx_to_skip.add(idx + 2)
+                idx_to_skip.add(idx + 3)
+                idx_to_skip.add(idx + 4)
+                idx_to_skip.add(idx + 5)
+                bad_element = stack[idx + 4].value
+                traced_stack.append(SetElement(bad_element))
+                continue
+            traced_stack.append(obj)
+
+        stack = traced_stack
+        stack[0] = RootObject(stack[0])
+
+        msg = io.StringIO()
+        for obj in stack:
+            if not isinstance(obj, DebugInfo):
+                msg.write(f"  {repr(obj)}\n")
+                continue
+            msg.write(obj.format())
+            msg.write("\n")
+        return msg.getvalue()
+
+
+def debug_dumps(importer, obj):
+    f = io.BytesIO()
+    p = DebugPickler(importer, f, protocol=3)
+    try:
+        p.dump(obj)
+    except (TypeError, PicklingError) as e:
+        # print(f"{str(e)}.\n\n"
+        #     "We think the problematic object is found at:\n"
+        #     f"{p.format_trace()}")
+        raise PicklingError(
+            f"{str(e)}.\n\n"
+            "We think the problematic object is found at:\n"
+            f"{p.format_trace()}"
+        ) from e
+    else:
+        raise ValueError(f"We expected pickling of {obj} to throw an exception")
 
 
 def create_pickler(data_buf, importer):

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -8,6 +8,7 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from pickle import PicklingError
 from typing import (
     Any,
     BinaryIO,
@@ -29,7 +30,7 @@ from torch.utils.hooks import RemovableHandle
 from ._digraph import DiGraph
 from ._importlib import _normalize_path
 from ._mangling import demangle, is_mangled
-from ._package_pickler import create_pickler
+from ._package_pickler import create_pickler, debug_dumps
 from ._stdlib import is_stdlib_module
 from .find_file_dependencies import find_files_source_depends_on
 from .glob_group import GlobGroup, GlobPattern
@@ -573,7 +574,10 @@ class PackageExporter:
         data_buf = io.BytesIO()
         pickler = create_pickler(data_buf, self.importer)
         pickler.persistent_id = self._persistent_id
-        pickler.dump(obj)
+        try:
+            pickler.dump(obj)
+        except (TypeError, PicklingError) as e:
+            debug_dumps(self.importer, obj)
         data_value = data_buf.getvalue()
 
         name_in_dependency_graph = f"<{package}.{resource}>"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70408

Summary:
Setting `PYTORCH_NVFUSER_ONE_OP_FUSION=1` will take all nodes nvFuser support, instead of waiting for fusion opportunity.

Reviewed By: samdow

Differential Revision: D33292195

Pulled By: davidberard98

fbshipit-source-id: 8ed5ce5e82fbb6737e8ab5ce4223b038eaf47756