### PR TITLE
[maskrcnn] enable stable sort in BoxWithNMSLimit op

### DIFF
--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -104,7 +104,7 @@ const auto& tscores = Input(0);
             -1, /* topN */
             legacy_plus_one_);
       } else {
-        std::sort(
+        std::stable_sort(
             inds.data(),
             inds.data() + inds.size(),
             [&cur_scores](int lhs, int rhs) {
@@ -148,7 +148,7 @@ const auto& tscores = Input(0);
           }
         }
 
-        std::sort(
+        std::stable_sort(
             ret.data(),
             ret.data() + ret.size(),
             [this, &scores](const KeepIndex& lhs, const KeepIndex& rhs) {

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -180,7 +180,7 @@ void GenerateProposalsOp<CPUContext>::ProposalsForOneImage(
   if (rpn_pre_nms_topN_ <= 0 || rpn_pre_nms_topN_ >= scores.size()) {
     // 4. sort all (proposal, score) pairs by score from highest to lowest
     // 5. take top pre_nms_topN (e.g. 6000)
-    std::sort(order.begin(), order.end(), [&scores](int lhs, int rhs) {
+    std::stable_sort(order.begin(), order.end(), [&scores](int lhs, int rhs) {
       return scores[lhs] > scores[rhs];
     });
   } else {

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -370,7 +370,7 @@ int convex_hull_graham(
   // Step 3:
   // Sort point 1 ~ num_in according to their relative cross-product values
   // (essentially sorting according to angles)
-  std::sort(
+  std::stable_sort(
       q + 1,
       q + num_in,
       [](const Eigen::Vector2f& A, const Eigen::Vector2f& B) -> bool {
@@ -711,7 +711,7 @@ std::vector<int> nms_cpu(
     bool legacy_plus_one = false) {
   std::vector<int> indices(proposals.rows());
   std::iota(indices.begin(), indices.end(), 0);
-  std::sort(
+  std::stable_sort(
       indices.data(),
       indices.data() + indices.size(),
       [&scores](int lhs, int rhs) { return scores(lhs) > scores(rhs); });


### PR DESCRIPTION
Summary:
D32694315 changes the implementation of sorting in NMS to stable sort. While the C2 operators are using non-stable sort. This causes test failure such as:
- mobile-vision/d2go/tests:fb_test_meta_arch_rcnn - test_export_caffe2 (d2go.tests.fb.test_meta_arch_rcnn.TestFBNetV2MaskRCNNFP32) (architecture: x86_64, buildmode: dev-nosan, buildsystem: buck, compiler: clang, sanitizer: none) https://www.internalfb.com/intern/testinfra/diagnostics/7318349463675961.562949999530318.1640814509/
- mobile-vision/d2go/tests:fb_test_meta_arch_rcnn - test_export_torchscript_mobile_c2_ops (d2go.tests.fb.test_meta_arch_rcnn.TestFBNetV2MaskRCNNFP32) (architecture: x86_64, buildmode: dev-nosan, buildsystem: buck, compiler: clang, sanitizer: none) https://www.internalfb.com/intern/testinfra/diagnostics/7318349463675961.844424980844724.1640814504/

To illustrate, in the failed test_export_caffe2 test, the inputs of BoxWithNMSLimit are:
```
(Pdb) ws.FetchBlob("246")
array([[0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568]], dtype=float32)
(Pdb) ws.FetchBlob("248")
array([[ 0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.]], dtype=float32)
(Pdb) ws.FetchBlob("249")
array([1.], dtype=float32)
```
This contains 81 boxes (representing 81 classes) with equal score, stable sort will return the class id 0; while the non-stable sort returns class id 50.

This diff changes the sorting to stable sort for BoxWithNMSLimit op.

Test Plan:
The D2 (https://github.com/pytorch/pytorch/commit/ea4d98388500496f04fd6a814b134c4242160267)Go's tests can pass after this change.
```
buck test mode/dev-nosan //mobile-vision/d2go/tests:fb_test_meta_arch_rcnn -- --run-disabled
```
https://www.internalfb.com/intern/testinfra/testrun/4785074687594820

Differential Revision: D33355251

