### PR TITLE
[LTC] Export torch::lazy::GetBackendDevice()

### DIFF
--- a/test/cpp/lazy/test_backend_device.cpp
+++ b/test/cpp/lazy/test_backend_device.cpp
@@ -95,6 +95,7 @@ TEST(BackendDeviceTest, GetBackendDevice1) {
 TEST(BackendDeviceTest, GetBackendDevice2) {
   auto tensor1 = torch::rand({0, 1, 3, 0});
   auto tensor2 = torch::rand({0, 1, 3, 0});
+  // TODO(alanwaketan): Cover the test case for GetBackendDevice().
   EXPECT_FALSE(GetBackendDevice(tensor1, tensor2));
 }
 

--- a/torch/csrc/lazy/backend/backend_device.h
+++ b/torch/csrc/lazy/backend/backend_device.h
@@ -62,7 +62,7 @@ TORCH_API c10::Device backendDeviceToAtenDevice(const BackendDevice& device);
 TORCH_API c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor);
 
 // For variadic template.
-c10::optional<BackendDevice> GetBackendDevice();
+TORCH_API c10::optional<BackendDevice> GetBackendDevice();
 
 template<typename T, typename... Args>
 c10::optional<BackendDevice> GetBackendDevice(const T& tensor, const Args&... forward_tensors) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70963

Summary:
This commit exports torch::lazy::GetBackendDevice().

Test Plan:
CI in the lazy_tensor_staging branch.

Differential Revision: [D33468938](https://our.internmc.facebook.com/intern/diff/D33468938)