### PR TITLE
Add scalar support for `logsumexp`.

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1322,9 +1322,9 @@ Tensor& logsumexp_out(const Tensor& self, IntArrayRef dims, bool keepdim, Tensor
     if (at::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
       // for integral inputs, promote input to default floating type.
       auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
-      logsumexp_out_impl(result, self.to(default_dtype), dims, keepdim, {}, false);
+      logsumexp_out_impl(result, result, self.to(default_dtype), dims, keepdim, {}, false);
     } else {
-      logsumexp_out_impl(result, self, dims, keepdim, {}, false);
+      logsumexp_out_impl(result, result, self, dims, keepdim, {}, false);
     }
   }
   namedinference::propagate_names_for_reduction(result, self, dims, keepdim);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11168,12 +11168,24 @@
 - func: special_polygamma.out(int n, Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
-- func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None) -> Tensor
   python_module: special
   variants: function
 
-- func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+- func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
+
+- func: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor out, Tensor sign_out)
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: _special_logsumexp_with_sign
+
+- func: _special_logsumexp_with_sign.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False, *, Tensor(a!) out, Tensor(s!) sign_out) -> (Tensor(a!), Tensor(s!))
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: _special_logsumexp_with_sign_out
 
 - func: special_expit(Tensor self) -> Tensor
   python_module: special

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11175,13 +11175,13 @@
 - func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
-- func: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)
+- func: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, *, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)
   python_module: special
   variants: function
   dispatch:
     CompositeExplicitAutograd: _special_logsumexp_with_sign
 
-- func: _special_logsumexp_with_sign.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False, *, Tensor(a!) value_out, Tensor(s!) sign_out) -> (Tensor(a!), Tensor(s!))
+- func: _special_logsumexp_with_sign.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor? b=None, bool return_sign=False, Tensor(a!) value_out, Tensor(s!) sign_out) -> (Tensor(a!), Tensor(s!))
   python_module: special
   variants: function
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11175,13 +11175,13 @@
 - func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
-- func: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor out, Tensor sign_out)
+- func: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)
   python_module: special
   variants: function
   dispatch:
     CompositeExplicitAutograd: _special_logsumexp_with_sign
 
-- func: _special_logsumexp_with_sign.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False, *, Tensor(a!) out, Tensor(s!) sign_out) -> (Tensor(a!), Tensor(s!))
+- func: _special_logsumexp_with_sign.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False, *, Tensor(a!) value_out, Tensor(s!) sign_out) -> (Tensor(a!), Tensor(s!))
   python_module: special
   variants: function
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11168,11 +11168,11 @@
 - func: special_polygamma.out(int n, Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
-- func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None) -> Tensor
+- func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False, *, Tensor? b=None) -> Tensor
   python_module: special
   variants: function
 
-- func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor? b=None, Tensor(a!) out) -> Tensor(a!)
   python_module: special
 
 - func: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, *, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)

--- a/test/test_namedtuple_return_api.py
+++ b/test/test_namedtuple_return_api.py
@@ -22,6 +22,7 @@ all_operators_with_namedtuple_return = {
     '_fake_quantize_per_tensor_affine_cachemask_tensor_qparams',
     '_fused_moving_avg_obs_fq_helper', 'linalg_lu_factor', 'linalg_lu_factor_ex', 'linalg_lu',
     '_det_lu_based_helper', '_lu_with_info', 'linalg_ldl_factor_ex', 'linalg_ldl_factor',
+    '_special_logsumexp_with_sign',
 }
 
 
@@ -114,6 +115,8 @@ class TestNamedTupleAPI(TestCase):
             op(operators=['aminmax'], input=(), names=('min', 'max'), hasout=True),
             op(operators=['_lu_with_info'],
                input=(), names=('LU', 'pivots', 'info'), hasout=False),
+            op(operators=['_special_logsumexp_with_sign'],
+               input=(torch.tensor([3, 4]), 0), names=('value_out', 'sign_out'), hasout=True)
         ]
 
         def get_func(f):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -529,7 +529,7 @@ class TestReductions(TestCase):
 
             # Evaluate the outputs and compare.
             actual = torch.special.logsumexp(a, 1, keepdim, b, return_sign)
-            expected = logsumexp(a, 1, b, keepdim, return_sign)
+            expected = logsumexp(a.cpu(), 1, b if b is None else b.cpu(), keepdim, return_sign)
 
             if return_sign:
                 actual, actual_sign = actual

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -942,8 +942,13 @@
   result: self_t.zero_()
 
 - name: logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
-  self: logsumexp_backward(grad, self, result, dim, keepdim)
+  self: logsumexp_backward(grad, self, result, {}, dim, keepdim, {}, false, 0)
   result: logsumexp_jvp(self_p, self_t, dim, keepdim)
+
+- name: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor out, Tensor sign_out)
+  self: logsumexp_backward(grad, self, out, sign_out, dim, keepdim, b, return_sign, 0)
+  b: logsumexp_backward(grad, self, out, sign_out, dim, keepdim, b, return_sign, 1)
+  output_differentiability: [True, False]
 
 - name: lstsq(Tensor self, Tensor A) -> (Tensor solution, Tensor QR)
   self: not_implemented("lstsq")

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -945,7 +945,7 @@
   self: logsumexp_backward(grad, self, result, {}, dim, keepdim, {}, false, 0)
   result: logsumexp_jvp(self_p, self_t, dim, keepdim)
 
-- name: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)
+- name: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, *, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)
   self: logsumexp_backward(grad, self, value_out, sign_out, dim, keepdim, b, return_sign, 0)
   b: logsumexp_backward(grad, self, value_out, sign_out, dim, keepdim, b, return_sign, 1)
   output_differentiability: [True, False]

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -945,9 +945,9 @@
   self: logsumexp_backward(grad, self, result, {}, dim, keepdim, {}, false, 0)
   result: logsumexp_jvp(self_p, self_t, dim, keepdim)
 
-- name: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor out, Tensor sign_out)
-  self: logsumexp_backward(grad, self, out, sign_out, dim, keepdim, b, return_sign, 0)
-  b: logsumexp_backward(grad, self, out, sign_out, dim, keepdim, b, return_sign, 1)
+- name: _special_logsumexp_with_sign(Tensor self, int[1] dim, bool keepdim=False, Tensor? b=None, bool return_sign=False) -> (Tensor value_out, Tensor sign_out)
+  self: logsumexp_backward(grad, self, value_out, sign_out, dim, keepdim, b, return_sign, 0)
+  b: logsumexp_backward(grad, self, value_out, sign_out, dim, keepdim, b, return_sign, 1)
   output_differentiability: [True, False]
 
 - name: lstsq(Tensor self, Tensor A) -> (Tensor solution, Tensor QR)

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -85,7 +85,7 @@ at::Tensor solve_jvp(const Tensor& X, const Tensor& A, const Tensor& dA, const T
 at::Tensor solve_backward_self(const at::Tensor & grad, const at::Tensor & self, const at::Tensor & A);
 at::Tensor solve_backward_A(const at::Tensor & grad, const at::Tensor & self, const at::Tensor & A, const at::Tensor & solution);
 at::Tensor cumsum_backward(const at::Tensor & grad, int64_t dim);
-at::Tensor logsumexp_backward(at::Tensor grad, const at::Tensor & self, at::Tensor result, at::IntArrayRef dim, bool keepdim);
+at::Tensor logsumexp_backward(at::Tensor grad, const at::Tensor & self, at::Tensor result, optional<at::Tensor> sign_result, IntArrayRef dim, bool keepdim, const optional<at::Tensor>& b, bool return_sign, int grad_index);
 at::Tensor logsumexp_jvp(const at::Tensor& self_p, const at::Tensor& self_t, IntArrayRef dim, bool keepdim);
 at::Tensor logcumsumexp_backward(at::Tensor grad, const at::Tensor & self, at::Tensor result, int64_t dim);
 at::Tensor unbind_backward(const variable_list& grads, int64_t dim);

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1014,6 +1014,8 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.special.i1e: lambda input: -1,
         torch.special.laguerre_polynomial_l: lambda input, n, out=None: -1,
         torch.special.legendre_polynomial_p: lambda input, n, out=None: -1,
+        torch.special.logit: lambda input: -1,
+        torch.special.logsumexp: lambda input, dim, keepdim=False, b=None, return_sign=False, out=None: -1,
         torch.special.log1p: lambda input: -1,
         torch.special.log_ndtr: lambda input: -1,
         torch.special.log_softmax: lambda input, dim, dtype=None: -1,

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -1264,7 +1264,8 @@ def _logsumexp_return_sign_true(
         >>> torch.dist(torch.logsumexp(a, 1), torch.log(torch.sum(torch.exp(a), 1)))
         tensor(1.6859e-07)
     """
-    return _special._special_logsumexp_with_sign(input, dim, keepdim, b, return_sign, out=out)
+    return _special._special_logsumexp_with_sign(input, dim, keepdim, b=b, return_sign=return_sign,
+                                                 out=out)
 
 
 logsumexp = boolean_dispatch(

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -1220,7 +1220,7 @@ Keyword args:
 def _logsumexp_return_sign_false(
         input: Tensor, dim: typing.List[int], keepdim: bool = False,
         b: typing.Optional[Tensor] = None, return_sign: bool = False, out: Tensor = None) -> Tensor:
-    return _special.special_logsumexp(input, dim, keepdim, b, out=out)
+    return _special.special_logsumexp(input, dim, keepdim, b=b, out=out)
 
 
 def _logsumexp_return_sign_true(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17340,7 +17340,11 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and(torch.bool, torch.bfloat16),
            dtypesIfCUDA=all_types_and(torch.bool, torch.bfloat16, torch.half),
            assert_autodiffed=True,
-           sample_inputs_func=sample_inputs_special_logsumexp),
+           sample_inputs_func=sample_inputs_special_logsumexp,
+           skips=(
+               # test does not work with passing lambda for op
+               DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
+           )),
     OpInfo('trace',
            dtypes=all_types_and_complex(),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),


### PR DESCRIPTION
This PR aims to bring `logsumexp` on par with the `scipy` implementation by adding an optional scalar argument, e.g. to subtract elements after taking the exponential. It fixes #32097. 

Gradients of the result are implemented with respect to both the original argument and the optional scalars. The optional sign information being returned is not differentiable.

Because the output depends on the `return_sign` argument, I have implemented an auxiliary function `_logsumexp2` akin to `_unique2` and then exposed the function using `boolean_dispatch`. This should maintain backwards compatibility both for python as well as the C++ api.

I was unsure on how to best add tests (input appreciated), but here's the basic idea.

```python
import torch as th
from scipy import special, optimize
import numpy as np
import itertools as it
th.set_default_dtype(th.float64)


def finite_difference_grad(func, x, *args, epsilon=1e-6, return_sign, **kwargs):
    """
    Compute the gradient of the first element returned by `func`, discarding signs
    if necessary.
    """
    x1 = x.detach().numpy().copy()
    x2 = x1.copy()
    x2.ravel()[0] += epsilon
    x1.ravel()[0] -= epsilon
    y2 = func(x2, *args, **kwargs, return_sign=return_sign)
    y1 = func(x1, *args, **kwargs, return_sign=return_sign)
    if return_sign:
        y2, _ = y2
        y1, _ = y1
    grad = (y2 - y1) / (2 * epsilon)
    return grad


def maybe_detach(x):
    return None if x is None else x.detach()


for return_sign, scaled, use_out in it.product(*([(False, True)] * 3)):
    print(f'return_sign={return_sign}, scaled={scaled}, use_out={use_out}')
    
    # Test for random values.
    x = (th.rand((4, 5)) - .5)
    if scaled:
        b = (th.rand(5) - .5)
    else:
        b = None
        
    if use_out:
        result_out = th.empty(4)
        sign_out = th.empty(4)
        out = (result_out, sign_out)
    else:
        out = None
        x.requires_grad_()
        if b is not None:
            b.requires_grad_()
    
    # Verify the output.
    expected = special.logsumexp(x.detach(), axis=-1, b=maybe_detach(b), return_sign=return_sign)
    actual = x.logsumexp(dim=-1, b=b, return_sign=return_sign, out=out)

    if return_sign:
        expected, expected_sign = expected
        actual, actual_sign = actual
        np.testing.assert_array_equal(actual_sign, expected_sign)
    np.testing.assert_allclose(actual.detach(), expected)

    # Skip the gradients when using out.
    if use_out:
        continue

    # Verify the gradients...
    actual[0].backward()

    # ... for the main input and ...
    actual_grad = x.grad
    expected_grad = finite_difference_grad(special.logsumexp, x, b=maybe_detach(b), 
                                           return_sign=return_sign, axis=-1)
    np.testing.assert_allclose(actual_grad.ravel()[0], expected_grad[0], rtol=1e-6)

    # ... for the scalars.
    if scaled:
        actual_grad = b.grad
        expected_grad = finite_difference_grad(
            lambda b, *args, **kwargs: special.logsumexp(x.detach(), axis=-1, b=b, return_sign=return_sign), 
            maybe_detach(b), return_sign=return_sign,
        )
        np.testing.assert_allclose(actual_grad.ravel()[0], expected_grad[0], rtol=1e-6)
```

I've also added a slightly more verbose error message to the parsing of `native_functions.yaml` to help with debugging.