### PR TITLE
Remove repeat test for types in test nn

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6269,9 +6269,9 @@ class TestNN(NNTestCase):
             output.mean().backward()
 
 
+    @skipIfRocm
     # For https://github.com/pytorch/pytorch/pull/1273
     # Almost identical to the above `test_Conv2d_naive_groups`
-    @skipIfRocm
     def test_Conv2d_groups_nobias(self):
         dev_dtypes = [("cpu", torch.float)]
         if TEST_CUDA:
@@ -13098,11 +13098,11 @@ class TestNNDeviceType(NNTestCase):
         torch.cuda.synchronize()
 
 
+    @onlyCUDA
+    @tf32_on_and_off(0.01)
+    @dtypes(*ALL_TENSORTYPES)
     # Very similar to test_Conv2d_naive_groups but with special care to handle
     # the number of groups == number of input channels
-    @onlyCUDA
-    @dtypes(*ALL_TENSORTYPES)
-    @tf32_on_and_off(0.01)
     def test_Conv2d_depthwise_naive_groups(self, device, dtype):
         for depth_multiplier in [1, 2]:
             m = nn.Conv2d(2, 2 * depth_multiplier, kernel_size=3, groups=2).to(device, dtype)

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -755,14 +755,6 @@ def process_intentional_test_runs(runs: List[TestCase]) -> Tuple[int, int]:
             num_pass += 1
 
     REPEAT_TEST_FOR_TYPES_TESTS = [
-        "test_Conv2d_deterministic_cudnn ",
-        "test_Conv2d_large_workspace",
-        "test_ConvTranspose2d_large_output_padding",
-        "test_Conv2d_depthwise_naive_groups_cuda",
-        "test_Conv3d_depthwise_naive_groups_cuda",
-        "test_noncontig_conv_grad_cuda",
-        "test_batchnorm_large_batch",
-        "test_conv_double_backward_cuda",
         "test_data_parallel_module",
         "test_data_parallel_module_kwargs_only",
         "test_data_parallel_module_kwargs_only_empty_list",


### PR DESCRIPTION
Helps fix a part of #69865

The first commit just migrates everything as is. 

The second commit uses the "device" variable instead of passing "cuda" everywhere