### PR TITLE
fixing BC serialization bug with nnq.dropout

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -628,9 +628,8 @@ class TestStaticQuantizedModule(QuantizationTestCase):
                          msg="Dropout module API failed")
 
     def test_dropout_qat_serialization_bc(self):
-        """Check to see whether the post_process_activation is dropped upon
-        convert"""
-        model = ManualLinearQATModel()
+        """Check to see whether the serialization is BC when QAT is used"""
+        model = ManualLinearQATModel("qnnpack")
         model.qconfig = torch.ao.quantization.get_default_qat_qconfig("qnnpack")
         model_prepare_dropout = torch.ao.quantization.prepare_qat(model, inplace=False)
 

--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -629,13 +629,13 @@ class TestStaticQuantizedModule(QuantizationTestCase):
 
     def test_dropout_qat_has_no_post_process_activation(self):
         """Check to make sure QAT doesn't add
-        post_process_activation to dropout module"""
+        activation_post_process to dropout module"""
         model = ManualLinearQATModel("qnnpack")
         model.qconfig = torch.ao.quantization.get_default_qat_qconfig("qnnpack")
         model_prepare = torch.ao.quantization.prepare_qat(model, inplace=False)
         self.assertTrue(hasattr(model_prepare, "dropout"))
-        self.assertFalse(hasattr(model_prepare.dropout, "post_process_activation"))
-        self.assertFalse(hasattr(model_prepare.dropout.state_dict(), "post_process_activation"))
+        self.assertFalse(hasattr(model_prepare.dropout, "activation_post_process"))
+        self.assertFalse(hasattr(model_prepare.dropout.state_dict(), "activation_post_process"))
 
     def _test_dropout_serialization(self, get_model, data1, data2):
         m1 = get_model()

--- a/torch/ao/quantization/quantization_mappings.py
+++ b/torch/ao/quantization/quantization_mappings.py
@@ -88,7 +88,6 @@ DEFAULT_QAT_MODULE_MAPPINGS : Dict[Callable, Any] = {
     nn.Conv2d: nnqat.Conv2d,
     nn.Conv3d: nnqat.Conv3d,
     nn.Linear: nnqat.Linear,
-    nn.Dropout: nnq.Dropout,
     nn.modules.linear.NonDynamicallyQuantizableLinear: nnqat.Linear,
     # Intrinsic modules:
     nni.ConvBn1d: nniqat.ConvBn1d,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71430

to fix https://github.com/pytorch/vision/issues/5198

problem was that nnq.dropout was supposed to lose its post_activation_process upon from_float being called, but for qat the module was being converted at the wrong point. This changed the state_dict and prevented it from being BC.

Differential Revision: [D33640816](https://our.internmc.facebook.com/intern/diff/D33640816/)