### PR TITLE
Add hook for functorch to error out with unoverridable autograd operations

### DIFF
--- a/aten/src/ATen/FuncTorchTLS.h
+++ b/aten/src/ATen/FuncTorchTLS.h
@@ -30,6 +30,8 @@ struct TORCH_API FuncTorchTLSBase {
   // This is a hook to get into functorch -- functorch will determine
   // if it should raise an error message
   virtual int64_t checkSupportsAutogradFunction() const = 0;
+  virtual void checkSupportsInplaceRequiresGrad() const = 0;
+  virtual void checkSupportsRetainGrad() const = 0;
 };
 
 // returns deepcopy of the functorch tls

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -37,6 +37,7 @@
 #include "torch/csrc/autograd/python_return_types.h"
 
 #include <ATen/core/Tensor.h>
+#include <ATen/FuncTorchTLS.h>
 #include "c10/util/Optional.h"
 #include "c10/core/Stream.h"
 
@@ -788,6 +789,12 @@ static PyObject * THPVariable_requires_grad_(PyObject* self, PyObject* args, PyO
 
   if(r.has_torch_function()){
     return handle_torch_function(r, self, args, kwargs, THPVariableClass, "torch.Tensor");
+  }
+
+  // temporary hack to improve functorch UX.
+  const auto& functorch_tls = at::functorch::functorchTLSAccessor();
+  if (functorch_tls) {
+    functorch_tls->checkSupportsInplaceRequiresGrad();
   }
 
   auto requires_grad = r.toBool(0);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72176

I went through the manual_cpp_binding operations in
native_functions.yaml looking for important things that people use that
don't go through the dispatcher and came up with this.

There's currently no mechanism for functorch (or Tensor subclasses)
to change the behavior of tensor.requires_grad_() and
tensor.retains_grad() because these don't go through the dispatcher at
all.

This PR adds a hook for functorch to be able to throw an error on these.
In the future they should probably be overridable with torch_dispatch
(or at least configurable!).

Differential Revision: [D33943151](https://our.internmc.facebook.com/intern/diff/D33943151)