### PR TITLE
[LTC] Export torch::lazy::GetBackendDevice()

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -530,7 +530,8 @@ test_lazy_tensor_core() {
   ln -sf "$TORCH_LIB_DIR"/libc10* torch/lib/
   ln -sf "$PWD"/lazy_tensor_core/build/lib.linux-x86_64-3.7/_LAZYC.cpython-37m-x86_64-linux-gnu.so lazy_tensor_core/build/lib.linux-x86_64-3.7/libptltc.so
   lazy_tensor_core/test/cpp/build/test_ptltc
-  python lazy_tensor_core/example.py
+  # this example script does not run on CI (import error)
+  #python lazy_tensor_core/example.py
   assert_git_not_dirty
 }
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -530,6 +530,7 @@ test_lazy_tensor_core() {
   ln -sf "$TORCH_LIB_DIR"/libc10* torch/lib/
   ln -sf "$PWD"/lazy_tensor_core/build/lib.linux-x86_64-3.7/_LAZYC.cpython-37m-x86_64-linux-gnu.so lazy_tensor_core/build/lib.linux-x86_64-3.7/libptltc.so
   lazy_tensor_core/test/cpp/build/test_ptltc
+  python lazy_tensor_core/example.py
   assert_git_not_dirty
 }
 

--- a/test/cpp/lazy/test_backend_device.cpp
+++ b/test/cpp/lazy/test_backend_device.cpp
@@ -95,6 +95,7 @@ TEST(BackendDeviceTest, GetBackendDevice1) {
 TEST(BackendDeviceTest, GetBackendDevice2) {
   auto tensor1 = torch::rand({0, 1, 3, 0});
   auto tensor2 = torch::rand({0, 1, 3, 0});
+  // TODO(alanwaketan): Cover the test case for GetBackendDevice().
   EXPECT_FALSE(GetBackendDevice(tensor1, tensor2));
 }
 

--- a/torch/csrc/lazy/backend/backend_device.h
+++ b/torch/csrc/lazy/backend/backend_device.h
@@ -62,7 +62,7 @@ TORCH_API c10::Device backendDeviceToAtenDevice(const BackendDevice& device);
 TORCH_API c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor);
 
 // For variadic template.
-c10::optional<BackendDevice> GetBackendDevice();
+TORCH_API c10::optional<BackendDevice> GetBackendDevice();
 
 template<typename T, typename... Args>
 c10::optional<BackendDevice> GetBackendDevice(const T& tensor, const Args&... forward_tensors) {


### PR DESCRIPTION
Summary:
This commit exports torch::lazy::GetBackendDevice().

Test Plan:
python lazy_tensor_core/example.py
