### PR TITLE
Fixes doc errors in `Tensor.triu()`, `Tensor.tril()`, `Tensor.ravel()`.

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2976,7 +2976,7 @@ In-place version of :meth:`~Tensor.deg2rad`
 
 add_docstr_all('ravel',
                r"""
-ravel(input) -> Tensor
+ravel() -> Tensor
 
 see :func:`torch.ravel`
 """)
@@ -4177,28 +4177,28 @@ See :func:`torch.triangular_solve`
 
 add_docstr_all('tril',
                r"""
-tril(k=0) -> Tensor
+tril(diagonal=0) -> Tensor
 
 See :func:`torch.tril`
 """)
 
 add_docstr_all('tril_',
                r"""
-tril_(k=0) -> Tensor
+tril_(diagonal=0) -> Tensor
 
 In-place version of :meth:`~Tensor.tril`
 """)
 
 add_docstr_all('triu',
                r"""
-triu(k=0) -> Tensor
+triu(diagonal=0) -> Tensor
 
 See :func:`torch.triu`
 """)
 
 add_docstr_all('triu_',
                r"""
-triu_(k=0) -> Tensor
+triu_(diagonal=0) -> Tensor
 
 In-place version of :meth:`~Tensor.triu`
 """)


### PR DESCRIPTION
Hi, PyTorch Team!
I am very much interested in starting up my contribution to PyTorch. I made several contributions in NumPy and CuPy, but this is my first PR towards PyTorch. I aim to contribute more in the upcoming future.

The PR fixes #70972  #70975.

#### Aim of PR
The functions like `Tensor.ravel`, `Tensor.tril`, `Tensor.tril_`, `Tensor.triu`, and `Tensor.triu_` had a couple of typos in docs. The PR aims to resolve that.

I'm looking forward to your viewpoints. Thanks!

cc: @kshitij12345 @vadimkantorov @Lezcano @TestSomething22

cc @brianjo @mruberry