### PR TITLE
[ONNX] Update opset_version restriction for local function

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -627,7 +627,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         # verify that the model state is preserved
         self.assertEqual(model.training, old_state)
 
-    @skipIfUnsupportedMinOpsetVersion(12)
+    @skipIfUnsupportedMinOpsetVersion(15)
     def test_local_function(self):
         class N(torch.nn.Module):
             def __init__(self, prob):
@@ -717,6 +717,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         funcs = onnx_model.functions
         self.assertEqual(len(funcs), 3)
 
+    @skipIfUnsupportedMinOpsetVersion(15)
     def test_local_function_overloads(self):
         class NWithOverloads(torch.nn.Module):
             def forward(self, x, y=None, z=None):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -286,10 +286,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1. Only custom opset domain name and version should be
             indicated through this argument.
-
-        export_modules_as_functions (bool or set of str, type or nn.Module, default False): Flag to enable
+        export_modules_as_functions (bool or set of type of nn.Module, default False): Flag to enable
             exporting all ``nn.Module`` forward calls as local functions in ONNX. Or a set to indicate the
-            particular modules to export as local functions in ONNX.
+            particular types of modules to export as local functions in ONNX.
             This feature requires ``opset_version`` >= 15, otherwise the export will fail. This is because
             ``opset_version`` < 15 implies IR version < 8, which means no local function support.
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -290,8 +290,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         export_modules_as_functions (bool or set of str, type or nn.Module, default False): Flag to enable
             exporting all ``nn.Module`` forward calls as local functions in ONNX. Or a set to indicate the
             particular modules to export as local functions in ONNX.
-            This feature requires ``opset_version`` >= 15, otherwise this argument will be ignored and the
-            behavior will be equivalent to setting this argument to False.
+            This feature requires ``opset_version`` >= 15, otherwise the export will fail. This is because
+            ``opset_version`` < 15 implies IR version < 8, which means no local function support.
 
             * ``False``(default): export ``nn.Module`` forward calls as fine grained nodes.
             * ``True``: export all ``nn.Module`` forward calls as local function nodes.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -286,6 +286,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
             the opset version is set to 1. Only custom opset domain name and version should be
             indicated through this argument.
+
         export_modules_as_functions (bool or set of type of nn.Module, default False): Flag to enable
             exporting all ``nn.Module`` forward calls as local functions in ONNX. Or a set to indicate the
             particular types of modules to export as local functions in ONNX.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -290,6 +290,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
         export_modules_as_functions (bool or set of str, type or nn.Module, default False): Flag to enable
             exporting all ``nn.Module`` forward calls as local functions in ONNX. Or a set to indicate the
             particular modules to export as local functions in ONNX.
+            This feature requires ``opset_version`` >= 15, otherwise this argument will be ignored and the
+            behavior will be equivalent to setting this argument to False.
 
             * ``False``(default): export ``nn.Module`` forward calls as fine grained nodes.
             * ``True``: export all ``nn.Module`` forward calls as local function nodes.

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -662,9 +662,9 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             onnx_shape_inference=True, export_modules_as_functions=False):
 
     if export_modules_as_functions is not False and opset_version < 15:
-        warnings.warn("`export_modules_as_functions` is ignored and the behavior is equivalent to setting "
-                      " this argument to False. This feature requires `opset_version` >= 15. ")
-        export_modules_as_functions = False
+        raise ValueError("`export_modules_as_functions` is not supported for `opset_version` < 15."
+                         "This is because `opset_version` < 15 implies IR version < 8, which means "
+                         "no local function support. ")
     export_modules_as_functions = _setup_trace_module_map(model, export_modules_as_functions)
 
     if isinstance(model, torch.nn.DataParallel):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -661,7 +661,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
             onnx_shape_inference=True, export_modules_as_functions=False):
 
-    if export_modules_as_functions is not False and opset_version < 15:
+    if export_modules_as_functions and opset_version < 15:
         raise ValueError("`export_modules_as_functions` is not supported for `opset_version` < 15."
                          "This is because `opset_version` < 15 implies IR version < 8, which means "
                          "no local function support. ")

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -661,6 +661,10 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             fixed_batch_size=False, custom_opsets=None, add_node_names=True,
             onnx_shape_inference=True, export_modules_as_functions=False):
 
+    if export_modules_as_functions is not False and opset_version < 15:
+        warnings.warn("`export_modules_as_functions` is ignored and the behavior is equivalent to setting "
+                      " this argument to False. This feature requires `opset_version` >= 15. ")
+        export_modules_as_functions = False
     export_modules_as_functions = _setup_trace_module_map(model, export_modules_as_functions)
 
     if isinstance(model, torch.nn.DataParallel):


### PR DESCRIPTION
Export should fail if export_modules_as_functions is set and opset_version<15.
This is because opeset_version < 15 implies IR version < 8, which means no local function support.