### PR TITLE
Remove unused `optimizers` variable in test

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2192,10 +2192,6 @@ class TestLRScheduler(TestCase):
     def _test(self, schedulers, targets, epochs=10):
         if isinstance(schedulers, _LRScheduler):
             schedulers = [schedulers]
-
-        optimizers = set()
-        for scheduler in schedulers:
-            optimizers.add(scheduler.optimizer)
         for epoch in range(epochs):
             for param_group, target in zip(self.opt.param_groups, targets):
                 self.assertEqual(target[epoch], param_group['lr'],


### PR DESCRIPTION
In `TestLRScheduler._test()`, an unused variable `optimizers` is created. This PR is a minor refactoring that removes the variable and the loop block that populates the set.