### PR TITLE
WIP: Port `index_fill` to structured kernel

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5898,26 +5898,43 @@
 - func: index_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor source, *, Scalar alpha=1) -> Tensor
   variants: function, method
 
-- func: index_fill_.int_Scalar(Tensor(a!) self, int dim, Tensor index, Scalar value) -> Tensor(a!)
+- func: index_fill.int_Scalar_out(Tensor self, int dim, Tensor index, Scalar value, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   device_check: NoCheck   # TensorIterator
-  variants: method
+  variants: function
+  precomputed:
+  - dim -> int dim
   dispatch:
-    CPU: index_fill_
-    CUDA: index_fill_
+    CPU, CUDA: index_fill_int_scalar_out
 
 - func: index_fill.int_Scalar(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
+  structured_delegate: index_fill.int_Scalar_out
+  device_check: NoCheck   # TensorIterator
+  variants: function, method
+
+- func: index_fill_.int_Scalar(Tensor(a!) self, int dim, Tensor index, Scalar value) -> Tensor(a!)
+  structured_delegate: index_fill.int_Scalar_out
+  device_check: NoCheck   # TensorIterator
+  variants: method
+
+- func: index_fill.int_Tensor_out(Tensor self, int dim, Tensor index, Tensor value, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  device_check: NoCheck   # TensorIterator
+  variants: function
+  precomputed:
+  - dim -> int dim
+  dispatch:
+    CPU, CUDA: index_fill_int_tensor_out
+
+- func: index_fill.int_Tensor(Tensor self, int dim, Tensor index, Tensor value) -> Tensor
+  structured_delegate: index_fill.int_Tensor_out
   device_check: NoCheck   # TensorIterator
   variants: function, method
 
 - func: index_fill_.int_Tensor(Tensor(a!) self, int dim, Tensor index, Tensor value) -> Tensor(a!)
+  structured_delegate: index_fill.int_Tensor_out
   device_check: NoCheck   # TensorIterator
   variants: method
-  dispatch:
-    CPU, CUDA: index_fill_
-
-- func: index_fill.int_Tensor(Tensor self, int dim, Tensor index, Tensor value) -> Tensor
-  device_check: NoCheck   # TensorIterator
-  variants: function, method
 
 - func: index_fill_.Dimname_Scalar(Tensor(a!) self, Dimname dim, Tensor index, Scalar value) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -101,6 +101,7 @@ Indexing, Slicing, Joining, Mutating Ops
     hsplit
     hstack
     index_add
+    index_fill
     index_select
     masked_select
     movedim

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6760,15 +6760,12 @@ else:
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             ind.index_copy_(0, ind.clone(), ind)
 
-    @expectedFailureMeta  # Warning not triggered
     @onlyNativeDeviceTypes
     def test_index_fill_mem_overlap(self, device):
         x = torch.rand((1,), device=device).expand((6,))
-        y = torch.rand((6,), device=device)
         ind = torch.tensor([2, 1, 0], device=device)
-        value = torch.rand((3,), device=device)
 
-        with self.assertWarnsRegex(UserWarning, "index_fill_ on expanded tensors"):
+        with self.assertWarnsRegex(UserWarning, "index_fill on expanded tensors"):
             x.index_fill_(0, ind, 1.0)
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             ind.index_fill_(0, ind, 0)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -761,10 +761,21 @@
   index: non_differentiable
   result: self_t.index_copy_(dim, index, source_t)
 
+- name: index_fill.int_Scalar(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
+  self: grad.index_fill(dim, index, 0)
+  index: non_differentiable
+  result: at::index_fill(self_t, dim, index, 0)
+
 - name: index_fill_.int_Scalar(Tensor(a!) self, int dim, Tensor index, Scalar value) -> Tensor(a!)
   self: grad.clone().index_fill_(dim, index, 0)
   index: non_differentiable
   result: self_t.index_fill_(dim, index, 0)
+
+- name: index_fill.int_Tensor(Tensor self, int dim, Tensor index, Tensor value) -> Tensor
+  self: grad.index_fill(dim, index, 0)
+  value: grad.index_select(dim, std::get<0>(at::_unique(index, /*sorted=*/false))).sum()
+  index: non_differentiable
+  result: at::index_fill(self_t, dim, index, value_t)
 
 - name: index_fill_.int_Tensor(Tensor(a!) self, int dim, Tensor index, Tensor value) -> Tensor(a!)
   self: grad.clone().index_fill_(dim, index, 0)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1875,7 +1875,8 @@ selecting the indices in the order given in :attr:`index`.
 Args:
     dim (int): dimension along which to index
     index (LongTensor): indices of :attr:`self` tensor to fill in
-    value (float): the value to fill with
+    value (float or Tensor): the value to fill with. If Tensor, it should
+        be a 0-dimensional value tensor.
 
 Example::
     >>> x = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.float)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -219,6 +219,12 @@ index_add(input, dim, index, source, *, alpha=1, out=None) -> Tensor
 See :meth:`~Tensor.index_add_` for function description.
 """)
 
+add_docstr(torch.index_fill, r"""
+index_fill(input, dim, index, value, out=None) -> Tensor
+
+See :meth:`~Tensor.index_fill_` for function description.
+""")
+
 add_docstr(torch.add, r"""
 add(input, other, *, alpha=1, out=None) -> Tensor
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13032,8 +13032,7 @@ op_db: List[OpInfo] = [
            ),
     OpInfo('index_fill',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           supports_inplace_autograd=False,
-           supports_out=False,
+           supports_out=True,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            # https://github.com/pytorch/pytorch/issues/66357


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/55070

Description:
- ported `index_fill` to structured kernel
- updated OpInfo
- updated docs

To enable index_fill op in functorch: https://github.com/pytorch/functorch/issues/260
cc @zou3519 
