### PR TITLE
[ONNX] Improve scope inference in function extraction

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -752,6 +752,23 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertIn("NWithOverloads.1", func_names)
         self.assertIn("NWithOverloads.2", func_names)
 
+    def test_local_function_infer_scopes(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                new_tensor_shape = x.size()[:-1] + \
+                    (1, 1, -1)
+                tensor = x.view(*new_tensor_shape)
+                return tensor
+
+        x = torch.randn(4, 5)
+        f = io.BytesIO()
+        torch.onnx.export(M(), (x,), f, export_modules_as_functions=True,
+                          opset_version=self.opset_version, do_constant_folding=False)
+
+        onnx_model = onnx.load(io.BytesIO(f.getvalue()))
+        funcs = onnx_model.functions
+        self.assertIn("M", [f.name for f in funcs])
+
     def test_aten_fallthrough(self):
         # Test aten export of op with no symbolic
         class Module(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -353,6 +353,12 @@ c10::optional<ScopePtr> FunctionExtractor::InferScope(Node* n) {
   }
   for (auto output : n->outputs()) {
     for (auto use : output->uses()) {
+      if (!IsValidScope(use.user->scope())) {
+        auto inferred_output_scope = InferScope(use.user);
+        if (inferred_output_scope.has_value() && IsValidScope(inferred_output_scope.value())) {
+          use.user->setScope(inferred_output_scope.value());
+        }
+      }
       output_scopes.emplace_back(use.user->scope());
     }
   }

--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -355,7 +355,8 @@ c10::optional<ScopePtr> FunctionExtractor::InferScope(Node* n) {
     for (auto use : output->uses()) {
       if (!IsValidScope(use.user->scope())) {
         auto inferred_output_scope = InferScope(use.user);
-        if (inferred_output_scope.has_value() && IsValidScope(inferred_output_scope.value())) {
+        if (inferred_output_scope.has_value() &&
+            IsValidScope(inferred_output_scope.value())) {
           use.user->setScope(inferred_output_scope.value());
         }
       }

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -189,6 +189,7 @@ Node* transformToONNXConcatNode(
 
     Node* unsqueezed_node =
         createONNXUnsqueeze(g, new_node, new_input, 0, opset_version);
+    unsqueezed_node->copyMetadata(lc_node);
     unsqueezed.emplace_back(unsqueezed_node->output());
   }
 


### PR DESCRIPTION
Cover more cases of scope inferencing where consecutive nodes don't have valid scope information. Usually these nodes are created in some pass where authors forgot to assign meaningful scope to them.
* One rule of `InferScope` is to check if the current node's outputs' users share the same scope. Recursively run `InferScope` on the user nodes if they are missing scope as well. Since the graph is SSA, the depth is finite.
* Fix one pass that missed scope information for a new node.