### PR TITLE
move header inclusion

### DIFF
--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -5,6 +5,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <ATen/code_template.h>
 #include <ATen/native/cuda/jit_utils.h>
 

--- a/aten/src/ATen/native/cuda/jit_utils.h
+++ b/aten/src/ATen/native/cuda/jit_utils.h
@@ -7,7 +7,6 @@
 
 #include <c10/util/irange.h>
 #include <ATen/cuda/detail/LazyNVRTC.h>
-#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 
 #ifdef __HIP_PLATFORM_HCC__
     // pass -- jiterator not supported on HIP platforms


### PR DESCRIPTION
A header is used only in the .cc file and it is included by the public header. This causes errors when I try to include the public header.
