### PR TITLE
missing reference to typing-extensions in libtorch docs

### DIFF
--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -46,4 +46,4 @@ You can build C++ libtorch.so directly with cmake.  For example, to build a Rele
    cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DPYTHON_EXECUTABLE:PATH=`which python3` -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
    cmake --build . --target install
 
-To use release branch v1.6.0, for example, replace ``master`` with ``v1.6.0``.  You will get errors if you do not have needed dependencies such as Python3's PyYAML package.
+To use release branch v1.6.0, for example, replace ``master`` with ``v1.6.0``.  You will get errors if you do not have needed dependencies such as Python3's PyYAML package, or `typing-extensions`.


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
