### PR TITLE
DOC: Initialize numpy compatibility note

### DIFF
--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -142,13 +142,13 @@ As a concrete example, consider the following snippet:
    >>> b_torch = torch.ones(3)
    >>> b_torch.dtype
    torch.float32
-   >>> torch.add(a_np, b_torch)
+   >>> torch.add(a_np, b_torch) # doctest: +SKIP
    Traceback (most recent call last):
    ...
    TypeError: add(): argument 'input' (position 1) must be Tensor, not numpy.ndarray
    >>> b_torch + a_np
    tensor([2., 2., 2.], dtype=torch.float64)
-   >>> a_np + b_torch
+   >>> a_np + b_torch # doctest: +SKIP
    Traceback (most recent call last):
    ...
    TypeError: Concatenation operation is not implemented for NumPy arrays, use np.concatenate() instead. Please do not rely on this error; it may not be given on all Python implementations.

--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -102,6 +102,22 @@ present / required, e.g. to generate visualizations, there is also the
         else:
             return torch_tensor.detach().numpy()
 
+For ``torch`` tensors which require gradients, they can still be manipulated as
+NumPy arrays within the ``no_grad()`` context manager.
+
+.. doctest::
+
+  >>> b_torch = torch.ones(3, requires_grad=True)
+  >>> b_torch.requires_grad == True
+  True
+  >>> b_torch.numpy() # doctest: +SKIP
+  Traceback (most recent call last):
+  ...
+  RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.
+  >>> with torch.no_grad():
+        print(b_torch.numpy())
+  [1. 1. 1.]
+
 Operations
 ----------
 

--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -1,0 +1,221 @@
+.. _numpy_compatibility:
+
+NumPy Compatibility
+=====================
+
+.. note::
+
+   **TL;DR:**
+
+   - Be explicit about obtaining and using NumPy arrays, or
+   - Avoid operators (``-``, ``+``, ``*``, ``/``) in favor of methods
+     (``np.subtract``, ``np.add``, ``np.multiply``, ``np.divide``)
+   - `This tutorial`_ shows a more concrete example of interoperability between
+     NumPy and PyTorch
+
+At the onset it should be stressed that PyTorch tensors and NumPy arrays are
+fundamentally different types. However, in the interests of being accessible to
+the wider scientific python ecosystem, there are implicit and explicit
+conversion methods. The major considerations to keep in mind are:
+
+- **Where** is the structure allocated?
+    * This may be on a compute device (e.g. a GPU) or the CPU
+- **What** is the underlying data?
+    * In particular, several functions will either return a copy or a view
+- **How** are modifications to the data handled?
+    * The data returned may be read-only, or may be writable
+
+From the end-user perspective, it is most desirable to have zero copy methods,
+however, for exploratory analyses and their visualizations in particular, it is
+often more important to have guaranteed conversions, even if copies are created.
+
+Basic interoperability
+------------------------
+
+NumPy arrays have no conception of the GPU, and so all conversions require a
+``cpu`` tensor. Similarly, the **computational graph** cannot be represented in
+```numpy``, and so the pre-requisite to have an operation or object without one,
+i.e. only leaf nodes are supported.
+
+.. code-block:: python
+
+   import torch
+   b_torch = torch.ones(3)
+   assert(b_torch.requires_grad == False)
+   assert(b_torch.is_cuda == False)
+   b_torch.numpy() # Fine, will work
+
+The interoperability guidelines places a strong emphasis on correctness over
+convenience. As the conversion to a NumPy array may potentially be a lossy
+operation (the computational graph), there are no inbuilt operations to do
+something which unconditionally returns a NumPy array.
+
+.. code-block:: python
+
+   # Never do this
+   def uncond_numpy(torch_tensor):
+        if torch_tensor.is_cuda:
+           warnings.warn("Moving back to CPU")
+           torch_tensor = torch_tensor.cpu()
+        if torch_tensor.requires_grad == False:
+            return torch_tensor.numpy()
+        else:
+            warnings.warn("Calling detach, probably lossy!")
+            return torch_tensor.detach().numpy()
+
+Operations
+------------
+
+All ``torch`` operators will helpfully fail with a ``TypeError`` if called with
+``numpy`` arrays. However, for **numpy methods**, using a ``torch.Tensor`` with
+an ``np.ndarray`` will return a ``torch.Tensor`` without creating any additional
+copies.
+
+ - Due to the :meth:`torch.Tensor.__array__()` implementation, a
+   ``np.ndarray`` which shares memory with the ``torch.Tensor`` is used for the
+   operation.
+ - The return type functionality is defined by
+   :meth:`torch.Tensor.__array_wrap__()`, and calls ``torch.from_numpy()``
+   internally.
+
+.. code-block:: python
+
+   import torch
+   import numpy as np
+   a_np = np.ones(3) # dtype=float64
+   b_torch = torch.ones(3) # dtype=float32
+   torch.add(a_np, b_torch) # TypeError
+   b_torch + a_np # TypeError
+   a_np + b_torch # OK but awkward
+   c_tmp = np.add(a_np, b_torch) # OK
+   # c_tmp.dtype is torch.float64
+
+Since the ``torch.Tensor`` methods will not work with ``np.ndarray`` objects, to
+prevent the apparent asymmetry of ``a_np * b_torch`` passing while ``b_torch *
+a_np`` fails, the user would **do best** to use NumPy functions instead:
+
+.. csv-table::
+   :header: Operator, NumPy Function, Description
+
+   "``+``", "``np.add()``", "Addition"
+   "``-``", "``np.subtract()``", "Subtraction"
+   "``*``", "``np.multiply()``", "Multiplication"
+   "``/``", "``np.divide()``", "Division"
+
+Conversions
+-------------
+
+Only a small subset of data type (``dtype``) objects defined in NumPy have an
+equivalent in PyTorch, namely:
+
+.. csv-table:: $ indicates the sizes supported, e.g. ``uint8``
+   :header: ``np.dtype``, ``torch.dtype``, sizes
+
+    "``bool_``", "``bool``", "N/A"
+    "``uint$``", "``uint$``", ":math:`8`"
+    "``int$``", "``int$``", ":math:`8, 16, 32, 64`"
+    "``float$``", "``float$``", ":math:`16, 32, 64`"
+    "``complex$``", "``complex$``", ":math:`64, 128`"
+
+.. warning::
+
+   The promotion and casting rules `of NumPy`_ differ from those `of PyTorch`_.
+
+To ``numpy``
+^^^^^^^^^^^^^
+
+The :meth:`torch.numpy()` method  and the :doc:`np.asarray()
+<numpy:reference/generated/numpy.asarray>` function returns a **view** of the
+underlying tensor as a ``np.ndarray`` object.
+
+.. code-block:: python
+
+    b_torch = torch.ones(3)
+    b_torch.numpy()[2] = 32
+    # b_torch is tensor([ 1.,  1., 32.])
+    a_np = np.array([1, 1, 32], dtype = np.float32)
+    np.array_equal(b_torch.numpy() == a_np) # True
+    c_tmp = np.asarray(b_torch, dtype = np.float32) # No copy if same dtype
+    # c_tmp is array([1., 1., 32.], dtype=float32)
+    c_tmp[2] = 1.
+    # b_torch is tensor([1., 1., 1.])
+
+.. note::
+
+   Since ``np.asarray()`` depends on the implementation of
+   ``torch.Tensor.__array__()`` which calls ``torch.numpy()``, the **leaf node**
+   requirement still needs to be satisfied by the user, i.e., ``requires_grad ==
+   False``
+
+From ``numpy``
+^^^^^^^^^^^^^^^^^
+
+To obtain a **view** of the data, :meth:`torch.from_numpy()` can be used.
+
+.. code-block:: python
+
+   import torch
+   import numpy as np
+   a_np = np.array([1, 2, 3], dtype = np.float64)
+   b_torch = torch.from_numpy(a_np)
+   # b_torch = torch.as_tensor(a_np) # see note
+   b_torch[2] = 23
+   assert(b_torch.numpy() == a_np) # True
+
+- :meth:`torch.from_numpy()` is guaranteed to share memory with NumPy.
+- :meth:`torch.as_tensor()` will try to stay away from copy operations, it
+  also has the effect of sharing memory. However, ``torch.as_tensor()`` has
+  slightly higher overhead as it checks and accepts other iteratable objects as
+  well, e.g. ``list`` objects.
+- :meth:`torch.from_dlpack()` called with a NumPy array as its argument will also generate a ``torch.Tensor`` view.
+
+To obtain a **copy** of the ``ndarray`` object, and not share memory, the
+:meth:`torch.tensor()` constructor accepts :meth:`np.ndarray` objects as a data
+source to construct and return a ``torch.Tensor``.
+
+.. note::
+
+   Recall that, if ``x`` is a tensor, ``torch.tensor(x)`` is equivalent to
+    ``x.clone().detach()``.
+
+.. code-block:: python
+
+   import torch
+   import numpy as np
+   a_np = np.array([1, 2, 3], dtype = np.float64)
+   b_torch = torch.tensor(a_np)
+   # b_torch.dtype is torch.float64
+   b_torch[2] = 23
+   assert(b_torch.numpy() == a_np) # Will fail
+
+Special considerations apply when calling NumPy functions on PyTorch tensors.
+Where possible, the equivalent PyTorch function is called.
+
+.. note::
+
+   This is due to the fact that ``torch.Tensor.__array_priority__`` is higher
+   than the NumPy default of ``0``.
+
+Indexing
+^^^^^^^^^^^^
+
+For the most part, both simple and "fancy" indexing work as expected. Edge cases
+are enumerated here.
+
+Negative strides
+~~~~~~~~~~~~~~~~~
+
+NumPy arrays may have negative strides, which is not true for PyTorch tensors.
+
+.. code-block:: python
+
+   import torch
+   import numpy as np
+   a_np = np.array([1, 2, 3])
+   b_torch = torch.from_numpy(a_np[::-1]) # Error
+   b_torch = torch.from_numpy(a_np[::-1].copy()) # Works
+   b_torch = torch.from_numpy(np.ascontiguousarray(a_np[::-1])) # Works
+
+.. _`of Numpy`: https://numpy.org/devdocs/reference/generated/numpy.promote_types.html#numpy.promote_types
+.. _`of PyTorch`: https://pytorch.org/docs/stable/tensor_attributes.html
+.. _`This tutorial`: https://pytorch.org/tutorials/advanced/numpy_extensions_tutorial.html

--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -1,15 +1,18 @@
 .. _numpy_compatibility:
 
+.. testsetup:: *
+
+   import numpy as np
+   import torch
+
 NumPy Compatibility
-=====================
+===================
 
 .. note::
 
    **TL;DR:**
 
-   - Be explicit about obtaining and using NumPy arrays, or
-   - Avoid operators (``-``, ``+``, ``*``, ``/``) in favor of methods
-     (``np.subtract``, ``np.add``, ``np.multiply``, ``np.divide``)
+   - Be explicit about obtaining and using NumPy arrays
    - `This tutorial`_ shows a more concrete example of interoperability between
      NumPy and PyTorch
 
@@ -30,44 +33,43 @@ however, for exploratory analyses and their visualizations in particular, it is
 often more important to have guaranteed conversions, even if copies are created.
 
 Basic interoperability
-------------------------
+----------------------
 
 NumPy arrays have no conception of the GPU, and so all conversions require a
 ``cpu`` tensor. Similarly, the **computational graph** cannot be represented in
 ```numpy``, and so the pre-requisite to have an operation or object without one,
 i.e. only leaf nodes are supported.
 
-.. code-block:: python
+.. doctest::
 
-   import torch
-   b_torch = torch.ones(3)
-   assert(b_torch.requires_grad == False)
-   assert(b_torch.is_cuda == False)
-   b_torch.numpy() # Fine, will work
+   >>> b_torch = torch.ones(3)
+   >>> assert(b_torch.requires_grad == False)
+   >>> assert(b_torch.is_cuda == False)
+   >>> b_torch.numpy()
+   array([1., 1., 1.], dtype=float32)
 
-The interoperability guidelines places a strong emphasis on correctness over
-convenience. As the conversion to a NumPy array may potentially be a lossy
+PyTorch will raise exceptions instead of allowing operations that may lead to
+incorrect results. As the conversion to a NumPy array may potentially be a lossy
 operation (the computational graph), there are no inbuilt operations to do
-something which unconditionally returns a NumPy array.
+something which unconditionally returns a NumPy array. Practically speaking, a
+function can be created locally to return a NumPy array, for say, visualizations.
 
 .. code-block:: python
 
-   # Never do this
+   # Possibly lossy function for visualizations
    def uncond_numpy(torch_tensor):
         if torch_tensor.is_cuda:
-           warnings.warn("Moving back to CPU")
            torch_tensor = torch_tensor.cpu()
         if torch_tensor.requires_grad == False:
             return torch_tensor.numpy()
         else:
-            warnings.warn("Calling detach, probably lossy!")
             return torch_tensor.detach().numpy()
 
 Operations
-------------
+----------
 
 All ``torch`` operators will helpfully fail with a ``TypeError`` if called with
-``numpy`` arrays. However, for **numpy methods**, using a ``torch.Tensor`` with
+``numpy`` arrays. However, for **numpy functions**, using a ``torch.Tensor`` with
 an ``np.ndarray`` will return a ``torch.Tensor`` without creating any additional
 copies.
 
@@ -78,21 +80,27 @@ copies.
    :meth:`torch.Tensor.__array_wrap__()`, and calls ``torch.from_numpy()``
    internally.
 
-.. code-block:: python
+.. doctest::
 
-   import torch
-   import numpy as np
-   a_np = np.ones(3) # dtype=float64
-   b_torch = torch.ones(3) # dtype=float32
-   torch.add(a_np, b_torch) # TypeError
-   b_torch + a_np # TypeError
-   a_np + b_torch # OK but awkward
-   c_tmp = np.add(a_np, b_torch) # OK
-   # c_tmp.dtype is torch.float64
+   >>> a_np = np.ones(3) # dtype=float64
+   >>> b_torch = torch.ones(3) # dtype=float32
+   >>> torch.add(a_np, b_torch)
+   Traceback (most recent call last):
+   ...
+   TypeError: add(): argument 'input' (position 1) must be Tensor, not numpy.ndarray
+   >>> b_torch + a_np
+   tensor([2., 2., 2.], dtype=torch.float64)
+   >>> a_np + b_torch
+   Traceback (most recent call last):
+   ...
+   TypeError: Concatenation operation is not implemented for NumPy arrays, use np.concatenate() instead. Please do not rely on this error; it may not be given on all Python implementations.
+   >>> np.add(a_np, b_torch)
+   tensor([2., 2., 2.], dtype=torch.float64)
 
-Since the ``torch.Tensor`` methods will not work with ``np.ndarray`` objects, to
-prevent the apparent asymmetry of ``a_np * b_torch`` passing while ``b_torch *
-a_np`` fails, the user would **do best** to use NumPy functions instead:
+If it is absolutely necessary to write functions where the input objects are not
+unconditionally known to be either PyTorch tensors or NumPy arrays, it is
+possible to ensure operator functionality by using NumPy functions explicitly as
+they are more forgiving than their PyTorch equivalents.
 
 .. csv-table::
    :header: Operator, NumPy Function, Description
@@ -103,7 +111,7 @@ a_np`` fails, the user would **do best** to use NumPy functions instead:
    "``/``", "``np.divide()``", "Division"
 
 Conversions
--------------
+-----------
 
 Only a small subset of data type (``dtype``) objects defined in NumPy have an
 equivalent in PyTorch, namely:
@@ -117,28 +125,28 @@ equivalent in PyTorch, namely:
     "``float$``", "``float$``", ":math:`16, 32, 64`"
     "``complex$``", "``complex$``", ":math:`64, 128`"
 
-.. warning::
-
-   The promotion and casting rules `of NumPy`_ differ from those `of PyTorch`_.
-
 To ``numpy``
-^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 The :meth:`torch.numpy()` method  and the :doc:`np.asarray()
 <numpy:reference/generated/numpy.asarray>` function returns a **view** of the
 underlying tensor as a ``np.ndarray`` object.
 
-.. code-block:: python
+.. doctest::
 
-    b_torch = torch.ones(3)
-    b_torch.numpy()[2] = 32
-    # b_torch is tensor([ 1.,  1., 32.])
-    a_np = np.array([1, 1, 32], dtype = np.float32)
-    np.array_equal(b_torch.numpy() == a_np) # True
-    c_tmp = np.asarray(b_torch, dtype = np.float32) # No copy if same dtype
-    # c_tmp is array([1., 1., 32.], dtype=float32)
-    c_tmp[2] = 1.
-    # b_torch is tensor([1., 1., 1.])
+    >>> b_torch = torch.ones(3)
+    >>> b_torch.numpy()[2] = 32
+    >>> b_torch
+    tensor([ 1.,  1., 32.])
+    >>> a_np = np.array([1, 1, 32], dtype = np.float32)
+    >>> np.array_equal(b_torch.numpy(), a_np) # True
+    True
+    >>> c_tmp = np.asarray(b_torch, dtype = np.float32) # No copy if same dtype
+    >>> c_tmp
+    array([ 1.,  1., 32.], dtype=float32)
+    >>> c_tmp[2] = 1.
+    >>> b_torch
+    tensor([1., 1., 1.])
 
 .. note::
 
@@ -148,26 +156,28 @@ underlying tensor as a ``np.ndarray`` object.
    False``
 
 From ``numpy``
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 To obtain a **view** of the data, :meth:`torch.from_numpy()` can be used.
 
-.. code-block:: python
+.. doctest::
 
-   import torch
-   import numpy as np
-   a_np = np.array([1, 2, 3], dtype = np.float64)
-   b_torch = torch.from_numpy(a_np)
-   # b_torch = torch.as_tensor(a_np) # see note
-   b_torch[2] = 23
-   assert(b_torch.numpy() == a_np) # True
+   >>> a_np = np.array([1, 2, 3], dtype = np.float64)
+   >>> b_torch = torch.from_numpy(a_np)
+   >>> # b_torch = torch.as_tensor(a_np) # see note
+   >>> b_torch[2] = 23
+   >>> b_torch
+   tensor([ 1.,  2., 23.], dtype=torch.float64)
+   >>> np.array_equal(b_torch.numpy(), a_np)
+   True
 
 - :meth:`torch.from_numpy()` is guaranteed to share memory with NumPy.
 - :meth:`torch.as_tensor()` will try to stay away from copy operations, it
   also has the effect of sharing memory. However, ``torch.as_tensor()`` has
   slightly higher overhead as it checks and accepts other iteratable objects as
   well, e.g. ``list`` objects.
-- :meth:`torch.from_dlpack()` called with a NumPy array as its argument will also generate a ``torch.Tensor`` view.
+- :meth:`torch.from_dlpack()` called with a NumPy array (``np.version.version >=
+  1.20``) as its argument will also generate a ``torch.Tensor`` view.
 
 To obtain a **copy** of the ``ndarray`` object, and not share memory, the
 :meth:`torch.tensor()` constructor accepts :meth:`np.ndarray` objects as a data
@@ -178,15 +188,15 @@ source to construct and return a ``torch.Tensor``.
    Recall that, if ``x`` is a tensor, ``torch.tensor(x)`` is equivalent to
     ``x.clone().detach()``.
 
-.. code-block:: python
+.. doctest::
 
-   import torch
-   import numpy as np
-   a_np = np.array([1, 2, 3], dtype = np.float64)
-   b_torch = torch.tensor(a_np)
-   # b_torch.dtype is torch.float64
-   b_torch[2] = 23
-   assert(b_torch.numpy() == a_np) # Will fail
+   >>> a_np = np.array([1, 2, 3], dtype = np.float64)
+   >>> b_torch = torch.tensor(a_np)
+   >>> b_torch
+   tensor([1., 2., 3.], dtype=torch.float64)
+   >>> b_torch[2] = 23
+   >>> np.array_equal(b_torch.numpy(), a_np)
+   False
 
 Special considerations apply when calling NumPy functions on PyTorch tensors.
 Where possible, the equivalent PyTorch function is called.
@@ -197,25 +207,23 @@ Where possible, the equivalent PyTorch function is called.
    than the NumPy default of ``0``.
 
 Indexing
-^^^^^^^^^^^^
+^^^^^^^^
 
 For the most part, both simple and "fancy" indexing work as expected. Edge cases
 are enumerated here.
 
 Negative strides
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 NumPy arrays may have negative strides, which is not true for PyTorch tensors.
 
-.. code-block:: python
+.. doctest::
 
-   import torch
-   import numpy as np
-   a_np = np.array([1, 2, 3])
-   b_torch = torch.from_numpy(a_np[::-1]) # Error
-   b_torch = torch.from_numpy(a_np[::-1].copy()) # Works
-   b_torch = torch.from_numpy(np.ascontiguousarray(a_np[::-1])) # Works
+   >>> a_np = np.array([1, 2, 3])
+   >>> b_torch = torch.from_numpy(a_np[::-1]) # doctest: +SKIP
+   Traceback (most recent call last):
+   ...
+   ValueError: At least one stride in the given numpy array is negative, and tensors with negative strides are not currently supported. (You can probably work around this by making a copy of your array  with array.copy().)
+   >>> b_torch = torch.from_numpy(np.ascontiguousarray(a_np[::-1]))
 
-.. _`of Numpy`: https://numpy.org/devdocs/reference/generated/numpy.promote_types.html#numpy.promote_types
-.. _`of PyTorch`: https://pytorch.org/docs/stable/tensor_attributes.html
 .. _`This tutorial`: https://pytorch.org/tutorials/advanced/numpy_extensions_tutorial.html

--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -12,7 +12,8 @@ NumPy Compatibility
 
    **TL;DR:**
 
-   - Be explicit about obtaining and using NumPy arrays, ``.numpy()`` will always ensure valid arrays
+   - Be explicit about obtaining and using NumPy arrays, ``.numpy(force=True)``
+     will always ensure valid arrays [from ``1.12``]
    - `This tutorial`_ shows a more concrete example of interoperability between
      NumPy and PyTorch
 
@@ -83,13 +84,12 @@ existing object. We can obtain a **view** or interpretation of a Tensor from
 NumPy array as well.
 
 The conversion to a NumPy array may potentially be a lossy operation (the
-computational graph), and so there are also no inbuilt operations to
-unconditionally return a NumPy array. Practically speaking, a function can be
-created locally to return a NumPy array, for say, visualizations.
+computational graph). Where the user is certain that such information is not
+present / required, e.g. to generate visualizations, there is also the
+``torch.numpy(force=True)``, which is conceptually equivalent to:
 
 .. code-block:: python
 
-   # Possibly lossy function for visualizations
    def uncond_numpy(torch_tensor):
         if torch_tensor.device != torch.device(type="cpu"):
            torch_tensor = torch_tensor.cpu()
@@ -165,9 +165,11 @@ As a concrete example, consider the following snippet:
                     object is described in the `interoperability with NumPy`_ document.
 
 If it is absolutely necessary to write functions where the input objects are not
-unconditionally known to be either PyTorch tensors or NumPy arrays, it is
-possible to ensure operator functionality by using NumPy functions explicitly as
-they are more forgiving than their PyTorch equivalents.
+unconditionally known to be either PyTorch tensors or NumPy arrays, it is is
+**strongly recommended** to use the ``torch.numpy(force=True)`` method
+explicitly. As a less clear alternative, it is also possible to ensure operator
+functionality by using NumPy functions since these will coerce tensors without
+throwing errors.
 
 .. csv-table::
    :header: Operator, NumPy Function, Description

--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -219,7 +219,8 @@ Essentially these can be expressed as:
 
 The :meth:`torch.numpy()` method  and the :doc:`np.asarray()
 <numpy:reference/generated/numpy.asarray>` function returns a **view** of the
-underlying tensor as a ``np.ndarray`` object.
+underlying tensor as a ``np.ndarray`` object. This means that these are good way
+to call functions which accept NumPy arrays.
 
 .. doctest::
 
@@ -292,7 +293,7 @@ To obtain a **view** of the data, :meth:`torch.from_numpy()` can be used.
 - :meth:`torch.from_numpy()` is guaranteed to share memory with NumPy.
 - :meth:`torch.as_tensor()` will try to stay away from copy operations, it
   also has the effect of sharing memory. However, ``torch.as_tensor()`` has
-  slightly higher overhead as it checks and accepts other iteratable objects as
+  slightly higher overhead as it checks and accepts other iterable objects as
   well, e.g. ``list`` objects.
 - :meth:`torch.from_dlpack()` called with a NumPy array (``np.version.version >=
   1.20``) as its argument will also generate a ``torch.Tensor`` view.

--- a/docs/source/notes/numpy_compatibility.rst
+++ b/docs/source/notes/numpy_compatibility.rst
@@ -49,7 +49,7 @@ often more important to have guaranteed conversions, even if copies are created.
 
    Do not use ``id`` to check for shared memory, as ``id`` is a CPython only
    implementation detail guaranteed to be unique. Also, for larger arrays,
-   :ref:`np.shares_memory <numpy::std:doc:reference/generated/numpy.shares_memory>` can be slow.
+   ``np.shares_memory`` can be slow.
 
 Basic interoperability
 ----------------------


### PR DESCRIPTION
Fixes #48628, #46829. 

- [x] This will need to be revised when #59790 is merged in. 
-  [x] Will also need a minor adjustment (describing the order in which NumPy attempts to convert a foreign object, and the addition of a hyperlink to the NumPy interoperability doc) when https://github.com/numpy/numpy/pull/20185 is merged.

@rgommers 