### PR TITLE
Add `scripts` to OSS merge rules

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -13,7 +13,7 @@
    },
    {
     "name": "OSS CI",
-    "patterns": [".github/**", ".circleci/**", ".jenkins/**"],
+    "patterns": [".github/**", ".circleci/**", ".jenkins/**", "scripts/**"],
     "approved_by": ["seemethere", "malfet", "suo"],
     "mandatory_app_id": 12274
    }


### PR DESCRIPTION
There is nothing but builds scripts for OSS in there

