### PR TITLE
[fx2trt][torchbench] enable shufflenet lowering

### DIFF
--- a/torch/fx/experimental/fx2trt/__init__.py
+++ b/torch/fx/experimental/fx2trt/__init__.py
@@ -8,4 +8,4 @@ from .converter_registry import (
 from .fx2trt import TRTInterpreter, TRTInterpreterResult
 from .input_tensor_spec import InputTensorSpec
 from .trt_module import TRTModule
-from .lower import LowerSetting
+from .lower import LowerSetting, Lowerer, lower_to_trt

--- a/torch/fx/experimental/fx2trt/example/lower_example.py
+++ b/torch/fx/experimental/fx2trt/example/lower_example.py
@@ -3,8 +3,7 @@ from copy import deepcopy
 
 import torch
 import typing as t
-from torch.fx.experimental.fx2trt import LowerSetting
-from torch.fx.experimental.fx2trt.lower import Lowerer
+from torch.fx.experimental.fx2trt import lower_to_trt
 import torchvision
 
 
@@ -12,52 +11,6 @@ import torchvision
 The purpose of this example is to demostrate the onverall flow of lowering a PyTorch model
 to TensorRT conveniently with lower.py.
 """
-def lower_to_trt(
-    module: torch.nn.Module,
-    input,
-    max_batch_size: int = 2048,
-    max_workspace_size=1 << 25,
-    explicit_batch_dimension=False,
-    fp16_mode=True,
-    enable_fuse=True,
-    verbose_log=False,
-    timing_cache_prefix="",
-    save_timing_cache=False,
-    cuda_graph_batch_size=-1,
-) -> torch.nn.Module:
-    """
-    Takes in original module, input and lowering setting, run lowering workflow to turn module
-    into lowered module, or so called TRTModule.
-
-    Args:
-    module: Original module for lowering.
-    input: Input for module.
-    max_batch_size: Maximum batch size (must be >= 1 to be set, 0 means not set)
-    max_workspace_size: Maximum size of workspace given to TensorRT.
-    explicit_batch_dimension: Use explicit batch dimension in TensorRT if set True, otherwise use implicit batch dimension.
-    fp16_mode: fp16 config given to TRTModule.
-    enable_fuse: Enable pass fusion during lowering if set to true. l=Lowering will try to find pattern defined
-    in torch.fx.experimental.fx2trt.passes from original module, and replace with optimized pass before apply lowering.
-    verbose_log: Enable verbose log for TensorRT if set True.
-    timing_cache_prefix: Timing cache file name for timing cache used by fx2trt.
-    save_timing_cache: Update timing cache with current timing cache data if set to True.
-    cuda_graph_batch_size: Cuda graph batch size, default to be -1.
-
-    Returns:
-    A torch.nn.Module lowered by TensorRT.
-    """
-    lower_setting = LowerSetting(
-        max_batch_size=max_batch_size,
-        max_workspace_size=max_workspace_size,
-        explicit_batch_dimension=explicit_batch_dimension,
-        fp16_mode=fp16_mode,
-        enable_fuse=enable_fuse,
-        verbose_log=verbose_log,
-        timing_cache_prefix=timing_cache_prefix,
-        save_timing_cache=save_timing_cache,
-    )
-    lowerer = Lowerer.create(lower_setting=lower_setting)
-    return lowerer(module, input)
 
 
 @dataclass

--- a/torch/fx/experimental/fx2trt/split.py
+++ b/torch/fx/experimental/fx2trt/split.py
@@ -4,13 +4,12 @@ import re
 import typing as t
 
 import torch.fx as fx
-from torch.fx.experimental.fx2trt.tools.trt_splitter import (
+from .tools.trt_splitter import (
     create_trt_operator_support,
     TRTSplitter,
 )
 from torch.fx.passes.operator_support import OperatorSupportBase
 from torch.fx.passes.splitter_base import _SplitterSettingBase
-from typing import Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ class SplitFunc:
         self,
         module: fx.GraphModule,
         input: Input,
-    ) -> Tuple[fx.GraphModule, t.Sequence["SplitInfo"]]:
+    ) -> t.Tuple[fx.GraphModule, t.Sequence["SplitInfo"]]:
         """Splits a module into lowerable and non-lowerable subnets.
 
         This function splits a module into lowerable subnets that can be run
@@ -87,7 +86,7 @@ class Splitter(SplitFunc):
             operator_supported=create_trt_operator_support(use_implicit_batch_dim),
         )
 
-    def __call__(self, module, input) -> Tuple[fx.GraphModule, t.Sequence[SplitInfo]]:
+    def __call__(self, module, input) -> t.Tuple[fx.GraphModule, t.Sequence[SplitInfo]]:
         trt_split_result = self._trt_split(module, input)
 
         logger.debug(


### PR DESCRIPTION
Summary:
Previously we have some unsupported ops and the perf improvement is not promising (10% on batch size 32)
```
Unsupported node types in the model:
acc_ops.reshape: ((), {'input': torch.float16})
mean: ((torch.float16,), {})
```

After the diff stack, we don't have any unsupported nodes.

Also moved `lower_to_trt` to lower.py.

Test Plan: buck run mode/dev-nosan -c python.package_style=inplace scripts/dsy842974287/cu_model:vision

Reviewed By: wushirong

Differential Revision: D33483843

