### PR TITLE
[Quant] Templatize activationLimits function

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -268,6 +268,11 @@ Tensor qnnpack_avg_pool2d(
       input.ndimension() == 4,
       "qnnpack_avg_pool2d(): Expected input to be 4-dimensional: got ",
       input.ndimension());
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+                "qnnpack_avg_pool2d(): Expected input data type ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(input.scalar_type()));
 
   int64_t batch_size = input.size(0);
   int64_t inC = input.size(1);

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -124,6 +124,13 @@ Tensor _add_scalar_out(Tensor& out, const Tensor& self, const Scalar& other) {
 template <bool ReLUFused = false>
 Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   TORCH_CHECK(qa.ndimension() > 0, "qnnpack_add(): Got empty input tensor.");
+  TORCH_CHECK(qa.scalar_type() == c10::kQUInt8 && qb.scalar_type() == c10::kQUInt8,
+                "qnnpack_add(): Expected both input data types to be ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(qa.scalar_type()),
+                " and ",
+                toString(qb.scalar_type()));
   Tensor qa_contig = qa.contiguous(qa.suggest_memory_format());
   // Reason for use qa's memory format for qb is that for the underlying
   // kernel can flatten all the dims and iterate over both the tensors.

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -167,12 +167,12 @@ Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   size_t num_elems = qa_contig.numel() / qa_contig.size(0);
   auto output_min = ReLUFused
       // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-      ? activationLimits(scale, zero_point, Activation::RELU)
+      ? activationLimits<uint8_t>(scale, zero_point, Activation::RELU)
             .first
       : std::numeric_limits<uint8_t>::min();
   auto output_max = ReLUFused
       // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-      ? activationLimits(scale, zero_point, Activation::RELU)
+      ? activationLimits<uint8_t>(scale, zero_point, Activation::RELU)
             .second
       : std::numeric_limits<uint8_t>::max();
   const pytorch_qnnp_status createStatus = pytorch_qnnp_create_add_nc_q8(

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -124,6 +124,8 @@ Tensor _add_scalar_out(Tensor& out, const Tensor& self, const Scalar& other) {
 template <bool ReLUFused = false>
 Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   TORCH_CHECK(qa.ndimension() > 0, "qnnpack_add(): Got empty input tensor.");
+  TORCH_CHECK(qa.sizes() == qb.sizes(),
+                "qnnpack_add(): qnnpack kernel does not support broadcasting");
   TORCH_CHECK(qa.scalar_type() == c10::kQUInt8 && qb.scalar_type() == c10::kQUInt8,
                 "qnnpack_add(): Expected both input data types to be ",
                 toString(c10::kQUInt8),
@@ -224,6 +226,7 @@ Tensor qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   check_inputs(qa, qb);
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
+      qa.sizes() == qb.sizes() && /* qnnpack does not support boradcasting */
       qa.scalar_type() == kQUInt8 && qb.scalar_type() == kQUInt8) {
     return qnnpack_add<ReLUFused>(qa, qb, scale, zero_point);
   }

--- a/aten/src/ATen/native/quantized/cpu/qchannel_shuffle.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qchannel_shuffle.cpp
@@ -31,8 +31,9 @@ Tensor quantized_channel_shuffle_impl(
       self.sizes());
   TORCH_CHECK(
       self.scalar_type() == kQUInt8,
-      "Quantized channel shuffle works only on uint8_t.",
-      "But got:", self.scalar_type());
+      "Quantized channel shuffle works only on ",
+      toString(c10::kQUInt8),
+      " but got ", self.scalar_type());
   const Tensor self_nhwc = self.contiguous(MemoryFormat::ChannelsLast);
   Tensor qy = at::native::empty_affine_quantized(
       self_nhwc.sizes(),

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -634,12 +634,12 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
 
   auto output_min = kReluFused
       // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-      ? activationLimits(output_scale, output_zero_point, Activation::RELU)
+      ? activationLimits<uint8_t>(output_scale, output_zero_point, Activation::RELU)
             .first
       : std::numeric_limits<uint8_t>::min();
   auto output_max = kReluFused
       // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-      ? activationLimits(output_scale, output_zero_point, Activation::RELU)
+      ? activationLimits<uint8_t>(output_scale, output_zero_point, Activation::RELU)
             .second
       : std::numeric_limits<uint8_t>::max();
 

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -294,6 +294,13 @@ at::Tensor PackedConvWeight<kSpatialDim>::apply_impl(
                                             : "quantized::conv";
   TORCH_CHECK(
       fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
+  TORCH_CHECK(act.scalar_type() == c10::kQUInt8,
+                func_name,
+                "(FBGEMM): Expected activation data type ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(act.scalar_type()));
+
   ConvDimChecks<kSpatialDim>(
       act.ndimension(), stride().size(), padding().size(),
       output_padding().size(), dilation().size(), func_name, transpose());
@@ -596,6 +603,12 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
               kSpatialDim == 2,
               func_name, kSpatialDim,
               "d (qnnpack): ConvTranspose cannot be fused with ReLU.");
+  TORCH_CHECK(act.scalar_type() == c10::kQUInt8,
+              func_name,
+              "(qnnpack): Expected activation data type ",
+              toString(c10::kQUInt8),
+              "but got ",
+              toString(act.scalar_type()));
   ConvDimChecks<kSpatialDim>(
       act.ndimension(), stride().size(), padding().size(),
       output_padding().size(), dilation().size(), func_name, transpose());

--- a/aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
@@ -19,6 +19,11 @@ namespace {
 #ifdef USE_PYTORCH_QNNPACK
 Tensor qnnpack_hardsigmoid(Tensor input) {
   TORCH_CHECK(input.ndimension() > 0, "qnnpack_hardsigmoid(): Got empty input tensor");
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+                "qnnpack_hardsigmoid(): Expected input data type ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(input.scalar_type()));
   initQNNPACK();
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());

--- a/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
@@ -19,6 +19,11 @@ namespace {
 #ifdef USE_PYTORCH_QNNPACK
 Tensor qnnpack_hardswish(const Tensor& qx, Tensor& qy) {
   TORCH_CHECK(qx.ndimension() > 0, "qnnpack_hardswish(): Got empty input tensor");
+  TORCH_CHECK(qx.scalar_type() == c10::kQUInt8,
+                "qnnpack_hardswish(): Expected input data type to be ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(qx.scalar_type()));
   initQNNPACK();
 
   size_t num_elems = qx.numel() / qx.size(0);

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -379,12 +379,12 @@ at::Tensor PackedLinearWeightsQnnp::apply_impl(
 
   auto output_min = ReluFused
       // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-      ? activationLimits(output_scale, output_zero_point, Activation::RELU)
+      ? activationLimits<uint8_t>(output_scale, output_zero_point, Activation::RELU)
             .first
       : std::numeric_limits<uint8_t>::min();
   auto output_max = ReluFused
       // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-      ? activationLimits(output_scale, output_zero_point, Activation::RELU)
+      ? activationLimits<uint8_t>(output_scale, output_zero_point, Activation::RELU)
             .second
       : std::numeric_limits<uint8_t>::max();
   TORCH_INTERNAL_ASSERT(packB != nullptr, "Packed Weights are NULL");

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -29,6 +29,11 @@ at::Tensor& PackedLinearWeight::apply_impl(
   // a fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(
       fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+                "Expected input data type ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(input.scalar_type()));
 
   // TODO: contiguous is called for further jit optimizations.
   auto input_contig = input.expect_contiguous();
@@ -273,6 +278,12 @@ at::Tensor PackedLinearWeightsQnnp::apply_impl(
   TORCH_CHECK(
       input.dim() >= 2,
       "quantized::linear(): Input tensor rank should be >= 2");
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+                "quantized::linear (qnnpack): Expected input data type ",
+                toString(c10::kQUInt8),
+                " but got ",
+                toString(input.scalar_type()));
+
   auto input_contig = input.contiguous();
 
   // Weight packing is not thread safe

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -352,26 +352,28 @@ inline T Round(const T x) {
 }
 #endif
 
-inline uint8_t QuantizeUint8(float scale, int32_t zero_point, float value) {
-  const int32_t qmin = std::numeric_limits<uint8_t>::min();
-  const int32_t qmax = std::numeric_limits<uint8_t>::max();
+template<typename T>
+inline T QuantizeValue(float scale, int32_t zero_point, float value) {
+  const int32_t qmin = std::numeric_limits<T>::min();
+  const int32_t qmax = std::numeric_limits<T>::max();
   auto r = zero_point + static_cast<int32_t>(Round(value / scale));
   r = std::max(r, qmin);
   r = std::min(r, qmax);
-  return static_cast<uint8_t>(r);
+  return static_cast<T>(r);
 }
 
-inline std::pair<uint8_t, uint8_t> activationLimits(
+template<typename T>
+inline std::pair<T, T> activationLimits(
     float scale,
     int32_t zero_point,
     Activation Ac) {
   switch (Ac) {
     case Activation::NONE:
-      return {std::numeric_limits<uint8_t>::min(),
-              std::numeric_limits<uint8_t>::max()};
+      return {std::numeric_limits<T>::min(),
+              std::numeric_limits<T>::max()};
     case Activation::RELU:
-      return {QuantizeUint8(scale, zero_point, 0.0),
-              std::numeric_limits<uint8_t>::max()};
+      return {QuantizeValue<T>(scale, zero_point, 0.0),
+              std::numeric_limits<T>::max()};
     default:
 #ifdef _MSC_VER
       __assume(0);

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -23,6 +23,11 @@ Tensor qnnpack_relu(Tensor input) {
   Tensor qy;
   TORCH_CHECK(
       input.ndimension() > 0, "qnnpack_relu(): Got empty input tensor");
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+               "qnnpack_relu(): Expected input data type ",
+               toString(c10::kQUInt8),
+               " but got ",
+               toString(input.scalar_type()));
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());
 

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -21,6 +21,11 @@ DEFINE_DISPATCH(qsigmoid_stub);
 Tensor qnnpack_sigmoid(
     Tensor input, double output_scale, int64_t output_zero_point) {
   TORCH_CHECK(input.ndimension() > 0, "qnnpack_sigmoid(): Got empty input tensor");
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+               "qnnpack_sigmoid(): Expected input data type ",
+               toString(c10::kQUInt8),
+               " but got ",
+               toString(input.scalar_type()));
 
   Tensor qy;
   initQNNPACK();

--- a/aten/src/ATen/native/quantized/cpu/qtanh.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qtanh.cpp
@@ -21,7 +21,11 @@ DEFINE_DISPATCH(qtanh_stub);
 // This ALWAYS outputs scale=2.0/256, zp=128, dtype=quint8
 Tensor qnnpack_tanh(Tensor input) {
   TORCH_CHECK(input.ndimension() > 0, "qnnpack_tanh(): Got empty input tensor");
-
+  TORCH_CHECK(input.scalar_type() == c10::kQUInt8,
+               "qnnpack_tanh(): Expected input data type ",
+               toString(c10::kQUInt8),
+               " but got ",
+               toString(input.scalar_type()));
   Tensor qy;
   constexpr float output_scale = 2.0f / 256.0f;
   constexpr int32_t output_zero_point = 128;

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
@@ -1,0 +1,58 @@
+#include <ATen/ATen.h>
+#include <ATen/native/quantized/cpu/fbgemm_utils.h>
+
+#ifdef USE_XNNPACK
+namespace at {
+namespace native {
+namespace xnnp_utils {
+
+at::Tensor reorder_weights_for_transpose_qconv(const at::Tensor& weight_nhwc,
+    int num_groups) {
+
+  TORCH_CHECK(weight_nhwc.size(0) % num_groups == 0,
+    "The number of groups cannot be satisfied by the provided weight tensor.");
+
+  at::Tensor reordered = at::_empty_affine_quantized(
+      weight_nhwc.sizes(),
+      at::device(c10::kCPU).dtype(c10::kQUInt8).memory_format(c10::MemoryFormat::ChannelsLast),
+      weight_nhwc.q_scale(),
+      weight_nhwc.q_zero_point(),
+      c10::nullopt);
+
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+  int input_channels_per_group = weight_nhwc.size(0) / num_groups;
+  int output_channels_per_group = weight_nhwc.size(1);
+  int kernel_width = weight_nhwc.size(3);
+  int kernel_height = weight_nhwc.size(2);
+
+  int o_offset = 1;
+  int h_offset = (output_channels_per_group);
+  int w_offset = (output_channels_per_group)*(kernel_height);
+  int i_offset = (output_channels_per_group)*(kernel_height)*(kernel_width);
+  int g_offset = (output_channels_per_group)*(kernel_height)*(kernel_width)*(input_channels_per_group);
+
+  uint8_t* out_ptr = reinterpret_cast<uint8_t*>(reordered.data_ptr<c10::quint8>());
+  int8_t* in_ptr = reinterpret_cast<int8_t*>(weight_nhwc.data_ptr<c10::qint8>());
+
+  int out_index = 0;
+  for (int g = 0; g < num_groups; g++) {
+    for (int o = 0; o < output_channels_per_group; o++) {
+      for (int w = 0; w < kernel_width; w++) {
+        for (int h = 0; h < kernel_height; h++) {
+          for (int i = 0; i < input_channels_per_group; i++) {
+            int in_index = (g*g_offset) + (i*i_offset) + (h*h_offset) + (w*w_offset) + (o*o_offset);
+            out_ptr[out_index] = static_cast<uint8_t>(static_cast<int32_t>(in_ptr[in_index]) + 128);
+            out_index++;
+          }
+        }
+      }
+    }
+  }
+  return reordered;
+}
+
+}  // xnnp_utils
+}  // native
+}  // at
+
+#endif  // USE_XNNPACK

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef USE_XNNPACK
+#include <ATen/native/xnnpack/Common.h>
+
+using xnnpack_operator = at::native::xnnpack::Operator;
+
+namespace at {
+namespace native {
+namespace xnnp_utils {
+
+  at::Tensor reorder_weights_for_transpose_qconv(const at::Tensor&, int);
+
+}  // xnnp_utils
+}  // native
+}  // at
+#endif  // USE_XNNPACK

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -27,7 +27,7 @@ class QConv1dBenchmark(op_bench.TorchBenchmarkBase):
         self.inputs = {
             "input": qX
         }
-
+        torch.backends.quantized.engine = 'qnnpack'
         self.qconv1d = nnq.Conv1d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv1d.set_weight_bias(self.qW, None)
         self.qconv1d.scale = torch.tensor(self.scale, dtype=torch.double)
@@ -57,6 +57,7 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
             "input": qX
         }
 
+        torch.backends.quantized.engine = 'qnnpack'
         self.qconv2d = nnq.Conv2d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv2d.set_weight_bias(self.qW, None)
         self.qconv2d.scale = torch.tensor(self.scale, dtype=torch.double)
@@ -67,7 +68,7 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
         return self.qconv2d(input)
 
 
-op_bench.generate_pt_test(configs.remove_cuda(configs.conv_1d_configs_short + configs.conv_1d_configs_long), QConv1dBenchmark)
+# op_bench.generate_pt_test(configs.remove_cuda(configs.conv_1d_configs_short + configs.conv_1d_configs_long), QConv1dBenchmark)
 op_bench.generate_pt_test(configs.remove_cuda(configs.conv_2d_configs_short + configs.conv_2d_configs_long), QConv2dBenchmark)
 
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4045,6 +4045,7 @@ class TestQuantizedConv(TestCase):
 
         # check that this doesn't error
         test_conv = torch.nn.quantized.Conv2d(input_channels, output_channels, 1)
+        test_conv.scale = Y_scale
         test_conv(X_q)
 
         # Test the module implementation
@@ -4144,6 +4145,7 @@ class TestQuantizedConv(TestCase):
 
         # check that this doesn't error
         test_conv = torch.nn.quantized.ConvTranspose1d(input_channels, output_channels, 1)
+        test_conv.scale = Y_scale
         test_conv(X_q)
 
         # Test the module implementation
@@ -4254,6 +4256,7 @@ class TestQuantizedConv(TestCase):
 
         # check that this doesn't error
         test_conv = torch.nn.quantized.ConvTranspose2d(input_channels, output_channels, 1)
+        test_conv.scale = Y_scale
         test_conv(X_q)
 
         # Test the module implementation
@@ -4374,6 +4377,7 @@ class TestQuantizedConv(TestCase):
 
         # check that this doesn't error
         test_conv = torch.nn.quantized.ConvTranspose3d(input_channels, output_channels, 1)
+        test_conv.scale = Y_scale
         test_conv(X_q)
 
         # Test the module implementation
@@ -4545,6 +4549,7 @@ class TestQuantizedConv(TestCase):
 
         # check that this doesn't error
         test_conv = torch.nn.quantized.Conv1d(input_channels, output_channels, 1)
+        test_conv.scale = Y_scale
         test_conv(X_q)
 
         # Test the module implementation
@@ -4660,6 +4665,7 @@ class TestQuantizedConv(TestCase):
 
             # check that this doesn't error
             test_conv = torch.nn.quantized.Conv3d(input_channels, output_channels, 1)
+            test_conv.scale = Y_scale
             test_conv(X_q)
 
             # Test the module implementation

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -1151,6 +1151,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp",
     "aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp",
     "aten/src/ATen/native/quantized/library.cpp",
+    "aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp",
     "aten/src/ATen/quantized/QTensorImpl.cpp",
     "aten/src/ATen/quantized/Quantizer.cpp",
     "aten/src/ATen/native/attention.cpp",


### PR DESCRIPTION
Summary: This is to allow using this function for uint8 as well as int8

Test Plan:
buck test caffe2/test:quantization
This primarily tests T=uint8

Reviewed By: kimishpatel

Differential Revision: D33520713

