### PR TITLE
CUDACachingAllocator: Keep one event queue per stream

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1275,11 +1275,11 @@ class DeviceCachingAllocator {
   void process_events() {
     insert_events_deferred_until_no_capture();
 
-    // Process outstanding cudaEvents. Events that are completed are removed
-    // from the queue, and the 'event_count' for the corresponding allocation
-    // is decremented. Stops at the first event which has not been completed.
-    // Since events on different devices or streams may occur out of order,
-    // the processing of some events may be delayed.
+    // Process outstanding cudaEvents. Events that are completed are
+    // removed from the queue, and the 'event_count' for the
+    // corresponding allocation is decremented. We maintain a separate
+    // list of events per stream to avoid head-of-line delays if one
+    // or more streams has long-running operations.
     for (auto it = cuda_events.begin(); it != cuda_events.end();) {
       while (!it->second.empty()) {
         auto& e = it->second.front();
@@ -1305,7 +1305,7 @@ class DeviceCachingAllocator {
       }
 
       // Copy the iterator and advance off because we may erase it if
-      // we clearted all the relevant events.
+      // we cleared all the events for this stream.
       auto candidate = it;
       it++;
 

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1303,13 +1303,10 @@ class DeviceCachingAllocator {
         it->second.pop_front();
       }
 
-      // Copy the iterator and advance off because we may erase it if
-      // we cleared all the events for this stream.
-      auto candidate = it;
-      it++;
-
-      if (candidate->second.empty()) {
-        cuda_events.erase(candidate);
+      if (it->second.empty()) {
+        it = cuda_events.erase(it);
+      } else {
+        it++;
       }
     }
   }


### PR DESCRIPTION
Fixes #71616

This fixes the leaks in my test case. I have not tested it on our big models yet, but will report back if we can.

This potentially impacts allocator performance in that it slightly increases the amount of CPU memory we allocate for data structures, and it means that `process_events` may look at a larger number of events in the case where there are multiple streams with long-running ops on them.

However, I suspect that in general, either:
- An application isn't using very many streams or very many long-running ops, in which case the performance is essentially the same
- Or, they are, which is precisely the case where #71616 bites you, and so freeing memory faster is probably more valuable than the slight CPU overhead here.

I'm not attached to this approach or any of its details, but figured it was worth throwing up for discussion.