### PR TITLE
[DO NOT MERGE] test.sh remove temporary NUM_TEST_SHARDS for Jenkins

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -78,12 +78,6 @@ fi
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # Print GPU info
   rocminfo | grep -E 'Name:.*\sgfx|Marketing'
-
-  # Manually set NUM_TEST_SHARDS since Jenkins doesn't do it
-  # TODO: Can remove this once ROCm migration from Jenkins to GHA is complete.
-  if [[ -z "${GITHUB_ACTIONS}" ]]; then
-    export NUM_TEST_SHARDS=2
-  fi
 fi
 
 # --user breaks ppc64le builds and these packages are already in ppc64le docker


### PR DESCRIPTION
Now that ROCm GHA migration is complete, remove the Jenkins work-around in test.sh.

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH