### PR TITLE
torch.futures doc formatting

### DIFF
--- a/torch/futures/__init__.py
+++ b/torch/futures/__init__.py
@@ -184,7 +184,7 @@ class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
 
         Args:
             callback(``Future``): a ``Callable`` that takes in one argument,
-            which is the reference to this ``Future``.
+                which is the reference to this ``Future``.
 
         .. note:: Note that if the callback function throws, either
             through the original future being completed with an exception and


### PR DESCRIPTION
Params is incorrectly formatted [here](https://pytorch.org/docs/master/futures.html?highlight=future#:~:text=way%20as%20then().-,Parameters,-callback%20(Future)%20%E2%80%93%20a):

![image](https://user-images.githubusercontent.com/14858254/148119877-6c719851-4edd-4126-8ef7-e6c1920304cf.png)

Updated docs:

https://docs-preview.pytorch.org/70630/futures.html?highlight=future#:~:text=way%20as%20then().-,Parameters,-callback%20(Future)%20%E2%80%93%20a

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#70630 doc formatting**



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang

Differential Revision: [D33478214](https://our.internmc.facebook.com/intern/diff/D33478214)