### PR TITLE
Back out "[pytorch][PR] Fix SVD error code handling for OpenBLAS 0.3.15+ and MKL 2022+"

### DIFF
--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -306,16 +306,6 @@ static inline void singleCheckErrors(int64_t info, const c10::string_view name, 
     batch_string = ": (Batch element " + std::to_string(batch_id) + ")";
   }
   if (info < 0) {
-    // Reference LAPACK 3.10+ changed `info` behavior for inputs with non-finite values
-    // Previously, it would return `info` > 0, but now it returns `info` = -4
-    // OpenBLAS 0.3.15+ uses the Reference LAPACK 3.10+.
-    // MKL 2022.0+ uses the Reference LAPACK 3.10+.
-    // Older version of MKL and OpenBLAS follow the old behavior (return `info` > 0).
-    // Here we check for the case where `info` is -4 and raise an error
-    if (name.find("svd") != name.npos) {
-      TORCH_CHECK_LINALG(info != -4, name, batch_string,
-          ": The algorithm failed to converge because the input matrix contained non-finite values.");
-    }
     TORCH_INTERNAL_ASSERT(false, name, batch_string,
         ": Argument ", -info, " has illegal value. Most certainly there is a bug in the implementation calling the backend library.");
   } else if (info > 0) {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1685,10 +1685,11 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     def test_norm_extreme_values(self, device):
+        if torch.device(device).type == 'cpu':
+            self.skipTest("Test broken on cpu (see gh-71645)")
+
         vector_ords = [0, 1, 2, 3, inf, -1, -2, -3, -inf]
-        # matrix_ords 'nuc', 2, -2 are skipped currently
-        # See issue https://github.com/pytorch/pytorch/issues/71911
-        matrix_ords = ['fro', 1, inf, -1, -inf]
+        matrix_ords = ['fro', 'nuc', 1, 2, inf, -1, -2, -inf]
         vectors = []
         matrices = []
         for pair in itertools.product([inf, -inf, 0.0, nan, 1.0], repeat=2):
@@ -1726,8 +1727,8 @@ class TestLinalg(TestCase):
                 if is_broken_matrix_norm_case(ord, x):
                     continue
                 else:
-                    result_n = np.linalg.norm(x_n, ord=ord)
                     result = torch.linalg.norm(x, ord=ord)
+                    result_n = np.linalg.norm(x_n, ord=ord)
                     self.assertEqual(result, result_n, msg=msg)
 
     # Test degenerate shape results match numpy for linalg.norm vector norms
@@ -2612,26 +2613,6 @@ class TestLinalg(TestCase):
 
                 S_s = torch.svd(A, compute_uv=False).S
                 self.assertEqual(S_s, S)
-
-    @skipMeta
-    @skipCUDAIfNoMagma
-    @skipCPUIfNoLapack
-    @dtypes(*floating_and_complex_types())
-    def test_svd_nan_error(self, device, dtype):
-        for svd in [torch.svd, torch.linalg.svd]:
-            # if input contains NaN then an error is triggered for svd
-            # When cuda < 11.5, cusolver raises CUSOLVER_STATUS_EXECUTION_FAILED when input contains nan.
-            # When cuda >= 11.5, cusolver normally finishes execution and sets info array indicating convergence issue.
-            error_msg = r'(CUSOLVER_STATUS_EXECUTION_FAILED|The algorithm failed to converge)'
-            a = torch.full((3, 3), float('nan'), dtype=dtype, device=device)
-            a[0] = float('nan')
-            with self.assertRaisesRegex(torch.linalg.LinAlgError, error_msg):
-                svd(a)
-            error_msg = r'(CUSOLVER_STATUS_EXECUTION_FAILED|\(Batch element 1\): The algorithm failed to converge)'
-            a = torch.randn(3, 33, 33, dtype=dtype, device=device)
-            a[1, 0, 0] = float('nan')
-            with self.assertRaisesRegex(torch.linalg.LinAlgError, error_msg):
-                svd(a)
 
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack


### PR DESCRIPTION
Summary:
Original commit changeset: fd1c86e37e40

Original Phabricator Diff: D33844257 (https://github.com/pytorch/pytorch/commit/2017b404eca7675d455d45a7480269f5271996ca)

Differential Revision: D33890846

