### PR TITLE
Pin numba to 0.54.1

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -120,7 +120,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install numba only on python-3.8 or below
   # For numba issue see https://github.com/pytorch/pytorch/issues/51511
   if [[ $(python -c "import sys; print(int(sys.version_info < (3, 9)))") == "1" ]]; then
-    as_jenkins pip install --progress-bar off numba librosa>=0.6.2
+    as_jenkins pip install --progress-bar off numba==0.54.1 librosa>=0.6.2
   else
     as_jenkins pip install --progress-bar off numba==0.49.0 librosa>=0.6.2
   fi


### PR DESCRIPTION
Not sure what is going on, but numba=0.55.0 currently installed in for example 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.7-clang9:0d18ad2827487386d2a7864b11fec5bc83de6545 is build against newer version of numpy, which was apparently silently fixed on the pypi side (as latest numba download is numba-0.55.0-1-cp37-cp37m-manylinux2014_x86_64.manylinux_2_17_x86_64.whl  )
Fixes https://github.com/pytorch/pytorch/issues/71320
