### PR TITLE
reduce plan generation log spam

### DIFF
--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -732,7 +732,7 @@ class AdagradOptimizer(Optimizer):
             self._aux_params.shared.append(iteration)
 
         if self.rowWise:
-            logger.info(
+            logger.debug(
                 "Using engine {} for rowWise Adagrad to train param {}".format(
                     self.engine, param
                 )
@@ -760,7 +760,7 @@ class AdagradOptimizer(Optimizer):
                     value=0.0,
                 )
         else:
-            logger.info(
+            logger.debug(
                 "Using engine {} for regular Adagrad to train param {}".format(
                     self.engine, param
                 )
@@ -926,14 +926,14 @@ class AdagradOptimizer(Optimizer):
             # Skip weight decay for 1d parameters
             if len(param_shape) == 1:
                 weight_decay = 0.0
-                logger.warn(
+                logger.warning(
                     "SKIPPING weight decay on 1d dense param: {}.shape is {}".format(
                         str(param), param_shape
                     )
                 )
             else:
                 weight_decay = self.weight_decay
-        logger.info(
+        logger.debug(
             "weight_decay for {} (shape:{}): {}".format(
                 str(param), param_shape, weight_decay
             )
@@ -967,7 +967,7 @@ class AdagradOptimizer(Optimizer):
                     input_args += [mask_blob, mask_changed_blob]
                 else:
                     op = "SparseAdagrad"
-            logger.info("using {} for {}".format(op, str(param)))
+            logger.debug("using {} for {}".format(op, str(param)))
 
             if self.prune_delays:
                 input_args += [lr_iteration, last_mask_updated_iter]


### PR DESCRIPTION
Summary: Change loglevel to `debug` in caffe2 `optimizer.py` for logging rowwise Adagrad engine.

Test Plan: CI + sandcastle

Differential Revision: D33439337

