### PR TITLE
Adapt llvm_codegen.cpp to LLVM TOT

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -524,7 +524,8 @@ llvm::Type* LLVMCodeGenImpl::dtypeToLLVMPtr(Dtype dtype) {
 }
 
 void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
-  auto voidPtrPtrTy = llvm::Type::getInt8PtrTy(getContext())->getPointerTo();
+  auto voidPtrTy = llvm::Type::getInt8PtrTy(getContext());
+  auto voidPtrPtrTy = voidPtrTy->getPointerTo();
   auto wrapper = llvm::Function::Create(
       llvm::FunctionType::get(IntTy_, {voidPtrPtrTy}, false),
       llvm::Function::ExternalLinkage,
@@ -535,10 +536,7 @@ void LLVMCodeGenImpl::emitWrapper(const std::vector<llvm::Type*>& params) {
   llvm::SmallVector<llvm::Value*, 6> wrappedArgs;
   for (const auto i : c10::irange(params.size())) {
     auto argp = irb_.CreateGEP(
-        wrapper->arg_begin()
-            ->getType()
-            ->getScalarType()
-            ->getPointerElementType(),
+        voidPtrTy,
         wrapper->arg_begin(),
         llvm::ConstantInt::getSigned(IntTy_, i));
     if (params[i]->isPointerTy()) {
@@ -1248,10 +1246,10 @@ void LLVMCodeGenImpl::visit(LoadPtr v) {
           first_idx);
       auto vaddr = irb_.CreateBitOrPointerCast(
           addr, llvm::PointerType::get(loadType, 0));
-#if LLVM_VERSION_MAJOR >= 13
-      value_ = irb_.CreateAlignedLoad(vaddr, llvm::MaybeAlign(4));
+#if LLVM_VERSION_MAJOR >= 12
+      value_ = irb_.CreateAlignedLoad(loadType, vaddr, llvm::MaybeAlign(4));
 #else
-      value_ = irb_.CreateAlignedLoad(vaddr, 4);
+      value_ = irb_.CreateAlignedLoad(loadType, vaddr, 4);
 #endif
       return;
     }
@@ -1292,7 +1290,7 @@ llvm::Value* LLVMCodeGenImpl::packFuncArgs(
   llvm::Value* packed = irb_.CreateAlloca(packed_type, one);
   for (const auto i : c10::irange(func_args.size())) {
     llvm::Value* dst_ptr = irb_.CreateInBoundsGEP(
-        packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
+        packed_type, packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
     irb_.CreateStore(func_args[i], dst_ptr);
   }
   return packed;
@@ -1306,8 +1304,9 @@ std::vector<llvm::Value*> LLVMCodeGenImpl::unpackFuncArgs(
   std::vector<llvm::Value*> func_args(arg_count);
   llvm::Value* zero = llvm::ConstantInt::get(IntTy_, 0);
   for (const auto i : c10::irange(arg_count)) {
+    llvm::Type* packed_type = packed->getType()->getPointerElementType();
     llvm::Value* dst_ptr = irb_.CreateInBoundsGEP(
-        packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
+        packed_type, packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
     func_args[i] =
         irb_.CreateLoad(dst_ptr->getType()->getPointerElementType(), dst_ptr);
   }
@@ -1931,9 +1930,7 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
   for (BufPtr b : bufs) {
     // Store value for buf pointer
     auto gep = irb_.CreateInBoundsGEP(
-        buf_ptrs->getType()->getScalarType()->getPointerElementType(),
-        buf_ptrs,
-        llvm::ConstantInt::getSigned(IntTy_, i));
+        Int8PtrTy_, buf_ptrs, llvm::ConstantInt::getSigned(IntTy_, i));
     b->base_handle()->accept(this);
     auto buf_ptr = this->value_;
     auto buf_void_ptr = irb_.CreatePointerCast(buf_ptr, Int8PtrTy_);
@@ -1941,27 +1938,21 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
 
     // Store dtype of the buf
     gep = irb_.CreateInBoundsGEP(
-        buf_dtypes->getType()->getScalarType()->getPointerElementType(),
-        buf_dtypes,
-        llvm::ConstantInt::getSigned(IntTy_, i));
+        ByteTy_, buf_dtypes, llvm::ConstantInt::getSigned(IntTy_, i));
     irb_.CreateStore(
         llvm::ConstantInt::getSigned(ByteTy_, (int8_t)b->dtype().scalar_type()),
         gep);
 
     // Store rank of the buf
     gep = irb_.CreateInBoundsGEP(
-        buf_ranks->getType()->getScalarType()->getPointerElementType(),
-        buf_ranks,
-        llvm::ConstantInt::getSigned(IntTy_, i));
+        LongTy_, buf_ranks, llvm::ConstantInt::getSigned(IntTy_, i));
     irb_.CreateStore(
         llvm::ConstantInt::getSigned(LongTy_, b->dims().size()), gep);
 
     // Store dims of the buf
     for (const auto dim : c10::irange(b->dims().size())) {
       gep = irb_.CreateInBoundsGEP(
-          buf_dims->getType()->getScalarType()->getPointerElementType(),
-          buf_dims,
-          llvm::ConstantInt::getSigned(IntTy_, dim_idx));
+          LongTy_, buf_dims, llvm::ConstantInt::getSigned(IntTy_, dim_idx));
       b->dims()[dim]->accept(this);
       auto dim_val = this->value_;
       irb_.CreateStore(irb_.CreateZExt(dim_val, LongTy_), gep);
@@ -1971,7 +1962,7 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
     // Store strides of the buf
     for (const auto dim : c10::irange(b->dims().size())) {
       gep = irb_.CreateInBoundsGEP(
-          buf_strides->getType()->getScalarType()->getPointerElementType(),
+          LongTy_,
           buf_strides,
           llvm::ConstantInt::getSigned(IntTy_, stride_idx));
       b->strides()[dim]->accept(this);
@@ -1986,9 +1977,7 @@ void LLVMCodeGenImpl::visit(ExternalCallPtr v) {
   i = 0;
   for (ExprPtr arg : v->args()) {
     auto gep = irb_.CreateInBoundsGEP(
-        extra_args->getType()->getScalarType()->getPointerElementType(),
-        extra_args,
-        llvm::ConstantInt::getSigned(IntTy_, i));
+        LongTy_, extra_args, llvm::ConstantInt::getSigned(IntTy_, i));
     arg->accept(this);
     irb_.CreateStore(irb_.CreateZExtOrBitCast(this->value_, LongTy_), gep);
     i++;


### PR DESCRIPTION
Summary:
Adapt to LLVM top-of-tree APIs.

For context: LLVM is moving towards opaque pointers for IR values: https://llvm.org/docs/OpaquePointers.html

I also changed some `value->getScalarType()->getPointerElementType()`  expressions to directly reference relevant types. This is simpler and more in line with the intentions of the opaque IR pointers. (In fact I would expect those expressions to break in the future). I did not fix places where the relevant type wasn't obvious to me though.

Test Plan:
-
```
$ cd fbsource/fbcode
$ tp2_update_fbcode llvm-fb --branch=staging
# symlinks point to d9c037cf2b4f0268cb1897b99c8c87c5d0232616 TP2 revision
$ buck build mode/opt-clang-thinlto unicorn:index_server -c unicorn.hfsort="1" -c cxx.profile="fbcode//fdo/autofdo/unicorn/index_server:autofdo" -c cxx.modules=False -c cxx.extra_cxxflags="-Wforce-no-error"
```
- Check sandcastle jobs

Differential Revision: D33431503

