### PR TITLE
[caffe2/server quant] use new depthwise conv fbgemm interface

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -1289,10 +1289,11 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
 #endif
     {
       if (quantize_groupwise_) {
-        depthwise_2d_per_channel_quantization_same_pad(
+        depthwise_2d_same_pad<QuantizationGranularity::OUT_CHANNEL>(
             N,
             H,
             W,
+            C,
             C,
             stride_h(),
             stride_w(),
@@ -1313,10 +1314,11 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             dnnlowp_get_thread_num(),
             dnnlowp_get_num_threads());
       } else {
-        depthwise_2d_same_pad(
+        depthwise_2d_same_pad<QuantizationGranularity::TENSOR>(
             N,
             H,
             W,
+            C,
             C,
             stride_h(),
             stride_w(),
@@ -1324,16 +1326,16 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             // need zero_point for padding
             in_qparams_[INPUT].zero_point,
             reinterpret_cast<const uint8_t*>(Xdata),
-            FilterQuantizationParams(0).zero_point,
+            &FilterQuantizationParams(0).zero_point,
             *Wq_depthwise_packed_,
-            requantization_params_[0].real_multiplier,
+            &requantization_params_[0].real_multiplier,
             out_qparams_.zero_point,
             Y_uint8_data,
             // column_offsets_ empty means column_offsets_ are folded into bias
             column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_quantized_data_,
             ReluFused,
-            1.0f, /*act_times_w_scale*/
+            nullptr, /*act_times_w_scale*/
             dnnlowp_get_thread_num(),
             dnnlowp_get_num_threads());
       }


### PR DESCRIPTION
Summary: Remove the use of deprecated old interface

Test Plan: CI

Differential Revision: D33533494

