### PR TITLE
fix python version error

### DIFF
--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -19,7 +19,7 @@ class TestFunctionalAutogradBenchmark(TestCase):
         # is not allowed to open it again. As this is a simple smoke test, we choose for now
         # not to run this on windows and keep the code here simple.
         with tempfile.NamedTemporaryFile() as out_file:
-            cmd = ['python' if not does_python_refer_to_2 else 'python3', \
+            cmd = ['python' if not does_python_refer_to_2 else 'python3',
                    '../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py']
             # Only run the warmup
             cmd += ['--num-iters', '0']

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -19,7 +19,8 @@ class TestFunctionalAutogradBenchmark(TestCase):
         # is not allowed to open it again. As this is a simple smoke test, we choose for now
         # not to run this on windows and keep the code here simple.
         with tempfile.NamedTemporaryFile() as out_file:
-            cmd = ['python' if not does_python_refer_to_2 else 'python3', '../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py']
+            cmd = ['python' if not does_python_refer_to_2 else 'python3', \
+                   '../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py']
             # Only run the warmup
             cmd += ['--num-iters', '0']
             # Only run the vjp task (fastest one)

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -8,6 +8,8 @@ import os
 import unittest
 
 PYTORCH_COLLECT_COVERAGE = bool(os.environ.get("PYTORCH_COLLECT_COVERAGE"))
+pyvers = subprocess.run(['python','--version'], stderr=subprocess.PIPE, stdout=subprocess.PIPE).stderr.decode()
+does_python_refer_to_2 = str(pyvers).split(' ')[-1].split('.')[0] == '2'
 
 # This is a very simple smoke test for the functional autograd benchmarking script.
 class TestFunctionalAutogradBenchmark(TestCase):
@@ -17,7 +19,7 @@ class TestFunctionalAutogradBenchmark(TestCase):
         # is not allowed to open it again. As this is a simple smoke test, we choose for now
         # not to run this on windows and keep the code here simple.
         with tempfile.NamedTemporaryFile() as out_file:
-            cmd = ['python', '../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py']
+            cmd = ['python' if not does_python_refer_to_2 else 'python3', '../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py']
             # Only run the warmup
             cmd += ['--num-iters', '0']
             # Only run the vjp task (fastest one)

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -8,7 +8,7 @@ import os
 import unittest
 
 PYTORCH_COLLECT_COVERAGE = bool(os.environ.get("PYTORCH_COLLECT_COVERAGE"))
-pyvers = subprocess.run(['python','--version'], stderr=subprocess.PIPE, stdout=subprocess.PIPE).stderr.decode()
+pyvers = subprocess.run(['python', '--version'], stderr=subprocess.PIPE, stdout=subprocess.PIPE).stderr.decode()
 does_python_refer_to_2 = str(pyvers).split(' ')[-1].split('.')[0] == '2'
 
 # This is a very simple smoke test for the functional autograd benchmarking script.

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -8,8 +8,6 @@ import os
 import unittest
 
 PYTORCH_COLLECT_COVERAGE = bool(os.environ.get("PYTORCH_COLLECT_COVERAGE"))
-pyvers = subprocess.run(['python', '--version'], stderr=subprocess.PIPE, stdout=subprocess.PIPE).stderr.decode()
-does_python_refer_to_2 = str(pyvers).split(' ')[-1].split('.')[0] == '2'
 
 # This is a very simple smoke test for the functional autograd benchmarking script.
 class TestFunctionalAutogradBenchmark(TestCase):
@@ -19,7 +17,7 @@ class TestFunctionalAutogradBenchmark(TestCase):
         # is not allowed to open it again. As this is a simple smoke test, we choose for now
         # not to run this on windows and keep the code here simple.
         with tempfile.NamedTemporaryFile() as out_file:
-            cmd = ['python' if not does_python_refer_to_2 else 'python3',
+            cmd = ['python3',
                    '../benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py']
             # Only run the warmup
             cmd += ['--num-iters', '0']


### PR DESCRIPTION
if python3 is the one running the tests but there exists a "python" installed as python2.7 the test will fail with a syntax issue
