### PR TITLE
Change to use current LLLVM APIs

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -535,14 +535,22 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
   llvm::SmallVector<llvm::Value*, 6> wrappedArgs;
   for (const auto i : c10::irange(params.size())) {
     auto argp = irb_.CreateGEP(
-        wrapper->arg_begin(), llvm::ConstantInt::getSigned(IntTy_, i));
+        wrapper->arg_begin()
+            ->getType()
+            ->getScalarType()
+            ->getPointerElementType(),
+        wrapper->arg_begin(),
+        llvm::ConstantInt::getSigned(IntTy_, i));
     if (params[i]->isPointerTy()) {
-      auto arg = irb_.CreatePointerCast(irb_.CreateLoad(argp), params[i]);
+      auto arg = irb_.CreatePointerCast(
+          irb_.CreateLoad(argp->getType()->getPointerElementType(), argp),
+          params[i]);
       wrappedArgs.push_back(arg);
     } else {
       auto p = irb_.CreatePointerCast(
-          irb_.CreateLoad(argp), params[i]->getPointerTo());
-      auto arg = irb_.CreateLoad(p);
+          irb_.CreateLoad(argp->getType()->getPointerElementType(), argp),
+          params[i]->getPointerTo());
+      auto arg = irb_.CreateLoad(p->getType()->getPointerElementType(), p);
       wrappedArgs.push_back(arg);
     }
   }
@@ -1159,8 +1167,9 @@ void LLVMCodeGenImpl::visit(RampPtr v) {
 llvm::Value* LLVMCodeGenImpl::emitUnmaskedLoad(
     llvm::Value* base,
     llvm::Value* idx) {
-  auto addr = irb_.CreateGEP(base, idx);
-  return irb_.CreateLoad(addr);
+  auto addr = irb_.CreateGEP(
+      base->getType()->getScalarType()->getPointerElementType(), base, idx);
+  return irb_.CreateLoad(addr->getType()->getPointerElementType(), addr);
 }
 
 llvm::Value* LLVMCodeGenImpl::emitMaskedLoad(
@@ -1178,8 +1187,9 @@ llvm::Value* LLVMCodeGenImpl::emitMaskedLoad(
 
   // Do the load
   irb_.SetInsertPoint(condblock);
-  auto addr = irb_.CreateGEP(base, idx);
-  auto load = irb_.CreateLoad(addr);
+  auto addr = irb_.CreateGEP(
+      base->getType()->getScalarType()->getPointerElementType(), base, idx);
+  auto load = irb_.CreateLoad(addr->getType()->getPointerElementType(), addr);
   irb_.CreateBr(tailblock);
 
   // Merge the masked and unmasked CFG edges
@@ -1232,7 +1242,10 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
       idx_ramp->base()->accept(this);
       auto first_idx = this->value_;
 
-      auto addr = irb_.CreateGEP(base, first_idx);
+      auto addr = irb_.CreateGEP(
+          base->getType()->getScalarType()->getPointerElementType(),
+          base,
+          first_idx);
       auto vaddr = irb_.CreateBitOrPointerCast(
           addr, llvm::PointerType::get(loadType, 0));
 #if LLVM_VERSION_MAJOR >= 13
@@ -1295,7 +1308,8 @@ std::vector<llvm::Value*> LLVMCodeGenImpl::unpackFuncArgs(
   for (const auto i : c10::irange(arg_count)) {
     llvm::Value* dst_ptr = irb_.CreateInBoundsGEP(
         packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
-    func_args[i] = irb_.CreateLoad(dst_ptr);
+    func_args[i] =
+        irb_.CreateLoad(dst_ptr->getType()->getPointerElementType(), dst_ptr);
   }
   return func_args;
 }
@@ -1468,7 +1482,8 @@ void LLVMCodeGenImpl::emitUnmaskedStore(
     llvm::Value* base,
     llvm::Value* idx,
     llvm::Value* val) {
-  auto addr = irb_.CreateGEP(base, idx);
+  auto addr = irb_.CreateGEP(
+      base->getType()->getScalarType()->getPointerElementType(), base, idx);
   irb_.CreateStore(val, addr);
 }
 
@@ -1487,7 +1502,8 @@ void LLVMCodeGenImpl::emitMaskedStore(
 
   // Do the store
   irb_.SetInsertPoint(condblock);
-  auto addr = irb_.CreateGEP(base, idx);
+  auto addr = irb_.CreateGEP(
+      base->getType()->getScalarType()->getPointerElementType(), base, idx);
   irb_.CreateStore(val, addr);
   irb_.CreateBr(tailblock);
 
@@ -1523,7 +1539,10 @@ void LLVMCodeGenImpl::visit(StorePtr v) {
       idx_ramp->base()->accept(this);
       auto first_idx = value_;
 
-      auto addr = irb_.CreateGEP(base, first_idx);
+      auto addr = irb_.CreateGEP(
+          base->getType()->getScalarType()->getPointerElementType(),
+          base,
+          first_idx);
       auto vaddr = irb_.CreateBitOrPointerCast(
           addr, llvm::PointerType::get(val->getType(), 0));
 
@@ -1912,7 +1931,9 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
   for (BufPtr b : bufs) {
     // Store value for buf pointer
     auto gep = irb_.CreateInBoundsGEP(
-        buf_ptrs, {llvm::ConstantInt::getSigned(IntTy_, i)});
+        buf_ptrs->getType()->getScalarType()->getPointerElementType(),
+        buf_ptrs,
+        llvm::ConstantInt::getSigned(IntTy_, i));
     b->base_handle()->accept(this);
     auto buf_ptr = this->value_;
     auto buf_void_ptr = irb_.CreatePointerCast(buf_ptr, Int8PtrTy_);
@@ -1920,21 +1941,27 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
 
     // Store dtype of the buf
     gep = irb_.CreateInBoundsGEP(
-        buf_dtypes, {llvm::ConstantInt::getSigned(IntTy_, i)});
+        buf_dtypes->getType()->getScalarType()->getPointerElementType(),
+        buf_dtypes,
+        llvm::ConstantInt::getSigned(IntTy_, i));
     irb_.CreateStore(
         llvm::ConstantInt::getSigned(ByteTy_, (int8_t)b->dtype().scalar_type()),
         gep);
 
     // Store rank of the buf
     gep = irb_.CreateInBoundsGEP(
-        buf_ranks, {llvm::ConstantInt::getSigned(IntTy_, i)});
+        buf_ranks->getType()->getScalarType()->getPointerElementType(),
+        buf_ranks,
+        llvm::ConstantInt::getSigned(IntTy_, i));
     irb_.CreateStore(
         llvm::ConstantInt::getSigned(LongTy_, b->dims().size()), gep);
 
     // Store dims of the buf
     for (const auto dim : c10::irange(b->dims().size())) {
       gep = irb_.CreateInBoundsGEP(
-          buf_dims, {llvm::ConstantInt::getSigned(IntTy_, dim_idx)});
+          buf_dims->getType()->getScalarType()->getPointerElementType(),
+          buf_dims,
+          llvm::ConstantInt::getSigned(IntTy_, dim_idx));
       b->dims()[dim]->accept(this);
       auto dim_val = this->value_;
       irb_.CreateStore(irb_.CreateZExt(dim_val, LongTy_), gep);
@@ -1944,7 +1971,9 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
     // Store strides of the buf
     for (const auto dim : c10::irange(b->dims().size())) {
       gep = irb_.CreateInBoundsGEP(
-          buf_strides, {llvm::ConstantInt::getSigned(IntTy_, stride_idx)});
+          buf_strides->getType()->getScalarType()->getPointerElementType(),
+          buf_strides,
+          llvm::ConstantInt::getSigned(IntTy_, stride_idx));
       b->strides()[dim]->accept(this);
       auto stride_val = this->value_;
       irb_.CreateStore(irb_.CreateZExt(stride_val, LongTy_), gep);
@@ -1957,7 +1986,9 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
   i = 0;
   for (ExprPtr arg : v->args()) {
     auto gep = irb_.CreateInBoundsGEP(
-        extra_args, {llvm::ConstantInt::getSigned(IntTy_, i)});
+        extra_args->getType()->getScalarType()->getPointerElementType(),
+        extra_args,
+        llvm::ConstantInt::getSigned(IntTy_, i));
     arg->accept(this);
     irb_.CreateStore(irb_.CreateZExtOrBitCast(this->value_, LongTy_), gep);
     i++;


### PR DESCRIPTION
Summary: In llvm-13 depricated APIs were removed. These APIs were just wrappers around APIs present in llvm-9+. Changed to use underlying APIs.

Test Plan: buck build mode/opt-clang-thinlto -j 70 unicorn/topaggr:top_aggregator_server -c unicorn.hfsort="1" -c cxx.extra_cxxflags="-Wforce-no-error -fbracket-depth=300" -c cxx.profile="fbcode//fdo/autofdo/unicorn/topaggr/top_aggregator_server:autofdo" -c cxx.modules=False

Reviewed By: WenleiHe

Differential Revision: D33169593

