### PR TITLE
Fix version strings in CI

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -6,14 +6,15 @@ tagged_version() {
   # Grabs version from either the env variable CIRCLE_TAG
   # or the pytorch git described version
   if [[ "$OSTYPE" == "msys" ]]; then
-    GIT_DESCRIBE="git --git-dir ${workdir}/p/.git describe"
+    GIT_DIR="${workdir}/p/.git"
   else
-    GIT_DESCRIBE="git --git-dir ${workdir}/pytorch/.git describe"
+    GIT_DIR="${workdir}/pytorch/.git"
   fi
+  GIT_DESCRIBE="git --git-dir ${GIT_DIR} describe --tags --match v[0-9]*.[0-9]*.[0-9]*"
   if [[ -n "${CIRCLE_TAG:-}" ]]; then
     echo "${CIRCLE_TAG}"
-  elif ${GIT_DESCRIBE} --exact --tags >/dev/null; then
-    ${GIT_DESCRIBE} --tags
+  elif ${GIT_DESCRIBE} --exact >/dev/null; then
+    ${GIT_DESCRIBE}
   else
     return 1
   fi


### PR DESCRIPTION
In CI PRs are being tagged like `ciflow/cpu/$PR_NUMBER` which is
causing version strings to be set as non-numbers. This breaks the
caffe2 build because it uses `CAFFE2_VERSION_MAJOR` etc. as numbers.

Here is an example build failure:
https://app.circleci.com/pipelines/github/pytorch/pytorch/443426/workflows/0d581c74-392b-4572-b3f3-52772becfc46/jobs/16961533?invite=true#step-105-3299
