### PR TITLE
[RPC] Fix a few flaky RPC tsan tests

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -4747,7 +4747,6 @@ class FaultyAgentRpcTest(RpcAgentTestFixture):
 
         # Ensure that the currently set default timeout is large enough such
         # that RPCs with delays still complete.
-        self.assertEqual(rpc.constants.DEFAULT_RPC_TIMEOUT_SEC, rpc.get_rpc_timeout())
         fut = rpc.rpc_async(
             dst_worker, torch.add, args=(torch.tensor(1), torch.tensor(1))
         )
@@ -4783,7 +4782,6 @@ class FaultyAgentRpcTest(RpcAgentTestFixture):
 
         # Ensure that the currently set default timeout is large enough such
         # that RPCs with delays still complete.
-        self.assertEqual(rpc.constants.DEFAULT_RPC_TIMEOUT_SEC, rpc.get_rpc_timeout())
         fut = rpc.rpc_async(
             dst_worker, my_script_func, args=(torch.tensor(1),)
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71460

When running with TSAN, we use a larger RPC timeout: https://github.com/pytorch/pytorch/blob/master/torch/testing/_internal/dist_utils.py#L68. As a result, the assertions here are invalid.

Tried to fix this by just setting `self.rpc_backend_options.rpc_timeout` to the new timeout, but `rpc_backend_options` is reconstructed every time it is accessed, so this doesn't work:: https://github.com/pytorch/pytorch/blob/master/torch/testing/_internal/distributed/rpc/tensorpipe_rpc_agent_test_fixture.py#L15


Just removing the asserts should be fine as they don't really add value to what's being tested.

Differential Revision: [D33648421](https://our.internmc.facebook.com/intern/diff/D33648421/)

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang