### PR TITLE
[PyTorch Edge] Add Quantized Matmul Op (Naive Implementation)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qmatmul.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qmatmul.cpp
@@ -1,0 +1,44 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+inline void check_inputs(const Tensor& qa, const Tensor& qb) {
+  TORCH_CHECK(
+      qa.scalar_type() == c10::kQInt8 || qa.scalar_type() == c10::kQUInt8,
+      "MatMul operands should use QInt8 or QUInt8 data types.");
+  TORCH_CHECK(
+      qa.scalar_type() == qb.scalar_type(),
+      "MatMul operands should have same data type.");
+  TORCH_CHECK(
+      qa.qscheme() == kPerTensorAffine || qa.qscheme() == kPerTensorSymmetric,
+      "Only per-tensor quantization is suported in Matmul.");
+  TORCH_CHECK(
+      qa.qscheme() == qb.qscheme(),
+      "Both inputs to Matmul must have the same quantization scheme.");
+}
+
+Tensor qmatmul(
+    const Tensor& qa,
+    const Tensor& qb,
+    const double output_scale,
+    const int64_t output_zero_point) {
+  check_inputs(qa, qb);
+  Tensor ra = at::dequantize(qa);
+  Tensor rb = at::dequantize(qb);
+  Tensor rc = at::matmul(ra, rb);
+  return at::quantize_per_tensor(
+      rc, output_scale, output_zero_point, qa.scalar_type());
+}
+
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::matmul"), TORCH_FN(qmatmul));
+}
+
+} // namespace
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -161,6 +161,7 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack_fp16(__torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack.legacy(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack_fp16.legacy(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::matmul(Tensor qa, Tensor qb, float scale, int zero_point)-> Tensor qc"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::mul(Tensor qa, Tensor qb, float scale, int zero_point)-> Tensor qc"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::mul.out(Tensor qa, Tensor qb, Tensor(a!) out)-> Tensor(a!) out"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::mul.Scalar(Tensor qa, Scalar b)-> Tensor qc"));

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -1137,6 +1137,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp",
     "aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp",
     "aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp",
+    "aten/src/ATen/native/quantized/cpu/qmatmul.cpp",
     "aten/src/ATen/native/quantized/cpu/qmul.cpp",
     "aten/src/ATen/native/quantized/cpu/qnormalization.cpp",
     "aten/src/ATen/native/quantized/cpu/qpool.cpp",


### PR DESCRIPTION
Summary: Adds Quantized Matmul op which just naively performs dequantize -> matmul -> quantize. (To be optimized in the future)

Test Plan:
From fbcode:
```buck test caffe2/test:quantization -- test_qmatmul```

Differential Revision: D33443161

