### PR TITLE
Fix for windows builds with python 3.10 , getting rid of ssize_t (ssize_t is not a C++ defined type)

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -208,7 +208,7 @@ PyObject * THCPModule_cudaCachingAllocator_raw_alloc(PyObject *_unused, PyObject
         "(ssize_t size, intptr_t stream);");
     return nullptr;
   }
-  ssize_t size = PyLong_AsSsize_t(size_o);
+  size_t size = PyLong_AsSsize_t(size_o);
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cudaStream_t stream = static_cast<cudaStream_t>(PyLong_AsVoidPtr(stream_o));
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -208,7 +208,7 @@ PyObject * THCPModule_cudaCachingAllocator_raw_alloc(PyObject *_unused, PyObject
         "(ssize_t size, intptr_t stream);");
     return nullptr;
   }
-  size_t size = PyLong_AsSsize_t(size_o);
+  auto size = PyLong_AsSsize_t(size_o);
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   cudaStream_t stream = static_cast<cudaStream_t>(PyLong_AsVoidPtr(stream_o));
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -5,22 +5,22 @@
 #include <torch/csrc/serialization.h>
 
 template <class io>
-ssize_t doPartialRead(io fildes, void* buf, size_t nbytes);
+Py_ssize_t doPartialRead(io fildes, void* buf, size_t nbytes);
 
 template <class io>
-ssize_t doPartialWrite(io fildes, void* buf, size_t nbytes);
+Py_ssize_t doPartialWrite(io fildes, void* buf, size_t nbytes);
 
-static ssize_t doPartialPythonReadBuffered(PyObject* fildes, void* buf, size_t nbytes);
-static ssize_t doPartialPythonReadInto(PyObject* fildes, void* buf, size_t nbytes);
-static ssize_t doPartialPythonWrite(PyObject* fildes, void* buf, size_t nbytes);
+static Py_ssize_t doPartialPythonReadBuffered(PyObject* fildes, void* buf, size_t nbytes);
+static Py_ssize_t doPartialPythonReadInto(PyObject* fildes, void* buf, size_t nbytes);
+static Py_ssize_t doPartialPythonWrite(PyObject* fildes, void* buf, size_t nbytes);
 
 template <>
-ssize_t doPartialRead<int>(int fildes, void* buf, size_t nbytes) {
+Py_ssize_t doPartialRead<int>(int fildes, void* buf, size_t nbytes) {
   return read(fildes, buf, nbytes);
 }
 
 template <>
-ssize_t doPartialRead<PyObject*>(PyObject* fildes, void* buf, size_t nbytes) {
+Py_ssize_t doPartialRead<PyObject*>(PyObject* fildes, void* buf, size_t nbytes) {
   // Try to use fildes.readinto() instead of fildes.read()
   // because it is more memory efficient.
   // TODO: Stop calling PyObject_HasAttrString() in a loop on our read loop
@@ -32,12 +32,12 @@ ssize_t doPartialRead<PyObject*>(PyObject* fildes, void* buf, size_t nbytes) {
 }
 
 template <>
-ssize_t doPartialWrite<int>(int fildes, void* buf, size_t nbytes) {
+Py_ssize_t doPartialWrite<int>(int fildes, void* buf, size_t nbytes) {
   return write(fildes, buf, nbytes);
 }
 
 template <>
-ssize_t doPartialWrite<PyObject*>(PyObject* fildes, void* buf, size_t nbytes) {
+Py_ssize_t doPartialWrite<PyObject*>(PyObject* fildes, void* buf, size_t nbytes) {
   return doPartialPythonWrite(fildes, buf, nbytes);
 }
 
@@ -50,7 +50,7 @@ static inline bool isUnsupportedOperation() {
 }
 
 // Call Python fildes.read(nbytes) and copy it to buf.
-static inline ssize_t doPartialPythonReadBuffered(PyObject* fildes, void* buf, size_t raw_nbytes) {
+static inline Py_ssize_t doPartialPythonReadBuffered(PyObject* fildes, void* buf, size_t raw_nbytes) {
   // If we request a large amount of data, f.read() will internally try to
   // allocate a buffer of that size.  This is counterproductive, because
   // it's not the buffer we ultimately want to write the data into.  Read
@@ -76,7 +76,7 @@ static inline ssize_t doPartialPythonReadBuffered(PyObject* fildes, void* buf, s
 }
 
 // Either does fildes.readinto(buf) or fildes.write(buf)
-static inline ssize_t doPartialPythonIO(PyObject* fildes, void* buf, size_t nbytes, bool is_read) {
+static inline Py_ssize_t doPartialPythonIO(PyObject* fildes, void* buf, size_t nbytes, bool is_read) {
   auto rw_flag = is_read ? PyBUF_WRITE : PyBUF_READ;
   THPObjectPtr memview(PyMemoryView_FromMemory(
       reinterpret_cast<char*>(buf), nbytes, rw_flag));
@@ -100,12 +100,12 @@ static inline ssize_t doPartialPythonIO(PyObject* fildes, void* buf, size_t nbyt
 }
 
 // Call Python fildes.readinto(buf)
-static ssize_t doPartialPythonReadInto(PyObject* fildes, void* buf, size_t nbytes) {
+static Py_ssize_t doPartialPythonReadInto(PyObject* fildes, void* buf, size_t nbytes) {
   return doPartialPythonIO(fildes, buf, nbytes, /* is_read */ true);
 }
 
 // Call Python fildes.write(buf)
-static ssize_t doPartialPythonWrite(PyObject* fildes, void* buf, size_t nbytes) {
+static Py_ssize_t doPartialPythonWrite(PyObject* fildes, void* buf, size_t nbytes) {
   return doPartialPythonIO(fildes, buf, nbytes, /* is_read */ false);
 }
 
@@ -117,7 +117,7 @@ void doRead(io fildes, void* raw_buf, size_t nbytes) {
     errno = 0; // doPartialRead may not set errno
     // we read in 1GB blocks to avoid bugs on Mac OS X Lion
     // see https://github.com/pytorch/pytorch/issues/1031 for more details
-    ssize_t r = doPartialRead(fildes, buf, std::min<size_t>(nbytes, 1073741824));
+    Py_ssize_t r = doPartialRead(fildes, buf, std::min<size_t>(nbytes, 1073741824));
     if (r < 0) {
       int err = errno;
       TORCH_INTERNAL_ASSERT(err != 0, "read(): impossible! r < 0, but no errno was set");
@@ -149,7 +149,7 @@ void doWrite(io fildes, void* raw_buf, size_t nbytes) {
     errno = 0; // doPartialWrite may not set errno
     // we write in 1GB blocks to avoid bugs on Mac OS X Lion
     // see https://github.com/pytorch/pytorch/issues/1031 for more details
-    ssize_t r = doPartialWrite(fildes, buf, std::min<size_t>(nbytes, 1073741824));
+    Py_ssize_t r = doPartialWrite(fildes, buf, std::min<size_t>(nbytes, 1073741824));
     if (r < 0) {
       int err = errno;
       TORCH_INTERNAL_ASSERT(err != 0, "write(): impossible! r < 0, but no errno was set");

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -912,7 +912,7 @@ bool FunctionSignature::parse(PyObject* self, PyObject* args, PyObject* kwargs, 
                               bool raise_exception) {
   auto nargs = args ? PyTuple_GET_SIZE(args) : 0;
   auto remaining_kwargs = kwargs ? PyDict_Size(kwargs) : 0;
-  size_t arg_pos = 0;
+  Py_ssize_t arg_pos = 0;
   bool allow_varargs_intlist = false;
 
   // if there is a single positional IntArrayRef argument, i.e. expand(..), view(...),

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -911,8 +911,8 @@ static void extra_kwargs(FunctionSignature& signature, PyObject* kwargs, Py_ssiz
 bool FunctionSignature::parse(PyObject* self, PyObject* args, PyObject* kwargs, PyObject* dst[],  // NOLINT
                               bool raise_exception) {
   auto nargs = args ? PyTuple_GET_SIZE(args) : 0;
-  ssize_t remaining_kwargs = kwargs ? PyDict_Size(kwargs) : 0;
-  ssize_t arg_pos = 0;
+  auto remaining_kwargs = kwargs ? PyDict_Size(kwargs) : 0;
+  size_t arg_pos = 0;
   bool allow_varargs_intlist = false;
 
   // if there is a single positional IntArrayRef argument, i.e. expand(..), view(...),


### PR DESCRIPTION
Fix for windows builds with python 3.10 , getting rid of ssize_t

Here is the completed bin build : https://app.circleci.com/pipelines/github/pytorch/pytorch/441527/workflows/144edb79-b398-4d70-92fe-b63158c1b439/jobs/16954881