### PR TITLE
[LTS] Check backward compatibility with PyTorch 1.8.1

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -302,7 +302,8 @@ test_backward_compatibility() {
   pushd test/backward_compatibility
   python -m venv venv
   . venv/bin/activate
-  pip_install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
+  # check for backward compatibility with torch 1.8.1
+  pip_install --pre torch==1.8.1 -f https://download.pytorch.org/whl/test/cpu/torch_test.html
   pip show torch
   python dump_all_function_schemas.py --filename nightly_schemas.txt
   deactivate


### PR DESCRIPTION
This PR fixes the backward compatibility test by checking for backward compatibility with PyTorch 1.8.1. Previously it was checking with the latest nightly version of PyTorch.

**Original job failure:** [pytorch_linux_backward_compatibility_check_test
](https://app.circleci.com/pipelines/github/pytorch/pytorch/443149/workflows/14509e7c-7888-4952-a8e2-37f9a766f121/jobs/16960541)


**Current success:** [pytorch_linux_backward_compatibility_check_test
](https://app.circleci.com/pipelines/github/pytorch/pytorch/443051/workflows/cd5afc8f-17ff-4d55-9bfd-9488c80bb12b/jobs/16959671)
