### PR TITLE
Skip meta device for test_svd_nan_error

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2613,6 +2613,7 @@ class TestLinalg(TestCase):
                 S_s = torch.svd(A, compute_uv=False).S
                 self.assertEqual(S_s, S)
 
+    @skipMeta
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())


### PR DESCRIPTION
A follow-up to https://github.com/pytorch/pytorch/pull/68812. The test checks the behavior that is not intended to work with tensors on the 'meta' device.
