### PR TITLE
fixing stride order for expanded tensor

### DIFF
--- a/aten/src/ATen/core/tensor_type.cpp
+++ b/aten/src/ATen/core/tensor_type.cpp
@@ -140,7 +140,7 @@ VaryingShape<Stride> TensorType::computeStrideProps(
     // case 1.b. short cut contiguous
     std::iota(stride_indices.rbegin(), stride_indices.rend(), 0);
   } else {
-    std::iota(stride_indices.begin(), stride_indices.end(), 0);
+    std::iota(stride_indices.rbegin(), stride_indices.rend(), 0);
     // case 2.
     //
     // For broadcasted dimension where stride is 0, we have to stick to

--- a/aten/src/ATen/test/stride_properties_test.cpp
+++ b/aten/src/ATen/test/stride_properties_test.cpp
@@ -67,3 +67,12 @@ TEST(StridePropertiesTest, ZeroStrideIndicesEagerConsistencyTest) {
     ref_iter++;
   }
 }
+
+TEST(StridePropertiesTest, ExpandedStrideIndicesTest) {
+  // NOLINTNEXTLINE(performance-for-range-copy)
+  Tensor t = at::rand({1});
+  // note: expand with dimension of size 1 is tricky as stride is different
+  // depending on the order of the unsqueezed dimension.
+  t = t.expand({4, 4, 4});
+  EXPECT_TRUE(CheckStrideIndices(t, at::MemoryFormat::Contiguous));
+}


### PR DESCRIPTION
The default initialization of stride order were not correct. This ended up with an expanded tensor showing wrong stride, since stride 0 is ignored by TensorIterator stride computation logic [Computing output strides].

Quick fix with cpp tests as well.

Note that things still look strange when we expand from a rank 1 size 1 tensor, as that gives us inconsistent strides.
```
In [7]: x = torch.rand([1])

In [8]: x.expand(1, 1, 4, 4).stride()
Out[8]: (0, 0, 0, 0)

In [9]: x.expand(4, 4, 1, 1).stride()
Out[9]: (0, 0, 1, 1)

In [10]: x.expand(4, 1, 4, 1).stride()
Out[10]: (0, 0, 0, 1)
```

Meanwhile, scalar tensor seems to work fine.
```
In [2]: x = torch.tensor(1.0)

In [3]: x.expand(4, 1, 1, 4).stride()
Out[3]: (0, 0, 0, 0)

In [4]: x.expand(4, 1, 4, 1).stride()
Out[4]: (0, 0, 0, 0)

In [5]: x.expand(4, 4, 1, 1).stride()
Out[5]: (0, 0, 0, 0)

In [6]: x.expand(1, 1, 4, 4).stride()
Out[6]: (0, 0, 0, 0)
```