### PR TITLE
[LTC] Fix stride accessors in LTCTensorImpl

### DIFF
--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -125,6 +125,11 @@ int64_t LTCTensorImpl::size(int64_t d) const {
   return c10::TensorImpl::size(d);
 }
 
+int64_t LTCTensorImpl::stride(int64_t d) const {
+  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
+  return c10::TensorImpl::stride(d);
+}
+
 void LTCTensorImpl::setup_size_properties() {
   size_t generation = tensor_.generation();
   if (generation != generation_) {
@@ -153,6 +158,11 @@ void LTCTensorImpl::setup_size_properties() {
 at::IntArrayRef LTCTensorImpl::sizes() const {
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::sizes();
+}
+
+at::IntArrayRef LTCTensorImpl::strides() const {
+  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
+  return c10::TensorImpl::strides();
 }
 
 int64_t LTCTensorImpl::dim() const {

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -121,11 +121,13 @@ void LTCTensorImpl::shallow_copy_from(
 }
 
 int64_t LTCTensorImpl::size(int64_t d) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::size(d);
 }
 
 int64_t LTCTensorImpl::stride(int64_t d) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::stride(d);
 }
@@ -156,21 +158,25 @@ void LTCTensorImpl::setup_size_properties() {
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
 
 at::IntArrayRef LTCTensorImpl::sizes() const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::sizes();
 }
 
 at::IntArrayRef LTCTensorImpl::strides() const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::strides();
 }
 
 int64_t LTCTensorImpl::dim() const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::dim();
 }
 
 int64_t LTCTensorImpl::numel() const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
   return c10::TensorImpl::numel();
 }

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -34,8 +34,11 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
 
   int64_t size(int64_t d) const override;
 
+  int64_t stride(int64_t d) const override;
+
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
   at::IntArrayRef sizes() const override;
+  at::IntArrayRef strides() const override;
   int64_t dim() const override;
   int64_t numel() const override;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70623

Summary: Strides on lazy tensor should only be read after calling setup_size_properties. This fixes a failure in hf_Longformer.

Test Plan: CI on the lazy_tensor_staging branch

Differential Revision: [D33410142](https://our.internmc.facebook.com/intern/diff/D33410142)