### PR TITLE
Fix usages of TORCH_CHECK/_INTERNAL_ASSERT without condition

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_alias_memory.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_alias_memory.cpp
@@ -957,6 +957,7 @@ class AllocateReuseModifier {
 
   void handle(const kir::IfThenElse* for_loop) {
     TORCH_INTERNAL_ASSERT(
+        false,
         "lower_alias_memory: IfThenElse before unrolling is not yet supported");
   }
 

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -187,8 +187,7 @@ bool LTCTensorImpl::is_contiguous(c10::MemoryFormat _unused) const {
 }
 
 const at::Storage& LTCTensorImpl::storage() const {
-  TORCH_CHECK("Lazy tensors do not have storage");
-  return storage_;
+  TORCH_CHECK(false, "Lazy tensors do not have storage");
 }
 
 #endif  // C10_DISABLE_TENSORIMPL_EXTENSIBILITY


### PR DESCRIPTION
Summary: Two locations of improper macro usage were reported (https://github.com/pytorch/pytorch/issues/71848), and this diff fixes them.  In both cases this is behavior-changing, since the incorrect usages would have passed assertion due interpreting the error string as the condition, and both cases should have been 'assert false'.

Test Plan: Run CI

Differential Revision: D33800406

