### PR TITLE
add the default destructor of TensorImpl

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -104,6 +104,9 @@ void TensorImpl::_set_fw_grad(
   autograd_meta_->set_fw_grad(new_grad, self, level, is_inplace_op);
 }
 
+// some compiler does not generate the destructor correctly
+TensorImpl::~TensorImpl() = default;
+
 TensorImpl::TensorImpl(
     Storage&& storage,
     DispatchKeySet key_set,

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -615,6 +615,7 @@ class C10_TensorImpl_Size_Check_Dummy_Class;
  */
 struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   TensorImpl() = delete;
+  virtual ~TensorImpl() override;
   // Note [Enum ImplType]
   // This enum is temporary. In the followup refactor we should
   // think about how to specialize TensorImpl creation for view


### PR DESCRIPTION
Summary:
# Context
Some compilers could not generate the destructor correctly.

# Mitigation
add the default destructor.

Test Plan: ^CI

Differential Revision: D33936970

