### PR TITLE
torchelastic: log events to torch.monitor

### DIFF
--- a/torch/distributed/elastic/events/__init__.py
+++ b/torch/distributed/elastic/events/__init__.py
@@ -27,6 +27,7 @@ import traceback
 from enum import Enum
 from typing import Dict, Optional
 
+from torch import monitor
 from torch.distributed.elastic.events.handlers import get_logging_handler
 
 from .api import (  # noqa: F401
@@ -69,6 +70,9 @@ def _get_or_create_logger(destination: str = "null") -> logging.Logger:
 
 def record(event: Event, destination: str = "null") -> None:
     _get_or_create_logger(destination).info(event.serialize())
+
+    if destination != "console" and isinstance(event, Event):
+        monitor.log_event(event.to_monitor_event())
 
 def record_rdzv_event(event: RdzvEvent) -> None:
     _get_or_create_logger("dynamic_rendezvous").info(event.serialize())


### PR DESCRIPTION
Summary:
This adds support so torchelastic events are also logged via `torch.monitor`. Once this is in a stable spot we'll remove the original torch elastic event interface and handlers.

This ignores events where the destination is `console` as well as `RdzvEvents` since per aivanou those aren't actually used.

This also switches the events lib_test to use `define_tests` instead of `define_mp_tests` since there's no need to run these test serially.

Test Plan:
```
buck test //caffe2/test/distributed/elastic/events:lib_test
```

Differential Revision: D33925442

