### PR TITLE
[jit][edge] Return a no-op nullptr for UnionType on mobile for backward compatibility.

### DIFF
--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -151,6 +151,12 @@ TypePtr TypeParser::parse() {
       // other class starts with __torch__ following by custom names
       return parseCustomType();
     }
+  } else if (token == "Union") {
+    // TODO Union types are not supported on embedded runtime, and we need to
+    // generate compiler errors for users scripting UnionTypes. Right now
+    // for preserving backward compatibility we have to return a nullptr since
+    // it does not get involved in type reflection.
+    return nullptr;
   } else {
     TORCH_CHECK(
         false,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71341

Old models containing UnionType need to be loaded even if they don't actually use Unions.
This is not the best solution, we need to catch this error on the compiler side instead, but before doing that we can land this first to at least mitigate model loading crash issues.

Differential Revision: [D33593276](https://our.internmc.facebook.com/intern/diff/D33593276/)