### PR TITLE
Add sigmoid_backward, binary_cross_entropy* ops used by dcgan

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -85,7 +85,6 @@ SKIP_TRAIN_ONLY = {
     # slow tests
     "timm_efficientnet",
     "Super_SloMo",
-    "dcgan",
     "BERT_pytorch",
     "demucs",
     "opacus_cifar10",

--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -76,6 +76,18 @@ std::vector<int64_t> expand_param_if_needed(
   }
 }
 
+std::vector<Shape> compute_shape_binary_cross_entropy(const at::Tensor & self, const at::Tensor & target, const c10::optional<at::Tensor> & weight, int64_t reduction) {
+  if(reduction == at::Reduction::None) {
+    return {Shape(self.scalar_type(), self.sizes().vec())};
+  }
+  return {Shape(self.scalar_type(), {})};
+}
+
+std::vector<Shape> compute_shape_binary_cross_entropy_backward(const at::Tensor & grad_output, const at::Tensor & self, const at::Tensor & target, const c10::optional<at::Tensor> & weight, int64_t reduction) {
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
+
 std::vector<Shape> compute_shape_constant_pad_nd(const at::Tensor & self, at::IntArrayRef pad, const at::Scalar & value) {
   // Based on aten/src/ATen/native/ConstantPadNd.cpp::constant_pad_nd
   TORCH_CHECK(pad.size() % 2 == 0, "Length of pad must be even but instead it equals ",

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -12,6 +12,8 @@ full_codegen:
   - avg_pool2d
   - avg_pool2d_backward
   - baddbmm
+  - binary_cross_entropy
+  - binary_cross_entropy_backward
   - bitwise_and.Tensor
   - bmm
   - constant_pad_nd
@@ -71,6 +73,7 @@ full_codegen:
   - relu_
   - rsqrt
   - sigmoid
+  - sigmoid_backward
   - silu
   - smooth_l1_loss
   - smooth_l1_loss_backward


### PR DESCRIPTION
together with changes to torchbench to avoid .item() calls, this makes dcgan as fast as overheads will allow