### PR TITLE
Removed JIT FC tweaks for interpolation options

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3863,17 +3863,12 @@ def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optiona
     if input.dim() == 5 and mode == "nearest":
         return torch._C._nn.upsample_nearest3d(input, output_size, scale_factors)
 
-    # TODO: Remove this scripting logic once the 2-week FC window has passed.
-    if mode == "nearest-exact":
-        if not torch.jit.is_scripting():
-            if input.dim() == 3 and mode == "nearest-exact":
-                return torch._C._nn._upsample_nearest_exact1d(input, output_size, scale_factors)
-            if input.dim() == 4 and mode == "nearest-exact":
-                return torch._C._nn._upsample_nearest_exact2d(input, output_size, scale_factors)
-            if input.dim() == 5 and mode == "nearest-exact":
-                return torch._C._nn._upsample_nearest_exact3d(input, output_size, scale_factors)
-        else:
-            raise RuntimeError("TorchScript currently does not support nearest-exact")
+    if input.dim() == 3 and mode == "nearest-exact":
+        return torch._C._nn._upsample_nearest_exact1d(input, output_size, scale_factors)
+    if input.dim() == 4 and mode == "nearest-exact":
+        return torch._C._nn._upsample_nearest_exact2d(input, output_size, scale_factors)
+    if input.dim() == 5 and mode == "nearest-exact":
+        return torch._C._nn._upsample_nearest_exact3d(input, output_size, scale_factors)
 
     if input.dim() == 3 and mode == "area":
         assert output_size is not None
@@ -3890,26 +3885,16 @@ def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optiona
         return torch._C._nn.upsample_linear1d(input, output_size, align_corners, scale_factors)
     if input.dim() == 4 and mode == "bilinear":
         assert align_corners is not None
-        # Enforce that the full call with the new kwarg is not invoked when scripting.
-        # TODO: Remove this scripting logic once the 2-week FC window has passed.
         if antialias:
-            if not torch.jit.is_scripting():
-                return torch._C._nn._upsample_bilinear2d_aa(input, output_size, align_corners, scale_factors)
-            else:
-                raise RuntimeError("TorchScript currently does not support antialias in interpolate")
+            return torch._C._nn._upsample_bilinear2d_aa(input, output_size, align_corners, scale_factors)
         return torch._C._nn.upsample_bilinear2d(input, output_size, align_corners, scale_factors)
     if input.dim() == 5 and mode == "trilinear":
         assert align_corners is not None
         return torch._C._nn.upsample_trilinear3d(input, output_size, align_corners, scale_factors)
     if input.dim() == 4 and mode == "bicubic":
         assert align_corners is not None
-        # Enforce that the full call with the new kwarg is not invoked when scripting.
-        # TODO: Remove this scripting logic once the 2-week FC window has passed.
         if antialias:
-            if not torch.jit.is_scripting():
-                return torch._C._nn._upsample_bicubic2d_aa(input, output_size, align_corners, scale_factors)
-            else:
-                raise RuntimeError("TorchScript currently does not support antialias in interpolate")
+            return torch._C._nn._upsample_bicubic2d_aa(input, output_size, align_corners, scale_factors)
         return torch._C._nn.upsample_bicubic2d(input, output_size, align_corners, scale_factors)
 
     if input.dim() == 3 and mode == "bilinear":


### PR DESCRIPTION
Description:
- Removed JIT FC tweaks for interpolation options : nearest-exact and antialiasing

They were added in 
- https://github.com/pytorch/pytorch/pull/64501 (Sept 04 2021)
- https://github.com/pytorch/pytorch/pull/65142 (Sept 16 2021)

cc @jbschlosser

