### PR TITLE
[ONNX] Relax sequence tensor dim_param serialization

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -612,7 +612,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         script_model = torch.jit.script(model)
         x = torch.randn(2, 3)
 
-        # Case 1: varying dimension size.
+        # Case 1: dynamic axis
         f = io.BytesIO()
         y = torch.randn(2, 3)
         torch.onnx.export(script_model, (x, y), f, opset_version=self.opset_version,

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -601,33 +601,36 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             torch.onnx.export(model, x, f, opset_version=self.opset_version)
 
     @skipIfUnsupportedMinOpsetVersion(11)
-    def test_loop_sequence_dim(self):
+    def test_sequence_dim(self):
         class Module(torch.nn.Module):
             def forward(self, x, y):
-                l = [x, y]
-                return l
+                return [x, y]
 
         model = Module()
-
+        # Export with scripting to keep output as Sequence type.
+        # Tracing unpacks the list.
+        script_model = torch.jit.script(model)
         x = torch.randn(2, 3)
 
         # Case 1: varying dimension size.
         f = io.BytesIO()
-        y = torch.randn(2, 4)
-        torch.onnx.export(torch.jit.script(model), (x, y), f, opset_version=self.opset_version,
+        y = torch.randn(2, 3)
+        torch.onnx.export(script_model, (x, y), f, opset_version=self.opset_version,
                           input_names=['x', 'y'], dynamic_axes={'y': [1]})
         onnx_model = onnx.load(io.BytesIO(f.getvalue()))
         loop_output_value_info_proto = onnx_model.graph.output[0]
-        ref_value_info_proto = onnx.helper.make_tensor_sequence_value_info(loop_output_value_info_proto.name, 1, [2, None])
+        ref_value_info_proto = onnx.helper.make_tensor_sequence_value_info(loop_output_value_info_proto.name,
+                                                                           1, [2, None])
         self.assertEqual(loop_output_value_info_proto, ref_value_info_proto)
 
-        # Case 2: static dimension size.
+        # Case 2: no dynamic axes.
         f = io.BytesIO()
         y = torch.randn(2, 3)
-        torch.onnx.export(torch.jit.script(model), (x, y), f, opset_version=self.opset_version)
+        torch.onnx.export(script_model, (x, y), f, opset_version=self.opset_version)
         onnx_model = onnx.load(io.BytesIO(f.getvalue()))
         loop_output_value_info_proto = onnx_model.graph.output[0]
-        ref_value_info_proto = onnx.helper.make_tensor_sequence_value_info(loop_output_value_info_proto.name, 1, [2, 3])
+        ref_value_info_proto = onnx.helper.make_tensor_sequence_value_info(loop_output_value_info_proto.name,
+                                                                           1, [2, 3])
         self.assertEqual(loop_output_value_info_proto, ref_value_info_proto)
 
     def test_export_mode(self):
@@ -1084,6 +1087,8 @@ class TestUtilityFuns_opset9(_BaseTestCase):
                 return y
 
         x = torch.tensor([1, 2])
+        # Move import to local as caffe2 backend requires additional build flag,
+        # and is only used in this test case.
         import caffe2.python.onnx.backend as backend
         verify(MyModel(), x, backend, do_constant_folding=False)
 

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -615,7 +615,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         f = io.BytesIO()
         y = torch.randn(2, 4)
         torch.onnx.export(torch.jit.script(model), (x, y), f, opset_version=self.opset_version,
-            input_names=['x', 'y'], dynamic_axes={'y': [1]})
+                          input_names=['x', 'y'], dynamic_axes={'y': [1]})
         onnx_model = onnx.load(io.BytesIO(f.getvalue()))
         loop_output_value_info_proto = onnx_model.graph.output[0]
         ref_value_info_proto = onnx.helper.make_tensor_sequence_value_info(loop_output_value_info_proto.name, 1, [2, None])

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -543,7 +543,8 @@ void GraphEncoder::EncodeValueInfoType(
         std::unordered_map<int64_t, std::string>>& dynamic_axes) {
   auto tensorTypeToONNXType = [&dynamic_axes, n, this](
                                   const TensorTypePtr& t,
-                                  onnx::TypeProto_Tensor* onnx_tensor_type) {
+                                  onnx::TypeProto_Tensor* onnx_tensor_type,
+                                  bool is_sequence_tensor) {
     std::string name = n->debugName();
     if (t->dim()) {
       onnx::TensorShapeProto* shape = onnx_tensor_type->mutable_shape();
@@ -558,7 +559,12 @@ void GraphEncoder::EncodeValueInfoType(
           }
         } else if (sizes[i].is_static()) {
           shape->mutable_dim(i)->set_dim_value(sizes[i].static_size());
-        } else {
+        } else if (!is_sequence_tensor) {
+          // Do not assign dim_param for sequence tensor type.
+          // Sequence of tensors could differ in dimension size.
+          // Use a dimension with neither dim_value nor dim_param set
+          // to denote an unknown dimension.
+          // Create and assign dim_param for normal tensor type.
           if (symbol_dim_map_.find(sizes[i]) == symbol_dim_map_.end()) {
             if (n->node()->kind() == prim::Param) {
               symbol_dim_map_[sizes[i]] = name + "_dim_" + std::to_string(i);
@@ -583,7 +589,7 @@ void GraphEncoder::EncodeValueInfoType(
       // Encode type if either shape or dtype exists.
       onnx::TypeProto_Tensor* onnx_tensor_type =
           onnx_type->mutable_tensor_type();
-      tensorTypeToONNXType(tensor_type, onnx_tensor_type);
+      tensorTypeToONNXType(tensor_type, onnx_tensor_type, tensor_type != n->type());
     }
   } else if (BoolTypePtr bool_type = node_type->cast<BoolType>()) {
     onnx::TypeProto_Tensor* onnx_tensor_type = onnx_type->mutable_tensor_type();

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -544,7 +544,7 @@ void GraphEncoder::EncodeValueInfoType(
   auto tensorTypeToONNXType = [&dynamic_axes, n, this](
                                   const TensorTypePtr& t,
                                   onnx::TypeProto_Tensor* onnx_tensor_type,
-                                  bool is_sequence_tensor) {
+                                  bool assign_dim_param) {
     std::string name = n->debugName();
     if (t->dim()) {
       onnx::TensorShapeProto* shape = onnx_tensor_type->mutable_shape();
@@ -559,12 +559,7 @@ void GraphEncoder::EncodeValueInfoType(
           }
         } else if (sizes[i].is_static()) {
           shape->mutable_dim(i)->set_dim_value(sizes[i].static_size());
-        } else if (!is_sequence_tensor) {
-          // Do not assign dim_param for sequence tensor type.
-          // Sequence of tensors could differ in dimension size.
-          // Use a dimension with neither dim_value nor dim_param set
-          // to denote an unknown dimension.
-          // Create and assign dim_param for normal tensor type.
+        } else if (assign_dim_param) {
           if (symbol_dim_map_.find(sizes[i]) == symbol_dim_map_.end()) {
             if (n->node()->kind() == prim::Param) {
               symbol_dim_map_[sizes[i]] = name + "_dim_" + std::to_string(i);
@@ -589,7 +584,13 @@ void GraphEncoder::EncodeValueInfoType(
       // Encode type if either shape or dtype exists.
       onnx::TypeProto_Tensor* onnx_tensor_type =
           onnx_type->mutable_tensor_type();
-      tensorTypeToONNXType(tensor_type, onnx_tensor_type, tensor_type != n->type());
+      // Do not assign dim_param for sequence tensor type.
+      // Sequence of tensors could differ in dimension size.
+      // Use a dimension with neither dim_value nor dim_param set
+      // to denote an unknown dimension.
+      // Create and assign dim_param for normal tensor type.
+      auto is_sequence_tensor = static_cast<bool>(n->type()->cast<ListType>());
+      tensorTypeToONNXType(tensor_type, onnx_tensor_type, !is_sequence_tensor);
     }
   } else if (BoolTypePtr bool_type = node_type->cast<BoolType>()) {
     onnx::TypeProto_Tensor* onnx_tensor_type = onnx_type->mutable_tensor_type();


### PR DESCRIPTION
Do not assign dim_param for sequence tensor type.
Sequence of tensors could differ in dimension size.
Use a dimension with neither dim_value nor dim_param set
to denote an unknown dimension.
Create and assign dim_param for normal tensor type.