### PR TITLE
[LTC] Sync LazyGraphExecutor and LazyTensor with the staging branch

### DIFF
--- a/torch/csrc/lazy/backend/backend_interface.h
+++ b/torch/csrc/lazy/backend/backend_interface.h
@@ -39,7 +39,9 @@ class TORCH_API BackendImplInterface {
   virtual BackendDataPtr MakeComputationDataFromTensor(
       const at::Tensor& tensor, const Shape& shape,
       const BackendDevice& device) const = 0;
-
+  virtual BackendDataPtr MakeComputationDataFromScalar(
+      const at::Scalar& scalar,
+      const torch::lazy::BackendDevice& device) const = 0;
   virtual BackendDataPtr CreateDataPlaceholder(
       const BackendDevice& device, const Shape& shape) const = 0;
 

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -17,8 +17,6 @@
 #include <torch/csrc/lazy/ts_backend/ops/expand.h>
 #include <torch/csrc/lazy/ts_backend/ops/scalar.h>
 
-#include <ATen/ScalarOps.h>
-
 namespace torch {
 namespace lazy {
 namespace {
@@ -527,6 +525,16 @@ Value LazyGraphExecutor::GetDeviceDataIrValue(
   return MakeNode<DeviceData>(std::move(data));
 }
 
+Value LazyGraphExecutor::GetIrValueForScalarFromCodegen(const at::Scalar& value) {
+  if (IsSpecialScalar(value)) {
+    return MakeNode<Scalar>(value, value.type());
+  }
+  auto cpu_device = getBackend()->GetBackendDevice(c10::Device(c10::kCPU, 0));
+  BackendDataPtr data = getBackend()->MakeComputationDataFromScalar(value, cpu_device);
+  data->SetInfo(std::make_shared<DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
+  return MakeNode<DeviceData>(std::move(data));
+}
+
 Value LazyGraphExecutor::GetIrValueForScalar(
     const at::Scalar& value,
     c10::ScalarType type,
@@ -534,7 +542,7 @@ Value LazyGraphExecutor::GetIrValueForScalar(
   if (IsSpecialScalar(value)) {
     return MakeNode<Scalar>(value, type);
   }
-  return GetDeviceDataIrValue(value, type, device);
+  return GetDeviceDataIrValue(value, type, getBackend()->GetBackendDevice(c10::Device(c10::kCPU, 0)));
 }
 
 Value LazyGraphExecutor::GetIrValueForScalar(
@@ -543,26 +551,18 @@ Value LazyGraphExecutor::GetIrValueForScalar(
   return GetIrValueForScalar(value, value.type(), device);
 }
 
-Value LazyGraphExecutor::GetIrValueForScalar(
-    const at::Scalar& value,
-    c10::ScalarType type,
-    c10::ArrayRef<int64_t> dimensions,
+Value LazyGraphExecutor::GetIrValueForExpandedScalar(
+    const at::Scalar& value, const Shape& shape,
     const BackendDevice& device) {
+  c10::ArrayRef<int64_t> dimensions = shape.sizes();
+  auto type = shape.scalar_type();
   Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
-    ir_value = MakeNode<Expand>(
-        ir_value,
-        dimensions.vec(),
-        /*is_scalar_expand=*/true);
+      ir_value = MakeNode<Expand>(
+          ir_value, dimensions.vec(),
+          /*is_scalar_expand=*/true);
   }
   return ir_value;
-}
-
-Value LazyGraphExecutor::GetIrValueForScalar(
-    const at::Scalar& value,
-    const Shape& shape,
-    const BackendDevice& device) {
-  return GetIrValueForScalar(value, shape.scalar_type(), shape.sizes(), device);
 }
 
 LazyGraphExecutor::Async::Async(

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 
+#include <aten/src/ATen/ops/scalar_tensor.h>
 #include <c10/util/Logging.h>
 #include <torch/csrc/lazy/core/config.h>
 #include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -1,6 +1,6 @@
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 
-#include <aten/src/ATen/ops/scalar_tensor.h>
+#include <ATen/ScalarOps.h>
 #include <c10/util/Logging.h>
 #include <torch/csrc/lazy/core/config.h>
 #include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -96,12 +96,14 @@ class TORCH_API LazyGraphExecutor {
   Value GetIrValueForScalar(
       const at::Scalar& value,
       const BackendDevice& device);
-  Value GetIrValueForScalar(
-      const at::Scalar& value,
-      c10::ScalarType type,
-      c10::ArrayRef<int64_t> dimensions,
-      const BackendDevice& device);
-  Value GetIrValueForScalar(
+
+  // TODO: even though this API is currently used **only** in codegen to
+  // generate real scalar IR values vs scalar tensors, we would like to
+  // use it in other cases where `GetIrValueForXXXScalar` is used, as well
+  // In order to do that, we need to untangle the cases where we don't need
+  // `expand` and where we don't expect a scalar tensor
+  Value GetIrValueForScalarFromCodegen(const at::Scalar& value);
+  Value GetIrValueForExpandedScalar(
       const at::Scalar& value,
       const Shape& shape,
       const BackendDevice& device);

--- a/torch/csrc/lazy/core/tensor.cpp
+++ b/torch/csrc/lazy/core/tensor.cpp
@@ -487,8 +487,12 @@ LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
 }
 
 LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device) {
-  return tensor.unsafeGetTensorImpl()->is_wrapped_number() ?
-      GetOrCreateLtcTensor(tensor, device) : GetLtcTensor(tensor);
+  // TODO: There are places in core where a scalar is wrapped but not marked as
+  // wrapped.
+  return (tensor.unsafeGetTensorImpl()->is_wrapped_number() ||
+          (tensor.dim() == 0 && tensor.numel() == 1))
+             ? GetOrCreateLtcTensor(tensor, device)
+             : GetLtcTensor(tensor);
 }
 
 at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor) {

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -181,26 +181,26 @@ class TORCH_API LazyTensor {
 // Section 1: at::Tensor => LazyTensor.
 // Extracts the LazyTensor out of an at::Tensor. Returns a null LazyTensor
 // if the tensor is not a lazy tensor.
-LazyTensor TryGetLtcTensor(const at::Tensor& tensor);
+TORCH_API LazyTensor TryGetLtcTensor(const at::Tensor& tensor);
 
 // Extracts the LazyTensor out of an at::Tensor. Throws an exception
 // if the tensor is not a lazy tensor.
-LazyTensor GetLtcTensor(const at::Tensor& tensor);
+TORCH_API LazyTensor GetLtcTensor(const at::Tensor& tensor);
 
 // Same as above, applied to a list of tensors.
-std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
+TORCH_API std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
 
 // If tensor is a lazy tensor type, returns the LazyTensor embedded within it,
 // otherwise creates a new lazy tensor type with tensor as data.
-LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
+TORCH_API LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
                                 const BackendDevice& device);
 
-LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device);
+TORCH_API LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device);
 
 // Section 2: LazyTensor => at::Tensor.
 // Creates an ATen tensor from an LazyTensor.
-at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor);
-at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor);
+TORCH_API at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor);
+TORCH_API at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor);
 
 template <size_t... Indices>
 auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70867

Summary:
This commit syncs LazyGraphExecutor and LazyTensor with the staging branch's
latest changes.

Test Plan:
CI in the lazy_tensor_staging branch.

Differential Revision: [D33440005](https://our.internmc.facebook.com/intern/diff/D33440005)