### PR TITLE
Exit once there's an environment error

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/test_python.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python.bat
@@ -1,4 +1,11 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+:: exit the batch once there's an error
+if not errorlevel 0 (
+    echo "setup pytorch env failed"
+    echo %errorlevel%
+    exit /b
+)
+
 pushd test
 if "%RUN_SMOKE_TESTS_ONLY%"=="1" (
     :: Download specified test cases to run

--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -1,4 +1,10 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+:: exit the batch once there's an error
+if not errorlevel 0 (
+    echo "setup pytorch env failed"
+    echo %errorlevel%
+    exit /b
+)
 
 pushd test
 

--- a/.jenkins/pytorch/win-test-helpers/test_python_second_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_second_shard.bat
@@ -1,4 +1,10 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+:: exit the batch once there's an error
+if not errorlevel 0 (
+    echo "setup pytorch env failed"
+    echo %errorlevel%
+    exit /b
+)
 
 echo Copying over test times file
 copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"


### PR DESCRIPTION
Narrow the scope of #69730.
Once there's an error, stop the script.
Since it's a random error, it most likely has something with the environment.

Let's see the stat.
