### PR TITLE
Simplify TensorImpl size check and fix error message

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2756,7 +2756,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     static_assert(sizeof(autograd_meta_)      == 4, "Size of autograd_meta_ changed!");
     static_assert(sizeof(named_tensor_meta_)  == 4  "Size of named_tensor_meta_ changed!");
     static_assert(sizeof(version_counter_)    == 4, "Size of version_counter_ changed!");
-    static_assert(sizeof(pyobj_interpreter_)  == 4  "Size of pyobj_interpreter_ changed!");
+    static_assert(sizeof(pyobj_interpreter_)  == 4, "Size of pyobj_interpreter_ changed!");
     static_assert(sizeof(pyobj_)              == 4, "Size of pyobj_ changed!");
     static_assert(sizeof(sizes_and_strides_)  <= 88,"Size of sizes_and_strides_ changed!");
     static_assert(sizeof(storage_offset_)     == 8, "Size of storage_offset_ changed!");
@@ -2782,7 +2782,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     static_assert(sizeof(autograd_meta_)      <= 16,"Size of autograd_meta_ changed!");
     static_assert(sizeof(named_tensor_meta_)  <= 16 "Size of named_tensor_meta_ changed!");
     static_assert(sizeof(version_counter_)    == 8, "Size of version_counter_ changed!");
-    static_assert(sizeof(pyobj_interpreter_)  == 8  "Size of pyobj_interpreter_ changed!");
+    static_assert(sizeof(pyobj_interpreter_)  == 8, "Size of pyobj_interpreter_ changed!");
     static_assert(sizeof(pyobj_)              == 8, "Size of pyobj_ changed!");
     static_assert(sizeof(sizes_and_strides_)  == 88,"Size of sizes_and_strides_ changed!");
     static_assert(sizeof(storage_offset_)     == 8, "Size of storage_offset_ changed!");

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2754,7 +2754,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     // clang-format off
     static_assert(sizeof(storage_)            == 4, "Size of storage_ changed!");
     static_assert(sizeof(autograd_meta_)      == 4, "Size of autograd_meta_ changed!");
-    static_assert(sizeof(named_tensor_meta_)  == 4  "Size of named_tensor_meta_ changed!");
+    static_assert(sizeof(named_tensor_meta_)  == 4, "Size of named_tensor_meta_ changed!");
     static_assert(sizeof(version_counter_)    == 4, "Size of version_counter_ changed!");
     static_assert(sizeof(pyobj_interpreter_)  == 4, "Size of pyobj_interpreter_ changed!");
     static_assert(sizeof(pyobj_)              == 4, "Size of pyobj_ changed!");
@@ -2780,7 +2780,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     // figured out how to detect those via macro preprocessors yet, so we use <=
     // comparisons for the relevant fields.
     static_assert(sizeof(autograd_meta_)      <= 16,"Size of autograd_meta_ changed!");
-    static_assert(sizeof(named_tensor_meta_)  <= 16 "Size of named_tensor_meta_ changed!");
+    static_assert(sizeof(named_tensor_meta_)  <= 16,"Size of named_tensor_meta_ changed!");
     static_assert(sizeof(version_counter_)    == 8, "Size of version_counter_ changed!");
     static_assert(sizeof(pyobj_interpreter_)  == 8, "Size of pyobj_interpreter_ changed!");
     static_assert(sizeof(pyobj_)              == 8, "Size of pyobj_ changed!");

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2730,44 +2730,6 @@ template <
     size_t cuda_version_major = C10_CUDA_VERSION_MAJOR,
     size_t ptr_size = sizeof(void*)>
 class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
-  // Names of (non-bitfield) fields in TensorImpl; used to provide
-  // compile-time info about fields whose size changes unexpectedly.
-  enum class FieldNameEnum {
-    storage_,
-    autograd_meta_,
-    named_tensor_meta_,
-    version_counter_,
-    pyobj_interpreter_,
-    pyobj_,
-    sizes_and_strides_,
-    storage_offset_,
-    numel_,
-    data_type_,
-    device_opt_,
-    key_set_,
-    TOTAL_SIZE
-  };
-
-  // Provides compile-time equality check that reveals what numbers
-  // were used and on which quantity
-  template <size_t Actual, size_t Expected, FieldNameEnum FiledName>
-  constexpr static bool are_equal() {
-    static_assert(
-        Actual == Expected,
-        "Actual and Expected sizes of a field did not match!");
-    return true;
-  }
-
-  // Provides compile-time <= check that reveals what numbers
-  // were used and on which quantity
-  template <size_t Actual, size_t Expected, FieldNameEnum FiledName>
-  constexpr static bool is_le() {
-    static_assert(
-        Actual <= Expected,
-        "Actual and Expected sizes of a field did not match!");
-    return true;
-  }
-
  public:
   // Compile-time check that TensorImpl field sizes are as expected
   //
@@ -2790,19 +2752,19 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     constexpr size_t tsize = 20 * sizeof(int64_t);
 
     // clang-format off
-    static_assert(are_equal<sizeof(storage_),            4,  FieldNameEnum::storage_>(),           "Size of storage_ changed!");
-    static_assert(are_equal<sizeof(autograd_meta_),      4,  FieldNameEnum::autograd_meta_>(),     "Size of autograd_meta_ changed!");
-    static_assert(are_equal<sizeof(named_tensor_meta_),  4,  FieldNameEnum::named_tensor_meta_>(), "Size of named_tensor_meta_ changed!");
-    static_assert(are_equal<sizeof(version_counter_),    4,  FieldNameEnum::version_counter_>(),   "Size of version_counter_ changed!");
-    static_assert(are_equal<sizeof(pyobj_interpreter_),  4,  FieldNameEnum::pyobj_interpreter_>(), "Size of pyobj_interpreter_ changed!");
-    static_assert(are_equal<sizeof(pyobj_),              4,  FieldNameEnum::pyobj_>(),             "Size of pyobj_ changed!");
-    static_assert(is_le<sizeof(sizes_and_strides_),     88, FieldNameEnum::sizes_and_strides_>(), "Size of sizes_and_strides_ changed!");
-    static_assert(are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>(),    "Size of storage_offset_ changed!");
-    static_assert(are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>(),             "Size of numel_ changed!");
-    static_assert(are_equal<sizeof(data_type_),          2,  FieldNameEnum::data_type_>(),         "Size of data_type_ changed!");
-    static_assert(are_equal<sizeof(device_opt_),         3,  FieldNameEnum::device_opt_>(),        "Size of device_opt_ changed!");
-    static_assert(are_equal<sizeof(key_set_),            8,  FieldNameEnum::key_set_>(),           "Size of key_set_ changed!");
-    static_assert(is_le<sizeof(TensorImpl),          tsize,  FieldNameEnum::TOTAL_SIZE>(),         "Total size changed!");
+    static_assert(sizeof(storage_)            == 4, "Size of storage_ changed!");
+    static_assert(sizeof(autograd_meta_)      == 4, "Size of autograd_meta_ changed!");
+    static_assert(sizeof(named_tensor_meta_)  == 4  "Size of named_tensor_meta_ changed!");
+    static_assert(sizeof(version_counter_)    == 4, "Size of version_counter_ changed!");
+    static_assert(sizeof(pyobj_interpreter_)  == 4  "Size of pyobj_interpreter_ changed!");
+    static_assert(sizeof(pyobj_)              == 4, "Size of pyobj_ changed!");
+    static_assert(sizeof(sizes_and_strides_)  <= 88,"Size of sizes_and_strides_ changed!");
+    static_assert(sizeof(storage_offset_)     == 8, "Size of storage_offset_ changed!");
+    static_assert(sizeof(numel_)              == 8, "Size of numel_ changed!");
+    static_assert(sizeof(data_type_)          == 2, "Size of data_type_ changed!");
+    static_assert(sizeof(device_opt_)         == 3, "Size of device_opt_ changed!");
+    static_assert(sizeof(key_set_)            == 8, "Size of key_set_ changed!");
+    static_assert(sizeof(TensorImpl)          <= tsize, "Total size changed!");
     // clang-format on
 
     return true;
@@ -2813,22 +2775,22 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
     constexpr size_t tsize = 26 * sizeof(int64_t);
 
     // clang-format off
-    static_assert(are_equal<sizeof(storage_),            8,  FieldNameEnum::storage_>(),           "Size of storage_ changed!");
+    static_assert(sizeof(storage_)            == 8, "Size of storage_ changed!");
     // On some systems involving NVCC the size of unique_ptr is 16 bytes. We haven't
     // figured out how to detect those via macro preprocessors yet, so we use <=
     // comparisons for the relevant fields.
-    static_assert(is_le<sizeof(autograd_meta_),         16,  FieldNameEnum::autograd_meta_>(),     "Size of autograd_meta_ changed!");
-    static_assert(is_le<sizeof(named_tensor_meta_),     16,  FieldNameEnum::named_tensor_meta_>(), "Size of named_tensor_meta_ changed!");
-    static_assert(are_equal<sizeof(version_counter_),    8,  FieldNameEnum::version_counter_>(),   "Size of version_counter_ changed!");
-    static_assert(are_equal<sizeof(pyobj_interpreter_),  8,  FieldNameEnum::pyobj_interpreter_>(), "Size of pyobj_interpreter_ changed!");
-    static_assert(are_equal<sizeof(pyobj_),              8,  FieldNameEnum::pyobj_>(),             "Size of pyobj_ changed!");
-    static_assert(are_equal<sizeof(sizes_and_strides_), 88, FieldNameEnum::sizes_and_strides_>(), "Size of sizes_and_strides_ changed!");
-    static_assert(are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>(),    "Size of storage_offset_ changed!");
-    static_assert(are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>(),             "Size of numel_ changed!");
-    static_assert(are_equal<sizeof(data_type_),          2,  FieldNameEnum::data_type_>(),         "Size of data_type_ changed!");
-    static_assert(are_equal<sizeof(device_opt_),         3,  FieldNameEnum::device_opt_>(),        "Size of device_opt_ changed!");
-    static_assert(are_equal<sizeof(key_set_),            8,  FieldNameEnum::key_set_>(),           "Size of key_set_ changed!");
-    static_assert(is_le<sizeof(TensorImpl),          tsize,  FieldNameEnum::TOTAL_SIZE>(),         "Total size changed!");
+    static_assert(sizeof(autograd_meta_)      <= 16,"Size of autograd_meta_ changed!");
+    static_assert(sizeof(named_tensor_meta_)  <= 16 "Size of named_tensor_meta_ changed!");
+    static_assert(sizeof(version_counter_)    == 8, "Size of version_counter_ changed!");
+    static_assert(sizeof(pyobj_interpreter_)  == 8  "Size of pyobj_interpreter_ changed!");
+    static_assert(sizeof(pyobj_)              == 8, "Size of pyobj_ changed!");
+    static_assert(sizeof(sizes_and_strides_)  == 88,"Size of sizes_and_strides_ changed!");
+    static_assert(sizeof(storage_offset_)     == 8, "Size of storage_offset_ changed!");
+    static_assert(sizeof(numel_)              == 8, "Size of numel_ changed!");
+    static_assert(sizeof(data_type_)          == 2, "Size of data_type_ changed!");
+    static_assert(sizeof(device_opt_)         == 3, "Size of device_opt_ changed!");
+    static_assert(sizeof(key_set_)            == 8, "Size of key_set_ changed!");
+    static_assert(sizeof(TensorImpl)          <= tsize, "Total size changed!");
     // clang-format on
 
     return true;


### PR DESCRIPTION
Today, the enum is ignored and the generic assert within the equal function is used leading to no information in the error message when this fails.