### PR TITLE
monitor: add docstrings to pybind interface

### DIFF
--- a/docs/source/monitor.rst
+++ b/docs/source/monitor.rst
@@ -9,11 +9,22 @@ torch.monitor
 ``torch.monitor`` provides an interface for logging events and counters from
 PyTorch.
 
+The stat interfaces are designed to be used for tracking high level metrics that
+are periodically logged out to be used for monitoring system performance. Since
+the stats aggregate with a specific window size you can log to them from
+critical loops with minimal performance impact.
+
+For more infrequent events or values such as loss, accuracy, usage tracking the
+event interface can be directly used.
+
+Event handlers can be registered to handle the events and pass them to an
+external event sink.
 
 API Reference
 -------------
 
 .. automodule:: torch.monitor
+    :members:
 
 .. autoclass:: torch.monitor.Aggregation
     :members:
@@ -22,15 +33,21 @@ API Reference
     :members:
 
 .. autoclass:: torch.monitor.IntervalStat
-    :members:
+    :members: +add, count, name
+    :special-members: __init__
 
 .. autoclass:: torch.monitor.FixedCountStat
+    :members: +add, count, name
+    :special-members: __init__
+
+.. autoclass:: torch.monitor.data_value_t
     :members:
 
 .. autoclass:: torch.monitor.Event
     :members:
+    :special-members: __init__
 
-.. autoclass:: torch.monitor.PythonEventHandler
+.. autoclass:: torch.monitor.EventHandlerHandle
     :members:
 
 .. autofunction:: torch.monitor.log_event

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -15,6 +15,7 @@ from torch.monitor import (
     log_event,
     register_event_handler,
     unregister_event_handler,
+    Stat,
 )
 
 class TestMonitor(TestCase):
@@ -30,6 +31,7 @@ class TestMonitor(TestCase):
             (Aggregation.SUM, Aggregation.COUNT),
             timedelta(milliseconds=1),
         )
+        self.assertIsInstance(s, Stat)
         self.assertEqual(s.name, "asdf")
 
         s.add(2)
@@ -49,6 +51,7 @@ class TestMonitor(TestCase):
             (Aggregation.SUM, Aggregation.COUNT),
             3,
         )
+        self.assertIsInstance(s, Stat)
         s.add(1)
         s.add(2)
         name = s.name

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -85,31 +85,139 @@ void initMonitorBindings(PyObject* module) {
 
   auto m = rootModule.def_submodule("_monitor");
 
-  py::enum_<Aggregation>(m, "Aggregation")
-      .value("VALUE", Aggregation::NONE)
-      .value("MEAN", Aggregation::MEAN)
-      .value("COUNT", Aggregation::COUNT)
-      .value("SUM", Aggregation::SUM)
-      .value("MAX", Aggregation::MAX)
-      .value("MIN", Aggregation::MIN)
+  py::enum_<Aggregation>(
+      m,
+      "Aggregation",
+      R"DOC(
+        These are types of aggregations that can be used to accumulate stats.
+      )DOC")
+      .value(
+          "VALUE",
+          Aggregation::NONE,
+          R"DOC(
+            VALUE returns the last value to be added.
+          )DOC")
+      .value(
+          "MEAN",
+          Aggregation::MEAN,
+          R"DOC(
+            MEAN computes the arithmetic mean of all the added values.
+          )DOC")
+      .value(
+          "COUNT",
+          Aggregation::COUNT,
+          R"DOC(
+            COUNT returns the total number of added values.
+          )DOC")
+      .value(
+          "SUM",
+          Aggregation::SUM,
+          R"DOC(
+            SUM returns the sum of the added values.
+          )DOC")
+      .value(
+          "MAX",
+          Aggregation::MAX,
+          R"DOC(
+            MAX returns the max of the added values.
+          )DOC")
+      .value(
+          "MIN",
+          Aggregation::MIN,
+          R"DOC(
+            MIN returns the min of the added values.
+          )DOC")
       .export_values();
 
-  py::class_<Stat<double>>(m, "Stat")
-      .def("add", &Stat<double>::add)
-      .def("get", &Stat<double>::get)
-      .def_property_readonly("name", &Stat<double>::name)
-      .def_property_readonly("count", &Stat<double>::count);
+  py::class_<Stat<double>>(
+      m,
+      "Stat",
+      R"DOC(
+        Parent class for all aggregating stat implementations.
+      )DOC")
+      .def(
+          "add",
+          &Stat<double>::add,
+          py::arg("v"),
+          R"DOC(
+            Adds a value to the stat to be aggregated according to the
+            configured stat type and aggregations.
+          )DOC")
+      .def(
+          "get",
+          &Stat<double>::get,
+          R"DOC(
+            Returns the current value of the stat, primarily for testing
+            purposes. If the stat has logged and no additional values have been
+            added this will be zero.
+          )DOC")
+      .def_property_readonly(
+          "name",
+          &Stat<double>::name,
+          R"DOC(
+            The name of the stat that was set during creation.
+          )DOC")
+      .def_property_readonly(
+          "count",
+          &Stat<double>::count,
+          R"DOC(
+            Number of data points that have currently been collected. Resets
+            once the event has been logged.
+          )DOC");
 
-  py::class_<IntervalStat<double>, Stat<double>>(m, "IntervalStat")
-      .def(py::init<
-           std::string,
-           std::vector<Aggregation>,
-           std::chrono::milliseconds>());
+  py::class_<IntervalStat<double>, Stat<double>>(
+      m,
+      "IntervalStat",
+      R"DOC(
+        IntervalStat is a Stat that logs once every ``window_size`` duration. This
+        should be set to something relatively high to avoid a huge number of
+        events being logged. Ex: 60s.
+        The stat will be logged as an event on the next ``add`` call after the
+        window ends.
+      )DOC")
+      .def(
+          py::init<
+              std::string,
+              std::vector<Aggregation>,
+              std::chrono::milliseconds>(),
+          py::arg("name"),
+          py::arg("aggregations"),
+          py::arg("window_size"),
+          R"DOC(
+           Constructs the ``IntervalStat``.
+          )DOC");
 
-  py::class_<FixedCountStat<double>, Stat<double>>(m, "FixedCountStat")
-      .def(py::init<std::string, std::vector<Aggregation>, int64_t>());
+  py::class_<FixedCountStat<double>, Stat<double>>(
+      m,
+      "FixedCountStat",
+      R"DOC(
+        FixedCountStat is a Stat that logs every ``window_size`` number of
+        ``add`` calls. For high performance stats this window size should be
+        fairly large to ensure that the event logging frequency is in the range
+        of 1s to 60s under normal usage. Core stats should error on the side of
+        logging less frequently.
+      )DOC")
+      .def(
+          py::init<std::string, std::vector<Aggregation>, int64_t>(),
+          py::arg("name"),
+          py::arg("aggregations"),
+          py::arg("window_size"),
+          R"DOC(
+           Constructs the ``FixedCountStat``.
+          )DOC");
 
-  py::class_<Event>(m, "Event")
+  py::class_<Event>(
+      m,
+      "Event",
+      R"DOC(
+        Event represents a specific typed event to be logged. This can represent
+        high-level data points such as loss or accuracy per epoch or more
+        low-level aggregations such as through the Stats provided through this
+        library.
+
+        All Events of the same type should have the same name so downstream
+        handlers can correctly process them.
+      )DOC")
       .def(
           py::init([](const std::string& name,
                       std::chrono::system_clock::time_point timestamp,
@@ -122,14 +230,47 @@ void initMonitorBindings(PyObject* module) {
           }),
           py::arg("name"),
           py::arg("timestamp"),
-          py::arg("data"))
-      .def_readwrite("name", &Event::name)
-      .def_readwrite("timestamp", &Event::timestamp)
-      .def_readwrite("data", &Event::data);
+          py::arg("data"),
+          R"DOC(
+           Constructs the ``Event``.
+          )DOC")
+      .def_readwrite(
+          "name",
+          &Event::name,
+          R"DOC(
+            The name of the ``Event``.
+          )DOC")
+      .def_readwrite(
+          "timestamp",
+          &Event::timestamp,
+          R"DOC(
+            The timestamp when the ``Event`` happened.
+          )DOC")
+      .def_readwrite(
+          "data",
+          &Event::data,
+          R"DOC(
+            The structured data contained within the ``Event``.
+          )DOC");
 
-  m.def("log_event", &logEvent);
+  m.def(
+      "log_event",
+      &logEvent,
+      py::arg("event"),
+      R"DOC(
+        log_event logs the specified event to all of the registered event
+        handlers. It's up to the event handlers to log the event out to the
+        corresponding event sink.
 
-  py::class_<data_value_t> dataClass(m, "data_value_t");
+        If there are no event handlers registered this method is a no-op.
+      )DOC");
+
+  py::class_<data_value_t> dataClass(
+      m,
+      "data_value_t",
+      R"DOC(
+        data_value_t is one of of ``str``, ``float``, ``int``, ``bool``.
+      )DOC");
 
   py::implicitly_convertible<std::string, data_value_t>();
   py::implicitly_convertible<double, data_value_t>();
@@ -137,17 +278,36 @@ void initMonitorBindings(PyObject* module) {
   py::implicitly_convertible<bool, data_value_t>();
 
   py::class_<PythonEventHandler, std::shared_ptr<PythonEventHandler>>
-      eventHandlerClass(m, "PythonEventHandler");
-  m.def("register_event_handler", [](std::function<void(const Event&)> f) {
-    auto handler = std::make_shared<PythonEventHandler>(f);
-    registerEventHandler(handler);
-    return handler;
-  });
+      eventHandlerClass(m, "EventHandlerHandle", R"DOC(
+        EventHandlerHandle is a wrapper type returned by
+        ``register_event_handler`` used to unregister the handler via
+        ``unregister_event_handler``. This cannot be directly initialized.
+      )DOC");
+  m.def(
+      "register_event_handler",
+      [](std::function<void(const Event&)> f) {
+        auto handler = std::make_shared<PythonEventHandler>(f);
+        registerEventHandler(handler);
+        return handler;
+      },
+      py::arg("callback"),
+      R"DOC(
+        register_event_handler registers a callback to be called whenever an
+        event is logged via ``log_event``. These handlers should avoid blocking
+        the main thread since that may interfere with training as they run
+        during the ``log_event`` call.
+      )DOC");
   m.def(
       "unregister_event_handler",
       [](std::shared_ptr<PythonEventHandler> handler) {
         unregisterEventHandler(handler);
-      });
+      },
+      py::arg("handler"),
+      R"DOC(
+        unregister_event_handler unregisters the ``EventHandlerHandle`` returned
+        after calling ``register_event_handler``. After this returns the event
+        handler will no longer receive events.
+      )DOC");
 }
 
 } // namespace monitor


### PR DESCRIPTION
This adds argument names and docstrings so the docs are a lot more understandable.

Test plan:

docs/tests CI should suffice

![Screenshot 2022-01-19 at 16-35-10 torch monitor — PyTorch master documentation](https://user-images.githubusercontent.com/909104/150240882-e69cfa17-e2be-4569-8ced-71979a89b369.png)


