### PR TITLE
Raise error when test suite has been stopped

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1666,6 +1666,7 @@ class TestCase(expecttest.TestCase):
             try:
                 torch.cuda.synchronize()
             except RuntimeError as rte:
+                print(f"torch cuda synchronize failed with: {rte}")
                 return True
             return False
         else:
@@ -1775,7 +1776,7 @@ class TestCase(expecttest.TestCase):
         # Early terminate test if necessary.
         if self._should_stop_test_suite():
             result.stop()
-            raise RuntimeError("Test suite had to be stopped! OH NO")
+            raise RuntimeError("Test suite had to be stopped as unrecoverable error occurred.")
 
         if not RETRY_TEST_CASES or not using_unittest:
             return

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1775,6 +1775,7 @@ class TestCase(expecttest.TestCase):
         # Early terminate test if necessary.
         if self._should_stop_test_suite():
             result.stop()
+            raise RuntimeError("Test suite had to be stopped! OH NO")
 
         if not RETRY_TEST_CASES or not using_unittest:
             return


### PR DESCRIPTION
Could help with #71973

Shows an error now instead of silently failing https://github.com/pytorch/pytorch/runs/4984879439?check_suite_focus=true