### PR TITLE
add SparseXPU to dispatch key set autogradother_backends

### DIFF
--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -259,6 +259,7 @@ constexpr DispatchKeySet autogradother_backends = DispatchKeySet(
      DispatchKey::SparseCUDA,
      DispatchKey::SparseHIP,
      DispatchKey::SparseVE,
+     DispatchKey::SparseXPU,
      DispatchKey::SparseCsrCPU,
      DispatchKey::SparseCsrCUDA,
      DispatchKey::Meta});


### PR DESCRIPTION
According to dispatch table computation logic, if no kernel
register to a certain dispatch key, will use CompositeExplicitAutograd
backend kernel, so we need add sparseXPU key to the alias key pool.

Signed-off-by: Ma, Jing1 <jing1.ma@intel.com>
