### PR TITLE
[warning] Disable broken assert

### DIFF
--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -435,7 +435,9 @@ void Module::train(bool on) {
     if (auto slot = m._ivalue()->type()->findAttributeSlot("training")) {
       m._ivalue()->setSlot(*slot, on);
     } else {
-      TORCH_INTERNAL_ASSERT("'training' attribute not found");
+      // FIXME[T110620981]: This assert was broken (never asserted), and once
+      // fixed it triggers test failures.  Fix me!
+      /* TORCH_INTERNAL_ASSERT(false, "'training' attribute not found"); */
     }
   }
 }


### PR DESCRIPTION
Summary: This assert was broken (never triggers).  Fixing the assert leads to test failures.  We need to fix those test failures, so a FIXME has been filed.  The urgency is avoiding the compile time failure that will come with enabling `-Wstring-conversion` as an error.

Test Plan: CI Pass

Differential Revision: D33754171

