### PR TITLE
No-batch-dim support for ConvTransposeNd

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -767,36 +767,51 @@ at::Tensor conv3d(
 }
 
 at::Tensor conv_transpose1d(
-    const Tensor& input, const Tensor& weight, const c10::optional<Tensor>& bias_opt,
+    const Tensor& input_, const Tensor& weight, const c10::optional<Tensor>& bias_opt,
     IntArrayRef stride, IntArrayRef padding, IntArrayRef output_padding, int64_t groups, IntArrayRef dilation) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 
-  return at::convolution(input, weight, bias, stride, padding, dilation,
-                         true, output_padding, groups);
+  TORCH_CHECK(input_.dim() == 2 || input_.dim() == 3,
+      "Expected 2D (unbatched) or 3D (batched) input to conv_transpose1d, but got input of size: ", input_.sizes());
+  auto is_batched = (input_.dim() == 3);
+  auto input = is_batched ? input_ : input_.unsqueeze(0);
+  auto output = at::convolution(
+      input, weight, bias, stride, padding, dilation, true, output_padding, groups);
+  return is_batched ? output : output.squeeze(0);
 }
 
 at::Tensor conv_transpose2d(
-    const Tensor& input, const Tensor& weight, const c10::optional<Tensor>& bias_opt,
+    const Tensor& input_, const Tensor& weight, const c10::optional<Tensor>& bias_opt,
     IntArrayRef stride, IntArrayRef padding, IntArrayRef output_padding, int64_t groups, IntArrayRef dilation) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 
-  return at::convolution(input, weight, bias, stride, padding, dilation,
-                         true, output_padding, groups);
+  TORCH_CHECK(input_.dim() == 3 || input_.dim() == 4,
+      "Expected 3D (unbatched) or 4D (batched) input to conv_transpose2d, but got input of size: ", input_.sizes());
+  auto is_batched = (input_.dim() == 4);
+  auto input = is_batched ? input_ : input_.unsqueeze(0);
+  auto output = at::convolution(
+      input, weight, bias, stride, padding, dilation, true, output_padding, groups);
+  return is_batched ? output : output.squeeze(0);
 }
 
 at::Tensor conv_transpose3d(
-    const Tensor& input, const Tensor& weight, const c10::optional<Tensor>& bias_opt,
+    const Tensor& input_, const Tensor& weight, const c10::optional<Tensor>& bias_opt,
     IntArrayRef stride, IntArrayRef padding, IntArrayRef output_padding, int64_t groups, IntArrayRef dilation) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 
-  return at::convolution(input, weight, bias, stride, padding, dilation,
-                         true, output_padding, groups);
+  TORCH_CHECK(input_.dim() == 4 || input_.dim() == 5,
+      "Expected 4D (unbatched) or 5D (batched) input to conv_transpose3d, but got input of size: ", input_.sizes());
+  auto is_batched = (input_.dim() == 5);
+  auto input = is_batched ? input_ : input_.unsqueeze(0);
+  auto output = at::convolution(
+      input, weight, bias, stride, padding, dilation, true, output_padding, groups);
+  return is_batched ? output : output.squeeze(0);
 }
 
 at::Tensor convolution(

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -481,6 +481,12 @@ module_db: List[ModuleInfo] = [
                module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=2, lazy=False)),
     ModuleInfo(torch.nn.Conv3d,
                module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=3, lazy=False)),
+    ModuleInfo(torch.nn.ConvTranspose1d,
+               module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=1, lazy=False)),
+    ModuleInfo(torch.nn.ConvTranspose2d,
+               module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=2, lazy=False)),
+    ModuleInfo(torch.nn.ConvTranspose3d,
+               module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=3, lazy=False)),
     ModuleInfo(torch.nn.ELU,
                module_inputs_func=module_inputs_torch_nn_ELU),
     ModuleInfo(torch.nn.L1Loss,
@@ -496,6 +502,21 @@ module_db: List[ModuleInfo] = [
                # See https://github.com/pytorch/pytorch/issues/70505 for more info.
                decorators=[skipMeta]),
     ModuleInfo(torch.nn.LazyConv3d,
+               module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=3, lazy=True),
+               # Lazy modules don't currently play well with ModuleInfo tests on the meta device.
+               # See https://github.com/pytorch/pytorch/issues/70505 for more info.
+               decorators=[skipMeta]),
+    ModuleInfo(torch.nn.LazyConvTranspose1d,
+               module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=1, lazy=True),
+               # Lazy modules don't currently play well with ModuleInfo tests on the meta device.
+               # See https://github.com/pytorch/pytorch/issues/70505 for more info.
+               decorators=[skipMeta]),
+    ModuleInfo(torch.nn.LazyConvTranspose2d,
+               module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=2, lazy=True),
+               # Lazy modules don't currently play well with ModuleInfo tests on the meta device.
+               # See https://github.com/pytorch/pytorch/issues/70505 for more info.
+               decorators=[skipMeta]),
+    ModuleInfo(torch.nn.LazyConvTranspose3d,
                module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=3, lazy=True),
                # Lazy modules don't currently play well with ModuleInfo tests on the meta device.
                # See https://github.com/pytorch/pytorch/issues/70505 for more info.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70507
* #70506

This PR adds no-batch-dim support for:
* `nn.ConvTranspose1d`, `nn.ConvTranspose2d`, `nn.ConvTranspose3d`
* `nn.LazyConvTranspose1d`, `nn.LazyConvTranspose2d`, `nn.LazyConvTranspose3d`
* `F.conv_transpose1d`, `F.conv_transpose2d`, `F.conv_transpose3d`

The support is added at the op level (e.g. `conv_transpose1d`) and tested via `ModuleInfo` entries with a reference function that compares the output from a single batch item input vs. the output from a no-batch-dim input.

Differential Revision: [D33355035](https://our.internmc.facebook.com/intern/diff/D33355035)