### PR TITLE
Add GitHub merge rules

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -1,0 +1,20 @@
+[
+   {
+    "name": "ONNX exporter",
+    "patterns": ["torch/onnx/**", "torch/csrc/jit/passes/onnx/**", "torch/csrc/jit/passes/onnx.*", "test/onnx/**"],
+    "approved_by": ["garymm"],
+    "mandatory_app_id": 12274
+   },
+   {
+    "name": "NVFuser",
+    "patterns": ["torch/csrc/jit/codegen/fuser/cuda/**", "torch/csrc/jit/codegen/cuda/**", "benchmarks/cpp/nvfuser/**"],
+    "approved_by": ["csarofeen", "ngimel"],
+    "mandatory_app_id": 12274
+   },
+   {
+    "name": "OSS CI",
+    "patterns": [".github/**", ".circleci/**", ".jenkins/**"],
+    "approved_by": ["seemethere", "malfet"],
+    "mandatory_app_id": 12274
+   }
+]


### PR DESCRIPTION
Following subfolders of the project were identified as one that can be
merged on github first and then asynchronously merged into Meta
codebase:
## ONNX exporter
PRs that include only files under `torch/onnx`, `torch/csrc/jit/passes/onnx` and `test/onnx` and are reviewed by @garymm
## CUDA fusers
PRs that include only files under
   `torch/csrc/jit/codegen/fuser/cuda`, `torch/csrc/jit/codegen/cuda` or `benchmarks/cpp/nvfuser` and reviewed by @csarofeen or @ngimel
## OSS CI
PR that include only files under `.circleci`, `.github` and `.jenkins` and reviewed either by @seemethere or myself

