### PR TITLE
[torch.package] allow OrderedImporter to fallback when importing dummy module

### DIFF
--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -193,7 +193,10 @@ class OrderedImporter(Importer):
                     "All importers in OrderedImporter must inherit from Importer."
                 )
             try:
-                return importer.import_module(module_name)
+                module = importer.import_module(module_name)
+                if module.__dict__.get("__torch_package_dummy_module__", False):
+                    continue
+                return module
             except ModuleNotFoundError as err:
                 last_err = err
 

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -316,6 +316,7 @@ class PackageImporter(Importer):
         ns["__cached__"] = None
         ns["__builtins__"] = self.patched_builtins
         ns["__torch_package__"] = True
+        ns["__torch_package_dummy_module__"] = is_package and not filename
 
         # Add this module to our private global registry. It should be unique due to mangling.
         assert module.__name__ not in _package_imported_modules


### PR DESCRIPTION
Summary:
There's an issue with (re)packaging models with torch.package when using OrderedImporter, specifically when using `tuple(previous_importer, sys_importer)`, where the expected behavior is that modules not previously packaged can be injected by falling back to the sys_importer:

1. Have model that has `from torchrec.distributed.types import ShardedTensor` and interns `torchrec.**`
2. `torchrec.distributed`'s `__init__.py` includes something like `from .types import ShardedTensor`
3. Import packaged model from 1, and add or modify some classes so that now new source code uses `from torchrec.distributed import ShardedTensor` (directly from `__init__`)
4. Boom

```
Traceback (most recent call last):
  File "<string>", line 49, in <module>
  File "<string>", line 47, in __run
  File ".../runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File ".../runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File ".../torch_package_testbed.py", line 56, in <module>
    main(sys.argv[1:])
  File ".../torch_package_testbed/torch_package_testbed.py", line 52, in main
    pe.save_pickle("default", "model_b", model_b)
  File ".../torch/package/package_exporter.py", line 924, in __exit__
    self.close()
  File ".../torch/package/package_exporter.py", line 1024, in close
    self._execute_dependency_graph()
  File ".../torch/package/package_exporter.py", line 965, in _execute_dependency_graph
    self._validate_dependency_graph()
  File ".../torch/package/package_exporter.py", line 947, in _validate_dependency_graph
    raise PackagingError(self.dependency_graph)
torch.package.package_exporter.PackagingError:
* Module had no __file__ defined.
    torchrec.distributed
```

Step #3 creates a dummy `torchrec.distributed` module with `types` as a submodule, but is missing other top-level variables. OrderedImporter succeeds in importing this dummy module, but it fails dependency graph validation because it has no backing `__file__` (nor should it because it was not created from source code).

This proposed fix adds an attribute that indicates that a module is a _PackageNode (not a _ModuleNode, which would indicate a loaded module) AND the _PackageNode has no `__file__`. The "not filename" condition is there because in the case that someone packages using `pe.save_pickle("default", "resource_name"...) where resource name does not end in `.py`, the _PackageNode will not be replaced by a _ModuleNode, but should not be skipped by OrderedImporter. This attribute can then be used to manually fallthrough to the next importer.

Differential Revision: D33662192

