### PR TITLE
Fix torch.{unique, unique_consecutive} out of bound

### DIFF
--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -107,7 +107,10 @@ std::tuple<Tensor, Tensor, Tensor> unique_consecutive_cpu_template(
     scalar_t *p = output_data;
     int64_t *q = counts_data;
     int64_t last = 0;
-    for (const auto i : c10::irange(numel)) {
+    if (return_inverse) {
+      inverse_data[0] = 0;
+    }
+    for (const auto i : c10::irange(1, numel)) {
       if (input_data[i] != *p) {
         *(++p) = input_data[i];
         if (return_counts) {
@@ -149,7 +152,8 @@ ForwardIt _unique_dim_cpu_impl(ForwardIt first, ForwardIt last,
     ForwardIt result = first;
     ForwardIt previous = first;
     int64_t *current_counts = counts_data;
-    for (ForwardIt current = first; current != last; current++) {
+    inverse_data[*(indices_data++)] = 0;
+    for (ForwardIt current = std::next(first); current != last; current++) {
       if (!at::equal(*current, *result)) {
         *(++result) = std::move(*current);
         *(current_counts++) = std::distance(previous, current);

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -398,6 +398,8 @@ class TestSortAndSelect(TestCase):
             x_empty = torch.empty(5, 0, dtype=dtype, device=device)
             x_ill_formed_empty = torch.empty(5, 0, 0, dtype=dtype, device=device)
             x_ill_formed_empty_another = torch.empty(5, 0, 5, dtype=dtype, device=device)
+            if dtype in floating_types_and(torch.float16, torch.bfloat16):
+                x_nan = torch.tensor([float("nan"), 0, 0, float("nan"), float("nan"), 1], dtype=dtype, device=device)
             expected_unique_dim0 = torch.tensor([[[1., 1.],
                                                   [0., 1.],
                                                   [2., 1.],
@@ -437,6 +439,10 @@ class TestSortAndSelect(TestCase):
             expected_unique_empty = torch.tensor([], dtype=dtype, device=device)
             expected_inverse_empty = torch.tensor([], dtype=torch.long, device=device)
             expected_counts_empty = torch.tensor([], dtype=torch.long, device=device)
+            if dtype in floating_types_and(torch.float16, torch.bfloat16):
+                expected_unique_nan = torch.tensor([float("nan"), 0, float("nan"), float("nan"), 1], dtype=dtype, device=device)
+                expected_inverse_nan = torch.tensor([0, 1, 1, 2, 3, 4], dtype=torch.long, device=device)
+                expected_counts_nan = torch.tensor([1, 2, 1, 1, 1], dtype=torch.long, device=device)
             # dim0
             x_unique = torch.unique(x, dim=0)
             self.assertEqual(expected_unique_dim0, x_unique)
@@ -547,6 +553,17 @@ class TestSortAndSelect(TestCase):
             self.assertEqual(expected_inverse_empty, x_inverse)
             self.assertEqual(expected_counts_empty, x_counts)
 
+            # test tensor with nan
+            if dtype in floating_types_and(torch.float16, torch.bfloat16):
+                x_unique, x_inverse, x_counts = torch.unique(
+                    x_nan,
+                    return_inverse=True,
+                    return_counts=True,
+                    dim=0)
+                self.assertEqual(expected_unique_nan, x_unique)
+                self.assertEqual(expected_inverse_nan, x_inverse)
+                self.assertEqual(expected_counts_nan, x_counts)
+
             # test not a well formed tensor
             # Checking for runtime error, as this is the expected behaviour
             with self.assertRaises(RuntimeError):
@@ -579,6 +596,9 @@ class TestSortAndSelect(TestCase):
                 dtype=dtype,
                 device=device
             )
+            # test tensor with nan
+            if dtype in floating_types_and(torch.float16, torch.bfloat16):
+                y_nan = torch.tensor([float("nan"), 0, 0, float("nan"), float("nan"), 1], dtype=dtype, device=device)
             expected_y_unique = torch.tensor(
                 [[0, 1],
                  [1, 2],
@@ -593,6 +613,11 @@ class TestSortAndSelect(TestCase):
             expected_y_counts = torch.tensor([3, 2, 1, 2, 1, 1], dtype=torch.int64, device=device)
             expected_y_inverse_bool = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 3, 3], dtype=torch.int64, device=device)
             expected_y_counts_bool = torch.tensor([3, 3, 2, 2], dtype=torch.int64, device=device)
+            if dtype in floating_types_and(torch.float16, torch.bfloat16):
+                expected_y_unique_nan = torch.tensor([float("nan"), 0, float("nan"), float("nan"), 1], dtype=dtype, device=device)
+                expected_y_inverse_nan = torch.tensor([0, 1, 1, 2, 3, 4], dtype=torch.long, device=device)
+                expected_y_counts_nan = torch.tensor([1, 2, 1, 1, 1], dtype=torch.long, device=device)
+
             y_unique, y_inverse, y_counts = torch.unique_consecutive(y, return_inverse=True, return_counts=True, dim=0)
             if x.dtype == torch.bool:
                 self.assertEqual(expected_y_inverse_bool, y_inverse)
@@ -600,6 +625,17 @@ class TestSortAndSelect(TestCase):
             else:
                 self.assertEqual(expected_y_inverse, y_inverse)
                 self.assertEqual(expected_y_counts, y_counts)
+
+            # test tensor with nan
+            if dtype in floating_types_and(torch.float16, torch.bfloat16):
+                y_unique, y_inverse, y_counts = torch.unique_consecutive(
+                    y_nan,
+                    return_inverse=True,
+                    return_counts=True,
+                    dim=0)
+                self.assertEqual(expected_y_unique_nan, y_unique)
+                self.assertEqual(expected_y_inverse_nan, y_inverse)
+                self.assertEqual(expected_y_counts_nan, y_counts)
 
         run_test(device, torch.float)
         run_test(device, torch.double)


### PR DESCRIPTION
## Summary:

This PR ensures that the input iterator is always in front of the output
iterator. Thus, we won't have a out of bound issue since the input
iterator will meet the end before output iterator meets.

Fixes #71089
