### PR TITLE
[torchelastic][etcd] Make default `last_call_timeout` as two times `timeout`

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_rendezvous_test.py
@@ -14,6 +14,7 @@ from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_han
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 
 if os.getenv("CIRCLECI"):
+    import sys
     print("T85992919 temporarily disabling in circle ci", file=sys.stderr)
     sys.exit(0)
 
@@ -79,3 +80,17 @@ class EtcdRendezvousTest(unittest.TestCase):
         etcd_rdzv = create_rdzv_handler(rdzv_params)
 
         self.assertEqual("etcd", etcd_rdzv.get_backend())
+
+    def test_check_default_last_call_timeout(self):
+        run_id = str(uuid.uuid4())
+        rdzv_params = RendezvousParameters(
+            backend="etcd",
+            endpoint=f"{self._etcd_server.get_endpoint()}",
+            run_id=run_id,
+            min_nodes=1,
+            max_nodes=1,
+            timeout=60,
+            protocol="http",
+        )
+
+        self.assertEqual(120, rdzv_params.last_call_timeout)


### PR DESCRIPTION
Summary:
Set `last_call_timeout` to `timeout*2` , and add a warning message if `last_call_timeout` is set manually.

More info: https://github.com/pytorch/pytorch/issues/67616#issuecomment-960516271

Test Plan: unittests

Differential Revision: D33863912

