### PR TITLE
[warnings][Caffe2] Suppress warnings in caffe2 headers

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -13,6 +13,10 @@
 #include <c10/util/math_compat.h>
 #include <ATen/AccumulateType.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
 
 /* The next function is taken from  https://github.com/antelopeusersgroup/antelope_contrib/blob/master/lib/location/libgenloc/erfinv.c.
 Below is the copyright.
@@ -2107,3 +2111,5 @@ calc_erfcx(T x)
     }
   }
 }
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -37,6 +37,11 @@ C10_DECLARE_bool(caffe2_keep_on_shrink);
 // respect caffe2_keep_on_shrink.
 C10_DECLARE_int64(caffe2_max_keep_on_shrink_memory);
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace at {
 class Tensor;
 class TensorBase;
@@ -2644,3 +2649,5 @@ static_assert(
     "See Note [TensorImpl size constraints] on how to proceed.");
 #endif
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -12,6 +12,11 @@
 #include <c10/util/numa.h>
 #include <c10/util/thread_name.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace c10 {
 
 // TODO: move this to C10 and make it C10_API
@@ -120,3 +125,5 @@ C10_DECLARE_SHARED_REGISTRY(
     bool);
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -483,4 +483,18 @@ __host__ __device__
 #endif
 #endif // HAS_DEMANGLE
 
+#ifdef __clang__
+#define _C10_PRAGMA__(string) _Pragma( #string )
+#define _C10_PRAGMA_(string) _C10_PRAGMA__( string )
+#define C10_CLANG_DIAGNOSTIC_PUSH() _Pragma("clang diagnostic push")
+#define C10_CLANG_DIAGNOSTIC_POP() _Pragma("clang diagnostic pop")
+#define C10_CLANG_DIAGNOSTIC_IGNORE(flag) _C10_PRAGMA_(clang diagnostic ignored flag)
+#define C10_CLANG_HAS_WARNING(flag) __has_warning( flag )
+#else
+#define C10_CLANG_DIAGNOSTIC_PUSH()
+#define C10_CLANG_DIAGNOSTIC_POP()
+#define C10_CLANG_DIAGNOSTIC_IGNORE(flag)
+#define C10_CLANG_HAS_WARNING(flag) 0
+#endif
+
 #endif // C10_MACROS_MACROS_H_

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -3,6 +3,11 @@
 #include <c10/macros/Macros.h>
 #include <limits>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace c10 {
 
 /// Constructors
@@ -306,3 +311,5 @@ class numeric_limits<c10::BFloat16> {
 };
 
 } // namespace std
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -16,6 +16,11 @@
 #include <CL/sycl.hpp>
 #endif
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace c10 {
 
 /// Constructors
@@ -302,3 +307,5 @@ class numeric_limits<c10::Half> {
 };
 
 } // namespace std
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -41,6 +41,11 @@
 
 #include <c10/util/Metaprogramming.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wstring-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
+#endif
+
 #define TR2_OPTIONAL_REQUIRES(...) \
   typename std::enable_if<__VA_ARGS__::value, bool>::type = false
 
@@ -1233,5 +1238,7 @@ struct hash<c10::optional<T&>> {
 #undef TR2_OPTIONAL_REQUIRES
 #undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 #undef TR2_OPTIONAL_HOST_CONSTEXPR
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 #endif // C10_UTIL_OPTIONAL_H_

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -38,6 +38,11 @@
 #include <type_traits>
 #include <utility>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace c10 {
 
 /// This is all the stuff common to all SmallVectors.
@@ -1455,3 +1460,5 @@ inline void swap(c10::SmallVector<T, N>& LHS, c10::SmallVector<T, N>& RHS) {
 }
 
 } // end namespace std
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -9,6 +9,11 @@
 #include <stdexcept>
 #include <string>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wdeprecated")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated")
+#endif
+
 namespace c10 {
 
 /**
@@ -682,3 +687,5 @@ struct hash<::c10::basic_string_view<CharT>> {
   }
 };
 } // namespace std
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -8,6 +8,11 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/util/intrusive_ptr.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 #if defined(EXPOSE_C2_OPS) || \
     !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
 namespace at {
@@ -639,4 +644,7 @@ void TensorPrinter::Print(const Tensor& tensor) {
 }
 
 } // namespace caffe2
+
+C10_CLANG_DIAGNOSTIC_POP()
+
 #endif // CAFFE2_CORE_TENSOR_H_


### PR DESCRIPTION
Summary: `caffe2` headers contain code that can elicit warnings when built with strict compiler flags.  Rather than force downstream/consuming code to weaken their compiler flags, suppress those warnings in the header using `#pragma clang diagnostic` suppressions.

Test Plan: CI Pass

Differential Revision: D33536233

