### PR TITLE
Add Relu truncation in Int8FC when followed_by=Relu and dequantize_output=1

### DIFF
--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -418,6 +418,11 @@ bool FullyConnectedDNNLowPOp<T, ReluFused>::RunOnDevice() {
               1); // num_threads
         }
       }
+      if (followed_by_ == "Relu") {
+        for (size_t i = 0; i < M * N; i++) {
+          Y_data[i] = std::max(Y_data[i], 0.0f);
+        }
+      }
     } // dequantize_output
   } else {
     // Quantize X

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
@@ -100,7 +100,7 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
 
         op_engine_list = [("FC", "")]
         if fuse_relu:
-            op_engine_list += [("Int8FCRelu", "DNNLOWP")]
+            op_engine_list += [("Int8FCRelu", "DNNLOWP"), ("Int8FC", "DNNLOWP")]
         else:
             op_engine_list += [
                 ("FC", "DNNLOWP"),
@@ -118,6 +118,11 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                 engine == "DNNLOWP" and weight_quantized and len(outputs) > 0
             )
             do_prepack_weight = engine == "DNNLOWP" and prepack_weight
+
+            if fuse_relu and op_type == "Int8FC":
+                followed_by = "Relu"
+            else:
+                followed_by = ""
 
             if do_quantize:
                 quantize = core.CreateOperator(
@@ -184,6 +189,7 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                     preserve_weight_sparsity=preserve_weight_sparsity,
                     engine=engine,
                     device_option=gc,
+                    followed_by=followed_by,
                 )
             else:
                 fc = core.CreateOperator(
@@ -201,6 +207,7 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                     preserve_weight_sparsity=preserve_weight_sparsity,
                     engine=engine,
                     device_option=gc,
+                    followed_by=followed_by,
                 )
             if do_quantize_weight or do_prepack_weight:
                 # When quantized weight is provided, we can't rescale the


### PR DESCRIPTION
Summary: Currently Int8FC's output doesn't not truncate negative values to 0 when use followed_by=Relu and dequantize_output=1 in argument list, which could cause wrong numeric results when user use dynamic Int8FC with Relu fusion. This diff added Relu truncation for this corner case and added the test case that would fail before the fix.

Test Plan:
Unit test

Before fix, test would fail:
```
Mismatched elements: 1 / 2 (50%)
Max absolute difference: 4977.734
Max relative difference: 0.
 x: array([[-4977.734, 33292.492]], dtype=float32)
 y: array([[    0.   , 33292.492]], dtype=float32)
```

Differential Revision: D33821092

