### PR TITLE
[fbcode][warnings] Suppress warnings in caffe2/c10

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -14,6 +14,11 @@
 #include <c10/util/Half.h>
 #include <c10/util/TypeCast.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace c10 {
 
 /**
@@ -200,3 +205,5 @@ AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_TO)
 #undef DEFINE_TO
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/BFloat16-math.h
+++ b/c10/util/BFloat16-math.h
@@ -3,6 +3,11 @@
 #include <c10/util/BFloat16-inl.h>
 #include <c10/util/math_compat.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
+
 namespace std {
 
 /// Used by vec256<c10::BFloat16>::map
@@ -175,3 +180,5 @@ C10_HOST_DEVICE inline c10::BFloat16 nextafter(
 }
 
 } // namespace std
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/MathConstants.h
+++ b/c10/util/MathConstants.h
@@ -4,6 +4,11 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
+
 namespace c10 {
 // TODO: Replace me with inline constexpr variable when C++17 becomes available
 namespace detail {
@@ -30,3 +35,5 @@ template <typename T>
 constexpr T pi = c10::detail::pi<T>();
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -45,6 +45,15 @@ C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wstring-conversion")
 C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
 #endif
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-conversion")
+#endif
 
 #define TR2_OPTIONAL_REQUIRES(...) \
   typename std::enable_if<__VA_ARGS__::value, bool>::type = false

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -11,6 +11,11 @@
 #include <string>
 #include <vector>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace c10 {
 
 namespace detail {
@@ -190,5 +195,7 @@ inline void printQuotedString(std::ostream& stmt, const string_view str) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 #endif // C10_UTIL_STRINGUTIL_H_

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -6,6 +6,14 @@
 
 #include <type_traits>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 namespace c10 {
 
 template <typename dest_t, typename src_t>
@@ -186,5 +194,7 @@ To checked_convert(From f, const char* name) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 // Trigger tests for D25440771. TODO: Remove this line any time you want.

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <limits>
 #include <type_traits>
+
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wstring-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
+#endif
 
 namespace c10 {
 
@@ -117,3 +123,5 @@ inline constexpr bool less_than_lowest(const T& x) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -8,6 +8,14 @@
 #include <thrust/complex.h>
 #endif
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wfloat-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wfloat-conversion")
+#endif
+
 namespace c10 {
 
 // c10::complex is an implementation of complex numbers that aims
@@ -594,6 +602,8 @@ C10_HOST_DEVICE complex<T> polar(const T& r, const T& theta = T()) {
 }
 
 } // namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 #define C10_INTERNAL_INCLUDE_COMPLEX_REMAINING_H
 // math functions are included in a separate file

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <c10/macros/Macros.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -24,6 +25,11 @@
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
+
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
@@ -2103,3 +2109,5 @@ struct power_of_two_std_hash : std::hash<T> {
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #endif
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -28,6 +28,11 @@
 #include <type_traits>
 #include <utility>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -2232,3 +2237,5 @@ struct power_of_two_std_hash : std::hash<T> {
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #endif
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -12,12 +12,18 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <c10/macros/Macros.h>
 #include <c10/util/llvmMathExtras.h>
 #include <cassert>
 #include <climits>
 #include <cstring>
 #include <iterator>
 #include <list>
+
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
 
 namespace c10 {
 
@@ -894,3 +900,5 @@ std::ostream& operator<<(
 }
 
 } // end namespace c10
+
+C10_CLANG_DIAGNOSTIC_POP()


### PR DESCRIPTION
Summary: Suppress remaining header based warnings in `caffe2/c10` when building with `clang`

Test Plan: CI pass

Differential Revision: D33600097

