### PR TITLE
Update linspace and bump version nuymber to 8

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -11,17 +11,8 @@
 namespace at { namespace native {
 
 
-Tensor& linspace_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
+Tensor& linspace_out(const Scalar& start, const Scalar& end, int64_t steps, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for linspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
-
   if (result.numel() != steps) {
     result.resize_({steps});
   }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -552,7 +552,7 @@ TensorOptions linspace_logspace_infer_options(
 Tensor linspace(
     const Scalar& start,
     const Scalar& end,
-    c10::optional<int64_t> steps,
+    int64_t steps,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
@@ -560,10 +560,9 @@ Tensor linspace(
   // See [Note: hacky wrapper removal for TensorOptions]
   TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
 
-  const auto steps_ = steps.value_or(100);
-  TORCH_CHECK(steps_ >= 0, "number of steps must be non-negative");
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   auto result_options = linspace_logspace_infer_options(start, end, options, "torch.linspace()");
-  Tensor result = at::empty({steps_}, result_options);
+  Tensor result = at::empty({steps}, result_options);
   return at::linspace_out(result, start, end, steps);
 }
 

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -51,16 +51,8 @@ void gpu_kernel_with_index(at::Tensor &output, func_t f) {
 namespace at {
 namespace native {
 
-Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
+Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for linspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
 
   if (result.numel() != steps) {
     result.resize_({steps});

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2613,9 +2613,9 @@
 
 - func: ldexp.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: linspace(Scalar start, Scalar end, int? steps=None, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: linspace.out(Scalar start, Scalar end, int? steps=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: linspace.out(Scalar start, Scalar end, int steps, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, Meta: linspace_out
     CUDA: linspace_cuda_out

--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -12,7 +12,7 @@ namespace serialize {
 constexpr uint64_t kMinSupportedFileFormatVersion = 0x1L;
 
 #if ENABLE_UPGRADERS
-constexpr uint64_t kMaxSupportedFileFormatVersion = 0x7L;
+constexpr uint64_t kMaxSupportedFileFormatVersion = 0x8L;
 #else
 constexpr uint64_t kMaxSupportedFileFormatVersion = 0x6L;
 #endif
@@ -58,13 +58,25 @@ constexpr uint64_t kMaxSupportedFileFormatVersion = 0x6L;
 // 6. Write version string to `./data/version` instead of `version`.
 
 #if ENABLE_UPGRADERS
-// This is set to 7 from 3 due to a different interpretation of what
-// file format version is. Whenever there is new upgrader introduced,
+// [12/15/2021]
+// kProducedFileFormatVersion is set to 7 from 3 due to a different
+// interpretation of what file format version is.
+// Whenever there is new upgrader introduced,
 // this number should be bumped.
+// The reasons that version is bumped in the past:
 //     1. aten::div is changed at version 4
 //     2. aten::full is changed at version 5
 //     3. torch.package uses version 6
-constexpr uint64_t kProducedFileFormatVersion = 0x7L;
+//     4. Introduce new upgrader design and set the version number to 7
+//        mark this change
+// --------------------------------------------------
+// We describe new operator version bump reasons here:
+// 1) [01/24/2022]
+//     We bump the version number to 8 to update aten::linspace
+//     and aten::linspace.out to error out when steps is not
+//     provided. (see: https://github.com/pytorch/pytorch/issues/55951)
+// 2) ...
+constexpr uint64_t kProducedFileFormatVersion = 0x8L;
 #else
 constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 #endif

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -84,6 +84,7 @@ ALLOW_LIST = [
     ("aten::linalg_svd", datetime.date(2022, 3, 31)),
     ("aten::linalg_svd_out", datetime.date(2022, 3, 31)),
     ("aten::_convolution_nogroup", datetime.date(9999, 1, 1)),
+    ("aten::linspace", datetime.date(2022, 3, 1)),  # TODO this will be removed soon
     ("aten::miopen_convolution_backward", datetime.date(9999, 1, 1)),
     ("aten::miopen_convolution_backward_bias", datetime.date(9999, 1, 1)),
     ("aten::miopen_convolution_backward_input", datetime.date(9999, 1, 1)),

--- a/test/jit/test_save_load_for_op_version.py
+++ b/test/jit/test_save_load_for_op_version.py
@@ -6,6 +6,7 @@ import os
 import sys
 import hypothesis.strategies as st
 from hypothesis import example, settings, given
+from typing import Union
 
 import torch
 
@@ -240,10 +241,6 @@ class TestSaveLoadForOpVersion(JitTestCase):
         except Exception as e:
             self.skipTest("Failed to load fixture!")
 
-        for m in (v3_module_float, v3_module_int):
-            self._verify_count("aten::div", m, 2)  # true_divide and divide alias to div
-            self._verify_count('prim::Constant[value="trunc"]', m, 1)  # rounding_mode argument
-
         current_mobile_module_float = self._save_load_mobile_module(MyModuleFloat)
         current_mobile_module_int = self._save_load_mobile_module(MyModuleInt)
 
@@ -425,3 +422,62 @@ class TestSaveLoadForOpVersion(JitTestCase):
                 self.assertEqual(mr, hr)
 
         _helper(v3_mobile_module, current_mobile_module)
+
+    def test_versioned_linspace(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super(Module, self).__init__()
+
+            def forward(self, a: Union[int, float, complex], b: Union[int, float, complex]):
+                c = torch.linspace(a, b, steps=5)
+                d = torch.linspace(a, b, steps=100)
+                return c, d
+
+        scripted_module = torch.jit.load(
+            pytorch_test_dir + "/jit/fixtures/test_versioned_linspace_v7.ptl")
+
+        buffer = io.BytesIO(scripted_module._save_to_buffer_for_lite_interpreter())
+        buffer.seek(0)
+        v7_mobile_module = _load_for_lite_interpreter(buffer)
+
+        current_mobile_module = self._save_load_mobile_module(Module)
+
+        sample_inputs = ((3, 10), (-10, 10), (4.0, 6.0), (3 + 4j, 4 + 5j))
+        for (a, b) in sample_inputs:
+            (output_with_step, output_without_step) = v7_mobile_module(a, b)
+            (current_with_step, current_without_step) = current_mobile_module(a, b)
+            # when no step is given, should have used 100
+            self.assertTrue(output_without_step.size(dim=0) == 100)
+            self.assertTrue(output_with_step.size(dim=0) == 5)
+            # outputs should be equal to the newest version
+            self.assertEqual(output_with_step, current_with_step)
+            self.assertEqual(output_without_step, current_without_step)
+
+    def test_versioned_linspace_out(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super(Module, self).__init__()
+
+            def forward(self, a: Union[int, float, complex], b: Union[int, float, complex], out: torch.Tensor):
+                return torch.linspace(a, b, steps=100, out=out)
+
+        model_path = pytorch_test_dir + "/jit/fixtures/test_versioned_linspace_out_v7.ptl"
+        loaded_model = torch.jit.load(model_path)
+        buffer = io.BytesIO(loaded_model._save_to_buffer_for_lite_interpreter())
+        buffer.seek(0)
+        v7_mobile_module = _load_for_lite_interpreter(buffer)
+        current_mobile_module = self._save_load_mobile_module(Module)
+
+        sample_inputs = (
+            (3, 10, torch.empty((100,), dtype=torch.int64), torch.empty((100,), dtype=torch.int64)),
+            (-10, 10, torch.empty((100,), dtype=torch.int64), torch.empty((100,), dtype=torch.int64)),
+            (4.0, 6.0, torch.empty((100,), dtype=torch.float64), torch.empty((100,), dtype=torch.float64)),
+            (3 + 4j, 4 + 5j, torch.empty((100,), dtype=torch.complex64), torch.empty((100,), dtype=torch.complex64)),
+        )
+        for (start, end, out_for_old, out_for_new) in sample_inputs:
+            output = v7_mobile_module(start, end, out_for_old)
+            output_current = current_mobile_module(start, end, out_for_new)
+            # when no step is given, should have used 100
+            self.assertTrue(output.size(dim=0) == 100)
+            # "Upgraded" model should match the new version output
+            self.assertEqual(output, output_current)

--- a/test/jit/test_upgraders.py
+++ b/test/jit/test_upgraders.py
@@ -26,8 +26,15 @@ class TestUpgraders(JitTestCase):
         torch.jit.save(loaded_model, buffer)
         buffer.seek(0)
         zipped_model = zipfile.ZipFile(buffer)
-        version = int(zipped_model.read('archive/version').decode("utf-8"))
-        return version
+        # there was a change in how we store version number
+        # in a package between version 3 and 7.
+        # So we have to check for both.
+        try:
+            version = int(zipped_model.read('archive/version').decode("utf-8"))
+            return version
+        except KeyError:
+            version = int(zipped_model.read('archive/.data/version').decode("utf-8"))
+            return version
 
     # TODO (tugsuu) We should ideally be generating this test cases.
     def test_populated_upgrader_graph(self):
@@ -130,6 +137,38 @@ class TestUpgraders(JitTestCase):
         loaded_func = torch.jit.load(buffer)
         version = self._load_model_version(loaded_func)
         self.assertTrue(version == 4)
+
+    @unittest.skipIf(not _is_upgraders_enabled(), "Skipping because upgraders are not enabled")
+    def test_aten_linspace(self):
+        model_path = pytorch_test_dir + "/jit/fixtures/test_versioned_linspace_v7.ptl"
+        loaded_model = torch.jit.load(model_path)
+        sample_inputs = ((3, 10), (-10, 10), (4.0, 6.0), (3 + 4j, 4 + 5j))
+        for (a, b) in sample_inputs:
+            output_with_step, output_without_step = loaded_model(a, b)
+            # when no step is given, should have used 100
+            self.assertTrue(output_without_step.size(dim=0) == 100)
+            self.assertTrue(output_with_step.size(dim=0) == 5)
+
+        version = self._load_model_version(loaded_model)
+        self.assertTrue(version == 8)
+
+    @unittest.skipIf(not _is_upgraders_enabled(), "Skipping because upgraders are not enabled")
+    def test_aten_linspace_out(self):
+        model_path = pytorch_test_dir + "/jit/fixtures/test_versioned_linspace_out_v7.ptl"
+        loaded_model = torch.jit.load(model_path)
+        sample_inputs = (
+            (3, 10, torch.empty((100,), dtype=torch.int64)),
+            (-10, 10, torch.empty((100,), dtype=torch.int64)),
+            (4.0, 6.0, torch.empty((100,), dtype=torch.float64)),
+            (3 + 4j, 4 + 5j, torch.empty((100,), dtype=torch.complex64)),
+        )
+        for (a, b, c) in sample_inputs:
+            output = loaded_model(a, b, c)
+            # when no step is given, should have used 100
+            self.assertTrue(output.size(dim=0) == 100)
+
+        version = self._load_model_version(loaded_model)
+        self.assertTrue(version == 8)
 
     @unittest.skipIf(not _is_upgraders_enabled(), "Skipping because upgraders are not enabled")
     def test_aten_test_serialization(self):

--- a/test/mobile/test_upgrader_bytecode_table_example.cpp
+++ b/test/mobile/test_upgrader_bytecode_table_example.cpp
@@ -46,6 +46,14 @@ getOperatorVersionMapForMobile() {
                     std::vector<Upgrader>({
                         Upgrader({0, 3, "div__Tensor_0_3", 3})
                     })},
+                {std::string("aten::linspace"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 7, "linspace_0_7", 7})
+                    })},
+                {std::string("aten::linspace.out"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 7, "linspace_out_0_7", 8})
+                    })},
       });
   return operatorVersionMapForMobile;
 }
@@ -277,6 +285,99 @@ const std::vector<ByteCodeFunctionWithOperator>& getUpgraderBytecodeList() {
                                    OperatorString({"aten::is_floating_point", "", 1}),
                                    OperatorString({"aten::div", "out", 3}),
                                    OperatorString({"aten::div", "out_mode", 4}),
+                           }), // operators list
+                   }),
+                   ByteCodeFunctionWithOperator({
+                           mobile::Function::registerFunc(
+                               "linspace_0_7",
+                               std::vector<Instruction>({
+                                           Instruction{OpCode::STOREN, 1, 7},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::LOADC, 0, 0},
+                                           Instruction{OpCode::OP, 0, 0},
+                                           Instruction{OpCode::JF, 10, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOADC, 1, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::LOAD, 6, 0},
+                                           Instruction{OpCode::LOAD, 7, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::JMP, 10, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::OP, 2, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::LOAD, 6, 0},
+                                           Instruction{OpCode::LOAD, 7, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::STORE, 8, 0},
+                                           Instruction{OpCode::DROPR, 7, 0},
+                                           Instruction{OpCode::DROPR, 6, 0},
+                                           Instruction{OpCode::DROPR, 5, 0},
+                                           Instruction{OpCode::DROPR, 4, 0},
+                                           Instruction{OpCode::DROPR, 2, 0},
+                                           Instruction{OpCode::DROPR, 1, 0},
+                                           Instruction{OpCode::DROPR, 3, 0},
+                                           Instruction{OpCode::MOVE, 8, 0},
+                                           Instruction{OpCode::RET, 0, 0},
+                                   }), // instructions list,
+                               std::vector<c10::IValue>({
+                                           c10::IValue(),
+                                           c10::IValue(100),
+                                   }), // constants list,
+                               std::vector<c10::TypePtr>(), // types list,
+                               8
+                           ),
+                           std::vector<OperatorString>({
+                                   OperatorString({"aten::__is__", "", 2}),
+                                   OperatorString({"aten::linspace", "", 7}),
+                                   OperatorString({"prim::unchecked_cast", "", 1}),
+                           }), // operators list
+                   }),
+                   ByteCodeFunctionWithOperator({
+                           mobile::Function::registerFunc(
+                               "linspace_out_0_7",
+                               std::vector<Instruction>({
+                                           Instruction{OpCode::STOREN, 1, 4},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::LOADC, 0, 0},
+                                           Instruction{OpCode::OP, 0, 0},
+                                           Instruction{OpCode::JF, 7, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOADC, 1, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::JMP, 7, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::OP, 2, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::STORE, 5, 0},
+                                           Instruction{OpCode::DROPR, 4, 0},
+                                           Instruction{OpCode::DROPR, 2, 0},
+                                           Instruction{OpCode::DROPR, 1, 0},
+                                           Instruction{OpCode::DROPR, 3, 0},
+                                           Instruction{OpCode::MOVE, 5, 0},
+                                           Instruction{OpCode::RET, 0, 0},
+                                   }), // instructions list,
+                               std::vector<c10::IValue>({
+                                           c10::IValue(),
+                                           c10::IValue(100),
+                                   }), // constants list,
+                               std::vector<c10::TypePtr>(), // types list,
+                               5
+                           ),
+                           std::vector<OperatorString>({
+                                   OperatorString({"aten::__is__", "", 2}),
+                                   OperatorString({"aten::linspace", "out", 4}),
+                                   OperatorString({"prim::unchecked_cast", "", 1}),
                            }), // operators list
                    }),
             });

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2736,17 +2736,13 @@ class TestTensorCreation(TestCase):
             self.assertEqual(t[0], a[0])
             self.assertEqual(t[steps - 1], a[steps - 1])
 
-    def _linspace_logspace_warning_helper(self, op, device, dtype):
+    def _logspace_warning_helper(self, op, device, dtype):
         with self.assertWarnsOnceRegex(UserWarning, "Not providing a value for .+"):
             op(0, 10, device=device, dtype=dtype)
 
     @dtypes(torch.float)
-    def test_linspace_steps_warning(self, device, dtype):
-        self._linspace_logspace_warning_helper(torch.linspace, device, dtype)
-
-    @dtypes(torch.float)
     def test_logspace_steps_warning(self, device, dtype):
-        self._linspace_logspace_warning_helper(torch.logspace, device, dtype)
+        self._logspace_warning_helper(torch.logspace, device, dtype)
 
     @onlyCUDA
     @largeTensorTest('16GB')
@@ -2951,6 +2947,9 @@ class TestTensorCreation(TestCase):
                          torch.zeros(1, device=device, dtype=dtype), atol=0, rtol=0)
         # steps = 0
         self.assertEqual(torch.linspace(0, 1, 0, device=device, dtype=dtype).numel(), 0, atol=0, rtol=0)
+
+        # steps not provided
+        self.assertRaises(TypeError, lambda: torch.linspace(0, 1, device=device, dtype=dtype))
 
         if dtype == torch.float:
             # passed dtype can't be safely casted to inferred dtype

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -330,7 +330,9 @@ class TestTypePromotion(TestCase):
         expected = torch.ones(0, dtype=torch.int64, device=device)
         self.assertEqual(torch.arange(False, False, device=device), expected)
 
-        self.assertEqual(torch.linspace(False, True, device=device), torch.linspace(0, 1, device=device))
+        bool_tensor_lin = torch.linspace(False, True, steps=100, device=device)
+        int_tensor_lin = torch.linspace(0, 1, steps=100, device=device)
+        self.assertEqual(bool_tensor_lin, int_tensor_lin)
         self.assertEqual(torch.logspace(False, True, device=device), torch.logspace(0, 1, device=device))
 
         # this seems like odd behavior but ints also create float tensors, numpy doesn't have this function.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5139,13 +5139,7 @@ spaced from :attr:`start` to :attr:`end`, inclusive. That is, the value are:
     \text{end})
 """ + """
 
-.. warning::
-    Not providing a value for :attr:`steps` is deprecated. For backwards
-    compatibility, not providing a value for :attr:`steps` will create a tensor
-    with 100 elements. Note that this behavior is not reflected in the
-    documented function signature and should not be relied on. In a future
-    PyTorch release, failing to provide a value for :attr:`steps` will throw a
-    runtime error.
+From PyTorch 1.11 linspace requires the steps argument. Use steps=100 to restore the previous behavior.
 
 Args:
     start (float): the starting value for the set of points

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -511,7 +511,7 @@ static PyObject * THPVariable_linspace(PyObject* self_, PyObject* args, PyObject
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-    "linspace(Scalar start, Scalar end, int64_t? steps=None, *, Tensor out=None, ScalarType dtype=None, Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False)",
+    "linspace(Scalar start, Scalar end, int64_t steps, *, Tensor out=None, ScalarType dtype=None, Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False)",
   }, /*traceable=*/true);
 
   ParsedArgs<9> parsed_args;
@@ -520,7 +520,7 @@ static PyObject * THPVariable_linspace(PyObject* self_, PyObject* args, PyObject
     return handle_torch_function(_r, nullptr, args, kwargs, THPVariableFunctionsModule, "torch");
   }
   if (_r.isNone(3)) {
-    // aten::linspace(Scalar start, Scalar end, int? steps=None, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+    // aten::linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
     // NOTE: r.scalartype(X) gives the default dtype if r.isNone(X)
     // This leads to problem in the operator argument checks,
@@ -533,22 +533,22 @@ static PyObject * THPVariable_linspace(PyObject* self_, PyObject* args, PyObject
         .pinned_memory(_r.toBool(7));
     torch::utils::maybe_initialize_cuda(options);
 
-    auto dispatch_linspace = [](Scalar start, Scalar end, c10::optional<int64_t> steps, TensorOptions options) -> Tensor {
+    auto dispatch_linspace = [](Scalar start, Scalar end, int64_t steps, TensorOptions options) -> Tensor {
       pybind11::gil_scoped_release no_gil;
       return torch::linspace(start, end, steps, options);
     };
-    return wrap(dispatch_linspace(_r.scalar(0), _r.scalar(1), _r.toInt64Optional(2), options));
+    return wrap(dispatch_linspace(_r.scalar(0), _r.scalar(1), _r.toInt64(2), options));
   } else {
     // aten::linspace.out(Scalar start, Scalar end, int? steps=None, *, Tensor(a!) out) -> Tensor(a!)
     check_out_type_matches(_r.tensor(3), _r.scalartype(4),
                            _r.isNone(4), _r.layoutOptional(5),
                            _r.device(6), _r.isNone(6));
 
-    auto dispatch_linspace_out = [](Tensor out, Scalar start, Scalar end, c10::optional<int64_t> steps) -> Tensor {
+    auto dispatch_linspace_out = [](Tensor out, Scalar start, Scalar end, int64_t steps) -> Tensor {
       pybind11::gil_scoped_release no_gil;
       return at::linspace_out(out, start, end, steps);
     };
-    return wrap(dispatch_linspace_out(_r.tensor(3), _r.scalar(0), _r.scalar(1), _r.toInt64Optional(2)).set_requires_grad(_r.toBool(8)));
+    return wrap(dispatch_linspace_out(_r.tensor(3), _r.scalar(0), _r.scalar(1), _r.toInt64(2)).set_requires_grad(_r.toBool(8)));
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/jit/mobile/upgrader_mobile.cpp
+++ b/torch/csrc/jit/mobile/upgrader_mobile.cpp
@@ -43,6 +43,14 @@ getOperatorVersionMapForMobile() {
                     std::vector<Upgrader>({
                         Upgrader({0, 3, "div__Tensor_0_3", 3})
                     })},
+                {std::string("aten::linspace"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 7, "linspace_0_7", 5})
+                    })},
+                {std::string("aten::linspace.out"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 7, "linspace_out_0_7", 6})
+                    })},
       });
   return operatorVersionMapForMobile;
 }
@@ -274,6 +282,99 @@ const std::vector<ByteCodeFunctionWithOperator>& getUpgraderBytecodeList() {
                                    OperatorString({"aten::is_floating_point", "", 1}),
                                    OperatorString({"aten::div", "out", 3}),
                                    OperatorString({"aten::div", "out_mode", 4}),
+                           }), // operators list
+                   }),
+                   ByteCodeFunctionWithOperator({
+                           mobile::Function::registerFunc(
+                               "linspace_0_7",
+                               std::vector<Instruction>({
+                                           Instruction{OpCode::STOREN, 1, 7},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::LOADC, 0, 0},
+                                           Instruction{OpCode::OP, 0, 0},
+                                           Instruction{OpCode::JF, 10, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOADC, 1, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::LOAD, 6, 0},
+                                           Instruction{OpCode::LOAD, 7, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::JMP, 10, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::OP, 2, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::LOAD, 6, 0},
+                                           Instruction{OpCode::LOAD, 7, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::STORE, 8, 0},
+                                           Instruction{OpCode::DROPR, 7, 0},
+                                           Instruction{OpCode::DROPR, 6, 0},
+                                           Instruction{OpCode::DROPR, 5, 0},
+                                           Instruction{OpCode::DROPR, 4, 0},
+                                           Instruction{OpCode::DROPR, 2, 0},
+                                           Instruction{OpCode::DROPR, 1, 0},
+                                           Instruction{OpCode::DROPR, 3, 0},
+                                           Instruction{OpCode::MOVE, 8, 0},
+                                           Instruction{OpCode::RET, 0, 0},
+                                   }), // instructions list,
+                               std::vector<c10::IValue>({
+                                           c10::IValue(),
+                                           c10::IValue(100),
+                                   }), // constants list,
+                               std::vector<c10::TypePtr>(), // types list,
+                               8
+                           ),
+                           std::vector<OperatorString>({
+                                   OperatorString({"aten::__is__", "", 2}),
+                                   OperatorString({"aten::linspace", "", 7}),
+                                   OperatorString({"prim::unchecked_cast", "", 1}),
+                           }), // operators list
+                   }),
+                   ByteCodeFunctionWithOperator({
+                           mobile::Function::registerFunc(
+                               "linspace_out_0_7",
+                               std::vector<Instruction>({
+                                           Instruction{OpCode::STOREN, 1, 4},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::LOADC, 0, 0},
+                                           Instruction{OpCode::OP, 0, 0},
+                                           Instruction{OpCode::JF, 7, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOADC, 1, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::JMP, 7, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::OP, 2, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::STORE, 5, 0},
+                                           Instruction{OpCode::DROPR, 4, 0},
+                                           Instruction{OpCode::DROPR, 2, 0},
+                                           Instruction{OpCode::DROPR, 1, 0},
+                                           Instruction{OpCode::DROPR, 3, 0},
+                                           Instruction{OpCode::MOVE, 5, 0},
+                                           Instruction{OpCode::RET, 0, 0},
+                                   }), // instructions list,
+                               std::vector<c10::IValue>({
+                                           c10::IValue(),
+                                           c10::IValue(100),
+                                   }), // constants list,
+                               std::vector<c10::TypePtr>(), // types list,
+                               5
+                           ),
+                           std::vector<OperatorString>({
+                                   OperatorString({"aten::__is__", "", 2}),
+                                   OperatorString({"aten::linspace", "out", 4}),
+                                   OperatorString({"prim::unchecked_cast", "", 1}),
                            }), // operators list
                    }),
             });

--- a/torch/csrc/jit/operator_upgraders/upgraders_entry.cpp
+++ b/torch/csrc/jit/operator_upgraders/upgraders_entry.cpp
@@ -15,7 +15,20 @@ namespace torch {
 namespace jit {
 
 static std::unordered_map<std::string, std::string> kUpgradersEntryMap(
-    {{"div_Tensor_0_3", R"SCRIPT(
+    {{"linspace_0_7", R"SCRIPT(
+def linspace_0_7(start: Union[int, float, complex], end: Union[int, float, complex], steps: Optional[int], *, dtype: Optional[int], layout: Optional[int],
+                 device: Optional[Device], pin_memory: Optional[bool]):
+  if (steps is None):
+    return torch.linspace(start=start, end=end, steps=100, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory)
+  return torch.linspace(start=start, end=end, steps=steps, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory)
+)SCRIPT"},
+     {"linspace_out_0_7", R"SCRIPT(
+def linspace_out_0_7(start: Union[int, float, complex], end: Union[int, float, complex], steps: Optional[int], *, out: Tensor):
+  if (steps is None):
+    return torch.linspace(start=start, end=end, steps=100, out=out)
+  return torch.linspace(start=start, end=end, steps=steps, out=out)
+)SCRIPT"},
+     {"div_Tensor_0_3", R"SCRIPT(
 def div_Tensor_0_3(self: Tensor, other: Tensor) -> Tensor:
   if (self.is_floating_point() or other.is_floating_point()):
     return self.true_divide(other)

--- a/torch/csrc/jit/operator_upgraders/version_map.cpp
+++ b/torch/csrc/jit/operator_upgraders/version_map.cpp
@@ -16,7 +16,15 @@ static bool isVersionMapSorted = false;
 // Note for developers: The list of upgraders should be SORTED
 // by the version number where the upgrader is registered.
 static std::unordered_map<std::string, std::vector<UpgraderEntry>> operatorVersionMap(
-    {{"aten::div.Tensor",
+    {{"aten::linspace",
+      {{8,
+        "linspace_0_7",
+        "aten::linspace(Scalar start, Scalar end, int? steps=None, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"}}},
+     {"aten::linspace.out",
+      {{8,
+        "linspace_out_0_7",
+        "aten::linspace.out(Scalar start, Scalar end, int? steps=None, *, Tensor(a!) out) -> Tensor(a!)"}}},
+     {"aten::div.Tensor",
       {{4,
         "div_Tensor_0_3",
         "aten::div.Tensor(Tensor self, Tensor other) -> Tensor"}}},


### PR DESCRIPTION
Summary: This PR adds upgraders for linspace and linspace.out as the optional step size will be deprecated soon. Old models will be using steps size of 100 when nothing is provided.

Test Plan: buck-out/gen/caffe2/test/jit#binary.par -r TestUpgraders.test_aten_linspace

Differential Revision: D33654308

Note that this PR introduces BC incompatible change since we are deprecating the option of not providing `steps` size for torch.linspace. If you didn't provide `steps` in your model, you need to do this to restore old behaviour:

`torch.linspace(start, end) -> torch.linspace(start, end, steps=100)`

