### PR TITLE
Fixed Typo in NLLLoss Function docstring

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -123,7 +123,7 @@ class NLLLoss(_WeightedLoss):
 
     .. math::
         \ell(x, y) = L = \{l_1,\dots,l_N\}^\top, \quad
-        l_n = - w_{y_n} x_{n,y_n}, \quad
+        l_n = - w_{y_n} x_n y_n, \quad
         w_{c} = \text{weight}[c] \cdot \mathbb{1}\{c \not= \text{ignore\_index}\},
 
     where :math:`x` is the input, :math:`y` is the target, :math:`w` is the weight, and


### PR DESCRIPTION
The documentation of the function [`NLLLoss`](https://pytorch.org/docs/stable/generated/torch.nn.NLLLoss.html) currently contains that the loss for a sample n is `l_n = - w_{y_n} x_{n,y_n}`, this indicates that x has two dimensions which is not the case.
The correct form should be `l_n = - w_{y_n} x_n y_n`.

