### PR TITLE
[DO NOT MERGE!] Verify the performance impact of #67977 with TorchBench CI 

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -46,6 +46,7 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           pushd "${PWD}"/benchmark
+          pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
           python install.py
       - name: Run TorchBench
         run: |

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -46,8 +46,11 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           pushd "${PWD}"/benchmark
+          pip uninstall -y torch torchvision torchtext
+          pip uninstall -y torch torchvision torchtext
+          pip uninstall -y torch torchvision torchtext
           pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-          python install.py
+          python install.py  --models hf_Bert hf_GPT2 hf_Bart hf_BigBird hf_DistilBert hf_GPT2 hf_Longformer hf_Reformer hf_T5
       - name: Run TorchBench
         run: |
           pushd "${HOME}"/pytorch

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -33,6 +33,7 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           conda install -y numpy=1.17 requests=2.22 ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six dataclasses pillow pytest tabulate gitpython
+          conda install -y ffmpeg=4.4.1
           conda install -y -c pytorch-nightly torchtext torchvision
       - name: Update self-hosted PyTorch
         run: |


### PR DESCRIPTION
This PR is to verify the performance impact of #67977 on TorchVision models.
This is because currently only TorchVision models support FP16 in TorchBench.

 /// CONVOLUTION RUN_TORCHBENCH: alexnet, mnasnet1_0, mobilenet_v2, mobilenet_v3_large, resnet18, resnet50, squeezenet1_1, resnext50_32x4d, shufflenet_v2_x1_0, vgg16


RUN_TORCHBENCH: hf_Bert, hf_GPT2, hf_Bart, hf_BigBird, hf_DistilBert, hf_GPT2, hf_Longformer, hf_Reformer, hf_T5