### PR TITLE
build: Don't include zip files in final manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,4 +25,4 @@ recursive-include scripts *.*
 recursive-include mypy_plugins *.*
 recursive-include modules *.*
 prune */__pycache__
-global-exclude *.o *.so *.dylib *.a .git *.pyc *.swp
+global-exclude *.o *.so *.dylib *.a .git *.pyc *.swp *.zip


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #71487
* #71484
* __->__ #71793

These zip files originate from caffe2 tests, they add bulk to our
packages and should probably not be included in the first place

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>