### PR TITLE
[Pytree] Follow Deepmind dict flattening rules

### DIFF
--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -40,7 +40,10 @@ def _register_pytree_node(typ: Any, flatten_fn: FlattenFunc, unflatten_fn: Unfla
     SUPPORTED_NODES[typ] = NodeDef(flatten_fn, unflatten_fn)
 
 def _dict_flatten(d: Dict[Any, Any]) -> Tuple[List[Any], Context]:
-    return list(d.values()), list(d.keys())
+    # Follow the flattening rules of Deepmind tree flattening.
+    keys = list(sorted(d.keys()))
+    values = [d[key] for key in keys]
+    return values, keys
 
 def _dict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]:
     return {key: value for key, value in zip(context, values)}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71001


Currently PyTree and Deepmind tree flattening results in different ordering. This PR ensures that they result in same flattening order. The deepmind rules are defined here - https://github.com/deepmind/tree/blob/b493c398700cf7c98251a175a1ba5cf4fc653b04/tree/__init__.py#L205-L212

@Chillee 
Differential Revision: [D33478711](https://our.internmc.facebook.com/intern/diff/D33478711)