### PR TITLE
Fix the numpy version to make it consistent with the benchmark repo.

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -36,7 +36,9 @@ jobs:
           # shellcheck disable=SC1091
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
-          conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
+          # The numpy version here must equal to the root requirements.txt in pytorch/benchmark
+          # Otherwise, the numpy used to build and run pytorch will disagree with their API versions
+          conda install -y numpy=1.21.0 requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"


### PR DESCRIPTION
During the AB-testing, the package `numpy` will be installed twice. The first time (https://github.com/pytorch/pytorch/blob/master/.github/workflows/run_torchbench.yml#L39) is to bootstrap the very first compilation of pytorch. The second time (https://github.com/pytorch/benchmark/blob/main/requirements.txt#L14) is installed as dependency of pytorch/benchmark.

Since they are installed from different sources (conda vs. pip), the API versions of two packages will conflict, and pytorch compiled against the conda version won't work with the pip package. Therefore, we hardcode the numpy version in conda to make it consistent with the numpy version in pytorch/benchmark requirements.txt.

RUN_TORCHBENCH: resnet18, resnet50
TORCHBENCH_BRANCH: wconstab/ltc