### PR TITLE
Remove `SHARED` for `caffe2_detectron_ops`

### DIFF
--- a/modules/detectron/CMakeLists.txt
+++ b/modules/detectron/CMakeLists.txt
@@ -33,7 +33,7 @@ if(BUILD_CAFFE2_OPS)
     target_link_libraries(caffe2_detectron_ops_hip torch)
     install(TARGETS caffe2_detectron_ops_hip DESTINATION lib)
   elseif(NOT IOS_PLATFORM)
-    add_library(caffe2_detectron_ops SHARED ${Detectron_CPU_SRCS})
+    add_library(caffe2_detectron_ops ${Detectron_CPU_SRCS})
     if(HAVE_SOVERSION)
       set_target_properties(caffe2_detectron_ops PROPERTIES
         VERSION ${TORCH_VERSION} SOVERSION ${TORCH_SOVERSION})


### PR DESCRIPTION
With `SHARED` for `caffe2_detectron_ops`, building static `libtorch` libraries will lead to an error:

```bash
$ cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=`which python` -DCMAKE_INSTALL_PREFIX=../pytorch-install ../pytorch

$ make
...
[100%] Linking CXX shared library ../../lib/libcaffe2_detectron_ops.so
/usr/bin/ld: ../../lib/libtensorpipe.a(utility.cc.o): relocation R_X86_64_PC32 against symbol `_ZTVSt9basic_iosIcSt11char_traitsIcEE@@GLIBCXX_3.4' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
modules/detectron/CMakeFiles/caffe2_detectron_ops.dir/build.make:285: recipe for target 'lib/libcaffe2_detectron_ops.so' failed
make[2]: *** [lib/libcaffe2_detectron_ops.so] Error 1
CMakeFiles/Makefile2:6077: recipe for target 'modules/detectron/CMakeFiles/caffe2_detectron_ops.dir/all' failed
make[1]: *** [modules/detectron/CMakeFiles/caffe2_detectron_ops.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
```
