### PR TITLE
.github: Add linux.4xlarge executor

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,7 @@ self-hosted-runner:
   labels:
     - linux.large
     - linux.2xlarge
+    - linux.4xlarge
     - linux.8xlarge.nvidia.gpu
     - linux.16xlarge.nvidia.gpu
     - windows.4xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -29,6 +29,10 @@ runner_types:
     os: linux
     max_available: 500
     disk_size: 150
+  linux.4xlarge:
+    instance_type: c5.4xlarge
+    os: linux
+    disk_size: 150
   linux.8xlarge.nvidia.gpu:
     instance_type: g3.8xlarge
     os: linux


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70474

Needed to compile linux wheels for CUDA 11.x since we were OOM'ing with
16GB of RAM

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33343322](https://our.internmc.facebook.com/intern/diff/D33343322)