### PR TITLE
[Operator Versioning] Remove version compare as they are decoupled now

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -102,9 +102,6 @@ constexpr uint64_t kMinProducedFileFormatVersion = 0x3L;
 //  0x7L: Enable support for operators with default arguments plus out arguments.
 constexpr uint64_t kProducedBytecodeVersion = 0x7L;
 
-static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
-    "kProducedBytecodeVersion must be higher or equal to kProducedFileFormatVersion.");
-
 // Introduce kMinSupportedBytecodeVersion and kMaxSupportedBytecodeVersion
 // for limited backward/forward compatibility support of bytecode. If
 // kMinSupportedBytecodeVersion <= model_version <= kMaxSupportedBytecodeVersion (in loader),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71461

After operator versioning work, the version in model file is used for operator versioning, while bytecode_version is used for bytecode versioning (for bytecode schema). They are two seperate things now and this comparison is not needed.

Differential Revision: [D33648592](https://our.internmc.facebook.com/intern/diff/D33648592/)