### PR TITLE
[fx2trt] Issue warnings instead of error if there's possible const folding opportunities

### DIFF
--- a/test/fx2trt/converters/acc_op/test_binary_ops.py
+++ b/test/fx2trt/converters/acc_op/test_binary_ops.py
@@ -9,19 +9,21 @@ from torch.testing._internal.common_fx2trt import AccTestCase, InputTensorSpec
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 
+NEED_TEST_BOTH_CONSTANTS_CASE = True
+
 elementwise_ops = [
-    ((lambda x, y: x + y), acc_ops.add),
-    ((lambda x, y: x - y), acc_ops.sub),
-    ((lambda x, y: x / y), acc_ops.div),
-    ((lambda x, y: x // y), acc_ops.floor_div),
-    ((lambda x, y: torch.div(x, y, rounding_mode="trunc")), acc_ops.trunc_div),
-    ((lambda x, y: torch.div(x, y, rounding_mode="floor")), acc_ops.floor_div),
-    ((lambda x, y: torch.div(x, y)), acc_ops.div),
+    ((lambda x, y: x + y), acc_ops.add, NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: x - y), acc_ops.sub, NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: x / y), acc_ops.div, NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: x // y), acc_ops.floor_div, NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: torch.div(x, y, rounding_mode="trunc")), acc_ops.trunc_div, not NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: torch.div(x, y, rounding_mode="floor")), acc_ops.floor_div, NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: torch.div(x, y)), acc_ops.div, NEED_TEST_BOTH_CONSTANTS_CASE),
     # torch.floor_divide rounds result toward zero, rather than -Inf.
     # https://github.com/pytorch/pytorch/issues/43874
-    ((lambda x, y: torch.floor_divide(x, y)), acc_ops.trunc_div),
-    ((lambda x, y: x * y), acc_ops.mul),
-    (torch.pow, acc_ops.pow),
+    ((lambda x, y: torch.floor_divide(x, y)), acc_ops.trunc_div, not NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: x * y), acc_ops.mul, NEED_TEST_BOTH_CONSTANTS_CASE),
+    (torch.pow, acc_ops.pow, not NEED_TEST_BOTH_CONSTANTS_CASE),
 ]
 
 
@@ -42,7 +44,7 @@ class TestBinaryOpConverters(AccTestCase):
         self.run_test(m, inputs, expected_ops={expected_op})
 
     @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops])
-    def test_elementwise_ops_constant(self, name, orig_op: Callable, expected_op):
+    def test_elementwise_ops_with_one_constant(self, name, orig_op: Callable, expected_op):
         class TestModule(nn.Module):
             def __init__(self, orig_op):
                 super().__init__()
@@ -56,6 +58,24 @@ class TestBinaryOpConverters(AccTestCase):
         m = TestModule(orig_op)
         inputs = [torch.randn(2, 2)]
         self.run_test(m, inputs, expected_ops={expected_op})
+
+    @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops if op[2]])
+    def test_elementwise_op_with_both_constants(self, name, orig_op: Callable, expected_op):
+        class TestModule(nn.Module):
+            def __init__(self, orig_op):
+                super().__init__()
+                self.constant0 = torch.nn.Parameter(torch.randn(1))
+                self.constant1 = torch.nn.Parameter(torch.randn(1))
+                self.orig_op = orig_op
+
+            def forward(self, x):
+                const = self.orig_op(self.constant0, self.constant1)
+                return self.orig_op(x, const)
+
+        m = TestModule(orig_op)
+        inputs = [torch.randn(2, 2)]
+        self.run_test(m, inputs, expected_ops={expected_op})
+
 
     @parameterized.expand(
         [

--- a/torch/fx/experimental/fx2trt/types.py
+++ b/torch/fx/experimental/fx2trt/types.py
@@ -9,6 +9,7 @@ if hasattr(trt, "__version__"):
     TRTPluginFieldCollection = trt.PluginFieldCollection
     TRTPlugin = trt.IPluginV2
     TRTDataType = trt.DataType
+    TRTElementWiseOp = trt.ElementWiseOperation
 else:
     TRTNetwork = "trt.INetworkDefinition"
     TRTTensor = "trt.tensorrt.ITensor"
@@ -16,6 +17,7 @@ else:
     TRTPluginFieldCollection = "trt.PluginFieldCollection"
     TRTPlugin = "trt.IPluginV2"
     TRTDataType = "trt.DataType"
+    TRTElementWiseOp = "trt.ElementWiseOperation"
 
 Shape = Sequence[int]
 ShapeRange = Tuple[Shape, Shape, Shape]


### PR DESCRIPTION
Summary: During the conversion stage, we might create some constants when size op is called and size is static. Raising error here causes problem for this case. Generally speaking it doesn't hurt to allow not const folding.

Test Plan: Test with D33483843

Differential Revision: D33484183

