### PR TITLE
Update torch flatbuffer usage to OSS version

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.h
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.h
@@ -61,6 +61,12 @@ class FlatbufferLoader {
       IValueParser parser);
   mobile::Module parseModule(mobile::serialization::Module* module);
 
+  typedef TypePtr (*TypeResolver)(
+      const std::string& type_str,
+      std::shared_ptr<CompilationUnit> cu);
+
+  void internal_registerTypeResolver(TypeResolver type_resolver);
+
   IValue& getIValue(uint32_t pos) {
     TORCH_CHECK(pos < all_ivalues_.size());
     return all_ivalues_[pos];
@@ -103,6 +109,7 @@ class FlatbufferLoader {
       IValueParser,
       static_cast<uint8_t>(mobile::serialization::IValueUnion::MAX) + 1>
       ivalue_parsers_;
+  TypeResolver type_resolver_ = nullptr;
   mobile::serialization::Module* module_ = nullptr;
 };
 


### PR DESCRIPTION
Summary: Update users of flatbuffer serializer/loader to use the version in torch/csrc.

Test Plan:
sandcastle

Ran `buck run :test_models -- -k test_aten_relu` passes

Differential Revision: D33720611

