### PR TITLE
[Caffe2][warnings] Suppress -Wimplicit-int-float-conversion in TypeSafeSignMath.h for clang

### DIFF
--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -8,6 +8,9 @@ C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wstring-conversion")
 C10_CLANG_DIAGNOSTIC_IGNORE("-Wstring-conversion")
 #endif
+#if C10_CLANG_HAS_WARNING("-Wimplicit-int-float-conversion")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
 
 namespace c10 {
 


### PR DESCRIPTION
Summary: Suppress `-Wimplicit-int-float-conversion` in `TypeSafeSignMath.h` when building with clang

Test Plan: CI check

Differential Revision: D33612983

