### PR TITLE
Load zip file in deploy interpreter

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -265,11 +265,12 @@ Interpreter::Interpreter(
     deploySetSelfPtr(handle_);
   }
 
+  auto extra_python_paths = env->getExtraPythonPaths();
   void* newInterpreterImpl = dlsym(handle_, "newInterpreterImpl");
   AT_ASSERT(newInterpreterImpl);
   pImpl_ = std::unique_ptr<InterpreterImpl>(
-      ((InterpreterImpl * (*)()) newInterpreterImpl)());
-
+      ((InterpreterImpl * (*)(const std::vector<std::string>&))
+           newInterpreterImpl)(extra_python_paths));
   env->configureInterpreter(this);
 }
 

--- a/torch/csrc/deploy/elf_file.cpp
+++ b/torch/csrc/deploy/elf_file.cpp
@@ -1,5 +1,6 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/deploy/elf_file.h>
+
 namespace torch {
 namespace deploy {
 

--- a/torch/csrc/deploy/environment.h
+++ b/torch/csrc/deploy/environment.h
@@ -1,4 +1,8 @@
 #pragma once
+#include <fmt/format.h>
+#include <torch/csrc/deploy/elf_file.h>
+#include <fstream>
+#include <string>
 
 namespace torch {
 namespace deploy {
@@ -11,9 +15,53 @@ class Interpreter;
  * a filesystem path for the installed libraries etc.
  */
 class Environment {
+  std::vector<std::string> extraPythonPaths_;
+  // all zipped python libraries will be written
+  // under this directory
+  std::string extraPythonLibrariesDir_;
+  void setupZippedPythonModules(const std::string& pythonAppDir) {
+#ifdef FBCODE_CAFFE2
+    std::string execPath;
+    std::ifstream("/proc/self/cmdline") >> execPath;
+    ElfFile elfFile(execPath.c_str());
+    // load the zipped torch modules
+    constexpr const char* ZIPPED_TORCH_NAME = ".torch_python_modules";
+    auto zippedTorchSection = elfFile.findSection(ZIPPED_TORCH_NAME);
+    TORCH_CHECK(
+        zippedTorchSection.has_value(), "Missing the zipped torch section");
+    const char* zippedTorchStart = zippedTorchSection->start;
+    auto zippedTorchSize = zippedTorchSection->len;
+
+    std::string zipArchive =
+        std::string(pythonAppDir) + "/torch_python_modules.zip";
+    auto zippedFile = fopen(zipArchive.c_str(), "wb");
+    TORCH_CHECK(
+        zippedFile != nullptr, "Fail to create file: ", strerror(errno));
+    fwrite(zippedTorchStart, 1, zippedTorchSize, zippedFile);
+    fclose(zippedFile);
+
+    extraPythonPaths_.push_back(zipArchive);
+#endif
+    extraPythonLibrariesDir_ = pythonAppDir;
+  }
+
  public:
-  virtual ~Environment() = default;
+  explicit Environment() {
+    char tempDirName[] = "/tmp/torch_deploy_zipXXXXXX";
+    char* tempDirectory = mkdtemp(tempDirName);
+    setupZippedPythonModules(tempDirectory);
+  }
+  explicit Environment(const std::string& pythonAppDir) {
+    setupZippedPythonModules(pythonAppDir);
+  }
+  virtual ~Environment() {
+    auto rmCmd = fmt::format("rm -rf {}", extraPythonLibrariesDir_);
+    system(rmCmd.c_str());
+  }
   virtual void configureInterpreter(Interpreter* interp) = 0;
+  virtual const std::vector<std::string>& getExtraPythonPaths() {
+    return extraPythonPaths_;
+  }
 };
 
 } // namespace deploy

--- a/torch/utils/_zip.py
+++ b/torch/utils/_zip.py
@@ -1,6 +1,8 @@
 import argparse
+import glob
+import os
 from pathlib import Path
-from zipfile import PyZipFile
+from zipfile import ZipFile
 
 # Exclude some standard library modules to:
 # 1. Slim down the final zipped file size
@@ -23,18 +25,35 @@ DENY_LIST = [
     "_bootstrap_external.py",
 ]
 
+def remove_prefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+def write_to_zip(file_path, strip_file_path, zf):
+    stripped_file_path = remove_prefix(file_path, strip_file_dir + "/")
+    path = Path(stripped_file_path)
+    if path.name in DENY_LIST:
+        return
+    zf.write(file_path, stripped_file_path)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Zip py source")
     parser.add_argument("paths", nargs="*", help="Paths to zip.")
     parser.add_argument("--install_dir", help="Root directory for all output files")
+    parser.add_argument("--strip_dir", help="The absolute directory we want to remove from zip")
     parser.add_argument("--zip_name", help="Output zip name")
     args = parser.parse_args()
 
     zip_file_name = args.install_dir + '/' + args.zip_name
-    zf = PyZipFile(zip_file_name, mode='w')
+    strip_file_dir = args.strip_dir
+    zf = ZipFile(zip_file_name, mode='w')
 
     for p in args.paths:
-        path = Path(p)
-        if path.name in DENY_LIST:
-            continue
-        zf.write(p)
+        if os.path.isdir(p):
+            files = glob.glob(p + "/**/*.py", recursive=True)
+            for file_path in files:
+                # strip the absolute path
+                write_to_zip(file_path, strip_file_dir + "/", zf)
+        else:
+            write_to_zip(p, strip_file_dir + "/", zf)


### PR DESCRIPTION
Summary: This PR replaces the old logic of loading frozen torch through cpython by directly loading zipped torch modules directly onto deploy interpreter. We use elf file to load the zip file as its' section and load it back in the interpreter executable. Then, we directly insert the zip file into sys.path of the each initialized interpreter. Python has implicit ZipImporter module that can load modules from zip file as long as they are inside sys.path.

Test Plan: buck test //caffe2/torch/csrc/deploy:test_deploy

Differential Revision: D32442552

