### PR TITLE
Make Kineto + distributed a warning rather than an error

### DIFF
--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -156,26 +156,31 @@ c10::intrusive_ptr<JitFuture> sendMessageWithAutograd(
       forceGradRecording,
       agent.getDeviceMap(dst));
 
-  c10::intrusive_ptr<JitFuture> fut;
   // If profiler is enabled, wrap this message with profiling metadata that will
   // tell the remote end to process this request with the profiler enabled.
-  if (!forceDisableProfiling && torch::autograd::profiler::profilerEnabled()) {
-    auto profilerConfig = torch::autograd::profiler::getProfilerConfig();
-    TORCH_CHECK(
-        torch::profiler::impl::profilerType() ==
-            torch::profiler::impl::ActiveProfilerType::LEGACY,
-        "Currently only the legacy autograd profiler is supported in a distributed context.");
-    auto msgWithProfiling = getMessageWithProfiling(
-        std::move(msg),
-        rpc::MessageType::RUN_WITH_PROFILING_REQ,
-        // NOLINTNEXTLINE(performance-move-const-arg)
-        std::move(profilerConfig));
-    fut = agent.send(dst, std::move(msgWithProfiling), rpcTimeoutSeconds);
-  } else {
-    fut = agent.send(dst, std::move(msg), rpcTimeoutSeconds);
+  if (!forceDisableProfiling) {
+    switch (torch::profiler::impl::profilerType()) {
+      case torch::profiler::impl::ActiveProfilerType::LEGACY:
+        {
+          auto profilerConfig = torch::autograd::profiler::getProfilerConfig();
+          auto msgWithProfiling = getMessageWithProfiling(
+            std::move(msg),
+            rpc::MessageType::RUN_WITH_PROFILING_REQ,
+            // NOLINTNEXTLINE(performance-move-const-arg)
+            std::move(profilerConfig));
+          return agent.send(dst, std::move(msgWithProfiling), rpcTimeoutSeconds);
+        }
+      case torch::profiler::impl::ActiveProfilerType::KINETO:
+        TORCH_WARN_ONCE(
+          "Profiling a distributed call with the Kineto profiler will profile "
+          "the caller, but not the worker.");
+        break;
+      default:
+        break;
+    }
   }
 
-  return fut;
+  return agent.send(dst, std::move(msg), rpcTimeoutSeconds);;
 }
 
 } // namespace autograd


### PR DESCRIPTION
Summary: D33283314 (https://github.com/pytorch/pytorch/commit/681e78bacec69c3ac6653483da2236d0e0416c6e) is causing jobs to fail when profiled, which is not ideal.

Differential Revision: D33437773



cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang