### PR TITLE
.github: Only call wait_for_ssh_to_drain if exists

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -158,7 +158,7 @@ concurrency:
 {%- endif %}
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/templates/docker_builds_ci_workflow.yml.j2
+++ b/.github/templates/docker_builds_ci_workflow.yml.j2
@@ -48,10 +48,6 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       !{{ common.parse_ref() }}
       !{{ common.teardown_ec2_linux() }}
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -138,10 +138,6 @@ jobs:
             artifacts.zip
       {%- endif %}
       !{{ common.teardown_ec2_linux() }}
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -238,10 +238,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -165,10 +165,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -228,10 +228,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -228,10 +228,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-binary-conda.yml
+++ b/.github/workflows/generated-linux-binary-conda.yml
@@ -176,7 +176,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -306,7 +306,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -421,7 +421,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -567,7 +567,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -703,7 +703,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -819,7 +819,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -968,7 +968,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1104,7 +1104,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1220,7 +1220,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1369,7 +1369,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1505,7 +1505,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1621,7 +1621,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1770,7 +1770,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1906,7 +1906,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2022,7 +2022,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2167,7 +2167,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2297,7 +2297,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2412,7 +2412,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2558,7 +2558,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2694,7 +2694,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2810,7 +2810,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2959,7 +2959,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3095,7 +3095,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3211,7 +3211,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3360,7 +3360,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3496,7 +3496,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3612,7 +3612,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3761,7 +3761,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3897,7 +3897,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4013,7 +4013,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4158,7 +4158,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4288,7 +4288,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4403,7 +4403,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4549,7 +4549,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4685,7 +4685,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4801,7 +4801,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4950,7 +4950,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5086,7 +5086,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5202,7 +5202,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5351,7 +5351,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5487,7 +5487,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5603,7 +5603,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5752,7 +5752,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5888,7 +5888,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6004,7 +6004,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6149,7 +6149,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6279,7 +6279,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6394,7 +6394,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6540,7 +6540,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6676,7 +6676,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6792,7 +6792,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6941,7 +6941,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7077,7 +7077,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7193,7 +7193,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7342,7 +7342,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7478,7 +7478,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7594,7 +7594,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7743,7 +7743,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7879,7 +7879,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7995,7 +7995,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
@@ -177,7 +177,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -308,7 +308,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -424,7 +424,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -570,7 +570,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -701,7 +701,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -817,7 +817,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -963,7 +963,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1094,7 +1094,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1210,7 +1210,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1356,7 +1356,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1487,7 +1487,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1603,7 +1603,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1750,7 +1750,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1887,7 +1887,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2004,7 +2004,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2151,7 +2151,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2288,7 +2288,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2405,7 +2405,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2552,7 +2552,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2689,7 +2689,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2806,7 +2806,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2953,7 +2953,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3090,7 +3090,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3207,7 +3207,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3357,7 +3357,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3494,7 +3494,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3611,7 +3611,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3761,7 +3761,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3898,7 +3898,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4015,7 +4015,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4165,7 +4165,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4302,7 +4302,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4419,7 +4419,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4569,7 +4569,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4706,7 +4706,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4823,7 +4823,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4973,7 +4973,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5110,7 +5110,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5227,7 +5227,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5377,7 +5377,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5514,7 +5514,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5631,7 +5631,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5781,7 +5781,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5918,7 +5918,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6035,7 +6035,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6185,7 +6185,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6322,7 +6322,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6439,7 +6439,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6589,7 +6589,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6726,7 +6726,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6843,7 +6843,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6993,7 +6993,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7130,7 +7130,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7247,7 +7247,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7397,7 +7397,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7534,7 +7534,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7651,7 +7651,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7801,7 +7801,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7938,7 +7938,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8055,7 +8055,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
@@ -177,7 +177,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -308,7 +308,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -424,7 +424,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -570,7 +570,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -701,7 +701,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -817,7 +817,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -963,7 +963,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1094,7 +1094,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1210,7 +1210,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1356,7 +1356,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1487,7 +1487,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1603,7 +1603,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1750,7 +1750,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1887,7 +1887,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2004,7 +2004,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2151,7 +2151,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2288,7 +2288,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2405,7 +2405,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2552,7 +2552,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2689,7 +2689,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2806,7 +2806,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2953,7 +2953,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3090,7 +3090,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3207,7 +3207,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3357,7 +3357,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3494,7 +3494,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3611,7 +3611,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3761,7 +3761,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3898,7 +3898,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4015,7 +4015,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4165,7 +4165,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4302,7 +4302,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4419,7 +4419,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4569,7 +4569,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4706,7 +4706,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4823,7 +4823,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4973,7 +4973,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5110,7 +5110,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5227,7 +5227,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5377,7 +5377,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5514,7 +5514,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5631,7 +5631,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5781,7 +5781,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5918,7 +5918,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6035,7 +6035,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6185,7 +6185,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6322,7 +6322,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6439,7 +6439,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6589,7 +6589,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6726,7 +6726,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6843,7 +6843,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6993,7 +6993,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7130,7 +7130,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7247,7 +7247,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7397,7 +7397,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7534,7 +7534,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7651,7 +7651,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7801,7 +7801,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7938,7 +7938,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8055,7 +8055,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-binary-manywheel.yml
+++ b/.github/workflows/generated-linux-binary-manywheel.yml
@@ -176,7 +176,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -306,7 +306,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -421,7 +421,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -567,7 +567,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -703,7 +703,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -819,7 +819,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -968,7 +968,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1104,7 +1104,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1220,7 +1220,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1369,7 +1369,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1505,7 +1505,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1621,7 +1621,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1770,7 +1770,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1906,7 +1906,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2022,7 +2022,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2168,7 +2168,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2299,7 +2299,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2415,7 +2415,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2561,7 +2561,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2692,7 +2692,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2808,7 +2808,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2953,7 +2953,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3083,7 +3083,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3198,7 +3198,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3344,7 +3344,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3480,7 +3480,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3596,7 +3596,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3745,7 +3745,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3881,7 +3881,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3997,7 +3997,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4146,7 +4146,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4282,7 +4282,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4398,7 +4398,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4547,7 +4547,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4683,7 +4683,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4799,7 +4799,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4945,7 +4945,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5076,7 +5076,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5192,7 +5192,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5338,7 +5338,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5469,7 +5469,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5585,7 +5585,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5730,7 +5730,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5860,7 +5860,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5975,7 +5975,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6121,7 +6121,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6257,7 +6257,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6373,7 +6373,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6522,7 +6522,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6658,7 +6658,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6774,7 +6774,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -6923,7 +6923,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7059,7 +7059,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7175,7 +7175,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7324,7 +7324,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7460,7 +7460,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7576,7 +7576,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7722,7 +7722,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7853,7 +7853,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -7969,7 +7969,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8115,7 +8115,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8246,7 +8246,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8362,7 +8362,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8507,7 +8507,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8637,7 +8637,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8752,7 +8752,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -8898,7 +8898,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9034,7 +9034,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9150,7 +9150,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9299,7 +9299,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9435,7 +9435,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9551,7 +9551,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9700,7 +9700,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9836,7 +9836,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -9952,7 +9952,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10101,7 +10101,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10237,7 +10237,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10353,7 +10353,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10499,7 +10499,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10630,7 +10630,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10746,7 +10746,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -10892,7 +10892,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -11023,7 +11023,7 @@ jobs:
         working-directory: pytorch/
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -11139,7 +11139,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -239,10 +239,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -527,7 +523,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -241,10 +241,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -529,7 +525,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -233,10 +233,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -237,10 +237,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -240,10 +240,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -240,10 +240,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -528,7 +524,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -238,10 +238,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -239,10 +239,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -527,7 +523,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -228,10 +228,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -228,10 +228,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -240,10 +240,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -528,7 +524,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -240,10 +240,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -528,7 +524,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -239,10 +239,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -527,7 +523,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -239,10 +239,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -239,10 +239,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -527,7 +523,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -238,10 +238,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -526,7 +522,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -227,10 +227,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -227,10 +227,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -237,10 +237,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -525,7 +521,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -239,10 +239,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -527,7 +523,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -238,10 +238,6 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-      - name: Hold runner for 2 hours or until ssh sessions have drained
-        # Always hold for active ssh sessions
-        if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
       - name: Clean up docker images
         if: always()
         run: |
@@ -526,7 +522,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -492,7 +492,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-windows-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-cxx11-abi.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -596,7 +596,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -880,7 +880,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1164,7 +1164,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1451,7 +1451,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1738,7 +1738,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2025,7 +2025,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2312,7 +2312,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2599,7 +2599,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2886,7 +2886,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3173,7 +3173,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3460,7 +3460,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3747,7 +3747,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4034,7 +4034,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4321,7 +4321,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4608,7 +4608,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4895,7 +4895,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5182,7 +5182,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5469,7 +5469,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5756,7 +5756,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-windows-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-pre-cxx11.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -596,7 +596,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -880,7 +880,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1164,7 +1164,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1451,7 +1451,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1738,7 +1738,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2025,7 +2025,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2312,7 +2312,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2599,7 +2599,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2886,7 +2886,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3173,7 +3173,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3460,7 +3460,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3747,7 +3747,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4034,7 +4034,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4321,7 +4321,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4608,7 +4608,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4895,7 +4895,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5182,7 +5182,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5469,7 +5469,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -5756,7 +5756,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/generated-windows-binary-wheel.yml
+++ b/.github/workflows/generated-windows-binary-wheel.yml
@@ -300,7 +300,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -575,7 +575,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -850,7 +850,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1125,7 +1125,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1397,7 +1397,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1672,7 +1672,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -1947,7 +1947,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2222,7 +2222,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2494,7 +2494,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -2769,7 +2769,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3044,7 +3044,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3319,7 +3319,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3591,7 +3591,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -3866,7 +3866,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4141,7 +4141,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |
@@ -4416,7 +4416,7 @@ jobs:
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()
-        run: .github/scripts/wait_for_ssh_to_drain.sh
+        run: [[ -e .github/scripts/wait_for_ssh_to_drain.sh ]] && .github/scripts/wait_for_ssh_to_drain.sh
       - name: Chown workspace
         if: always()
         run: |


### PR DESCRIPTION
There was some confusion over this script failing out after checkout
fails so in order to alleviate some of that confusion we should only run
the script if it exists

Signed-off-by: Eli Uriegas <eliuriegasfb.com>

ghstack-source-id: 76668b3d38001c117f35104f1a784d9c5b33be20
Pull Request resolved: https://github.com/pytorch/pytorch/pull/71954
