### PR TITLE
[warnings][caffe2] Fix asserts yielding -Wstring-conversion warnings

### DIFF
--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -315,15 +315,15 @@ class CudaKernelGenerator : private kir::IrVisitor {
   }
 
   void visit(const kir::IterDomain* node) final {
-    TORCH_INTERNAL_ASSERT(!"Unreachable");
+    TORCH_INTERNAL_ASSERT(false && "Unreachable");
   }
 
   void visit(const kir::TensorDomain* node) final {
-    TORCH_INTERNAL_ASSERT(!"Unreachable");
+    TORCH_INTERNAL_ASSERT(false && "Unreachable");
   }
 
   void visit(const kir::TensorView* tv) final {
-    TORCH_INTERNAL_ASSERT(!"Unreachable");
+    TORCH_INTERNAL_ASSERT(false && "Unreachable");
   }
 
   void visit(const kir::UnaryOp* node) final {


### PR DESCRIPTION
Summary:
Find and replace `assert(!"` with `assert(false && "`
Excludes headers and paths that contain "third-party" or "external"

Clang raises a `-Wstring-conversion` warning when treating a string as a boolean.  This is not uncommon for asserts though (e.g. `assert(!"should never happen")`).  Clang does permit `expr && "string"` though in order to support these assertion use cases.

Test Plan: ci pass

Differential Revision: D33823092

