### PR TITLE
Makes TORCH_VERSION C++ macro consistent with Python

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -84,15 +84,18 @@ endmacro()
 ################################################################################################
 # Parses a version string that might have values beyond major, minor, and patch
 # and set version variables for the library.
+# Values beyond the patch version are set to LIBNAME_VERSION_HASH.
 # Usage:
 #   caffe2_parse_version_str(<library_name> <version_string>)
 function(caffe2_parse_version_str LIBNAME VERSIONSTR)
   string(REGEX REPLACE "^([0-9]+).*$" "\\1" ${LIBNAME}_VERSION_MAJOR "${VERSIONSTR}")
   string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*$" "\\1" ${LIBNAME}_VERSION_MINOR  "${VERSIONSTR}")
   string(REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*$" "\\1" ${LIBNAME}_VERSION_PATCH "${VERSIONSTR}")
+  string(REGEX REPLACE "[0-9]+\\.[0-9]+\\.[0-9]+(.*)$" "\\1" ${LIBNAME}_VERSION_HASH "${VERSIONSTR}")
   set(${LIBNAME}_VERSION_MAJOR ${${LIBNAME}_VERSION_MAJOR} ${ARGN} PARENT_SCOPE)
   set(${LIBNAME}_VERSION_MINOR ${${LIBNAME}_VERSION_MINOR} ${ARGN} PARENT_SCOPE)
   set(${LIBNAME}_VERSION_PATCH ${${LIBNAME}_VERSION_PATCH} ${ARGN} PARENT_SCOPE)
+  set(${LIBNAME}_VERSION_HASH ${${LIBNAME}_VERSION_HASH} ${ARGN} PARENT_SCOPE)
   set(${LIBNAME}_VERSION "${${LIBNAME}_VERSION_MAJOR}.${${LIBNAME}_VERSION_MINOR}.${${LIBNAME}_VERSION_PATCH}" PARENT_SCOPE)
 endfunction()
 

--- a/tools/setup_helpers/gen_version_header.py
+++ b/tools/setup_helpers/gen_version_header.py
@@ -51,6 +51,10 @@ def main(args: argparse.Namespace) -> None:
         version = f.read().strip()
     (major, minor, patch) = parse_version(version)
 
+
+    # NOTE: intentionally doesn't define the TORCH_VERSION_HASH
+    #   macro because it's populated by the git commit hash and these
+    #   replacements only occur on BAZEL builds
     replacements = {
         "@TORCH_VERSION_MAJOR@": str(major),
         "@TORCH_VERSION_MINOR@": str(minor),

--- a/torch/csrc/api/include/torch/version.h.in
+++ b/torch/csrc/api/include/torch/version.h.in
@@ -9,6 +9,9 @@
 /// Indicates the patch version of LibTorch.
 #define TORCH_VERSION_PATCH @TORCH_VERSION_PATCH@
 
+/// Indicates the commit hash of LibTorch.
+#define TORCH_VERSION_HASH @TORCH_VERSION_HASH@
+
 /// Indicates the version of LibTorch.
 #define TORCH_VERSION \
-  "@TORCH_VERSION_MAJOR@.@TORCH_VERSION_MINOR@.@TORCH_VERSION_PATCH@"
+  "@TORCH_VERSION_MAJOR@.@TORCH_VERSION_MINOR@.@TORCH_VERSION_PATCH@@TORCH_VERSION_HASH@"


### PR DESCRIPTION
This update only applies to CMake builds. version.h after this change:

```
#pragma once

/// Indicates the major version of LibTorch.
#define TORCH_VERSION_MAJOR 1

/// Indicates the minor version of LibTorch.
#define TORCH_VERSION_MINOR 11

/// Indicates the patch version of LibTorch.
#define TORCH_VERSION_PATCH 0

/// Indicates the commit hash of LibTorch.
#define TORCH_VERSION_HASH a0+gitbc026c0

/// Indicates the version of LibTorch.
#define TORCH_VERSION \
  "1.11.0a0+gitbc026c0"
```

Printing `TORCH_VERSION` and `torch.__version__` now prints:

```
1.11.0a0+gitbc026c0
1.11.0a0+gitbc026c0
``` 