### PR TITLE
Fix binary bitwise converter for when lhs is scalar

### DIFF
--- a/test/fx2trt/converters/acc_op/test_binary_ops.py
+++ b/test/fx2trt/converters/acc_op/test_binary_ops.py
@@ -125,5 +125,23 @@ class TestBinaryOpConverters(AccTestCase):
 
         self.run_test_with_dynamic_shape(Op(), input_specs, expected_ops={expected_op})
 
+    def test_elementwise_ops_with_scalar_lhs(self):
+        def orig_op(x, y):
+            return x + y
+
+        class TestModule(nn.Module):
+            def __init__(self, orig_op):
+                super().__init__()
+                self.constant = torch.randn(1)
+                self.orig_op = orig_op
+
+            def forward(self, x):
+                return self.orig_op(x, self.constant)
+
+        m = TestModule(orig_op)
+        inputs = [torch.randn(10)]
+        self.run_test(m, inputs, expected_ops={acc_ops.add}, test_explicit_batch_dim=False, test_implicit_batch_dim=True)
+
+
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Summary:
When lhs is scalar, and rhs has shape [1,], then currently the assert will fail because lhs shape has fewer dimensions than rhs shape.
This happens when using implicit batch dimension, when we removed the 1st dimensino from input tensor, causing it to have shape [].

Fix it by reducing the rhs constant with a squeeze_left, so it becomes a tensor too. More generally, we squeeze_left on input if it's
a constant tensor. This is safe because broadcast will pad dimensions on the left (prepend) to make lhs and rhs shape compatible.

Differential Revision: D33909485

