### PR TITLE
[FSDP] full state dict

### DIFF
--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -1,0 +1,116 @@
+# Owner(s): ["oncall: distributed"]
+
+from functools import partial
+
+import torch
+import torch.nn as nn
+import torch.distributed as dist
+from torch.distributed._fsdp.fully_sharded_data_parallel import (
+    FullyShardedDataParallel as FSDP,
+    CPUOffload,
+)
+from torch.testing._internal.common_distributed import (
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+    _zero_model,
+    _get_state_dict,
+    _get_full_param,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    parametrize,
+    instantiate_parametrized_tests,
+)
+
+
+class TestFSDPStateDict(FSDPTest):
+    def _get_simple_nested_model(self, *fsdp_args, **fsdp_kwargs):
+        model = FSDP(
+            nn.Sequential(
+                FSDP(nn.Linear(10, 10, bias=False), *fsdp_args, **fsdp_kwargs),
+                nn.Linear(10, 10, bias=False),
+            ),
+            *fsdp_args,
+            **fsdp_kwargs,
+        )
+        return model
+
+    def _get_simple_model(self, *fsdp_args, **fsdp_kwargs):
+        model = FSDP(nn.Linear(10, 10, bias=False), *fsdp_args, **fsdp_kwargs)
+        return model
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "cpu_offload",
+        [CPUOffload(offload_params=True), CPUOffload(offload_params=False)],
+    )
+    @parametrize("fp16", [True, False])
+    def test_basic_save_and_load_state_dict(self, cpu_offload, fp16):
+        for model_call in [
+            partial(self._get_simple_nested_model, cpu_offload=cpu_offload),
+            partial(self._get_simple_model, cpu_offload=cpu_offload),
+        ]:
+            model = model_call()
+            fsdp_state_dict = _get_state_dict(model, cpu_offload.offload_params, fp16)
+            if fp16:
+                for tensor in fsdp_state_dict.values():
+                    self.assertEqual(tensor.dtype, torch.float16)
+
+            model_new = model_call()
+            if not cpu_offload.offload_params:
+                model_new = model_new.cuda()
+            if fp16:
+                model_new.half()
+
+            _zero_model(model_new)
+
+            with model._summon_full_params(), model_new._summon_full_params():
+                params = list(model.parameters())
+                params_new = list(model_new.parameters())
+                self.assertNotEqual(params, params_new)
+
+            model_new.load_state_dict(fsdp_state_dict)
+            with model_new._summon_full_params():
+                with model._summon_full_params():
+                    params = list(model.parameters())
+                    params_new = list(model_new.parameters())
+                    self.assertEqual(params, params_new)
+                    if fp16:
+                        for tensor in model_new.parameters():
+                            self.assertEqual(tensor.dtype, torch.float16)
+
+    def test_save_and_load_after_forward(self):
+        """
+        Test that saving after some training results in params being updated as
+        expected.
+        """
+        torch.cuda.set_device(self.rank)
+        model = self._get_wrapped_model(group=torch.distributed.distributed_c10d._get_default_group())
+        optim = torch.optim.SGD(model.parameters(), lr=0.1)
+        initial_params = _get_full_param(model)
+        for _ in range(6):
+            inp = model.module.get_input(torch.device("cuda"))
+            output = model(*inp)
+            loss = model.module.get_loss(inp, output).cuda()
+            model.module.run_backward(loss)
+            optim.step()
+
+        new_params = _get_full_param(model)
+        self.assertNotEqual(initial_params, new_params)
+        state_dict = {k: v.clone() for k, v in model.state_dict().items()}
+        _zero_model(model)
+        zerod_params = _get_full_param(model)
+        for param in zerod_params:
+            self.assertEqual(0, param.sum().item())
+
+        model.load_state_dict(state_dict)
+        loaded_params = _get_full_param(model)
+        self.assertEqual(loaded_params, new_params)
+
+
+instantiate_parametrized_tests(TestFSDPStateDict)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -1,0 +1,278 @@
+# Owner(s): ["oncall: distributed"]
+import sys
+import math
+
+import torch
+import torch.nn as nn
+from torch import distributed as dist
+from torch.distributed._fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed._fsdp import CPUOffload
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+)
+from torch.testing._internal.common_utils import (
+    TEST_WITH_DEV_DBG_ASAN,
+    run_tests,
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+class TestSummonFullParams(FSDPTest):
+    @property
+    def world_size(self):
+        return 2
+
+    def get_model_param_count(self, m):
+        return sum([p.numel() for p in m.parameters()])
+
+    # padding ensures that all shards have the same size with the least amount of padding
+    def get_expected_sharded_size(self, global_size):
+        return int(math.ceil(global_size / self.world_size))
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "writeback",
+        [True, False]
+    )
+    @parametrize(
+        "cpu_offload",
+        [CPUOffload(offload_params=True), CPUOffload(offload_params=False)]
+    )
+    @parametrize(
+        "modify_outer",
+        [True, False]
+    )
+    def test_summon_full_param_writeback(self, writeback, cpu_offload, modify_outer):
+        model = FSDP(nn.Sequential(
+            FSDP(nn.Linear(5, 5, bias=False)),
+            nn.Linear(5, 3, bias=False)
+        )).cuda(self.rank)
+
+        # set the value
+        outer_param = model.get_parameter("_fsdp_wrapped_module.flat_param")
+        inner_param = model.get_parameter("_fsdp_wrapped_module._fpw_module.0._fsdp_wrapped_module.flat_param")
+        p = outer_param if modify_outer else inner_param
+
+        with torch.no_grad():
+            # This sets the local shard value
+            p[0] = self.rank + 2
+
+        with model._summon_full_params(writeback=writeback):
+            with torch.no_grad():
+                p.copy_(torch.zeros_like(p))
+
+        if writeback:
+            self.assertEqual(p.cpu()[0], 0)
+        else:
+            self.assertEqual(p.cpu()[0], self.rank + 2)
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_full_param_shard_value(self):
+
+        raw_model = nn.Linear(10, 11)
+        raw_model_size = self.get_model_param_count(raw_model)
+        expected_shard_size = self.get_expected_sharded_size(raw_model_size)
+
+        model = FSDP(raw_model.cuda(self.rank))
+        self.assertEqual(expected_shard_size, self.get_model_param_count(model))
+
+        # we're assuming a single flatenned param
+        self.assertEqual(1, len(list(model.parameters())))
+
+        my_shard = torch.clone(next(model.parameters()))
+
+        with model._summon_full_params():
+            self.assertEqual(raw_model_size, self.get_model_param_count(model))
+            all_shards = next(model.parameters())
+            my_slice = torch.chunk(all_shards, self.world_size)[self.rank]
+
+            # shards are padded but the full_param tensor is not
+            a, b = my_shard[0: my_slice.numel()], my_slice
+            self.assertTrue(torch.equal(my_shard[0: my_slice.numel()].cpu(), my_slice.cpu()))
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "recurse",
+        [True, False]
+    )
+    @parametrize(
+        "summon_outer",
+        [True, False]
+    )
+    def test_summon_full_param_recursive(self, recurse, summon_outer):
+        model = FSDP(nn.Sequential(
+            FSDP(nn.Linear(5, 5, bias=False)),
+            nn.Linear(5, 3, bias=False)
+        )).cuda(self.rank)
+
+        global_inner_numel = self.get_model_param_count(nn.Linear(5, 5, bias=False))
+        global_outer_numel = self.get_model_param_count(nn.Linear(5, 3, bias=False))
+
+        shard_inner_numel = int(math.ceil(global_inner_numel / self.world_size))
+        shard_outer_numel = int(math.ceil(global_outer_numel / self.world_size))
+
+        outer_param = model.get_parameter("_fsdp_wrapped_module.flat_param")
+        inner_param = model.get_parameter("_fsdp_wrapped_module._fpw_module.0._fsdp_wrapped_module.flat_param")
+        self.assertEqual(shard_outer_numel, outer_param.numel())
+        self.assertEqual(shard_inner_numel, inner_param.numel())
+
+        model_to_summon = model if summon_outer else model[0]
+        # outer is summoned if _summon_full_param is called on the outer FSDP module
+        expected_outer_numel = global_outer_numel if summon_outer else shard_outer_numel
+
+        # inner is summoned if _summon_full_param is called with recursion or on the inner FSDP module
+        expected_inner_numel = global_inner_numel if recurse or not summon_outer else shard_inner_numel
+
+        with model_to_summon._summon_full_params(recurse=recurse):
+            self.assertEqual(expected_outer_numel, outer_param.numel())
+            self.assertEqual(expected_inner_numel, inner_param.numel())
+
+    @skip_if_lt_x_gpu(2)
+    def test_cannot_summon_full_params_from_forward(self):
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = nn.Parameter(torch.zeros(5))
+
+            def forward(self, fsdp_module):
+                with fsdp_module._summon_full_params():
+                    pass
+
+        model = FSDP(MyModule()).cuda(self.rank)
+        with self.assertRaisesRegex(ValueError, "current state is TrainingState_.FORWARD"):
+            model(model)
+
+
+    @skip_if_lt_x_gpu(2)
+    def test_cannot_summon_full_params_from_backward(self):
+        model = FSDP(nn.Linear(2, 1)).cuda(self.rank)
+
+        output = model(torch.ones(2).cuda(self.rank))
+
+        def bad_backwards_hook(tensor):
+            with model._summon_full_params():
+                pass
+            return None
+
+        self.assertTrue(output.requires_grad)
+        output.register_hook(bad_backwards_hook)
+
+        with self.assertRaisesRegex(ValueError, "current state is TrainingState_.BACKWARD_PRE"):
+            output.backward()
+
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_full_params_respects_reshard_after_forward(self):
+        model = FSDP(nn.Sequential(
+            FSDP(nn.Linear(5, 5, bias=False)),
+            nn.Linear(5, 3, bias=False)
+        )).cuda(self.rank)
+
+        outer_param = model.get_parameter("_fsdp_wrapped_module.flat_param")
+        inner_param = model.get_parameter("_fsdp_wrapped_module._fpw_module.0._fsdp_wrapped_module.flat_param")
+        outer_full_param_size = outer_param.numel() * self.world_size
+
+        # trigger lazy init
+        model(torch.zeros(5).cuda(self.rank))
+
+        # the root FSDP module keeps all params around
+        self.assertEqual(outer_full_param_size, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        # similarly _summon_full_params should have the same behavior
+        with model._summon_full_params():
+            pass
+        self.assertEqual(outer_full_param_size, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_single_param(self):
+        model = FSDP(nn.Linear(1, 1, bias=False)).cuda(self.rank)
+
+        p = model.get_parameter("_fsdp_wrapped_module.flat_param")
+        self.assertEqual(1, p.numel())
+
+        with torch.no_grad():
+            # This sets the local shard value
+            p[0] = self.rank + 2
+
+        with model._summon_full_params(writeback=True):
+            self.assertEqual(1, p.numel())
+            with torch.no_grad():
+                p.copy_(torch.zeros_like(p))
+
+        # most ranks hold no data and wrote to padding so only rank zero will observe the above write
+        if self.rank == 0:
+            self.assertEqual(0, p[0])
+        else:
+            self.assertEqual(self.rank + 2, p[0])
+
+    @skip_if_lt_x_gpu(2)
+    def test_reshard_outside_forward_backward_iteration(self):
+        model = FSDP(nn.Sequential(
+            FSDP(nn.Linear(5, 5, bias=False)),
+            nn.Linear(5, 1, bias=False)
+        )).cuda(self.rank)
+
+        outer_param = model.get_parameter("_fsdp_wrapped_module.flat_param")
+        inner_param = model.get_parameter("_fsdp_wrapped_module._fpw_module.0._fsdp_wrapped_module.flat_param")
+        outer_full_param_size = outer_param.numel() * self.world_size
+
+        # First lets validate our assumption about resharding
+
+        output = model(torch.zeros(5).cuda(self.rank))
+        # the root FSDP module keeps all params around
+        self.assertEqual(outer_full_param_size, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        output.backward()
+        # we reshard everything after backward() finishes
+        self.assertEqual(0, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        # now lets repeat it with summon done in between
+
+        output = model(torch.zeros(5).cuda(self.rank))
+        with model._summon_full_params():
+            pass
+        self.assertEqual(outer_full_param_size, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        output.backward()
+        with model._summon_full_params():
+            pass
+        self.assertEqual(0, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+
+    @skip_if_lt_x_gpu(2)
+    def test_params_are_unflatenned(self):
+        model = FSDP(nn.Linear(self.world_size, 1, bias=False)).cuda(self.rank)
+
+        flattened_param = model.get_parameter("_fsdp_wrapped_module.flat_param")
+        self.assertEqual(1, flattened_param.numel())
+
+        with model._summon_full_params():
+            a = model.weight.flatten().detach()
+            b = flattened_param.detach()
+            self.assertTrue(torch.equal(a, b))
+
+instantiate_parametrized_tests(TestSummonFullParams)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/_fsdp/flatten_params_wrapper.py
@@ -205,7 +205,10 @@ class FlattenParamsWrapper(nn.Module):
         """Forward indexing calls in case the module is a nn.Sequential."""
         return self.module.__getitem__(key)
 
-    def forward(self, *inputs: Any, **kwinputs: Any) -> Any:
+    def _unflatten_params_if_needed(self) -> None:
         if self.flat_param is not None:
             self._unflatten_params_as_views()
+
+    def forward(self, *inputs: Any, **kwinputs: Any) -> Any:
+        self._unflatten_params_if_needed()
         return self.module(*inputs, **kwinputs)

--- a/torch/distributed/_fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/_fsdp/fully_sharded_data_parallel.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import traceback
 from dataclasses import dataclass
@@ -9,6 +10,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Generator,
     Set,
     Tuple,
     Union,
@@ -82,6 +84,7 @@ class TrainingState_(Enum):
     FORWARD = auto()
     BACKWARD_PRE = auto()
     BACKWARD_POST = auto()
+    SUMMON_FULL_PARAMS = auto()
 
 
 class FullyShardedDataParallel(nn.Module):
@@ -202,7 +205,7 @@ class FullyShardedDataParallel(nn.Module):
             if not hasattr(param, "_is_sharded"):
                 params.append(param)
 
-        self._fsdp_wrapped_module: nn.Module = FlattenParamsWrapper(
+        self._fsdp_wrapped_module: FlattenParamsWrapper = FlattenParamsWrapper(
             module, param_list=params
         )
         del module  # free original module in case it helps garbage collection
@@ -628,6 +631,76 @@ class FullyShardedDataParallel(nn.Module):
         self.training_state = TrainingState_.IDLE
 
         return outputs
+
+    @torch.no_grad()
+    def _write_back_current_shard(self):
+        for p in self.params:
+            if not p._is_sharded:  # type: ignore[attr-defined]
+                pass
+            chunks = p._full_param_padded.chunk(self.world_size)  # type: ignore[attr-defined]
+            assert len(chunks) > self.rank
+            chunk = chunks[self.rank]
+            p._local_shard.copy_(chunk)  # type: ignore[attr-defined]
+
+    def _collect_local_params(self):
+        def _is_full_param_in_use(p: Parameter):
+            return p._is_sharded and p._full_param_padded.storage().size() > 0  # type: ignore[attr-defined]
+
+        return [p for p in self.params if not _is_full_param_in_use(p)]
+
+
+    @contextlib.contextmanager
+    def _summon_full_params(self, recurse: bool = True, writeback: bool = True) -> Generator:
+        """
+        A context manager to expose full params for the current FSDP instance.
+        Can be useful *after* forward/backward for a model to get the params for
+        additional processing or checking.
+        .. note:: This can be used on inner FSDPs.
+        .. note:: This can *not* be used within a forward or backward pass. Nor
+            can forward and backward be started from within this context.
+        .. note:: Parameters will revert to their local shards after the context manager
+            exits, storage behavior is the same as forward.
+        .. note:: The full parameters can be modified, but only the portion
+            corresponding to the local param shard will persist after the
+            context manager exits (unless ``writeback=False``, in which case
+            changes will be discarded).
+        Args:
+            recurse (bool, Optional): recursively summon all params for nested
+                FSDP instances (default: True)
+            writeback (bool, Optional): if ``False``, modifications to params are
+                discarded after the context manager exists;
+                enabling this can be slightly more efficient (default: True)
+        """
+        if recurse:
+            with contextlib.ExitStack() as stack:
+                # Summon all params for any nested FSDP instances.
+                for module in self.modules():
+                    if isinstance(module, FullyShardedDataParallel):
+                        stack.enter_context(module._summon_full_params(recurse=False, writeback=writeback))
+                # Yield to the caller, with full params in all nested instances.
+                yield
+            # Exiting from the ExitStack will re-shard params.
+            return
+        else:
+            torch.cuda.synchronize()
+            self._lazy_init()
+            self._assert_state([TrainingState_.IDLE])
+            # Set the state so that we assert when trying to go into
+            # forward/backward.
+            self.training_state = TrainingState_.SUMMON_FULL_PARAMS
+
+            currently_local_params = self._collect_local_params()
+            self._rebuild_full_params()
+            self._fsdp_wrapped_module._unflatten_params_if_needed()
+
+            try:
+                yield
+            finally:
+                if writeback:
+                    self._write_back_current_shard()
+                self._free_full_params(currently_local_params)
+                self._use_param_local_shard()
+                self.training_state = TrainingState_.IDLE
 
     def _register_pre_backward_hooks(self, outputs: Any) -> Any:
         """Register pre-backward hook to run before the wrapped module's

--- a/torch/distributed/_fsdp/utils.py
+++ b/torch/distributed/_fsdp/utils.py
@@ -1,10 +1,27 @@
 from typing import Dict, List, Tuple, Union, Any, Callable, Set
+from enum import Enum, auto
 
 import torch
 
 
 """Useful functions to deal with tensor types with other python container types."""
 
+class TrainingState_(Enum):
+    """
+    Simple enum to indicate what state FSDP is in. Used for asserting
+    to make sure APIs are called in the correct state.
+    ..note::
+        ``BACKWARD_PRE`` and ``BACKWARD_POST`` states are used to ensure we
+        receives backward hooks in the correct order. It is used to catch
+        unexpected order of hooks being called (likely due to our
+        hook registration logic or autograd engine logic changes).
+    """
+
+    IDLE = auto()
+    FORWARD = auto()
+    BACKWARD_PRE = auto()
+    BACKWARD_POST = auto()
+    SUMMON_FULL_PARAMS = auto()
 
 def _apply_to_tensors(
     fn: Callable, container: Union[torch.Tensor, Dict, List, Tuple, Set]
@@ -22,3 +39,53 @@ def _apply_to_tensors(
             return x
 
     return apply(container)
+
+def _replace_by_prefix(
+    state_dict: Dict[str, Any], old_prefix: str, new_prefix: str,
+):
+    """
+        Replace all keys that match a given old_prefix with a new_prefix (in-place).
+        Usage::
+            state_dict = {"layer.xyz": torch.tensor(1)}
+            replace_by_prefix_(state_dict, "layer.", "module.layer.")
+            assert state_dict == {"module.layer.xyz": torch.tensor(1)}
+    """
+    for key in list(state_dict.keys()):
+        if not key.startswith(old_prefix):
+            continue
+        new_key = new_prefix + key[len(old_prefix) :]
+        state_dict[new_key] = state_dict[key]
+        del state_dict[key]
+
+def post_state_dict_hook(
+    module,
+    state_dict: Dict[str, Any],
+    prefix,
+    *args
+) -> Dict[str, Any]:
+    """
+    Hook that runs after model.state_dict() is called before returning result to
+    user. For FSDP, we may have to clone the tensors in state_dict as params go
+    back to sharded version after summon_full_params ends, and also remove
+    "_fsdp_wrapped_module" prefix.
+    """
+    for key in state_dict.keys():
+        # Due to recursive call of summon_full_params, avoid unnecessary reclone of
+        if (
+            module.training_state == TrainingState_.SUMMON_FULL_PARAMS and
+            not getattr(state_dict[key], "_has_been_cloned", False)
+        ):
+            state_dict[key] = state_dict[key].clone()
+            state_dict[key]._has_been_cloned = True
+    # TODO: remove prefix?
+    _replace_by_prefix(state_dict, prefix + "_fsdp_wrapped_module.", prefix)
+    return state_dict
+
+def pre_load_state_dict_hook(state_dict, prefix, *args) -> None:
+    """
+    Hook that runs before load_state_dict() call to model. For FSDP, we
+    resubstitute the "_fsdp_wrapped_module" prefix so that FSDP instances can
+    correctly load state_dicts. Removing and addied back the prefixes also helps
+    extend FSDP state_dict to be loaded by non-FSDP instances in the future.
+    """
+    _replace_by_prefix(state_dict, prefix, prefix + "_fsdp_wrapped_module.")

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -32,6 +32,27 @@ class FSDPInitMode(Enum):
     # Don't move model to CUDA at all.
     CUDA_NEVER = 3
 
+def _get_full_param(fsdp_model: FullyShardedDataParallel):
+    with fsdp_model._summon_full_params():
+        params = list(p.clone().detach_() for p in fsdp_model.parameters())
+
+    return params
+
+def _zero_model(fsdp_model: FullyShardedDataParallel):
+    with fsdp_model._summon_full_params():
+        for param in fsdp_model.parameters():
+            with torch.no_grad():
+                param.zero_()
+
+def _get_state_dict(model, cpu_offload=False, half=False):
+    if not cpu_offload:
+        model = model.cuda()
+    if half:
+        model.half()
+
+    return model.state_dict()
+
+
 # get full params of a model recursively. Note that if CPU offloading, it will
 # also automatically move the parameters to GPU, due to _rebuild_full_params
 # call.
@@ -379,7 +400,7 @@ class FSDPTest(MultiProcessTestCase):
         dist.destroy_process_group()
         sys.exit(0)
 
-    def _train_for_several_steps(self, model, num_steps, autocast, lr=0.01, fsdp_cpu_offload=None):
+    def _train_for_several_steps(self, model, num_steps, autocast, lr=0.01, fsdp_cpu_offload=None, save_model=False):
         cpu_offload_params = fsdp_cpu_offload and fsdp_cpu_offload.offload_params
 
         model_device = next(model.parameters()).device
@@ -412,6 +433,16 @@ class FSDPTest(MultiProcessTestCase):
                     # p._is_sharded=False
                     self.assertEqual(p.device, torch.device("cpu"))
             optim.step()
+            # if save_model, simulate save + load.
+
+            if save_model:
+                state_dict = {k: v.clone() for k, v in model.state_dict().items()}
+                # Zero params, if save/load state_dict did not work properly, this
+                # would break the parity test with DDP.
+                _zero_model(model)
+
+                model.load_state_dict(state_dict)
+
         if isinstance(model, FullyShardedDataParallel):
             model._assert_state(TrainingState_.IDLE)
         return loss.detach()
@@ -426,6 +457,7 @@ class FSDPTest(MultiProcessTestCase):
         lr=0.01,
         cpu_offload=CPUOffload(),
         backward_prefetch=None,
+        save_model=True,
         **kwargs
     ):
         group = dist.distributed_c10d._get_default_group()
@@ -438,6 +470,7 @@ class FSDPTest(MultiProcessTestCase):
             )
         else:
             model = ref_ddp_fn(model)
+        # DDP training
         ref_loss = self._train_for_several_steps(
             model, num_steps, autocast=False, lr=lr, fsdp_cpu_offload=cpu_offload
         )
@@ -475,9 +508,10 @@ class FSDPTest(MultiProcessTestCase):
             if only_check_err else suppress()
         )
         with ctx:
+            # FSDP training
             shard_loss = self._train_for_several_steps(
                 model, num_steps, autocast=False, lr=lr,
-                fsdp_cpu_offload=cpu_offload,
+                fsdp_cpu_offload=cpu_offload, save_model=save_model
             )
         # We only check for errors in the case we have the following setup:
         # model = FSDP(model, cpu_offload=True)


### PR DESCRIPTION
Summary:
Implements `state_dict` and `load_state_dict` APIs for FSDP, with the following limitations:

1. Does not support `state_dict_device` (i.e. specifying which device params should be on) which fairscale does currently support
2. Does not yet support offload of state_dict onto CPU
3. Loads state_dict on all ranks currently. In the future we could add support for loading this on only rank 0, to avoid redundancy across ranks as usually only one rank is responsible for saving/loading the model. Along with (2) this would enable larger models to have state_dict called.

As discussed in FSDP checkpoint API proposal, `state_dict` will basically be a `full_state_dict` where full parameters are returned on all ranks. As a result this implies that the model must actually be able to fit on a single GPU. We are in the process of building sharding solution to support similar checkpoint APIs without this constraint.

Test Plan: CI

Differential Revision: D33887577

