### PR TITLE
[LTC] Add a RValue ctor to torch::lazy::Value

### DIFF
--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -206,7 +206,7 @@ class GenLazyNativeFuncDefinition:
 
         assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
         first_tensor = value_types[0]
-        bridge_str = f"""auto result = torch::lazy::CreateAtenFromLtcTensor(torch::lazy::LazyTensor::Create(node, lazy_{first_tensor.name}.GetDevice()));"""
+        bridge_str = f"""auto result = torch::lazy::CreateAtenFromLtcTensor(torch::lazy::LazyTensor::Create(std::move(node), lazy_{first_tensor.name}.GetDevice()));"""
         if returns_length > 1:
             bridge_str = f"""std::vector<{self.tensor_class}> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
@@ -221,7 +221,6 @@ class GenLazyNativeFuncDefinition:
 
 
         return [f"""\
-    // TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
     {sig.decl(name=f"{self.class_method_name}::{schema.aten_name}")} {{
         TORCH_LAZY_FN_COUNTER("lazy::");
         {get_device_str}

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -65,7 +65,8 @@ using OutputMap = std::unordered_map<Output, T, Output::Hasher>;
 // Represents an input/operand for a Node object.
 struct TORCH_API Value {
   Value() = default;
-  /* implicit */ Value(NodePtr node, size_t index = 0) : node(std::move(node)), index(index) {}
+  /* implicit */ Value(NodePtr&& node, size_t index = 0) : node(std::move(node)), index(index) {}
+  /* implicit */ Value(const NodePtr& node, size_t index = 0) : node(node), index(index) {}
 
   hash_t hash() const;
 


### PR DESCRIPTION
Summary:
This commit adds a RValue ctor to torch::lazy::Value.

Test Plan:
./lazy_tensor_core/test/cpp/build/test_ptltc

