### PR TITLE
[Pytorch Edge] Wrap lowered module in to_backend

### DIFF
--- a/test/cpp/jit/test_backend.cpp
+++ b/test/cpp/jit/test_backend.cpp
@@ -338,9 +338,15 @@ TEST(BackendTestDebugInfo, TestCompiler) {
   lm._save_for_mobile(ss, ExtraFilesMap(), true);
   auto mlm = _load_for_mobile(ss);
   std::string error_pattern = R"(
-  Module hierarchy:top(m)::<unknown>.aten::add
+  Module hierarchy:top(m)::<unknown>.__loweredModule__(m)::forward.aten::add
 Traceback of TorchScript (most recent call last):
-  File "<string>", line 5, in <unknown>
+  File "<string>", line 3, in <unknown>
+
+            def forward(self, x: Tensor, h: Tensor):
+                return self.__loweredModule__.forward(x, h)
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+
+  File "<string>", line 5, in forward
                 typed_inputs: List[Any] = [x, h, ]
                 if self.__backend.is_available() :
                   _0, = self.__backend.execute(self.__handles["forward"], typed_inputs)
@@ -392,9 +398,15 @@ TEST(BackendTestDebugInfo, TestExceptionStackForCompilerWithModuleHierarchy) {
   lm._save_for_mobile(ss, ExtraFilesMap(), true);
   auto mlm = _load_for_mobile(ss);
   std::string error_pattern = R"(
-  Module hierarchy:top(C)::<unknown>.A0(A)::forward.aten::add
+  Module hierarchy:top(C)::<unknown>.__loweredModule__(C)::forward.A0(A)::forward.aten::add
 Traceback of TorchScript (most recent call last):
-  File "<string>", line 5, in <unknown>
+  File "<string>", line 3, in <unknown>
+
+            def forward(self, x: Tensor, y: Tensor):
+                return self.__loweredModule__.forward(x, y)
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+
+  File "<string>", line 5, in forward
                 typed_inputs: List[Any] = [x, y, ]
                 if self.__backend.is_available() :
                   _0, = self.__backend.execute(self.__handles["forward"], typed_inputs)
@@ -485,9 +497,15 @@ TEST(
    *
    */
   std::string error_pattern = R"(
-  Module hierarchy:top(C)::<unknown>.B0(B)::forward.A0(A)::forward.aten::add
+  Module hierarchy:top(C)::<unknown>.__loweredModule__(C)::forward.B0(B)::forward.A0(A)::forward.aten::add
 Traceback of TorchScript (most recent call last):
-  File "<string>", line 5, in <unknown>
+  File "<string>", line 3, in <unknown>
+
+            def forward(self, x: Tensor, y: Tensor):
+                return self.__loweredModule__.forward(x, y)
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+
+  File "<string>", line 5, in forward
                 typed_inputs: List[Any] = [x, y, ]
                 if self.__backend.is_available() :
                   _0, = self.__backend.execute(self.__handles["forward"], typed_inputs)
@@ -572,13 +590,19 @@ TEST(BackendTestDebugInfo, TestExceptionStackForCompilerWithLoweredSubModule) {
   c._save_for_mobile(ss, ExtraFilesMap(), true);
   auto c_loaded = _load_for_mobile(ss);
   std::string error_pattern = R"(
-  Module hierarchy:top(C)::<unknown>.A0(A)::forward.aten::add
+  Module hierarchy:top(C)::<unknown>.A0(A)::forward.__loweredModule__(A)::forward.aten::add
 Traceback of TorchScript (most recent call last):
   File "<string>", line 3, in <unknown>
 
     def forward(self, x, y):
       return self.A0.forward(x, y) + self.B0.forward(x)
              ~~~~~~~~~~~~~~~ <--- HERE
+
+  File "<string>", line 3, in forward
+
+            def forward(self, x: Tensor, y: Tensor):
+                return self.__loweredModule__.forward(x, y)
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
 
   File "<string>", line 5, in forward
                 typed_inputs: List[Any] = [x, y, ]
@@ -693,13 +717,19 @@ TEST(
    *
    *  */
   std::string error_pattern = R"(
-  Module hierarchy:top(C)::<unknown>.A0(A)::forward.AA0(AA)::forward.aten::add
+  Module hierarchy:top(C)::<unknown>.A0(A)::forward.__loweredModule__(A)::forward.AA0(AA)::forward.aten::add
 Traceback of TorchScript (most recent call last):
   File "<string>", line 3, in <unknown>
 
     def forward(self, x, y):
       return self.A0.forward(x, y) + self.B0.forward(x)
              ~~~~~~~~~~~~~~~ <--- HERE
+
+  File "<string>", line 3, in forward
+
+            def forward(self, x: Tensor, y: Tensor):
+                return self.__loweredModule__.forward(x, y)
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
 
   File "<string>", line 5, in forward
                 typed_inputs: List[Any] = [x, y, ]

--- a/test/jit/test_backends.py
+++ b/test/jit/test_backends.py
@@ -157,13 +157,13 @@ class BasicModuleTest(JitBackendTestCase):
         self.test_execution()
 
         # Save the compile spec to compare against the version retrieved after loading.
-        pre_compile_spec = self.lowered_module.__getattr__("__method_compile_spec")
+        pre_compile_spec = self.lowered_module.__getattr__("__loweredModule__").__getattr__("__method_compile_spec")
 
         # Save and load the lowered module.
         self.save_load()
 
         # Get the compile spec after loading.
-        post_compile_spec = self.lowered_module.__getattr__("__method_compile_spec")
+        post_compile_spec = self.lowered_module.__getattr__("__loweredModule__").__getattr__("__method_compile_spec")
 
         # Compile specs should match.
         self.assertEqual(pre_compile_spec, post_compile_spec)
@@ -345,51 +345,51 @@ class SelectiveLoweringTest(JitBackendTestCase):
         FileCheck() \
             .check("OuterModule") \
             .check_not("__torch__.torch.classes.__backends__.test_backend") \
-            .check("LoweredModule.test_backend") \
+            .check("LoweredWrapper.test_backend") \
             .run(self.lowered_module.graph)
 
         # Check that self.lowered_module.sub1/sub2 were not lowered but that BasicModule has been replaced in their graphs.
         FileCheck() \
             .check("MiddleModule") \
             .check("BasicModule") \
-            .check_not("LoweredModule.test_backend") \
+            .check_not("LoweredWrapper.test_backend") \
             .run(self.scripted_module.sub1.graph)
         FileCheck() \
             .check("MiddleModule") \
             .check_not("__torch__.torch.classes.__backends__.test_backend") \
-            .check("LoweredModule.test_backend") \
+            .check("LoweredWrapper.test_backend") \
             .run(self.lowered_module.sub1.graph)
 
         FileCheck() \
             .check("MiddleModule") \
             .check("BasicModule") \
-            .check_not("LoweredModule.test_backend") \
+            .check_not("LoweredWrapper.test_backend") \
             .run(self.scripted_module.sub2.graph)
         FileCheck() \
             .check("MiddleModule") \
             .check_not("__torch__.torch.classes.__backends__.test_backend") \
-            .check("LoweredModule.test_backend") \
+            .check("LoweredWrapper.test_backend") \
             .run(self.lowered_module.sub2.graph)
 
-        # Check that self.lowered_module.sub1/sub2.submodule were lowered. Its graph should mention
-        # __torch__.torch.classes.__backends__.test_backend, the TorchBind class for executing functions
-        # on the test JIT backend.
+        # Check that self.lowered_module.sub1/sub2.submodule were lowered. They should have a new attribute
+        # __loweredModule__ whose graph should mention __torch__.torch.classes.__backends__.test_backend,
+        # the TorchBind class for executing functions on the test JIT backend.
         FileCheck() \
             .check("LoweredModule.test_backend") \
             .check("__torch__.torch.classes.__backends__.test_backend") \
-            .run(self.lowered_module.sub1.submodule.graph)
+            .run(self.lowered_module.sub1.submodule.__loweredModule__.graph)
 
         FileCheck() \
             .check("LoweredModule.test_backend") \
             .check("__torch__.torch.classes.__backends__.test_backend") \
-            .run(self.lowered_module.sub2.submodule.graph)
+            .run(self.lowered_module.sub2.submodule.__loweredModule__.graph)
 
         # Check that self.other and self.other.submodule have been left untouched by the selective lowering process.
         FileCheck() \
             .check("MiddleModule") \
             .check("BasicModule") \
             .check_not("__torch__.torch.classes.__backends__.test_backend") \
-            .check_not("LoweredModule.test_backend") \
+            .check_not("LoweredWrapper.test_backend") \
             .run(self.scripted_module.other.graph)
         FileCheck() \
             .check("BasicModule") \
@@ -748,3 +748,31 @@ class CompModuleTestSameNameWithCompiler(JitBackendTestCase):
         s = 3
         # Test forward.
         self.check_function("forward", (a, b, s))
+
+class AddedAttributesTest(JitBackendTestCase):
+    """
+    Tests for adding attributes to a model after lowering.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Create Python, JIT and backend versions of BasicModule.
+        self.module = BasicModule()
+        self.scripted_module = torch.jit.script(BasicModule())
+        self.lowered_module = to_test_backend_multi(
+            self.scripted_module,
+            {"accum": {"": ""}, "sub_accum": {"": ""}, "forward": {"": ""}},
+        )
+
+    def test_attribute(self):
+        input = [(torch.ones(5),)]
+        pre_bundled = self.lowered_module(*input[0])
+        # Attach bundled inputs which adds several attributes and functions to the model
+        self.lowered_module = torch.utils.bundled_inputs.augment_model_with_bundled_inputs(lowered_module, input)
+        post_bundled = self.lowered_module(*self.lowered_module.get_all_bundled_inputs()[0])
+        # Save and load the lowered module.
+        self.save_load()
+        # Use bundled after save and load to prove its preserved
+        post_load = self.lowered_module(*self.lowered_module.get_all_bundled_inputs()[0])
+        self.assertEqual(pre_bundled, post_bundled)
+        self.assertEqual(post_bundled, post_load)


### PR DESCRIPTION
Summary:
Problem: _jit_to_backend overrides get/set state. This means any attributes added to the module after lowering will not be preserved after serialization. For edge workflows the biggest problem here is it breaks bundled_inputs.
Solution?:
Real quick and easy way to handle issues with to_backend overriding get/set state. Wraps the lowered module in another module and has forwarding functions for the api specified in 'method_compile_spec'.
The tradeoff with this approach is now the actual workhorse of the module is 1 layer deep which might make debugging slightly grosser/more difficult/confusing. The other approach Martin David and I talked about would be to only lower the portions that require custom get/set state logic. This leaves the top level the same, and only specific backened internals are changed. Personally I'm not sure how much that really addresses the debugging concern all that well. It seems like if you cracked the model open you'd still run into similar amounts of confusion with a lot of the variables and logic referenced coming from another module.
The other concern with this approach is whether or not 'compile_spec' specifies the public api of the module (since thats our source of truth for this wrapper). While it may not be enforced, it certainly seems to be true by convention and the to_backend api already uses it as a source of truth for all functions that get generated in the resulting module. I say we just formally commit to this (compile spec keys being functions) being the contract of the api instead of just assuming it to be the case and then having weird behavior if its not.

Test Plan:
TODO unit test

CI to check for existing behavior and contracts.

manually tested in a notebook with bundled inputs.

{P475790313}

Differential Revision: D33694257

