### PR TITLE
The Cacherator

### DIFF
--- a/aten/src/ATen/jit_macros.h
+++ b/aten/src/ATen/jit_macros.h
@@ -6,15 +6,12 @@
     #define USE_JITERATOR true
     #define jiterator_stringify(...) std::string(#__VA_ARGS__);
 #else
+    // TODO: update this to become a static assertion
     #define jiterator_stringify(...) std::string("USE_JITERATOR is undefined");
 #endif // USE_ROCM
 
-// USE_JITERATOR_WITH_CACHE, controls whether jitted kernels are cached
+// BUILD_JITERATOR_WITH_CACHE, controls whether jitted kernels can be cached
 // Currently unsupported on Windows
 #ifndef _WIN32
-    #define USE_JITERATOR_WITH_CACHE true
+    #define BUILD_JITERATOR_WITH_CACHE true
 #endif // _WIN32
-
-// #define JITERATOR_CACHE_PATH "~/.cache/torch/kernels/"
-
-#define JITERATOR_CACHE_PATH "/private/home/mruberry/"

--- a/aten/src/ATen/jit_macros.h
+++ b/aten/src/ATen/jit_macros.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// USE_JITERATOR, controls whether we jit some elementwise kernels
+// Currently unsupported on ROCm GPUs
+#ifndef USE_ROCM
+    #define USE_JITERATOR true
+    #define jiterator_stringify(...) std::string(#__VA_ARGS__);
+#else
+    #define jiterator_stringify(...) std::string("USE_JITERATOR is undefined");
+#endif // USE_ROCM
+
+// USE_JITERATOR_WITH_CACHE, controls whether jitted kernels are cached
+// Currently unsupported on Windows
+#ifndef _WIN32
+    #define USE_JITERATOR_WITH_CACHE true
+#endif // _WIN32
+
+// #define JITERATOR_CACHE_PATH "~/.cache/torch/kernels/"
+
+#define JITERATOR_CACHE_PATH "/private/home/mruberry/"

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <ATen/jit_macros.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/TensorIteratorDynamicCasting.h>
@@ -79,15 +80,14 @@ __device__ inline void elementwise_kernel_helper(func_t f, policy_t policy) {
 // memory access introduce regression on ROCm.
 
 #if !defined(USE_ROCM)
-#include <ATen/native/cuda/CUDALoops.cuh>
-#define USE_JITERATOR
+  #include <ATen/native/cuda/CUDALoops.cuh>
 #else
-#include <ATen/native/cuda/ROCmLoops.cuh>
+  #include <ATen/native/cuda/ROCmLoops.cuh>
 #endif
 
 namespace at { namespace native {
-#ifdef USE_JITERATOR
 
+#ifdef USE_JITERATOR
 /* Note [Jiterator]
 The "jiterator" simply just-in-time compiles the same kernels that
 Loops.cuh (and CUDALoops.cuh) usually build. This reduces build time,
@@ -207,7 +207,7 @@ void opmath_jitted_gpu_kernel_with_scalars(TensorIteratorBase& iter, const std::
     jitted_gpu_kernel<name, return_type, f_inputs_type, 2>(iter, f);
   }
 }
-#endif //USE_JITERATOR
+#endif // USE_JITERATOR
 
 template <typename func_t>
 void gpu_kernel(TensorIteratorBase& iter, const func_t& f) {

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -91,11 +91,16 @@ namespace at { namespace native {
 /* Note [Jiterator]
 The "jiterator" simply just-in-time compiles the same kernels that
 Loops.cuh (and CUDALoops.cuh) usually build. This reduces build time,
-build size, and CUDA context size.
+build size, and initial CUDA context size.
+
+By default on non-Windows systems, it also caches compiled kernels in ~/.cache/torch/kernels.
+This behavior is controlled with two environment variables:
+  - USE_PYTORCH_KERNEL_CACHE, if set to zero then this will disable all cache use
+  - PYTORCH_KERNEL_CACHE_PATH, if set specifies the folder to use for cached kernels
 
 The jiterator currently has some limitations, however. It cannot:
-  - handle float16, bfloat16, or complex datatypes
-  - handle scalar inputs
+  - handle math on complex datatypes
+  - handle kernels with scalar parameters
 
 These improvements will likely come soon.
 

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -3,7 +3,6 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/jit_macros.h>
 #include <c10/macros/Macros.h>
-#include <ATen/jit_macros.h>
 #include <ATen/native/cuda/jit_utils.h>
 
 namespace at {

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <ATen/AccumulateType.h>
+#include <ATen/jit_macros.h>
 #include <c10/macros/Macros.h>
+#include <ATen/jit_macros.h>
 #include <ATen/native/cuda/jit_utils.h>
 
 namespace at {
@@ -110,9 +112,7 @@ static inline C10_HOST_DEVICE scalar_t calc_i0(scalar_t _x) {
 
 // See note [Jiterator]
 // TODO: elaborate in this comment on the structure of math.cuh
-// The jiterator is not currently supported on ROCm
-// TODO: update this to USE_JITERATOR in the future (requires refactoring the macro)
-#ifndef USE_ROCM
+#ifdef USE_JITERATOR
 
 const auto ndtri_string = jiterator_stringify(
   /*
@@ -1381,7 +1381,7 @@ const auto erfcx_string = jiterator_stringify(
   }
 ); // erfcx_string
 
-#else // USE_ROCM
+#else // !USE_JITERATOR -- kernels must be precompiled
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_gcd(scalar_t a_in, scalar_t b_in) {
@@ -1647,7 +1647,7 @@ static inline C10_HOST_DEVICE scalar_t calc_i1e(scalar_t _x) {
   return (_x < scalar_t{0.0}) ? -out : out;
 }
 
-#endif // USE_ROCM (false/true)
+#endif // USE_JITERATOR (this closes the "else" branch of a if/else preprocessor directive)
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -1,18 +1,16 @@
-#include <sstream>
-
 #include <c10/core/ScalarType.h>
 #include <c10/util/irange.h>
 #include <c10/util/hash.h>
+#include <c10/util/Optional.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/code_template.h>
 #include <ATen/native/cuda/jit_utils.h>
 
-#include <chrono>
-#include <sstream> // might need
-#include <fstream> // might be faster to use sys/stat to state files on Linux
-#include <cstdio> // fopen
+#include <sstream>
+#include <fstream>
+#include <cstdio>
 #include <iterator> // istreambuf_iterator
 #include <cstdlib>
 #include <string>
@@ -728,6 +726,74 @@ std::string generate_code(
   return code;
 }
 
+
+#ifdef BUILD_JITERATOR_WITH_CACHE
+// Acquires (possibly creating) the kernel cache directory
+c10::optional<std::string> get_cache_dir() {
+  // If the environment variable USE_TORCH_KERNEL_CACHE is set to "0" then no persistent cache is used
+  const char* uptkc = std::getenv("USE_PYTORCH_KERNEL_CACHE");
+  const bool use_kernel_cache = (uptkc == nullptr) ? true : std::strcmp(uptkc, "0");
+
+  if (!use_kernel_cache) {
+    return {};
+  }
+
+  // Cache path comes from PYTORCH_KERNEL_CACHE_PATH, then XDG_CACHE_HOME, then HOME environment variables
+  std::string cache_dir;
+  char* ptkcp = std::getenv("PYTORCH_KERNEL_CACHE_PATH");
+  if (ptkcp != nullptr) {
+    cache_dir = std::string(ptkcp);
+  } else {
+    // USES XDG_CACHE_HOME if it's set
+    ptkcp = std::getenv("XDG_CACHE_HOME");
+    if (ptkcp != nullptr) {
+      cache_dir = std::string(ptkcp) + "/torch/kernels";
+    } else {
+      // Falls back to HOME/.cache
+      ptkcp = std::getenv("HOME");
+      if (ptkcp == nullptr) {
+        TORCH_WARN_ONCE("No PYTORCH_KERNEL_CACHE_PATH or HOME environment variable set!",
+                        " This disables kernel caching.");
+        return {};
+      } else {
+        cache_dir = std::string(ptkcp) + "/.cache/torch/kernels";
+      }
+    }
+  }
+
+  // Creates the cache directory if it does not exist
+  const char* p_cache_dir = cache_dir.c_str();
+  const bool cache_dir_exists = (access(p_cache_dir, F_OK) == 0);
+  if (!cache_dir_exists) {
+    if (mkdir(p_cache_dir, S_IRWXU | S_IRWXG | S_IRWXO) != 0) {
+      TORCH_WARN_ONCE("Specified kernel cache directory could not be created! This disables kernel caching.",
+                      " Specified directory is ", cache_dir, ".",
+                      " This warning will appear only once per process.");
+      return {};
+    }
+  }
+
+  // Checks that the cache directory is readable and writable
+  const bool cache_dir_readable = (access(p_cache_dir, R_OK) == 0);
+  if (!cache_dir_readable) {
+    TORCH_WARN_ONCE("Specified kernel cache directory is not readable! This disables kernel caching.",
+                    " Specified directory is ", cache_dir, ".",
+                    " This warning will appear only once per process.");
+    return {};
+  }
+
+  const bool cache_dir_writable = (access(p_cache_dir, W_OK) == 0);
+  if (!cache_dir_writable) {
+    TORCH_WARN_ONCE("Specified kernel cache directory is not writable! This disables kernel caching.",
+                    " Specified directory is ", cache_dir, ".",
+                    " This warning will appear only once per process.");
+    return {};
+  }
+
+  return cache_dir;
+}
+#endif // BUILD_JITERATOR_WITH_CACHE
+
 // Compiles the kernel, or acquires if from the cache if caching
 NvrtcFunction jit_pwise_function(
     const std::string& code,
@@ -748,92 +814,44 @@ NvrtcFunction jit_pwise_function(
   std::string name = kernel_name + "_kernel";
 
   #ifdef BUILD_JITERATOR_WITH_CACHE
-    // If the environment variable USE_TORCH_KERNEL_CACHE is set to "0" then no persistent cache is used
-    const char* uptkc = std::getenv("USE_PYTORCH_KERNEL_CACHE");
-    bool use_kernel_cache = (uptkc == nullptr) ? true : std::strcmp(uptkc, "0");
-    std::string file_path;
+    static const c10::optional<std::string> cache_dir = get_cache_dir();
 
-    if (use_kernel_cache) {
-      // If caching, generates a key and queries if the program is already available
+    std::string file_path;
+    if (cache_dir.has_value()) {
+      // Attemps to read from the cache.
       // Cubin name is <kernel name>_arch<major>.<minor>_nvrtc<major>.<minor>_<ptx or sass>_<program length>_<string hash>
       // Note that the SHA1 hash used in the file name is NOT the SHA1 hash of the file's contents,
       //   because we hash on the CUDA code, but we save the compiled ptx or sass
 
-      // Acquires cache path from environment variable
-      // Constructs kernel cache path
-      // Uses the environment variable if it's set
-      char* ptkcp = std::getenv("PYTORCH_KERNEL_CACHE_PATH");
-      std::string cache_dir;
+      // Acquires SHA1 hash
+      c10::sha1 sha1_hash{code};
+      const auto hash_code = sha1_hash.str();
 
-      if (ptkcp != nullptr) {
-        cache_dir = std::string(ptkcp);
+      // Constructs file path by appending constructed cubin name to cache path
+      std::stringstream ss;
+      ss << *cache_dir << "/";
+      ss << kernel_name;
+      ss << "_arch" << cuda_major << "." << cuda_minor;
+      ss << "_nvrtc" << nvrtc_major << "." << nvrtc_minor;
+      ss << (compile_to_sass ? "_sass" : "_ptx");
+      ss << "_" << code.length();
+      ss << "_" << hash_code;
+      file_path = ss.str();
+
+      std::ifstream readin{file_path, std::ios::in | std::ifstream::binary};
+      if (readin.fail()) {
+        // NOTE: this does not warn because the file might not exist
+        // TODO: consider if this should explicilty check for the file's existence or not to throw
+        //   an informative warning
+        readin.close();
       } else {
-        // USES XDG_CACHE_HOME if it's set
-        ptkcp = std::getenv("XDG_CACHE_HOME");
-        if (ptkcp != nullptr) {
-          cache_dir = std::string(ptkcp) + "/torch/kernels";
-        } else {
-          // Falls back to HOME/.cache
-          ptkcp = std::getenv("HOME");
-          TORCH_CHECK(ptkcp != nullptr, "No PYTORCH_KERNEL_CACHE_PATH environment variable set",
-                                        " or fallback HOME environment variable set but attempting to cache!");
-          cache_dir = std::string(ptkcp) + "/.cache/torch/kernels";
-        }
-      }
-
-      const bool cache_dir_exists = (access(cache_dir.c_str(), F_OK) == 0);
-      if (!cache_dir_exists) {
-        mkdir(cache_dir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
-      }
-
-      const bool cache_dir_readable = (access(cache_dir.c_str(), R_OK) == 0);
-      const bool cache_dir_writable = (access(cache_dir.c_str(), W_OK) == 0);
-
-      if (!cache_dir_readable) {
-        TORCH_WARN_ONCE("Specified kernel cache directory is not readable! This disables caching.",
-                        " Specified directory is ", cache_dir, ".",
-                        " This warning will appear only once per process.");
-        use_kernel_cache = false;
-      }
-
-      if (!cache_dir_writable) {
-        TORCH_WARN_ONCE("Specified kernel cache directory is not writable! This disables caching.",
-                        " Specified directory is ", cache_dir, ".",
-                        " This warning will appear only once per process.");
-        use_kernel_cache = false;
-      }
-
-      if (use_kernel_cache) {
-        // Acquires SHA1 hash
-        c10::sha1 sha1_hash{code};
-        const auto hash_code = sha1_hash.str();
-
-        // Constructs file path by appending constructed cubin name to cache path
-        std::stringstream ss;
-        ss << cache_dir << "/";
-        ss << kernel_name;
-        ss << "_arch" << cuda_major << "." << cuda_minor;
-        ss << "_nvrtc" << nvrtc_major << "." << nvrtc_minor;
-        ss << (compile_to_sass ? "_sass" : "_ptx");
-        ss << "_" << code.length();
-        ss << "_" << hash_code;
-        file_path = ss.str();
-
-        std::ifstream readin{file_path, std::ios::in | std::ifstream::binary};
-        if (readin.fail()) {
-          // NOTE: this does not warn because the file might not exist
-          // TODO: consider if this should explicilty check for the file's existence or not to throw
-          //   an informative warning
-          readin.close();
-        } else {
-          // TODO: try passing the "mapped" file directly to cuModuleLoadCall instead of using an intermediate buffer
-          std::vector<char> buffer(std::istreambuf_iterator<char>(readin), {});
-          AT_CUDA_DRIVER_CHECK(nvrtc.cuModuleLoadData(&(compiled_kernel_.module), buffer.data()));
-          AT_CUDA_DRIVER_CHECK(
-            nvrtc.cuModuleGetFunction(&(compiled_kernel_.function), compiled_kernel_.module, name.c_str()));
-          readin.close();
-          return compiled_kernel_;
-        }
+        // TODO: try passing the "mapped" file directly to cuModuleLoadCall instead of using an intermediate buffer
+        std::vector<char> buffer(std::istreambuf_iterator<char>(readin), {});
+        AT_CUDA_DRIVER_CHECK(nvrtc.cuModuleLoadData(&(compiled_kernel_.module), buffer.data()));
+        AT_CUDA_DRIVER_CHECK(
+          nvrtc.cuModuleGetFunction(&(compiled_kernel_.function), compiled_kernel_.module, name.c_str()));
+        readin.close();
+        return compiled_kernel_;
       }
     }
   #endif // BUILD_JITERATOR_WITH_CACHE
@@ -910,7 +928,7 @@ NvrtcFunction jit_pwise_function(
   AT_CUDA_NVRTC_CHECK(nvrtc.nvrtcDestroyProgram(&program));
 
   #ifdef BUILD_JITERATOR_WITH_CACHE
-    if (use_kernel_cache) {
+    if (cache_dir.has_value()) {
       // Writes the program to the cache if caching
       // NOTE: Actually writes to a per-process temporary file to avoid multi-process contention.
       //   The temporary file is then renamed to the actual file.

--- a/c10/util/hash.h
+++ b/c10/util/hash.h
@@ -1,12 +1,16 @@
 #pragma once
 
-#include <c10/util/ArrayRef.h>
-#include <c10/util/complex.h>
+#include <iomanip>
 #include <functional>
 #include <vector>
+#include <sstream>
+
+#include <c10/util/ArrayRef.h>
+#include <c10/util/complex.h>
+
 namespace c10 {
 
-// NOTE: hash_combine is based on implementation from Boost
+// NOTE: hash_combine and SHA1 hashing is based on implementation from Boost
 //
 // Boost Software License - Version 1.0 - August 17th, 2003
 //
@@ -35,6 +39,198 @@ namespace c10 {
 inline size_t hash_combine(size_t seed, size_t value) {
   return seed ^ (value + 0x9e3779b9 + (seed << 6u) + (seed >> 2u));
 }
+
+// Creates the SHA1 hash of a string. A 160-bit hash.
+// Based on the implementation in Boost (see notice above).
+// Note that SHA1 hashes are no longer considered cryptographically
+//   secure, but are the standard hash for generating unique ids.
+// Usage:
+//   // Let 'code' be a std::string
+//   c10::sha1 sha1_hash{code};
+//   const auto hash_code = sha1_hash.str();
+// TODO: Compare vs OpenSSL and/or CryptoPP implementations
+struct sha1 {
+  typedef unsigned int(digest_type)[5];
+
+  sha1(const std::string &s = "") {
+    if (!s.empty()) {
+      reset();
+      process_bytes(s.c_str(), s.size());
+    }
+  }
+
+  void reset() {
+    h_[0] = 0x67452301;
+    h_[1] = 0xEFCDAB89;
+    h_[2] = 0x98BADCFE;
+    h_[3] = 0x10325476;
+    h_[4] = 0xC3D2E1F0;
+
+    block_byte_index_ = 0;
+    bit_count_low = 0;
+    bit_count_high = 0;
+  }
+
+  std::string str() {
+    unsigned int digest[5];
+    get_digest(digest);
+
+    std::ostringstream buf;
+    for (int i = 0; i < 5; ++i) {
+      buf << std::hex << std::setfill('0') << std::setw(8) << digest[i];
+    }
+
+    return buf.str();
+  }
+
+private:
+  unsigned int left_rotate(unsigned int x, std::size_t n) {
+    return (x << n) ^ (x >> (32 - n));
+  }
+
+  void process_block_impl() {
+    unsigned int w[80];
+
+    for (std::size_t i = 0; i < 16; ++i) {
+      w[i]  = (block_[i*4 + 0] << 24);
+      w[i] |= (block_[i*4 + 1] << 16);
+      w[i] |= (block_[i*4 + 2] << 8);
+      w[i] |= (block_[i*4 + 3]);
+    }
+
+    for (std::size_t i = 16; i < 80; ++i) {
+      w[i] = left_rotate((w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16]), 1);
+    }
+
+    unsigned int a = h_[0];
+    unsigned int b = h_[1];
+    unsigned int c = h_[2];
+    unsigned int d = h_[3];
+    unsigned int e = h_[4];
+
+    for (std::size_t i = 0; i < 80; ++i) {
+      unsigned int f;
+      unsigned int k;
+
+      if (i<20) {
+        f = (b & c) | (~b & d);
+        k = 0x5A827999;
+      } else if (i<40) {
+        f = b ^ c ^ d;
+        k = 0x6ED9EBA1;
+      } else if (i<60) {
+        f = (b & c) | (b & d) | (c & d);
+        k = 0x8F1BBCDC;
+      } else {
+        f = b ^ c ^ d;
+        k = 0xCA62C1D6;
+      }
+
+      unsigned temp = left_rotate(a, 5) + f + e + k + w[i];
+      e = d;
+      d = c;
+      c = left_rotate(b, 30);
+      b = a;
+      a = temp;
+    }
+
+    h_[0] += a;
+    h_[1] += b;
+    h_[2] += c;
+    h_[3] += d;
+    h_[4] += e;
+  }
+
+  void process_byte_impl(unsigned char byte) {
+    block_[block_byte_index_++] = byte;
+
+    if (block_byte_index_ == 64) {
+      block_byte_index_ = 0;
+      process_block_impl();
+    }
+  }
+
+  void process_byte(unsigned char byte) {
+    process_byte_impl(byte);
+
+    // size_t max value = 0xFFFFFFFF
+    //if (bit_count_low + 8 >= 0x100000000) { // would overflow
+    //if (bit_count_low >= 0x100000000-8) {
+    if (bit_count_low < 0xFFFFFFF8) {
+      bit_count_low += 8;
+    } else {
+      bit_count_low = 0;
+
+      if (bit_count_high <= 0xFFFFFFFE) {
+        ++bit_count_high;
+      } else {
+        TORCH_CHECK(false, "sha1 too many bytes");
+      }
+    }
+  }
+
+  void process_block(void const* bytes_begin, void const* bytes_end) {
+    unsigned char const* begin = static_cast<unsigned char const*>(bytes_begin);
+    unsigned char const* end = static_cast<unsigned char const*>(bytes_end);
+    for(; begin != end; ++begin) {
+      process_byte(*begin);
+    }
+  }
+
+  void process_bytes(void const* buffer, std::size_t byte_count) {
+    unsigned char const* b = static_cast<unsigned char const*>(buffer);
+    process_block(b, b + byte_count);
+  }
+
+
+  void get_digest(digest_type& digest) {
+    // append the bit '1' to the message
+    process_byte_impl(0x80);
+
+    // append k bits '0', where k is the minimum number >= 0
+    // such that the resulting message length is congruent to 56 (mod 64)
+    // check if there is enough space for padding and bit_count
+    if (block_byte_index_ > 56) {
+      // finish this block
+      while (block_byte_index_ != 0) {
+        process_byte_impl(0);
+      }
+
+      // one more block
+      while (block_byte_index_ < 56) {
+        process_byte_impl(0);
+      }
+    } else {
+      while (block_byte_index_ < 56) {
+        process_byte_impl(0);
+      }
+    }
+
+    // append length of message (before pre-processing)
+    // as a 64-bit big-endian integer
+    process_byte_impl( static_cast<unsigned char>((bit_count_high>>24) & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_high>>16) & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_high>>8 ) & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_high)     & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_low>>24) & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_low>>16) & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_low>>8 ) & 0xFF) );
+    process_byte_impl( static_cast<unsigned char>((bit_count_low)     & 0xFF) );
+
+    // get final digest
+    digest[0] = h_[0];
+    digest[1] = h_[1];
+    digest[2] = h_[2];
+    digest[3] = h_[3];
+    digest[4] = h_[4];
+  }
+
+  unsigned int h_[5];
+  unsigned char block_[64];
+  std::size_t block_byte_index_;
+  std::size_t bit_count_low;
+  std::size_t bit_count_high;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // c10::hash implementation

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -177,7 +177,7 @@ endif()
 if(BUILD_SPLIT_CUDA)
   # Splitting the source files that'll be in torch_cuda between torch_cuda_cu and torch_cuda_cpp
   foreach(tmp ${Caffe2_GPU_SRCS})
-    if("${tmp}" MATCHES "(.*aten.*\\.cu|.*(b|B)las.*|.*((s|S)olver|Register.*CUDA|Legacy|THC|TensorShapeCUDA|BatchLinearAlgebra|ReduceOps|Equal|Activation|ScanKernels|Sort|TensorTopK|TensorModeKernel|IndexKernel).*\\.cpp)" AND NOT "${tmp}" MATCHES ".*(THC((CachingHost)?Allocator|General)).*")
+    if("${tmp}" MATCHES "(.*aten.*\\.cu|.*(b|B)las.*|.*((s|S)olver|Register.*CUDA|Legacy|THC|TensorShapeCUDA|BatchLinearAlgebra|ReduceOps|Equal|Activation|ScanKernels|Sort|TensorTopK|TensorModeKernel|IndexKernel|jit_utils).*\\.cpp)" AND NOT "${tmp}" MATCHES ".*(THC((CachingHost)?Allocator|General)).*")
       # Currently, torch_cuda_cu will have all the .cu files in aten, as well as some others that depend on those files
       list(APPEND Caffe2_GPU_SRCS_CU ${tmp})
     else()


### PR DESCRIPTION
This PR adds a persistent filesystem cache for jitted kernels. The cache is disabled on Windows because it relies on POSIX headers.

The cache writes, by default, to `~/.cache/torch/kernels`, but the location can be controlled by setting the `PYTORCH_KERNEL_CACHE_PATH`. A separate environment variable, `USE_PYTORCH_KERNEL_CACHE`, will disable all caching logic when set to zero.

The use of a persistent fileystem cache dramatically lowers the "first call time" for an operator AFTER its has been compiled, because it skips (most of) the jit compilation process. On systems where we're compiling only to ptx that ptx still has to be just-in-time compiled by the driver API, so an additional latency of around 10 milliseconds is expected at first call time. On systems which compile to SASS the additional first call time latency is about one millisecond. This compares with times of 150 milliseconds+ for just-in-time kernel compilation.

Files in the cache use a mostly human readable string that includes an SHA1 hash of the CUDA C string used to generate them. Note that this is not an SHA1 hash of the file's contents, because the contents are the compiled ptx or SASS. No verification is done when the file is loaded to ensure the kernel is what's expected, but it's far more likely you'll be struck by a meteor than observe two file names conflict. Using SHA1 hashes to generate unique ids this way is a common practice (GitHub does it, too). 

This cache design could be reused by other fusion systems and should allow us to jiterate more operations without fear of regressing the "incremental development" scenario where users are tweaking or extending programs slightly, rerunning then, and then repeating that process again and again. Without a cache each run of the program would have to recompile every jitted kernel, but with this cache we expect a negligible impact to the user experience.

cc @kshitij12345, @xwang233 