### PR TITLE
ci: Comment out pull_request trigger for binary builds

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -27,8 +27,10 @@ name: !{{ build_environment }}
 {%- endmacro %}
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, !{{ ciflow_config.trigger_action }}]
+# NOTE: Uncomment this to test within your PR
+# TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
+#  pull_request:
+#    types: [opened, synchronize, reopened, !{{ ciflow_config.trigger_action }}]
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-conda.yml
+++ b/.github/workflows/generated-linux-binary-conda.yml
@@ -4,8 +4,10 @@
 name: linux-binary-conda
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, unassigned]
+# NOTE: Uncomment this to test within your PR
+# TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
+#  pull_request:
+#    types: [opened, synchronize, reopened, unassigned]
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
@@ -4,8 +4,10 @@
 name: linux-binary-libtorch-cxx11-abi
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, unassigned]
+# NOTE: Uncomment this to test within your PR
+# TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
+#  pull_request:
+#    types: [opened, synchronize, reopened, unassigned]
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
@@ -4,8 +4,10 @@
 name: linux-binary-libtorch-pre-cxx11
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, unassigned]
+# NOTE: Uncomment this to test within your PR
+# TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
+#  pull_request:
+#    types: [opened, synchronize, reopened, unassigned]
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-manywheel.yml
+++ b/.github/workflows/generated-linux-binary-manywheel.yml
@@ -4,8 +4,10 @@
 name: linux-binary-manywheel
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, unassigned]
+# NOTE: Uncomment this to test within your PR
+# TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
+#  pull_request:
+#    types: [opened, synchronize, reopened, unassigned]
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71244

Binary builds adds a lot of skipped jobs to the default ciflow workflow
so we're commenting out the pull_request trigger for now until the new
ciflow mechanism becomes available

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33555049](https://our.internmc.facebook.com/intern/diff/D33555049)