### PR TITLE
use c10/macros/cmake_macros.h in fbcode build

### DIFF
--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -1,7 +1,13 @@
 #pragma once
 
 #ifndef C10_USING_CUSTOM_GENERATED_MACROS
+
+// We have not yet modified the AMD HIP build to generate this file so
+// we add an extra option to specifically ignore it.
+#ifndef C10_CUDA_NO_CMAKE_CONFIGURE_FILE
 #include <c10/cuda/impl/cuda_cmake_macros.h>
+#endif // C10_CUDA_NO_CMAKE_CONFIGURE_FILE
+
 #endif
 
 // See c10/macros/Export.h for a detailed explanation of what the function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #70846
* #70845
* #70844
* #70843
* #70842
* #70841
* #70840
* #70839
* #70838
* #70837
* #70836
* __->__ #70835
* #70834
* #70833
* #70832

This is a step towards OSS/fbcode convergence since OSS uses this file
in both CMake and Bazel.

Differential Revision: [D33299102](https://our.internmc.facebook.com/intern/diff/D33299102/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D33299102/)!