### PR TITLE
Obliviate ALL_TENSORTYPES and ALL_TENSORTYPES2.

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -35,6 +35,7 @@ from torch.nn import Parameter
 from torch.nn.parameter import UninitializedParameter, UninitializedBuffer
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes
+from torch.testing._internal.common_cuda import SM53OrLater, CUDA11OrLater
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
     get_function_arglist, load_tests, \

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -34,7 +34,8 @@ from torch.nn.utils import parameters_to_vector, vector_to_parameters
 from torch.nn import Parameter
 from torch.nn.parameter import UninitializedParameter, UninitializedBuffer
 from torch.nn.parallel._functions import Broadcast
-from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes
+from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes, \
+    floating_types_and
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
     get_function_arglist, load_tests, \

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA((torch.float, torch.double), (torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypesIfCUDA(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half)))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes((torch.float, torch.double), (torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypes(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half)))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -37,8 +37,8 @@ from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
-    get_function_arglist, load_tests, ALL_TENSORTYPES, \
-    ALL_TENSORTYPES2, suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC, \
+    get_function_arglist, load_tests, \
+    suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
@@ -13072,7 +13072,7 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @tf32_on_and_off(0.01)
-    @dtypes(*ALL_TENSORTYPES)
+    @dtypes(*get_all_fp_dtypes(include_bfloat16=False))
     # Very similar to test_Conv2d_naive_groups but with special care to handle
     # the number of groups == number of input channels
     def test_Conv2d_depthwise_naive_groups(self, device, dtype):
@@ -13114,7 +13114,7 @@ class TestNNDeviceType(NNTestCase):
                              atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
     @onlyCUDA
-    @dtypes(*ALL_TENSORTYPES)
+    @dtypes(*get_all_fp_dtypes(include_bfloat16=False))
     @tf32_on_and_off(0.005)
     def test_Conv3d_depthwise_naive_groups(self, device, dtype):
         for depth_multiplier in [1, 2]:
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*ALL_TENSORTYPES2)
+    @dtypesIfCUDA(*get_all_fp_dtypes(include_bfloat16=(TEST_WITH_ROCM or (CUDA11OrLater and SM53OrLater))))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*ALL_TENSORTYPES2)
+    @dtypes(*get_all_fp_dtypes(include_bfloat16=(TEST_WITH_ROCM or (CUDA11OrLater and SM53OrLater))))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
+    @dtypesIfCUDA(*(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
+    @dtypes(*(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -34,8 +34,7 @@ from torch.nn.utils import parameters_to_vector, vector_to_parameters
 from torch.nn import Parameter
 from torch.nn.parameter import UninitializedParameter, UninitializedBuffer
 from torch.nn.parallel._functions import Broadcast
-from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes, \
-    floating_types_and
+from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
     get_function_arglist, load_tests, \
@@ -15660,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half)))
+    @dtypesIfCUDA((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half)))
+    @dtypes((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
+    @dtypesIfCUDA(*(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half)))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(floating_types_and((torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
+    @dtypes(*(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half)))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else *(torch.float, torch.double, torch.half))
+    @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else *(torch.float, torch.double, torch.half))
+    @dtypes(*((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(**floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypesIfCUDA((torch.float, torch.double), (torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(**floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypes((torch.float, torch.double), (torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM: (torch.half))))
+    @dtypesIfCUDA(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM: (torch.half))))
+    @dtypes(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM else (torch.half))))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(floating_types_and(dtypes=*(torch.half, if TEST_WITH_ROCM: torch.bfloat16))))
+    @dtypesIfCUDA(*(floating_types_and(dtypes=*(torch.half, torch.bfloat16) if TEST_WITH_ROCM: *(torch.half))))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(floating_types_and(dtypes=*(torch.half, if TEST_WITH_ROCM: torch.bfloat16))))
+    @dtypes(*(floating_types_and(dtypes=*(torch.half, torch.bfloat16) if TEST_WITH_ROCM: *(torch.half))))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,8 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
+    @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half)
+        if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16786,8 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
+    @dtypes(*((torch.float, torch.double, torch.bfloat16, torch.half)
+        if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypes(*floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypesIfCUDA(**floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
+    @dtypes(**floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13072,7 +13072,7 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @tf32_on_and_off(0.01)
-    @dtypes(*get_all_fp_dtypes(include_bfloat16=False))
+    @dtypes(torch.float, torch.double, torch.half)
     # Very similar to test_Conv2d_naive_groups but with special care to handle
     # the number of groups == number of input channels
     def test_Conv2d_depthwise_naive_groups(self, device, dtype):
@@ -13114,7 +13114,7 @@ class TestNNDeviceType(NNTestCase):
                              atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
     @onlyCUDA
-    @dtypes(*get_all_fp_dtypes(include_bfloat16=False))
+    @dtypes(torch.float, torch.double, torch.half)
     @tf32_on_and_off(0.005)
     def test_Conv3d_depthwise_naive_groups(self, device, dtype):
         for depth_multiplier in [1, 2]:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*get_all_fp_dtypes(include_bfloat16=AMPERE_OR_ROCM))
+    @dtypesIfCUDA(*get_all_fp_dtypes(include_bfloat16=TEST_WITH_ROCM))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*get_all_fp_dtypes(include_bfloat16=AMPERE_OR_ROCM))
+    @dtypes(*get_all_fp_dtypes(include_bfloat16=TEST_WITH_ROCM))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*get_all_fp_dtypes(include_bfloat16=TEST_WITH_ROCM))
+    @dtypesIfCUDA(*(floating_types_and(dtypes=*(torch.half, if TEST_WITH_ROCM: torch.bfloat16))))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*get_all_fp_dtypes(include_bfloat16=TEST_WITH_ROCM))
+    @dtypes(*(floating_types_and(dtypes=*(torch.half, if TEST_WITH_ROCM: torch.bfloat16))))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -35,7 +35,6 @@ from torch.nn import Parameter
 from torch.nn.parameter import UninitializedParameter, UninitializedBuffer
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_fp_dtypes, get_all_math_dtypes
-from torch.testing._internal.common_cuda import SM53OrLater, CUDA11OrLater
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
     get_function_arglist, load_tests, \
@@ -15660,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*get_all_fp_dtypes(include_bfloat16=(TEST_WITH_ROCM or (CUDA11OrLater and SM53OrLater))))
+    @dtypesIfCUDA(*get_all_fp_dtypes(include_bfloat16=AMPERE_OR_ROCM))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*get_all_fp_dtypes(include_bfloat16=(TEST_WITH_ROCM or (CUDA11OrLater and SM53OrLater))))
+    @dtypes(*get_all_fp_dtypes(include_bfloat16=AMPERE_OR_ROCM))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
     @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half)
-        if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
+                    if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16787,7 +16787,7 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @dtypes(*((torch.float, torch.double, torch.bfloat16, torch.half)
-        if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
+              if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15660,7 +15660,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half)))
+    @dtypesIfCUDA(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16786,7 +16786,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half)))
+    @dtypes(floating_types_and(torch.half, torch.bfloat16 if TEST_WITH_ROCM else torch.half))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half))
+    @dtypesIfCUDA(*(torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else *(torch.float, torch.double, torch.half))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes((torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else (torch.float, torch.double, torch.half))
+    @dtypes(*(torch.float, torch.double, torch.bfloat16, torch.half) if TEST_WITH_ROCM else *(torch.float, torch.double, torch.half))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15659,7 +15659,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(embedding.weight.grad._indices(), tensorTwice)
         self.assertEqual(embedding.weight.grad._values(), onesTwice)
 
-    @dtypesIfCUDA(*(floating_types_and(dtypes=*(torch.half, torch.bfloat16) if TEST_WITH_ROCM: *(torch.half))))
+    @dtypesIfCUDA(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM: (torch.half))))
     @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
@@ -16785,7 +16785,7 @@ class TestNNDeviceType(NNTestCase):
             torch.__future__.set_overwrite_module_params_on_conversion(False)
 
     @onlyCUDA
-    @dtypes(*(floating_types_and(dtypes=*(torch.half, torch.bfloat16) if TEST_WITH_ROCM: *(torch.half))))
+    @dtypes(*(floating_types_and(dtypes=(torch.half, torch.bfloat16) if TEST_WITH_ROCM: (torch.half))))
     def test_embedding_max_norm_device(self, device, dtype):
         embedding = nn.Embedding(22, 5, max_norm=1.0).to(device, dtype=dtype)
         # nn.Embedding only takes LongTensor as input

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -797,21 +797,6 @@ if IS_WINDOWS:
 # Dict of torch dtype -> NumPy dtype
 torch_to_numpy_dtype_dict = {value : key for (key, value) in numpy_to_torch_dtype_dict.items()}
 
-ALL_TENSORTYPES = [torch.float,
-                   torch.double,
-                   torch.half]
-
-# bfloat16 bringup is currently only available on ROCm
-# ALL_TENSORTYPES2 will eventually be unified with ALL_TENSORTYPES
-# when bfloat16 bringup is complete on all platforms
-if TEST_WITH_ROCM:
-    ALL_TENSORTYPES2 = [torch.float,
-                        torch.double,
-                        torch.half,
-                        torch.bfloat16]
-else:
-    ALL_TENSORTYPES2 = ALL_TENSORTYPES
-
 def skipIfRocm(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Hi,
The PR fixes #71096.  It aims to scan all the test files and replace ` ALL_TENSORTYPES` and `ALL_TENSORTYPES2` with `get_all_fp_dtypes`.

I'm looking forward to your viewpoints!

Thanks!

cc: @janeyx99 @kshitij12345 