### PR TITLE
is_alias_of changes for storageless tensors

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -301,7 +301,7 @@ class TORCH_API TensorBase {
     return impl_->storage();
   }
   bool is_alias_of(const at::TensorBase& other) const{
-    return impl_->storage().is_alias_of(other.storage());
+    return impl_->is_alias_of(*other.unsafeGetTensorImpl());
   }
 
   inline bool _is_zerotensor() const {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -822,6 +822,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return is_contiguous_;
   }
 
+  virtual bool is_alias_of(const TensorImpl& other) const {
+    return has_storage() && storage().is_alias_of(other.storage());
+  }
+
  private:
   bool is_contiguous_nondefault_policy_impl(at::MemoryFormat) const;
 

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -1096,3 +1096,14 @@ TEST(TensorTest, ReshapeAlias) {
     z.grad()
   ));
 }
+
+TEST(TensorTest, IsAliasOf) {
+  auto a = torch::empty(4);
+  auto b = a.view({2, 2});
+  ASSERT_TRUE(a.is_alias_of(b));
+  auto c = torch::empty(4);
+  ASSERT_TRUE(!a.is_alias_of(c));
+  auto d = b.view({1, 4});
+  ASSERT_TRUE(d.is_alias_of(b));
+  ASSERT_TRUE(d.is_alias_of(a));
+}


### PR DESCRIPTION
The is_alias_of() method should check has_storage() before
returning true/false for storageless tensors. Also, it should be
possible to override the default behavior by making it virtual.

Fixes #71377
