### PR TITLE
remove hasPrimaryContext workaround on ROCm

### DIFF
--- a/test/test_cuda_primary_ctx.py
+++ b/test/test_cuda_primary_ctx.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: cuda"]
 
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests, skipIfRocmVersionLessThan
 import sys
 import unittest
 
@@ -25,6 +25,7 @@ class TestCudaPrimaryCtx(TestCase):
         "where CUDA contexts are never created. Use either run_test.py or add "
         "--subprocess to run each test in a different subprocess.")
 
+    @skipIfRocmVersionLessThan((4, 4, 21504))
     def setUp(self):
         for device in range(torch.cuda.device_count()):
             # Ensure context has not been created beforehand

--- a/test/test_cuda_primary_ctx.py
+++ b/test/test_cuda_primary_ctx.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: cuda"]
 
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests, skipIfRocm
+from torch.testing._internal.common_utils import TestCase, run_tests
 import sys
 import unittest
 
@@ -25,7 +25,6 @@ class TestCudaPrimaryCtx(TestCase):
         "where CUDA contexts are never created. Use either run_test.py or add "
         "--subprocess to run each test in a different subprocess.")
 
-    @skipIfRocm
     def setUp(self):
         for device in range(torch.cuda.device_count()):
             # Ensure context has not been created beforehand

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1262,14 +1262,7 @@ void GraphTask::stash_current_streams() {
   caller_current_streams_.resize(num_gpus);
   if (num_gpus > 0) {
     for (c10::DeviceIndex idx = 0; idx < num_gpus;  idx++) {
-#if defined(USE_ROCM)
-      // If the build targets ROCM, stash streams for all visible devices unconditionally, to work around
-      // https://github.com/pytorch/pytorch/issues/59750.
-      // TODO: Remove ROCM-specific behavior when https://github.com/pytorch/pytorch/issues/59750 is fixed.
-      if (true) {
-#else
       if (at::detail::getCUDAHooks().hasPrimaryContext(idx)) {
-#endif
         caller_current_streams_[idx] = guard.getStream({c10::DeviceType::CUDA, idx});
       } else {
         caller_current_streams_[idx] = c10::nullopt;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1263,6 +1263,9 @@ void GraphTask::stash_current_streams() {
   if (num_gpus > 0) {
     for (c10::DeviceIndex idx = 0; idx < num_gpus;  idx++) {
 #if defined(USE_ROCM) && (ROCM_VERSION < 50000)
+      // If the build targets ROCM, stash streams for all visible devices unconditionally, to work around
+      // https://github.com/pytorch/pytorch/issues/59750.
+      // TODO: Remove ROCM-specific behavior when https://github.com/pytorch/pytorch/issues/59750 is fixed.
       if (true) {
 #else	      
       if (at::detail::getCUDAHooks().hasPrimaryContext(idx)) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1262,7 +1262,11 @@ void GraphTask::stash_current_streams() {
   caller_current_streams_.resize(num_gpus);
   if (num_gpus > 0) {
     for (c10::DeviceIndex idx = 0; idx < num_gpus;  idx++) {
+#if defined(USE_ROCM) && (ROCM_VERSION < 50000)
+      if (true) {
+#else	      
       if (at::detail::getCUDAHooks().hasPrimaryContext(idx)) {
+#endif
         caller_current_streams_[idx] = guard.getStream({c10::DeviceType::CUDA, idx});
       } else {
         caller_current_streams_[idx] = c10::nullopt;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1267,7 +1267,7 @@ void GraphTask::stash_current_streams() {
       // https://github.com/pytorch/pytorch/issues/59750.
       // TODO: Remove ROCM-specific behavior when https://github.com/pytorch/pytorch/issues/59750 is fixed.
       if (true) {
-#else	      
+#else
       if (at::detail::getCUDAHooks().hasPrimaryContext(idx)) {
 #endif
         caller_current_streams_[idx] = guard.getStream({c10::DeviceType::CUDA, idx});


### PR DESCRIPTION
As issue #59750 is fixed, this PR is to remove the workaround implemented for it on ROCm.

Enabled hasPrimaryContext() related PyTorch unit tests on ROCm.

cc: @amathews-amd, @jithunnair-amd


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH