### PR TITLE
ci: Add PR trigger for binary builds workflows

### DIFF
--- a/.github/generated-ciflow-ruleset.json
+++ b/.github/generated-ciflow-ruleset.json
@@ -104,6 +104,10 @@
       "win-vs2019-cuda11.3-py3"
     ],
     "ciflow/default": [
+      "linux-binary-conda",
+      "linux-binary-libtorch-cxx11-abi",
+      "linux-binary-libtorch-pre-cxx11",
+      "linux-binary-manywheel",
       "linux-bionic-py3.7-clang9",
       "linux-docs",
       "linux-vulkan-bionic-py3.7-clang9",

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -836,7 +836,7 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
         package_type="manywheel",
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(),
         ciflow_config=CIFlowConfig(
-            labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
             isolated_workflow=True,
         ),
     ),
@@ -845,7 +845,7 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
         package_type="conda",
         build_configs=generate_binary_build_matrix.generate_conda_matrix(),
         ciflow_config=CIFlowConfig(
-            labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
             isolated_workflow=True,
         ),
     ),
@@ -857,7 +857,7 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
             generate_binary_build_matrix.CXX11_ABI
         ),
         ciflow_config=CIFlowConfig(
-            labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
             isolated_workflow=True,
         ),
     ),
@@ -869,7 +869,7 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
             generate_binary_build_matrix.PRE_CXX11_ABI
         ),
         ciflow_config=CIFlowConfig(
-            labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
             isolated_workflow=True,
         ),
     ),

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -27,10 +27,14 @@ name: !{{ build_environment }}
 {%- endmacro %}
 
 on:
-# NOTE: Uncomment this to test within your PR
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
-#  pull_request:
-#    types: [opened, synchronize, reopened, !{{ ciflow_config.trigger_action }}]
+  pull_request:
+    types: [opened, synchronize, reopened, !{{ ciflow_config.trigger_action }}]
+    # NOTE: This workflow should only trigger when changes are made to binary builds
+    # Should catch most of the binary build / test scripts
+    paths:
+      - '.github/workflows/generated-linux-binary-*.yml'
+      - '.circleci/scripts/binary_*.sh'
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-conda.yml
+++ b/.github/workflows/generated-linux-binary-conda.yml
@@ -45,8 +45,8 @@ jobs:
     if: ${{ (github.repository == 'pytorch/pytorch') && (
             (github.event_name == 'push') ||
             (github.event_name == 'schedule') ||
-            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/conda')) ||
-            (false))
+            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/conda') || contains(github.event.pull_request.labels.*.name, 'ciflow/default')) ||
+            ((github.event_name == 'pull_request' && github.event.action != 'unassigned') && !contains(join(github.event.pull_request.labels.*.name), 'ciflow/')))
          }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generated-linux-binary-conda.yml
+++ b/.github/workflows/generated-linux-binary-conda.yml
@@ -4,10 +4,14 @@
 name: linux-binary-conda
 
 on:
-# NOTE: Uncomment this to test within your PR
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
-#  pull_request:
-#    types: [opened, synchronize, reopened, unassigned]
+  pull_request:
+    types: [opened, synchronize, reopened, unassigned]
+    # NOTE: This workflow should only trigger when changes are made to binary builds
+    # Should catch most of the binary build / test scripts
+    paths:
+      - '.github/workflows/generated-linux-binary-*.yml'
+      - '.circleci/scripts/binary_*.sh'
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
@@ -45,8 +45,8 @@ jobs:
     if: ${{ (github.repository == 'pytorch/pytorch') && (
             (github.event_name == 'push') ||
             (github.event_name == 'schedule') ||
-            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/libtorch')) ||
-            (false))
+            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/libtorch') || contains(github.event.pull_request.labels.*.name, 'ciflow/default')) ||
+            ((github.event_name == 'pull_request' && github.event.action != 'unassigned') && !contains(join(github.event.pull_request.labels.*.name), 'ciflow/')))
          }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
@@ -4,10 +4,14 @@
 name: linux-binary-libtorch-cxx11-abi
 
 on:
-# NOTE: Uncomment this to test within your PR
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
-#  pull_request:
-#    types: [opened, synchronize, reopened, unassigned]
+  pull_request:
+    types: [opened, synchronize, reopened, unassigned]
+    # NOTE: This workflow should only trigger when changes are made to binary builds
+    # Should catch most of the binary build / test scripts
+    paths:
+      - '.github/workflows/generated-linux-binary-*.yml'
+      - '.circleci/scripts/binary_*.sh'
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
@@ -4,10 +4,14 @@
 name: linux-binary-libtorch-pre-cxx11
 
 on:
-# NOTE: Uncomment this to test within your PR
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
-#  pull_request:
-#    types: [opened, synchronize, reopened, unassigned]
+  pull_request:
+    types: [opened, synchronize, reopened, unassigned]
+    # NOTE: This workflow should only trigger when changes are made to binary builds
+    # Should catch most of the binary build / test scripts
+    paths:
+      - '.github/workflows/generated-linux-binary-*.yml'
+      - '.circleci/scripts/binary_*.sh'
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
@@ -45,8 +45,8 @@ jobs:
     if: ${{ (github.repository == 'pytorch/pytorch') && (
             (github.event_name == 'push') ||
             (github.event_name == 'schedule') ||
-            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/libtorch')) ||
-            (false))
+            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/libtorch') || contains(github.event.pull_request.labels.*.name, 'ciflow/default')) ||
+            ((github.event_name == 'pull_request' && github.event.action != 'unassigned') && !contains(join(github.event.pull_request.labels.*.name), 'ciflow/')))
          }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generated-linux-binary-manywheel.yml
+++ b/.github/workflows/generated-linux-binary-manywheel.yml
@@ -45,8 +45,8 @@ jobs:
     if: ${{ (github.repository == 'pytorch/pytorch') && (
             (github.event_name == 'push') ||
             (github.event_name == 'schedule') ||
-            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/wheel')) ||
-            (false))
+            (contains(github.event.pull_request.labels.*.name, 'ciflow/binaries') || contains(github.event.pull_request.labels.*.name, 'ciflow/binaries/wheel') || contains(github.event.pull_request.labels.*.name, 'ciflow/default')) ||
+            ((github.event_name == 'pull_request' && github.event.action != 'unassigned') && !contains(join(github.event.pull_request.labels.*.name), 'ciflow/')))
          }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generated-linux-binary-manywheel.yml
+++ b/.github/workflows/generated-linux-binary-manywheel.yml
@@ -4,10 +4,14 @@
 name: linux-binary-manywheel
 
 on:
-# NOTE: Uncomment this to test within your PR
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
-#  pull_request:
-#    types: [opened, synchronize, reopened, unassigned]
+  pull_request:
+    types: [opened, synchronize, reopened, unassigned]
+    # NOTE: This workflow should only trigger when changes are made to binary builds
+    # Should catch most of the binary build / test scripts
+    paths:
+      - '.github/workflows/generated-linux-binary-*.yml'
+      - '.circleci/scripts/binary_*.sh'
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #71433
* __->__ #71431

Adds a PR trigger based on paths to the binary build workflows to make
it easier to test / verify changes to the binary build workflows without
adding a bunch of skipped checks to the majority of our workflows

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33641276](https://our.internmc.facebook.com/intern/diff/D33641276)