### PR TITLE
Adding leaky_relu support for fx2trt

### DIFF
--- a/test/fx2trt/converters/acc_op/test_leaky_relu.py
+++ b/test/fx2trt/converters/acc_op/test_leaky_relu.py
@@ -1,0 +1,32 @@
+# Owner(s): ["oncall: fx"]
+
+import torch
+import torch.fx.experimental.fx_acc.acc_ops as acc_ops
+import torch.nn as nn
+from torch.testing._internal.common_fx2trt import AccTestCase, InputTensorSpec
+
+
+class TestLeakyReLUConverter(AccTestCase):
+    def test_leaky_relu(self):
+        class TestModule(nn.Module):
+            def forward(self, x):
+                return nn.functional.leaky_relu(x, negative_slope=0.05)
+
+        inputs = [torch.randn(1, 10)]
+        self.run_test(TestModule(), inputs, expected_ops={acc_ops.leaky_relu})
+
+    def test_leaky_relu_with_dynamic_shape(self):
+        class TestModule(nn.Module):
+            def forward(self, x):
+                return nn.functional.leaky_relu(x)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1), (1, 2, 3), (3, 3, 3))],
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            TestModule(), input_specs, expected_ops={acc_ops.leaky_relu}
+        )

--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -66,7 +66,6 @@ class AccTracerTest(unittest.TestCase):
 
         a = torch.randn(*input_shape)
         traced = acc_tracer.trace(m, [a])
-
         ph_a = acc_op_node = None
         for node in traced.graph.nodes:
             if node.op == "placeholder":
@@ -1371,6 +1370,9 @@ class AccTracerTest(unittest.TestCase):
     def test_relu(self):
         self._make_acc_op_function_test(acc_ops.relu, torch.relu)
 
+    def test_leaky_relu(self):
+        self._make_acc_op_function_test(acc_ops.leaky_relu, torch.nn.functional.leaky_relu)
+
     def test_sigmoid(self):
         self._make_acc_op_function_test(acc_ops.sigmoid, torch.sigmoid)
 
@@ -1897,6 +1899,7 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.div,
                 acc_ops.pow,
                 acc_ops.relu,
+                acc_ops.leaky_relu,
                 acc_ops.tuple_construct,
                 acc_ops.unsqueeze,
                 acc_ops.sigmoid,

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -613,6 +613,18 @@ def acc_ops_relu(
     operation_type = trt.ActivationType.RELU
     return add_activation_layer(network, input_val, operation_type, target, name)
 
+@tensorrt_converter(acc_ops.leaky_relu)
+def acc_ops_leaky_relu(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    input_val = kwargs["input"]
+    negative_slope = kwargs["negative_slope"]
+    operation_type = trt.ActivationType.LEAKY_RELU
+    return add_activation_layer(network, input_val, operation_type, target, name, negative_slope)
 
 @tensorrt_converter(acc_ops.sin)
 def acc_ops_sin(

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -705,6 +705,11 @@ def pow(*, input, exponent):
 def relu(*, input, inplace=False):
     return nn.functional.relu(**locals())
 
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.leaky_relu))
+@register_acc_op
+def leaky_relu(*, input, negative_slope=0.01, inplace=False):
+    return nn.functional.leaky_relu(**locals())
 
 @register_custom_acc_mapper_fn(
     op_and_target=("call_function", torch.log1p),


### PR DESCRIPTION
Summary:
Add op support in fx2trt for leaky_relu
1. add support in acc_ops and corresponding unit test
2. add support in acc_ops_converters and corresponding unit test

Differential Revision: D33399095

