### PR TITLE
[warnings][caffe2] Fix broken asserts (never trigger)

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -265,7 +265,7 @@ __device__ __inline__ void vectorized_layer_norm_kernel_impl(
   T_ACC* /*mean*/,
   T_ACC* /*rstd*/,
   T* /*Y*/){
-    CUDA_KERNEL_ASSERT("doesn't work with double");
+    CUDA_KERNEL_ASSERT(false && "doesn't work with double");
   }
 
 //to avoid windows SFINAE errors

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -315,15 +315,15 @@ class CudaKernelGenerator : private kir::IrVisitor {
   }
 
   void visit(const kir::IterDomain* node) final {
-    TORCH_INTERNAL_ASSERT(!"Unreachable");
+    TORCH_INTERNAL_ASSERT(false && "Unreachable");
   }
 
   void visit(const kir::TensorDomain* node) final {
-    TORCH_INTERNAL_ASSERT(!"Unreachable");
+    TORCH_INTERNAL_ASSERT(false && "Unreachable");
   }
 
   void visit(const kir::TensorView* tv) final {
-    TORCH_INTERNAL_ASSERT(!"Unreachable");
+    TORCH_INTERNAL_ASSERT(false && "Unreachable");
   }
 
   void visit(const kir::UnaryOp* node) final {

--- a/torch/csrc/jit/mobile/register_ops_common_utils.cpp
+++ b/torch/csrc/jit/mobile/register_ops_common_utils.cpp
@@ -89,7 +89,8 @@ IValue tensorToListRecursive(
     } else if (inner_result.isBool()) {
       result.emplace_back(inner_result.toBool());
     } else {
-      TORCH_INTERNAL_ASSERT("Unknown return type for tensorToListRecursive");
+      TORCH_INTERNAL_ASSERT(
+          false && "Unknown return type for tensorToListRecursive");
     }
 
     data += strides[cur_dim] * element_size;


### PR DESCRIPTION
Summary:
`assert("string")` evaluates as `assert(true)` and thus never fires (oops!)
`assert(false && "string")` is the prescribed and supported way clang supports asserting "never" so that a string can be captured

Test Plan: ci pass

Differential Revision: D33824206

