### PR TITLE
<Qunat> remove inplace hardtanh in test

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -4751,7 +4751,6 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 x = self.hardtanh(x)
                 self.hardtanh_(x)
                 x = F.hardtanh(x)
-                F.hardtanh_(x)
                 return x
 
         data = (torch.rand((1, 2, 5, 5), dtype=torch.float),)
@@ -4759,7 +4758,6 @@ class TestQuantizeFxOps(QuantizationTestCase):
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
             ns.call_module(nnq.Conv2d),
-            ns.call_function(F.hardtanh_),
             ns.call_method('dequantize')
         ]
         for quant_type in self.static_quant_types:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71519

Summary:
Remove inplace hardtanh in fx quantized op test case

Test Plan:
python3 test/test_quantization.py TestQuantizeFxOps.test_clamp

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D33675227](https://our.internmc.facebook.com/intern/diff/D33675227)