### PR TITLE
Remove obsolete 'dataclasses' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ setuptools
 six
 types-dataclasses
 typing_extensions
-dataclasses; python_version<"3.7"


### PR DESCRIPTION
Since [Python 3.6 was deprecated](https://github.com/pytorch/pytorch/pull/70493) and Python 3.7 has `dataclasses` as a [part of std library](https://docs.python.org/3/library/dataclasses.html), we don't need them as a dependency anymore.