### PR TITLE
ci: Make linux.*xlarge non-ephemeral

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -5,6 +5,9 @@
 #
 # NOTE (Apr, 5, 2021): Linux runners are currently all an amazonlinux2
 #
+# NOTE (Jan 5, 2021): Linux runners are all non-ephemeral to reduce the amount of CreateInstaces calls
+#                     to avoid RequestLimitExceeded issues
+#
 # TODO: Add some documentation on how the auto-scaling works
 #
 # NOTE: Default values,
@@ -29,10 +32,13 @@ runner_types:
     os: linux
     max_available: 500
     disk_size: 150
-  linux.4xlarge:
+    is_ephemeral: false
+  linux.4xlarge: # for binary-builds
     instance_type: c5.4xlarge
     os: linux
+    max_available: 250
     disk_size: 150
+    is_ephemeral: false
   linux.8xlarge.nvidia.gpu:
     instance_type: g3.8xlarge
     os: linux


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70869

Makes linux runners non-ephemeral to reduce the amount of
CreateInstance calls that we have going towards AWS as well as to reduce
the amount of github API calls we make in order to create new instances.

Should help alleviate some of the queuing issues we may observe due to
AWS / Github rate limits

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33436874](https://our.internmc.facebook.com/intern/diff/D33436874)