### PR TITLE
Move implementation of empty_like for sparse COO

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -261,17 +261,6 @@ Tensor empty_like(
           .merge_in(options_)
           .merge_memory_format(optional_memory_format);
 
-  TORCH_CHECK(
-      !(options.layout() != kStrided &&
-          optional_memory_format.has_value()),
-      "memory format option is only supported by strided tensors");
-  if (options.layout() == kSparse && self.is_sparse()) {
-    auto result = at::empty({0}, options); // to be resized
-    result.sparse_resize_and_clear_(
-        self.sizes(), self.sparse_dim(), self.dense_dim());
-    return result;
-  }
-
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Preserve);
 
   if (self.is_quantized()) {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -261,6 +261,11 @@ Tensor empty_like(
           .merge_in(options_)
           .merge_memory_format(optional_memory_format);
 
+  TORCH_CHECK(
+      !(options.layout() != kStrided &&
+          optional_memory_format.has_value()),
+      "memory format option is only supported by strided tensors");
+
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Preserve);
 
   if (self.is_quantized()) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1943,6 +1943,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: empty_like
+    SparseCPU, SparseCUDA: empty_like_sparse_coo
 
 - func: empty_strided(int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/sparse/ParamUtils.cpp
+++ b/aten/src/ATen/native/sparse/ParamUtils.cpp
@@ -18,7 +18,7 @@ std::pair<Tensor, Tensor> softmax_sparse_input_preprocessing(
           ": with half to float conversion is not supported on " +
           input_.device().str());
   auto input = input_.coalesce();
-  Tensor output = at::native::empty_like(input);
+  Tensor output = at::native::empty_like_sparse_coo(input);
   TORCH_CHECK(
       dim_ >= 0 && dim_ < input.dim(),
       ": dim must be non-negative and less than input dimensions");
@@ -39,7 +39,7 @@ std::tuple<Tensor, Tensor, Tensor> softmax_backward_sparse_input_preprocessing(
   auto grad = grad_.coalesce();
   auto output = output_.coalesce();
 
-  Tensor grad_input = at::native::empty_like(output);
+  Tensor grad_input = at::native::empty_like_sparse_coo(output);
   TORCH_CHECK(
       dim >= 0 && dim < grad.dim(),
       ": dim must be non-negative and less than input dimensions");

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -819,5 +819,27 @@ Tensor sparse_mask_helper_cpu(
   return r_values;
 }
 
+Tensor empty_like_sparse_coo(
+    const Tensor& self,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+
+  TORCH_CHECK(
+      !(options.layout() != kStrided &&
+          optional_memory_format.has_value()),
+      "memory format option is only supported by strided tensors");
+
+  TORCH_INTERNAL_ASSERT(options.layout() == kSparse && self.is_sparse());
+
+  auto result = at::empty({0}, options);
+  result.sparse_resize_and_clear_(
+      self.sizes(), self.sparse_dim(), self.dense_dim());
+  return result;
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -826,19 +826,31 @@ Tensor empty_like_sparse_coo(
     c10::optional<Device> device,
     c10::optional<bool> pin_memory,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
-  TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+  TensorOptions options_ = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+
+  TORCH_CHECK(
+    !(options_.has_memory_format() && optional_memory_format.has_value()),
+    "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
+    "the redundant setter.");
+
+  TensorOptions options =
+      self.options()
+          .merge_in(options_)
+          .merge_memory_format(optional_memory_format);
 
   TORCH_CHECK(
       !(options.layout() != kStrided &&
           optional_memory_format.has_value()),
       "memory format option is only supported by strided tensors");
 
-  TORCH_INTERNAL_ASSERT(options.layout() == kSparse && self.is_sparse());
-
-  auto result = at::empty({0}, options);
-  result.sparse_resize_and_clear_(
-      self.sizes(), self.sparse_dim(), self.dense_dim());
-  return result;
+  if (options.layout() == kSparse) {
+    auto result = at::empty({0}, options);
+    result.sparse_resize_and_clear_(
+        self.sizes(), self.sparse_dim(), self.dense_dim());
+    return result;
+  } else {
+    return at::native::empty_like(self, dtype, layout, device, pin_memory, optional_memory_format);
+  }
 }
 
 } // namespace native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68084
* #68083
* __->__ #71103

Previously the implementation of empty_like for sparse COO was a
conditional path in generic implementation.
This PR makes use of the Dispatcher and moves the implementation into a
separate function.

cc @nikitaved @pearu @cpuhrsch

Differential Revision: [D33511240](https://our.internmc.facebook.com/intern/diff/D33511240)