### PR TITLE
Add private conversion function from CSR to block CSR

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8601,6 +8601,9 @@
     CPU: _convert_indices_from_csr_to_coo_structured_cpu
     CUDA: _convert_indices_from_csr_to_coo_structured_cuda
 
+- func: _csr_to_block_csr(Tensor self, int[2] block_size) -> Tensor
+  python_module: sparse
+
 ## NN wrappers
 
 - func: mse_loss.out(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -1,10 +1,10 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <ATen/SparseTensorUtils.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/mkl/Sparse.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/CPUBlas.h>
@@ -91,8 +91,8 @@
 #include <ATen/ops/tanh_native.h>
 #include <ATen/ops/trunc.h>
 #include <ATen/ops/trunc_native.h>
-#include <ATen/ops/zeros.h>
 #include <ATen/ops/zero_native.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 #include <algorithm>
@@ -100,19 +100,22 @@
 namespace at {
 namespace meta {
 
-TORCH_META_FUNC(_convert_indices_from_coo_to_csr) (
-  const Tensor& self, const int64_t size, const bool out_int32
-) {
+TORCH_META_FUNC(_convert_indices_from_coo_to_csr)
+(const Tensor& self, const int64_t size, const bool out_int32) {
   TORCH_CHECK(self.dim() <= 1, "Input is supposed to be a vector");
   ScalarType scalar_type = out_int32 ? ScalarType::Int : ScalarType::Long;
-  c10::TensorOptions options = TensorOptions().device(self.options().device()).dtype(scalar_type);
+  c10::TensorOptions options =
+      TensorOptions().device(self.options().device()).dtype(scalar_type);
   set_output(size + 1, options);
 }
 
-TORCH_META_FUNC(_convert_indices_from_csr_to_coo) (
-  const Tensor& crow_indices, const Tensor& col_indices, const bool out_int32, const bool transpose
-) {
-  TORCH_CHECK(crow_indices.dim() == 1, "crow_indices is supposed to be a vector");
+TORCH_META_FUNC(_convert_indices_from_csr_to_coo)
+(const Tensor& crow_indices,
+ const Tensor& col_indices,
+ const bool out_int32,
+ const bool transpose) {
+  TORCH_CHECK(
+      crow_indices.dim() == 1, "crow_indices is supposed to be a vector");
   TORCH_CHECK(col_indices.dim() == 1, "col_indices is supposed to be a vector");
   ScalarType scalar_type = out_int32 ? ScalarType::Int : ScalarType::Long;
   c10::TensorOptions options = crow_indices.options().dtype(scalar_type);
@@ -126,7 +129,10 @@ namespace {
 constexpr int64_t GRAIN_SIZE = at::internal::GRAIN_SIZE;
 
 template <typename input_t, typename output_t>
-void convert_indices_from_coo_to_csr_cpu(const Tensor& result, const Tensor& input, const int64_t size) {
+void convert_indices_from_coo_to_csr_cpu(
+    const Tensor& result,
+    const Tensor& input,
+    const int64_t size) {
   int64_t numel = input.numel();
   const input_t* data_in = input.data_ptr<input_t>();
   output_t* data_out = result.data_ptr<output_t>();
@@ -175,7 +181,7 @@ Tensor& unary_op_out(F op_out, const Tensor& self, Tensor& result) {
   return result;
 }
 
-template <typename F, typename ...Args>
+template <typename F, typename... Args>
 Tensor& unary_op_inplace(Tensor& self, const F& op_inplace, Args&&... args) {
   TORCH_INTERNAL_ASSERT(self.is_sparse_csr());
 
@@ -185,7 +191,11 @@ Tensor& unary_op_inplace(Tensor& self, const F& op_inplace, Args&&... args) {
 }
 
 template <typename input_t, typename output_t>
-void convert_indices_from_csr_to_coo_cpu(const Tensor& indices, const Tensor& crow_indices, const Tensor& col_indices, const bool transpose=false) {
+void convert_indices_from_csr_to_coo_cpu(
+    const Tensor& indices,
+    const Tensor& crow_indices,
+    const Tensor& col_indices,
+    const bool transpose = false) {
   int64_t nrows = crow_indices.numel() - 1;
   if (nrows == 0) {
     indices.zero_();
@@ -194,16 +204,18 @@ void convert_indices_from_csr_to_coo_cpu(const Tensor& indices, const Tensor& cr
   auto crow_indices_ = crow_indices.expect_contiguous();
   const input_t* crow_indices_data_in = crow_indices_->data_ptr<input_t>();
   TORCH_INTERNAL_ASSERT(indices.is_contiguous());
-  auto row0 = indices.select(0, transpose?1:0);
-  auto row1 = indices.select(0, transpose?0:1);
+  auto row0 = indices.select(0, transpose ? 1 : 0);
+  auto row1 = indices.select(0, transpose ? 0 : 1);
   output_t* data_out = row0.data_ptr<output_t>();
   row1.copy_(*col_indices.expect_contiguous());
   at::parallel_for(0, nrows, GRAIN_SIZE, [&](int64_t start, int64_t end) {
     for (const auto i : c10::irange(start, end)) {
-      std::fill(&data_out[crow_indices_data_in[i]], &data_out[crow_indices_data_in[i + 1]], static_cast<output_t>(i));
+      std::fill(
+          &data_out[crow_indices_data_in[i]],
+          &data_out[crow_indices_data_in[i + 1]],
+          static_cast<output_t>(i));
     }
   });
-
 }
 
 } // end anonymous namespace
@@ -222,26 +234,27 @@ inline Tensor get_result_tensor_for_unary_op(F op, const Tensor& input) {
 
   // To handle type promotion for inputs to unary ops,
   // we first get the result from the underlined op, and use the result
-  // to create a sparse CSR tensor, which is used as the input to the out= variant
+  // to create a sparse CSR tensor, which is used as the input to the out=
+  // variant
   auto result_values = op(values);
 
   auto result = at::native::_sparse_csr_tensor_unsafe(
-    input.crow_indices().clone(),
-    input.col_indices().clone(),
-    result_values,
-    input.sizes(),
-    result_values.scalar_type(),
-    input.layout(),
-    result_values.device());
+      input.crow_indices().clone(),
+      input.col_indices().clone(),
+      result_values,
+      input.sizes(),
+      result_values.scalar_type(),
+      input.layout(),
+      result_values.device());
 
   return result;
 }
-}
+} // namespace
 
 static constexpr bool is_mkl_supported() {
 #ifdef _MSC_VER
   return false;
-#elif  __APPLE__ || __MACH__
+#elif __APPLE__ || __MACH__
   return false;
 #else
   return true;
@@ -249,41 +262,46 @@ static constexpr bool is_mkl_supported() {
 }
 
 // Only accept squares sparse matrices or dense input as a vector
-// TODO: Check what happens with MKL, the output error reported with non square matrices tends to be high
-// See: https://github.com/pytorch/pytorch/issues/58770
+// TODO: Check what happens with MKL, the output error reported with non square
+// matrices tends to be high See:
+// https://github.com/pytorch/pytorch/issues/58770
 bool is_square_or_vec(int64_t dim_i, int64_t dim_j, int64_t dim_k) {
-  return (dim_i == dim_k  && dim_k == dim_j) || (dim_i == dim_j && dim_k == 1);
+  return (dim_i == dim_k && dim_k == dim_j) || (dim_i == dim_j && dim_k == 1);
 }
 
-Tensor& normal_sparse_csr_(Tensor& self, double mean, double std, c10::optional<Generator> gen) {
+Tensor& normal_sparse_csr_(
+    Tensor& self,
+    double mean,
+    double std,
+    c10::optional<Generator> gen) {
   return unary_op_inplace(self, &Tensor::normal_, mean, std, gen);
 }
 
 /* Implementation of Unary Ufuncs, those supported for Sparse CSR Layout
  * Only simple funcs, with 0->0 correspondence are currently supported. */
 
-#define CREATE_UNARY_UFUNC_OUT(op_name)                                    \
-  Tensor& op_name##_sparse_csr_out(const Tensor& self, Tensor& result) {   \
-    return unary_op_out(&at::op_name##_outf, self, result);                \
+#define CREATE_UNARY_UFUNC_OUT(op_name)                                  \
+  Tensor& op_name##_sparse_csr_out(const Tensor& self, Tensor& result) { \
+    return unary_op_out(&at::op_name##_outf, self, result);              \
   }
 
-#define CREATE_UNARY_UFUNC_FUNCTIONAL(op_name)                             \
-  Tensor op_name##_sparse_csr(const Tensor& self) {                        \
-    return get_result_tensor_for_unary_op(&at::op_name, self);             \
+#define CREATE_UNARY_UFUNC_FUNCTIONAL(op_name)                 \
+  Tensor op_name##_sparse_csr(const Tensor& self) {            \
+    return get_result_tensor_for_unary_op(&at::op_name, self); \
   }
 
-#define CREATE_UNARY_UFUNC_INPLACE(op_name)                                \
-  Tensor& op_name##_sparse_csr_(Tensor& self) {                            \
-    return unary_op_inplace(self, &Tensor::op_name##_);                    \
+#define CREATE_UNARY_UFUNC_INPLACE(op_name)             \
+  Tensor& op_name##_sparse_csr_(Tensor& self) {         \
+    return unary_op_inplace(self, &Tensor::op_name##_); \
   }
 
-#define CREATE_UNARY_UFUNC(op_name)                                        \
-  CREATE_UNARY_UFUNC_OUT(op_name);                                         \
-  CREATE_UNARY_UFUNC_FUNCTIONAL(op_name);                                  \
+#define CREATE_UNARY_UFUNC(op_name)       \
+  CREATE_UNARY_UFUNC_OUT(op_name);        \
+  CREATE_UNARY_UFUNC_FUNCTIONAL(op_name); \
   CREATE_UNARY_UFUNC_INPLACE(op_name);
 
-#define CREATE_UNARY_UFUNC_NO_INPLACE(op_name)                             \
-  CREATE_UNARY_UFUNC_OUT(op_name);                                         \
+#define CREATE_UNARY_UFUNC_NO_INPLACE(op_name) \
+  CREATE_UNARY_UFUNC_OUT(op_name);             \
   CREATE_UNARY_UFUNC_FUNCTIONAL(op_name);
 
 // Exhaustive list of the unary ufuncs supported by sparse CSR
@@ -339,8 +357,12 @@ CREATE_UNARY_UFUNC_FUNCTIONAL(isnan);
 CREATE_UNARY_UFUNC_FUNCTIONAL(isinf);
 
 template <typename scalar_t>
-void addmm_out_sparse_csr_native_cpu(const Tensor& sparse, const Tensor& dense, const Tensor& r, Scalar alpha, Scalar beta) {
-
+void addmm_out_sparse_csr_native_cpu(
+    const Tensor& sparse,
+    const Tensor& dense,
+    const Tensor& r,
+    Scalar alpha,
+    Scalar beta) {
   auto dim_i = sparse.size(0);
   auto dim_k = dense.size(1);
 
@@ -350,38 +372,42 @@ void addmm_out_sparse_csr_native_cpu(const Tensor& sparse, const Tensor& dense, 
 
   scalar_t cast_alpha = alpha.to<scalar_t>();
   r.mul_(beta);
-  AT_DISPATCH_INDEX_TYPES(col_indices.scalar_type(), "csr_mm_crow_indices", [&]() {
-    auto csr_accessor = csr.accessor<index_t, 1>();
-    auto col_indices_accessor = col_indices.accessor<index_t, 1>();
+  AT_DISPATCH_INDEX_TYPES(
+      col_indices.scalar_type(), "csr_mm_crow_indices", [&]() {
+        auto csr_accessor = csr.accessor<index_t, 1>();
+        auto col_indices_accessor = col_indices.accessor<index_t, 1>();
 
-    auto values_accessor = values.accessor<scalar_t, 1>();
-    scalar_t* dense_ptr = dense.data_ptr<scalar_t>();
-    scalar_t* r_ptr = r.data_ptr<scalar_t>();
+        auto values_accessor = values.accessor<scalar_t, 1>();
+        scalar_t* dense_ptr = dense.data_ptr<scalar_t>();
+        scalar_t* r_ptr = r.data_ptr<scalar_t>();
 
-    int64_t dense_stride0 = dense.stride(0);
-    int64_t dense_stride1 = dense.stride(1);
-    int64_t r_stride0 = r.stride(0);
-    int64_t r_stride1 = r.stride(1);
+        int64_t dense_stride0 = dense.stride(0);
+        int64_t dense_stride1 = dense.stride(1);
+        int64_t r_stride0 = r.stride(0);
+        int64_t r_stride1 = r.stride(1);
 
-    at::parallel_for(
-        0,
-        dim_i,
-        internal::GRAIN_SIZE,
-        [&](int64_t irow_start, int64_t irow_end) {
-            for (index_t h = irow_start; h < irow_end; ++h) {
-              index_t i_start = csr_accessor[h];
-              index_t i_end = csr_accessor[h+1];
-              for (index_t i = i_start; i < i_end; i++) {
-                scalar_t val = values_accessor[i];
-                index_t col = col_indices_accessor[i];
-                at::native::cpublas::axpy<scalar_t>(dim_k,
-                    cast_alpha * val,
-                    dense_ptr + col * dense_stride0, dense_stride1,
-                    r_ptr + h * r_stride0, r_stride1);
+        at::parallel_for(
+            0,
+            dim_i,
+            internal::GRAIN_SIZE,
+            [&](int64_t irow_start, int64_t irow_end) {
+              for (index_t h = irow_start; h < irow_end; ++h) {
+                index_t i_start = csr_accessor[h];
+                index_t i_end = csr_accessor[h + 1];
+                for (index_t i = i_start; i < i_end; i++) {
+                  scalar_t val = values_accessor[i];
+                  index_t col = col_indices_accessor[i];
+                  at::native::cpublas::axpy<scalar_t>(
+                      dim_k,
+                      cast_alpha * val,
+                      dense_ptr + col * dense_stride0,
+                      dense_stride1,
+                      r_ptr + h * r_stride0,
+                      r_stride1);
+                }
               }
-            }
-    });
-  });
+            });
+      });
 }
 
 // Functions for matrix multiplication.
@@ -396,8 +422,8 @@ Tensor& addmm_out_sparse_csr_cpu(
 
   // TODO: remove this, there are no codegenerated checks for devices yet
   TORCH_CHECK(
-    !self.is_cuda(),
-    "Expected all tensors to be on the same device. addmm expected 't' to be CPU tensor, but got CUDA tensor");
+      !self.is_cuda(),
+      "Expected all tensors to be on the same device. addmm expected 't' to be CPU tensor, but got CUDA tensor");
   TORCH_CHECK(
       !result.is_cuda(),
       "Expected all tensors to be on the same device. addmm: expected 'out' to be CPU tensor, but got CUDA tensor");
@@ -408,13 +434,24 @@ Tensor& addmm_out_sparse_csr_cpu(
       !mat2.is_cuda(),
       "Expected all tensors to be on the same device. addmm: expected 'mat2' to be a CPU tensor, but got a CUDA tensor");
 
-  // All the checks are from addmm_out_cuda_impl (ATen/native/cuda/Blas.cpp) and TORCH_META_FUNC(addmm) (ATen/native/LinearAlgebra.cpp)
+  // All the checks are from addmm_out_cuda_impl (ATen/native/cuda/Blas.cpp) and
+  // TORCH_META_FUNC(addmm) (ATen/native/LinearAlgebra.cpp)
   // TODO: remove code duplication and unify code
-  TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor");
-  TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix, got ", mat2.dim(), "-D tensor");
   TORCH_CHECK(
-      mat1.sizes()[1] == mat2.sizes()[0], "mat1 and mat2 shapes cannot be multiplied (",
-      mat1.sizes()[0], "x", mat1.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")");
+      mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor");
+  TORCH_CHECK(
+      mat2.dim() == 2, "mat2 must be a matrix, got ", mat2.dim(), "-D tensor");
+  TORCH_CHECK(
+      mat1.sizes()[1] == mat2.sizes()[0],
+      "mat1 and mat2 shapes cannot be multiplied (",
+      mat1.sizes()[0],
+      "x",
+      mat1.sizes()[1],
+      " and ",
+      mat2.sizes()[0],
+      "x",
+      mat2.sizes()[1],
+      ")");
 
   IntArrayRef mat1_sizes = mat1.sizes();
   IntArrayRef mat2_sizes = mat2.sizes();
@@ -428,9 +465,19 @@ Tensor& addmm_out_sparse_csr_cpu(
     self__sizes = self_->sizes();
   }
 
-  TORCH_CHECK(((self_->dim() == 2) && (self_->sizes()[0] == mat1.sizes()[0]) && (self_->sizes()[1] == mat2.sizes()[1])),
-  "The input tensor must be a matrix with size ", mat1.sizes()[0], "x", mat2.sizes()[1], ", but got a ", self_->dim(),
-  "-D tensor with size ", self__sizes[0], "x", self__sizes[1]);
+  TORCH_CHECK(
+      ((self_->dim() == 2) && (self_->sizes()[0] == mat1.sizes()[0]) &&
+       (self_->sizes()[1] == mat2.sizes()[1])),
+      "The input tensor must be a matrix with size ",
+      mat1.sizes()[0],
+      "x",
+      mat2.sizes()[1],
+      ", but got a ",
+      self_->dim(),
+      "-D tensor with size ",
+      self__sizes[0],
+      "x",
+      self__sizes[1]);
 
   if (&result != &self) {
     if (result.layout() == kStrided) {
@@ -447,7 +494,8 @@ Tensor& addmm_out_sparse_csr_cpu(
   }
 
   if (mat1._nnz() == 0 && mat2.layout() == kStrided) {
-    // According to docs, when beta==0 values in self should be ignored. nans and infs should not propagate
+    // According to docs, when beta==0 values in self should be ignored. nans
+    // and infs should not propagate
     if (beta.toComplexDouble() == 0.) {
       result.zero_();
     } else {
@@ -466,16 +514,18 @@ Tensor& addmm_out_sparse_csr_cpu(
   }
 
 #if !AT_USE_MKL_SPARSE()
-    if (mat2.is_sparse_csr() && result.is_sparse_csr()) {
-      TORCH_CHECK(
-          false,
-          "Calling addmm on sparse CPU tensors requires Linux platform. ",
-          "Please use PyTorch built with MKL on Linux.");
-    }
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(result.layout() == kStrided);
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(result.scalar_type(), "addmm_sparse_dense", [&] {
-        addmm_out_sparse_csr_native_cpu<scalar_t>(mat1, mat2, result, alpha, beta);
-    });
+  if (mat2.is_sparse_csr() && result.is_sparse_csr()) {
+    TORCH_CHECK(
+        false,
+        "Calling addmm on sparse CPU tensors requires Linux platform. ",
+        "Please use PyTorch built with MKL on Linux.");
+  }
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(result.layout() == kStrided);
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
+      result.scalar_type(), "addmm_sparse_dense", [&] {
+        addmm_out_sparse_csr_native_cpu<scalar_t>(
+            mat1, mat2, result, alpha, beta);
+      });
 #else
   sparse::impl::mkl::addmm_out_sparse_csr(mat1, mat2, beta, alpha, result);
 #endif
@@ -507,9 +557,7 @@ Tensor& _sparse_csr_mm_out(
   return at::addmm_out(result, zero, mat1, mat2, 0.0, 1.0);
 }
 
-Tensor _sparse_csr_mm(
-    const Tensor& mat1,
-    const Tensor& mat2) {
+Tensor _sparse_csr_mm(const Tensor& mat1, const Tensor& mat2) {
   Tensor zero;
   if (mat1.is_sparse_csr() && mat2.is_sparse_csr()) {
     // TODO: replace with at::zeros when it's implemented for sparse csr
@@ -533,14 +581,20 @@ Tensor _sparse_csr_addmm(
 }
 
 // Functions for element-wise addition.
-Tensor add_sparse_csr(const Tensor& self, const Tensor& other, const Scalar& alpha) {
+Tensor add_sparse_csr(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
   auto commonDtype = at::result_type(self, other);
   alpha_check(commonDtype, alpha);
   Tensor result = at::empty({0, 0}, self.options().dtype(commonDtype));
   return at::add_out(result, self, other, alpha); // redispatch!
 }
 
-Tensor& add_sparse_csr_(Tensor& self, const Tensor& other, const Scalar& alpha) {
+Tensor& add_sparse_csr_(
+    Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
   return at::add_out(self, self, other, alpha); // redispatch!
 }
 
@@ -599,14 +653,24 @@ void add_out_dense_sparse_csr_cpu(
   }
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-      kHalf, kBool, kBFloat16,
+      kHalf,
+      kBool,
+      kBFloat16,
       commonDtype,
       "add_out_op2_sparse_csr",
-      [&valuesBuffer, &resultBuffer, &alpha, &src_crow_indices, &src_col_indices]() {
+      [&valuesBuffer,
+       &resultBuffer,
+       &alpha,
+       &src_crow_indices,
+       &src_col_indices]() {
         AT_DISPATCH_INDEX_TYPES(
             src_crow_indices.scalar_type(),
             "csr_add_out_crow_indices",
-            [&valuesBuffer, &resultBuffer, &alpha, &src_crow_indices, &src_col_indices]() {
+            [&valuesBuffer,
+             &resultBuffer,
+             &alpha,
+             &src_crow_indices,
+             &src_col_indices]() {
               auto values_accessor = valuesBuffer.accessor<scalar_t, 1>();
               scalar_t* out_ptr = resultBuffer.data_ptr<scalar_t>();
               scalar_t cast_value = alpha.to<scalar_t>();
@@ -625,8 +689,8 @@ void add_out_dense_sparse_csr_cpu(
 
                 for (index_t i = start_index; i < end_index; ++i) {
                   auto icol = col_indices_accessor[i];
-                  auto index = resultBuffer.storage_offset() + irow * out_strides0 +
-                      icol * out_strides1;
+                  auto index = resultBuffer.storage_offset() +
+                      irow * out_strides0 + icol * out_strides1;
                   out_ptr[index] += cast_value * values_accessor[i];
                 }
               }
@@ -657,32 +721,249 @@ Tensor& add_out_sparse_csr_cpu(
   return out;
 }
 
-TORCH_IMPL_FUNC(_convert_indices_from_coo_to_csr_structured_cpu) (
-  const Tensor& input, const int64_t size, const bool out_int32, const Tensor& result
-) {
+TORCH_IMPL_FUNC(_convert_indices_from_coo_to_csr_structured_cpu)
+(const Tensor& input,
+ const int64_t size,
+ const bool out_int32,
+ const Tensor& result) {
   if (out_int32) {
-    AT_DISPATCH_INTEGRAL_TYPES(input.scalar_type(), "convert_indices_from_coo_to_csr_cpu", [&] {
-      convert_indices_from_coo_to_csr_cpu<scalar_t, int>(result, input, size);
-    });
+    AT_DISPATCH_INTEGRAL_TYPES(
+        input.scalar_type(), "convert_indices_from_coo_to_csr_cpu", [&] {
+          convert_indices_from_coo_to_csr_cpu<scalar_t, int>(
+              result, input, size);
+        });
   } else {
-    AT_DISPATCH_INTEGRAL_TYPES(input.scalar_type(), "convert_indices_from_coo_to_csr_cpu", [&] {
-      convert_indices_from_coo_to_csr_cpu<scalar_t, int64_t>(result, input, size);
-    });
+    AT_DISPATCH_INTEGRAL_TYPES(
+        input.scalar_type(), "convert_indices_from_coo_to_csr_cpu", [&] {
+          convert_indices_from_coo_to_csr_cpu<scalar_t, int64_t>(
+              result, input, size);
+        });
   }
 }
 
-TORCH_IMPL_FUNC(_convert_indices_from_csr_to_coo_structured_cpu) (
-  const Tensor& crow_indices, const Tensor& col_indices, const bool out_int32, const bool transpose, const Tensor& result
-) {
+TORCH_IMPL_FUNC(_convert_indices_from_csr_to_coo_structured_cpu)
+(const Tensor& crow_indices,
+ const Tensor& col_indices,
+ const bool out_int32,
+ const bool transpose,
+ const Tensor& result) {
   if (out_int32) {
-    AT_DISPATCH_INTEGRAL_TYPES(crow_indices.scalar_type(), "convert_indices_from_csr_to_coo_cpu", [&] {
-      convert_indices_from_csr_to_coo_cpu<scalar_t, int32_t>(result, crow_indices, col_indices, transpose);
-    });
+    AT_DISPATCH_INTEGRAL_TYPES(
+        crow_indices.scalar_type(), "convert_indices_from_csr_to_coo_cpu", [&] {
+          convert_indices_from_csr_to_coo_cpu<scalar_t, int32_t>(
+              result, crow_indices, col_indices, transpose);
+        });
   } else {
-    AT_DISPATCH_INTEGRAL_TYPES(crow_indices.scalar_type(), "convert_indices_from_csr_to_coo_cpu", [&] {
-      convert_indices_from_csr_to_coo_cpu<scalar_t, int64_t>(result, crow_indices, col_indices, transpose);
-    });
+    AT_DISPATCH_INTEGRAL_TYPES(
+        crow_indices.scalar_type(), "convert_indices_from_csr_to_coo_cpu", [&] {
+          convert_indices_from_csr_to_coo_cpu<scalar_t, int64_t>(
+              result, crow_indices, col_indices, transpose);
+        });
   }
+}
+
+/*
+ * Based on
+ * https://github.com/scipy/scipy/blob/8a64c938ddf1ae4c02a08d2c5e38daeb8d061d38/scipy/sparse/sparsetools/csr.h
+ */
+template <class I, class T>
+void _csr_to_block_csr_cpu_kernel(
+    const I n_row,
+    const I n_col,
+    const I R,
+    const I C,
+    const I* input_crow_indices,
+    const I* input_col_indices,
+    const T* input_values,
+    I* result_crow_indices,
+    I* result_col_indices,
+    T* result_values) {
+  // All blocks are possible, that is, may be allocated if a single non-zero
+  // value lives within them. Otherwise they're not.
+
+  // Allocate pointers for all possible column blocks plus 1
+  std::vector<T*> blocks(n_col / C + 1, (T*)0);
+
+  assert(n_row % R == 0);
+  assert(n_col % C == 0);
+
+  // Major assumptions
+  // 1. Blocks must be square
+
+  // Number of blocks along rows
+  I n_brow = n_row / R;
+  // Number of blocks along columns
+  // I n_bcol = n_col / C;
+
+  // Number of elements per block
+  I RC = R * C;
+  // Number of blocks overall
+  I n_blks = 0;
+
+  result_crow_indices[0] = 0;
+
+  // Iterate over blocks along rows
+  for (I block_i = 0; block_i < n_brow; block_i++) {
+    // Iterate over rows within block
+    for (I r = 0; r < R; r++) {
+      I i = R * block_i + r; // row index
+      for (I jj = input_crow_indices[i]; jj < input_crow_indices[i + 1]; jj++) {
+        I j = input_col_indices[jj]; // column index
+
+        // Block corresponding to column index
+        I block_j = j / C;
+        // Column within block
+        I c = j % C;
+
+        if (blocks[block_j] == 0) {
+          blocks[block_j] = result_values + RC * n_blks;
+          result_col_indices[n_blks] = block_j;
+          n_blks++;
+        }
+
+        // Specific blocks entries should not be visited more than once.
+        // Scipy code does an addition here. Why?
+        *(blocks[block_j] + C * r + c) = input_values[jj];
+      }
+    }
+
+    for (I jj = input_crow_indices[R * block_i];
+         jj < input_crow_indices[R * (block_i + 1)];
+         jj++) {
+      blocks[input_col_indices[jj] / C] = 0;
+    }
+
+    result_crow_indices[block_i + 1] = n_blks;
+  }
+}
+
+/*
+ * Based on
+ * https://github.com/scipy/scipy/blob/8a64c938ddf1ae4c02a08d2c5e38daeb8d061d38/scipy/sparse/sparsetools/csr.h
+ */
+template <class I>
+I csr_count_blocks(
+    const I n_row,
+    const I n_col,
+    const I R,
+    const I C,
+    const I Ap[],
+    const I Aj[]) {
+  std::vector<I> mask(n_col / C + 1, -1);
+  I n_blks = 0;
+  for (I i = 0; i < n_row; i++) {
+    I bi = i / R;
+    for (I jj = Ap[i]; jj < Ap[i + 1]; jj++) {
+      I bj = Aj[jj] / C;
+      if (mask[bj] != bi) {
+        mask[bj] = bi;
+        n_blks++;
+      }
+    }
+  }
+  return n_blks;
+}
+
+Tensor _csr_to_block_csr_cpu(const Tensor& self, IntArrayRef blocksize) {
+  TORCH_CHECK(
+      blocksize[0] == blocksize[1],
+      "blocks must be square. ",
+      "Got (",
+      blocksize[0],
+      ", ",
+      blocksize[1],
+      ") instead.");
+  TORCH_CHECK(
+      self.size(0) % blocksize[0] == 0 && self.size(1) % blocksize[1] == 0,
+      "Block sparse CSR Tensors must have a size that is an ",
+      "integral multiple of their block size. ",
+      "Got Tensor of size (",
+      self.size(0),
+      ", ",
+      self.size(1),
+      ") with block size (",
+      blocksize[0],
+      ", ",
+      blocksize[1],
+      ") instead.");
+  Tensor input_values = self.values().contiguous();
+  Tensor input_crow_indices = self.crow_indices().contiguous();
+  Tensor input_col_indices = self.col_indices().contiguous();
+
+  // First we determine the number of blocks needed. For each given block, if it
+  // contains a non-zero element we will allocate values and indices for it.
+  int64_t num_blocks;
+  int64_t n_row = self.size(0);
+  int64_t n_col = self.size(1);
+  AT_DISPATCH_INDEX_TYPES(
+      input_crow_indices.scalar_type(), "_csr_to_block_csr_cpu", [&] {
+        num_blocks = csr_count_blocks<index_t>(
+            n_row,
+            n_col,
+            blocksize[0],
+            blocksize[1],
+            input_crow_indices.data_ptr<index_t>(),
+            input_col_indices.data_ptr<index_t>());
+      });
+
+  Tensor result_values =
+      input_values.new_zeros({num_blocks, blocksize[0], blocksize[1]});
+  Tensor result_crow_indices =
+      input_crow_indices.new_empty({(n_row / blocksize[0]) + 1});
+  Tensor result_col_indices = input_col_indices.new_empty({num_blocks});
+
+  // Next we copy over non-zero elements into the allocated blocks.
+  AT_DISPATCH_INDEX_TYPES(
+      input_crow_indices.scalar_type(), "_csr_to_block_csr_cpu", [&] {
+        AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
+            input_values.scalar_type(), "_csr_to_block_csr_cpu", [&] {
+              _csr_to_block_csr_cpu_kernel<index_t, scalar_t>(
+                  n_row,
+                  n_col,
+                  blocksize[0],
+                  blocksize[1],
+                  input_crow_indices.data_ptr<index_t>(),
+                  input_col_indices.data_ptr<index_t>(),
+                  input_values.data_ptr<scalar_t>(),
+                  result_crow_indices.data_ptr<index_t>(),
+                  result_col_indices.data_ptr<index_t>(),
+                  result_values.data_ptr<scalar_t>());
+            });
+      });
+  return at::native::_sparse_csr_tensor_unsafe(
+      result_crow_indices,
+      result_col_indices,
+      result_values,
+      self.sizes(),
+      result_values.scalar_type(),
+      self.layout(),
+      result_values.device());
+}
+
+Tensor _csr_to_block_csr(const Tensor& self, IntArrayRef blocksize) {
+  Tensor self_values = self.values();
+  Tensor self_crow_indices = self.crow_indices();
+  Tensor self_col_indices = self.col_indices();
+  Tensor cpu_result = _csr_to_block_csr_cpu(
+      _sparse_csr_tensor_unsafe(self_crow_indices.cpu(),
+                                self_col_indices.cpu(),
+                                self_values.cpu(),
+                                self.sizes(),
+                                self_values.scalar_type(),
+                                self.layout(),
+                                self_values.device()),
+      blocksize);
+  Tensor result_values = cpu_result.values().to(self_values.options());
+  Tensor result_crow_indices = cpu_result.crow_indices().to(self_crow_indices.options());
+  Tensor result_col_indices = cpu_result.col_indices().to(self_col_indices.options());
+  return at::native::_sparse_csr_tensor_unsafe(
+      result_crow_indices,
+      result_col_indices,
+      result_values,
+      self.sizes(),
+      result_values.scalar_type(),
+      self.layout(),
+      result_values.device());
 }
 
 } // namespace native

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     'sum',
     'softmax',
     'log_softmax',
+    '_csr_to_block_csr',
 ]
 
 
@@ -262,3 +263,5 @@ Args:
         performed. This is useful for preventing data type
         overflows. Default: None
 """)
+
+_csr_to_block_csr = _sparse._csr_to_block_csr


### PR DESCRIPTION
This PR adds a private function that converts a CSR Tensor into a [scipy-style block CSR Tensor](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.bsr_matrix.html#scipy.sparse.bsr_matrix).

It uses the scipy CSR to BSR conversion routines (and credits them accordingly).

The main purpose of this function is to easily create a block CSR Tensor for matrix multiplication.

Follow up work includes
- Blocksize support for sparse_csr_tensor
- Parallel CPU kernel
- CUDA kernels
- Faster arg sanitization
- Benchmarking of cuSPARSE backend
- Dense to/from block CSR
- Autograd support
- Column-major blocks
- Block CSR to CSR conversion