### PR TITLE
Parallelize docker dependency builds

### DIFF
--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -122,7 +122,7 @@ wget https://ossci-linux.s3.amazonaws.com/valgrind-${VALGRIND_VERSION}.tar.bz2
 tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
 cd valgrind-${VALGRIND_VERSION}
 ./configure --prefix=/usr/local
-make -j 4
+make -j6
 sudo make install
 cd ../../
 rm -rf valgrind_build

--- a/.circleci/docker/common/install_openssl.sh
+++ b/.circleci/docker/common/install_openssl.sh
@@ -9,6 +9,6 @@ tar xf "${OPENSSL}.tar.gz"
 cd "${OPENSSL}"
 ./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
 # NOTE: opensl errors out when built with the -j option
-make install_sw
+make -j6 install_sw
 cd ..
 rm -rf "${OPENSSL}"

--- a/.circleci/docker/common/install_openssl.sh
+++ b/.circleci/docker/common/install_openssl.sh
@@ -8,7 +8,7 @@ wget -q -O "${OPENSSL}.tar.gz" "https://ossci-linux.s3.amazonaws.com/${OPENSSL}.
 tar xf "${OPENSSL}.tar.gz"
 cd "${OPENSSL}"
 ./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
-# NOTE: opensl errors out when built with the -j option
-make -j6 install_sw
+# NOTE: openssl install errors out when built with the -j option
+make -j6; make install_sw
 cd ..
 rm -rf "${OPENSSL}"

--- a/.circleci/docker/common/install_protobuf.sh
+++ b/.circleci/docker/common/install_protobuf.sh
@@ -14,9 +14,9 @@ install_protobuf_317() {
 
   curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz"
   tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-all-3.17.3.tar.gz
-  # -j2 to balance memory usage and speed.
+  # -j6 to balance memory usage and speed.
   # naked `-j` seems to use too much memory.
-  pushd "$pb_dir" && ./configure && make -j2 && make -j2 check && sudo make -j2 install && sudo ldconfig
+  pushd "$pb_dir" && ./configure && make -j6 && make -j6 check && sudo make -j6 install && sudo ldconfig
   popd
   rm -rf $pb_dir
 }


### PR DESCRIPTION
Those scripts are run on 8 vCPU instances, so passing at least `-j6` makes sense

