### PR TITLE
Replace LOG by LOG_EVERY_N to avoid log spamming

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -8,6 +8,7 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/StreamGuard.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
 #include <c10/util/hash.h>
 #include <c10/util/irange.h>
 #include <c10d/comm.hpp>

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -365,7 +365,7 @@ void Reducer::mark_variable_ready_dense(size_t variable_index) {
             // themselves in order to compute higher order derivatives. However,
             // DDP will not sync up these gradients currently (see
             // https://github.com/pytorch/pytorch/issues/63812).
-            LOG(WARNING)
+            LOG_EVERY_N(WARNING, 1000)
                 << "Using DistributedDataParallel with create_graph=True "
                 << " is not well-supported. The higher-order gradient will "
                 << " not be synchronized across ranks, and backpropagation "

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -366,7 +366,7 @@ void Reducer::mark_variable_ready_dense(size_t variable_index) {
             // themselves in order to compute higher order derivatives. However,
             // DDP will not sync up these gradients currently (see
             // https://github.com/pytorch/pytorch/issues/63812).
-            LOG_EVERY_N(WARNING, 1000)
+            C10_LOG_EVERY_N(WARNING, 1000)
                 << "Using DistributedDataParallel with create_graph=True "
                 << " is not well-supported. The higher-order gradient will "
                 << " not be synchronized across ranks, and backpropagation "


### PR DESCRIPTION
The warning in DDP can cause log spamming. Suggest printing this warning every N times instead.
