### PR TITLE
[pytorch] move ATen/CUDAGeneratorImpl.h to ATen/cuda

### DIFF
--- a/aten/src/ATen/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/CUDAGeneratorImpl.h
@@ -1,3 +1,0 @@
-#pragma once
-// TODO: Remove this header once the other projects are updated to use ATen/cuda/CUDAGeneratorImpl
-#include <ATen/cuda/CUDAGeneratorImpl.h>


### PR DESCRIPTION
Summary:
This patch follows up D33414890 (https://github.com/pytorch/pytorch/commit/5cae40c169b3da48d2782947d072d20b7acb15d1).

This patch removes an alias header "`ATen/CUDAGeneratorImpl.h`" since it has been moved to `ATen/cuda/CUDAGeneratorImpl.h`. This change should have already been propagated.

Test Plan: Internal and external CI

Differential Revision: D33534276

