### PR TITLE
[quant] Add QuantizedLSTM class

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2437,7 +2437,7 @@ class TestQuantizedOps(TestCase):
                 torch.nn.LSTM: torch.nn.quantizable.LSTM
             },
             'observed_to_quantized_custom_module_class': {
-                torch.nn.quantizable.LSTM: torch.nn.quantizable.LSTM
+                torch.nn.quantizable.LSTM: torch.nn.quantized.LSTM
             }
         }
 

--- a/torch/nn/quantizable/modules/activation.py
+++ b/torch/nn/quantizable/modules/activation.py
@@ -1,7 +1,7 @@
 import torch
+import torch.jit
 from torch import nn
 import torch.nn.functional as nnF
-import torch.nn.quantized as nnq
 
 from torch import Tensor
 from typing import Optional, Tuple
@@ -73,7 +73,7 @@ class MultiheadAttention(nn.MultiheadAttention):
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias, **factory_kwargs)  # type: ignore[assignment]
 
         # Functionals
-        self.q_scaling_product = nnq.FloatFunctional()
+        self.q_scaling_product = torch.nn.quantized.FloatFunctional()
 
         # Quant/Dequant
         self.quant_attn_output = torch.ao.quantization.QuantStub()

--- a/torch/nn/quantizable/modules/rnn.py
+++ b/torch/nn/quantizable/modules/rnn.py
@@ -380,5 +380,8 @@ class LSTM(torch.nn.Module):
 
     @classmethod
     def from_observed(cls, other):
-        return torch.ao.quantization.convert(other, inplace=False,
-                                             remove_qconfig=True)
+        # The whole flow is float -> observed -> quantized
+        # This class does float -> observed only
+        raise NotImplementedError("It looks like you are trying to convert a "
+                                  "non-quantizable LSTM module. Please, see "
+                                  "the examples on quantizable LSTMs.")

--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -9,6 +9,7 @@ from .conv import _ConvNd, Conv1d, Conv2d, Conv3d
 from .conv import ConvTranspose1d, ConvTranspose2d, ConvTranspose3d
 from .linear import Linear
 from .embedding_ops import Embedding, EmbeddingBag
+from .rnn import LSTM
 
 from .functional_modules import FloatFunctional, FXFloatFunctional, QFunctional
 
@@ -109,6 +110,7 @@ __all__ = [
     'LayerNorm',
     'LeakyReLU',
     'Linear',
+    'LSTM',
     'MaxPool2d',
     'Quantize',
     'ReLU6',

--- a/torch/nn/quantized/modules/rnn.py
+++ b/torch/nn/quantized/modules/rnn.py
@@ -1,0 +1,44 @@
+import torch
+
+class LSTM(torch.nn.quantizable.LSTM):
+    r"""A quantized long short-term memory (LSTM).
+
+    For the description and the argument types, please, refer to :class:`~torch.nn.LSTM`
+
+    Attributes:
+        layers : instances of the `_LSTMLayer`
+
+    .. note::
+        To access the weights and biases, you need to access them per layer.
+        See examples in :class:`~torch.nn.quantizable.LSTM`
+
+    Examples::
+
+        >>> custom_module_config = {
+        ...     'float_to_observed_custom_module_class': {
+        ...         nn.LSTM: nn.quantizable.LSTM,
+        ...     },
+        ...     'observed_to_quantized_custom_module_class': {
+        ...         nn.quantizable.LSTM: nn.quantized.LSTM,
+        ...     }
+        ... }
+        >>> tq.prepare(model, prepare_custom_module_class=custom_module_config)
+        >>> tq.convert(model, convert_custom_module_class=custom_module_config)
+    """
+    _FLOAT_MODULE = torch.nn.quantizable.LSTM
+
+    def _get_name(self):
+        return 'QuantizedLSTM'
+
+    @classmethod
+    def from_float(cls, *args, **kwargs):
+        # The whole flow is float -> observed -> quantized
+        # This class does observed -> quantized only
+        raise NotImplementedError("It looks like you are trying to convert a "
+                                  "non-observed LSTM module. Please, see "
+                                  "the examples on quantizable LSTMs.")
+
+    @classmethod
+    def from_observed(cls, other):
+        return torch.ao.quantization.convert(other, inplace=False,
+                                             remove_qconfig=True)


### PR DESCRIPTION
Summary:
The nn.LSTM is quantized through the custom module mechanism, which uses the nn.quantizable.LSTM for both observed and quantized paths. This is potentially a source of confusion. This creates a `quantized.LSTM` class, which completely takes the quantized path. Note that after this, the old usage will throw an error.

New way of using it:

```
>>> custom_module_config = {
...     'float_to_observed_custom_module_class': {
...         nn.LSTM: nn.quantizable.LSTM,
...     },
...     'observed_to_quantized_custom_module_class': {
...         nn.quantizable.LSTM: nn.quantized.LSTM,
...     }
... }
>>> tq.prepare(model, prepare_custom_module_class=custom_module_config)
>>> tq.convert(model, convert_custom_module_class=custom_module_config)
```

Test Plan: `python test/test_quantization.py`

Differential Revision: D33451338

