### PR TITLE
[LTS] CherryPick: Fix docker builds for Python-3.6

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -13,7 +13,12 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
       CONDA_FILE="Miniconda2-latest-Linux-x86_64.sh"
     ;;
     3)
-      CONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
+      if [ "$ANACONDA_PYTHON_VERSION" = "3.6" ]; then
+        # Latest release of Conda that still supports python-3.6
+        CONDA_FILE="Miniconda3-py37_4.10.3-Linux-x86_64.sh"
+      else
+        CONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
+      fi
     ;;
     *)
       echo "Unsupported ANACONDA_PYTHON_VERSION: $ANACONDA_PYTHON_VERSION"
@@ -56,7 +61,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   pushd /opt/conda
 
   # Track latest conda update
-  as_jenkins conda update -y -n base conda
+  if [ "$ANACONDA_PYTHON_VERSION" != "3.6" ]; then
+    as_jenkins conda update -y -n base conda
+  fi
 
   # Install correct Python version
   as_jenkins conda install -y python="$ANACONDA_PYTHON_VERSION"


### PR DESCRIPTION
This PR cherry picks the commit https://github.com/pytorch/pytorch/commit/77213fa4d3ce09ba47c9b95c8dd11de9453533f2 from the master branch that pins conda to 4.10 for 3.6 builds.
