### PR TITLE
[PyTorch][Lazy] Make hashing null optionals cheap

### DIFF
--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -133,7 +133,11 @@ static inline hash_t Hash(const c10::string_view& value) {
 // we want to include a contribution to the hash to distinguish
 // cases where one or another option was null, but we hope it doesn't
 // collide with an actually scalar value.
-static const int64_t kNullOpt = -3333;
+//
+// Use an arbitrary randomly-selected 64-bit integer rather than a
+// small constant that we then hash at runtime so we don't have to
+// repeatedly hash a constant at runtime.
+static const int64_t kNullOpt = 0x8655d738f3678dda;
 
 // Hashing for c10::optional types contributes to hash
 // for optionals with null value, important to distinguish
@@ -143,7 +147,7 @@ hash_t Hash(const c10::optional<T>& value) {
   if (value.has_value()) {
     return Hash(value.value());
   } else {
-    return Hash(kNullOpt);
+    return kNullOpt;
   }
 }
 
@@ -163,7 +167,7 @@ hash_t Hash(const c10::optional<std::vector<T>>& value) {
   if (value.has_value()) {
     return ContainerHash(value.value());
   } else {
-    return Hash(kNullOpt);
+    return kNullOpt;
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71290

The existing code called an out-of-line hash function on a constant. This is just going to get the same random-looking 64-bit integer every time, so I just changed the constant to an integer I generated with `hex(random.randint(0x1000000000000000, 0xFFFFFFFFFFFFFFFF))` to get the same effect but without the runtime hashing.

Differential Revision: [D33574676](https://our.internmc.facebook.com/intern/diff/D33574676/)