### PR TITLE
Release GIL when assigning to real or imag components

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1061,9 +1061,13 @@ int THPVariable_set_real(THPVariable *self, THPVariable *real, void *unused)
 {
   HANDLE_TH_ERRORS
   auto& self_ = THPVariable_Unpack(self);
-  auto self_real = at::real(self_);
-  self_real.copy_(THPVariable_Unpack(real));
-  return 0;
+  auto& real_ = THPVariable_Unpack(real);
+  {
+    pybind11::gil_scoped_release no_gil;
+    auto self_real = at::real(self_);
+    self_real.copy_(real_);
+    return 0;
+  }
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 
@@ -1071,9 +1075,13 @@ int THPVariable_set_imag(THPVariable* self, THPVariable *imag, void *unused)
 {
   HANDLE_TH_ERRORS
   auto& self_ = THPVariable_Unpack(self);
-  auto self_imag = at::imag(self_);
-  self_imag.copy_(THPVariable_Unpack(imag));
-  return 0;
+  auto& imag_ = THPVariable_Unpack(imag);
+  {
+    pybind11::gil_scoped_release no_gil;
+    auto self_imag = at::imag(self_);
+    self_imag.copy_(imag_);
+    return 0;
+  }
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #71747
* #71728

The getter is trivial as it's just creating a view tensor, but the
setter is actually copying data so does call into kernel code.

Differential Revision: [D33770046](https://our.internmc.facebook.com/intern/diff/D33770046)