### PR TITLE
Don't build lazy tensor under bazel builds

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -305,7 +305,7 @@ fi
 
 # Test Lazy Tensor Core. Don't merge to master.
 # Restrict lazy tensor to cuda environments to limit potential breakages for the feature branch.
-if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.3* ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *linux-xenial-cuda11.3* && "$BUILD_ENVIRONMENT" != *bazel* ]]; then
   pushd lazy_tensor_core/
   ./scripts/apply_patches.sh
   DEBUG=1 python setup.py install


### PR DESCRIPTION
- no particular reason _to_ build it here, but the installation
  procedure would need to be updated and it currently fails, so
  disable it.
