### PR TITLE
Run the pr-label check on PR closed action and validate closed_by

### DIFF
--- a/.github/scripts/process_commit.py
+++ b/.github/scripts/process_commit.py
@@ -72,7 +72,7 @@ def post_pytorch_comment(pr_number: int, merger: str) -> Any:
     https://github.com/pytorch/pytorch/labels?q=release+notes+or+topic"}
 
     response = requests.post(
-        f"{PYTORCH_REPO}/{pr_number}/comments",
+        f"{PYTORCH_REPO}/issues/{pr_number}/comments",
         json.dumps(message),
         headers=dict(Accept="application/vnd.github.v3+json"))
     return response.json()

--- a/.github/scripts/process_commit.py
+++ b/.github/scripts/process_commit.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 """
-This script finds the merger responsible for labeling a PR by a commit SHA. It is used by the workflow in
+This script finds the user/pr creator responsible for labeling a PR by a commit SHA. It is used by the workflow in
 '.github/workflows/pr-labels.yml'. If there exists no PR associated with the commit or the PR is properly labeled,
 this script is a no-op.
 
-Note: we ping the merger only, not the reviewers, as the reviewers can sometimes be external to pytorch
+Note: we ping the user only, not the reviewers, as the reviewers can sometimes be external to pytorch
 with no labeling responsibility, so we don't want to bother them.
 This script is based on: https://github.com/pytorch/vision/blob/main/.github/process_commit.py
 """
 
 import sys
-from typing import Any, Set, Tuple
-
+from typing import Any, Set, Tuple, List
+import re
+import json
 import requests
 
 # For a PR to be properly labeled it should have release notes label and one topic label
+PULL_REQUEST_EXP = "Pull Request resolved:.*pull/(.*)"
 PRIMARY_LEBEL_FILTER = "release notes:"
 SECONDARY_LEBELS = {
     "topic: bc_breaking",
@@ -27,27 +29,43 @@ SECONDARY_LEBELS = {
     "topic: developer feature",
     "topic: non-user visible",
 }
+PYTORCH_REPO = "https://api.github.com/repos/pytorch/pytorch"
 
 def query_pytroch(cmd: str, *, accept: str) -> Any:
-    response = requests.get(f"https://api.github.com/repos/pytorch/pytorch/{cmd}", headers=dict(Accept=accept))
+    response = requests.get(f"{PYTORCH_REPO}/{cmd}", headers=dict(Accept=accept))
     return response.json()
 
 
 def get_pr_number(commit_hash: str) -> Any:
-    # See https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-    data = query_pytroch(f"commits/{commit_hash}/pulls", accept="application/vnd.github.groot-preview+json")
-    if not data:
+    data = query_pytroch(f"commits/{commit_hash}", accept="application/vnd.github.v3+json")
+    if not data or (not data["commit"]["message"]):
         return None
-    return data[0]["number"]
+    message = data["commit"]["message"]
+    p = re.compile(PULL_REQUEST_EXP)
+    result = p.search(message)
+    if not result:
+        return None
+    return result.group(1)
 
 
-def get_pr_merger_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
+def get_pr_user_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
     # See https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
     data = query_pytroch(f"pulls/{pr_number}", accept="application/vnd.github.v3+json")
-    merger = data["merged_by"]["login"]
+    user = data["user"]["login"]
     labels = {label["name"] for label in data["labels"]}
-    return merger, labels
+    return user, labels
 
+def post_pytroch_comment(pr_number: int, merger: str) -> Any:
+    message = {'body' : f"Hey {merger}. \
+    You merged this PR, but no release notes category and topic labels were added. \
+    The list of valid release and topic labels is available \
+    https://github.com/pytorch/pytorch/labels?page=2&q=release+notes+or+topic"}
+
+    response = requests.post(
+        f"{PYTORCH_REPO}/{pr_number}/comments",
+        json.dumps(message),
+        headers=dict(Accept="application/vnd.github.v3+json"))
+    return response.json()
 
 if __name__ == "__main__":
     commit_hash = sys.argv[1]
@@ -56,11 +74,17 @@ if __name__ == "__main__":
     if not pr_number:
         sys.exit(0)
 
-    merger, labels = get_pr_merger_and_labels(pr_number)
-    response = query_pytroch("labels", accept="application/json")
-    response_labels = list(map(lambda x: str(x["name"]), response.json()))
-    primary_labels = set(filter(lambda x: x.startswith(PRIMARY_LEBEL_FILTER), response_labels))
+    user, labels = get_pr_user_and_labels(pr_number)
+    collected_labels: List[str] = list()
+    for page in range(0, 10):
+        response = query_pytroch(f"labels?per_page=100&page={page}", accept="application/json")
+        page_labels = list(map(lambda x: str(x["name"]), response))
+        if not page_labels:
+            break
+            collected_labels += page_labels
+
+    primary_labels = set(filter(lambda x: x.startswith(PRIMARY_LEBEL_FILTER), collected_labels))
     is_properly_labeled = bool(primary_labels.intersection(labels) and SECONDARY_LEBELS.intersection(labels))
 
     if not is_properly_labeled:
-        print(f"@{merger}")
+        post_pytroch_comment(pr_number, user)

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -23,17 +23,9 @@ jobs:
         id: commit
         env:
           SHA1: ${{ github.sha }}
-        run: |
-          MERGER=$(python .github/scripts/process_commit.py "${SHA1}")
-          echo "::set-output name=merger::${MERGER}"
-
-      - name: Ping merger responsible for labeling if necessary
-        if: ${{ steps.commit.outputs.merger != '' }}
-        uses: mshick/add-pr-comment@v1
-        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          message: |
-            Hey ${{ steps.commit.outputs.merger }}!
+        run: python .github/scripts/process_commit.py "${SHA1}"
 
-            You merged this PR, but no release notes category and topic labels were added. The list of valid release and topic labels is available at https://github.com/pytorch/pytorch/labels?q=release and https://github.com/pytorch/pytorch/blob/master/.github/scripts/process_commit.py
+concurrency:
+  group: pr-labels-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true


### PR DESCRIPTION
Fixes #68459
This PR implements reminder to assign the release notes and topic labels to each PR when merged. Here is an example of the message that set on the issue related to PR: 

> Hey atalman. You merged this PR, but no release notes category and topic labels were added. >
> The list of valid release and topic labels is available https://github.com/pytorch/pytorch/labels?q=release+notes+or+topic

Tested by manually running process_commit.py script in standalone mode passing following  commit_hash = "e020414cb25cd763103f77a10c6225ce27cbbb6e" which should resolve to this PR