### PR TITLE
Speed up quantized upsampling for channels last

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -1981,6 +1981,9 @@ void qupsample_bilinear2d_nhwc_kernel(
         const auto rwidth = area_pixel_compute_scale<float>(
             input_width, output_width, align_corners, scales_w);
 
+        const int64_t input_q_zero_point = input.q_zero_point();
+        const int64_t output_q_zero_point = output.q_zero_point();
+
         for (const auto b : c10::irange(nbatch)) {
           auto* i_p = reinterpret_cast<typename scalar_t::underlying*>(
               idata + b * input_height * input_width * channels);
@@ -2021,8 +2024,8 @@ void qupsample_bilinear2d_nhwc_kernel(
                   output_height,
                   output_width,
                   channels,
-                  output.q_zero_point(),
-                  input.q_zero_point(),
+                  output_q_zero_point,
+                  input_q_zero_point,
                   inverse_scale,
                   h0lambda,
                   h1lambda,
@@ -2040,8 +2043,8 @@ void qupsample_bilinear2d_nhwc_kernel(
                          w1lambda * pos1[(h1p * input_width + w1p) * channels]);
                 pos2[0] = at::native::quantize_val<scalar_t>(
                               inverse_scale,
-                              output.q_zero_point(),
-                              result - input.q_zero_point())
+                              output_q_zero_point,
+                              result - input_q_zero_point)
                               .val_;
                 pos1 += 1;
                 pos2 += 1;


### PR DESCRIPTION
Moving the calls to `q_zero_point()` outside the for loop considerably
speeds up upsampling for channels last format.

This fix is very similar to https://github.com/pytorch/pytorch/pull/66525 but applies it for channels last format.

Fixes #70902
