### PR TITLE
Add Third-Party Ruy Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,3 +145,6 @@
 [submodule "third_party/flatbuffers"]
 	path = third_party/flatbuffers
 	url = https://github.com/google/flatbuffers.git
+[submodule "third_party/ruy"]
+	path = third_party/ruy
+	url = https://github.com/google/ruy.git


### PR DESCRIPTION
Ruy will be used for quantized matmul support

Commit created with
` git submodule add https://github.com/google/ruy.git third_party/ruy`