### PR TITLE
enable init_rpc without world_size

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -423,6 +423,12 @@ TensorPipeAgent::TensorPipeAgent(
       nameToAddressStore_("addrs", store),
       shutdownStore_("shutdown", store),
       worldSize_(worldSize) {
+  // if worldSize_ is -1, then this is a dynamic group
+  if (worldSize == -1) {
+    worldSize_ = store->getWorldSize();
+    isDynamic = true;
+  }
+
   // collect worker names
   prepareNames();
 
@@ -1099,6 +1105,7 @@ void TensorPipeAgent::join(bool shutdown) {
   // from the callback of a future).
   while (true) {
     {
+      worldSize_ = shutdownStore_.getWorldSize();
       std::unique_lock<std::mutex> lock(callCountMutex_);
       // It is enough to wait for there to be no more active client calls, since
       // each server call corresponds to a client call for some other worker.

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -331,7 +331,8 @@ class TORCH_API TensorPipeAgent : public RpcAgent {
   // Store keys that will used to count joined processes and active calls during
   // the shutdown process
   ::c10d::PrefixStore shutdownStore_;
-  const int worldSize_;
+  int worldSize_;
+  bool isDynamic{false};
 
   std::atomic<uint64_t> nextMessageID_{0};
 

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -158,6 +158,10 @@ if is_available():
                 backend
             )
 
+        # world_size is None, then it is a dynamic group
+        if not world_size:
+            world_size = -1
+
         # Rendezvous.
         # This rendezvous state sometimes is destroyed before all processes
         # finishing handshaking. To avoid that issue, we make it global to
@@ -176,6 +180,8 @@ if is_available():
             global _init_counter
             store = dist.PrefixStore(str("rpc_prefix_{}".format(_init_counter)), store)
             _init_counter += 1
+
+        print(f"rank: {rank}, world_size: {world_size}")
 
         # Initialize autograd before RPC since _init_rpc_backend guarantees all
         # processes sync via the store. If we initialize autograd after RPC,
@@ -229,7 +235,6 @@ if is_available():
             world_size=world_size,
             rpc_backend_options=rpc_backend_options,
         )
-
         api._init_rpc_states(rpc_agent)
 
     @api._require_initialized

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -257,7 +257,7 @@ def _tensorpipe_init_backend_handler(store, name, rank, world_size, rpc_backend_
     # on that process before rpc.shutdown(), as the agent initialization can
     # take longer than 5s.
     api._all_gather(None, timeout=rpc_backend_options.rpc_timeout)
-
+    
     try:
         _tensorpipe_check_remote_device_maps(agent, rpc_backend_options)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#71571 enable init_rpc without world_size**
* #70941 add world_size attribute to store
* #70005 [WIP] Update rpc device map

Assumptions:
- Still need to specify name + rank when initializing rpc (`rpc.init_rpc("worker0", rank=0)`)
- There needs to be a rank 0 (to hold the store) and rank 0 cannot leave the group
- To shutdown a member a dynamic group need to do an ungraceful shutdown(`rpc.shutdown(graceful=False)`)
- RPC calls against member which has left the group will fail.
- distributed autograd is not supported.
- no way of guaranteeing that a node has been initialized and is in the group

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang