### PR TITLE
[caffe2] Rename c10d::detail::vformat to resolve conflict with fmt

### DIFF
--- a/torch/csrc/distributed/c10d/logging.h
+++ b/torch/csrc/distributed/c10d/logging.h
@@ -13,17 +13,17 @@
 namespace c10d {
 namespace detail {
 template <typename... T>
-std::string vformat(fmt::string_view fmt, T&&... args) {
-  return fmt::vformat(fmt, fmt::make_format_args(std::forward<T>(args)...));
+std::string log_vformat(fmt::string_view fmt, T&&... args) {
+  return fmt::vformat(fmt, fmt::make_format_args(args...));
 }
 }  // namespace detail
 }  // namespace c10d
 
 #define C10D_ERROR(...)\
-    LOG_IF(ERROR,   FLAGS_caffe2_log_level <= 2) << c10d::detail::vformat(__VA_ARGS__)
+    LOG_IF(ERROR,   FLAGS_caffe2_log_level <= 2) << c10d::detail::log_vformat(__VA_ARGS__)
 
 #define C10D_WARNING(...)\
-    LOG_IF(WARNING, FLAGS_caffe2_log_level <= 1) << c10d::detail::vformat(__VA_ARGS__)
+    LOG_IF(WARNING, FLAGS_caffe2_log_level <= 1) << c10d::detail::log_vformat(__VA_ARGS__)
 
 #define C10D_INFO(...)\
-    LOG_IF(INFO,    FLAGS_caffe2_log_level <= 0) << c10d::detail::vformat(__VA_ARGS__)
+    LOG_IF(INFO,    FLAGS_caffe2_log_level <= 0) << c10d::detail::log_vformat(__VA_ARGS__)


### PR DESCRIPTION
Summary: As it turned out calling the function `vformat` was a bad idea because it caused a subtle compilation error due to a conflict with `fmt::vformat` and as a result wrong function overload being found during lookup.

Test Plan:
```
buck build //caffe2:libtorch
```

Differential Revision: D33864790

