### PR TITLE
Improve disable name match

### DIFF
--- a/.pytorch_disabled_tests.json
+++ b/.pytorch_disabled_tests.json
@@ -1,1 +1,0 @@
-{"test_conv_double_backward (__main__.TestNN)": ["https://github.com/pytorch/pytorch/issues/70640", ["mac"]], "test_conv_double_backward_cuda_float32 (__main__.TestNN)": ["https://github.com/pytorch/pytorch/issues/70640", ["linux"]]}

--- a/.pytorch_disabled_tests.json
+++ b/.pytorch_disabled_tests.json
@@ -1,0 +1,1 @@
+{"test_conv_double_backward (__main__.TestNN)": ["https://github.com/pytorch/pytorch/issues/70640", ["mac"]], "test_conv_double_backward_cuda_float32 (__main__.TestNN)": ["https://github.com/pytorch/pytorch/issues/70640", ["linux"]]}

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1397,28 +1397,30 @@ def check_if_enable(test: unittest.TestCase):
     sanitized_test_method_name = remove_device_and_dtype_suffixes(test._testMethodName)
     if not IS_SANDCASTLE and disabled_tests_dict is not None:
         for disabled_test, (issue_url, platforms) in disabled_tests_dict.items():
-            disabled_test_name = disabled_test.split()[0]
-            disabled_test_suite = disabled_test.split()[1][1:-1]
-            # if test method name or its sanitized version exactly matches the disabled test method name
-            # AND allow non-parametrized suite names to disable parametrized ones (TestSuite disables TestSuiteCPU/CUDA)
-            if (test._testMethodName == disabled_test_name or sanitized_test_method_name == disabled_test_name) \
-               and disabled_test_suite in test_suite:
-                platform_to_conditional: Dict = {
-                    "mac": IS_MACOS,
-                    "macos": IS_MACOS,
-                    "win": IS_WINDOWS,
-                    "windows": IS_WINDOWS,
-                    "linux": IS_LINUX,
-                    "rocm": TEST_WITH_ROCM,
-                    "asan": TEST_WITH_ASAN
-                }
-                if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
-                    skip_msg = f"Test is disabled because an issue exists disabling it: {issue_url}" \
-                        f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}. " \
-                        "If you're seeing this on your local machine and would like to enable this test, " \
-                        "please make sure IN_CI is not set and you are not using the flag --import-disabled-tests."
-                    print(skip_msg)
-                    raise unittest.SkipTest(skip_msg)
+            disable_test_parts = disabled_test.split()
+            if len(disable_test_parts) > 1:
+                disabled_test_name = disable_test_parts[0]
+                disabled_test_suite = disable_test_parts[1][1:-1]
+                # if test method name or its sanitized version exactly matches the disabled test method name
+                # AND allow non-parametrized suite names to disable parametrized ones (TestSuite disables TestSuiteCPU)
+                if (test._testMethodName == disabled_test_name or sanitized_test_method_name == disabled_test_name) \
+                   and disabled_test_suite in test_suite:
+                    platform_to_conditional: Dict = {
+                        "mac": IS_MACOS,
+                        "macos": IS_MACOS,
+                        "win": IS_WINDOWS,
+                        "windows": IS_WINDOWS,
+                        "linux": IS_LINUX,
+                        "rocm": TEST_WITH_ROCM,
+                        "asan": TEST_WITH_ASAN
+                    }
+                    if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
+                        skip_msg = f"Test is disabled because an issue exists disabling it: {issue_url}" \
+                            f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}. " \
+                            "If you're seeing this on your local machine and would like to enable this test, " \
+                            "please make sure IN_CI is not set and you are not using the flag --import-disabled-tests."
+                        print(skip_msg)
+                        raise unittest.SkipTest(skip_msg)
     if TEST_SKIP_FAST:
         if not getattr(test, test._testMethodName).__dict__.get('slow_test', False):
             raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1390,7 +1390,7 @@ def remove_device_and_dtype_suffixes(test_name: str) -> str:
 def check_if_enable(test: unittest.TestCase):
     test_suite = str(test.__class__).split('\'')[1]
     raw_test_name = f'{test._testMethodName} ({test_suite})'
-    sanitized_test_name = f'{remove_device_and_dtype_suffixes(test._testMethodName)} ({test_suite})'
+    sanitized_test_name = remove_device_and_dtype_suffixes(test._testMethodName)
     print(sanitized_test_name)
     if slow_tests_dict is not None and raw_test_name in slow_tests_dict:
         getattr(test, test._testMethodName).__dict__['slow_test'] = True
@@ -1398,26 +1398,26 @@ def check_if_enable(test: unittest.TestCase):
             raise unittest.SkipTest("test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test")
     if not IS_SANDCASTLE and disabled_tests_dict is not None:
         for test, (issue_url, platforms) in disabled_tests_dict:
-            test_name = test.split()[0]
-            test_suite = test.split()[1][1:-1]
-            issue_url, platforms = disabled_tests_dict[sanitized_test_name] \
-                if sanitized_test_name in disabled_tests_dict else disabled_tests_dict[raw_test_name]
-            platform_to_conditional: Dict = {
-                "mac": IS_MACOS,
-                "macos": IS_MACOS,
-                "win": IS_WINDOWS,
-                "windows": IS_WINDOWS,
-                "linux": IS_LINUX,
-                "rocm": TEST_WITH_ROCM,
-                "asan": TEST_WITH_ASAN
-            }
-            if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
-                skip_msg = f"Test is disabled because an issue exists disabling it: {issue_url}" \
-                    f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}. " \
-                    "If you're seeing this on your local machine and would like to enable this test, " \
-                    "please make sure IN_CI is not set and you are not using the flag --import-disabled-tests."
-                print(skip_msg)
-                raise unittest.SkipTest(skip_msg)
+            disable_test_name = test.split()[0]
+            disable_test_suite = test.split()[1][1:-1]
+            if (test._testMethodName is disable_test_name or sanitized_test_name is disable_test_name) \
+               and test_suite in disable_test_suite:
+                platform_to_conditional: Dict = {
+                    "mac": IS_MACOS,
+                    "macos": IS_MACOS,
+                    "win": IS_WINDOWS,
+                    "windows": IS_WINDOWS,
+                    "linux": IS_LINUX,
+                    "rocm": TEST_WITH_ROCM,
+                    "asan": TEST_WITH_ASAN
+                }
+                if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
+                    skip_msg = f"Test is disabled because an issue exists disabling it: {issue_url}" \
+                        f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}. " \
+                        "If you're seeing this on your local machine and would like to enable this test, " \
+                        "please make sure IN_CI is not set and you are not using the flag --import-disabled-tests."
+                    print(skip_msg)
+                    raise unittest.SkipTest(skip_msg)
     if TEST_SKIP_FAST:
         if not getattr(test, test._testMethodName).__dict__.get('slow_test', False):
             raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")


### PR DESCRIPTION
Allows disabling issues to disable all parametrized tests with @dtypes.

Tested locally with: 
1. .pytorch-disabled-tests.json as
```
{"test_bitwise_ops (__main__.TestBinaryUfuncs)": ["https://github.com/pytorch/pytorch/issues/99999", ["mac"]]}
```
and running `python test_binary_ufuncs.py --import-disabled-tests -k test_bitwise_ops` yields all tests skipped.

2. .pytorch-disabled-tests.json as
```
{"test_bitwise_ops_cpu_int16 (__main__.TestBinaryUfuncsCPU)": ["https://github.com/pytorch/pytorch/issues/99999", ["mac"]]}
```
and running `python test_binary_ufuncs.py --import-disabled-tests -k test_bitwise_ops` yields only `test_bitwise_ops_cpu_int16` skipped.

NOTE: this only works with dtype parametrization, not all prefixes, e.g., disabling `test_async_script` would NOT disable `test_async_script_capture`. This is the most intuitive behavior, I believe, but I can be convinced otherwise.