### PR TITLE
[LTS] CherryPick: Skip all dataloader tests with asan

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -21,7 +21,7 @@ from torch.utils.data.dataset import random_split
 from torch._utils import ExceptionWrapper
 from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS,
                                                   IS_PYTORCH_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
-                                                  load_tests, TEST_WITH_ROCM, TEST_WITH_TSAN, IS_SANDCASTLE)
+                                                  load_tests, TEST_WITH_ROCM, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE)
 
 try:
     import psutil

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -769,6 +769,9 @@ class BulkLoadingSampler(torch.utils.data.Sampler):
     TEST_WITH_TSAN,
     "Fails with TSAN with the following error: starting new threads after multi-threaded "
     "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223")
 class TestDataLoader(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This PR cherry picks the commit https://github.com/pytorch/pytorch/commit/9d13ae450a24a16e848ef35fc08a7f9d40571886 from the master branch which skips all data loader tests with asan. This is due to flaky tests as noted in issue https://github.com/pytorch/pytorch/issues/66223.