### PR TITLE
[warning] Fix TORCH_INTERNAL_ASSERT calls missing condition to check

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -446,7 +446,7 @@ Tensor& add_relu_impl(
     max_val = std::numeric_limits<double>::max();
   } else {
     TORCH_INTERNAL_ASSERT(
-        "Unsupported datatype for add_relu:", self.dtype().name());
+        false, "Unsupported datatype for add_relu:", self.dtype().name());
   }
 
   result = iter.output();

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -959,6 +959,7 @@ class QEmbeddingBag final {
           false);
     } else {
       TORCH_INTERNAL_ASSERT(
+          false,
           "Currently only support 8-bit embedding_bag quantization");
     }
   }
@@ -995,6 +996,7 @@ class QEmbedding final {
           true);
     } else {
       TORCH_INTERNAL_ASSERT(
+          false,
           "Currently only support 8-bit embedding quantization");
     }
     return output;

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -166,7 +166,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
 
     if (is_per_channel && ukernel_type == pytorch_qnnp_ukernel_type_xzp_gemm) {
       TORCH_INTERNAL_ASSERT(
-          "Per channel quantized weights are not supported for XZP kernels");
+          false, "Per channel quantized weights are not supported for XZP kernels");
     }
 
     pytorch_qnnp_operator_t convolution{nullptr};
@@ -175,7 +175,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
         calloc(1, sizeof(struct pytorch_qnnp_operator)));
     if (convolution == nullptr) {
       TORCH_INTERNAL_ASSERT(
-          "failed to allocate %zu bytes for pytorch_qnnp_operator structure",
+          false, "failed to allocate %zu bytes for pytorch_qnnp_operator structure",
           sizeof(struct pytorch_qnnp_operator));
     }
 
@@ -449,7 +449,7 @@ C10_UNUSED std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scal
       weight_zp[i] = (uint8_t)(per_channel_zero_points[i] + 128);
     }
   } else {
-    TORCH_INTERNAL_ASSERT("Unsupported quantization scheme.");
+    TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
   }
   at:: Tensor weight_scales =
     at::empty(
@@ -470,7 +470,7 @@ C10_UNUSED std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scal
       weight_scales_data[i] = static_cast<float>(per_channel_scales[i]);
     }
   } else {
-    TORCH_INTERNAL_ASSERT("Unsupported quantization scheme.");
+    TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
   }
   for (const auto i : c10::irange(num_output_channels, num_output_channels_padded)) {
     weight_scales_data[i] = 1.f;

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -44,7 +44,7 @@ std::string opTypeToString(OpType opType) {
     case OpType::_REDUCE_SCATTER_BASE:
       return "_REDUCE_SCATTER_BASE";
     default:
-      TORCH_INTERNAL_ASSERT("Unknown op type!");
+      TORCH_INTERNAL_ASSERT(false, "Unknown op type!");
   }
   return "UNKNOWN";
 }

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -337,7 +337,8 @@ std::unordered_map<ParallelType, kir::IterDomain*, TypeHash> getParallelDomains(
   } else if (val->isA<kir::TensorIndex>()) {
     kir_tv = val->as<kir::TensorIndex>()->view();
   } else {
-    TORCH_INTERNAL_ASSERT("Provided val is not TensorIndex or TensorView.");
+    TORCH_INTERNAL_ASSERT(
+        false, "Provided val is not TensorIndex or TensorView.");
   }
 
   std::unordered_map<ParallelType, kir::IterDomain*, TypeHash> parallel_domains;

--- a/torch/csrc/jit/codegen/cuda/scheduler/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler/normalization.cpp
@@ -685,7 +685,7 @@ ReductionParams OuterPersistentHeuristic(
              max_input_dtype_size * 4 >
          scheduler_utils::register_file_size * 3) {
     if (bdimx == 1) {
-      TORCH_INTERNAL_ASSERT("Error generating persistent kernel.");
+      TORCH_INTERNAL_ASSERT(false, "Error generating persistent kernel.");
     }
     bdimx = ceilDiv(bdimx, 2);
   }


### PR DESCRIPTION
Summary:
This will fix a ton of broken asserts that should always fire but never actually fire.
All would have been caught with `-Wstring-conversion` warnings enabled.

Test Plan: CI Pass

Differential Revision: D33743605

