### PR TITLE
[warning] Fix TORCH_INTERNAL_ASSERT calls missing condition to check 2/x

### DIFF
--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -325,6 +325,7 @@ Node* insertEmbeddingBagOps(Node* observer, const std::string& op_name) {
     quant_fn = "quantized::embedding_bag_byte_rowwise_offsets";
   } else {
     TORCH_INTERNAL_ASSERT(
+        false,
         "Graph Mode Quantization currently supports 4-bit and 8-bit embedding bag quantization.");
   }
 

--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -516,22 +516,22 @@ script::Module optimizeForMobile(
 
 void insertPrePackedOps(std::shared_ptr<Graph>& graph) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 void insertPrePackedOps(script::Module& module) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 void fusePrePackedLinearConvWithClamp(script::Module& module) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 void FoldPrePackingOps(script::Module& m) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 script::Module optimizeForMobile(
@@ -539,6 +539,7 @@ script::Module optimizeForMobile(
     const std::set<MobileOptimizerType>& blocklist,
     const std::vector<std::string>& preserved_methods) {
   TORCH_INTERNAL_ASSERT(
+      false,
       "Mobile optimization only available with XNNPACK at the moment. "
       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
   return module;

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -792,7 +792,7 @@ void GraphExecutor::debugFlushCompilationCache() {
     ppImpl->debugFlushCompilationCache();
   } else {
     // we are deprecating legacy executor
-    TORCH_INTERNAL_ASSERT("Not Implemented for Legacy Executor");
+    TORCH_INTERNAL_ASSERT(false, "Not Implemented for Legacy Executor");
   }
 }
 

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -196,7 +196,8 @@ IValue tensorToListRecursive(
     } else if (inner_result.isBool()) {
       result.emplace_back(inner_result.toBool());
     } else {
-      TORCH_INTERNAL_ASSERT("Unknown return type for tensorToListRecursive");
+      TORCH_INTERNAL_ASSERT(
+          false, "Unknown return type for tensorToListRecursive");
     }
 
     data += strides[cur_dim] * element_size;


### PR DESCRIPTION
Summary:
This will fix a ton of broken asserts that should always fire but never actually fire.
All would have been caught with `-Wstring-conversion` warnings enabled.

Test Plan: CI Pass

Differential Revision: D33754170

