### PR TITLE
torch/monitor: support tensors logged as part of events

### DIFF
--- a/test/cpp/monitor/test_counters.cpp
+++ b/test/cpp/monitor/test_counters.cpp
@@ -238,11 +238,9 @@ TEST(MonitorTest, IntervalStatEvent) {
   Event e = guard.handler->events.at(0);
   ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, data_value_t> data{
-      {"a.sum", 3L},
-      {"a.count", 2L},
-  };
-  ASSERT_EQ(e.data, data);
+  ASSERT_EQ(e.data.size(), 2);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.sum")), 3L);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.count")), 2L);
 }
 
 TEST(MonitorTest, IntervalStatEventDestruction) {
@@ -263,11 +261,9 @@ TEST(MonitorTest, IntervalStatEventDestruction) {
   Event e = guard.handler->events.at(0);
   ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, data_value_t> data{
-      {"a.sum", 1L},
-      {"a.count", 1L},
-  };
-  ASSERT_EQ(e.data, data);
+  ASSERT_EQ(e.data.size(), 2);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.sum")), 1L);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.count")), 1L);
 }
 
 TEST(MonitorTest, FixedCountStatEvent) {
@@ -293,11 +289,9 @@ TEST(MonitorTest, FixedCountStatEvent) {
   Event e = guard.handler->events.at(0);
   ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, data_value_t> data{
-      {"a.sum", 4L},
-      {"a.count", 3L},
-  };
-  ASSERT_EQ(e.data, data);
+  ASSERT_EQ(e.data.size(), 2);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.sum")), 4L);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.count")), 3L);
 }
 
 TEST(MonitorTest, FixedCountStatEventDestruction) {
@@ -319,9 +313,7 @@ TEST(MonitorTest, FixedCountStatEventDestruction) {
   Event e = guard.handler->events.at(0);
   ASSERT_EQ(e.name, "torch.monitor.Stat");
   ASSERT_NE(e.timestamp, std::chrono::system_clock::time_point{});
-  std::unordered_map<std::string, data_value_t> data{
-      {"a.sum", 1L},
-      {"a.count", 1L},
-  };
-  ASSERT_EQ(e.data, data);
+  ASSERT_EQ(e.data.size(), 2);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.sum")), 1L);
+  ASSERT_EQ(c10::get<int64_t>(e.data.at("a.count")), 1L);
 }

--- a/test/cpp/monitor/test_events.cpp
+++ b/test/cpp/monitor/test_events.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <torch/csrc/monitor/events.h>
+#include <torch/torch.h>
 
 using namespace torch::monitor;
 
@@ -20,6 +21,7 @@ TEST(EventsTest, EventHandler) {
   e.data["double"] = 1234.5678;
   e.data["int"] = 1234L;
   e.data["bool"] = true;
+  e.data["tensor"] = torch::ones(5);
 
   // log to nothing
   logEvent(e);

--- a/torch/csrc/monitor/events.h
+++ b/torch/csrc/monitor/events.h
@@ -4,14 +4,16 @@
 #include <string>
 #include <unordered_map>
 
-#include <c10/util/variant.h>
+#include <ATen/Tensor.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/variant.h>
 
 namespace torch {
 namespace monitor {
 
 // data_value_t is the type for Event data values.
-using data_value_t = c10::variant<std::string, double, int64_t, bool>;
+using data_value_t =
+    c10::variant<std::string, double, int64_t, bool, at::Tensor>;
 
 // Event represents a single event that can be logged out to an external
 // tracker. This does acquire a lock on logging so should be used relatively
@@ -35,10 +37,7 @@ struct TORCH_API Event {
   std::unordered_map<std::string, data_value_t> data;
 };
 
-TORCH_API inline bool operator==(const Event& lhs, const Event& rhs) {
-  return lhs.name == rhs.name && lhs.timestamp == rhs.timestamp &&
-      lhs.data == rhs.data;
-}
+TORCH_API bool operator==(const Event& lhs, const Event& rhs);
 
 // EventHandler represents an abstract event handler that can be registered to
 // capture events. Every time an event is logged every handler will be called


### PR DESCRIPTION
Summary: This adds support for logging tensors as part of events. This greatly increases the potential type of events that could be logged (such as images, histograms, etc)

Test Plan: buck test //caffe2/test:monitor //caffe2/test/cpp/monitor:monitor

Differential Revision: D33802539

