### PR TITLE
`torch.normal()` docs miss-describe the shape of `(Tensor, Tensor)` ops.

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7336,7 +7336,7 @@ The :attr:`std` is a tensor with the standard deviation of
 each output element's normal distribution
 
 The shapes of :attr:`mean` and :attr:`std` don't need to match,
-but they must be :ref:`broadcastable
+but they must be :ref:`broadcastable`.
 
 .. note:: The returned shape will be the broadcast shape.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7335,11 +7335,10 @@ each output element's normal distribution
 The :attr:`std` is a tensor with the standard deviation of
 each output element's normal distribution
 
-The shapes of :attr:`mean` and :attr:`std` don't need to match, but the
-total number of elements in each tensor need to be the same.
+The shapes of :attr:`mean` and :attr:`std` don't need to match,
+but they must be :ref:`broadcastable
 
-.. note:: When the shapes do not match, the shape of :attr:`mean`
-          is used as the shape for the returned output tensor
+.. note:: The returned shape will be the broadcast shape.
 
 .. note:: When :attr:`std` is a CUDA tensor, this function synchronizes
           its device with the CPU.


### PR DESCRIPTION
```
>>> torch.normal(torch.tensor([1., 3.]), torch.tensor([[[4.], [3.], [9.]]]))
tensor([[[-4.6375, 12.0626],
         [ 7.3851,  4.8983],
         [ 1.3091, -3.4629]]])
```
