### PR TITLE
.github: Improve syncbranch debugability

### DIFF
--- a/.github/scripts/syncbranches.py
+++ b/.github/scripts/syncbranches.py
@@ -10,15 +10,15 @@ def parse_args() -> Any:
     parser.add_argument("--sync-branch", default="sync")
     parser.add_argument("--default-branch", type=str, default="main")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--debug", action="store_true")
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    repo = GitRepo(get_git_repo_dir())
+    repo = GitRepo(get_git_repo_dir(), debug=args.debug)
     repo.cherry_pick_commits(args.sync_branch, args.default_branch)
-    if not args.dry_run:
-        repo.push(args.default_branch)
+    repo.push(args.default_branch, args.dry_run)
 
 
 if __name__ == '__main__':

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -262,7 +262,7 @@ class GitHubPR:
             self.merge_ghstack_into(repo)
 
         if not dry_run:
-            repo.push(self.default_branch())
+            repo.push(self.default_branch(), dry_run)
 
 
 @dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71596

Adds a dry_run to test out push as well as adding in a debug flag to
allow you to see what git commands are running

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D33695224](https://our.internmc.facebook.com/intern/diff/D33695224)