### PR TITLE
Fix hardcoded `TsNode` in `lazy_ir.py` 

### DIFF
--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -139,7 +139,7 @@ class {schema.node_name} : public {self.node_base} {{
 
   std::string ToString() const override {{
     std::stringstream ss;
-    ss << TsNode::ToString();
+    ss << {self.node_base}::ToString();
     {members_to_string_str}
     return ss.str();
   }}

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -1,4 +1,5 @@
-from typing import List, Union
+from abc import ABC, abstractmethod
+from typing import Callable, List, Union
 from dataclasses import dataclass
 from tools.codegen.context import method_with_native_function
 from tools.codegen.model import (BackendIndex, NativeFunction,
@@ -75,14 +76,20 @@ def aten_symbol(schema: LazyIrSchema) -> str:
     return f'at::aten::{schema.aten_name}'
 
 @dataclass(frozen=True)
-class LazyIR:
+class LazyIR(ABC):
     backend_index: BackendIndex
     node_base: str
+    lowering_context_type: str
+    lowering_return_type: str
 
     @method_with_native_function
     def __call__(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         func = f.functional.func if isinstance(f, NativeFunctionsGroup) else f.func
         return self.gen(f)
+
+    @abstractmethod
+    def lowering_body(self, f):
+        pass
 
     def gen(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         # for now, we just want one IR class decl and soon after also the method defs
@@ -144,9 +151,9 @@ class {schema.node_name} : public {self.node_base} {{
     return ss.str();
   }}
 
-  torch::lazy::TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
-                   torch::lazy::TSLoweringContext* loctx) const override {{
-    {ts_lowering_body(f)}
+  {self.lowering_return_type} Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+                   {self.lowering_context_type}* loctx) const override {{
+    {self.lowering_body(f)}
   }}
 
   {scalar_decls}
@@ -155,6 +162,15 @@ class {schema.node_name} : public {self.node_base} {{
 }};
 
 """, ]
+
+
+@dataclass(frozen=True)
+class TSLazyIR(LazyIR):
+    lowering_context_type: str = "torch::lazy::TSLoweringContext"
+    lowering_return_type: str = "torch::lazy::TSOpVector"
+
+    def lowering_body(self, f):
+        return ts_lowering_body(f)
 
 
 def lazy_tensor_decls(value_types: List[NamedCType], tensor_class: str, schema: LazyIrSchema) -> str:

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -79,6 +79,7 @@ def aten_symbol(schema: LazyIrSchema) -> str:
 class LazyIR(ABC):
     backend_index: BackendIndex
     node_base: str
+    lowering_function_type: str
     lowering_context_type: str
     lowering_return_type: str
 
@@ -151,8 +152,8 @@ class {schema.node_name} : public {self.node_base} {{
     return ss.str();
   }}
 
-  {self.lowering_return_type} Lower(std::shared_ptr<torch::jit::GraphFunction> function,
-                   {self.lowering_context_type}* loctx) const override {{
+  {self.lowering_return_type} Lower({self.lowering_function_type} function,
+                   {self.lowering_context_type} loctx) const override {{
     {self.lowering_body(f)}
   }}
 
@@ -166,7 +167,8 @@ class {schema.node_name} : public {self.node_base} {{
 
 @dataclass(frozen=True)
 class TSLazyIR(LazyIR):
-    lowering_context_type: str = "torch::lazy::TSLoweringContext"
+    lowering_function_type: str = "std::shared_ptr<torch::jit::GraphFunction>"
+    lowering_context_type: str = "torch::lazy::TSLoweringContext*"
     lowering_return_type: str = "torch::lazy::TSOpVector"
 
     def lowering_body(self, f):

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -3,7 +3,8 @@ import argparse
 import os
 import yaml
 from collections import namedtuple
-from typing import List, Dict, Union, Sequence, Optional, Callable, Iterable, Iterator, Tuple
+from typing import List, Dict, Union, Sequence, Optional, Callable, Iterable, Iterator, Tuple, Type
+from tools.codegen.dest.lazy_ir import LazyIR, TSLazyIR
 from tools.codegen.gen import get_grouped_native_functions, parse_native_yaml
 from tools.codegen.model import (FunctionSchema,
                                  NativeFunction, NativeFunctionsGroup, OperatorName)
@@ -68,12 +69,12 @@ def main() -> None:
 
     run(options.source_yaml, options.output_dir, options.dry_run, options.impl_path,
         options.gen_ts_lowerings, options.node_base, options.node_base_hdr,
-        options.tensor_class, options.tensor_class_hdr)
+        options.tensor_class, options.tensor_class_hdr, TSLazyIR)
 
 
 def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[str],
         gen_ts_lowerings: bool, node_base: str, node_base_hdr: Optional[str],
-        tensor_class: str, tensor_class_hdr: str) -> None:
+        tensor_class: str, tensor_class_hdr: str, lazy_ir_cls: Type[LazyIR]) -> None:
 
     # Assumes that this file lives at PYTORCH_ROOT/tools/codegen/gen_backend_stubs.py
     pytorch_root = pathlib.Path(__file__).parent.parent.parent.absolute()
@@ -220,7 +221,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         'DispatchKey': backend_key,
         'dispatch_namespace': backend_key.lower(),
         'ir_declarations': list(concat_map_codegen(
-            dest.LazyIR(backend_indices[backend_key], node_base),
+            lazy_ir_cls(backend_indices[backend_key], node_base),
             grouped_native_functions
         )),
     })


### PR DESCRIPTION
There are a number of places where TorchScript specific classes are hardcoded into the lazy tensor autogen code. Fixing those instances to make them more general.
- There is a hardcoded instance of `TsNode` in `tools/codegen/dest/lazy_ir.py`. Fixing that to be `self.node_base` instead.
- There are hardocded instances of `TSOpVector` and `TSLoweringContext` as well which were replaced by overridable fields in the dataclass.

With these changes, a custom `LazyIR` subclass can be passed into the `gen_lazy_tensor.run` to custom the autogen for lazy tensors.

CC: @wconstab 