### PR TITLE
Avoid unnecessary copy of ExecutionPlan in operator()

### DIFF
--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -397,7 +397,7 @@ struct DifferentiableGraphOp {
 
     detachVariables(stack);
     if (IsNewExecutorEnabled()) {
-      ExecutionPlan plan =
+      const ExecutionPlan& plan =
           f_ptr->getPlanFor(stack, GraphExecutor::getDefaultNumBailOuts());
       InterpreterState(plan.code).run(stack);
     } else {


### PR DESCRIPTION
Summary: Remove unnecessary copy

Test Plan: CI + perf measurement

Reviewed By: marksantaniello

Differential Revision: D33816746

