### PR TITLE
[caffe2][c10] Fix signed/unsigned int64 mismatch

### DIFF
--- a/caffe2/queue/blobs_queue.cc
+++ b/caffe2/queue/blobs_queue.cc
@@ -170,7 +170,7 @@ bool BlobsQueue::canWrite() {
   // writer is always within [reader, reader + size)
   // we can write if reader is within [reader, reader + size)
   CAFFE_ENFORCE_LE(reader_, writer_);
-  CAFFE_ENFORCE_LE(writer_, reader_ + queue_.size());
+  CAFFE_ENFORCE_LE(writer_, static_cast<int64_t>(reader_ + queue_.size()));
   // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   return writer_ != reader_ + queue_.size();
 }


### PR DESCRIPTION
Summary:
The MSVC build has gotten rather verbose with warnings lately.
For example this comparison is meant to be int64 vs int64 like the one on the line prior to it, but adding an unsigned value (size_t) to int64_t returns unsigned. Cast this to make it consistent.
```
third-party\toolchains\vs2017_15.9\buildtools\vc\tools\msvc\14.16.27023\include\xstddef(322): warning C4018: '<=': signed/unsigned mismatch
xplat\caffe2\c10\util\logging.h(208): note: see reference to function template instantiation 'bool std::less_equal<void>::operator ()<const T1&,const T2&>(_Ty1,_Ty2) const' being compiled
        with
        [
            T1=int64_t,
            T2=unsigned __int64,
            _Ty1=const int64_t &,
            _Ty2=const unsigned __int64 &
        ]
xplat\caffe2\caffe2\queue\blobs_queue.cc(173): note: see reference to function template instantiation 'void c10::enforce_detail::enforceThatImpl<std::less_equal<void>,int64_t,unsigned __int64,>(Pred,const T1 &,const T2 &,const char *,int,const char *,const void *)' being compiled
        with
        [
            Pred=std::less_equal<void>,
            T1=int64_t,
            T2=unsigned __int64
        ]
```

Test Plan: CI

Differential Revision: D33791102

