### PR TITLE
fx quant: fix test_fx_acc_tracer::test_quantized_batch_norm2d

### DIFF
--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -492,6 +492,10 @@ class AccTracerTest(unittest.TestCase):
                 bn_mean = node
             elif node.op == "get_attr" and node.target == "bn.running_var":
                 bn_var = node
+            elif node.op == "get_attr" and node.target == "bn.scale":
+                bn_scale = node
+            elif node.op == "get_attr" and node.target == "bn.zero_point":
+                bn_zero_point = node
             elif node.op == "call_function":
                 self.assertEqual(node.target, acc_ops.quantized_batch_norm2d)
                 self.assertEqual(node.kwargs["input"], ph)
@@ -499,6 +503,8 @@ class AccTracerTest(unittest.TestCase):
                 self.assertEqual(node.kwargs["bias"], bias_attr)
                 self.assertEqual(node.kwargs["running_mean"], bn_mean)
                 self.assertEqual(node.kwargs["running_var"], bn_var)
+                self.assertEqual(node.kwargs["acc_out_ty"][6]["scale"], bn_scale)
+                self.assertEqual(node.kwargs["acc_out_ty"][6]["zero_point"], bn_zero_point)
                 bn = node
             elif node.op == "output":
                 self.assertEqual(bn, node.args[0])


### PR DESCRIPTION
Summary:
D33330022 was landed with a Meta test failure (ghstack clobbered the fix),
resubmitting the Meta-only part to fix CI.

Test Plan:
```
buck test mode/opt //caffe2/test:test_fx_acc_tracer -- --exact 'caffe2/test:test_fx_acc_tracer - test_quantized_batch_norm2d (fx_acc.test_acc_tracer.AccTracerTest)' --run-disabled
```

Reviewed By: HDCharles

Differential Revision: D33531994

