### PR TITLE
Remove the dependency of pytorch nightly.

### DIFF
--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -53,6 +53,7 @@ def find_current_branch(repo_path: str) -> str:
     repo = git.Repo(repo_path)
     name: str = repo.active_branch.name
     return name
+
 def deploy_torchbench_config(output_dir: str, config: str) -> None:
     # Create test dir if needed
     pathlib.Path(output_dir).mkdir(exist_ok=True)

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -24,16 +24,6 @@ jobs:
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
         with:
           path: pytorch
-      - name: Checkout Torchvision
-        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
-        with:
-          repository: pytorch/vision
-          path: vision
-      - name: Checkout Torchtext
-        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
-        with:
-          repository: pytorch/text
-          path: text
       - name: Update self-hosted PyTorch
         run: |
           pushd "${HOME}"/pytorch
@@ -50,7 +40,7 @@ jobs:
                            future six dataclasses pillow pytest tabulate gitpython git-lfs
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
-      - name: Build the self-hosted PyTorch domain packages
+      - name: Build self-hosted PyTorch domain packages
         run: |
           # shellcheck disable=SC1091
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
@@ -63,14 +53,17 @@ jobs:
           export USE_CUDNN=1
           export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
           # build the packages
-          pushd pytorch
+          pushd "${HOME}"/pytorch
+          git checkout "${PR_BASE_SHA}" && git submodule sync && git submodule init --recursive
           python setup.py install
           popd
           pushd vision
-          python setup.py install
+          git checkout main && git submodule sync && git submodule init --recursive
+          python setup.py clean install
           popd
           pushd text
-          python setup.py install
+          git checkout main && git submodule sync && git submodule init --recursive
+          python setup.py clean install
           popd
       - name: Setup TorchBench branch
         run: |

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -24,17 +24,19 @@ jobs:
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
         with:
           path: pytorch
-      - name: Update self-hosted PyTorch domain packages
+      - name: Checkout Torchvision
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          repository: pytorch/vision
+          path: vision
+      - name: Checkout Torchtext
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          repository: pytorch/text
+          path: text
+      - name: Update self-hosted PyTorch
         run: |
           pushd "${HOME}"/pytorch
-          git remote prune origin
-          git fetch
-          popd
-          pushd "${HOME}"/vision
-          git remote prune origin
-          git fetch
-          popd
-          pushd "${HOME}"/text
           git remote prune origin
           git fetch
           popd
@@ -60,18 +62,15 @@ jobs:
           export USE_MKL=1
           export USE_CUDNN=1
           export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
-          # build PyTorch with base sha version
-          pushd "${HOME}"/pytorch
-          git checkout "${PR_BASE_SHA}" && git submodule update --init --recursive
+          # build the packages
+          pushd pytorch
           python setup.py install
           popd
-          pushd "${HOME}"/vision
-          git checkout main && git submodule update --init --recursive
+          pushd vision
           python setup.py install
           popd
-          pushd "${HOME}"/text
-          git checkout main && git submodule update --init --recursive
-          python setup.py clean install
+          pushd text
+          python setup.py install
           popd
       - name: Setup TorchBench branch
         run: |

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -54,15 +54,15 @@ jobs:
           export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
           # build the packages
           pushd "${HOME}"/pytorch
-          git checkout "${PR_BASE_SHA}" && git submodule sync && git submodule init --recursive
+          git checkout "${PR_BASE_SHA}" && git submodule sync && git submodule update --init --recursive
           python setup.py install
           popd
           pushd vision
-          git checkout main && git submodule sync && git submodule init --recursive
+          git checkout main && git submodule sync && git submodule update --init --recursive
           python setup.py clean install
           popd
           pushd text
-          git checkout main && git submodule sync && git submodule init --recursive
+          git checkout main && git submodule sync && git submodule update --init --recursive
           python setup.py clean install
           popd
       - name: Setup TorchBench branch

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -46,14 +46,15 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           # setup build env
-          export USE_CUDA=1
-          export USE_CUDNN=1
-          export USE_MKLDNN=1
-          export BUILD_TEST=0
-          export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
+          USE_CUDA=1
+          USE_CUDNN=1
+          USE_MKLDNN=1
+          BUILD_TEST=0
+          CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
+          PR_MERGE_BASE=$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")
           # build the packages
           pushd "${HOME}"/pytorch
-          git checkout "${PR_BASE_SHA}" && git submodule sync && git submodule update --init --recursive
+          git checkout "${PR_MERGE_BASE}" && git submodule sync && git submodule update --init --recursive
           python setup.py clean
           python setup.py install
           popd

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -47,10 +47,9 @@ jobs:
           conda activate pr-ci
           # setup build env
           export USE_CUDA=1
-          export BUILD_TEST=0
-          export USE_MKLDNN=1
-          export USE_MKL=1
           export USE_CUDNN=1
+          export USE_MKLDNN=1
+          export BUILD_TEST=0
           export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
           # build the packages
           pushd "${HOME}"/pytorch

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -58,12 +58,12 @@ jobs:
           python setup.py clean
           python setup.py install
           popd
-          pushd vision
+          pushd ${HOME}"/vision
           git checkout main && git submodule sync && git submodule update --init --recursive
           python setup.py clean
           python setup.py install
           popd
-          pushd text
+          pushd ${HOME}"/text
           git checkout main && git submodule sync && git submodule update --init --recursive
           python setup.py clean
           python setup.py install

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -51,9 +51,9 @@ jobs:
           USE_MKLDNN=1
           BUILD_TEST=0
           CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
-          PR_MERGE_BASE=$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")
           # build the packages
           pushd "${HOME}"/pytorch
+          PR_MERGE_BASE=$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")
           git checkout "${PR_MERGE_BASE}" && git submodule sync && git submodule update --init --recursive
           python setup.py clean
           python setup.py install

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -24,13 +24,21 @@ jobs:
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
         with:
           path: pytorch
-      - name: Update self-hosted PyTorch
+      - name: Update self-hosted PyTorch domain packages
         run: |
           pushd "${HOME}"/pytorch
           git remote prune origin
           git fetch
           popd
-      - name: Create conda environment
+          pushd "${HOME}"/vision
+          git remote prune origin
+          git fetch
+          popd
+          pushd "${HOME}"/text
+          git remote prune origin
+          git fetch
+          popd
+      - name: Create conda environment and install deps
         run: |
           conda create -y -n pr-ci python="${PYTHON_VERSION}"
           # shellcheck disable=SC1091
@@ -40,7 +48,31 @@ jobs:
                            future six dataclasses pillow pytest tabulate gitpython git-lfs
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
-          conda install -y pytorch torchvision torchtext cudatoolkit="${CUDA_VERSION}" -c pytorch-nightly
+      - name: Build the self-hosted PyTorch domain packages
+        run: |
+          # shellcheck disable=SC1091
+          . "${HOME}"/anaconda3/etc/profile.d/conda.sh
+          conda activate pr-ci
+          # setup build env
+          export USE_CUDA=1
+          export BUILD_TEST=0
+          export USE_MKLDNN=1
+          export USE_MKL=1
+          export USE_CUDNN=1
+          export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
+          # build PyTorch with base sha version
+          pushd "${HOME}"/pytorch
+          git checkout "${PR_BASE_SHA}" && git submodule update --init --recursive
+          python setup.py install
+          popd
+          pushd "${HOME}"/vision
+          git checkout main && git submodule update --init --recursive
+          python setup.py install
+          popd
+          pushd "${HOME}"/text
+          git checkout main && git submodule update --init --recursive
+          python setup.py clean install
+          popd
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -37,37 +37,9 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
-                           future six dataclasses pillow pytest tabulate gitpython git-lfs
+                           future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
-      - name: Build self-hosted PyTorch domain packages
-        run: |
-          # shellcheck disable=SC1091
-          . "${HOME}"/anaconda3/etc/profile.d/conda.sh
-          conda activate pr-ci
-          # setup build env
-          USE_CUDA=1
-          USE_CUDNN=1
-          USE_MKLDNN=1
-          BUILD_TEST=0
-          CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
-          # build the packages
-          pushd "${HOME}"/pytorch
-          PR_MERGE_BASE=$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")
-          git checkout "${PR_MERGE_BASE}" && git submodule sync && git submodule update --init --recursive
-          python setup.py clean
-          python setup.py install
-          popd
-          pushd "${HOME}"/vision
-          git checkout main && git submodule sync && git submodule update --init --recursive
-          python setup.py clean
-          python setup.py install
-          popd
-          pushd "${HOME}"/text
-          git checkout main && git submodule sync && git submodule update --init --recursive
-          python setup.py clean
-          python setup.py install
-          popd
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091
@@ -83,13 +55,6 @@ jobs:
           path: benchmark
           lfs: true
           ref: ${{ env.TORCHBENCH_BRANCH }}
-      - name: Install TorchBench dependencies
-        run: |
-          # shellcheck disable=SC1091
-          . "${HOME}"/anaconda3/etc/profile.d/conda.sh
-          conda activate pr-ci
-          pushd "${PWD}"/benchmark
-          python install.py
       - name: Run TorchBench
         run: |
           pushd "${HOME}"/pytorch

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -57,12 +57,12 @@ jobs:
           python setup.py clean
           python setup.py install
           popd
-          pushd ${HOME}"/vision
+          pushd "${HOME}"/vision
           git checkout main && git submodule sync && git submodule update --init --recursive
           python setup.py clean
           python setup.py install
           popd
-          pushd ${HOME}"/text
+          pushd "${HOME}"/text
           git checkout main && git submodule sync && git submodule update --init --recursive
           python setup.py clean
           python setup.py install

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -55,15 +55,18 @@ jobs:
           # build the packages
           pushd "${HOME}"/pytorch
           git checkout "${PR_BASE_SHA}" && git submodule sync && git submodule update --init --recursive
+          python setup.py clean
           python setup.py install
           popd
           pushd vision
           git checkout main && git submodule sync && git submodule update --init --recursive
-          python setup.py clean install
+          python setup.py clean
+          python setup.py install
           popd
           pushd text
           git checkout main && git submodule sync && git submodule update --init --recursive
-          python setup.py clean install
+          python setup.py clean
+          python setup.py install
           popd
       - name: Setup TorchBench branch
         run: |


### PR DESCRIPTION
This PR removes the PyTorch nightly dependencies of TorchBench CI. Instead, it relies on the bisection script to install TorchBench dependencies (https://github.com/pytorch/benchmark/pull/694).
This will unblock TorchBench CI users when the nightly build fails (e.g., https://github.com/pytorch/pytorch/issues/71260)

RUN_TORCHBENCH: resnet18
TORCHBENCH_BRANCH: xz9/optimize-bisection