### PR TITLE
torch/monitor: make tests more robust on windows

### DIFF
--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -28,10 +28,16 @@ class TestMonitor(TestCase):
             (Aggregation.SUM, Aggregation.COUNT),
             timedelta(milliseconds=1),
         )
-        s.add(2)
-        time.sleep(0.002)
-        s.add(3)
         self.assertEqual(s.name, "asdf")
+
+        s.add(2)
+        for _ in range(100):
+            # NOTE: different platforms sleep may be inaccurate so we loop
+            # instead (i.e. win)
+            time.sleep(1 / 1000)  # ms
+            s.add(3)
+            if len(events) >= 1:
+                break
         self.assertGreaterEqual(len(events), 1)
         unregister_event_handler(handle)
 


### PR DESCRIPTION
Summary: 

Fixes #71553

Test Plan:
add ciflow/windows to CI

  buck test //caffe2/test:monitor -- --stress-runs 100 test_interval_sec

I don't have a windows machine so need to rely on CI to test

Differential Revision: D33691540

