### PR TITLE
Update logspace and bump the version number to 9

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -37,16 +37,8 @@ Tensor& linspace_out(const Scalar& start, const Scalar& end, int64_t steps, Tens
   return result;
 }
 
-Tensor& logspace_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, double base, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
+Tensor& logspace_out(const Scalar& start, const Scalar& end, int64_t steps, double base, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for logspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
 
   if (result.numel() != steps) {
     result.resize_({steps});

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -571,7 +571,7 @@ Tensor linspace(
 Tensor logspace(
     const Scalar& start,
     const Scalar& end,
-    c10::optional<int64_t> steps,
+    int64_t steps,
     double base,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
@@ -580,10 +580,9 @@ Tensor logspace(
   // See [Note: hacky wrapper removal for TensorOptions]
   TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
 
-  const auto steps_ = steps.value_or(100);
-  TORCH_CHECK(steps_ >= 0, "number of steps must be non-negative");
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   auto result_options = linspace_logspace_infer_options(start, end, options, "torch.logspace()");
-  Tensor result = at::empty({steps_}, result_options);
+  Tensor result = at::empty({steps}, result_options);
   return at::logspace_out(result, start, end, steps, base);
 }
 

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -102,16 +102,8 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps,
   return result;
 }
 
-Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, double base, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
+Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, double base, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for logspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
 
   if (result.numel() != steps) {
     result.resize_({steps});

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2777,9 +2777,9 @@
   dispatch:
     CompositeExplicitAutograd: logdet
 
-- func: logspace(Scalar start, Scalar end, int? steps=None, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace(Scalar start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: logspace.out(Scalar start, Scalar end, int? steps=None, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
+- func: logspace.out(Scalar start, Scalar end, int steps, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, Meta: logspace_out
     CUDA: logspace_cuda_out

--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -12,7 +12,7 @@ namespace serialize {
 constexpr uint64_t kMinSupportedFileFormatVersion = 0x1L;
 
 #if ENABLE_UPGRADERS
-constexpr uint64_t kMaxSupportedFileFormatVersion = 0x8L;
+constexpr uint64_t kMaxSupportedFileFormatVersion = 0x9L;
 #else
 constexpr uint64_t kMaxSupportedFileFormatVersion = 0x6L;
 #endif
@@ -75,8 +75,11 @@ constexpr uint64_t kMaxSupportedFileFormatVersion = 0x6L;
 //     We bump the version number to 8 to update aten::linspace
 //     and aten::linspace.out to error out when steps is not
 //     provided. (see: https://github.com/pytorch/pytorch/issues/55951)
-// 2) ...
-constexpr uint64_t kProducedFileFormatVersion = 0x8L;
+// 2) [01/30/2022]
+//     Bump the version number to 9 to update aten::logspace and
+//     and aten::logspace.out to error out when steps is not
+//     provided. (see: https://github.com/pytorch/pytorch/issues/55951)
+constexpr uint64_t kProducedFileFormatVersion = 0x9L;
 #else
 constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 #endif

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -86,6 +86,7 @@ ALLOW_LIST = [
     ("aten::_max_pool1d_cpu_forward", datetime.date(2022, 2, 8)),
     ("aten::_convolution_nogroup", datetime.date(9999, 1, 1)),
     ("aten::linspace", datetime.date(2022, 3, 1)),  # TODO this will be removed soon
+    ("aten::logspace", datetime.date(2022, 3, 1)),  # TODO this will be removed soon
     ("aten::miopen_convolution_backward", datetime.date(9999, 1, 1)),
     ("aten::miopen_convolution_backward_bias", datetime.date(9999, 1, 1)),
     ("aten::miopen_convolution_backward_input", datetime.date(9999, 1, 1)),

--- a/test/jit/test_save_load_for_op_version.py
+++ b/test/jit/test_save_load_for_op_version.py
@@ -481,3 +481,62 @@ class TestSaveLoadForOpVersion(JitTestCase):
             self.assertTrue(output.size(dim=0) == 100)
             # "Upgraded" model should match the new version output
             self.assertEqual(output, output_current)
+
+    def test_versioned_logspace(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super(Module, self).__init__()
+
+            def forward(self, a: Union[int, float, complex], b: Union[int, float, complex]):
+                c = torch.logspace(a, b, steps=5)
+                d = torch.logspace(a, b, steps=100)
+                return c, d
+
+        scripted_module = torch.jit.load(
+            pytorch_test_dir + "/jit/fixtures/test_versioned_logspace_v8.ptl")
+
+        buffer = io.BytesIO(scripted_module._save_to_buffer_for_lite_interpreter())
+        buffer.seek(0)
+        v8_mobile_module = _load_for_lite_interpreter(buffer)
+
+        current_mobile_module = self._save_load_mobile_module(Module)
+
+        sample_inputs = ((3, 10), (-10, 10), (4.0, 6.0), (3 + 4j, 4 + 5j))
+        for (a, b) in sample_inputs:
+            (output_with_step, output_without_step) = v8_mobile_module(a, b)
+            (current_with_step, current_without_step) = current_mobile_module(a, b)
+            # when no step is given, should have used 100
+            self.assertTrue(output_without_step.size(dim=0) == 100)
+            self.assertTrue(output_with_step.size(dim=0) == 5)
+            # outputs should be equal to the newest version
+            self.assertEqual(output_with_step, current_with_step)
+            self.assertEqual(output_without_step, current_without_step)
+
+    def test_versioned_logspace_out(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super(Module, self).__init__()
+
+            def forward(self, a: Union[int, float, complex], b: Union[int, float, complex], out: torch.Tensor):
+                return torch.logspace(a, b, steps=100, out=out)
+
+        model_path = pytorch_test_dir + "/jit/fixtures/test_versioned_logspace_out_v8.ptl"
+        loaded_model = torch.jit.load(model_path)
+        buffer = io.BytesIO(loaded_model._save_to_buffer_for_lite_interpreter())
+        buffer.seek(0)
+        v8_mobile_module = _load_for_lite_interpreter(buffer)
+        current_mobile_module = self._save_load_mobile_module(Module)
+
+        sample_inputs = (
+            (3, 10, torch.empty((100,), dtype=torch.int64), torch.empty((100,), dtype=torch.int64)),
+            (-10, 10, torch.empty((100,), dtype=torch.int64), torch.empty((100,), dtype=torch.int64)),
+            (4.0, 6.0, torch.empty((100,), dtype=torch.float64), torch.empty((100,), dtype=torch.float64)),
+            (3 + 4j, 4 + 5j, torch.empty((100,), dtype=torch.complex64), torch.empty((100,), dtype=torch.complex64)),
+        )
+        for (start, end, out_for_old, out_for_new) in sample_inputs:
+            output = v8_mobile_module(start, end, out_for_old)
+            output_current = current_mobile_module(start, end, out_for_new)
+            # when no step is given, should have used 100
+            self.assertTrue(output.size(dim=0) == 100)
+            # "Upgraded" model should match the new version output
+            self.assertEqual(output, output_current)

--- a/test/jit/test_upgraders.py
+++ b/test/jit/test_upgraders.py
@@ -171,6 +171,38 @@ class TestUpgraders(JitTestCase):
         self.assertTrue(version == 8)
 
     @unittest.skipIf(not _is_upgraders_enabled(), "Skipping because upgraders are not enabled")
+    def test_aten_logspace(self):
+        model_path = pytorch_test_dir + "/jit/fixtures/test_versioned_logspace_v8.ptl"
+        loaded_model = torch.jit.load(model_path)
+        sample_inputs = ((3, 10), (-10, 10), (4.0, 6.0), (3 + 4j, 4 + 5j))
+        for (a, b) in sample_inputs:
+            output_with_step, output_without_step = loaded_model(a, b)
+            # when no step is given, should have used 100
+            self.assertTrue(output_without_step.size(dim=0) == 100)
+            self.assertTrue(output_with_step.size(dim=0) == 5)
+
+        version = self._load_model_version(loaded_model)
+        self.assertTrue(version == 9)
+
+    @unittest.skipIf(not _is_upgraders_enabled(), "Skipping because upgraders are not enabled")
+    def test_aten_logspace_out(self):
+        model_path = pytorch_test_dir + "/jit/fixtures/test_versioned_logspace_out_v8.ptl"
+        loaded_model = torch.jit.load(model_path)
+        sample_inputs = (
+            (3, 10, torch.empty((100,), dtype=torch.int64)),
+            (-10, 10, torch.empty((100,), dtype=torch.int64)),
+            (4.0, 6.0, torch.empty((100,), dtype=torch.float64)),
+            (3 + 4j, 4 + 5j, torch.empty((100,), dtype=torch.complex64)),
+        )
+        for (a, b, c) in sample_inputs:
+            output = loaded_model(a, b, c)
+            # when no step is given, should have used 100
+            self.assertTrue(output.size(dim=0) == 100)
+
+        version = self._load_model_version(loaded_model)
+        self.assertTrue(version == 9)
+
+    @unittest.skipIf(not _is_upgraders_enabled(), "Skipping because upgraders are not enabled")
     def test_aten_test_serialization(self):
         model_path = pytorch_test_dir + "/jit/fixtures/_test_serialization_subcmul_v2.pt"
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2736,14 +2736,6 @@ class TestTensorCreation(TestCase):
             self.assertEqual(t[0], a[0])
             self.assertEqual(t[steps - 1], a[steps - 1])
 
-    def _logspace_warning_helper(self, op, device, dtype):
-        with self.assertWarnsOnceRegex(UserWarning, "Not providing a value for .+"):
-            op(0, 10, device=device, dtype=dtype)
-
-    @dtypes(torch.float)
-    def test_logspace_steps_warning(self, device, dtype):
-        self._logspace_warning_helper(torch.logspace, device, dtype)
-
     @onlyCUDA
     @largeTensorTest('16GB')
     def test_range_factories_64bit_indexing(self, device):
@@ -3092,6 +3084,8 @@ class TestTensorCreation(TestCase):
         torch.logspace(_from, to, 137, device=device, dtype=dtype, out=res2)
         self.assertEqual(res1, res2, atol=0, rtol=0)
         self.assertRaises(RuntimeError, lambda: torch.logspace(0, 1, -1, device=device, dtype=dtype))
+        # steps not provided
+        self.assertRaises(TypeError, lambda: torch.logspace(0, 1, device=device, dtype=dtype))
         self.assertEqual(torch.logspace(0, 1, 1, device=device, dtype=dtype),
                          torch.ones(1, device=device, dtype=dtype), atol=0, rtol=0)
 

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -333,7 +333,9 @@ class TestTypePromotion(TestCase):
         bool_tensor_lin = torch.linspace(False, True, steps=100, device=device)
         int_tensor_lin = torch.linspace(0, 1, steps=100, device=device)
         self.assertEqual(bool_tensor_lin, int_tensor_lin)
-        self.assertEqual(torch.logspace(False, True, device=device), torch.logspace(0, 1, device=device))
+        bool_tensor_log = torch.linspace(False, True, steps=100, device=device)
+        int_tensor_log = torch.linspace(0, 1, steps=100, device=device)
+        self.assertEqual(bool_tensor_log, int_tensor_log)
 
         # this seems like odd behavior but ints also create float tensors, numpy doesn't have this function.
         self.assertEqual(torch.scalar_tensor(False, device=device), torch.tensor(0., device=device))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5469,13 +5469,8 @@ with base :attr:`base`. That is, the values are:
     \text{base}^{\text{end}})
 """ + """
 
-.. warning::
-    Not providing a value for :attr:`steps` is deprecated. For backwards
-    compatibility, not providing a value for :attr:`steps` will create a tensor
-    with 100 elements. Note that this behavior is not reflected in the
-    documented function signature and should not be relied on. In a future
-    PyTorch release, failing to provide a value for :attr:`steps` will throw a
-    runtime error.
+
+From PyTorch 1.11 logspace requires the steps argument. Use steps=100 to restore the previous behavior.
 
 Args:
     start (float): the starting value for the set of points

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -559,7 +559,7 @@ static PyObject * THPVariable_logspace(PyObject* self_, PyObject* args, PyObject
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-    "logspace(Scalar start, Scalar end, int64_t? steps=None, double base=10.0, *, Tensor out=None, ScalarType dtype=None, Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False)",
+    "logspace(Scalar start, Scalar end, int64_t steps, double base=10.0, *, Tensor out=None, ScalarType dtype=None, Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False)",
   }, /*traceable=*/true);
 
   ParsedArgs<10> parsed_args;
@@ -568,7 +568,7 @@ static PyObject * THPVariable_logspace(PyObject* self_, PyObject* args, PyObject
     return handle_torch_function(_r, nullptr, args, kwargs, THPVariableFunctionsModule, "torch");
   }
   if (_r.isNone(4)) {
-    // aten::logspace(Scalar start, Scalar end, int? steps=None, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+    // aten::logspace(Scalar start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
     // NOTE: r.scalartype(X) gives the default dtype if r.isNone(X)
     // This leads to problem in the operator argument checks,
@@ -581,22 +581,22 @@ static PyObject * THPVariable_logspace(PyObject* self_, PyObject* args, PyObject
         .pinned_memory(_r.toBool(8));
     torch::utils::maybe_initialize_cuda(options);
 
-    auto dispatch_logspace = [](Scalar start, Scalar end, c10::optional<int64_t> steps, double base, TensorOptions options) -> Tensor {
+    auto dispatch_logspace = [](Scalar start, Scalar end, int64_t steps, double base, TensorOptions options) -> Tensor {
       pybind11::gil_scoped_release no_gil;
       return torch::logspace(start, end, steps, base, options);
     };
-    return wrap(dispatch_logspace(_r.scalar(0), _r.scalar(1), _r.toInt64Optional(2), _r.toDouble(3), options));
+    return wrap(dispatch_logspace(_r.scalar(0), _r.scalar(1), _r.toInt64(2), _r.toDouble(3), options));
   } else {
-    // aten::logspace.out(Scalar start, Scalar end, int? steps=None, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
+    // aten::logspace.out(Scalar start, Scalar end, int steps, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
     check_out_type_matches(_r.tensor(4), _r.scalartype(5),
                            _r.isNone(5), _r.layoutOptional(6),
                            _r.device(7), _r.isNone(7));
 
-    auto dispatch_logspace_out = [](Tensor out, Scalar start, Scalar end, c10::optional<int64_t> steps, double base) -> Tensor {
+    auto dispatch_logspace_out = [](Tensor out, Scalar start, Scalar end, int64_t steps, double base) -> Tensor {
       pybind11::gil_scoped_release no_gil;
       return at::logspace_out(out, start, end, steps, base);
     };
-    return wrap(dispatch_logspace_out(_r.tensor(4), _r.scalar(0), _r.scalar(1), _r.toInt64Optional(2), _r.toDouble(3)).set_requires_grad(_r.toBool(9)));
+    return wrap(dispatch_logspace_out(_r.tensor(4), _r.scalar(0), _r.scalar(1), _r.toInt64(2), _r.toDouble(3)).set_requires_grad(_r.toBool(9)));
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/jit/mobile/upgrader_mobile.cpp
+++ b/torch/csrc/jit/mobile/upgrader_mobile.cpp
@@ -51,6 +51,14 @@ getOperatorVersionMapForMobile() {
                     std::vector<Upgrader>({
                         Upgrader({0, 7, "linspace_out_0_7", 6})
                     })},
+                {std::string("aten::logspace"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 8, "logspace_0_8", 7})
+                    })},
+                {std::string("aten::logspace.out"),
+                    std::vector<Upgrader>({
+                        Upgrader({0, 8, "logspace_out_0_8", 8})
+                    })},
       });
   return operatorVersionMapForMobile;
 }
@@ -374,6 +382,105 @@ const std::vector<ByteCodeFunctionWithOperator>& getUpgraderBytecodeList() {
                            std::vector<OperatorString>({
                                    OperatorString({"aten::__is__", "", 2}),
                                    OperatorString({"aten::linspace", "out", 4}),
+                                   OperatorString({"prim::unchecked_cast", "", 1}),
+                           }), // operators list
+                   }),
+                   ByteCodeFunctionWithOperator({
+                           mobile::Function::registerFunc(
+                               "logspace_0_8",
+                               std::vector<Instruction>({
+                                           Instruction{OpCode::STOREN, 1, 8},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::LOADC, 0, 0},
+                                           Instruction{OpCode::OP, 0, 0},
+                                           Instruction{OpCode::JF, 11, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOADC, 1, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::LOAD, 6, 0},
+                                           Instruction{OpCode::LOAD, 7, 0},
+                                           Instruction{OpCode::LOAD, 8, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::JMP, 11, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::OP, 2, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::LOAD, 6, 0},
+                                           Instruction{OpCode::LOAD, 7, 0},
+                                           Instruction{OpCode::LOAD, 8, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::STORE, 9, 0},
+                                           Instruction{OpCode::DROPR, 8, 0},
+                                           Instruction{OpCode::DROPR, 7, 0},
+                                           Instruction{OpCode::DROPR, 6, 0},
+                                           Instruction{OpCode::DROPR, 5, 0},
+                                           Instruction{OpCode::DROPR, 4, 0},
+                                           Instruction{OpCode::DROPR, 2, 0},
+                                           Instruction{OpCode::DROPR, 1, 0},
+                                           Instruction{OpCode::DROPR, 3, 0},
+                                           Instruction{OpCode::MOVE, 9, 0},
+                                           Instruction{OpCode::RET, 0, 0},
+                                   }), // instructions list,
+                               std::vector<c10::IValue>({
+                                           c10::IValue(),
+                                           c10::IValue(100),
+                                   }), // constants list,
+                               std::vector<c10::TypePtr>(), // types list,
+                               9
+                           ),
+                           std::vector<OperatorString>({
+                                   OperatorString({"aten::__is__", "", 2}),
+                                   OperatorString({"aten::logspace", "", 8}),
+                                   OperatorString({"prim::unchecked_cast", "", 1}),
+                           }), // operators list
+                   }),
+                   ByteCodeFunctionWithOperator({
+                           mobile::Function::registerFunc(
+                               "logspace_out_0_8",
+                               std::vector<Instruction>({
+                                           Instruction{OpCode::STOREN, 1, 5},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::LOADC, 0, 0},
+                                           Instruction{OpCode::OP, 0, 0},
+                                           Instruction{OpCode::JF, 8, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOADC, 1, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::JMP, 8, 0},
+                                           Instruction{OpCode::LOAD, 1, 0},
+                                           Instruction{OpCode::LOAD, 2, 0},
+                                           Instruction{OpCode::LOAD, 3, 0},
+                                           Instruction{OpCode::OP, 2, 0},
+                                           Instruction{OpCode::LOAD, 4, 0},
+                                           Instruction{OpCode::LOAD, 5, 0},
+                                           Instruction{OpCode::OP, 1, 0},
+                                           Instruction{OpCode::STORE, 6, 0},
+                                           Instruction{OpCode::DROPR, 5, 0},
+                                           Instruction{OpCode::DROPR, 4, 0},
+                                           Instruction{OpCode::DROPR, 2, 0},
+                                           Instruction{OpCode::DROPR, 1, 0},
+                                           Instruction{OpCode::DROPR, 3, 0},
+                                           Instruction{OpCode::MOVE, 6, 0},
+                                           Instruction{OpCode::RET, 0, 0},
+                                   }), // instructions list,
+                               std::vector<c10::IValue>({
+                                           c10::IValue(),
+                                           c10::IValue(100),
+                                   }), // constants list,
+                               std::vector<c10::TypePtr>(), // types list,
+                               6
+                           ),
+                           std::vector<OperatorString>({
+                                   OperatorString({"aten::__is__", "", 2}),
+                                   OperatorString({"aten::logspace", "out", 5}),
                                    OperatorString({"prim::unchecked_cast", "", 1}),
                            }), // operators list
                    }),

--- a/torch/csrc/jit/operator_upgraders/upgraders_entry.cpp
+++ b/torch/csrc/jit/operator_upgraders/upgraders_entry.cpp
@@ -15,7 +15,20 @@ namespace torch {
 namespace jit {
 
 static std::unordered_map<std::string, std::string> kUpgradersEntryMap(
-    {{"linspace_0_7", R"SCRIPT(
+    {{"logspace_0_8", R"SCRIPT(
+def logspace_0_8(start: Union[int, float, complex], end: Union[int, float, complex], steps: Optional[int], base: float, *, dtype: Optional[int], layout: Optional[int],
+                 device: Optional[Device], pin_memory: Optional[bool]):
+  if (steps is None):
+    return torch.logspace(start=start, end=end, steps=100, base=base, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory)
+  return torch.logspace(start=start, end=end, steps=steps, base=base, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory)
+)SCRIPT"},
+     {"logspace_out_0_8", R"SCRIPT(
+def logspace_out_0_8(start: Union[int, float, complex], end: Union[int, float, complex], steps: Optional[int], base: float, *, out: Tensor):
+  if (steps is None):
+    return torch.logspace(start=start, end=end, steps=100, base=base, out=out)
+  return torch.logspace(start=start, end=end, steps=steps, base=base, out=out)
+)SCRIPT"},
+     {"linspace_0_7", R"SCRIPT(
 def linspace_0_7(start: Union[int, float, complex], end: Union[int, float, complex], steps: Optional[int], *, dtype: Optional[int], layout: Optional[int],
                  device: Optional[Device], pin_memory: Optional[bool]):
   if (steps is None):

--- a/torch/csrc/jit/operator_upgraders/version_map.cpp
+++ b/torch/csrc/jit/operator_upgraders/version_map.cpp
@@ -16,7 +16,15 @@ static bool isVersionMapSorted = false;
 // Note for developers: The list of upgraders should be SORTED
 // by the version number where the upgrader is registered.
 static std::unordered_map<std::string, std::vector<UpgraderEntry>> operatorVersionMap(
-    {{"aten::linspace",
+    {{"aten::logspace",
+      {{9,
+        "logspace_0_8",
+        "aten::logspace(Scalar start, Scalar end, int? steps=None, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"}}},
+     {"aten::logspace.out",
+      {{9,
+        "logspace_out_0_8",
+        "aten::logspace.out(Scalar start, Scalar end, int? steps=None, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)"}}},
+     {"aten::linspace",
       {{8,
         "linspace_0_7",
         "aten::linspace(Scalar start, Scalar end, int? steps=None, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"}}},


### PR DESCRIPTION
Summary: This PR adds upgraders for logspace and logspace.out as the optional step size will be deprecated soon. Old models will be using steps size of 100 when nothing is provided.

Differential Revision: D33885098

Note that this PR introduces BC incompatible change since we are deprecating the option of not providing steps size for torch.logspace. If you didn't provide steps in your model, you need to do this to restore old behaviour:

`torch.logspace(start, end) -> torch.logspace(start, end, steps=100)`

