### PR TITLE
Make upgrader test model generation more robust

### DIFF
--- a/test/jit/fixtures_srcs/generate_models.py
+++ b/test/jit/fixtures_srcs/generate_models.py
@@ -135,8 +135,12 @@ def get_output_model_version(script_module: torch.nn.Module) -> int:
     torch.jit.save(script_module, buffer)
     buffer.seek(0)
     zipped_model = zipfile.ZipFile(buffer)
-    version = int(zipped_model.read('archive/version').decode("utf-8"))
-    return version
+    try:
+        version = int(zipped_model.read('archive/version').decode("utf-8"))
+        return version
+    except KeyError:
+        version = int(zipped_model.read('archive/.data/version').decode("utf-8"))
+        return version
 
 """
 Loop through all test modules. If the corresponding model doesn't exist in
@@ -158,9 +162,6 @@ def generate_models(model_directory_path: Path):
     all_models = get_all_models(model_directory_path)
     for a_module, expect_operator in ALL_MODULES.items():
         print(a_module, expect_operator)
-        script_module = torch.jit.script(a_module)
-        actual_model_version = get_output_model_version(script_module)
-
         # For example: TestVersionedDivTensorExampleV7
         torch_module_name = type(a_module).__name__
 
@@ -169,10 +170,15 @@ def generate_models(model_directory_path: Path):
             '_' + char.lower() if char.isupper() else char for char in torch_module_name
         ]).lstrip('_')
 
+        # Some models may not compile anymore, so skip the ones
+        # that already has pt file for them.
         logger.info(f"Processing {torch_module_name}")
         if model_exist(model_name, all_models):
             logger.info(f"Model {model_name} already exists, skipping")
             continue
+
+        script_module = torch.jit.script(a_module)
+        actual_model_version = get_output_model_version(script_module)
 
         current_operator_version = torch._C._get_max_operator_version()
         if actual_model_version >= current_operator_version + 1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72030

This fixes two things:
1. When the version number is higher than 4, we save them under .data/version instead of version. So the way we load model's version number needs to reflect that 
2. Sometime the old model we are writing for upgrader testing won't compile in new runtime. (linspace requiring steps size ) Therefore, we should skip over the cases where they already have generated model files. 
Differential Revision: [D33863263](https://our.internmc.facebook.com/intern/diff/D33863263)