### PR TITLE
Import packaging.version in torch_version, if available

### DIFF
--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -8,7 +8,7 @@ class _LazyImport:
        def v():
            return Version('1.2.3')
     and
-       Versoin = _LazyImport('Version')
+       Version = _LazyImport('Version')
        def v():
            return Version('1.2.3')
     The difference here is that in later example imports
@@ -18,7 +18,12 @@ class _LazyImport:
         self._cls_name = cls_name
 
     def get_cls(self):
-        from pkg_resources import packaging  # type: ignore[attr-defined]
+        try:
+            import packaging.version
+        except ImportError:
+            # If packaging isn't installed, try and use the vendored copy
+            # in pkg_resources
+            from pkg_resources import packaging  # type: ignore[attr-defined]
         return getattr(packaging.version, self._cls_name)
 
     def __call__(self, *args, **kwargs):

--- a/torch/torch_version.py
+++ b/torch/torch_version.py
@@ -19,7 +19,7 @@ class _LazyImport:
 
     def get_cls(self):
         try:
-            import packaging.version
+            import packaging.version  # type: ignore[import]
         except ImportError:
             # If packaging isn't installed, try and use the vendored copy
             # in pkg_resources


### PR DESCRIPTION
Resolves #71280

We used to use `from pkg_resources import packaging`. To recap, this has
three potential problems:
1) `pkg_resources` is a really slow import
2) We have an undeclared runtime dependency on `setuptools`
3) We're relying on `pkg_resources`'s secret vendored copy of
   `packaging`. This is obviously not part of the public API of
   `pkg_resources`.

In #71345 this was made a lazy import, which is great! It means we don't
run into these problems as long as users don't use `torch.__version__`.

This change additionally helps further address problems 1 and 3, by
directly importing `packaging`, if present, and only falling back to the
vendored copy in `pkg_resources`.

Benchmark for speed difference in a virtual environment with a couple
hundred packages installed:
```
λ hyperfine -w 2 'python -c "from pkg_resources import packaging"' 'python -c "import packaging.version"'
Benchmark 1: python -c "from pkg_resources import packaging"
  Time (mean ± σ):     706.7 ms ±  77.1 ms    [User: 266.5 ms, System: 156.8 ms]
  Range (min … max):   627.9 ms … 853.2 ms    10 runs

Benchmark 2: python -c "import packaging.version"
  Time (mean ± σ):      53.8 ms ±   8.5 ms    [User: 34.8 ms, System: 14.4 ms]
  Range (min … max):    46.3 ms …  72.3 ms    53 runs

Summary
  'python -c "import packaging.version"' ran
   13.14 ± 2.52 times faster than 'python -c "from pkg_resources import packaging"'
```
