### PR TITLE
[ONNX] Minor doc update (#69501)

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -583,10 +583,24 @@ Q: Are lists of Tensors exportable to ONNX?
   Yes, for ``opset_version`` >= 11, since ONNX introduced the Sequence type in opset 11.
 
 
+Contributing / developing
+-------------------------
+`Developer docs <https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter>`_.
+
 Functions
---------------------------
+---------
 .. autofunction:: export
 .. autofunction:: export_to_pretty_string
 .. autofunction:: register_custom_op_symbolic
 .. autofunction:: select_model_mode_for_export
 .. autofunction:: is_in_onnx_export
+
+Classes
+-------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    SymbolicContext

--- a/torch/onnx/README.md
+++ b/torch/onnx/README.md
@@ -1,0 +1,7 @@
+# torch.onnx
+
+Torch->ONNX converter / exporter.
+
+[User-facing docs](https://pytorch.org/docs/master/onnx.html).
+
+[Developer docs](https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter).


### PR DESCRIPTION
Fix the wiki URL.

Also minor reorganization in onnx.rst.

[ONNX] restore documentation of public functions (#69623)

The build-docs check requires all public functions to be documented.
These should really not be public, but we'll fix that later.'
