### PR TITLE
[FSDP] Correctly pin_memory for CPU offload.

### DIFF
--- a/torch/distributed/_fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/_fsdp/fully_sharded_data_parallel.py
@@ -485,7 +485,8 @@ class FullyShardedDataParallel(nn.Module):
         # transfer.
         if self.cpu_offload.offload_params:
             assert p._local_shard.device == torch.device("cpu")  # type: ignore[attr-defined]
-            p._local_shard.pin_memory()  # type: ignore[attr-defined]
+            # Note: need to assign here to ensure local_shard is a pinned memory tensor.
+            p._local_shard = p._local_shard.pin_memory()  # type: ignore[attr-defined]
             # When offloading parameters, also move the grad shard to CPU during
             # backward pass. In this case, it's important to pre-allocate the
             # CPU grad shard in pinned memory so that we can do a non-blocking


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70639

x.pin_memory() results in a copied tensor in pinned memory, so it
needs to be reassigned. Internal benchmark shows ~6% win on ResNet model and ~2% win on roberta model.

Differential Revision: [D33300535](https://our.internmc.facebook.com/intern/diff/D33300535/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D33300535/)!