### PR TITLE
[warnings][Caffe2] Suppress warnings in non-c10 headers

### DIFF
--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -13,6 +13,14 @@
 #include <array>
 #include <bitset>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+#if C10_CLANG_HAS_WARNING("-Wdeprecated-copy-dtor")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-copy-dtor")
+#endif
+
 namespace at {
 class Tensor;
 class OptionalTensorRef;
@@ -795,3 +803,5 @@ private:
 };
 
 }  // namespace at
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/aten/src/ATen/TensorMeta.h
+++ b/aten/src/ATen/TensorMeta.h
@@ -4,6 +4,11 @@
 #include <c10/core/TensorOptions.h>
 #include <ATen/core/Dimname.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wdeprecated-copy-dtor")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-copy-dtor")
+#endif
+
 namespace at {
 
 class Tensor;
@@ -74,3 +79,5 @@ struct TORCH_API MetaBase {
 } // namespace impl
 
 } // namespace at
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -38,6 +38,11 @@
 #include <ATen/core/ivalue.h>
 #endif
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 C10_DECLARE_bool(caffe2_operator_throw_if_fp_exceptions);
 C10_DECLARE_bool(caffe2_operator_throw_if_fp_overflow_exceptions);
 #ifdef __GNU_LIBRARY__
@@ -1600,5 +1605,7 @@ inline unique_ptr<ExternalTensorFunctionsBase> CreateExternalTensorFunctions(
 #endif // C10_MOBILE
 
 } // namespace caffe2
+
+C10_CLANG_DIAGNOSTIC_POP()
 
 #endif // CAFFE2_CORE_OPERATOR_H_

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -23,6 +23,11 @@
 #include <utility>
 #include <vector>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace torch { namespace autograd {
 
 struct Edge;
@@ -618,3 +623,5 @@ edge_list collect_next_edges(Variables&&... variables) {
   return std::move(make.next_edges);
 }
 }} // namespace torch::autograd
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace torch {
 namespace jit {
 
@@ -541,3 +546,5 @@ struct Lexer {
 };
 } // namespace jit
 } // namespace torch
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -10,6 +10,11 @@
 #include <iostream>
 #include <vector>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wshorten-64-to-32")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+#endif
+
 namespace torch {
 namespace jit {
 
@@ -503,3 +508,5 @@ struct hash<torch::jit::CompleteArgumentSpec> {
   }
 };
 } // namespace std
+
+C10_CLANG_DIAGNOSTIC_POP()

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -9,6 +9,11 @@
 #include <torch/csrc/Export.h>
 #include <torch/csrc/jit/frontend/source_range.h>
 
+C10_CLANG_DIAGNOSTIC_PUSH()
+#if C10_CLANG_HAS_WARNING("-Wdeprecated-copy-dtor")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-copy-dtor")
+#endif
+
 C10_DECLARE_bool(torch_jit_disable_warning_prints);
 C10_DECLARE_bool(torch_jit_enable_rethrow_caught_exception);
 
@@ -159,3 +164,5 @@ TORCH_API std::vector<std::string> currentModuleHierarchy();
 
 } // namespace jit
 } // namespace torch
+
+C10_CLANG_DIAGNOSTIC_POP()


### PR DESCRIPTION
Summary: Round out suppressing warnings in `caffe2` headers

Test Plan: CI check

Differential Revision: D33613084

