### PR TITLE
FX quant: allow duplicate named_modules during fbgemm lowering

### DIFF
--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -28,7 +28,7 @@ def _lower_weighted_ref_module(model: QuantizedGraphModule, ref_class: Type[torc
     pattern = (torch.quantize_per_tensor,
                (ref_class, "dequantize"),
                MatchAllNode, MatchAllNode, MatchAllNode)
-    modules = dict(model.named_modules())
+    modules = dict(model.named_modules(remove_duplicate=False))
     nodes = list(model.graph.nodes)
     # TODO: maybe orgnize this better (e.g. break down to more functions)
     # to make this function more readable


### PR DESCRIPTION
Summary:
Earlier, when replacing deq-ref-quant modules, we get non-duplicate
named modules only. When model contains dupicate names, the lowering fails the
second time.
This PR allows duplicates when getting the named modules.

Test Plan: buck test //caffe2/torch/fb/model_transform/quantization/tests:fx_quant_api_test

Differential Revision: D33440028

