### PR TITLE
Do not use `ssize_t` in `python_arg_parser.[cpp|h]`

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -296,12 +296,14 @@ auto handle_torch_function_indexing(PyObject* self, PyObject* index, PyObject* v
   }
   std::vector<py::handle> overridable_args;
   is_tensor_and_append_overloaded(self, &overridable_args);
-  Py_ssize_t size = PyTuple_GET_SIZE(index_tup.ptr());
-  for (Py_ssize_t i = 0; i < size; i++) {
-    PyObject *obj = PyTuple_GetItem(index_tup.ptr(), i);
+  auto  size = PyTuple_GET_SIZE(index_tup.ptr());
+  for (auto i : c10::irange(size)) {
+    auto *obj = PyTuple_GetItem(index_tup.ptr(), i);
     is_tensor_and_append_overloaded(obj, &overridable_args);
   }
-  if (val != nullptr) is_tensor_and_append_overloaded(val, &overridable_args);
+  if (val != nullptr) {
+    is_tensor_and_append_overloaded(val, &overridable_args);
+  }
   py::object func = PyObject_FastGetAttrString(THPVariableClass, (char *)func_name);
   py::object args = (val == nullptr) ? py::make_tuple(py::handle(self), py::handle(index)) : py::make_tuple(py::handle(self), py::handle(index), py::handle(val));
   return handle_torch_function_no_python_arg_parser(overridable_args, args.ptr(), nullptr, func_name, func.ptr(), "torch.Tensor");
@@ -828,7 +830,7 @@ std::string FunctionSignature::toString() const {
 }
 
 [[noreturn]]
-static void extra_args(const FunctionSignature& signature, ssize_t nargs) {
+static void extra_args(const FunctionSignature& signature, Py_ssize_t nargs) {
   const long max_pos_args = signature.max_pos_args;
   const long min_args = signature.min_args;
   const long nargs_ = nargs;
@@ -865,8 +867,8 @@ static void missing_args(const FunctionSignature& signature, int idx) {
       ss.str().c_str());
 }
 
-static ssize_t find_param(FunctionSignature& signature, PyObject* name) {
-  ssize_t i = 0;
+static Py_ssize_t find_param(FunctionSignature& signature, PyObject* name) {
+  Py_ssize_t i = 0;
   for (auto& param : signature.params) {
     int cmp = PyObject_RichCompareBool(name, param.python_name, Py_EQ);
     if (cmp < 0) {
@@ -880,10 +882,10 @@ static ssize_t find_param(FunctionSignature& signature, PyObject* name) {
 }
 
 [[noreturn]]
-static void extra_kwargs(FunctionSignature& signature, PyObject* kwargs, ssize_t num_pos_args) {
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  PyObject *key, *value;
-  ssize_t pos = 0;
+static void extra_kwargs(FunctionSignature& signature, PyObject* kwargs, Py_ssize_t num_pos_args) {
+  PyObject *key = nullptr;
+  PyObject *value  = nullptr;
+  Py_ssize_t pos = 0;
 
   while (PyDict_Next(kwargs, &pos, &key, &value)) {
     if (!THPUtils_checkString(key)) {
@@ -1076,8 +1078,8 @@ PythonArgs PythonArgParser::raw_parse(PyObject* self, PyObject* args, PyObject* 
 void PythonArgParser::print_error(PyObject* self, PyObject* args, PyObject* kwargs, PyObject* parsed_args[]) {  // NOLINT
   // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
   auto num_args = PyTuple_GET_SIZE(args) + (kwargs ? PyDict_Size(kwargs) : 0);
-  std::vector<int> plausible_idxs;
-  ssize_t i = 0;
+  std::vector<unsigned> plausible_idxs;
+  unsigned i = 0;
   for (auto& signature : signatures_) {
     if (num_args >= signature.min_args && num_args <= signature.max_args && !signature.hidden) {
       plausible_idxs.push_back(i);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -120,7 +120,7 @@ private:
 
   std::vector<FunctionSignature> signatures_;
   std::string function_name;
-  ssize_t max_args;
+  size_t max_args;
   bool traceable;
 };
 
@@ -135,9 +135,9 @@ struct PYBIND11_EXPORT FunctionSignature {
   std::string name;
   std::vector<FunctionParameter> params;
   std::vector<py::handle> overloaded_args;
-  ssize_t min_args;
-  ssize_t max_args;
-  ssize_t max_pos_args;
+  size_t min_args;
+  size_t max_args;
+  size_t max_pos_args;
   int index;
   bool hidden;
   bool deprecated;


### PR DESCRIPTION
Use `Py_ssize_t` when calling Python API
Use `c10::irange` to automatically infer loop type
 Use `size_t` or `unsigned` for unsigned type

 Partially addresses https://github.com/pytorch/pytorch/issues/69948