### PR TITLE
[ONNX] Export aten::mul(bool, bool) to onnx::and instead of onnx::mul

### DIFF
--- a/test/onnx/expect/TestOperators.test_mul_bool.expect
+++ b/test/onnx/expect/TestOperators.test_mul_bool.expect
@@ -1,0 +1,55 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "onnx::And_0"
+    input: "onnx::And_1"
+    output: "2"
+    name: "And_0"
+    op_type: "And"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "onnx::And_0"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "onnx::And_1"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/expect/TestOperators.test_mul_float_bool.expect
+++ b/test/onnx/expect/TestOperators.test_mul_float_bool.expect
@@ -1,0 +1,66 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "onnx::Cast_0"
+    output: "onnx::Mul_2"
+    name: "Cast_0"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 1
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::Mul_2"
+    input: "onnx::Mul_1"
+    output: "3"
+    name: "Mul_1"
+    op_type: "Mul"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "onnx::Cast_0"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "onnx::Mul_1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "3"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -172,6 +172,11 @@ class TestOperators(TestCase):
         x = torch.randn(2, 3, requires_grad=True).double()
         self.assertONNX(lambda x: 1 - x, (x,))
 
+    def test_mul_bool(self):
+        x = torch.tensor([True, False, True, False])
+        y = torch.tensor([True, True, False, False])
+        self.assertONNX(lambda x, y: torch.mul(x, y), (x, y))
+
     def test_transpose(self):
         x = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
         self.assertONNX(lambda x: x.transpose(0, 1).transpose(1, 0), x)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -177,6 +177,11 @@ class TestOperators(TestCase):
         y = torch.tensor([True, True, False, False])
         self.assertONNX(lambda x, y: torch.mul(x, y), (x, y))
 
+    def test_mul_float_bool(self):
+        x = torch.tensor([True, False, True, False])
+        y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        self.assertONNX(lambda x, y: torch.mul(x, y), (x, y))
+
     def test_transpose(self):
         x = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
         self.assertONNX(lambda x: x.transpose(0, 1).transpose(1, 0), x)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10209,6 +10209,15 @@ class TestONNXRuntime(unittest.TestCase):
         loaded_model = onnx.load_from_string(f.getvalue())
         self.assertEqual(loaded_model.graph.output[0].type.tensor_type.shape.dim[1].dim_value, 128)
 
+    def test_mul_bool(self):
+        class MyModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.mul(x, y)
+
+        x = torch.tensor([True, False, True, False])
+        y = torch.tensor([True, True, False, False])
+        self.run_test(MyModel(), (x, y))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,
               **extra_kwargs):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10214,9 +10214,28 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.mul(x, y)
 
-        x = torch.tensor([True, False, True, False])
-        y = torch.tensor([True, True, False, False])
-        self.run_test(MyModel(), (x, y))
+        x = [True, False, True, False]
+        y = [True, True, False, False]
+        x_t = torch.tensor(x)
+        y_t = torch.tensor(y)
+        self.run_test(MyModel(), (x_t, y_t))
+
+        for x_s, y_s in zip(x, y):
+          self.run_test(MyModel(), (x_s, y_s))
+
+    def test_mul_float_bool(self):
+        class MyModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.mul(x, y)
+
+        x = [True, False, True, False]
+        y = [1.0, 2.0, 3.0, 4.0]
+        x_t = torch.tensor(x)
+        y_t = torch.tensor(y)
+        self.run_test(MyModel(), (x_t, y_t))
+
+        for x_s, y_s in zip(x, y):
+          self.run_test(MyModel(), (x_s, y_s))
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10221,7 +10221,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(MyModel(), (x_t, y_t))
 
         for x_s, y_s in zip(x, y):
-          self.run_test(MyModel(), (x_s, y_s))
+            self.run_test(MyModel(), (x_s, y_s))
 
     def test_mul_float_bool(self):
         class MyModel(torch.nn.Module):
@@ -10235,7 +10235,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(MyModel(), (x_t, y_t))
 
         for x_s, y_s in zip(x, y):
-          self.run_test(MyModel(), (x_s, y_s))
+            self.run_test(MyModel(), (x_s, y_s))
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -316,12 +316,12 @@ def _slice_helper(g, input, axes, starts, ends, steps=None, dynamic_slice=False)
 
 _fp_tensor_types = set((torch.float16, torch.float32, torch.float64, torch.bfloat16))
 _fp_scalar_types = set(("Float", "Double", "Half", "BFloat16"))
-_bool_tensor_types = set((torch.bool))
-_bool_scalar_types = set(("Bool"))
+_bool_tensor_types = set((torch.bool,))
+_bool_scalar_types = set(("Bool",))
 
 def _is_specific_type_group(value, tensor_types, scalar_types):
     if value is None:
-      return False
+        return False
     if isinstance(value, torch.Tensor):
         return value.dtype in tensor_types
     else:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -104,9 +104,9 @@ def rsub(g, self, other, alpha=None):
 
 def mul(g, self, other):
     if sym_help._is_bool(self):
-      return g.op("And", self, other)
+        return g.op("And", self, other)
     else:
-      return g.op("Mul", self, other)
+        return g.op("Mul", self, other)
 
 
 def div(g, self, other, *args):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -103,7 +103,7 @@ def rsub(g, self, other, alpha=None):
 
 
 def mul(g, self, other):
-    if sym_help._is_bool(self):
+    if sym_help._is_bool(self) and sym_help._is_bool(other):
         return g.op("And", self, other)
     else:
         return g.op("Mul", self, other)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -103,7 +103,10 @@ def rsub(g, self, other, alpha=None):
 
 
 def mul(g, self, other):
-    return g.op("Mul", self, other)
+    if sym_help._is_bool(self):
+      return g.op("And", self, other)
+    else:
+      return g.op("Mul", self, other)
 
 
 def div(g, self, other, *args):


### PR DESCRIPTION
As title. We don't need to implement `onnx::mul` for bool because it's already `onnx::and`. It's also semantically better to keep boolean to use their specific operations (AND, OR, XOR, etc). In addition, [ONNX](https://github.com/onnx/onnx/blob/main/docs/Operators.md#type-constraints-85) doesn't have `Mul` for boolean types.
