### PR TITLE
Fix symbolic shape function for `flatten`

### DIFF
--- a/torch/csrc/jit/runtime/shape_functions.h
+++ b/torch/csrc/jit/runtime/shape_functions.h
@@ -448,7 +448,7 @@ def flatten(input: List[int], start_dim: int, end_dim: int):
             out.append(elem)
         return out
     slice_numel = 1
-    for i in range(start_dim, end_dim - start_dim + 1):
+    for i in range(start_dim, end_dim + 1):
         slice_numel *= input[i]
     # TODO: use slicing when slice optimization has landed
     # slice_numel = multiply_integers(input[start_dim:end_dim - start_dim + 1])


### PR DESCRIPTION
Python `range` is (start,end) not (start, length). Sot it should be `for i in range(start_dim, end_dim + 1):` instead of `for i in range(start_dim, end_dim - start_dim + 1):`.

