### PR TITLE
Have getFilesToLevels return a reference

### DIFF
--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -369,8 +369,8 @@ std::ostream& operator<<(std::ostream& output, const NetDef& n) {
   template <>                                                          \
   C10_EXPORT T ArgumentHelper::GetSingleArgument<T>(                   \
       c10::string_view name, const T& default_value) const {           \
-    auto it = CAFFE2_ARG_MAP_FIND(arg_map_, name);                      \
-    if (it == arg_map_.end()) {                                         \
+    auto it = CAFFE2_ARG_MAP_FIND(arg_map_, name);                     \
+    if (it == arg_map_.end()) {                                        \
       VLOG(1) << "Using default parameter value " << default_value     \
               << " for parameter " << name;                            \
       return default_value;                                            \
@@ -380,7 +380,7 @@ std::ostream& operator<<(std::ostream& output, const NetDef& n) {
         "Argument ",                                                   \
         name,                                                          \
         " does not have the right field: expected field " #fieldname); \
-    auto value = it->second.fieldname();                               \
+    const auto& value = it->second.fieldname();                        \
     if (enforce_lossless_conversion) {                                 \
       auto supportsConversion =                                        \
           SupportsLosslessConversion<decltype(value), T>(value);       \

--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -1,4 +1,3 @@
-
 #include <cstdlib>
 #include <iomanip>
 #include <sstream>
@@ -50,7 +49,7 @@ class JitLoggingConfig {
     parse();
   }
 
-  std::unordered_map<std::string, size_t> getFilesToLevels() {
+  const std::unordered_map<std::string, size_t>& getFilesToLevels() {
     return this->files_to_levels;
   }
 
@@ -112,16 +111,16 @@ void JitLoggingConfig::parse() {
 }
 
 bool is_enabled(const char* cfname, JitLoggingLevels level) {
-  const std::unordered_map<std::string, size_t> files_to_levels =
+  const auto& files_to_levels =
       JitLoggingConfig::getInstance().getFilesToLevels();
   std::string fname{cfname};
   fname = c10::detail::StripBasename(fname);
-  auto end_index = fname.find_last_of('.') == std::string::npos
+  const auto end_index = fname.find_last_of('.') == std::string::npos
       ? fname.size()
       : fname.find_last_of('.');
-  auto fname_no_ext = fname.substr(0, end_index);
+  const auto fname_no_ext = fname.substr(0, end_index);
 
-  auto it = files_to_levels.find(fname_no_ext);
+  const auto it = files_to_levels.find(fname_no_ext);
   if (it == files_to_levels.end()) {
     return false;
   }


### PR DESCRIPTION
Summary:
The copy induced by getFilesToLevels is currently consuming 3,457,470,000 cycles per day. A reference might fix that.

Reference:
```
["Inline torch::jit::JitLoggingConfig::getFilesToLevels[abi:cxx11] @ caffe2/torch/csrc/jit/jit_log.cpp:54"]
```

Differential Revision: D33479180

