### PR TITLE
[LTS] CherryPick: Fix cuda debug nightly build not enough space issue

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -15,8 +15,48 @@ else
   export VC_YEAR=2019
 fi
 
+<<<<<<< HEAD
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
   export BUILD_SPLIT_CUDA="ON"
+=======
+if [[ "${DESIRED_CUDA}" == "cu111" || "${DESIRED_CUDA}" == "cu113" ]]; then
+    export BUILD_SPLIT_CUDA="ON"
+fi
+
+echo "Free Space for CUDA DEBUG BUILD"
+if [[ "$CIRCLECI" == 'true' ]]; then
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft.NET" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft.NET"
+    fi
+
+    if [[ -d "C:\\Program Files\\dotnet" ]]; then
+        rm -rf "C:\\Program Files\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\dotnet" ]]; then
+        rm -rf "C:\\Program Files (x86)\\dotnet"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Microsoft SQL Server" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Microsoft SQL Server"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Xamarin" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Xamarin"
+    fi
+
+    if [[ -d "C:\\Program Files (x86)\\Google" ]]; then
+        rm -rf "C:\\Program Files (x86)\\Google"
+    fi
+>>>>>>> 3dc588d577... Fix: no enough space for cu102 debug nightly build (#62465)
 fi
 
 set +x

--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -15,20 +15,12 @@ else
   export VC_YEAR=2019
 fi
 
-<<<<<<< HEAD
 if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
-  export BUILD_SPLIT_CUDA="ON"
-=======
-if [[ "${DESIRED_CUDA}" == "cu111" || "${DESIRED_CUDA}" == "cu113" ]]; then
     export BUILD_SPLIT_CUDA="ON"
 fi
 
 echo "Free Space for CUDA DEBUG BUILD"
 if [[ "$CIRCLECI" == 'true' ]]; then
-    if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community" ]]; then
-        rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
-    fi
-
     if [[ -d "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0" ]]; then
         rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
     fi
@@ -56,7 +48,6 @@ if [[ "$CIRCLECI" == 'true' ]]; then
     if [[ -d "C:\\Program Files (x86)\\Google" ]]; then
         rm -rf "C:\\Program Files (x86)\\Google"
     fi
->>>>>>> 3dc588d577... Fix: no enough space for cu102 debug nightly build (#62465)
 fi
 
 set +x


### PR DESCRIPTION
This PR cherry picks the commit https://github.com/pytorch/pytorch/commit/3dc588d577c38c4330cefcd3853882d6fc9d50d7 that fixes the `not enough space` issue for cuda debug nightly build. 

Binary build workflow is tested in the corresponding test PR https://github.com/pytorch/pytorch/pull/71533. 

**Original status of binary build workflow:** https://app.circleci.com/pipelines/github/pytorch/pytorch?branch=pull%2F71535&filter=all

**Status of binary build workflow after this fix:** https://app.circleci.com/pipelines/github/pytorch/pytorch?branch=pull%2F71533&filter=all