### PR TITLE
.github: Add needs build for generate-test-matrix

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -145,6 +145,7 @@ jobs:
 {%- if not exclude_test %}
 {% block test +%}
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: !{{ common.timeout_minutes }}
     env:

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -83,6 +83,7 @@ jobs:
 {%- if not exclude_test %}
 {% block test +%}
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: !{{ common.timeout_minutes }}
     env:

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -126,6 +126,7 @@ jobs:
           rm -rf ./*
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: !{{ common.timeout_minutes }}
     env:

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.6-clang9.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.6-clang9.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.6-gcc7.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-asan.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-clang7-onnx.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc5.4.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.6-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.6-gcc7.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -92,6 +92,7 @@ jobs:
 
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.6-gcc5.4.yml
@@ -251,6 +251,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.6-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.6-gcc7.yml
@@ -248,6 +248,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -248,6 +248,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.6-gcc7-debug.yml
@@ -249,6 +249,7 @@ jobs:
           docker system prune -af
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -136,6 +136,7 @@ jobs:
           rm -rf ./*
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -136,6 +136,7 @@ jobs:
           rm -rf ./*
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -130,6 +130,7 @@ jobs:
           rm -rf ./*
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -139,6 +139,7 @@ jobs:
           rm -rf ./*
 
   generate-test-matrix:
+    needs: build
     runs-on: ubuntu-18.04
     timeout-minutes: 240
     env:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70456

`generate-test-matrix` was getting run for workflows that did not have ciflow enabled for them. this makes it so that `generate-test-matrix` is now dependent on `build` being run.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33338946](https://our.internmc.facebook.com/intern/diff/D33338946)