### PR TITLE
fix CAFFE2_BUILD_MAIN_LIB to the correct C10_BUILD_MAIN_LIB

### DIFF
--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -56,7 +56,7 @@ cc_library(
         ]),
         [],
     ),
-    copts = ["-DCAFFE2_BUILD_MAIN_LIB"],
+    local_defines = ["C10_BUILD_MAIN_LIB"],
     deps = [
         ":headers",
         "@fmt",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

This is the C10 library, it that's the main lib we are building
here. While here, use `local_defines` instead of `copts` for this
definition.

Differential Revision: [D33429420](https://our.internmc.facebook.com/intern/diff/D33429420/)