### PR TITLE
[fx2trt] break down div

### DIFF
--- a/test/fx2trt/converters/acc_op/test_binary_ops.py
+++ b/test/fx2trt/converters/acc_op/test_binary_ops.py
@@ -12,13 +12,14 @@ from torch.testing._internal.common_utils import run_tests
 elementwise_ops = [
     ((lambda x, y: x + y), acc_ops.add),
     ((lambda x, y: x - y), acc_ops.sub),
-    # Avoid dividing by 0.
-    ((lambda x, y: x / (y + 1.0)), acc_ops.div),
-    ((lambda x, y: x // (y + 1.0)), acc_ops.div),
-    ((lambda x, y: torch.div(x, y + 1.0, rounding_mode="trunc")), acc_ops.div),
-    ((lambda x, y: torch.div(x, y + 1.0, rounding_mode="floor")), acc_ops.div),
-    ((lambda x, y: torch.div(x, y + 1.0)), acc_ops.div),
-    ((lambda x, y: torch.floor_divide(x, y + 1.0)), acc_ops.div),
+    ((lambda x, y: x / y), acc_ops.div),
+    ((lambda x, y: x // y), acc_ops.floor_div),
+    ((lambda x, y: torch.div(x, y, rounding_mode="trunc")), acc_ops.trunc_div),
+    ((lambda x, y: torch.div(x, y, rounding_mode="floor")), acc_ops.floor_div),
+    ((lambda x, y: torch.div(x, y)), acc_ops.div),
+    # torch.floor_divide rounds result toward zero, rather than -Inf.
+    # https://github.com/pytorch/pytorch/issues/43874
+    ((lambda x, y: torch.floor_divide(x, y)), acc_ops.trunc_div),
     ((lambda x, y: x * y), acc_ops.mul),
     (torch.pow, acc_ops.pow),
 ]
@@ -36,7 +37,8 @@ class TestBinaryOpConverters(AccTestCase):
                 return self.orig_op(x, x)
 
         m = TestModule(orig_op)
-        inputs = [torch.randn(1, 1)]
+        # Avoid dividing by 0.
+        inputs = [torch.rand(1, 1) + 1]
         self.run_test(m, inputs, expected_ops={expected_op})
 
     @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops])

--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -1451,6 +1451,17 @@ class AccTracerTest(unittest.TestCase):
     def test_torch_mul(self):
         self._make_acc_op_function_test(acc_ops.mul, lambda x: torch.mul(x, 7))
 
+    def test_div(self):
+        self._make_acc_op_function_test(acc_ops.div, lambda x: torch.div(x, 2))
+        self._make_acc_op_function_test(acc_ops.div, lambda x: x / 2)
+
+    def test_floor_div(self):
+        self._make_acc_op_function_test(acc_ops.floor_div, lambda x: torch.div(x, 2, rounding_mode="floor"))
+
+    def test_trunc_div(self):
+        self._make_acc_op_function_test(acc_ops.trunc_div, lambda x: torch.div(x, 2, rounding_mode="trunc"))
+        self._make_acc_op_function_test(acc_ops.trunc_div, lambda x: torch.floor_divide(x, 2))
+
     def test_view(self):
         """
         Test that Tensor.view is traced correctly.
@@ -1906,6 +1917,8 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.sub,
                 acc_ops.mul,
                 acc_ops.div,
+                acc_ops.floor_div,
+                acc_ops.trunc_div,
                 acc_ops.pow,
                 acc_ops.relu,
                 acc_ops.leaky_relu,

--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -171,7 +171,7 @@ class OpSupports:
             submodules: t.Mapping[str, torch.nn.Module],
             node: torch.fx.Node,
         ) -> bool:
-            for arg in node._input_nodes:
+            for arg in node.all_input_nodes:
                 # escape dtype check for get_attr node
                 if arg.op == "get_attr":
                     continue


### PR DESCRIPTION
Summary:
Break down div to smaller ops to make those div ops look like all other elementwise ops.

Use operator div ops instead of torch div if possible to avoid converting literal numbers to torch tensor (like in the following).
```
a = 1
b = 2

// `c` would be 0.5
c = a / b

// `c` would be torch.tensor([0.5])
c = torch.div(a, b)
```

The problem we saw on shufflenet is that there's size op followed by a div op which results in int64 tensors in acc traced graph (acc tracer turns operator.div to acc_ops.div which uses torch.div). And trt splitter splits out the reshape op that consumes the div op because we have a rule to split out ops that takes in int64 tensors as inputs.

Test Plan: Unit tests.

Reviewed By: wushirong

Differential Revision: D33482231

