### PR TITLE
reduce igamma instantiations

### DIFF
--- a/aten/src/ATen/native/cuda/IGammaKernel.cu
+++ b/aten/src/ATen/native/cuda/IGammaKernel.cu
@@ -510,6 +510,19 @@ __noinline__ __host__ __device__ scalar_t calc_igamma(scalar_t a, scalar_t x) {
   return _igam_helper_series(a, x);
 }
 
+template<typename scalar_t>
+struct CalcIgamma{
+  CalcIgamma(bool calc_igammac): calc_igammac_(calc_igammac){}
+  bool calc_igammac_;
+  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
+    if (calc_igammac_) {
+      return calc_igammac(a,b);
+    } else {
+      return calc_igamma(a,b);
+    }
+  }
+};
+
 }
 
 // end of regularized lower & upper incomplete gamma
@@ -519,18 +532,14 @@ namespace at { namespace native {
 void igamma_kernel_cuda(TensorIteratorBase& iter) {
 
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igamma_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return calc_igamma(a, b);
-    });
+    gpu_kernel(iter, CalcIgamma<scalar_t>(false));
   });
 }
 
 void igammac_kernel_cuda(TensorIteratorBase& iter) {
 
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igammac_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return calc_igammac(a, b);
-    });
+    gpu_kernel(iter, CalcIgamma<scalar_t>(true));
   });
 }
 


### PR DESCRIPTION
Don't compile scalar versions of the kernel (there is no scalar overload), combine igamma and igammac kernels. 
Igamma cubin size 10 MB -> 2 MB on V100
