### PR TITLE
[LTS] CherryPick: Pin SciPy to 1.6.3 on mac

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil
+pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil "scipy==1.6.3"
 
 # TODO move this to docker
 pip install unittest-xml-reporting pytest

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -20,6 +20,10 @@ change. This file contains two types of randomized tests:
    it's fine to increment the seed of the failing test (but you shouldn't need
    to increment it more than once; otherwise something is probably actually
    wrong).
+
+3. `test_geometric_sample`, `test_binomial_sample` and `test_poisson_sample`
+   are validated against `scipy.stats.` which are not guaranteed to be identical
+   across different versions of scipy (namely, they yield invalid results in 1.7+)
 """
 
 import math


### PR DESCRIPTION
This PR cherry picks the commit https://github.com/pytorch/pytorch/commit/af984c78a975400ffd8c475a7e00abb25e590bb1 from the master brach which pins SciPy to 1.6.3 on mac. Otherwise, some distribution tests fail due to `scipy.stats.[poission|geom|binom]` returning different results between 1.6.x and 1.7+ versions of SciPy.

**Original job failure:** [pytorch_macos_10_13_py3_test](https://app.circleci.com/pipelines/github/pytorch/pytorch/443149/workflows/14509e7c-7888-4952-a8e2-37f9a766f121/jobs/16960533)

**Current success:** [pytorch_macos_10_13_py3_test](https://app.circleci.com/pipelines/github/pytorch/pytorch/443076/workflows/3fa51f8d-a52b-4374-a9bd-a63b9bfbf597/jobs/16960036)