### PR TITLE
[WIP] [ONNX] Enable symbolic shape inference from ONNX to simplify current shape inference

### DIFF
--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -205,6 +205,22 @@ c10::optional<c10::SymbolicShape> ConstantValueMap::GetShapeValue(
   return ConstantValueMap::getInstance().shapeValueMap[tensorName];
 }
 
+std::unordered_map<std::string, ::ONNX_NAMESPACE::TensorShapeProto> ConstantValueMap::GetGeneratedShape() {
+  return ConstantValueMap::getInstance().generatedShapeDataByName;
+}
+
+void ConstantValueMap::SetGeneratedShape(std::unordered_map<std::string, ::ONNX_NAMESPACE::TensorShapeProto> generated_shape) {
+  ConstantValueMap::getInstance().generatedShapeDataByName = generated_shape;
+}
+
+SymbolDimMap& ConstantValueMap::GetSymbolMap() {
+  return ConstantValueMap::getInstance().symbolMap;
+}
+
+void ConstantValueMap::SetSymbolMap(SymbolDimMap symbol_map) {
+  ConstantValueMap::getInstance().symbolMap = symbol_map;
+}
+
 template <typename Map>
 void UpdateStrKey(
     Map& map,
@@ -236,6 +252,8 @@ void ConstantValueMap::UpdateValueName(
       ConstantValueMap::getInstance().useInferredTypeMap, old_name, new_name);
   UpdateStrKey<decltype(shapeValueMap)>(
       ConstantValueMap::getInstance().shapeValueMap, old_name, new_name);
+  UpdateStrKey<decltype(generatedShapeDataByName)>(
+      ConstantValueMap::getInstance().generatedShapeDataByName, old_name, new_name);
 }
 
 void ConstantValueMap::ClearMaps() {
@@ -245,6 +263,8 @@ void ConstantValueMap::ClearMaps() {
   ConstantValueMap::getInstance().typeReliableMap.clear();
   ConstantValueMap::getInstance().useInferredTypeMap.clear();
   ConstantValueMap::getInstance().shapeValueMap.clear();
+  ConstantValueMap::getInstance().generatedShapeDataByName.clear();
+  ConstantValueMap::getInstance().symbolMap.clear();
 }
 
 // For debug only.

--- a/torch/csrc/jit/passes/onnx/constant_map.h
+++ b/torch/csrc/jit/passes/onnx/constant_map.h
@@ -3,6 +3,8 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <mutex>
 #include <unordered_map>
+#include <onnx/shape_inference/implementation.h>
+#include <torch/csrc/jit/serialization/export.h>
 
 namespace torch {
 namespace jit {
@@ -10,6 +12,11 @@ namespace jit {
 class ConstantValueMap {
  public:
   static ConstantValueMap& getInstance();
+  static std::unordered_map<std::string, ::ONNX_NAMESPACE::TensorShapeProto> GetGeneratedShape();
+  static void SetGeneratedShape(std::unordered_map<std::string, ::ONNX_NAMESPACE::TensorShapeProto> generated_shape);
+
+  static SymbolDimMap& GetSymbolMap();
+  static void SetSymbolMap(SymbolDimMap symbol_map);
 
   static void SetRank(const std::string& tensorName, size_t rankValue);
   static bool HasRank(const std::string& tensorName);
@@ -81,6 +88,8 @@ class ConstantValueMap {
   // from a node. shapeValueMap stores the value of the tensor from a node when
   // this tensor represents a shape.
   std::unordered_map<std::string, c10::SymbolicShape> shapeValueMap;
+  std::unordered_map<std::string, ::ONNX_NAMESPACE::TensorShapeProto> generatedShapeDataByName;
+  SymbolDimMap symbolMap;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1054,7 +1054,6 @@ void ProcessReshapeNode(Node* n, int opset_version) {
 
   if (ConstantValueMap::HasShapeValue(n->input(1)->debugName()) &&
       ConstantValueMap::HasShape(n->input(0)->debugName())) {
-        ConstantValueMap::PrintMaps();
     auto shape_vector_0 =
         ConstantValueMap::GetShape(n->input(0)->debugName()).value();
     auto shape_vector_1 =

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -2065,7 +2065,7 @@ void ONNXShapeTypeInference(
 
     std::vector<string> original_keys;
     for (auto gs: generated_shape) {
-      if (outputs_map.count(gs.first) > 0) { 
+      if (outputs_map.count(gs.first) > 0) {
         generated_shape[outputs_map[gs.first]] = gs.second;
         if (gs.first != outputs_map[gs.first]) {
           original_keys.push_back(gs.first);
@@ -2136,8 +2136,8 @@ void ONNXShapeTypeInference(
       generated_shape.erase(outputs_map[output->debugName()]);
     }
   }
-  ConstantValueMap::SetGeneratedShape(generated_shape);  
-  
+  ConstantValueMap::SetGeneratedShape(generated_shape);
+
   if (IsValidONNXNode(n)) {
     ProcessConstantValueMap(n, opset_version);
     if (n->kind() != prim::ListConstruct) {


### PR DESCRIPTION
**Description**
*Please note that this PR is still proof-of-concept. Any feedback is welcome.
- Obtain the result (generatedShapeDataByName) from onnx::shape_inference::InferShapesAndDataPropagation. If PyTorch cannot consume latest ONNX shortly, we can still use ONNX node-level shape inference here to obtain those symbolic shape inference data. To keep this POC PR simple, use `onnx::shape_inference::InferShapesAndDataPropagation` here for now
- (WIP) First utilize it with Shape op. In some test cases, the symbolic shape from Shape op  can be correctly obtained. I am still working on the rest of test failures.
- Next step -- try to utilize it with more ops.

ONNX symbolic shape inference support is limited now. Here are the supported ops:
- Shape
- Reshape
- Squeeze
- Unsqueeze
- Cast
- Add
- Sub
- Mul
- Gather
- Slice
- Concat

Will focus on enabling these ops in the exporter first. In the future we can enable more ops in ONNX and then utilize them in the exporter.

**Motivation**
ONNX has introduced symbolic shape inference as [data propagation](https://github.com/onnx/onnx/blob/master/docs/proposals/SymbolicShapeInfProposal.md) since recent ONNX 1.10. This PR is trying to enable symbolic shape inference from ONNX to simplify current shape inference.

BTW, currently the result of symbolic shape inference from ONNX is only used internally in ONNX graph-level shape inference. To make it be usable for others, this PR is needed: https://github.com/onnx/onnx/pull/3879. Also this one is needed: https://github.com/onnx/onnx/pull/3784
