### PR TITLE
[SR] Eliminate op_name_ in ProcessedNode

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1782,12 +1782,7 @@ ProcessedNode::ProcessedNode(
     : node_(node),
       fn_(fn),
       inputs_(std::move(inputs)),
-      outputs_offset_(outputs_offset)
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-      ,
-      op_name_(node->kind().toQualString())
-#endif
-{
+      outputs_offset_(outputs_offset) {
   TORCH_CHECK(
       node->outputs().size() < (1 << (sizeof(num_outputs_) * 8)),
       node->outputs().size(),

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -785,13 +785,7 @@ class TORCH_API ProcessedNode {
         // TODO(T105178680): For this task, we should move
         // block runners out of ProcessedNode. Then, we don't have to deal
         // with this caveat.
-        block_runners_(nullptr)
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-        ,
-        op_name_(other.op_name_)
-#endif
-  {
-  }
+        block_runners_(nullptr) {}
 
   ProcessedNode& operator=(const ProcessedNode& other) {
     if (&other == this) {
@@ -805,9 +799,6 @@ class TORCH_API ProcessedNode {
     num_outputs_ = other.num_outputs_;
     values_ = other.values_;
     block_runners_ = nullptr;
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-    op_name_ = other.op_name_;
-#endif
     return *this;
   }
 
@@ -863,7 +854,7 @@ class TORCH_API ProcessedNode {
 
 #ifndef PYTORCH_DISABLE_PER_OP_PROFILING
   const char* get_op_name() const {
-    return op_name_;
+    return node_->kind().toQualString();
   }
 #endif
 
@@ -920,10 +911,10 @@ class TORCH_API ProcessedNode {
   // For control flow; processed nodes may have sub-blocks which can
   // be executed by op implementations.
   std::unique_ptr<std::vector<BlockRunner>> block_runners_;
-#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  const char* op_name_;
-#endif
 };
+static_assert(
+    sizeof(ProcessedNode) == 56,
+    "ProcessedNode size has changed, please make sure this is intentional");
 
 // `StaticRuntime` is the owner of the array of IValues (used for constants,
 // inputs, and intermediate tensors) that all `BlockRunner`s share.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #71926
* #71854
* #71807
* #69838
* #69837
* #69836
* #69835
* #69834

To address concerns over space increase from control flow.

`op_name_` was only stored as a minor optimization to avoid name lookup during logging, we can safely get rid of it. Thanks to the sampling mechanism, `get_op_name()` is called very infrequently, so this shouldn't cause too much of a regression

Differential Revision: [D33821005](https://our.internmc.facebook.com/intern/diff/D33821005/)