### PR TITLE
Change ParameterList and ParameterDict to be able to contain any kind of objects

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -747,7 +747,7 @@ class TestDataParallel(TestCase):
                 self.check_fn = check_fn
 
             def forward(self, inp):
-                self.check_fn()
+                self.check_fn(self)
                 return inp
 
         p1 = torch.nn.Parameter(torch.rand(10))

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -741,32 +741,43 @@ class TestDataParallel(TestCase):
     @sandcastle_skip_if(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_parameter_list_dict_replica(self):
         class MyMod(torch.nn.Module):
-            def __init__(self, data):
+            def __init__(self, data, check_fn):
                 super(MyMod, self).__init__()
                 self.data = data
+                self.check_fn = check_fn
 
             def forward(self, inp):
+                self.check_fn()
                 return inp
 
         p1 = torch.nn.Parameter(torch.rand(10))
         p2 = torch.nn.Parameter(torch.rand(10))
-        module = MyMod(torch.nn.ParameterList([p1, p2])).cuda()
+        key0 = 0
+        key1 = 1
+
+        def check_fn(self_):
+            self.assertEqual(p1, self_.data[key0])
+            self.assertEqual(p2, self_.data[key1])
+            self.assertTrue(self_.data[key0].requires_grad)
+            self.assertTrue(self_.data[key1].requires_grad)
+            self.assertIsNotNone(self_.data[key0].grad_fn)
+            self.assertIsNotNone(self_.data[key1].grad_fn)
+
+        module = MyMod(torch.nn.ParameterList([p1, p2]), check_fn).cuda()
         model = dp.DataParallel(module)
         input = torch.randn((8, 8), device="cuda")
 
-        with self.assertWarnsRegex(
-                UserWarning,
-                r"nn\.ParameterList is being used with DataParallel but this"):
-            model(input)
+        # Runs the check_fn
+        model(input)
 
-        module = MyMod(torch.nn.ParameterDict({"0": p1, "1": p2})).cuda()
+        key0 = "0"
+        key1 = "1"
+        module = MyMod(torch.nn.ParameterDict({"0": p1, "1": p2}), check_fn).cuda()
         model = dp.DataParallel(module)
         input = torch.randn((8, 8), device="cuda")
 
-        with self.assertWarnsRegex(
-                UserWarning,
-                r"nn\.ParameterDict is being used with DataParallel but this"):
-            model(input)
+        # Runs the check_fn
+        model(input)
 
 
 class TestDataParallelDeviceType(TestCase):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2047,6 +2047,8 @@ class TestNN(NNTestCase):
             self.assertIsNotNone(p2.grad_fn)
             self.assertIs(p2._base, p)
 
+        self.assertEqual(param_dict["foo"], new_param_dict["foo"])
+
     def test_add_module(self):
         methods_to_test = ['add_module', 'register_module']
         for fn in methods_to_test:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1853,10 +1853,6 @@ class TestNN(NNTestCase):
         with self.assertRaises(ValueError):
             parameter_dict.update(Parameter(torch.randn(10, 10)))
 
-        # Any hashable type is a valid key
-        parameter_dict[1] = Parameter(torch.randn(10, 10))
-        del parameter_dict[1]
-
         p_pop = parameter_dict.pop('p4')
         self.assertIs(p_pop, parameters['p4'])
         parameters.pop('p4')

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -418,7 +418,7 @@ class ParameterList(Module):
     r"""Holds parameters in a list.
 
     :class:`~torch.nn.ParameterList` can be used like a regular Python
-    list, but Tensor that are :class:`~torch.nn.Parameter` are properly registered,
+    list, but Tensors that are :class:`~torch.nn.Parameter` are properly registered,
     and will be visible by all :class:`~torch.nn.Module` methods.
 
     Args:
@@ -680,10 +680,7 @@ class ParameterDict(Module):
             key (string): key to get from the ParameterDict
             default (Parameter, optional): value to return if key not present
         """
-        if key in self:
-            return self[key]
-        else:
-            return default
+        return self[key] if key in self else default
 
     def fromkeys(self, keys: Iterable[str], default: Optional[Any] = None) -> 'ParameterDict':
         r"""Return a new ParameterDict with the keys provided

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -8,7 +8,7 @@ from .module import Module
 from ..parameter import Parameter
 from torch._jit_internal import _copy_to_script_wrapper
 
-from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, TYPE_CHECKING, overload, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, overload, Tuple, TypeVar, Union
 
 T = TypeVar('T', bound=Module)
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -421,6 +421,10 @@ class ParameterList(Module):
     list, but Tensors that are :class:`~torch.nn.Parameter` are properly registered,
     and will be visible by all :class:`~torch.nn.Module` methods.
 
+    Note that both the constructor, assigning an element of the list, the
+    :meth:`~torch.nn.ParameterDict.append` method and the :meth:`~torch.nn.ParameterDict.extend`
+    method will convert any :class:`~torch.Tensor` into :class:`~torch.nn.Parameter`.
+
     Args:
         parameters (iterable, optional): an iterable of elements to add to the list.
 
@@ -554,7 +558,8 @@ class ParameterDict(Module):
     will preserve their ordering.
 
     Note that both the constructor, assigning an element of the dictionary and the
-    :meth:`~torch.nn.ParameterDict.update` method will convert any ``Tensor`` into ``Parameter``.
+    :meth:`~torch.nn.ParameterDict.update` method will convert any :class:`~torch.Tensor` into
+    :class:`~torch.nn.Parameter`.
 
     Args:
         values (iterable, optional): a mapping (dictionary) of

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -421,7 +421,7 @@ class ParameterList(Module):
     list, but Tensors that are :class:`~torch.nn.Parameter` are properly registered,
     and will be visible by all :class:`~torch.nn.Module` methods.
 
-    Note that both the constructor, assigning an element of the list, the
+    Note that the constructor, assigning an element of the list, the
     :meth:`~torch.nn.ParameterDict.append` method and the :meth:`~torch.nn.ParameterDict.extend`
     method will convert any :class:`~torch.Tensor` into :class:`~torch.nn.Parameter`.
 
@@ -557,7 +557,7 @@ class ParameterDict(Module):
     merged mapping. On the other hand, ``OrderedDict`` or another :class:`~torch.nn.ParameterDict`
     will preserve their ordering.
 
-    Note that both the constructor, assigning an element of the dictionary and the
+    Note that the constructor, assigning an element of the dictionary and the
     :meth:`~torch.nn.ParameterDict.update` method will convert any :class:`~torch.Tensor` into
     :class:`~torch.nn.Parameter`.
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -10,9 +10,6 @@ from torch._jit_internal import _copy_to_script_wrapper
 
 from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, TYPE_CHECKING, overload, Tuple, TypeVar, Union
 
-if TYPE_CHECKING:
-    from torch.nn import Parameter
-
 T = TypeVar('T', bound=Module)
 
 
@@ -579,7 +576,7 @@ class ParameterDict(Module):
 
     def __init__(self, parameters: Optional[Mapping[str, Any]] = None) -> None:
         super(ParameterDict, self).__init__()
-        self._idxs = {}
+        self._idxs: Dict[Any, None] = {}
         # BC-breaking if this was passed plain Tensors before
         if parameters is not None:
             self.update(parameters)
@@ -703,7 +700,7 @@ class ParameterDict(Module):
         """
         return (self[k] for k in self._idxs)
 
-    def update(self, parameters: Mapping[str, Any]) -> None:
+    def update(self, parameters: Union[Mapping[str, Any], 'ParameterDict']) -> None:
         r"""Update the :class:`~torch.nn.ParameterDict` with the key-value pairs from a
         mapping or an iterable, overwriting existing keys.
 


### PR DESCRIPTION
The only difference with plain list/dict now is that nn.Parameters are
handled specially and registered as parameters properly.

test_nn and parametrization works locally.
Will see in CI if DP is fixed as well.

Tentative fix for #36035