### PR TITLE
Implement `__ipow__`  to make it compatible with the Python Array API 

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -480,7 +480,6 @@ class TestBinaryUfuncs(TestCase):
         for shape in shapes:
             lhs = make_tensor(shape, device, dtype, **op.lhs_make_tensor_kwargs)
             rhs = make_tensor(shape, device, dtype, **op.rhs_make_tensor_kwargs)
-
             lhs_non_contig = lhs.clone().expand(3, -1, -1)
             rhs_non_contig = rhs.clone().expand(3, -1, -1)
 
@@ -1121,6 +1120,7 @@ class TestBinaryUfuncs(TestCase):
         t -= 1
         t *= 1
         t /= 1
+        t **= 1
         with self.assertWarnsOnceRegex(UserWarning, 'floor_divide'):
             t //= 1
         t %= 1

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -631,8 +631,7 @@ class Tensor(torch._C._TensorBase):
     def __ipow__(self, other):  # type: ignore[misc]
         if has_torch_function_variadic(self, other):
             return handle_torch_function(Tensor.__ipow__, (self, other), self, other)
-        dtype = torch.result_type(self, other)
-        return torch.pow(self, other, out=self)
+        return self.pow_(other)
 
     @_wrap_type_error_to_not_implemented
     def __rpow__(self, other):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -632,7 +632,7 @@ class Tensor(torch._C._TensorBase):
         if has_torch_function_variadic(self, other):
             return handle_torch_function(Tensor.__ipow__, (self, other), self, other)
         dtype = torch.result_type(self, other)
-        return torch.pow(self, other, out=self).to(dtype=dtype, device=self.device)
+        return torch.pow(self, other, out=self)
 
     @_wrap_type_error_to_not_implemented
     def __rpow__(self, other):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -626,7 +626,7 @@ class Tensor(torch._C._TensorBase):
         if self.dim() == 0:
             return self.item().__format__(format_spec)
         return object.__format__(self, format_spec)
-    
+
     @_wrap_type_error_to_not_implemented
     def __ipow__(self, other):  # type: ignore[misc]
         if has_torch_function_variadic(self, other):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -626,11 +626,13 @@ class Tensor(torch._C._TensorBase):
         if self.dim() == 0:
             return self.item().__format__(format_spec)
         return object.__format__(self, format_spec)
-
+    
+    @_wrap_type_error_to_not_implemented
     def __ipow__(self, other):  # type: ignore[misc]
         if has_torch_function_variadic(self, other):
             return handle_torch_function(Tensor.__ipow__, (self, other), self, other)
-        return NotImplemented
+        dtype = torch.result_type(self, other)
+        return torch.pow(self, other, out=self).to(dtype=dtype, device=self.device)
 
     @_wrap_type_error_to_not_implemented
     def __rpow__(self, other):


### PR DESCRIPTION
Fixes a part of #58742

This PR adds the implementation for `__ipow__` to make it compliant with the [Python Array API](https://data-apis.org/array-api/latest/API_specification/array_object.html?highlight=__ipow__)

cc @kshitij12345 