### PR TITLE
Optimize Lazy-Eager fallback

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -136,9 +136,10 @@ class DivAddMul(nn.Module):
     def __init__(self, dims, device='cuda', jit=False):
         super(DivAddMul, self).__init__()
         self.attention_head_size = dims[1]
+        self.W = torch.ones(*dims[-2:], device=device, dtype=torch.float32)
         self.name = "DivAddMul[" + ','.join([str(d) for d in dims]) + ']'
         self.example_inputs = (
-            torch.randn(*dims, device=device, dtype=torch.float32),
+            torch.ones(*dims, device=device, dtype=torch.float32),
             torch.randn(*dims, device=device, dtype=torch.float32),
         )
 
@@ -149,10 +150,11 @@ class DivAddMul(nn.Module):
         return self.name
 
     def forward(self, inputs, mask):
-        out1 = inputs / math.sqrt(self.attention_head_size)
-        out2 = out1 + mask
-        out3 = out2 * 5.0
-        return out3
+        out3 = ((inputs / 0.1) + mask) * 2.0
+        out5 = out3.matmul(self.W)
+        out8 = ((out5 / 0.1) + mask) * 2.00
+        return out8
+
 toy_models = [
     HardSwishBenchmark,
     DivAddMulBenchmark,

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -436,6 +436,17 @@ def lazy_compute_experiment(args, experiment, results, benchmark, lazy_benchmark
               f"{pvalue:.2e},{args.warmup},{args.repeat},{warmup_time:.2f},{bench_time:.2f}")
     return (speedup, pvalue)
 
+def just_run_once(args, lazy_benchmark):
+    torch.manual_seed(1337)
+    if args.test == 'eval':
+        model, example_inputs = lazy_benchmark.get_module()
+        results.append(call_model_with(model, example_inputs))
+    elif args.test == 'train':
+        lazy_benchmark.train(niter=1)
+    ltm.mark_step()
+    ltm.wait_device_ops()
+    if current_device == 'cuda':
+        torch.cuda.synchronize()
 
 def check_results_impl(correct_result, lazy_result):
     # recursive helper for dealing with nested data structures
@@ -574,6 +585,7 @@ if __name__ == "__main__" :
     parser.add_argument("--torchbench_dir", type=str, help="path to torchbenchmark repo")
     parser.add_argument("--output_dir", type=str, default=".", help="path to write output files")
     parser.add_argument("--dump_lazy_counters", action='store_true', help="dump lazy counter values after each timing run")
+    parser.add_argument("--just_run_once", action="store_true")
     parser.add_argument("--run_tracing_execute_noops", action='store_true',
                         help="Run the tracing portion only, with noop backend, useful for running under a profiler.")
     parser.add_argument("--run_in_subprocess", "-s", type=str, help="which model run in subprocess.This will ignore filter and exclude")
@@ -615,7 +627,10 @@ if __name__ == "__main__" :
                     run_tracing_execute_noops(args.test, lazy_benchmark)
                     # when profiling, we really don't want to do anything else
                     exit(0)
-
+                if args.just_run_once:
+                    just_run_once(args, lazy_benchmark)
+                    exit(0)
+                
                 with pick_grad(args, name):
                     with fuser(args.fuser) if args.fuser != 'noopt' else optimized_execution(False):
                         if args.fuser == 'noopt':

--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -397,7 +397,7 @@ std::vector<at::Tensor> LtcCreateTensorList(const at::TensorList& tensors) {
     }
   }
   auto defined_aten_ltc_tensors =
-      torch::lazy::LazyGraphExecutor::Get()->GetTensors(&ltc_tensors);
+      torch::lazy::LazyGraphExecutor::Get()->GetTensors(&ltc_tensors, /*use_current_thread=*/false);
   // Insert undefined tensors into the result, back into the original undefined
   // positions.
   for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Functions.h>
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/native/CPUFallback.h>
+#include <torch/csrc/lazy/core/lazy_graph_executor.h>
 #include <torch/library.h>
 
 namespace torch_lazy_tensors {
@@ -11,47 +12,37 @@ namespace {
 using torch::lazy::LazyTensor;
 using torch::lazy::GetLtcTensor;
 
-std::vector<at::Tensor> _to_eager(at::TensorList tensors,
-                                  c10::DeviceType device_type) {
-  switch (device_type) {
-    case at::kCPU: {
-      return at::_to_cpu(tensors);
-    }
-    default: {
-      std::vector<at::Tensor> eager_tensors;
-      for (const auto& t : tensors) {
-        c10::TensorOptions options = t.options().device(device_type);
-        at::Tensor eager_tensor = t.to(options,
-                                       /*non_blocking*/ false, /*copy*/ false);
-        eager_tensors.push_back(eager_tensor);
-      }
-      return eager_tensors;
-    }
-  }
-}
-
-// convenience helper for converting tensors to cpu
-
 std::vector<at::Tensor> to_eager(const at::TensorList& tensors,
-                                 c10::DeviceType device_type) {
-  // We can't just call _to_eager() on the entire list of Tensors because it
-  // will break on undefined tensors. Separate out undefined tensors first.
+                                 c10::DeviceType eager_device_type) {
+  // Tensors may originate on different devices, or be undefined.
+  // We identify the true 'lazy tensors' and transfer them as a group,
+  // and we avoid copying tensors already on the correct eager device.
   std::vector<at::Tensor> eager_tensors(tensors.size());
-  std::vector<at::Tensor> valid_tensors;
+  std::vector<LazyTensor> lazy_tensors;
   std::vector<bool> to_translate(tensors.size());
   for (size_t i = 0; i < tensors.size(); ++i) {
     const at::Tensor& tensor = tensors[i];
-    // Explicitly handling undefined tensors here instead of letting `_to_eager`
-    // handle it. Otherwise, we'd need to require all backends with their own
-    // implementation of _to_eager to properly handle undefined tensors.
-    if (tensor.defined()) {
-      to_translate[i] = true;
-      valid_tensors.push_back(tensor);
+
+    if (tensor.defined() && tensor.device().type() != eager_device_type) {
+      if (tensor.device().type() == c10::kLazy) {
+        to_translate[i] = true;
+        lazy_tensors.emplace_back(GetLtcTensor(tensor));
+      } else {
+        // Non-lazy tensors on the wrong device
+        // TODO(whc) when does this happen?
+        eager_tensors[i] = tensor.to(eager_device_type);
+      }
     } else {
+      // Undefined tensors or tensors already on the correct eager device
+      // can simply be left alone
+      // TODO(whc) is it really OK if undefined tensors on 'lazy' device are not .to'd?
       eager_tensors[i] = tensor;
     }
   }
-  auto eager_valid_tensors = _to_eager(valid_tensors, device_type);
+
+  // Transfer all the lazy tensors as one computation rather than calling .to on each one
+  auto eager_valid_tensors = LazyGraphExecutor::Get()->GetTensors(&lazy_tensors);
+
   for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {
     if (to_translate[i]) {
       eager_tensors[i] = std::move(eager_valid_tensors[defined_pos++]);
@@ -122,8 +113,7 @@ void eager_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack,
       tensorlist_args.push_back(ivalue.toTensorList());
     }
   }
-  // XLA requires all of the tensor arguments to be gathered up and converted to
-  // CPU together.
+
   auto eager_tensors = to_eager(tensor_args, device_type);
 
   for (auto i = 0; i < tensor_args_indices.size(); ++i) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
@@ -1,7 +1,6 @@
 #include "lazy_tensor_core/csrc/ts_backend/EagerFallback.h"
 
 #include <sstream>
-
 #include <ATen/Functions.h>
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/native/CPUFallback.h>
@@ -9,6 +8,8 @@
 
 namespace torch_lazy_tensors {
 namespace {
+using torch::lazy::LazyTensor;
+using torch::lazy::GetLtcTensor;
 
 std::vector<at::Tensor> _to_eager(at::TensorList tensors,
                                   c10::DeviceType device_type) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.cpp
@@ -11,9 +11,10 @@ namespace torch_lazy_tensors {
 namespace {
 using torch::lazy::LazyTensor;
 using torch::lazy::GetLtcTensor;
+using torch::lazy::LazyGraphExecutor;
 
 std::vector<at::Tensor> to_eager(const at::TensorList& tensors,
-                                 c10::DeviceType eager_device_type) {
+                                 c10::DeviceType eager_device_type, bool use_main_thread) {
   // Tensors may originate on different devices, or be undefined.
   // We identify the true 'lazy tensors' and transfer them as a group,
   // and we avoid copying tensors already on the correct eager device.
@@ -41,7 +42,7 @@ std::vector<at::Tensor> to_eager(const at::TensorList& tensors,
   }
 
   // Transfer all the lazy tensors as one computation rather than calling .to on each one
-  auto eager_valid_tensors = LazyGraphExecutor::Get()->GetTensors(&lazy_tensors);
+  auto eager_valid_tensors = LazyGraphExecutor::Get()->GetTensors(&lazy_tensors, use_main_thread);
 
   for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {
     if (to_translate[i]) {
@@ -84,7 +85,7 @@ c10::optional<c10::Device> compute_target_device(std::vector<at::Tensor>& t_args
 }  // namespace
 
 void eager_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack,
-                    c10::DeviceType device_type) {
+                    c10::DeviceType device_type, bool use_main_thread) {
   auto& schema_args = op.schema().arguments();
   const auto num_arguments = schema_args.size();
   auto arguments = torch::jit::last(stack, num_arguments);
@@ -108,13 +109,13 @@ void eager_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack,
       // TensorList args onto the CPU at the same time. We can improve this if
       // we need better perf for XLA's CPU fallbacks.
       auto eager_ivalue = c10::IValue(c10::List<at::Tensor>(
-          to_eager(ivalue.toTensorList().vec(), device_type)));
+          to_eager(ivalue.toTensorList().vec(), device_type, use_main_thread)));
       (*stack)[arguments_begin + idx] = std::move(eager_ivalue);
       tensorlist_args.push_back(ivalue.toTensorList());
     }
   }
 
-  auto eager_tensors = to_eager(tensor_args, device_type);
+  auto eager_tensors = to_eager(tensor_args, device_type,  use_main_thread);
 
   for (auto i = 0; i < tensor_args_indices.size(); ++i) {
     auto idx = tensor_args_indices[i];

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/EagerFallback.h
@@ -7,6 +7,6 @@
 namespace torch_lazy_tensors {
 
 void eager_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack,
-                    c10::DeviceType device_type);
+                    c10::DeviceType device_type, bool use_main_thread);
 
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -13,6 +13,17 @@ namespace torch_lazy_tensors {
 static std::unordered_map<std::string, ::torch::lazy::Counter*>
     _eager_fallback_counters;
 
+bool force_eager_fallback(c10::Symbol op) {
+  static char* force_str = std::getenv("LTC_FORCE_FALLBACK");
+  if (force_str != nullptr) {
+    static auto force_sym = c10::Symbol::fromQualString(std::string(force_str));
+    if (op == force_sym) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack) {
   LTC_FN_TRACK(3);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -42,6 +42,9 @@ void ltc_eager_fallback(const c10::OperatorHandle& op,
   auto& args = op.schema().arguments();
   auto arguments = torch::jit::last(stack, args.size());
 
+  // TODO(whc) why do we do this at all?  And if we want to log the tensors,
+  // why don't we log them after we have already transferred them to eager tensors
+  // inside `eager_fallback`?
   // Log each tensor argument.
   for (int64_t idx = 0; idx < arguments.size(); ++idx) {
     const auto& ivalue = arguments[idx];

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.cpp
@@ -54,8 +54,10 @@ void ltc_eager_fallback(const c10::OperatorHandle& op,
   }
 
   // Call the actual boxed CPU fallback.
+  // we definitely want to use the current thread here- it adds latency to hand off to a
+  // background thread for fallback
   eager_fallback(op, stack,
-                 torch::lazy::getBackend()->EagerFallbackDeviceType());
+                 torch::lazy::getBackend()->EagerFallbackDeviceType(), /*use_current_thread=*/true);
 }
 
 TORCH_LIBRARY_IMPL(_, Lazy, m) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
@@ -4,6 +4,7 @@
 
 namespace torch_lazy_tensors {
 
+bool force_eager_fallback(c10::Symbol op);
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/Operators.h>
 #include <ATen/native/CPUFallback.h>
 
 namespace torch_lazy_tensors {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h
@@ -5,6 +5,7 @@
 
 namespace torch_lazy_tensors {
 
+bool fallback_main_thread();
 bool force_eager_fallback(c10::Symbol op);
 void ltc_eager_fallback(const c10::OperatorHandle& op,
                         torch::jit::Stack* stack);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -384,6 +384,11 @@ at::Tensor & LazyNativeFunctions::normal_(at::Tensor & self, double mean, double
     // Unconditionally fall back.
     // implementing normal_ via lazy tensor caused differences in results compared to eager.
     return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
+    
+    // if (force_eager_fallback(c10::Symbol::fromQualString("aten::normal_"))) {
+    //   return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
+    // }
+
     // if (generator.has_value()) {
     //   return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
     // }

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -49,6 +49,22 @@ def node_ctor_inputs(schema: LazyIrSchema) -> str:
     node_ctor_values = [node_ctor_arg_rvalue_string(arg, schema) for arg in schema.filtered_types()]
     return ",\n                              ".join(node_ctor_values)
 
+def gen_fallback_code(schema: LazyIrSchema, overload_name: str) -> str:
+    """
+    Generate code that falls back to eager conditioned on a predicate
+    """
+    fallback_args = ",\n                ".join([arg.name for arg in schema.filtered_types()])
+    if len(overload_name):
+        aten_op_str = f"ATEN_OP2({schema.aten_name}, {overload_name})"
+    else:
+        aten_op_str = f"ATEN_OP({schema.aten_name})"
+    return f"""
+        if (force_eager_fallback({aten_symbol(schema)})) {{
+            return at::native::call_fallback_fn<&ltc_eager_fallback, {aten_op_str}>::call(
+                {fallback_args}
+            );
+        }}
+"""
 
 def aten_symbol(schema: LazyIrSchema) -> str:
     missing_interned_strings = {
@@ -178,6 +194,7 @@ class GenLazyNativeFuncDefinition:
         scalar_types = schema.filtered_types(values=False, scalars=True)
         returns_length = len(schema.returns)
 
+        fallback_str = gen_fallback_code(schema, overload_name=func.func.name.overload_name)
         value_types_names = ", ".join([f"{t.name}" for t in value_types])
         get_device_str = f"""auto device = torch::lazy::GetBackendDevice({value_types_names});"""
         lazy_tensor_decls_str = lazy_tensor_decls(value_types, self.tensor_class, schema)
@@ -223,6 +240,7 @@ class GenLazyNativeFuncDefinition:
         return [f"""\
     // TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
     {sig.decl(name=f"{self.class_method_name}::{schema.aten_name}")} {{
+        {fallback_str}
         TORCH_LAZY_FN_COUNTER("lazy::");
         {get_device_str}
         {lazy_tensor_decls_str}

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -160,10 +160,12 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     fm.write_with_template(f'{backend_key}NativeFunctions.cpp', 'DispatchKeyNativeFunctions.cpp', lambda: {
         'includes': [f'#include <{path}>' for path in [
             tensor_class_hdr,
+            "ATen/Functions.h",
             "ATen/MetaFunctions.h",
             "torch/csrc/lazy/core/lazy_graph_executor.h",
             "torch/csrc/lazy/core/metrics.h",
             "torch/csrc/lazy/core/shape.h",
+            "lazy_tensor_core/csrc/ts_backend/aten_eager_fallback.h",
             f"{output_dir}/{backend_key}NativeFunctions.h",
             f"{output_dir}/{backend_key}LazyIr.h",
             f"{output_dir}/{backend_key}ShapeInference.h",

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -77,7 +77,8 @@ class TORCH_API LazyGraphExecutor {
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.
-  std::vector<at::Tensor> GetTensors(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensors(std::vector<LazyTensor>* tensors,
+                                     bool use_current_thread);
 
   size_t IncTrimCounter();
 
@@ -194,7 +195,8 @@ class TORCH_API LazyGraphExecutor {
   std::shared_ptr<Async> TryRunCachedSync(
       std::vector<LazyTensor>* tensors,
       SyncTensorCollection* coll,
-      PostOrderData* po_data);
+      PostOrderData* po_data,
+      bool use_current_thread);
 
   CompilationResult Compile(
       const std::vector<LazyTensor>& tensors,
@@ -214,7 +216,8 @@ class TORCH_API LazyGraphExecutor {
   std::shared_ptr<Async> SyncTensorsGraphInternal(
       std::vector<LazyTensor>* tensors,
       c10::ArrayRef<std::string> devices,
-      const SyncTensorsConfig& config);
+      const SyncTensorsConfig& config,
+      bool use_current_thread);
 
   // Schedules the execution of a sync tensors operation in background. The
   // asynchronous operation will hold the device locks by capturing the ones
@@ -223,15 +226,18 @@ class TORCH_API LazyGraphExecutor {
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
       std::vector<BackendDataPtr> tensors_data,
-      ComputationCache::TypePtr cached_computation);
+      ComputationCache::TypePtr cached_computation,
+      bool use_current_thread);
 
   std::shared_ptr<Async> ScheduleSyncTensorsGraph(
       std::vector<LazyTensor>* tensors,
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
-      ComputationCache::TypePtr cached_computation);
+      ComputationCache::TypePtr cached_computation,
+      bool use_current_thread);
 
-  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors,
+                                          bool use_current_thread);
 
   std::vector<at::Tensor> FetchTensors(
       std::vector<LazyTensor>* tensors,


### PR DESCRIPTION
This bundles 2 changes, 
 - grab all the tensors that need to be to-cuda'd into one synctensorsgraph instead of several
 - do the fallback compilation on the current thread instead of background thread
RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc