### PR TITLE
[LTS] CherryPick: Temporary disable some numba integration tests

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -229,6 +229,7 @@ class TestNumbaIntegration(common.TestCase):
                 numba.cuda.as_cuda_array(cudat), numba.cuda.devicearray.DeviceNDArray
             )
 
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
@@ -314,6 +315,7 @@ class TestNumbaIntegration(common.TestCase):
             torch_ary = torch.as_tensor(numba_ary, device="cuda")
             self.assertTrue(torch_ary.is_contiguous())
 
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
@@ -325,6 +327,7 @@ class TestNumbaIntegration(common.TestCase):
         del numba_ary
         self.assertEqual(torch_ary.cpu().data.numpy(), numpy.arange(6))  # `torch_ary` is still alive
 
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")


### PR DESCRIPTION
This PR cherry picks the commit https://github.com/pytorch/pytorch/commit/b6bbb41fd8aacdcf4cf29c3002cec225fcb94e8c from the master branch that disables some numba integration tests due to failures as reported in issue https://github.com/pytorch/pytorch/issues/54418. 

**Original job failure:** [pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test1](https://app.circleci.com/pipelines/github/pytorch/pytorch/443149/workflows/14509e7c-7888-4952-a8e2-37f9a766f121/jobs/16960583)

**Current success:** [pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test1](https://app.circleci.com/pipelines/github/pytorch/pytorch/443070/workflows/e7613016-a5ec-478f-9fe9-37a01465f6ff/jobs/16959984)
