### PR TITLE
port //c10/macros to common build structure

### DIFF
--- a/c10/macros/BUILD.bazel
+++ b/c10/macros/BUILD.bazel
@@ -1,33 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load(":cmake_configure_file.bzl", "cmake_configure_file")
+load("//:tools/bazel.bzl", "rules")
+load(":build.bzl", "define_targets")
 
-cc_library(
-    name = "macros",
-    srcs = [":cmake_macros_h"],
-    hdrs = [
-        "Macros.h",
-        # Despite the documentation in Macros.h, Export.h is included
-        # directly by many downstream files. Thus, we declare it as a
-        # public header in this file.
-        "Export.h",
-    ],
-    linkstatic = True,
-    local_defines = ["C10_BUILD_MAIN_LIB"],
-    visibility = ["//visibility:public"],
-)
-
-cmake_configure_file(
-    name = "cmake_macros_h",
-    src = "cmake_macros.h.in",
-    out = "cmake_macros.h",
-    definitions = [
-        "C10_BUILD_SHARED_LIBS",
-        "C10_USE_MSVC_STATIC_RUNTIME",
-    ] + select({
-        "//c10:using_gflags": ["C10_USE_GFLAGS"],
-        "//conditions:default": [],
-    }) + select({
-        "//c10:using_glog": ["C10_USE_GLOG"],
-        "//conditions:default": [],
-    }),
-)
+define_targets(rules = rules)

--- a/c10/macros/build.bzl
+++ b/c10/macros/build.bzl
@@ -1,0 +1,31 @@
+def define_targets(rules):
+    rules.cc_library(
+        name = "macros",
+        srcs = [":cmake_macros_h"],
+        hdrs = [
+            "Macros.h",
+            # Despite the documentation in Macros.h, Export.h is included
+            # directly by many downstream files. Thus, we declare it as a
+            # public header in this file.
+            "Export.h",
+        ],
+        linkstatic = True,
+        local_defines = ["C10_BUILD_MAIN_LIB"],
+        visibility = ["//visibility:public"],
+    )
+
+    rules.cmake_configure_file(
+        name = "cmake_macros_h",
+        src = "cmake_macros.h.in",
+        out = "cmake_macros.h",
+        definitions = [
+            "C10_BUILD_SHARED_LIBS",
+            "C10_USE_MSVC_STATIC_RUNTIME",
+        ] + rules.select({
+            "//c10:using_gflags": ["C10_USE_GFLAGS"],
+            "//conditions:default": [],
+        }) + rules.select({
+            "//c10:using_glog": ["C10_USE_GLOG"],
+            "//conditions:default": [],
+        }),
+    )

--- a/tools/bazel.bzl
+++ b/tools/bazel.bzl
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//c10/macros:cmake_configure_file.bzl", "cmake_configure_file")
+
+# Rules implementation for the Bazel build system. Since the common
+# build structure aims to replicate Bazel as much as possible, most of
+# the rules simply forward to the Bazel definitions.
+rules = struct(
+    cc_library = cc_library,
+    cmake_configure_file = cmake_configure_file,
+    select = select,
+)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

This is the first change that uses a common build file, build.bzl, to
hold most of the build logic.

Differential Revision: [D33299331](https://our.internmc.facebook.com/intern/diff/D33299331/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D33299331/)!