### PR TITLE
Structured Kernel Precompute codegen handle fields without replacement 

### DIFF
--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -231,13 +231,13 @@ TORCH_IMPL_FUNC(fractional_max_pool3d_out_cpu)(
   int64_t outputH,
   int64_t outputW,
   const at::Tensor& randomSamples,
-  const at::Tensor& output,
-  const at::Tensor& indices,
   int64_t numBatch,
   int64_t numPlanes,
   int64_t inputT,
   int64_t inputH,
-  int64_t inputW) {
+  int64_t inputW,
+  const at::Tensor& output,
+  const at::Tensor& indices) {
 
   /* get contiguous input */
   auto input = input_.contiguous();

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -80,7 +80,8 @@ TORCH_PRECOMPUTE_META_FUNC(fractional_max_pool3d)(
     set_output(1, {numBatch, numPlanes, outputT, outputH, outputW}, input_.options().dtype(kLong));
   }
 
-  return TORCH_PRECOMPUTE_STRUCT(fractional_max_pool3d)().set_poolSizeT(poolSizeT).set_poolSizeH(poolSizeH).set_poolSizeW(poolSizeW)
+  return TORCH_PRECOMPUTE_STRUCT(fractional_max_pool3d)().set_numBatch(numBatch).set_numPlanes(numPlanes).set_inputT(inputT).set_inputH(inputH).set_inputW(inputW)
+                                                         .set_poolSizeT(poolSizeT).set_poolSizeH(poolSizeH).set_poolSizeW(poolSizeW)
                                                          .set_outputT(outputT).set_outputH(outputH).set_outputW(outputW);
 }
 
@@ -231,28 +232,12 @@ TORCH_IMPL_FUNC(fractional_max_pool3d_out_cpu)(
   int64_t outputW,
   const at::Tensor& randomSamples,
   const at::Tensor& output,
-  const at::Tensor& indices) {
-
-  int64_t numBatch = 1;
-  int64_t planeDim = 0;
-  int64_t timeDim = 1;
-  int64_t heightDim = 2;
-  int64_t widthDim = 3;
-
-  int64_t ndims = input_.ndimension();
-  if (ndims == 5) {
-    numBatch = input_.size(0);
-    planeDim++;
-    timeDim++;
-    heightDim++;
-    widthDim++;
-  }
-
-  /* sizes */
-  int64_t numPlanes = input_.size(planeDim);
-  int64_t inputT = input_.size(timeDim);
-  int64_t inputH = input_.size(heightDim);
-  int64_t inputW = input_.size(widthDim);
+  const at::Tensor& indices,
+  int64_t numBatch,
+  int64_t numPlanes,
+  int64_t inputT,
+  int64_t inputH,
+  int64_t inputW) {
 
   /* get contiguous input */
   auto input = input_.contiguous();

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -253,6 +253,8 @@ TORCH_IMPL_FUNC(fractional_max_pool3d_out_cuda) (
   auto output_ = output;
   auto indices_ = indices;
   auto input_ = input;
+
+  int64_t ndims = input_.ndimension();
   if(ndims == 4) {
     output_ = output_.reshape({1, numPlanes, outputT, outputH, outputW});
     indices_ = indices_.reshape({1, numPlanes, outputT, outputH, outputW});

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -243,27 +243,12 @@ TORCH_IMPL_FUNC(fractional_max_pool3d_out_cuda) (
   int64_t outputW,
   const Tensor& randomSamples,
   const Tensor& output,
-  const Tensor& indices
-) {
-
-  int64_t planeDim = 0;
-  int64_t dimt = 1;
-  int64_t dimh = 2;
-  int64_t dimw = 3;
-
-  int64_t ndims = input.ndimension();
-  if (ndims == 5) {
-    planeDim++;
-    dimt++;
-    dimh++;
-    dimw++;
-  }
-
-  /* sizes */
-  int64_t numPlanes = input.size(planeDim);
-  int64_t inputT = input.size(dimt);
-  int64_t inputH = input.size(dimh);
-  int64_t inputW = input.size(dimw);
+  const Tensor& indices,
+  int64_t numBatch,
+  int64_t numPlanes,
+  int64_t inputT,
+  int64_t inputH,
+  int64_t inputW) {
 
   auto output_ = output;
   auto indices_ = indices;

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -242,13 +242,13 @@ TORCH_IMPL_FUNC(fractional_max_pool3d_out_cuda) (
   int64_t outputH,
   int64_t outputW,
   const Tensor& randomSamples,
-  const Tensor& output,
-  const Tensor& indices,
   int64_t numBatch,
   int64_t numPlanes,
   int64_t inputT,
   int64_t inputH,
-  int64_t inputW) {
+  int64_t inputW,
+  const Tensor& output,
+  const Tensor& indices) {
 
   auto output_ = output;
   auto indices_ = indices;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9240,6 +9240,7 @@
   python_module: nn
   structured: True
   precomputed:
+  - int numBatch, int numPlanes, int inputT, int inputH, int inputW
   - kernel_size -> int poolSizeT, int poolSizeH, int poolSizeW
   - output_size -> int outputT, int outputH, int outputW
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9240,9 +9240,9 @@
   python_module: nn
   structured: True
   precomputed:
-  - int numBatch, int numPlanes, int inputT, int inputH, int inputW
   - kernel_size -> int poolSizeT, int poolSizeH, int poolSizeW
   - output_size -> int outputT, int outputH, int outputW
+  - int numBatch, int numPlanes, int inputT, int inputH, int inputW
   dispatch:
     CPU: fractional_max_pool3d_out_cpu
     CUDA: fractional_max_pool3d_out_cuda

--- a/tools/codegen/api/structured.py
+++ b/tools/codegen/api/structured.py
@@ -90,7 +90,6 @@ def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
         # certain parameters replaced with precomputed counterparts
         # as specified in native_functions.yaml.
         non_out_args_replaced: List[Union[Argument, TensorOptionsArguments, SelfArgument]] = []
-
         for a in g.out.func.arguments.non_out:
             if isinstance(a, Argument) and a.name in g.out.precomputed.replace:
                 # If a is in precompute.replace, append the parameters
@@ -102,6 +101,9 @@ def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
                 non_out_args_replaced.append(a)
 
         args.extend(non_out_args_replaced)
+        # precomputed.add is the list of parameters that are added
+        # without replacement
+        args.extend(g.out.precomputed.add)
     else:
         args.extend(g.out.func.arguments.non_out)
 

--- a/tools/codegen/api/structured.py
+++ b/tools/codegen/api/structured.py
@@ -84,7 +84,6 @@ def argument(a: Union[Argument, SelfArgument, TensorOptionsArguments]) -> List[B
 
 def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
     args: List[Union[Argument, TensorOptionsArguments, SelfArgument]] = []
-    precomputed_add_args: List[Argument] = []
 
     if g.out.precomputed:
         # A list of parameters for the impl function with
@@ -102,14 +101,13 @@ def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
                 non_out_args_replaced.append(a)
 
         args.extend(non_out_args_replaced)
-        # precomputed.add is the list of parameters that are added
-        # without replacement
-        precomputed_add_args = g.out.precomputed.add
+        # g.out.precomputed.add is the list of parameters that are added
+        # without replacement after the non out args and just before the out args
+        args.extend(g.out.precomputed.add)
     else:
         args.extend(g.out.func.arguments.non_out)
 
     args.extend(g.out.func.arguments.out)
-    args.extend(precomputed_add_args)
     return [r for arg in args for r in argument(arg)]
 
 def meta_arguments(g: NativeFunctionsGroup) -> List[Binding]:

--- a/tools/codegen/api/structured.py
+++ b/tools/codegen/api/structured.py
@@ -84,6 +84,7 @@ def argument(a: Union[Argument, SelfArgument, TensorOptionsArguments]) -> List[B
 
 def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
     args: List[Union[Argument, TensorOptionsArguments, SelfArgument]] = []
+    precomputed_add_args: List[Argument] = []
 
     if g.out.precomputed:
         # A list of parameters for the impl function with
@@ -103,11 +104,12 @@ def impl_arguments(g: NativeFunctionsGroup) -> List[Binding]:
         args.extend(non_out_args_replaced)
         # precomputed.add is the list of parameters that are added
         # without replacement
-        args.extend(g.out.precomputed.add)
+        precomputed_add_args = g.out.precomputed.add
     else:
         args.extend(g.out.func.arguments.non_out)
 
     args.extend(g.out.func.arguments.out)
+    args.extend(precomputed_add_args)
     return [r for arg in args for r in argument(arg)]
 
 def meta_arguments(g: NativeFunctionsGroup) -> List[Binding]:

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -643,7 +643,8 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 # Put all of the contents of the precompute struct into the context
                 # so that translate will be able to return the correct args for the
                 # call to the impl.
-                for precomputed_elems in self.g.out.precomputed.replace.values():
+                precomputed_values = [*self.g.out.precomputed.replace.values(), self.g.out.precomputed.add]
+                for precomputed_elems in precomputed_values:
                     for arg in precomputed_elems:
                         context.append(Expr(
                             expr=f"precompute.{arg.name}",

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import os
 from typing import List, Dict, Optional, Tuple, Set, Any, Union, Sequence, TypeVar
 from typing_extensions import Literal
@@ -508,7 +509,8 @@ def compute_meta_function_declaration(g: NativeFunctionsGroup) -> Optional[str]:
             # Generate the template declaration with one bool parameter for each
             # precomputed element. Each parameter is true if the corresponding (in
             # terms of position) precomputed element has been set.
-            precomputed_elements = [elem for replace_list in precomputed.replace.values() for elem in replace_list]
+            precomputed_values = [*precomputed.replace.values(), precomputed.add]
+            precomputed_elements = [elem for replace_list in precomputed_values for elem in replace_list]
             precomputed_template_parameters = [elem.name.upper() for elem in precomputed_elements]
             precomputed_template_params_str = ", ".join(f"bool {param} = false" for param in precomputed_template_parameters)
             precompute_template_decl = f"template <{precomputed_template_params_str}>"

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import os
 from typing import List, Dict, Optional, Tuple, Set, Any, Union, Sequence, TypeVar
 from typing_extensions import Literal

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -1603,7 +1603,7 @@ class Precompute:
         assert isinstance(src, list)
 
         # src is a list of strings of the format:
-        #   [{add decl}, ...]
+        #   [{add decl}[, {add decl}, ...]]
         #   {kernel param name} -> {replacement decl}[, {replacement decl}, ...]
         # The first line is optional and contains the precomputed parameters that are
         # added without replacement.
@@ -1618,6 +1618,8 @@ class Precompute:
         replace = {}
         for raw_replace_item in src:
             assert isinstance(raw_replace_item, str)
+            assert ' -> ' in raw_replace_item, 'precomputed parameters with no replacement' \
+                                                'are allowed only in the first line'
 
             arg, with_list_raw = raw_replace_item.split(' -> ')
             with_list = with_list_raw.split(',')

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -1603,23 +1603,23 @@ class Precompute:
         assert isinstance(src, list)
 
         # src is a list of strings of the format:
-        #   [{add decl}[, {add decl}, ...]]
         #   {kernel param name} -> {replacement decl}[, {replacement decl}, ...]
-        # The first line is optional and contains the precomputed parameters that are
+        #   [{add decl}[, {add decl}, ...]]
+        # The last line is optional and contains the precomputed parameters that are
         # added without replacement.
         # The other lines are parsed to get the names of which precomputed elements
         # should replace which kernel arguments.
         add_args = []
-        if ' -> ' not in src[0]:
-            add_list = src[0].split(',')
+        if ' -> ' not in src[-1]:
+            add_list = src[-1].split(',')
             add_args = [Argument.parse(name.strip()) for name in add_list]
-            src = src[1:]
+            src = src[:-1]
 
         replace = {}
         for raw_replace_item in src:
             assert isinstance(raw_replace_item, str)
             assert ' -> ' in raw_replace_item, 'precomputed parameters without replacement' \
-                                               ' are allowed only in the first line'
+                                               ' are allowed only in the last line'
 
             arg, with_list_raw = raw_replace_item.split(' -> ')
             with_list = with_list_raw.split(',')

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -1618,8 +1618,8 @@ class Precompute:
         replace = {}
         for raw_replace_item in src:
             assert isinstance(raw_replace_item, str)
-            assert ' -> ' in raw_replace_item, 'precomputed parameters with no replacement' \
-                                                'are allowed only in the first line'
+            assert ' -> ' in raw_replace_item, 'precomputed parameters without replacement' \
+                                               ' are allowed only in the first line'
 
             arg, with_list_raw = raw_replace_item.split(' -> ')
             with_list = with_list_raw.split(',')


### PR DESCRIPTION
I've added the parsing of an optional first line in native_functions.yaml after the precomputed keyword for arguments that will be precomputed without replacement. This line is optional, must be the first and does not contain any arrow.

These new fields are precomputed as before in the meta function and added to the precompute struct returned by the meta function. For now I've put them as last args of the impl function where they can be reused.

example: 

native_function.yaml:
```
  ...
  precomputed:
  - int numBatch, int numPlanes, int inputT, int inputH, int inputW   <- new
  - kernel_size -> int poolSizeT, int poolSizeH, int poolSizeW
  - output_size -> int outputT, int outputH, int outputW
```

meta: 
```
TORCH_PRECOMPUTE_META_FUNC(fractional_max_pool3d)(
  const at::Tensor& input_,
  IntArrayRef pool_size,
  IntArrayRef output_size,
  const at::Tensor& randomSamples
) {
    ...

return TORCH_PRECOMPUTE_STRUCT(fractional_max_pool3d)().set_numBatch(numBatch).set_numPlanes(numPlanes).set_inputT(inputT).set_inputH(inputH).set_inputW(inputW)
  .set_poolSizeT(poolSizeT) ...
}
```

impl:
```
TORCH_IMPL_FUNC(fractional_max_pool3d_out_cpu)(
  const at::Tensor& input_,
  int64_t poolSizeT,
  int64_t poolSizeH,
  int64_t poolSizeW,
  int64_t outputT,
  int64_t outputH,
  int64_t outputW,
  const at::Tensor& randomSamples,
  const at::Tensor& output,
  const at::Tensor& indices,
  int64_t numBatch,    <- for now I've put them here
  int64_t numPlanes,
  int64_t inputT,
  int64_t inputH,
  int64_t inputW) {
```


Fixes #71314