### PR TITLE
Support `full_codegen` for `abs`, `min`, `max`, and `neg`

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/LazyShapeInference.cpp
@@ -129,6 +129,14 @@ std::vector<Shape> compute_shape_arange_out(const at::Scalar & start, const at::
   return {Shape(out.scalar_type(), {size})};
 }
 
+std::vector<Shape> compute_shape_abs(const at::Tensor & self) {
+  if (self.is_complex()) {
+    const auto float_type = c10::toValueType(self.scalar_type());
+    return {Shape(float_type, self.sizes().vec())};
+  }
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
 std::vector<Shape> compute_shape_binary_cross_entropy(const at::Tensor & self, const at::Tensor & target, const c10::optional<at::Tensor> & weight, int64_t reduction) {
   if(reduction == at::Reduction::None) {
     return {Shape(self.scalar_type(), self.sizes().vec())};
@@ -210,6 +218,18 @@ std::vector<Shape> compute_shape_masked_fill_(at::Tensor & self, const at::Tenso
 
 std::vector<Shape> compute_shape_masked_fill_(at::Tensor & self, const at::Tensor & mask, const at::Tensor & value) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
+std::vector<Shape> compute_shape_max(const at::Tensor & self) {
+  TORCH_CHECK(self.numel() > 0,
+            "max(): Expected reduction dim to be specified for input.numel() == 0. Specify the reduction dim with the 'dim' argument.");
+  return {Shape(self.scalar_type(), {})};
+}
+
+std::vector<Shape> compute_shape_min(const at::Tensor & self){
+  TORCH_CHECK(self.numel() > 0,
+            "min(): Expected reduction dim to be specified for input.numel() == 0. Specify the reduction dim with the 'dim' argument.");
+    return {Shape(self.scalar_type(), {})};
 }
 
 std::vector<Shape> compute_shape_embedding(const at::Tensor & weight, const at::Tensor & indices, int64_t padding_idx, bool scale_grad_by_freq, bool sparse){

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -5,6 +5,7 @@ full_codegen:
   - _log_softmax_backward_data
   - _softmax
   - _softmax_backward_data
+  - abs
   - add.Tensor
   - addcdiv
   - addcmul
@@ -53,10 +54,12 @@ full_codegen:
   - lt.Tensor
   - masked_fill_.Scalar
   - masked_fill_.Tensor
+  - max
   - max_pool2d_with_indices
   - max_pool2d_with_indices_backward
   - mean
   - mean.dim
+  - min
   - mm
   - mul.Tensor
   - mv
@@ -66,6 +69,7 @@ full_codegen:
   - native_layer_norm_backward
   - ne.Scalar
   - ne.Tensor
+  - neg
   - nll_loss_backward
   - nll_loss_forward
   - nll_loss2d_backward


### PR DESCRIPTION
This task adds LazyTensor support for ops in `pyhpc_isoneutral_mixing` benchmark

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc-noopt