### PR TITLE
Make `get_file_pathnames_from_root` output order deterministic

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -290,6 +290,17 @@ class TestIterableDataPipeBasic(TestCase):
             self.assertTrue((pathname in self.temp_files) or (pathname in self.temp_sub_files))
         self.assertEqual(count, len(self.temp_files) + len(self.temp_sub_files))
 
+    def test_listdirfilesdeterministic_iterable_datapipe(self):
+        temp_dir = self.temp_dir.name
+
+        datapipe = dp.iter.FileLister(temp_dir, '')
+        # The output order should be always the same.
+        self.assertEqual(list(datapipe), list(datapipe))
+
+        datapipe = dp.iter.FileLister(temp_dir, '', recursive=True)
+        # The output order should be always the same.
+        self.assertEqual(list(datapipe), list(datapipe))
+
     def test_readfilesfromdisk_iterable_datapipe(self):
         # test import datapipe class directly
         from torch.utils.data.datapipes.iter import (

--- a/torch/utils/data/datapipes/iter/filelister.py
+++ b/torch/utils/data/datapipes/iter/filelister.py
@@ -15,21 +15,22 @@ class FileListerIterDataPipe(IterDataPipe[str]):
     """
 
     def __init__(
-            self,
-            root: str = '.',
-            masks: Union[str, List[str]] = '',
-            *,
-            recursive: bool = False,
-            abspath: bool = False,
-            length: int = -1,
-            non_deterministic: bool = False):
+        self,
+        root: str = '.',
+        masks: Union[str, List[str]] = '',
+        *,
+        recursive: bool = False,
+        abspath: bool = False,
+        non_deterministic: bool = False,
+        length: int = -1
+    ) -> None:
         super().__init__()
         self.root: str = root
         self.masks: Union[str, List[str]] = masks
         self.recursive: bool = recursive
         self.abspath: bool = abspath
-        self.length: int = length
         self.non_deterministic: bool = non_deterministic
+        self.length: int = length
 
     def __iter__(self) -> Iterator[str] :
         yield from get_file_pathnames_from_root(self.root, self.masks, self.recursive, self.abspath,

--- a/torch/utils/data/datapipes/iter/filelister.py
+++ b/torch/utils/data/datapipes/iter/filelister.py
@@ -21,16 +21,19 @@ class FileListerIterDataPipe(IterDataPipe[str]):
             *,
             recursive: bool = False,
             abspath: bool = False,
-            length: int = -1):
+            length: int = -1,
+            non_deterministic: bool = False):
         super().__init__()
         self.root: str = root
         self.masks: Union[str, List[str]] = masks
         self.recursive: bool = recursive
         self.abspath: bool = abspath
         self.length: int = length
+        self.non_deterministic: bool = non_deterministic
 
     def __iter__(self) -> Iterator[str] :
-        yield from get_file_pathnames_from_root(self.root, self.masks, self.recursive, self.abspath)
+        yield from get_file_pathnames_from_root(self.root, self.masks, self.recursive, self.abspath,
+                                                self.non_deterministic)
 
     def __len__(self):
         if self.length == -1:

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -46,7 +46,7 @@ def get_file_pathnames_from_root(
         masks: Union[str, List[str]],
         recursive: bool = False,
         abspath: bool = False,
-        deterministic_order: bool = True) -> Iterable[str]:
+        non_deterministic: bool = False) -> Iterable[str]:
 
     # print out an error message and raise the error out
     def onerror(err : OSError):
@@ -56,14 +56,14 @@ def get_file_pathnames_from_root(
     for path, dirs, files in os.walk(root, onerror=onerror):
         if abspath:
             path = os.path.abspath(path)
-        if deterministic_order:
+        if not non_deterministic:
             files.sort()
         for f in files:
             if match_masks(f, masks):
                 yield os.path.join(path, f)
         if not recursive:
             break
-        if deterministic_order:
+        if not non_deterministic:
             dirs.sort()
 
 

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -45,7 +45,8 @@ def get_file_pathnames_from_root(
         root: str,
         masks: Union[str, List[str]],
         recursive: bool = False,
-        abspath: bool = False) -> Iterable[str]:
+        abspath: bool = False,
+        deterministic_order: bool = True) -> Iterable[str]:
 
     # print out an error message and raise the error out
     def onerror(err : OSError):
@@ -55,11 +56,15 @@ def get_file_pathnames_from_root(
     for path, dirs, files in os.walk(root, onerror=onerror):
         if abspath:
             path = os.path.abspath(path)
+        if deterministic_order:
+            files.sort()
         for f in files:
             if match_masks(f, masks):
                 yield os.path.join(path, f)
         if not recursive:
             break
+        if deterministic_order:
+            dirs.sort()
 
 
 def get_file_binaries_from_pathnames(pathnames: Iterable, mode: str):


### PR DESCRIPTION
Fixes #70103

I used an argument so it can be disabled. I called it `deterministic_order` because `sort` can be confusing, as it's actually sorted but by dir levels.
