### PR TITLE
Support to p4d.24xlarge instance.

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -57,6 +57,12 @@ runner_types:
     max_available: 10
     disk_size: 150
     is_ephemeral: false
+  linux.p4d24xlarge.nvidia.gpu:
+    instance_type: p4d.24xlarge
+    os: linux
+    max_available: 1
+    disk_size: 512
+    is_ephemeral: false
   windows.4xlarge:
     instance_type: c5d.4xlarge
     os: windows


### PR DESCRIPTION
We are adding support to benchmark workloads with AWS p4dn.24xlarge instance with Nvidia A100 GPU.

TODO items:
- Make this runner to be at org-level so that other repositories (such as pytorch/benchmark) can utilize
- Test if there is capacity issue with a nightly CI