### PR TITLE
[Profiler] Fix memory profile type from recent refactor

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -316,6 +316,10 @@ class TestProfiler(TestCase):
                             assert "Device Type" in evt["args"]
                             assert "Device Id" in evt["args"]
                             assert "Bytes" in evt["args"]
+
+                            # Memory should be an instantaneous event.
+                            assert "dur" not in evt["args"]
+                            assert "cat" not in evt["args"]
                     assert found_memory_events
 
         if torch.cuda.is_available():

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -91,7 +91,7 @@ void TraceWrapper::addMemoryUsageActivity(
 #ifdef USE_KINETO
   TORCH_CHECK((bool)(*this), "Cannot add event to non-existent trace.");
   cpu_trace_->activities.emplace_back(libkineto::GenericTraceActivity(
-    cpu_trace_->span, libkineto::ActivityType::CPU_OP, name));
+    cpu_trace_->span, libkineto::ActivityType::CPU_INSTANT_EVENT, name));
   auto& act = cpu_trace_->activities.back();
   act.device = device_and_resource.device;
   act.resource = device_and_resource.resource;


### PR DESCRIPTION
Summary: I accidentally changed CPU_INSTANT_EVENT to CPU_OP, which broke TensorBoard.

Test Plan: Make memory profiling unit test check this case.

Differential Revision: D33637286

