### PR TITLE
Use C10_UNUSED instead of (void)X

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -131,8 +131,7 @@ static std::tuple<double, int64_t> __printFormat(std::ostream& stream, const Ten
 
 static void __printIndent(std::ostream &stream, int64_t indent)
 {
-  for (const auto i : c10::irange(indent)) {
-    (void)i; //Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(indent)) {
     stream << " ";
   }
 }

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -972,8 +972,7 @@ inline void convert(const src_T *src, dst_T *dst, int64_t n) {
 #ifndef _MSC_VER
 # pragma unroll
 #endif
-  for (const auto i : c10::irange(n)) {
-    (void)i; //Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(n)) {
     *dst = c10::static_cast_with_inter_type<dst_T, src_T>::apply(*src);
     src++;
     dst++;

--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -18,8 +18,7 @@ Tensor make_feature_noise(const Tensor& input) {
   sizes.reserve(input.dim());
   sizes.push_back(input_sizes[0]);
   sizes.push_back(input_sizes[1]);
-  for (const auto i : c10::irange(2, input.dim())) {
-    (void)i; //Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(2, input.dim())) {
     sizes.push_back(1);
   }
   return at::empty(sizes, input.options());

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -392,8 +392,7 @@ Tensor einsum(c10::string_view equation, TensorList operands) {
         // Add missing dimensions covered by the ellipsis
         const auto num_missing_dim =
             ell_num_dim - (original_sizes.size() - labels.size() + 1);
-        for (const auto k : c10::irange(num_missing_dim)) {
-          (void)k; //Suppress unused warning
+        for (C10_UNUSED const auto k : c10::irange(num_missing_dim)) {
           operand = operand.unsqueeze(j);
         }
         for (const auto k : c10::irange(ell_num_dim)) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2091,8 +2091,7 @@ void compute_T18_scale_square(
   for (const auto i : c10::irange(mexp_scaled.size(0))) {
     auto s_val = s_cpu.select(0, i).template item<int64_t>();
     auto mexp = mexp_scaled.select(0, i);
-    for (const auto p : c10::irange(s_val)) {
-      (void)p; //Suppress unused variable warning
+    for (C10_UNUSED const auto p : c10::irange(s_val)) {
       mexp = at::matmul(mexp, mexp);
     }
     mexp_out.select(0, i).copy_(mexp);

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -228,8 +228,7 @@ void batch_iterator_with_broadcasting(const Tensor& a, const Tensor& b, const fu
     auto* b_batch_idx_ptr = data[0];
     auto* a_batch_idx_ptr = data[1];
 
-    for (const auto elem : c10::irange(nelems)) {
-      (void)elem; //Suppress unused variable warning
+    for (C10_UNUSED const auto elem : c10::irange(nelems)) {
       auto b_curr_linear_batch_idx = *reinterpret_cast<int64_t*>(b_batch_idx_ptr);
       auto a_curr_linear_batch_idx = *reinterpret_cast<int64_t*>(a_batch_idx_ptr);
 

--- a/aten/src/ATen/native/LossMultiLabelMargin.cpp
+++ b/aten/src/ATen/native/LossMultiLabelMargin.cpp
@@ -64,8 +64,7 @@ static void multilabel_margin_loss_forward_out_frame(
 
     accscalar_t sum = 0;
 
-    for (const auto t : c10::irange(nframe)) {
-      (void)t; //Suppress unused variable warning
+    for (C10_UNUSED const auto t : c10::irange(nframe)) {
       sum += multilabel_margin_loss_forward_inner_sum_cpu(
           input_data, target_data, is_target_data, dim);
 
@@ -173,8 +172,7 @@ static void multilabel_margin_loss_backward_out_frame(
       reduction == Reduction::Mean ? 1. / (nframe * dim) : 1. / dim);
 
   scalar_t* grad_input_row_data = grad_input.data_ptr<scalar_t>();
-  for (const auto t : c10::irange(nframe)) {
-    (void)t; //Suppress unused variable warning
+  for (C10_UNUSED const auto t : c10::irange(nframe)) {
     for (const auto dt : c10::irange(dim)) {
       int64_t target_idx = target_data[dt];
       if (target_idx < 0) {

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -170,8 +170,7 @@ std::tuple<Tensor, Tensor> _pad_packed_sequence(const Tensor& data, const Tensor
     }
     int64_t dec = prev_batch_size - batch_size;
     if (dec > 0) {
-      for (const auto j : c10::irange(dec)) {
-        (void)j; //Suppress unused variable warning
+      for (C10_UNUSED const auto j : c10::irange(dec)) {
         (*lengths--) = i;
       }
     }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -771,8 +771,7 @@ static inline Tensor diff_helper(const Tensor& self, int64_t n, int64_t dim) {
   bool is_kBool = (self.dtype() == at::kBool);
   n = n >= self.size(dim) ? self.size(dim) : n;
 
-  for (const auto i : c10::irange(n)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(n)) {
     if (is_kBool) {
       result = at::logical_xor(at::narrow(result, dim, 1, out_len), at::narrow(result, dim, 0, out_len));
     } else {
@@ -1948,8 +1947,7 @@ bool cpu_equal(const Tensor& self, const Tensor& other) {
       }
       char* self_data = data[0];
       char* other_data = data[1];
-      for (const auto i : c10::irange(dim_size)) {
-        (void)i; //Suppress unused variable warning
+      for (C10_UNUSED const auto i : c10::irange(dim_size)) {
         if (*((scalar_t*)self_data) != *((scalar_t*)other_data)) {
           result = false;
           return;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -391,8 +391,7 @@ const Tensor& value){
       }
     }
   }
-  for (const auto i : c10::irange(num_ind, self.ndimension())) {
-    (void)i; //Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(num_ind, self.ndimension())) {
     mask = mask.unsqueeze(-1);
   }
   return std::make_tuple(true, mask);
@@ -1787,8 +1786,7 @@ Tensor& nonzero_out_cpu(const Tensor& self, Tensor& result) {
 
         for (const auto i : c10::irange(n2)) {
           const char* ptr = data[0] + i * strides[1];
-          for (const auto j : c10::irange(n1)) {
-            (void)j; //Suppress unused variable warning
+          for (C10_UNUSED const auto j : c10::irange(n1)) {
             const auto& val = *reinterpret_cast<const scalar_t*>(ptr);
             // If nonzero, write index
             if (val != scalar_t(0)) {

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -109,8 +109,7 @@ static void upsample_bicubic2d_backward_out_frame(
       for (const auto output_x : c10::irange(output_width)) {
         scalar_t* in = &idata[output_y * input_width + output_x];
         scalar_t* out = &odata[output_y * output_width + output_x];
-        for (const auto c : c10::irange(channels)) {
-          (void)c; //Suppress unused variable warning
+        for (C10_UNUSED const auto c : c10::irange(channels)) {
           in[0] = out[0];
           in += input_width * input_height;
           out += output_width * output_height;
@@ -146,8 +145,7 @@ static void upsample_bicubic2d_backward_out_frame(
       get_cubic_upsample_coefficients<scalar_t>(x_coeffs, t_x);
       get_cubic_upsample_coefficients<scalar_t>(y_coeffs, t_y);
 
-      for (const auto c : c10::irange(channels)) {
-        (void)c; //Suppress unused variable warning
+      for (C10_UNUSED const auto c : c10::irange(channels)) {
         scalar_t out_value = out[output_y * output_width + output_x];
 
         for (const auto i : c10::irange(4)) {

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -393,8 +393,7 @@ struct Dist {
     const scalar_t * t1_end = t1 + l1_size;
     const scalar_t * t2_end = t2 + l2_size;
 
-    for (const auto l : c10::irange(d)) {
-      (void)l; //Suppress unused variable warning
+    for (C10_UNUSED const auto l : c10::irange(d)) {
       for (; t1 != t1_end; t1 += m, res += m) {
         const Vec vec_t1 = Vec::loadu(t1, count);
         Vec res_vec = Vec::loadu(res, count);

--- a/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
+++ b/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
@@ -28,8 +28,7 @@ void _compute_linear_combination_cpu_kernel(
         auto* RESTRICT in_ptr = data[1];
         auto* RESTRICT coeff_ptr = data[2];
 
-        for (const auto elem : c10::irange(n)) {
-          (void)elem; //Suppress unused variable warning
+        for (C10_UNUSED const auto elem : c10::irange(n)) {
           auto* RESTRICT out_data = reinterpret_cast<scalar_t*>(out_ptr);
           auto* RESTRICT in_data = reinterpret_cast<scalar_t*>(in_ptr);
           using primitive_t = typename scalar_value_type<scalar_t>::type;

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -156,8 +156,7 @@ void cpu_take_put_kernel(
   auto loop = [&](char** data, const int64_t* strides, int64_t n) {
     auto* iterated_data_bytes = data[0];
     auto* index_data_bytes = data[1];
-    for (const auto elem : c10::irange(n)) {
-      (void)elem; //Suppress unused variable warning
+    for (C10_UNUSED const auto elem : c10::irange(n)) {
       auto idx = *reinterpret_cast<int64_t*>(index_data_bytes);
       auto& iterated = *reinterpret_cast<scalar_t*>(iterated_data_bytes);
 
@@ -274,8 +273,7 @@ void index_fill_kernel(
     auto handle_nonzero_idx_stride = [&](char** data, const int64_t* strides, int64_t n) {
       auto* self_data_bytes = data[0];
       auto* index_data_bytes = data[1];
-      for (const auto elem : c10::irange(n)) {
-        (void)elem; //Suppress unused variable warning
+      for (C10_UNUSED const auto elem : c10::irange(n)) {
         auto* self_data = reinterpret_cast<scalar_t*>(self_data_bytes);
         auto idx = *reinterpret_cast<int64_t*>(index_data_bytes);
         TORCH_CHECK_INDEX(idx >= -self_dim_size && idx < self_dim_size,
@@ -301,8 +299,7 @@ void index_fill_kernel(
       if (idx < 0) {
         idx += self_dim_size;
       }
-      for (const auto elem : c10::irange(n)) {
-        (void)elem; //Suppress unused variable warning
+      for (C10_UNUSED const auto elem : c10::irange(n)) {
         auto* self_data = reinterpret_cast<scalar_t*>(self_data_bytes);
 
         self_data[idx * self_dim_stride] = fill_val;
@@ -335,8 +332,7 @@ void index_copy_kernel(
       auto* self_data_bytes = data[0];
       auto* index_data_bytes = data[1];
       auto* source_data_bytes = data[2];
-      for (const auto elem : c10::irange(n)) {
-        (void)elem; //Suppress unused variable warning
+      for (C10_UNUSED const auto elem : c10::irange(n)) {
         auto* self_data = reinterpret_cast<scalar_t*>(self_data_bytes);
         auto idx = *reinterpret_cast<int64_t*>(index_data_bytes);
         auto* source_data = reinterpret_cast<scalar_t*>(source_data_bytes);
@@ -359,8 +355,7 @@ void index_copy_kernel(
       TORCH_CHECK_INDEX(idx >= 0 && idx < self_dim_size,
             "index_copy_(): index ", idx, " is out of bounds for dimension ",
             dim, " with size ", self_dim_size);
-      for (const auto elem : c10::irange(n)) {
-        (void)elem; //Suppress unused variable warning
+      for (C10_UNUSED const auto elem : c10::irange(n)) {
         auto* self_data = reinterpret_cast<scalar_t*>(self_data_bytes);
         auto* source_data = reinterpret_cast<scalar_t*>(source_data_bytes);
 

--- a/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
@@ -136,8 +136,7 @@ void unpack_pivots_cpu_kernel(
     auto* unpacked_pivots_ptr = data[0];
     const auto* pivots_ptr = data[1];
 
-    for (const auto elem : c10::irange(nelems)) {
-      (void)elem; //Suppress unused variable warning
+    for (C10_UNUSED const auto elem : c10::irange(nelems)) {
       // WARNING: torch.lu returns int32 pivots,
       // this behavior could change in the future.
       auto* unpacked_pivots_data = reinterpret_cast<int32_t*>(unpacked_pivots_ptr);

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -69,8 +69,7 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
 
 template <typename F>
 static inline void UNARY_OUTER_LOOP(char* data[2], const int64_t strides[2], int64_t n, F f) {
-  for (const auto j : c10::irange(n)) {
-    (void)j; //Suppress unused variable warning
+  for (C10_UNUSED const auto j : c10::irange(n)) {
     f();
     data[0] += strides[0];
     data[1] += strides[1];

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -55,8 +55,7 @@ static inline void cpu_cum_base_kernel(const Tensor& result,
     auto* result_data_bytes = data[0];
     const auto* self_data_bytes = data[1];
 
-    for (const auto i : c10::irange(n)) {
-      (void)i; //Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(n)) {
       f(
         (scalar_t*)result_data_bytes, result_dim_stride,
         (scalar_t*)self_data_bytes, self_dim_stride, init_val

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -147,8 +147,7 @@ struct cpu_scatter_gather_base_kernel {
           // whether `n` is smaller than `index_dim_size`
 
           if ((dim== self.dim() - 1) || (n < index_dim_size)) {
-            for (const auto nelem : c10::irange(n)) {
-              (void)nelem; //Suppress unused variable warning
+            for (C10_UNUSED const auto nelem : c10::irange(n)) {
               // dim loop is a separate code block
               // for better performance
               _cpu_scatter_gather_dim_loop<is_scatter_like>()(
@@ -165,8 +164,7 @@ struct cpu_scatter_gather_base_kernel {
             for (const auto i : c10::irange(index_dim_size)) {
               auto* self_data = self_data_bytes;
               auto* index_data = (char*)((int64_t*)index_data_bytes + i * index_dim_stride);
-              for (const auto nelem : c10::irange(n)) {
-                (void)nelem; //Suppress unused variable warning
+              for (C10_UNUSED const auto nelem : c10::irange(n)) {
                 int64_t idx_dim = *(int64_t*)index_data;
                 // we are not putting idx_dim in the error message because it disables
                 // loop optimization in clang-7
@@ -230,8 +228,7 @@ struct cpu_scatter_gather_base_kernel {
           // whether dim is the last dimension and/or
           // whether `n` is smaller than `index_dim_size`
           if ((dim== self.dim() - 1) || (n < index_dim_size)) {
-            for (const auto nelem : c10::irange(n)) {
-              (void)nelem; //Suppress unused variable warning
+            for (C10_UNUSED const auto nelem : c10::irange(n)) {
               // dim loop is a separate code block
               // for better performance
               _cpu_scatter_gather_dim_loop<is_scatter_like>()(
@@ -252,8 +249,7 @@ struct cpu_scatter_gather_base_kernel {
               auto* self_data = self_data_bytes;
               auto* index_data = (char*)((int64_t*)index_data_bytes + i * index_dim_stride);
               auto* src_data = src_data_bytes;
-              for (const auto nelem : c10::irange(n)) {
-                (void)nelem; //Suppress unused variable warning
+              for (C10_UNUSED const auto nelem : c10::irange(n)) {
                 int64_t idx_dim = *(int64_t*)index_data;
                 // we are not putting idx_dim in the error message because it disables
                 // loop optimization in clang-7

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -56,8 +56,7 @@ void _dim_apply(
         auto* values_data_bytes = data[0];
         auto* indices_data_bytes = data[1];
 
-        for (const auto i : c10::irange(n)) {
-          (void)i; //Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(n)) {
           f(
             reinterpret_cast<scalar_t*>(values_data_bytes),
             values_dim_stride,

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -74,8 +74,7 @@ static inline void compare_base_kernel(const Tensor& result1, const Tensor& resu
     auto* result1_data_bytes = data[0];
     auto* result2_data_bytes = data[1];
     const auto* self_data_bytes = data[2];
-    for (const auto i : c10::irange(n)) {
-      (void)i; //Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(n)) {
       f((scalar_t*)result1_data_bytes,
         (scalar_t_2*)result2_data_bytes,
         (scalar_t*)self_data_bytes,
@@ -236,8 +235,7 @@ static void mode_kernel_impl(
 
           std::vector<std::pair<scalar_t, int64_t>> elements(self_dim_size);
 
-          for (const auto k : c10::irange(n)) {
-            (void)k; //Suppress unused variable warning
+          for (C10_UNUSED const auto k : c10::irange(n)) {
             scalar_t* values_data = (scalar_t*)values_data_bytes;
             int64_t* indices_data = (int64_t*)indices_data_bytes;
             const scalar_t* self_data = (scalar_t*)self_data_bytes;

--- a/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
@@ -78,8 +78,7 @@ void _unfold_backward_internal_kernel(
     if (is_step_ge_size) {
       auto* RESTRICT idx_last_dim_ptr = data[3];
 
-      for (const auto elem : c10::irange(nelems)) {
-        (void)elem; //Suppress unused variable warning
+      for (C10_UNUSED const auto elem : c10::irange(nelems)) {
         auto* RESTRICT grad_out_data = reinterpret_cast<scalar_t*>(grad_out_ptr);
         auto* RESTRICT grad_in_data = reinterpret_cast<scalar_t*>(grad_in_ptr);
 
@@ -96,8 +95,7 @@ void _unfold_backward_internal_kernel(
       }
     }
     else {
-      for (const auto elem : c10::irange(nelems)) {
-        (void)elem; //Suppress unused variable warning
+      for (C10_UNUSED const auto elem : c10::irange(nelems)) {
         auto* RESTRICT grad_out_data = reinterpret_cast<scalar_t*>(grad_out_ptr);
         auto* RESTRICT grad_in_data = reinterpret_cast<scalar_t*>(grad_in_ptr);
 

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -634,8 +634,7 @@ struct HelperInterpBase {
     auto new_shape = std::vector<int64_t>(ndims, 1);
     new_shape[reshape_dim] = output_size;
 
-    for (const auto j : c10::irange(interp_size)) {
-      (void)j; //Suppress unused variable warning
+    for (C10_UNUSED const auto j : c10::irange(interp_size)) {
       output.emplace_back(empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
       output.emplace_back(empty(new_shape, CPU(output_type)));
     }
@@ -756,8 +755,7 @@ struct HelperInterpNearest : public HelperInterpBase {
     auto new_shape = std::vector<int64_t>(ndims, 1);
     new_shape[reshape_dim] = output_size;
 
-    for (const auto j : c10::irange(interp_size)) {
-      (void)j; //Suppress unused variable warning
+    for (C10_UNUSED const auto j : c10::irange(interp_size)) {
       output.emplace_back(empty(new_shape, CPU(c10::CppTypeToScalarType<int64_t>())));
       // Defines weights for consistency, but not used
       output.emplace_back(at::ones(new_shape, CPU(output_type)));

--- a/aten/src/ATen/native/cuda/jit_utils.h
+++ b/aten/src/ATen/native/cuda/jit_utils.h
@@ -225,8 +225,7 @@ struct CodeTemplate {
   // or trailing newlines. It's the responsibility of the calling function
   // to indent correctly in the context.
   void emitIndent(std::ostream& out, size_t indent) const {
-    for (const auto i : c10::irange(indent)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(indent)) {
       out << " ";
     }
   }

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -41,8 +41,7 @@ void layer_norm_cpu_out(
   for (const auto idx : c10::irange(axis)) {
     stat_shape.emplace_back(input_shape[idx]);
   }
-  for (const auto idx : c10::irange(axis, input.dim())) {
-    (void)idx; // Suppress unused variable warning
+  for (C10_UNUSED const auto idx : c10::irange(axis, input.dim())) {
     stat_shape.emplace_back(1);
   }
 
@@ -219,8 +218,7 @@ std::tuple<Tensor, Tensor, Tensor> math_native_layer_norm(
   for (const auto idx : c10::irange(axis)) {
     stat_shape.push_back(input_shape[idx]);
   }
-  for (const auto idx : c10::irange(axis, input.dim())) {
-    (void)idx; // Suppress unused variable
+  for (C10_UNUSED const auto idx : c10::irange(axis, input.dim())) {
     stat_shape.push_back(1);
   }
   mean = mean.view(stat_shape);

--- a/aten/src/ATen/native/quantized/cpu/conv_serialization.h
+++ b/aten/src/ATen/native/quantized/cpu/conv_serialization.h
@@ -132,8 +132,7 @@ ConvParamsSerializationTypeV3 parse_conv_serialized_state(c10::IValue v) {
       config_vals.push_back(dilation[0].item<int16_t>());
     }
     // output_padding does not exist in v1, so we fill in a default value
-    for (const auto i : c10::irange(kSpatialDim)) {
-      (void)i; // Suppress unused variable
+    for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
       config_vals.push_back(0);
     }
     config_vals.push_back(groups[0].item<int16_t>());
@@ -289,23 +288,19 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> deserialize_conv(
   torch::List<int64_t> stride, padding, output_padding, dilation;
   // skip kSpatialDim
   int idx = 1;
-  for (const auto i : c10::irange(kSpatialDim)) {
-    (void)i; // Suppress unused variable
+  for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
     stride.emplace_back(config_vals.at(idx));
     idx++;
   }
-  for (const auto i : c10::irange(kSpatialDim)) {
-    (void)i; // Suppress unused variable
+  for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
     padding.emplace_back(config_vals.at(idx));
     idx++;
   }
-  for (const auto i : c10::irange(kSpatialDim)) {
-    (void)i; // Suppress unused variable
+  for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
     dilation.emplace_back(config_vals.at(idx));
     idx++;
   }
-  for (const auto i : c10::irange(kSpatialDim)) {
-    (void)i; // Suppress unused variable
+  for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
     output_padding.emplace_back(config_vals.at(idx));
     idx++;
   }

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -330,8 +330,7 @@ class QConvPackWeightInt8 final {
       int64_t groups) {
     torch::List<int64_t> output_padding;
     output_padding.reserve(kSpatialDim);
-    for (const auto idx : c10::irange(kSpatialDim)) {
-      (void)idx; //Suppress unused variable warning
+    for (C10_UNUSED const auto idx : c10::irange(kSpatialDim)) {
       output_padding.push_back((int64_t)0);
     }
     return _run(weight, bias, stride, padding, output_padding, dilation, groups,

--- a/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
@@ -80,8 +80,7 @@ static void upsample_bilinear2d_out_frame(
       const typename scalar_t::underlying* pos1 = i_p + h1 * input_width + w1;
       typename scalar_t::underlying* pos2 = o_p + h2 * output_width + w2;
 
-      for (const auto c : c10::irange(channels)) {
-        (void)c; //Suppress unused variable warning
+      for (C10_UNUSED const auto c : c10::irange(channels)) {
         float result = h0lambda * (w0lambda * pos1[0] + w1lambda * pos1[w1p]) +
             h1lambda *
                 (w0lambda * pos1[h1p * input_width] +

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
@@ -55,8 +55,7 @@ static void upsample_nearest2d_out_frame(
       const auto* pos1 = &i_p[h1 * input_width + w1];
       auto* pos2 = &o_p[h2 * output_width + w2];
 
-      for (const auto c : c10::irange(channels)) {
-        (void)c; //Suppress unused variable warning
+      for (C10_UNUSED const auto c : c10::irange(channels)) {
         pos2[0] = pos1[0];
         pos1 += input_height * input_width;
         pos2 += output_height * output_width;

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest3d.cpp
@@ -63,8 +63,7 @@ static void upsample_nearest3d_out_frame(
         const auto* pos1 = &i_p[d1 * input_height * input_width + h1 * input_width + w1];
         auto* pos2 = &o_p[d2 * output_height * output_width + h2 * output_width + w2];
 
-        for (const auto c : c10::irange(channels)) {
-          (void)c; //Suppress unused variable warning
+        for (C10_UNUSED const auto c : c10::irange(channels)) {
           pos2[0] = pos1[0];
           pos1 += input_depth * input_height * input_width;
           pos2 += output_depth * output_height * output_width;

--- a/aten/src/ATen/native/sparse/SparseMatMul.cpp
+++ b/aten/src/ATen/native/sparse/SparseMatMul.cpp
@@ -153,8 +153,7 @@ void _csr_matmult(
       }
     }
 
-    for (const auto jj : c10::irange(length)) {
-      (void)jj; //Suppress unused variable warning
+    for (C10_UNUSED const auto jj : c10::irange(length)) {
       Cj[nnz] = head;
       Cx[nnz] = sums[head];
       nnz++;

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -85,8 +85,7 @@ void TestAdd(DeprecatedTypeProperties& type) {
 void TestZeros(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor a = zeros({1024, 1024}, type);
-  for (const auto i : c10::irange(1, 1000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(1, 1000)) {
     a = zeros({128, 128}, type);
   }
   auto end = std::chrono::high_resolution_clock::now();
@@ -104,8 +103,7 @@ void TestLoadsOfAdds(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor d = ones({3, 4}, type);
   Tensor r = zeros({3, 4}, type);
-  for (const auto i : c10::irange(100000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(100000)) {
     add_out(r, r, d);
   }
   auto end = std::chrono::high_resolution_clock::now();
@@ -122,8 +120,7 @@ void TestLoadOfAddsWithCopy(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor d = ones({3, 4}, type);
   Tensor r = zeros({3, 4}, type);
-  for (const auto i : c10::irange(100000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(100000)) {
     r = add(r, d);
   }
   auto end = std::chrono::high_resolution_clock::now();

--- a/aten/src/ATen/test/cpu_generator_test.cpp
+++ b/aten/src/ATen/test/cpu_generator_test.cpp
@@ -161,8 +161,7 @@ TEST(CPUGeneratorImpl, TestPhiloxEngineOffset1) {
   // So if you want to skip 8 values, offset would
   // be 2, since 2*4=8.
   at::Philox4_32_10 engine2(123, 1, 2);
-  for (const auto i : c10::irange(8)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(8)) {
     // Note: instead of using the engine() call 8 times
     // we could have achieved the same functionality by
     // calling the incr() function twice.
@@ -223,16 +222,14 @@ TEST(CPUGeneratorImpl, TestMT19937EngineReproducibility) {
   // test with zero seed
   at::mt19937 engine1(0);
   std::mt19937 engine2(0);
-  for (const auto i : c10::irange(10000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(10000)) {
     ASSERT_EQ(engine1(), engine2());
   }
 
   // test with large seed
   engine1 = at::mt19937(2147483647);
   engine2 = std::mt19937(2147483647);
-  for (const auto i : c10::irange(10000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(10000)) {
     ASSERT_EQ(engine1(), engine2());
   }
 
@@ -241,8 +238,7 @@ TEST(CPUGeneratorImpl, TestMT19937EngineReproducibility) {
   auto seed = rd();
   engine1 = at::mt19937(seed);
   engine2 = std::mt19937(seed);
-  for (const auto i : c10::irange(10000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(10000)) {
     ASSERT_EQ(engine1(), engine2());
   }
 

--- a/aten/src/ATen/test/thread_init_test.cpp
+++ b/aten/src/ATen/test/thread_init_test.cpp
@@ -14,8 +14,7 @@ void test(int given_num_threads) {
   ASSERT_TRUE(given_num_threads >= 0);
   ASSERT_EQ(at::get_num_threads(), given_num_threads);
   auto t_sum = t.sum();
-  for (const auto i : c10::irange(1000)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(1000)) {
     t_sum = t_sum + t.sum();
   }
 }

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -1053,8 +1053,7 @@ namespace {
         float minv = static_cast<float>(static_cast<double>(min_val) * 2.0);
         float maxv = static_cast<float>(static_cast<double>(max_val) * 2.0);
         ValueGen<float> gen(minv, maxv, seed.add(2));
-        for (const auto i : c10::irange(trials)) {
-            (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(trials)) {
             float scale = generator_sc.get();
             float inv_scale = 1.0f / static_cast<float>(scale);
             auto zero_point_val = generator_zp.get();
@@ -1091,8 +1090,7 @@ namespace {
         ValueGen<int> generator(min_val, max_val, seed.add(1));
         //scale
         ValueGen<float> generator_sc(1.f, 15.f, seed.add(2));
-        for (const auto i : c10::irange(trials)) {
-            (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(trials)) {
             float scale = generator_sc.get();
             int32_t zero_point_val = generator.get();
             float scale_zp_premul = -(scale * zero_point_val);
@@ -1139,8 +1137,7 @@ namespace {
         ValueGen<int32_t> generator(min_val, max_val, seed);
         //scale
         ValueGen<float> generator_sc(1.f, 15.f, seed.add(1));
-        for (const auto i : c10::irange(trials)) {
-            (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(trials)) {
             float multiplier = 1.f / (generator_sc.get());
             auto zero_point_val = generator.get();
             int index = 0;
@@ -1177,8 +1174,7 @@ namespace {
         typename vec::int_vec_return_type  expected_int_ret;
         auto seed = TestSeed();
         ValueGen<underlying> generator(min_val, max_val, seed);
-        for (const auto i : c10::irange(trials)) {
-            (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(trials)) {
             //generate vals
             for (int j = 0; j < vec::size(); j++) {
                 qint_vals[j] = generator.get();

--- a/aten/src/ATen/test/vec_test_all_types.h
+++ b/aten/src/ATen/test/vec_test_all_types.h
@@ -950,8 +950,7 @@ void test_unary(
         UVT start = dmn_argc > 0 ? dmn.ArgsDomain[0].start : default_start;
         UVT end = dmn_argc > 0 ? dmn.ArgsDomain[0].end : default_end;
         ValueGen<VT> generator(start, end, seed.add(changeSeedBy));
-        for (const auto trial : c10::irange(trialCount)) {
-            (void)trial; // Suppress unused variable warning
+        for (C10_UNUSED const auto trial : c10::irange(trialCount)) {
             for (const auto k : c10::irange(el_count)) {
                 vals[k] = generator.get();
                 call_filter(filter, vals[k]);
@@ -1010,8 +1009,7 @@ void test_binary(
         UVT end1 = dmn_argc > 1 ? dmn.ArgsDomain[1].end : default_end;
         ValueGen<VT> generator0(start0, end0, seed.add(changeSeedBy));
         ValueGen<VT> generator1(start1, end1, seed.add(changeSeedBy + 1));
-        for (const auto trial : c10::irange(trialCount)) {
-            (void)trial; // Suppress unused variable warning
+        for (C10_UNUSED const auto trial : c10::irange(trialCount)) {
             for (const auto k : c10::irange(el_count)) {
                 vals0[k] = generator0.get();
                 vals1[k] = generator1.get();
@@ -1076,8 +1074,7 @@ void test_ternary(
         ValueGen<VT> generator1(start1, end1, seed.add(changeSeedBy + 1));
         ValueGen<VT> generator2(start2, end2, seed.add(changeSeedBy + 2));
 
-        for (const auto trial : c10::irange(trialCount)) {
-            (void)trial; // Suppress unused variable warning
+        for (C10_UNUSED const auto trial : c10::irange(trialCount)) {
             for (const auto k : c10::irange(el_count)) {
                 vals0[k] = generator0.get();
                 vals1[k] = generator1.get();

--- a/aten/src/ATen/test/vmap_test.cpp
+++ b/aten/src/ATen/test/vmap_test.cpp
@@ -170,8 +170,7 @@ TEST(VmapTest, TestBatchedTensorActualDim) {
   {
     // ActualDim on kVmapMaxTensorDims sized underlying tensor
     auto tensor = ones({});
-    for (const auto i : c10::irange(kVmapMaxTensorDims)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(kVmapMaxTensorDims)) {
       tensor = tensor.unsqueeze(0);
     }
     ASSERT_EQ(tensor.dim(), kVmapMaxTensorDims);

--- a/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
@@ -23,8 +23,7 @@ static void FusedOverhead(benchmark::State& state) {
   auto z = torch::ones({1});
 
   // Warmup.
-  for (const auto i : c10::irange(8)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(8)) {
     m.run_method("two_adds", x, y, z);
   }
 
@@ -45,8 +44,7 @@ static void UnfusedOverhead(benchmark::State& state) {
   auto z = torch::ones({1});
 
   // Warmup.
-  for (const auto i : c10::irange(8)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(8)) {
     m.run_method("two_adds", x, y, z);
   }
 

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -35,14 +35,12 @@ dict_int_int test_dict(dict_int_int& dict) {
 
   // erase via iterators
   auto begin = dict.begin();
-  for (const auto i : c10::irange(20)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(20)) {
     begin++;
   }
 
   auto end = begin;
-  for (const auto i : c10::irange(20)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(20)) {
     erase_set.insert(end->first);
     end++;
   }
@@ -136,13 +134,11 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
 
     // erase a few entries via iterator
     auto begin = dict.begin();
-    for (const auto j : c10::irange(10)) {
-      (void)j; // Suppress unused variable warning
+    for (C10_UNUSED const auto j : c10::irange(10)) {
       begin++;
     }
     auto end = begin;
-    for (const auto j : c10::irange(7)) {
-      (void)j; // Suppress unused variable warning
+    for (C10_UNUSED const auto j : c10::irange(7)) {
       erase_set.insert(end->first);
       end++;
     }

--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -249,8 +249,7 @@ class TORCH_API DBReader {
     *value = cursor_->value();
 
     // In sharded mode, each read skips num_shards_ records
-    for (const auto s : c10::irange(num_shards_)) {
-      (void)s; // Suppress unused variable
+    for (C10_UNUSED const auto s : c10::irange(num_shards_)) {
       cursor_->Next();
       if (!cursor_->Valid()) {
         MoveToBeginning();
@@ -294,8 +293,7 @@ class TORCH_API DBReader {
 
   void MoveToBeginning() const {
     cursor_->SeekToFirst();
-    for (const auto s : c10::irange(shard_id_)) {
-      (void)s; // Suppress unused variable
+    for (C10_UNUSED const auto s : c10::irange(shard_id_)) {
       cursor_->Next();
       CAFFE_ENFORCE(
           cursor_->Valid(), "Db has fewer rows than shard id: ", s, shard_id_);

--- a/caffe2/operators/bisect_percentile_op.h
+++ b/caffe2/operators/bisect_percentile_op.h
@@ -79,8 +79,7 @@ class BisectPercentileOp final : public Operator<Context> {
       cur_index = i;
       feature_start_index = index[i];
       feature_length = pct_lens_[i];
-      for (const auto j : c10::irange(batch_size)) {
-        (void)j; // Suppress unused variable warning
+      for (C10_UNUSED const auto j : c10::irange(batch_size)) {
         pct_output[cur_index] = compute_percentile(
             pct_raw_.begin() + feature_start_index,
             pct_mapping_.begin() + feature_start_index,

--- a/caffe2/operators/gather_ranges_to_dense_op.h
+++ b/caffe2/operators/gather_ranges_to_dense_op.h
@@ -43,8 +43,7 @@ class GatherRangesToDenseOp final : public Operator<Context> {
     CAFFE_ENFORCE_GT(
         minObservation_, 0, "The number of observations is at least 1");
     // Initialize the empty and mismatch counter.
-    for (const auto i : c10::irange(OutputSize())) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(OutputSize())) {
       emptyRanges_.push_back(0);
       mismatchedRanges_.push_back(0);
       mismatchedLengths_.push_back(set<int>());

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -290,8 +290,7 @@ class SparseLengthsSumSparseLookupOp final : public Operator<CPUContext> {
         return false;
       }
       int32_t skipped = 0;
-      for (const auto i : c10::irange(current_length)) {
-        (void)i; // Suppress unused variable warning
+      for (C10_UNUSED const auto i : c10::irange(current_length)) {
         IndexType compressed_idx = indices_data[current];
         if (compressed_idx < 0 || compressed_idx >= compressed_data_size) {
           return false;

--- a/caffe2/operators/lstm_utils.h
+++ b/caffe2/operators/lstm_utils.h
@@ -158,8 +158,7 @@ chunk(const Tensor& input, int chunks, int axis, CPUContext* context) {
   }
   size_t input_offset = 0;
   std::vector<Tensor> outputs;
-  for (const auto i : c10::irange(chunks)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(chunks)) {
     auto axis_dim = split_size;
     output_dims[canonical_axis] = split_size;
     Tensor output(output_dims, CPU);

--- a/caffe2/operators/numpy_tile_op.h
+++ b/caffe2/operators/numpy_tile_op.h
@@ -101,10 +101,8 @@ class NumpyTileOp : public Operator<Context> {
       int64_t num_tiles,
       const char* input_data,
       char* output_data) {
-    for (const auto i : c10::irange(outer_dim)) {
-      (void)i; // Suppress unused variable warning
-      for (const auto t : c10::irange(num_tiles)) {
-        (void)t; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(outer_dim)) {
+      for (C10_UNUSED const auto t : c10::irange(num_tiles)) {
         context_.CopyItemsSameDevice(meta, inner_dim, input_data, output_data);
         output_data += inner_dim * item_size;
       }

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -2227,8 +2227,7 @@ TEST(DataLoaderTest, ChunkDatasetCrossChunkShuffle) {
 
         for (const auto i : c10::irange((chunk_count + cross_chunk_shuffle_count - 1) /
                  cross_chunk_shuffle_count)) {
-          for (const auto j : c10::irange(chunk_size)) {
-            (void)j; // Suppress unused variable warning
+          for (C10_UNUSED const auto j : c10::irange(chunk_size)) {
             for (const auto k : c10::irange(cross_chunk_shuffle_count)) {
               if (i * cross_chunk_shuffle_count + k < chunk_count) {
                 expected_result.push_back(i * cross_chunk_shuffle_count + k);

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -1171,8 +1171,7 @@ TEST_F(FunctionalTest, GumbelSoftmax) {
 
     auto counts = torch::zeros_like(logits);
     torch::Tensor y_draw;
-    for (const auto i : c10::irange(num_draws)) {
-        (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(num_draws)) {
         y_draw = F::gumbel_softmax(logits, F::GumbelSoftmaxFuncOptions().hard(true));
         counts += y_draw;
     }

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -123,8 +123,7 @@ bool test_mnist(
   torch::Device device(with_cuda ? torch::kCUDA : torch::kCPU);
   model->to(device);
 
-  for (const auto epoch : c10::irange(number_of_epochs)) {
-    (void)epoch; // Suppress unused variable warning
+  for (C10_UNUSED const auto epoch : c10::irange(number_of_epochs)) {
     // NOLINTNEXTLINE(performance-for-range-copy)
     for (torch::data::Example<> batch : *data_loader) {
       auto data = batch.data.to(device);

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -3489,8 +3489,7 @@ namespace detail {
     std::uniform_int_distribution<int> d_2_10(2, 10);
     std::uniform_int_distribution<int> d_3_10(3, 10);
     bool registration_checked = false;
-    for (const auto i : c10::irange(100)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(100)) {
       const auto batch_sz = d_2_10(generator);
       const auto seq_len = d_2_10(generator);
       const auto d_head = d_3_10(generator);

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -369,8 +369,7 @@ int64_t PackedSequenceTest_max_length = 6;
 std::vector<torch::Tensor> PackedSequenceTest_ordered_sequence(torch::ScalarType tensor_type) {
   std::vector<torch::Tensor> seqs;
   seqs.reserve(PackedSequenceTest_batch_size);
-  for (const auto i : c10::irange(PackedSequenceTest_batch_size)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(PackedSequenceTest_batch_size)) {
     seqs.emplace_back(torch::empty({
       torch::randint(1, PackedSequenceTest_max_length, {1}).item<int64_t>()
     }, tensor_type));

--- a/test/cpp/api/operations.cpp
+++ b/test/cpp/api/operations.cpp
@@ -12,8 +12,7 @@ struct OperationTest : torch::test::SeedingFixture {
 };
 
 TEST_F(OperationTest, Lerp) {
-  for (const auto i : c10::irange(TEST_AMOUNT)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(TEST_AMOUNT)) {
     // test lerp_kernel_scalar
     auto start = torch::rand({3, 5});
     auto end = torch::rand({3, 5});
@@ -37,8 +36,7 @@ TEST_F(OperationTest, Lerp) {
 }
 
 TEST_F(OperationTest, Cross) {
-  for (const auto i : c10::irange(TEST_AMOUNT)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(TEST_AMOUNT)) {
     // input
     auto a = torch::rand({10, 3});
     auto b = torch::rand({10, 3});

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -144,8 +144,7 @@ void check_exact_values(
 TEST(OptimTest, OptimizerAccessors) {
   auto options = AdagradOptions(1.0);
   std::vector<torch::Tensor> params;
-  for (const auto i : c10::irange(3)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(3)) {
     params.push_back(torch::randn(10));
   }
   auto optimizer = Adagrad(params, options);

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -1057,8 +1057,7 @@ TEST(Reductions, ReduceSplitRfactor) {
   SimpleIREvaluator cg(s, {b, c});
 
   cg.call({in, out});
-  for (const auto i : c10::irange(M)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(M)) {
     ASSERT_EQ(out[0], 4950);
   }
 }

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -3885,8 +3885,7 @@ TEST(Simplify, SimplifyEliminateEmptyFor) {
   {
     // Flatten many layers around an empty block to an empty block.
     StmtPtr last = alloc<Block>(std::vector<StmtPtr>({}));
-    for (const auto i : c10::irange(11)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(11)) {
       VarHandle loopVar("loopVar", kInt);
       last = For::make(loopVar, 0, 10, last);
     }
@@ -3970,8 +3969,7 @@ TEST(Simplify, SimplifyFlattenBlock) {
   {
     // Flatten many layers around an empty block to an empty block.
     StmtPtr last = alloc<Block>(std::vector<StmtPtr>({}));
-    for (const auto i : c10::irange(11)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(11)) {
       last = alloc<Block>(std::vector<StmtPtr>({last}));
     }
 

--- a/test/custom_operator/op.cpp
+++ b/test/custom_operator/op.cpp
@@ -12,8 +12,7 @@ torch::List<torch::Tensor> custom_op(
     int64_t repeat) {
   torch::List<torch::Tensor> output;
   output.reserve(repeat);
-  for (const auto i : c10::irange(repeat)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(repeat)) {
     output.push_back(tensor * scalar);
   }
   return output;

--- a/torch/csrc/api/include/torch/data/dataloader/base.h
+++ b/torch/csrc/api/include/torch/data/dataloader/base.h
@@ -85,8 +85,7 @@ class DataLoaderBase {
     // Send one 'quit' message per worker. Since a worker dies (exits its
     // thread) after receiving this message, each `QuitWorker()` message will be
     // read by exactly one worker.
-    for (const auto w : c10::irange(options_.workers)) {
-      (void)w; // Suppress unused variable warning
+    for (C10_UNUSED const auto w : c10::irange(options_.workers)) {
       push_job(QuitWorker());
     }
     for (auto& worker : workers_) {
@@ -150,8 +149,7 @@ class DataLoaderBase {
   /// Schedules `requested_jobs` many new batches to be fetched. The actual
   /// number of jobs scheduled may be less if the DataLoader exhausts.
   void prefetch(size_t requested_jobs) {
-    for (const auto r : c10::irange(requested_jobs)) {
-      (void)r; // Suppress unused variable
+    for (C10_UNUSED const auto r : c10::irange(requested_jobs)) {
       if (auto batch_request = get_batch_request()) {
         this->push_job(std::move(*batch_request));
       } else {

--- a/torch/csrc/api/include/torch/nn/modules/utils.h
+++ b/torch/csrc/api/include/torch/nn/modules/utils.h
@@ -21,8 +21,7 @@ inline std::vector<int64_t> _reverse_repeat_vector(at::ArrayRef<int64_t> t, int6
   std::vector<int64_t> ret;
   ret.reserve(t.size() * n);
   for (auto rit = t.rbegin(); rit != t.rend(); ++rit) {
-    for (const auto i : c10::irange(n)) {
-      (void)i; // Suppress unused variable
+    for (C10_UNUSED const auto i : c10::irange(n)) {
       ret.emplace_back(*rit);
     }
   }

--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -206,8 +206,7 @@ TransformerEncoderImpl::TransformerEncoderImpl(
 
 void TransformerEncoderImpl::reset() {
   layers = this->register_module("layers", ModuleList());
-  for (const auto i : c10::irange(options.num_layers())) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(options.num_layers())) {
     layers->push_back(options.encoder_layer()->clone());
   }
 
@@ -268,8 +267,7 @@ TransformerDecoderImpl::TransformerDecoderImpl(
 void TransformerDecoderImpl::reset() {
 
   layers = this->register_module("layers", ModuleList());
-  for (const auto i : c10::irange(options.num_layers())) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(options.num_layers())) {
     layers->push_back(options.decoder_layer()->clone());
   }
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -932,8 +932,7 @@ Tensor repeat_backward(Tensor grad, IntArrayRef repeats, IntArrayRef input_shape
   }
   const auto input_dims = input_shape.size();
   int64_t num_unsqueezed = grad.dim() - input_dims;
-  for (const auto i : c10::irange(num_unsqueezed)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(num_unsqueezed)) {
     grad = grad.sum(0, false);
   }
 
@@ -2295,8 +2294,7 @@ std::tuple<Tensor, Tensor, Tensor> prelu_double_backward(
       // so the expand succeeds.
       auto dims_to_unsqueeze = std::max<int64_t>(input.dim() - 2, 0);
       auto ggW_expanded = ggW;
-      for(const auto i : c10::irange(dims_to_unsqueeze)) {
-          (void)i; // Suppress unused variable warning
+      for(C10_UNUSED const auto i : c10::irange(dims_to_unsqueeze)) {
           ggW_expanded = ggW_expanded.unsqueeze(1);
       }
       ggW_expanded = ggW_expanded.expand_as(ggI);
@@ -2315,8 +2313,7 @@ std::tuple<Tensor, Tensor, Tensor> prelu_double_backward(
       if (gO.requires_grad()) {
           // expand weight as input as in ggW/ggI above
           auto weight_expanded = weight;
-          for(const auto i : c10::irange(dims_to_unsqueeze)) {
-              (void)i; // Suppress unused variable warning
+          for(C10_UNUSED const auto i : c10::irange(dims_to_unsqueeze)) {
               weight_expanded = weight_expanded.unsqueeze(1);
           }
           weight_expanded = weight_expanded.expand_as(input);

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -40,9 +40,7 @@ struct TORCH_API NotImplemented : public Error {
 struct TORCH_API DelayedError : public Node {
   DelayedError(std::string msg, int num_inputs)
     : msg(std::move(msg)) {
-    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-    for (const auto i : c10::irange(num_inputs)) {
-      (void)i; //Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(num_inputs)) {
       add_input_metadata(Node::undefined_input());
     }
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -72,8 +72,7 @@ struct CollectiveFingerPrint {
     for (auto& tensor_shape : tensors_to_verify) {
       std::vector<at::Tensor> outputs;
       outputs.reserve(pg->getSize());
-      for (const auto i : c10::irange(pg->getSize())) {
-        (void)i; //Suppress unused variable warning
+      for (C10_UNUSED const auto i : c10::irange(pg->getSize())) {
         outputs.emplace_back(at::zeros_like(tensor_shape));
       }
       output_tensors.emplace_back(outputs);

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -461,8 +461,7 @@ struct slot_list_impl {
     if (!size_) {
       size_ = size_t(0);
       // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
-      for (const value_type& s : *(this)) {
-        (void)s; // Suppress unused variable warning
+      for (C10_UNUSED const value_type& s : *(this)) {
         ++*size_;
       }
     }

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -197,8 +197,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
   }
 
   std::ostream& indent() {
-    for (const auto i : c10::irange(block_nest_level_)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(block_nest_level_)) {
       code_ << kTab;
     }
     return code_;

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -705,8 +705,7 @@ struct CudaGraphFuser {
 
     bchunk->removeInput(producer_index);
     // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
-    for (const auto i : c10::irange(nchunks)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(nchunks)) {
       bchunk->eraseOutput(nchunks * producer_index);
     }
 

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -24,8 +24,7 @@ class TORCH_CUDA_CU_API IrPrinter : public OptInConstDispatch {
 
   // Indent the generated code
   void indent() {
-    for (const auto i : c10::irange(indent_size_)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(indent_size_)) {
       os_ << "  ";
     }
   }

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -42,8 +42,7 @@ std::vector<size_t> toVector(const at::DimVector& small_vec) {
 
 void encodeBuffer(size_t value, std::string& buffer) {
   const char* v = reinterpret_cast<char*>(&value);
-  for (const auto i : c10::irange(sizeof(size_t))) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(sizeof(size_t))) {
     buffer.push_back(*(v++));
   }
 }

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -66,8 +66,7 @@ void IrPrinter::printKernel(const Kernel* kernel) {
 }
 
 std::ostream& IrPrinter::indent() {
-  for (const auto i : c10::irange(indent_level_)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(indent_level_)) {
     ir_str_ << kTab;
   }
   ir_str_ << margin_;

--- a/torch/csrc/jit/codegen/cuda/lower_alias_memory.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_alias_memory.cpp
@@ -169,8 +169,7 @@ class BufferReuseDebugPrinter {
   void printAllocInfo(const kir::Allocate* alloc);
 
   std::stringstream& indent() {
-    for (const auto i : c10::irange(indent_level_)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(indent_level_)) {
       os_ << "  ";
     }
     return os_;

--- a/torch/csrc/jit/codegen/cuda/parallel_dimension_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/parallel_dimension_map.cpp
@@ -303,8 +303,7 @@ bool ParallelDimensionMap::equalDim(kir::Val* dim1, kir::Val* dim2) {
       (dim1_def->isA<kir::UnaryOp>() && dim2_def->isA<kir::UnaryOp>() &&
        (dim1_def->as<kir::UnaryOp>()->operation() ==
         dim2_def->as<kir::UnaryOp>()->operation()))) {
-    for (const auto i : c10::irange(dim1_def->inputs().size())) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(dim1_def->inputs().size())) {
       if (!equalDim(dim1_def->inputs()[0], dim2_def->inputs()[0])) {
         return false;
       }

--- a/torch/csrc/jit/frontend/code_template.h
+++ b/torch/csrc/jit/frontend/code_template.h
@@ -208,8 +208,7 @@ struct CodeTemplate {
   // or trailing newlines. It's the responsibility of the calling function
   // to indent correctly in the context.
   void emitIndent(std::ostream& out, size_t indent) const {
-    for (const auto i : c10::irange(indent)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(indent)) {
       out << " ";
     }
   }

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -296,8 +296,7 @@ SourceRange Node::sourceRange() const {
 }
 
 static std::ostream& indent(std::ostream& out, size_t level) {
-  for (const auto i : c10::irange(level)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(level)) {
     out << "  ";
   }
   return out;
@@ -1775,8 +1774,7 @@ Node* Graph::createTupleSlice(
   new_vals.reserve(num_values);
 
   int64_t i = beg;
-  for (const auto j : c10::irange(num_values)) {
-    (void)j; // Suppress unused variable warning
+  for (C10_UNUSED const auto j : c10::irange(num_values)) {
     auto idx = insertConstant(IValue(static_cast<int64_t>(i)));
     auto tupleIndex = insertNode(createTupleIndex(tup, idx, tt->elements()[i]));
 
@@ -1824,8 +1822,7 @@ Node* Graph::createListUnpack(Value* v, size_t size) {
   ListTypePtr list_type = v->type()->expect<ListType>();
   TypePtr elem_type = list_type->getElementType();
   auto n = create(prim::ListUnpack, {v}, 0);
-  for (const auto i : c10::irange(size)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(size)) {
     n->addOutput()->setType(elem_type);
   }
   return n;

--- a/torch/csrc/jit/mobile/promoted_prim_ops.cpp
+++ b/torch/csrc/jit/mobile/promoted_prim_ops.cpp
@@ -132,8 +132,7 @@ void toList(Stack& stack) {
       "Output annotation list dimension and runtime tensor dimension must match for tolist()");
 
   // Wrap out_ty in a ListType dim times.
-  for (const auto i : c10::irange(dim_val)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(dim_val)) {
     out_ty = ListType::create(out_ty);
   }
 

--- a/torch/csrc/jit/passes/frozen_conv_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_folding.cpp
@@ -303,8 +303,8 @@ void FoldFrozenConvMulOrDiv(Block* b) {
       // channels-out resize it to the shape that will broadcast to
       // weight_tensor when the op is run so we dont change weight size
       std::vector<int64_t> weight_compatible_size = {out_channels};
-      for (const auto i : c10::irange(1, weight_tensor.ndimension())) {
-        (void)i; // Suppress unused variable warning
+      for (C10_UNUSED const auto i :
+           c10::irange(1, weight_tensor.ndimension())) {
         weight_compatible_size.push_back(1);
       }
 

--- a/torch/csrc/jit/passes/frozen_graph_optimizations.cpp
+++ b/torch/csrc/jit/passes/frozen_graph_optimizations.cpp
@@ -18,8 +18,7 @@ void OptimizeFrozenGraph(
   FrozenConcatLinear(graph);
   // run a couple times to capture Conv -> Mul -> Add etc
   if (optimize_numerics) {
-    for (const auto i : c10::irange(2)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(2)) {
       FoldFrozenConvBatchnorm(graph);
       FoldFrozenConvAddOrSub(graph);
       FoldFrozenConvMulOrDiv(graph);

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -829,8 +829,7 @@ struct GraphFuser {
     }
 
     bchunk->removeInput(producer_index);
-    for (const auto i : c10::irange(nchunks)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(nchunks)) {
       bchunk->eraseOutput(nchunks * producer_index);
     }
 

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -129,8 +129,7 @@ void repeatBody(Block* body, size_t times, Block* dest) {
   std::vector<Value*> io = dest->inputs().vec();
   TORCH_INTERNAL_ASSERT(
       !body->inputs().at(0)->hasUses(), "loop counter should be unused");
-  for (const auto i : c10::irange(times)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(times)) {
     io[0] = body->inputs().at(0);
     io = insertBlockCopy(*graph, body, io);
   }

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -217,23 +217,19 @@ void unpackQuantizedWeightsHelper(
         const int64_t kSpatialDim = config_vals.at(0);
         // skip kSpatialDim
         int idx = 1;
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           stride_int.emplace_back(config_vals.at(idx));
           idx++;
         }
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           padding_int.emplace_back(config_vals.at(idx));
           idx++;
         }
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           dilation_int.emplace_back(config_vals.at(idx));
           idx++;
         }
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           output_padding_int.emplace_back(config_vals.at(idx));
           idx++;
         }
@@ -272,23 +268,19 @@ void unpackQuantizedWeightsHelper(
         const int64_t kSpatialDim = conv_params_packed[0].item<int64_t>();
         // skip kSpatialDim
         int64_t idx = 1;
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           stride_int.emplace_back(conv_params_packed[idx].item<int64_t>());
           idx++;
         }
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           padding_int.emplace_back(conv_params_packed[idx].item<int64_t>());
           idx++;
         }
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           dilation_int.emplace_back(conv_params_packed[idx].item<int64_t>());
           idx++;
         }
-        for (const auto i : c10::irange(kSpatialDim)) {
-          (void)i; // Suppress unused variable warning
+        for (C10_UNUSED const auto i : c10::irange(kSpatialDim)) {
           output_padding_int.emplace_back(
               conv_params_packed[idx].item<int64_t>());
           idx++;

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -74,8 +74,7 @@ std::string getQuantizeForScalar(const std::string& value) {
           )" +
       value + "_tensor : Tensor = aten::scalar_tensor(" + value + ", " + value +
       "_float_scalar_type";
-  for (const auto i : c10::irange(3)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(3)) {
     quantize_pattern += ", " + value + "_none";
   }
   quantize_pattern += ")";

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -134,8 +134,7 @@ void initScriptListBindings(PyObject* module) {
 
             auto seq = std::make_shared<ScriptList>(self->type());
 
-            for (const auto i : c10::irange(slicelength)) {
-              (void)i; // Suppress unused variable warning
+            for (C10_UNUSED const auto i : c10::irange(slicelength)) {
               seq->append(self->getItem(start));
               start += step;
             }

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -397,8 +397,7 @@ void listMulIntLeftInPlace(Stack& stack) {
     list.clear();
   } else if (n > 1) {
     size_t list_size = list.size();
-    for (const auto i : c10::irange(1, n)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(1, n)) {
       for (const auto j : c10::irange(list_size)) {
         list.push_back(list.get(j));
       }
@@ -416,8 +415,7 @@ void listMulIntLeft(Stack& stack) {
   const auto size = list.size() * n;
   ret.reserve(size);
 
-  for (const auto i : c10::irange(n)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(n)) {
     for (IValue e : list) {
       ret.push_back(std::move(e));
     }
@@ -434,8 +432,7 @@ void listMulIntRight(Stack& stack) {
   const auto size = list.size() * n;
   ret.reserve(size);
 
-  for (const auto i : c10::irange(n)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(n)) {
     for (IValue e : list) {
       ret.push_back(std::move(e));
     }
@@ -468,8 +465,7 @@ void listSlice(Stack& stack) {
   sliced_list.reserve(num_values);
 
   int i = start;
-  for (const auto j : c10::irange(num_values)) {
-    (void)j; // Suppress unused variable warning
+  for (C10_UNUSED const auto j : c10::irange(num_values)) {
     sliced_list.push_back(list.get(i));
     i += step;
   }

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -44,8 +44,7 @@ std::string stringSlice(
 
   int64_t i = start_val;
   std::string result = "";
-  for (const auto j : c10::irange(num_vals)) {
-    (void)j; // Suppress unused variable warning
+  for (C10_UNUSED const auto j : c10::irange(num_vals)) {
     result += string[i];
     i += step;
   }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1322,8 +1322,7 @@ float StaticRuntime::benchmark_model(
 
   const bool is_kwargs_empty = kwargs_list.size() == 0;
   const KeywordArgs empty_kwargs;
-  for (const auto i : c10::irange(warmup_runs)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(warmup_runs)) {
     for (const auto j : c10::irange(args_list.size())) {
       operator()(args_list[j], is_kwargs_empty ? empty_kwargs : kwargs_list[j]);
       if (manage_output_tensors_enabled_) {
@@ -1332,8 +1331,7 @@ float StaticRuntime::benchmark_model(
     }
   }
   caffe2::Timer timer;
-  for (const auto i : c10::irange(main_runs)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(main_runs)) {
     for (const auto j : c10::irange(args_list.size())) {
       operator()(args_list[j], is_kwargs_empty ? empty_kwargs : kwargs_list[j]);
       if (manage_output_tensors_enabled_) {
@@ -1454,8 +1452,7 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   results.first_iter_time = timer.MilliSeconds();
 
   // warmup runs
-  for (const auto i : c10::irange(warmup_runs - 1)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(warmup_runs - 1)) {
     for (const auto j : c10::irange(args_list.size())) {
       operator()(args_list[j], is_kwargs_empty ? empty_kwargs : kwargs_list[j]);
       if (manage_output_tensors) {
@@ -1465,9 +1462,7 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   }
 
   // main runs
-  for (const auto i : c10::irange(main_runs)) {
-    (void)i; // Suppress unused variable warning
-
+  for (C10_UNUSED const auto i : c10::irange(main_runs)) {
     for (const auto j : c10::irange(args_list.size())) {
       set_inputs(args_list[j], is_kwargs_empty ? empty_kwargs : kwargs_list[j]);
 

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -381,8 +381,7 @@ Module ScriptModuleDeserializer::LEGACY_convertModule(
     }
   }
 
-  for (const auto i : c10::irange(numPushed)) {
-    (void)i; // Suppress unused variable warning
+  for (C10_UNUSED const auto i : c10::irange(numPushed)) {
     LEGACY_moduleStack_.pop_back();
   }
   return module;

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -435,8 +435,7 @@ struct PythonPrintImpl {
   size_t level = 0;
   // indent to the current indent level
   TaggedStringStream& indent() {
-    for (const auto i : c10::irange(level)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(level)) {
       body_ << "  ";
     }
     return body_;
@@ -1263,8 +1262,7 @@ struct PythonPrintImpl {
   IValue createBroadList(dtype value, const int64_t& N) {
     c10::List<dtype> repeated;
     repeated.reserve(N);
-    for (const auto i : c10::irange(N)) {
-      (void)i; // Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(N)) {
       repeated.push_back(value);
     }
     return repeated;

--- a/torch/csrc/lazy/core/thread_pool.cpp
+++ b/torch/csrc/lazy/core/thread_pool.cpp
@@ -18,8 +18,7 @@ class ThreadPool {
  public:
   explicit ThreadPool(size_t num_threads) {
     threads_.reserve(num_threads);
-    for (const auto i : c10::irange(num_threads)) {
-      (void)i; //Suppress unused variable warning
+    for (C10_UNUSED const auto i : c10::irange(num_threads)) {
       threads_.emplace_back([this]() { Worker(); });
     }
   }

--- a/torch/csrc/utils/tensor_apply.cpp
+++ b/torch/csrc/utils/tensor_apply.cpp
@@ -46,8 +46,7 @@ static void recursive_apply(IntArrayRef sizes, ScalarType scalarType, int64_t di
   }
 
   auto n = sizes[dim];
-  for(const auto i : c10::irange(n)) {
-    (void)i; // Suppress unused variable warning
+  for(C10_UNUSED const auto i : c10::irange(n)) {
     recursive_apply(sizes, scalarType, dim + 1, fn, strided_data);
     for (auto& td : strided_data) {
       td.step(dim);


### PR DESCRIPTION
Summary:
Auto-generated with
```
buck run //scripts/rbarnes/regex_multiline_replacer:regex_multiline_replacer -- --find '^(\s*for\s*\()(const.*\n)\s*\(void\)[A-Za-z]+;\s*//\s*Suppress.*\s*\n(.*)'  --replace '\1C10_UNUSED \2\3' `find caffe2/ -regex ".*\.\(cpp\|h\)"`
```

Differential Revision: D33432600

