### PR TITLE
fix: clip-onnx spec 9 & 11

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3428,10 +3428,10 @@ class TestONNXRuntime(unittest.TestCase):
                 return torch.clamp(x, 0, 1)
 
         x = torch.randn(3, 3)
-        self.run_test(MyClip9(),x)
-        self.run_test(MyClip9(),x.to(torch.int32))
-        if self.opset_version >= 12: # awaiting bugfix in ORT to remove this constraint.
-            self.run_test(MyClip9(),x.to(torch.double))
+        self.run_test(MyClip9(), x)
+        self.run_test(MyClip9(), x.to(torch.int32))
+        if self.opset_version >= 12:  # awaiting bugfix in ORT to remove this constraint.
+            self.run_test(MyClip9(), x.to(torch.double))
 
     @skipIfUnsupportedOpsetVersion([7])
     def test_normalize(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3421,6 +3421,18 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(3, 3)
         self.run_test(MyReluModule(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_clip9(self):
+        class MyClip9(torch.nn.Module):
+            def forward(self, x):
+                return torch.clamp(x, 0, 1)
+
+        x = torch.randn(3, 3)
+        self.run_test(MyClip9(),x)
+        self.run_test(MyClip9(),x.to(torch.int32))
+        if self.opset_version >= 12: # awaiting bugfix in ORT to remove this constraint.
+            self.run_test(MyClip9(),x.to(torch.double))
+
     @skipIfUnsupportedOpsetVersion([7])
     def test_normalize(self):
         class Model(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3422,16 +3422,16 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(MyReluModule(), x)
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    def test_clip9(self):
-        class MyClip9(torch.nn.Module):
+    def test_clip6(self):
+        class MyClip6(torch.nn.Module):
             def forward(self, x):
                 return torch.clamp(x, 0, 1)
 
         x = torch.randn(3, 3)
-        self.run_test(MyClip9(), x)
-        self.run_test(MyClip9(), x.to(torch.int32))
+        self.run_test(MyClip6(), x)
+        self.run_test(MyClip6(), x.to(torch.int32))
         if self.opset_version >= 12:  # awaiting bugfix in ORT to remove this constraint.
-            self.run_test(MyClip9(), x.to(torch.double))
+            self.run_test(MyClip6(), x.to(torch.double))
 
     @skipIfUnsupportedOpsetVersion([7])
     def test_normalize(self):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -18,7 +18,7 @@ from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_blo
 # This file exports ONNX ops for opset 11
 
 def _clamp_common_types(g, self, min, max):
-    # clip-6 is only available to float, double, and float16.
+    # clip-11 is only available to float, double, and float16.
     # for other types, we first cast to float, then do clip and cast back.
     origin_dtype = self.type().scalarType()
     is_fp_clamp = self.type().scalarType(
@@ -26,7 +26,7 @@ def _clamp_common_types(g, self, min, max):
 
     if not is_fp_clamp:
         warnings.warn(
-            "ONNX opset < 11 does not support clamp/clip to non-float types. Using cast-clip-cast instead.")
+            "ONNX opset 11 does not support clamp/clip to non-float types. Using cast-clip-cast instead.")
         self = g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx["Float"])
         if min.type().scalarType() != "Float":
             min = g.op("Cast", min, to_i=sym_help.cast_pytorch_to_onnx["Float"])

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1603,7 +1603,7 @@ def _clamp_common_types(g, self, min_f=None, max_f=None):
 
     if not is_fp_clamp:
         warnings.warn(
-            "ONNX opset < 11 does not support clamp/clip to non-float types. Using cast-clip-cast instead.")
+            "ONNX opset 6 does not support clamp/clip to non-float types. Using cast-clip-cast instead.")
         self = g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx["Float"])
 
     self = g.op("Clip", self, min_f=min_f, max_f=max_f)


### PR DESCRIPTION
clip-v6 and clip-v9 only support float(16/32/64) as inputs such that prior implementation will make exported `clamp(int_min, int_max)` fail in ONNXRuntime. 

![image](https://user-images.githubusercontent.com/38074777/147964382-23d8e173-8de4-4b26-be19-c165ee419b4a.png)

To fix it, use the "cast-clip-cast" pattern as a workaround.

cc: @peterbell10 @BowenBao 