### PR TITLE
[Model Averaging] Update the documentation of PeriodicModelAverager

### DIFF
--- a/torch/distributed/algorithms/model_averaging/averagers.py
+++ b/torch/distributed/algorithms/model_averaging/averagers.py
@@ -68,7 +68,7 @@ class PeriodicModelAverager(ModelAverager):
         >>>  # After 100 steps, run model averaging every 4 steps.
         >>>  # Note that ``warmup_steps`` must be the same as ``start_localSGD_iter`` used in ``PostLocalSGDState``.
         >>>  averager = averagers.PeriodicModelAverager(period=4, warmup_steps=100)
-        >>>  for step in range(0, 20):
+        >>>  for step in range(0, 200):
         >>>     optimizer.zero_grad()
         >>>     loss = loss_fn(output, labels)
         >>>     loss.backward()


### PR DESCRIPTION
Here 20 is a bad example, since the warmup step is set as 100. 200 iterations will make much more sense.


cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang