### PR TITLE
improve quantized error checking for structured kernels

### DIFF
--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -808,4 +808,14 @@ inline TensorOptions dispatchKeyToTensorOptions(DispatchKey dispatch_key) {
       .device(dispatchKeyToDeviceType(dispatch_key));
 }
 
+namespace detail {
+inline bool backend_supports_empty_operator(const TensorOptions options) {
+  // Quantized backends don't support at::empty().
+  // They have separate operators like at::empty_quantized() that take in
+  // extra information about how to quantize the tensor.
+  return !isQIntType(typeMetaToScalarType(options.dtype()));
+}
+
+} // namespace detail
+
 } // namespace c10


### PR DESCRIPTION
This PR improves the error messaging for structured operators that don't have a quantized backend implementation.

`at::native_batch_norm` does not currently have a quantized implementation. The current error when you try to run that op with quantized tensors is:
```
"Could not run 'aten::native_batch_norm' with arguments from the 'QuantizedCPU' backend"
```

Making the operator structured (in https://github.com/pytorch/pytorch/pull/67343) makes the error message worse though:
```
Could not run 'aten::empty.memory_format' with arguments from the 'QuantizedCPU' backend
```

Why does that happen? After making `native_batch_norm` structured, it gets a code-generated `CompositeExplicitAutograd` kernel. The codegen'd kernel just constructs an empty tensor using `at::empty()` and calls into the `out=` kernel.

This is useful for most backends because they can choose to implement only the `out=` operator if they want to, and get a composite out-of-place kernel that would work automatically.

This ends up being bad for quantization though because quantization doesn't support `at::empty()`, so we end up breaking with a (pretty useless) error message.

In this PR, I add a dynamic check for if the operator we're trying to call is meant to be quantized, and if it is I return an undefined tensor. This lets us try to dispatch all the way to `native_batch_norm.out`, at which point the dispatcher complains with a (friendlier) error message.

**Testing**

I tested the PR by rebasing https://github.com/pytorch/pytorch/pull/67343 on top of it and running `python test/test_quantization.py TestFuseEager.test_fuse_module_train` to confirm that the error message now mentions `native_batch_norm` instead of `empty.memory_format`

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#71928 improve quantized error checking for structured kernels**

Differential Revision: [D33823417](https://our.internmc.facebook.com/intern/diff/D33823417)