### PR TITLE
structured kernels for vision_maskrcnn for missing ops 

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -223,6 +223,8 @@ namespace c10 {
   _(aten, linalg_vector_norm)        \
   _(aten, linalg_matrix_norm)        \
   _(aten, matmul)                    \
+  _(aten, minimum)                   \
+  _(aten, maximum)                   \
   _(aten, linalg_matmul)             \
   _(aten, linalg_matrix_exp)         \
   _(aten, append)                    \

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -97,6 +97,17 @@ full_codegen:
   - triu
   - trunc
   - zero_
+  - any
+  - bitwise_or.Tensor
+  - log
+  - max.dim
+  - maximum
+  - minimum
+  - neg
+  - remainder.Tensor
+  - upsample_bilinear2d
+  - upsample_nearest2d
+  - upsample_nearest2d_backward
 supported:
   - as_strided
   - as_strided_


### PR DESCRIPTION
we are missing 19 ops in total. according to native_functions.yaml, 11 of these are already structured.
I'll add the ops that require shape functions in smaller batches next 
