### PR TITLE
[jit] Split DynamicType conformance test into smaller pieces.

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -2142,7 +2142,7 @@ TEST_P(LiteInterpreterDynamicTypeTestFixture, Conformance) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(
+INSTANTIATE_TEST_CASE_P(
     PyTorch,
     LiteInterpreterDynamicTypeTestFixture,
     ::testing::Range(

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -2055,6 +2055,67 @@ void enumerateTupleType(
   }
 }
 
+class LiteInterpreterDynamicTypeTestFixture
+    : public ::testing::TestWithParam<int> {
+ protected:
+  void SetUp() {
+    cu = std::make_shared<CompilationUnit>();
+    std::vector<TypePtr> keyTypes = {
+        AnyType::get(),
+        IntType::get(),
+        BoolType::get(),
+        FloatType::get(),
+        ComplexType::get(),
+        StringType::get(),
+        TensorType::get(),
+        DeviceObjType::get(),
+    };
+    types = {
+        NoneType::get(),
+        NumberType::get(),
+        ClassType::create("__torch__.TestClass1", cu),
+        ClassType::create("__torch__.TestClass2", cu),
+        AnyListType::get(),
+        AnyTupleType::get(),
+        StreamObjType::get(),
+        CapsuleType::get(),
+        GeneratorType::get(),
+        StorageType::get(),
+        VarType::create("t"),
+        VarType::create("v"),
+        AnyClassType::get()};
+    std::copy(keyTypes.begin(), keyTypes.end(), back_inserter(types));
+    auto expandTypes = [&](size_t tupleSize) {
+      std::vector<TypePtr> nested;
+      for (const auto& type : types) {
+        if (!(type == AnyType::get())) {
+          nested.push_back(ListType::create(type));
+          if (!(type == NoneType::get() ||
+                type->kind() == OptionalType::Kind)) {
+            nested.push_back(OptionalType::create(type));
+          }
+        }
+        for (const auto& keyType : keyTypes) {
+          nested.push_back(DictType::create(keyType, type));
+        }
+      }
+      std::vector<TypePtr> tmp;
+      enumerateTupleType(tupleSize, tmp, types, nested);
+      std::move(
+          std::begin(nested), std::end(nested), std::back_inserter(types));
+    };
+    expandTypes(1);
+    expandTypes(1);
+  }
+  std::shared_ptr<CompilationUnit> cu;
+  std::vector<TypePtr> types;
+
+ public:
+  static constexpr size_t kNumSplits = 10;
+};
+
+constexpr size_t LiteInterpreterDynamicTypeTestFixture::kNumSplits;
+
 /**
  * Enumerate all possible JIT types appearing in mobile runtime, and test
  * whether subtyping relation is preserved after one of the JIT types is
@@ -2065,55 +2126,14 @@ void enumerateTupleType(
  * of types. We call expandTypes() twice to test types nested less or equal
  * to two levels. e.g. List[Optional[Tensor]], Optional[Dict[Int, Bool]], etc.
  */
-TEST(LiteInterpreterTest, DynamicType) {
-  auto cu = std::make_shared<CompilationUnit>();
-  std::vector<TypePtr> keyTypes = {
-      AnyType::get(),
-      IntType::get(),
-      BoolType::get(),
-      FloatType::get(),
-      ComplexType::get(),
-      StringType::get(),
-      TensorType::get(),
-      DeviceObjType::get(),
-  };
-  std::vector<TypePtr> types = {
-      NoneType::get(),
-      NumberType::get(),
-      ClassType::create("__torch__.TestClass1", cu),
-      ClassType::create("__torch__.TestClass2", cu),
-      AnyListType::get(),
-      AnyTupleType::get(),
-      StreamObjType::get(),
-      CapsuleType::get(),
-      GeneratorType::get(),
-      StorageType::get(),
-      VarType::create("t"),
-      VarType::create("v"),
-      AnyClassType::get()};
-  std::copy(keyTypes.begin(), keyTypes.end(), back_inserter(types));
-  auto expandTypes = [&](size_t tupleSize) {
-    std::vector<TypePtr> nested;
-    for (const auto& type : types) {
-      if (!(type == AnyType::get())) {
-        nested.push_back(ListType::create(type));
-        if (!(type == NoneType::get() || type->kind() == OptionalType::Kind)) {
-          nested.push_back(OptionalType::create(type));
-        }
-      }
-      for (const auto& keyType : keyTypes) {
-        nested.push_back(DictType::create(keyType, type));
-      }
-    }
-    std::vector<TypePtr> tmp;
-    enumerateTupleType(tupleSize, tmp, types, nested);
-    std::move(std::begin(nested), std::end(nested), std::back_inserter(types));
-  };
-  expandTypes(1);
-  expandTypes(1);
+TEST_P(LiteInterpreterDynamicTypeTestFixture, Conformance) {
+  size_t num = types.size() / LiteInterpreterDynamicTypeTestFixture::kNumSplits;
+  size_t begin = num * GetParam();
+  size_t end = std::min(types.size(), begin + num);
   for (const auto& a : types) {
     auto da = DynamicType::create(*a);
-    for (const auto& b : types) {
+    for (size_t i = begin; i < end; i++) {
+      const auto& b = types[i];
       bool result = a->isSubtypeOf(*b);
       EXPECT_EQ(result, da->isSubtypeOf(*b));
       result = b->isSubtypeOf(*a);
@@ -2121,6 +2141,15 @@ TEST(LiteInterpreterTest, DynamicType) {
     }
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    PyTorch,
+    LiteInterpreterDynamicTypeTestFixture,
+    ::testing::Range(
+        0,
+        static_cast<int>(LiteInterpreterDynamicTypeTestFixture::kNumSplits)));
+
+#undef NUM_SPLITS
 
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -2058,7 +2058,7 @@ void enumerateTupleType(
 class LiteInterpreterDynamicTypeTestFixture
     : public ::testing::TestWithParam<size_t> {
  protected:
-  void SetUp() {
+  void SetUp() override {
     cu = std::make_shared<CompilationUnit>();
     std::vector<TypePtr> keyTypes = {
         AnyType::get(),
@@ -2089,14 +2089,14 @@ class LiteInterpreterDynamicTypeTestFixture
       std::vector<TypePtr> nested;
       for (const auto& type : types) {
         if (!(type == AnyType::get())) {
-          nested.push_back(ListType::create(type));
+          nested.emplace_back(ListType::create(type));
           if (!(type == NoneType::get() ||
                 type->kind() == OptionalType::Kind)) {
-            nested.push_back(OptionalType::create(type));
+            nested.emplace_back(OptionalType::create(type));
           }
         }
         for (const auto& keyType : keyTypes) {
-          nested.push_back(DictType::create(keyType, type));
+          nested.emplace_back(DictType::create(keyType, type));
         }
       }
       std::vector<TypePtr> tmp;

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -2056,7 +2056,7 @@ void enumerateTupleType(
 }
 
 class LiteInterpreterDynamicTypeTestFixture
-    : public ::testing::TestWithParam<int> {
+    : public ::testing::TestWithParam<size_t> {
  protected:
   void SetUp() {
     cu = std::make_shared<CompilationUnit>();
@@ -2146,10 +2146,8 @@ INSTANTIATE_TEST_SUITE_P(
     PyTorch,
     LiteInterpreterDynamicTypeTestFixture,
     ::testing::Range(
-        0,
-        static_cast<int>(LiteInterpreterDynamicTypeTestFixture::kNumSplits)));
-
-#undef NUM_SPLITS
+        static_cast<size_t>(0),
+        LiteInterpreterDynamicTypeTestFixture::kNumSplits));
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71275

Currently it's taking more than 10 minutes to run the conformance test. Instead we should use parametrized test to shard into test segments so that they can run in parallel.

Differential Revision: [D33570442](https://our.internmc.facebook.com/intern/diff/D33570442/)