### PR TITLE
Immediately wrap function in gradcheck to filter non-differentiable outputs

### DIFF
--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -436,8 +436,7 @@ def _get_numerical_vJu(fn, inputs, inp_indices, func_out, all_u, all_v, eps, is_
         # Filter out the Ju for non floating point outputs
         filtered_Ju = []
         func_out = _as_tuple(func_out)
-        # We only need to compute the numerical vJu corresponding to outputs that require grad
-        # assert len(all_Ju) == len(func_out)
+        assert len(all_Ju) == len(func_out)
         for Ju, output in zip(all_Ju, func_out):
             if _is_float_or_complex_tensor(output):
                 filtered_Ju.append(Ju)

--- a/torch/autograd/gradcheck_utils.py
+++ b/torch/autograd/gradcheck_utils.py
@@ -12,19 +12,20 @@ def _as_tuple(x):
     else:
         return x,
 
-def _is_differentiable(obj, need_requires_grad):
+def _is_differentiable(obj: Any, need_requires_grad: bool) -> bool:
     return _is_float_or_complex_tensor(obj) and (obj.requires_grad or not need_requires_grad)
 
-def _is_float_or_complex_tensor(obj):
+def _is_float_or_complex_tensor(obj: Any) -> bool:
     return is_tensor_like(obj) and (obj.is_floating_point() or obj.is_complex())
 
-def _tuple_indices_where(tup, cond_fn: Callable[..., bool]):
-    assert isinstance(tup, Tuple)
+def _tuple_indices_where(tup: Tuple[Any, ...], cond_fn: Callable[..., bool]):
     return tuple(i for (i, obj) in enumerate(tup) if cond_fn(obj))
 
-def _tuple_apply_indices(tup, indices: Tuple[int, ...]):
-    assert isinstance(tup, Tuple)
+def _tuple_apply_indices(tup: Tuple[Any, ...], indices: Tuple[int, ...]):
     return tuple(obj for (i, obj) in enumerate(tup) if i in indices)
+
+def _is_tuple_indices_subset(tup: Tuple[int, ...], tup_subset: Tuple[int, ...]) -> bool:
+    return all(i in set(tup) for i in tup_subset)
 
 class GradcheckError(RuntimeError):
     # Custom error so that user errors are not caught in the gradcheck's try-catch
@@ -51,28 +52,40 @@ class GradcheckFunction(Callable):
     wrapped_fn: Callable[..., Tuple[torch.Tensor, ...]]
     wrapped_fn_out_no_req_grad: Callable[..., Tuple[torch.Tensor, ...]]
 
-    def __init__(self, fn_raw, inputs_raw, outputs_raw, diff_in_indices, diff_out_indices, need_requires_grad):
+    def __init__(self, fn_raw, inputs_raw, outputs_raw, custom_diff_in_indices, custom_diff_out_indices, need_requires_grad):
         self.fn_raw = fn_raw
         self.inputs_raw = inputs_raw
         self.outputs_raw = outputs_raw
 
-        # "maybe_req_grad" means that we require outputs to have requires_grad=True when used for backward AD but not forward AD
+        # NB: maybe_req_grad = require to have requires_grad=True when used for bw but not fw AD
         is_diff_maybe_req_grad = functools.partial(_is_differentiable, need_requires_grad=need_requires_grad)
         is_diff_no_req_grad = functools.partial(_is_differentiable, need_requires_grad=False)
 
-        diff_in_indices = _tuple_indices_where(inputs_raw, is_diff_maybe_req_grad) if diff_in_indices is None else diff_in_indices
-        diff_out_indices_maybe_req_grad = _tuple_indices_where(outputs_raw, is_diff_maybe_req_grad) if diff_out_indices is None else diff_out_indices
-        # What should be the behavior here? When user marks an output as non-differentiable with diff_out_indices...
-        # Currently, we just ignore it. Alternatively, we can check if its numerical Jacobian is zero
-        diff_out_indices_no_req_grad = _tuple_indices_where(outputs_raw, is_diff_no_req_grad) if diff_out_indices is None else diff_out_indices
+        # Get the default differentiable indices for inputs and outputs
+        diff_in_indices = _tuple_indices_where(inputs_raw, is_diff_maybe_req_grad)
+        diff_out_indices_maybe_req_grad = _tuple_indices_where(outputs_raw, is_diff_maybe_req_grad)
+        diff_out_indices_no_req_grad = _tuple_indices_where(outputs_raw, is_diff_no_req_grad)
 
+        # Combine the default indices with custom indices if provided
+        error_if_not_subset = "Expect all inputs or output indices to correspond to differentiable inputs or outputs"
+        if custom_diff_in_indices is not None:
+            assert _is_tuple_indices_subset(diff_in_indices, custom_diff_in_indices), error_if_not_subset
+            diff_in_indices = custom_diff_in_indices
+        if custom_diff_out_indices is not None:
+            # TODO: if we pass in tensors that don't require grad, but custom indices are provided, it will fail when
+            #       needs_requires_grad=True
+            # TODO: why is this the corect behavior? If user marks non-differentiable, that means that we should ignore
+            #       it completely? or should we verify that its numerical Jacobian is zero
+            assert _is_tuple_indices_subset(diff_out_indices_maybe_req_grad, custom_diff_out_indices), error_if_not_subset
+            assert _is_tuple_indices_subset(diff_out_indices_no_req_grad, custom_diff_out_indices), error_if_not_subset
+            diff_out_indices_maybe_req_grad = custom_diff_out_indices
+            diff_out_indices_no_req_grad = custom_diff_out_indices
+
+        # Apply indices to inputs and outputs
         self.inputs = _tuple_apply_indices(self.inputs_raw, diff_in_indices)
         self.outputs = _tuple_apply_indices(self.outputs_raw, diff_out_indices_maybe_req_grad)
 
-        # NB: we have two versions: 'maybe_req_grad' and 'no_req_grad'
-        #    1)
-        #    2) no_req_grad never requires outputs to have requires_grad=True
-        #       Currently, this is only useful for check_no_differentiable_outputs
+        # Wrap the function based in differentiable inputs and outputs
         def make_wrapped_fn(out_maybe_req_grad):
             def wrapped_fn(*diff_inputs):
                 inputs_raw = list(self.inputs_raw)
@@ -86,6 +99,7 @@ class GradcheckFunction(Callable):
 
         self.wrapped_fn_maybe_req_grad = make_wrapped_fn(True)
         if need_requires_grad:
+            # We don't need _check_no_differentiable_outputs for forward AD
             self.wrapped_fn_out_no_req_grad = make_wrapped_fn(False)
 
     def __call__(self, *args, **kwargs):

--- a/torch/autograd/gradcheck_utils.py
+++ b/torch/autograd/gradcheck_utils.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
-from typing import Callable
+import torch
+from typing import Callable, Tuple, Any
 from torch.overrides import is_tensor_like
+import functools
 
 def _as_tuple(x):
     if isinstance(x, tuple):
@@ -10,12 +12,84 @@ def _as_tuple(x):
     else:
         return x,
 
+def _is_differentiable(obj, need_requires_grad):
+    return _is_float_or_complex_tensor(obj) and (obj.requires_grad or not need_requires_grad)
+
 def _is_float_or_complex_tensor(obj):
     return is_tensor_like(obj) and (obj.is_floating_point() or obj.is_complex())
+
+def _tuple_indices_where(tup, cond_fn: Callable[..., bool]):
+    assert isinstance(tup, Tuple)
+    return tuple(i for (i, obj) in enumerate(tup) if cond_fn(obj))
+
+def _tuple_apply_indices(tup, indices: Tuple[int, ...]):
+    assert isinstance(tup, Tuple)
+    return tuple(obj for (i, obj) in enumerate(tup) if i in indices)
 
 class GradcheckError(RuntimeError):
     # Custom error so that user errors are not caught in the gradcheck's try-catch
     pass
+
+class GradcheckFunction(Callable):
+    # Wraps a raw function so that the non-differentiable inputs are captured instead
+    # of passed, and the non-differentiable outputs are filtered out.
+    #
+    # Whether we require the tensor to have requires_grad=True to count as differentiable
+    # can be customized depending on whether this is being constructed for use with
+    # forward-mode AD or reverse-mode AD.
+    #
+    # If we filter out inputs/outputs that don't require grad (i.e., need_requires_grad=True),
+    # we also expose an alternative function `diff_out_indices_no_req_grad`,
+    # for the _check_no_differentiable_outputs check
+
+    fn_raw: Callable[..., Any]
+    inputs_raw: Tuple[Any]
+    outputs_raw: Tuple[Any]
+
+    inputs: Tuple[torch.Tensor, ...]
+    outputs: Tuple[torch.Tensor, ...]
+    wrapped_fn: Callable[..., Tuple[torch.Tensor, ...]]
+    wrapped_fn_out_no_req_grad: Callable[..., Tuple[torch.Tensor, ...]]
+
+    def __init__(self, fn_raw, inputs_raw, outputs_raw, diff_in_indices, diff_out_indices, need_requires_grad):
+        self.fn_raw = fn_raw
+        self.inputs_raw = inputs_raw
+        self.outputs_raw = outputs_raw
+
+        # "maybe_req_grad" means that we require outputs to have requires_grad=True when used for backward AD but not forward AD
+        is_diff_maybe_req_grad = functools.partial(_is_differentiable, need_requires_grad=need_requires_grad)
+        is_diff_no_req_grad = functools.partial(_is_differentiable, need_requires_grad=False)
+
+        diff_in_indices = _tuple_indices_where(inputs_raw, is_diff_maybe_req_grad) if diff_in_indices is None else diff_in_indices
+        diff_out_indices_maybe_req_grad = _tuple_indices_where(outputs_raw, is_diff_maybe_req_grad) if diff_out_indices is None else diff_out_indices
+        # What should be the behavior here? When user marks an output as non-differentiable with diff_out_indices...
+        # Currently, we just ignore it. Alternatively, we can check if its numerical Jacobian is zero
+        diff_out_indices_no_req_grad = _tuple_indices_where(outputs_raw, is_diff_no_req_grad) if diff_out_indices is None else diff_out_indices
+
+        self.inputs = _tuple_apply_indices(self.inputs_raw, diff_in_indices)
+        self.outputs = _tuple_apply_indices(self.outputs_raw, diff_out_indices_maybe_req_grad)
+
+        # NB: we have two versions: 'maybe_req_grad' and 'no_req_grad'
+        #    1)
+        #    2) no_req_grad never requires outputs to have requires_grad=True
+        #       Currently, this is only useful for check_no_differentiable_outputs
+        def make_wrapped_fn(out_maybe_req_grad):
+            def wrapped_fn(*diff_inputs):
+                inputs_raw = list(self.inputs_raw)
+                for diff_idx, idx in enumerate(diff_in_indices):
+                    inputs_raw[idx] = diff_inputs[diff_idx]
+                if out_maybe_req_grad:
+                    return _tuple_apply_indices(_as_tuple(fn_raw(*inputs_raw)), diff_out_indices_maybe_req_grad)
+                else:
+                    return _tuple_apply_indices(_as_tuple(fn_raw(*inputs_raw)), diff_out_indices_no_req_grad)
+            return wrapped_fn
+
+        self.wrapped_fn_maybe_req_grad = make_wrapped_fn(True)
+        if need_requires_grad:
+            self.wrapped_fn_out_no_req_grad = make_wrapped_fn(False)
+
+    def __call__(self, *args, **kwargs):
+        return self.wrapped_fn_maybe_req_grad(*args, **kwargs)
 
 @dataclass(frozen=True)
 class GradcheckInfo():
@@ -32,3 +106,5 @@ class GradcheckInfo():
     check_batched_forward_grad: bool
     check_forward_ad: bool
     check_backward_ad: bool
+    diff_in_indices: Tuple[int, ...]
+    diff_out_indices: Tuple[int, ...]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72271
* __->__ #72166
* #72165

Currently filtering out non-differentiable inputs/outputs is done in ad-hoc ways in different parts of gradcheck.py, this PR is the first step to rationalizing that behavior.

Differential Revision: [D33991620](https://our.internmc.facebook.com/intern/diff/D33991620)