### PR TITLE
[jit][edge] Create convinience wrapper for dynamic type construcytors.

### DIFF
--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -113,9 +113,9 @@ DynamicType::DynamicType(const Type& other) : SharedType(DynamicType::Kind) {
     return;
   }
   switch (kind) {
-#define CASE_TYPE(T, _) \
-  case T##Type::Kind:   \
-    tag_ = Tag::T;      \
+#define CASE_TYPE(T, _, __) \
+  case T##Type::Kind:       \
+    tag_ = Tag::T;          \
     break;
     FORALL_DYNAMIC_TYPES(CASE_TYPE)
 #undef CASE_TYPE
@@ -196,8 +196,8 @@ TypePtr DynamicType::containedType(size_t i) const {
 
 TypeKind DynamicType::dynamicKind() const {
   switch (tag_) {
-#define CASE_TYPE(T, _) \
-  case Tag::T:          \
+#define CASE_TYPE(T, _, __) \
+  case Tag::T:              \
     return TypeKind::T##Type;
     FORALL_DYNAMIC_TYPES(CASE_TYPE)
 #undef CASE_TYPE
@@ -358,11 +358,14 @@ ivalue::TupleTypeFactory<TupleType>::fallback(const Type& type) {
 #endif
 }
 
-#define DYNAMIC_TYPE_TAG_VALUE(NAME, _)                               \
-  const DynamicTypePtr& DynamicTypeTrait<NAME##Type>::getBaseType() { \
-    static auto type = makeBaseType(tagValue());                      \
-    return type;                                                      \
-  }
+#define DYNAMIC_TYPE_TAG_VALUE(NAME, _, IS_BASE_TYPE) \
+  template <typename T>                               \
+  std::enable_if_t<IS_BASE_TYPE, T>                   \
+  DynamicTypeTrait<NAME##Type>::getBaseType() {       \
+    static auto type = makeBaseType(tagValue());      \
+    return type;                                      \
+  }                                                   \
+  constexpr bool DynamicTypeTrait<NAME##Type>::isBaseType;
 FORALL_DYNAMIC_TYPES(DYNAMIC_TYPE_TAG_VALUE)
 #undef DYNAMIC_TYPE_TAG_VALUE
 

--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -20,11 +20,15 @@ bool contains(DynamicType::Tag lhs, DynamicType::Tag rhs) {
   return contains(lhs, static_cast<DynamicTypeBits>(rhs));
 }
 
-C10_NOINLINE DynamicTypePtr makeBaseType(DynamicType::Tag tag) {
+} // namespace
+
+namespace detail {
+
+DynamicTypePtr makeBaseType(DynamicType::Tag tag) {
   return std::make_shared<DynamicType>(tag, DynamicType::Arguments{});
 }
 
-} // namespace
+} // namespace detail
 
 std::string DynamicType::str() const {
   if (name_) {
@@ -358,13 +362,7 @@ ivalue::TupleTypeFactory<TupleType>::fallback(const Type& type) {
 #endif
 }
 
-#define DYNAMIC_TYPE_TAG_VALUE(NAME, _, IS_BASE_TYPE) \
-  template <typename T>                               \
-  std::enable_if_t<IS_BASE_TYPE, T>                   \
-  DynamicTypeTrait<NAME##Type>::getBaseType() {       \
-    static auto type = makeBaseType(tagValue());      \
-    return type;                                      \
-  }                                                   \
+#define DYNAMIC_TYPE_TAG_VALUE(NAME, _, __) \
   constexpr bool DynamicTypeTrait<NAME##Type>::isBaseType;
 FORALL_DYNAMIC_TYPES(DYNAMIC_TYPE_TAG_VALUE)
 #undef DYNAMIC_TYPE_TAG_VALUE

--- a/aten/src/ATen/core/dynamic_type.h
+++ b/aten/src/ATen/core/dynamic_type.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 
 #include <ATen/core/class_type.h>
 #include <ATen/core/ivalue.h>
@@ -24,32 +25,35 @@ constexpr DynamicTypeBits kDynamicTupleTypeBit = DYNAMIC_TYPE_BIT(8);
 constexpr DynamicTypeBits kDynamicClassTypeBit = DYNAMIC_TYPE_BIT(10);
 
 #define FORALL_DYNAMIC_TYPES(_)                                              \
-  _(Tensor, DYNAMIC_TYPE_BIT(0))                                             \
-  _(None, kDynamicNoneTypeBit)                                               \
-  _(Bool, DYNAMIC_TYPE_BIT(2))                                               \
-  _(Int, kDynamicIntTypeBit)                                                 \
-  _(Float, kDynamicFloatTypeBit)                                             \
-  _(Complex, kDynamicComplexTypeBit)                                         \
+  _(Tensor, DYNAMIC_TYPE_BIT(0), 1)                                          \
+  _(None, kDynamicNoneTypeBit, 1)                                            \
+  _(Bool, DYNAMIC_TYPE_BIT(2), 1)                                            \
+  _(Int, kDynamicIntTypeBit, 1)                                              \
+  _(Float, kDynamicFloatTypeBit, 1)                                          \
+  _(Complex, kDynamicComplexTypeBit, 1)                                      \
   _(Number,                                                                  \
-    (kDynamicIntTypeBit | kDynamicFloatTypeBit | kDynamicComplexTypeBit))    \
-  _(String, DYNAMIC_TYPE_BIT(6))                                             \
-  _(List, kDynamicListTypeBit)                                               \
-  _(Tuple, (kDynamicTupleTypeBit | kDynamicCovariantTypeBit))                \
-  _(Dict, DYNAMIC_TYPE_BIT(9))                                               \
-  _(Class, kDynamicClassTypeBit)                                             \
+    (kDynamicIntTypeBit | kDynamicFloatTypeBit | kDynamicComplexTypeBit),    \
+    1)                                                                       \
+  _(String, DYNAMIC_TYPE_BIT(6), 1)                                          \
+  _(List, kDynamicListTypeBit, 0)                                            \
+  _(Tuple, (kDynamicTupleTypeBit | kDynamicCovariantTypeBit), 0)             \
+  _(Dict, DYNAMIC_TYPE_BIT(9), 0)                                            \
+  _(Class, kDynamicClassTypeBit, 0)                                          \
   _(Optional,                                                                \
-    (DYNAMIC_TYPE_BIT(11) | kDynamicNoneTypeBit | kDynamicCovariantTypeBit)) \
-  _(AnyList, (kDynamicListTypeBit | kDynamicAnyTypeBit))                     \
+    (DYNAMIC_TYPE_BIT(11) | kDynamicNoneTypeBit | kDynamicCovariantTypeBit), \
+    0)                                                                       \
+  _(AnyList, (kDynamicListTypeBit | kDynamicAnyTypeBit), 1)                  \
   _(AnyTuple,                                                                \
-    (kDynamicTupleTypeBit | kDynamicCovariantTypeBit | kDynamicAnyTypeBit))  \
-  _(DeviceObj, DYNAMIC_TYPE_BIT(12))                                         \
-  _(StreamObj, DYNAMIC_TYPE_BIT(13))                                         \
-  _(Capsule, DYNAMIC_TYPE_BIT(14))                                           \
-  _(Generator, DYNAMIC_TYPE_BIT(15))                                         \
-  _(Storage, DYNAMIC_TYPE_BIT(16))                                           \
-  _(Var, DYNAMIC_TYPE_BIT(17))                                               \
-  _(AnyClass, kDynamicClassTypeBit | kDynamicAnyTypeBit)                     \
-  _(Any, 0xffffffff)
+    (kDynamicTupleTypeBit | kDynamicCovariantTypeBit | kDynamicAnyTypeBit),  \
+    1)                                                                       \
+  _(DeviceObj, DYNAMIC_TYPE_BIT(12), 1)                                      \
+  _(StreamObj, DYNAMIC_TYPE_BIT(13), 1)                                      \
+  _(Capsule, DYNAMIC_TYPE_BIT(14), 1)                                        \
+  _(Generator, DYNAMIC_TYPE_BIT(15), 1)                                      \
+  _(Storage, DYNAMIC_TYPE_BIT(16), 1)                                        \
+  _(Var, DYNAMIC_TYPE_BIT(17), 0)                                            \
+  _(AnyClass, (kDynamicClassTypeBit | kDynamicAnyTypeBit), 1)                \
+  _(Any, 0xffffffff, 1)
 
 class DynamicType;
 using DynamicTypePtr = std::shared_ptr<DynamicType>;
@@ -123,7 +127,7 @@ class DynamicType : public SharedType {
   };
 
   enum class Tag : DynamicTypeBits {
-#define DYNAMIC_TYPE_ITEM(NAME, VAL) NAME = VAL,
+#define DYNAMIC_TYPE_ITEM(NAME, VAL, _) NAME = VAL,
     FORALL_DYNAMIC_TYPES(DYNAMIC_TYPE_ITEM)
 #undef DYNAMIC_TYPE_ITEM
   };
@@ -189,13 +193,16 @@ struct DynamicTypeTrait {
     return DynamicType::Tag::Any;
   }
 };
-#define DYNAMIC_TYPE_TAG_VALUE(NAME, _)           \
-  template <>                                     \
-  struct TORCH_API DynamicTypeTrait<NAME##Type> { \
-    static auto tagValue() {                      \
-      return DynamicType::Tag::NAME;              \
-    }                                             \
-    static const DynamicTypePtr& getBaseType();   \
+
+#define DYNAMIC_TYPE_TAG_VALUE(NAME, _, IS_BASE_TYPE)       \
+  template <>                                               \
+  struct TORCH_API DynamicTypeTrait<NAME##Type> {           \
+    static auto tagValue() {                                \
+      return DynamicType::Tag::NAME;                        \
+    }                                                       \
+    template <typename T = const DynamicTypePtr&>           \
+    static std::enable_if_t<IS_BASE_TYPE, T> getBaseType(); \
+    static constexpr bool isBaseType = IS_BASE_TYPE;        \
   };
 FORALL_DYNAMIC_TYPES(DYNAMIC_TYPE_TAG_VALUE)
 #undef DYNAMIC_TYPE_TAG_VALUE

--- a/aten/src/ATen/core/type_factory.h
+++ b/aten/src/ATen/core/type_factory.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/dynamic_type.h>
 #include <ATen/core/jit_type.h>
+#include <type_traits>
 
 namespace c10 {
 
@@ -30,6 +31,22 @@ struct TORCH_API DynamicTypeFactory {
   }
   static const std::unordered_map<std::string, c10::TypePtr>& basePythonTypes();
 };
+
+// Helper functions for constructing DynamicTypes inline.
+template <
+    typename T,
+    std::enable_if_t<DynamicTypeTrait<T>::isBaseType, int> = 0>
+DynamicTypePtr dynT() {
+  return DynamicTypeTrait<T>::getBaseType();
+}
+
+template <
+    typename T,
+    typename... Args,
+    std::enable_if_t<!DynamicTypeTrait<T>::isBaseType, int> = 0>
+DynamicTypePtr dynT(Args&&... args) {
+  return DynamicTypeFactory::create<T>(std::forward<Args>(args)...);
+}
 
 struct TORCH_API DefaultTypeFactory {
   template <typename T, typename... Args>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71457

Today DynamicType is hard to be created because we have separare APIs for different types. In this diff we introduce an easier API to create types like the following:
```
#include <ATen/core/type_factory.h>

auto type = dynT<ListType>(dynT<TensorType>()); // etc...
```

Differential Revision: [D33647746](https://our.internmc.facebook.com/intern/diff/D33647746/)