### PR TITLE
Fix trt const_fold as output use case

### DIFF
--- a/test/fx2trt/trt_lower/test_fx2trt_lower.py
+++ b/test/fx2trt/trt_lower/test_fx2trt_lower.py
@@ -27,3 +27,14 @@ class _Mod(nn.Module):
 
 if __name__ == '__main__':
     run_tests()
+
+def test_lower_const_fold():
+    class TestModule(torch.nn.Module):
+        def __init__(self):
+            self.a = torch.randn(1)
+
+        def forward(self, x):
+            return (torch.sqrt(x), self.a)
+
+    lower = Lowerer.create(LowerSetting())
+    assert lower(TestModule(), [2, 2])

--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -295,6 +295,6 @@ def split_by_tags(gm: torch.fx.GraphModule, tags: List[str]) -> torch.fx.GraphMo
     # then we need to make sure get_attr is copied to the new graph.
     for x in flatten(output_node.args[0]):
         if x.op == "get_attr":
-            setattr(main_root, x.name, getattr(gm, x.name))
+            setattr(main_root, x.name, getattr(gm, x.target))  # type: ignore[arg-type]
 
     return torch.fx.GraphModule(main_root, main_g)


### PR DESCRIPTION
Summary:
Issue found by D33517596, error message is:
AttributeError: 'GraphModule' object has no attribute '_fx_const_folded_attrs'
When const_fold is set for graphModule, the attribute name is in upper case while the const_fold node name in lower case, thus causing searching by name in https://fburl.com/code/mjv4gnfo fail.

Test Plan:
unit
 buck test mode/opt -j 10 caffe2/test/fx2trt/trt_lower:test_fx2trt_lower

Reviewed By: khabinov

Differential Revision: D33541168

