### PR TITLE
Fix github repo detection

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -16,7 +16,7 @@ def get_git_remote_name() -> str:
 
 def get_git_repo_dir() -> str:
     from pathlib import Path
-    return os.getenv("GIT_REPO_DIR", str(Path(__file__).resolve().parent.parent))
+    return os.getenv("GIT_REPO_DIR", str(Path(__file__).resolve().parent.parent.parent))
 
 
 def fuzzy_list_to_dict(items: List[Tuple[str, str]]) -> Dict[str, List[str]]:


### PR DESCRIPTION
Otherwise, rev-list will only pick-up commits in `.github` repo

Before:
```
% git -C .github rev-list 1eb6146d967b2d09af37c54af411d03f0b790209..1ff7f65cc1ad499a71457368894ca14bed069749 -- .
598b55fd1894b7edb21f208b1c86fd6a377ebc69
ae089d6bdf03f1fadbc76fdf3d284081396251e8
```
After
```
% git -C . rev-list 1eb6146d967b2d09af37c54af411d03f0b790209..1ff7f65cc1ad499a71457368894ca14bed069749 -- . 
1ff7f65cc1ad499a71457368894ca14bed069749
2ac58b0dc13f152bea180dd3d64b7c36fe0ba755
598b55fd1894b7edb21f208b1c86fd6a377ebc69
55899528a266363d27e0cf5e82b1b94524509756
ae089d6bdf03f1fadbc76fdf3d284081396251e8
```
