### PR TITLE
Space issue + docs + macos scipy + macos mkl + asan + ios_arm64

### DIFF
--- a/.circleci/cimodel/data/simple/ios_definitions.py
+++ b/.circleci/cimodel/data/simple/ios_definitions.py
@@ -62,9 +62,9 @@ class IOSJob:
 
 WORKFLOW_DATA = [
     IOSJob(XCODE_VERSION, ArchVariant("x86_64"), is_org_member_context=False),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64")),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "metal"), extra_props={"use_metal": miniutils.quote(str(int(True)))}),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "custom"), extra_props={"op_list": "mobilenetv2.yaml"}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64")),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "metal"), extra_props={"use_metal": miniutils.quote(str(int(True)))}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "custom"), extra_props={"op_list": "mobilenetv2.yaml"}),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7240,26 +7240,6 @@ workflows:
           ios_arch: x86_64
           ios_platform: SIMULATOR
           name: pytorch_ios_12_0_0_x86_64_build
-      - pytorch_ios_build:
-          build_environment: pytorch-ios-12.0.0-arm64_build
-          context: org-member
-          ios_arch: arm64
-          ios_platform: OS
-          name: pytorch_ios_12_0_0_arm64_build
-      - pytorch_ios_build:
-          build_environment: pytorch-ios-12.0.0-arm64_metal_build
-          context: org-member
-          ios_arch: arm64
-          ios_platform: OS
-          name: pytorch_ios_12_0_0_arm64_metal_build
-          use_metal: "1"
-      - pytorch_ios_build:
-          build_environment: pytorch-ios-12.0.0-arm64_custom_build
-          context: org-member
-          ios_arch: arm64
-          ios_platform: OS
-          name: pytorch_ios_12_0_0_arm64_custom_build
-          op_list: mobilenetv2.yaml
       - pytorch_linux_build:
           build_environment: pytorch-linux-xenial-py3-clang5-mobile-build
           build_only: "1"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,12 +8,13 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
+export VC_YEAR=2019
 
-if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
-  export VC_YEAR=2017
-else
-  export VC_YEAR=2019
-fi
+# if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+#   export VC_YEAR=2017
+# else
+#   export VC_YEAR=2019
+# fi
 
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -19,6 +19,41 @@ if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"
 fi
 
+echo "Free Space for CUDA DEBUG BUILD"
+if [[ "$CIRCLECI" == 'true' ]]; then
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft.NET" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft.NET"
+    fi
+
+    if [[ -d "C:\\Program Files\\dotnet" ]]; then
+        rm -rf "C:\\Program Files\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\dotnet" ]]; then
+        rm -rf "C:\\Program Files (x86)\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft SQL Server" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft SQL Server"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Xamarin" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Xamarin"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Google" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Google"
+    fi
+fi
+
 set +x
 export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}
 export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,13 +8,12 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
-export VC_YEAR=2019
 
-# if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
-#   export VC_YEAR=2017
-# else
-#   export VC_YEAR=2019
-# fi
+if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+  export VC_YEAR=2017
+else
+  export VC_YEAR=2019
+fi
 
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -21,10 +21,6 @@ fi
 
 echo "Free Space for CUDA DEBUG BUILD"
 if [[ "$CIRCLECI" == 'true' ]]; then
-    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
-        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
-    fi
-
     if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
         rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
     fi

--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -19,8 +19,14 @@ if [ ! -d "${WORKSPACE_DIR}/miniconda3" ]; then
   retry bash ${WORKSPACE_DIR}/miniconda3.sh -b -p ${WORKSPACE_DIR}/miniconda3
 fi
 export PATH="${WORKSPACE_DIR}/miniconda3/bin:$PATH"
-source ${WORKSPACE_DIR}/miniconda3/bin/activate
-retry conda install -y mkl mkl-include numpy=1.18.5 pyyaml=5.3 setuptools=46.0.0 cmake cffi ninja typing_extensions dataclasses
+# shellcheck disable=SC1091
+source "${WORKSPACE_DIR}"/miniconda3/bin/activate
+
+# NOTE: mkl 2021.3.0+ cmake requires sub-command PREPEND, may break the build
+retry conda install -y \
+  mkl=2021.2.0 mkl-include=2021.2.0 \
+  numpy=1.18.5 pyyaml=5.3 setuptools=46.0.0 \
+  cmake cffi ninja typing_extensions dataclasses
 
 # The torch.hub tests make requests to GitHub.
 #

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil
+pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil "scipy==1.6.3"
 
 # TODO move this to docker
 pip install unittest-xml-reporting pytest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==2.4.4
+docutils==0.16
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -20,6 +20,10 @@ change. This file contains two types of randomized tests:
    it's fine to increment the seed of the failing test (but you shouldn't need
    to increment it more than once; otherwise something is probably actually
    wrong).
+
+3. `test_geometric_sample`, `test_binomial_sample` and `test_poisson_sample`
+   are validated against `scipy.stats.` which are not guaranteed to be identical
+   across different versions of scipy (namely, they yield invalid results in 1.7+)
 """
 
 import math

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -21,7 +21,7 @@ from torch.utils.data.dataset import random_split
 from torch._utils import ExceptionWrapper
 from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS,
                                                   IS_PYTORCH_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
-                                                  load_tests, TEST_WITH_ROCM, TEST_WITH_TSAN, IS_SANDCASTLE)
+                                                  load_tests, TEST_WITH_ROCM, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE)
 
 try:
     import psutil

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -769,6 +769,9 @@ class BulkLoadingSampler(torch.utils.data.Sampler):
     TEST_WITH_TSAN,
     "Fails with TSAN with the following error: starting new threads after multi-threaded "
     "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223")
 class TestDataLoader(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Cuda 111 space error fix. docutils pinned 0.16 since latest version 0.17 has issues with sphinx.

scipy on macos fix to 1.6.3 since some distribution tests fail with scripy 1.7. Master branch does the same in PR 64922. 

pin macos mkl conda version to fix the cmake build. Master branch does the same on PR 61773. 

cherry-pick commit https://github.com/pytorch/pytorch/commit/9d13ae450a24a16e848ef35fc08a7f9d40571886 which skips all data loader tests with asan. This is due to flaky tests as noted in issue 66223.

remove ios arm64 tests since arm64 is not supported.
