### PR TITLE
Sparse CSR: Handle zero matrix consistently for triangular_solve

### DIFF
--- a/aten/src/ATen/native/mkl/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/mkl/SparseBlasImpl.cpp
@@ -419,6 +419,8 @@ void triangular_solve_out_sparse_csr(
       "Please use PyTorch built with MKL on Linux.");
 #else
   if (B.numel() == 0 || X.numel() == 0 || A._nnz() == 0) {
+    // If A has no nnz, then A is singular and we can't solve.
+    X.fill_(NAN);
     return;
   }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -1063,6 +1063,11 @@ void triangular_solve_out_sparse_csr(
     bool upper,
     bool transpose,
     bool unitriangular) {
+  if (B.numel() == 0 || X.numel() == 0 || A._nnz() == 0) {
+    // If A has no nnz, then A is singular and we can't solve.
+    X.fill_(NAN);
+    return;
+  }
   if (A.values().dim() == 3 && A.values().size(-1) > 1) {
     if (B.size(-1) == 1) {
       return block_sparse_triangular_solve_vec(A, B, X, upper, transpose, unitriangular);
@@ -1077,10 +1082,6 @@ void triangular_solve_out_sparse_csr(
       "PyTorch with at least CUDA 11.3. ",
       "Please use PyTorch built with newer CUDA version.");
 #else
-  if (B.numel() == 0 || X.numel() == 0 || A._nnz() == 0) {
-    return;
-  }
-
   c10::MaybeOwned<Tensor> X_ = prepare_dense_matrix_for_cusparse(X);
   // It should be possible to use mixed memory format
   // but there is a bug in CUDA 11.3.1 version:


### PR DESCRIPTION
This PR enables `test_block_triangular` tests on the CPU.
These tests revealed that there was a problem with how the nnz==0 case is handled. Now we return a tensor filled with NaNs both on CUDA and CPU.



cc @nikitaved @pearu @cpuhrsch