### PR TITLE
index_backward: use out-of-place index_put if any input is subclass

### DIFF
--- a/aten/src/ATen/TensorSubclassLikeUtils.h
+++ b/aten/src/ATen/TensorSubclassLikeUtils.h
@@ -44,7 +44,7 @@ inline bool areAnyTensorSubclassLike(TensorList tensors) {
   return std::any_of(tensors.begin(), tensors.end(), isTensorSubclassLike);
 }
 
-inline bool areAnyOptionalTensorSubclassLike(const torch::List<c10::optional<Tensor>>& tensors) {
+inline bool areAnyOptionalTensorSubclassLike(const c10::List<c10::optional<Tensor>>& tensors) {
   return std::any_of(tensors.begin(), tensors.end(), [](const optional<Tensor>& opt_tensor) {
     return (opt_tensor.has_value() && isTensorSubclassLike(opt_tensor.value()));
     });

--- a/aten/src/ATen/TensorSubclassLikeUtils.h
+++ b/aten/src/ATen/TensorSubclassLikeUtils.h
@@ -44,4 +44,10 @@ inline bool areAnyTensorSubclassLike(TensorList tensors) {
   return std::any_of(tensors.begin(), tensors.end(), isTensorSubclassLike);
 }
 
+inline bool areAnyOptionalTensorSubclassLike(const torch::List<c10::optional<Tensor>>& tensors) {
+  return std::any_of(tensors.begin(), tensors.end(), [](const optional<Tensor>& opt_tensor) {
+    return (opt_tensor.has_value() && isTensorSubclassLike(opt_tensor.value()));
+    });
+}
+
 }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3890,7 +3890,18 @@ Tensor embedding_dense_double_backward(const Tensor & grad, const Tensor & indic
 }
 
 Tensor index_backward(Tensor zeros_like_self, const torch::List<c10::optional<Tensor>>& indices, const Tensor& grad) {
-  return at::_index_put_impl_(zeros_like_self, indices, grad, true, true);
+  c10::SmallVector<Tensor> inputs;
+  for (const c10::optional<Tensor> index : indices) {
+    if (index.has_value()) {
+      inputs.push_back(index.value());
+    }
+  }
+  inputs.push_back(zeros_like_self);
+  inputs.push_back(grad);
+
+  return areAnyTensorSubclassLike(inputs)
+      ? zeros_like_self.index_put(indices, grad, true)
+      : at::_index_put_impl_(zeros_like_self, indices, grad, true, true);
 }
 
 Tensor _cudnn_ctc_loss_backward(const Tensor& grad_out, const Tensor& loss, const Tensor& raw_grad, bool zero_infinity) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3890,16 +3890,8 @@ Tensor embedding_dense_double_backward(const Tensor & grad, const Tensor & indic
 }
 
 Tensor index_backward(Tensor zeros_like_self, const torch::List<c10::optional<Tensor>>& indices, const Tensor& grad) {
-  c10::SmallVector<Tensor> inputs;
-  for (const c10::optional<Tensor> index : indices) {
-    if (index.has_value()) {
-      inputs.push_back(index.value());
-    }
-  }
-  inputs.push_back(zeros_like_self);
-  inputs.push_back(grad);
-
-  return areAnyTensorSubclassLike(inputs)
+  return (areAnyTensorSubclassLike({zeros_like_self, grad}) ||
+          areAnyOptionalTensorSubclassLike(indices))
       ? zeros_like_self.index_put(indices, grad, true)
       : at::_index_put_impl_(zeros_like_self, indices, grad, true, true);
 }


### PR DESCRIPTION
Reference: https://github.com/pytorch/functorch/issues/393

Context : 

The derivative of `__getitem__`/`index` is 
https://github.com/pytorch/pytorch/blob/f5a71ec2d6956a1ba393657f4b8297bb931eeec2/tools/autograd/derivatives.yaml#L733-L734

where `index_backward` is defined as
https://github.com/pytorch/pytorch/blob/f5a71ec2d6956a1ba393657f4b8297bb931eeec2/torch/csrc/autograd/FunctionsManual.cpp#L3892-L3894

Problem arises when `grad` is not BatchedTensor but one of the other input is. In that case, `grad.new_zeros` returns an unbatched tensor and call to the inplace `_index_put_impl_` errors as it expects `zeros_like_self` to be Batched.

To avoid this, we dispatch to out-of-place `index_put` if any of the input tensor is subclassed otherwise we dispatch to the inplace `_index_put_impl_`.