### PR TITLE
Add all remaining ops that can be codegen'd

### DIFF
--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -58,7 +58,7 @@ using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;
 // have to be added first via TensorIteratorConfig::add_owned_output(at::Tensor).
 // After adding all outputs, the inputs can be added via
 // TensorIteratorConfig::add_owned_input(at::Tensor).
-// Adding another output after inputs have been added will rise an exception.
+// Adding another output after inputs have been added will raise an exception.
 //
 // Note [Common Dtype Computation]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5598,7 +5598,6 @@
     CPU: fused_moving_avg_obs_fake_quant_cpu
     CUDA: fused_moving_avg_obs_fake_quant_cuda
 
-
 - func: _choose_qparams_per_tensor(Tensor self, bool reduce_range=False) -> (float, int)
   variants: function
 

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -1,6 +1,8 @@
 backend: Lazy
 cpp_namespace: torch_lazy_tensors
 full_codegen:
+  - _adaptive_avg_pool2d
+  - _adaptive_avg_pool2d_backward
   - _log_softmax
   - _log_softmax_backward_data
   - _softmax
@@ -11,18 +13,23 @@ full_codegen:
   - addcmul
   - addmm
   - arange.start_out
+  - all
+  - any
   - avg_pool2d
   - avg_pool2d_backward
   - baddbmm
   - binary_cross_entropy
   - binary_cross_entropy_backward
   - bitwise_and.Tensor
+  - bitwise_or.Tensor
   - bmm
+  - clamp
+  - clamp_min
   - constant_pad_nd
   - convolution
   - convolution_backward
   - cos
-  - clamp
+  - cumsum
   - div.Tensor
   - div.Tensor_mode
   - elu
@@ -32,20 +39,30 @@ full_codegen:
   - eq.Scalar
   - eq.Tensor
   - exp
+  - flip
   - floor
   - frac
+  - gather
   - ge.Scalar
   - ge.Tensor
   - gelu
   - gelu_backward
+  - glu
+  - glu_backward
+  - grid_sampler_2d
+  - grid_sampler_2d_backward
   - gt.Scalar
   - gt.Tensor
+  - hardsigmoid
+  - hardswish_
   - index_select
   - kl_div_backward
+  - l1_loss_backward
   - le.Scalar
   - le.Tensor
   - leaky_relu
   - leaky_relu_backward
+  - log
   - log2
   - logdet
   - log_sigmoid_backward
@@ -55,11 +72,14 @@ full_codegen:
   - masked_fill_.Scalar
   - masked_fill_.Tensor
   - max
+  - max.dim
   - max_pool2d_with_indices
   - max_pool2d_with_indices_backward
+  - maximum
   - mean
   - mean.dim
   - min
+  - minimum
   - mm
   - mul.Tensor
   - mv
@@ -77,9 +97,13 @@ full_codegen:
   - norm.ScalarOpt_dim
   - pow.Tensor_Scalar
   - pow.Tensor_Tensor
+  - reciprocal
   - relu
   - relu_
+  - remainder.Tensor
   - rsqrt
+  - scatter_add
+  - sgn
   - sigmoid
   - sigmoid_backward
   - silu
@@ -100,8 +124,13 @@ full_codegen:
   - threshold_backward
   - topk
   - trace
+  - tril
   - triu
   - trunc
+  - upsample_bilinear2d
+  - upsample_bilinear2d_backward
+  - upsample_nearest2d
+  - upsample_nearest2d_backward
   - zero_
 supported:
   - as_strided


### PR DESCRIPTION
This adds all the "easy" ops from our `Lazy TorchBench` document. I've commented out some ops that I want to implement as structured kernels instead of codegen'ing.

@wconstab The one op that's commented out that I don't plan to implement as a structured kernel is `_fused_moving_avg_obs_fq_helper`. I found it very difficult to trace. Please also see the note I left you in the PR. It's doable; it would just take a day of work. Let's see if there's an easier way to get coverage for it