### PR TITLE
Refactor convolution_backward's CudaDepthwise3d case

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1629,7 +1629,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
       TORCH_CHECK(input.ndimension() == 5);
       std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
         conv_depthwise3d_backward_stub(
-          input.device().type(), grad_output.contiguous(), input.contiguous(), weight, kernel_size, params.stride,
+          input.device().type(), grad_output, input, weight, kernel_size, params.stride,
           params.padding, params.dilation, output_mask);
       break;
     case ConvBackend::Cudnn:

--- a/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
@@ -535,14 +535,13 @@ std::tuple<Tensor&, Tensor&, Tensor&> _depthwise_3d_backward_cuda_out(
       kernel_size, stride, padding, dilation);
 
   const Tensor grad_output_ = grad_output.contiguous();
-  const Tensor input_ = input.contiguous();
-  const Tensor weight_ = weight.contiguous();
 
   Tensor grad_input_ =
       (output_mask[0] ?  grad_input
                       : Tensor());
 
   if (output_mask[0]) {
+    const Tensor weight_ = weight.contiguous();
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         grad_output.scalar_type(),
         "conv_depthwise3d",
@@ -577,6 +576,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> _depthwise_3d_backward_cuda_out(
   }
 
   if (output_mask[1]) {
+    const Tensor input_ = input.contiguous();
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         grad_output.scalar_type(),
         "conv_depthwise3d",
@@ -590,7 +590,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> _depthwise_3d_backward_cuda_out(
                       "Input tensor is too large.");
           TORCH_CHECK(grad_output_.numel() <= int_max,
                       "Output tensor is too large.");
-          TORCH_CHECK(weight_.numel() <= int_max,
+          TORCH_CHECK(weight.numel() <= int_max,
                       "Weight tensor is too large.");
           for (int i = 0; i < 3; ++i) {
             TORCH_CHECK(padding[i] * 2 + input.size(i + 2) <= int_max,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #71492 Refactor convolution_backward Miopen cases
* #71491 Refactor convolution_backward's cudnn cases
* **#71490 Refactor convolution_backward's CudaDepthwise3d case**
* #71489 Refactor convolution_backward's CudaDepthwise2d case

Deleted unnecessary .contiguous() calls in convolution_backward. The
CudaDepthwise3d case always hits _depthwise_3d_backward_cuda_out,
which will make arguments contiguous as necessary.

Changed _depthwise_3d_backward_cuda_out
- to make the input contiguous only when we're computing grad_weight
- to make the weight contiguous only when we're computing grad_input

Test Plan:
- pytest test/test_nn.py -v -k "conv"

Differential Revision: [D33664696](https://our.internmc.facebook.com/intern/diff/D33664696)