### PR TITLE
[BE]Clarify how to check memory saving if using gradient_as_bucket_view

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -478,6 +478,8 @@ class DistributedDataParallel(Module, Joinable):
                       gradients. If hitting such errors, please fix it by
                       referring to the :meth:`~torch.optim.Optimizer.zero_grad`
                       function in ``torch/optim/optimizer.py`` as a solution.
+                      Note that gradients will be views after first iteration, so
+                      the peak memory saving should be checked after first iteration.
         static_graph (bool): When set to ``True``, DDP knows the trained graph is
                      static. Static graph means 1) The set of used and unused
                      parameters will not change during the whole training loop; in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71483
* #71459

claify that peak memory saving should be checked after first iteration when using gradient_as_bucket_view

Differential Revision: [D33662424](https://our.internmc.facebook.com/intern/diff/D33662424/)