### PR TITLE
Add option to load historic operators in IR when the operator is deprecated

### DIFF
--- a/test/cpp/jit/test_upgrader_utils.cpp
+++ b/test/cpp/jit/test_upgrader_utils.cpp
@@ -69,21 +69,30 @@ TEST(UpgraderUtils, CanLoadHistoricOp) {
   std::vector<std::string> schemas = {"foo.bar()", "foo.foo()"};
 
   // symbol based look up
-  test_only_add_entry("foo.first", dummy_entry[0]);
-  test_only_add_entry("foo.second", dummy_entry[1]);
+  test_only_add_entry("old_op_not_exist.first", dummy_entry[0]);
+  test_only_add_entry("old_op_not_exist.second", dummy_entry[1]);
 
-  auto oldSchemas = loadPossibleHistoricOps("foo", 2);
+  auto oldSchemas = loadPossibleHistoricOps("old_op_not_exist", 2);
   EXPECT_EQ(oldSchemas.size(), 2);
   for (const auto& entry : oldSchemas) {
     EXPECT_TRUE(
         std::find(schemas.begin(), schemas.end(), entry) != schemas.end());
   }
 
-  auto oldSchemasWithCurrentVersion = loadPossibleHistoricOps("foo", 9);
+  auto oldSchemasWithCurrentVersion =
+      loadPossibleHistoricOps("old_op_not_exist", 9);
   EXPECT_EQ(oldSchemasWithCurrentVersion.size(), 0);
 
-  test_only_remove_entry("foo.first");
-  test_only_remove_entry("foo.second");
+  test_only_remove_entry("old_op_not_exist.first");
+  test_only_remove_entry("old_op_not_exist.first");
+
+  // it is ok to have old schemas without overload
+  test_only_add_entry("old_op_not_exist_no_overload", dummy_entry[0]);
+  auto oldSchemasNoOverload =
+      loadPossibleHistoricOps("old_op_not_exist_no_overload", 2);
+  EXPECT_EQ(oldSchemasNoOverload.size(), 1);
+  EXPECT_EQ(oldSchemasNoOverload[0], "foo.bar()");
+  test_only_remove_entry("old_op_not_exist_no_overload");
 }
 
 } // namespace jit

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -615,6 +615,8 @@ static Value* emitBuiltinNode(
   if (!version.has_value() ||
       isOpSymbolCurrent(matched_schema.schema_name, version.value())) {
     n->getOperation();
+  } else {
+    n->setHistoricSchemaName(matched_schema.schema_name);
   }
 
   return packOutputs(graph, n->outputs(), matched_schema.return_field_names);
@@ -678,6 +680,17 @@ Value* emitBuiltinCall(
       schemas.push_back(&op->schema());
   }
 
+  // we might have seen old historic
+  // ops that are deprecated
+  if (variants.size() == 0) {
+    auto oldSchemas =
+        loadPossibleHistoricOps(name.toQualString(), graph_version);
+    for (const auto& old_schema_entry : oldSchemas) {
+      FunctionSchema old_schema = parseSchema(old_schema_entry);
+      upgrader_schemas.push_back(old_schema);
+    }
+  }
+
   // TODO (tugsuu): make sure this is optimized later
   for (const auto& schema : upgrader_schemas) {
     schemas.push_back(&schema);
@@ -710,7 +723,7 @@ Value* emitBuiltinCall(
 
   auto matched = matchSchemas(schemas, loc, graph, args, kwargs, self);
 
-  if (matched.first < variants.size()) {
+  if (matched.first < variants.size() + upgrader_schemas.size()) {
     return emitBuiltinNode(matched.second, loc, graph, name, graph_version);
   } else {
     auto& fn = *builtin_functions[matched.first - variants.size()];

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -682,12 +682,13 @@ Value* emitBuiltinCall(
 
   // we might have seen old historic
   // ops that are deprecated
-  if (variants.size() == 0) {
+  if (variants.empty()) {
     auto oldSchemas =
         loadPossibleHistoricOps(name.toQualString(), graph_version);
+    upgrader_schemas.reserve(oldSchemas.size());
     for (const auto& old_schema_entry : oldSchemas) {
       FunctionSchema old_schema = parseSchema(old_schema_entry);
-      upgrader_schemas.push_back(old_schema);
+      upgrader_schemas.emplace_back(old_schema);
     }
   }
 

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -338,7 +338,11 @@ struct TORCH_API Node {
   topo_position_t topo_position_ = 0;
   // a managing wrapper for Python to allow invalidation
   std::shared_ptr<Wrap<Node>> wrap_;
-  // stores the full schema name, if the operator is historic
+  // Stores the full schema name, if the operator is historic
+  // When the operator is deprecated or the name of the operator
+  // is changed, we need to rely on this name
+  // to retrieve old schemas to successfully apply upgraders
+  // for this operator.
   c10::optional<std::string> historic_schema_name_ = c10::nullopt;
 
  protected:
@@ -364,7 +368,7 @@ struct TORCH_API Node {
     return wrap_;
   }
 
-  c10::optional<std::string> getHistoricSchemaName() {
+  const c10::optional<std::string> getHistoricSchemaName() {
     return historic_schema_name_;
   }
 

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -338,6 +338,8 @@ struct TORCH_API Node {
   topo_position_t topo_position_ = 0;
   // a managing wrapper for Python to allow invalidation
   std::shared_ptr<Wrap<Node>> wrap_;
+  // stores the full schema name, if the operator is historic
+  c10::optional<std::string> historic_schema_name_ = c10::nullopt;
 
  protected:
   Node(Graph* graph_, NodeKind kind_); // defined after graph
@@ -360,6 +362,14 @@ struct TORCH_API Node {
       wrap_ = std::make_shared<Wrap<Node>>(this);
     }
     return wrap_;
+  }
+
+  c10::optional<std::string> getHistoricSchemaName() {
+    return historic_schema_name_;
+  }
+
+  void setHistoricSchemaName(const std::string& name) {
+    historic_schema_name_ = name;
   }
 
   Node*& next() {

--- a/torch/csrc/jit/operator_upgraders/utils.cpp
+++ b/torch/csrc/jit/operator_upgraders/utils.cpp
@@ -61,7 +61,7 @@ std::vector<std::string> loadPossibleHistoricOps(
   for (const auto& entry : get_operator_version_map()) {
     auto old_symbol_name = entry.first;
     // strip off the overload name, if exist
-    auto base_name = old_symbol_name.substr(0, old_symbol_name.find("."));
+    auto base_name = old_symbol_name.substr(0, old_symbol_name.find('.'));
     if (base_name == name) {
       auto possibleUpgrader = findUpgrader(entry.second, version.value());
       if (possibleUpgrader.has_value()) {

--- a/torch/csrc/jit/operator_upgraders/utils.cpp
+++ b/torch/csrc/jit/operator_upgraders/utils.cpp
@@ -60,7 +60,9 @@ std::vector<std::string> loadPossibleHistoricOps(
 
   for (const auto& entry : get_operator_version_map()) {
     auto old_symbol_name = entry.first;
-    if (old_symbol_name.find(name) == 0) {
+    // strip off the overload name, if exist
+    auto base_name = old_symbol_name.substr(0, old_symbol_name.find("."));
+    if (base_name == name) {
       auto possibleUpgrader = findUpgrader(entry.second, version.value());
       if (possibleUpgrader.has_value()) {
         possibleSchemas.push_back(possibleUpgrader.value().old_schema);

--- a/torch/csrc/jit/operator_upgraders/utils.cpp
+++ b/torch/csrc/jit/operator_upgraders/utils.cpp
@@ -49,5 +49,27 @@ bool isOpSymbolCurrent(const std::string& name, size_t current_version) {
   return true;
 }
 
+std::vector<std::string> loadPossibleHistoricOps(
+    const std::string& name,
+    c10::optional<size_t> version) {
+  std::vector<std::string> possibleSchemas;
+
+  if (!version.has_value()) {
+    return possibleSchemas;
+  }
+
+  for (const auto& entry : get_operator_version_map()) {
+    auto old_symbol_name = entry.first;
+    if (old_symbol_name.find(name) == 0) {
+      auto possibleUpgrader = findUpgrader(entry.second, version.value());
+      if (possibleUpgrader.has_value()) {
+        possibleSchemas.push_back(possibleUpgrader.value().old_schema);
+      }
+    }
+  }
+
+  return possibleSchemas;
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/operator_upgraders/utils.h
+++ b/torch/csrc/jit/operator_upgraders/utils.h
@@ -30,5 +30,9 @@ TORCH_API bool isOpSymbolCurrent(
     const std::string& name,
     size_t current_version);
 
+TORCH_API std::vector<std::string> loadPossibleHistoricOps(
+    const std::string& name,
+    c10::optional<size_t> version);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/operator_upgraders/utils.h
+++ b/torch/csrc/jit/operator_upgraders/utils.h
@@ -30,6 +30,10 @@ TORCH_API bool isOpSymbolCurrent(
     const std::string& name,
     size_t current_version);
 
+// Returns the possible old schemas for the operator that
+// doesn't exist anymore. This can be true for deprecated
+// operators. Since name is always a symbol name, there
+// can be multiple schemas for different overloads.
 TORCH_API std::vector<std::string> loadPossibleHistoricOps(
     const std::string& name,
     c10::optional<size_t> version);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71148

Differential Revision: [D33521300](https://our.internmc.facebook.com/intern/diff/D33521300)