### PR TITLE
[nnc] Update cuda codegen to use llvm for thread and block extent computations

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -1024,6 +1024,20 @@ void CudaCodeGen::Initialize() {
     thread_block_size_ = -1;
   }
 
+#ifdef TORCH_ENABLE_LLVM
+  // Build an LLVM based eval expression for the extents
+  block_extents_compiled_.reserve(block_extents.size());
+  for (const auto& be : block_extents) {
+    block_extents_compiled_.emplace_back(
+        ExprEval<LLVMCodeGen>(ExprHandle(be), buffer_args));
+  }
+  thread_extents_compiled_.reserve(thread_extents.size());
+  for (const auto& te : thread_extents) {
+    thread_extents_compiled_.emplace_back(
+        ExprEval<LLVMCodeGen>(ExprHandle(te), buffer_args));
+  }
+#endif
+
   GRAPH_DEBUG(
       "Fused TE CUDA kernel:\n",
       oss_.str(),
@@ -1117,18 +1131,28 @@ void CudaCodeGen::call_raw(const std::vector<void*>& raw_args) {
       gpu_block_extents_v[i] = immediateAs<int64_t>(gpu_block_extents[i]);
       continue;
     }
+#ifdef TORCH_ENABLE_LLVM
+    gpu_block_extents_v[i] =
+        block_extents_compiled_[i].value<int64_t>(raw_args);
+#else
     ExprEval<SimpleIREvaluator> eval(
         ExprHandle(gpu_block_extents[i]), buffer_args);
     gpu_block_extents_v[i] = eval.value<int64_t>(raw_args);
+#endif
   }
   for (size_t i = 0; i < gpu_thread_extents.size(); i++) {
     if (gpu_thread_extents[i]->isConstant()) {
       gpu_thread_extents_v[i] = immediateAs<int64_t>(gpu_thread_extents[i]);
       continue;
     }
+#ifdef TORCH_ENABLE_LLVM
+    gpu_thread_extents_v[i] =
+        thread_extents_compiled_[i].value<int64_t>(raw_args);
+#else
     ExprEval<SimpleIREvaluator> eval(
         ExprHandle(gpu_thread_extents[i]), buffer_args);
     gpu_thread_extents_v[i] = eval.value<int64_t>(raw_args);
+#endif
   }
 
   // Skip launching the kernel if there are no elements to process.

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -10,9 +10,11 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
+#include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
 #include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+#include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 #include <torch/csrc/jit/tensorexpr/unique_name_manager.h>
 
 namespace torch {
@@ -274,6 +276,11 @@ class TORCH_CUDA_CU_API CudaCodeGen : public CodeGen {
   CUfunction function_;
   bool has_random_ = false;
   int thread_block_size_ = -1;
+
+#ifdef TORCH_ENABLE_LLVM
+  std::vector<ExprEval<LLVMCodeGen>> block_extents_compiled_;
+  std::vector<ExprEval<LLVMCodeGen>> thread_extents_compiled_;
+#endif
 
   std::string GetUniqueFuncName(const std::string& func_prefix);
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72038
* #72036
* __->__ #72035
* #72032
* #71651
* #71650
* #71173

Differential Revision: [D33864650](https://our.internmc.facebook.com/intern/diff/D33864650)