### PR TITLE
[caffe2] don't use __FUNCSIG__ when building for Windows with clang

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -132,7 +132,7 @@ inline constexpr uint64_t type_index_impl() {
 // of this function, including its template parameter, i.e. including the
 // type we want an id for. We use this name and run crc64 on it to get a type
 // id.
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
   return crc64(__FUNCSIG__, sizeof(__FUNCSIG__)).checksum();
 #elif defined(__clang__)
   return crc64(__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__)).checksum();


### PR DESCRIPTION
Summary: When building with strict(er) compiler warnings on Windows, clang complains that `__FUNCSIC__` is a proprietary language extension. When using clang, it seems we can use `__PRETTY_FUNCTION__` instead, like we do on other platforms. This is also in line with the logic on L100:127.

Test Plan: CI

Differential Revision: D33386400

