### PR TITLE
Add mul_ converter and leaf module code example

### DIFF
--- a/torch/fx/experimental/fx2trt/tools/trt_splitter.py
+++ b/torch/fx/experimental/fx2trt/tools/trt_splitter.py
@@ -11,6 +11,7 @@ from torch.fx.experimental.fx2trt import (
     NO_EXPLICIT_BATCH_DIM_SUPPORT,
     NO_IMPLICIT_BATCH_DIM_SUPPORT,
 )
+from torch.fx.passes.tools_common import get_acc_ops_name
 import torch.fx.passes.operator_support as ops
 from torch.fx.passes.tools_common import Tensors
 
@@ -98,13 +99,3 @@ class TRTSplitter(splitter_base._SplitterBase):
                 reports += f"{node.format_node()}\n"
 
         return reports
-
-
-def get_acc_ops_name(k):
-    if isinstance(k, str):
-        return k
-    elif k.__module__ and "acc_ops" in k.__module__:
-        return f"acc_ops.{k.__name__}"
-    else:
-        module = k.__module__
-        return f"{module if module else ''}.{k.__name__}".replace('_', '')

--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -14,6 +14,18 @@ NodeSet = Set[torch.fx.Node]
 Names = List[str]
 CALLABLE_NODE_OPS = {"call_module", "call_function", "call_method"}
 
+
+@compatibility(is_backward_compatible=False)
+def get_acc_ops_name(k):
+    if isinstance(k, str):
+        return k
+    elif k.__module__ and "acc_ops" in k.__module__:
+        return f"acc_ops.{k.__name__}"
+    else:
+        module = k.__module__
+        return f"{module if module else ''}.{k.__name__}".replace('_', '')
+
+
 @compatibility(is_backward_compatible=False)
 def get_node_target(submodules: Mapping[str, torch.nn.Module], node: torch.fx.Node) -> str:
     """
@@ -36,7 +48,9 @@ def get_node_target(submodules: Mapping[str, torch.nn.Module], node: torch.fx.No
 
     if node.op == "call_module":
         assert isinstance(node.target, str)
-        return torch.typename(submodules[node.target])
+        submod = submodules[node.target]
+        submod_type = getattr(submod, "_base_class_origin", type(submod))
+        return get_acc_ops_name(submod_type)
     elif node.op == "call_function":
         target: Any = node.target
         return (


### PR DESCRIPTION
Summary:
add mul_ converter

Facebook :
enable splitter to properly read the leaf module specified by acc_tracer leaf module list, and parse leaf module as run_on_acc if customize leaf module converter is provided.
add scratch board for customize leaf module converter and example code for std_conv2d_same converter.

Reviewed By: 842974287

Differential Revision: D33698402

