### PR TITLE
Add Autocast support for Einsum

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -325,6 +325,7 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL(ADD_NS(addmv), "addmv", Tensor (const Tensor &, const Tensor &, const Tensor &, const Scalar&, const Scalar&), lower_precision_fp)
   KERNEL(ADD_NS(addr), "addr", Tensor (const Tensor &, const Tensor &, const Tensor &, const Scalar&, const Scalar&), lower_precision_fp)
   KERNEL(ADD_NS(matmul), "matmul", Tensor (const Tensor &, const Tensor &), lower_precision_fp)
+  KERNEL(ADD_NS(einsum), "einsum", Tensor (c10::string_view, TensorList), lower_precision_fp)
   KERNEL(ADD_NS(mm), "mm", Tensor (const Tensor &, const Tensor &), lower_precision_fp)
   KERNEL(ADD_NS(mv), "mv", Tensor (const Tensor &, const Tensor &), lower_precision_fp)
   KERNEL(ADD_NS(linear), "linear", Tensor (const Tensor &, const Tensor &, const c10::optional<Tensor>&), lower_precision_fp)

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -220,7 +220,6 @@ namespace c10 {
   _(onnx, Constant)                  \
   _(onnx, ConstantFill)              \
   _(onnx, Div)                       \
-  _(onnx, Einsum)                    \
   _(onnx, GRU)                       \
   _(onnx, Gather)                    \
   _(onnx, Gemm)                      \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -220,6 +220,7 @@ namespace c10 {
   _(onnx, Constant)                  \
   _(onnx, ConstantFill)              \
   _(onnx, Div)                       \
+  _(onnx, Einsum)                    \
   _(onnx, GRU)                       \
   _(onnx, Gather)                    \
   _(onnx, Gemm)                      \

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -101,6 +101,7 @@ class AutocastTestLists(object):
             ("addmv", pointwise0_fp32 + mat2_fp32 + pointwise1_fp32),
             ("addr", mat0_fp32 + pointwise0_fp32 + pointwise1_fp32),
             ("matmul", mat0_fp32 + mat1_fp32),
+            ("einsum", mat0_fp32 + mat1_fp32),
             ("mm", mat0_fp32 + mat1_fp32),
             ("mv", mat0_fp32 + pointwise0_fp32),
             ("chain_matmul", mat0_fp32 + mat1_fp32 + mat2_fp32),

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -101,7 +101,7 @@ class AutocastTestLists(object):
             ("addmv", pointwise0_fp32 + mat2_fp32 + pointwise1_fp32),
             ("addr", mat0_fp32 + pointwise0_fp32 + pointwise1_fp32),
             ("matmul", mat0_fp32 + mat1_fp32),
-            ("einsum", mat0_fp32 + mat1_fp32),
+            ("einsum", "bkhd,bqhd->bqkh", mat0_fp32 + mat1_fp32),
             ("mm", mat0_fp32 + mat1_fp32),
             ("mv", mat0_fp32 + pointwise0_fp32),
             ("chain_matmul", mat0_fp32 + mat1_fp32 + mat2_fp32),


### PR DESCRIPTION
ONNX spec for Einsum requires all inputs to be the same dtype.

PyTorch runtime does not allow executing aten::einsum with
mismatching types by default, so the export would never succeed,

However, when the model is wrapped by `torch.autocast()`,
the run succeeds and the ONNX converter will create an Einsum ONNX node 
with mismatch types as input, which is not allowed by the aforementioned schema.

This PR adds onnx::Einsum to the Autocast enabled list, which outputs lower resolution tensors