### PR TITLE
Refactor convolution_backward's CudaDepthwise2d case

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1621,7 +1621,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
     {
       std::array<bool, 2> input_weight_output_mask = {output_mask[0], output_mask[1]};
       std::tie(backend_grad_input, backend_grad_weight) =
-        conv_depthwise2d_backward_stub(input.device().type(), grad_output.contiguous(), input.contiguous(),
+        conv_depthwise2d_backward_stub(input.device().type(), grad_output, input,
           weight, kernel_size, params.stride, params.padding, params.dilation, input_weight_output_mask);
       break;
     }

--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -568,10 +568,10 @@ std::tuple<Tensor&, Tensor&> conv_depthwise2d_backward_cuda_out(
     IntArrayRef dilation,
     Tensor & grad_input,
     Tensor & grad_weight) {
-  auto self = self_.expect_contiguous();
   auto grad_output = grad_output_.expect_contiguous();
 
   if (grad_weight.defined()) {
+    auto self = self_.expect_contiguous();
     conv_depthwise2d_grad_weight_out(
         *self, *grad_output, grad_weight,
         kernel_size[1], kernel_size[0],
@@ -583,7 +583,7 @@ std::tuple<Tensor&, Tensor&> conv_depthwise2d_backward_cuda_out(
   if (grad_input.defined()) {
     auto weight = weight_.expect_contiguous();
     conv_depthwise2d_backward_out(
-        *self, *grad_output, grad_input, *weight,
+        self_, *grad_output, grad_input, *weight,
         kernel_size[1], kernel_size[0],
         stride[1], stride[0],
         padding[1], padding[0],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #71492 Refactor convolution_backward Miopen cases
* #71491 Refactor convolution_backward's cudnn cases
* #71490 Refactor convolution_backward's CudaDepthwise3d case
* **#71489 Refactor convolution_backward's CudaDepthwise2d case**

Deleted unnecessary .contiguous() calls in convolution_backward. The
CudaDepthwise2d case always hits conv_depthwise2d_backward_cuda_out,
which makes the grad_output / self contiguous.

Changed conv_depthwise2d_backward_cuda_out to change `self_` (aka the
image input to convolution) to be contiguous only when we're computing
the grad_weight. This is because when we are computing the grad_input,
we only need the values from the grad_output and the weight.

Test Plan:
- pytest test/test_nn.py -v -k "conv"

Differential Revision: [D33664697](https://our.internmc.facebook.com/intern/diff/D33664697)