### PR TITLE
.github: Set rocm workflows to only run on PRs

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -198,6 +198,7 @@ class CIWorkflow:
     fx2trt_test: bool = False
     timeout_after: int = 240
     xcode_version: str = ''
+    only_on_pr: bool = False
 
     # The following variables will be set as environment variables,
     # so it's easier for both shell and Python scripts to consume it if false is represented as the empty string.
@@ -606,6 +607,7 @@ LINUX_WORKFLOWS = [
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-rocm4.5-py3.7",
         test_runner_type=LINUX_ROCM_TEST_RUNNER,
         num_test_shards=2,
+        only_on_pr=True,
         ciflow_config=CIFlowConfig(
             labels=set([LABEL_CIFLOW_LINUX, LABEL_CIFLOW_ROCM]),
         ),

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -13,7 +13,7 @@ on:
 {%- if is_scheduled %}
   schedule:
     - cron: !{{ is_scheduled }}
-{%- else %}
+{%- elif not only_on_pr %}
   push:
     branches:
       - master

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -6,10 +6,6 @@ name: linux-bionic-rocm4.5-py3.7
 on:
   pull_request:
     types: [opened, synchronize, reopened, unassigned]
-  push:
-    branches:
-      - master
-      - release/*
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71560

Also adds a mechanism for all workflows to do this

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport @KyleCZH