### PR TITLE
Space fix + Doc fix + Numba

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,12 +8,13 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
+export VC_YEAR=2019
 
-if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
-  export VC_YEAR=2017
-else
-  export VC_YEAR=2019
-fi
+# if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+#   export VC_YEAR=2017
+# else
+#   export VC_YEAR=2019
+# fi
 
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -19,6 +19,41 @@ if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"
 fi
 
+echo "Free Space for CUDA DEBUG BUILD"
+if [[ "$CIRCLECI" == 'true' ]]; then
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft.NET" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft.NET"
+    fi
+
+    if [[ -d "C:\\Program Files\\dotnet" ]]; then
+        rm -rf "C:\\Program Files\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\dotnet" ]]; then
+        rm -rf "C:\\Program Files (x86)\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft SQL Server" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft SQL Server"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Xamarin" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Xamarin"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Google" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Google"
+    fi
+fi
+
 set +x
 export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}
 export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,13 +8,12 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
-export VC_YEAR=2019
 
-# if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
-#   export VC_YEAR=2017
-# else
-#   export VC_YEAR=2019
-# fi
+if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+  export VC_YEAR=2017
+else
+  export VC_YEAR=2019
+fi
 
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -21,10 +21,6 @@ fi
 
 echo "Free Space for CUDA DEBUG BUILD"
 if [[ "$CIRCLECI" == 'true' ]]; then
-    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
-        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
-    fi
-
     if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
         rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
     fi

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==2.4.4
+docutils==0.16
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -261,7 +261,7 @@ class TestNumbaIntegration(common.TestCase):
             ]
             # Zero-copy when using `torch.as_tensor()`
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary)
+                numba_ary = numba.cuda.to_device(numpy_ary, sync=false)
                 torch_ary = torch.as_tensor(numba_ary, device="cuda")
                 self.assertEqual(numba_ary.__cuda_array_interface__, torch_ary.__cuda_array_interface__)
                 self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
@@ -272,7 +272,7 @@ class TestNumbaIntegration(common.TestCase):
 
             # Implicit-copy because `torch_ary` is a CPU array
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary)
+                numba_ary = numba.cuda.to_device(numpy_ary, sync=false)
                 torch_ary = torch.as_tensor(numba_ary, device="cpu")
                 self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
@@ -282,7 +282,7 @@ class TestNumbaIntegration(common.TestCase):
 
             # Explicit-copy when using `torch.tensor()`
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary)
+                numba_ary = numba.cuda.to_device(numpy_ary, sync=false)
                 torch_ary = torch.tensor(numba_ary, device="cuda")
                 self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -261,7 +261,7 @@ class TestNumbaIntegration(common.TestCase):
             ]
             # Zero-copy when using `torch.as_tensor()`
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary, sync=false)
+                numba_ary = numba.cuda.to_device(numpy_ary, sync=False)
                 torch_ary = torch.as_tensor(numba_ary, device="cuda")
                 self.assertEqual(numba_ary.__cuda_array_interface__, torch_ary.__cuda_array_interface__)
                 self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
@@ -272,7 +272,7 @@ class TestNumbaIntegration(common.TestCase):
 
             # Implicit-copy because `torch_ary` is a CPU array
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary, sync=false)
+                numba_ary = numba.cuda.to_device(numpy_ary, sync=False)
                 torch_ary = torch.as_tensor(numba_ary, device="cpu")
                 self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
@@ -282,7 +282,7 @@ class TestNumbaIntegration(common.TestCase):
 
             # Explicit-copy when using `torch.tensor()`
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary, sync=false)
+                numba_ary = numba.cuda.to_device(numpy_ary, sync=False)
                 torch_ary = torch.tensor(numba_ary, device="cuda")
                 self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -272,7 +272,7 @@ class TestNumbaIntegration(common.TestCase):
 
             # Implicit-copy because `torch_ary` is a CPU array
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary, sync=False)
+                numba_ary = numba.cuda.to_device(numpy_ary)
                 torch_ary = torch.as_tensor(numba_ary, device="cpu")
                 self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
@@ -282,7 +282,7 @@ class TestNumbaIntegration(common.TestCase):
 
             # Explicit-copy when using `torch.tensor()`
             for numpy_ary in numpy_arys:
-                numba_ary = numba.cuda.to_device(numpy_ary, sync=False)
+                numba_ary = numba.cuda.to_device(numpy_ary)
                 torch_ary = torch.tensor(numba_ary, device="cuda")
                 self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
@@ -319,7 +319,7 @@ class TestNumbaIntegration(common.TestCase):
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
     def test_from_cuda_array_interface_lifetime(self):
         """torch.as_tensor(obj) tensor grabs a reference to obj so that the lifetime of obj exceeds the tensor"""
-        numba_ary = numba.cuda.to_device(numpy.arange(6))
+        numba_ary = numba.cuda.to_device(numpy.arange(6), sync=False)
         torch_ary = torch.as_tensor(numba_ary, device="cuda")
         self.assertEqual(torch_ary.__cuda_array_interface__, numba_ary.__cuda_array_interface__)  # No copy
         del numba_ary
@@ -333,7 +333,7 @@ class TestNumbaIntegration(common.TestCase):
         """torch.as_tensor() tensor device must match active numba context."""
 
         # Zero-copy: both torch/numba default to device 0 and can interop freely
-        numba_ary = numba.cuda.to_device(numpy.arange(6))
+        numba_ary = numba.cuda.to_device(numpy.arange(6), sync=False)
         torch_ary = torch.as_tensor(numba_ary, device="cuda")
         self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
         self.assertEqual(torch_ary.__cuda_array_interface__, numba_ary.__cuda_array_interface__)


### PR DESCRIPTION
Cuda 111 space error fix. docutils pinned 0.16 since latest version 0.17 has issues with sphinx. 
There appears to be a mismatch between pytorch and numba version for pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test1. Testing a solution where sync is turned off for numba. 