### PR TITLE
Fix genSparseCSRTensor: generate non-trivial values for uint8 dtype.

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1782,7 +1782,9 @@ class TestCase(expecttest.TestCase):
                 count = crow_indices[i + 1] - crow_indices[i]
                 col_indices[crow_indices[i]:crow_indices[i + 1]], _ = torch.sort(
                     torch.randperm(n_cols, dtype=index_dtype, device=device)[:count])
-            values = make_tensor([nnz], device=device, dtype=dtype, low=-1, high=1)
+            low = -1 if dtype != torch.uint8 else 0
+            high = 1 if dtype != torch.uint8 else 2
+            values = make_tensor([nnz], device=device, dtype=dtype, low=low, high=high)
             return values, crow_indices, col_indices
 
         values, crow_indices, col_indices = random_sparse_csr(size[0], size[1], nnz)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #70582
* #70581
* __->__ #70580



cc @nikitaved @pearu @cpuhrsch

Differential Revision: [D33413597](https://our.internmc.facebook.com/intern/diff/D33413597)