### PR TITLE
Update _create_c10d_store to check port value

### DIFF
--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -147,6 +147,9 @@ def _create_c10d_store(hostname, port, rank, world_size, timeout) -> Store:
     and port are correctly passed via ``hostname`` and ``port``. All
     non-zero ranks will create and return a TCPStore client.
     """
+    # check if port is uint16_t
+    if not 0 <= port < 2**16:
+        raise ValueError(f"port must have value from 0 to 65535 but was {port}.")
 
     if _torchelastic_use_agent_store():
         attempt = os.environ["TORCHELASTIC_RESTART_COUNT"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#71863 Update _create_c10d_store to check port value**

Port number is int in python, but needs to be uint16_t when called for TCPStore constructor.

Related to #67172

Differential Revision: [D33793270](https://our.internmc.facebook.com/intern/diff/D33793270)