### PR TITLE
allow Bazel to build without glog and gflags

### DIFF
--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -1,6 +1,31 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//third_party:substitution.bzl", "header_template_rule")
 load("//tools/config:defs.bzl", "if_cuda")
+
+# The bool_flag targets allow configuring the build from the
+# command-line, e.g. --//c10:use_gflags or --no//c10:use_gflags to
+# disable.
+
+bool_flag(
+    name = "use_gflags",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "use_glog",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "using_gflags",
+    flag_values = {":use_gflags": "true"},
+)
+
+config_setting(
+    name = "using_glog",
+    flag_values = {":use_glog": "true"},
+)
 
 header_template_rule(
     name = "cuda_cmake_macros_h",
@@ -23,11 +48,15 @@ cc_library(
         "util/*.hpp",
     ]),
     deps = [
-        "@com_github_gflags_gflags//:gflags",
-        "@com_github_glog//:glog",
         ":cuda_cmake_macros_h",
         "//c10/macros",
-    ],
+    ] + select({
+        ":using_gflags": ["@com_github_gflags_gflags//:gflags"],
+        "//conditions:default": [],
+    }) + select({
+        ":using_glog": ["@com_github_glog//:glog"],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
 )
 

--- a/c10/macros/BUILD.bazel
+++ b/c10/macros/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//third_party:substitution.bzl", "header_template_rule")
+load(":cmake_configure_file.bzl", "cmake_configure_file")
 
 cc_library(
     name = "macros",
@@ -16,12 +16,18 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-header_template_rule(
+cmake_configure_file(
     name = "cmake_macros_h",
     src = "cmake_macros.h.in",
     out = "cmake_macros.h",
-    substitutions = {
-        "cmakedefine": "define",
-        "#define C10_USE_NUMA": "/* #undef C10_USE_NUMA */",
-    },
+    definitions = [
+        "C10_BUILD_SHARED_LIBS",
+        "C10_USE_MSVC_STATIC_RUNTIME",
+    ] + select({
+        "//c10:using_gflags": ["C10_USE_GFLAGS"],
+        "//conditions:default": [],
+    }) + select({
+        "//c10:using_glog": ["C10_USE_GLOG"],
+        "//conditions:default": [],
+    }),
 )

--- a/c10/macros/cmake_configure_file.bzl
+++ b/c10/macros/cmake_configure_file.bzl
@@ -1,0 +1,65 @@
+# Forked from header_template_rule. header_template_rule is not
+# compatible with our usage of select because its substitutions
+# attribute is a dict, and dicts may not be appended with select. We
+# get around this limitation by using a list as our substitutions.
+def _cmake_configure_file_impl(ctx):
+    command = ["cat $1"]
+    for definition in ctx.attr.definitions:
+        command.append(
+            "| sed 's@#cmakedefine {}@#define {}@'".format(
+                definition,
+                definition,
+            ),
+        )
+
+    # Replace any that remain with /* #undef FOO */.
+    command.append("| sed --regexp-extended 's@#cmakedefine (\\w+)@/* #undef \\1 */@'")
+    command.append("> $2")
+
+    ctx.actions.run_shell(
+        inputs = [ctx.file.src],
+        outputs = [ctx.outputs.out],
+        command = " ".join(command),
+        arguments = [
+            ctx.file.src.path,
+            ctx.outputs.out.path,
+        ],
+    )
+    return [
+        # create a provider which says that this
+        # out file should be made available as a header
+        CcInfo(compilation_context = cc_common.create_compilation_context(
+
+            # pass out the include path for finding this header
+            includes = depset([ctx.outputs.out.dirname, ctx.bin_dir.path]),
+
+            # and the actual header here.
+            headers = depset([ctx.outputs.out]),
+        )),
+    ]
+
+cmake_configure_file = rule(
+    implementation = _cmake_configure_file_impl,
+    doc = """
+Mimics CMake's configure_file in Bazel.
+
+Args:
+  name: A unique name for this rule.
+  src: The input file template.
+  out: The generated output.
+  definitions: A mapping of identifier in template to its value.
+""",
+    attrs = {
+        # We use attr.string_list for compatibility with select and
+        # config_setting. See the comment above _cmake_configure_file_impl
+        # for more information.
+        "definitions": attr.string_list(mandatory = True),
+        "out": attr.output(mandatory = True),
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+    # output_to_genfiles is required for header files.
+    output_to_genfiles = True,
+)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #70846
* #70845
* #70844
* #70843
* #70842
* #70841
* #70840
* #70839
* #70838
* #70837
* #70836
* #70835
* __->__ #70834
* #70833
* #70832

We support both, so we want to ensure both continue to work.

Differential Revision: [D33297464](https://our.internmc.facebook.com/intern/diff/D33297464/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D33297464/)!