### PR TITLE
Allow disabling nvfuser without CUDA

### DIFF
--- a/torch/csrc/jit/passes/cuda_graph_fuser.h
+++ b/torch/csrc/jit/passes/cuda_graph_fuser.h
@@ -12,11 +12,11 @@ namespace jit {
 struct C10_EXPORT RegisterCudaFuseGraph
     : public PassManager<RegisterCudaFuseGraph> {
   static bool registerPass(bool enabled) {
-    TORCH_CHECK(
-        at::globalContext().hasCUDA() && !at::globalContext().hasHIP(),
-        "Running CUDA fuser is only supported on CUDA builds.");
     bool old_flag = PassManager::isRegistered();
     if (enabled) {
+      TORCH_CHECK(
+          at::globalContext().hasCUDA() && !at::globalContext().hasHIP(),
+          "Running CUDA fuser is only supported on CUDA builds.");
       PassManager::registerPass(fuser::cuda::fuseGraph);
     } else {
       PassManager::clearPass();


### PR DESCRIPTION
On a CPU-only build of pytorch `torch._C._jit_set_nvfuser_enabled(False)` would throw an error (even though it is a no-op operation), with this fix:
```
>>> torch._C._jit_set_nvfuser_enabled(False)
False
>>> torch._C._jit_set_nvfuser_enabled(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Running CUDA fuser is only supported on CUDA builds.
>>> 
```