### PR TITLE
Drop omp simd from batch_permutation_op.cc

### DIFF
--- a/caffe2/operators/batch_permutation_op.cc
+++ b/caffe2/operators/batch_permutation_op.cc
@@ -21,11 +21,7 @@ void batch_permutation_loop(
   long numBytes = K * sizeof(float);
   if (forwards) {
 #ifdef _OPENMP
-#if (_OPENMP >= 201307)
-#pragma omp parallel for simd
-#else
 #pragma omp parallel for
-#endif
 #endif
     for (int n = 0; n < N; n++) {
       int origIdx = n * K;


### PR DESCRIPTION
Summary:
Fixes
```
     36 stderr: caffe2/caffe2/operators/batch_permutation_op.cc:25:1: error: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Werror,-Wpass-failed=transform-warning]
      3 caffe2/caffe2/operators/batch_permutation_op.cc:25:1: error: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Werror,-Wpass-failed=transform-warning]
```

Test Plan: Sandcastle

Reviewed By: meyering

Differential Revision: D33378925

