### PR TITLE
Prevent import race condition that leaves torch.package.PackagePickler with unwanted dispatch table entries.

### DIFF
--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -14,11 +14,18 @@ class PackagePickler(_Pickler):
     to find objects and modules to save.
     """
 
-    dispatch = _Pickler.dispatch.copy()
-
     def __init__(self, importer: Importer, *args, **kwargs):
         self.importer = importer
         super().__init__(*args, **kwargs)
+
+        # Make sure the dispatch table copied from _Pickler is up-to-date.
+        # Previous issues have been encountered where a library (e.g. dill)
+        # mutate _Pickler.dispatch, PackagePickler makes a copy when this lib
+        # is imported, then the offending library removes its dispatch entries,
+        # leaving PackagePickler with a stale dispatch table that may cause
+        # unwanted behavior.
+        self.dispatch = _Pickler.dispatch.copy()
+        self.dispatch[FunctionType] = PackagePickler.save_global
 
     def save_global(self, obj, name=None):
         # unfortunately the pickler code is factored in a way that
@@ -89,8 +96,6 @@ class PackagePickler(_Pickler):
                 ) from None
 
         self.memoize(obj)
-
-    dispatch[FunctionType] = save_global
 
 
 def create_pickler(data_buf, importer):


### PR DESCRIPTION
Summary:
TL;DR In come cases:
1) user imports `dill`, which mutates `_Pickler.dispatch`,
2) user imports lib that imports `torch.package`
3) `PackagePickler.dispatch = _Pickler.dispatch.copy()` makes a copy of the mutated table
4) user calls `dill.extend(use_dill=False)` to reset `_Pickler.dispatch`, expecting everything to be okay
5) `PackagePickler` is used to pickle something like `ModuleDict`. `PackagePickler.dispatch` has stale entries to dill pickle functions like `save_module_dict`, which sometimes hard-code calls to `StockPickler.save_global`, which is unaware of torch.package module prefixes.
6) Exception is raised, e.g. `Got unhandled exception Can't pickle <class '<torch_package_2>.caffe2.mylib'>: it's not found as <class '<torch_package_2>.caffe2.mylib'>`

Differential Revision: D33483672

