### PR TITLE
[bug fix] for add_activation layer, mobilenetv2 is fixed

### DIFF
--- a/test/fx2trt/converters/acc_op/test_hardtanh.py
+++ b/test/fx2trt/converters/acc_op/test_hardtanh.py
@@ -5,13 +5,19 @@ import torch.fx.experimental.fx_acc.acc_ops as acc_ops
 import torch.nn as nn
 from torch.testing._internal.common_fx2trt import AccTestCase
 from torch.testing._internal.common_utils import run_tests
+from parameterized import parameterized
 
 
 class TestHardtanhConverter(AccTestCase):
-    def test_hardtanh(self):
+    @parameterized.expand([
+        (-2.0, 6),
+        (0, 1),
+        (0.5, 7),
+    ])
+    def test_hardtanh(self, test_min_value, test_max_value):
         class Hardtanh(nn.Module):
             def forward(self, x):
-                return nn.functional.hardtanh(x, min_val=-0.5)
+                return nn.functional.hardtanh(x, min_val=test_min_value, max_val=test_max_value)
 
         inputs = [torch.randn(2, 10, 10, 10)]
         self.run_test(Hardtanh(), inputs, expected_ops={acc_ops.hardtanh})

--- a/torch/fx/experimental/fx2trt/converters/converter_utils.py
+++ b/torch/fx/experimental/fx2trt/converters/converter_utils.py
@@ -446,9 +446,9 @@ def add_activation_layer(
             "of the TensorRT region!"
         )
     layer = network.add_activation(input_val, operation_type)
-    if alpha:
+    if alpha is not None:
         layer.alpha = alpha
-    if beta:
+    if beta is not None:
         layer.beta = beta
     set_layer_name(layer, target, name)
     return layer.get_output(0)


### PR DESCRIPTION
Summary:
as titled
add local trt test for easy verification

Test Plan:
buck run mode/opt  -c=python.package_style=inplace   scripts/wwei6:trt_local_test
buck test mode/dev-nosan caffe2/test/fx2trt/converters:test_hardtanh

Differential Revision: D33824456

