### PR TITLE
[Profiler] Defer KinetoEvent and GenericTraceActivity creation to post processing.

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -11,27 +11,6 @@ namespace torch {
 namespace autograd {
 namespace profiler {
 
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct KinetoObserverContext : public at::ObserverContext {
-  int64_t startUs;
-  int64_t endUS;
-  uint64_t correlationId;
-  uint64_t startThreadId;
-  uint64_t endThreadId;
-  c10::optional<std::vector<std::vector<int64_t>>> shapes;
-  c10::optional<std::vector<std::string>> dtypes;
-  int64_t sequenceNr;
-  uint64_t fwdThreadId;
-  uint8_t recFunScope;
-  c10::optional<std::vector<std::string>> stack;
-  c10::optional<std::vector<std::string>> module_hierarchy;
-  // Extra arguments for computing op flops
-  c10::optional<std::unordered_map<std::string, c10::IValue>> extraArgs;
-  torch::profiler::impl::CUDAEventStub cuda_event_start_ = nullptr;
-  torch::profiler::impl::CUDAEventStub cuda_event_end_ = nullptr;
-  int64_t debug_handle;
-};
-
 struct TORCH_API KinetoEvent {
   uint64_t startThreadId() const {
     return start_thread_id_;


### PR DESCRIPTION
Summary:
This is the first of the optimizing changes. One of the issues with kineto sometimes being unavailable is we cannot use it as a storage mechanism. KinetoEvent currently fills this role, however KinetoEvent is VERY expensive. A second issue is that because we currently write to two objects, we hold the state lock for the duration of both event creations which is not ideal.

This applies the following optimizations:
1) Intermediate data is stored in a deque in KinetoThreadLocalState, which saves a data->KinetoObserverContext->KinetoEvent double copy. The new KinetoObserverContext just holds a pointer to the element in the deque.
2) OpEventData is much lighter weight (though still far from ideal)

Test Plan:
Script: P470970719
Result: P470970794
For the base case (no special flags), 40% reduction in the `profiler_kineto` portion of the overhead.

Differential Revision: D32691800

