### PR TITLE
Add gitutils tests

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 from collections import defaultdict
-from collections.abc import Iterator
 from datetime import datetime
-from typing import cast, Any, Dict, List, Optional, Tuple, Union
+from typing import cast, Any, Dict, Iterator, List, Optional, Tuple, Union
 import os
 import re
 

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from gitutils import PeekableIterator
+from unittest import TestCase, main
+
+class TestPeekableIterator(TestCase):
+    def test_iterator(self, input_: str = "abcdef") -> None:
+        iter_ = PeekableIterator(input_)
+        for idx, c in enumerate(iter_):
+            self.assertEqual(c, input_[idx])
+
+    def test_is_iterable(self) -> None:
+        from collections.abc import Iterator
+        iter_ = PeekableIterator("")
+        self.assertTrue(isinstance(iter_, Iterator))
+
+    def test_peek(self, input_: str = "abcdef") -> None:
+        iter_ = PeekableIterator(input_)
+        for idx, c in enumerate(iter_):
+            if idx + 1 < len(input_):
+                self.assertEqual(iter_.peek(), input_[idx + 1])
+            else:
+                self.assertTrue(iter_.peek() is None)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6 - 3.9'
+          python-version: 3.8
           architecture: x64
       - name: Checkout PyTorch
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
@@ -25,11 +25,13 @@ jobs:
         # .circleci/docker/common/install_conda.sh
         run: |
           set -eux
-          pip install -r requirements.txt
-          pip install boto3==1.16.34
+          python3 -mpip install -r requirements.txt
+          python3 -mpip install boto3==1.16.34
           make setup_lint
       - name: Test tools
-        run: python -m unittest discover -vs tools/test -p 'test_*.py'
+        run: |
+          python3 -m unittest discover -vs tools/test -p 'test_*.py'
+          python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
 
 concurrency:
   group: test-tools-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Test PeekableIterator behavior

Add `.github/scripts/test_*.py` to list of tests run by test_tools
workflow and pin Python version to 3.7 in test_tools workflow

Change PeekableIterator inheritance from collections.abc.Iterator, to
typing.Iterator, which is a correct alias starting from Python-3.7
