### PR TITLE
Use SLEEF functions for erf/exp on macOS ARM64

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -11,6 +11,14 @@
 // However for now opting for STL, since we are not building
 // with Sleef for mobile yet.
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#if defined(__aarch64__) && defined(TARGET_OS_MAC)
+#include <sleef.h>
+#endif
+
 namespace at {
 namespace vec {
 // See Note [CPU_CAPABILITY namespace]
@@ -353,7 +361,11 @@ public:
     return loadu(tmp);
   }
   Vectorized<float> erf() const {
+#if defined(TARGET_OS_MAC)
+    return Vectorized<float>(Sleef_erff4_u10(values.val[0]), Sleef_erff4_u10(values.val[1]));
+#else
     return map(std::erf);
+#endif
   }
   Vectorized<float> erfc() const {
     return map(std::erfc);
@@ -362,7 +374,11 @@ public:
     return map(calc_erfinv);
   }
   Vectorized<float> exp() const {
+#if defined(TARGET_OS_MAC)
+    return Vectorized<float>(Sleef_expf4_u10(values.val[0]), Sleef_expf4_u10(values.val[1]));
+#else
     return map(std::exp);
+#endif
   }
   Vectorized<float> expm1() const {
     return map(std::expm1);


### PR DESCRIPTION
The NEON `Vectorized<float>` implementation does not use SLEEF functions in order to compile on mobile platforms. However, SLEEF is already compiled on macOS ARM64 and is safe to use on that platform.

Since transformers rely heavily on `erf` (GELU) and `exp` (softmax), using the SLEEF implementations of `erf`/`exp` can provide large speedups of transformers on Apple M1 Macs. For instance, we have found spaCy transformer models to be 20% faster when using the SLEEF implementation of these functions.

This PR is a follow-up to #70354, but with a more limited scope as suggested in https://github.com/pytorch/pytorch/pull/70354#pullrequestreview-852154370.

Profile of a tranformer model before this change:

<img width="860" alt="Screen Shot 2022-01-14 at 09 37 56" src="https://user-images.githubusercontent.com/49398/149480928-948c78d0-1a4d-4729-b7de-b10e08b745c9.png">

Most time is spent in `erff`/`expf`.

Profile of the same transformer model after this change:

<img width="875" alt="Screen Shot 2022-01-14 at 09 39 39" src="https://user-images.githubusercontent.com/49398/149481711-c4ba2749-b791-489c-865e-4b43bad4b0b6.png">

Time spent in `erff` is reduced from 1.94min to 1.18min, time spent in `expf` is reduced from 60s to 8s.