### PR TITLE
[quant] Remove some redundant entries in backend_config_dict for TensorRT

### DIFF
--- a/test/fx2trt/test_quant_trt.py
+++ b/test/fx2trt/test_quant_trt.py
@@ -727,15 +727,18 @@ class TestQuantizeFxTRTOps(QuantizationTestCase):
         self.checkGraphModuleNodes(m.standalone, expected_node_occurrence=standalone_node_occurrence)
         m = _convert_fx_do_not_use(m, is_reference=True, backend_config_dict=backend_config_dict)
         node_occurrence = {
-            ns.call_function(torch.quantize_per_tensor): 3,
+            # two inputs for standalone module
+            ns.call_function(torch.quantize_per_tensor): 2,
             ns.call_module(nn.Conv2d): 1,
             ns.call_method("dequantize"): 1,
         }
         self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
         standalone_node_occurrence = {
+            # output for the pattern in standalone module
             ns.call_function(torch.quantize_per_tensor): 1,
             ns.call_module(nn.Conv2d): 1,
             ns.call_module(torch.nn.ReLU): 1,
+            # two input and one output for the pattern in standalone module
             ns.call_method("dequantize"): 3,
         }
         self.checkGraphModuleNodes(m.standalone, expected_node_occurrence=standalone_node_occurrence)

--- a/torch/ao/quantization/fx/backend_config/tensorrt.py
+++ b/torch/ao/quantization/fx/backend_config/tensorrt.py
@@ -64,8 +64,6 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse2(nni.LinearReLU),
-        "root_module": torch.nn.Linear,
-        "reference_quantized_module_for_root": torch.nn.quantized._reference.Linear,
     }
     linear_relu_mf_config = {
         "pattern": (torch.nn.functional.relu, torch.nn.Linear),
@@ -74,8 +72,6 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse2(nni.LinearReLU),
-        "root_module": torch.nn.Linear,
-        "reference_quantized_module_for_root": torch.nn.quantized._reference.Linear,
     }
 
     linear_relu_fused_config = {
@@ -161,8 +157,6 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse2(nni.ConvReLU2d),
-        "root_module": torch.nn.Conv2d,
-        "reference_quantized_module_for_root": torch.nn.quantized._reference.Conv2d,
     }
     conv2d_relu_mm_config = {
         "pattern": (torch.nn.ReLU, torch.nn.Conv2d),
@@ -171,8 +165,6 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse2(nni.ConvReLU2d),
-        "root_module": torch.nn.Conv2d,
-        "reference_quantized_module_for_root": torch.nn.quantized._reference.Conv2d,
     }
     addmm_config = {
         "pattern": torch.addmm,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #70971
* #70964

Summary:
"root_module" and "reference_quantized_module_for_root" are only used in convert, removed
them for fused module and qat module swapping configurations
We may be able to remove some other fields as well.

Test Plan:

python test/fx2trt/test_quant_trt.py TestQuantizeFxTRTOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D33470739](https://our.internmc.facebook.com/intern/diff/D33470739)