### PR TITLE
Support `torch.broadcast_arrays` alias 

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -171,6 +171,10 @@ std::vector<Tensor> broadcast_tensors(TensorList tensors) {
   return expand_outplace(tensors);
 }
 
+std::vector<Tensor> broadcast_arrays(TensorList tensors) {
+  return at::broadcast_tensors(tensors);
+}
+
 static bool should_skip(const Tensor& t) {
   return t.numel() == 0 && t.dim() == 1;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1071,6 +1071,8 @@
 
 # alias for broadcast_tensors
 - func: broadcast_arrays(Tensor[] tensors) -> Tensor[]
+  device_check: NoCheck
+  device_guard: False
 
 - func: broadcast_to(Tensor(a) self, int[] size) -> Tensor(a)
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1069,6 +1069,9 @@
   device_check: NoCheck
   device_guard: False
 
+# alias for broadcast_tensors
+- func: broadcast_arrays(Tensor[] tensors) -> Tensor[]
+
 - func: broadcast_to(Tensor(a) self, int[] size) -> Tensor(a)
   variants: function, method
 

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -490,6 +490,7 @@ Other Operations
     bincount
     block_diag
     broadcast_tensors
+    broadcast_arrays
     broadcast_to
     broadcast_shapes
     bucketize

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -104,6 +104,7 @@ const std::unordered_map<Symbol, Symbol>& getOperatorAliasMap() {
       {aten::arcsinh_, aten::asinh_},
       {aten::arctanh, aten::atanh},
       {aten::arctanh_, aten::atanh_},
+      {aten::broadcast_arrays, aten::broadcast_tensors},
       {aten::fix, aten::trunc},
       {aten::fix_, aten::trunc_},
       {aten::negative, aten::neg},

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -23,6 +23,7 @@ __all__ = [
     'align_tensors',
     'broadcast_shapes',
     'broadcast_tensors',
+    'broadcast_arrays',
     'cartesian_prod',
     'block_diag',
     'cdist',
@@ -74,6 +75,11 @@ def broadcast_tensors(*tensors):
         return handle_torch_function(broadcast_tensors, tensors, *tensors)
     return _VF.broadcast_tensors(tensors)  # type: ignore[attr-defined]
 
+def broadcast_arrays(*tensors):
+    r"""broadcast_arrays(*tensors) -> List of Tensors
+    Alias of :func:`torch.broadcast_tensors`.
+    """
+    return broadcast_tensors(*tensors)
 
 def broadcast_shapes(*shapes):
     r"""broadcast_shapes(*shapes) -> Size

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -367,6 +367,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.block_diag: lambda *tensors: -1,
         torch.bmm: lambda input, mat2, out=None: -1,
         torch.broadcast_tensors: lambda *tensors: -1,
+        torch.broadcast_arrays: lambda *tensors: -1,
         torch.broadcast_to: lambda self, size: -1,
         torch.bucketize: lambda input, boundaries, out_int32=False, right=False, out=None: -1,
         torch.cartesian_prod: lambda *tensors: -1,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8647,6 +8647,7 @@ op_db: List[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_broadcast_to),
     OpInfo('broadcast_tensors',
+           aliases=('broadcast_arrays', ),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            supports_out=False,
            supports_forward_ad=True,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8660,7 +8660,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', dtypes=[torch.float32]),
                # broadcast_arrays returns an iterable of tensors.
                # AttributeError: 'tuple' object has no attribute 'dtype'
-               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_jit_alias_remapping'),),
+               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_jit_alias_remapping'),
            ),
            sample_inputs_func=sample_inputs_broadcast_tensors),
     OpInfo('block_diag',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8658,6 +8658,9 @@ op_db: List[OpInfo] = [
                # INTERNAL ASSERT FAILED at "../torch/csrc/jit/passes/utils/check_alias_annotation.cpp":252,
                # please report a bug to PyTorch.
                DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', dtypes=[torch.float32]),
+               # broadcast_arrays returns an iterable of tensors.
+               # AttributeError: 'tuple' object has no attribute 'dtype'
+               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_jit_alias_remapping'),),
            ),
            sample_inputs_func=sample_inputs_broadcast_tensors),
     OpInfo('block_diag',


### PR DESCRIPTION
Fixes a part of #58742

This PR adds the `broadcast_arrays` alias to `broadcast_tensors` to make it compliant with the [Python Array API ](https://data-apis.org/array-api/latest/API_specification/data_type_functions.html?highlight=broadcast_arrays#broadcast-arrays-arrays)

cc @kshitij12345 


