### PR TITLE
- Fixed memory leak in ir_simplifier.cpp

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1866,7 +1866,7 @@ class ModRound {
   ExprPtr mod_divisor;
 };
 
-c10::optional<class ModRound*> isModRound(TermPtr e) {
+c10::optional< class ModRound > isModRound(TermPtr e) {
   DivPtr div{nullptr};
   ModPtr mod{nullptr};
   ExprPtr denom{nullptr};
@@ -1968,8 +1968,7 @@ c10::optional<class ModRound*> isModRound(TermPtr e) {
     scalar = immLike(multiplier, 1);
   }
 
-  // TODO: this leaks memory!
-  return new ModRound(scalar, denom, divisor, mod_divisor);
+  return ModRound(scalar, denom, divisor, mod_divisor);
 }
 
 // Search the polynomial for Terms that can be merged in
@@ -2035,26 +2034,26 @@ ExprPtr simplifyRoundModPattern(PolynomialPtr poly) {
         TermPtr mr = mod_rounds[j];
         auto a = isModRound(mr);
         CHECK(a);
-        ModRound* mod_round = dynamic_cast<ModRound*>(*a);
+        ModRound& mod_round = *a;
 
         // TODO: for now don't attempt partial factorization of this
         // optimization. E.g. it's possible to do: 2 * (x/y%z) * y + (x%y) =>
         // x%(y*z) + (x/y%z) * y
         if (!immediateEquals(
-                evaluateOp(alloc<Sub>(mod_round->scalar, m->scalar())), 0)) {
+                evaluateOp(alloc<Sub>(mod_round.scalar, m->scalar())), 0)) {
           continue;
         }
         // Valid optimization if mod LHS matches denom and mod RHS matches
         // divisor.
-        if (hasher.hash(mod_round->denom) == hasher.hash(mod_lhs) &&
-            hasher.hash(mod_round->divisor) == hasher.hash(mod_rhs)) {
+        if (hasher.hash(mod_round.denom) == hasher.hash(mod_lhs) &&
+            hasher.hash(mod_round.divisor) == hasher.hash(mod_rhs)) {
           // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
           TermPtr merged_m = alloc<Term>(
               hasher,
-              mod_round->scalar,
+              mod_round.scalar,
               IRSimplifier::simplify(alloc<Mod>(
-                  mod_round->denom,
-                  alloc<Mul>(mod_round->divisor, mod_round->mod_divisor))));
+                  mod_round.denom,
+                  alloc<Mul>(mod_round.divisor, mod_round.mod_divisor))));
           mods_merged.push_back(merged_m);
           merged = true;
           repeat = true;


### PR DESCRIPTION
The leak was causing long running inference loops to exhaust system memory. I tracked down the issue and noted that ModRound can be copied by value without worrying about a performance hit.

I originally branched from release/1.10 and made these changes. This commit includes the same changes but from master as requested in the original PR https://github.com/pytorch/pytorch/pull/71077