### PR TITLE
[LTS] CherryPick: Pin docutils to 0.16 

### DIFF
--- a/docs/cpp/requirements.txt
+++ b/docs/cpp/requirements.txt
@@ -1,6 +1,7 @@
 sphinx==3.1.2
 breathe==4.25.0
 exhale==0.2.3
+docutils==0.16
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 bs4
 lxml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==2.4.4
+docutils==0.16
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib


### PR DESCRIPTION
This PR cherry picks the commit https://github.com/pytorch/pytorch/commit/fffdc5fa2f51885e670e02f86dde88d7a2f93f5e from the master branch that pins docutils to 0.16. The latest version 0.17 of docutils has problems with sphinx. 

**Original job failures:** [pytorch_cpp_doc_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/443149/workflows/14509e7c-7888-4952-a8e2-37f9a766f121/jobs/16960542), [pytorch_doc_test](https://app.circleci.com/pipelines/github/pytorch/pytorch/443149/workflows/14509e7c-7888-4952-a8e2-37f9a766f121/jobs/16960547), [pytorch_python_doc_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/443149/workflows/14509e7c-7888-4952-a8e2-37f9a766f121/jobs/16960548)

**Current success:** [pytorch_cpp_doc_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/443057/workflows/001fe969-3e2a-4703-9942-15cbe8a7d8bb/jobs/16959834), [pytorch_doc_test](https://app.circleci.com/pipelines/github/pytorch/pytorch/443057/workflows/001fe969-3e2a-4703-9942-15cbe8a7d8bb/jobs/16959836), [pytorch_python_doc_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/443057/workflows/001fe969-3e2a-4703-9942-15cbe8a7d8bb/jobs/16959835)