### PR TITLE
Refactor convolution_backward Miopen cases

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1697,14 +1697,18 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
       std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
         miopen_convolution_backward_stub(
           input.device().type(),
-          input.contiguous(backend_memory_format), grad_output, weight, params.padding, params.stride,
+          // Only make input contiguous when it is necessary for the backwards computation
+          output_mask[1] ? input.contiguous(backend_memory_format) : input,
+          grad_output, weight, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic, output_mask);
       break;
     case ConvBackend::MiopenDepthwise:
       std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
           miopen_depthwise_convolution_backward_stub(
             input.device().type(),
-            input.contiguous(backend_memory_format), grad_output, weight, params.padding, params.stride,
+            // Only make input contiguous when it is necessary for the backwards computation
+            output_mask[1] ? input.contiguous(backend_memory_format) : input,
+            grad_output, weight, params.padding, params.stride,
             params.dilation, params.groups, params.benchmark, params.deterministic, output_mask);
       break;
     case ConvBackend::MiopenTranspose:
@@ -1712,7 +1716,9 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
       std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
         miopen_convolution_transpose_backward_stub(
           input.device().type(),
-          input.contiguous(backend_memory_format), grad_output, weight, params.padding, params.output_padding,
+          // Only make input contiguous when it is necessary for the backwards computation
+          output_mask[1] ? input.contiguous(backend_memory_format) : input,
+          grad_output, weight, params.padding, params.output_padding,
           params.stride, params.dilation, params.groups, params.benchmark, params.deterministic, output_mask);
       break;
     case ConvBackend::Mkldnn:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#71492 Refactor convolution_backward Miopen cases**
* #71491 Refactor convolution_backward's cudnn cases
* #71490 Refactor convolution_backward's CudaDepthwise3d case
* #71489 Refactor convolution_backward's CudaDepthwise2d case

We do not need to make the input contiguous unless it is necessary for
backward computation. The input is only necessary for backward
computation when we're computing `grad_weight`; otherwise, to compute
grad_input or grad_bias the input is not used.

Differential Revision: [D33664695](https://our.internmc.facebook.com/intern/diff/D33664695)