### PR TITLE
[caffe2] Fix compilation with fmt 8.x

### DIFF
--- a/torch/csrc/distributed/c10d/logging.h
+++ b/torch/csrc/distributed/c10d/logging.h
@@ -10,11 +10,20 @@
 
 #include <c10/util/Logging.h>
 
+namespace c10d {
+namespace detail {
+template <typename... T>
+std::string vformat(fmt::string_view fmt, T&&... args) {
+  return fmt::vformat(fmt, fmt::make_format_args(std::forward<T>(args)...));
+}
+}  // namespace detail
+}  // namespace c10d
+
 #define C10D_ERROR(...)\
-    LOG_IF(ERROR,   FLAGS_caffe2_log_level <= 2) << fmt::format(__VA_ARGS__)
+    LOG_IF(ERROR,   FLAGS_caffe2_log_level <= 2) << c10d::detail::vformat(__VA_ARGS__)
 
 #define C10D_WARNING(...)\
-    LOG_IF(WARNING, FLAGS_caffe2_log_level <= 1) << fmt::format(__VA_ARGS__)
+    LOG_IF(WARNING, FLAGS_caffe2_log_level <= 1) << c10d::detail::vformat(__VA_ARGS__)
 
 #define C10D_INFO(...)\
-    LOG_IF(INFO,    FLAGS_caffe2_log_level <= 0) << fmt::format(__VA_ARGS__)
+    LOG_IF(INFO,    FLAGS_caffe2_log_level <= 0) << c10d::detail::vformat(__VA_ARGS__)


### PR DESCRIPTION
Summary:
Fix a few issues that block migration to fmt 8.x:

1. Format strings must be known at compile time by default
2. `formatter` specialization must be visible when formatting an object

Test Plan: sandcastleit

Differential Revision: D33835157

