### PR TITLE
[caffe2][torch] Remove unreferenced local variable e

### DIFF
--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -907,7 +907,7 @@ struct Const : public Expr {
     try {
       // NOLINTNEXTLINE(modernize-use-nullptr)
       return c10::stoll(subtree(0)->stringValue(), /*__idx=*/0, /*base=*/0);
-    } catch (const std::out_of_range& e) {
+    } catch (const std::out_of_range&) {
       throw ErrorReport(range()) << "Integral constant out of range "
                                     "(must fit in a signed 64 bit integer)";
     }


### PR DESCRIPTION
Summary:
Fix this warning that flags on the MSVC build:
```
caffe2\torch\csrc\jit\frontend\tree_views.h(919): warning C4101: 'e': unreferenced local variable
```

Test Plan: CI

Differential Revision: D33784473

