### PR TITLE
Binary compatibility fix

### DIFF
--- a/.circleci/cimodel/data/simple/ios_definitions.py
+++ b/.circleci/cimodel/data/simple/ios_definitions.py
@@ -62,9 +62,9 @@ class IOSJob:
 
 WORKFLOW_DATA = [
     IOSJob(XCODE_VERSION, ArchVariant("x86_64"), is_org_member_context=False),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64")),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "metal"), extra_props={"use_metal": miniutils.quote(str(int(True)))}),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "custom"), extra_props={"op_list": "mobilenetv2.yaml"}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64")),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "metal"), extra_props={"use_metal": miniutils.quote(str(int(True)))}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "custom"), extra_props={"op_list": "mobilenetv2.yaml"}),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7240,26 +7240,6 @@ workflows:
           ios_arch: x86_64
           ios_platform: SIMULATOR
           name: pytorch_ios_12_0_0_x86_64_build
-      - pytorch_ios_build:
-          build_environment: pytorch-ios-12.0.0-arm64_build
-          context: org-member
-          ios_arch: arm64
-          ios_platform: OS
-          name: pytorch_ios_12_0_0_arm64_build
-      - pytorch_ios_build:
-          build_environment: pytorch-ios-12.0.0-arm64_metal_build
-          context: org-member
-          ios_arch: arm64
-          ios_platform: OS
-          name: pytorch_ios_12_0_0_arm64_metal_build
-          use_metal: "1"
-      - pytorch_ios_build:
-          build_environment: pytorch-ios-12.0.0-arm64_custom_build
-          context: org-member
-          ios_arch: arm64
-          ios_platform: OS
-          name: pytorch_ios_12_0_0_arm64_custom_build
-          op_list: mobilenetv2.yaml
       - pytorch_linux_build:
           build_environment: pytorch-linux-xenial-py3-clang5-mobile-build
           build_only: "1"

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -61,7 +61,7 @@ git --no-pager log --max-count 1
 popd
 
 # Clone the Builder master repo
-retry git clone -q https://github.com/pytorch/builder.git -b jambayk/conda-3.6-cpuonly "$BUILDER_ROOT"
+retry git clone -q https://github.com/jambayk/builder.git -b jambayk/conda-3.6-cpuonly "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -61,7 +61,7 @@ git --no-pager log --max-count 1
 popd
 
 # Clone the Builder master repo
-retry git clone -q https://github.com/pytorch/builder.git -b lts/release/1.8 "$BUILDER_ROOT"
+retry git clone -q https://github.com/pytorch/builder.git -b jambayk/conda-3.6-cpuonly "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -61,7 +61,7 @@ git --no-pager log --max-count 1
 popd
 
 # Clone the Builder master repo
-retry git clone -q https://github.com/jambayk/builder.git -b jambayk/conda-3.6-cpuonly "$BUILDER_ROOT"
+retry git clone -q https://github.com/jambayk/builder.git -b jambayk/conda-3.6-cpuonly-dep "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,12 +8,13 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
+export VC_YEAR=2019
 
-if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
-  export VC_YEAR=2017
-else
-  export VC_YEAR=2019
-fi
+# if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+#   export VC_YEAR=2017
+# else
+#   export VC_YEAR=2019
+# fi
 
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -19,6 +19,41 @@ if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"
 fi
 
+echo "Free Space for CUDA DEBUG BUILD"
+if [[ "$CIRCLECI" == 'true' ]]; then
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft.NET" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft.NET"
+    fi
+
+    if [[ -d "C:\\Program Files\\dotnet" ]]; then
+        rm -rf "C:\\Program Files\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\dotnet" ]]; then
+        rm -rf "C:\\Program Files (x86)\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft SQL Server" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft SQL Server"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Xamarin" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Xamarin"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Google" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Google"
+    fi
+fi
+
 set +x
 export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}
 export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,13 +8,12 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
-export VC_YEAR=2019
 
-# if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
-#   export VC_YEAR=2017
-# else
-#   export VC_YEAR=2019
-# fi
+if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+  export VC_YEAR=2017
+else
+  export VC_YEAR=2019
+fi
 
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -21,10 +21,6 @@ fi
 
 echo "Free Space for CUDA DEBUG BUILD"
 if [[ "$CIRCLECI" == 'true' ]]; then
-    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
-        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
-    fi
-
     if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
         rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
     fi

--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -19,8 +19,14 @@ if [ ! -d "${WORKSPACE_DIR}/miniconda3" ]; then
   retry bash ${WORKSPACE_DIR}/miniconda3.sh -b -p ${WORKSPACE_DIR}/miniconda3
 fi
 export PATH="${WORKSPACE_DIR}/miniconda3/bin:$PATH"
-source ${WORKSPACE_DIR}/miniconda3/bin/activate
-retry conda install -y mkl mkl-include numpy=1.18.5 pyyaml=5.3 setuptools=46.0.0 cmake cffi ninja typing_extensions dataclasses
+# shellcheck disable=SC1091
+source "${WORKSPACE_DIR}"/miniconda3/bin/activate
+
+# NOTE: mkl 2021.3.0+ cmake requires sub-command PREPEND, may break the build
+retry conda install -y \
+  mkl=2021.2.0 mkl-include=2021.2.0 \
+  numpy=1.18.5 pyyaml=5.3 setuptools=46.0.0 \
+  cmake cffi ninja typing_extensions dataclasses
 
 # The torch.hub tests make requests to GitHub.
 #

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil
+pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil "scipy==1.6.3"
 
 # TODO move this to docker
 pip install unittest-xml-reporting pytest

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -77,11 +77,21 @@ EXCLUDE(native_metal_srcs "${native_metal_srcs}" ${metal_test_srcs})
 file(GLOB metal_prepack_h "native/metal/MetalPrepackOpContext.h")
 file(GLOB metal_prepack_cpp "native/metal/MetalPrepackOpRegister.cpp")
 
+file(GLOB native_ao_sparse_cpp
+            "native/ao_sparse/*.cpp"
+            "native/ao_sparse/cpu/*.cpp"
+            "native/ao_sparse/quantized/*.cpp"
+            "native/ao_sparse/quantized/cpu/*.cpp")
 file(GLOB native_sparse_cpp "native/sparse/*.cpp")
 file(GLOB native_quantized_cpp
             "native/quantized/*.cpp"
             "native/quantized/cpu/*.cpp")
 file(GLOB native_h "native/*.h")
+file(GLOB native_ao_sparse_h
+            "native/ao_sparse/*.h"
+            "native/ao_sparse/cpu/*.h"
+            "native/ao_sparse/quantized/*.h"
+            "native/ao_sparse/quantized/cpu/*.h")
 file(GLOB native_quantized_h "native/quantized/*.h" "native/quantized/cpu/*.h")
 file(GLOB native_cpu_h "native/cpu/*.h")
 
@@ -116,7 +126,7 @@ append_filelist("jit_core_sources" ATen_CORE_SRCS)
 
 add_subdirectory(quantized)
 add_subdirectory(nnapi)
-set(all_cpu_cpp ${base_cpp} ${ATen_CORE_SRCS} ${native_cpp} ${native_sparse_cpp} ${native_quantized_cpp} ${native_mkl_cpp} ${native_mkldnn_cpp} ${native_utils_cpp} ${native_xnnpack} ${generated_cpp} ${core_generated_cpp} ${ATen_CPU_SRCS} ${ATen_QUANTIZED_SRCS} ${ATen_NNAPI_SRCS} ${cpu_kernel_cpp})
+set(all_cpu_cpp ${base_cpp} ${ATen_CORE_SRCS} ${native_cpp} ${native_ao_sparse_cpp} ${native_sparse_cpp} ${native_quantized_cpp} ${native_mkl_cpp} ${native_mkldnn_cpp} ${native_utils_cpp} ${native_xnnpack} ${generated_cpp} ${core_generated_cpp} ${ATen_CPU_SRCS} ${ATen_QUANTIZED_SRCS} ${ATen_NNAPI_SRCS} ${cpu_kernel_cpp})
 if(AT_MKL_ENABLED)
   set(all_cpu_cpp ${all_cpu_cpp} ${mkl_cpp})
 endif()
@@ -405,7 +415,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake-exports/ATenConfig.cmake"
 
 set(INSTALL_HEADERS ${base_h} ${ATen_CORE_HEADERS})
 if(NOT INTERN_BUILD_MOBILE)
-  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
+  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_ao_sparse_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
 else()
   if(USE_PYTORCH_METAL)
     if(IOS)

--- a/aten/src/ATen/native/ao_sparse/README
+++ b/aten/src/ATen/native/ao_sparse/README
@@ -1,0 +1,23 @@
+For C++ implementation, there are no plans to migrate quantization kernels.  For sparsity, we plan to follow the structure below:
+
+./torch/aten/src/ATen
+├── (...)
+├── native
+│   ├── ao_sparse  # New folder containing ops with sparse packed weights
+│   │   ├── cpu
+│   │   ├── cuda
+│   │   └── quantized  # New folder with fused sparse and quantized packed weights
+│   │       ├── cpu
+│   │       └── cuda
+│   ├── quantized  # Existing quantized kernels
+│   │   ├── cpu
+│   │   │   ├── kernels
+│   │   │   └── qnnpack  # Existing mobile quantized and sparse kernels
+│   │   ├── cuda
+│   │   ├── QTensor.cpp
+│   │   ├── library.cpp
+│   │   └── (*.cpp, *.h)
+│   └── sparse  # Existing folder containing torch.sparse methods
+└── quantized  # Quantized Tensor definition and methods
+    ├── QTensorImpl.{cpp,h}
+    └── Quantizer.{cpp,h}

--- a/aten/src/ATen/native/ao_sparse/library.cpp
+++ b/aten/src/ATen/native/ao_sparse/library.cpp
@@ -1,0 +1,27 @@
+#include <torch/library.h>
+
+#include <torch/custom_class.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+// Register operators
+TORCH_LIBRARY(sparse, m) {
+  register_sparse_linear_params();
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparse::sparse_qlinear(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparse::sparse_qlinear_relu(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparse::sparse_qlinear_dynamic(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparse::sparse_qlinear_relu_dynamic(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack) -> Tensor Y"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparse::sparse_qlinear_prepack(Tensor W, Tensor? B, int out_features_block_size, int in_features_block_size) -> __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparse::sparse_qlinear_unpack(__torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin, int[] block_pattern)"));
+}

--- a/aten/src/ATen/native/ao_sparse/library.cpp
+++ b/aten/src/ATen/native/ao_sparse/library.cpp
@@ -3,25 +3,28 @@
 #include <torch/custom_class.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
 
-torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+namespace ao {
+namespace sparse {
+torch::class_<LinearPackedParamsBase> register_linear_params();
+}}
 
 // Register operators
 TORCH_LIBRARY(sparse, m) {
-  register_sparse_linear_params();
+  ao::sparse::register_linear_params();
 
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "sparse::sparse_qlinear(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
+      "sparse::qlinear(Tensor X, __torch__.torch.classes.sparse.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "sparse::sparse_qlinear_relu(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
+      "sparse::qlinear_relu(Tensor X, __torch__.torch.classes.sparse.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
 
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "sparse::sparse_qlinear_dynamic(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack) -> Tensor Y"));
+      "sparse::qlinear_dynamic(Tensor X, __torch__.torch.classes.sparse.LinearPackedParamsBase W_prepack) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "sparse::sparse_qlinear_relu_dynamic(Tensor X, __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack) -> Tensor Y"));
+      "sparse::qlinear_relu_dynamic(Tensor X, __torch__.torch.classes.sparse.LinearPackedParamsBase W_prepack) -> Tensor Y"));
 
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "sparse::sparse_qlinear_prepack(Tensor W, Tensor? B, int out_features_block_size, int in_features_block_size) -> __torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack"));
+      "sparse::qlinear_prepack(Tensor W, Tensor? B, int out_features_block_size, int in_features_block_size) -> __torch__.torch.classes.sparse.LinearPackedParamsBase W_prepack"));
 
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "sparse::sparse_qlinear_unpack(__torch__.torch.classes.sparse.SparseLinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin, int[] block_pattern)"));
+      "sparse::qlinear_unpack(__torch__.torch.classes.sparse.LinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin, int[] block_pattern)"));
 }

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.cpp
@@ -1,0 +1,70 @@
+#include <ATen/ATen.h>
+
+#include <torch/custom_class.h>
+
+#include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+#include <ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params() {
+  static auto register_linear_params =
+      torch::class_<SparseLinearPackedParamsBase>(
+          "sparse", "SparseLinearPackedParamsBase")
+          .def_pickle(
+              [](const c10::intrusive_ptr<SparseLinearPackedParamsBase>& params)
+                  -> SerializationTypeSparseLinearPacked { // __getstate__
+                return params->unpack();
+              },
+              [](SerializationTypeSparseLinearPacked state)
+                  -> c10::intrusive_ptr<
+                      SparseLinearPackedParamsBase> { // __setstate__
+                at::Tensor weight;
+                c10::optional<at::Tensor> bias;
+                int64_t out_features_block_size, in_features_block_size;
+                weight = std::move(std::get<0>(state));
+                bias = std::move(std::get<1>(state));
+                out_features_block_size = std::get<2>(state)[0];
+                in_features_block_size = std::get<2>(state)[1];
+
+#ifdef USE_FBGEMM
+                if (at::globalContext().qEngine() == at::QEngine::FBGEMM) {
+                  if (weight.scalar_type() == at::kQInt8) {
+                    return SparsePackedLinearWeight::prepack(
+                        weight,
+                        bias,
+                        out_features_block_size,
+                        in_features_block_size);
+                  } else {
+                    TORCH_CHECK(
+                        false,
+                        "Unsupported data type",
+                        c10::toString(weight.scalar_type()),
+                        " in serialized SparseLinearPackedParams object!");
+                  }
+                }
+#endif // USE_FBGEMM
+#ifdef USE_PYTORCH_QNNPACK
+                if (at::globalContext().qEngine() == at::QEngine::QNNPACK) {
+                  if (weight.scalar_type() == at::kQInt8) {
+                    return SparsePackedLinearWeightQnnp::prepack(
+                        weight,
+                        bias,
+                        out_features_block_size,
+                        in_features_block_size);
+                  } else {
+                    TORCH_CHECK(
+                        false,
+                        "Unsupported data type",
+                        c10::toString(weight.scalar_type()),
+                        " in serialized LinearPackedParams object!");
+                  }
+                }
+#endif // USE_FBGEMM
+                TORCH_CHECK(false, "Unknown qengine");
+              });
+  return register_linear_params;
+}
+
+namespace {
+static auto sparse_linear_params = register_sparse_linear_params();
+}

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <c10/core/QScheme.h>
+
+#ifdef USE_FBGEMM
+#include <fbgemm/Fbgemm.h>
+#include <fbgemm/FbgemmSparse.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+
+struct TORCH_API SparsePackedLinearWeight
+    : public SparseLinearPackedParamsBase {
+  SparsePackedLinearWeight(std::unique_ptr<fbgemm::BCSRMatrix<int8_t>> w, c10::optional<at::Tensor> bias, std::vector<int32_t> col_offsets, std::vector<float> w_scale, std::vector<int32_t> w_zp, c10::QScheme q_scheme, const int64_t out_features_block_size /* block sparsity size across output_features */, const int64_t in_features_block_size /* block sparsity size across input_features */)
+      : SparseLinearPackedParamsBase(
+            out_features_block_size,
+            in_features_block_size),
+        w(std::move(w)),
+        bias_(std::move(bias)),
+        col_offsets(std::move(col_offsets)),
+        w_scale(std::move(w_scale)),
+        w_zp(std::move(w_zp)),
+        q_scheme(q_scheme) {}
+  std::unique_ptr<fbgemm::BCSRMatrix<int8_t>> w;
+  c10::optional<at::Tensor> bias_;
+  std::vector<int32_t> col_offsets;
+  std::vector<float> w_scale;
+  std::vector<int32_t> w_zp;
+  c10::QScheme q_scheme;
+
+  at::Tensor apply(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override;
+  at::Tensor apply_relu(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override;
+
+  at::Tensor apply_dynamic(const at::Tensor& input) override {
+    TORCH_INTERNAL_ASSERT(
+        false,
+        "Sparse quantized dynamic linear with fused relu is not yet "
+        "supported on qnnpack backend.");
+    return at::Tensor();
+  }
+  at::Tensor apply_dynamic_relu(const at::Tensor& input) override {
+    TORCH_INTERNAL_ASSERT(
+        false,
+        "Sparse quantized dynamic linear with fused relu is not yet "
+        "supported on qnnpack backend.");
+    return at::Tensor();
+  }
+
+  SerializationTypeSparseLinearPacked unpack() override;
+
+  c10::optional<at::Tensor> bias() override {
+    return bias_;
+  }
+
+  static c10::intrusive_ptr<SparseLinearPackedParamsBase> prepack(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size);
+
+ private:
+  template <bool ReluFused>
+  at::Tensor apply_impl(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point);
+};
+
+#endif // USE_FBGEMM

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h
@@ -8,10 +8,20 @@
 #include <fbgemm/FbgemmSparse.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
 
-struct TORCH_API SparsePackedLinearWeight
-    : public SparseLinearPackedParamsBase {
-  SparsePackedLinearWeight(std::unique_ptr<fbgemm::BCSRMatrix<int8_t>> w, c10::optional<at::Tensor> bias, std::vector<int32_t> col_offsets, std::vector<float> w_scale, std::vector<int32_t> w_zp, c10::QScheme q_scheme, const int64_t out_features_block_size /* block sparsity size across output_features */, const int64_t in_features_block_size /* block sparsity size across input_features */)
-      : SparseLinearPackedParamsBase(
+namespace ao {
+namespace sparse {
+
+struct TORCH_API PackedLinearWeight
+    : public LinearPackedParamsBase {
+  PackedLinearWeight(std::unique_ptr<fbgemm::BCSRMatrix<int8_t>> w,
+                     c10::optional<at::Tensor> bias,
+                     std::vector<int32_t> col_offsets,
+                     std::vector<float> w_scale,
+                     std::vector<int32_t> w_zp,
+                     c10::QScheme q_scheme,
+                     const int64_t out_features_block_size /* block sparsity size across output_features */,
+                     const int64_t in_features_block_size /* block sparsity size across input_features */)
+      : LinearPackedParamsBase(
             out_features_block_size,
             in_features_block_size),
         w(std::move(w)),
@@ -51,13 +61,13 @@ struct TORCH_API SparsePackedLinearWeight
     return at::Tensor();
   }
 
-  SerializationTypeSparseLinearPacked unpack() override;
+  LinearPackedSerializationType unpack() override;
 
   c10::optional<at::Tensor> bias() override {
     return bias_;
   }
 
-  static c10::intrusive_ptr<SparseLinearPackedParamsBase> prepack(
+  static c10::intrusive_ptr<LinearPackedParamsBase> prepack(
       const at::Tensor& weight,
       const c10::optional<at::Tensor>& bias,
       const int64_t out_features_block_size,
@@ -70,5 +80,7 @@ struct TORCH_API SparsePackedLinearWeight
       double output_scale,
       int64_t output_zero_point);
 };
+
+}}  // namespace ao::sparse
 
 #endif // USE_FBGEMM

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/packed_params.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/packed_params.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+
+#include <ATen/core/ivalue.h>
+
+// <Weight, bias, out_features_block_size, in_features_block_size>
+using SerializationTypeSparseLinearPacked =
+    std::tuple<at::Tensor, c10::optional<at::Tensor>, std::vector<int64_t>>;
+
+struct SparseLinearPackedParamsBase : public torch::jit::CustomClassHolder {
+ public:
+  SparseLinearPackedParamsBase(
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size)
+      : out_features_block_size_(out_features_block_size),
+        in_features_block_size_(in_features_block_size) {}
+
+  virtual at::Tensor apply(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) = 0;
+  virtual at::Tensor apply_relu(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) = 0;
+
+  virtual at::Tensor apply_dynamic(const at::Tensor& input) = 0;
+  virtual at::Tensor apply_dynamic_relu(const at::Tensor& input) = 0;
+
+  virtual SerializationTypeSparseLinearPacked unpack() = 0;
+
+  virtual c10::optional<at::Tensor> bias() = 0;
+
+  virtual void set_bias(const c10::optional<at::Tensor>& bias) {
+    throw std::runtime_error(
+        "set_bias is not implemented for this packed "
+        "parameter type");
+  }
+
+ protected:
+  const int64_t out_features_block_size_, in_features_block_size_;
+};

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/packed_params.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/packed_params.h
@@ -4,13 +4,16 @@
 
 #include <ATen/core/ivalue.h>
 
+namespace ao {
+namespace sparse {
+
 // <Weight, bias, out_features_block_size, in_features_block_size>
-using SerializationTypeSparseLinearPacked =
+using LinearPackedSerializationType =
     std::tuple<at::Tensor, c10::optional<at::Tensor>, std::vector<int64_t>>;
 
-struct SparseLinearPackedParamsBase : public torch::jit::CustomClassHolder {
+struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
  public:
-  SparseLinearPackedParamsBase(
+  LinearPackedParamsBase(
       const int64_t out_features_block_size,
       const int64_t in_features_block_size)
       : out_features_block_size_(out_features_block_size),
@@ -28,7 +31,7 @@ struct SparseLinearPackedParamsBase : public torch::jit::CustomClassHolder {
   virtual at::Tensor apply_dynamic(const at::Tensor& input) = 0;
   virtual at::Tensor apply_dynamic_relu(const at::Tensor& input) = 0;
 
-  virtual SerializationTypeSparseLinearPacked unpack() = 0;
+  virtual LinearPackedSerializationType unpack() = 0;
 
   virtual c10::optional<at::Tensor> bias() = 0;
 
@@ -41,3 +44,5 @@ struct SparseLinearPackedParamsBase : public torch::jit::CustomClassHolder {
  protected:
   const int64_t out_features_block_size_, in_features_block_size_;
 };
+
+}}  // namespace ao::sparse

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear.cpp
@@ -1,0 +1,249 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/custom_class.h>
+#include <torch/library.h>
+
+#include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_FBGEMM
+
+template <bool ReluFused>
+at::Tensor SparsePackedLinearWeight::apply_impl(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  // uint8 * int8 -> uint8 (no quantization/dequantization)
+
+  // We make a strong guarantee that models using these operators will have
+  // the same numerics across different machines. Therefore, we do not provide
+  // a fallback path and rather fail loudly if we cannot run FBGEMM.
+  TORCH_CHECK(
+      fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
+
+  // TODO: contiguous is called for further jit optimizations.
+  auto input_contig = input.contiguous();
+  const auto* input_ptr =
+      reinterpret_cast<uint8_t*>(input_contig.data_ptr<c10::quint8>());
+
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "The dimension of input tensor should be larger than or equal to 2");
+  int64_t batch_size = size_to_dim_(input.dim() - 1, input.sizes());
+
+  auto packW = w.get();
+
+  int64_t out_channels = static_cast<int64_t>(packW->R);
+  int64_t K = input.size(input.dim() - 1);
+  TORCH_CHECK(
+      K == static_cast<int64_t>(packW->C),
+      "The number of columns in the packW should be equal to K: " +
+          std::to_string(K));
+
+  float input_scale_float = input.q_scale();
+  int32_t input_zero_point_int32 = input.q_zero_point();
+
+  std::vector<float> output_multiplier_float(1, 0.0);
+  std::vector<float> act_times_w_scale(1, 0.0);
+  TORCH_CHECK(
+      w_scale.size() == w_zp.size(),
+      "Weight scales and zero points vectors should have the same size.");
+  if (q_scheme == c10::kPerTensorAffine) {
+    // Process the per tensor quantization.
+    act_times_w_scale[0] = (input_scale_float * w_scale[0]);
+    output_multiplier_float[0] =
+        act_times_w_scale[0] / static_cast<float>(output_scale);
+  } else if (q_scheme == c10::kPerChannelAffine) {
+    // Process the per channel quantization.
+    output_multiplier_float.resize(out_channels, 0.0);
+    act_times_w_scale.resize(out_channels, 1.0f);
+    for (int i = 0; i < out_channels; ++i) {
+      act_times_w_scale[i] = (input_scale_float * w_scale[i]);
+      output_multiplier_float[i] =
+          act_times_w_scale[i] / static_cast<float>(output_scale);
+    }
+  }
+  int32_t output_zero_point_int32 = static_cast<int32_t>(output_zero_point);
+
+  const float* bias_ptr = nullptr;
+  at::Tensor bias;
+  if (this->bias_.has_value()) {
+    bias = this->bias_.value();
+    bias = bias.contiguous();
+    TORCH_CHECK(bias.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias.size(0) == out_channels,
+        "bias should have out_channels elements: " +
+            std::to_string(out_channels));
+    bias_ptr = reinterpret_cast<float*>(bias.data_ptr<float>());
+  }
+
+  // The resulting matrix here is 2-D, let's view it with the original
+  // left hand dimensions of the input. Here are two examples:
+  // 1. If the input tensor is {batch_size, K}, the output tensor is
+  // {batch_size, out_channels}.
+  // 2. If the input tensor is {x, batch_size, K}, the output tensor is {x,
+  // batch_size, out_channels}.
+  std::vector<int64_t> out_sizes = input.sizes().vec();
+  out_sizes.back() = out_channels; // NOLINT
+  // Allocate output Tensor and a buffer for fbgemmPacked to use
+  auto output_tr = at::_empty_affine_quantized(
+      out_sizes,
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      output_scale,
+      output_zero_point);
+  auto output = at::_empty_affine_quantized(
+      out_sizes,
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      output_scale,
+      output_zero_point);
+
+  auto buffer = at::empty(out_sizes, output.options().dtype(at::kInt));
+
+  // fbgemm kernel computes the following:
+  // C(output) = A(weight) x B(input), where C, A, B are out_channels x
+  // batch_size, out_channels x K, K x batch_size matrices, respectively.
+  // Therefore we need to transpose input
+  auto input_tr = at::_empty_affine_quantized(
+      input.sizes(),
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      input_scale_float,
+      input_zero_point_int32);
+
+  auto* input_tr_ptr =
+      reinterpret_cast<uint8_t*>(input_tr.data_ptr<c10::quint8>());
+  // TODO: Activation transpose before and after the kernel can be removed if we
+  // keep activation tensor always tranposed.
+  fbgemm::transpose_simd<uint8_t>(
+      batch_size, K, input_ptr, K, input_tr_ptr, batch_size);
+
+  int num_tasks = at::get_num_threads();
+  at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
+    for (int task_id = begin; task_id < end; ++task_id) {
+      fbgemm::trRequantizationParams_t reqParams = {
+          input_zero_point_int32,
+          w_zp.data(),
+          output_zero_point_int32,
+          static_cast<float>(output_scale),
+          col_offsets.data(),
+          /*activation offsets*/ nullptr,
+          bias_ptr,
+          act_times_w_scale.data()};
+
+      if (q_scheme == c10::kPerTensorAffine) {
+        // Process the per tensor quantization.
+        //
+        // After the uint8 * int8 matrix multiplication is performed, this
+        // operation does:
+        //  1) Add in row and column offsets to the rows and columns,
+        //  respectively.
+        //  2) Add in the bias term.
+
+        // Do the GEMM
+        fbgemm::fbgemmSparseDenseInt8MM<
+            ReluFused,
+            fbgemm::QuantizationGranularity::TENSOR>(
+            batch_size,
+            w,
+            input_tr_ptr,
+            /*ldb=*/batch_size,
+            /*C_i32=*/buffer.data_ptr<int32_t>(),
+            /*C_u8=*/
+            reinterpret_cast<uint8_t*>(output_tr.data_ptr<c10::quint8>()),
+            /*ldc=*/batch_size,
+            /*rParams=*/reqParams,
+            /*accum=*/false,
+            /*thread_id=*/task_id,
+            /*num_threads=*/num_tasks);
+      } else if (q_scheme == c10::kPerChannelAffine) {
+        // Process the per channel quantization.
+        //
+        // After the uint8 * int8 matrix multiplication is performed, this
+        // operation does:
+        //  1) Add in row and column offsets to the rows and columns,
+        //  respectively.
+        //  2) Add in the bias term.
+
+        // Do the GEMM
+        fbgemm::fbgemmSparseDenseInt8MM<
+            ReluFused,
+            fbgemm::QuantizationGranularity::OUT_CHANNEL>(
+            batch_size,
+            w,
+            input_tr_ptr,
+            /*ldb=*/batch_size,
+            /*C_i32=*/buffer.data_ptr<int32_t>(),
+            /*C_u8=*/
+            reinterpret_cast<uint8_t*>(output_tr.data_ptr<c10::quint8>()),
+            /*ldc=*/batch_size,
+            /*rParams=*/reqParams,
+            /*accum*/ false,
+            /*thread_id=*/task_id,
+            /*num_threads=*/num_tasks);
+      }
+    }
+  });
+
+  // transpose output_tr back to batch_size x out_channels
+  fbgemm::transpose_simd<uint8_t>(
+      out_channels,
+      batch_size,
+      reinterpret_cast<uint8_t*>(output_tr.data_ptr<c10::quint8>()),
+      batch_size,
+      reinterpret_cast<uint8_t*>(output.data_ptr<c10::quint8>()),
+      out_channels);
+
+  return output;
+}
+
+at::Tensor SparsePackedLinearWeight::apply(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl<false>(input, output_scale, output_zero_point);
+}
+
+at::Tensor SparsePackedLinearWeight::apply_relu(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl<true>(input, output_scale, output_zero_point);
+}
+
+#endif // USE_FBGEMM
+
+namespace torch {
+namespace ao {
+namespace sparse {
+
+namespace {
+
+template <bool ReluFused>
+class SparseQLinearInt8 final {
+ public:
+  static at::Tensor run(
+      const at::Tensor& input,
+      const c10::intrusive_ptr<SparseLinearPackedParamsBase>& packed_weight,
+      double output_scale,
+      int64_t output_zero_point) {
+    if (ReluFused) {
+      return packed_weight->apply_relu(input, output_scale, output_zero_point);
+    } else {
+      return packed_weight->apply(input, output_scale, output_zero_point);
+    }
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparse, QuantizedCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparse::sparse_qlinear"),
+      TORCH_FN(SparseQLinearInt8<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparse::sparse_qlinear_relu"),
+      TORCH_FN(SparseQLinearInt8<true>::run));
+}
+
+} // namespace
+}}} // namespace torch::ao::sparse

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_dynamic.cpp
@@ -1,0 +1,193 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/custom_class.h>
+#include <torch/library.h>
+
+#include <ATen/native/quantized/cpu/quant_utils.h>
+#include <caffe2/utils/threadpool/pthreadpool-cpp.h>
+
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+#include <ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_PYTORCH_QNNPACK
+template <>
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic_impl<true>(
+    const at::Tensor& input) {
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "Sparse quantized dynamic linear with fused relu is not yet "
+      "supported on qnnpack backend.");
+  return at::Tensor();
+}
+
+template <>
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic_impl<false>(
+    const at::Tensor& input) {
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "quantized_sparse_linear(): Input tensor rank should be >= 2");
+
+  size_t rows_input = 1;
+  size_t cols_input = input.size(input.dim() - 1);
+  for (size_t i = 0; i < input.dim() - 1; ++i) {
+    rows_input *= input.size(i);
+  }
+  TORCH_CHECK(
+      cols_input == orig_weight_.size(1),
+      "quantized_sparse_lienar: Input tensor's last and weight tensor's"
+      " second dimension must match.");
+
+  float x_min;
+  float x_max;
+  if (input.numel() > 0) {
+    x_min = input.min().item<float>();
+    x_max = input.max().item<float>();
+  } else {
+    // On empty input, no output data will be generated,
+    // so use arbitrary qparams.
+    x_min = 0;
+    x_max = 0;
+  }
+
+  auto q_params = quant_utils::ChooseQuantizationParams(
+      /*min=*/x_min,
+      /*max=*/x_max,
+      /*qmin=*/0,
+      /*qmax=*/255);
+
+  // Quantize input
+  at::Tensor q_input = at::quantize_per_tensor(
+      input, q_params.scale, q_params.zero_point, c10::kQUInt8);
+
+  auto q_input_contig = q_input.contiguous();
+  if (sparse_linear_op_ == nullptr) {
+    // We calculate requant scale here as the vector holding the requant scale
+    // is owned by this module. The pointer is then passed to qnnpack backend.
+    generate_requantization_scales(
+        w_scales_, q_input_contig.q_scale(), 1.f, requantization_scales_);
+    input_scale_ = q_input_contig.q_scale();
+    pytorch_qnnp_operator_t sparse_linear_op{nullptr};
+    pytorch_qnnp_status status =
+        pytorch_qnnp_create_fully_connected_sparse_dq_nc_q8(
+            orig_weight_.size(1),
+            orig_weight_.size(0),
+            q_input_contig.q_zero_point(),
+            w_zero_points_.data(),
+            bcsr_matrix_->col_indices.data(),
+            bcsr_matrix_->row_values.data(),
+            bcsr_matrix_->values.data(),
+            bcsr_matrix_->row_block_size, /* out_features_block_size */
+            bcsr_matrix_->col_block_size, /* in_features_block_size */
+            0, /* output zero point: not used */
+            std::numeric_limits<uint8_t>::min(),
+            std::numeric_limits<uint8_t>::max(),
+            0, /* flags */
+            requantization_scales_.data(),
+            true, /* use prepacking kernel */
+            &sparse_linear_op);
+    TORCH_CHECK(
+        status == pytorch_qnnp_status_success,
+        "Failed to create sparse linear operator on"
+        " qnnpack backend.");
+    sparse_linear_op_ =
+        std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter>(
+            sparse_linear_op);
+  }
+
+  // Input on next iteration can be different, thus resulting in
+  // different input scale. This will require us to recalculate requantization
+  // scales.
+  if (input_scale_ != q_input_contig.q_scale()) {
+    generate_requantization_scales(
+        w_scales_, q_input_contig.q_scale(), 1.f, requantization_scales_);
+  }
+  // Update input related quantization params in the operator.
+  sparse_linear_op_->dynamic_conv_quantization_params.input_zero_point =
+      q_input_contig.q_zero_point();
+  sparse_linear_op_->dynamic_conv_quantization_params.multipliers =
+      requantization_scales_.data();
+
+  std::vector<int64_t> out_sizes = input.sizes().vec();
+  size_t rows_w = orig_weight_.size(0);
+  out_sizes.back() = rows_w;
+
+  auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
+
+  pytorch_qnnp_status status =
+      pytorch_qnnp_setup_fully_connected_sparse_dq_nc_q8(
+          sparse_linear_op_.get(),
+          rows_input, /* batch size */
+          reinterpret_cast<uint8_t*>(q_input_contig.data_ptr<c10::quint8>()),
+          cols_input, /* num input channels */
+          bias_.data_ptr<float>(),
+          output.data_ptr<float>(),
+          rows_w /* num output channels */);
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "Failed to setup sparse linear operator on"
+      " qnnpack backend.");
+
+  status = pytorch_qnnp_run_operator(
+      sparse_linear_op_.get(), caffe2::pthreadpool_());
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "Failed to run sparse linear operator on"
+      " qnnpack backend.");
+
+  return output;
+}
+
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic(
+    const at::Tensor& input) {
+  return apply_dynamic_impl<false>(input);
+}
+
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic_relu(
+    const at::Tensor& input) {
+  return apply_dynamic_impl<true>(input);
+}
+
+#endif // USE_PYTORCH_QNNPACK
+
+namespace torch {
+namespace ao {
+namespace sparse {
+
+namespace {
+
+template <bool ReluFused>
+class SparseQLinearDynamicInt8 final {
+ public:
+  static at::Tensor run(
+      const at::Tensor& input,
+      const c10::intrusive_ptr<SparseLinearPackedParamsBase>& packed_weight) {
+    auto& ctx = at::globalContext();
+#ifdef USE_PYTORCH_QNNPACK
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
+      if (ReluFused) {
+        return packed_weight->apply_dynamic_relu(input);
+      } else {
+        return packed_weight->apply_dynamic(input);
+      }
+    }
+#endif
+    TORCH_CHECK(
+        false,
+        "Didn't find engine for operation ao::sparse::sparse_qlinear_dynamic",
+        toString(ctx.qEngine()));
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparse, CPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparse::sparse_qlinear_dynamic"),
+      TORCH_FN(SparseQLinearDynamicInt8<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparse::sparse_qlinear_relu_dynamic"),
+      TORCH_FN(SparseQLinearDynamicInt8<true>::run));
+}
+
+} // namespace
+}}} // namespace torch::ao::sparse

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_prepack.cpp
@@ -1,0 +1,230 @@
+#include <ATen/ATen.h>
+#include <torch/custom_class.h>
+
+#include <ATen/cpp_custom_type_hack.h>
+#include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+#include <ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h>
+
+#include <algorithm>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_FBGEMM
+namespace {
+// Calculate the column offsets.
+// Note this includes the sum of the columns as well as the scalar term
+// B_zero_point * K, whereas the row_offsets created by
+// packing of activation is only the sum of the A rows.
+void calc_col_offsets_transpose(
+    int K,
+    int N,
+    const int8_t* Bint8,
+    int32_t* B_zero_point,
+    int32_t* col_offsets,
+    c10::QScheme qtype) {
+  for (size_t i = 0; i < N; ++i) {
+    int32_t sum = 0;
+    for (size_t j = 0; j < K; ++j) {
+      sum += Bint8[i * K + j];
+    }
+    if (qtype == c10::kPerTensorAffine) {
+      col_offsets[i] = sum - B_zero_point[0] * K;
+    } else {
+      col_offsets[i] = sum - B_zero_point[i] * K;
+    }
+  }
+}
+} // namespace
+
+c10::intrusive_ptr<SparseLinearPackedParamsBase> SparsePackedLinearWeight::
+    prepack(
+        const at::Tensor& weight,
+        const c10::optional<at::Tensor>& bias,
+        const int64_t out_features_block_size,
+        const int64_t in_features_block_size) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "The weight tensor for ao::sparse::sparse_qlinear_prepack (fbgemm) should"
+      " be 2-dimensional.");
+
+  auto N = weight.size(0);
+  auto K = weight.size(1);
+
+  auto weight_contig = weight.contiguous();
+  const auto qtype = weight.qscheme();
+  std::vector<int32_t> weight_zero_points_int32(1, 0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_zero_points_int32[0] = weight.q_zero_point();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_zero_points_int32.resize(N, 0);
+    for (int i = 0; i < N; ++i) {
+      weight_zero_points_int32[i] =
+          weight.q_per_channel_zero_points()[i].item<int32_t>();
+    }
+  }
+  TORCH_CHECK(
+      std::all_of(
+          weight_zero_points_int32.cbegin(),
+          weight_zero_points_int32.cend(),
+          [](int32_t i) { return i == 0; }),
+      "zero point(s) should be 0 for the weight tensor of sparse qlinear op");
+  std::vector<float> weight_scales_float(1, 0.0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_scales_float[0] = weight.q_scale();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_scales_float.resize(N, 0.0);
+    for (int i = 0; i < N; ++i) {
+      weight_scales_float[i] = weight.q_per_channel_scales()[i].item<float>();
+    }
+  }
+
+  int8_t* weight_ptr_int8 =
+      reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+
+  std::vector<int32_t> col_offsets(N);
+  calc_col_offsets_transpose(
+      /*K=*/K,
+      /*N=*/N,
+      /*Bint8=*/weight_ptr_int8,
+      /*B_zero_point=*/weight_zero_points_int32.data(),
+      /*col_offsets=*/col_offsets.data(),
+      /*qtype=*/qtype);
+
+  c10::optional<at::Tensor> bias_contig;
+  if (bias.has_value()) {
+    const at::Tensor& bias_vec = bias.value();
+    TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_vec.size(0) == N,
+        "bias should have N elements: " + std::to_string(N));
+    bias_contig = bias->contiguous();
+  }
+
+  auto bcsr = fbgemm::fbgemmDenseToBCSR<int8_t>(N, K, weight_ptr_int8);
+  auto ret_ptr = c10::make_intrusive<SparsePackedLinearWeight>(
+      std::move(bcsr),
+      bias_contig,
+      col_offsets,
+      weight_scales_float,
+      weight_zero_points_int32,
+      qtype,
+      out_features_block_size,
+      in_features_block_size);
+  return ret_ptr;
+}
+
+#endif // USE_FBGEMM
+
+#ifdef USE_PYTORCH_QNNPACK
+c10::intrusive_ptr<SparseLinearPackedParamsBase> SparsePackedLinearWeightQnnp::
+    prepack(
+        const at::Tensor& weight,
+        const c10::optional<at::Tensor>& bias,
+        const int64_t out_features_block_size,
+        const int64_t in_features_block_size) {
+  at::native::initQNNPACK();
+  return c10::make_intrusive<SparsePackedLinearWeightQnnp>(
+      weight, bias, out_features_block_size, in_features_block_size);
+}
+
+SparsePackedLinearWeightQnnp::SparsePackedLinearWeightQnnp(
+    const at::Tensor& weight,
+    const c10::optional<at::Tensor>& bias,
+    const int64_t out_features_block_size,
+    const int64_t in_features_block_size)
+    : SparseLinearPackedParamsBase(
+          out_features_block_size,
+          in_features_block_size),
+      orig_weight_(weight),
+      orig_bias_(bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "sparse_qlinear (qnnpack): Weight tensor rank should be == 2");
+  TORCH_CHECK(out_features_block_size > 0, "Row block size must be > 0.");
+  TORCH_CHECK(in_features_block_size > 0, "Row block size must be > 0.");
+
+  int64_t rows_w = weight.size(0);
+  if (bias.has_value()) {
+    bias_ = bias.value();
+  } else {
+    bias_ = at::zeros(rows_w, weight.options().dtype(at::kFloat));
+  }
+  TORCH_CHECK(
+      (bias_.ndimension() == 1 && bias_.size(0) == rows_w),
+      "sparse_qlinear_prepack (qnnpack): Given weight of size ",
+      weight.sizes(),
+      ", expected bias to be 1-dimensional with ",
+      rows_w,
+      " elements",
+      ", but got bias of size ",
+      bias_.sizes(),
+      " instead");
+
+  // Given bias is supposed to be 1 dim, it is already contiguous,
+  // but the weight might be non-contiguous.
+  at::Tensor weight_contig = orig_weight_.contiguous();
+
+  q_scheme_ = orig_weight_.qscheme();
+  std::tie(w_zero_points_, w_scales_) =
+      make_zero_points_and_scales_tensor(weight_contig);
+  const float* weight_scales_data = w_scales_.data_ptr<float>();
+  at::Tensor qnnp_weight = at::_empty_affine_quantized(
+      weight_contig.sizes(),
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      weight_scales_data[0],
+      w_zero_points_[0]);
+  auto* qnnp_w_data = qnnp_weight.data_ptr<c10::quint8>();
+  auto wt_numel = weight_contig.numel();
+  int8_t* w_data =
+      reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+  for (int i = 0; i < wt_numel; ++i) {
+    qnnp_w_data[i] = static_cast<c10::quint8>(w_data[i] + 128);
+  }
+  bcsr_matrix_ = qnnpack::generateBlockCSRMatrix(
+      reinterpret_cast<uint8_t*>(qnnp_w_data),
+      orig_weight_.size(0), /* output_channels */
+      orig_weight_.size(1), /* input_channels */
+      out_features_block_size,
+      in_features_block_size,
+      w_zero_points_.data());
+}
+#endif // USE_PYTORCH_QNNPACK
+
+namespace {
+
+class SparseQLinearPackWeightInt8 final {
+ public:
+  static c10::intrusive_ptr<SparseLinearPackedParamsBase> run(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size) {
+    auto& ctx = at::globalContext();
+
+#ifdef USE_FBGEMM
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
+      return SparsePackedLinearWeight::prepack(
+          weight, bias, out_features_block_size, in_features_block_size);
+    }
+#endif
+#ifdef USE_PYTORCH_QNNPACK
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
+      return SparsePackedLinearWeightQnnp::prepack(
+          weight, bias, out_features_block_size, in_features_block_size);
+    }
+#endif
+    TORCH_CHECK(
+        false,
+        "Didn't find engine for operation ao::sparse::sparse_qlinear_prepack ",
+        toString(ctx.qEngine()));
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparse, QuantizedCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparse::sparse_qlinear_prepack"),
+      TORCH_FN(SparseQLinearPackWeightInt8::run));
+}
+} // namespace

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_unpack.cpp
@@ -1,0 +1,74 @@
+#include <ATen/ATen.h>
+#include <torch/custom_class.h>
+
+#include <ATen/cpp_custom_type_hack.h>
+#include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+#include <ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_FBGEMM
+
+SerializationTypeSparseLinearPacked SparsePackedLinearWeight::unpack() {
+  auto packW = w.get();
+
+  int64_t N = static_cast<int64_t>(packW->R);
+  int64_t K = static_cast<int64_t>(packW->C);
+
+  at::Tensor weight_origin;
+  if (q_scheme == c10::kPerTensorAffine) {
+    weight_origin = at::_empty_affine_quantized(
+        {N, K}, at::device(c10::kCPU).dtype(c10::kQInt8), w_scale[0], w_zp[0]);
+  } else if (q_scheme == c10::kPerChannelAffine) {
+    auto scales = at::from_blob(
+        w_scale.data(), w_scale.size(), device(c10::kCPU).dtype(c10::kFloat));
+    auto zero_points = at::from_blob(
+        w_zp.data(), w_zp.size(), device(c10::kCPU).dtype(c10::kInt));
+
+    weight_origin = at::_empty_per_channel_affine_quantized(
+        {N, K},
+        scales.toType(c10::kDouble),
+        zero_points.toType(c10::kLong),
+        0, // The output channel axis is 0
+        device(c10::kCPU).dtype(c10::kQInt8));
+  }
+
+  // TODO: uncomment once unpack is implemented for BCSRMatrix
+  // int8_t* weight_ptr_int8 =
+  //     reinterpret_cast<int8_t*>(weight_origin.data_ptr<c10::qint8>());
+  // packW->unpack(weight_ptr_int8);
+  std::vector<int64_t> block_pattern(
+      {out_features_block_size_, in_features_block_size_});
+
+  return std::make_tuple(weight_origin, bias_, std::move(block_pattern));
+}
+
+#endif // USE_FBGEMM
+
+#ifdef USE_PYTORCH_QNNPACK
+
+SerializationTypeSparseLinearPacked SparsePackedLinearWeightQnnp::unpack() {
+  std::vector<int64_t> block_pattern(
+      {out_features_block_size_, in_features_block_size_});
+  return std::make_tuple(orig_weight_, orig_bias_, std::move(block_pattern));
+}
+
+#endif // USE_FBGEMM
+
+namespace {
+
+class SparseQLinearUnpackWeightInt8 final {
+ public:
+  static SerializationTypeSparseLinearPacked run(
+      const c10::intrusive_ptr<SparseLinearPackedParamsBase>& packed_weight) {
+    return packed_weight->unpack();
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparse, QuantizedCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparse::sparse_qlinear_unpack"),
+      TORCH_FN(SparseQLinearUnpackWeightInt8::run));
+}
+} // namespace

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <c10/core/QScheme.h>
+
+#ifdef USE_PYTORCH_QNNPACK
+// TODO: Refacto qnnpack_utils.h so as to separate code
+// needed for quantized op from the generic qnnpack specific
+// quantization utilities.
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <pack_block_sparse.h>
+#include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
+
+struct TORCH_API SparsePackedLinearWeightQnnp
+    : public SparseLinearPackedParamsBase {
+  SparsePackedLinearWeightQnnp(const at::Tensor& weight, const c10::optional<at::Tensor>& bias, const int64_t out_features_block_size /* block sparsity size across output_features */, const int64_t in_features_block_size /* block sparsity size across input_features */);
+  at::Tensor orig_weight_;
+  c10::optional<at::Tensor> orig_bias_;
+  // Seperate copy of bias exist so that we can fill in zeros when
+  // optional bias does not exist. This is to compy with qnnpack operator that
+  // expects bias to be present.
+  // In case bias is present bias_ is just a reference to orig_bias_
+  at::Tensor bias_;
+  c10::QScheme q_scheme_;
+  double input_scale_;
+  std::unique_ptr<qnnpack::BCSRMatrix> bcsr_matrix_;
+  at::Tensor w_scales_;
+  std::vector<uint8_t> w_zero_points_;
+  std::vector<float> requantization_scales_;
+  std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter>
+      sparse_linear_op_{nullptr};
+
+  at::Tensor apply(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override {
+    TORCH_CHECK(
+        false, "Static quantized sparse linear unimplemented on QNNPACK");
+  }
+  at::Tensor apply_relu(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override {
+    TORCH_CHECK(
+        false, "Static quantized sparse linear unimplemented on QNNPACK");
+  }
+
+  at::Tensor apply_dynamic(const at::Tensor& input) override;
+  at::Tensor apply_dynamic_relu(const at::Tensor& input) override;
+
+  SerializationTypeSparseLinearPacked unpack() override;
+
+  c10::optional<at::Tensor> bias() override {
+    return orig_bias_;
+  }
+
+  static c10::intrusive_ptr<SparseLinearPackedParamsBase> prepack(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size);
+
+ private:
+  template <bool ReluFused>
+  at::Tensor apply_impl(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point);
+  template <bool ReluFused>
+  at::Tensor apply_dynamic_impl(const at::Tensor& input);
+};
+
+#endif // USE_PYTORCH_QNNPACK

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h
@@ -11,9 +11,12 @@
 #include <pack_block_sparse.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
 
-struct TORCH_API SparsePackedLinearWeightQnnp
-    : public SparseLinearPackedParamsBase {
-  SparsePackedLinearWeightQnnp(const at::Tensor& weight, const c10::optional<at::Tensor>& bias, const int64_t out_features_block_size /* block sparsity size across output_features */, const int64_t in_features_block_size /* block sparsity size across input_features */);
+namespace ao {
+namespace sparse {
+
+struct TORCH_API PackedLinearWeightQnnp
+    : public LinearPackedParamsBase {
+  PackedLinearWeightQnnp(const at::Tensor& weight, const c10::optional<at::Tensor>& bias, const int64_t out_features_block_size /* block sparsity size across output_features */, const int64_t in_features_block_size /* block sparsity size across input_features */);
   at::Tensor orig_weight_;
   c10::optional<at::Tensor> orig_bias_;
   // Seperate copy of bias exist so that we can fill in zeros when
@@ -48,13 +51,13 @@ struct TORCH_API SparsePackedLinearWeightQnnp
   at::Tensor apply_dynamic(const at::Tensor& input) override;
   at::Tensor apply_dynamic_relu(const at::Tensor& input) override;
 
-  SerializationTypeSparseLinearPacked unpack() override;
+  LinearPackedSerializationType unpack() override;
 
   c10::optional<at::Tensor> bias() override {
     return orig_bias_;
   }
 
-  static c10::intrusive_ptr<SparseLinearPackedParamsBase> prepack(
+  static c10::intrusive_ptr<LinearPackedParamsBase> prepack(
       const at::Tensor& weight,
       const c10::optional<at::Tensor>& bias,
       const int64_t out_features_block_size,
@@ -69,5 +72,7 @@ struct TORCH_API SparsePackedLinearWeightQnnp
   template <bool ReluFused>
   at::Tensor apply_dynamic_impl(const at::Tensor& input);
 };
+
+}}  // namespace ao::sparse
 
 #endif // USE_PYTORCH_QNNPACK

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==2.4.4
+docutils==0.16
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -20,6 +20,10 @@ change. This file contains two types of randomized tests:
    it's fine to increment the seed of the failing test (but you shouldn't need
    to increment it more than once; otherwise something is probably actually
    wrong).
+
+3. `test_geometric_sample`, `test_binomial_sample` and `test_poisson_sample`
+   are validated against `scipy.stats.` which are not guaranteed to be identical
+   across different versions of scipy (namely, they yield invalid results in 1.7+)
 """
 
 import math

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -21,7 +21,7 @@ from torch.utils.data.dataset import random_split
 from torch._utils import ExceptionWrapper
 from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS,
                                                   IS_PYTORCH_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
-                                                  load_tests, TEST_WITH_ROCM, TEST_WITH_TSAN, IS_SANDCASTLE)
+                                                  load_tests, TEST_WITH_ROCM, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE)
 
 try:
     import psutil

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -769,6 +769,9 @@ class BulkLoadingSampler(torch.utils.data.Sampler):
     TEST_WITH_TSAN,
     "Fails with TSAN with the following error: starting new threads after multi-threaded "
     "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223")
 class TestDataLoader(TestCase):
 
     def setUp(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11132,6 +11132,15 @@ dedent """
                 for i in range(.5):
                     print(i)
 
+    def test_parse_none_type_annotation(self):
+        cu = torch.jit.CompilationUnit('''
+            def foo(x : NoneType) -> NoneType:
+                return x
+        ''')
+
+        foo_code = cu.find_function('foo').code
+        FileCheck().check(": None").check("-> None").run(foo_code)
+
     def test_zip_enumerate_modulelist(self):
         class Sub(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -119,7 +119,8 @@ namespace jit {
   _(TK_WITH_ITEM, "withitem", "")                \
   _(TK_AS, "as", "as")                           \
   _(TK_PROP, "property", "")                     \
-  _(TK_ELLIPSIS, "Ellipsis", "Ellipsis")
+  _(TK_ELLIPSIS, "Ellipsis", "Ellipsis")         \
+  _(TK_NONE_TYPE, "NoneType", "NoneType")
 
 enum TokenKind {
   // we use characters to represent themselves so skip all valid characters

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -115,7 +115,8 @@ struct ParserImpl {
       } break;
       case TK_TRUE:
       case TK_FALSE:
-      case TK_NONE: {
+      case TK_NONE:
+      case TK_NONE_TYPE: {
         auto k = L.cur().kind;
         auto r = L.cur().range;
         prefix = create_compound(k, r, {});

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -60,13 +60,14 @@ TypePtr SchemaTypeParser::parseBaseType() {
       {"int", IntType::get()},
       {"bool", BoolType::get()},
       {"None", NoneType::get()},
+      {"NoneType", NoneType::get()},
       {"Capsule", CapsuleType::get()},
       {"Any", at::AnyType::get()},
       {"AnyClassType", at::AnyClassType::get()},
       {"AnyEnumType", at::AnyEnumType::get()},
   };
   auto tok = L.cur();
-  if (!L.nextIf(TK_NONE)) {
+  if (!L.nextIf(TK_NONE) && !L.nextIf(TK_NONE_TYPE)) {
     L.expect(TK_IDENT);
   }
   std::string text = tok.text();

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -190,6 +190,9 @@ c10::optional<std::string> ScriptTypeParser::parseBaseTypeName(
     case TK_NONE: {
       return "None";
     }
+    case TK_NONE_TYPE: {
+      return "NoneType";
+    }
     case '.': {
       auto select = Select(expr);
       const std::string& name = select.selector().name();

--- a/torch/csrc/jit/frontend/string_to_type.cpp
+++ b/torch/csrc/jit/frontend/string_to_type.cpp
@@ -17,6 +17,7 @@ const std::unordered_map<std::string, TypePtr>& string_to_type_lut() {
       // parsing serialized methods that use implicit conversions to Scalar
       {"number", NumberType::get()},
       {"None", NoneType::get()},
+      {"NoneType", NoneType::get()},
       {"Any", AnyType::get()},
       {"Capsule", CapsuleType::get()},
       {"list", AnyListType::get()},

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -291,6 +291,7 @@ struct Expr : public TreeView {
       case TK_TRUE:
       case TK_FALSE:
       case TK_NONE:
+      case TK_NONE_TYPE:
       case TK_CAST:
       case TK_APPLY:
       case '.':


### PR DESCRIPTION
Cherry pick commit https://github.com/pytorch/pytorch/commit/3db2333d09051b7c24afae6170311774cd74b7ac that updates `NoneType::annotation_str` to return `NoneType`. It also updates the lexer and schema type parser to accept `NoneType` as an annotation..
