### PR TITLE
Use `ptrdiff_t` rather than `ssize_t`

### DIFF
--- a/torch/csrc/jit/python/python_list.h
+++ b/torch/csrc/jit/python/python_list.h
@@ -39,7 +39,7 @@ class ScriptList final {
  public:
   // TODO: Do these make sense?
   using size_type = size_t;
-  using diff_type = ssize_t;
+  using diff_type = ptrdiff_t;
 
   // Constructor for empty lists created during slicing, extending, etc.
   ScriptList(const TypePtr& type) : list_(AnyType::get()) {


### PR DESCRIPTION
`diff_type` kind of naturally should be `ptrdiff_t`, as `ssize_t` is actually defined [here](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html) as :
> The type ssize_t shall be capable of storing values at least in the range [-1, {SSIZE_MAX}].

