### PR TITLE
(1/2) Make TorchScript Preserve Fully Qualified Class Name for Python Exceptions: backend change

### DIFF
--- a/torch/csrc/jit/mobile/promoted_prim_ops.cpp
+++ b/torch/csrc/jit/mobile/promoted_prim_ops.cpp
@@ -14,7 +14,12 @@ void tupleIndex(Stack& stack) {
 }
 
 void raiseException(Stack& stack) {
-  throw JITException(pop(stack).toStringRef());
+  c10::optional<std::string> qualified_class_name =
+      pop(stack).toOptional<std::string>();
+  std::string message;
+  pop(stack, message);
+
+  throw JITException(message, qualified_class_name);
 }
 
 void is(Stack& stack) {

--- a/torch/csrc/jit/runtime/jit_exception.cpp
+++ b/torch/csrc/jit/runtime/jit_exception.cpp
@@ -3,7 +3,11 @@
 namespace torch {
 namespace jit {
 
-JITException::JITException(const std::string& msg) : std::runtime_error(msg) {}
+JITException::JITException(
+    const std::string& msg,
+    c10::optional<std::string> python_class_name)
+    : std::runtime_error(msg),
+      python_class_name_(std::move(python_class_name)) {}
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/jit_exception.h
+++ b/torch/csrc/jit/runtime/jit_exception.h
@@ -2,13 +2,24 @@
 
 #include <stdexcept>
 
+#include <c10/util/Optional.h>
 #include <torch/csrc/Export.h>
+#include <string>
 
 namespace torch {
 namespace jit {
 
 struct TORCH_API JITException : public std::runtime_error {
-  explicit JITException(const std::string& msg);
+  explicit JITException(
+      const std::string& msg,
+      c10::optional<std::string> python_class_name = c10::nullopt);
+
+  c10::optional<std::string> getPythonClassName() const {
+    return python_class_name_;
+  }
+
+ private:
+  c10::optional<std::string> python_class_name_;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -406,7 +406,8 @@ static const OperatorGeneratorArgs opGenArgs[] = {
         numToTensorScalar,
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
-        TORCH_SELECTIVE_SCHEMA("prim::RaiseException(str msg) -> ()"),
+        TORCH_SELECTIVE_SCHEMA(
+            "prim::RaiseException(str msg, str? cls=None) -> ()"),
         raiseException,
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #70471
* __->__ #70470

Reland for D33282878 . Land backend change first to maintain FC. Will wait for 2 weeks after this diff is in. And than land the front-end change in next diff.

Differential Revision: [D33342547](https://our.internmc.facebook.com/intern/diff/D33342547/)