### PR TITLE
Install the most recent nightly build in case of nightly build failure.

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -37,7 +37,8 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
-                           future six dataclasses pillow pytest tabulate gitpython git-lfs beautifulsoup4
+                           future six dataclasses pillow pytest tabulate gitpython git-lfs beautifulsoup4 \
+                           tqdm
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -30,6 +30,13 @@ jobs:
           git remote prune origin
           git fetch
           popd
+      - name: Checkout TorchBench
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          repository: pytorch/benchmark
+          path: benchmark
+          lfs: true
+          ref: ${{ env.TORCHBENCH_BRANCH }}
       - name: Create conda environment
         run: |
           conda create -y -n pr-ci python="${PYTHON_VERSION}"
@@ -37,10 +44,13 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
-                           future six dataclasses pillow pytest tabulate gitpython git-lfs
+                           future six dataclasses pillow pytest tabulate gitpython git-lfs beautifulsoup4
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
-          conda install -y pytorch torchvision torchtext cudatoolkit="${CUDA_VERSION}" -c pytorch-nightly
+          # install the most recent successful nightly build
+          python benchmark/torchbenchmark/utils/torch_nightly.py --dump-latest-build nightly.txt \
+                                                                 --packages torch torchvision torchtext
+          pip install -f nightly.txt
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091
@@ -49,13 +59,6 @@ jobs:
           PR_BODY_FILE=/tmp/pr-body.txt
           echo "$PR_BODY" > ${PR_BODY_FILE}
           python pytorch/.github/scripts/run_torchbench.py --pr-body "${PR_BODY_FILE}" set-torchbench-branch
-      - name: Checkout TorchBench
-        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
-        with:
-          repository: pytorch/benchmark
-          path: benchmark
-          lfs: true
-          ref: ${{ env.TORCHBENCH_BRANCH }}
       - name: Install TorchBench dependencies
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -68,6 +68,9 @@ jobs:
           # usually, this doesn't break the binary compatibility
           # use "--no-deps" to install the packages by force
           pip install -r nightly.txt --no-deps
+          python -c 'import torch; print(torch.__version__)'
+          python -c 'import torchvision; print(torchvision.__version__)'
+          python -c 'import torchtext; print(torchtext.__version__)'
           pushd benchmark
           python install.py
       - name: Install TorchBench dependencies

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -48,8 +48,8 @@ jobs:
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
           # install the most recent successful nightly build
-          python benchmark/torchbenchmark/utils/torch_nightly.py --dump-latest-build nightly.txt \
-                                                                 --packages torch torchvision torchtext
+          python benchmark/torchbenchmark/util/torch_nightly.py --dump-latest-wheels nightly.txt \
+                                                                --packages torch torchvision torchtext
           pip install -r nightly.txt
       - name: Setup TorchBench branch
         run: |

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -50,7 +50,7 @@ jobs:
           # install the most recent successful nightly build
           python benchmark/torchbenchmark/utils/torch_nightly.py --dump-latest-build nightly.txt \
                                                                  --packages torch torchvision torchtext
-          pip install -f nightly.txt
+          pip install -r nightly.txt
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -30,13 +30,6 @@ jobs:
           git remote prune origin
           git fetch
           popd
-      - name: Checkout TorchBench
-        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
-        with:
-          repository: pytorch/benchmark
-          path: benchmark
-          lfs: true
-          ref: ${{ env.TORCHBENCH_BRANCH }}
       - name: Create conda environment
         run: |
           conda create -y -n pr-ci python="${PYTHON_VERSION}"
@@ -45,12 +38,6 @@ jobs:
           conda activate pr-ci
           conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs beautifulsoup4
-          # install magma
-          conda install -y -c pytorch "${MAGMA_VERSION}"
-          # install the most recent successful nightly build
-          python benchmark/torchbenchmark/util/torch_nightly.py --dump-latest-wheels nightly.txt \
-                                                                --packages torch torchvision torchtext
-          pip install -r nightly.txt
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091
@@ -59,6 +46,24 @@ jobs:
           PR_BODY_FILE=/tmp/pr-body.txt
           echo "$PR_BODY" > ${PR_BODY_FILE}
           python pytorch/.github/scripts/run_torchbench.py --pr-body "${PR_BODY_FILE}" set-torchbench-branch
+      - name: Checkout TorchBench
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          repository: pytorch/benchmark
+          path: benchmark
+          lfs: true
+          ref: ${{ env.TORCHBENCH_BRANCH }}
+      - name: Install PyTorch Nightly packages
+        run: |
+          # shellcheck disable=SC1091
+          . "${HOME}"/anaconda3/etc/profile.d/conda.sh
+          conda activate pr-ci
+          # install magma
+          conda install -y -c pytorch "${MAGMA_VERSION}"
+          # install the most recent successful nightly build
+          python benchmark/torchbenchmark/util/torch_nightly.py --dump-latest-wheels nightly.txt \
+                                                                --packages torch torchvision torchtext
+          pip install -r nightly.txt
       - name: Install TorchBench dependencies
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -68,6 +68,8 @@ jobs:
           # usually, this doesn't break the binary compatibility
           # use "--no-deps" to install the packages by force
           pip install -r nightly.txt --no-deps
+          pushd benchmark
+          python install.py
       - name: Install TorchBench dependencies
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -63,7 +63,11 @@ jobs:
           # install the most recent successful nightly build
           python benchmark/torchbenchmark/util/torch_nightly.py --dump-latest-wheels nightly.txt \
                                                                 --packages torch torchvision torchtext
-          pip install -r nightly.txt
+          # when nightly build fails, the dependencies of packages could also skew up
+          # e.g. torchvision 20220112 could depend on torch 20220111, not 20220112
+          # usually, this doesn't break the binary compatibility
+          # use "--no-deps" to install the packages by force
+          pip install -r nightly.txt --no-deps
       - name: Install TorchBench dependencies
         run: |
           # shellcheck disable=SC1091


### PR DESCRIPTION
Sometimes PyTorch nightly build fails (e.g. https://github.com/pytorch/pytorch/issues/71260). In this case, both conda and pip will fail if installing nightly packages.

However this shouldn't block users from using the TorchBench CI, because we could use slightly older nightly packages to bootstrap. This PR uses the `torch_nightly.py` script in TorchBench to generate a list of nightly wheels that contain the most recent successful nightly build, and use it for bootstrapping the CI.

RUN_TORCHBENCH: resnet18
TORCHBENCH_BRANCH: xz9/add-latest-nightly