### PR TITLE
Fix fx docs

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -488,8 +488,9 @@ class Graph:
             g.inserting_before(n) #  set the insert point permanently
 
         Args:
+
             n (Optional[Node]): The node before which to insert. If None this will insert before
-              the beginning of the entire graph.
+                the beginning of the entire graph.
 
         Returns:
             A resource manager that will restore the insert point on ``__exit__``.
@@ -511,8 +512,9 @@ class Graph:
             g.inserting_after(n) #  set the insert point permanently
 
         Args:
+
             n (Optional[Node]): The node before which to insert. If None this will insert after
-              the beginning of the entire graph.
+                the beginning of the entire graph.
 
         Returns:
             A resource manager that will restore the insert point on ``__exit__``.
@@ -698,8 +700,7 @@ class Graph:
                       type_expr: Optional[Any] = None) -> Node:
         """
         Insert a ``call_function`` ``Node`` into the ``Graph``. A ``call_function`` node
-        represents a call to a Python callable, specified by ``the_function``. ``the_function``
-        can be
+        represents a call to a Python callable, specified by ``the_function``.
 
         Args:
 
@@ -716,7 +717,7 @@ class Graph:
             type_expr (Optional[Any]): an optional type annotation representing the
                 Python type the output of this node will have.
 
-        Returns
+        Returns:
 
             The newly created and inserted ``call_function`` node.
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -244,8 +244,8 @@ class Node:
     @compatibility(is_backward_compatible=True)
     def append(self, x: 'Node') -> None:
         """
-        Insert x after this node in the list of nodes in the graph.
-        Equvalent to ``self.next.prepend(x)``
+        Insert ``x`` after this node in the list of nodes in the graph.
+        Equivalent to ``self.next.prepend(x)``
 
         Args:
             x (Node): The node to put after this node. Must be a member of the same graph.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#72108 Fix fx docs**

Fix `torch.fx` documentation. Some APIs docs are rendered incorrectly due to wrong-indents, missing colon, etc. This commit fixes the ones I saw. 

Differential Revision: [D33916855](https://our.internmc.facebook.com/intern/diff/D33916855)