### PR TITLE
improve CPU performance for log_softmax when dim != -1 on both float32 and bfloat16 (#64726)

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -456,6 +456,7 @@ DEFINE_DISPATCH(softmax_backward_lastdim_kernel);
 DEFINE_DISPATCH(log_softmax_backward_lastdim_kernel);
 
 DEFINE_DISPATCH(softmax_kernel);
+DEFINE_DISPATCH(log_softmax_kernel);
 
 Tensor softmax(const Tensor& self, Dimname dim, optional<ScalarType> dtype) {
   return at::softmax(self, dimname_to_position(self, dim), dtype);

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -283,4 +283,32 @@ void binary_kernel_reduce_vec(TensorIteratorBase& iter, func_t op, vec_func_t vo
   });
 }
 
+// when reduction is on most inner dimension (dim 0 in TensorIterator)
+// and input has contiguous most inner dimension, `binary_kernel_reduce_lastdim`
+// can be used.
+static inline bool is_reduce_lastdim(TensorIteratorBase& iter) {
+  return iter.num_reduce_dims() == 1 && iter.is_dim_reduced(0)
+      && iter.ninputs() == 1 && iter.strides(1)[0] == iter.element_size(1);
+}
+
+template <typename reduce_func_t>
+void binary_kernel_reduce_lastdim(TensorIteratorBase& iter, reduce_func_t reduce_op) {
+  auto shape = iter.shape();
+  int64_t dim_size = shape[0];
+  int64_t grain_size = std::max((int64_t) 1, at::internal::GRAIN_SIZE / dim_size);
+  TensorIterator sub_iter(iter);
+  // create sub iterator to parallel on all non-reduce-dims
+  sub_iter.narrow(0, 0, 1);
+  auto loop = [&](char** data, const int64_t* strides, int64_t size) {
+    char* out = data[0];
+    char* in = data[1];
+    for (int64_t i = 0; i < size; ++i) {
+      reduce_op(out, in, dim_size);
+      out += strides[0];
+      in += strides[1];
+    }
+  };
+  sub_iter.for_each(loop, grain_size);
+}
+
 }}}  // namespace at::native::<anonymous>

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/cpu/vec/vec.h>
+#include <ATen/cpu/vec/functional.h>
 #include <ATen/native/ReduceOps.h>
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/Resize.h>
@@ -191,6 +192,19 @@ static void prod_kernel_impl(TensorIterator& iter) {
   }
 }
 
+template <typename scalar_t, typename acc_t>
+inline void norm_two_reduce_step(Vectorized<acc_t>& acc_vec, Vectorized<scalar_t>& data_vec) {
+  acc_vec += data_vec * data_vec;
+}
+
+template <>
+inline void norm_two_reduce_step(Vectorized<float>& acc_fvec, Vectorized<BFloat16>& data_bvec) {
+  Vectorized<float> data_fvec0, data_fvec1;
+  std::tie(data_fvec0, data_fvec1) = convert_bfloat16_float(data_bvec);
+  acc_fvec += data_fvec0 * data_fvec0;
+  acc_fvec += data_fvec1 * data_fvec1;
+}
+
 static void norm_kernel_tensor_iterator_impl(
     TensorIterator& iter,
     const Scalar& p) {
@@ -204,6 +218,9 @@ static void norm_kernel_tensor_iterator_impl(
   } else {
     AT_ERROR("norm_kernel_tensor_iterator_impl expects norm to be integer or float");
   }
+
+  bool use_fast_path = is_reduce_lastdim(iter) && iter.dtype(0) == iter.input_dtype()
+      && (iter.input_dtype() == kFloat || iter.input_dtype() == kBFloat16);
 
   // In the dispatch code blocks below, reduction kernels accumulate results as
   // the type `acc_t`. When `scalar_t` is complex, `acc_t` is the downgraded
@@ -227,6 +244,36 @@ static void norm_kernel_tensor_iterator_impl(
       );
     });
   } else if (val == 2) {
+    if (use_fast_path) {
+      AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, iter.input_dtype(), "norm_cpu", [&] {
+        // use float as accumulate type for BFloat16
+        using acc_t = vec_scalar_t<scalar_t>;
+        binary_kernel_reduce_lastdim(iter, [](char* result_data_bytes, char* self_data_bytes, int64_t size) {
+          scalar_t* result_data = (scalar_t*)result_data_bytes;
+          scalar_t* self_data = (scalar_t*)self_data_bytes;
+
+          using Vec = Vectorized<scalar_t>;
+          using fVec = Vectorized<acc_t>;
+          fVec acc_vec{acc_t(0)};
+          acc_t buffer[fVec::size()];
+          int64_t d = 0;
+          for (; d < size - (size % Vec::size()); d += Vec::size()) {
+            Vec data_vec = Vec::loadu(self_data + d);
+            norm_two_reduce_step(acc_vec, data_vec);
+          }
+          acc_vec.store(buffer);
+          for (int j = 1; j < fVec::size(); j++) {
+            buffer[0] = buffer[0] + buffer[j];
+          }
+          for (; d < size; d++) {
+            acc_t data_val = acc_t(self_data[d]);
+            buffer[0] += data_val * data_val;
+          }
+          result_data[0] = scalar_t(std::sqrt(buffer[0]));
+        });
+      });
+      return;
+    }
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.input_dtype(), "norm_cpu", [&] {
       using acc_t = typename scalar_value_type<scalar_t>::type;
       binary_kernel_reduce(
@@ -396,6 +443,21 @@ static void max_values_kernel_impl(TensorIterator& iter) {
 
 static void argmax_kernel_impl(TensorIterator &iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(1), "argmax_cpu", [&] {
+    if (is_reduce_lastdim(iter)) {
+      using arg_t = std::pair<scalar_t, int64_t>;
+      auto op = ArgMaxOps<scalar_t>{};
+      binary_kernel_reduce_lastdim(iter, [&](char* result_data_bytes, char* self_data_bytes, int64_t size) {
+        int64_t* result_data = (int64_t*)result_data_bytes;
+        scalar_t* self_data = (scalar_t*)self_data_bytes;
+
+        arg_t acc = arg_t(lower_bound<scalar_t>(), 0);
+        for (int64_t i = 0; i < size; i++) {
+          acc = op.reduce(acc, self_data[i], i);
+        }
+        result_data[0] = acc.second;
+      });
+      return;
+    }
     binary_kernel_reduce(
       iter,
       ArgMaxOps<scalar_t>{},
@@ -405,6 +467,21 @@ static void argmax_kernel_impl(TensorIterator &iter) {
 
 static void argmin_kernel_impl(TensorIterator &iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(1), "argmin_cpu", [&] {
+    if (is_reduce_lastdim(iter)) {
+      using arg_t = std::pair<scalar_t, int64_t>;
+      auto op = ArgMinOps<scalar_t>{};
+      binary_kernel_reduce_lastdim(iter, [&](char* result_data_bytes, char* self_data_bytes, int64_t size) {
+        int64_t* result_data = (int64_t*)result_data_bytes;
+        scalar_t* self_data = (scalar_t*)self_data_bytes;
+
+        arg_t acc = arg_t(upper_bound<scalar_t>(), 0);
+        for (int64_t i = 0; i < size; i++) {
+          acc = op.reduce(acc, self_data[i], i);
+        }
+        result_data[0] = acc.second;
+      });
+      return;
+    }
     binary_kernel_reduce(
       iter,
       ArgMinOps<scalar_t>{},

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -397,6 +397,248 @@ inline void _vec_softmax(
       });
 }
 
+// NB: fast kernel for log_softmax when dim != -1
+// input shape is normalized to {outer_size, dim_size, inner_size}
+//
+// The algorithm requires to load input tensor 3 times, to increase parallelsim
+// and cache hit rate, inner_size is blocked as:
+//   inner_size: {CHUNK_SIZE, CHUNK_SIZE, ..., Remainder}
+//
+// Parallel on {outer_size, num_chunks} and do vertical reduction on each block of
+// {dim_size, CHUNK_SIZE}, block size (128KB) selected to be L2 hit.
+//
+template <typename scalar_t>
+inline void _vec_logsoftmax(
+    scalar_t* input_data_base,
+    scalar_t* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using Vec = vec::Vectorized<scalar_t>;
+  int64_t BLOCK_SIZE = 128 * 1024;
+  int64_t CHUNK_SIZE = std::max(int64_t(BLOCK_SIZE / dim_size / sizeof(scalar_t)), (int64_t) Vec::size());
+  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
+
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  at::parallel_for(0, outer_size * num_chunks, grain_size, [&](int64_t begin, int64_t end) {
+    // thread local temp buffer which holds vertical reduction result: max and sum.
+    std::unique_ptr<scalar_t []> buffer(new scalar_t[CHUNK_SIZE * 2]);
+    scalar_t* input_max_data = buffer.get();
+    scalar_t* tmp_sum_data = buffer.get() + CHUNK_SIZE;
+
+    for (int64_t i = begin; i < end; i++) {
+      int64_t outer_idx = i / num_chunks;
+      int64_t k = i % num_chunks;
+      int64_t inner_idx_begin = k * CHUNK_SIZE;
+      int64_t size = std::min(CHUNK_SIZE, inner_size - inner_idx_begin);
+
+      // init
+      Vec zero_vec = Vec(scalar_t(0));
+      Vec min_vec = Vec(-std::numeric_limits<scalar_t>::infinity());
+      int64_t d0 = 0;
+      for (; d0 < size - (size % Vec::size()); d0 += Vec::size()) {
+        min_vec.store(input_max_data + d0);
+        zero_vec.store(tmp_sum_data + d0);
+      }
+      for (; d0 < size; d0++) {
+        input_max_data[d0] = -std::numeric_limits<scalar_t>::infinity();
+        tmp_sum_data[d0] = scalar_t(0);
+      }
+
+      // compute max
+      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+        scalar_t* input_ptr = input_data_base + outer_idx * dim_size * inner_size
+            + dim_idx * inner_size + inner_idx_begin;
+
+        int64_t d1 = 0;
+        for (; d1 < size - (size % Vec::size()); d1 += Vec::size()) {
+          Vec data_vec = Vec::loadu(input_ptr + d1);
+          Vec max_vec = Vec::loadu(input_max_data + d1);
+          max_vec = Vec::blendv(max_vec, data_vec, data_vec > max_vec);
+          max_vec.store(input_max_data + d1);
+        }
+        for (; d1 < size; d1++) {
+          scalar_t data_val = input_ptr[d1];
+          scalar_t max_val = input_max_data[d1];
+          input_max_data[d1] = data_val > max_val ? data_val : max_val;
+        }
+      }
+
+      // compute sum of (x - max).exp()
+      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+        scalar_t* input_ptr = input_data_base + outer_idx * dim_size * inner_size
+            + dim_idx * inner_size + inner_idx_begin;
+
+        int64_t d2 = 0;
+        for (; d2 < size - (size % Vec::size()); d2 += Vec::size()) {
+          Vec data_vec = Vec::loadu(input_ptr + d2);
+          Vec sum_vec = Vec::loadu(tmp_sum_data + d2);
+          Vec max_vec = Vec::loadu(input_max_data + d2);
+          sum_vec += (data_vec - max_vec).exp();
+          sum_vec.store(tmp_sum_data + d2);
+        }
+        for (; d2 < size; d2++) {
+          scalar_t data_val = input_ptr[d2];
+          scalar_t max_val = input_max_data[d2];
+          tmp_sum_data[d2] += std::exp(data_val - max_val);
+        }
+      }
+
+      // apply log
+      vec::map([](Vec x) { return x.log(); }, tmp_sum_data, tmp_sum_data, size);
+
+      // compute x - max - sum
+      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+        int64_t offset = outer_idx * dim_size * inner_size + dim_idx * inner_size + inner_idx_begin;
+        scalar_t* input_ptr = input_data_base + offset;
+        scalar_t* output_ptr = output_data_base + offset;
+
+        int64_t d3 = 0;
+        for (; d3 < size - (size % Vec::size()); d3 += Vec::size()) {
+          Vec data_vec = Vec::loadu(input_ptr + d3);
+          Vec max_vec = Vec::loadu(input_max_data + d3);
+          Vec sum_vec = Vec::loadu(tmp_sum_data + d3);
+          Vec out_vec = data_vec - max_vec - sum_vec;
+          out_vec.store(output_ptr + d3);
+        }
+        for (; d3 < size; d3++) {
+          output_ptr[d3] = input_ptr[d3] - input_max_data[d3] - tmp_sum_data[d3];
+        }
+      }
+    }
+  });
+}
+
+template <>
+inline void _vec_logsoftmax<BFloat16>(
+    BFloat16* input_data_base,
+    BFloat16* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using bVec = vec::Vectorized<BFloat16>;
+  using fVec = vec::Vectorized<float>;
+  int64_t BLOCK_SIZE = 128 * 1024;
+  int64_t CHUNK_SIZE = std::max(int64_t(BLOCK_SIZE / dim_size / sizeof(BFloat16)), (int64_t) bVec::size());
+  CHUNK_SIZE = CHUNK_SIZE / bVec::size() * bVec::size();
+  int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
+
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  at::parallel_for(0, outer_size * num_chunks, grain_size, [&](int64_t begin, int64_t end) {
+    std::unique_ptr<float []> buffer(new float[CHUNK_SIZE * 2]);
+    float* input_max_data = buffer.get();
+    float* tmp_sum_data = buffer.get() + CHUNK_SIZE;
+
+    // thread local buffer that holds input data in float32 to save next 2 dtype conversion
+    std::unique_ptr<float []> input_buffer(new float[dim_size * CHUNK_SIZE]);
+    float* input_buffer_data = input_buffer.get();
+
+    // init
+    for (int64_t i = begin; i < end; i++) {
+      int64_t outer_idx = i / num_chunks;
+      int64_t k = i % num_chunks;
+      int64_t inner_idx_begin = k * CHUNK_SIZE;
+      int64_t size = std::min(CHUNK_SIZE, inner_size - inner_idx_begin);
+
+      fVec zero_fvec = fVec(float(0));
+      fVec min_fvec = fVec(-std::numeric_limits<float>::infinity());
+      int64_t d0 = 0;
+      for (; d0 < size - (size % bVec::size()); d0 += bVec::size()) {
+        min_fvec.store(input_max_data + d0);
+        min_fvec.store(input_max_data + d0 + fVec::size());
+        zero_fvec.store(tmp_sum_data + d0);
+        zero_fvec.store(tmp_sum_data + d0 + fVec::size());
+      }
+      for (; d0 < size; d0++) {
+        input_max_data[d0] = -std::numeric_limits<float>::infinity();
+        tmp_sum_data[d0] = float(0);
+      }
+
+      // compute max
+      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+        BFloat16* input_ptr = input_data_base + outer_idx * dim_size * inner_size
+            + dim_idx * inner_size + inner_idx_begin;
+        float* input_buffer_ptr = input_buffer_data + dim_idx * CHUNK_SIZE;
+
+        int64_t d1 = 0;
+        for (; d1 < size - (size % bVec::size()); d1 += bVec::size()) {
+          bVec data_bvec = bVec::loadu(input_ptr + d1);
+          fVec data_fvec0, data_fvec1;
+          std::tie(data_fvec0, data_fvec1) = convert_bfloat16_float(data_bvec);
+          fVec max_fvec0 = fVec::loadu(input_max_data + d1);
+          fVec max_fvec1 = fVec::loadu(input_max_data + d1 + fVec::size());
+          max_fvec0 = fVec::blendv(max_fvec0, data_fvec0, data_fvec0 > max_fvec0);
+          max_fvec1 = fVec::blendv(max_fvec1, data_fvec1, data_fvec1 > max_fvec1);
+          max_fvec0.store(input_max_data + d1);
+          max_fvec0.store(input_max_data + d1 + fVec::size());
+
+          // cache the 'converted' float input
+          data_fvec0.store(input_buffer_ptr + d1);
+          data_fvec1.store(input_buffer_ptr + d1 + fVec::size());
+        }
+        for (; d1 < size; d1++) {
+          float data_val = float(input_ptr[d1]);
+          float max_val = input_max_data[d1];
+          input_max_data[d1] = data_val > max_val ? data_val : max_val;
+          input_buffer_ptr[d1] = data_val;
+        }
+      }
+
+      // compute sum of (x - max).exp()
+      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+        float* input_buffer_ptr = input_buffer_data + dim_idx * CHUNK_SIZE;
+
+        int64_t d2 = 0;
+        for (; d2 < size - (size % bVec::size()); d2 += bVec::size()) {
+          fVec data_fvec0 = fVec::loadu(input_buffer_ptr + d2);
+          fVec data_fvec1 = fVec::loadu(input_buffer_ptr + d2 + fVec::size());
+          fVec sum_fvec0 = fVec::loadu(tmp_sum_data + d2);
+          fVec sum_fvec1 = fVec::loadu(tmp_sum_data + d2 + fVec::size());
+          fVec max_fvec0 = fVec::loadu(input_max_data + d2);
+          fVec max_fvec1 = fVec::loadu(input_max_data + d2 + fVec::size());
+          sum_fvec0 += (data_fvec0 - max_fvec0).exp();
+          sum_fvec1 += (data_fvec1 - max_fvec1).exp();
+          sum_fvec0.store(tmp_sum_data + d2);
+          sum_fvec1.store(tmp_sum_data + d2 + fVec::size());
+        }
+        for (; d2 < size; d2++) {
+          float data_val = input_buffer_ptr[d2];
+          float max_val = input_max_data[d2];
+          tmp_sum_data[d2] += std::exp(data_val - max_val);
+        }
+      }
+
+      // apply log
+      vec::map([](fVec x) { return x.log(); }, tmp_sum_data, tmp_sum_data, size);
+
+      // compute x - max - sum
+      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+        float* input_buffer_ptr = input_buffer_data + dim_idx * CHUNK_SIZE;
+        BFloat16* output_ptr = output_data_base + outer_idx * dim_size * inner_size
+            + dim_idx * inner_size + inner_idx_begin;
+
+        int64_t d3 = 0;
+        for (; d3 < size - (size % bVec::size()); d3 += bVec::size()) {
+          fVec data_fvec0 = fVec::loadu(input_buffer_ptr + d3);
+          fVec data_fvec1 = fVec::loadu(input_buffer_ptr + d3 + fVec::size());
+          fVec max_fvec0 = fVec::loadu(input_max_data + d3);
+          fVec max_fvec1 = fVec::loadu(input_max_data + d3 + fVec::size());
+          fVec sum_fvec0 = fVec::loadu(tmp_sum_data + d3);
+          fVec sum_fvec1 = fVec::loadu(tmp_sum_data + d3 + fVec::size());
+          fVec out_fvec0 = data_fvec0 - max_fvec0 - sum_fvec0;
+          fVec out_fvec1 = data_fvec1 - max_fvec1 - sum_fvec1;
+          bVec out_bvec = convert_float_bfloat16(out_fvec0, out_fvec1);
+          out_bvec.store(output_ptr + d3);
+        }
+        for (; d3 < size; d3++) {
+          output_ptr[d3] = BFloat16(input_buffer_ptr[d3] - input_max_data[d3] - tmp_sum_data[d3]);
+        }
+      }
+    }
+  });
+}
+
 template <typename scalar_t, bool LogSoftMax>
 struct vec_softmax {
   static void apply(const Tensor& output, const Tensor& input, int64_t dim) {
@@ -409,7 +651,8 @@ struct vec_softmax {
     scalar_t* input_data_base = input.data_ptr<scalar_t>();
     scalar_t* output_data_base = output.data_ptr<scalar_t>();
     if (LogSoftMax) {
-      AT_ERROR("vec_softmax not implemented for LogSoftMax");
+      _vec_logsoftmax(
+          input_data_base, output_data_base, outer_size, inner_size, dim_size);
     } else {
       _vec_softmax(
           input_data_base, output_data_base, outer_size, inner_size, dim_size);
@@ -461,6 +704,12 @@ static void log_softmax_lastdim_kernel_impl(
       [&] { vec_host_softmax_lastdim<scalar_t, true>::apply(result, self); });
 }
 
+static void log_softmax_kernel_impl(const Tensor& result, const Tensor& self, int64_t dim) {
+  AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::BFloat16, self.scalar_type(),
+    "softmax_kernel_impl",
+    [&] { vec_softmax<scalar_t, true>::apply(result, self, dim); });
+}
+
 static void softmax_backward_lastdim_kernel_impl(
     const Tensor& grad_input,
     const Tensor& grad,
@@ -497,5 +746,6 @@ REGISTER_DISPATCH(
     &log_softmax_backward_lastdim_kernel_impl);
 
 REGISTER_DISPATCH(softmax_kernel, &softmax_kernel_impl);
+REGISTER_DISPATCH(log_softmax_kernel, &log_softmax_kernel_impl);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/SoftmaxKernel.h
+++ b/aten/src/ATen/native/cpu/SoftmaxKernel.h
@@ -16,6 +16,7 @@ DECLARE_DISPATCH(backward_fn, log_softmax_backward_lastdim_kernel);
 
 using forward_fn_with_dim = void(*)(const Tensor &, const Tensor &, const int64_t);
 DECLARE_DISPATCH(forward_fn_with_dim, softmax_kernel);
+DECLARE_DISPATCH(forward_fn_with_dim, log_softmax_kernel);
 
 }
 }

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -459,6 +459,18 @@ class TestReductions(TestCase):
             with self.assertRaisesRegex(RuntimeError, "only tensors with up to 64 dims are supported"):
                 op(x, -1)
 
+    @onlyCPU
+    @dtypes(torch.float, torch.bfloat16)
+    def test_dim_reduction_lastdim(self, device, dtype):
+        x = torch.randn(3, 5, 40, device=device, dtype=dtype)
+        x = x[:, :, 0:40:2]
+        x2 = x.contiguous()
+        ops = [torch.norm, torch.argmax, torch.argmin]
+        for op in ops:
+            y = op(x, dim=-1)
+            y2 = op(x2, dim=-1)
+            self.assertEqual(y, y2)
+
     @skipIfNoSciPy
     def test_logsumexp(self, device):
         from scipy.special import logsumexp


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/64726

Test Plan: Imported from OSS

Differential Revision: D33862416

Pulled By: frank-wei

