### PR TITLE
fixing of usage of rel_tol for test adadelta

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -612,7 +612,7 @@ class TestOptim(TestCase):
     # ROCm precision is too low to pass this test
     @skipIfRocm
     def test_adadelta(self):
-        #Handles https://github.com/pytorch/pytorch/issues/69698
+        # Handles https://github.com/pytorch/pytorch/issues/69698
         self.rel_tol = 4e-3
         for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
             self._test_basic_cases(
@@ -635,7 +635,7 @@ class TestOptim(TestCase):
                 optimizer(None, lr=1e-2, rho=1.1)
 
     def test_adadelta_complex(self):
-        #Handles https://github.com/pytorch/pytorch/issues/69698
+        # Handles https://github.com/pytorch/pytorch/issues/69698
         self.rel_tol = 2e-2
         for optimizer in [optim.Adadelta]:
             self._test_complex_optimizer(

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -22,7 +22,6 @@ from torch.optim.lr_scheduler import LambdaLR, MultiplicativeLR, SequentialLR, S
 from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests, \
     skipIfRocm
-from torch.testing._internal.common_device_type import toleranceOverride, tol
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
@@ -611,10 +610,10 @@ class TestOptim(TestCase):
             optim.SparseAdam([{"params": [torch.zeros(3, layout=torch.sparse_coo)]}])
 
     # ROCm precision is too low to pass this test
-    # Tolerance Override Handles https://github.com/pytorch/pytorch/issues/69698
     @skipIfRocm
-    @toleranceOverride({torch.float32: tol(4e-3, 0)})
     def test_adadelta(self):
+        #Handles https://github.com/pytorch/pytorch/issues/69698
+        self.rel_tol = 4e-3
         for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
             self._test_basic_cases(
                 lambda weight, bias: optimizer([weight, bias])
@@ -635,9 +634,9 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid rho value: 1.1"):
                 optimizer(None, lr=1e-2, rho=1.1)
 
-    # Tolerance Override Handles https://github.com/pytorch/pytorch/issues/69698
-    @toleranceOverride({torch.float32: tol(2e-2, 0)})
     def test_adadelta_complex(self):
+        #Handles https://github.com/pytorch/pytorch/issues/69698
+        self.rel_tol = 2e-2
         for optimizer in [optim.Adadelta]:
             self._test_complex_optimizer(
                 lambda weight: optimizer([weight])


### PR DESCRIPTION
Recently I made a PR to change some test tolerances: https://github.com/pytorch/pytorch/pull/69919
It turns out that the previous decorator does not work with the test optim unit test framework. I have summarized the issue in the following doc:
https://docs.google.com/document/d/1BOrp29r31A2WXwM0O6ydsCs43wi01sAgdduKd7is_ec/edit?usp=sharing